### PR TITLE
feat(code-sdk): scope dynamic workflows by caller

### DIFF
--- a/.changeset/calm-workflows-scope.md
+++ b/.changeset/calm-workflows-scope.md
@@ -1,0 +1,9 @@
+---
+'@mastra/server': minor
+---
+
+Added server-derived ownership for dynamic workflow list, get, and upsert routes.
+
+Authenticated callers only list, get, and upsert definitions owned by the author in their request context. Callers with `stored-workflows:admin` can inspect definitions across authors and update an owned definition without transferring it. Legacy definitions without an author remain hidden from regular callers and read-only for admins.
+
+Deletion, execution, and nested workflow references aren't owner-scoped by this change.

--- a/.changeset/calm-workflows-scope.md
+++ b/.changeset/calm-workflows-scope.md
@@ -7,3 +7,13 @@ Added server-derived ownership for dynamic workflow list, get, and upsert routes
 Authenticated callers only list, get, and upsert definitions owned by the author in their request context. Callers with `stored-workflows:admin` can inspect definitions across authors and update an owned definition without transferring it. Legacy definitions without an author remain hidden from regular callers and read-only for admins.
 
 Deletion, execution, and nested workflow references aren't owner-scoped by this change.
+
+Previously, management routes could accept a caller-selected author. Hosts should now map verified identity into the request context and omit author ownership from request bodies:
+
+```ts
+authConfig: {
+  mapUserToResourceId: user => user.id,
+}
+```
+
+The built-in list, get, and upsert routes derive ownership from that server-populated resource ID. Cross-author administration requires `stored-workflows:admin`.

--- a/.changeset/gentle-workflows-authorize.md
+++ b/.changeset/gentle-workflows-authorize.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': minor
+---
+
+Add a `createSaveWorkflowTool` factory with an optional deny-only authorization hook that receives the native request context and a detached workflow definition.

--- a/.changeset/gentle-workflows-authorize.md
+++ b/.changeset/gentle-workflows-authorize.md
@@ -3,3 +3,17 @@
 ---
 
 Add a `createSaveWorkflowTool` factory with an optional deny-only authorization hook that receives the native request context and a detached workflow definition.
+
+```ts
+import { createSaveWorkflowTool } from '@mastra/code-sdk';
+
+const saveWorkflowTool = createSaveWorkflowTool({
+  authorize: ({ requestContext }) => {
+    if (requestContext.get('role') !== 'workflow-author') {
+      throw new Error('Workflow save denied');
+    }
+  },
+});
+```
+
+Throwing from `authorize` rejects the save before Mastra validates, persists, or registers the workflow.

--- a/.changeset/secure-workflows-delete.md
+++ b/.changeset/secure-workflows-delete.md
@@ -14,6 +14,14 @@ Added owner-qualified dynamic workflow deletion and same-owner validation for dy
 
 `Mastra.deleteDynamicWorkflow()` serializes deletion with registration, removes storage before the live dynamic workflow, and never unregisters a code-defined workflow. Storage adapters atomically include a supplied author in the delete predicate. Trusted dynamic workflow registration rejects nested dynamic workflows owned by another author or lacking ownership metadata before changing the live registry.
 
+```ts
+const deleted = await mastra.deleteDynamicWorkflow('campaign-assets', {
+  authorId: authenticatedUser.id,
+});
+```
+
+Owned rows now require their immutable `authorId` on every update, so omitting ownership cannot bypass an adapter's atomic owner predicate. Unscoped deletion still removes a live-only dynamic registration when no stored row exists.
+
 Authenticated server deletion now derives ownership from request context. Missing and cross-owner definitions return the same response, admins delete using the stored immutable owner, and legacy unowned definitions remain mutation-quarantined.
 
 Mastra Code deletion now delegates storage and live-registry cleanup to `Mastra.deleteDynamicWorkflow()` instead of maintaining a second deletion sequence. Its local tool remains a privileged, unscoped surface; this change does not add caller ownership to Mastra Code.

--- a/.changeset/secure-workflows-delete.md
+++ b/.changeset/secure-workflows-delete.md
@@ -1,0 +1,21 @@
+---
+'@mastra/core': minor
+'@mastra/server': minor
+'@mastra/libsql': patch
+'@mastra/mongodb': patch
+'@mastra/mssql': patch
+'@mastra/mysql': patch
+'@mastra/pg': patch
+'@mastra/spanner': patch
+'@mastra/code-sdk': patch
+---
+
+Added owner-qualified dynamic workflow deletion and same-owner validation for dynamic nested workflows.
+
+`Mastra.deleteDynamicWorkflow()` serializes deletion with registration, removes storage before the live dynamic workflow, and never unregisters a code-defined workflow. Storage adapters atomically include a supplied author in the delete predicate. Trusted dynamic workflow registration rejects nested dynamic workflows owned by another author or lacking ownership metadata before changing the live registry.
+
+Authenticated server deletion now derives ownership from request context. Missing and cross-owner definitions return the same response, admins delete using the stored immutable owner, and legacy unowned definitions remain mutation-quarantined.
+
+Mastra Code deletion now delegates storage and live-registry cleanup to `Mastra.deleteDynamicWorkflow()` instead of maintaining a second deletion sequence. Its local tool remains a privileged, unscoped surface; this change does not add caller ownership to Mastra Code.
+
+Workflow execution and control routes are not owner-scoped by this change.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -1,0 +1,11 @@
+---
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/mssql': patch
+'@mastra/mysql': patch
+'@mastra/pg': patch
+---
+
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -8,4 +8,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior. Concurrent registrations on one Mastra instance are serialized so a rejected registration can't roll back the successful live workflow.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -8,4 +8,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior. Concurrent registrations on one Mastra instance are serialized so a rejected registration can't roll back the successful live workflow.
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.

--- a/.changeset/tame-pans-juggle.md
+++ b/.changeset/tame-pans-juggle.md
@@ -16,3 +16,14 @@ await prepareAgentControllerMount({ workflowAccessPolicy });
 ```
 
 Configured policies pass the trusted author to native Core APIs and fail closed for unresolved or cross-owner Dynamic Workflows while keeping code-defined workflows available.
+
+Hosts that do not use a Mastra Code controller session can supply the Workflow Builder's native model directly or through a request-context resolver while retaining the same access policy:
+
+```ts
+import { createMastraCodeWorkflowBuilderAgent } from '@mastra/code-sdk/agents/workflow-builder-agent';
+
+const workflowBuilder = createMastraCodeWorkflowBuilderAgent({
+  model: 'openai/gpt-5.6-sol',
+  accessPolicy: workflowAccessPolicy,
+});
+```

--- a/.changeset/tame-pans-juggle.md
+++ b/.changeset/tame-pans-juggle.md
@@ -25,5 +25,8 @@ import { createMastraCodeWorkflowBuilderAgent } from '@mastra/code-sdk/agents/wo
 const workflowBuilder = createMastraCodeWorkflowBuilderAgent({
   model: 'openai/gpt-5.6-sol',
   accessPolicy: workflowAccessPolicy,
+  additionalSurfaceInstructions: 'Include the host presentation metadata required for each saved workflow.',
 });
 ```
+
+Additional surface instructions are appended after Mastra's shared authoring playbook and Mastra Code's persistence policy; they cannot replace either contract.

--- a/.changeset/tame-pans-juggle.md
+++ b/.changeset/tame-pans-juggle.md
@@ -1,0 +1,18 @@
+---
+'@mastra/code-sdk': minor
+---
+
+Add request-context-aware Dynamic Workflow access policy support to Mastra Code authoring, discovery, execution, and deletion.
+
+```ts
+import { prepareAgentControllerMount } from '@mastra/code-sdk';
+import type { DynamicWorkflowAccessPolicy } from '@mastra/code-sdk/workflows/access-policy';
+
+const workflowAccessPolicy: DynamicWorkflowAccessPolicy = {
+  resolveAuthorId: ({ requestContext }) => requestContext.get('verified-user-id'),
+};
+
+await prepareAgentControllerMount({ workflowAccessPolicy });
+```
+
+Configured policies pass the trusted author to native Core APIs and fail closed for unresolved or cross-owner Dynamic Workflows while keeping code-defined workflows available.

