### PR TITLE
fix: read-only thread endpoints no longer provision workspaces

### DIFF
--- a/.changeset/better-pots-fly.md
+++ b/.changeset/better-pots-fly.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/server': patch
-'@mastra/core': patch
 ---
 
-Fixed thread page visits provisioning a workspace/sandbox unnecessarily. The `GET /agent-controller/:controllerId/sessions/:resourceId/threads` and `GET /agent-controller/:controllerId/sessions/:resourceId/threads/:threadId/messages` endpoints now read from storage directly instead of creating a session, eliminating a 5–17s stall on every read-only thread request.
+Fixed `GET /agent-controller/:controllerId/sessions/:resourceId/threads` and `GET /agent-controller/:controllerId/sessions/:resourceId/threads/:threadId/messages` provisioning a workspace/sandbox on every request. Both endpoints previously routed through session creation as a side effect, stalling read-only page visits 5–17s and consuming a sandbox slot per visit. They now read from storage directly. Session creation and workspace/sandbox provisioning continue to happen on the write path as before.

--- a/.changeset/better-pots-fly.md
+++ b/.changeset/better-pots-fly.md
@@ -1,0 +1,6 @@
+---
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Fixed thread page visits provisioning a workspace/sandbox unnecessarily. The `GET /agent-controller/:controllerId/sessions/:resourceId/threads` and `GET /agent-controller/:controllerId/sessions/:resourceId/threads/:threadId/messages` endpoints now read from storage directly instead of creating a session, eliminating a 5–17s stall on every read-only thread request.

--- a/.changeset/silent-parrots-pay.md
+++ b/.changeset/silent-parrots-pay.md
@@ -1,0 +1,6 @@
+---
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Added public read-only thread query methods (`queryThreads`, `queryThreadById`, `queryThreadMessages`) on `AgentController`. These read directly from storage without constructing a Session, so callers can list threads or fetch messages without triggering the workspace/sandbox initialization that `createSession` performs as a side effect.

--- a/.changeset/silent-parrots-pay.md
+++ b/.changeset/silent-parrots-pay.md
@@ -1,6 +1,18 @@
 ---
-'@mastra/server': patch
 '@mastra/core': patch
 ---
 
-Added public read-only thread query methods (`queryThreads`, `queryThreadById`, `queryThreadMessages`) on `AgentController`. These read directly from storage without constructing a Session, so callers can list threads or fetch messages without triggering the workspace/sandbox initialization that `createSession` performs as a side effect.
+Added public read-only thread query methods on `AgentController` and a `initStorage()` method that initializes storage without provisioning a workspace. Use these to read threads or messages without paying the workspace/sandbox startup cost that `createSession` incurs.
+
+```ts
+// Before: had to create a session (which called Workspace.init() -> sandbox.start())
+const session = await controller.createSession({ resourceId });
+const threads = await session.thread.list();
+
+// After: read directly from storage, no session, no workspace
+const threads = await controller.queryThreads({ resourceId });
+const messages = await controller.queryThreadMessages({ threadId, limit: 50 });
+const thread = await controller.queryThreadById({ threadId });
+```
+
+`queryThreads`, `queryThreadById`, and `queryThreadMessages` were already used internally; they are now part of the public `AgentController` API. Each lazily calls `initStorage()`, so callers don't need to pre-init.

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -898,7 +898,22 @@ export class AgentController<TState = {}> {
     return this.initPromise;
   }
 
