### PR TITLE
feat(server): authorize dynamic workflow execution

### DIFF
--- a/.changeset/calm-workflows-guard.md
+++ b/.changeset/calm-workflows-guard.md
@@ -2,9 +2,13 @@
 '@mastra/server': minor
 ---
 
-Scope dynamic workflow execution and run-control routes to the authenticated definition owner. New runs derive their `resourceId` from request context, client-provided resource IDs can't override it, and cross-owner requests return `404`.
+Dynamic workflow discovery, execution, and run-control routes now require an authenticated caller. Requests without caller identity return `401`; cross-owner workflow and run requests return non-disclosing `404` responses. New runs derive their `resourceId` from request context, and client-provided resource IDs can't override it.
 
 ```ts
-const workflow = mastraClient.getWorkflow('campaign-workflow')
-const run = await workflow.createRun()
+const response = await fetch('/api/workflows/campaign-workflow/runs', {
+  method: 'POST',
+  headers: { Authorization: `Bearer ${token}` },
+})
 ```
+
+Before upgrading, assign `authorId` to existing dynamic definitions and `resourceId` to resumable runs. Legacy unowned definitions and runs remain fail-closed; local Studio deployments must configure authentication rather than treating missing identity as public access.

--- a/.changeset/calm-workflows-guard.md
+++ b/.changeset/calm-workflows-guard.md
@@ -1,0 +1,10 @@
+---
+'@mastra/server': minor
+---
+
+Scope dynamic workflow execution and run-control routes to the authenticated definition owner. New runs derive their `resourceId` from request context, client-provided resource IDs can't override it, and cross-owner requests return `404`.
+
+```ts
+const workflow = mastraClient.getWorkflow('campaign-workflow')
+const run = await workflow.createRun()
+```

--- a/.changeset/calm-workflows-scope.md
+++ b/.changeset/calm-workflows-scope.md
@@ -1,0 +1,9 @@
+---
+'@mastra/server': minor
+---
+
+Added server-derived ownership for dynamic workflow list, get, and upsert routes.
+
+Authenticated callers only list, get, and upsert definitions owned by the author in their request context. Callers with `stored-workflows:admin` can inspect definitions across authors and update an owned definition without transferring it. Legacy definitions without an author remain hidden from regular callers and read-only for admins.
+
+Deletion, execution, and nested workflow references aren't owner-scoped by this change.

--- a/.changeset/calm-workflows-scope.md
+++ b/.changeset/calm-workflows-scope.md
@@ -7,3 +7,13 @@ Added server-derived ownership for dynamic workflow list, get, and upsert routes
 Authenticated callers only list, get, and upsert definitions owned by the author in their request context. Callers with `stored-workflows:admin` can inspect definitions across authors and update an owned definition without transferring it. Legacy definitions without an author remain hidden from regular callers and read-only for admins.
 
 Deletion, execution, and nested workflow references aren't owner-scoped by this change.
+
+Previously, management routes could accept a caller-selected author. Hosts should now map verified identity into the request context and omit author ownership from request bodies:
+
+```ts
+authConfig: {
+  mapUserToResourceId: user => user.id,
+}
+```
+
+The built-in list, get, and upsert routes derive ownership from that server-populated resource ID. Cross-author administration requires `stored-workflows:admin`.

--- a/.changeset/kind-runs-restart.md
+++ b/.changeset/kind-runs-restart.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': minor
+---
+
+Allow active workflow run discovery and restart to be scoped by `resourceId`, while preserving the existing no-argument behavior.
+
+```ts
+await workflow.restartAllActiveWorkflowRuns({ resourceId: 'user-123' })
+```

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -1,0 +1,11 @@
+---
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/mssql': patch
+'@mastra/mysql': patch
+'@mastra/pg': patch
+---
+
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -8,4 +8,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior. Concurrent registrations on one Mastra instance are serialized so a rejected registration can't roll back the successful live workflow.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -8,4 +8,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior. Concurrent registrations on one Mastra instance are serialized so a rejected registration can't roll back the successful live workflow.
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.

