### PR TITLE
perf(playground-ui): re-parse only the block a streamed reply is still writing

### DIFF
--- a/.changeset/funny-books-create.md
+++ b/.changeset/funny-books-create.md
@@ -1,0 +1,9 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Streamed markdown now renders block by block. A growing reply re-parses only the block still being written instead of the whole message on every chunk, so a long reply no longer costs more per chunk as it gets longer, and a reply that finishes streaming keeps every element it already put on screen instead of remounting.
+
+Half-written markdown also renders as what it is about to become: `**bold` reads as bold while its closing marker is still in flight, and a link shows its text until the URL lands, instead of flashing raw syntax on screen.
+
+One caveat: splitting a text into blocks is deliberately conservative rather than a second full parse. Anything it cannot decide — an unclosed fence, an indented continuation, a link reference or footnote definition — is kept whole, so those replies render exactly as before and simply do not get the speedup.

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -149,6 +149,7 @@
     "react-resizable-panels": "^4.7.3",
     "recharts": "^3.8.0",
     "remark-gfm": "^4.0.1",
+    "remend": "^1.3.0",
     "shiki": "^1.29.2",
     "sonner": "^2.0.7",
     "use-debounce": "^10.1.0",

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/blocks.test.ts
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/blocks.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { splitBlocks } from './blocks';
+
+describe('splitBlocks', () => {
+  it('cuts a reply at its blank lines', () => {
+    expect(splitBlocks('First para.\n\nSecond para.')).toEqual(['First para.\n\n', 'Second para.']);
+    expect(splitBlocks('Para.\n\n- one\n- two\n\n## Heading\n\n```js\ncode\n```\n\nEnd.')).toHaveLength(5);
+  });
+
+  it.each([
+    ['a fence holding a blank line', '```ts\nconst a = 1;\n\nconst b = 2;\n```', 1],
+    ['a fence the stream has not closed', 'Here:\n\n```ts\nconst a = 1;\n\nconst b', 2],
+    ['a list whose items are spaced out', '- one\n\n- two\n\n- three', 1],
+    ['a list item with its own paragraph', '1. one\n\n   still one\n\n2. two', 1],
+    ['an indented code block holding a blank line', 'Run:\n\n    npm i\n\n    npm test', 1],
+    ['a reply whose link reference resolves across a break', 'See [docs][d].\n\n[d]: https://mastra.ai', 1],
+    ['a reply whose footnote resolves across a break', 'Text[^1]\n\n[^1]: The note.\n\nAfter.', 1],
+  ])('keeps %s whole', (_, markdown, blocks) => {
+    expect(splitBlocks(markdown)).toHaveLength(blocks);
+  });
+
+  it.each([
+    'Plain text with no break at all',
+    'Para.\n\n- one\n- two\n\n## Heading\n\n```js\ncode\n```\n\nEnd.',
+    'Trailing blanks follow this.\n\n\n',
+    'Run:\n\n    npm i\n\n    npm test',
+    '',
+  ])('rejoins to the reply it was given', markdown => {
+    expect(splitBlocks(markdown).join('')).toBe(markdown);
+  });
+});

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/blocks.test.ts
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/blocks.test.ts
@@ -20,6 +20,10 @@ describe('splitBlocks', () => {
     expect(splitBlocks(markdown)).toHaveLength(blocks);
   });
 
