### PR TITLE
fix(storage): persist dynamic workflow bundles atomically

### DIFF
--- a/.changeset/quiet-workflows-commit.md
+++ b/.changeset/quiet-workflows-commit.md
@@ -1,0 +1,23 @@
+---
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/mongodb': patch
+'@mastra/mssql': patch
+'@mastra/mysql': patch
+'@mastra/pg': patch
+'@mastra/spanner': patch
+---
+
+Persist dynamic workflow bundles atomically through the workflow-definitions
+storage domain. `Mastra.addDynamicWorkflows()` now commits every root and nested
+definition together, or leaves both storage and the live registry unchanged.
+
+Custom workflow-definition stores must implement `upsertMany()` with the same
+all-or-nothing semantics. MongoDB deployments must use a replica set or sharded
+cluster because standalone MongoDB cannot provide multi-document transactions.
+
+```ts
+await mastra.addDynamicWorkflows([helperDefinition, rootDefinition], {
+  authorId: verifiedOwnerId,
+});
+```

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -1,0 +1,11 @@
+---
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/mssql': patch
+'@mastra/mysql': patch
+'@mastra/pg': patch
+---
+
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -8,4 +8,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior. Concurrent registrations on one Mastra instance are serialized so a rejected registration can't roll back the successful live workflow.

--- a/.changeset/sweet-ducks-cheat.md
+++ b/.changeset/sweet-ducks-cheat.md
@@ -8,4 +8,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior. Concurrent registrations on one Mastra instance are serialized so a rejected registration can't roll back the successful live workflow.
+Fixed dynamic workflow definitions so an explicit author cannot replace an existing owner. Owner-qualified updates now remain safe if a definition is deleted and recreated concurrently, while omitting the author preserves legacy unscoped update behavior.

--- a/.changeset/warm-pianos-push.md
+++ b/.changeset/warm-pianos-push.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': minor
+---
+
+Added trusted author metadata for dynamic workflow registration.
+
+```ts
+await mastra.addDynamicWorkflow(definition, { authorId: verifiedUserId });
+```
+
+The author is persisted with the definition and remains outside untrusted workflow JSON. This metadata does not enforce access control.
+
+See [#21444](https://github.com/mastra-ai/mastra/issues/21444) for the remaining tenant-isolation design.

--- a/.changeset/wise-owls-queue.md
+++ b/.changeset/wise-owls-queue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Serialize dynamic workflow registrations on each Mastra instance so a rejected registration cannot roll back a workflow that another registration successfully replaced.

--- a/.changeset/wise-owls-queue.md
+++ b/.changeset/wise-owls-queue.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Serialize dynamic workflow registrations on each Mastra instance so a rejected registration cannot roll back a workflow that another registration successfully replaced.
+Serialize dynamic workflow registrations with overlapping workflow ids so a rejected registration cannot roll back a workflow that another registration successfully replaced. Unrelated ids no longer wait behind network storage I/O. Callers may cancel or bound queue admission; a rejected waiter never starts a storage mutation.

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -156,7 +156,7 @@ await mastra.addDynamicWorkflow(untrustedDefinition, {
 })
 ```
 
-Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+Mastra stores `authorId` with the definition in the same write. Once set, the author is immutable: replacing the definition without `authorId` retains its stored author, while using a different author fails with an ownership conflict. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -129,7 +129,7 @@ When a root workflow references helper workflows that aren't registered yet, add
 await mastra.addDynamicWorkflows([rootDefinition, helperDefinition])
 ```
 
-Mastra validates the bundle as a unit and determines the registration order from the dependencies. If validation fails, none of the definitions are registered.
+Mastra validates the bundle as a unit and determines the registration order from the dependencies. It atomically persists all members through the workflow-definitions storage domain, so validation or storage failure leaves neither partial rows nor partial registration.
 
 ### Manage definitions over HTTP
 

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -146,6 +146,18 @@ Stored definitions use the `workflowDefinitions` storage domain. On startup, Mas
 
 Without a storage adapter that supports this domain, `addDynamicWorkflow()` still registers the workflow in memory, but the definition is lost when the process restarts. See the [storage reference](/reference/storage/overview) for adapter support.
 
+### Record a verified author
+
+Pass trusted author metadata as the second argument. Keep it outside the workflow definition when the definition comes from a user, agent, or external system.
+
+```typescript
+await mastra.addDynamicWorkflow(untrustedDefinition, {
+  authorId: authenticatedUser.id,
+})
+```
+
+Mastra stores `authorId` with the definition in the same write. This metadata doesn't enforce access control. Authorize the caller before registration and before later reads, updates, deletion, or execution.
+
 ## Related
 
 - [Dynamic workflow definition](/reference/workflows/dynamic-workflow-definition)

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -83,8 +83,8 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
-- `options.authorId` is stored on the definition in the same write and becomes immutable. When replacing an existing definition, omitting `options.authorId` retains its stored author, while using a different author fails with an ownership conflict. It records a verified author but doesn't restrict access by itself. Authorize registration and every later read, update, deletion, and execution at the server boundary.
-- Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
+- `options.authorId` is stored on the definition in the same write and becomes immutable. When replacing an existing definition, omitting `options.authorId` retains its stored author, while using a different author fails with an ownership conflict. It records a verified author but doesn't restrict access by itself. When `options.authorId` is provided, a `workflowDefinitions` storage domain is required. Authorize registration and every later read, update, deletion, and execution at the server boundary.
+- Without a storage adapter that supports the `workflowDefinitions` domain, a workflow with no `options.authorId` is still validated and registered in memory, but the definition is lost on restart. Authored registration fails instead.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 
 ## Related

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -20,29 +20,34 @@ See [Dynamic workflows](/docs/workflows/dynamic-workflows) for a complete setup 
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflow({
-  id: 'greeting-workflow',
-  description: 'Returns a greeting for the supplied name',
-  inputSchema: {
-    type: 'object',
-    properties: { name: { type: 'string' } },
-    required: ['name'],
-  },
-  outputSchema: {
-    type: 'object',
-    properties: { message: { type: 'string' } },
-    required: ['message'],
-  },
-  graph: [
-    {
-      type: 'mapping',
-      id: 'create-greeting',
-      mapConfig: JSON.stringify({
-        message: { template: 'Hello, ${initData.name}!' },
-      }),
+await mastra.addDynamicWorkflow(
+  {
+    id: 'greeting-workflow',
+    description: 'Returns a greeting for the supplied name',
+    inputSchema: {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
     },
-  ],
-})
+    outputSchema: {
+      type: 'object',
+      properties: { message: { type: 'string' } },
+      required: ['message'],
+    },
+    graph: [
+      {
+        type: 'mapping',
+        id: 'create-greeting',
+        mapConfig: JSON.stringify({
+          message: { template: 'Hello, ${initData.name}!' },
+        }),
+      },
+    ],
+  },
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 
 const run = await mastra.getWorkflow('greeting-workflow').createRun()
 const result = await run.start({ inputData: { name: 'Ada' } })
@@ -58,6 +63,13 @@ const result = await run.start({ inputData: { name: 'Ada' } })
     description:
       'The workflow definition: id, optional description and metadata, JSON Schema input/output schemas, optional state and request-context schemas, and the step graph.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata supplied by the host. Use `authorId` for a verified author identity that must not come from the workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -69,6 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
+- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -46,6 +46,8 @@ await mastra.addDynamicWorkflow(
   },
   {
     authorId: authenticatedUser.id,
+    waitTimeoutMs: 5_000,
+    signal: request.signal,
   },
 )
 
@@ -67,7 +69,7 @@ const result = await run.start({ inputData: { name: 'Ada' } })
     name: 'options',
     type: 'DynamicWorkflowRegistrationOptions',
     description:
-      'Trusted persistence metadata supplied by the host. Use `authorId` for a verified author identity that must not come from the workflow definition.',
+      'Trusted persistence metadata supplied by the host. Use `authorId` for a verified author identity that must not come from the workflow definition. `waitTimeoutMs` and `signal` limit queue admission only; after admission, persistence completes even if either later expires.',
     isOptional: true,
   },
 ]}
@@ -81,7 +83,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
-- `options.authorId` is stored on the definition in the same write and becomes immutable. When replacing an existing definition, omitting `options.authorId` retains its stored author, while using a different author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored on the definition in the same write and becomes immutable. When replacing an existing definition, omitting `options.authorId` retains its stored author, while using a different author fails with an ownership conflict. It records a verified author but doesn't restrict access by itself. Authorize registration and every later read, update, deletion, and execution at the server boundary.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -81,7 +81,7 @@ A promise that resolves once the definition is validated, registered, and persis
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
 - Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
-- `options.authorId` is stored on the definition in the same write. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored on the definition in the same write and becomes immutable. When replacing an existing definition, omitting `options.authorId` retains its stored author, while using a different author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -22,10 +22,15 @@ The whole bundle is validated up front. Members are then registered in dependenc
 ## Usage example
 
 ```typescript
-await mastra.addDynamicWorkflows([
-  helperDefinition, // nested by the root — order in the array doesn't matter
-  rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
-])
+await mastra.addDynamicWorkflows(
+  [
+    helperDefinition, // nested by the root — order in the array doesn't matter
+    rootDefinition, // graph contains { type: 'workflow', workflowId: helperDefinition.id }
+  ],
+  {
+    authorId: authenticatedUser.id,
+  },
+)
 ```
 
 ## Parameters