--- a/.changeset/warm-pianos-push.md
+++ b/.changeset/warm-pianos-push.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': minor
+---
+
+Added trusted author metadata for dynamic workflow registration.
+
+```ts
+await mastra.addDynamicWorkflow(definition, { authorId: verifiedUserId });
+```
+
+The author is persisted with the definition and remains outside untrusted workflow JSON. This metadata does not enforce access control.
+
+See [#21444](https://github.com/mastra-ai/mastra/issues/21444) for the remaining tenant-isolation design.

--- a/.changeset/wise-owls-queue.md
+++ b/.changeset/wise-owls-queue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Serialize dynamic workflow registrations on each Mastra instance so a rejected registration cannot roll back a workflow that another registration successfully replaced.

--- a/docs/src/content/en/docs/server/mastra-client.mdx
+++ b/docs/src/content/en/docs/server/mastra-client.mdx
@@ -120,9 +120,9 @@ Durable storage requires a configured storage adapter that supports the `workflo
 
 Stored definitions support declarative agent, tool, mapping, nested workflow, parallel, foreach, sleep, sleep-until, conditional, and loop entries. They can't contain JavaScript closures. Conditional and loop logic must use the declarative predicate format, and referenced agents, tools, and nested workflows must already be registered.
 
-Authenticated servers derive the author for list, get, and upsert operations from the server-owned request context. Regular callers only list, get, and upsert their own definitions. Callers with `stored-workflows:admin` can inspect every definition and update an owned definition without transferring it. Definitions without ownership metadata are hidden from regular callers and read-only for admins.
+Authenticated servers derive the author for list, get, upsert, and delete operations from the server-owned request context. Regular callers only manage their own definitions. Callers with `stored-workflows:admin` can inspect every definition and update or delete an owned definition without transferring or bypassing its owner. Definitions without ownership metadata are hidden from regular callers and read-only for admins.
 
-These routes require `stored-workflows:read` or `stored-workflows:write`. Deletion and execution aren't owner-scoped yet. The `workflows:execute` permission can run a registered workflow, but it doesn't establish definition ownership.
+These routes require `stored-workflows:read` or `stored-workflows:write`. Execution isn't owner-scoped yet. The `workflows:execute` permission can run a registered workflow, but it doesn't establish definition ownership.
 
 :::
 

--- a/docs/src/content/en/docs/server/mastra-client.mdx
+++ b/docs/src/content/en/docs/server/mastra-client.mdx
@@ -120,7 +120,9 @@ Durable storage requires a configured storage adapter that supports the `workflo
 
 Stored definitions support declarative agent, tool, mapping, nested workflow, parallel, foreach, sleep, sleep-until, conditional, and loop entries. They can't contain JavaScript closures. Conditional and loop logic must use the declarative predicate format, and referenced agents, tools, and nested workflows must already be registered.
 
-Authenticated servers require `stored-workflows:read` or `stored-workflows:write` for definition operations and `workflows:execute` to run the workflow.
+Authenticated servers derive the author for list, get, and upsert operations from the server-owned request context. Regular callers only list, get, and upsert their own definitions. Callers with `stored-workflows:admin` can inspect every definition and update an owned definition without transferring it. Definitions without ownership metadata are hidden from regular callers and read-only for admins.
+
+These routes require `stored-workflows:read` or `stored-workflows:write`. Deletion and execution aren't owner-scoped yet. The `workflows:execute` permission can run a registered workflow, but it doesn't establish definition ownership.
 
 :::
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -101,9 +101,14 @@ The definition uses JSON Schema because it must survive a JSON round trip. The `
 A definition can come from any source that produces JSON. For example, an API route can accept a definition created by a visual editor and register it directly:
 
 ```typescript
+const authenticatedUser = await authenticate(request)
 const definition = await request.json()
-await mastra.addDynamicWorkflow(definition)
+await mastra.addDynamicWorkflow(definition, {
+  authorId: authenticatedUser.id,
+})
 ```
+
+Derive `authorId` from verified server identity. Never accept it from the submitted workflow definition.
 
 ### Register dependencies first
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -143,9 +143,9 @@ Applications don't need direct access to the `Mastra` instance to manage dynamic
 - [Client SDK workflows API](/reference/client-js/workflows): Call `upsertDynamicWorkflow()` from a JavaScript or TypeScript client.
 - [Server routes](/reference/server/routes): Send definitions to `POST /api/stored/workflows`.
 
-On authenticated servers, listing, reading, and upserting dynamic workflows derives the author from the server-owned request context. Regular callers can only list, read, and replace their own definitions. Callers with `stored-workflows:admin` can inspect every definition and can replace an owned definition without changing its author. Definitions created before ownership metadata was available are hidden from regular callers and read-only for admins.
+On authenticated servers, listing, reading, upserting, and deleting dynamic workflows derives the author from the server-owned request context. Regular callers can only manage their own definitions. Callers with `stored-workflows:admin` can inspect every definition and can replace or delete an owned definition without changing or bypassing its author. Definitions created before ownership metadata was available are hidden from regular callers and read-only for admins.
 
-These management routes still require `stored-workflows:read` or `stored-workflows:write`. Deletion and execution aren't owner-scoped yet. Running the registered workflow requires `workflows:execute`, but this permission doesn't establish tenant ownership by itself.
+These management routes still require `stored-workflows:read` or `stored-workflows:write`. Execution isn't owner-scoped yet. Running the registered workflow requires `workflows:execute`, but this permission doesn't establish tenant ownership by itself.
 
 ### Persist definitions
 
@@ -163,7 +163,9 @@ await mastra.addDynamicWorkflow(untrustedDefinition, {
 })
 ```
 
-Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. The authenticated server's list, get, and upsert routes enforce this ownership. Direct Core calls, deletion, execution, and nested workflow references still require application-level authorization.
+Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. A trusted definition can only nest dynamic workflows with the same stored author; code-defined workflows remain application-level registrations. The authenticated server's list, get, upsert, and delete routes enforce definition ownership. Execution and direct Core calls without trusted author metadata still require application-level authorization.
+
+Delete through `Mastra.deleteDynamicWorkflow(id, { authorId })` when using Core directly. Storage compares the expected author in the delete operation, and Mastra unregisters the live dynamic workflow only after that row is deleted. Code-defined workflows are never unregistered by this method.
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -156,7 +156,7 @@ await mastra.addDynamicWorkflow(untrustedDefinition, {
 })
 ```
 
-Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -138,7 +138,9 @@ Applications don't need direct access to the `Mastra` instance to manage dynamic
 - [Client SDK workflows API](/reference/client-js/workflows): Call `upsertDynamicWorkflow()` from a JavaScript or TypeScript client.
 - [Server routes](/reference/server/routes): Send definitions to `POST /api/stored/workflows`.
 
-On authenticated servers, dynamic-workflow management requires the `stored-workflows:read` and `stored-workflows:write` permissions. Running the registered workflow requires `workflows:execute`.
+On authenticated servers, listing, reading, and upserting dynamic workflows derives the author from the server-owned request context. Regular callers can only list, read, and replace their own definitions. Callers with `stored-workflows:admin` can inspect every definition and can replace an owned definition without changing its author. Definitions created before ownership metadata was available are hidden from regular callers and read-only for admins.
+
+These management routes still require `stored-workflows:read` or `stored-workflows:write`. Deletion and execution aren't owner-scoped yet. Running the registered workflow requires `workflows:execute`, but this permission doesn't establish tenant ownership by itself.
 
 ### Persist definitions
 
@@ -156,7 +158,7 @@ await mastra.addDynamicWorkflow(untrustedDefinition, {
 })
 ```
 
-Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. The authenticated server's list, get, and upsert routes enforce this ownership. Direct Core calls, deletion, execution, and nested workflow references still require application-level authorization.
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -146,6 +146,18 @@ Stored definitions use the `workflowDefinitions` storage domain. On startup, Mas
 
 Without a storage adapter that supports this domain, `addDynamicWorkflow()` still registers the workflow in memory, but the definition is lost when the process restarts. See the [storage reference](/reference/storage/overview) for adapter support.
 
+### Record a verified author
+
+Pass trusted author metadata as the second argument. Keep it outside the workflow definition when the definition comes from a user, agent, or external system.
+
+```typescript
+await mastra.addDynamicWorkflow(untrustedDefinition, {
+  authorId: authenticatedUser.id,
+})
+```
+
+Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+
 ## Related
 
 - [Dynamic workflow definition](/reference/workflows/dynamic-workflow-definition)

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -81,7 +81,8 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
-- `options.authorId` is stored on the definition in the same write and becomes immutable. When replacing an existing definition, omitting `options.authorId` retains its stored author, while using a different author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored on the definition in the same write and becomes immutable. When replacing an existing definition, omitting `options.authorId` retains its stored author, while using a different author fails with an ownership conflict.
+- When `options.authorId` is present, dynamic nested workflows must have the same stored author. Code-defined nested workflows remain available as application-level registrations. Ownership is checked before the live registry changes.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -20,29 +20,34 @@ See [Dynamic workflows](/docs/workflows/dynamic-workflows) for a complete setup 
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflow({
-  id: 'greeting-workflow',
-  description: 'Returns a greeting for the supplied name',
-  inputSchema: {
-    type: 'object',
-    properties: { name: { type: 'string' } },
-    required: ['name'],
-  },
-  outputSchema: {
-    type: 'object',
-    properties: { message: { type: 'string' } },
-    required: ['message'],
-  },
-  graph: [
-    {
-      type: 'mapping',
-      id: 'create-greeting',
-      mapConfig: JSON.stringify({
-        message: { template: 'Hello, ${initData.name}!' },
-      }),
+await mastra.addDynamicWorkflow(
+  {
+    id: 'greeting-workflow',
+    description: 'Returns a greeting for the supplied name',
+    inputSchema: {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
     },
-  ],
-})
+    outputSchema: {
+      type: 'object',
+      properties: { message: { type: 'string' } },
+      required: ['message'],
+    },
+    graph: [
+      {
+        type: 'mapping',
+        id: 'create-greeting',
+        mapConfig: JSON.stringify({
+          message: { template: 'Hello, ${initData.name}!' },
+        }),
+      },
+    ],
+  },
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 
 const run = await mastra.getWorkflow('greeting-workflow').createRun()
 const result = await run.start({ inputData: { name: 'Ada' } })
@@ -58,6 +63,13 @@ const result = await run.start({ inputData: { name: 'Ada' } })
     description:
       'The workflow definition: id, optional description and metadata, JSON Schema input/output schemas, optional state and request-context schemas, and the step graph.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata supplied by the host. Use `authorId` for a verified author identity that must not come from the workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -69,6 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
+- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -81,7 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
-- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored on the definition in the same write and becomes immutable. When replacing an existing definition, omitting `options.authorId` retains its stored author, while using a different author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -22,10 +22,15 @@ The whole bundle is validated up front. Members are then registered in dependenc
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflows([
-  helperDefinition, // nested by the root — order in the array doesn't matter
-  rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
-])
+await mastra.addDynamicWorkflows(
+  [
+    helperDefinition, // nested by the root — order in the array doesn't matter
+    rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
+  ],
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 ```
 
 ## Parameters
@@ -38,6 +43,13 @@ await mastra.addDynamicWorkflows([
     description:
       'The workflow definitions to add. Nested-workflow references may resolve against the live registries or against other members of the same bundle.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata applied to every definition in the bundle. Use `authorId` for a verified author identity that must not come from a workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -48,6 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
+- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -60,7 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
-- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored with every bundle member and becomes immutable. When replacing existing members, omitting `options.authorId` retains each member's stored author, while a member whose ID belongs to another author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -60,7 +60,8 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
-- `options.authorId` is stored with every bundle member and becomes immutable. When replacing existing members, omitting `options.authorId` retains each member's stored author, while a member whose ID belongs to another author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored with every bundle member and becomes immutable. When replacing existing members, omitting `options.authorId` retains each member's stored author, while a member whose ID belongs to another author fails with an ownership conflict.
+- When `options.authorId` is present, every dynamic nested workflow inside or outside the bundle must have the same stored author. Code-defined nested workflows remain available as application-level registrations. Ownership is checked before the live registry changes.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/docs/src/content/en/reference/server/routes.mdx
+++ b/docs/src/content/en/reference/server/routes.mdx
@@ -211,11 +211,11 @@ Dynamic workflow definitions (beta) are workflows expressed as JSON, persisted t
 | `GET` | `/api/stored/workflows` | List the caller's dynamic workflow definitions. Admins can filter by `status` and `authorId` |
 | `GET` | `/api/stored/workflows/:dynamicWorkflowId` | Get a caller-owned dynamic workflow definition. Admins can read any definition |
 | `POST` | `/api/stored/workflows` | Upsert a caller-owned definition (plus optional helper `dependencies`) and live-register it |
-| `DELETE` | `/api/stored/workflows/:dynamicWorkflowId` | Delete a dynamic workflow definition and unregister the live workflow |
+| `DELETE` | `/api/stored/workflows/:dynamicWorkflowId` | Delete a caller-owned dynamic workflow definition and unregister the live workflow |
 
-On authenticated servers, the read routes require the `stored-workflows:read` permission and the write routes require `stored-workflows:write`. List, get, and upsert derive the author from the server-owned request context. Regular callers can't select another `authorId`. The `stored-workflows:admin` permission bypasses read scoping and preserves the existing author during updates. Legacy definitions without an author are hidden from regular callers and read-only for admins.
+On authenticated servers, the read routes require the `stored-workflows:read` permission and the write routes require `stored-workflows:write`. List, get, upsert, and delete derive the author from the server-owned request context. Regular callers can't select another `authorId`. The `stored-workflows:admin` permission bypasses read scoping and preserves the existing author during updates and owner-qualified deletion. Legacy definitions without an author are hidden from regular callers and read-only for admins.
 
-Deletion and execution aren't owner-scoped yet. Registered dynamic workflows are executed through the ordinary `/api/workflows/:workflowId` routes above, which require workflow permissions but don't enforce definition ownership.
+Execution isn't owner-scoped yet. Registered dynamic workflows are executed through the ordinary `/api/workflows/:workflowId` routes above, which require workflow permissions but don't enforce definition ownership.
 
 ### Create run request body
 

--- a/docs/src/content/en/reference/server/routes.mdx
+++ b/docs/src/content/en/reference/server/routes.mdx
@@ -208,12 +208,14 @@ Dynamic workflow definitions (beta) are workflows expressed as JSON, persisted t
 
 | Method | Path | Description |
 | - | - | - |
-| `GET` | `/api/stored/workflows` | List dynamic workflow definitions, filterable by `status` and `authorId` |
-| `GET` | `/api/stored/workflows/:dynamicWorkflowId` | Get a dynamic workflow definition by ID |
-| `POST` | `/api/stored/workflows` | Upsert a definition (plus optional helper `dependencies`) and live-register it |
+| `GET` | `/api/stored/workflows` | List the caller's dynamic workflow definitions. Admins can filter by `status` and `authorId` |
+| `GET` | `/api/stored/workflows/:dynamicWorkflowId` | Get a caller-owned dynamic workflow definition. Admins can read any definition |
+| `POST` | `/api/stored/workflows` | Upsert a caller-owned definition (plus optional helper `dependencies`) and live-register it |
 | `DELETE` | `/api/stored/workflows/:dynamicWorkflowId` | Delete a dynamic workflow definition and unregister the live workflow |
 
-On authenticated servers, the read routes require the `stored-workflows:read` permission and the write routes require `stored-workflows:write`. Registered dynamic workflows are executed through the ordinary `/api/workflows/:workflowId` routes above.
+On authenticated servers, the read routes require the `stored-workflows:read` permission and the write routes require `stored-workflows:write`. List, get, and upsert derive the author from the server-owned request context. Regular callers can't select another `authorId`. The `stored-workflows:admin` permission bypasses read scoping and preserves the existing author during updates. Legacy definitions without an author are hidden from regular callers and read-only for admins.
+
+Deletion and execution aren't owner-scoped yet. Registered dynamic workflows are executed through the ordinary `/api/workflows/:workflowId` routes above, which require workflow permissions but don't enforce definition ownership.
 
 ### Create run request body
 

--- a/mastracode/sdk/README.md
+++ b/mastracode/sdk/README.md
@@ -79,6 +79,31 @@ await deleteWorkflow(mastra, definition.id);
 
 Pass the session request context to `runWorkflow` when workflow agent steps need the session-selected model. You can also pass an event callback as the fifth argument to render workflow step progress.
 
+Multi-user hosts can scope Dynamic Workflow authoring and management to a trusted identity already installed in Mastra's `RequestContext`:
+
+```ts
+import { mountAgentControllerOnMastra } from '@mastra/code-sdk';
+import type { RequestContext } from '@mastra/core/request-context';
+import type { DynamicWorkflowAccessPolicy } from '@mastra/code-sdk/workflows/access-policy';
+import { createWorkflowService } from '@mastra/code-sdk/workflows/service';
+
+const workflowAccessPolicy: DynamicWorkflowAccessPolicy = {
+  resolveAuthorId: ({ requestContext }) => requestContext.get('verified-user-id') as string | undefined,
+};
+
+const { mastra } = await mountAgentControllerOnMastra({
+  cwd: process.cwd(),
+  workflowAccessPolicy,
+});
+
+const workflows = createWorkflowService({ accessPolicy: workflowAccessPolicy });
+async function listForRequest(requestContext: RequestContext) {
+  return workflows.listWorkflows(mastra, { requestContext });
+}
+```
+
+The host is responsible for authenticating the request and setting the trusted context value. When a policy is configured but does not resolve an author, Dynamic Workflow discovery and mutations fail closed. Code-defined workflows remain available. The same policy is used by the code agent's workflow tools and the Workflow Builder, so callers cannot select an author through tool input.
+
 Deep modules are available as subpath imports, e.g.:
 
 ```ts

--- a/mastracode/sdk/src/agents/tools.ts
+++ b/mastracode/sdk/src/agents/tools.ts
@@ -17,10 +17,8 @@ import type { MastraCodeComposedState } from '../schema.js';
 import { MC_TOOLS } from '../tool-names.js';
 import { createWebSearchTool, createWebExtractTool, hasTavilyKey, requestSandboxAccessTool } from '../tools/index.js';
 import { createWorkflowTool } from '../tools/workflows/create-workflow.js';
-import { deleteWorkflowTool } from '../tools/workflows/delete-workflow.js';
-import { getWorkflowTool } from '../tools/workflows/get-workflow.js';
-import { listWorkflowsTool } from '../tools/workflows/list-workflows.js';
-import { runWorkflowTool } from '../tools/workflows/run-workflow.js';
+import { createWorkflowManagementTools } from '../tools/workflows/factory.js';
+import type { CreateWorkflowToolsetOptions } from '../tools/workflows/factory.js';
 import { WORKFLOW_MANAGEMENT_TOOL_IDS } from '../tools/workflows/tool-ids.js';
 
 /** Minimal shape for tools passed to createDynamicTools. */
@@ -118,7 +116,9 @@ export function createDynamicTools(
   disabledTools?: string[],
   storage?: MastraCompositeStore,
   pluginTools?: Record<string, ToolLike>,
+  workflowToolOptions?: CreateWorkflowToolsetOptions,
 ) {
+  const workflowManagementTools = createWorkflowManagementTools(workflowToolOptions);
   return function getDynamicTools({
     requestContext,
   }: {
@@ -140,10 +140,7 @@ export function createDynamicTools(
       // sub-agent; the other four are Dynamic Workflow management operations.
       // Permission categories live in permissions.ts (TOOL_CATEGORY_MAP).
       [WORKFLOW_MANAGEMENT_TOOL_IDS.createWorkflow]: createWorkflowTool,
-      [WORKFLOW_MANAGEMENT_TOOL_IDS.listWorkflows]: listWorkflowsTool,
-      [WORKFLOW_MANAGEMENT_TOOL_IDS.getWorkflow]: getWorkflowTool,
-      [WORKFLOW_MANAGEMENT_TOOL_IDS.runWorkflow]: runWorkflowTool,
-      [WORKFLOW_MANAGEMENT_TOOL_IDS.deleteWorkflow]: deleteWorkflowTool,
+      ...workflowManagementTools,
     };
 
     if (storage) {

--- a/mastracode/sdk/src/agents/workflow-builder-agent.test.ts
+++ b/mastracode/sdk/src/agents/workflow-builder-agent.test.ts
@@ -54,7 +54,17 @@ describe('workflowBuilderAgent', () => {
     const agent = createMastraCodeWorkflowBuilderAgent({
       model,
       accessPolicy: { resolveAuthorId },
+      additionalSurfaceInstructions: '# Host presentation contract\n\nKeep presentation metadata child-simple.',
     });
+
+    const instructions = await agent.getInstructions();
+    expect(instructions).toContain('# Composition procedure');
+    expect(instructions).toContain('# Mastra Code authoring policy');
+    expect(instructions).toContain('# Mastra Code execution and response protocol');
+    expect(instructions).toContain('# Host presentation contract\n\nKeep presentation metadata child-simple.');
+    expect(instructions.indexOf('# Host presentation contract')).toBeGreaterThan(
+      instructions.indexOf('# Mastra Code execution and response protocol'),
+    );
 
     await expect(agent.getModel({ requestContext })).resolves.toMatchObject({
       modelId: hostModel.modelId,

--- a/mastracode/sdk/src/agents/workflow-builder-agent.test.ts
+++ b/mastracode/sdk/src/agents/workflow-builder-agent.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { RequestContext } from '@mastra/core/request-context';
+import { MastraLanguageModelV2Mock } from '@mastra/core/test-utils/llm-mock';
+import { describe, expect, it, vi } from 'vitest';
 
-import { workflowBuilderAgent } from './workflow-builder-agent.js';
+import { WORKFLOW_AUTHORING_TOOL_IDS } from '../tools/workflows/tool-ids.js';
+import { createMastraCodeWorkflowBuilderAgent, workflowBuilderAgent } from './workflow-builder-agent.js';
+
+const mappingGraph = {
+  id: 'host-owned-workflow',
+  inputSchema: { type: 'object', properties: { value: { type: 'string' } }, required: ['value'] },
+  outputSchema: { type: 'object', properties: { value: { type: 'string' } }, required: ['value'] },
+  graph: [{ type: 'mapping', id: 'echo-value', mapConfig: { value: { initData: true, path: 'value' } } }],
+};
 
 describe('workflowBuilderAgent', () => {
   it('combines shared composition guidance with Mastra Code persistence policy', async () => {
@@ -24,5 +34,45 @@ describe('workflowBuilderAgent', () => {
     expect(instructions).toContain('permanent, user-visible registry entries');
     expect(instructions).not.toContain('# Studio authoring policy');
     expect(instructions).not.toContain('submit-workflow-draft');
+  });
+
+  it('keeps the Mastra Code controller model resolver as the default', async () => {
+    await expect(workflowBuilderAgent.getModel({ requestContext: new RequestContext() })).rejects.toThrow(
+      'this run started without a controller session context',
+    );
+  });
+
+  it('uses a host model resolver while preserving trusted workflow ownership', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('verifiedAuthorId', 'tenant-a');
+    const hostModel = new MastraLanguageModelV2Mock();
+    const model = vi.fn(({ requestContext }) => {
+      expect(requestContext.get('verifiedAuthorId')).toBe('tenant-a');
+      return hostModel;
+    });
+    const resolveAuthorId = vi.fn(({ requestContext }) => requestContext.get('verifiedAuthorId') as string);
+    const agent = createMastraCodeWorkflowBuilderAgent({
+      model,
+      accessPolicy: { resolveAuthorId },
+    });
+
+    await expect(agent.getModel({ requestContext })).resolves.toMatchObject({
+      modelId: hostModel.modelId,
+      provider: hostModel.provider,
+    });
+    expect(model).toHaveBeenCalledWith(expect.objectContaining({ requestContext }));
+
+    const tools = await agent.listTools({ requestContext });
+    const addDynamicWorkflow = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      (tools[WORKFLOW_AUTHORING_TOOL_IDS.saveWorkflow] as any).execute(mappingGraph, {
+        mastra: { addDynamicWorkflow },
+        requestContext,
+      }),
+    ).resolves.toEqual({ ok: true, id: 'host-owned-workflow' });
+    expect(resolveAuthorId).toHaveBeenCalledWith({ requestContext });
+    expect(addDynamicWorkflow).toHaveBeenCalledWith(expect.objectContaining({ id: 'host-owned-workflow' }), {
+      authorId: 'tenant-a',
+    });
   });
 });

--- a/mastracode/sdk/src/agents/workflow-builder-agent.ts
+++ b/mastracode/sdk/src/agents/workflow-builder-agent.ts
@@ -10,7 +10,7 @@
  * construct the entire definition in one thought, save it. No setter loop,
  * no per-step mutations.
  */
-import { createWorkflowBuilderAgent } from '@mastra/core/workflows/builder';
+import { createWorkflowBuilderAgent, type WorkflowBuilderAgentOptions } from '@mastra/core/workflows/builder';
 import type { CreateWorkflowToolsetOptions } from '../tools/workflows/factory.js';
 import { createWorkflowAuthoringTools } from '../tools/workflows/factory.js';
 import { listAvailableAgentsTool } from '../tools/workflows/list-available-agents.js';
@@ -18,8 +18,17 @@ import { listAvailableToolsTool } from '../tools/workflows/list-available-tools.
 import { WORKFLOW_AUTHORING_TOOL_IDS } from '../tools/workflows/tool-ids.js';
 import { getDynamicModel } from './model.js';
 
-export function createMastraCodeWorkflowBuilderAgent(options: CreateWorkflowToolsetOptions = {}) {
-  const workflowTools = createWorkflowAuthoringTools(options);
+export interface CreateMastraCodeWorkflowBuilderAgentOptions extends CreateWorkflowToolsetOptions {
+  /**
+   * Native model or request-context resolver for hosts that do not use a
+   * Mastra Code controller session. Defaults to Mastra Code's session model.
+   */
+  model?: WorkflowBuilderAgentOptions<'workflow-builder'>['model'];
+}
+
+export function createMastraCodeWorkflowBuilderAgent(options: CreateMastraCodeWorkflowBuilderAgentOptions = {}) {
+  const { model = getDynamicModel, ...workflowToolOptions } = options;
+  const workflowTools = createWorkflowAuthoringTools(workflowToolOptions);
   return createWorkflowBuilderAgent({
     id: 'workflow-builder',
     name: 'Workflow Builder',
@@ -74,11 +83,10 @@ Your fourth tool is \`save-workflow\`, which persists and live-registers a defin
 5. If the tool rejects the definition, do not claim success. Use the returned diagnostics and authoritative discovery to correct every named issue, rerun the shared pre-action check, and make one sequential corrected complete save attempt. Do not rationalize a registry mismatch as a missing engine feature.
 6. After success, follow the shared summary rules and end with the concrete run command \`/workflows run <id> {…}\` for the requested workflow. If you saved helper workflows, name them so the user knows they now exist in the registry.
 `,
-    // Same dynamic model resolver mastracode's main code-agent uses — picks up
-    // the user's configured provider/model from session state. When the parent
-    // code-agent delegates to this sub-agent (via `create-workflow`), the
-    // request context propagates so the same model resolves.
-    model: getDynamicModel,
+    // The default is the same dynamic resolver as mastracode's main code-agent.
+    // Hosts without a controller session can supply any native Agent model
+    // value or request-context resolver through the factory option.
+    model,
   });
 }
 

--- a/mastracode/sdk/src/agents/workflow-builder-agent.ts
+++ b/mastracode/sdk/src/agents/workflow-builder-agent.ts
@@ -11,24 +11,26 @@
  * no per-step mutations.
  */
 import { createWorkflowBuilderAgent } from '@mastra/core/workflows/builder';
+import type { CreateWorkflowToolsetOptions } from '../tools/workflows/factory.js';
+import { createWorkflowAuthoringTools } from '../tools/workflows/factory.js';
 import { listAvailableAgentsTool } from '../tools/workflows/list-available-agents.js';
 import { listAvailableToolsTool } from '../tools/workflows/list-available-tools.js';
-import { listAvailableWorkflowsTool } from '../tools/workflows/list-available-workflows.js';
-import { saveWorkflowTool } from '../tools/workflows/save-workflow.js';
 import { WORKFLOW_AUTHORING_TOOL_IDS } from '../tools/workflows/tool-ids.js';
 import { getDynamicModel } from './model.js';
 
-export const workflowBuilderAgent = createWorkflowBuilderAgent({
-  id: 'workflow-builder',
-  name: 'Workflow Builder',
-  description: 'Turns plain-language workflow descriptions into runnable, persisted workflow definitions.',
-  tools: {
-    [WORKFLOW_AUTHORING_TOOL_IDS.listAgents]: listAvailableAgentsTool,
-    [WORKFLOW_AUTHORING_TOOL_IDS.listTools]: listAvailableToolsTool,
-    [WORKFLOW_AUTHORING_TOOL_IDS.listWorkflows]: listAvailableWorkflowsTool,
-    [WORKFLOW_AUTHORING_TOOL_IDS.saveWorkflow]: saveWorkflowTool,
-  },
-  surfaceInstructions: `# Mastra Code authoring policy
+export function createMastraCodeWorkflowBuilderAgent(options: CreateWorkflowToolsetOptions = {}) {
+  const workflowTools = createWorkflowAuthoringTools(options);
+  return createWorkflowBuilderAgent({
+    id: 'workflow-builder',
+    name: 'Workflow Builder',
+    description: 'Turns plain-language workflow descriptions into runnable, persisted workflow definitions.',
+    tools: {
+      [WORKFLOW_AUTHORING_TOOL_IDS.listAgents]: listAvailableAgentsTool,
+      [WORKFLOW_AUTHORING_TOOL_IDS.listTools]: listAvailableToolsTool,
+      [WORKFLOW_AUTHORING_TOOL_IDS.listWorkflows]: workflowTools[WORKFLOW_AUTHORING_TOOL_IDS.listWorkflows],
+      [WORKFLOW_AUTHORING_TOOL_IDS.saveWorkflow]: workflowTools[WORKFLOW_AUTHORING_TOOL_IDS.saveWorkflow],
+    },
+    surfaceInstructions: `# Mastra Code authoring policy
 
 Your job: turn the user's verbatim plain-language request into a complete Dynamic Workflow definition and persist it with save-workflow. Success means save-workflow returned \`{ ok: true, id }\` for the workflow the user asked for; do not claim success before that result.
 
@@ -72,9 +74,12 @@ Your fourth tool is \`save-workflow\`, which persists and live-registers a defin
 5. If the tool rejects the definition, do not claim success. Use the returned diagnostics and authoritative discovery to correct every named issue, rerun the shared pre-action check, and make one sequential corrected complete save attempt. Do not rationalize a registry mismatch as a missing engine feature.
 6. After success, follow the shared summary rules and end with the concrete run command \`/workflows run <id> {…}\` for the requested workflow. If you saved helper workflows, name them so the user knows they now exist in the registry.
 `,
-  // Same dynamic model resolver mastracode's main code-agent uses — picks up
-  // the user's configured provider/model from session state. When the parent
-  // code-agent delegates to this sub-agent (via `create-workflow`), the
-  // request context propagates so the same model resolves.
-  model: getDynamicModel,
-});
+    // Same dynamic model resolver mastracode's main code-agent uses — picks up
+    // the user's configured provider/model from session state. When the parent
+    // code-agent delegates to this sub-agent (via `create-workflow`), the
+    // request context propagates so the same model resolves.
+    model: getDynamicModel,
+  });
+}
+
+export const workflowBuilderAgent = createMastraCodeWorkflowBuilderAgent();

--- a/mastracode/sdk/src/agents/workflow-builder-agent.ts
+++ b/mastracode/sdk/src/agents/workflow-builder-agent.ts
@@ -24,10 +24,15 @@ export interface CreateMastraCodeWorkflowBuilderAgentOptions extends CreateWorkf
    * Mastra Code controller session. Defaults to Mastra Code's session model.
    */
   model?: WorkflowBuilderAgentOptions<'workflow-builder'>['model'];
+  /**
+   * Host-specific authoring guidance appended after Mastra's shared playbook
+   * and Mastra Code's persistence policy. It cannot replace either contract.
+   */
+  additionalSurfaceInstructions?: string;
 }
 
 export function createMastraCodeWorkflowBuilderAgent(options: CreateMastraCodeWorkflowBuilderAgentOptions = {}) {
-  const { model = getDynamicModel, ...workflowToolOptions } = options;
+  const { model = getDynamicModel, additionalSurfaceInstructions, ...workflowToolOptions } = options;
   const workflowTools = createWorkflowAuthoringTools(workflowToolOptions);
   return createWorkflowBuilderAgent({
     id: 'workflow-builder',
@@ -82,7 +87,7 @@ Your fourth tool is \`save-workflow\`, which persists and live-registers a defin
 4. Wait for the tool result. Success means exactly that \`save-workflow\` returned \`{ ok: true, id }\`; at that point the workflow is persisted and live-registered.
 5. If the tool rejects the definition, do not claim success. Use the returned diagnostics and authoritative discovery to correct every named issue, rerun the shared pre-action check, and make one sequential corrected complete save attempt. Do not rationalize a registry mismatch as a missing engine feature.
 6. After success, follow the shared summary rules and end with the concrete run command \`/workflows run <id> {…}\` for the requested workflow. If you saved helper workflows, name them so the user knows they now exist in the registry.
-`,
+${additionalSurfaceInstructions ? `\n${additionalSurfaceInstructions}` : ''}`,
     // The default is the same dynamic resolver as mastracode's main code-agent.
     // Hosts without a controller session can supply any native Agent model
     // value or request-context resolver through the factory option.

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -64,6 +64,7 @@ import {
 import { attachOMThreadStatePersistence, restoreOMThreadStateForCurrentThread } from './agents/thread-caveman-state.js';
 import { createDynamicTools, createToolHooks } from './agents/tools.js';
 import type { PostToolObserver, ToolLike } from './agents/tools.js';
+import { createMastraCodeWorkflowBuilderAgent } from './agents/workflow-builder-agent.js';
 
 import { getDynamicWorkspace, getGoalJudgeTools } from './agents/workspace.js';
 import { AuthStorage } from './auth/storage.js';
@@ -112,6 +113,7 @@ import type { StorageResult } from './utils/storage-factory.js';
 import { createStorageMaintenance, DEFAULT_RETENTION, resolveLocalDbFiles } from './utils/storage-maintenance.js';
 import type { StorageMaintenance } from './utils/storage-maintenance.js';
 import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
+import type { DynamicWorkflowAccessPolicy } from './workflows/access-policy.js';
 import { registerWorkflowBuilderPrimitives } from './workflows/register-primitives.js';
 
 const CODE_AGENT_ID = 'code-agent';
@@ -257,6 +259,12 @@ export interface MastraCodeConfig {
   inputProcessors?: InputProcessor[];
   /** Tools removed from the dynamic tool set before exposure to the model */
   disabledTools?: string[];
+  /**
+   * Optional tenant policy for Dynamic Workflow discovery, authoring,
+   * execution, and deletion. Code-defined workflows remain globally visible.
+   * When configured, an unresolved author fails closed.
+   */
+  workflowAccessPolicy?: DynamicWorkflowAccessPolicy;
   /**
    * Custom storage config instead of auto-detected default, or a pre-built
    * store instance. An instance is used as-is: no connection test and no
@@ -821,6 +829,8 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
     }
   };
 
+  const workflowToolOptions = { accessPolicy: config?.workflowAccessPolicy };
+  const workflowBuilderAgent = createMastraCodeWorkflowBuilderAgent(workflowToolOptions);
   const codeAgent: Agent = createCodingAgent({
     id: CODE_AGENT_ID,
     name: 'Code Agent',
@@ -855,7 +865,14 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
         },
       },
     },
-    tools: createDynamicTools(mcpManager, config?.extraTools, config?.disabledTools, storage, pluginTools),
+    tools: createDynamicTools(
+      mcpManager,
+      config?.extraTools,
+      config?.disabledTools,
+      storage,
+      pluginTools,
+      workflowToolOptions,
+    ),
     hooks: createToolHooks(hookManager, config?.postToolObserver),
     scorers: {
       outcome: {
@@ -1208,6 +1225,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
     // orchestration to it — code-agent already has full workspace / MCP / web
     // access via its dynamic tool factory.
     codeAgent,
+    workflowBuilderAgent,
     // Lets the composition layer publish the created session back into the
     // config closures (e.g. notification stream options read it lazily).
     setActiveSession: (session: Session<MastraCodeState>) => {
@@ -1340,7 +1358,7 @@ export async function wireSessionConcerns(
  */
 export async function bootLocalAgentController(config?: MastraCodeConfig) {
   const base = await createMastraCodeAgentController(config);
-  const { controller, sessionId, ownerId, projectPath, codeAgent, mcpManager } = base;
+  const { controller, sessionId, ownerId, projectPath, codeAgent, workflowBuilderAgent, mcpManager } = base;
 
   await controller.init();
   // Register workflow primitives (sub-agent + workspace tools + code-agent
@@ -1348,7 +1366,9 @@ export async function bootLocalAgentController(config?: MastraCodeConfig) {
   // Mastra so the dynamic-workflow loading in startWorkers() can rehydrate
   // saved workflows against the right tool/agent registry.
   const mastra = controller.getMastra();
-  if (mastra) await registerWorkflowBuilderPrimitives(mastra, { projectPath, codeAgent, mcpManager });
+  if (mastra) {
+    await registerWorkflowBuilderPrimitives(mastra, { projectPath, codeAgent, workflowBuilderAgent, mcpManager });
+  }
   await mastra?.startWorkers();
   base.registerConfiguredProcessorsWithMastra();
   base.startPluginSignalProviders();
@@ -1434,7 +1454,7 @@ export async function prepareAgentControllerMount(
   finalize: () => Promise<void>;
 }> {
   const base = await createMastraCodeAgentController(config);
-  const { controller, storage, authStorage, projectPath, codeAgent, mcpManager } = base;
+  const { controller, storage, authStorage, projectPath, codeAgent, workflowBuilderAgent, mcpManager } = base;
   const controllerId = config?.controllerId ?? controller.id;
   const apiRoutes = config?.buildApiRoutes?.({ controller, authStorage });
   const extraServerConfig = config?.buildServerConfig?.({ controller, authStorage });
@@ -1462,7 +1482,9 @@ export async function prepareAgentControllerMount(
     await controller.init();
     if (weOwnTheMastra) {
       const mastra = controller.getMastra();
-      if (mastra) await registerWorkflowBuilderPrimitives(mastra, { projectPath, codeAgent, mcpManager });
+      if (mastra) {
+        await registerWorkflowBuilderPrimitives(mastra, { projectPath, codeAgent, workflowBuilderAgent, mcpManager });
+      }
     }
     await controller.getMastra()?.startWorkers();
     // Anchored here rather than at a `new Mastra(...)` call site: finalize runs

--- a/mastracode/sdk/src/tools/workflows/__tests__/save-workflow.predicate.test.ts
+++ b/mastracode/sdk/src/tools/workflows/__tests__/save-workflow.predicate.test.ts
@@ -8,8 +8,9 @@
  * 2. `execute` — must call `mastra.addDynamicWorkflow` with the normalized
  *    canonical shape, so the SDK and Core schemas agree end-to-end.
  */
+import { RequestContext } from '@mastra/core/request-context';
 import { describe, it, expect, vi } from 'vitest';
-import { saveWorkflowTool } from '../save-workflow.js';
+import { createSaveWorkflowTool, saveWorkflowTool } from '../save-workflow.js';
 
 function invoke(input: unknown, mastra: unknown) {
   // Call the raw execute; callers of the tool are responsible for schema
@@ -135,5 +136,57 @@ describe('save-workflow — execute', () => {
       const mastra = { addDynamicWorkflow } as unknown;
       await expect(invoke(loopGraphWithPredicate, mastra)).rejects.toThrow(/unresolved reference to tool "inc-tool"/);
     });
+  });
+
+  describe('when mastra.addDynamicWorkflow rejects (storage failure)', () => {
+    it('propagates the underlying error unchanged', async () => {
+      const addDynamicWorkflow = vi.fn().mockRejectedValue(new Error('workflow storage unavailable'));
+      const mastra = { addDynamicWorkflow } as unknown;
+      await expect(invoke(loopGraphWithPredicate, mastra)).rejects.toThrow(/workflow storage unavailable/);
+    });
+  });
+});
+
+describe('createSaveWorkflowTool — authorization', () => {
+  it('passes the native request context and a detached definition to the policy', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('tenantId', 'tenant-1');
+    const addDynamicWorkflow = vi.fn().mockResolvedValue(undefined);
+    let receivedRequestContext: RequestContext | undefined;
+    let receivedDefinition: unknown;
+    const authorize = vi.fn(({ definition, requestContext: context }) => {
+      receivedRequestContext = context;
+      receivedDefinition = structuredClone(definition);
+      (definition as { id: string }).id = 'attempted-rewrite';
+    });
+    const tool = createSaveWorkflowTool({ authorize });
+
+    const result = await (tool as any).execute(loopGraphWithPredicate, {
+      mastra: { addDynamicWorkflow },
+      requestContext,
+    });
+
+    expect(result).toEqual({ ok: true, id: 'wf-loop' });
+    expect(authorize).toHaveBeenCalledTimes(1);
+    expect(receivedRequestContext).toBe(requestContext);
+    expect(receivedDefinition).toStrictEqual(loopGraphWithPredicate);
+    expect(addDynamicWorkflow).toHaveBeenCalledWith(loopGraphWithPredicate);
+  });
+
+  it('does not call Mastra when the policy denies by throwing', async () => {
+    const addDynamicWorkflow = vi.fn().mockResolvedValue(undefined);
+    const tool = createSaveWorkflowTool({
+      authorize: async () => {
+        throw new Error('workflow save not authorized');
+      },
+    });
+
+    await expect(
+      (tool as any).execute(loopGraphWithPredicate, {
+        mastra: { addDynamicWorkflow },
+        requestContext: new RequestContext(),
+      }),
+    ).rejects.toThrow(/workflow save not authorized/);
+    expect(addDynamicWorkflow).not.toHaveBeenCalled();
   });
 });

--- a/mastracode/sdk/src/tools/workflows/__tests__/save-workflow.predicate.test.ts
+++ b/mastracode/sdk/src/tools/workflows/__tests__/save-workflow.predicate.test.ts
@@ -189,4 +189,39 @@ describe('createSaveWorkflowTool — authorization', () => {
     ).rejects.toThrow(/workflow save not authorized/);
     expect(addDynamicWorkflow).not.toHaveBeenCalled();
   });
+
+  it('stamps the trusted policy author through the native registration options', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('verifiedAuthorId', 'tenant-a');
+    const addDynamicWorkflow = vi.fn().mockResolvedValue(undefined);
+    const authorize = vi.fn();
+    const tool = createSaveWorkflowTool({
+      accessPolicy: {
+        resolveAuthorId: ({ requestContext }) => requestContext.get('verifiedAuthorId') as string,
+      },
+      authorize,
+    });
+
+    expect((tool as any).inputSchema.safeParse({ ...loopGraphWithPredicate, authorId: 'forged-author' }).success).toBe(
+      false,
+    );
+    await expect(
+      (tool as any).execute(loopGraphWithPredicate, { mastra: { addDynamicWorkflow }, requestContext }),
+    ).resolves.toEqual({ ok: true, id: 'wf-loop' });
+    expect(authorize).toHaveBeenCalledWith(expect.objectContaining({ authorId: 'tenant-a', requestContext }));
+    expect(addDynamicWorkflow).toHaveBeenCalledWith(loopGraphWithPredicate, { authorId: 'tenant-a' });
+  });
+
+  it('does not mutate storage when the access policy cannot resolve a caller', async () => {
+    const addDynamicWorkflow = vi.fn().mockResolvedValue(undefined);
+    const tool = createSaveWorkflowTool({ accessPolicy: { resolveAuthorId: () => undefined } });
+
+    await expect(
+      (tool as any).execute(loopGraphWithPredicate, {
+        mastra: { addDynamicWorkflow },
+        requestContext: new RequestContext(),
+      }),
+    ).rejects.toThrow('Dynamic workflow not found.');
+    expect(addDynamicWorkflow).not.toHaveBeenCalled();
+  });
 });

--- a/mastracode/sdk/src/tools/workflows/__tests__/save-workflow.predicate.test.ts
+++ b/mastracode/sdk/src/tools/workflows/__tests__/save-workflow.predicate.test.ts
@@ -8,7 +8,9 @@
  * 2. `execute` — must call `mastra.addDynamicWorkflow` with the normalized
  *    canonical shape, so the SDK and Core schemas agree end-to-end.
  */
+import { Mastra } from '@mastra/core/mastra';
 import { RequestContext } from '@mastra/core/request-context';
+import { InMemoryStore } from '@mastra/core/storage';
 import { describe, it, expect, vi } from 'vitest';
 import { createSaveWorkflowTool, saveWorkflowTool } from '../save-workflow.js';
 
@@ -51,6 +53,13 @@ const loopGraphWithPredicate = {
       predicate: { op: 'gte', left: { path: 'inputData.count' }, right: { literal: 3 } },
     },
   ],
+};
+
+const mappingGraph = {
+  id: 'wf-owned',
+  inputSchema: { type: 'object', properties: { value: { type: 'string' } }, required: ['value'] },
+  outputSchema: { type: 'object', properties: { value: { type: 'string' } }, required: ['value'] },
+  graph: [{ type: 'mapping', id: 'echo-value', mapConfig: { value: { initData: true, path: 'value' } } }],
 };
 
 describe('save-workflow — input schema', () => {
@@ -210,6 +219,32 @@ describe('createSaveWorkflowTool — authorization', () => {
     ).resolves.toEqual({ ok: true, id: 'wf-loop' });
     expect(authorize).toHaveBeenCalledWith(expect.objectContaining({ authorId: 'tenant-a', requestContext }));
     expect(addDynamicWorkflow).toHaveBeenCalledWith(loopGraphWithPredicate, { authorId: 'tenant-a' });
+  });
+
+  it('persists the trusted policy author through Mastra storage', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('verifiedAuthorId', 'tenant-a');
+    const mastra = new Mastra({
+      logger: false,
+      storage: new InMemoryStore({ id: 'save-workflow-owner' }),
+    });
+    const tool = createSaveWorkflowTool({
+      accessPolicy: {
+        resolveAuthorId: ({ requestContext }) => requestContext.get('verifiedAuthorId') as string,
+      },
+    });
+
+    await expect((tool as any).execute(mappingGraph, { mastra, requestContext })).resolves.toEqual({
+      ok: true,
+      id: 'wf-owned',
+    });
+
+    await expect(
+      mastra
+        .getStorage()
+        ?.getStore('workflowDefinitions')
+        .then(store => store?.get('wf-owned')),
+    ).resolves.toMatchObject({ id: 'wf-owned', authorId: 'tenant-a' });
   });
 
   it('does not mutate storage when the access policy cannot resolve a caller', async () => {

--- a/mastracode/sdk/src/tools/workflows/delete-workflow.ts
+++ b/mastracode/sdk/src/tools/workflows/delete-workflow.ts
@@ -5,20 +5,27 @@
 import type { Mastra } from '@mastra/core/mastra';
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
-import { deleteWorkflow } from '../../workflows/service.js';
+import type { DynamicWorkflowAccessPolicy } from '../../workflows/access-policy.js';
+import { createWorkflowService } from '../../workflows/service.js';
 
-export const deleteWorkflowTool = createTool({
-  id: 'delete-workflow',
-  description: 'Remove a saved dynamic workflow from storage and unregister its live in-process instance. Idempotent.',
-  inputSchema: z.object({
-    id: z.string().describe('The workflow id to delete.'),
-  }),
-  outputSchema: z.object({
-    ok: z.literal(true),
-    id: z.string(),
-  }),
-  execute: async ({ id }, { mastra }) => {
-    if (!mastra) throw new Error('delete-workflow requires a Mastra context.');
-    return deleteWorkflow(mastra as Mastra, id);
-  },
-});
+export function createDeleteWorkflowTool(accessPolicy?: DynamicWorkflowAccessPolicy) {
+  const service = createWorkflowService({ accessPolicy });
+  return createTool({
+    id: 'delete-workflow',
+    description:
+      'Remove a saved dynamic workflow from storage and unregister its live in-process instance. Idempotent.',
+    inputSchema: z.object({
+      id: z.string().describe('The workflow id to delete.'),
+    }),
+    outputSchema: z.object({
+      ok: z.literal(true),
+      id: z.string(),
+    }),
+    execute: async ({ id }, { mastra, requestContext }) => {
+      if (!mastra) throw new Error('delete-workflow requires a Mastra context.');
+      return service.deleteWorkflow(mastra as Mastra, id, { requestContext });
+    },
+  });
+}
+
+export const deleteWorkflowTool = createDeleteWorkflowTool();

--- a/mastracode/sdk/src/tools/workflows/delete-workflow.ts
+++ b/mastracode/sdk/src/tools/workflows/delete-workflow.ts
@@ -1,7 +1,6 @@
 /**
- * Parent-mode tool: delete a saved workflow from storage and unregister the
- * live in-process Workflow instance so a subsequent save-workflow with the
- * same id re-registers cleanly.
+ * Parent-mode tool: delete a saved dynamic workflow from storage and
+ * unregister its live in-process instance.
  */
 import type { Mastra } from '@mastra/core/mastra';
 import { createTool } from '@mastra/core/tools';
@@ -10,8 +9,7 @@ import { deleteWorkflow } from '../../workflows/service.js';
 
 export const deleteWorkflowTool = createTool({
   id: 'delete-workflow',
-  description:
-    'Remove a saved workflow from storage and unregister the live in-process Workflow instance. Idempotent. Subsequent save-workflow calls with the same id re-register cleanly.',
+  description: 'Remove a saved dynamic workflow from storage and unregister its live in-process instance. Idempotent.',
   inputSchema: z.object({
     id: z.string().describe('The workflow id to delete.'),
   }),

--- a/mastracode/sdk/src/tools/workflows/factory.ts
+++ b/mastracode/sdk/src/tools/workflows/factory.ts
@@ -1,0 +1,33 @@
+import type { DynamicWorkflowAccessPolicy } from '../../workflows/access-policy.js';
+import { createDeleteWorkflowTool } from './delete-workflow.js';
+import { createGetWorkflowTool } from './get-workflow.js';
+import { createListAvailableWorkflowsTool } from './list-available-workflows.js';
+import { createListWorkflowsTool } from './list-workflows.js';
+import { createRunWorkflowTool } from './run-workflow.js';
+import { createSaveWorkflowTool, type CreateSaveWorkflowToolOptions } from './save-workflow.js';
+import { WORKFLOW_AUTHORING_TOOL_IDS, WORKFLOW_MANAGEMENT_TOOL_IDS } from './tool-ids.js';
+
+export interface CreateWorkflowToolsetOptions {
+  accessPolicy?: DynamicWorkflowAccessPolicy;
+  saveAuthorization?: CreateSaveWorkflowToolOptions['authorize'];
+}
+
+export function createWorkflowManagementTools(options: CreateWorkflowToolsetOptions = {}) {
+  const { accessPolicy } = options;
+  return {
+    [WORKFLOW_MANAGEMENT_TOOL_IDS.listWorkflows]: createListWorkflowsTool(accessPolicy),
+    [WORKFLOW_MANAGEMENT_TOOL_IDS.getWorkflow]: createGetWorkflowTool(accessPolicy),
+    [WORKFLOW_MANAGEMENT_TOOL_IDS.runWorkflow]: createRunWorkflowTool(accessPolicy),
+    [WORKFLOW_MANAGEMENT_TOOL_IDS.deleteWorkflow]: createDeleteWorkflowTool(accessPolicy),
+  };
+}
+
+export function createWorkflowAuthoringTools(options: CreateWorkflowToolsetOptions = {}) {
+  return {
+    [WORKFLOW_AUTHORING_TOOL_IDS.listWorkflows]: createListAvailableWorkflowsTool(options.accessPolicy),
+    [WORKFLOW_AUTHORING_TOOL_IDS.saveWorkflow]: createSaveWorkflowTool({
+      accessPolicy: options.accessPolicy,
+      authorize: options.saveAuthorization,
+    }),
+  };
+}

--- a/mastracode/sdk/src/tools/workflows/get-workflow.ts
+++ b/mastracode/sdk/src/tools/workflows/get-workflow.ts
@@ -4,33 +4,39 @@
 import type { Mastra } from '@mastra/core/mastra';
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
-import { getWorkflow } from '../../workflows/service.js';
+import type { DynamicWorkflowAccessPolicy } from '../../workflows/access-policy.js';
+import { createWorkflowService } from '../../workflows/service.js';
 
-export const getWorkflowTool = createTool({
-  id: 'get-workflow',
-  description: 'Return the full stored definition of a workflow (input/output schemas + the step graph).',
-  inputSchema: z.object({
-    id: z.string().describe('The workflow id.'),
-  }),
-  outputSchema: z.object({
-    id: z.string(),
-    description: z.string().optional(),
-    status: z.enum(['active', 'archived']),
-    inputSchema: z.any().optional(),
-    outputSchema: z.any().optional(),
-    graph: z.array(z.any()).optional(),
-  }),
-  execute: async ({ id }, { mastra }) => {
-    if (!mastra) throw new Error('get-workflow requires a Mastra context.');
-    const def = await getWorkflow(mastra as Mastra, id);
-    if (!def) throw new Error(`No workflow with id "${id}".`);
-    return {
-      id: def.id,
-      description: def.description,
-      status: def.status,
-      inputSchema: def.inputSchema,
-      outputSchema: def.outputSchema,
-      graph: def.graph,
-    };
-  },
-});
+export function createGetWorkflowTool(accessPolicy?: DynamicWorkflowAccessPolicy) {
+  const service = createWorkflowService({ accessPolicy });
+  return createTool({
+    id: 'get-workflow',
+    description: 'Return the full stored definition of a workflow (input/output schemas + the step graph).',
+    inputSchema: z.object({
+      id: z.string().describe('The workflow id.'),
+    }),
+    outputSchema: z.object({
+      id: z.string(),
+      description: z.string().optional(),
+      status: z.enum(['active', 'archived']),
+      inputSchema: z.any().optional(),
+      outputSchema: z.any().optional(),
+      graph: z.array(z.any()).optional(),
+    }),
+    execute: async ({ id }, { mastra, requestContext }) => {
+      if (!mastra) throw new Error('get-workflow requires a Mastra context.');
+      const def = await service.getWorkflow(mastra as Mastra, id, { requestContext });
+      if (!def) throw new Error(`No workflow with id "${id}".`);
+      return {
+        id: def.id,
+        description: def.description,
+        status: def.status,
+        inputSchema: def.inputSchema,
+        outputSchema: def.outputSchema,
+        graph: def.graph,
+      };
+    },
+  });
+}
+
+export const getWorkflowTool = createGetWorkflowTool();

--- a/mastracode/sdk/src/tools/workflows/list-available-workflows.ts
+++ b/mastracode/sdk/src/tools/workflows/list-available-workflows.ts
@@ -7,36 +7,43 @@
 import type { Mastra } from '@mastra/core/mastra';
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
+import type { DynamicWorkflowAccessPolicy } from '../../workflows/access-policy.js';
+import { createWorkflowService } from '../../workflows/service.js';
 import { extractJsonSchema } from './extract-json-schema.js';
 
-export const listAvailableWorkflowsTool = createTool({
-  id: 'list-available-workflows',
-  description:
-    'Returns the workflows currently registered on the Mastra instance (both code-defined and dynamic). The ids returned here are the only valid values you can put in `{ type: "workflow", workflowId }` graph entries. Each row includes `inputSchema` and `outputSchema` as JSON Schema — read them to know what shape the nested workflow expects and produces; never invent field names.',
-  inputSchema: z.object({}),
-  outputSchema: z.object({
-    workflows: z.array(
-      z.object({
-        id: z.string(),
-        description: z.string().optional(),
-        inputSchema: z.any().optional(),
-        outputSchema: z.any().optional(),
-      }),
-    ),
-  }),
-  execute: async (_input, { mastra }) => {
-    if (!mastra) throw new Error('list-available-workflows requires a Mastra context.');
-    const all = (mastra as Mastra).listWorkflows?.() ?? {};
-    return {
-      workflows: Object.entries(all).map(([id, wf]) => {
-        const w = wf as { description?: string; inputSchema?: unknown; outputSchema?: unknown } | undefined;
-        return {
-          id,
-          description: w?.description,
-          inputSchema: extractJsonSchema(w?.inputSchema, 'input'),
-          outputSchema: extractJsonSchema(w?.outputSchema, 'output'),
-        };
-      }),
-    };
-  },
-});
+export function createListAvailableWorkflowsTool(accessPolicy?: DynamicWorkflowAccessPolicy) {
+  const service = createWorkflowService({ accessPolicy });
+  return createTool({
+    id: 'list-available-workflows',
+    description:
+      'Returns the workflows currently registered on the Mastra instance (both code-defined and dynamic). The ids returned here are the only valid values you can put in `{ type: "workflow", workflowId }` graph entries. Each row includes `inputSchema` and `outputSchema` as JSON Schema — read them to know what shape the nested workflow expects and produces; never invent field names.',
+    inputSchema: z.object({}),
+    outputSchema: z.object({
+      workflows: z.array(
+        z.object({
+          id: z.string(),
+          description: z.string().optional(),
+          inputSchema: z.any().optional(),
+          outputSchema: z.any().optional(),
+        }),
+      ),
+    }),
+    execute: async (_input, { mastra, requestContext }) => {
+      if (!mastra) throw new Error('list-available-workflows requires a Mastra context.');
+      const all = await service.listAccessibleRegisteredWorkflows(mastra as Mastra, { requestContext });
+      return {
+        workflows: Object.entries(all).map(([id, wf]) => {
+          const w = wf as { description?: string; inputSchema?: unknown; outputSchema?: unknown } | undefined;
+          return {
+            id,
+            description: w?.description,
+            inputSchema: extractJsonSchema(w?.inputSchema, 'input'),
+            outputSchema: extractJsonSchema(w?.outputSchema, 'output'),
+          };
+        }),
+      };
+    },
+  });
+}
+
+export const listAvailableWorkflowsTool = createListAvailableWorkflowsTool();

--- a/mastracode/sdk/src/tools/workflows/list-workflows.ts
+++ b/mastracode/sdk/src/tools/workflows/list-workflows.ts
@@ -4,28 +4,34 @@
 import type { Mastra } from '@mastra/core/mastra';
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
-import { listWorkflows } from '../../workflows/service.js';
+import type { DynamicWorkflowAccessPolicy } from '../../workflows/access-policy.js';
+import { createWorkflowService } from '../../workflows/service.js';
 
-export const listWorkflowsTool = createTool({
-  id: 'list-workflows',
-  description: 'List active Dynamic Workflows persisted to storage. Returns id + description + status for each.',
-  inputSchema: z.object({}),
-  outputSchema: z.object({
-    workflows: z.array(
-      z.object({
-        id: z.string(),
-        description: z.string().optional(),
-        status: z.enum(['active', 'archived']),
-      }),
-    ),
-    total: z.number(),
-  }),
-  execute: async (_input, { mastra }) => {
-    if (!mastra) throw new Error('list-workflows requires a Mastra context.');
-    const { workflows, total } = await listWorkflows(mastra as Mastra);
-    return {
-      workflows: workflows.map(wf => ({ id: wf.id, description: wf.description, status: wf.status })),
-      total,
-    };
-  },
-});
+export function createListWorkflowsTool(accessPolicy?: DynamicWorkflowAccessPolicy) {
+  const service = createWorkflowService({ accessPolicy });
+  return createTool({
+    id: 'list-workflows',
+    description: 'List active Dynamic Workflows persisted to storage. Returns id + description + status for each.',
+    inputSchema: z.object({}),
+    outputSchema: z.object({
+      workflows: z.array(
+        z.object({
+          id: z.string(),
+          description: z.string().optional(),
+          status: z.enum(['active', 'archived']),
+        }),
+      ),
+      total: z.number(),
+    }),
+    execute: async (_input, { mastra, requestContext }) => {
+      if (!mastra) throw new Error('list-workflows requires a Mastra context.');
+      const { workflows, total } = await service.listWorkflows(mastra as Mastra, { requestContext });
+      return {
+        workflows: workflows.map(wf => ({ id: wf.id, description: wf.description, status: wf.status })),
+        total,
+      };
+    },
+  });
+}
+
+export const listWorkflowsTool = createListWorkflowsTool();

--- a/mastracode/sdk/src/tools/workflows/run-workflow.ts
+++ b/mastracode/sdk/src/tools/workflows/run-workflow.ts
@@ -5,57 +5,63 @@
 import type { Mastra } from '@mastra/core/mastra';
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
-import { runWorkflow } from '../../workflows/service.js';
+import type { DynamicWorkflowAccessPolicy } from '../../workflows/access-policy.js';
+import { createWorkflowService } from '../../workflows/service.js';
 import { withEphemeralMemory } from './ephemeral-memory.js';
 
-export const runWorkflowTool = createTool({
-  id: 'run-workflow',
-  description:
-    'Run a saved workflow by id with the provided input data. Returns the run result inline. Use when the user asks you to "run X", "execute X", or asks for the outcome of a saved workflow.',
-  inputSchema: z.object({
-    workflowId: z.string().describe('The id of the saved workflow to run.'),
-    inputData: z.any().describe('The input object the workflow consumes. Must match the workflow inputSchema.'),
-  }),
-  outputSchema: z.object({
-    status: z.string(),
-    result: z.any().optional(),
-    error: z.any().optional(),
-  }),
-  execute: async ({ workflowId, inputData }, { mastra, requestContext }) => {
-    if (!mastra) throw new Error('run-workflow requires a Mastra context.');
-    // Forward the caller's requestContext so agent steps can resolve dynamic
-    // model/tool bindings from session state, and swap the caller's chat
-    // memory scope for a fresh isolated one for the duration of the run so
-    // the workflow's agent step doesn't write into (or read from) the parent
-    // chat thread. See ephemeral-memory.ts.
-    return withEphemeralMemory(requestContext, async ephemeralRequestContext => {
-      const result = await runWorkflow(mastra as Mastra, workflowId, inputData, ephemeralRequestContext);
-      if (result.status === 'tripwire' && result.tripwire) {
-        return {
-          status: result.status,
-          error: `Tripwire: ${result.tripwire.reason ?? 'unknown'} (processor: ${result.tripwire.processorId ?? 'unknown'})`,
-        };
-      }
-      let errorText: string | undefined;
-      if (result.error instanceof Error) {
-        errorText = `${result.error.name}: ${result.error.message}`;
-        const cause = (result.error as { cause?: unknown }).cause;
-        if (cause) {
+export function createRunWorkflowTool(accessPolicy?: DynamicWorkflowAccessPolicy) {
+  const service = createWorkflowService({ accessPolicy });
+  return createTool({
+    id: 'run-workflow',
+    description:
+      'Run a saved workflow by id with the provided input data. Returns the run result inline. Use when the user asks you to "run X", "execute X", or asks for the outcome of a saved workflow.',
+    inputSchema: z.object({
+      workflowId: z.string().describe('The id of the saved workflow to run.'),
+      inputData: z.any().describe('The input object the workflow consumes. Must match the workflow inputSchema.'),
+    }),
+    outputSchema: z.object({
+      status: z.string(),
+      result: z.any().optional(),
+      error: z.any().optional(),
+    }),
+    execute: async ({ workflowId, inputData }, { mastra, requestContext }) => {
+      if (!mastra) throw new Error('run-workflow requires a Mastra context.');
+      // Forward the caller's requestContext so agent steps can resolve dynamic
+      // model/tool bindings from session state, and swap the caller's chat
+      // memory scope for a fresh isolated one for the duration of the run so
+      // the workflow's agent step doesn't write into (or read from) the parent
+      // chat thread. See ephemeral-memory.ts.
+      return withEphemeralMemory(requestContext, async ephemeralRequestContext => {
+        const result = await service.runWorkflow(mastra as Mastra, workflowId, inputData, ephemeralRequestContext);
+        if (result.status === 'tripwire' && result.tripwire) {
+          return {
+            status: result.status,
+            error: `Tripwire: ${result.tripwire.reason ?? 'unknown'} (processor: ${result.tripwire.processorId ?? 'unknown'})`,
+          };
+        }
+        let errorText: string | undefined;
+        if (result.error instanceof Error) {
+          errorText = `${result.error.name}: ${result.error.message}`;
+          const cause = (result.error as { cause?: unknown }).cause;
+          if (cause) {
+            try {
+              errorText += ` | cause: ${JSON.stringify(cause, Object.getOwnPropertyNames(cause))}`;
+            } catch {
+              errorText += ` | cause: ${String(cause)}`;
+            }
+          }
+          if (result.error.stack) errorText += `\nstack: ${result.error.stack}`;
+        } else if (result.error) {
           try {
-            errorText += ` | cause: ${JSON.stringify(cause, Object.getOwnPropertyNames(cause))}`;
+            errorText = JSON.stringify(result.error, Object.getOwnPropertyNames(result.error));
           } catch {
-            errorText += ` | cause: ${String(cause)}`;
+            errorText = String(result.error);
           }
         }
-        if (result.error.stack) errorText += `\nstack: ${result.error.stack}`;
-      } else if (result.error) {
-        try {
-          errorText = JSON.stringify(result.error, Object.getOwnPropertyNames(result.error));
-        } catch {
-          errorText = String(result.error);
-        }
-      }
-      return { status: result.status, result: result.result, error: errorText };
-    });
-  },
-});
+        return { status: result.status, result: result.result, error: errorText };
+      });
+    },
+  });
+}
+
+export const runWorkflowTool = createRunWorkflowTool();

--- a/mastracode/sdk/src/tools/workflows/save-workflow.ts
+++ b/mastracode/sdk/src/tools/workflows/save-workflow.ts
@@ -8,8 +8,13 @@
  * `submit-workflow-draft` and lives in `@mastra/core/workflows/builder`.
  */
 import type { Mastra } from '@mastra/core/mastra';
+import type { RequestContext } from '@mastra/core/request-context';
 import { createTool } from '@mastra/core/tools';
-import { normalizeWorkflowBuilderDefinition, workflowBuilderDefinitionSchema } from '@mastra/core/workflows/builder';
+import {
+  normalizeWorkflowBuilderDefinition,
+  workflowBuilderDefinitionSchema,
+  type WorkflowBuilderDefinition,
+} from '@mastra/core/workflows/builder';
 import { z } from 'zod';
 
 export { WORKFLOW_BUILDER_MAPPING_CONFIG_DESCRIPTION as MAPPING_CONFIG_DESCRIPTION } from '@mastra/core/workflows/builder';
@@ -19,26 +24,59 @@ export const workflowDefinitionInputSchema = z.preprocess(
   workflowBuilderDefinitionSchema,
 );
 
-export const saveWorkflowTool = createTool({
-  id: 'save-workflow',
-  description:
-    'Persist a Dynamic Workflow definition and live-register it on the running Mastra instance. Supports all ten persisted graph families: agent, tool, mapping, nested workflow, parallel, foreach, sleep, sleepUntil, conditional, and loop. Conditional and loop entries require declarative predicates; JS closures cannot round-trip through storage. After this returns, the workflow is immediately runnable. Call it exactly once with the complete definition; there is no incremental save API.',
-  inputSchema: workflowDefinitionInputSchema,
-  outputSchema: z.object({
-    ok: z.literal(true),
-    id: z.string(),
-  }),
-  execute: async (def, { mastra }) => {
-    if (!mastra) throw new Error('save-workflow requires a Mastra context.');
-    const m = mastra as Mastra;
-    const normalizedDefinition = normalizeWorkflowBuilderDefinition(def);
+export interface SaveWorkflowAuthorizationContext {
+  /**
+   * A detached copy of the complete definition. Mutating it cannot change the
+   * definition passed to `Mastra.addDynamicWorkflow()`.
+   */
+  definition: Readonly<WorkflowBuilderDefinition>;
+  requestContext: RequestContext;
+}
 
-    // `mastra.addDynamicWorkflow` performs registry pre-flight — a mis-classified
-    // agentId/toolId or unregistered id throws before rehydration with an
-    // actionable message listing every offender. It also rejects JSON Schemas
-    // that use keywords the storage-side converter can't rehydrate
-    // (oneOf/anyOf/allOf/not/$ref/patternProperties/discriminator).
-    await m.addDynamicWorkflow(normalizedDefinition as Parameters<Mastra['addDynamicWorkflow']>[0]);
-    return { ok: true as const, id: normalizedDefinition.id };
-  },
-});
+export interface CreateSaveWorkflowToolOptions {
+  /**
+   * Optional deny-only policy hook. Throw to reject the save. Return normally
+   * to allow it. The callback cannot replace or rewrite the saved definition.
+   */
+  authorize?: (context: SaveWorkflowAuthorizationContext) => void | Promise<void>;
+}
+
+/**
+ * Creates the native Dynamic Workflow save tool with an optional host policy.
+ * Validation, persistence, registration, and rollback remain owned by
+ * `Mastra.addDynamicWorkflow()`.
+ */
+export function createSaveWorkflowTool(options: CreateSaveWorkflowToolOptions = {}) {
+  return createTool({
+    id: 'save-workflow',
+    description:
+      'Persist a Dynamic Workflow definition and live-register it on the running Mastra instance. Supports all ten persisted graph families: agent, tool, mapping, nested workflow, parallel, foreach, sleep, sleepUntil, conditional, and loop. Conditional and loop entries require declarative predicates; JS closures cannot round-trip through storage. After this returns, the workflow is immediately runnable. Call it exactly once with the complete definition; there is no incremental save API.',
+    inputSchema: workflowDefinitionInputSchema,
+    outputSchema: z.object({
+      ok: z.literal(true),
+      id: z.string(),
+    }),
+    execute: async (def, { mastra, requestContext }) => {
+      if (!mastra) throw new Error('save-workflow requires a Mastra context.');
+      const m = mastra as Mastra;
+      const normalizedDefinition = normalizeWorkflowBuilderDefinition(def);
+
+      if (options.authorize) {
+        // Normalize again to give policy code a detached JSON-safe value. The
+        // callback can inspect or reject, but cannot mutate the accepted input.
+        const authorizationDefinition = normalizeWorkflowBuilderDefinition(normalizedDefinition);
+        await options.authorize({ definition: authorizationDefinition, requestContext });
+      }
+
+      // `mastra.addDynamicWorkflow` performs registry pre-flight — a mis-classified
+      // agentId/toolId or unregistered id throws before rehydration with an
+      // actionable message listing every offender. It also rejects JSON Schemas
+      // that use keywords the storage-side converter can't rehydrate
+      // (oneOf/anyOf/allOf/not/$ref/patternProperties/discriminator).
+      await m.addDynamicWorkflow(normalizedDefinition as Parameters<Mastra['addDynamicWorkflow']>[0]);
+      return { ok: true as const, id: normalizedDefinition.id };
+    },
+  });
+}
+
+export const saveWorkflowTool = createSaveWorkflowTool();

--- a/mastracode/sdk/src/tools/workflows/save-workflow.ts
+++ b/mastracode/sdk/src/tools/workflows/save-workflow.ts
@@ -16,6 +16,8 @@ import {
   type WorkflowBuilderDefinition,
 } from '@mastra/core/workflows/builder';
 import { z } from 'zod';
+import type { DynamicWorkflowAccessPolicy } from '../../workflows/access-policy.js';
+import { resolveDynamicWorkflowAuthorId } from '../../workflows/access-policy.js';
 
 export { WORKFLOW_BUILDER_MAPPING_CONFIG_DESCRIPTION as MAPPING_CONFIG_DESCRIPTION } from '@mastra/core/workflows/builder';
 
@@ -31,9 +33,12 @@ export interface SaveWorkflowAuthorizationContext {
    */
   definition: Readonly<WorkflowBuilderDefinition>;
   requestContext: RequestContext;
+  /** Trusted owner resolved from the request context when an access policy is configured. */
+  authorId?: string;
 }
 
 export interface CreateSaveWorkflowToolOptions {
+  accessPolicy?: DynamicWorkflowAccessPolicy;
   /**
    * Optional deny-only policy hook. Throw to reject the save. Return normally
    * to allow it. The callback cannot replace or rewrite the saved definition.
@@ -61,11 +66,20 @@ export function createSaveWorkflowTool(options: CreateSaveWorkflowToolOptions = 
       const m = mastra as Mastra;
       const normalizedDefinition = normalizeWorkflowBuilderDefinition(def);
 
+      if ((options.accessPolicy || options.authorize) && !requestContext) {
+        throw new Error('save-workflow authorization requires a request context.');
+      }
+
+      const authorId = await resolveDynamicWorkflowAuthorId(options.accessPolicy, requestContext);
+      if (options.accessPolicy && !authorId) {
+        throw new Error('Dynamic workflow not found.');
+      }
+
       if (options.authorize) {
         // Normalize again to give policy code a detached JSON-safe value. The
         // callback can inspect or reject, but cannot mutate the accepted input.
         const authorizationDefinition = normalizeWorkflowBuilderDefinition(normalizedDefinition);
-        await options.authorize({ definition: authorizationDefinition, requestContext });
+        await options.authorize({ definition: authorizationDefinition, requestContext: requestContext!, authorId });
       }
 
       // `mastra.addDynamicWorkflow` performs registry pre-flight — a mis-classified
@@ -73,7 +87,9 @@ export function createSaveWorkflowTool(options: CreateSaveWorkflowToolOptions = 
       // actionable message listing every offender. It also rejects JSON Schemas
       // that use keywords the storage-side converter can't rehydrate
       // (oneOf/anyOf/allOf/not/$ref/patternProperties/discriminator).
-      await m.addDynamicWorkflow(normalizedDefinition as Parameters<Mastra['addDynamicWorkflow']>[0]);
+      const definition = normalizedDefinition as Parameters<Mastra['addDynamicWorkflow']>[0];
+      if (authorId !== undefined) await m.addDynamicWorkflow(definition, { authorId });
+      else await m.addDynamicWorkflow(definition);
       return { ok: true as const, id: normalizedDefinition.id };
     },
   });

--- a/mastracode/sdk/src/workflows/__tests__/service.access-policy.test.ts
+++ b/mastracode/sdk/src/workflows/__tests__/service.access-policy.test.ts
@@ -1,0 +1,121 @@
+import { Mastra } from '@mastra/core/mastra';
+import { RequestContext } from '@mastra/core/request-context';
+import { InMemoryStore } from '@mastra/core/storage';
+import { createWorkflow, toStorableGraph } from '@mastra/core/workflows';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import type { DynamicWorkflowAccessPolicy } from '../access-policy.js';
+import { createWorkflowService } from '../service.js';
+
+const accessPolicy: DynamicWorkflowAccessPolicy = {
+  resolveAuthorId: ({ requestContext }) => requestContext.get('verifiedAuthorId') as string | undefined,
+};
+
+function requestContext(authorId?: string) {
+  const context = new RequestContext();
+  if (authorId) context.set('verifiedAuthorId', authorId);
+  return context;
+}
+
+function definition(id: string) {
+  const workflow = createWorkflow({
+    id,
+    inputSchema: z.object({ value: z.string() }),
+    outputSchema: z.object({ value: z.string() }),
+  })
+    .map({ value: { template: '${initData.value}' } })
+    .commit();
+  return {
+    id,
+    inputSchema: { type: 'object', properties: { value: { type: 'string' } }, required: ['value'] },
+    outputSchema: { type: 'object', properties: { value: { type: 'string' } }, required: ['value'] },
+    graph: JSON.parse(JSON.stringify(toStorableGraph(workflow.stepGraph))),
+  };
+}
+
+function codeWorkflow() {
+  return createWorkflow({
+    id: 'code-workflow',
+    inputSchema: z.object({ value: z.string() }),
+    outputSchema: z.object({ value: z.string() }),
+  })
+    .map({ value: { template: '${initData.value}' } })
+    .commit();
+}
+
+async function setup() {
+  const mastra = new Mastra({
+    logger: false,
+    storage: new InMemoryStore({ id: 'workflow-access-policy' }),
+    workflows: { codeWorkflow: codeWorkflow() },
+  });
+  await mastra.addDynamicWorkflow(definition('tenant-a-workflow'), { authorId: 'tenant-a' });
+  await mastra.addDynamicWorkflow(definition('tenant-b-workflow'), { authorId: 'tenant-b' });
+  return mastra;
+}
+
+describe('createWorkflowService access policy', () => {
+  it('lists and gets only the caller dynamic definitions while retaining code workflow discovery', async () => {
+    const mastra = await setup();
+    const service = createWorkflowService({ accessPolicy });
+    const context = { requestContext: requestContext('tenant-a') };
+
+    await expect(service.listWorkflows(mastra, context)).resolves.toMatchObject({
+      workflows: [{ id: 'tenant-a-workflow' }],
+      total: 1,
+    });
+    await expect(service.getWorkflow(mastra, 'tenant-a-workflow', context)).resolves.toMatchObject({
+      id: 'tenant-a-workflow',
+    });
+    await expect(service.getWorkflow(mastra, 'tenant-b-workflow', context)).resolves.toBeNull();
+
+    const registered = await service.listAccessibleRegisteredWorkflows(mastra, context);
+    expect(Object.keys(registered)).toContain('codeWorkflow');
+    expect(Object.values(registered).map(workflow => workflow.id)).toContain('tenant-a-workflow');
+    expect(Object.values(registered).map(workflow => workflow.id)).not.toContain('tenant-b-workflow');
+  });
+
+  it('denies cross-owner execution and deletion without disclosing the owner', async () => {
+    const mastra = await setup();
+    const service = createWorkflowService({ accessPolicy });
+    const tenantA = requestContext('tenant-a');
+
+    await expect(service.runWorkflow(mastra, 'tenant-b-workflow', { value: 'secret' }, tenantA)).rejects.toThrow(
+      'Dynamic workflow not found.',
+    );
+    await expect(service.runWorkflow(mastra, 'missing-workflow', { value: 'secret' }, tenantA)).rejects.toThrow(
+      'Dynamic workflow not found.',
+    );
+    await expect(service.deleteWorkflow(mastra, 'tenant-b-workflow', { requestContext: tenantA })).resolves.toEqual({
+      ok: true,
+      id: 'tenant-b-workflow',
+    });
+    expect(
+      await mastra
+        .getStorage()
+        ?.getStore('workflowDefinitions')
+        .then(store => store?.get('tenant-b-workflow')),
+    ).toMatchObject({ authorId: 'tenant-b' });
+  });
+
+  it('fails closed for dynamic workflows when the policy cannot resolve a caller', async () => {
+    const mastra = await setup();
+    const service = createWorkflowService({ accessPolicy });
+    const context = { requestContext: requestContext() };
+
+    await expect(service.listWorkflows(mastra, context)).resolves.toEqual({ workflows: [], total: 0 });
+    await expect(service.getWorkflow(mastra, 'tenant-a-workflow', context)).resolves.toBeNull();
+    await expect(
+      service.runWorkflow(mastra, 'tenant-a-workflow', { value: 'secret' }, context.requestContext),
+    ).rejects.toThrow('Dynamic workflow not found.');
+
+    const registered = await service.listAccessibleRegisteredWorkflows(mastra, context);
+    expect(Object.keys(registered)).toEqual(['codeWorkflow']);
+
+    await expect(service.runWorkflow(mastra, 'codeWorkflow', { value: 'public' })).resolves.toMatchObject({
+      status: 'success',
+      result: { value: 'public' },
+    });
+  });
+});

--- a/mastracode/sdk/src/workflows/access-policy.ts
+++ b/mastracode/sdk/src/workflows/access-policy.ts
@@ -1,0 +1,32 @@
+import type { RequestContext } from '@mastra/core/request-context';
+
+export interface DynamicWorkflowAccessPolicy {
+  /**
+   * Resolve the trusted owner for the current Mastra Code request. The host
+   * should read identity installed by its authentication middleware, never a
+   * workflow id or owner supplied in tool input.
+   *
+   * Returning `null` or `undefined` fails closed for dynamic workflows.
+   */
+  resolveAuthorId: (context: {
+    requestContext: RequestContext;
+  }) => string | null | undefined | Promise<string | null | undefined>;
+}
+
+export class DynamicWorkflowAccessDeniedError extends Error {
+  constructor() {
+    super('Dynamic workflow not found.');
+    this.name = 'DynamicWorkflowAccessDeniedError';
+  }
+}
+
+export async function resolveDynamicWorkflowAuthorId(
+  policy: DynamicWorkflowAccessPolicy | undefined,
+  requestContext: RequestContext | undefined,
+): Promise<string | undefined> {
+  if (!policy) return undefined;
+  if (!requestContext) return undefined;
+
+  const authorId = await policy.resolveAuthorId({ requestContext });
+  return typeof authorId === 'string' && authorId.length > 0 ? authorId : undefined;
+}

--- a/mastracode/sdk/src/workflows/register-primitives.ts
+++ b/mastracode/sdk/src/workflows/register-primitives.ts
@@ -30,7 +30,7 @@ import { createNotificationInboxTool } from '@mastra/core/notifications';
 import { LocalFilesystem, LocalSandbox, Workspace, createWorkspaceTools } from '@mastra/core/workspace';
 import { MASTRACODE_WORKSPACE_TOOLS } from '../agents/tool-availability.js';
 import { LazyNotificationsStorage } from '../agents/tools.js';
-import { workflowBuilderAgent } from '../agents/workflow-builder-agent.js';
+import { workflowBuilderAgent as defaultWorkflowBuilderAgent } from '../agents/workflow-builder-agent.js';
 import type { McpManager } from '../mcp';
 import { MC_TOOLS } from '../tool-names.js';
 import { createWebExtractTool, createWebSearchTool, hasTavilyKey } from '../tools/web-search.js';
@@ -50,6 +50,8 @@ export interface RegisterWorkflowBuilderPrimitivesOptions {
    * (workspace/MCP/web/etc.) via its own `tools: createDynamicTools(...)`.
    */
   codeAgent: Agent;
+  /** Request-aware workflow builder instance created with the host access policy. */
+  workflowBuilderAgent?: Agent;
   /**
    * McpManager for snapshotting MCP tools at boot. Omit or pass undefined
    * if MCP is disabled — workflow-builder will just see fewer tools.
@@ -61,7 +63,13 @@ export async function registerWorkflowBuilderPrimitives(
   mastra: Mastra,
   options: RegisterWorkflowBuilderPrimitivesOptions,
 ): Promise<void> {
-  const { projectPath, allowedPaths = [], codeAgent, mcpManager } = options;
+  const {
+    projectPath,
+    allowedPaths = [],
+    codeAgent,
+    workflowBuilderAgent = defaultWorkflowBuilderAgent,
+    mcpManager,
+  } = options;
 
   // 1. Agents workflows can compose.
   mastra.addAgent(workflowBuilderAgent, 'workflow-builder');

--- a/mastracode/sdk/src/workflows/service.ts
+++ b/mastracode/sdk/src/workflows/service.ts
@@ -1,7 +1,7 @@
 /**
- * Thin wrapper around `mastra.getStorage().getStore('workflowDefinitions')` and
- * `mastra.getWorkflow(id).createRun().stream(...)` so both the parent-mode
- * tools and the `/workflows` slash command go through one implementation.
+ * Thin wrapper around Mastra's dynamic workflow and run APIs so both the
+ * parent-mode tools and the `/workflows` slash command go through one
+ * implementation.
  */
 import type { Mastra } from '@mastra/core/mastra';
 
@@ -40,7 +40,6 @@ interface WorkflowRunOutputLike {
 interface WorkflowDefinitionsStore {
   list: (args?: { status?: 'active' | 'archived' }) => Promise<{ definitions: StoredWorkflowRow[]; total: number }>;
   get: (id: string) => Promise<StoredWorkflowRow | null>;
-  delete: (id: string) => Promise<void>;
 }
 
 async function workflowDefinitionsStore(mastra: Mastra): Promise<WorkflowDefinitionsStore> {
@@ -68,12 +67,7 @@ export async function getWorkflow(mastra: Mastra, id: string): Promise<StoredWor
 }
 
 export async function deleteWorkflow(mastra: Mastra, id: string): Promise<{ ok: true; id: string }> {
-  const store = await workflowDefinitionsStore(mastra);
-  await store.delete(id);
-  // Also unregister the live in-process Workflow instance so a subsequent
-  // save-workflow with the same id re-registers cleanly instead of getting
-  // no-op'd by addWorkflow's first-write-wins guard.
-  mastra.removeWorkflow(id);
+  await mastra.deleteDynamicWorkflow(id);
   return { ok: true, id };
 }
 

--- a/mastracode/sdk/src/workflows/service.ts
+++ b/mastracode/sdk/src/workflows/service.ts
@@ -4,6 +4,13 @@
  * implementation.
  */
 import type { Mastra } from '@mastra/core/mastra';
+import type { RequestContext } from '@mastra/core/request-context';
+import type { WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  DynamicWorkflowAccessDeniedError,
+  type DynamicWorkflowAccessPolicy,
+  resolveDynamicWorkflowAuthorId,
+} from './access-policy.js';
 
 export interface StoredWorkflowRow {
   id: string;
@@ -37,95 +44,160 @@ interface WorkflowRunOutputLike {
   result: Promise<unknown>;
 }
 
-interface WorkflowDefinitionsStore {
-  list: (args?: { status?: 'active' | 'archived' }) => Promise<{ definitions: StoredWorkflowRow[]; total: number }>;
-  get: (id: string) => Promise<StoredWorkflowRow | null>;
+export interface WorkflowServiceContext {
+  requestContext?: RequestContext;
 }
 
-async function workflowDefinitionsStore(mastra: Mastra): Promise<WorkflowDefinitionsStore> {
+export interface CreateWorkflowServiceOptions {
+  accessPolicy?: DynamicWorkflowAccessPolicy;
+}
+
+async function workflowDefinitionsStore(mastra: Mastra): Promise<WorkflowDefinitionsStorage> {
   const storage = mastra.getStorage();
   if (!storage) throw new Error('Storage is not configured on the Mastra instance.');
-  // `getStore` is a generic domain accessor; workflowDefinitions is registered
-  // by mastracode. The domain shape is validated at boot; cast the resolved
-  // store to the interface we exercise.
-  const store = (await (storage as unknown as { getStore: (name: string) => Promise<unknown> }).getStore(
-    'workflowDefinitions',
-  )) as WorkflowDefinitionsStore | undefined;
+  const store = await storage.getStore('workflowDefinitions');
   if (!store) throw new Error('workflowDefinitions storage domain is not available.');
   return store;
 }
 
-export async function listWorkflows(mastra: Mastra): Promise<{ workflows: StoredWorkflowRow[]; total: number }> {
-  const store = await workflowDefinitionsStore(mastra);
-  const result = await store.list({ status: 'active' });
-  return { workflows: result.definitions, total: result.total };
-}
-
-export async function getWorkflow(mastra: Mastra, id: string): Promise<StoredWorkflowRow | null> {
-  const store = await workflowDefinitionsStore(mastra);
-  return store.get(id);
-}
-
-export async function deleteWorkflow(mastra: Mastra, id: string): Promise<{ ok: true; id: string }> {
-  await mastra.deleteDynamicWorkflow(id);
-  return { ok: true, id };
-}
-
-export async function runWorkflow(
+async function assertDynamicWorkflowAccess(
   mastra: Mastra,
-  workflowId: string,
-  inputData: unknown,
-  /**
-   * Optional. When provided, passed through to `run.stream(...)` so agent steps
-   * (like `code-agent`) that depend on session state — `getDynamicModel` reads
-   * `controller.session.modelId` off it — can resolve correctly.
-   *
-   * Chat-driven `run-workflow` inherits its context from the parent code-agent
-   * turn, so this is unused there. The `/workflows run` slash handler builds a
-   * synthetic context from the current TUI session and passes it here.
-   */
-  requestContext?: unknown,
-  /**
-   * Optional. When provided, invoked for every `WorkflowStreamEvent` the run
-   * emits — used by the `/workflows run` slash handler to render live per-step
-   * progress in the TUI. Non-fatal: errors in the callback are swallowed so a
-   * misbehaving consumer can't take the workflow down.
-   */
-  onEvent?: WorkflowRunEventCallback,
-): Promise<RunResult> {
-  // `getWorkflow` is generic over the statically-registered workflow map, but
-  // stored workflows are registered dynamically at load time — the id is a
-  // runtime value, not a compile-time key. `as never` widens the arg past the
-  // generic constraint; the runtime lookup already validates.
-  let wf: ReturnType<Mastra['getWorkflow']> | undefined;
-  let lookupError: unknown;
-  try {
-    wf = mastra.getWorkflow(workflowId as never);
-  } catch (error) {
-    lookupError = error;
+  id: string,
+  authorId: string | undefined,
+  scoped: boolean,
+): Promise<StoredWorkflowRow> {
+  const definition = await (await workflowDefinitionsStore(mastra)).get(id);
+  if (!definition || (scoped && (!authorId || definition.authorId !== authorId))) {
+    throw new DynamicWorkflowAccessDeniedError();
   }
-  if (!wf) {
-    throw new Error(`No workflow registered with id "${workflowId}". Was it built and saved?`, { cause: lookupError });
-  }
-
-  const run = await wf.createRun();
-  if (!onEvent) {
-    return (await run.start({
-      inputData,
-      requestContext: requestContext as Parameters<typeof run.start>[0]['requestContext'],
-    })) as RunResult;
-  }
-
-  const output = run.stream({
-    inputData,
-    requestContext: requestContext as Parameters<typeof run.stream>[0]['requestContext'],
-  }) as unknown as WorkflowRunOutputLike;
-  for await (const event of output.fullStream) {
-    try {
-      onEvent(event);
-    } catch {
-      // Never let a bad consumer break the run.
-    }
-  }
-  return (await output.result) as RunResult;
+  return definition;
 }
+
+export function createWorkflowService(options: CreateWorkflowServiceOptions = {}) {
+  const { accessPolicy } = options;
+
+  async function resolveAuthorId(context?: WorkflowServiceContext): Promise<string | undefined> {
+    return resolveDynamicWorkflowAuthorId(accessPolicy, context?.requestContext);
+  }
+
+  return {
+    async listWorkflows(
+      mastra: Mastra,
+      context?: WorkflowServiceContext,
+    ): Promise<{ workflows: StoredWorkflowRow[]; total: number }> {
+      const authorId = await resolveAuthorId(context);
+      if (accessPolicy && !authorId) return { workflows: [], total: 0 };
+      const result = await (
+        await workflowDefinitionsStore(mastra)
+      ).list({
+        status: 'active',
+        ...(authorId !== undefined ? { authorId } : {}),
+      });
+      return { workflows: result.definitions, total: result.total };
+    },
+
+    async getWorkflow(mastra: Mastra, id: string, context?: WorkflowServiceContext): Promise<StoredWorkflowRow | null> {
+      const authorId = await resolveAuthorId(context);
+      if (accessPolicy && !authorId) return null;
+      const definition = await (await workflowDefinitionsStore(mastra)).get(id);
+      if (!definition || (authorId !== undefined && definition.authorId !== authorId)) return null;
+      return definition;
+    },
+
+    async listAccessibleRegisteredWorkflows(mastra: Mastra, context?: WorkflowServiceContext) {
+      const authorId = await resolveAuthorId(context);
+      if (!accessPolicy) return mastra.listWorkflows?.() ?? {};
+
+      const result = authorId
+        ? await (await workflowDefinitionsStore(mastra)).list({ status: 'active', authorId })
+        : { definitions: [] };
+      const accessibleDynamicIds = new Set(result.definitions.map(definition => definition.id));
+      return Object.fromEntries(
+        Object.entries(mastra.listWorkflows?.() ?? {}).filter(([, workflow]) => {
+          const workflowId = (workflow as { id: string }).id;
+          return mastra.getWorkflowOrigin(workflowId) !== 'dynamic' || accessibleDynamicIds.has(workflowId);
+        }),
+      );
+    },
+
+    async deleteWorkflow(
+      mastra: Mastra,
+      id: string,
+      context?: WorkflowServiceContext,
+    ): Promise<{ ok: true; id: string }> {
+      const authorId = await resolveAuthorId(context);
+      if (accessPolicy && !authorId) return { ok: true, id };
+      await mastra.deleteDynamicWorkflow(id, authorId !== undefined ? { authorId } : undefined);
+      return { ok: true, id };
+    },
+
+    async runWorkflow(
+      mastra: Mastra,
+      workflowId: string,
+      inputData: unknown,
+      /**
+       * Optional. When provided, passed through to `run.stream(...)` so agent steps
+       * (like `code-agent`) that depend on session state — `getDynamicModel` reads
+       * `controller.session.modelId` off it — can resolve correctly.
+       *
+       * Chat-driven `run-workflow` inherits its context from the parent code-agent
+       * turn, so this is unused there. The `/workflows run` slash handler builds a
+       * synthetic context from the current TUI session and passes it here.
+       */
+      requestContext?: RequestContext,
+      /**
+       * Optional. When provided, invoked for every `WorkflowStreamEvent` the run
+       * emits — used by the `/workflows run` slash handler to render live per-step
+       * progress in the TUI. Non-fatal: errors in the callback are swallowed so a
+       * misbehaving consumer can't take the workflow down.
+       */
+      onEvent?: WorkflowRunEventCallback,
+    ): Promise<RunResult> {
+      // `getWorkflow` is generic over the statically-registered workflow map, but
+      // stored workflows are registered dynamically at load time — the id is a
+      // runtime value, not a compile-time key. `as never` widens the arg past the
+      // generic constraint; the runtime lookup already validates.
+      let wf: ReturnType<Mastra['getWorkflow']> | undefined;
+      let lookupError: unknown;
+      try {
+        wf = mastra.getWorkflow(workflowId as never);
+      } catch (error) {
+        lookupError = error;
+      }
+      if (!wf) {
+        if (accessPolicy) throw new DynamicWorkflowAccessDeniedError();
+        throw new Error(`No workflow registered with id "${workflowId}". Was it built and saved?`, {
+          cause: lookupError,
+        });
+      }
+
+      if (mastra.getWorkflowOrigin?.(wf.id) === 'dynamic') {
+        const authorId = await resolveAuthorId({ requestContext });
+        await assertDynamicWorkflowAccess(mastra, wf.id, authorId, Boolean(accessPolicy));
+      }
+
+      const run = await wf.createRun();
+      if (!onEvent) {
+        return (await run.start({ inputData, requestContext })) as RunResult;
+      }
+
+      const output = run.stream({ inputData, requestContext }) as unknown as WorkflowRunOutputLike;
+      for await (const event of output.fullStream) {
+        try {
+          onEvent(event);
+        } catch {
+          // Never let a bad consumer break the run.
+        }
+      }
+      return (await output.result) as RunResult;
+    },
+  };
+}
+
+const defaultWorkflowService = createWorkflowService();
+
+export const listWorkflows = defaultWorkflowService.listWorkflows;
+export const getWorkflow = defaultWorkflowService.getWorkflow;
+export const listAccessibleRegisteredWorkflows = defaultWorkflowService.listAccessibleRegisteredWorkflows;
+export const deleteWorkflow = defaultWorkflowService.deleteWorkflow;
+export const runWorkflow = defaultWorkflowService.runWorkflow;

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { InMemoryStore, WorkflowDefinitionOwnershipConflictError } from '../storage';
 import { createTool } from '../tools';
+import { createWorkflow } from '../workflows/create';
 import { Mastra } from './index';
 
 const lookupCustomer = createTool({
@@ -48,6 +49,15 @@ function helperDefinition(id: string, sourceField: string) {
   };
 }
 
+function nestedDefinition(id: string, workflowId: string) {
+  return {
+    id,
+    inputSchema: objectSchema({ email1: stringSchema, email2: stringSchema }, ['email1', 'email2']),
+    outputSchema: customerSchema,
+    graph: [{ type: 'workflow' as const, id: `${id}-call`, workflowId }],
+  };
+}
+
 /** The root: a real parallel over both helpers, merged by call-site id. */
 const rootDefinition = {
   id: 'parallel-customer-lookup',
@@ -79,6 +89,16 @@ function createMastra(id: string) {
     tools: { 'lookup-customer': lookupCustomer } as any,
     storage: new InMemoryStore({ id }),
   });
+}
+
+function codeWorkflow() {
+  return createWorkflow({
+    id: 'code-workflow',
+    inputSchema: z.object({ email1: z.string(), email2: z.string() }),
+    outputSchema: z.object({ customerId: z.string(), email: z.string() }),
+  })
+    .tool(lookupCustomer)
+    .commit();
 }
 
 describe('Mastra.addDynamicWorkflows', () => {
@@ -332,6 +352,85 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect(mastra.getWorkflow('lookup-first-customer')).toBe(original);
     const store = (await storage.getStore('workflowDefinitions'))!;
     expect((await store.get('lookup-first-customer'))?.authorId).toBe('verified-author');
+  });
+
+  it('allows a trusted definition to nest a dynamic workflow owned by the same author', async () => {
+    const mastra = createMastra('bundle-nested-same-owner');
+    await mastra.addDynamicWorkflow(helperDefinition('owned-helper', 'email1'), { authorId: 'author-1' });
+
+    await expect(
+      mastra.addDynamicWorkflow(nestedDefinition('owned-root', 'owned-helper'), { authorId: 'author-1' }),
+    ).resolves.toBeUndefined();
+
+    expect(mastra.getWorkflow('owned-root')).toBeDefined();
+  });
+
+  it('rejects a cross-owner dynamic nested workflow before mutating the registry', async () => {
+    const mastra = createMastra('bundle-nested-cross-owner');
+    await mastra.addDynamicWorkflow(helperDefinition('private-helper', 'email1'), { authorId: 'author-1' });
+    const originalHelper = mastra.getWorkflow('private-helper');
+
+    await expect(
+      mastra.addDynamicWorkflow(nestedDefinition('foreign-root', 'private-helper'), { authorId: 'author-2' }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(mastra.getWorkflow('private-helper')).toBe(originalHelper);
+    expect(() => mastra.getWorkflow('foreign-root')).toThrow();
+    const store = (await mastra.getStorage()!.getStore('workflowDefinitions'))!;
+    await expect(store.get('foreign-root')).resolves.toBeNull();
+  });
+
+  it('rejects a legacy unowned dynamic nested workflow for a trusted author', async () => {
+    const mastra = createMastra('bundle-nested-legacy-owner');
+    await mastra.addDynamicWorkflow(helperDefinition('legacy-helper', 'email1'));
+
+    await expect(
+      mastra.addDynamicWorkflow(nestedDefinition('owned-root', 'legacy-helper'), { authorId: 'author-1' }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(() => mastra.getWorkflow('owned-root')).toThrow();
+  });
+
+  it('rejects a trusted definition that collides with a code-defined workflow', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-code-collision' });
+    const code = codeWorkflow();
+    const mastra = new Mastra({
+      logger: false,
+      tools: { 'lookup-customer': lookupCustomer } as any,
+      workflows: { 'code-workflow': code } as any,
+      storage,
+    });
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('code-workflow', 'email1'), { authorId: 'author-1' }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(mastra.getWorkflow('code-workflow')).toBe(code);
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    await expect(store.get('code-workflow')).resolves.toBeNull();
+  });
+
+  it('rejects a code-defined collision even when a same-owner stored shadow exists', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-code-shadow-collision' });
+    const code = codeWorkflow();
+    const mastra = new Mastra({
+      logger: false,
+      tools: { 'lookup-customer': lookupCustomer } as any,
+      workflows: { 'code-workflow': code } as any,
+      storage,
+    });
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    await store.upsert({ ...helperDefinition('code-workflow', 'email1'), authorId: 'author-1' } as any);
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('code-workflow', 'email2'), { authorId: 'author-1' }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(mastra.getWorkflow('code-workflow')).toBe(code);
+    await expect(store.get('code-workflow')).resolves.toMatchObject({
+      authorId: 'author-1',
+      description: 'Looks up the customer named by "email1".',
+    });
   });
 
   it('serializes overlapping bundles so a rejected owner cannot roll back the winner', async () => {

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import { InMemoryStore } from '../storage';
+import { InMemoryStore, WorkflowDefinitionOwnershipConflictError } from '../storage';
 import { createTool } from '../tools';
 import { Mastra } from './index';
 
@@ -296,6 +296,26 @@ describe('Mastra.addDynamicWorkflows', () => {
     const definition = await store.get('lookup-first-customer');
 
     expect(definition?.authorId).toBe('verified-author');
+  });
+
+  it('rejects a different trusted author and restores the previous registration', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-conflict' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+      authorId: 'verified-author',
+    });
+    const original = mastra.getWorkflow('lookup-first-customer');
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email2'), {
+        authorId: 'other-author',
+      }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(mastra.getWorkflow('lookup-first-customer')).toBe(original);
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    expect((await store.get('lookup-first-customer'))?.authorId).toBe('verified-author');
   });
 
   it('is a no-op for an empty bundle', async () => {

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -318,6 +318,62 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect((await store.get('lookup-first-customer'))?.authorId).toBe('verified-author');
   });
 
+  it('serializes overlapping bundles so a rejected owner cannot roll back the winner', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-concurrent-owner-conflict' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const realUpsert = store.upsert.bind(store);
+
+    let releaseFirstUpsert!: () => void;
+    const firstUpsertEntered = new Promise<void>(resolve => {
+      releaseFirstUpsert = resolve;
+    });
+    let upsertCalls = 0;
+    store.upsert = (async definition => {
+      upsertCalls += 1;
+      if (upsertCalls === 1) {
+        releaseFirstUpsert();
+        // Keep the first bundle inside persistence for one event-loop turn.
+        // Without registration serialization, the overlapping bundle can
+        // replace its registry slots and win storage before this write resumes.
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+      }
+      return realUpsert(definition);
+    }) as typeof store.upsert;
+
+    const winner = mastra.addDynamicWorkflows(
+      [
+        { ...helperDefinition('shared-helper', 'email1'), description: 'winner' },
+        helperDefinition('winner-only', 'email1'),
+      ],
+      { authorId: 'winner-author' },
+    );
+    await firstUpsertEntered;
+
+    const loser = mastra.addDynamicWorkflows(
+      [
+        { ...helperDefinition('shared-helper', 'email2'), description: 'loser' },
+        helperDefinition('loser-only', 'email2'),
+      ],
+      { authorId: 'loser-author' },
+    );
+
+    const [winnerResult, loserResult] = await Promise.allSettled([winner, loser]);
+    expect(winnerResult.status).toBe('fulfilled');
+    expect(loserResult).toMatchObject({
+      status: 'rejected',
+      reason: expect.any(WorkflowDefinitionOwnershipConflictError),
+    });
+
+    expect(await store.get('shared-helper')).toMatchObject({ authorId: 'winner-author', description: 'winner' });
+    expect(await store.get('winner-only')).toMatchObject({ authorId: 'winner-author' });
+    expect(await store.get('loser-only')).toBeNull();
+
+    expect(mastra.getWorkflow('shared-helper').description).toBe('winner');
+    expect(mastra.getWorkflow('winner-only')).toBeDefined();
+    expect(() => mastra.getWorkflow('loser-only')).toThrow();
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -283,6 +283,22 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect(definitions.every(definition => definition.authorId === 'verified-author')).toBe(true);
   });
 
+  it('rejects an authored bundle before live registration when workflow definition storage is unavailable', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-no-definition-store' });
+    const getStore = storage.getStore.bind(storage);
+    storage.getStore = (async domain =>
+      domain === 'workflowDefinitions' ? undefined : getStore(domain)) as typeof storage.getStore;
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+        authorId: 'verified-author',
+      }),
+    ).rejects.toThrow(/workflowDefinitions storage domain is required/);
+
+    expect(() => mastra.getWorkflow('lookup-first-customer')).toThrow();
+  });
+
   it('preserves an existing author when a trusted author is omitted on replacement', async () => {
     const storage = new InMemoryStore({ id: 'bundle-author-preserved' });
     const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -262,6 +262,42 @@ describe('Mastra.addDynamicWorkflows', () => {
     ]);
   });
 
+  it('persists one trusted author for every member outside the workflow definitions', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    const untrustedHelper = {
+      ...helperDefinition('lookup-first-customer', 'email1'),
+      authorId: 'forged-author',
+    };
+
+    await mastra.addDynamicWorkflows(
+      [untrustedHelper, helperDefinition('lookup-second-customer', 'email2'), rootDefinition],
+      { authorId: 'verified-author' },
+    );
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const { definitions } = await store.list({ status: 'active' });
+
+    expect(definitions).toHaveLength(3);
+    expect(definitions.every(definition => definition.authorId === 'verified-author')).toBe(true);
+  });
+
+  it('preserves an existing author when a trusted author is omitted on replacement', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-preserved' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+      authorId: 'verified-author',
+    });
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email2'));
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const definition = await store.get('lookup-first-customer');
+
+    expect(definition?.authorId).toBe('verified-author');
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -4855,6 +4855,9 @@ export class Mastra<
    *   before anything is mutated.
    * - If hydration or persistence fails partway, the in-memory registry is
    *   restored to its prior state.
+   * - Registrations are serialized on this Mastra instance through validation,
+   *   hydration, and persistence so one caller's rollback cannot undo another
+   *   caller's accepted live registration.
    * - Storage writes happen last. A storage-level failure mid-bundle is the
    *   one residual window where rows can be partially written; the registry is
    *   still rolled back, and the orphaned rows are inert until the next boot.
@@ -4901,6 +4904,13 @@ export class Mastra<
           graph: def.graph,
         }),
       }));
+
+      const store = await this.#storage?.getStore('workflowDefinitions');
+      if (options?.authorId !== undefined && !store) {
+        throw new Error(
+          'A workflowDefinitions storage domain is required when registering an authored dynamic workflow.',
+        );
+      }
 
       // Members may nest each other, so the index every member validates against
       // is the live registries plus the bundle itself — not the registry alone.
@@ -4966,7 +4976,6 @@ export class Mastra<
           this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
         }
 
-        const store = await this.#storage?.getStore('workflowDefinitions');
         if (store) {
           for (const { normalized } of ordered) {
             await store.upsert({

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -688,6 +688,7 @@ export class Mastra<
   #workflows: TWorkflows;
   #harnesses: Record<string, Harness<any>> = {};
   #hiddenWorkflowKeys = new Set<string>();
+  #dynamicWorkflowRegistrationTail: Promise<void> = Promise.resolve();
   #observability: ObservabilityEntrypoint;
   #observabilityExplicit = false;
   #onScorerHook?: ReturnType<typeof createOnScorerHook>;
@@ -4758,6 +4759,26 @@ export class Mastra<
   }
 
   /**
+   * Runs dynamic workflow registrations one at a time so each rollback owns a
+   * stable registry snapshot. An instance-wide queue also makes overlapping
+   * bundles deadlock-free because callers never acquire per-workflow locks.
+   */
+  async #serializeDynamicWorkflowRegistration<T>(operation: () => Promise<T>): Promise<T> {
+    const prior = this.#dynamicWorkflowRegistrationTail;
+    let release!: () => void;
+    this.#dynamicWorkflowRegistrationTail = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    await prior;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  /**
    * Flattens this instance's registries into the index the dynamic-workflow
    * validation core resolves references and schemas against. Registered keys
    * and canonical ids both count as valid references. Schemas are converted
@@ -4854,116 +4875,118 @@ export class Mastra<
   ): Promise<void> {
     if (defs.length === 0) return;
 
-    const seen = new Set<string>();
-    for (const def of defs) {
-      if (seen.has(def.id)) {
-        throw new Error(
-          `Dynamic workflow bundle contains more than one definition with id "${def.id}". Ids must be unique within a bundle.`,
-        );
-      }
-      seen.add(def.id);
-    }
-
-    // Save-path is strict (boot-time load is lenient — see #loadDynamicWorkflows).
-    // Normalization coerces the wire shape; one validation call per member
-    // covers structure, JSON-Schema keywords, references, and schema-flow.
-    const members = defs.map(def => ({
-      normalized: normalizeWorkflowBuilderDefinition({
-        id: def.id,
-        description: def.description,
-        metadata: def.metadata,
-        inputSchema: def.inputSchema,
-        outputSchema: def.outputSchema,
-        stateSchema: def.stateSchema,
-        requestContextSchema: def.requestContextSchema,
-        graph: def.graph,
-      }),
-    }));
-
-    // Members may nest each other, so the index every member validates against
-    // is the live registries plus the bundle itself — not the registry alone.
-    const index = this.#buildWorkflowRegistryIndex();
-    const bundleIds = new Set(members.map(member => member.normalized.id));
-    for (const { normalized } of members) {
-      (index.workflows ??= {})[normalized.id] = {
-        inputSchema: normalized.inputSchema,
-        outputSchema: normalized.outputSchema,
-      } as WorkflowRegistrySchemas;
-    }
-    for (const { normalized } of members) {
-      assertValidDynamicWorkflow(normalized, index);
-    }
-
-    // Hydration resolves nested workflows through the live registry, so a
-    // member cannot be hydrated before the bundle members it nests.
-    const ordered: typeof members = [];
-    const remaining = new Map(members.map(member => [member.normalized.id, member] as const));
-    const hydrated = new Set<string>();
-    let progress = true;
-    while (remaining.size > 0 && progress) {
-      progress = false;
-      for (const [id, member] of Array.from(remaining)) {
-        const pending = Array.from(collectNestedWorkflowIds(member.normalized.graph)).filter(
-          dependency => dependency !== id && bundleIds.has(dependency) && !hydrated.has(dependency),
-        );
-        if (pending.length > 0) continue;
-        remaining.delete(id);
-        hydrated.add(id);
-        ordered.push(member);
-        progress = true;
-      }
-    }
-    if (remaining.size > 0) {
-      throw new Error(
-        `Dynamic workflow bundle has a circular nested-workflow dependency among: ${Array.from(remaining.keys())
-          .sort()
-          .join(', ')}.`,
-      );
-    }
-
-    // Snapshot the registry slots this bundle will overwrite so a failure
-    // anywhere below leaves the instance exactly as it was found.
-    const registry = this.#workflows as Record<string, AnyWorkflow>;
-    const priorWorkflows = new Map<string, AnyWorkflow | undefined>();
-    const priorHiddenKeys = new Set<string>();
-    for (const { normalized } of ordered) {
-      priorWorkflows.set(normalized.id, registry[normalized.id]);
-      if (this.#hiddenWorkflowKeys.has(normalized.id)) priorHiddenKeys.add(normalized.id);
-    }
-    const restoreRegistry = () => {
-      for (const [id, prior] of priorWorkflows) {
-        if (prior) registry[id] = prior;
-        else delete registry[id];
-        if (priorHiddenKeys.has(id)) this.#hiddenWorkflowKeys.add(id);
-      }
-    };
-
-    try {
-      for (const { normalized } of ordered) {
-        const { workflow } = await rehydrateWorkflow(normalized, this);
-        this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
+    await this.#serializeDynamicWorkflowRegistration(async () => {
+      const seen = new Set<string>();
+      for (const def of defs) {
+        if (seen.has(def.id)) {
+          throw new Error(
+            `Dynamic workflow bundle contains more than one definition with id "${def.id}". Ids must be unique within a bundle.`,
+          );
+        }
+        seen.add(def.id);
       }
 
-      const store = await this.#storage?.getStore('workflowDefinitions');
-      if (store) {
-        for (const { normalized } of ordered) {
-          await store.upsert({
-            id: normalized.id,
-            description: normalized.description,
-            metadata: normalized.metadata,
-            inputSchema: normalized.inputSchema,
-            outputSchema: normalized.outputSchema,
-            stateSchema: normalized.stateSchema,
-            requestContextSchema: normalized.requestContextSchema,
-            graph: normalized.graph,
-            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
-          });
+      // Save-path is strict (boot-time load is lenient — see #loadDynamicWorkflows).
+      // Normalization coerces the wire shape; one validation call per member
+      // covers structure, JSON-Schema keywords, references, and schema-flow.
+      const members = defs.map(def => ({
+        normalized: normalizeWorkflowBuilderDefinition({
+          id: def.id,
+          description: def.description,
+          metadata: def.metadata,
+          inputSchema: def.inputSchema,
+          outputSchema: def.outputSchema,
+          stateSchema: def.stateSchema,
+          requestContextSchema: def.requestContextSchema,
+          graph: def.graph,
+        }),
+      }));
+
+      // Members may nest each other, so the index every member validates against
+      // is the live registries plus the bundle itself — not the registry alone.
+      const index = this.#buildWorkflowRegistryIndex();
+      const bundleIds = new Set(members.map(member => member.normalized.id));
+      for (const { normalized } of members) {
+        (index.workflows ??= {})[normalized.id] = {
+          inputSchema: normalized.inputSchema,
+          outputSchema: normalized.outputSchema,
+        } as WorkflowRegistrySchemas;
+      }
+      for (const { normalized } of members) {
+        assertValidDynamicWorkflow(normalized, index);
+      }
+
+      // Hydration resolves nested workflows through the live registry, so a
+      // member cannot be hydrated before the bundle members it nests.
+      const ordered: typeof members = [];
+      const remaining = new Map(members.map(member => [member.normalized.id, member] as const));
+      const hydrated = new Set<string>();
+      let progress = true;
+      while (remaining.size > 0 && progress) {
+        progress = false;
+        for (const [id, member] of Array.from(remaining)) {
+          const pending = Array.from(collectNestedWorkflowIds(member.normalized.graph)).filter(
+            dependency => dependency !== id && bundleIds.has(dependency) && !hydrated.has(dependency),
+          );
+          if (pending.length > 0) continue;
+          remaining.delete(id);
+          hydrated.add(id);
+          ordered.push(member);
+          progress = true;
         }
       }
-    } catch (error) {
-      restoreRegistry();
-      throw error;
-    }
+      if (remaining.size > 0) {
+        throw new Error(
+          `Dynamic workflow bundle has a circular nested-workflow dependency among: ${Array.from(remaining.keys())
+            .sort()
+            .join(', ')}.`,
+        );
+      }
+
+      // Snapshot the registry slots this bundle will overwrite so a failure
+      // anywhere below leaves the instance exactly as it was found.
+      const registry = this.#workflows as Record<string, AnyWorkflow>;
+      const priorWorkflows = new Map<string, AnyWorkflow | undefined>();
+      const priorHiddenKeys = new Set<string>();
+      for (const { normalized } of ordered) {
+        priorWorkflows.set(normalized.id, registry[normalized.id]);
+        if (this.#hiddenWorkflowKeys.has(normalized.id)) priorHiddenKeys.add(normalized.id);
+      }
+      const restoreRegistry = () => {
+        for (const [id, prior] of priorWorkflows) {
+          if (prior) registry[id] = prior;
+          else delete registry[id];
+          if (priorHiddenKeys.has(id)) this.#hiddenWorkflowKeys.add(id);
+        }
+      };
+
+      try {
+        for (const { normalized } of ordered) {
+          const { workflow } = await rehydrateWorkflow(normalized, this);
+          this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
+        }
+
+        const store = await this.#storage?.getStore('workflowDefinitions');
+        if (store) {
+          for (const { normalized } of ordered) {
+            await store.upsert({
+              id: normalized.id,
+              description: normalized.description,
+              metadata: normalized.metadata,
+              inputSchema: normalized.inputSchema,
+              outputSchema: normalized.outputSchema,
+              stateSchema: normalized.stateSchema,
+              requestContextSchema: normalized.requestContextSchema,
+              graph: normalized.graph,
+              ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
+            });
+          }
+        }
+      } catch (error) {
+        restoreRegistry();
+        throw error;
+      }
+    });
   }
 
   /**

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -54,7 +54,7 @@ import { Schedules } from '../schedules/schedules';
 import type { SchedulesConfig, ScheduleHooks } from '../schedules/types';
 import type { MastraServerBase } from '../server/base';
 import type { ApiRoute, Middleware, ServerConfig, StudioConfig } from '../server/types';
-import type { MastraCompositeStore, WorkflowRuns } from '../storage';
+import type { MastraCompositeStore, WorkflowDefinition, WorkflowRuns } from '../storage';
 import { InMemoryStore, WorkflowDefinitionOwnershipConflictError } from '../storage';
 import { BackgroundTasksInMemory } from '../storage/domains/background-tasks/inmemory';
 import { InMemoryDB } from '../storage/domains/inmemory-db';
@@ -4858,7 +4858,7 @@ export class Mastra<
           id,
           options?.authorId !== undefined ? { authorId: options.authorId } : undefined,
         );
-        if (!deletedFromStorage) return false;
+        if (!deletedFromStorage && options?.authorId !== undefined) return false;
       }
 
       const unregistered = this.getWorkflowOrigin(id) === 'dynamic' ? this.removeWorkflow(id) : false;
@@ -4938,12 +4938,18 @@ export class Mastra<
           'A workflowDefinitions storage domain is required when registering an authored dynamic workflow.',
         );
       }
+      const existingDefinitions = new Map<string, WorkflowDefinition | null>();
+      if (store) {
+        for (const { normalized } of members) {
+          existingDefinitions.set(normalized.id, await store.get(normalized.id));
+        }
+      }
       if (options?.authorId !== undefined) {
         // Trusted ownership is validated before hydration changes the live
         // registry. Bundle members may only create or replace definitions for
         // the supplied owner.
         for (const { normalized } of members) {
-          const existing = await store.get(normalized.id);
+          const existing = existingDefinitions.get(normalized.id);
           if (
             this.getWorkflowOrigin(normalized.id) === 'code' ||
             (existing && existing.authorId !== options.authorId) ||
@@ -4966,11 +4972,11 @@ export class Mastra<
         // the caller. Missing or legacy ownership fails closed.
         for (const nestedId of externalNestedIds) {
           if (this.getWorkflowOrigin(nestedId) !== 'dynamic') continue;
-          const nested = await store.get(nestedId);
+          const nested = await store!.get(nestedId);
           if (!nested || nested.authorId !== options.authorId) {
             throw new WorkflowDefinitionOwnershipConflictError(nestedId);
           }
-      }
+        }
       }
 
       // Members may nest each other, so the index every member validates against
@@ -5039,6 +5045,7 @@ export class Mastra<
 
         if (store) {
           for (const { normalized } of ordered) {
+            const retainedAuthorId = options?.authorId ?? existingDefinitions.get(normalized.id)?.authorId;
             await store.upsert({
               id: normalized.id,
               description: normalized.description,
@@ -5048,7 +5055,7 @@ export class Mastra<
               stateSchema: normalized.stateSchema,
               requestContextSchema: normalized.requestContextSchema,
               graph: normalized.graph,
-              ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
+              ...(retainedAuthorId !== undefined ? { authorId: retainedAuthorId } : {}),
             });
           }
         }

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -99,6 +99,21 @@ import { createRunScope } from './run-scope';
 import type { VersionOverrides, VersionSelector } from './types';
 
 /**
+ * Trusted metadata applied while a dynamic workflow is persisted.
+ *
+ * Keep these values outside the JSON workflow definition when that definition
+ * comes from an untrusted authoring surface. This metadata is persisted with
+ * the definition but does not itself enforce authorization.
+ */
+export interface DynamicWorkflowRegistrationOptions {
+  /**
+   * Verified identity responsible for the stored definition. Callers must
+   * authorize this value before registration.
+   */
+  authorId?: string;
+}
+
+/**
  * Creates an error for when a null/undefined value is passed to an add* method.
  * This commonly occurs when config is spread ({ ...config }) and the original
  * object had getters or non-enumerable properties.
@@ -4796,8 +4811,11 @@ export class Mastra<
    * await run.start({ inputData: { location: 'Helsinki' } });
    * ```
    */
-  public async addDynamicWorkflow(def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput): Promise<void> {
-    await this.addDynamicWorkflows([def]);
+  public async addDynamicWorkflow(
+    def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput,
+    options?: DynamicWorkflowRegistrationOptions,
+  ): Promise<void> {
+    await this.addDynamicWorkflows([def], options);
   }
 
   /**
@@ -4832,6 +4850,7 @@ export class Mastra<
    */
   public async addDynamicWorkflows(
     defs: readonly (DynamicWorkflowGraph | WorkflowBuilderDefinitionInput)[],
+    options?: DynamicWorkflowRegistrationOptions,
   ): Promise<void> {
     if (defs.length === 0) return;
 
@@ -4937,6 +4956,7 @@ export class Mastra<
             stateSchema: normalized.stateSchema,
             requestContextSchema: normalized.requestContextSchema,
             graph: normalized.graph,
+            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
           });
         }
       }

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -55,7 +55,7 @@ import type { SchedulesConfig, ScheduleHooks } from '../schedules/types';
 import type { MastraServerBase } from '../server/base';
 import type { ApiRoute, Middleware, ServerConfig, StudioConfig } from '../server/types';
 import type { MastraCompositeStore, WorkflowRuns } from '../storage';
-import { InMemoryStore } from '../storage';
+import { InMemoryStore, WorkflowDefinitionOwnershipConflictError } from '../storage';
 import { BackgroundTasksInMemory } from '../storage/domains/background-tasks/inmemory';
 import { InMemoryDB } from '../storage/domains/inmemory-db';
 import type { Schedule, ScheduleUpdate, SchedulesStorage } from '../storage/domains/schedules/base';
@@ -4840,6 +4840,33 @@ export class Mastra<
   }
 
   /**
+   * Deletes a persisted dynamic workflow and its live registration as one
+   * serialized instance operation. Supplying `authorId` makes storage perform
+   * an atomic owner-qualified delete; a missing or different owner returns
+   * `false` without touching the live registry.
+   *
+   * Code-defined workflows are never unregistered by this method.
+   */
+  public async deleteDynamicWorkflow(id: string, options?: DynamicWorkflowRegistrationOptions): Promise<boolean> {
+    return this.#serializeDynamicWorkflowRegistration(async () => {
+      const store = await this.#storage?.getStore('workflowDefinitions');
+      if (options?.authorId !== undefined && !store) return false;
+
+      let deletedFromStorage = false;
+      if (store) {
+        deletedFromStorage = await store.delete(
+          id,
+          options?.authorId !== undefined ? { authorId: options.authorId } : undefined,
+        );
+        if (!deletedFromStorage) return false;
+      }
+
+      const unregistered = this.getWorkflowOrigin(id) === 'dynamic' ? this.removeWorkflow(id) : false;
+      return deletedFromStorage || unregistered;
+    });
+  }
+
+  /**
    * Persist and live-register a set of dynamic workflow definitions that depend
    * on each other — typically a root workflow plus the helper workflows it
    * nests, none of which exist yet.
@@ -4910,6 +4937,40 @@ export class Mastra<
         throw new Error(
           'A workflowDefinitions storage domain is required when registering an authored dynamic workflow.',
         );
+      }
+      if (options?.authorId !== undefined) {
+        // Trusted ownership is validated before hydration changes the live
+        // registry. Bundle members may only create or replace definitions for
+        // the supplied owner.
+        for (const { normalized } of members) {
+          const existing = await store.get(normalized.id);
+          if (
+            this.getWorkflowOrigin(normalized.id) === 'code' ||
+            (existing && existing.authorId !== options.authorId) ||
+            (!existing && this.getWorkflowOrigin(normalized.id) === 'dynamic')
+          ) {
+            throw new WorkflowDefinitionOwnershipConflictError(normalized.id);
+          }
+        }
+
+        const bundleIds = new Set(members.map(member => member.normalized.id));
+        const externalNestedIds = new Set<string>();
+        for (const { normalized } of members) {
+          for (const nestedId of collectNestedWorkflowIds(normalized.graph)) {
+            if (!bundleIds.has(nestedId)) externalNestedIds.add(nestedId);
+          }
+        }
+
+        // Code-defined workflows are application-global registrations. A
+        // dynamic nested target, however, must have a stored owner matching
+        // the caller. Missing or legacy ownership fails closed.
+        for (const nestedId of externalNestedIds) {
+          if (this.getWorkflowOrigin(nestedId) !== 'dynamic') continue;
+          const nested = await store.get(nestedId);
+          if (!nested || nested.authorId !== options.authorId) {
+            throw new WorkflowDefinitionOwnershipConflictError(nestedId);
+          }
+      }
       }
 
       // Members may nest each other, so the index every member validates against

--- a/packages/core/src/mastra/remove-workflow.test.ts
+++ b/packages/core/src/mastra/remove-workflow.test.ts
@@ -196,6 +196,17 @@ describe('Mastra.deleteDynamicWorkflow', () => {
     await expect(store.get('stored-only')).resolves.toBeNull();
   });
 
+  it('removes a live-only dynamic workflow during an unscoped deletion', async () => {
+    const storage = new InMemoryStore({ id: 'delete-live-only' });
+    const mastra = new Mastra({ logger: false, tools: { 'double-tool': doubleTool } as any, storage });
+    await mastra.addDynamicWorkflow(storedDefinition('live-only', 'live'));
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    await expect(store.delete('live-only')).resolves.toBe(true);
+
+    await expect(mastra.deleteDynamicWorkflow('live-only')).resolves.toBe(true);
+    expect(() => mastra.getWorkflow('live-only')).toThrow();
+  });
+
   it('serializes delete with same-id registration so the replacement remains live', async () => {
     const storage = new InMemoryStore({ id: 'delete-registration-race' });
     const mastra = new Mastra({ logger: false, tools: { 'double-tool': doubleTool } as any, storage });

--- a/packages/core/src/mastra/remove-workflow.test.ts
+++ b/packages/core/src/mastra/remove-workflow.test.ts
@@ -132,6 +132,108 @@ describe('Mastra.addDynamicWorkflow replaces on re-save', () => {
   });
 });
 
+describe('Mastra.deleteDynamicWorkflow', () => {
+  function storedDefinition(id: string, template: string) {
+    return {
+      id,
+      description: template,
+      inputSchema: { type: 'object', properties: { value: { type: 'number' } }, required: ['value'] },
+      outputSchema: { type: 'object', properties: { message: { type: 'string' } }, required: ['message'] },
+      graph: JSON.parse(JSON.stringify(toStorableGraph(buildWorkflow(template).stepGraph))),
+    };
+  }
+
+  it('leaves storage and registry untouched when the expected owner does not match', async () => {
+    const storage = new InMemoryStore({ id: 'delete-owner-mismatch' });
+    const mastra = new Mastra({ logger: false, tools: { 'double-tool': doubleTool } as any, storage });
+    await mastra.addDynamicWorkflow(storedDefinition('owned-wf', 'original'), { authorId: 'author-1' });
+    const original = mastra.getWorkflow('owned-wf');
+
+    await expect(mastra.deleteDynamicWorkflow('owned-wf', { authorId: 'author-2' })).resolves.toBe(false);
+
+    expect(mastra.getWorkflow('owned-wf')).toBe(original);
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    await expect(store.get('owned-wf')).resolves.toMatchObject({ authorId: 'author-1' });
+  });
+
+  it('deletes the expected owner from storage before unregistering the dynamic workflow', async () => {
+    const storage = new InMemoryStore({ id: 'delete-owner-match' });
+    const mastra = new Mastra({ logger: false, tools: { 'double-tool': doubleTool } as any, storage });
+    await mastra.addDynamicWorkflow(storedDefinition('owned-wf', 'original'), { authorId: 'author-1' });
+
+    await expect(mastra.deleteDynamicWorkflow('owned-wf', { authorId: 'author-1' })).resolves.toBe(true);
+
+    expect(() => mastra.getWorkflow('owned-wf')).toThrow();
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    await expect(store.get('owned-wf')).resolves.toBeNull();
+  });
+
+  it('never unregisters a code-defined workflow when deleting a same-id stored shadow', async () => {
+    const storage = new InMemoryStore({ id: 'delete-code-shadow' });
+    const codeWorkflow = buildWorkflow('code');
+    const mastra = new Mastra({
+      logger: false,
+      tools: { 'double-tool': doubleTool } as any,
+      workflows: { wf: codeWorkflow } as any,
+      storage,
+    });
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    await store.upsert({ ...storedDefinition('wf', 'shadow'), authorId: 'author-1' } as any);
+
+    await expect(mastra.deleteDynamicWorkflow('wf', { authorId: 'author-1' })).resolves.toBe(true);
+
+    expect(mastra.getWorkflow('wf')).toBe(codeWorkflow);
+    await expect(store.get('wf')).resolves.toBeNull();
+  });
+
+  it('reports a persisted deletion when no live workflow is registered', async () => {
+    const storage = new InMemoryStore({ id: 'delete-storage-only' });
+    const mastra = new Mastra({ logger: false, tools: { 'double-tool': doubleTool } as any, storage });
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    await store.upsert({ ...storedDefinition('stored-only', 'stored'), authorId: 'author-1' } as any);
+
+    await expect(mastra.deleteDynamicWorkflow('stored-only', { authorId: 'author-1' })).resolves.toBe(true);
+    await expect(store.get('stored-only')).resolves.toBeNull();
+  });
+
+  it('serializes delete with same-id registration so the replacement remains live', async () => {
+    const storage = new InMemoryStore({ id: 'delete-registration-race' });
+    const mastra = new Mastra({ logger: false, tools: { 'double-tool': doubleTool } as any, storage });
+    await mastra.addDynamicWorkflow(storedDefinition('raced-wf', 'original'), { authorId: 'author-1' });
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const realDelete = store.delete.bind(store);
+    let releaseDelete!: () => void;
+    const deleteGate = new Promise<void>(resolve => {
+      releaseDelete = resolve;
+    });
+    let markDeleteEntered!: () => void;
+    const deleteEntered = new Promise<void>(resolve => {
+      markDeleteEntered = resolve;
+    });
+    store.delete = (async (...args: Parameters<typeof realDelete>) => {
+      markDeleteEntered();
+      await deleteGate;
+      return realDelete(...args);
+    }) as typeof store.delete;
+
+    const deletion = mastra.deleteDynamicWorkflow('raced-wf', { authorId: 'author-1' });
+    await deleteEntered;
+    const replacement = mastra.addDynamicWorkflow(storedDefinition('raced-wf', 'replacement'), {
+      authorId: 'author-1',
+    });
+    releaseDelete();
+
+    await expect(deletion).resolves.toBe(true);
+    await expect(replacement).resolves.toBeUndefined();
+    expect(mastra.getWorkflow('raced-wf').description).toBe('replacement');
+    await expect(store.get('raced-wf')).resolves.toMatchObject({
+      authorId: 'author-1',
+      description: 'replacement',
+    });
+  });
+});
+
 describe('Mastra.getWorkflowOrigin', () => {
   it("stamps 'code' for statically declared workflows and clears on remove", () => {
     const wf = buildWorkflow('v=${stepResults.double-tool.doubled}');

--- a/packages/core/src/storage/domains/workflow-definitions/base.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/base.ts
@@ -42,6 +42,8 @@ export interface WorkflowDefinition {
 
   /** Provenance — distinguishes user-stored from code-registered workflows. */
   source: 'storage';
+
+  /** Immutable owner assigned when the definition is created. */
   authorId?: string;
 
   createdAt: Date;
@@ -58,6 +60,8 @@ export interface CreateWorkflowDefinitionInput {
   stateSchema?: unknown;
   requestContextSchema?: unknown;
   graph: ValidatableStepFlowEntry[];
+
+  /** Immutable owner to assign when the definition is created. */
   authorId?: string;
 }
 
@@ -72,6 +76,8 @@ export interface UpdateWorkflowDefinitionInput {
   requestContextSchema?: unknown;
   graph?: ValidatableStepFlowEntry[];
   status?: 'active' | 'archived';
+
+  /** Expected immutable owner. A different owner produces a conflict. */
   authorId?: string;
 }
 
@@ -86,10 +92,42 @@ export interface ListWorkflowDefinitionsOutput {
 }
 
 /**
+ * Thrown when an upsert attempts to claim a workflow definition that already
+ * belongs to a different author. The message intentionally does not disclose
+ * the existing author.
+ */
+export class WorkflowDefinitionOwnershipConflictError extends Error {
+  readonly workflowId: string;
+
+  constructor(workflowId: string) {
+    super(`Workflow definition "${workflowId}" conflicts with an existing definition.`);
+    this.name = 'WorkflowDefinitionOwnershipConflictError';
+    this.workflowId = workflowId;
+  }
+}
+
+/**
+ * Treat an explicitly supplied author as both creation ownership and the
+ * expected owner on update. Omitting authorId preserves legacy/unscoped
+ * behavior; supplying it can never create or transfer ownership after a row
+ * already exists.
+ */
+export function assertWorkflowDefinitionAuthor(
+  existing: Pick<WorkflowDefinition, 'id' | 'authorId'>,
+  input: Pick<UpdateWorkflowDefinitionInput, 'authorId'>,
+): void {
+  if (input.authorId !== undefined && existing.authorId !== input.authorId) {
+    throw new WorkflowDefinitionOwnershipConflictError(existing.id);
+  }
+}
+
+/**
  * Abstract storage domain for persisted workflow definitions.
  *
  * Versioning is intentionally out of scope for v1 — `upsert` overwrites in
- * place. A future revision can layer the {@link VersionedStorageDomain}
+ * place. Ownership is the exception: an explicitly supplied `authorId` is an
+ * immutable compare condition, so concurrent creators cannot take over the
+ * winning row. A future revision can layer the {@link VersionedStorageDomain}
  * pattern on top without breaking the rehydration path.
  */
 export abstract class WorkflowDefinitionsStorage extends StorageDomain {

--- a/packages/core/src/storage/domains/workflow-definitions/base.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/base.ts
@@ -91,6 +91,11 @@ export interface ListWorkflowDefinitionsOutput {
   total: number;
 }
 
+export interface DeleteWorkflowDefinitionOptions {
+  /** Expected immutable owner. When supplied, a different or missing owner is not deleted. */
+  authorId?: string;
+}
+
 /**
  * Thrown when an upsert attempts to claim a workflow definition that already
  * belongs to a different author. The message intentionally does not disclose
@@ -138,5 +143,9 @@ export abstract class WorkflowDefinitionsStorage extends StorageDomain {
   abstract upsert(input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput): Promise<WorkflowDefinition>;
   abstract get(id: string): Promise<WorkflowDefinition | null>;
   abstract list(args?: ListWorkflowDefinitionsInput): Promise<ListWorkflowDefinitionsOutput>;
-  abstract delete(id: string): Promise<void>;
+  /**
+   * Deletes one definition and reports whether a row matched. When `authorId`
+   * is supplied, adapters must include it in the atomic delete predicate.
+   */
+  abstract delete(id: string, options?: DeleteWorkflowDefinitionOptions): Promise<boolean>;
 }

--- a/packages/core/src/storage/domains/workflow-definitions/base.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/base.ts
@@ -112,16 +112,16 @@ export class WorkflowDefinitionOwnershipConflictError extends Error {
 }
 
 /**
- * Treat an explicitly supplied author as both creation ownership and the
- * expected owner on update. Omitting authorId preserves legacy/unscoped
- * behavior; supplying it can never create or transfer ownership after a row
- * already exists.
+ * Treat the supplied author as both creation ownership and the expected owner
+ * on update. Once a row has an owner, every update must supply that same owner;
+ * omitting it is not an unscoped bypass. Legacy unowned rows remain updatable
+ * only by callers that also omit ownership.
  */
 export function assertWorkflowDefinitionAuthor(
   existing: Pick<WorkflowDefinition, 'id' | 'authorId'>,
   input: Pick<UpdateWorkflowDefinitionInput, 'authorId'>,
 ): void {
-  if (input.authorId !== undefined && existing.authorId !== input.authorId) {
+  if (existing.authorId !== input.authorId) {
     throw new WorkflowDefinitionOwnershipConflictError(existing.id);
   }
 }

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.test.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { InMemoryDB } from '../inmemory-db';
+import { WorkflowDefinitionOwnershipConflictError } from './base';
 import { InMemoryWorkflowDefinitionsStorage } from './inmemory';
 
 const graph = [{ type: 'tool', id: 'echo-tool', toolId: 'echo-tool' }] as any;
@@ -36,14 +37,24 @@ describe('InMemoryWorkflowDefinitionsStorage', () => {
   });
 
   describe('update', () => {
-    it('updates authorId on an existing definition', async () => {
+    it('keeps authorId immutable on an existing definition', async () => {
       await storage.upsert({ ...baseInput(), authorId: 'author-1' });
-      const updated = await storage.upsert({ id: 'wf-1', authorId: 'author-2' });
-      expect(updated.authorId).toBe('author-2');
+      await expect(storage.upsert({ id: 'wf-1', authorId: 'author-2' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
       const fetched = await storage.get('wf-1');
-      expect(fetched?.authorId).toBe('author-2');
+      expect(fetched?.authorId).toBe('author-1');
       // Unspecified columns survive the partial upsert.
       expect(fetched?.graph).toEqual(graph);
+    });
+
+    it('does not disclose the existing author in ownership conflicts', async () => {
+      await storage.upsert({ ...baseInput(), authorId: 'private-owner' });
+
+      const error = await storage.upsert({ id: 'wf-1', authorId: 'other-owner' }).catch(cause => cause);
+
+      expect(error).toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+      expect(error.message).not.toContain('private-owner');
     });
   });
 });

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
@@ -1,6 +1,7 @@
 import type { InMemoryDB } from '../inmemory-db';
 import type {
   CreateWorkflowDefinitionInput,
+  DeleteWorkflowDefinitionOptions,
   ListWorkflowDefinitionsInput,
   ListWorkflowDefinitionsOutput,
   UpdateWorkflowDefinitionInput,
@@ -90,8 +91,10 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
     return { definitions: cloned, total: cloned.length };
   }
 
-  async delete(id: string): Promise<void> {
-    this.db.workflowDefinitions.delete(id);
+  async delete(id: string, options?: DeleteWorkflowDefinitionOptions): Promise<boolean> {
+    const existing = this.db.workflowDefinitions.get(id);
+    if (!existing || (options?.authorId !== undefined && existing.authorId !== options.authorId)) return false;
+    return this.db.workflowDefinitions.delete(id);
   }
 
   private deepCopy(def: WorkflowDefinition): WorkflowDefinition {

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
@@ -6,7 +6,7 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from './base';
-import { WorkflowDefinitionsStorage } from './base';
+import { assertWorkflowDefinitionAuthor, WorkflowDefinitionsStorage } from './base';
 
 export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStorage {
   private db: InMemoryDB;
@@ -25,6 +25,7 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
     const existing = this.db.workflowDefinitions.get(input.id);
 
     if (existing) {
+      assertWorkflowDefinitionAuthor(existing, input);
       const merged: WorkflowDefinition = {
         ...existing,
         ...('description' in input && input.description !== undefined && { description: input.description }),
@@ -36,7 +37,6 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
           input.requestContextSchema !== undefined && { requestContextSchema: input.requestContextSchema }),
         ...('graph' in input && input.graph !== undefined && { graph: input.graph }),
         ...('status' in input && input.status !== undefined && { status: input.status }),
-        ...('authorId' in input && input.authorId !== undefined && { authorId: input.authorId }),
         updatedAt: now,
       };
       this.db.workflowDefinitions.set(input.id, merged);

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -112,7 +112,7 @@
   "author": "",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@mastra/core": ">=1.50.0-0 <2.0.0-0",
+    "@mastra/core": ">=1.59.0-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/packages/server/src/server/handlers/dynamic-workflows.test.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.test.ts
@@ -894,12 +894,70 @@ describe('Dynamic Workflows handlers', () => {
       ).rejects.toBeInstanceOf(HTTPException);
     });
 
-    it('is idempotent on a missing id', async () => {
-      const result = await DELETE_DYNAMIC_WORKFLOW_ROUTE.handler({
-        ...ctx(mastra),
-        dynamicWorkflowId: 'never-existed',
+    it('returns the same 404 for missing and cross-owner ids without deleting the owner', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-private'),
       });
-      expect(result.success).toBe(true);
+
+      for (const dynamicWorkflowId of ['never-existed', 'wf-private']) {
+        await expect(
+          DELETE_DYNAMIC_WORKFLOW_ROUTE.handler({
+            ...ctx(mastra, { authorId: 'user-a' }),
+            dynamicWorkflowId,
+          }),
+        ).rejects.toMatchObject({ status: 404, message: 'Not found' });
+      }
+
+      const row = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        dynamicWorkflowId: 'wf-private',
+      });
+      expect(row.authorId).toBe('user-b');
+      expect(mastra.getWorkflow('wf-private')).toBeDefined();
+    });
+
+    it('lets an admin delete an owned definition without accepting a caller-supplied owner', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-admin-delete'),
+      });
+
+      await expect(
+        DELETE_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'admin', admin: true }),
+          dynamicWorkflowId: 'wf-admin-delete',
+        }),
+      ).resolves.toMatchObject({ success: true });
+      expect(() => mastra.getWorkflow('wf-admin-delete')).toThrow();
+    });
+
+    it('keeps legacy unowned definitions mutation-quarantined for users and admins', async () => {
+      await mastra.addDynamicWorkflow(workflowDefinition('wf-legacy-delete'));
+
+      await expect(
+        DELETE_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          dynamicWorkflowId: 'wf-legacy-delete',
+        }),
+      ).rejects.toMatchObject({ status: 404 });
+      await expect(
+        DELETE_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'admin', admin: true }),
+          dynamicWorkflowId: 'wf-legacy-delete',
+        }),
+      ).rejects.toMatchObject({ status: 409 });
+
+      expect(mastra.getWorkflow('wf-legacy-delete')).toBeDefined();
+    });
+
+    it('requires a stable caller before delete', async () => {
+      await expect(
+        DELETE_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: null }),
+          dynamicWorkflowId: 'missing',
+        }),
+      ).rejects.toMatchObject({ status: 401 });
     });
   });
 

