### PR TITLE
fix(cli): preserve build externals mode

### DIFF
--- a/.changeset/fast-beans-type.md
+++ b/.changeset/fast-beans-type.md
@@ -2,4 +2,4 @@
 'mastra': patch
 ---
 
-Preserve the external dependency build mode when projects configure bundler options. Packages listed in bundler.externals are now installed as runtime dependencies, keeping deployment manifests complete and application bundles small.
+Preserve the external dependency build mode when projects configure bundler options. Packages listed in bundler.externals are now installed as runtime dependencies, keeping deployment manifests complete and application bundles small. Deployment environments must have registry access to install these packages, including restricted or offline environments.

--- a/.changeset/fast-beans-type.md
+++ b/.changeset/fast-beans-type.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Preserve the external dependency build mode when projects configure bundler options. Packages listed in bundler.externals are now installed as runtime dependencies, keeping deployment manifests complete and application bundles small.

--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -318,6 +318,19 @@ describe.sequential.for([['pnpm'] as const])(`%s monorepo`, ([pkgManager]) => {
       expect(hasWorkspaceMappedPath).toBeFalsy();
     });
 
+    it('should keep default and user-configured externals in the output manifest', async () => {
+      const packageJsonPath = join(fixturePath, 'apps', 'custom', '.mastra', 'output', 'package.json');
+      const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf-8'));
+
+      expect(packageJson.dependencies).toEqual(
+        expect.objectContaining({
+          '@mastra/core': expect.any(String),
+          bcrypt: expect.any(String),
+          typescript: expect.any(String),
+        }),
+      );
+    });
+
     afterAll(async () => {
       if (proc) {
         try {

--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -318,6 +318,7 @@ describe.sequential.for([['pnpm'] as const])(`%s monorepo`, ([pkgManager]) => {
       expect(hasWorkspaceMappedPath).toBeFalsy();
     });
 
+    // This stays in the monorepo E2E suite because it builds the generated fixture and validates its output manifest.
     it('should keep default and user-configured externals in the output manifest', async () => {
       const packageJsonPath = join(fixturePath, 'apps', 'custom', '.mastra', 'output', 'package.json');
       const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf-8'));

--- a/packages/cli/src/commands/build/BuildBundler.test.ts
+++ b/packages/cli/src/commands/build/BuildBundler.test.ts
@@ -93,7 +93,7 @@ describe('BuildBundler', () => {
       });
     });
 
-    it('optimizes dependencies when a bundler config omits externals', async () => {
+    it('defaults to externals true when a bundler config omits externals', async () => {
       const { Bundler } = await import('@mastra/deployer/bundler');
       vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({ sourcemap: true });
       const { BuildBundler } = await import('./BuildBundler');
@@ -102,16 +102,16 @@ describe('BuildBundler', () => {
       const options = await (bundler as any).getUserBundlerOptions('/entry.ts', '/output');
 
       expect(options).toEqual({
-        sourcemap: true,
-      });
-      expect(options.externals).toBeUndefined();
-    });
-
-    it('preserves explicit externals true in a custom bundler config', async () => {
-      const { Bundler } = await import('@mastra/deployer/bundler');
-      vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({
         externals: true,
         sourcemap: true,
+      });
+    });
+
+    it('keeps configured externals as runtime dependencies while preserving externals true', async () => {
+      const { Bundler } = await import('@mastra/deployer/bundler');
+      vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({
+        externals: ['@duckdb/node-bindings', 'existing-package'],
+        dynamicPackages: ['existing-package', 'dynamic-package'],
       });
       const { BuildBundler } = await import('./BuildBundler');
       const bundler = new BuildBundler();
@@ -120,6 +120,23 @@ describe('BuildBundler', () => {
 
       expect(options).toEqual({
         externals: true,
+        dynamicPackages: ['existing-package', 'dynamic-package', '@duckdb/node-bindings'],
+      });
+    });
+
+    it.each([true, false])('preserves explicit externals %s in a custom bundler config', async externals => {
+      const { Bundler } = await import('@mastra/deployer/bundler');
+      vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({
+        externals,
+        sourcemap: true,
+      });
+      const { BuildBundler } = await import('./BuildBundler');
+      const bundler = new BuildBundler();
+
+      const options = await (bundler as any).getUserBundlerOptions('/entry.ts', '/output');
+
+      expect(options).toEqual({
+        externals,
         sourcemap: true,
       });
     });

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -2,7 +2,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Config } from '@mastra/core/mastra';
 import { FileService } from '@mastra/deployer/build';
-import { Bundler, IS_DEFAULT } from '@mastra/deployer/bundler';
+import { Bundler } from '@mastra/deployer/bundler';
 import { copy } from 'fs-extra';
 import { shouldSkipDotenvLoading } from '../utils.js';
 
@@ -21,14 +21,18 @@ export class BuildBundler extends Bundler {
     outputDirectory: string,
   ): Promise<NonNullable<Config['bundler']>> {
     const bundlerOptions = await super.getUserBundlerOptions(mastraEntryFile, outputDirectory);
+    const configuredExternals = Array.isArray(bundlerOptions.externals) ? bundlerOptions.externals : [];
 
-    if (!bundlerOptions?.[IS_DEFAULT]) {
+    if (bundlerOptions.externals === true || bundlerOptions.externals === false) {
       return bundlerOptions;
     }
+
+    const dynamicPackages = [...new Set([...(bundlerOptions.dynamicPackages ?? []), ...configuredExternals])];
 
     return {
       ...bundlerOptions,
       externals: true,
+      ...(dynamicPackages.length > 0 ? { dynamicPackages } : {}),
     };
   }
 


### PR DESCRIPTION
`mastra build` defaults to keeping non-workspace packages external so deployment artifacts install their runtime dependencies. Adding any `bundler` config accidentally disabled that default; with an externals array, packages such as `@mastra/core` were bundled and omitted from the generated manifest.

This keeps the external-all build mode unless a project explicitly sets `externals` to a boolean. Packages named in an externals array are added to `dynamicPackages`, so native or statically invisible dependencies are still declared in `.mastra/output/package.json`. Projects whose bundler config omitted `externals` will therefore produce smaller application bundles and declare more runtime dependencies, restoring the CLI's documented default. Experiment-worker artifact digests and build keys may change once, causing one rebuild per environment, and runtime installation requires registry access.

Before:
```ts
bundler: { externals: ['@duckdb/node-bindings'] }
// @mastra/core missing from output/package.json
```

After:
```ts
bundler: { externals: ['@duckdb/node-bindings'] }
// @mastra/core and @duckdb/node-bindings are runtime dependencies
```

Verified against a project scaffolded with `create-mastra@1.24.0`. The unpatched CLI produced a 10,026,071-byte `mastra.mjs` with no `@mastra/core` manifest entry. The patched CLI produced a 4,809-byte bundle and declared both `@mastra/core` and `@duckdb/node-bindings`. Focused BuildBundler tests, the full CLI suite, the CLI build, and the monorepo artifact test also pass. The broader deployer analysis inconsistency is tracked separately in #21477.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The build now keeps important packages out of the application bundle when you configure bundler options. It also records those packages for installation during deployment, so the application can find them at runtime.

## Changes

- Preserve default external-all mode unless `externals` is explicitly set to `true` or `false`.
- Merge packages from the `externals` array into deduplicated `dynamicPackages`.
- Include external packages such as `@mastra/core`, `bcrypt`, and `typescript` in `.mastra/output/package.json`.
- Update `BuildBundler` tests for default, configured, and explicit `externals` values.
- Add monorepo build coverage for generated runtime dependencies.
- Add a patch changeset for `mastra`.

## Verification

- Focused `BuildBundler` tests.
- Full CLI test suite.
- CLI build.
- Monorepo artifact test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->