@@ -38,6 +43,13 @@ await mastra.addDynamicWorkflows([
     description:
       'The workflow definitions to add. Nested-workflow references may resolve against the live registries or against other members of the same bundle.',
   },
+  {
+    name: 'options',
+    type: 'DynamicWorkflowRegistrationOptions',
+    description:
+      'Trusted persistence metadata applied to every definition in the bundle. Use `authorId` for a verified author identity that must not come from a workflow definition.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -48,6 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
+- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -29,6 +29,8 @@ await mastra.addDynamicWorkflows(
   ],
   {
     authorId: authenticatedUser.id,
+    waitTimeoutMs: 5_000,
+    signal: request.signal,
   },
 )
 ```
@@ -47,7 +49,7 @@ await mastra.addDynamicWorkflows(
     name: 'options',
     type: 'DynamicWorkflowRegistrationOptions',
     description:
-      'Trusted persistence metadata applied to every definition in the bundle. Use `authorId` for a verified author identity that must not come from a workflow definition.',
+      'Trusted persistence metadata applied to every definition in the bundle. Use `authorId` for a verified author identity that must not come from a workflow definition. `waitTimeoutMs` and `signal` limit queue admission only; after admission, persistence completes even if either later expires.',
     isOptional: true,
   },
 ]}
@@ -60,9 +62,10 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
-- `options.authorId` is stored with every bundle member and becomes immutable. When replacing existing members, omitting `options.authorId` retains each member's stored author, while a member whose ID belongs to another author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
-- A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
-- Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
+- `options.authorId` is stored with every bundle member and becomes immutable. When replacing existing members, omitting `options.authorId` retains each member's stored author, while a member whose ID belongs to another author fails with an ownership conflict. It records a verified author but doesn't restrict access by itself. Authorize registration and every later read, update, deletion, and execution at the server boundary.
+- MongoDB requires a replica set or sharded cluster for multi-member registration because `upsertMany()` uses a transaction. Standalone MongoDB supports only single-member registration.
+- A rejected bundle registers and persists nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated. Registration is rolled back if persistence fails.
+- Storage writes happen last through `WorkflowDefinitionsStorage.upsertMany()`, which commits every member atomically. Custom workflow-definition stores must provide the same all-or-nothing guarantee.
 
 ## Related
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -60,7 +60,7 @@ A promise that resolves once every member is validated, registered, and persiste
 ## Behavior
 
 - References resolve against the instance's registries union the bundle's own IDs, so a root may nest a helper introduced in the same call. Registration order is derived from the dependency graph, not the array order.
-- `options.authorId` is stored with every bundle member. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
+- `options.authorId` is stored with every bundle member and becomes immutable. When replacing existing members, omitting `options.authorId` retains each member's stored author, while a member whose ID belongs to another author fails with an ownership conflict. It records a verified author but doesn't restrict reads, writes, or execution by itself. Enforce access before calling this method.
 - A rejected bundle registers nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated, and if registration or persistence fails partway, the in-memory registry is restored to its prior state.
 - Storage writes happen last. A storage-level failure mid-bundle can leave some rows written, but the registry is still rolled back and the orphaned rows are inert until the next boot.
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflows.mdx
@@ -65,7 +65,7 @@ A promise that resolves once every member is validated, registered, and persiste
 - `options.authorId` is stored with every bundle member and becomes immutable. When replacing existing members, omitting `options.authorId` retains each member's stored author, while a member whose ID belongs to another author fails with an ownership conflict. It records a verified author but doesn't restrict access by itself. Authorize registration and every later read, update, deletion, and execution at the server boundary.
 - MongoDB requires a replica set or sharded cluster for multi-member registration because `upsertMany()` uses a transaction. Standalone MongoDB supports only single-member registration.
 - A rejected bundle registers and persists nothing. Duplicate IDs, invalid members, and dependency cycles are detected before anything is mutated. Registration is rolled back if persistence fails.
-- Storage writes happen last through `WorkflowDefinitionsStorage.upsertMany()`, which commits every member atomically. Custom workflow-definition stores must provide the same all-or-nothing guarantee.
+- Storage writes happen last. Multi-member bundles use `WorkflowDefinitionsStorage.upsertMany()` to commit every member atomically; a single-member array uses `upsert()`. Custom workflow-definition stores must provide the same all-or-nothing guarantee.
 
 ## Related
 

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -390,6 +390,80 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect(() => mastra.getWorkflow('loser-only')).toThrow();
   });
 
+  it('does not let a hung write block unrelated ids and times out an overlapping waiter before mutation', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-keyed-registration-queue' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const realUpsert = store.upsert.bind(store);
+
+    let releaseHungWrite!: () => void;
+    const hungWrite = new Promise<void>(resolve => {
+      releaseHungWrite = resolve;
+    });
+    let markHungWriteEntered!: () => void;
+    const hungWriteEntered = new Promise<void>(resolve => {
+      markHungWriteEntered = resolve;
+    });
+    const mutatedDescriptions: string[] = [];
+    store.upsert = (async definition => {
+      if (definition.id === 'blocked' && definition.description === 'first') {
+        markHungWriteEntered();
+        await hungWrite;
+      }
+      mutatedDescriptions.push(definition.description ?? '');
+      return realUpsert(definition);
+    }) as typeof store.upsert;
+
+    const first = mastra.addDynamicWorkflow(
+      { ...helperDefinition('blocked', 'email1'), description: 'first' },
+      { authorId: 'owner' },
+    );
+    await hungWriteEntered;
+
+    await expect(
+      mastra.addDynamicWorkflow(
+        { ...helperDefinition('unrelated', 'email1'), description: 'unrelated' },
+        { authorId: 'owner' },
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      mastra.addDynamicWorkflow(
+        { ...helperDefinition('blocked', 'email2'), description: 'timed-out' },
+        { authorId: 'owner', waitTimeoutMs: 1 },
+      ),
+    ).rejects.toThrow(/Timed out waiting/);
+    const controller = new AbortController();
+    controller.abort(new Error('caller cancelled'));
+    await expect(
+      mastra.addDynamicWorkflow(
+        { ...helperDefinition('blocked', 'email2'), description: 'cancelled' },
+        { authorId: 'owner', signal: controller.signal },
+      ),
+    ).rejects.toThrow(/caller cancelled/);
+    expect(mutatedDescriptions).not.toContain('timed-out');
+    expect(mutatedDescriptions).not.toContain('cancelled');
+    expect(mastra.getWorkflow('blocked').description).toBe('first');
+
+    let laterSettled = false;
+    const later = mastra
+      .addDynamicWorkflow({ ...helperDefinition('blocked', 'email2'), description: 'later' }, { authorId: 'owner' })
+      .finally(() => {
+        laterSettled = true;
+      });
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+    expect(laterSettled).toBe(false);
+
+    releaseHungWrite();
+    await first;
+    await later;
+    expect(await store.get('blocked')).toMatchObject({ description: 'later', authorId: 'owner' });
+    expect(await store.get('unrelated')).toMatchObject({ description: 'unrelated', authorId: 'owner' });
+    expect(mutatedDescriptions).not.toContain('timed-out');
+    expect(mutatedDescriptions).not.toContain('cancelled');
+    expect(mutatedDescriptions).toContain('later');
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import { InMemoryStore } from '../storage';
+import { InMemoryStore, WorkflowDefinitionOwnershipConflictError } from '../storage';
 import { createTool } from '../tools';
 import { Mastra } from './index';
 
@@ -296,6 +296,26 @@ describe('Mastra.addDynamicWorkflows', () => {
     const definition = await store.get('lookup-first-customer');
 
     expect(definition?.authorId).toBe('verified-author');
+  });
+
+  it('rejects a different trusted author and restores the previous registration', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-conflict' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+      authorId: 'verified-author',
+    });
+    const original = mastra.getWorkflow('lookup-first-customer');
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email2'), {
+        authorId: 'other-author',
+      }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(mastra.getWorkflow('lookup-first-customer')).toBe(original);
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    expect((await store.get('lookup-first-customer'))?.authorId).toBe('verified-author');
   });
 
   it('is a no-op for an empty bundle', async () => {

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -318,6 +318,62 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect((await store.get('lookup-first-customer'))?.authorId).toBe('verified-author');
   });
 
+  it('serializes overlapping bundles so a rejected owner cannot roll back the winner', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-concurrent-owner-conflict' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const realUpsert = store.upsert.bind(store);
+
+    let releaseFirstUpsert!: () => void;
+    const firstUpsertEntered = new Promise<void>(resolve => {
+      releaseFirstUpsert = resolve;
+    });
+    let upsertCalls = 0;
+    store.upsert = (async definition => {
+      upsertCalls += 1;
+      if (upsertCalls === 1) {
+        releaseFirstUpsert();
+        // Keep the first bundle inside persistence for one event-loop turn.
+        // Without registration serialization, the overlapping bundle can
+        // replace its registry slots and win storage before this write resumes.
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+      }
+      return realUpsert(definition);
+    }) as typeof store.upsert;
+
+    const winner = mastra.addDynamicWorkflows(
+      [
+        { ...helperDefinition('shared-helper', 'email1'), description: 'winner' },
+        helperDefinition('winner-only', 'email1'),
+      ],
+      { authorId: 'winner-author' },
+    );
+    await firstUpsertEntered;
+
+    const loser = mastra.addDynamicWorkflows(
+      [
+        { ...helperDefinition('shared-helper', 'email2'), description: 'loser' },
+        helperDefinition('loser-only', 'email2'),
+      ],
+      { authorId: 'loser-author' },
+    );
+
+    const [winnerResult, loserResult] = await Promise.allSettled([winner, loser]);
+    expect(winnerResult.status).toBe('fulfilled');
+    expect(loserResult).toMatchObject({
+      status: 'rejected',
+      reason: expect.any(WorkflowDefinitionOwnershipConflictError),
+    });
+
+    expect(await store.get('shared-helper')).toMatchObject({ authorId: 'winner-author', description: 'winner' });
+    expect(await store.get('winner-only')).toMatchObject({ authorId: 'winner-author' });
+    expect(await store.get('loser-only')).toBeNull();
+
+    expect(mastra.getWorkflow('shared-helper').description).toBe('winner');
+    expect(mastra.getWorkflow('winner-only')).toBeDefined();
+    expect(() => mastra.getWorkflow('loser-only')).toThrow();
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -283,6 +283,22 @@ describe('Mastra.addDynamicWorkflows', () => {
     expect(definitions.every(definition => definition.authorId === 'verified-author')).toBe(true);
   });
 
+  it('rejects an authored bundle before live registration when workflow definition storage is unavailable', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-no-definition-store' });
+    const getStore = storage.getStore.bind(storage);
+    storage.getStore = (async domain =>
+      domain === 'workflowDefinitions' ? undefined : getStore(domain)) as typeof storage.getStore;
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await expect(
+      mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+        authorId: 'verified-author',
+      }),
+    ).rejects.toThrow(/workflowDefinitions storage domain is required/);
+
+    expect(() => mastra.getWorkflow('lookup-first-customer')).toThrow();
+  });
+
   it('preserves an existing author when a trusted author is omitted on replacement', async () => {
     const storage = new InMemoryStore({ id: 'bundle-author-preserved' });
     const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -262,6 +262,42 @@ describe('Mastra.addDynamicWorkflows', () => {
     ]);
   });
 
+  it('persists one trusted author for every member outside the workflow definitions', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    const untrustedHelper = {
+      ...helperDefinition('lookup-first-customer', 'email1'),
+      authorId: 'forged-author',
+    };
+
+    await mastra.addDynamicWorkflows(
+      [untrustedHelper, helperDefinition('lookup-second-customer', 'email2'), rootDefinition],
+      { authorId: 'verified-author' },
+    );
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const { definitions } = await store.list({ status: 'active' });
+
+    expect(definitions).toHaveLength(3);
+    expect(definitions.every(definition => definition.authorId === 'verified-author')).toBe(true);
+  });
+
+  it('preserves an existing author when a trusted author is omitted on replacement', async () => {
+    const storage = new InMemoryStore({ id: 'bundle-author-preserved' });
+    const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
+
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email1'), {
+      authorId: 'verified-author',
+    });
+    await mastra.addDynamicWorkflow(helperDefinition('lookup-first-customer', 'email2'));
+
+    const store = (await storage.getStore('workflowDefinitions'))!;
+    const definition = await store.get('lookup-first-customer');
+
+    expect(definition?.authorId).toBe('verified-author');
+  });
+
   it('is a no-op for an empty bundle', async () => {
     const mastra = createMastra('bundle-empty');
     await expect(mastra.addDynamicWorkflows([])).resolves.toBeUndefined();

--- a/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
+++ b/packages/core/src/mastra/add-dynamic-workflows-bundle.test.ts
@@ -191,18 +191,14 @@ describe('Mastra.addDynamicWorkflows', () => {
    * member has already been hydrated and live-registered — so they are the
    * ones that actually exercise the registry rollback.
    */
-  it('unregisters every member when persistence fails partway through the bundle', async () => {
+  it('unregisters every member when atomic bundle persistence fails', async () => {
     const storage = new InMemoryStore({ id: 'bundle-rollback-persist' });
     const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
 
     const store = (await storage.getStore('workflowDefinitions'))!;
-    const realUpsert = store.upsert.bind(store);
-    let upserts = 0;
-    store.upsert = (async (definition: Parameters<typeof realUpsert>[0]) => {
-      upserts += 1;
-      if (upserts === 2) throw new Error('storage exploded mid-bundle');
-      return realUpsert(definition);
-    }) as typeof store.upsert;
+    store.upsertMany = (async () => {
+      throw new Error('storage rejected bundle');
+    }) as typeof store.upsertMany;
 
     await expect(
       mastra.addDynamicWorkflows([
@@ -210,7 +206,7 @@ describe('Mastra.addDynamicWorkflows', () => {
         helperDefinition('lookup-second-customer', 'email2'),
         rootDefinition,
       ]),
-    ).rejects.toThrow('storage exploded mid-bundle');
+    ).rejects.toThrow('storage rejected bundle');
 
     // All three were registered before the write failed; none may survive it.
     expect(() => mastra.getWorkflow('lookup-first-customer')).toThrow();
@@ -226,9 +222,9 @@ describe('Mastra.addDynamicWorkflows', () => {
     const original = mastra.getWorkflow('lookup-first-customer');
 
     const store = (await storage.getStore('workflowDefinitions'))!;
-    store.upsert = (async () => {
+    store.upsertMany = (async () => {
       throw new Error('storage exploded on replace');
-    }) as typeof store.upsert;
+    }) as typeof store.upsertMany;
 
     await expect(
       mastra.addDynamicWorkflows([
@@ -338,14 +334,14 @@ describe('Mastra.addDynamicWorkflows', () => {
     const storage = new InMemoryStore({ id: 'bundle-concurrent-owner-conflict' });
     const mastra = new Mastra({ logger: false, tools: { 'lookup-customer': lookupCustomer } as any, storage });
     const store = (await storage.getStore('workflowDefinitions'))!;
-    const realUpsert = store.upsert.bind(store);
+    const realUpsertMany = store.upsertMany.bind(store);
 
     let releaseFirstUpsert!: () => void;
     const firstUpsertEntered = new Promise<void>(resolve => {
       releaseFirstUpsert = resolve;
     });
     let upsertCalls = 0;
-    store.upsert = (async definition => {
+    store.upsertMany = (async definitions => {
       upsertCalls += 1;
       if (upsertCalls === 1) {
         releaseFirstUpsert();
@@ -354,8 +350,8 @@ describe('Mastra.addDynamicWorkflows', () => {
         // replace its registry slots and win storage before this write resumes.
         await new Promise<void>(resolve => setTimeout(resolve, 0));
       }
-      return realUpsert(definition);
-    }) as typeof store.upsert;
+      return realUpsertMany(definitions);
+    }) as typeof store.upsertMany;
 
     const winner = mastra.addDynamicWorkflows(
       [

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -4826,6 +4826,7 @@ export class Mastra<
       }
       await Promise.race(blockers);
       admitted = true;
+      clearTimeout(waitWarning);
       return await operation();
     } finally {
       if (timeout) clearTimeout(timeout);
@@ -4918,9 +4919,9 @@ export class Mastra<
    *   caller's accepted live registration. Unrelated ids proceed independently.
    * - `waitTimeoutMs` and `signal` apply before admission. A rejected waiter
    *   performs no registry or storage mutation; admitted writes are fully awaited.
-   * - Storage writes happen last. A storage-level failure mid-bundle is the
-   *   one residual window where rows can be partially written; the registry is
-   *   still rolled back, and the orphaned rows are inert until the next boot.
+   * - Storage writes happen last through the workflow-definition store's
+   *   atomic bundle contract. A failure leaves both storage and the live
+   *   registry exactly as they were before registration began.
    *
    * `addDynamicWorkflow()` is the single-member case.
    *
@@ -5042,19 +5043,19 @@ export class Mastra<
         }
 
         if (store) {
-          for (const { normalized } of ordered) {
-            await store.upsert({
-              id: normalized.id,
-              description: normalized.description,
-              metadata: normalized.metadata,
-              inputSchema: normalized.inputSchema,
-              outputSchema: normalized.outputSchema,
-              stateSchema: normalized.stateSchema,
-              requestContextSchema: normalized.requestContextSchema,
-              graph: normalized.graph,
-              ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
-            });
-          }
+          const inputs = ordered.map(({ normalized }) => ({
+            id: normalized.id,
+            description: normalized.description,
+            metadata: normalized.metadata,
+            inputSchema: normalized.inputSchema,
+            outputSchema: normalized.outputSchema,
+            stateSchema: normalized.stateSchema,
+            requestContextSchema: normalized.requestContextSchema,
+            graph: normalized.graph,
+            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
+          }));
+          if (inputs.length === 1) await store.upsert(inputs[0]!);
+          else await store.upsertMany(inputs);
         }
       } catch (error) {
         restoreRegistry();

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -4855,6 +4855,9 @@ export class Mastra<
    *   before anything is mutated.
    * - If hydration or persistence fails partway, the in-memory registry is
    *   restored to its prior state.
+   * - Registrations are serialized on this Mastra instance through validation,
+   *   hydration, and persistence so one caller's rollback cannot undo another
+   *   caller's accepted live registration.
    * - Storage writes happen last. A storage-level failure mid-bundle is the
    *   one residual window where rows can be partially written; the registry is
    *   still rolled back, and the orphaned rows are inert until the next boot.
@@ -4901,6 +4904,13 @@ export class Mastra<
           graph: def.graph,
         }),
       }));
+
+      const store = await this.#storage?.getStore('workflowDefinitions');
+      if (options?.authorId !== undefined && !store) {
+        throw new Error(
+          'A workflowDefinitions storage domain is required when registering an authored dynamic workflow.',
+        );
+      }
 
       // Members may nest each other, so the index every member validates against
       // is the live registries plus the bundle itself — not the registry alone.
@@ -4966,7 +4976,6 @@ export class Mastra<
           this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
         }
 
-        const store = await this.#storage?.getStore('workflowDefinitions');
         if (store) {
           for (const { normalized } of ordered) {
             await store.upsert({

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -688,6 +688,7 @@ export class Mastra<
   #workflows: TWorkflows;
   #harnesses: Record<string, Harness<any>> = {};
   #hiddenWorkflowKeys = new Set<string>();
+  #dynamicWorkflowRegistrationTail: Promise<void> = Promise.resolve();
   #observability: ObservabilityEntrypoint;
   #observabilityExplicit = false;
   #onScorerHook?: ReturnType<typeof createOnScorerHook>;
@@ -4758,6 +4759,26 @@ export class Mastra<
   }
 
   /**
+   * Runs dynamic workflow registrations one at a time so each rollback owns a
+   * stable registry snapshot. An instance-wide queue also makes overlapping
+   * bundles deadlock-free because callers never acquire per-workflow locks.
+   */
+  async #serializeDynamicWorkflowRegistration<T>(operation: () => Promise<T>): Promise<T> {
+    const prior = this.#dynamicWorkflowRegistrationTail;
+    let release!: () => void;
+    this.#dynamicWorkflowRegistrationTail = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    await prior;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  /**
    * Flattens this instance's registries into the index the dynamic-workflow
    * validation core resolves references and schemas against. Registered keys
    * and canonical ids both count as valid references. Schemas are converted
@@ -4854,116 +4875,118 @@ export class Mastra<
   ): Promise<void> {
     if (defs.length === 0) return;
 
-    const seen = new Set<string>();
-    for (const def of defs) {
-      if (seen.has(def.id)) {
-        throw new Error(
-          `Dynamic workflow bundle contains more than one definition with id "${def.id}". Ids must be unique within a bundle.`,
-        );
-      }
-      seen.add(def.id);
-    }
-
-    // Save-path is strict (boot-time load is lenient — see #loadDynamicWorkflows).
-    // Normalization coerces the wire shape; one validation call per member
-    // covers structure, JSON-Schema keywords, references, and schema-flow.
-    const members = defs.map(def => ({
-      normalized: normalizeWorkflowBuilderDefinition({
-        id: def.id,
-        description: def.description,
-        metadata: def.metadata,
-        inputSchema: def.inputSchema,
-        outputSchema: def.outputSchema,
-        stateSchema: def.stateSchema,
-        requestContextSchema: def.requestContextSchema,
-        graph: def.graph,
-      }),
-    }));
-
-    // Members may nest each other, so the index every member validates against
-    // is the live registries plus the bundle itself — not the registry alone.
-    const index = this.#buildWorkflowRegistryIndex();
-    const bundleIds = new Set(members.map(member => member.normalized.id));
-    for (const { normalized } of members) {
-      (index.workflows ??= {})[normalized.id] = {
-        inputSchema: normalized.inputSchema,
-        outputSchema: normalized.outputSchema,
-      } as WorkflowRegistrySchemas;
-    }
-    for (const { normalized } of members) {
-      assertValidDynamicWorkflow(normalized, index);
-    }
-
-    // Hydration resolves nested workflows through the live registry, so a
-    // member cannot be hydrated before the bundle members it nests.
-    const ordered: typeof members = [];
-    const remaining = new Map(members.map(member => [member.normalized.id, member] as const));
-    const hydrated = new Set<string>();
-    let progress = true;
-    while (remaining.size > 0 && progress) {
-      progress = false;
-      for (const [id, member] of Array.from(remaining)) {
-        const pending = Array.from(collectNestedWorkflowIds(member.normalized.graph)).filter(
-          dependency => dependency !== id && bundleIds.has(dependency) && !hydrated.has(dependency),
-        );
-        if (pending.length > 0) continue;
-        remaining.delete(id);
-        hydrated.add(id);
-        ordered.push(member);
-        progress = true;
-      }
-    }
-    if (remaining.size > 0) {
-      throw new Error(
-        `Dynamic workflow bundle has a circular nested-workflow dependency among: ${Array.from(remaining.keys())
-          .sort()
-          .join(', ')}.`,
-      );
-    }
-
-    // Snapshot the registry slots this bundle will overwrite so a failure
-    // anywhere below leaves the instance exactly as it was found.
-    const registry = this.#workflows as Record<string, AnyWorkflow>;
-    const priorWorkflows = new Map<string, AnyWorkflow | undefined>();
-    const priorHiddenKeys = new Set<string>();
-    for (const { normalized } of ordered) {
-      priorWorkflows.set(normalized.id, registry[normalized.id]);
-      if (this.#hiddenWorkflowKeys.has(normalized.id)) priorHiddenKeys.add(normalized.id);
-    }
-    const restoreRegistry = () => {
-      for (const [id, prior] of priorWorkflows) {
-        if (prior) registry[id] = prior;
-        else delete registry[id];
-        if (priorHiddenKeys.has(id)) this.#hiddenWorkflowKeys.add(id);
-      }
-    };
-
-    try {
-      for (const { normalized } of ordered) {
-        const { workflow } = await rehydrateWorkflow(normalized, this);
-        this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
+    await this.#serializeDynamicWorkflowRegistration(async () => {
+      const seen = new Set<string>();
+      for (const def of defs) {
+        if (seen.has(def.id)) {
+          throw new Error(
+            `Dynamic workflow bundle contains more than one definition with id "${def.id}". Ids must be unique within a bundle.`,
+          );
+        }
+        seen.add(def.id);
       }
 
-      const store = await this.#storage?.getStore('workflowDefinitions');
-      if (store) {
-        for (const { normalized } of ordered) {
-          await store.upsert({
-            id: normalized.id,
-            description: normalized.description,
-            metadata: normalized.metadata,
-            inputSchema: normalized.inputSchema,
-            outputSchema: normalized.outputSchema,
-            stateSchema: normalized.stateSchema,
-            requestContextSchema: normalized.requestContextSchema,
-            graph: normalized.graph,
-            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
-          });
+      // Save-path is strict (boot-time load is lenient — see #loadDynamicWorkflows).
+      // Normalization coerces the wire shape; one validation call per member
+      // covers structure, JSON-Schema keywords, references, and schema-flow.
+      const members = defs.map(def => ({
+        normalized: normalizeWorkflowBuilderDefinition({
+          id: def.id,
+          description: def.description,
+          metadata: def.metadata,
+          inputSchema: def.inputSchema,
+          outputSchema: def.outputSchema,
+          stateSchema: def.stateSchema,
+          requestContextSchema: def.requestContextSchema,
+          graph: def.graph,
+        }),
+      }));
+
+      // Members may nest each other, so the index every member validates against
+      // is the live registries plus the bundle itself — not the registry alone.
+      const index = this.#buildWorkflowRegistryIndex();
+      const bundleIds = new Set(members.map(member => member.normalized.id));
+      for (const { normalized } of members) {
+        (index.workflows ??= {})[normalized.id] = {
+          inputSchema: normalized.inputSchema,
+          outputSchema: normalized.outputSchema,
+        } as WorkflowRegistrySchemas;
+      }
+      for (const { normalized } of members) {
+        assertValidDynamicWorkflow(normalized, index);
+      }
+
+      // Hydration resolves nested workflows through the live registry, so a
+      // member cannot be hydrated before the bundle members it nests.
+      const ordered: typeof members = [];
+      const remaining = new Map(members.map(member => [member.normalized.id, member] as const));
+      const hydrated = new Set<string>();
+      let progress = true;
+      while (remaining.size > 0 && progress) {
+        progress = false;
+        for (const [id, member] of Array.from(remaining)) {
+          const pending = Array.from(collectNestedWorkflowIds(member.normalized.graph)).filter(
+            dependency => dependency !== id && bundleIds.has(dependency) && !hydrated.has(dependency),
+          );
+          if (pending.length > 0) continue;
+          remaining.delete(id);
+          hydrated.add(id);
+          ordered.push(member);
+          progress = true;
         }
       }
-    } catch (error) {
-      restoreRegistry();
-      throw error;
-    }
+      if (remaining.size > 0) {
+        throw new Error(
+          `Dynamic workflow bundle has a circular nested-workflow dependency among: ${Array.from(remaining.keys())
+            .sort()
+            .join(', ')}.`,
+        );
+      }
+
+      // Snapshot the registry slots this bundle will overwrite so a failure
+      // anywhere below leaves the instance exactly as it was found.
+      const registry = this.#workflows as Record<string, AnyWorkflow>;
+      const priorWorkflows = new Map<string, AnyWorkflow | undefined>();
+      const priorHiddenKeys = new Set<string>();
+      for (const { normalized } of ordered) {
+        priorWorkflows.set(normalized.id, registry[normalized.id]);
+        if (this.#hiddenWorkflowKeys.has(normalized.id)) priorHiddenKeys.add(normalized.id);
+      }
+      const restoreRegistry = () => {
+        for (const [id, prior] of priorWorkflows) {
+          if (prior) registry[id] = prior;
+          else delete registry[id];
+          if (priorHiddenKeys.has(id)) this.#hiddenWorkflowKeys.add(id);
+        }
+      };
+
+      try {
+        for (const { normalized } of ordered) {
+          const { workflow } = await rehydrateWorkflow(normalized, this);
+          this.#replaceDynamicWorkflow(workflow as AnyWorkflow, normalized.id);
+        }
+
+        const store = await this.#storage?.getStore('workflowDefinitions');
+        if (store) {
+          for (const { normalized } of ordered) {
+            await store.upsert({
+              id: normalized.id,
+              description: normalized.description,
+              metadata: normalized.metadata,
+              inputSchema: normalized.inputSchema,
+              outputSchema: normalized.outputSchema,
+              stateSchema: normalized.stateSchema,
+              requestContextSchema: normalized.requestContextSchema,
+              graph: normalized.graph,
+              ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
+            });
+          }
+        }
+      } catch (error) {
+        restoreRegistry();
+        throw error;
+      }
+    });
   }
 
   /**

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -111,6 +111,10 @@ export interface DynamicWorkflowRegistrationOptions {
    * authorize this value before registration.
    */
   authorId?: string;
+  /** Maximum time to wait for an overlapping registration already using the same workflow id(s). */
+  waitTimeoutMs?: number;
+  /** Cancels only while waiting to enter registration; admitted storage mutations are always awaited. */
+  signal?: AbortSignal;
 }
 
 /**
@@ -688,7 +692,7 @@ export class Mastra<
   #workflows: TWorkflows;
   #harnesses: Record<string, Harness<any>> = {};
   #hiddenWorkflowKeys = new Set<string>();
-  #dynamicWorkflowRegistrationTail: Promise<void> = Promise.resolve();
+  #dynamicWorkflowRegistrationTails = new Map<string, Promise<void>>();
   #observability: ObservabilityEntrypoint;
   #observabilityExplicit = false;
   #onScorerHook?: ReturnType<typeof createOnScorerHook>;
@@ -4759,22 +4763,76 @@ export class Mastra<
   }
 
   /**
-   * Runs dynamic workflow registrations one at a time so each rollback owns a
-   * stable registry snapshot. An instance-wide queue also makes overlapping
-   * bundles deadlock-free because callers never acquire per-workflow locks.
+   * Serializes only registrations with overlapping ids. All ids are reserved
+   * synchronously before waiting, so bundles cannot deadlock. Cancellation and
+   * timeout apply to queue admission only: a rejected waiter never starts a
+   * storage mutation, while an admitted mutation remains awaited to completion.
    */
-  async #serializeDynamicWorkflowRegistration<T>(operation: () => Promise<T>): Promise<T> {
-    const prior = this.#dynamicWorkflowRegistrationTail;
+  async #serializeDynamicWorkflowRegistration<T>(
+    ids: readonly string[],
+    options: DynamicWorkflowRegistrationOptions | undefined,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    if (options?.signal?.aborted) {
+      throw options.signal.reason ?? new Error('Dynamic workflow registration aborted.');
+    }
+    if (
+      options?.waitTimeoutMs !== undefined &&
+      (!Number.isFinite(options.waitTimeoutMs) || options.waitTimeoutMs < 0)
+    ) {
+      throw new Error('Dynamic workflow registration waitTimeoutMs must be a finite non-negative number.');
+    }
+    const uniqueIds = Array.from(new Set(ids)).sort();
+    const priors = uniqueIds.map(id => this.#dynamicWorkflowRegistrationTails.get(id) ?? Promise.resolve());
+    const admission = Promise.all(priors).then(() => undefined);
     let release!: () => void;
-    this.#dynamicWorkflowRegistrationTail = new Promise<void>(resolve => {
+    const slot = new Promise<void>(resolve => {
       release = resolve;
     });
+    for (const id of uniqueIds) this.#dynamicWorkflowRegistrationTails.set(id, slot);
+    void slot.then(() => {
+      for (const id of uniqueIds) {
+        if (this.#dynamicWorkflowRegistrationTails.get(id) === slot) this.#dynamicWorkflowRegistrationTails.delete(id);
+      }
+    });
 
-    await prior;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const waitWarning = setTimeout(() => {
+      this.#logger?.warn?.(`Dynamic workflow registration is waiting for ids: ${uniqueIds.join(', ')}.`);
+    }, 5_000);
+    let removeAbortListener: (() => void) | undefined;
+    let admitted = false;
     try {
+      const blockers: Promise<void>[] = [admission];
+      if (options?.signal) {
+        blockers.push(
+          new Promise<void>((_, reject) => {
+            const rejectAbort = () =>
+              reject(options.signal?.reason ?? new Error('Dynamic workflow registration aborted.'));
+            options.signal!.addEventListener('abort', rejectAbort, { once: true });
+            removeAbortListener = () => options.signal!.removeEventListener('abort', rejectAbort);
+          }),
+        );
+      }
+      if (options?.waitTimeoutMs !== undefined) {
+        blockers.push(
+          new Promise<void>((_, reject) => {
+            timeout = setTimeout(
+              () => reject(new Error(`Timed out waiting to register dynamic workflow ids: ${uniqueIds.join(', ')}.`)),
+              options.waitTimeoutMs,
+            );
+          }),
+        );
+      }
+      await Promise.race(blockers);
+      admitted = true;
       return await operation();
     } finally {
-      release();
+      if (timeout) clearTimeout(timeout);
+      clearTimeout(waitWarning);
+      removeAbortListener?.();
+      if (admitted) release();
+      else void admission.then(release, release);
     }
   }
 
@@ -4855,9 +4913,11 @@ export class Mastra<
    *   before anything is mutated.
    * - If hydration or persistence fails partway, the in-memory registry is
    *   restored to its prior state.
-   * - Registrations are serialized on this Mastra instance through validation,
+   * - Registrations with overlapping ids are serialized through validation,
    *   hydration, and persistence so one caller's rollback cannot undo another
-   *   caller's accepted live registration.
+   *   caller's accepted live registration. Unrelated ids proceed independently.
+   * - `waitTimeoutMs` and `signal` apply before admission. A rejected waiter
+   *   performs no registry or storage mutation; admitted writes are fully awaited.
    * - Storage writes happen last. A storage-level failure mid-bundle is the
    *   one residual window where rows can be partially written; the registry is
    *   still rolled back, and the orphaned rows are inert until the next boot.
@@ -4878,7 +4938,12 @@ export class Mastra<
   ): Promise<void> {
     if (defs.length === 0) return;
 
-    await this.#serializeDynamicWorkflowRegistration(async () => {
+    const serializeRegistration = this.#serializeDynamicWorkflowRegistration.bind(
+      this,
+      defs.map(def => def.id),
+      options,
+    );
+    await serializeRegistration(async () => {
       const seen = new Set<string>();
       for (const def of defs) {
         if (seen.has(def.id)) {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -99,6 +99,21 @@ import { createRunScope } from './run-scope';
 import type { VersionOverrides, VersionSelector } from './types';
 
 /**
+ * Trusted metadata applied while a dynamic workflow is persisted.
+ *
+ * Keep these values outside the JSON workflow definition when that definition
+ * comes from an untrusted authoring surface. This metadata is persisted with
+ * the definition but does not itself enforce authorization.
+ */
+export interface DynamicWorkflowRegistrationOptions {
+  /**
+   * Verified identity responsible for the stored definition. Callers must
+   * authorize this value before registration.
+   */
+  authorId?: string;
+}
+
+/**
  * Creates an error for when a null/undefined value is passed to an add* method.
  * This commonly occurs when config is spread ({ ...config }) and the original
  * object had getters or non-enumerable properties.
@@ -4796,8 +4811,11 @@ export class Mastra<
    * await run.start({ inputData: { location: 'Helsinki' } });
    * ```
    */
-  public async addDynamicWorkflow(def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput): Promise<void> {
-    await this.addDynamicWorkflows([def]);
+  public async addDynamicWorkflow(
+    def: DynamicWorkflowGraph | WorkflowBuilderDefinitionInput,
+    options?: DynamicWorkflowRegistrationOptions,
+  ): Promise<void> {
+    await this.addDynamicWorkflows([def], options);
   }
 
   /**
@@ -4832,6 +4850,7 @@ export class Mastra<
    */
   public async addDynamicWorkflows(
     defs: readonly (DynamicWorkflowGraph | WorkflowBuilderDefinitionInput)[],
+    options?: DynamicWorkflowRegistrationOptions,
   ): Promise<void> {
     if (defs.length === 0) return;
 
@@ -4937,6 +4956,7 @@ export class Mastra<
             stateSchema: normalized.stateSchema,
             requestContextSchema: normalized.requestContextSchema,
             graph: normalized.graph,
+            ...(options?.authorId !== undefined ? { authorId: options.authorId } : {}),
           });
         }
       }