--- a/.changeset/warm-pianos-push.md
+++ b/.changeset/warm-pianos-push.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': minor
+---
+
+Added trusted author metadata for dynamic workflow registration.
+
+```ts
+await mastra.addDynamicWorkflow(definition, { authorId: verifiedUserId });
+```
+
+The author is persisted with the definition and remains outside untrusted workflow JSON. This metadata does not enforce access control.
+
+See [#21444](https://github.com/mastra-ai/mastra/issues/21444) for the remaining tenant-isolation design.

--- a/.changeset/wise-owls-queue.md
+++ b/.changeset/wise-owls-queue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Serialize dynamic workflow registrations on each Mastra instance so a rejected registration cannot roll back a workflow that another registration successfully replaced.

--- a/docs/src/content/en/docs/server/mastra-client.mdx
+++ b/docs/src/content/en/docs/server/mastra-client.mdx
@@ -120,7 +120,9 @@ Durable storage requires a configured storage adapter that supports the `workflo
 
 Stored definitions support declarative agent, tool, mapping, nested workflow, parallel, foreach, sleep, sleep-until, conditional, and loop entries. They can't contain JavaScript closures. Conditional and loop logic must use the declarative predicate format, and referenced agents, tools, and nested workflows must already be registered.
 
-Authenticated servers require `stored-workflows:read` or `stored-workflows:write` for definition operations and `workflows:execute` to run the workflow.
+Authenticated servers derive the author for list, get, and upsert operations from the server-owned request context. Regular callers only list, get, and upsert their own definitions. Callers with `stored-workflows:admin` can inspect every definition and update an owned definition without transferring it. Definitions without ownership metadata are hidden from regular callers and read-only for admins.
+
+These routes require `stored-workflows:read` or `stored-workflows:write`. Deletion and execution aren't owner-scoped yet. The `workflows:execute` permission can run a registered workflow, but it doesn't establish definition ownership.
 
 :::
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -101,9 +101,14 @@ The definition uses JSON Schema because it must survive a JSON round trip. The `
 A definition can come from any source that produces JSON. For example, an API route can accept a definition created by a visual editor and register it directly:
 
 ```typescript
+const authenticatedUser = await authenticate(request)
 const definition = await request.json()
-await mastra.addDynamicWorkflow(definition)
+await mastra.addDynamicWorkflow(definition, {
+  authorId: authenticatedUser.id,
+})
 ```
+
+Derive `authorId` from verified server identity. Never accept it from the submitted workflow definition.
 
 ### Register dependencies first
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -156,7 +156,7 @@ await mastra.addDynamicWorkflow(untrustedDefinition, {
 })
 ```
 
-Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -138,7 +138,9 @@ Applications don't need direct access to the `Mastra` instance to manage dynamic
 - [Client SDK workflows API](/reference/client-js/workflows): Call `upsertDynamicWorkflow()` from a JavaScript or TypeScript client.
 - [Server routes](/reference/server/routes): Send definitions to `POST /api/stored/workflows`.
 
-On authenticated servers, dynamic-workflow management requires the `stored-workflows:read` and `stored-workflows:write` permissions. Running the registered workflow requires `workflows:execute`.
+On authenticated servers, listing, reading, and upserting dynamic workflows derives the author from the server-owned request context. Regular callers can only list, read, and replace their own definitions. Callers with `stored-workflows:admin` can inspect every definition and can replace an owned definition without changing its author. Definitions created before ownership metadata was available are hidden from regular callers and read-only for admins.
+
+These management routes still require `stored-workflows:read` or `stored-workflows:write`. Deletion and execution aren't owner-scoped yet. Running the registered workflow requires `workflows:execute`, but this permission doesn't establish tenant ownership by itself.
 
 ### Persist definitions
 
@@ -156,7 +158,7 @@ await mastra.addDynamicWorkflow(untrustedDefinition, {
 })
 ```
 
-Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. The authenticated server's list, get, and upsert routes enforce this ownership. Direct Core calls, deletion, execution, and nested workflow references still require application-level authorization.
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -143,9 +143,9 @@ Applications don't need direct access to the `Mastra` instance to manage dynamic
 - [Client SDK workflows API](/reference/client-js/workflows): Call `upsertDynamicWorkflow()` from a JavaScript or TypeScript client.
 - [Server routes](/reference/server/routes): Send definitions to `POST /api/stored/workflows`.
 
-On authenticated servers, listing, reading, and upserting dynamic workflows derives the author from the server-owned request context. Regular callers can only list, read, and replace their own definitions. Callers with `stored-workflows:admin` can inspect every definition and can replace an owned definition without changing its author. Definitions created before ownership metadata was available are hidden from regular callers and read-only for admins.
+On authenticated servers, listing, reading, upserting, and executing dynamic workflows derives the author from the server-owned request context. Regular callers can only list, read, replace, and execute their own definitions. Runs created through the workflow routes use that authenticated author as their `resourceId`; a client-provided `resourceId` can't select another owner. Run listing and controls apply the same owner scope and return `404` for another owner's definition or run. Callers with `stored-workflows:admin` can inspect every definition and can replace an owned definition without changing its author, but ordinary workflow execution still requires the definition owner. Definitions created before ownership metadata was available are hidden from regular callers, read-only for admins, and unavailable through the ordinary execution routes.
 
-These management routes still require `stored-workflows:read` or `stored-workflows:write`. Deletion and execution aren't owner-scoped yet. Running the registered workflow requires `workflows:execute`, but this permission doesn't establish tenant ownership by itself.
+Management routes still require `stored-workflows:read` or `stored-workflows:write`, and execution still requires the corresponding workflow permissions. Definition deletion and nested workflow reference authorization aren't covered by execution ownership.
 
 ### Persist definitions
 
@@ -163,7 +163,7 @@ await mastra.addDynamicWorkflow(untrustedDefinition, {
 })
 ```
 
-Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. The authenticated server's list, get, and upsert routes enforce this ownership. Direct Core calls, deletion, execution, and nested workflow references still require application-level authorization.
+Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. The authenticated server's definition and ordinary workflow execution routes enforce this ownership. Direct Core calls, definition deletion, and nested workflow references retain their existing authorization boundary.
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -146,6 +146,18 @@ Stored definitions use the `workflowDefinitions` storage domain. On startup, Mas
 
 Without a storage adapter that supports this domain, `addDynamicWorkflow()` still registers the workflow in memory, but the definition is lost when the process restarts. See the [storage reference](/reference/storage/overview) for adapter support.
 
+### Record a verified author
+
+Pass trusted author metadata as the second argument. Keep it outside the workflow definition when the definition comes from a user, agent, or external system.
+
+```typescript
+await mastra.addDynamicWorkflow(untrustedDefinition, {
+  authorId: authenticatedUser.id,
+})
+```
+
+Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+
 ## Related
 
 - [Dynamic workflow definition](/reference/workflows/dynamic-workflow-definition)

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -506,6 +506,12 @@ Use `restartAllActiveWorkflowRuns()` to restart all active workflow runs of a wo
 workflow.restartAllActiveWorkflowRuns()
 ```
 
+Pass a `resourceId` to restart only active runs owned by that resource:
+
+```typescript
+await workflow.restartAllActiveWorkflowRuns({ resourceId: 'user-123' })
+```
+
 ### Restarting an active workflow run with `restart()`
 
 Use `restart()` to restart an active workflow run from the last active step. This will resume execution from the last active step, and the workflow will continue from there.

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -20,29 +20,34 @@ See [Dynamic workflows](/docs/workflows/dynamic-workflows) for a complete setup 
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflow({
-  id: 'greeting-workflow',
-  description: 'Returns a greeting for the supplied name',
-  inputSchema: {
-    type: 'object',
-    properties: { name: { type: 'string' } },
-    required: ['name'],
-  },
-  outputSchema: {
-    type: 'object',
-    properties: { message: { type: 'string' } },
-    required: ['message'],
-  },
-  graph: [
-    {
-      type: 'mapping',
-      id: 'create-greeting',
-      mapConfig: JSON.stringify({
-        message: { template: 'Hello, ${initData.name}!' },
-      }),
+await mastra.addDynamicWorkflow(
+  {
+    id: 'greeting-workflow',
+    description: 'Returns a greeting for the supplied name',
+    inputSchema: {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
     },
-  ],
-})
+    outputSchema: {
+      type: 'object',
+      properties: { message: { type: 'string' } },
+      required: ['message'],
+    },
+    graph: [
+      {
+        type: 'mapping',
+        id: 'create-greeting',
+        mapConfig: JSON.stringify({
+          message: { template: 'Hello, ${initData.name}!' },
+        }),
+      },
+    ],
+  },
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 
 const run = await mastra.getWorkflow('greeting-workflow').createRun()
 const result = await run.start({ inputData: { name: 'Ada' } })
@@ -58,6 +63,13 @@ const result = await run.start({ inputData: { name: 'Ada' } })
     description:
       'The workflow definition: id, optional description and metadata, JSON Schema input/output schemas, optional state and request-context schemas, and the step graph.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata supplied by the host. Use `authorId` for a verified author identity that must not come from the workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -69,6 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
+- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -81,7 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
-- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored on the definition in the same write and becomes immutable. When replacing an existing definition, omitting `options.authorId` retains its stored author, while using a different author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -22,10 +22,15 @@ The whole bundle is validated up front. Members are then registered in dependenc
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflows([
-  helperDefinition, // nested by the root — order in the array doesn't matter
-  rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
-])
+await mastra.addDynamicWorkflows(
+  [
+    helperDefinition, // nested by the root — order in the array doesn't matter
+    rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
+  ],
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 ```
 
 ## Parameters
@@ -38,6 +43,13 @@ await mastra.addDynamicWorkflows([
     description:
       'The workflow definitions to add. Nested-workflow references may resolve against the live registries or against other members of the same bundle.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata applied to every definition in the bundle. Use `authorId` for a verified author identity that must not come from a workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -48,6 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
+- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -60,7 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
-- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored with every bundle member and becomes immutable. When replacing existing members, omitting `options.authorId` retains each member's stored author, while a member whose ID belongs to another author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/docs/src/content/en/reference/server/routes.mdx
+++ b/docs/src/content/en/reference/server/routes.mdx
@@ -215,7 +215,7 @@ Dynamic workflow definitions (beta) are workflows expressed as JSON, persisted t
 
 On authenticated servers, the read routes require the `stored-workflows:read` permission and the write routes require `stored-workflows:write`. List, get, and upsert derive the author from the server-owned request context. Regular callers can't select another `authorId`. The `stored-workflows:admin` permission bypasses read scoping and preserves the existing author during updates. Legacy definitions without an author are hidden from regular callers and read-only for admins.
 
-Deletion and execution aren't owner-scoped yet. Registered dynamic workflows are executed through the ordinary `/api/workflows/:workflowId` routes above, which require workflow permissions but don't enforce definition ownership.
+Registered dynamic workflows are executed through the ordinary `/api/workflows/:workflowId` routes above. On authenticated servers, these routes resolve the definition owner from request context, bind new runs to that owner as their `resourceId`, and scope run listing and controls to the same owner. A client-provided `resourceId` can't override this scope. Cross-owner definition and run requests return `404` without disclosing whether the target exists. Code-defined workflows retain their existing resource behavior. Definition deletion and nested workflow reference authorization are separate boundaries.
 
 ### Create run request body
 

--- a/docs/src/content/en/reference/server/routes.mdx
+++ b/docs/src/content/en/reference/server/routes.mdx
@@ -208,12 +208,14 @@ Dynamic workflow definitions (beta) are workflows expressed as JSON, persisted t
 
 | Method | Path | Description |
 | - | - | - |
-| `GET` | `/api/stored/workflows` | List dynamic workflow definitions, filterable by `status` and `authorId` |
-| `GET` | `/api/stored/workflows/:dynamicWorkflowId` | Get a dynamic workflow definition by ID |
-| `POST` | `/api/stored/workflows` | Upsert a definition (plus optional helper `dependencies`) and live-register it |
+| `GET` | `/api/stored/workflows` | List the caller's dynamic workflow definitions. Admins can filter by `status` and `authorId` |
+| `GET` | `/api/stored/workflows/:dynamicWorkflowId` | Get a caller-owned dynamic workflow definition. Admins can read any definition |
+| `POST` | `/api/stored/workflows` | Upsert a caller-owned definition (plus optional helper `dependencies`) and live-register it |
 | `DELETE` | `/api/stored/workflows/:dynamicWorkflowId` | Delete a dynamic workflow definition and unregister the live workflow |
 
-On authenticated servers, the read routes require the `stored-workflows:read` permission and the write routes require `stored-workflows:write`. Registered dynamic workflows are executed through the ordinary `/api/workflows/:workflowId` routes above.
+On authenticated servers, the read routes require the `stored-workflows:read` permission and the write routes require `stored-workflows:write`. List, get, and upsert derive the author from the server-owned request context. Regular callers can't select another `authorId`. The `stored-workflows:admin` permission bypasses read scoping and preserves the existing author during updates. Legacy definitions without an author are hidden from regular callers and read-only for admins.
+
+Deletion and execution aren't owner-scoped yet. Registered dynamic workflows are executed through the ordinary `/api/workflows/:workflowId` routes above, which require workflow permissions but don't enforce definition ownership.
 
 ### Create run request body
 

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import { InMemoryStore } from '../storage';
+import { InMemoryStore, WorkflowDefinitionOwnershipConflictError } from '../storage';
 import { createTool } from '../tools';
 import { Mastra } from './index';
 
@@ -296,6 +296,26 @@ describe('Mastra.addDynamicWorkflows', () => {
     const definition = await store.get('lookup-first-customer');
 
     expect(definition?.authorId).toBe('verified-author');
+  });
+
+  it('rejects a different trusted author and restores the previous registration', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-conflict' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+      authorId: 'verified-author',
+    });
+    const original = mastra.getWorkflow('lookup-first-customer');
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email2'), {
+        authorId: 'other-author',
+      }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(mastra.getWorkflow('lookup-first-customer')).toBe(original);
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    expect((await store.get('lookup-first-customer'))?.authorId).toBe('verified-author');
   });
 
   it('is a no-op for an empty bundle', async () => {

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -318,6 +318,62 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect((await store.get('lookup-first-customer'))?.authorId).toBe('verified-author');
   });
 
+  it('serializes overlapping bundles so a rejected owner cannot roll back the winner', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-concurrent-owner-conflict' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const realUpsert = store.upsert.bind(store);
+
+    let releaseFirstUpsert!: () => void;
+    const firstUpsertEntered = new Promise<void>(resolve => {
+      releaseFirstUpsert = resolve;
+    });
+    let upsertCalls = 0;
+    store.upsert = (async definition => {
+      upsertCalls += 1;
+      if (upsertCalls === 1) {
+        releaseFirstUpsert();
+        // Keep the first bundle inside persistence for one event-loop turn.
+        // Without registration serialization, the overlapping bundle can
+        // replace its registry slots and win storage before this write resumes.
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+      }
+      return realUpsert(definition);
+    }) as typeof store.upsert;
+
+    const winner = mastra.addDynamicWorkflows(
+      [
+        { ...helperDefinition('shared-helper', 'email1'), description: 'winner' },
+        helperDefinition('winner-only', 'email1'),
+      ],
+      { authorId: 'winner-author' },
+    );
+    await firstUpsertEntered;
+
+    const loser = mastra.addDynamicWorkflows(
+      [
+        { ...helperDefinition('shared-helper', 'email2'), description: 'loser' },
+        helperDefinition('loser-only', 'email2'),
+      ],
+      { authorId: 'loser-author' },
+    );
+
+    const [winnerResult, loserResult] = await Promise.allSettled([winner, loser]);
+    expect(winnerResult.status).toBe('fulfilled');
+    expect(loserResult).toMatchObject({
+      status: 'rejected',
+      reason: expect.any(WorkflowDefinitionOwnershipConflictError),
+    });
+
+    expect(await store.get('shared-helper')).toMatchObject({ authorId: 'winner-author', description: 'winner' });
+    expect(await store.get('winner-only')).toMatchObject({ authorId: 'winner-author' });
+    expect(await store.get('loser-only')).toBeNull();
+
+    expect(mastra.getWorkflow('shared-helper').description).toBe('winner');
+    expect(mastra.getWorkflow('winner-only')).toBeDefined();
+    expect(() => mastra.getWorkflow('loser-only')).toThrow();
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -283,6 +283,22 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect(definitions.every(definition => definition.authorId === 'verified-author')).toBe(true);
   });
 
+  it('rejects an authored bundle before live registration when workflow definition storage is unavailable', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-no-definition-store' });
+    const getStore = storage.getStore.bind(storage);
+    storage.getStore = (async domain =>
+      domain === 'workflowDefinitions' ? undefined : getStore(domain)) as typeof storage.getStore;
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+        authorId: 'verified-author',
+      }),
+    ).rejects.toThrow(/workflowDefinitions storage domain is required/);
+
+    expect(() => mastra.getWorkflow('lookup-first-customer')).toThrow();
+  });
+
   it('preserves an existing author when a trusted author is omitted on replacement', async () => {
     const storage = new InMemoryStore({ id: 'bundle-author-preserved' });
     const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -262,6 +262,42 @@ describe('Mastra.addDynamicWorkflows', () => {
     ]);
   });
 
+  it('persists one trusted author for every member outside the workflow definitions', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    const untrustedHelper = {
+      ...helperDefinition('lookup-first-customer', 'email1'),
+      authorId: 'forged-author',
+    };
+
+    await mastra.addDynamicWorkflows(
+      [untrustedHelper, helperDefinition('lookup-second-customer', 'email2'), rootDefinition],
+      { authorId: 'verified-author' },
+    );
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const { definitions } = await store.list({ status: 'active' });
+
+    expect(definitions).toHaveLength(3);
+    expect(definitions.every(definition => definition.authorId === 'verified-author')).toBe(true);
+  });
+
+  it('preserves an existing author when a trusted author is omitted on replacement', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-preserved' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+      authorId: 'verified-author',
+    });
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email2'));
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const definition = await store.get('lookup-first-customer');
+
+    expect(definition?.authorId).toBe('verified-author');
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -4855,6 +4855,9 @@ export class Mastra<
    *   before anything is mutated.
    * - If hydration or persistence fails partway, the in-memory registry is
    *   restored to its prior state.
+   * - Registrations are serialized on this Mastra instance through validation,
+   *   hydration, and persistence so one caller's rollback cannot undo another
+   *   caller's accepted live registration.
    * - Storage writes happen last. A storage-level failure mid-bundle is the
    *   one residual window where rows can be partially written; the registry is
    *   still rolled back, and the orphaned rows are inert until the next boot.
@@ -4901,6 +4904,13 @@ export class Mastra<
           graph: def.graph,
         }),
       }));
+
+      const store = await this.#storage?.getStore('workflowDefinitions');
+      if (options?.authorId !== undefined && !store) {
+        throw new Error(
+          'A workflowDefinitions storage domain is required when registering an authored dynamic workflow.',
+        );
+      }
 
       // Members may nest each other, so the index every member validates against
       // is the live registries plus the bundle itself — not the registry alone.
@@ -4966,7 +4976,6 @@ export class Mastra<
           this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
         }
 
-        const store = await this.#storage?.getStore('workflowDefinitions');
         if (store) {
           for (const { normalized } of ordered) {
             await store.upsert({

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -688,6 +688,7 @@ export class Mastra<
   #workflows: TWorkflows;
   #harnesses: Record<string, Harness<any>> = {};
   #hiddenWorkflowKeys = new Set<string>();
+  #dynamicWorkflowRegistrationTail: Promise<void> = Promise.resolve();
   #observability: ObservabilityEntrypoint;
   #observabilityExplicit = false;
   #onScorerHook?: ReturnType<typeof createOnScorerHook>;
@@ -4758,6 +4759,26 @@ export class Mastra<
   }
 
   /**
+   * Runs dynamic workflow registrations one at a time so each rollback owns a
+   * stable registry snapshot. An instance-wide queue also makes overlapping
+   * bundles deadlock-free because callers never acquire per-workflow locks.
+   */
+  async #serializeDynamicWorkflowRegistration<T>(operation: () => Promise<T>): Promise<T> {
+    const prior = this.#dynamicWorkflowRegistrationTail;
+    let release!: () => void;
+    this.#dynamicWorkflowRegistrationTail = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    await prior;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  /**
    * Flattens this instance's registries into the index the dynamic-workflow
    * validation core resolves references and schemas against. Registered keys
    * and canonical ids both count as valid references. Schemas are converted
@@ -4854,116 +4875,118 @@ export class Mastra<
   ): Promise<void> {
     if (defs.length === 0) return;
 
-    const seen = new Set<string>();
-    for (const def of defs) {
-      if (seen.has(def.id)) {
-        throw new Error(
-          `Dynamic workflow bundle contains more than one definition with id "${def.id}". Ids must be unique within a bundle.`,
-        );
-      }
-      seen.add(def.id);
-    }
-
-    // Save-path is strict (boot-time load is lenient — see #loadDynamicWorkflows).
-    // Normalization coerces the wire shape; one validation call per member
-    // covers structure, JSON-Schema keywords, references, and schema-flow.
-    const members = defs.map(def => ({
-      normalized: normalizeWorkflowBuilderDefinition({
-        id: def.id,
-        description: def.description,
-        metadata: def.metadata,
-        inputSchema: def.inputSchema,
-        outputSchema: def.outputSchema,
-        stateSchema: def.stateSchema,
-        requestContextSchema: def.requestContextSchema,
-        graph: def.graph,
-      }),
-    }));
-
-    // Members may nest each other, so the index every member validates against
-    // is the live registries plus the bundle itself — not the registry alone.
-    const index = this.#buildWorkflowRegistryIndex();
-    const bundleIds = new Set(members.map(member => member.normalized.id));
-    for (const { normalized } of members) {
-      (index.workflows ??= {})[normalized.id] = {
-        inputSchema: normalized.inputSchema,
-        outputSchema: normalized.outputSchema,
-      } as WorkflowRegistrySchemas;
-    }
-    for (const { normalized } of members) {
-      assertValidDynamicWorkflow(normalized, index);
-    }
-
-    // Hydration resolves nested workflows through the live registry, so a
-    // member cannot be hydrated before the bundle members it nests.
-    const ordered: typeof members = [];
-    const remaining = new Map(members.map(member => [member.normalized.id, member] as const));
-    const hydrated = new Set<string>();
-    let progress = true;
-    while (remaining.size > 0 && progress) {
-      progress = false;
-      for (const [id, member] of Array.from(remaining)) {
-        const pending = Array.from(collectNestedWorkflowIds(member.normalized.graph)).filter(
-          dependency => dependency !== id && bundleIds.has(dependency) && !hydrated.has(dependency),
-        );
-        if (pending.length > 0) continue;
-        remaining.delete(id);
-        hydrated.add(id);
-        ordered.push(member);
-        progress = true;
-      }
-    }
-    if (remaining.size > 0) {
-      throw new Error(
-        `Dynamic workflow bundle has a circular nested-workflow dependency among: ${Array.from(remaining.keys())
-          .sort()
-          .join(', ')}.`,
-      );
-    }
-
-    // Snapshot the registry slots this bundle will overwrite so a failure
-    // anywhere below leaves the instance exactly as it was found.
-    const registry = this.#workflows as Record<string, AnyWorkflow>;
-    const priorWorkflows = new Map<string, AnyWorkflow | undefined>();
-    const priorHiddenKeys = new Set<string>();
-    for (const { normalized } of ordered) {
-      priorWorkflows.set(normalized.id, registry[normalized.id]);
-      if (this.#hiddenWorkflowKeys.has(normalized.id)) priorHiddenKeys.add(normalized.id);
-    }
-    const restoreRegistry = () => {
-      for (const [id, prior] of priorWorkflows) {
-        if (prior) registry[id] = prior;
-        else delete registry[id];
-        if (priorHiddenKeys.has(id)) this.#hiddenWorkflowKeys.add(id);
-      }
-    };
-
-    try {
-      for (const { normalized } of ordered) {
-        const { workflow } = await rehydrateWorkflow(normalized, this);
-        this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
+    await this.#serializeDynamicWorkflowRegistration(async () => {
+      const seen = new Set<string>();
+      for (const def of defs) {
+        if (seen.has(def.id)) {
+          throw new Error(
+            `Dynamic workflow bundle contains more than one definition with id "${def.id}". Ids must be unique within a bundle.`,
+          );
+        }
+        seen.add(def.id);
       }
 
-      const store = await this.#storage?.getStore('workflowDefinitions');
-      if (store) {
-        for (const { normalized } of ordered) {
-          await store.upsert({
-            id: normalized.id,
-            description: normalized.description,
-            metadata: normalized.metadata,
-            inputSchema: normalized.inputSchema,
-            outputSchema: normalized.outputSchema,
-            stateSchema: normalized.stateSchema,
-            requestContextSchema: normalized.requestContextSchema,
-            graph: normalized.graph,
-            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
-          });
+      // Save-path is strict (boot-time load is lenient — see #loadDynamicWorkflows).
+      // Normalization coerces the wire shape; one validation call per member
+      // covers structure, JSON-Schema keywords, references, and schema-flow.
+      const members = defs.map(def => ({
+        normalized: normalizeWorkflowBuilderDefinition({
+          id: def.id,
+          description: def.description,
+          metadata: def.metadata,
+          inputSchema: def.inputSchema,
+          outputSchema: def.outputSchema,
+          stateSchema: def.stateSchema,
+          requestContextSchema: def.requestContextSchema,
+          graph: def.graph,
+        }),
+      }));
+
+      // Members may nest each other, so the index every member validates against
+      // is the live registries plus the bundle itself — not the registry alone.
+      const index = this.#buildWorkflowRegistryIndex();
+      const bundleIds = new Set(members.map(member => member.normalized.id));
+      for (const { normalized } of members) {
+        (index.workflows ??= {})[normalized.id] = {
+          inputSchema: normalized.inputSchema,
+          outputSchema: normalized.outputSchema,
+        } as WorkflowRegistrySchemas;
+      }
+      for (const { normalized } of members) {
+        assertValidDynamicWorkflow(normalized, index);
+      }
+
+      // Hydration resolves nested workflows through the live registry, so a
+      // member cannot be hydrated before the bundle members it nests.
+      const ordered: typeof members = [];
+      const remaining = new Map(members.map(member => [member.normalized.id, member] as const));
+      const hydrated = new Set<string>();
+      let progress = true;
+      while (remaining.size > 0 && progress) {
+        progress = false;
+        for (const [id, member] of Array.from(remaining)) {
+          const pending = Array.from(collectNestedWorkflowIds(member.normalized.graph)).filter(
+            dependency => dependency !== id && bundleIds.has(dependency) && !hydrated.has(dependency),
+          );
+          if (pending.length > 0) continue;
+          remaining.delete(id);
+          hydrated.add(id);
+          ordered.push(member);
+          progress = true;
         }
       }
-    } catch (error) {
-      restoreRegistry();
-      throw error;
-    }
+      if (remaining.size > 0) {
+        throw new Error(
+          `Dynamic workflow bundle has a circular nested-workflow dependency among: ${Array.from(remaining.keys())
+            .sort()
+            .join(', ')}.`,
+        );
+      }
+
+      // Snapshot the registry slots this bundle will overwrite so a failure
+      // anywhere below leaves the instance exactly as it was found.
+      const registry = this.#workflows as Record<string, AnyWorkflow>;
+      const priorWorkflows = new Map<string, AnyWorkflow | undefined>();
+      const priorHiddenKeys = new Set<string>();
+      for (const { normalized } of ordered) {
+        priorWorkflows.set(normalized.id, registry[normalized.id]);
+        if (this.#hiddenWorkflowKeys.has(normalized.id)) priorHiddenKeys.add(normalized.id);
+      }
+      const restoreRegistry = () => {
+        for (const [id, prior] of priorWorkflows) {
+          if (prior) registry[id] = prior;
+          else delete registry[id];
+          if (priorHiddenKeys.has(id)) this.#hiddenWorkflowKeys.add(id);
+        }
+      };
+
+      try {
+        for (const { normalized } of ordered) {
+          const { workflow } = await rehydrateWorkflow(normalized, this);
+          this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
+        }
+
+        const store = await this.#storage?.getStore('workflowDefinitions');
+        if (store) {
+          for (const { normalized } of ordered) {
+            await store.upsert({
+              id: normalized.id,
+              description: normalized.description,
+              metadata: normalized.metadata,
+              inputSchema: normalized.inputSchema,
+              outputSchema: normalized.outputSchema,
+              stateSchema: normalized.stateSchema,
+              requestContextSchema: normalized.requestContextSchema,
+              graph: normalized.graph,
+              ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
+            });
+          }
+        }
+      } catch (error) {
+        restoreRegistry();
+        throw error;
+      }
+    });
   }
 
   /**

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -99,6 +99,21 @@ import { createRunScope } from './run-scope';
 import type { VersionOverrides, VersionSelector } from './types';
 
 /**
+ * Trusted metadata applied while a dynamic workflow is persisted.
+ *
+ * Keep these values outside the JSON workflow definition when that definition
+ * comes from an untrusted authoring surface. This metadata is persisted with
+ * the definition but does not itself enforce authorization.
+ */
+export interface DynamicWorkflowRegistrationOptions {
+  /**
+   * Verified identity responsible for the stored definition. Callers must
+   * authorize this value before registration.
+   */
+  authorId?: string;
+}
+
+/**
  * Creates an error for when a null/undefined value is passed to an add* method.
  * This commonly occurs when config is spread ({ ...config }) and the original
  * object had getters or non-enumerable properties.
@@ -4796,8 +4811,11 @@ export class Mastra<
    * await run.start({ inputData: { location: 'Helsinki' } });
    * ```
    */
-  public async addDynamicWorkflow(def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput): Promise<void> {
-    await this.addDynamicWorkflows([def]);
+  public async addDynamicWorkflow(
+    def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput,
+    options?: DynamicWorkflowRegistrationOptions,
+  ): Promise<void> {
+    await this.addDynamicWorkflows([def], options);
   }
 
   /**
@@ -4832,6 +4850,7 @@ export class Mastra<
    */
   public async addDynamicWorkflows(
     defs: readonly (DynamicWorkflowGraph | WorkflowBuilderDefinitionInput)[],
+    options?: DynamicWorkflowRegistrationOptions,
   ): Promise<void> {
     if (defs.length === 0) return;
 
@@ -4937,6 +4956,7 @@ export class Mastra<
             stateSchema: normalized.stateSchema,
             requestContextSchema: normalized.requestContextSchema,
             graph: normalized.graph,
+            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
           });
         }
       }

--- a/packages/core/src/storage/domains/workflow-definitions/base.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/base.ts
@@ -42,6 +42,8 @@ export interface WorkflowDefinition {
 
   /** Provenance — distinguishes user-stored from code-registered workflows. */
   source: 'storage';
+
+  /** Immutable owner assigned when the definition is created. */
   authorId?: string;
 
   createdAt: Date;
@@ -58,6 +60,8 @@ export interface CreateWorkflowDefinitionInput {
   stateSchema?: unknown;
   requestContextSchema?: unknown;
   graph: ValidatableStepFlowEntry[];
+
+  /** Immutable owner to assign when the definition is created. */
   authorId?: string;
 }
 
@@ -72,6 +76,8 @@ export interface UpdateWorkflowDefinitionInput {
   requestContextSchema?: unknown;
   graph?: ValidatableStepFlowEntry[];
   status?: 'active' | 'archived';
+
+  /** Expected immutable owner. A different owner produces a conflict. */
   authorId?: string;
 }
 
@@ -86,10 +92,42 @@ export interface ListWorkflowDefinitionsOutput {
 }
 
 /**
+ * Thrown when an upsert attempts to claim a workflow definition that already
+ * belongs to a different author. The message intentionally does not disclose
+ * the existing author.
+ */
+export class WorkflowDefinitionOwnershipConflictError extends Error {
+  readonly workflowId: string;
+
+  constructor(workflowId: string) {
+    super(`Workflow definition "${workflowId}" conflicts with an existing definition.`);
+    this.name = 'WorkflowDefinitionOwnershipConflictError';
+    this.workflowId = workflowId;
+  }
+}
+
+/**
+ * Treat an explicitly supplied author as both creation ownership and the
+ * expected owner on update. Omitting authorId preserves legacy/unscoped
+ * behavior; supplying it can never create or transfer ownership after a row
+ * already exists.
+ */
+export function assertWorkflowDefinitionAuthor(
+  existing: Pick<WorkflowDefinition, 'id' | 'authorId'>,
+  input: Pick<UpdateWorkflowDefinitionInput, 'authorId'>,
+): void {
+  if (input.authorId !== undefined && existing.authorId !== input.authorId) {
+    throw new WorkflowDefinitionOwnershipConflictError(existing.id);
+  }
+}
+
+/**
  * Abstract storage domain for persisted workflow definitions.
  *
  * Versioning is intentionally out of scope for v1 — `upsert` overwrites in
- * place. A future revision can layer the {@link VersionedStorageDomain}
+ * place. Ownership is the exception: an explicitly supplied `authorId` is an
+ * immutable compare condition, so concurrent creators cannot take over the
+ * winning row. A future revision can layer the {@link VersionedStorageDomain}
  * pattern on top without breaking the rehydration path.
  */
 export abstract class WorkflowDefinitionsStorage extends StorageDomain {

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.test.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { InMemoryDB } from '../inmemory-db';
+import { WorkflowDefinitionOwnershipConflictError } from './base';
 import { InMemoryWorkflowDefinitionsStorage } from './inmemory';
 
 const graph = [{ type: 'tool', id: 'echo-tool', toolId: 'echo-tool' }] as any;
@@ -36,14 +37,24 @@ describe('InMemoryWorkflowDefinitionsStorage', () => {
   });
 
   describe('update', () => {
-    it('updates authorId on an existing definition', async () => {
+    it('keeps authorId immutable on an existing definition', async () => {
       await storage.upsert({ ...baseInput(), authorId: 'author-1' });
-      const updated = await storage.upsert({ id: 'wf-1', authorId: 'author-2' });
-      expect(updated.authorId).toBe('author-2');
+      await expect(storage.upsert({ id: 'wf-1', authorId: 'author-2' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
       const fetched = await storage.get('wf-1');
-      expect(fetched?.authorId).toBe('author-2');
+      expect(fetched?.authorId).toBe('author-1');
       // Unspecified columns survive the partial upsert.
       expect(fetched?.graph).toEqual(graph);
+    });
+
+    it('does not disclose the existing author in ownership conflicts', async () => {
+      await storage.upsert({ ...baseInput(), authorId: 'private-owner' });
+
+      const error = await storage.upsert({ id: 'wf-1', authorId: 'other-owner' }).catch(cause => cause);
+
+      expect(error).toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+      expect(error.message).not.toContain('private-owner');
     });
   });
 });

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
@@ -6,7 +6,7 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from './base';
-import { WorkflowDefinitionsStorage } from './base';
+import { assertWorkflowDefinitionAuthor, WorkflowDefinitionsStorage } from './base';
 
 export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStorage {
   private db: InMemoryDB;
@@ -25,6 +25,7 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
     const existing = this.db.workflowDefinitions.get(input.id);
 
     if (existing) {
+      assertWorkflowDefinitionAuthor(existing, input);
       const merged: WorkflowDefinition = {
         ...existing,
         ...('description' in input && input.description !== undefined && { description: input.description }),
@@ -36,7 +37,6 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
           input.requestContextSchema !== undefined && { requestContextSchema: input.requestContextSchema }),
         ...('graph' in input && input.graph !== undefined && { graph: input.graph }),
         ...('status' in input && input.status !== undefined && { status: input.status }),
-        ...('authorId' in input && input.authorId !== undefined && { authorId: input.authorId }),
         updatedAt: now,
       };
       this.db.workflowDefinitions.set(input.id, merged);

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -29,6 +29,31 @@ import { createStep } from './workflow';
 // Shared storage for all tests - provides persistence for resume tests
 const sharedStorage = new MockStore();
 
+describe('workflow active run resource scoping', () => {
+  it('forwards the resource filter to each native active-run query', async () => {
+    const step = createStep({
+      id: 'step',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      execute: async () => ({}),
+    });
+    const workflow = createWorkflow({
+      id: 'resource-scoped-active-runs',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      steps: [step],
+    })
+      .then(step)
+      .commit();
+    const listWorkflowRuns = vi.spyOn(workflow, 'listWorkflowRuns').mockResolvedValue({ runs: [], total: 0 });
+
+    await workflow.listActiveWorkflowRuns({ resourceId: 'tenant-a' });
+
+    expect(listWorkflowRuns).toHaveBeenNthCalledWith(1, { status: 'running', resourceId: 'tenant-a' });
+    expect(listWorkflowRuns).toHaveBeenNthCalledWith(2, { status: 'waiting', resourceId: 'tenant-a' });
+  });
+});
+
 // Create a shared Mastra instance for tests that need it
 let _mastra: Mastra;
 

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2926,10 +2926,11 @@ export class Workflow<
     return workflowsStore.listWorkflowRuns({ workflowName: this.id, ...(args ?? {}) });
   }
 
-  public async listActiveWorkflowRuns() {
+  public async listActiveWorkflowRuns(options?: { resourceId?: string }) {
+    const resourceFilter = options?.resourceId === undefined ? {} : { resourceId: options.resourceId };
     const [runningRuns, waitingRuns] = await Promise.all([
-      this.listWorkflowRuns({ status: 'running' }),
-      this.listWorkflowRuns({ status: 'waiting' }),
+      this.listWorkflowRuns({ status: 'running', ...resourceFilter }),
+      this.listWorkflowRuns({ status: 'waiting', ...resourceFilter }),
     ]);
 
     return {
@@ -2938,18 +2939,18 @@ export class Workflow<
     };
   }
 
-  public async restartAllActiveWorkflowRuns(): Promise<void> {
+  public async restartAllActiveWorkflowRuns(options?: { resourceId?: string }): Promise<void> {
     if (this.engineType !== 'default') {
       this.logger.debug('Cannot restart active workflow runs for engine type', { engineType: this.engineType });
       return;
     }
-    const activeRuns = await this.listActiveWorkflowRuns();
+    const activeRuns = await this.listActiveWorkflowRuns(options);
     if (activeRuns.runs.length > 0) {
       this.logger.debug('Restarting active workflow runs', { count: activeRuns.runs.length });
     }
     for (const runSnapshot of activeRuns.runs) {
       try {
-        const run = await this.createRun({ runId: runSnapshot.runId });
+        const run = await this.createRun({ runId: runSnapshot.runId, resourceId: runSnapshot.resourceId ?? undefined });
         await run.restart();
         this.logger.debug('Restarted workflow run', { workflowId: this.id, runId: runSnapshot.runId });
       } catch (error) {

--- a/packages/server/src/server/handlers/dynamic-workflows.test.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.test.ts
@@ -7,6 +7,7 @@ import { createTool } from '@mastra/core/tools';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_USER_PERMISSIONS_KEY } from '../constants';
 import { HTTPException } from '../http-exception';
 import { upsertDynamicWorkflowBodySchema } from '../schemas/dynamic-workflows';
 import type { ServerContext } from '../server-adapter';
@@ -83,10 +84,15 @@ function buildMastra() {
   return mastra;
 }
 
-function ctx(mastra: MastraType): ServerContext {
+function ctx(mastra: MastraType, options: { authorId?: string | null; admin?: boolean } = {}): ServerContext {
+  const requestContext = new RequestContext();
+  const authorId = options.authorId === undefined ? 'test-user' : options.authorId;
+  if (authorId) requestContext.set(MASTRA_RESOURCE_ID_KEY, authorId);
+  if (options.admin) requestContext.set(MASTRA_USER_PERMISSIONS_KEY, ['stored-workflows:admin']);
+
   return {
     mastra,
-    requestContext: new RequestContext(),
+    requestContext,
     abortSignal: new AbortController().signal,
   };
 }
@@ -106,6 +112,18 @@ const baseSchemas = {
   inputSchema: objectWith({ value: stringSchema }, ['value']),
   outputSchema: objectWith({ value: stringSchema }, ['value']),
 };
+
+function workflowDefinition(id: string, description?: string) {
+  return {
+    id,
+    description,
+    metadata: undefined,
+    stateSchema: undefined,
+    requestContextSchema: undefined,
+    ...baseSchemas,
+    graph: toolOnlyGraph(),
+  };
+}
 
 // =============================================================================
 // Tests
@@ -186,6 +204,222 @@ describe('Dynamic Workflows handlers', () => {
       });
       expect(row.id).toBe('wf-get');
       expect(row.status).toBe('active');
+    });
+  });
+
+  describe('trusted author scoping', () => {
+    it('scopes ordinary lists to the caller and reserves cross-author filters for admins', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        ...workflowDefinition('wf-a'),
+      });
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-b'),
+      });
+
+      const userAList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(userAList.workflows.map(workflow => workflow.id)).toEqual(['wf-a']);
+
+      const userAExplicitList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        status: undefined,
+        authorId: 'user-a',
+      });
+      expect(userAExplicitList.workflows.map(workflow => workflow.id)).toEqual(['wf-a']);
+
+      await expect(
+        LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          status: undefined,
+          authorId: 'user-b',
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+
+      const adminList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(adminList.workflows.map(workflow => workflow.id).sort()).toEqual(['wf-a', 'wf-b']);
+
+      const adminFiltered = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        status: undefined,
+        authorId: 'user-b',
+      });
+      expect(adminFiltered.workflows.map(workflow => workflow.id)).toEqual(['wf-b']);
+    });
+
+    it('returns the same 404 for missing and cross-owner reads while allowing an admin read', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-private'),
+      });
+
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          dynamicWorkflowId: 'wf-private',
+        }),
+      ).rejects.toMatchObject({ status: 404, message: 'Not found' });
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          dynamicWorkflowId: 'missing',
+        }),
+      ).rejects.toMatchObject({ status: 404, message: 'Not found' });
+
+      const adminRead = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        dynamicWorkflowId: 'wf-private',
+      });
+      expect(adminRead.authorId).toBe('user-b');
+    });
+
+    it('requires a stable caller for list, get, and upsert', async () => {
+      await expect(
+        LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+          ...ctx(mastra, { authorId: null }),
+          status: undefined,
+          authorId: undefined,
+        }),
+      ).rejects.toMatchObject({ status: 401 });
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: null }),
+          dynamicWorkflowId: 'missing',
+        }),
+      ).rejects.toMatchObject({ status: 401 });
+      await expect(
+        UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: null }),
+          ...workflowDefinition('wf-missing-caller'),
+        }),
+      ).rejects.toMatchObject({ status: 401 });
+    });
+
+    it('derives the owner from RequestContext and strips a forged body author', async () => {
+      const parsed = upsertDynamicWorkflowBodySchema.parse({
+        ...workflowDefinition('wf-forged'),
+        authorId: 'user-b',
+      });
+      expect(parsed).not.toHaveProperty('authorId');
+
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        ...parsed,
+      });
+
+      const row = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        dynamicWorkflowId: 'wf-forged',
+      });
+      expect(row.authorId).toBe('user-a');
+    });
+
+    it('rejects a cross-owner update with a non-disclosing conflict', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-owned', 'original'),
+      });
+
+      await expect(
+        UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          ...workflowDefinition('wf-owned', 'takeover'),
+        }),
+      ).rejects.toMatchObject({
+        status: 409,
+        message: 'Dynamic workflow conflicts with an existing definition',
+      });
+
+      const row = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        dynamicWorkflowId: 'wf-owned',
+      });
+      expect(row).toMatchObject({ authorId: 'user-b', description: 'original' });
+    });
+
+    it('lets an admin update an owned bundle without transferring its owner', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-owned', 'original'),
+      });
+
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        ...workflowDefinition('wf-owned', 'admin edit'),
+        dependencies: [workflowDefinition('wf-helper')],
+      });
+
+      const store = (await mastra.getStorage()!.getStore('workflowDefinitions'))!;
+      await expect(store.get('wf-owned')).resolves.toMatchObject({ authorId: 'user-b', description: 'admin edit' });
+      await expect(store.get('wf-helper')).resolves.toMatchObject({ authorId: 'user-b' });
+    });
+
+    it("doesn't let an existing helper choose the owner of a new admin-created root", async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-helper', 'original'),
+      });
+
+      await expect(
+        UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'admin', admin: true }),
+          ...workflowDefinition('wf-new-root'),
+          dependencies: [workflowDefinition('wf-helper', 'admin edit')],
+        }),
+      ).rejects.toMatchObject({
+        status: 409,
+        message: 'Dynamic workflow conflicts with an existing definition',
+      });
+
+      const store = (await mastra.getStorage()!.getStore('workflowDefinitions'))!;
+      await expect(store.get('wf-new-root')).resolves.toBeNull();
+      await expect(store.get('wf-helper')).resolves.toMatchObject({ authorId: 'user-b', description: 'original' });
+    });
+
+    it('keeps legacy unowned definitions hidden from users and read-only for admins', async () => {
+      await mastra.addDynamicWorkflow(workflowDefinition('wf-legacy'));
+
+      const userList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(userList.workflows).toEqual([]);
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          dynamicWorkflowId: 'wf-legacy',
+        }),
+      ).rejects.toMatchObject({ status: 404, message: 'Not found' });
+
+      const adminRead = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        dynamicWorkflowId: 'wf-legacy',
+      });
+      expect(adminRead.authorId).toBeUndefined();
+      const adminList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(adminList.workflows.map(workflow => workflow.id)).toEqual(['wf-legacy']);
+
+      for (const caller of [{ authorId: 'user-a' }, { authorId: 'admin', admin: true }]) {
+        await expect(
+          UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+            ...ctx(mastra, caller),
+            ...workflowDefinition('wf-legacy', 'claimed'),
+          }),
+        ).rejects.toMatchObject({ status: 409 });
+      }
     });
   });
 

