### PR TITLE
fix(core): isolate dynamic workspace skills by request

### DIFF
--- a/.changeset/true-pianos-teach.md
+++ b/.changeset/true-pianos-teach.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed dynamic workspace skills so concurrent requests keep isolated skill sets.

--- a/packages/core/src/agent/__tests__/agent-skills-wiring.test.ts
+++ b/packages/core/src/agent/__tests__/agent-skills-wiring.test.ts
@@ -343,6 +343,56 @@ describe('Agent-level skills wiring', () => {
 
       expect(resolver).toHaveBeenCalledTimes(2);
     });
+
+    it('uses request-bound workspace skill views for programmatic access', async () => {
+      const premiumSkill: Skill = {
+        name: 'premium-skill',
+        description: 'Only available to premium requests.',
+        instructions: 'Use premium instructions.',
+        path: '/skills/premium-skill',
+        source: { type: 'local', projectPath: '/skills/premium-skill' },
+        references: [],
+        scripts: [],
+        assets: [],
+      };
+      const basicView = createMockWorkspaceSkills();
+      const premiumView = createMockWorkspaceSkills();
+      premiumView.get = vi
+        .fn()
+        .mockImplementation((name: string) => Promise.resolve(name === premiumSkill.name ? premiumSkill : null));
+      premiumView.list = vi.fn().mockResolvedValue([
+        mockWorkspaceSkillMeta,
+        {
+          name: premiumSkill.name,
+          path: premiumSkill.path,
+          description: premiumSkill.description,
+        },
+      ]);
+
+      const rootSkills = createMockWorkspaceSkills();
+      rootSkills.forContext = vi.fn(async ({ requestContext }) =>
+        requestContext?.get('userTier') === 'premium' ? premiumView : basicView,
+      );
+
+      const agent = new Agent({
+        id: 'dynamic-workspace-skills',
+        instructions: 'You have request-scoped workspace skills.',
+        model: mockModel,
+        workspace: {
+          skills: rootSkills,
+          getToolsConfig: () => undefined,
+          filesystem: undefined,
+          sandbox: undefined,
+        } as unknown as Workspace,
+      });
+      const premiumContext = new RequestContext([['userTier', 'premium']]);
+      const basicContext = new RequestContext([['userTier', 'basic']]);
+
+      await expect(agent.getSkill('premium-skill', { requestContext: premiumContext })).resolves.toBe(premiumSkill);
+      await expect(agent.getSkill('premium-skill', { requestContext: basicContext })).resolves.toBeNull();
+      await expect(agent.getSkill('premium-skill', { requestContext: premiumContext })).resolves.toBe(premiumSkill);
+      expect(rootSkills.forContext).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe('tracing context for dynamic resolvers', () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1330,7 +1330,10 @@ export class Agent<
 
     // Resolve workspace-level skills (if configured)
     const workspace = workspaceOverride ?? (await this.getWorkspace({ requestContext: rc }));
-    const workspaceSkills = workspace?.skills;
+    const workspaceSkillsRoot = workspace?.skills;
+    const workspaceSkills = workspaceSkillsRoot?.forContext
+      ? await workspaceSkillsRoot.forContext({ requestContext: rc })
+      : workspaceSkillsRoot;
 
     // Merge if both exist (agent skills win on name conflicts)
     if (agentSkills && workspaceSkills) {

--- a/packages/core/src/processors/processors/skill-search.ts
+++ b/packages/core/src/processors/processors/skill-search.ts
@@ -237,7 +237,10 @@ export class SkillSearchProcessor implements Processor<'skill-search'> {
     const { tools, messageList } = args;
     const threadId = this.getThreadId(args);
     const threadState = this.getThreadState(threadId);
-    const skills = this.skills;
+    const rootSkills = this.skills;
+    const skills = rootSkills?.forContext
+      ? await rootSkills.forContext({ requestContext: args.requestContext })
+      : rootSkills;
 
     if (!skills) {
       return { tools };

--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -119,10 +119,10 @@ export class SkillsProcessor implements Processor<'skills-processor'> {
    * Remapped locations are registered as aliases with the skills registry so
    * the `skill` and `skill_read` tools can resolve them back to the skill.
    */
-  private formatLocation(skill: Skill): string {
+  private formatLocation(skill: Skill, skills: WorkspaceSkills): string {
     if (!this._formatLocation) return `${skill.path}/SKILL.md`;
     const location = this._formatLocation(skill);
-    this._skills?.registerLocationAlias?.(location, skill.path);
+    skills.registerLocationAlias?.(location, skill.path);
     return location;
   }
 
@@ -137,15 +137,15 @@ export class SkillsProcessor implements Processor<'skills-processor'> {
    * Format available skills metadata based on configured format.
    * Skills are sorted by name for deterministic output (prompt cache stability).
    */
-  private async formatAvailableSkills(): Promise<string> {
-    const skillsList = await this._skills?.list();
+  private async formatAvailableSkills(skills: WorkspaceSkills): Promise<string> {
+    const skillsList = await skills.list();
     if (!skillsList || skillsList.length === 0) {
       return '';
     }
 
     // Get full skill objects to include source info (parallel fetch).
     // Use meta.path (not meta.name) so same-named skills each resolve to their specific entry.
-    const skillPromises = skillsList.map(meta => this._skills?.get(meta.path));
+    const skillPromises = skillsList.map(meta => skills.get(meta.path));
     const fullSkills = (await Promise.all(skillPromises)).filter((s): s is Skill => s !== undefined && s !== null);
     const dedupedSkills = Array.from(new Map(fullSkills.map(skill => [skill.path, skill])).values());
 
@@ -159,7 +159,7 @@ export class SkillsProcessor implements Processor<'skills-processor'> {
             skill => `  <skill>
     <name>${this.escapeXml(skill.name)}</name>
     <description>${this.escapeXml(skill.description)}</description>
-    <location>${this.escapeXml(this.formatLocation(skill))}</location>
+    <location>${this.escapeXml(this.formatLocation(skill, skills))}</location>
     <source>${this.escapeXml(this.formatSourceType(skill))}</source>
   </skill>`,
           )
@@ -177,7 +177,7 @@ ${JSON.stringify(
   dedupedSkills.map(s => ({
     name: s.name,
     description: s.description,
-    location: this.formatLocation(s),
+    location: this.formatLocation(s, skills),
     source: this.formatSourceType(s),
   })),
   null,
@@ -189,7 +189,7 @@ ${JSON.stringify(
         const skillsMd = dedupedSkills
           .map(
             skill =>
-              `- **${skill.name}** [${this.formatSourceType(skill)}] (${this.formatLocation(skill)}): ${skill.description}`,
+              `- **${skill.name}** [${this.formatSourceType(skill)}] (${this.formatLocation(skill, skills)}): ${skill.description}`,
           )
           .join('\n');
         return `# Available Skills
@@ -225,16 +225,18 @@ ${skillsMd}`;
    * message.  Tools are provided by `Agent.listSkillTools()` instead.
    */
   async processInputStep({ messageList, stepNumber, requestContext }: ProcessInputStepArgs) {
+    const skills = this._skills?.forContext ? await this._skills.forContext({ requestContext }) : this._skills;
+
     // Refresh skills on first step only (not every step in the agentic loop)
     if (stepNumber === 0) {
-      await this._skills?.maybeRefresh({ requestContext });
+      await skills?.maybeRefresh({ requestContext });
     }
-    const skillsList = await this._skills?.list();
+    const skillsList = await skills?.list();
     const hasSkills = skillsList && skillsList.length > 0;
 
     // Inject available skills metadata (if any skills discovered)
-    if (hasSkills) {
-      const availableSkillsMessage = await this.formatAvailableSkills();
+    if (hasSkills && skills) {
+      const availableSkillsMessage = await this.formatAvailableSkills(skills);
       if (availableSkillsMessage) {
         messageList.addSystem({
           role: 'system',
@@ -246,7 +248,7 @@ ${skillsMd}`;
       // registered as aliases with the skills registry, so the location field
       // stays a valid tool identifier. Only when the skills implementation
       // cannot register aliases does the guidance fall back to by-name usage.
-      const locationResolvable = !this._formatLocation || typeof this._skills?.registerLocationAlias === 'function';
+      const locationResolvable = !this._formatLocation || typeof skills.registerLocationAlias === 'function';
       const locationGuidance = locationResolvable
         ? 'If multiple skills share the same name, use the exact location (shown in the location field) instead of the name to disambiguate. ' +
           'The location field identifies a skill for the `skill` and `skill_read` tools; it is not guaranteed to exist on your workspace filesystem, so read skill files with `skill_read` rather than with filesystem tools. '

--- a/packages/core/src/skills/agent-skills-resolver.ts
+++ b/packages/core/src/skills/agent-skills-resolver.ts
@@ -144,6 +144,14 @@ class MergedWorkspaceSkills implements WorkspaceSkills {
     this.#secondary = secondary;
   }
 
+  async forContext(context: { requestContext?: RequestContext }): Promise<WorkspaceSkills> {
+    const [primary, secondary] = await Promise.all([
+      this.#primary.forContext ? this.#primary.forContext(context) : this.#primary,
+      this.#secondary.forContext ? this.#secondary.forContext(context) : this.#secondary,
+    ]);
+    return new MergedWorkspaceSkills(primary, secondary);
+  }
+
   async list() {
     const primaryList = await this.#primary.list();
     const secondaryList = await this.#secondary.list();

--- a/packages/core/src/workspace/skills/types.ts
+++ b/packages/core/src/workspace/skills/types.ts
@@ -232,6 +232,16 @@ export interface WorkspaceSkills {
   // ===========================================================================
 
   /**
+   * Resolve a request-bound view when skills paths depend on request context.
+   *
+   * The returned view remains stable for the duration of the request even if
+   * another request resolves a different path set. Implementations with only
+   * static skills may return themselves. Optional for custom implementations;
+   * callers fall back to maybeRefresh when it is not provided.
+   */
+  forContext?(context: SkillsContext): Promise<WorkspaceSkills>;
+
+  /**
    * List discovered skills as canonical metadata entries.
    *
    * Alias paths that resolve to the same underlying skill are de-duplicated.

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -2684,6 +2684,45 @@ Premium instructions.
       expect(premiumResult.map(s => s.name).sort()).toEqual(['basic-skill', 'premium-skill']);
     });
 
+    it('should keep request-bound views isolated when contexts are interleaved', async () => {
+      const filesystem = createMockFilesystem({
+        'skills/basic/basic-skill/SKILL.md': BASIC_SKILL_MD,
+        'skills/premium/premium-skill/SKILL.md': PREMIUM_SKILL_MD,
+      });
+      const searchEngine = createMockSearchEngine();
+      const requestContext = (tier: string) => ({
+        get: (key: string) => (key === 'userTier' ? tier : undefined),
+      });
+
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        searchEngine,
+        skills: ctx => {
+          const tier = (ctx.requestContext as ReturnType<typeof requestContext>)?.get('userTier');
+          return tier === 'premium' ? ['skills/basic', 'skills/premium'] : ['skills/basic'];
+        },
+      });
+
+      // Resolve different path sets concurrently to exercise independent
+      // discovery and shared search-index writes.
+      const [premiumView, basicView] = await Promise.all([
+        skills.forContext({ requestContext: requestContext('premium') as never }),
+        skills.forContext({ requestContext: requestContext('basic') as never }),
+      ]);
+      expect(await premiumView.has('premium-skill')).toBe(true);
+      expect(await basicView.has('premium-skill')).toBe(false);
+
+      // A second request must not replace the first request's skill map or search view.
+      expect(await premiumView.has('premium-skill')).toBe(true);
+      expect(await basicView.search('Premium')).toEqual([]);
+      expect((await premiumView.search('Premium')).map(result => result.skillName)).toEqual(['premium-skill']);
+
+      // Equivalent path sets reuse the immutable view instead of repeating discovery.
+      await expect(skills.forContext({ requestContext: requestContext('premium') as never })).resolves.toBe(
+        premiumView,
+      );
+    });
+
     it('should detect when dynamic paths change and trigger refresh', async () => {
       const filesystem = createMockFilesystem({
         'skills/path-a/skill-a/SKILL.md': BASIC_SKILL_MD.replace('basic-skill', 'skill-a'),

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -46,6 +46,17 @@ interface InternalSkill extends Skill {
   indexableContent: string;
 }
 
+interface SharedSkillIndexRegistry {
+  instances: Set<WorkspaceSkillsImpl>;
+}
+
+interface WorkspaceSkillsImplInternalConfig {
+  /** Namespace search document IDs so request-scoped views cannot remove each other's entries. */
+  indexNamespace?: string;
+  /** Registry shared by request-scoped views that use the same search engine. */
+  indexRegistry?: SharedSkillIndexRegistry;
+}
+
 // =============================================================================
 // WorkspaceSkillsImpl
 // =============================================================================
@@ -88,6 +99,12 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
   readonly #validateOnLoad: boolean;
   readonly #assertAvailable?: () => void;
   readonly #checkSkillFileMtime: boolean;
+  readonly #indexNamespace: string;
+  readonly #indexRegistry: SharedSkillIndexRegistry;
+
+  /** Immutable views keyed by the canonical path set returned for a request context. */
+  #contextViews: Map<string, Promise<WorkspaceSkillsImpl>> = new Map();
+  #nextContextViewId = 0;
 
   /** Map of skill name -> array of candidates (supports same-named skills from different sources) */
   #skills: Map<string, InternalSkill[]> = new Map();
@@ -113,18 +130,69 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
   static readonly GLOB_RESOLVE_INTERVAL = 5_000; // Re-walk glob dirs every 5s
   static readonly STALENESS_CHECK_COOLDOWN = 2_000; // Skip staleness check for 2s after discovery
 
-  constructor(config: WorkspaceSkillsImplConfig) {
+  constructor(config: WorkspaceSkillsImplConfig, internal: WorkspaceSkillsImplInternalConfig = {}) {
     this.#source = config.source;
     this.#skillsResolver = config.skills;
     this.#searchEngine = config.searchEngine;
     this.#validateOnLoad = config.validateOnLoad ?? true;
     this.#assertAvailable = config.assertAvailable;
     this.#checkSkillFileMtime = config.checkSkillFileMtime ?? false;
+    this.#indexNamespace = internal.indexNamespace ?? '';
+    this.#indexRegistry = internal.indexRegistry ?? { instances: new Set() };
+    this.#indexRegistry.instances.add(this);
   }
 
   // ===========================================================================
   // Discovery
   // ===========================================================================
+
+  /**
+   * Resolve an immutable skills view for a request context.
+   *
+   * Dynamic resolvers are evaluated once when selecting the view. Views are
+   * cached by canonical path set, so one request cannot replace another
+   * request's discovered skills while an agent turn is in progress.
+   */
+  async forContext(context: SkillsContext): Promise<WorkspaceSkills> {
+    if (Array.isArray(this.#skillsResolver)) {
+      return this;
+    }
+
+    const resolvedPaths = await this.#resolvePaths(context);
+    const canonicalPaths = [...resolvedPaths].sort();
+    const cacheKey = JSON.stringify(canonicalPaths);
+
+    let pendingView = this.#contextViews.get(cacheKey);
+    if (!pendingView) {
+      const viewId = ++this.#nextContextViewId;
+      pendingView = (async () => {
+        const view = new WorkspaceSkillsImpl(
+          {
+            source: this.#source,
+            skills: canonicalPaths,
+            searchEngine: this.#searchEngine,
+            validateOnLoad: this.#validateOnLoad,
+            assertAvailable: this.#assertAvailable,
+            checkSkillFileMtime: this.#checkSkillFileMtime,
+          },
+          {
+            indexNamespace: `${this.#indexNamespace || 'context'}-${viewId}`,
+            indexRegistry: this.#indexRegistry,
+          },
+        );
+        await view.maybeRefresh();
+        return view;
+      })();
+      this.#contextViews.set(cacheKey, pendingView);
+      pendingView.catch(() => {
+        if (this.#contextViews.get(cacheKey) === pendingView) {
+          this.#contextViews.delete(cacheKey);
+        }
+      });
+    }
+
+    return pendingView;
+  }
 
   async list(): Promise<SkillMetadata[]> {
     await this.#ensureInitialized();
@@ -439,9 +507,16 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
 
     // Ask the search engine for enough rows to survive post-search filtering and
     // canonical alias de-duplication before applying the final topK.
-    const totalIndexedDocuments = [...this.#skills.values()].reduce(
-      (count, candidates) =>
-        count + candidates.reduce((skillCount, skill) => skillCount + 1 + skill.references.length, 0),
+    // The search engine is shared by request-scoped views. Ask for enough rows
+    // to survive filtering documents that belong only to another view.
+    const totalIndexedDocuments = [...this.#indexRegistry.instances].reduce(
+      (total, instance) =>
+        total +
+        [...instance.#skills.values()].reduce(
+          (count, candidates) =>
+            count + candidates.reduce((skillCount, skill) => skillCount + 1 + skill.references.length, 0),
+          0,
+        ),
       0,
     );
     const expandedTopK = Math.max(skillNames ? topK * 3 : topK, totalIndexedDocuments);
@@ -1137,7 +1212,10 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
   async #removeSkillFromIndex(skill: InternalSkill): Promise<void> {
     if (!this.#searchEngine?.remove) return;
 
-    const ids = [`skill:${skill.path}:SKILL.md`, ...skill.references.map(r => `skill:${skill.path}:${r}`)];
+    const ids = [
+      this.#getSearchDocumentId(skill.path, 'SKILL.md'),
+      ...skill.references.map(r => this.#getSearchDocumentId(skill.path, r)),
+    ];
     for (const id of ids) {
       try {
         await this.#searchEngine.remove(id);
@@ -1167,7 +1245,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
 
     // Index the main skill instructions
     await this.#searchEngine.index({
-      id: `skill:${skill.path}:SKILL.md`,
+      id: this.#getSearchDocumentId(skill.path, 'SKILL.md'),
       content: skill.instructions,
       metadata: {
         skillPath: skill.path,
@@ -1183,7 +1261,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
           const rawContent = await this.#source.readFile(fullPath);
           const content = typeof rawContent === 'string' ? rawContent : rawContent.toString('utf-8');
           await this.#searchEngine!.index({
-            id: `skill:${skill.path}:${refPath}`,
+            id: this.#getSearchDocumentId(skill.path, refPath),
             content,
             metadata: {
               skillPath: skill.path,
@@ -1195,6 +1273,11 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
         }
       }),
     );
+  }
+
+  #getSearchDocumentId(skillPath: string, source: string): string {
+    const namespace = this.#indexNamespace ? `${this.#indexNamespace}:` : '';
+    return `skill:${namespace}${skillPath}:${source}`;
   }
 
   /**


### PR DESCRIPTION
## Description

- resolves dynamic workspace skill paths into immutable, request-bound views instead of mutating one workspace-wide skill map
- caches concurrent discovery per canonical path set and namespaces search documents so one view cannot remove another view's index entries
- propagates the selected view through eager skills, skill search, agent tool access, and merged agent/workspace skills
- adds regression coverage for concurrent premium/basic discovery, interleaved reads, search isolation, and agent-level request-context wiring
- includes a patch changeset for `@mastra/core`

### Design question for review

This draft keeps path-set views for the lifetime of the workspace. That guarantees an in-flight request can continue using its selected view, but a high-cardinality resolver may need a bounded eviction or explicit lifecycle policy. I would appreciate maintainer guidance on the preferred lifetime before marking this ready.

## Related issue(s)

Fixes #21305

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Validation

- `pnpm --filter ./packages/core exec vitest run src/workspace/skills/workspace-skills.test.ts src/agent/__tests__/agent-skills-wiring.test.ts` (122 tests)
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm build:core`
- `pnpm oxfmt:changed`

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR