### PR TITLE
feat(voyageai): add voyage-code-4 embedding model

### DIFF
--- a/.changeset/voyage-code-4-model.md
+++ b/.changeset/voyage-code-4-model.md
@@ -1,0 +1,18 @@
+---
+'@mastra/voyageai': minor
+---
+
+Added the `voyage-code-4` code embedding model.
+
+Use it through the pre-configured accessor or by passing the model id directly:
+
+```typescript
+import { voyage } from '@mastra/voyageai';
+
+// Pre-configured accessor
+await voyage.code4.doEmbed({ values: ['function foo() {}'] });
+
+// Or by model id
+const model = voyage.embedding('voyage-code-4');
+await model.doEmbed({ values: ['function foo() {}'] });
+```

--- a/embedders/voyageai/README.md
+++ b/embedders/voyageai/README.md
@@ -54,6 +54,7 @@ await voyage.v4lite.doEmbed({ values: ['...'] }); // voyage-4-lite (1M batch tok
 await voyage.large.doEmbed({ values: ['...'] }); // voyage-3-large
 await voyage.v35.doEmbed({ values: ['...'] }); // voyage-3.5
 await voyage.v35lite.doEmbed({ values: ['...'] }); // voyage-3.5-lite
+await voyage.code4.doEmbed({ values: ['...'] }); // voyage-code-4
 await voyage.code.doEmbed({ values: ['...'] }); // voyage-code-3
 await voyage.finance.doEmbed({ values: ['...'] }); // voyage-finance-2
 await voyage.law.doEmbed({ values: ['...'] }); // voyage-law-2
@@ -190,6 +191,7 @@ console.log(grouped.embeddingsByDocument); // [[[...], [...]], [[...]]]
 | `voyage-3-large`   | Best quality, multilingual              | 256/512/1024/2048 | 120k         |
 | `voyage-3.5`       | Balanced quality/speed                  | 256/512/1024/2048 | 320k         |
 | `voyage-3.5-lite`  | Lowest latency/cost                     | 256/512/1024/2048 | 1M           |
+| `voyage-code-4`    | Code retrieval, latest generation       | 256/512/1024/2048 | 32k          |
 | `voyage-code-3`    | Code retrieval                          | 256/512/1024/2048 | 32k          |
 | `voyage-finance-2` | Finance domain                          | 1024              | 32k          |
 | `voyage-law-2`     | Legal domain                            | 1024              | 32k          |
@@ -334,6 +336,7 @@ type VoyageTextModel =
   | 'voyage-3-large'
   | 'voyage-3.5'
   | 'voyage-3.5-lite'
+  | 'voyage-code-4'
   | 'voyage-code-3'
   | 'voyage-finance-2'
   | 'voyage-law-2';

--- a/embedders/voyageai/src/__tests__/integration.test.ts
+++ b/embedders/voyageai/src/__tests__/integration.test.ts
@@ -116,6 +116,7 @@ describeWithApiKey('VoyageAI Integration Tests', () => {
       expect(voyage.large.modelId).toBe('voyage-3-large');
       expect(voyage.v35.modelId).toBe('voyage-3.5');
       expect(voyage.v35lite.modelId).toBe('voyage-3.5-lite');
+      expect(voyage.code4.modelId).toBe('voyage-code-4');
       expect(voyage.code.modelId).toBe('voyage-code-3');
       expect(voyage.finance.modelId).toBe('voyage-finance-2');
       expect(voyage.law.modelId).toBe('voyage-law-2');
@@ -130,6 +131,7 @@ describeWithApiKey('VoyageAI Integration Tests', () => {
       // Voyage-3 series V2
       expect(voyage.largeV2.specificationVersion).toBe('v2');
       expect(voyage.v35V2.specificationVersion).toBe('v2');
+      expect(voyage.code4V2.specificationVersion).toBe('v2');
       expect(voyage.codeV2.specificationVersion).toBe('v2');
     });
 

--- a/embedders/voyageai/src/__tests__/text-embedding.test.ts
+++ b/embedders/voyageai/src/__tests__/text-embedding.test.ts
@@ -5,6 +5,7 @@ import {
   createVoyageTextEmbedding,
   createVoyageTextEmbeddingV2,
 } from '../text-embedding';
+import { TEXT_MODEL_INFO } from '../types';
 
 // Mock functions
 const mockEmbed = vi.fn();
@@ -291,5 +292,33 @@ describe('Factory functions', () => {
 
     expect(model.specificationVersion).toBe('v2');
     expect(model.modelId).toBe('voyage-3.5');
+  });
+
+  it('createVoyageTextEmbedding should create voyage-code-4 V3 model', () => {
+    const model = createVoyageTextEmbedding('voyage-code-4');
+
+    expect(model.specificationVersion).toBe('v3');
+    expect(model.modelId).toBe('voyage-code-4');
+  });
+
+  it('createVoyageTextEmbeddingV2 should create voyage-code-4 V2 model', () => {
+    const model = createVoyageTextEmbeddingV2('voyage-code-4');
+
+    expect(model.specificationVersion).toBe('v2');
+    expect(model.modelId).toBe('voyage-code-4');
+  });
+});
+
+describe('TEXT_MODEL_INFO metadata', () => {
+  it('should expose voyage-code-4 metadata mirroring voyage-code-3', () => {
+    const code4 = TEXT_MODEL_INFO['voyage-code-4'];
+
+    expect(code4).toBeDefined();
+    expect(code4).toEqual(TEXT_MODEL_INFO['voyage-code-3']);
+    expect(code4.maxInputTokens).toBe(32000);
+    expect(code4.defaultDimension).toBe(1024);
+    expect(code4.supportedDimensions).toEqual([256, 512, 1024, 2048]);
+    expect(code4.isMultimodal).toBe(false);
+    expect(code4.isContextualized).toBe(false);
   });
 });