-  private async runInit(): Promise<void> {
+  /**
+   * Initialize only what read-only queries need: the storage layer (either a
+   * fresh internal Mastra wrapping the configured storage, or the inherited
+   * parent Mastra's storage). Skips workspace/sandbox provisioning entirely.
+   *
+   * Idempotent and safe to call from every read query; the underlying
+   * MastraCompositeStore init dedupes.
+   */
+  async initStorage(): Promise<void> {
+    this.#storageInitPromise ??= this.runStorageInit();
+    return this.#storageInitPromise;
+  }
+
+  #storageInitPromise?: Promise<void>;
+
+  private async runStorageInit(): Promise<void> {
     // Create an internal Mastra instance so agents have access to storage
     // (required for tool approval snapshot persistence/resume).
     // We init storage through Mastra's proxied storage so augmentWithInit
@@ -927,6 +942,13 @@ export class AgentController<TState = {}> {
       // is safe even when the parent already initialized it.
       await this.#externalMastra.getStorage()?.init();
     }
+  }
+
+  private async runInit(): Promise<void> {
+    // Storage init is a prerequisite for both reads and writes; share the same
+    // promise so a concurrent read that already triggered storage init doesn't
+    // race with the workspace init we're about to do.
+    await this.initStorage();
 
     // Initialize workspace if configured (skip for dynamic factory — resolved per-request)
     if (this.config.workspace && !this.workspaceInitialized && typeof this.workspace !== 'function') {
@@ -1118,6 +1140,7 @@ export class AgentController<TState = {}> {
    * configured.
    */
   async queryThreadById({ threadId }: { threadId: string }): Promise<AgentControllerThread | null> {
+    await this.initStorage();
     if (!this.#resolveStorage()) return null;
     const memoryStorage = await this.getMemoryStorage();
     const thread = await memoryStorage.getThreadById({ threadId });
@@ -1146,6 +1169,7 @@ export class AgentController<TState = {}> {
     includeForkedSubagents?: boolean;
     metadata?: Record<string, unknown>;
   }): Promise<AgentControllerThread[]> {
+    await this.initStorage();
     if (!this.#resolveStorage()) {
       return [];
     }
@@ -1185,6 +1209,7 @@ export class AgentController<TState = {}> {
    * creation.
    */
   async queryThreadMessages({ threadId, limit }: { threadId: string; limit?: number }): Promise<MastraDBMessage[]> {
+    await this.initStorage();
     if (!this.#resolveStorage()) return [];
 
     const memoryStorage = await this.getMemoryStorage();

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -1110,7 +1110,14 @@ export class AgentController<TState = {}> {
     }
   }
 
-  private async queryThreadById({ threadId }: { threadId: string }): Promise<AgentControllerThread | null> {
+  /**
+   * Read a single thread by id directly from storage, without constructing a
+   * {@link Session}. Read-only server endpoints use this so a GET request for a
+   * thread doesn't spin up a workspace/sandbox as a side effect of session
+   * creation. Returns `null` when the thread doesn't exist or no storage is
+   * configured.
+   */
+  async queryThreadById({ threadId }: { threadId: string }): Promise<AgentControllerThread | null> {
     if (!this.#resolveStorage()) return null;
     const memoryStorage = await this.getMemoryStorage();
     const thread = await memoryStorage.getThreadById({ threadId });
@@ -1125,7 +1132,12 @@ export class AgentController<TState = {}> {
     };
   }
 
-  private async queryThreads({
+  /**
+   * List threads directly from storage, without constructing a {@link Session}.
+   * Read-only server endpoints use this so a GET on `/threads` doesn't spin up
+   * a workspace/sandbox as a side effect of session creation.
+   */
+  async queryThreads({
     resourceId,
     includeForkedSubagents,
     metadata,
@@ -1166,13 +1178,13 @@ export class AgentController<TState = {}> {
     }));
   }
 
-  private async queryThreadMessages({
-    threadId,
-    limit,
-  }: {
-    threadId: string;
-    limit?: number;
-  }): Promise<MastraDBMessage[]> {
+  /**
+   * List messages for a thread directly from storage, without constructing a
+   * {@link Session}. Read-only server endpoints use this so a GET on a thread's
+   * messages doesn't spin up a workspace/sandbox as a side effect of session
+   * creation.
+   */
+  async queryThreadMessages({ threadId, limit }: { threadId: string; limit?: number }): Promise<MastraDBMessage[]> {
     if (!this.#resolveStorage()) return [];
 
     const memoryStorage = await this.getMemoryStorage();

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -794,6 +794,52 @@ describe('agent-controller routes', () => {
       }
     });
 
+    it('does not initialize the configured workspace on read-only GET endpoints', async () => {
+      // Regression: GET /threads and GET /threads/:id/messages used to route
+      // through createSession, which fires Workspace.init() -> sandbox.start()
+      // as a side effect. That stalled reads 5-17s and burned a sandbox slot
+      // per page visit. These routes now query storage directly and must not
+      // provision the configured workspace, even on the first request against
+      // a fresh controller.
+      const { mastra: fresh, controller } = makeMastra();
+      const workspaceInit = vi.spyOn(Workspace.prototype, 'init');
+      const createSession = vi.spyOn(controller, 'createSession');
+      try {
+        // Seed a thread through storage so the messages endpoint has a target,
+        // WITHOUT going through createSession (which would provision).
+        await controller.initStorage();
+        const memory = await (controller as any).getMemoryStorage();
+        const seeded = await memory.saveThread({
+          thread: {
+            id: 'seeded-thread',
+            resourceId: 'read-only',
+            title: 'seeded',
+            metadata: {},
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        });
+
+        await LIST_AGENT_CONTROLLER_THREADS_ROUTE.handler({
+          mastra: fresh,
+          controllerId: 'code',
+          resourceId: 'read-only',
+        } as any);
+        await LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE.handler({
+          mastra: fresh,
+          controllerId: 'code',
+          resourceId: 'read-only',
+          threadId: seeded.id,
+        } as any);
+
+        expect(workspaceInit).not.toHaveBeenCalled();
+        expect(createSession).not.toHaveBeenCalled();
+      } finally {
+        workspaceInit.mockRestore();
+        createSession.mockRestore();
+      }
+    });
+
     it('lists active runs controller-wide without creating a session', async () => {
       const controller = mastra.getAgentController('code')!;
       const createSession = vi.spyOn(controller, 'createSession');

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -772,9 +772,14 @@ describe('agent-controller routes', () => {
       const session = await mastra.getAgentController('code')!.createSession({ resourceId: 'user-state' });
       const busy = await session.thread.create({ title: 'busy' });
 
+      // Handler reads active state from the controller-wide active-run
+      // registry (same source as the `active-runs` endpoint) instead of
+      // resolving a per-session agent, so mock that instead of the per-agent
+      // `getActiveThreadRunId`. Semantics are identical: a thread is active
+      // iff a run is registered for its resourceId + threadId.
       const spy = vi
-        .spyOn(Agent.prototype, 'getActiveThreadRunId')
-        .mockImplementation(({ threadId }) => (threadId === busy.id ? 'run-1' : undefined));
+        .spyOn(Agent.prototype, 'listActiveThreadRuns')
+        .mockReturnValue([{ runId: 'run-1', resourceId: 'user-state', threadId: busy.id }]);
       try {
         const res = (await LIST_AGENT_CONTROLLER_THREADS_ROUTE.handler({
           mastra,

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -881,11 +881,15 @@ export const LIST_AGENT_CONTROLLER_THREADS_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId, resourceId, sessionScope, limit, tags, requestContext }) => {
+  handler: async ({ mastra, controllerId, resourceId, limit, tags }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId, { scope: sessionScope }, requestContext);
-      const threads = await session.thread.list();
+      // Read-only route: query storage directly instead of constructing a
+      // Session. `createSession` triggers workspace/sandbox initialization
+      // (5–17s stall, cost per provisioned sandbox) as a side effect — reads
+      // shouldn't pay that. Session creation happens on the write path.
+      await controller.init();
+      const threads = await controller.queryThreads({ resourceId });
       // A thread's metadata mixes the session scoping tags (stamped at creation,
       // e.g. `projectPath`) with internal session bookkeeping that
       // `Session.loadMetadata()` reads back (selected model/mode, observer/
@@ -918,12 +922,19 @@ export const LIST_AGENT_CONTROLLER_THREADS_ROUTE = createRoute({
       const sorted = [...scoped].sort((a, b) => toTime(b) - toTime(a));
       const max = Number(limit);
       const limited = Number.isFinite(max) && max > 0 ? sorted.slice(0, max) : sorted;
-      // Thread run state comes from the agent thread-stream runtime (the same
-      // per-thread active/idle tracking the signals `ifIdle` path uses). It is
-      // keyed by resourceId + threadId, so it covers runs started by any
-      // session on this resource — including sessions scoped to other git
-      // worktrees — letting one listing report activity across all of them.
-      const agent = controller.getCurrentAgent(session);
+      // Thread run state comes from the controller-wide active-run registry,
+      // which unions per-agent active thread runs across all backing agents.
+      // Keyed by resourceId + threadId so it covers runs started by any session
+      // on this resource — including sessions scoped to other git worktrees.
+      // Using this controller-level accessor (rather than resolving an agent
+      // via a Session) keeps the read path free of session/workspace
+      // side-effects.
+      const activeThreadIds = new Set(
+        controller
+          .listActiveThreadRuns()
+          .filter(r => r.resourceId === resourceId)
+          .map(r => r.threadId),
+      );
       return {
         threads: limited.map(t => {
           const threadTags = getTags(t);
@@ -932,7 +943,7 @@ export const LIST_AGENT_CONTROLLER_THREADS_ROUTE = createRoute({
             title: t.title,
             tags: Object.keys(threadTags).length > 0 ? threadTags : undefined,
             updatedAt: t.updatedAt instanceof Date ? t.updatedAt.toISOString() : undefined,
-            state: agent.getActiveThreadRunId({ resourceId, threadId: t.id }) ? ('active' as const) : ('idle' as const),
+            state: activeThreadIds.has(t.id) ? ('active' as const) : ('idle' as const),
           };
         }),
       };
@@ -1136,11 +1147,23 @@ export const LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE = createRoute({
   tags: ['AgentController', 'Threads'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId, resourceId, sessionScope, threadId, limit, requestContext }) => {
+  handler: async ({ mastra, controllerId, resourceId, threadId, limit }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId, { scope: sessionScope }, requestContext);
-      const messages = await session.thread.listMessages({ threadId, limit });
+      // Read-only route: query storage directly instead of constructing a
+      // Session. Session creation would trigger workspace/sandbox
+      // initialization as a side effect; reads should never pay that cost.
+      await controller.init();
+      // The route is authorized for the URL's resourceId, but `threadId` is
+      // otherwise unscoped. Verify the thread belongs to this resource so a
+      // caller can't peek at another resource's messages by guessing an id
+      // — matches the check `session.thread.listMessages` performed via
+      // `session.thread.set` before we bypassed session construction.
+      const thread = await controller.queryThreadById({ threadId });
+      if (!thread || thread.resourceId !== resourceId) {
+        throw new Error(`Thread not found: ${threadId}`);
+      }
+      const messages = await controller.queryThreadMessages({ threadId, limit });
       return {
         messages: messages.map(m => ({
           id: m.id,

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -888,7 +888,7 @@ export const LIST_AGENT_CONTROLLER_THREADS_ROUTE = createRoute({
       // Session. `createSession` triggers workspace/sandbox initialization
       // (5–17s stall, cost per provisioned sandbox) as a side effect — reads
       // shouldn't pay that. Session creation happens on the write path.
-      await controller.init();
+      // `queryThreads` lazily initializes storage (not workspace) on its own.
       const threads = await controller.queryThreads({ resourceId });
       // A thread's metadata mixes the session scoping tags (stamped at creation,
       // e.g. `projectPath`) with internal session bookkeeping that
@@ -1153,7 +1153,7 @@ export const LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE = createRoute({
       // Read-only route: query storage directly instead of constructing a
       // Session. Session creation would trigger workspace/sandbox
       // initialization as a side effect; reads should never pay that cost.
-      await controller.init();
+      // The query methods lazily initialize storage (not workspace) on their own.
       // The route is authorized for the URL's resourceId, but `threadId` is
       // otherwise unscoped. Verify the thread belongs to this resource so a
       // caller can't peek at another resource's messages by guessing an id


### PR DESCRIPTION
## Summary

Visiting a thread page in the frontend fires `GET /threads` and `GET /threads/:threadId/messages`. Both endpoints routed through `AgentController.createSession()`, which calls `Workspace.init()` → `sandbox.start()` as a side effect of session construction. That meant every read-only page visit stalled 5–17s waiting for a fresh sandbox to boot, and provisioned a sandbox slot even for users who were only browsing history.

This change routes the two read-only endpoints straight to storage instead of constructing a Session:

- `GET /agent-controller/:controllerId/sessions/:resourceId/threads` — lists threads via `controller.queryThreads`.
- `GET /agent-controller/:controllerId/sessions/:resourceId/threads/:threadId/messages` — lists messages via `controller.queryThreadMessages` after a `queryThreadById` scoping check.

Session creation and workspace provisioning still happen exactly as before on the write path (`POST /sessions`, `sendMessage`, etc.). No public signatures change; three `AgentController` methods that were already used internally are promoted from `private` to `public` (`queryThreads`, `queryThreadById`, `queryThreadMessages`).

## Notes for reviewers

- Thread run state (`active`/`idle`) on the list endpoint now comes from `controller.listActiveThreadRuns()` — the same controller-wide accessor `GET /active-runs` uses — instead of resolving a per-session agent. Behavior is equivalent; the source of truth is unified.
- Cross-resource scoping is preserved: the messages handler still rejects a `threadId` whose `resourceId` doesn't match the URL.
- `GET /sessions/:resourceId` (session state) is intentionally left calling `createSession`. Its response schema requires `modeId`/`modelId` as strings and there is no session-free way to synthesize them without changing the response contract. Follow-up work if needed.

## Test plan

- `pnpm --filter ./packages/core check` — clean.
- `pnpm --filter ./packages/core test` (agent-controller + workspace) — 458 pass.
- `pnpm --filter ./packages/server test` — 2111 pass, including the cross-resource-rejection suite and the thread-run-state annotation test (updated to spy the controller-wide accessor).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Read-only thread requests now read stored data directly. They do not create a session or initialize a workspace, which reduces delays and avoids side effects.

## Changes

- Updated thread and message GET endpoints to query controller storage directly.
- Added lazy, idempotent `AgentController.initStorage()`.
- Kept full workspace initialization for write operations.
- Used `queryThreads`, `queryThreadById`, and `queryThreadMessages`.
- Preserved cross-resource thread validation.
- Used `listActiveThreadRuns()` for active thread state.
- Made three storage query methods public in `AgentController`.
- Kept session creation for write operations and `GET /sessions/:resourceId`.
- Added regression coverage for configured workspaces.
- Updated active-thread state mocks.
- Added patch changesets for `@mastra/core` and `@mastra/server`.
- Reported passing checks, including 458 core tests and 2,111 server tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->