--- a/packages/core/src/storage/domains/workflow-definitions/base.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/base.ts
@@ -42,6 +42,8 @@ export interface WorkflowDefinition {
 
   /** Provenance — distinguishes user-stored from code-registered workflows. */
   source: 'storage';
+
+  /** Immutable owner assigned when the definition is created. */
   authorId?: string;
 
   createdAt: Date;
@@ -58,6 +60,8 @@ export interface CreateWorkflowDefinitionInput {
   stateSchema?: unknown;
   requestContextSchema?: unknown;
   graph: ValidatableStepFlowEntry[];
+
+  /** Immutable owner to assign when the definition is created. */
   authorId?: string;
 }
 
@@ -72,6 +76,8 @@ export interface UpdateWorkflowDefinitionInput {
   requestContextSchema?: unknown;
   graph?: ValidatableStepFlowEntry[];
   status?: 'active' | 'archived';
+
+  /** Expected immutable owner. A different owner produces a conflict. */
   authorId?: string;
 }
 
@@ -86,10 +92,42 @@ export interface ListWorkflowDefinitionsOutput {
 }
 
 /**
+ * Thrown when an upsert attempts to claim a workflow definition that already
+ * belongs to a different author. The message intentionally does not disclose
+ * the existing author.
+ */
+export class WorkflowDefinitionOwnershipConflictError extends Error {
+  readonly workflowId: string;
+
+  constructor(workflowId: string) {
+    super(`Workflow definition "${workflowId}" conflicts with an existing definition.`);
+    this.name = 'WorkflowDefinitionOwnershipConflictError';
+    this.workflowId = workflowId;
+  }
+}
+
+/**
+ * Treat an explicitly supplied author as both creation ownership and the
+ * expected owner on update. Omitting authorId preserves legacy/unscoped
+ * behavior; supplying it can never create or transfer ownership after a row
+ * already exists.
+ */
+export function assertWorkflowDefinitionAuthor(
+  existing: Pick<WorkflowDefinition, 'id' | 'authorId'>,
+  input: Pick<UpdateWorkflowDefinitionInput, 'authorId'>,
+): void {
+  if (input.authorId !== undefined && existing.authorId !== input.authorId) {
+    throw new WorkflowDefinitionOwnershipConflictError(existing.id);
+  }
+}
+
+/**
  * Abstract storage domain for persisted workflow definitions.
  *
  * Versioning is intentionally out of scope for v1 — `upsert` overwrites in
- * place. A future revision can layer the {@link VersionedStorageDomain}
+ * place. Ownership is the exception: an explicitly supplied `authorId` is an
+ * immutable compare condition, so concurrent creators cannot take over the
+ * winning row. A future revision can layer the {@link VersionedStorageDomain}
  * pattern on top without breaking the rehydration path.
  */
 export abstract class WorkflowDefinitionsStorage extends StorageDomain {

--- a/packages/core/src/storage/domains/workflow-definitions/base.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/base.ts
@@ -136,6 +136,20 @@ export abstract class WorkflowDefinitionsStorage extends StorageDomain {
   }
 
   abstract upsert(input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput): Promise<WorkflowDefinition>;
+
+  /**
+   * Atomically create or update a related set of workflow definitions.
+   *
+   * Implementations must apply every ownership comparison and write in one
+   * storage transaction: either every returned definition is durable or none
+   * of the inputs has changed storage. The result order matches the input
+   * order. This is the persistence boundary used by dynamic workflow bundles,
+   * whose members may reference each other and therefore cannot safely become
+   * visible one row at a time.
+   */
+  abstract upsertMany(
+    inputs: readonly (CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput)[],
+  ): Promise<WorkflowDefinition[]>;
   abstract get(id: string): Promise<WorkflowDefinition | null>;
   abstract list(args?: ListWorkflowDefinitionsInput): Promise<ListWorkflowDefinitionsOutput>;
   abstract delete(id: string): Promise<void>;

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.test.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { InMemoryDB } from '../inmemory-db';
+import { WorkflowDefinitionOwnershipConflictError } from './base';
 import { InMemoryWorkflowDefinitionsStorage } from './inmemory';
 
 const graph = [{ type: 'tool', id: 'echo-tool', toolId: 'echo-tool' }] as any;
@@ -36,14 +37,24 @@ describe('InMemoryWorkflowDefinitionsStorage', () => {
   });
 
   describe('update', () => {
-    it('updates authorId on an existing definition', async () => {
+    it('keeps authorId immutable on an existing definition', async () => {
       await storage.upsert({ ...baseInput(), authorId: 'author-1' });
-      const updated = await storage.upsert({ id: 'wf-1', authorId: 'author-2' });
-      expect(updated.authorId).toBe('author-2');
+      await expect(storage.upsert({ id: 'wf-1', authorId: 'author-2' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
       const fetched = await storage.get('wf-1');
-      expect(fetched?.authorId).toBe('author-2');
+      expect(fetched?.authorId).toBe('author-1');
       // Unspecified columns survive the partial upsert.
       expect(fetched?.graph).toEqual(graph);
+    });
+
+    it('does not disclose the existing author in ownership conflicts', async () => {
+      await storage.upsert({ ...baseInput(), authorId: 'private-owner' });
+
+      const error = await storage.upsert({ id: 'wf-1', authorId: 'other-owner' }).catch(cause => cause);
+
+      expect(error).toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+      expect(error.message).not.toContain('private-owner');
     });
   });
 });

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
@@ -21,8 +21,27 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
   }
 
   async upsert(input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput): Promise<WorkflowDefinition> {
+    const [definition] = await this.upsertMany([input]);
+    if (!definition) throw new Error(`Failed to persist workflow definition "${input.id}".`);
+    return definition;
+  }
+
+  async upsertMany(
+    inputs: readonly (CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput)[],
+  ): Promise<WorkflowDefinition[]> {
+    const staged = new Map(this.db.workflowDefinitions);
+    const definitions = inputs.map(input => this.applyUpsert(staged, input));
+    this.db.workflowDefinitions.clear();
+    for (const [id, definition] of staged) this.db.workflowDefinitions.set(id, definition);
+    return definitions.map(definition => this.deepCopy(definition));
+  }
+
+  private applyUpsert(
+    definitions: Map<string, WorkflowDefinition>,
+    input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
+  ): WorkflowDefinition {
     const now = new Date();
-    const existing = this.db.workflowDefinitions.get(input.id);
+    const existing = definitions.get(input.id);
 
     if (existing) {
       assertWorkflowDefinitionAuthor(existing, input);
@@ -39,8 +58,8 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
         ...('status' in input && input.status !== undefined && { status: input.status }),
         updatedAt: now,
       };
-      this.db.workflowDefinitions.set(input.id, merged);
-      return this.deepCopy(merged);
+      definitions.set(input.id, merged);
+      return merged;
     }
 
     // Creation requires the full schema set + graph. Check values, not key
@@ -73,8 +92,8 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
       createdAt: now,
       updatedAt: now,
     };
-    this.db.workflowDefinitions.set(input.id, def);
-    return this.deepCopy(def);
+    definitions.set(input.id, def);
+    return def;
   }
 
   async get(id: string): Promise<WorkflowDefinition | null> {

--- a/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
+++ b/packages/core/src/storage/domains/workflow-definitions/inmemory.ts
@@ -6,7 +6,7 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from './base';
-import { WorkflowDefinitionsStorage } from './base';
+import { assertWorkflowDefinitionAuthor, WorkflowDefinitionsStorage } from './base';
 
 export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStorage {
   private db: InMemoryDB;
@@ -25,6 +25,7 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
     const existing = this.db.workflowDefinitions.get(input.id);
 
     if (existing) {
+      assertWorkflowDefinitionAuthor(existing, input);
       const merged: WorkflowDefinition = {
         ...existing,
         ...('description' in input && input.description !== undefined && { description: input.description }),
@@ -36,7 +37,6 @@ export class InMemoryWorkflowDefinitionsStorage extends WorkflowDefinitionsStora
           input.requestContextSchema !== undefined && { requestContextSchema: input.requestContextSchema }),
         ...('graph' in input && input.graph !== undefined && { graph: input.graph }),
         ...('status' in input && input.status !== undefined && { status: input.status }),
-        ...('authorId' in input && input.authorId !== undefined && { authorId: input.authorId }),
         updatedAt: now,
       };
       this.db.workflowDefinitions.set(input.id, merged);

--- a/stores/_test-utils/src/domains/workflow-definitions/index.ts
+++ b/stores/_test-utils/src/domains/workflow-definitions/index.ts
@@ -85,6 +85,20 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
       expect(updated).toMatchObject({ authorId: 'author-1', description: 'renamed' });
     });
 
+    it('atomically rejects a bundle when any member conflicts with an existing owner', async () => {
+      await store.upsert({ ...baseInput('owned'), authorId: 'author-2' });
+
+      await expect(
+        store.upsertMany([
+          { ...baseInput('new-member'), authorId: 'author-1' },
+          { ...baseInput('owned'), description: 'forged update', authorId: 'author-1' },
+        ]),
+      ).rejects.toThrow();
+
+      expect(await store.get('new-member')).toBeNull();
+      expect(await store.get('owned')).toMatchObject({ authorId: 'author-2', description: 'workflow owned' });
+    });
+
     it('does not let an author claim a legacy unowned row', async () => {
       await store.upsert(baseInput('wf-1'));
 

--- a/stores/_test-utils/src/domains/workflow-definitions/index.ts
+++ b/stores/_test-utils/src/domains/workflow-definitions/index.ts
@@ -1,3 +1,4 @@
+import { WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 import type { MastraStorage, WorkflowDefinitionsStorage } from '@mastra/core/storage';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
@@ -68,12 +69,30 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
       expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime());
     });
 
-    it('updates authorId on existing rows', async () => {
+    it('rejects ownership transfer on existing rows', async () => {
       await store.upsert({ ...baseInput('wf-1'), authorId: 'author-1' });
-      const updated = await store.upsert({ id: 'wf-1', authorId: 'author-2' });
-      expect(updated.authorId).toBe('author-2');
+      await expect(store.upsert({ id: 'wf-1', authorId: 'author-2' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
       const fetched = await store.get('wf-1');
-      expect(fetched?.authorId).toBe('author-2');
+      expect(fetched?.authorId).toBe('author-1');
+    });
+
+    it('allows the existing owner to update an owned row', async () => {
+      await store.upsert({ ...baseInput('wf-1'), authorId: 'author-1' });
+      const updated = await store.upsert({ id: 'wf-1', authorId: 'author-1', description: 'renamed' });
+
+      expect(updated).toMatchObject({ authorId: 'author-1', description: 'renamed' });
+    });
+
+    it('does not let an author claim a legacy unowned row', async () => {
+      await store.upsert(baseInput('wf-1'));
+
+      await expect(store.upsert({ id: 'wf-1', authorId: 'author-1' })).rejects.toBeInstanceOf(
+        WorkflowDefinitionOwnershipConflictError,
+      );
+      const stored = await store.get('wf-1');
+      expect(stored?.authorId).toBeUndefined();
     });
 
     it('preserves unspecified columns across a partial upsert', async () => {
@@ -105,6 +124,20 @@ export function createWorkflowDefinitionsTests({ storage }: WorkflowDefinitionsT
       }
       const all = await store.list();
       expect(all.total).toBe(1);
+    });
+
+    it('lets exactly one author win concurrent creation of the same id', async () => {
+      const results = await Promise.allSettled([
+        store.upsert({ ...baseInput('wf-owner-race'), authorId: 'author-1' }),
+        store.upsert({ ...baseInput('wf-owner-race'), authorId: 'author-2' }),
+      ]);
+
+      expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+      const rejected = results.find(result => result.status === 'rejected');
+      expect(rejected).toMatchObject({ reason: expect.any(WorkflowDefinitionOwnershipConflictError) });
+
+      const stored = await store.get('wf-owner-race');
+      expect(['author-1', 'author-2']).toContain(stored?.authorId);
     });
 
     it('rejects creation when required fields are explicitly undefined', async () => {

--- a/stores/libsql/src/storage/db/utils.ts
+++ b/stores/libsql/src/storage/db/utils.ts
@@ -191,7 +191,15 @@ export function createExecuteWriteOperationWithRetry({
   };
 }
 
-export function prepareStatement({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): {
+export function prepareStatement({
+  tableName,
+  record,
+  insertMode = 'replace',
+}: {
+  tableName: TABLE_NAMES;
+  record: Record<string, any>;
+  insertMode?: 'replace' | 'insert';
+}): {
   sql: string;
   args: InValue[];
 } {
@@ -225,7 +233,7 @@ export function prepareStatement({ tableName, record }: { tableName: TABLE_NAMES
     .join(', ');
 
   return {
-    sql: `INSERT OR REPLACE INTO ${parsedTableName} (${columns.join(', ')}) VALUES (${placeholders})`,
+    sql: `${insertMode === 'replace' ? 'INSERT OR REPLACE' : 'INSERT'} INTO ${parsedTableName} (${columns.join(', ')}) VALUES (${placeholders})`,
     args: values,
   };
 }

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
@@ -8,7 +8,7 @@
  *  - the domain is reachable through the LibSQLStore composite
  */
 import { createClient } from '@libsql/client';
-import { TABLE_WORKFLOW_DEFINITIONS } from '@mastra/core/storage';
+import { TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 import type { SerializedStepFlowEntry } from '@mastra/core/workflows';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -81,7 +81,7 @@ describe('WorkflowDefinitionsLibSQL', () => {
     expect(updated.graph).toEqual(graph);
   });
 
-  it('updates authorId on an existing row and keeps createdAt stable', async () => {
+  it('rejects an authorId change and keeps the original row stable', async () => {
     const wd = (await store.getStore('workflowDefinitions'))!;
 
     const created = await wd.upsert({
@@ -93,14 +93,53 @@ describe('WorkflowDefinitionsLibSQL', () => {
     });
     expect(created.authorId).toBe('author-1');
 
-    await new Promise(r => setTimeout(r, 5));
-    const updated = await wd.upsert({ id: 'wf-author', authorId: 'author-2' });
-    expect(updated.authorId).toBe('author-2');
-    expect(updated.createdAt.getTime()).toBe(created.createdAt.getTime());
-    expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime());
+    await expect(wd.upsert({ id: 'wf-author', authorId: 'author-2' })).rejects.toBeInstanceOf(
+      WorkflowDefinitionOwnershipConflictError,
+    );
 
     const fetched = await wd.get('wf-author');
-    expect(fetched?.authorId).toBe('author-2');
+    expect(fetched?.authorId).toBe('author-1');
+    expect(fetched?.createdAt.getTime()).toBe(created.createdAt.getTime());
+    expect(fetched?.updatedAt.getTime()).toBe(created.updatedAt.getTime());
+  });
+
+  it('does not update a different owner after a delete-and-recreate race', async () => {
+    const wd = (await store.getStore('workflowDefinitions'))!;
+    await wd.upsert({
+      id: 'wf-recreated',
+      description: 'original owner',
+      inputSchema,
+      outputSchema,
+      graph,
+      authorId: 'author-1',
+    });
+
+    const originalGet = wd.get.bind(wd);
+    const getSpy = vi.spyOn(wd, 'get');
+    let reads = 0;
+    getSpy.mockImplementation(async id => {
+      const current = await originalGet(id);
+      reads += 1;
+      if (reads === 2) {
+        getSpy.mockRestore();
+        await wd.delete(id);
+        await wd.upsert({
+          id,
+          description: 'new owner',
+          inputSchema,
+          outputSchema,
+          graph,
+          authorId: 'author-2',
+        });
+      }
+      return current;
+    });
+
+    await expect(
+      wd.upsert({ id: 'wf-recreated', description: 'stale update', authorId: 'author-1' }),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(await wd.get('wf-recreated')).toMatchObject({ authorId: 'author-2', description: 'new owner' });
   });
 
   it('round-trips JSON columns intact', async () => {

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.test.ts
@@ -103,6 +103,21 @@ describe('WorkflowDefinitionsLibSQL', () => {
     expect(fetched?.updatedAt.getTime()).toBe(created.updatedAt.getTime());
   });
 
+  it('rolls back every member when one bundle member conflicts', async () => {
+    const wd = (await store.getStore('workflowDefinitions'))!;
+    await wd.upsert({ id: 'owned', description: 'winner', inputSchema, outputSchema, graph, authorId: 'author-2' });
+
+    await expect(
+      wd.upsertMany([
+        { id: 'new-member', inputSchema, outputSchema, graph, authorId: 'author-1' },
+        { id: 'owned', description: 'forged', authorId: 'author-1' },
+      ]),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(await wd.get('new-member')).toBeNull();
+    expect(await wd.get('owned')).toMatchObject({ authorId: 'author-2', description: 'winner' });
+  });
+
   it('does not update a different owner after a delete-and-recreate race', async () => {
     const wd = (await store.getStore('workflowDefinitions'))!;
     await wd.upsert({

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.ts
@@ -6,7 +6,12 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from '@mastra/core/storage';
-import { TABLE_SCHEMAS, TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_SCHEMAS,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { buildSelectColumns } from '../../db/utils';
@@ -131,6 +136,10 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     // Update — only patch fields present in the input
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
@@ -142,11 +151,11 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/libsql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/libsql/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,4 @@
-import type { Client, InValue } from '@libsql/client';
+import type { Client, InValue, InStatement } from '@libsql/client';
 import type {
   CreateWorkflowDefinitionInput,
   ListWorkflowDefinitionsInput,
@@ -10,11 +10,12 @@ import {
   assertWorkflowDefinitionAuthor,
   TABLE_SCHEMAS,
   TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionOwnershipConflictError,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
-import { buildSelectColumns } from '../../db/utils';
+import { buildSelectColumns, prepareStatement, prepareUpdateStatement } from '../../db/utils';
 
 function parseJson<T = unknown>(val: unknown, column: string, rowId: unknown): T | undefined {
   if (val == null) return undefined;
@@ -90,37 +91,11 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
     const existing = await this.get(input.id);
 
     if (!existing) {
-      // Create — every required field must be present
-      if (!('inputSchema' in input) || !input.inputSchema)
-        throw new Error(`Cannot create workflow definition "${input.id}": inputSchema is required.`);
-      if (!('outputSchema' in input) || !input.outputSchema)
-        throw new Error(`Cannot create workflow definition "${input.id}": outputSchema is required.`);
-      if (!('graph' in input) || !input.graph)
-        throw new Error(`Cannot create workflow definition "${input.id}": graph is required.`);
-
-      const record: Record<string, any> = {
-        id: input.id,
-        description: input.description ?? null,
-        metadata: input.metadata ?? null,
-        inputSchema: input.inputSchema,
-        outputSchema: input.outputSchema,
-        stateSchema: input.stateSchema ?? null,
-        requestContextSchema: input.requestContextSchema ?? null,
-        graph: input.graph,
-        status: 'active',
-        source: 'storage',
-        authorId: 'authorId' in input ? (input.authorId ?? null) : null,
-        createdAt: now,
-        updatedAt: now,
-      };
+      this.assertCreateInput(input);
+      const record = this.mergeRecord(null, input, now);
       try {
-        // insertOnly: a plain INSERT so a concurrent create is detected as a
-        // key violation instead of INSERT OR REPLACE silently clobbering the
-        // winning row (and its createdAt).
         await this.#db.insertOnly({ tableName: TABLE_WORKFLOW_DEFINITIONS, record });
       } catch (error) {
-        // A concurrent upsert may have created the row after our existence
-        // check; fall back to updating it so the upsert stays idempotent.
         if (!(await this.get(input.id))) throw error;
         return this.#applyUpdate(input, now);
       }
@@ -132,6 +107,55 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
     return this.#applyUpdate(input, now);
   }
 
+  async upsertMany(
+    inputs: readonly (CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput)[],
+  ): Promise<WorkflowDefinition[]> {
+    const statements: InStatement[] = [];
+    const now = new Date();
+    for (const input of inputs) {
+      const existing = await this.get(input.id);
+      if (!existing) this.assertCreateInput(input);
+      else assertWorkflowDefinitionAuthor(existing, input);
+
+      if (input.authorId !== undefined) {
+        // This write-time guard is part of the same batch transaction as every
+        // upsert. A conflicting row makes the deliberately invalid sentinel
+        // insert violate the primary-key NOT NULL constraint, rolling back the
+        // complete bundle before any member becomes visible.
+        statements.push({
+          sql: `INSERT INTO "${TABLE_WORKFLOW_DEFINITIONS}" ("id") SELECT NULL FROM "${TABLE_WORKFLOW_DEFINITIONS}" WHERE "id" = ? AND "authorId" IS NOT ?`,
+          args: [input.id, input.authorId],
+        });
+      }
+      const record = this.mergeRecord(existing, input, now);
+      const statement = prepareStatement({ tableName: TABLE_WORKFLOW_DEFINITIONS, record, insertMode: 'insert' });
+      const mutableColumns = Object.keys(record).filter(column => !['id', 'authorId', 'createdAt'].includes(column));
+      statement.sql = `${statement.sql} ON CONFLICT("id") DO UPDATE SET ${mutableColumns
+        .map(column => `"${column}" = excluded."${column}"`)
+        .join(', ')}`;
+      statements.push(statement);
+    }
+    try {
+      if (statements.length > 0) await this.#client.batch(statements, 'write');
+    } catch (error) {
+      for (const input of inputs) {
+        const existing = await this.get(input.id);
+        if (existing && input.authorId !== undefined && existing.authorId !== input.authorId) {
+          throw new WorkflowDefinitionOwnershipConflictError(input.id);
+        }
+      }
+      throw error;
+    }
+    return Promise.all(
+      inputs.map(async input => {
+        const definition = await this.get(input.id);
+        if (!definition) throw new Error(`Failed to persist workflow definition "${input.id}".`);
+        assertWorkflowDefinitionAuthor(definition, input);
+        return definition;
+      }),
+    );
+  }
+
   async #applyUpdate(
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
@@ -139,8 +163,6 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
     const existing = await this.get(input.id);
     if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
     assertWorkflowDefinitionAuthor(existing, input);
-
-    // Update — only patch fields present in the input
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -157,6 +179,37 @@ export class WorkflowDefinitionsLibSQL extends WorkflowDefinitionsStorage {
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
     assertWorkflowDefinitionAuthor(updated, input);
     return updated;
+  }
+
+  private assertCreateInput(input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput): void {
+    if (!('inputSchema' in input) || !input.inputSchema)
+      throw new Error(`Cannot create workflow definition "${input.id}": inputSchema is required.`);
+    if (!('outputSchema' in input) || !input.outputSchema)
+      throw new Error(`Cannot create workflow definition "${input.id}": outputSchema is required.`);
+    if (!('graph' in input) || !input.graph)
+      throw new Error(`Cannot create workflow definition "${input.id}": graph is required.`);
+  }
+
+  private mergeRecord(
+    existing: WorkflowDefinition | null,
+    input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
+    now: Date,
+  ): Record<string, any> {
+    return {
+      id: input.id,
+      description: input.description ?? existing?.description ?? null,
+      metadata: input.metadata ?? existing?.metadata ?? null,
+      inputSchema: input.inputSchema ?? existing?.inputSchema,
+      outputSchema: input.outputSchema ?? existing?.outputSchema,
+      stateSchema: input.stateSchema ?? existing?.stateSchema ?? null,
+      requestContextSchema: input.requestContextSchema ?? existing?.requestContextSchema ?? null,
+      graph: input.graph ?? existing?.graph,
+      status: ('status' in input ? input.status : undefined) ?? existing?.status ?? 'active',
+      source: 'storage',
+      authorId: input.authorId ?? existing?.authorId ?? null,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
   }
 
   async get(id: string): Promise<WorkflowDefinition | null> {

--- a/stores/mongodb/src/storage/connectors/MongoDBConnector.ts
+++ b/stores/mongodb/src/storage/connectors/MongoDBConnector.ts
@@ -137,6 +137,24 @@ export class MongoDBConnector {
     }
   }
 
+  /** Run a callback only when MongoDB can guarantee transaction atomicity. */
+  async withRequiredTransaction<T>(fn: (session: ClientSession) => Promise<T>): Promise<T> {
+    const supported = await this.supportsTransactions();
+    if (!supported || !this.#client) {
+      throw new Error('This operation requires a MongoDB replica set or sharded cluster with transaction support.');
+    }
+    const session = this.#client.startSession();
+    try {
+      let result!: T;
+      await session.withTransaction(async () => {
+        result = await fn(session);
+      });
+      return result;
+    } finally {
+      await session.endSession();
+    }
+  }
+
   async close() {
     if (this.#client) {
       await this.#client.close();

--- a/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
@@ -96,9 +96,27 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
   }
 
   async upsert(input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput): Promise<WorkflowDefinition> {
+    return this.applyUpsert(input);
+  }
+
+  async upsertMany(
+    inputs: readonly (CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput)[],
+  ): Promise<WorkflowDefinition[]> {
+    if (inputs.length === 0) return [];
+    return this.#connector.withRequiredTransaction(async session => {
+      const definitions: WorkflowDefinition[] = [];
+      for (const input of inputs) definitions.push(await this.applyUpsert(input, session));
+      return definitions;
+    });
+  }
+
+  private async applyUpsert(
+    input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
+    session?: import('mongodb').ClientSession,
+  ): Promise<WorkflowDefinition> {
     const now = new Date();
     const collection = await this.getCollection(TABLE_WORKFLOW_DEFINITIONS);
-    const existing = await collection.findOne<Record<string, any>>({ id: input.id });
+    const existing = await collection.findOne<Record<string, any>>({ id: input.id }, { session });
 
     if (!existing) {
       if (!('inputSchema' in input) || input.inputSchema === undefined)
@@ -124,28 +142,32 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
         updatedAt: now,
       };
       try {
-        await collection.insertOne(doc);
+        await collection.insertOne(doc, { session });
       } catch (error) {
+        // A duplicate-key error aborts a MongoDB transaction. Let the whole
+        // bundle roll back instead of attempting more work in that session.
+        if (session) throw error;
         // A concurrent upsert may have created the document after our
         // existence check; fall back to updating it so the upsert stays
         // idempotent. Only duplicate-key failures (code 11000) qualify —
         // anything else is a real persistence error and must propagate.
         const isDuplicateKey = (error as { code?: number })?.code === 11000;
-        if (!isDuplicateKey || !(await collection.findOne({ id: input.id }))) throw error;
-        return this.applyUpdate(input, now);
+        if (!isDuplicateKey || !(await collection.findOne({ id: input.id }, { session }))) throw error;
+        return this.applyUpdate(input, now, session);
       }
       return docToDefinition(doc);
     }
 
-    return this.applyUpdate(input, now);
+    return this.applyUpdate(input, now, session);
   }
 
   private async applyUpdate(
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
+    session?: import('mongodb').ClientSession,
   ): Promise<WorkflowDefinition> {
     const collection = await this.getCollection(TABLE_WORKFLOW_DEFINITIONS);
-    const existing = await collection.findOne<Record<string, any>>({ id: input.id });
+    const existing = await collection.findOne<Record<string, any>>({ id: input.id }, { session });
     if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
     assertWorkflowDefinitionAuthor(docToDefinition(existing), input);
 
@@ -160,8 +182,8 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
     if ('graph' in input && input.graph !== undefined) update.graph = input.graph;
     if ('status' in input && input.status !== undefined) update.status = input.status;
     const filter = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
-    await collection.updateOne(filter, { $set: update });
-    const updated = await collection.findOne<Record<string, any>>({ id: input.id });
+    await collection.updateOne(filter, { $set: update }, { session });
+    const updated = await collection.findOne<Record<string, any>>({ id: input.id }, { session });
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
     const definition = docToDefinition(updated);
     assertWorkflowDefinitionAuthor(definition, input);

--- a/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mongodb/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,8 @@
-import { TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import type {
   CreateWorkflowDefinitionInput,
   ListWorkflowDefinitionsInput,
@@ -141,6 +145,9 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
     now: Date,
   ): Promise<WorkflowDefinition> {
     const collection = await this.getCollection(TABLE_WORKFLOW_DEFINITIONS);
+    const existing = await collection.findOne<Record<string, any>>({ id: input.id });
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(docToDefinition(existing), input);
 
     const update: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) update.description = input.description;
@@ -152,12 +159,13 @@ export class MongoDBWorkflowDefinitionsStore extends WorkflowDefinitionsStorage 
       update.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) update.graph = input.graph;
     if ('status' in input && input.status !== undefined) update.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) update.authorId = input.authorId;
-
-    await collection.updateOne({ id: input.id }, { $set: update });
+    const filter = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await collection.updateOne(filter, { $set: update });
     const updated = await collection.findOne<Record<string, any>>({ id: input.id });
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
-    return docToDefinition(updated);
+    const definition = docToDefinition(updated);
+    assertWorkflowDefinitionAuthor(definition, input);
+    return definition;
   }
 
   async get(id: string): Promise<WorkflowDefinition | null> {

--- a/stores/mssql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mssql/src/storage/domains/workflow-definitions/index.ts
@@ -12,10 +12,24 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from '@mastra/core/storage';
-import type sql from 'mssql';
+import sql from 'mssql';
 
 import { MssqlDB, resolveMssqlConfig } from '../../db';
 import type { MssqlDomainConfig } from '../../db';
+
+function isDeadlockVictim(error: unknown): boolean {
+  const seen = new Set<object>();
+  let current: unknown = error;
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const candidate = current as { number?: number; code?: number | string; cause?: unknown };
+    if (candidate.number === 1205 || candidate.code === 1205 || candidate.code === 'EREQUEST') {
+      if (candidate.number === 1205 || String((current as { message?: string }).message).includes('1205')) return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
 import { getSchemaName, getTableName } from '../utils';
 
 function parseJson(value: unknown, column: string, rowId: unknown): unknown {
@@ -132,8 +146,64 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
   }
 
   async upsert(input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput): Promise<WorkflowDefinition> {
+    return this.applyUpsert(input);
+  }
+
+  async upsertMany(
+    inputs: readonly (CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput)[],
+  ): Promise<WorkflowDefinition[]> {
+    if (inputs.length === 0) return [];
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await this.upsertManyTransaction(inputs);
+      } catch (error) {
+        if (!isDeadlockVictim(error) || attempt >= 2) throw error;
+        await new Promise(resolve => setTimeout(resolve, 10 * 2 ** attempt));
+      }
+    }
+  }
+
+  private async upsertManyTransaction(
+    inputs: readonly (CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput)[],
+  ): Promise<WorkflowDefinition[]> {
+    const transaction = this.pool.transaction();
+    try {
+      await transaction.begin();
+      const definitions: WorkflowDefinition[] = [];
+      for (const input of inputs) definitions.push(await this.applyUpsert(input, transaction));
+      await transaction.commit();
+      return definitions;
+    } catch (error) {
+      try {
+        await transaction.rollback();
+      } catch {
+        // Preserve the persistence error that caused the rollback.
+      }
+      throw error;
+    }
+  }
+
+  private async loadDefinition(id: string, transaction?: sql.Transaction): Promise<WorkflowDefinition | null> {
+    if (!transaction) return this.get(id);
+    const tableName = getTableName({
+      indexName: TABLE_WORKFLOW_DEFINITIONS,
+      schemaName: getSchemaName(this.schema),
+    });
+    const request = new sql.Request(transaction);
+    request.input('workflowDefinitionId', id);
+    const result = await request.query(
+      `SELECT * FROM ${tableName} WITH (UPDLOCK, HOLDLOCK) WHERE [id] = @workflowDefinitionId`,
+    );
+    const row = result.recordset[0] as Record<string, unknown> | undefined;
+    return row ? rowToDefinition(row) : null;
+  }
+
+  private async applyUpsert(
+    input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
+    transaction?: sql.Transaction,
+  ): Promise<WorkflowDefinition> {
     const now = new Date();
-    const existing = await this.get(input.id);
+    const existing = await this.loadDefinition(input.id, transaction);
 
     if (!existing) {
       if (!('inputSchema' in input) || input.inputSchema === undefined)
@@ -159,26 +229,27 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
         updatedAt: now,
       };
       try {
-        await this.db.insert({ tableName: TABLE_WORKFLOW_DEFINITIONS, record });
+        await this.db.insert({ tableName: TABLE_WORKFLOW_DEFINITIONS, record, transaction });
       } catch (error) {
         // A concurrent upsert may have created the row after our existence
         // check; fall back to updating it so the upsert stays idempotent.
-        if (!(await this.get(input.id))) throw error;
-        return this.applyUpdate(input, now);
+        if (!(await this.loadDefinition(input.id, transaction))) throw error;
+        return this.applyUpdate(input, now, transaction);
       }
-      const created = await this.get(input.id);
+      const created = await this.loadDefinition(input.id, transaction);
       if (!created) throw new Error(`Failed to persist workflow definition "${input.id}".`);
       return created;
     }
 
-    return this.applyUpdate(input, now);
+    return this.applyUpdate(input, now, transaction);
   }
 
   private async applyUpdate(
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
+    transaction?: sql.Transaction,
   ): Promise<WorkflowDefinition> {
-    const existing = await this.get(input.id);
+    const existing = await this.loadDefinition(input.id, transaction);
     if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
     assertWorkflowDefinitionAuthor(existing, input);
 
@@ -193,8 +264,8 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
     const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
-    const updated = await this.get(input.id);
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data, transaction });
+    const updated = await this.loadDefinition(input.id, transaction);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
     assertWorkflowDefinitionAuthor(updated, input);
     return updated;

--- a/stores/mssql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mssql/src/storage/domains/workflow-definitions/index.ts
@@ -22,10 +22,8 @@ function isDeadlockVictim(error: unknown): boolean {
   let current: unknown = error;
   while (current && typeof current === 'object' && !seen.has(current)) {
     seen.add(current);
-    const candidate = current as { number?: number; code?: number | string; cause?: unknown };
-    if (candidate.number === 1205 || candidate.code === 1205 || candidate.code === 'EREQUEST') {
-      if (candidate.number === 1205 || String((current as { message?: string }).message).includes('1205')) return true;
-    }
+    const candidate = current as { number?: number; cause?: unknown };
+    if (candidate.number === 1205) return true;
     current = candidate.cause;
   }
   return false;

--- a/stores/mssql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mssql/src/storage/domains/workflow-definitions/index.ts
@@ -1,6 +1,7 @@
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -177,6 +178,10 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -187,11 +192,11 @@ export class WorkflowDefinitionsMSSQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/mssql/src/storage/domains/workflow-definitions/index.unit.test.ts
+++ b/stores/mssql/src/storage/domains/workflow-definitions/index.unit.test.ts
@@ -1,0 +1,41 @@
+import type { CreateWorkflowDefinitionInput, WorkflowDefinition } from '@mastra/core/storage';
+import type sql from 'mssql';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WorkflowDefinitionsMSSQL } from './index';
+
+const input = {
+  id: 'workflow',
+  inputSchema: { type: 'object' },
+  outputSchema: { type: 'object' },
+  graph: [],
+} satisfies CreateWorkflowDefinitionInput;
+
+describe('WorkflowDefinitionsMSSQL deadlock retry', () => {
+  it('retries a nested SQL Server deadlock error', async () => {
+    const store = new WorkflowDefinitionsMSSQL({ pool: {} as sql.ConnectionPool });
+    const target = store as unknown as {
+      upsertManyTransaction(inputs: readonly CreateWorkflowDefinitionInput[]): Promise<WorkflowDefinition[]>;
+    };
+    const deadlock = { cause: { number: 1205 } };
+    const upsertManyTransaction = vi
+      .spyOn(target, 'upsertManyTransaction')
+      .mockRejectedValueOnce(deadlock)
+      .mockResolvedValueOnce([{ id: input.id } as WorkflowDefinition]);
+
+    await expect(store.upsertMany([input])).resolves.toEqual([{ id: input.id }]);
+    expect(upsertManyTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry an unrelated EREQUEST whose message mentions 1205', async () => {
+    const store = new WorkflowDefinitionsMSSQL({ pool: {} as sql.ConnectionPool });
+    const target = store as unknown as {
+      upsertManyTransaction(inputs: readonly CreateWorkflowDefinitionInput[]): Promise<WorkflowDefinition[]>;
+    };
+    const unrelated = { code: 'EREQUEST', message: 'Unrelated identifier 1205 failed.' };
+    const upsertManyTransaction = vi.spyOn(target, 'upsertManyTransaction').mockRejectedValue(unrelated);
+
+    await expect(store.upsertMany([input])).rejects.toBe(unrelated);
+    expect(upsertManyTransaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/stores/mysql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mysql/src/storage/domains/workflow-definitions/index.ts
@@ -2,6 +2,7 @@ import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
   assertWorkflowDefinitionAuthor,
+  hasErrorCode,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -11,11 +12,17 @@ import type {
   UpdateWorkflowDefinitionInput,
   WorkflowDefinition,
 } from '@mastra/core/storage';
-import type { Pool, RowDataPacket } from 'mysql2/promise';
+import type { Pool, PoolConnection, RowDataPacket } from 'mysql2/promise';
 
 import type { StoreOperationsMySQL } from '../operations';
 import { generateTableSQL } from '../operations';
-import { formatTableName, quoteIdentifier, transformFromSqlRow } from '../utils';
+import {
+  formatTableName,
+  prepareInsertOnlyStatement,
+  prepareUpdateStatement,
+  quoteIdentifier,
+  transformFromSqlRow,
+} from '../utils';
 
 function rowToDefinition(row: Record<string, unknown>): WorkflowDefinition {
   const transformed = transformFromSqlRow<Record<string, unknown>>({
@@ -75,8 +82,35 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
   }
 
   async upsert(input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput): Promise<WorkflowDefinition> {
+    return this.applyUpsert(input);
+  }
+
+  async upsertMany(
+    inputs: readonly (CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput)[],
+  ): Promise<WorkflowDefinition[]> {
+    if (inputs.length === 0) return [];
+    return this.operations.withTransaction(async connection => {
+      const definitions: WorkflowDefinition[] = [];
+      for (const input of inputs) definitions.push(await this.applyUpsert(input, connection));
+      return definitions;
+    });
+  }
+
+  private async loadDefinition(id: string, connection?: PoolConnection): Promise<WorkflowDefinition | null> {
+    if (!connection) return this.get(id);
+    const [rows] = await connection.execute<RowDataPacket[]>(
+      `SELECT * FROM ${formatTableName(TABLE_WORKFLOW_DEFINITIONS, this.database)} WHERE ${quoteIdentifier('id', 'column name')} = ? FOR UPDATE`,
+      [id],
+    );
+    return rows.length ? rowToDefinition(rows[0] as Record<string, unknown>) : null;
+  }
+
+  private async applyUpsert(
+    input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
+    connection?: PoolConnection,
+  ): Promise<WorkflowDefinition> {
     const now = new Date();
-    const existing = await this.get(input.id);
+    const existing = await this.loadDefinition(input.id, connection);
 
     if (!existing) {
       if (!('inputSchema' in input) || input.inputSchema === undefined)
@@ -105,26 +139,37 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
         // insertOnly: a plain INSERT so a concurrent create is detected as a
         // duplicate-key error instead of ON DUPLICATE KEY UPDATE silently
         // clobbering the winning row (and its createdAt).
-        await this.operations.insertOnly({ tableName: TABLE_WORKFLOW_DEFINITIONS, record });
+        if (connection) {
+          const statement = prepareInsertOnlyStatement({
+            tableName: TABLE_WORKFLOW_DEFINITIONS,
+            record,
+            database: this.database,
+          });
+          await connection.execute(statement.sql, statement.args);
+        } else {
+          await this.operations.insertOnly({ tableName: TABLE_WORKFLOW_DEFINITIONS, record });
+        }
       } catch (error) {
         // A concurrent upsert may have created the row after our existence
         // check; fall back to updating it so the upsert stays idempotent.
-        if (!(await this.get(input.id))) throw error;
-        return this.applyUpdate(input, now);
+        if (!hasErrorCode(error, new Set([1062, 'ER_DUP_ENTRY']))) throw error;
+        if (!(await this.loadDefinition(input.id, connection))) throw error;
+        return this.applyUpdate(input, now, connection);
       }
-      const created = await this.get(input.id);
+      const created = await this.loadDefinition(input.id, connection);
       if (!created) throw new Error(`Failed to persist workflow definition "${input.id}".`);
       return created;
     }
 
-    return this.applyUpdate(input, now);
+    return this.applyUpdate(input, now, connection);
   }
 
   private async applyUpdate(
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
+    connection?: PoolConnection,
   ): Promise<WorkflowDefinition> {
-    const existing = await this.get(input.id);
+    const existing = await this.loadDefinition(input.id, connection);
     if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
     assertWorkflowDefinitionAuthor(existing, input);
 
@@ -139,8 +184,18 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
     const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
-    await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
-    const updated = await this.get(input.id);
+    if (connection) {
+      const statement = prepareUpdateStatement({
+        tableName: TABLE_WORKFLOW_DEFINITIONS,
+        updates: data,
+        keys,
+        database: this.database,
+      });
+      await connection.execute(statement.sql, statement.args);
+    } else {
+      await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
+    }
+    const updated = await this.loadDefinition(input.id, connection);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
     assertWorkflowDefinitionAuthor(updated, input);
     return updated;

--- a/stores/mysql/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/mysql/src/storage/domains/workflow-definitions/index.ts
@@ -1,6 +1,7 @@
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -123,6 +124,10 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -133,11 +138,11 @@ export class WorkflowDefinitionsMySQL extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.operations.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/pg/src/storage/domains/workflow-definitions/index.test.ts
+++ b/stores/pg/src/storage/domains/workflow-definitions/index.test.ts
@@ -1,3 +1,4 @@
+import { WorkflowDefinitionOwnershipConflictError } from '@mastra/core/storage';
 import { Pool } from 'pg';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -64,6 +65,20 @@ describe('WorkflowDefinitionsPG', () => {
     expect(updated.description).toBe('renamed');
     expect(updated.createdAt.getTime()).toBe(created.createdAt.getTime());
     expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime());
+  });
+
+  it('rolls back every member when one bundle member conflicts', async () => {
+    await store.upsert({ ...baseInput, id: 'owned', description: 'winner', authorId: 'author-2' });
+
+    await expect(
+      store.upsertMany([
+        { ...baseInput, id: 'new-member', authorId: 'author-1' },
+        { id: 'owned', description: 'forged', authorId: 'author-1' },
+      ]),
+    ).rejects.toBeInstanceOf(WorkflowDefinitionOwnershipConflictError);
+
+    expect(await store.get('new-member')).toBeNull();
+    expect(await store.get('owned')).toMatchObject({ authorId: 'author-2', description: 'winner' });
   });
 
   it('lists workflows, filters by status, and archives via update', async () => {

--- a/stores/pg/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/pg/src/storage/domains/workflow-definitions/index.ts
@@ -13,6 +13,7 @@ import type {
   WorkflowDefinition,
 } from '@mastra/core/storage';
 
+import type { TxClient } from '../../client';
 import { PgDB, resolvePgConfig, generateTableSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { getSchemaName, getTableName, parseJsonResilient } from '../utils';
@@ -124,8 +125,39 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
   }
 
   async upsert(input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput): Promise<WorkflowDefinition> {
+    return this.applyUpsert(input);
+  }
+
+  async upsertMany(
+    inputs: readonly (CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput)[],
+  ): Promise<WorkflowDefinition[]> {
+    if (inputs.length === 0) return [];
+    return this.#db.client.tx(async transaction => {
+      const definitions: WorkflowDefinition[] = [];
+      for (const input of inputs) definitions.push(await this.applyUpsert(input, transaction));
+      return definitions;
+    });
+  }
+
+  private tableName(): string {
+    return getTableName({
+      indexName: TABLE_WORKFLOW_DEFINITIONS,
+      schemaName: getSchemaName(this.#schema),
+    });
+  }
+
+  private async loadDefinition(id: string, transaction?: TxClient): Promise<WorkflowDefinition | null> {
+    if (!transaction) return this.get(id);
+    const row = await transaction.oneOrNone(`SELECT * FROM ${this.tableName()} WHERE "id" = $1 FOR UPDATE`, [id]);
+    return row ? rowToDefinition(row as Record<string, unknown>) : null;
+  }
+
+  private async applyUpsert(
+    input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
+    transaction?: TxClient,
+  ): Promise<WorkflowDefinition> {
     const now = new Date();
-    const existing = await this.get(input.id);
+    const existing = await this.loadDefinition(input.id, transaction);
 
     if (!existing) {
       if (!('inputSchema' in input) || !input.inputSchema)
@@ -151,26 +183,38 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
         updatedAt: now,
       };
       try {
-        await this.#db.insert({ tableName: TABLE_WORKFLOW_DEFINITIONS, record });
+        if (transaction) {
+          const columns = Object.keys(record);
+          const insertResult = await transaction.query(
+            `INSERT INTO ${this.tableName()} (${columns.map(column => `"${column}"`).join(', ')}) VALUES (${columns
+              .map((_, index) => `$${index + 1}`)
+              .join(', ')}) ON CONFLICT ("id") DO NOTHING`,
+            columns.map(column => record[column]),
+          );
+          if (insertResult.rowCount === 0) return this.applyUpdate(input, now, transaction);
+        } else {
+          await this.#db.insert({ tableName: TABLE_WORKFLOW_DEFINITIONS, record });
+        }
       } catch (error) {
         // A concurrent upsert may have created the row after our existence
         // check; fall back to updating it so the upsert stays idempotent.
-        if (!(await this.get(input.id))) throw error;
-        return this.applyUpdate(input, now);
+        if (!(await this.loadDefinition(input.id, transaction))) throw error;
+        return this.applyUpdate(input, now, transaction);
       }
-      const created = await this.get(input.id);
+      const created = await this.loadDefinition(input.id, transaction);
       if (!created) throw new Error(`Failed to persist workflow definition "${input.id}".`);
       return created;
     }
 
-    return this.applyUpdate(input, now);
+    return this.applyUpdate(input, now, transaction);
   }
 
   private async applyUpdate(
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
+    transaction?: TxClient,
   ): Promise<WorkflowDefinition> {
-    const existing = await this.get(input.id);
+    const existing = await this.loadDefinition(input.id, transaction);
     if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
     assertWorkflowDefinitionAuthor(existing, input);
 
@@ -185,19 +229,30 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
     const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
-    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
-    const updated = await this.get(input.id);
+    if (transaction) {
+      const fields = Object.keys(data);
+      const values = fields.map(field => data[field]);
+      values.push(input.id);
+      let where = `"id" = $${values.length}`;
+      if (input.authorId !== undefined) {
+        values.push(input.authorId);
+        where += ` AND "authorId" = $${values.length}`;
+      }
+      await transaction.query(
+        `UPDATE ${this.tableName()} SET ${fields.map((field, index) => `"${field}" = $${index + 1}`).join(', ')} WHERE ${where}`,
+        values,
+      );
+    } else {
+      await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
+    }
+    const updated = await this.loadDefinition(input.id, transaction);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
     assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 
   async get(id: string): Promise<WorkflowDefinition | null> {
-    const tableName = getTableName({
-      indexName: TABLE_WORKFLOW_DEFINITIONS,
-      schemaName: getSchemaName(this.#schema),
-    });
-    const row = await this.#db.client.oneOrNone(`SELECT * FROM ${tableName} WHERE "id" = $1`, [id]);
+    const row = await this.#db.client.oneOrNone(`SELECT * FROM ${this.tableName()} WHERE "id" = $1`, [id]);
     return row ? rowToDefinition(row as Record<string, unknown>) : null;
   }
 

--- a/stores/pg/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/pg/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,9 @@
-import { TABLE_SCHEMAS, TABLE_WORKFLOW_DEFINITIONS, WorkflowDefinitionsStorage } from '@mastra/core/storage';
+import {
+  assertWorkflowDefinitionAuthor,
+  TABLE_SCHEMAS,
+  TABLE_WORKFLOW_DEFINITIONS,
+  WorkflowDefinitionsStorage,
+} from '@mastra/core/storage';
 import type {
   CreateIndexOptions,
   CreateWorkflowDefinitionInput,
@@ -165,6 +170,10 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -175,11 +184,11 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.#db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 

--- a/stores/pg/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/pg/src/storage/domains/workflow-definitions/index.ts
@@ -198,6 +198,9 @@ export class WorkflowDefinitionsPG extends WorkflowDefinitionsStorage {
       } catch (error) {
         // A concurrent upsert may have created the row after our existence
         // check; fall back to updating it so the upsert stays idempotent.
+        // A failed statement aborts the transaction, so querying it again
+        // would mask the original persistence error.
+        if (transaction) throw error;
         if (!(await this.loadDefinition(input.id, transaction))) throw error;
         return this.applyUpdate(input, now, transaction);
       }

--- a/stores/pg/src/storage/domains/workflow-definitions/transaction-errors.unit.test.ts
+++ b/stores/pg/src/storage/domains/workflow-definitions/transaction-errors.unit.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DbClient, TxClient } from '../../client';
+import { WorkflowDefinitionsPG } from './index';
+
+describe('WorkflowDefinitionsPG transaction errors', () => {
+  it('preserves the failed statement error without querying the aborted transaction', async () => {
+    const persistenceError = new Error('insert failed');
+    const transaction = {
+      oneOrNone: vi.fn().mockResolvedValueOnce(null),
+      query: vi.fn().mockRejectedValue(persistenceError),
+    } as unknown as TxClient;
+    const client = {
+      tx: vi.fn(async callback => callback(transaction)),
+    } as unknown as DbClient;
+    const store = new WorkflowDefinitionsPG({ client });
+
+    await expect(
+      store.upsertMany([
+        {
+          id: 'workflow',
+          inputSchema: { type: 'object' },
+          outputSchema: { type: 'object' },
+          graph: [],
+        },
+      ]),
+    ).rejects.toBe(persistenceError);
+    expect(transaction.oneOrNone).toHaveBeenCalledTimes(1);
+  });
+});

--- a/stores/spanner/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/spanner/src/storage/domains/workflow-definitions/index.ts
@@ -1,4 +1,4 @@
-import type { Database } from '@google-cloud/spanner';
+import type { Database, Transaction } from '@google-cloud/spanner';
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
@@ -98,8 +98,48 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
   }
 
   async upsert(input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput): Promise<WorkflowDefinition> {
+    return this.applyUpsert(input);
+  }
+
+  async upsertMany(
+    inputs: readonly (CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput)[],
+  ): Promise<WorkflowDefinition[]> {
+    if (inputs.length === 0) return [];
+    let definitions: WorkflowDefinition[] = [];
+    await this.db.runWithAbortRetry(() =>
+      this.database.runTransactionAsync(async transaction => {
+        try {
+          definitions = [];
+          for (const input of inputs) definitions.push(await this.applyUpsert(input, transaction));
+          await transaction.commit();
+        } catch (error) {
+          await transaction.rollback().catch(rollbackError => {
+            throw new AggregateError([error, rollbackError], 'Transaction and rollback both failed');
+          });
+          throw error;
+        }
+      }),
+    );
+    return definitions;
+  }
+
+  private async loadDefinition(id: string, transaction?: Transaction): Promise<WorkflowDefinition | null> {
+    if (!transaction) return this.get(id);
+    const [rows] = await transaction.run({
+      sql: `SELECT * FROM ${quoteIdent(TABLE_WORKFLOW_DEFINITIONS, 'table name')} WHERE ${quoteIdent('id', 'column name')} = @id LIMIT 1`,
+      params: { id },
+      json: true,
+    });
+    const row = (rows as Array<Record<string, any>>)[0];
+    return row ? rowToDefinition(row) : null;
+  }
+
+  private async applyUpsert(
+    input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
+    transaction?: Transaction,
+  ): Promise<WorkflowDefinition> {
     const now = new Date();
-    const existing = await this.get(input.id);
+    const existing = await this.loadDefinition(input.id, transaction);
 
     if (!existing) {
       if (!('inputSchema' in input) || input.inputSchema === undefined)
@@ -125,26 +165,27 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
         updatedAt: now,
       };
       try {
-        await this.db.insert({ tableName: TABLE_WORKFLOW_DEFINITIONS, record });
+        await this.db.insert({ tableName: TABLE_WORKFLOW_DEFINITIONS, record, transaction });
       } catch (error) {
         // A concurrent upsert may have created the row after our existence
         // check; fall back to updating it so the upsert stays idempotent.
-        if (!(await this.get(input.id))) throw error;
-        return this.applyUpdate(input, now);
+        if (!(await this.loadDefinition(input.id, transaction))) throw error;
+        return this.applyUpdate(input, now, transaction);
       }
-      const created = await this.get(input.id);
+      const created = await this.loadDefinition(input.id, transaction);
       if (!created) throw new Error(`Failed to persist workflow definition "${input.id}".`);
       return created;
     }
 
-    return this.applyUpdate(input, now);
+    return this.applyUpdate(input, now, transaction);
   }
 
   private async applyUpdate(
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
+    transaction?: Transaction,
   ): Promise<WorkflowDefinition> {
-    const existing = await this.get(input.id);
+    const existing = await this.loadDefinition(input.id, transaction);
     if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
     assertWorkflowDefinitionAuthor(existing, input);
 
@@ -159,8 +200,8 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
     const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
-    const updated = await this.get(input.id);
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data, transaction });
+    const updated = await this.loadDefinition(input.id, transaction);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
     assertWorkflowDefinitionAuthor(updated, input);
     return updated;

--- a/stores/spanner/src/storage/domains/workflow-definitions/index.ts
+++ b/stores/spanner/src/storage/domains/workflow-definitions/index.ts
@@ -2,6 +2,7 @@ import type { Database } from '@google-cloud/spanner';
 import {
   TABLE_WORKFLOW_DEFINITIONS,
   WORKFLOW_DEFINITIONS_SCHEMA,
+  assertWorkflowDefinitionAuthor,
   WorkflowDefinitionsStorage,
 } from '@mastra/core/storage';
 import type {
@@ -143,6 +144,10 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
     input: CreateWorkflowDefinitionInput | UpdateWorkflowDefinitionInput,
     now: Date,
   ): Promise<WorkflowDefinition> {
+    const existing = await this.get(input.id);
+    if (!existing) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(existing, input);
+
     const data: Record<string, any> = { updatedAt: now };
     if ('description' in input && input.description !== undefined) data.description = input.description;
     if ('metadata' in input && input.metadata !== undefined) data.metadata = input.metadata;
@@ -153,11 +158,11 @@ export class WorkflowDefinitionsSpanner extends WorkflowDefinitionsStorage {
       data.requestContextSchema = input.requestContextSchema;
     if ('graph' in input && input.graph !== undefined) data.graph = input.graph;
     if ('status' in input && input.status !== undefined) data.status = input.status;
-    if ('authorId' in input && input.authorId !== undefined) data.authorId = input.authorId;
-
-    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys: { id: input.id }, data });
+    const keys = { id: input.id, ...(input.authorId !== undefined ? { authorId: input.authorId } : {}) };
+    await this.db.update({ tableName: TABLE_WORKFLOW_DEFINITIONS, keys, data });
     const updated = await this.get(input.id);
     if (!updated) throw new Error(`Failed to update workflow definition "${input.id}".`);
+    assertWorkflowDefinitionAuthor(updated, input);
     return updated;
   }
 


### PR DESCRIPTION
## Summary

- add an atomic `WorkflowDefinitionsStorage.upsertMany()` contract for dynamic workflow bundles
- implement all-or-nothing persistence for in-memory, LibSQL, MongoDB, MSSQL, MySQL, PostgreSQL, and Spanner stores
- make `Mastra.addDynamicWorkflows()` use the bundle contract while preserving single-definition compatibility
- add shared ownership-conflict rollback conformance plus store-specific rollback coverage
- document the atomic storage guarantee and MongoDB transaction requirement

## Stack

Depends on #21448. Review the final commit (`67fddd7489`) for this slice.

## Verification

- Core focused dynamic workflow tests: 20 passed
- Core type check: passed
- adapter TypeScript checks: LibSQL, MongoDB, MSSQL, MySQL, PostgreSQL, Spanner passed
- adapter builds: all six passed
- live workflow-definition suites: LibSQL 11; PostgreSQL 7 direct and 30 shared; MySQL 15; MongoDB 15; MSSQL 15; Spanner 15
- changed-file oxfmt, oxlint, and git diff check: passed

The Spanner emulator image served tests successfully, although its compose healthcheck reports unhealthy because the current image does not satisfy the `nc -z` health command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Dynamic workflow definitions now save as one complete group. If any part fails, the system removes all changes instead of leaving partial data.

## Summary

- Added atomic `WorkflowDefinitionsStorage.upsertMany()` support.
- Implemented transactional bundle persistence for InMemory, LibSQL, MongoDB, MSSQL, MySQL, PostgreSQL, and Spanner stores.
- Updated `Mastra.addDynamicWorkflow()` and `Mastra.addDynamicWorkflows()` with trusted author metadata, immutable ownership, rollback, per-ID serialization, admission timeouts, and cancellation.
- Added ownership-conflict handling and shared validation.
- Added rollback, ownership, concurrency, cancellation, storage-availability, MSSQL deadlock, and PostgreSQL transaction-error tests.
- Documented atomic persistence, author metadata, ownership rules, and MongoDB transaction requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->