--- a/packages/server/src/server/handlers/dynamic-workflows.test.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.test.ts
@@ -384,6 +384,26 @@ describe('Dynamic Workflows handlers', () => {
       await expect(store.get('wf-helper')).resolves.toMatchObject({ authorId: 'user-b', description: 'original' });
     });
 
+    it('lets an admin create a new root from a helper owned by that same admin principal', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        ...workflowDefinition('wf-admin-helper', 'original'),
+      });
+
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        ...workflowDefinition('wf-admin-root'),
+        dependencies: [workflowDefinition('wf-admin-helper', 'admin edit')],
+      });
+
+      const store = (await mastra.getStorage()!.getStore('workflowDefinitions'))!;
+      await expect(store.get('wf-admin-root')).resolves.toMatchObject({ authorId: 'admin' });
+      await expect(store.get('wf-admin-helper')).resolves.toMatchObject({
+        authorId: 'admin',
+        description: 'admin edit',
+      });
+    });
+
     it('keeps legacy unowned definitions hidden from users and read-only for admins', async () => {
       await mastra.addDynamicWorkflow(workflowDefinition('wf-legacy'));
 

--- a/packages/server/src/server/handlers/dynamic-workflows.test.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.test.ts
@@ -7,6 +7,7 @@ import { createTool } from '@mastra/core/tools';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_USER_PERMISSIONS_KEY } from '../constants';
 import { HTTPException } from '../http-exception';
 import { upsertDynamicWorkflowBodySchema } from '../schemas/dynamic-workflows';
 import type { ServerContext } from '../server-adapter';
@@ -83,10 +84,15 @@ function buildMastra() {
   return mastra;
 }
 
-function ctx(mastra: MastraType): ServerContext {
+function ctx(mastra: MastraType, options: { authorId?: string | null; admin?: boolean } = {}): ServerContext {
+  const requestContext = new RequestContext();
+  const authorId = options.authorId === undefined ? 'test-user' : options.authorId;
+  if (authorId) requestContext.set(MASTRA_RESOURCE_ID_KEY, authorId);
+  if (options.admin) requestContext.set(MASTRA_USER_PERMISSIONS_KEY, ['stored-workflows:admin']);
+
   return {
     mastra,
-    requestContext: new RequestContext(),
+    requestContext,
     abortSignal: new AbortController().signal,
   };
 }
@@ -106,6 +112,18 @@ const baseSchemas = {
   inputSchema: objectWith({ value: stringSchema }, ['value']),
   outputSchema: objectWith({ value: stringSchema }, ['value']),
 };
+
+function workflowDefinition(id: string, description?: string) {
+  return {
+    id,
+    description,
+    metadata: undefined,
+    stateSchema: undefined,
+    requestContextSchema: undefined,
+    ...baseSchemas,
+    graph: toolOnlyGraph(),
+  };
+}
 
 // =============================================================================
 // Tests
@@ -186,6 +204,222 @@ describe('Dynamic Workflows handlers', () => {
       });
       expect(row.id).toBe('wf-get');
       expect(row.status).toBe('active');
+    });
+  });
+
+  describe('trusted author scoping', () => {
+    it('scopes ordinary lists to the caller and reserves cross-author filters for admins', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        ...workflowDefinition('wf-a'),
+      });
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-b'),
+      });
+
+      const userAList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(userAList.workflows.map(workflow => workflow.id)).toEqual(['wf-a']);
+
+      const userAExplicitList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        status: undefined,
+        authorId: 'user-a',
+      });
+      expect(userAExplicitList.workflows.map(workflow => workflow.id)).toEqual(['wf-a']);
+
+      await expect(
+        LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          status: undefined,
+          authorId: 'user-b',
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+
+      const adminList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(adminList.workflows.map(workflow => workflow.id).sort()).toEqual(['wf-a', 'wf-b']);
+
+      const adminFiltered = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        status: undefined,
+        authorId: 'user-b',
+      });
+      expect(adminFiltered.workflows.map(workflow => workflow.id)).toEqual(['wf-b']);
+    });
+
+    it('returns the same 404 for missing and cross-owner reads while allowing an admin read', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-private'),
+      });
+
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          dynamicWorkflowId: 'wf-private',
+        }),
+      ).rejects.toMatchObject({ status: 404, message: 'Not found' });
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          dynamicWorkflowId: 'missing',
+        }),
+      ).rejects.toMatchObject({ status: 404, message: 'Not found' });
+
+      const adminRead = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        dynamicWorkflowId: 'wf-private',
+      });
+      expect(adminRead.authorId).toBe('user-b');
+    });
+
+    it('requires a stable caller for list, get, and upsert', async () => {
+      await expect(
+        LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+          ...ctx(mastra, { authorId: null }),
+          status: undefined,
+          authorId: undefined,
+        }),
+      ).rejects.toMatchObject({ status: 401 });
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: null }),
+          dynamicWorkflowId: 'missing',
+        }),
+      ).rejects.toMatchObject({ status: 401 });
+      await expect(
+        UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: null }),
+          ...workflowDefinition('wf-missing-caller'),
+        }),
+      ).rejects.toMatchObject({ status: 401 });
+    });
+
+    it('derives the owner from RequestContext and strips a forged body author', async () => {
+      const parsed = upsertDynamicWorkflowBodySchema.parse({
+        ...workflowDefinition('wf-forged'),
+        authorId: 'user-b',
+      });
+      expect(parsed).not.toHaveProperty('authorId');
+
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        ...parsed,
+      });
+
+      const row = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        dynamicWorkflowId: 'wf-forged',
+      });
+      expect(row.authorId).toBe('user-a');
+    });
+
+    it('rejects a cross-owner update with a non-disclosing conflict', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-owned', 'original'),
+      });
+
+      await expect(
+        UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          ...workflowDefinition('wf-owned', 'takeover'),
+        }),
+      ).rejects.toMatchObject({
+        status: 409,
+        message: 'Dynamic workflow conflicts with an existing definition',
+      });
+
+      const row = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        dynamicWorkflowId: 'wf-owned',
+      });
+      expect(row).toMatchObject({ authorId: 'user-b', description: 'original' });
+    });
+
+    it('lets an admin update an owned bundle without transferring its owner', async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-owned', 'original'),
+      });
+
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        ...workflowDefinition('wf-owned', 'admin edit'),
+        dependencies: [workflowDefinition('wf-helper')],
+      });
+
+      const store = (await mastra.getStorage()!.getStore('workflowDefinitions'))!;
+      await expect(store.get('wf-owned')).resolves.toMatchObject({ authorId: 'user-b', description: 'admin edit' });
+      await expect(store.get('wf-helper')).resolves.toMatchObject({ authorId: 'user-b' });
+    });
+
+    it("doesn't let an existing helper choose the owner of a new admin-created root", async () => {
+      await UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-b' }),
+        ...workflowDefinition('wf-helper', 'original'),
+      });
+
+      await expect(
+        UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'admin', admin: true }),
+          ...workflowDefinition('wf-new-root'),
+          dependencies: [workflowDefinition('wf-helper', 'admin edit')],
+        }),
+      ).rejects.toMatchObject({
+        status: 409,
+        message: 'Dynamic workflow conflicts with an existing definition',
+      });
+
+      const store = (await mastra.getStorage()!.getStore('workflowDefinitions'))!;
+      await expect(store.get('wf-new-root')).resolves.toBeNull();
+      await expect(store.get('wf-helper')).resolves.toMatchObject({ authorId: 'user-b', description: 'original' });
+    });
+
+    it('keeps legacy unowned definitions hidden from users and read-only for admins', async () => {
+      await mastra.addDynamicWorkflow(workflowDefinition('wf-legacy'));
+
+      const userList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'user-a' }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(userList.workflows).toEqual([]);
+      await expect(
+        GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+          ...ctx(mastra, { authorId: 'user-a' }),
+          dynamicWorkflowId: 'wf-legacy',
+        }),
+      ).rejects.toMatchObject({ status: 404, message: 'Not found' });
+
+      const adminRead = await GET_DYNAMIC_WORKFLOW_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        dynamicWorkflowId: 'wf-legacy',
+      });
+      expect(adminRead.authorId).toBeUndefined();
+      const adminList = await LIST_DYNAMIC_WORKFLOWS_ROUTE.handler({
+        ...ctx(mastra, { authorId: 'admin', admin: true }),
+        status: undefined,
+        authorId: undefined,
+      });
+      expect(adminList.workflows.map(workflow => workflow.id)).toEqual(['wf-legacy']);
+
+      for (const caller of [{ authorId: 'user-a' }, { authorId: 'admin', admin: true }]) {
+        await expect(
+          UPSERT_DYNAMIC_WORKFLOW_ROUTE.handler({
+            ...ctx(mastra, caller),
+            ...workflowDefinition('wf-legacy', 'claimed'),
+          }),
+        ).rejects.toMatchObject({ status: 409 });
+      }
     });
   });
 