+  it('reads a definition inside a fence as the code it is', () => {
+    expect(splitBlocks('```py\n[x]: int\n```\n\nAfter.')).toHaveLength(2);
+  });
+
   it.each([
     'Plain text with no break at all',
     'Para.\n\n- one\n- two\n\n## Heading\n\n```js\ncode\n```\n\nEnd.',

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/blocks.ts
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/blocks.ts
@@ -2,7 +2,7 @@ const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/;
 const FENCE_CLOSE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/;
 const LIST_ITEM = /^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:[ \t]|$)/;
 const INDENTED = /^(?:\t| {2,})/;
-const DEFINITION = /^ {0,3}\[[^\]]+\]:/m;
+const DEFINITION = /^ {0,3}\[[^\]]+\]:/;
 
 function fenceOpenedBy(line: string): string | undefined {
   return FENCE_OPEN.exec(line)?.[1];
@@ -27,11 +27,9 @@ function startsBlock(line: string, inList: boolean): boolean {
  * Each rule only ever merges: over-merging costs a re-parse, while cutting a
  * construct in two changes what it renders as. Link reference and footnote
  * definitions resolve across blank lines, which no line-level rule can see, so
- * a text carrying one is left whole.
+ * reaching one outside a fence abandons the split for the whole text.
  */
 export function splitBlocks(markdown: string): string[] {
-  if (DEFINITION.test(markdown)) return [markdown];
-
   const lines = markdown.split('\n');
   const starts = [0];
   let fence: string | undefined;
@@ -49,6 +47,8 @@ export function splitBlocks(markdown: string): string[] {
       broken = started;
       continue;
     }
+
+    if (DEFINITION.test(line)) return [markdown];
 
     if (broken && startsBlock(line, inList)) {
       starts.push(index);

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/blocks.ts
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/blocks.ts
@@ -1,0 +1,71 @@
+const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/;
+const FENCE_CLOSE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/;
+const LIST_ITEM = /^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:[ \t]|$)/;
+const INDENTED = /^(?:\t| {2,})/;
+const DEFINITION = /^ {0,3}\[[^\]]+\]:/m;
+
+function fenceOpenedBy(line: string): string | undefined {
+  return FENCE_OPEN.exec(line)?.[1];
+}
+
+// Both are runs of one character, so `startsWith` is "same marker, at least as long".
+function closesFence(line: string, marker: string): boolean {
+  return FENCE_CLOSE.exec(line)?.[1]?.startsWith(marker) ?? false;
+}
+
+function startsBlock(line: string, inList: boolean): boolean {
+  if (INDENTED.test(line)) return false;
+
+  return !(inList && LIST_ITEM.test(line));
+}
+
+/**
+ * Cuts markdown into top-level blocks so a growing reply re-parses its last
+ * block instead of all of them. Rejoining the result returns the input, and
+ * every block renders as it would have inside the whole.
+ *
+ * Each rule only ever merges: over-merging costs a re-parse, while cutting a
+ * construct in two changes what it renders as. Link reference and footnote
+ * definitions resolve across blank lines, which no line-level rule can see, so
+ * a text carrying one is left whole.
+ */
+export function splitBlocks(markdown: string): string[] {
+  if (DEFINITION.test(markdown)) return [markdown];
+
+  const lines = markdown.split('\n');
+  const starts = [0];
+  let fence: string | undefined;
+  let started = false;
+  let broken = false;
+  let inList = false;
+
+  for (const [index, line] of lines.entries()) {
+    if (fence) {
+      if (closesFence(line, fence)) fence = undefined;
+      continue;
+    }
+
+    if (line.trim() === '') {
+      broken = started;
+      continue;
+    }
+
+    if (broken && startsBlock(line, inList)) {
+      starts.push(index);
+      started = false;
+    }
+
+    if (!started) inList = LIST_ITEM.test(line);
+
+    started = true;
+    broken = false;
+    fence = fenceOpenedBy(line);
+  }
+
+  return starts.map((start, position) => {
+    const end = starts[position + 1];
+    const block = lines.slice(start, end ?? lines.length).join('\n');
+
+    return end === undefined ? block : `${block}\n`;
+  });
+}

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.memo.test.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.memo.test.tsx
@@ -40,4 +40,13 @@ describe('MarkdownRenderer memoization', () => {
 
     expect(parsed).toEqual(['already **done**']);
   });
+
+  it('re-parses only the block a streamed reply is still growing', () => {
+    const { rerender } = render(<MarkdownRenderer streaming>{'First para.\n\nSecond'}</MarkdownRenderer>);
+
+    parsed.length = 0;
+    rerender(<MarkdownRenderer streaming>{'First para.\n\nSecond para.'}</MarkdownRenderer>);
+
+    expect(parsed).toEqual(['Second para.']);
+  });
 });

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
@@ -219,6 +219,57 @@ describe('MarkdownRenderer', () => {
     expect([...words].map(node => node.textContent)).toEqual(['Hello', 'there,']);
   });
 