--- a/embedders/voyageai/src/index.ts
+++ b/embedders/voyageai/src/index.ts
@@ -171,6 +171,7 @@ export const voyage: VoyageTextEmbeddingModelV3 & {
   large: VoyageTextEmbeddingModelV3;
   v35: VoyageTextEmbeddingModelV3;
   v35lite: VoyageTextEmbeddingModelV3;
+  code4: VoyageTextEmbeddingModelV3;
   code: VoyageTextEmbeddingModelV3;
   finance: VoyageTextEmbeddingModelV3;
   law: VoyageTextEmbeddingModelV3;
@@ -184,6 +185,7 @@ export const voyage: VoyageTextEmbeddingModelV3 & {
   largeV2: VoyageTextEmbeddingModelV2;
   v35V2: VoyageTextEmbeddingModelV2;
   v35liteV2: VoyageTextEmbeddingModelV2;
+  code4V2: VoyageTextEmbeddingModelV2;
   codeV2: VoyageTextEmbeddingModelV2;
   financeV2: VoyageTextEmbeddingModelV2;
   lawV2: VoyageTextEmbeddingModelV2;
@@ -254,6 +256,7 @@ export const voyage: VoyageTextEmbeddingModelV3 & {
     large: { get: () => lazy('large', () => createVoyageTextEmbedding('voyage-3-large')) },
     v35: { get: () => lazy('v35', () => createVoyageTextEmbedding('voyage-3.5')) },
     v35lite: { get: () => lazy('v35lite', () => createVoyageTextEmbedding('voyage-3.5-lite')) },
+    code4: { get: () => lazy('code4', () => createVoyageTextEmbedding('voyage-code-4')) },
     code: { get: () => lazy('code', () => createVoyageTextEmbedding('voyage-code-3')) },
     finance: { get: () => lazy('finance', () => createVoyageTextEmbedding('voyage-finance-2')) },
     law: { get: () => lazy('law', () => createVoyageTextEmbedding('voyage-law-2')) },
@@ -265,6 +268,7 @@ export const voyage: VoyageTextEmbeddingModelV3 & {
     largeV2: { get: () => lazy('largeV2', () => createVoyageTextEmbeddingV2('voyage-3-large')) },
     v35V2: { get: () => lazy('v35V2', () => createVoyageTextEmbeddingV2('voyage-3.5')) },
     v35liteV2: { get: () => lazy('v35liteV2', () => createVoyageTextEmbeddingV2('voyage-3.5-lite')) },
+    code4V2: { get: () => lazy('code4V2', () => createVoyageTextEmbeddingV2('voyage-code-4')) },
     codeV2: { get: () => lazy('codeV2', () => createVoyageTextEmbeddingV2('voyage-code-3')) },
     financeV2: { get: () => lazy('financeV2', () => createVoyageTextEmbeddingV2('voyage-finance-2')) },
     lawV2: { get: () => lazy('lawV2', () => createVoyageTextEmbeddingV2('voyage-law-2')) },

--- a/embedders/voyageai/src/types.ts
+++ b/embedders/voyageai/src/types.ts
@@ -16,6 +16,7 @@ export type VoyageTextModel =
   | 'voyage-3-large'
   | 'voyage-3.5'
   | 'voyage-3.5-lite'
+  | 'voyage-code-4'
   | 'voyage-code-3'
   | 'voyage-finance-2'
   | 'voyage-law-2';
@@ -243,6 +244,13 @@ export const TEXT_MODEL_INFO: Record<VoyageTextModel, Omit<VoyageModelInfo, 'id'
   },
   'voyage-3.5-lite': {
     maxInputTokens: 1000000,
+    defaultDimension: 1024,
+    supportedDimensions: [256, 512, 1024, 2048],
+    isMultimodal: false,
+    isContextualized: false,
+  },
+  'voyage-code-4': {
+    maxInputTokens: 32000,
     defaultDimension: 1024,
     supportedDimensions: [256, 512, 1024, 2048],
     isMultimodal: false,


### PR DESCRIPTION
Closes #21485

Adds the `voyage-code-4` embedding model to the VoyageAI integration, alongside the existing `voyage-code-3`.

The model is not publicly released yet, so its parameters mirror `voyage-code-3` and will be corrected if the published specification differs.

Reopened from #21457, which was closed for having no linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

VoyageAI now supports the `voyage-code-4` model for code embeddings. Users can access it through `voyage.code4`, `voyage.code4V2`, or the model factory.

## Changes

- Added `voyage-code-4` to the supported VoyageAI model types.
- Configured the model with a 32,000-token context limit.
- Supported dimensions are 256, 512, 1,024, and 2,048.
- Added `voyage.code4` and `voyage.code4V2` accessors.
- Added documentation and a minor changeset.
- Added tests for model metadata, factories, and accessors.
- Matched `voyage-code-3` specifications until the official `voyage-code-4` specification is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->