--- a/packages/server/src/server/handlers/dynamic-workflows.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.ts
@@ -237,8 +237,8 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
 /**
  * DELETE /stored/workflows/:dynamicWorkflowId — delete a dynamic workflow.
  *
- * Removes the row from storage AND un-registers the live Workflow instance so
- * a subsequent POST with the same id starts from a clean slate. Idempotent.
+ * Removes the caller-owned row from storage and un-registers the matching live
+ * dynamic Workflow instance. Missing and cross-owner ids are indistinguishable.
  */
 export const DELETE_DYNAMIC_WORKFLOW_ROUTE = createRoute({
   method: 'DELETE',
@@ -247,20 +247,31 @@ export const DELETE_DYNAMIC_WORKFLOW_ROUTE = createRoute({
   pathParamSchema: dynamicWorkflowIdPathParams,
   responseSchema: deleteDynamicWorkflowResponseSchema,
   summary: 'Delete a dynamic workflow definition',
-  description: 'Removes a dynamic workflow definition and unregisters the live workflow instance. Idempotent.',
+  description: 'Removes a caller-owned dynamic workflow definition and unregisters its live workflow instance.',
   tags: ['Dynamic Workflows'],
   requiresAuth: true,
   requiresPermission: 'stored-workflows:write',
-  handler: async ({ mastra, dynamicWorkflowId }) => {
+  handler: async ({ mastra, requestContext, dynamicWorkflowId }) => {
     try {
+      const principal = getDynamicWorkflowPrincipal(requestContext);
       const storage = mastra.getStorage();
       if (!storage) throw new HTTPException(500, { message: 'Storage is not configured' });
 
       const store = await storage.getStore('workflowDefinitions');
       if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
 
-      await store.delete(dynamicWorkflowId);
-      (mastra as Mastra).removeWorkflow(dynamicWorkflowId);
+      let expectedAuthorId = principal.authorId;
+      if (principal.isAdmin) {
+        const existing = await store.get(dynamicWorkflowId);
+        if (!existing) throwDynamicWorkflowNotFound();
+        if (!existing.authorId) throwDynamicWorkflowConflict();
+        expectedAuthorId = existing.authorId;
+      }
+
+      const deleted = await (mastra as Mastra).deleteDynamicWorkflow(dynamicWorkflowId, {
+        authorId: expectedAuthorId,
+      });
+      if (!deleted) throwDynamicWorkflowNotFound();
       return { success: true as const, message: `Workflow ${dynamicWorkflowId} deleted` };
     } catch (error) {
       return handleError(error, 'Error deleting dynamic workflow');

--- a/packages/server/src/server/handlers/dynamic-workflows.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.ts
@@ -1,4 +1,5 @@
 import type { Mastra } from '@mastra/core/mastra';
+import { WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 
 import { HTTPException } from '../http-exception';
 import {
@@ -12,13 +13,42 @@ import {
 } from '../schemas/dynamic-workflows';
 import { createRoute } from '../server-adapter/routes/route-builder';
 
+import { getCallerAuthorId, hasAdminBypass } from './authorship';
 import { handleError } from './error';
+
+const DYNAMIC_WORKFLOW_RESOURCE = 'stored-workflows';
+
+type DynamicWorkflowPrincipal = {
+  authorId: string;
+  isAdmin: boolean;
+};
+
+function getDynamicWorkflowPrincipal(
+  requestContext: Parameters<typeof getCallerAuthorId>[0],
+): DynamicWorkflowPrincipal {
+  const authorId = getCallerAuthorId(requestContext);
+  if (!authorId) {
+    throw new HTTPException(401, { message: 'Authentication required' });
+  }
+
+  return {
+    authorId,
+    isAdmin: hasAdminBypass(requestContext, DYNAMIC_WORKFLOW_RESOURCE),
+  };
+}
+
+function throwDynamicWorkflowNotFound(): never {
+  throw new HTTPException(404, { message: 'Not found' });
+}
+
+function throwDynamicWorkflowConflict(): never {
+  throw new HTTPException(409, { message: 'Dynamic workflow conflicts with an existing definition' });
+}
 
 /**
  * GET /stored/workflows — list stored static workflow definitions.
  *
- * Mirrors `LIST_STORED_AGENTS_ROUTE` but without favorites/visibility/authorship
- * scoping (which the workflow-definitions domain doesn't carry in v1).
+ * Non-admin callers are scoped to the author derived from RequestContext.
  */
 export const LIST_DYNAMIC_WORKFLOWS_ROUTE = createRoute({
   method: 'GET',
@@ -27,19 +57,28 @@ export const LIST_DYNAMIC_WORKFLOWS_ROUTE = createRoute({
   queryParamSchema: listDynamicWorkflowsQuerySchema,
   responseSchema: listDynamicWorkflowsResponseSchema,
   summary: 'List dynamic workflow definitions',
-  description: 'Returns workflow definitions persisted to storage. Filterable by status and authorId.',
+  description:
+    'Returns workflow definitions persisted to storage. Non-admin callers only receive their own definitions.',
   tags: ['Dynamic Workflows'],
   requiresAuth: true,
   requiresPermission: 'stored-workflows:read',
-  handler: async ({ mastra, status, authorId }) => {
+  handler: async ({ mastra, requestContext, status, authorId }) => {
     try {
+      const principal = getDynamicWorkflowPrincipal(requestContext);
+      if (!principal.isAdmin && authorId !== undefined && authorId !== principal.authorId) {
+        throw new HTTPException(400, { message: 'authorId can only select the authenticated caller' });
+      }
+
       const storage = mastra.getStorage();
       if (!storage) throw new HTTPException(500, { message: 'Storage is not configured' });
 
       const store = await storage.getStore('workflowDefinitions');
       if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
 
-      const result = await store.list({ status: status ?? 'active', authorId });
+      const result = await store.list({
+        status: status ?? 'active',
+        authorId: principal.isAdmin ? authorId : principal.authorId,
+      });
       return { workflows: result.definitions, total: result.total };
     } catch (error) {
       return handleError(error, 'Error listing dynamic workflows');
@@ -61,8 +100,9 @@ export const GET_DYNAMIC_WORKFLOW_ROUTE = createRoute({
   tags: ['Dynamic Workflows'],
   requiresAuth: true,
   requiresPermission: 'stored-workflows:read',
-  handler: async ({ mastra, dynamicWorkflowId }) => {
+  handler: async ({ mastra, requestContext, dynamicWorkflowId }) => {
     try {
+      const principal = getDynamicWorkflowPrincipal(requestContext);
       const storage = mastra.getStorage();
       if (!storage) throw new HTTPException(500, { message: 'Storage is not configured' });
 
@@ -70,7 +110,9 @@ export const GET_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
 
       const def = await store.get(dynamicWorkflowId);
-      if (!def) throw new HTTPException(404, { message: `Dynamic workflow "${dynamicWorkflowId}" not found` });
+      if (!def || (!principal.isAdmin && (!def.authorId || def.authorId !== principal.authorId))) {
+        throwDynamicWorkflowNotFound();
+      }
       return def;
     } catch (error) {
       return handleError(error, 'Error getting dynamic workflow');
@@ -101,6 +143,7 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
   requiresPermission: 'stored-workflows:write',
   handler: async ({
     mastra,
+    requestContext,
     id,
     description,
     metadata,
@@ -112,6 +155,13 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
     dependencies,
   }) => {
     try {
+      const principal = getDynamicWorkflowPrincipal(requestContext);
+      const storage = mastra.getStorage();
+      if (!storage) throw new HTTPException(500, { message: 'Storage is not configured' });
+
+      const store = await storage.getStore('workflowDefinitions');
+      if (!store) throw new HTTPException(500, { message: 'workflowDefinitions storage domain is not available' });
+
       // Pick the body fields explicitly — handler args also carry server
       // context (requestContext, abortSignal, ...) which must not leak into
       // the stored definition.
@@ -121,6 +171,35 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       // its helpers behind as orphans. Order within the bundle is derived
       // from the graphs, not from the order the client sent them in.
       const bundle = [...(dependencies ?? []), def];
+
+      // Ownership is supplied by the server, outside the untrusted graph.
+      // Existing rows are read only to choose the expected immutable owner;
+      // storage enforces that owner again in the write predicate so a
+      // concurrent delete/recreate can't turn this check into a takeover.
+      const existing = await Promise.all(bundle.map(member => store.get(member.id)));
+      if (existing.some(member => member && !member.authorId)) {
+        // Legacy rows have no trusted owner to preserve. Administrators may
+        // inspect them through GET/list, but mutation stays quarantined until
+        // an explicit migration assigns an owner.
+        throwDynamicWorkflowConflict();
+      }
+
+      const existingOwners = new Set(existing.flatMap(member => (member?.authorId ? [member.authorId] : [])));
+      let registrationAuthorId = principal.authorId;
+      if (principal.isAdmin) {
+        if (existingOwners.size > 1) throwDynamicWorkflowConflict();
+        const existingRoot = existing.at(-1);
+        if (!existingRoot && existingOwners.size > 0) {
+          // An existing helper must not choose the owner of a new root. Admins
+          // may extend an owned root with new helpers, but creating a new root
+          // that references someone else's helper requires a separate,
+          // explicit ownership design.
+          throwDynamicWorkflowConflict();
+        }
+        registrationAuthorId = existingRoot?.authorId ?? principal.authorId;
+      } else if (existingOwners.size > 1 || (existingOwners.size === 1 && !existingOwners.has(principal.authorId))) {
+        throwDynamicWorkflowConflict();
+      }
       // The wire schema is deliberately looser than the core authoring type:
       // it admits `mapping` entries as children of parallel/conditional/loop,
       // which `WorkflowBuilderExecutableInnerEntry` excludes. That is not
@@ -138,13 +217,18 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
       // rehydration, so nothing reaches the engine unvalidated; the cast
       // documents this boundary. Narrowing the schema to delete the cast
       // would trade a repairable issue for a generic 400.
-      await mastra.addDynamicWorkflows(bundle as Parameters<Mastra['addDynamicWorkflows']>[0]);
+      await mastra.addDynamicWorkflows(bundle as Parameters<Mastra['addDynamicWorkflows']>[0], {
+        authorId: registrationAuthorId,
+      });
       return {
         ok: true as const,
         id: def.id,
         ...(dependencies?.length ? { dependencyIds: dependencies.map(dependency => dependency.id) } : {}),
       };
     } catch (error) {
+      if (error instanceof WorkflowDefinitionOwnershipConflictError) {
+        throwDynamicWorkflowConflict();
+      }
       return handleError(error, 'Error upserting dynamic workflow');
     }
   },

--- a/packages/server/src/server/handlers/dynamic-workflows.ts
+++ b/packages/server/src/server/handlers/dynamic-workflows.ts
@@ -194,7 +194,7 @@ export const UPSERT_DYNAMIC_WORKFLOW_ROUTE = createRoute({
           // may extend an owned root with new helpers, but creating a new root
           // that references someone else's helper requires a separate,
           // explicit ownership design.
-          throwDynamicWorkflowConflict();
+          if (!existingOwners.has(principal.authorId)) throwDynamicWorkflowConflict();
         }
         registrationAuthorId = existingRoot?.authorId ?? principal.authorId;
       } else if (existingOwners.size > 1 || (existingOwners.size === 1 && !existingOwners.has(principal.authorId))) {
@@ -268,7 +268,7 @@ export const DELETE_DYNAMIC_WORKFLOW_ROUTE = createRoute({
         expectedAuthorId = existing.authorId;
       }
 
-      const deleted = await (mastra as Mastra).deleteDynamicWorkflow(dynamicWorkflowId, {
+      const deleted = await mastra.deleteDynamicWorkflow(dynamicWorkflowId, {
         authorId: expectedAuthorId,
       });
       if (!deleted) throwDynamicWorkflowNotFound();

--- a/stores/_test-utils/src/domains/workflow-definitions/index.ts
+++ b/stores/_test-utils/src/domains/workflow-definitions/index.ts
@@ -102,13 +102,25 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
         stateSchema: { type: 'object' },
         authorId: 'author-1',
       });
-      const updated = await store.upsert({ id: 'wf-1', description: 'renamed' });
+      const updated = await store.upsert({ id: 'wf-1', authorId: 'author-1', description: 'renamed' });
       expect(updated.description).toBe('renamed');
       expect(updated.metadata).toEqual({ owner: 'me' });
       expect(updated.stateSchema).toEqual({ type: 'object' });
       expect(updated.authorId).toBe('author-1');
       expect(updated.inputSchema).toEqual(baseInput('wf-1').inputSchema);
       expect(updated.graph).toEqual(baseGraph);
+    });
+
+    it('rejects an unscoped update to an owned row', async () => {
+      await store.upsert({ ...baseInput('wf-owned'), authorId: 'author-1' });
+
+      await expect(store.upsert({ id: 'wf-owned', description: 'unscoped takeover' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
+      await expect(store.get('wf-owned')).resolves.toMatchObject({
+        authorId: 'author-1',
+        description: 'workflow wf-owned',
+      });
     });
 
     it('handles concurrent upserts of the same id without failing', async () => {

--- a/stores/_test-utils/src/domains/workflow-definitions/index.ts
+++ b/stores/_test-utils/src/domains/workflow-definitions/index.ts
@@ -163,8 +163,19 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
 
     it('deletes a workflow definition', async () => {
       await store.upsert(baseInput('wf-1'));
-      await store.delete('wf-1');
+      await expect(store.delete('wf-1')).resolves.toBe(true);
       expect(await store.get('wf-1')).toBeNull();
+      await expect(store.delete('wf-1')).resolves.toBe(false);
+    });
+
+    it('atomically deletes only the expected owner', async () => {
+      await store.upsert({ ...baseInput('wf-1'), authorId: 'author-1' });
+
+      await expect(store.delete('wf-1', { authorId: 'author-2' })).resolves.toBe(false);
+      await expect(store.get('wf-1')).resolves.toMatchObject({ authorId: 'author-1' });
+
+      await expect(store.delete('wf-1', { authorId: 'author-1' })).resolves.toBe(true);
+      await expect(store.get('wf-1')).resolves.toBeNull();
     });
 
     it('preserves optional metadata and schemas across round-trip', async () => {

--- a/stores/_test-utils/src/domains/workflow-definitions/index.ts
+++ b/stores/_test-utils/src/domains/workflow-definitions/index.ts
@@ -1,3 +1,4 @@
+import { WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 import type { MastraStorage, WorkflowDefinitionsStorage } from '@mastra/core/storage';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
@@ -68,12 +69,30 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
       expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime());
     });
 
-    it('updates authorId on existing rows', async () => {
+    it('rejects ownership transfer on existing rows', async () => {
       await store.upsert({ ...baseInput('wf-1'), authorId: 'author-1' });
-      const updated = await store.upsert({ id: 'wf-1', authorId: 'author-2' });
-      expect(updated.authorId).toBe('author-2');
+      await expect(store.upsert({ id: 'wf-1', authorId: 'author-2' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
       const fetched = await store.get('wf-1');
-      expect(fetched?.authorId).toBe('author-2');
+      expect(fetched?.authorId).toBe('author-1');
+    });
+
+    it('allows the existing owner to update an owned row', async () => {
+      await store.upsert({ ...baseInput('wf-1'), authorId: 'author-1' });
+      const updated = await store.upsert({ id: 'wf-1', authorId: 'author-1', description: 'renamed' });
+
+      expect(updated).toMatchObject({ authorId: 'author-1', description: 'renamed' });
+    });
+
+    it('does not let an author claim a legacy unowned row', async () => {
+      await store.upsert(baseInput('wf-1'));
+
+      await expect(store.upsert({ id: 'wf-1', authorId: 'author-1' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
+      const stored = await store.get('wf-1');
+      expect(stored?.authorId).toBeUndefined();
     });
 
     it('preserves unspecified columns across a partial upsert', async () => {
@@ -105,6 +124,20 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
       }
       const all = await store.list();
       expect(all.total).toBe(1);
+    });
+
+    it('lets exactly one author win concurrent creation of the same id', async () => {
+      const results = await Promise.allSettled([
+        store.upsert({ ...baseInput('wf-owner-race'), authorId: 'author-1' }),
+        store.upsert({ ...baseInput('wf-owner-race'), authorId: 'author-2' }),
+      ]);
+
+      expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+      const rejected = results.find(result => result.status === 'rejected');
+      expect(rejected).toMatchObject({ reason: expect.any(WorkflowDefinitionOwnershipConflictError) });
+
+      const stored = await store.get('wf-owner-race');
+      expect(['author-1', 'author-2']).toContain(stored?.authorId);
     });
 
     it('rejects creation when required fields are explicitly undefined', async () => {

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
@@ -8,7 +8,7 @@
  *  - the domain is reachable through the LibSQLStore composite
  */
 import { createClient } from '@libsql/client';
-import { TABLE_WORKFLOW_DEFINITIONS } from '@mastra/core/storage';
+import { TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 import type { SerializedStepFlowEntry } from '@mastra/core/workflows';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -81,7 +81,7 @@ describe('WorkflowDefinitionsLibSQL', () => {
     expect(updated.graph).toEqual(graph);
   });
 
-  it('updates authorId on an existing row and keeps createdAt stable', async () => {
+  it('rejects an authorId change and keeps the original row stable', async () => {
     const wd = (await store.getStore('workflowDefinitions'))!;
 
     const created = await wd.upsert({
@@ -93,14 +93,53 @@ describe('WorkflowDefinitionsLibSQL', () => {
     });
     expect(created.authorId).toBe('author-1');
 
-    await new Promise(r => setTimeout(r, 5));
-    const updated = await wd.upsert({ id: 'wf-author', authorId: 'author-2' });
-    expect(updated.authorId).toBe('author-2');
-    expect(updated.createdAt.getTime()).toBe(created.createdAt.getTime());
-    expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime());
+    await expect(wd.upsert({ id: 'wf-author', authorId: 'author-2' })).rejects.toBeInstanceOf(
+      WorkflowDefinitionOwnershipConflictError,
+    );
 
     const fetched = await wd.get('wf-author');
-    expect(fetched?.authorId).toBe('author-2');
+    expect(fetched?.authorId).toBe('author-1');
+    expect(fetched?.createdAt.getTime()).toBe(created.createdAt.getTime());
+    expect(fetched?.updatedAt.getTime()).toBe(created.updatedAt.getTime());
+  });
+
+  it('does not update a different owner after a delete-and-recreate race', async () => {
+    const wd = (await store.getStore('workflowDefinitions'))!;
+    await wd.upsert({
+      id: 'wf-recreated',
+      description: 'original owner',
+      inputSchema,
+      outputSchema,
+      graph,
+      authorId: 'author-1',
+    });
+
+    const originalGet = wd.get.bind(wd);
+    const getSpy = vi.spyOn(wd, 'get');
+    let reads = 0;
+    getSpy.mockImplementation(async id => {
+      const current = await originalGet(id);
+      reads += 1;
+      if (reads === 2) {
+        getSpy.mockRestore();
+        await wd.delete(id);
+        await wd.upsert({
+          id,
+          description: 'new owner',
+          inputSchema,
+          outputSchema,
+          graph,
+          authorId: 'author-2',
+        });
+      }
+      return current;
+    });
+
+    await expect(
+      wd.upsert({ id: 'wf-recreated', description: 'stale update', authorId: 'author-1' }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(await wd.get('wf-recreated')).toMatchObject({ authorId: 'author-2', description: 'new owner' });
   });
 
   it('round-trips JSON columns intact', async () => {

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.ts
@@ -1,6 +1,7 @@
 import type { Client, InValue } from '@libsql/client';
 import type {
   CreateWorkflowDefinitionInput,
+  DeleteWorkflowDefinitionOptions,
   ListWorkflowDefinitionsInput,
   ListWorkflowDefinitionsOutput,
   UpdateWorkflowDefinitionInput,
@@ -188,10 +189,11 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
     return { definitions, total: definitions.length };
   }
 
-  async delete(id: string): Promise<void> {
-    await this.#client.execute({
-      sql: `DELETE FROM "${TABLE_WORKFLOW_DEFINITIONS}" WHERE id = ?`,
-      args: [id],
+  async delete(id: string, options?: DeleteWorkflowDefinitionOptions): Promise<boolean> {
+    const result = await this.#client.execute({
+      sql: `DELETE FROM "${TABLE_WORKFLOW_DEFINITIONS}" WHERE id = ?${options?.authorId !== undefined ? ' AND authorId = ?' : ''}`,
+      args: options?.authorId !== undefined ? [id, options.authorId] : [id],
     });
+    return (result.rowsAffected ?? 0) > 0;
   }
 }

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.ts
@@ -6,7 +6,12 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from '@mastra/core/storage';
-import { TABLE_SCHEMAS, TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_SCHEMAS,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';
@@ -131,6 +136,10 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     // Update — only patch fields present in the input
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
@@ -142,11 +151,11 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@mastra/core/storage';
 import type {
   CreateWorkflowDefinitionInput,
+  DeleteWorkflowDefinitionOptions,
   ListWorkflowDefinitionsInput,
   ListWorkflowDefinitionsOutput,
   UpdateWorkflowDefinitionInput,
@@ -184,8 +185,12 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
     return { definitions, total: definitions.length };
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: string, options?: DeleteWorkflowDefinitionOptions): Promise<boolean> {
     const collection = await this.getCollection(TABLE_WORKFLOW_DEFINITIONS);
-    await collection.deleteOne({ id });
+    const result = await collection.deleteOne({
+      id,
+      ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
+    });
+    return result.deletedCount > 0;
   }
 }

--- a/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,8 @@
-import { TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import type {
   CreateWorkflowDefinitionInput,
   ListWorkflowDefinitionsInput,
@@ -141,6 +145,9 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
     now: Date,
   ): Promise<WorkflowDefinition> {
     const collection = await this.getCollection(TABLE_WORKFLOW_DEFINITIONS);
+    const existing = await collection.findOne<Record<string, any>>({ id: input.id });
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(docToDefinition(existing), input);
 
     const update: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) update.description = input.description;
@@ -152,12 +159,13 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
       update.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) update.graph = input.graph;
     if ('status' in input && input.status !== undefined) update.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) update.authorId = input.authorId;
-
-    await collection.updateOne({ id: input.id }, { $set: update });
+    const filter = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await collection.updateOne(filter, { $set: update });
     const updated = await collection.findOne<Record<string, any>>({ id: input.id });
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
-    return docToDefinition(updated);
+    const definition = docToDefinition(updated);
+    assertWorkflowDefinitionAuthor(definition, input);
+    return definition;
   }
 
   async get(id: string): Promise<WorkflowDefinition | null> {

--- a/stores/mssql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mssql/src/storage/domains/workflow-definitions/index.ts
@@ -7,6 +7,7 @@ import {
 import type {
   CreateIndexOptions,
   CreateWorkflowDefinitionInput,
+  DeleteWorkflowDefinitionOptions,
   ListWorkflowDefinitionsInput,
   ListWorkflowDefinitionsOutput,
   UpdateWorkflowDefinitionInput,
@@ -229,13 +230,17 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
     return { definitions, total: definitions.length };
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: string, options?: DeleteWorkflowDefinitionOptions): Promise<boolean> {
     const tableName = getTableName({
       indexName: TABLE_WORKFLOW_DEFINITIONS,
       schemaName: getSchemaName(this.schema),
     });
     const request = this.pool.request();
     request.input('id', id);
-    await request.query(`DELETE FROM ${tableName} WHERE [id] = @id`);
+    if (options?.authorId !== undefined) request.input('authorId', options.authorId);
+    const result = await request.query(
+      `DELETE FROM ${tableName} WHERE [id] = @id${options?.authorId !== undefined ? ' AND [authorId] = @authorId' : ''}`,
+    );
+    return (result.rowsAffected?.[0] ?? 0) > 0;
   }
 }

--- a/stores/mssql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mssql/src/storage/domains/workflow-definitions/index.ts
@@ -1,6 +1,7 @@
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -177,6 +178,10 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -187,11 +192,11 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/mysql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mysql/src/storage/domains/workflow-definitions/index.ts
@@ -6,12 +6,13 @@ import {
 } from '@mastra/core/storage';
 import type {
   CreateWorkflowDefinitionInput,
+  DeleteWorkflowDefinitionOptions,
   ListWorkflowDefinitionsInput,
   ListWorkflowDefinitionsOutput,
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from '@mastra/core/storage';
-import type { Pool, RowDataPacket } from 'mysql2/promise';
+import type { Pool, ResultSetHeader, RowDataPacket } from 'mysql2/promise';
 
 import type { StoreOperationsMySQL } from '../operations';
 import { generateTableSQL } from '../operations';
@@ -175,10 +176,11 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
     return { definitions, total: definitions.length };
   }
 
-  async delete(id: string): Promise<void> {
-    await this.pool.execute(
-      `DELETE FROM ${formatTableName(TABLE_WORKFLOW_DEFINITIONS, this.database)} WHERE ${quoteIdentifier('id', 'column name')} = ?`,
-      [id],
+  async delete(id: string, options?: DeleteWorkflowDefinitionOptions): Promise<boolean> {
+    const [result] = await this.pool.execute<ResultSetHeader>(
+      `DELETE FROM ${formatTableName(TABLE_WORKFLOW_DEFINITIONS, this.database)} WHERE ${quoteIdentifier('id', 'column name')} = ?${options?.authorId !== undefined ? ` AND ${quoteIdentifier('authorId', 'column name')} = ?` : ''}`,
+      options?.authorId !== undefined ? [id, options.authorId] : [id],
     );
+    return result.affectedRows > 0;
   }
 }

--- a/stores/mysql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mysql/src/storage/domains/workflow-definitions/index.ts
@@ -1,6 +1,7 @@
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -123,6 +124,10 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -133,11 +138,11 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/pg/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/pg/src/storage/domains/workflow-definitions/index.ts
@@ -7,6 +7,7 @@ import {
 import type {
   CreateIndexOptions,
   CreateWorkflowDefinitionInput,
+  DeleteWorkflowDefinitionOptions,
   ListWorkflowDefinitionsInput,
   ListWorkflowDefinitionsOutput,
   UpdateWorkflowDefinitionInput,
@@ -225,11 +226,16 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
     return { definitions, total: definitions.length };
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: string, options?: DeleteWorkflowDefinitionOptions): Promise<boolean> {
     const tableName = getTableName({
       indexName: TABLE_WORKFLOW_DEFINITIONS,
       schemaName: getSchemaName(this.#schema),
     });
-    await this.#db.client.none(`DELETE FROM ${tableName} WHERE "id" = $1`, [id]);
+    const params = options?.authorId !== undefined ? [id, options.authorId] : [id];
+    const result = await this.#db.client.query(
+      `DELETE FROM ${tableName} WHERE "id" = $1${options?.authorId !== undefined ? ' AND "authorId" = $2' : ''}`,
+      params,
+    );
+    return (result.rowCount ?? 0) > 0;
   }
 }

--- a/stores/pg/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/pg/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,9 @@
-import { TABLE_SCHEMAS, TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_SCHEMAS,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import type {
   CreateIndexOptions,
   CreateWorkflowDefinitionInput,
@@ -165,6 +170,10 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -175,11 +184,11 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/spanner/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/spanner/src/storage/domains/workflow-definitions/index.ts
@@ -8,6 +8,7 @@ import {
 import type {
   CreateIndexOptions,
   CreateWorkflowDefinitionInput,
+  DeleteWorkflowDefinitionOptions,
   ListWorkflowDefinitionsInput,
   ListWorkflowDefinitionsOutput,
   UpdateWorkflowDefinitionInput,
@@ -192,10 +193,11 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
     return { definitions, total: definitions.length };
   }
 
-  async delete(id: string): Promise<void> {
-    await this.db.runDml({
-      sql: `DELETE FROM ${quoteIdent(TABLE_WORKFLOW_DEFINITIONS, 'table name')} WHERE id = @id`,
-      params: { id },
+  async delete(id: string, options?: DeleteWorkflowDefinitionOptions): Promise<boolean> {
+    const rowCount = await this.db.runDml({
+      sql: `DELETE FROM ${quoteIdent(TABLE_WORKFLOW_DEFINITIONS, 'table name')} WHERE id = @id${options?.authorId !== undefined ? ' AND authorId = @authorId' : ''}`,
+      params: { id, ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}) },
     });
+    return rowCount > 0;
   }
 }

--- a/stores/spanner/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/spanner/src/storage/domains/workflow-definitions/index.ts
@@ -2,6 +2,7 @@ import type { Database } from '@google-cloud/spanner';
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -143,6 +144,10 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -153,11 +158,11 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 


### PR DESCRIPTION
## Summary

- add a host-supplied `RequestContext` to trusted Dynamic Workflow author policy to Mastra Code
- scope Workflow Builder discovery/save and code-agent list/get/run/delete tools through one request-aware factory
- delegate author persistence, filtering, registration, execution, and deletion to native Core APIs
- keep code-defined workflows available while unresolved and cross-owner Dynamic Workflows fail closed

## Native ownership

The host authenticates the request and resolves an author already installed in `RequestContext`. Mastra Code does not parse client workflow/resource ids as identity, invent namespaces, copy server auth logic, or store workflow/run lifecycle state.

The policy passes `authorId` to native `addDynamicWorkflow`, workflow-definition storage list/get checks, and native `deleteDynamicWorkflow`; runs use the native registered Workflow and native run lifecycle.

## Stack

This draft is conceptually stacked after #21442, #21456, #21458, and #21459. The branch contains the required #21442 save-authoring commits and is based on the #21459 head; those commits should be dropped/rebased as the prerequisites land.

## Tests

- `pnpm --filter @mastra/code-sdk test -- src/workflows/__tests__/service.access-policy.test.ts src/tools/workflows/__tests__/save-workflow.predicate.test.ts src/workflows/__tests__/service.dispatch.test.ts src/workflows/__tests__/service.delete-workflow.test.ts src/agents/extra-tools.test.ts` (45 passed)
- `pnpm --filter @mastra/code-sdk lint` (passed)
- `pnpm --filter @mastra/code-sdk build:lib` (passed, including generated public declarations)
- `pnpm exec oxfmt --check ...changed files` (passed)
- `git diff --check` (passed)

The full Windows package test run reached 70 files / 874 passing tests but is baseline-blocked by unbuilt unrelated workspace package entries and Unix-path assumptions. `tsc --noEmit` is likewise blocked by missing declarations for unrelated workspace packages; the package build itself succeeds and emits the new public declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR links each dynamic workflow to its authenticated owner. Users can access only their own workflows, while admins have controlled broader access.

## Summary

- Add trusted `authorId` metadata to dynamic workflow registration.
- Enforce immutable ownership during updates and nested workflow validation.
- Add owner-qualified, serialized dynamic workflow deletion.
- Apply ownership checks across supported storage adapters.
- Scope server list, get, upsert, and delete routes by authenticated `RequestContext`.
- Hide legacy unowned workflows from regular callers and keep them read-only for admins.
- Preserve code-defined workflows and fail closed for unresolved or cross-owner dynamic workflows.
- Add request-aware Mastra Code workflow services and tool factories.
- Support `DynamicWorkflowAccessPolicy` and deny-only save authorization hooks.
- Support host-provided Workflow Builder models, model resolvers, and additive authoring guidance.
- Prevent forged author values and delegate persistence, registration, execution, and deletion to Core APIs.
- Update documentation, changesets, and comprehensive Core, server, storage, and Mastra Code tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->