+  it('remounts no block as the reply grows past it', () => {
+    const { container, rerender } = render(<MarkdownRenderer streaming>{'First para.\n\nSecond'}</MarkdownRenderer>);
+
+    const paragraphs = [...container.querySelectorAll('p')];
+
+    rerender(<MarkdownRenderer streaming>{'First para.\n\nSecond para.'}</MarkdownRenderer>);
+
+    expect([...container.querySelectorAll('p')]).toEqual(paragraphs);
+  });
+
+  it('keeps every element on screen when a reply stops streaming', () => {
+    const reply = 'Intro para.\n\nSecond para.\n\n```ts\nconst ok = true;\n```\n';
+    const { container, rerender } = render(
+      <TooltipProvider>
+        <MarkdownRenderer streaming>{reply}</MarkdownRenderer>
+      </TooltipProvider>,
+    );
+
+    const before = [...container.querySelectorAll('p, figure')];
+
+    rerender(
+      <TooltipProvider>
+        <MarkdownRenderer>{reply}</MarkdownRenderer>
+      </TooltipProvider>,
+    );
+
+    expect([...container.querySelectorAll('p, figure')]).toEqual(before);
+    expect(container.querySelectorAll('.mastra-markdown-word')).toHaveLength(0);
+  });
+
+  it('reveals the last word of a block once the reply moves past it', () => {
+    const { container } = render(<MarkdownRenderer streaming>{'First para.\n\nSecond'}</MarkdownRenderer>);
+
+    const held = [...container.querySelectorAll('.mastra-markdown-word-pending')].map(node => node.textContent);
+
+    expect(held).toEqual(['Second']);
+  });
+
+  it('closes a marker the stream has not caught up with', () => {
+    const { container } = render(<MarkdownRenderer streaming>{'A **bold wo'}</MarkdownRenderer>);
+
+    expect(container.querySelector('strong')?.textContent).toBe('bold wo');
+  });
+
+  it('renders a half-written link as its text rather than a dead anchor', () => {
+    const { container } = render(<MarkdownRenderer streaming>{'See [the docs](https://mastra'}</MarkdownRenderer>);
+
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('the docs');
+  });
+
   it('never sets a text-wrap style that re-breaks lines already on screen', () => {
     const css = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'markdown-renderer.css'), 'utf8');
 

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
@@ -249,11 +249,16 @@ describe('MarkdownRenderer', () => {
     expect(container.querySelectorAll('.mastra-markdown-word')).toHaveLength(0);
   });
 