--- a/packages/server/src/server/handlers/dynamic-workflows.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.ts
@@ -1,4 +1,5 @@
 import type { Mastra } from '@mastra/core/mastra';
+import { WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 
 import { HTTPException } from '../http-exception';
 import {
@@ -12,13 +13,42 @@ import {
 } from '../schemas/dynamic-workflows';
 import { createRoute } from '../server-adapter/routes/route-builder';
 
+import { getCallerAuthorId, hasAdminBypass } from './authorship';
 import { handleError } from './error';
+
+const DYNAMIC_WORKFLOW_RESOURCE = 'stored-workflows';
+
+type DynamicWorkflowPrincipal = {
+  authorId: string;
+  isAdmin: boolean;
+};
+
+function getDynamicWorkflowPrincipal(
+  requestContext: Parameters<typeof getCallerAuthorId>[0],
+): DynamicWorkflowPrincipal {
+  const authorId = getCallerAuthorId(requestContext);
+  if (!authorId) {
+    throw new HTTPException(401, { message: 'Authentication required' });
+  }
+
+  return {
+    authorId,
+    isAdmin: hasAdminBypass(requestContext, DYNAMIC_WORKFLOW_RESOURCE),
+  };
+}
+
+function throwDynamicWorkflowNotFound(): never {
+  throw new HTTPException(404, { message: 'Not found' });
+}
+
+function throwDynamicWorkflowConflict(): never {
+  throw new HTTPException(409, { message: 'Dynamic workflow conflicts with an existing definition' });
+}
 
 /**
  * GET /stored/workflows — list stored static workflow definitions.
  *
- * Mirrors `LIST_STORED_AGENTS_ROUTE` but without favorites/visibility/authorship
- * scoping (which the workflow-definitions domain doesn't carry in v1).
+ * Non-admin callers are scoped to the author derived from RequestContext.
  */
 export const LIST_DYNAMIC_WORKFLOWS_ROUTE = createRoute({
   method: 'GET',
@@ -27,19 +57,28 @@ export const LIST_DYNAMIC_WORKFLOWS_ROUTE = createRoute({
   queryParamSchema: listDynamicWorkflowsQuerySchema,
   responseSchema: listDynamicWorkflowsResponseSchema,
   summary: 'List dynamic workflow definitions',
-  description: 'Returns workflow definitions persisted to storage. Filterable by status and authorId.',
+  description:
+    'Returns workflow definitions persisted to storage. Non-admin callers only receive their own definitions.',
   tags: ['Dynamic Workflows'],
   requiresAuth: true,
   requiresPermission: 'stored-workflows:read',
-  handler: async ({ mastra, status, authorId }) => {
+  handler: async ({ mastra, requestContext, status, authorId }) => {
     try {
+      const principal = getDynamicWorkflowPrincipal(requestContext);
+      if (!principal.isAdmin && authorId !== undefined && authorId !== principal.authorId) {
+        throw new HTTPException(400, { message: 'authorId can only select the authenticated caller' });
+      }
+
       const storage = mastra.getStorage();
       if (!storage) throw new HTTPException(500, { message: 'Storage is not configured' });
 
       const store = await storage.getStore('workflowDefinitions');
       if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
 
-      const result = await store.list({ status: status ?? 'active', authorId });
+      const result = await store.list({
+        status: status ?? 'active',
+        authorId: principal.isAdmin ? authorId : principal.authorId,
+      });
       return { workflows: result.definitions, total: result.total };
     } catch (error) {
       return handleError(error, 'Error listing dynamic workflows');
@@ -61,8 +100,9 @@ export const GET_DYNAMIC_WORKFLOW_ROUTE = createRoute({
   tags: ['Dynamic Workflows'],
   requiresAuth: true,
   requiresPermission: 'stored-workflows:read',
-  handler: async ({ mastra, dynamicWorkflowId }) => {
+  handler: async ({ mastra, requestContext, dynamicWorkflowId }) => {
     try {
+      const principal = getDynamicWorkflowPrincipal(requestContext);
       const storage = mastra.getStorage();
       if (!storage) throw new HTTPException(500, { message: 'Storage is not configured' });
 
@@ -70,7 +110,9 @@ export const GET_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
 
       const def = await store.get(dynamicWorkflowId);
-      if (!def) throw new HTTPException(404, { message: `Dynamic workflow "${dynamicWorkflowId}" not found` });
+      if (!def || (!principal.isAdmin && (!def.authorId || def.authorId !== principal.authorId))) {
+        throwDynamicWorkflowNotFound();
+      }
       return def;
     } catch (error) {
       return handleError(error, 'Error getting dynamic workflow');
@@ -101,6 +143,7 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
   requiresPermission: 'stored-workflows:write',
   handler: async ({
     mastra,
+    requestContext,
     id,
     description,
     metadata,
@@ -112,6 +155,13 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
     dependencies,
   }) => {
     try {
+      const principal = getDynamicWorkflowPrincipal(requestContext);
+      const storage = mastra.getStorage();
+      if (!storage) throw new HTTPException(500, { message: 'Storage is not configured' });
+
+      const store = await storage.getStore('workflowDefinitions');
+      if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
+
       // Pick the body fields explicitly — handler args also carry server
       // context (requestContext, abortSignal, ...) which must not leak into
       // the stored definition.
@@ -121,6 +171,35 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       // its helpers behind as orphans. Order within the bundle is derived
       // from the graphs, not from the order the client sent them in.
       const bundle = [...(dependencies ?? []), def];
+
+      // Ownership is supplied by the server, outside the untrusted graph.
+      // Existing rows are read only to choose the expected immutable owner;
+      // storage enforces that owner again in the write predicate so a
+      // concurrent delete/recreate can't turn this check into a takeover.
+      const existing = await Promise.all(bundle.map(member => store.get(member.id)));
+      if (existing.some(member => member && !member.authorId)) {
+        // Legacy rows have no trusted owner to preserve. Administrators may
+        // inspect them through GET/list, but mutation stays quarantined until
+        // an explicit migration assigns an owner.
+        throwDynamicWorkflowConflict();
+      }
+
+      const existingOwners = new Set(existing.flatMap(member => (member?.authorId ? [member.authorId] : [])));
+      let registrationAuthorId = principal.authorId;
+      if (principal.isAdmin) {
+        if (existingOwners.size > 1) throwDynamicWorkflowConflict();
+        const existingRoot = existing.at(-1);
+        if (!existingRoot && existingOwners.size > 0) {
+          // An existing helper must not choose the owner of a new root. Admins
+          // may extend an owned root with new helpers, but creating a new root
+          // that references someone else's helper requires a separate,
+          // explicit ownership design.
+          throwDynamicWorkflowConflict();
+        }
+        registrationAuthorId = existingRoot?.authorId ?? principal.authorId;
+      } else if (existingOwners.size > 1 || (existingOwners.size === 1 && !existingOwners.has(principal.authorId))) {
+        throwDynamicWorkflowConflict();
+      }
       // The wire schema is deliberately looser than the core authoring type:
       // it admits `mapping` entries as children of parallel/conditional/loop,
       // which `WorkflowBuilderExecutableInnerEntry` excludes. That is not
@@ -138,13 +217,18 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       // rehydration, so nothing reaches the engine unvalidated; the cast
       // documents this boundary. Narrowing the schema to delete the cast
       // would trade a repairable issue for a generic 400.
-      await mastra.addDynamicWorkflows(bundle as Parameters<Mastra['addDynamicWorkflows']>[0]);
+      await mastra.addDynamicWorkflows(bundle as Parameters<Mastra['addDynamicWorkflows']>[0], {
+        authorId: registrationAuthorId,
+      });
       return {
         ok: true as const,
         id: def.id,
         ...(dependencies?.length ? { dependencyIds: dependencies.map(dependency => dependency.id) } : {}),
       };
     } catch (error) {
+      if (error instanceof WorkflowDefinitionOwnershipConflictError) {
+        throwDynamicWorkflowConflict();
+      }
       return handleError(error, 'Error upserting dynamic workflow');
     }
   },

--- a/packages/server/src/server/handlers/dynamic-workflows.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.ts
@@ -177,6 +177,7 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       // storage enforces that owner again in the write predicate so a
       // concurrent delete/recreate can't turn this check into a takeover.
       const existing = await Promise.all(bundle.map(member => store.get(member.id)));
+      const existingById = new Map(bundle.map((member, index) => [member.id, existing[index]] as const));
       if (existing.some(member => member && !member.authorId)) {
         // Legacy rows have no trusted owner to preserve. Administrators may
         // inspect them through GET/list, but mutation stays quarantined until
@@ -188,7 +189,7 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       let registrationAuthorId = principal.authorId;
       if (principal.isAdmin) {
         if (existingOwners.size > 1) throwDynamicWorkflowConflict();
-        const existingRoot = existing.at(-1);
+        const existingRoot = existingById.get(def.id);
         if (!existingRoot && existingOwners.size > 0) {
           // An existing helper must not choose the owner of a new root. Admins
           // may extend an owned root with new helpers, but creating a new root

--- a/packages/server/src/server/handlers/workflows.test.ts
+++ b/packages/server/src/server/handlers/workflows.test.ts
@@ -169,6 +169,26 @@ describe('dynamic workflow execution ownership', () => {
     expect(otherCounts).not.toHaveProperty('owned-dynamic');
   });
 
+  it('does not cache caller-filtered dynamic counts when identity comes only from the user context', async () => {
+    const mastra = await createOwnedDynamicWorkflow();
+    const ownerContext = new RequestContext();
+    ownerContext.set(MASTRA_USER_KEY, { id: 'user-a' });
+    const otherContext = new RequestContext();
+    otherContext.set(MASTRA_USER_KEY, { id: 'user-b' });
+
+    const ownerCounts = await LIST_WORKFLOW_RUN_COUNTS_ROUTE.handler({
+      ...createTestServerContext({ mastra }),
+      requestContext: ownerContext,
+    });
+    const otherCounts = await LIST_WORKFLOW_RUN_COUNTS_ROUTE.handler({
+      ...createTestServerContext({ mastra }),
+      requestContext: otherContext,
+    });
+
+    expect(ownerCounts).toHaveProperty('owned-dynamic');
+    expect(otherCounts).not.toHaveProperty('owned-dynamic');
+  });
+
   it('returns a non-disclosing 404 from every ordinary dynamic workflow execution and run-control route', async () => {
     const mastra = await createOwnedDynamicWorkflow();
     const requestContext = authenticatedContext('user-b');

--- a/packages/server/src/server/handlers/workflows.test.ts
+++ b/packages/server/src/server/handlers/workflows.test.ts
@@ -6,7 +6,7 @@ import { createStep, createWorkflow } from '@mastra/core/workflows';
 import type { Workflow } from '@mastra/core/workflows';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { z } from 'zod/v4';
-import { MASTRA_RESOURCE_ID_KEY } from '../constants';
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_USER_KEY } from '../constants';
 import { HTTPException } from '../http-exception';
 import { checkRouteFGA } from '../server-adapter';
 import { WORKFLOWS_ROUTES } from '../server-adapter/routes/workflows';
@@ -23,6 +23,7 @@ import {
   CREATE_WORKFLOW_RUN_ROUTE,
   START_WORKFLOW_RUN_ROUTE,
   RESUME_ASYNC_WORKFLOW_ROUTE,
+  RESUME_NO_WAIT_WORKFLOW_ROUTE,
   RESUME_WORKFLOW_ROUTE,
   RESUME_STREAM_WORKFLOW_ROUTE,
   OBSERVE_STREAM_WORKFLOW_ROUTE,
@@ -30,6 +31,14 @@ import {
   LIST_WORKFLOW_RUNS_ROUTE,
   STREAM_WORKFLOW_ROUTE,
   TIME_TRAVEL_WORKFLOW_ROUTE,
+  TIME_TRAVEL_ASYNC_WORKFLOW_ROUTE,
+  TIME_TRAVEL_STREAM_WORKFLOW_ROUTE,
+  RESTART_ASYNC_WORKFLOW_ROUTE,
+  RESTART_WORKFLOW_ROUTE,
+  RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ASYNC_ROUTE,
+  RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ROUTE,
+  STREAM_LEGACY_WORKFLOW_ROUTE,
+  OBSERVE_STREAM_LEGACY_WORKFLOW_ROUTE,
 } from './workflows';
 
 function createMockWorkflow(name: string) {
@@ -85,6 +94,177 @@ function createReusableMockWorkflow(name: string) {
 function serializeWorkflow(workflow: Workflow) {
   return getWorkflowInfo(workflow);
 }
+
+function authenticatedContext(userId: string) {
+  const requestContext = new RequestContext();
+  requestContext.set(MASTRA_RESOURCE_ID_KEY, userId);
+  requestContext.set(MASTRA_USER_KEY, { id: userId });
+  return requestContext;
+}
+
+async function createOwnedDynamicWorkflow(ownerId = 'user-a') {
+  const echoTool = createTool({
+    id: 'dynamic-echo',
+    description: 'echoes input',
+    inputSchema: z.object({ value: z.string() }),
+    outputSchema: z.object({ value: z.string() }),
+    execute: async ({ value }) => ({ value }),
+  });
+  const mastra = new Mastra({
+    logger: false,
+    tools: { 'dynamic-echo': echoTool } as any,
+    storage: new MockStore(),
+  });
+
+  await mastra.addDynamicWorkflow(
+    {
+      id: 'owned-dynamic',
+      inputSchema: {
+        type: 'object',
+        properties: { value: { type: 'string' } },
+        required: ['value'],
+      },
+      outputSchema: {
+        type: 'object',
+        properties: { value: { type: 'string' } },
+        required: ['value'],
+      },
+      graph: [{ type: 'tool', id: 'echo', toolId: 'dynamic-echo' }],
+    },
+    { authorId: ownerId },
+  );
+
+  return mastra;
+}
+
+describe('dynamic workflow execution ownership', () => {
+  it('filters dynamic workflow discovery to the authenticated owner while retaining code workflows', async () => {
+    const mastra = await createOwnedDynamicWorkflow();
+    const codeWorkflow = createMockWorkflow('code-workflow');
+    mastra.addWorkflow(codeWorkflow, 'code-workflow');
+
+    const ownerResult = await LIST_WORKFLOWS_ROUTE.handler({
+      ...createTestServerContext({ mastra }),
+      requestContext: authenticatedContext('user-a'),
+    });
+    const otherResult = await LIST_WORKFLOWS_ROUTE.handler({
+      ...createTestServerContext({ mastra }),
+      requestContext: authenticatedContext('user-b'),
+    });
+
+    expect(ownerResult).toHaveProperty('owned-dynamic');
+    expect(ownerResult).toHaveProperty('code-workflow');
+    expect(otherResult).not.toHaveProperty('owned-dynamic');
+    expect(otherResult).toHaveProperty('code-workflow');
+
+    const ownerCounts = await LIST_WORKFLOW_RUN_COUNTS_ROUTE.handler({
+      ...createTestServerContext({ mastra }),
+      requestContext: authenticatedContext('user-a'),
+    });
+    const otherCounts = await LIST_WORKFLOW_RUN_COUNTS_ROUTE.handler({
+      ...createTestServerContext({ mastra }),
+      requestContext: authenticatedContext('user-b'),
+    });
+    expect(ownerCounts).toHaveProperty('owned-dynamic');
+    expect(otherCounts).not.toHaveProperty('owned-dynamic');
+  });
+
+  it('returns a non-disclosing 404 from every ordinary dynamic workflow execution and run-control route', async () => {
+    const mastra = await createOwnedDynamicWorkflow();
+    const requestContext = authenticatedContext('user-b');
+    const routes = [
+      GET_WORKFLOW_BY_ID_ROUTE,
+      LIST_WORKFLOW_RUNS_ROUTE,
+      GET_WORKFLOW_RUN_BY_ID_ROUTE,
+      DELETE_WORKFLOW_RUN_BY_ID_ROUTE,
+      CREATE_WORKFLOW_RUN_ROUTE,
+      STREAM_WORKFLOW_ROUTE,
+      RESUME_STREAM_WORKFLOW_ROUTE,
+      START_ASYNC_WORKFLOW_ROUTE,
+      START_WORKFLOW_RUN_ROUTE,
+      OBSERVE_STREAM_WORKFLOW_ROUTE,
+      RESUME_ASYNC_WORKFLOW_ROUTE,
+      RESUME_NO_WAIT_WORKFLOW_ROUTE,
+      RESUME_WORKFLOW_ROUTE,
+      RESTART_ASYNC_WORKFLOW_ROUTE,
+      RESTART_WORKFLOW_ROUTE,
+      RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ASYNC_ROUTE,
+      RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ROUTE,
+      TIME_TRAVEL_ASYNC_WORKFLOW_ROUTE,
+      TIME_TRAVEL_WORKFLOW_ROUTE,
+      TIME_TRAVEL_STREAM_WORKFLOW_ROUTE,
+      CANCEL_WORKFLOW_RUN_ROUTE,
+      STREAM_LEGACY_WORKFLOW_ROUTE,
+      OBSERVE_STREAM_LEGACY_WORKFLOW_ROUTE,
+    ];
+
+    for (const route of routes) {
+      await expect(
+        (route.handler as any)({
+          ...createTestServerContext({ mastra }),
+          requestContext,
+          workflowId: 'owned-dynamic',
+          runId: 'opaque-run',
+          resourceId: 'user-a',
+        }),
+      ).rejects.toMatchObject({ status: 404, message: 'Workflow not found' });
+    }
+  });
+
+  it('requires an authenticated principal for direct dynamic workflow resolution', async () => {
+    const mastra = await createOwnedDynamicWorkflow();
+
+    await expect(
+      GET_WORKFLOW_BY_ID_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        workflowId: 'owned-dynamic',
+      }),
+    ).rejects.toMatchObject({ status: 401, message: 'Authentication required' });
+  });
+
+  it('binds new runs to the authenticated owner and ignores a client-supplied resource id', async () => {
+    const mastra = await createOwnedDynamicWorkflow();
+    const requestContext = authenticatedContext('user-a');
+
+    const created = await CREATE_WORKFLOW_RUN_ROUTE.handler({
+      ...createTestServerContext({ mastra }),
+      requestContext,
+      workflowId: 'owned-dynamic',
+      runId: 'owned-run',
+      resourceId: 'user-b',
+      disableScorers: undefined,
+    });
+    const workflow = mastra.getWorkflow('owned-dynamic');
+    const storedRun = await workflow.getWorkflowRunById(created.runId);
+
+    expect(storedRun?.resourceId).toBe('user-a');
+
+    const listed = await LIST_WORKFLOW_RUNS_ROUTE.handler({
+      ...createTestServerContext({ mastra }),
+      requestContext,
+      workflowId: 'owned-dynamic',
+      resourceId: 'user-b',
+    });
+    expect(listed.runs.map(run => run.runId)).toContain('owned-run');
+  });
+
+  it('returns 404 when a dynamic workflow run is not bound to the definition owner', async () => {
+    const mastra = await createOwnedDynamicWorkflow();
+    const workflow = mastra.getWorkflow('owned-dynamic');
+    await workflow.createRun({ runId: 'wrong-owner-run', resourceId: 'user-b' });
+
+    await expect(
+      GET_WORKFLOW_RUN_BY_ID_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        requestContext: authenticatedContext('user-a'),
+        workflowId: 'owned-dynamic',
+        runId: 'wrong-owner-run',
+        fields: undefined,
+        withNestedWorkflows: undefined,
+      }),
+    ).rejects.toMatchObject({ status: 404, message: 'Workflow run not found' });
+  });
+});
 
 describe('vNext Workflow Handlers', () => {
   let mockMastra: Mastra;
@@ -262,15 +442,19 @@ describe('vNext Workflow Handlers', () => {
         storage: new MockStore(),
       });
 
-      await mastraForStored.addDynamicWorkflow({
-        id: 'stored-only',
-        inputSchema: { type: 'object', properties: {}, required: [] },
-        outputSchema: { type: 'object', properties: { result: { type: 'string' } }, required: ['result'] },
-        graph: [{ type: 'step', step: { id: 'echo' } }] as any,
-      });
+      await mastraForStored.addDynamicWorkflow(
+        {
+          id: 'stored-only',
+          inputSchema: { type: 'object', properties: {}, required: [] },
+          outputSchema: { type: 'object', properties: { result: { type: 'string' } }, required: ['result'] },
+          graph: [{ type: 'step', step: { id: 'echo' } }] as any,
+        },
+        { authorId: 'test-user' },
+      );
 
       const result = await LIST_WORKFLOWS_ROUTE.handler({
         ...createTestServerContext({ mastra: mastraForStored }),
+        requestContext: authenticatedContext('test-user'),
       });
       expect(result['stored-only']?.origin).toBe('dynamic');
       // Code-defined workflows keep their 'code' origin in the same response.

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -335,7 +335,8 @@ export const LIST_WORKFLOW_RUN_COUNTS_ROUTE = createRoute({
 
       // The shared cache holds the unscoped, unfiltered map — usable only when
       // neither per-user FGA filtering nor a resource scope applies.
-      const cacheable = !fgaProvider && !effectiveResourceId;
+      const callerAuthorId = requestContext ? getCallerAuthorId(requestContext) : null;
+      const cacheable = !fgaProvider && !effectiveResourceId && !callerAuthorId;
       if (cacheable) {
         const cached = runCountsCache.get(mastra);
         if (cached && runCountsNow() - cached.at < RUN_COUNTS_CACHE_TTL_MS) {

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -39,8 +39,9 @@ import {
 import { createRoute } from '../server-adapter/routes/route-builder';
 import type { Context } from '../types';
 import { getWorkflowInfo, WorkflowRegistry } from '../utils';
+import { getCallerAuthorId } from './authorship';
 import { handleError } from './error';
-import { getEffectiveResourceId, validateRunOwnership } from './utils';
+import { getEffectiveResourceId, validateRunOwnership as validateStoredRunOwnership } from './utils';
 
 /**
  * Statuses a run cannot come back from. Streaming one of these runIds again would
@@ -111,7 +112,46 @@ export interface WorkflowContext extends Context {
   requestContext?: RequestContext;
 }
 
-async function listWorkflowsFromSystem({ mastra, workflowId }: WorkflowContext) {
+type ResolvedWorkflow = {
+  workflow: any;
+  runOwnerId?: string;
+  activeRunsFilter?: { resourceId: string };
+  assertRun: (run: { resourceId?: string | null } | null | undefined) => Promise<void>;
+};
+
+async function getDynamicWorkflowResourceId({
+  mastra,
+  workflow,
+  workflowId,
+  requestContext,
+}: {
+  mastra: Mastra;
+  workflow: any;
+  workflowId: string;
+  requestContext?: RequestContext;
+}): Promise<string | undefined> {
+  if (workflow.origin !== 'dynamic') return undefined;
+
+  const callerAuthorId = requestContext ? getCallerAuthorId(requestContext) : null;
+  if (!callerAuthorId) {
+    throw new HTTPException(401, { message: 'Authentication required' });
+  }
+
+  const definitions = await mastra.getStorage()?.getStore('workflowDefinitions');
+  const definition = await definitions?.get(workflowId);
+  if (!definition?.authorId || definition.authorId !== callerAuthorId) {
+    throw new HTTPException(404, { message: 'Workflow not found' });
+  }
+
+  return callerAuthorId;
+}
+
+async function resolveWorkflow(
+  mastra: Mastra,
+  workflowId: string,
+  requestContext?: RequestContext,
+  clientResourceId?: string,
+): Promise<ResolvedWorkflow> {
   const logger = mastra.getLogger();
 
   if (!workflowId) {
@@ -155,7 +195,36 @@ async function listWorkflowsFromSystem({ mastra, workflowId }: WorkflowContext) 
     throw new HTTPException(404, { message: 'Workflow not found' });
   }
 
-  return { workflow };
+  const dynamicResourceId = await getDynamicWorkflowResourceId({ mastra, workflow, workflowId, requestContext });
+  const runOwnerId = dynamicResourceId ?? getEffectiveResourceId(requestContext, clientResourceId);
+  return {
+    workflow,
+    runOwnerId,
+    activeRunsFilter: dynamicResourceId === undefined ? undefined : { resourceId: dynamicResourceId },
+    assertRun: async run => {
+      if (dynamicResourceId !== undefined) {
+        if (!run || run.resourceId !== dynamicResourceId) {
+          throw new HTTPException(404, { message: 'Workflow run not found' });
+        }
+        return;
+      }
+      await validateStoredRunOwnership(run, runOwnerId);
+    },
+  };
+}
+
+async function getAccessibleDynamicWorkflowIds(
+  mastra: Mastra,
+  requestContext: RequestContext | undefined,
+): Promise<Set<string>> {
+  const callerAuthorId = requestContext ? getCallerAuthorId(requestContext) : null;
+  if (!callerAuthorId) return new Set();
+
+  const definitions = await mastra.getStorage()?.getStore('workflowDefinitions');
+  if (!definitions) return new Set();
+
+  const result = await definitions.list({ status: 'active', authorId: callerAuthorId });
+  return new Set(result.definitions.map(definition => definition.id));
 }
 
 // ============================================================================
@@ -177,8 +246,12 @@ export const LIST_WORKFLOWS_ROUTE = createRoute({
   handler: (async ({ mastra, partial, requestContext }: any) => {
     try {
       const workflows = mastra.listWorkflows({ serialized: false });
+      const accessibleDynamicWorkflowIds = await getAccessibleDynamicWorkflowIds(mastra, requestContext);
       const isPartial = partial === 'true';
       const _workflows = Object.entries(workflows).reduce<Record<string, WorkflowInfo>>((acc, [key, workflow]) => {
+        if ((workflow as any).origin === 'dynamic' && !accessibleDynamicWorkflowIds.has((workflow as any).id)) {
+          return acc;
+        }
         acc[key] = getWorkflowInfo(workflow as any, isPartial);
         return acc;
       }, {});
@@ -244,10 +317,14 @@ export const LIST_WORKFLOW_RUN_COUNTS_ROUTE = createRoute({
       }
 
       const workflows = mastra.listWorkflows({ serialized: false });
+      const accessibleDynamicWorkflowIds = await getAccessibleDynamicWorkflowIds(mastra, requestContext);
 
       const counts: Record<string, WorkflowRunCounts> = {};
       const workflowIdToRegistryKey = new Map<string, string>();
       for (const [registryKey, workflow] of Object.entries(workflows)) {
+        if ((workflow as any).origin === 'dynamic' && !accessibleDynamicWorkflowIds.has((workflow as any).id)) {
+          continue;
+        }
         counts[registryKey] = { running: 0, suspended: 0 };
         workflowIdToRegistryKey.set((workflow as any).id, registryKey);
       }
@@ -325,12 +402,12 @@ export const GET_WORKFLOW_BY_ID_ROUTE = createRoute({
   description: 'Returns details for a specific workflow',
   tags: ['Workflows'],
   requiresAuth: true,
-  handler: (async ({ mastra, workflowId }: any) => {
+  handler: (async ({ mastra, workflowId, requestContext }: any) => {
     try {
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow } = await resolveWorkflow(mastra, workflowId, requestContext);
       return getWorkflowInfo(workflow, false);
     } catch (error) {
       return handleError(error, 'Error getting workflow');
@@ -363,9 +440,6 @@ export const LIST_WORKFLOW_RUNS_ROUTE = createRoute({
     requestContext,
   }) => {
     try {
-      // Use effective resourceId (context key takes precedence over client-provided value)
-      const effectiveResourceId = getEffectiveResourceId(requestContext, resourceId);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -391,7 +465,7 @@ export const LIST_WORKFLOW_RUNS_ROUTE = createRoute({
       if (finalPage !== undefined && (!Number.isInteger(finalPage) || finalPage < 0)) {
         throw new HTTPException(400, { message: 'page must be a non-negative integer' });
       }
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, runOwnerId } = await resolveWorkflow(mastra, workflowId, requestContext, resourceId);
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
       }
@@ -400,7 +474,7 @@ export const LIST_WORKFLOW_RUNS_ROUTE = createRoute({
         toDate: toDate ? (typeof toDate === 'string' ? new Date(toDate) : toDate) : undefined,
         perPage: finalPerPage,
         page: finalPage,
-        resourceId: effectiveResourceId,
+        resourceId: runOwnerId,
         status,
       })) || {
         runs: [],
@@ -427,8 +501,6 @@ export const GET_WORKFLOW_RUN_BY_ID_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, fields, withNestedWorkflows, requestContext }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -437,7 +509,7 @@ export const GET_WORKFLOW_RUN_BY_ID_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'Run ID is required' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -455,7 +527,7 @@ export const GET_WORKFLOW_RUN_BY_ID_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       return run;
     } catch (error) {
@@ -476,8 +548,6 @@ export const DELETE_WORKFLOW_RUN_BY_ID_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -486,7 +556,7 @@ export const DELETE_WORKFLOW_RUN_BY_ID_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'Run ID is required' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -497,7 +567,7 @@ export const DELETE_WORKFLOW_RUN_BY_ID_ROUTE = createRoute({
       if (!run) {
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       await workflow.deleteWorkflowRunById(runId);
 
@@ -526,20 +596,24 @@ export const CREATE_WORKFLOW_RUN_ROUTE = createRoute({
   requiresPermission: ['workflows:write', 'workflows:execute'],
   handler: async ({ mastra, workflowId, runId, resourceId, disableScorers, requestContext }) => {
     try {
-      // Use effective resourceId (context key takes precedence over client-provided value)
-      const effectiveResourceId = getEffectiveResourceId(requestContext, resourceId);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, runOwnerId, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext, resourceId);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
       }
 
-      const run = await workflow.createRun({ runId, resourceId: effectiveResourceId, disableScorers });
+      if (runId) {
+        const existingRun = await workflow.getWorkflowRunById(runId, { withNestedWorkflows: false });
+        if (existingRun) {
+          await assertRun(existingRun);
+        }
+      }
+
+      const run = await workflow.createRun({ runId, resourceId: runOwnerId, disableScorers });
 
       return { runId: run.runId };
     } catch (error) {
@@ -561,9 +635,6 @@ export const STREAM_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, resourceId, requestContext, ...params }) => {
     try {
-      // Use effective resourceId (context key takes precedence over client-provided value)
-      const effectiveResourceId = getEffectiveResourceId(requestContext, resourceId);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -572,13 +643,17 @@ export const STREAM_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to stream workflow' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, runOwnerId, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext, resourceId);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
       }
 
       const existingRun = await workflow.getWorkflowRunById(runId, { withNestedWorkflows: false });
+
+      if (existingRun) {
+        await assertRun(existingRun);
+      }
 
       if (existingRun && TERMINAL_RUN_STATUSES.includes(existingRun.status)) {
         throw new HTTPException(409, {
@@ -590,7 +665,7 @@ export const STREAM_WORKFLOW_ROUTE = createRoute({
 
       const serverCache = mastra.getServerCache();
 
-      const run = await workflow.createRun({ runId, resourceId: effectiveResourceId });
+      const run = await workflow.createRun({ runId, resourceId: runOwnerId });
       const result = run.stream({ ...params, requestContext });
 
       if (serverCache) {
@@ -618,8 +693,6 @@ export const RESUME_STREAM_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext, ...params }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -628,7 +701,7 @@ export const RESUME_STREAM_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to resume workflow' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -640,7 +713,7 @@ export const RESUME_STREAM_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
       const serverCache = mastra.getServerCache();
@@ -672,20 +745,24 @@ export const START_ASYNC_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, resourceId, requestContext, ...params }) => {
     try {
-      // Use effective resourceId (context key takes precedence over client-provided value)
-      const effectiveResourceId = getEffectiveResourceId(requestContext, resourceId);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, runOwnerId, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext, resourceId);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
       }
 
-      const _run = await workflow.createRun({ runId, resourceId: effectiveResourceId });
+      if (runId) {
+        const existingRun = await workflow.getWorkflowRunById(runId, { withNestedWorkflows: false });
+        if (existingRun) {
+          await assertRun(existingRun);
+        }
+      }
+
+      const _run = await workflow.createRun({ runId, resourceId: runOwnerId });
       const result = await _run.start({ ...params, requestContext });
       return result;
     } catch (error) {
@@ -708,8 +785,6 @@ export const START_WORKFLOW_RUN_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext, ...params }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -718,7 +793,7 @@ export const START_WORKFLOW_RUN_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to start run' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -730,7 +805,7 @@ export const START_WORKFLOW_RUN_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
       // Fire-and-forget: attach .catch so a rejected start (e.g. invalid input
@@ -765,8 +840,6 @@ export const OBSERVE_STREAM_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, offset, requestContext }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -775,7 +848,7 @@ export const OBSERVE_STREAM_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to observe workflow stream' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -787,7 +860,7 @@ export const OBSERVE_STREAM_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
       const serverCache = mastra.getServerCache();
@@ -824,8 +897,6 @@ export const RESUME_ASYNC_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext, ...params }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -834,7 +905,7 @@ export const RESUME_ASYNC_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to resume workflow' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -846,7 +917,7 @@ export const RESUME_ASYNC_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
       const result = await _run.resume({ ...params, requestContext });
@@ -883,8 +954,6 @@ export const RESUME_NO_WAIT_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext, ...params }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -893,7 +962,7 @@ export const RESUME_NO_WAIT_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to resume workflow' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -905,7 +974,7 @@ export const RESUME_NO_WAIT_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
       const result = await _run.resumeAsync({ ...params, requestContext });
@@ -931,8 +1000,6 @@ export const RESUME_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext, ...params }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -941,7 +1008,7 @@ export const RESUME_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to resume workflow' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -953,7 +1020,7 @@ export const RESUME_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
 
@@ -984,8 +1051,6 @@ export const RESTART_ASYNC_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext, ...params }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -994,7 +1059,7 @@ export const RESTART_ASYNC_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to restart workflow' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -1006,7 +1071,7 @@ export const RESTART_ASYNC_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
       const result = await _run.restart({ ...params, requestContext });
@@ -1032,8 +1097,6 @@ export const RESTART_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext, ...params }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -1042,7 +1105,7 @@ export const RESTART_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to restart workflow' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -1054,7 +1117,7 @@ export const RESTART_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
 
@@ -1079,19 +1142,19 @@ export const RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ASYNC_ROUTE = createRoute({
   description: 'Restarts all active workflow runs asynchronously',
   tags: ['Workflows'],
   requiresAuth: true,
-  handler: async ({ mastra, workflowId }) => {
+  handler: async ({ mastra, workflowId, requestContext }) => {
     try {
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, activeRunsFilter } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
       }
 
-      await workflow.restartAllActiveWorkflowRuns();
+      await workflow.restartAllActiveWorkflowRuns(activeRunsFilter);
 
       return { message: 'All active workflow runs restarted' };
     } catch (error) {
@@ -1110,19 +1173,19 @@ export const RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ROUTE = createRoute({
   description: 'Restarts all active workflow runs',
   tags: ['Workflows'],
   requiresAuth: true,
-  handler: async ({ mastra, workflowId }) => {
+  handler: async ({ mastra, workflowId, requestContext }) => {
     try {
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, activeRunsFilter } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
       }
 
-      void workflow.restartAllActiveWorkflowRuns().catch(error => {
+      void workflow.restartAllActiveWorkflowRuns(activeRunsFilter).catch(error => {
         mastra.getLogger().error('Failed to restart active workflow runs', { error, workflowId });
       });
 
@@ -1147,8 +1210,6 @@ export const TIME_TRAVEL_ASYNC_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext, ...params }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -1157,7 +1218,7 @@ export const TIME_TRAVEL_ASYNC_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to time travel workflow' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -1169,7 +1230,7 @@ export const TIME_TRAVEL_ASYNC_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
       const result = await _run.timeTravel({ ...params, requestContext });
@@ -1195,8 +1256,6 @@ export const TIME_TRAVEL_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext, ...params }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -1205,7 +1264,7 @@ export const TIME_TRAVEL_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to time travel workflow' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -1217,7 +1276,7 @@ export const TIME_TRAVEL_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
 
@@ -1247,8 +1306,6 @@ export const TIME_TRAVEL_STREAM_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext, ...params }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -1257,7 +1314,7 @@ export const TIME_TRAVEL_STREAM_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to time travel workflow stream' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -1268,7 +1325,7 @@ export const TIME_TRAVEL_STREAM_WORKFLOW_ROUTE = createRoute({
       if (!existingRun) {
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
-      await validateRunOwnership(existingRun, effectiveResourceId);
+      await assertRun(existingRun);
 
       const serverCache = mastra.getServerCache();
 
@@ -1298,8 +1355,6 @@ export const CANCEL_WORKFLOW_RUN_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -1308,7 +1363,7 @@ export const CANCEL_WORKFLOW_RUN_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to cancel workflow run' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -1320,7 +1375,7 @@ export const CANCEL_WORKFLOW_RUN_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
 
@@ -1348,8 +1403,6 @@ export const STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, resourceId, requestContext, ...params }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, resourceId);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -1358,7 +1411,7 @@ export const STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to resume workflow' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, runOwnerId, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext, resourceId);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -1366,7 +1419,12 @@ export const STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
 
       const serverCache = mastra.getServerCache();
 
-      const run = await workflow.createRun({ runId, resourceId: effectiveResourceId });
+      const existingRun = await workflow.getWorkflowRunById(runId, { withNestedWorkflows: false });
+      if (existingRun) {
+        await assertRun(existingRun);
+      }
+
+      const run = await workflow.createRun({ runId, resourceId: runOwnerId });
       const result = run.streamLegacy({
         ...params,
         requestContext,
@@ -1398,8 +1456,6 @@ export const OBSERVE_STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, requestContext }) => {
     try {
-      const effectiveResourceId = getEffectiveResourceId(requestContext, undefined);
-
       if (!workflowId) {
         throw new HTTPException(400, { message: 'Workflow ID is required' });
       }
@@ -1408,7 +1464,7 @@ export const OBSERVE_STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'runId required to observe workflow stream' });
       }
 
-      const { workflow } = await listWorkflowsFromSystem({ mastra, workflowId });
+      const { workflow, assertRun } = await resolveWorkflow(mastra, workflowId, requestContext);
 
       if (!workflow) {
         throw new HTTPException(404, { message: 'Workflow not found' });
@@ -1420,7 +1476,7 @@ export const OBSERVE_STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow run not found' });
       }
 
-      await validateRunOwnership(run, effectiveResourceId);
+      await assertRun(run);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
       const serverCache = mastra.getServerCache();

--- a/stores/_test-utils/src/domains/workflow-definitions/index.ts
+++ b/stores/_test-utils/src/domains/workflow-definitions/index.ts
@@ -1,3 +1,4 @@
+import { WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 import type { MastraStorage, WorkflowDefinitionsStorage } from '@mastra/core/storage';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
@@ -68,12 +69,30 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
       expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime());
     });
 
-    it('updates authorId on existing rows', async () => {
+    it('rejects ownership transfer on existing rows', async () => {
       await store.upsert({ ...baseInput('wf-1'), authorId: 'author-1' });
-      const updated = await store.upsert({ id: 'wf-1', authorId: 'author-2' });
-      expect(updated.authorId).toBe('author-2');
+      await expect(store.upsert({ id: 'wf-1', authorId: 'author-2' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
       const fetched = await store.get('wf-1');
-      expect(fetched?.authorId).toBe('author-2');
+      expect(fetched?.authorId).toBe('author-1');
+    });
+
+    it('allows the existing owner to update an owned row', async () => {
+      await store.upsert({ ...baseInput('wf-1'), authorId: 'author-1' });
+      const updated = await store.upsert({ id: 'wf-1', authorId: 'author-1', description: 'renamed' });
+
+      expect(updated).toMatchObject({ authorId: 'author-1', description: 'renamed' });
+    });
+
+    it('does not let an author claim a legacy unowned row', async () => {
+      await store.upsert(baseInput('wf-1'));
+
+      await expect(store.upsert({ id: 'wf-1', authorId: 'author-1' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
+      const stored = await store.get('wf-1');
+      expect(stored?.authorId).toBeUndefined();
     });
 
     it('preserves unspecified columns across a partial upsert', async () => {
@@ -105,6 +124,20 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
       }
       const all = await store.list();
       expect(all.total).toBe(1);
+    });
+
+    it('lets exactly one author win concurrent creation of the same id', async () => {
+      const results = await Promise.allSettled([
+        store.upsert({ ...baseInput('wf-owner-race'), authorId: 'author-1' }),
+        store.upsert({ ...baseInput('wf-owner-race'), authorId: 'author-2' }),
+      ]);
+
+      expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+      const rejected = results.find(result => result.status === 'rejected');
+      expect(rejected).toMatchObject({ reason: expect.any(WorkflowDefinitionOwnershipConflictError) });
+
+      const stored = await store.get('wf-owner-race');
+      expect(['author-1', 'author-2']).toContain(stored?.authorId);
     });
 
     it('rejects creation when required fields are explicitly undefined', async () => {

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
@@ -8,7 +8,7 @@
  *  - the domain is reachable through the LibSQLStore composite
  */
 import { createClient } from '@libsql/client';
-import { TABLE_WORKFLOW_DEFINITIONS } from '@mastra/core/storage';
+import { TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 import type { SerializedStepFlowEntry } from '@mastra/core/workflows';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -81,7 +81,7 @@ describe('WorkflowDefinitionsLibSQL', () => {
     expect(updated.graph).toEqual(graph);
   });
 
-  it('updates authorId on an existing row and keeps createdAt stable', async () => {
+  it('rejects an authorId change and keeps the original row stable', async () => {
     const wd = (await store.getStore('workflowDefinitions'))!;
 
     const created = await wd.upsert({
@@ -93,14 +93,53 @@ describe('WorkflowDefinitionsLibSQL', () => {
     });
     expect(created.authorId).toBe('author-1');
 
-    await new Promise(r => setTimeout(r, 5));
-    const updated = await wd.upsert({ id: 'wf-author', authorId: 'author-2' });
-    expect(updated.authorId).toBe('author-2');
-    expect(updated.createdAt.getTime()).toBe(created.createdAt.getTime());
-    expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime());
+    await expect(wd.upsert({ id: 'wf-author', authorId: 'author-2' })).rejects.toBeInstanceOf(
+      WorkflowDefinitionOwnershipConflictError,
+    );
 
     const fetched = await wd.get('wf-author');
-    expect(fetched?.authorId).toBe('author-2');
+    expect(fetched?.authorId).toBe('author-1');
+    expect(fetched?.createdAt.getTime()).toBe(created.createdAt.getTime());
+    expect(fetched?.updatedAt.getTime()).toBe(created.updatedAt.getTime());
+  });
+
+  it('does not update a different owner after a delete-and-recreate race', async () => {
+    const wd = (await store.getStore('workflowDefinitions'))!;
+    await wd.upsert({
+      id: 'wf-recreated',
+      description: 'original owner',
+      inputSchema,
+      outputSchema,
+      graph,
+      authorId: 'author-1',
+    });
+
+    const originalGet = wd.get.bind(wd);
+    const getSpy = vi.spyOn(wd, 'get');
+    let reads = 0;
+    getSpy.mockImplementation(async id => {
+      const current = await originalGet(id);
+      reads += 1;
+      if (reads === 2) {
+        getSpy.mockRestore();
+        await wd.delete(id);
+        await wd.upsert({
+          id,
+          description: 'new owner',
+          inputSchema,
+          outputSchema,
+          graph,
+          authorId: 'author-2',
+        });
+      }
+      return current;
+    });
+
+    await expect(
+      wd.upsert({ id: 'wf-recreated', description: 'stale update', authorId: 'author-1' }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(await wd.get('wf-recreated')).toMatchObject({ authorId: 'author-2', description: 'new owner' });
   });
 
   it('round-trips JSON columns intact', async () => {

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.ts
@@ -6,7 +6,12 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from '@mastra/core/storage';
-import { TABLE_SCHEMAS, TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_SCHEMAS,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';
@@ -131,6 +136,10 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     // Update — only patch fields present in the input
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
@@ -142,11 +151,11 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,8 @@
-import { TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import type {
   CreateWorkflowDefinitionInput,
   ListWorkflowDefinitionsInput,
@@ -141,6 +145,9 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
     now: Date,
   ): Promise<WorkflowDefinition> {
     const collection = await this.getCollection(TABLE_WORKFLOW_DEFINITIONS);
+    const existing = await collection.findOne<Record<string, any>>({ id: input.id });
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(docToDefinition(existing), input);
 
     const update: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) update.description = input.description;
@@ -152,12 +159,13 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
       update.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) update.graph = input.graph;
     if ('status' in input && input.status !== undefined) update.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) update.authorId = input.authorId;
-
-    await collection.updateOne({ id: input.id }, { $set: update });
+    const filter = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await collection.updateOne(filter, { $set: update });
     const updated = await collection.findOne<Record<string, any>>({ id: input.id });
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
-    return docToDefinition(updated);
+    const definition = docToDefinition(updated);
+    assertWorkflowDefinitionAuthor(definition, input);
+    return definition;
   }
 
   async get(id: string): Promise<WorkflowDefinition | null> {

--- a/stores/mssql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mssql/src/storage/domains/workflow-definitions/index.ts
@@ -1,6 +1,7 @@
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -177,6 +178,10 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -187,11 +192,11 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/mysql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mysql/src/storage/domains/workflow-definitions/index.ts
@@ -1,6 +1,7 @@
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -123,6 +124,10 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -133,11 +138,11 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/pg/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/pg/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,9 @@
-import { TABLE_SCHEMAS, TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_SCHEMAS,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import type {
   CreateIndexOptions,
   CreateWorkflowDefinitionInput,
@@ -165,6 +170,10 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -175,11 +184,11 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/spanner/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/spanner/src/storage/domains/workflow-definitions/index.ts
@@ -2,6 +2,7 @@ import type { Database } from '@google-cloud/spanner';
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -143,6 +144,10 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -153,11 +158,11 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 


### PR DESCRIPTION
## Summary

- stack on #21456 so dynamic workflow definitions already carry immutable server-derived ownership
- scope ordinary dynamic workflow discovery, execution, streaming, observation, cancellation, resume, restart, time travel, and run management to the authenticated definition owner
- derive native run `resourceId` from request context, ignore client ownership overrides, and return non-disclosing 404s across owners
- add a native Core `resourceId` filter for active-run discovery/restart while preserving no-argument system recovery and code-workflow behavior

## Native boundary

Mastra continues to own workflow definitions, native run snapshots, storage, execution, streaming, and lifecycle controls. This change adds authorization at the existing server workflow resolver and filters the existing Core recovery primitive; it adds no lifecycle store, event decoder, product bridge, or custom runner.

Direct Core/internal worker execution is unchanged. Dynamic-definition deletion and nested-reference authorization are intentionally out of scope.

## Tests

- `pnpm --filter ./packages/server exec vitest run src/server/handlers/workflows.test.ts` — 74 passed
- `pnpm --filter ./packages/core exec vitest run src/workflows/workflow.test.ts` — 308 passed, 4 skipped, no type errors
- `pnpm --filter @mastra/server lint` — passed
- `pnpm --filter @mastra/core lint` — passed
- `pnpm exec changeset status --since 7424844518399e0dc71a841904f00a2f8e80b8a6` — passed
- formatter and `git diff --check` — passed

Full package build JS emission completed, but declaration generation in this fresh sparse clone remains blocked by unrelated pre-existing workspace dependency/type failures (including missing generated vendored AI SDK and external-type declarations, plus existing agent/observability errors). The focused suites and lint gates above are green.

Stacked on #21456; review this PR's new commit `e51911b6f5` after that base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Dynamic workflows now belong to the authenticated user who created them. Users can access only their own workflows and runs, while unauthorized requests return `404` without revealing whether the resource exists.

## Changes

- Added immutable `authorId` ownership for dynamic workflow definitions.
- Restricted dynamic workflow discovery, retrieval, updates, execution, streaming, observation, cancellation, resume, restart, time travel, and run management to the owning authenticated context.
- Added admin access for inspecting all definitions and updating owned definitions without transferring ownership.
- Ignored client-provided `resourceId` values for dynamic workflow runs.
- Added `resourceId` filters to `listActiveWorkflowRuns()` and `restartAllActiveWorkflowRuns()`.
- Preserved no-argument system recovery and existing code-workflow behavior.
- Added serialized dynamic workflow registration and rollback-safe ownership checks.
- Updated storage adapters, tests, changesets, and documentation.

Direct Core or internal worker execution, dynamic workflow deletion, and nested-reference authorization remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->