### PR TITLE
fix: harden experiment artifact builds

### DIFF
--- a/.changeset/sunny-ravens-wear.md
+++ b/.changeset/sunny-ravens-wear.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed experiment worker builds so Mastra configuration initialization runs outside the artifact directory without deleting packaged database assets.

--- a/.changeset/three-rockets-lay.md
+++ b/.changeset/three-rockets-lay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Improved pnpm build failures to name blocked dependencies and report the required allowBuilds configuration as a user error.

--- a/e2e-tests/experiment-worker/scenarios/index.ts
+++ b/e2e-tests/experiment-worker/scenarios/index.ts
@@ -96,6 +96,7 @@ export const sandboxCancellationScenario = resourceScenario('sandbox-cancellatio
 ]);
 
 export const persistenceIsolationScenario = resourceScenario('persistence-isolation', [
+  'config-initialization-isolated',
   'application-storage-written',
   'vector-adapter-executed',
   'experiment-records-absent',

--- a/e2e-tests/experiment-worker/tests/runtime-resources.test.ts
+++ b/e2e-tests/experiment-worker/tests/runtime-resources.test.ts
@@ -57,6 +57,8 @@ describe('experiment worker workspace, sandbox, and persistence behavior', () =>
     await installPnpmProject(projectRoot, inject('registry'));
     const build = await buildWorker(projectRoot);
     manifest = (await inspectManifest(build.artifactRoot)).manifest;
+    expect(await pathExists(join(build.artifactRoot, 'app-storage.db'))).toBe(false);
+    expect(await pathExists(join(build.artifactRoot, 'vector-store.db'))).toBe(false);
     artifactRoot = resources.trackPath(
       await copyArtifact({
         artifactRoot: build.artifactRoot,
@@ -238,6 +240,7 @@ describe('experiment worker workspace, sandbox, and persistence behavior', () =>
       const vectorStoreExists = await pathExists(join(artifactRoot, 'vector-store.db'));
       expect(vectorStoreExists).toBe(true);
       await recordAssertionEvidence(persistenceIsolationScenario, {
+        'config-initialization-isolated': true,
         'application-storage-written': completed,
         'vector-adapter-executed': vectorStoreExists,
         'experiment-records-absent': true,

--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -572,4 +572,35 @@ describe.sequential.for([['pnpm'] as const])(`%s monorepo`, ([pkgManager]) => {
       timeout,
     );
   });
+
+  describe.sequential('pnpm build approvals', () => {
+    it(
+      'reports blocked native build scripts as a user configuration error',
+      async () => {
+        const isolatedFixturePath = await mkdtemp(join(tmpdir(), `mastra-monorepo-build-approval-test-${pkgManager}-`));
+        try {
+          await setupMonorepo(isolatedFixturePath, pkgManager);
+          const workspacePath = join(isolatedFixturePath, 'pnpm-workspace.yaml');
+          const workspace = await readFile(workspacePath, 'utf8');
+          await writeFile(workspacePath, workspace.replace('  bcrypt: true\n', ''));
+
+          await removeOutputDir(isolatedFixturePath);
+          const build = await execa(pkgManager, ['build'], {
+            cwd: join(isolatedFixturePath, 'apps', 'custom'),
+            env: process.env,
+            reject: false,
+          });
+          const output = `${build.stdout}\n${build.stderr}`;
+
+          expect(build.exitCode).not.toBe(0);
+          expect(output).toContain('pnpm blocked build scripts for: bcrypt');
+          expect(output).toContain('Add these packages to allowBuilds in pnpm-workspace.yaml and retry the build.');
+          expect(output).not.toContain('DEPLOYER_BUNDLER_BUNDLE_STAGE_FAILED');
+        } finally {
+          await rm(isolatedFixturePath, { recursive: true, force: true });
+        }
+      },
+      timeout,
+    );
+  });
 });

--- a/packages/cli/src/commands/experiment/ExperimentBundler.test.ts
+++ b/packages/cli/src/commands/experiment/ExperimentBundler.test.ts
@@ -40,7 +40,7 @@ describe('ExperimentBundler', () => {
   };
 
   afterEach(async () => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { recursive: true, force: true })));
   });
 
@@ -187,32 +187,93 @@ describe('ExperimentBundler', () => {
     });
   });
 
-  it('removes local database state before creating the artifact manifest', async () => {
+  it('evaluates Mastra configuration in a scratch directory and reports output-directory side effects', async () => {
+    const originalWorkingDirectory = process.cwd();
+    const output = await createTemporaryDirectory('mastra-experiment-worker-');
+    const { Bundler } = await import('@mastra/deployer/bundler');
+    vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockImplementationOnce(async () => {
+      expect(process.cwd()).not.toBe(originalWorkingDirectory);
+      await mkdir(join(output, 'runtime-state'));
+      await writeFile(join(output, 'mastra.db'), 'local state');
+      await writeFile(join(output, 'runtime-state', 'vector.data'), 'local state');
+      return { externals: [] };
+    });
+    const { ExperimentBundler } = await import('./ExperimentBundler');
+
+    await expect((new ExperimentBundler() as any).getUserBundlerOptions('/entry.ts', output)).rejects.toThrow(
+      'Mastra configuration initialization created or modified unexpected files in the experiment worker artifact: mastra.db, runtime-state/vector.data',
+    );
+    expect(process.cwd()).toBe(originalWorkingDirectory);
+    await expect(readFile(join(output, 'mastra.db'), 'utf8')).resolves.toBe('local state');
+    await expect(readFile(join(output, 'runtime-state', 'vector.data'), 'utf8')).resolves.toBe('local state');
+  });
+
+  it('reports files modified during Mastra configuration initialization', async () => {
+    const output = await createTemporaryDirectory('mastra-experiment-worker-');
+    await writeFile(join(output, 'package.json'), '{"type":"module"}');
+    const { Bundler } = await import('@mastra/deployer/bundler');
+    vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockImplementationOnce(async () => {
+      await writeFile(join(output, 'package.json'), '{}');
+      return { externals: [] };
+    });
+    const { ExperimentBundler } = await import('./ExperimentBundler');
+
+    await expect((new ExperimentBundler() as any).getUserBundlerOptions('/entry.ts', output)).rejects.toThrow(
+      'Mastra configuration initialization created or modified unexpected files in the experiment worker artifact: package.json',
+    );
+  });
+
+  it('reports files deleted during Mastra configuration initialization', async () => {
+    const output = await createTemporaryDirectory('mastra-experiment-worker-');
+    await writeFile(join(output, 'package.json'), '{"type":"module"}');
+    const { Bundler } = await import('@mastra/deployer/bundler');
+    vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockImplementationOnce(async () => {
+      await rm(join(output, 'package.json'));
+      return { externals: [] };
+    });
+    const { ExperimentBundler } = await import('./ExperimentBundler');
+
+    await expect((new ExperimentBundler() as any).getUserBundlerOptions('/entry.ts', output)).rejects.toThrow(
+      'Mastra configuration initialization created or modified unexpected files in the experiment worker artifact: package.json',
+    );
+  });
+
+  it('restores the working directory when Mastra configuration initialization fails', async () => {
+    const originalWorkingDirectory = process.cwd();
+    const output = await createTemporaryDirectory('mastra-experiment-worker-');
+    const { Bundler } = await import('@mastra/deployer/bundler');
+    vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockRejectedValueOnce(
+      new Error('configuration failed'),
+    );
+    const { ExperimentBundler } = await import('./ExperimentBundler');
+
+    await expect((new ExperimentBundler() as any).getUserBundlerOptions('/entry.ts', output)).rejects.toThrow(
+      'configuration failed',
+    );
+    expect(process.cwd()).toBe(originalWorkingDirectory);
+  });
+
+  it('preserves database assets included in the artifact', async () => {
     const { ExperimentBundler } = await import('./ExperimentBundler');
     const output = await createTemporaryDirectory('mastra-experiment-worker-');
     const nestedDirectory = join(output, 'runtime-state');
     await mkdir(nestedDirectory);
     await writeFile(join(output, 'index.mjs'), '');
     await writeFile(join(output, 'package.json'), '{}');
-    const localStorageFiles = [
-      'mastra.db',
-      'mastra.db-shm',
-      'mastra.db-wal',
-      'mastra.duckdb',
-      'mastra.duckdb.wal',
-      'runtime-state/cache.sqlite',
-      'runtime-state/cache.sqlite-wal',
-    ];
-    await Promise.all(localStorageFiles.map(path => writeFile(join(output, path), 'local state')));
+    const databaseAssets = ['seed.db', 'runtime-state/seed.sqlite'];
+    await Promise.all(databaseAssets.map(path => writeFile(join(output, path), 'seed data')));
 
     await new ExperimentBundler().writeArtifactManifest(output, '1.2.3');
 
     const manifest = JSON.parse(await readFile(join(output, 'experiment-worker-manifest.json'), 'utf8'));
-    expect(manifest.files.map((file: { path: string }) => file.path)).toEqual(['index.mjs', 'package.json']);
+    expect(manifest.files.map((file: { path: string }) => file.path)).toEqual([
+      'index.mjs',
+      'package.json',
+      'runtime-state/seed.sqlite',
+      'seed.db',
+    ]);
     await Promise.all(
-      localStorageFiles.map(path =>
-        expect(readFile(join(output, path), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' }),
-      ),
+      databaseAssets.map(path => expect(readFile(join(output, path), 'utf8')).resolves.toBe('seed data')),
     );
   });
 

--- a/packages/cli/src/commands/experiment/ExperimentBundler.ts
+++ b/packages/cli/src/commands/experiment/ExperimentBundler.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { lstat, readFile, readdir, readlink, rm, writeFile } from 'node:fs/promises';
+import { lstat, mkdtemp, readFile, readdir, readlink, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Config } from '@mastra/core/mastra';
@@ -57,7 +58,29 @@ export class ExperimentBundler extends Bundler {
     mastraEntryFile: string,
     outputDirectory: string,
   ): Promise<NonNullable<Config['bundler']>> {
-    const bundlerOptions = await super.getUserBundlerOptions(mastraEntryFile, outputDirectory);
+    const existingOutputFiles = await collectFileSignatures(outputDirectory);
+    const scratchDirectory = await mkdtemp(join(tmpdir(), 'mastra-experiment-config-'));
+    const originalWorkingDirectory = process.cwd();
+    let bundlerOptions: NonNullable<Config['bundler']>;
+    try {
+      process.chdir(scratchDirectory);
+      bundlerOptions = await super.getUserBundlerOptions(mastraEntryFile, outputDirectory);
+    } finally {
+      process.chdir(originalWorkingDirectory);
+      await rm(scratchDirectory, { recursive: true, force: true });
+    }
+
+    const currentOutputFiles = await collectFileSignatures(outputDirectory);
+    const outputPaths = new Set([...existingOutputFiles.keys(), ...currentOutputFiles.keys()]);
+    const unexpectedOutputFiles = [...outputPaths]
+      .filter(path => path !== 'bundler-config.mjs' && existingOutputFiles.get(path) !== currentOutputFiles.get(path))
+      .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+    if (unexpectedOutputFiles.length > 0) {
+      throw new Error(
+        `Mastra configuration initialization created or modified unexpected files in the experiment worker artifact: ${unexpectedOutputFiles.join(', ')}`,
+      );
+    }
+
     if (!Array.isArray(bundlerOptions.externals)) return bundlerOptions;
 
     return {
@@ -86,7 +109,6 @@ export class ExperimentBundler extends Bundler {
   async writeArtifactManifest(outputDirectory: string, cliVersion: string): Promise<void> {
     await Promise.all([
       removePnpmInstallMetadata(outputDirectory),
-      removeLocalStorageArtifacts(outputDirectory),
       rm(join(outputDirectory, this.analyzeOutputDir), { recursive: true, force: true }),
     ]);
     const files = await collectFileDigests(outputDirectory);
@@ -163,26 +185,42 @@ export function resolveRuntimePath(
 
 type ArtifactFileDigest = { path: string; sha256: string; type?: 'file' | 'symlink'; target?: string };
 
-const LOCAL_STORAGE_ARTIFACT_PATTERN = /(?:\.db(?:-.+)?|\.duckdb(?:\.wal)?|\.sqlite(?:-.+)?)$/;
-
-export async function removeLocalStorageArtifacts(root: string): Promise<void> {
+async function collectFileSignatures(root: string): Promise<Map<string, string>> {
+  const files = new Map<string, string>();
   const visit = async (directory: string): Promise<void> => {
-    const entries = await readdir(directory, { withFileTypes: true });
-    await Promise.all(
-      entries.map(async entry => {
-        const entryPath = join(directory, entry.name);
-        if (entry.isDirectory()) {
-          if (entry.name !== 'node_modules') await visit(entryPath);
-          return;
-        }
-        if (LOCAL_STORAGE_ARTIFACT_PATTERN.test(entry.name)) {
-          await rm(entryPath, { force: true });
-        }
-      }),
-    );
+    let entries;
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw error;
+    }
+    for (const entry of entries.sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0))) {
+      const entryPath = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await visit(entryPath);
+        continue;
+      }
+
+      const artifactPath = relative(root, entryPath).replaceAll('\\', '/');
+      const stats = await lstat(entryPath);
+      if (stats.isFile()) {
+        files.set(
+          artifactPath,
+          `file:${createHash('sha256')
+            .update(await readFile(entryPath))
+            .digest('hex')}`,
+        );
+      } else if (stats.isSymbolicLink()) {
+        files.set(artifactPath, `symlink:${await readlink(entryPath)}`);
+      } else {
+        files.set(artifactPath, `other:${stats.mode}`);
+      }
+    }
   };
 
   await visit(root);
+  return files;
 }
 
 export async function removePnpmInstallMetadata(root: string): Promise<void> {

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -785,7 +785,10 @@ export const tools = [${toolsExports.join(', ')}]`,
         );
       }
     } catch (error) {
-      if (error instanceof MastraError && error.id === 'DEPLOYER_BUNDLER_FACTORY_UI_MISSING') {
+      if (
+        error instanceof MastraError &&
+        (error.id === 'DEPLOYER_BUNDLER_FACTORY_UI_MISSING' || error.id === 'DEPLOYER_PNPM_IGNORED_BUILDS')
+      ) {
         throw error;
       }
 

--- a/packages/deployer/src/deploy/log.ts
+++ b/packages/deployer/src/deploy/log.ts
@@ -44,6 +44,15 @@ export function createChildProcessLogger({ logger, root }: { logger: IMastraLogg
         stdio: ['ignore', 'pipe', 'pipe'],
       });
 
+      let stdout = '';
+      let stderr = '';
+      subprocess.stdout?.on('data', chunk => {
+        stdout += chunk.toString();
+      });
+      subprocess.stderr?.on('data', chunk => {
+        stderr += chunk.toString();
+      });
+
       // Pipe stdout and stderr through the logging stream.
       // { end: false } prevents the first stream to close from ending pinoStream
       // while the other may still be writing.
@@ -55,9 +64,9 @@ export function createChildProcessLogger({ logger, root }: { logger: IMastraLogg
         subprocess.on('close', code => {
           pinoStream.end();
           if (code === 0) {
-            resolve({ success: true });
+            resolve({ success: true, stdout, stderr });
           } else {
-            reject(new Error(`Process exited with code ${code}`));
+            reject(Object.assign(new Error(`Process exited with code ${code}`), { stdout, stderr }));
           }
         });
 

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -1,6 +1,20 @@
 import { MastraError } from '@mastra/core/error';
 import { describe, expect, it } from 'vitest';
-import { copyPnpmWorkspaceSettings } from './deps';
+import { copyPnpmWorkspaceSettings, getPnpmIgnoredBuildPackages } from './deps';
+
+describe('getPnpmIgnoredBuildPackages', () => {
+  it('extracts package names from pnpm ignored-build diagnostics', () => {
+    expect(
+      getPnpmIgnoredBuildPackages(
+        '[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: utf-8-validate@6.0.5, @duckdb/node-bindings@1.3.2, fixture-native-build@file:fixture-native-build-1.0.0.tgz',
+      ),
+    ).toEqual(['utf-8-validate', '@duckdb/node-bindings', 'fixture-native-build']);
+  });
+
+  it('ignores unrelated package-manager output', () => {
+    expect(getPnpmIgnoredBuildPackages('Process exited with code 1')).toEqual([]);
+  });
+});
 
 describe('copyPnpmWorkspaceSettings', () => {
   it('copies pnpm install policy without copying source workspace packages', () => {

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -41,6 +41,27 @@ function getTopLevelYamlKey(line: string) {
   return match?.[1];
 }
 
+const PNPM_IGNORED_BUILDS_ERROR = 'ERR_PNPM_IGNORED_BUILDS';
+
+export function getPnpmIgnoredBuildPackages(output: string): string[] {
+  const match = new RegExp(`\\[?${PNPM_IGNORED_BUILDS_ERROR}\\]?[^\\n]*Ignored build scripts:\\s*([^\\n]+)`).exec(
+    output,
+  );
+  if (!match?.[1]) return [];
+
+  return match[1]
+    .split(',')
+    .map(specifier => specifier.trim())
+    .filter(Boolean)
+    .map(specifier => {
+      if (specifier.startsWith('@')) {
+        const versionSeparator = specifier.indexOf('@', 1);
+        return versionSeparator === -1 ? specifier : specifier.slice(0, versionSeparator);
+      }
+      return specifier.split('@', 1)[0]!;
+    });
+}
+
 function validatePnpmBuildApprovals(key: string, block: string): void {
   if (key !== 'allowBuilds' && key !== 'onlyBuiltDependencies') return;
 
@@ -333,11 +354,33 @@ export class Deps extends MastraBase {
       root: dir,
     });
 
-    return cpLogger({
-      cmd: `${pm} ${installCommand}`,
-      args,
-      env: process.env as Record<string, string>,
-    });
+    try {
+      return await cpLogger({
+        cmd: `${pm} ${installCommand}`,
+        args,
+        env: process.env as Record<string, string>,
+      });
+    } catch (error) {
+      if (pm !== 'pnpm') throw error;
+
+      const processOutput =
+        error && typeof error === 'object'
+          ? `${'stdout' in error ? String(error.stdout) : ''}\n${'stderr' in error ? String(error.stderr) : ''}`
+          : '';
+      const ignoredPackages = getPnpmIgnoredBuildPackages(processOutput);
+      if (ignoredPackages.length === 0) throw error;
+
+      throw new MastraError(
+        {
+          id: 'DEPLOYER_PNPM_IGNORED_BUILDS',
+          domain: ErrorDomain.DEPLOYER,
+          category: ErrorCategory.USER,
+          details: { packageNames: ignoredPackages.join(', ') },
+          text: `pnpm blocked build scripts for: ${ignoredPackages.join(', ')}. Add these packages to allowBuilds in pnpm-workspace.yaml and retry the build.`,
+        },
+        error,
+      );
+    }
   }
 
   public async installPackages(packages: string[]) {


### PR DESCRIPTION
Fixes #21480.

Experiment worker builds now evaluate Mastra configuration from a temporary working directory. The build restores the original working directory even when configuration loading fails, rejects files that configuration initialization adds, changes, or removes inside the artifact, and no longer silently deletes packaged database assets.

Before, relative storage configuration could write state into the artifact and a filename denylist removed matching files. Now initialization state stays outside the artifact, while intentional assets such as `seed.db` remain packaged.

pnpm install failures now retain their logged stdout and stderr, recognize `ERR_PNPM_IGNORED_BUILDS`, and report the blocked package names as a user configuration error with an `allowBuilds` remediation. The typed error is preserved through the bundler instead of being wrapped as a generic system failure.

Validated with focused CLI and deployer unit tests, experiment-worker persistence E2E coverage, monorepo blocked-build E2E coverage, package builds, and lint checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The build now checks that application setup does not change the packaged files. It also gives clear instructions when pnpm blocks required package build scripts.

## Changes

- Run experiment worker configuration in a temporary working directory.
- Restore the original working directory after success or failure.
- Fail the build when initialization creates, changes, or removes artifact files.
- Preserve intentional database assets such as `seed.db`.
- Capture pnpm stdout and stderr during dependency installation.
- Detect `ERR_PNPM_IGNORED_BUILDS` and report affected packages as `USER` configuration errors.
- Include `allowBuilds` guidance in blocked-build errors.
- Preserve typed dependency errors through bundling.
- Add unit and end-to-end coverage for artifact isolation, database persistence, blocked builds, CLI behavior, deployer behavior, builds, and linting.
- Add patch changesets for `mastra` and `@mastra/deployer`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->