-  it('reveals the last word of a block once the reply moves past it', () => {
-    const { container } = render(<MarkdownRenderer streaming>{'First para.\n\nSecond'}</MarkdownRenderer>);
+  it('fades the word a block was holding once the reply moves past it', () => {
+    const { container, rerender } = render(<MarkdownRenderer streaming>{'First'}</MarkdownRenderer>);
+
+    const first = container.querySelector('.mastra-markdown-word-pending');
+
+    rerender(<MarkdownRenderer streaming>{'First\n\nSecond'}</MarkdownRenderer>);
 
     const held = [...container.querySelectorAll('.mastra-markdown-word-pending')].map(node => node.textContent);
 
+    expect(first?.className).toBe('mastra-markdown-word');
     expect(held).toEqual(['Second']);
   });
 

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
@@ -1,9 +1,11 @@
 import { memo } from 'react';
 import type { MouseEvent, MouseEventHandler, ReactNode } from 'react';
 import Markdown from 'react-markdown';
-import type { Components, ExtraProps } from 'react-markdown';
+import type { Components, ExtraProps, Options } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remend from 'remend';
 
+import { splitBlocks } from './blocks';
 import { rehypeWordSpans } from './word-spans';
 import { CodeBlock } from '@/ds/components/CodeBlock';
 import { cn } from '@/lib/utils';
@@ -25,9 +27,11 @@ export interface MarkdownRendererProps {
  * (file contents, tool output, web pages): react-markdown escapes raw HTML and
  * drops dangerous link schemes, so nothing here reaches the DOM as markup.
  *
- * Memoized because react-markdown re-parses on every render and a streaming
- * reply re-renders its whole transcript on every delta: without this, each
- * chunk re-parses every settled message on the page as well as the live one.
+ * react-markdown re-parses on every render, and a streaming reply re-renders
+ * its whole transcript on every delta. Memoizing spares the settled messages;
+ * rendering block by block — streaming or not — spares every block of the live
+ * one but the last, and lets a reply settle without remounting what is already
+ * on screen.
  */
 export const MarkdownRenderer = memo(function MarkdownRenderer({
   children,
@@ -35,17 +39,55 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   externalLinkTarget = 'tab',
   streaming = false,
 }: MarkdownRendererProps) {
+  const blocks = splitBlocks(decodeEscapedNewlines(children));
+  const last = blocks.length - 1;
+  const components = externalLinkTarget === 'window' ? WINDOW_COMPONENTS : COMPONENTS;
+
   return (
-    <Markdown
-      remarkPlugins={REMARK_PLUGINS}
-      rehypePlugins={streaming ? WORD_SPAN_PLUGINS : undefined}
-      components={externalLinkTarget === 'window' ? WINDOW_COMPONENTS : COMPONENTS}
-      className={cn('mastra-markdown', streaming && 'mastra-markdown-streaming', className)}
-    >
-      {decodeEscapedNewlines(children)}
+    <div className={cn('mastra-markdown', streaming && 'mastra-markdown-streaming', className)}>
+      {blocks.map((block, index) => {
+        const growing = streaming && index === last;
+
+        return (
+          <MarkdownBlock
+            key={index}
+            content={growing ? remend(block, REMEND_OPTIONS) : block}
+            rehypePlugins={wordSpansFor(streaming, growing)}
+            components={components}
+          />
+        );
+      })}
+    </div>
+  );
+});
+
+/** Keyed by position at the call site: a content key remounts on every character. */
+const MarkdownBlock = memo(function MarkdownBlock({
+  components,
+  content,
+  rehypePlugins,
+}: {
+  components: Components;
+  content: string;
+  rehypePlugins: Options['rehypePlugins'];
+}) {
+  return (
+    <Markdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={rehypePlugins} components={components}>
+      {content}
     </Markdown>
   );
 });
+
+const NO_WORD_SPANS: Options['rehypePlugins'] = [];
+const GROWING_WORD_SPANS: Options['rehypePlugins'] = [[rehypeWordSpans, { complete: false }]];
+const SETTLED_WORD_SPANS: Options['rehypePlugins'] = [[rehypeWordSpans, { complete: true }]];
+
+/** Module constants, so a block that keeps its plugins keeps its memo too. */
+function wordSpansFor(streaming: boolean, growing: boolean): Options['rehypePlugins'] {
+  if (!streaming) return NO_WORD_SPANS;
+
+  return growing ? GROWING_WORD_SPANS : SETTLED_WORD_SPANS;
+}
 
 // Agent networks emit their text with literal `\n`. Only unescape when the text
 // has no real newline, otherwise a `"a\nb"` inside a code fence gets shredded.
@@ -121,7 +163,11 @@ function markdownLink(externalLinkTarget: MarkdownExternalLinkTarget): NonNullab
 }
 
 const REMARK_PLUGINS = [remarkGfm];
-const WORD_SPAN_PLUGINS = [rehypeWordSpans];
+
+// Links stay text until their URL lands: remend's placeholder href would render
+// a live anchor to nowhere. No math is rendered here, so pairing `$$` would only
+// turn one literal into another.
+const REMEND_OPTIONS = { katex: false, linkMode: 'text-only' } as const;
 
 // Elements are listed one by one: react-markdown also passes its `node`, which
 // React would forward to the DOM as a stray attribute. Everything else is

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/word-spans.ts
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/word-spans.ts
@@ -29,19 +29,20 @@ function textOf(nodes: MarkdownChild[]): string {
  * The word still being typed is held invisible instead of faded: React reuses
  * its span as characters land, so a mount animation would never cover them.
  * Marking it complete swaps the class, which starts the fade on that same span.
- * Emphasis splits such a word across nodes (`Hel**lo**`), so its boundary is
- * read from the whole reply rather than from each text node.
+ * Emphasis splits such a word across nodes (`Hel**lo**`), so its boundary comes
+ * from the whole text, not from each text node. Only the block still growing has
+ * one at all — `complete` lets the settled ones reveal their last word.
  *
  * Only the tail is marked. A restructure — a paragraph becoming a list item
  * once the next character lands — remounts the subtree, so the window bounds
  * that re-fade rather than removing it.
  */
-export function rehypeWordSpans() {
+export function rehypeWordSpans({ complete = false }: { complete?: boolean } = {}) {
   return (tree: { children: MarkdownChild[] }) => {
     const reply = textOf(tree.children);
     const total = reply.length;
     const animateFrom = total - ANIMATED_TAIL_CHARS;
-    const pendingFrom = total - (/\S*$/.exec(reply)?.[0].length ?? 0);
+    const pendingFrom = complete ? Number.POSITIVE_INFINITY : total - (/\S*$/.exec(reply)?.[0].length ?? 0);
     let offset = 0;
 
     const wordProperties = (startsAt: number, endsAt: number) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5776,6 +5776,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      remend:
+        specifier: ^1.3.0
+        version: 1.3.0
       shiki:
         specifier: ^1.29.2
         version: 1.29.2


### PR DESCRIPTION
A long streamed reply no longer gets slower to render the further it goes, and half-written markdown reads as what it is about to become instead of flashing its syntax.

Before, every chunk of a streaming reply re-parsed the entire message: at 300 chunks the last one paid for all 300, so the tail of a long answer visibly dragged. Now the text is cut into top-level blocks and each is rendered on its own, so a chunk only re-parses the block it lands in. I measured it by replaying the same 331-delta stream of a 13 KB reply through both versions of the component in jsdom: 3459 ms before, 183 ms after, so about 19x on that shape. It is a synthetic stream in a fake DOM, not a browser trace, but the parsing work it removes is the same work a browser does.

The blocks are keyed by position and rendered the same way whether or not the text is streaming, which also means nothing remounts when a reply finishes. That last part came out of reviewing my own first attempt: it flipped between two different trees at that moment, which remounted the whole message and made its code blocks flash unhighlighted while shiki ran again. There is now a test pinning DOM identity across that transition, and another pinning that the word a block was holding back gains the fade class on the very same span rather than a new one.

The splitter is deliberately dumb and only ever merges. An unclosed fence, an indented continuation, a loose list, or a link reference or footnote definition outside a fence leaves the text whole, because a wrong cut changes what the markdown renders as while a wrong merge just costs a re-parse. On top of that, remend (Apache-2.0, no runtime deps, already in the lockfile) closes the markers the stream has not caught up with on the block still being written, so `**bold` reads as bold and a link shows its text until its URL lands. I left links in text-only mode on purpose: remend's placeholder href would otherwise render a live anchor to nowhere.

Tests, typecheck and lint run clean on playground-ui, factory-ui and playground, and I checked each new assertion can actually fail by breaking the code it covers. What I have not done is watch a real reply stream in a browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The renderer now updates only the part of a streamed message that is still changing. Finished content stays in place, which prevents visual flicker and unnecessary code-block remounts.

## Changes

- Split Markdown into stable, position-keyed top-level blocks.
- Re-parse only the active block during streaming.
- Preserve DOM identity for completed blocks and code blocks.
- Use `remend` for incomplete emphasis and links.
- Keep incomplete links as text until their URLs are complete.
- Keep unsafe-to-split content intact, including unclosed fences, indented continuations, loose lists, link references, and footnote definitions.
- Allow link references and footnote definitions inside fenced code.
- Add `complete` handling to `rehypeWordSpans`.
- Add `remend` as a runtime dependency.
- Add tests for block splitting, parse counts, streaming behavior, DOM identity, pending-word spans, and incomplete Markdown.

## Validation

Tests, typecheck, and lint passed for `playground-ui`, `factory-ui`, and `playground`. Browser validation of a long streamed reply was not performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->