### PR TITLE
fix(workflows): pin dynamic run revisions

### DIFF
--- a/.changeset/quiet-ravens-pin.md
+++ b/.changeset/quiet-ravens-pin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Refresh storage-backed dynamic workflows when creating a new run and persist the exact root-plus-nested dynamic definition revision in run snapshots, so replicas converge while existing runs remain pinned across resume and restart. Code-defined nested workflows continue to follow the host deployment and must remain resume-compatible.

--- a/.changeset/quiet-ravens-pin.md
+++ b/.changeset/quiet-ravens-pin.md
@@ -2,4 +2,8 @@
 '@mastra/core': patch
 ---
 
-Refresh storage-backed dynamic workflows when creating a new run and persist the exact root-plus-nested dynamic definition revision in run snapshots, so replicas converge while existing runs remain pinned across resume and restart. Code-defined nested workflows continue to follow the host deployment and must remain resume-compatible.
+- Refresh storage-backed dynamic workflows when creating a new run so replicas converge on the active definition.
+- Pin the root and nested dynamic definition revision in each run snapshot so existing runs keep their graph across resume and restart.
+- Preserve code-defined nested workflows as the host deployment's authority. Keep those workflows resume-compatible across deployments.
+
+Before upgrading, allow in-flight dynamic runs created by older versions to finish. Those snapshots don't contain a pinned definition revision, so Mastra now fails closed when you resume or restart them instead of using a possibly different graph.

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -121,6 +121,8 @@ await mastra.addDynamicWorkflow(updatedDefinition)
 
 New runs read the active definition from storage before they are created, so another Mastra instance can accept the update without leaving this instance's next run on a stale in-memory graph. Mastra persists the exact root and nested dynamic-definition closure with each run snapshot. Runs created before the update therefore continue with their original graph, including after a process restart.
 
+A custom `pruneSnapshot` hook must preserve `dynamicWorkflowDefinitions`, or the dynamic workflow run fails closed when it resumes.
+
 Runs created by an older Mastra version don't contain this pinned definition closure. After upgrading, Mastra fails closed instead of resuming one of those runs against a definition that may have changed.
 
 The pinned closure covers storage-backed dynamic definitions. A nested code-defined workflow still follows the code deployed by the host, so deploy that code compatibly while its runs can be resumed.

--- a/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
+++ b/docs/src/content/en/docs/workflows/dynamic-workflows.mdx
@@ -119,7 +119,11 @@ Add a new definition with the same `id` to replace the persisted definition and 
 await mastra.addDynamicWorkflow(updatedDefinition)
 ```
 
-New runs use the updated graph. Runs that already started continue with their original graph.
+New runs read the active definition from storage before they are created, so another Mastra instance can accept the update without leaving this instance's next run on a stale in-memory graph. Mastra persists the exact root and nested dynamic-definition closure with each run snapshot. Runs created before the update therefore continue with their original graph, including after a process restart.
+
+Runs created by an older Mastra version don't contain this pinned definition closure. After upgrading, Mastra fails closed instead of resuming one of those runs against a definition that may have changed.
+
+The pinned closure covers storage-backed dynamic definitions. A nested code-defined workflow still follows the code deployed by the host, so deploy that code compatibly while its runs can be resumed.
 
 ### Add nested workflows together
 
@@ -142,7 +146,7 @@ On authenticated servers, dynamic-workflow management requires the `stored-workf
 
 ### Persist definitions
 
-Stored definitions use the `workflowDefinitions` storage domain. On startup, Mastra loads active definitions from storage and registers them in dependency order.
+Stored definitions use the `workflowDefinitions` storage domain. On startup, Mastra loads active definitions from storage and registers them in dependency order. It also rechecks storage when a dynamic workflow creates a run. The startup registry is therefore a runnable cache, not the authority for choosing a new run's definition revision.
 
 Without a storage adapter that supports this domain, `addDynamicWorkflow()` still registers the workflow in memory, but the definition is lost when the process restarts. See the [storage reference](/reference/storage/overview) for adapter support.
 

--- a/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
+++ b/docs/src/content/en/reference/core/addDynamicWorkflow.mdx
@@ -68,7 +68,9 @@ A promise that resolves once the definition is validated, registered, and persis
 ## Behavior
 
 - The definition is fully validated (structure, references, schema flow) before anything is mutated. Agents, tools, and workflows referenced by the graph must already be registered on the instance.
-- Adding a definition with an existing ID replaces both the stored definition and the live registration. In-flight runs keep the graph they started with.
+- Adding a definition with an existing ID replaces both the stored definition and the live registration. Storage-backed instances re-read the active root and nested definitions when creating a new run, so replicas converge without relying on an in-memory invalidation event.
+- Each run snapshot pins the exact dynamic-definition closure used to create it. A run created before an update keeps that revision through resume and restart. Legacy snapshots without a pinned revision fail closed after upgrade rather than resuming against a possibly different graph.
+- The pinned closure contains storage-backed dynamic definitions. Nested code-defined workflows continue to use the host's deployed code and must remain resume-compatible across deployments.
 - Without a storage adapter that supports the `workflowDefinitions` domain, the workflow is still validated and registered in memory, but the definition is lost on restart.
 - To add a root workflow together with helper workflows it nests, use [`addDynamicWorkflows()`](/reference/core/addDynamicWorkflows).
 

--- a/packages/core/src/mastra/dynamic-workflow-run-revisions.test.ts
+++ b/packages/core/src/mastra/dynamic-workflow-run-revisions.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { InMemoryStore } from '../storage';
+import { createWorkflow } from '../workflows/create';
+import type { DynamicWorkflowGraph } from '../workflows/dynamic';
+import { createStep } from '../workflows/workflow';
+import { Mastra } from './index';
+
+const emptyObjectSchema = { type: 'object', properties: {}, additionalProperties: false } as const;
+const valueSchema = {
+  type: 'object',
+  properties: { value: { type: 'string' } },
+  required: ['value'],
+  additionalProperties: false,
+} as const;
+
+function valueWorkflow(id: string, value: string): DynamicWorkflowGraph {
+  return {
+    id,
+    inputSchema: emptyObjectSchema,
+    outputSchema: valueSchema,
+    graph: [
+      {
+        type: 'mapping',
+        id: 'result',
+        mapConfig: JSON.stringify({ value: { value } }),
+      },
+    ],
+  };
+}
+
+function nestedRoot(id: string, childId: string): DynamicWorkflowGraph {
+  return {
+    id,
+    inputSchema: emptyObjectSchema,
+    outputSchema: valueSchema,
+    graph: [{ type: 'workflow', id: 'child-result', workflowId: childId }],
+  };
+}
+
+function approvalWorkflow() {
+  const approval = createStep({
+    id: 'approval',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ value: z.string() }),
+    suspendSchema: z.object({ reason: z.string() }),
+    resumeSchema: z.object({ approved: z.boolean() }),
+    execute: async ({ resumeData, suspend }) => {
+      if (!resumeData) await suspend({ reason: 'Approve' });
+      return { value: 'v1' };
+    },
+  });
+  return createWorkflow({
+    id: 'approval-workflow',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ value: z.string() }),
+    steps: [approval],
+  })
+    .then(approval)
+    .commit();
+}
+
+async function runValue(mastra: Mastra, workflowId: string, runId?: string): Promise<string> {
+  const run = await mastra.getWorkflow(workflowId).createRun(runId ? { runId } : undefined);
+  const result = await run.start({ inputData: {} });
+  expect(result.status).toBe('success');
+  return (result as { result: { value: string } }).result.value;
+}
+
+describe('dynamic workflow run revisions', () => {
+  it('refreshes a stale replica for a new run while a run created before the update keeps its graph', async () => {
+    const storage = new InMemoryStore({ id: 'dynamic-replica-refresh' });
+    const writer = new Mastra({ logger: false, storage });
+    const reader = new Mastra({ logger: false, storage });
+    const secondReader = new Mastra({ logger: false, storage });
+
+    await writer.addDynamicWorkflow(valueWorkflow('campaign', 'v1'));
+    await reader.startWorkers();
+    await secondReader.startWorkers();
+
+    const oldRun = await reader.getWorkflow('campaign').createRun();
+    await writer.addDynamicWorkflow(valueWorkflow('campaign', 'v2'));
+
+    expect(await Promise.all([runValue(reader, 'campaign'), runValue(secondReader, 'campaign')])).toEqual(['v2', 'v2']);
+    const oldResult = await oldRun.start({ inputData: {} });
+    expect(oldResult.status).toBe('success');
+    expect((oldResult as { result: { value: string } }).result.value).toBe('v1');
+
+    await reader.stopWorkers();
+    await secondReader.stopWorkers();
+  });
+
+  it('restores the persisted run revision after a process restart', async () => {
+    const storage = new InMemoryStore({ id: 'dynamic-revision-restart' });
+    const writer = new Mastra({ logger: false, storage });
+    const firstReader = new Mastra({ logger: false, storage });
+
+    await writer.addDynamicWorkflow(valueWorkflow('campaign', 'v1'));
+    await firstReader.startWorkers();
+    const pendingRun = await firstReader.getWorkflow('campaign').createRun({ runId: 'pinned-run' });
+    expect(pendingRun.runId).toBe('pinned-run');
+    await firstReader.stopWorkers();
+
+    await writer.addDynamicWorkflow(valueWorkflow('campaign', 'v2'));
+    const restartedReader = new Mastra({ logger: false, storage });
+    await restartedReader.startWorkers();
+
+    expect(await runValue(restartedReader, 'campaign', 'pinned-run')).toBe('v1');
+    expect(await runValue(restartedReader, 'campaign')).toBe('v2');
+
+    await restartedReader.stopWorkers();
+  });
+
+  it('resumes a suspended run from its pinned dynamic revision after restart', async () => {
+    const storage = new InMemoryStore({ id: 'dynamic-suspended-revision' });
+    const writer = new Mastra({ logger: false, storage, workflows: { approval: approvalWorkflow() } });
+    const firstReader = new Mastra({ logger: false, storage, workflows: { approval: approvalWorkflow() } });
+
+    await writer.addDynamicWorkflow(nestedRoot('campaign', 'approval-workflow'));
+    await firstReader.startWorkers();
+    const run = await firstReader.getWorkflow('campaign').createRun({ runId: 'suspended-run' });
+    expect(await run.start({ inputData: {} })).toMatchObject({ status: 'suspended' });
+    const workflowStore = await storage.getStore('workflows');
+    expect(
+      await workflowStore?.loadWorkflowSnapshot({ workflowName: 'campaign', runId: 'suspended-run' }),
+    ).toMatchObject({ status: 'suspended' });
+
+    await writer.addDynamicWorkflow(valueWorkflow('campaign', 'v2'));
+    await firstReader.stopWorkers();
+
+    const restartedReader = new Mastra({ logger: false, storage, workflows: { approval: approvalWorkflow() } });
+    await restartedReader.startWorkers();
+    expect(
+      await workflowStore?.loadWorkflowSnapshot({ workflowName: 'campaign', runId: 'suspended-run' }),
+    ).toMatchObject({ status: 'suspended' });
+    const resumedRun = await restartedReader.getWorkflow('campaign').createRun({ runId: 'suspended-run' });
+    expect(
+      await workflowStore?.loadWorkflowSnapshot({ workflowName: 'campaign', runId: 'suspended-run' }),
+    ).toMatchObject({ status: 'suspended' });
+    const resumed = await resumedRun.resume({ resumeData: { approved: true } });
+    expect(resumed).toMatchObject({ status: 'success', result: { value: 'v1' } });
+    expect(await runValue(restartedReader, 'campaign')).toBe('v2');
+
+    await restartedReader.stopWorkers();
+  });
+
+  it('fails closed for a legacy stored run without a pinned definition revision', async () => {
+    const storage = new InMemoryStore({ id: 'dynamic-legacy-run' });
+    const mastra = new Mastra({ logger: false, storage });
+    await mastra.addDynamicWorkflow(valueWorkflow('campaign', 'v1'));
+
+    const workflowStore = await storage.getStore('workflows');
+    await workflowStore!.persistWorkflowSnapshot({
+      workflowName: 'campaign',
+      runId: 'legacy-run',
+      snapshot: {
+        runId: 'legacy-run',
+        status: 'suspended',
+        value: {},
+        context: {},
+        serializedStepGraph: [],
+        activePaths: [],
+        activeStepsPath: {},
+        suspendedPaths: {},
+        resumeLabels: {},
+        waitingPaths: {},
+        timestamp: Date.now(),
+      },
+    });
+
+    await expect(mastra.getWorkflow('campaign').createRun({ runId: 'legacy-run' })).rejects.toThrow(
+      /does not contain a pinned definition revision/,
+    );
+  });
+
+  it('refreshes the full nested definition closure rather than retaining a stale child', async () => {
+    const storage = new InMemoryStore({ id: 'dynamic-nested-replica-refresh' });
+    const writer = new Mastra({ logger: false, storage });
+    const reader = new Mastra({ logger: false, storage });
+
+    await writer.addDynamicWorkflows([valueWorkflow('child', 'v1'), nestedRoot('root', 'child')]);
+    await reader.startWorkers();
+    expect(await runValue(reader, 'root')).toBe('v1');
+
+    const oldRootRun = await reader.getWorkflow('root').createRun();
+
+    await writer.addDynamicWorkflow(valueWorkflow('child', 'v2'));
+    expect(await runValue(reader, 'root')).toBe('v2');
+    const oldRootResult = await oldRootRun.start({ inputData: {} });
+    expect(oldRootResult.status).toBe('success');
+    expect((oldRootResult as { result: { value: string } }).result.value).toBe('v1');
+
+    await reader.stopWorkers();
+  });
+
+  it('does not fall back to a stale live child when its stored definition becomes inactive', async () => {
+    const storage = new InMemoryStore({ id: 'dynamic-inactive-child' });
+    const writer = new Mastra({ logger: false, storage });
+    const reader = new Mastra({ logger: false, storage });
+
+    await writer.addDynamicWorkflows([valueWorkflow('child', 'v1'), nestedRoot('root', 'child')]);
+    await reader.startWorkers();
+    const definitionStore = await storage.getStore('workflowDefinitions');
+    await definitionStore!.upsert({ id: 'child', status: 'archived' });
+
+    await expect(reader.getWorkflow('root').createRun()).rejects.toThrow(/inactive or missing stored workflow "child"/);
+
+    await reader.stopWorkers();
+  });
+});

--- a/packages/core/src/mastra/dynamic-workflow-run-revisions.test.ts
+++ b/packages/core/src/mastra/dynamic-workflow-run-revisions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { InMemoryStore } from '../storage';
 import { createWorkflow } from '../workflows/create';
@@ -52,6 +52,46 @@ function approvalWorkflow() {
   });
   return createWorkflow({
     id: 'approval-workflow',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ value: z.string() }),
+    steps: [approval],
+  })
+    .then(approval)
+    .commit();
+}
+
+function codeValueWorkflow(id: string, value: string) {
+  const valueStep = createStep({
+    id: 'value',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ value: z.string() }),
+    execute: async () => ({ value }),
+  });
+  return createWorkflow({
+    id,
+    inputSchema: z.object({}),
+    outputSchema: z.object({ value: z.string() }),
+    steps: [valueStep],
+  })
+    .then(valueStep)
+    .commit();
+}
+
+function countedApprovalWorkflow(onResume: () => void) {
+  const approval = createStep({
+    id: 'approval',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ value: z.string() }),
+    suspendSchema: z.object({ reason: z.string() }),
+    resumeSchema: z.object({ approved: z.boolean() }),
+    execute: async ({ resumeData, suspend }) => {
+      if (!resumeData) await suspend({ reason: 'Approve' });
+      onResume();
+      return { value: 'approved' };
+    },
+  });
+  return createWorkflow({
+    id: 'counted-approval',
     inputSchema: z.object({}),
     outputSchema: z.object({ value: z.string() }),
     steps: [approval],
@@ -171,6 +211,121 @@ describe('dynamic workflow run revisions', () => {
     await expect(mastra.getWorkflow('campaign').createRun({ runId: 'legacy-run' })).rejects.toThrow(
       /does not contain a pinned definition revision/,
     );
+  });
+
+  it('restores a pinned revision from a raw JSON string snapshot', async () => {
+    const storage = new InMemoryStore({ id: 'dynamic-string-snapshot' });
+    const writer = new Mastra({ logger: false, storage });
+    await writer.addDynamicWorkflow(valueWorkflow('campaign', 'v1'));
+    await writer.getWorkflow('campaign').createRun({ runId: 'string-run' });
+
+    const workflowStore = await storage.getStore('workflows');
+    const getWorkflowRunById = workflowStore!.getWorkflowRunById.bind(workflowStore);
+    vi.spyOn(workflowStore!, 'getWorkflowRunById').mockImplementation(async args => {
+      const storedRun = await getWorkflowRunById(args);
+      return storedRun ? { ...storedRun, snapshot: JSON.stringify(storedRun.snapshot) } : null;
+    });
+
+    const reader = new Mastra({ logger: false, storage });
+    await reader.startWorkers();
+    expect(await runValue(reader, 'campaign', 'string-run')).toBe('v1');
+    await reader.stopWorkers();
+  });
+
+  it('keeps a code-defined nested workflow authoritative during refresh', async () => {
+    const storage = new InMemoryStore({ id: 'dynamic-code-precedence' });
+    const writer = new Mastra({ logger: false, storage });
+    await writer.addDynamicWorkflows([valueWorkflow('child', 'stored'), nestedRoot('root', 'child')]);
+
+    const codeChild = codeValueWorkflow('child', 'code');
+    const reader = new Mastra({ logger: false, storage, workflows: { child: codeChild } });
+    await reader.startWorkers();
+
+    expect(await runValue(reader, 'root')).toBe('code');
+    expect(reader.getWorkflow('child')).toBe(codeChild);
+    await reader.stopWorkers();
+  });
+
+  it('publishes only the requested root and reuses its unchanged materialized revision', async () => {
+    const storage = new InMemoryStore({ id: 'dynamic-root-cache' });
+    const writer = new Mastra({ logger: false, storage });
+    const reader = new Mastra({ logger: false, storage });
+    await writer.addDynamicWorkflows([valueWorkflow('child', 'v1'), nestedRoot('root', 'child')]);
+    await reader.startWorkers();
+
+    const registeredChild = reader.getWorkflow('child');
+    await reader.getWorkflow('root').createRun();
+    const firstRevision = reader.getWorkflow('root');
+    expect(reader.getWorkflow('child')).toBe(registeredChild);
+
+    await reader.getWorkflow('root').createRun();
+    expect(reader.getWorkflow('root')).toBe(firstRevision);
+
+    await writer.addDynamicWorkflow(nestedRoot('root', 'child'));
+    await reader.getWorkflow('root').createRun();
+    expect(reader.getWorkflow('root')).not.toBe(firstRevision);
+    await reader.stopWorkers();
+  });
+
+  it('refreshes unrelated dynamic roots independently', async () => {
+    const storage = new InMemoryStore({ id: 'dynamic-root-refresh-queues' });
+    const mastra = new Mastra({ logger: false, storage });
+    await mastra.addDynamicWorkflows([valueWorkflow('first', 'one'), valueWorkflow('second', 'two')]);
+
+    const definitionStore = await storage.getStore('workflowDefinitions');
+    const list = definitionStore!.list.bind(definitionStore);
+    let entered = 0;
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    vi.spyOn(definitionStore!, 'list').mockImplementation(async args => {
+      entered += 1;
+      if (entered === 1) await firstBlocked;
+      return list(args);
+    });
+
+    const firstRun = mastra.getWorkflow('first').createRun();
+    await vi.waitFor(() => expect(entered).toBe(1));
+    const secondRun = mastra.getWorkflow('second').createRun();
+    await vi.waitFor(() => expect(entered).toBe(2));
+    releaseFirst();
+    await Promise.all([firstRun, secondRun]);
+  });
+
+  it('shares a pinned run and serializes concurrent resumes for the same dynamic run id', async () => {
+    const storage = new InMemoryStore({ id: 'dynamic-concurrent-resume' });
+    const writer = new Mastra({
+      logger: false,
+      storage,
+      workflows: { approval: countedApprovalWorkflow(() => {}) },
+    });
+    await writer.addDynamicWorkflow(nestedRoot('campaign', 'counted-approval'));
+    const initialRun = await writer.getWorkflow('campaign').createRun({ runId: 'shared-run' });
+    expect(await initialRun.start({ inputData: {} })).toMatchObject({ status: 'suspended' });
+
+    let resumeEffects = 0;
+    const reader = new Mastra({
+      logger: false,
+      storage,
+      workflows: { approval: countedApprovalWorkflow(() => resumeEffects++) },
+    });
+    await reader.startWorkers();
+
+    const [first, second] = await Promise.all([
+      reader.getWorkflow('campaign').createRun({ runId: 'shared-run' }),
+      reader.getWorkflow('campaign').createRun({ runId: 'shared-run' }),
+    ]);
+    expect(first).toBe(second);
+
+    const resumes = await Promise.allSettled([
+      first.resume({ resumeData: { approved: true } }),
+      second.resume({ resumeData: { approved: true } }),
+    ]);
+    expect(resumes.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    expect(resumes.filter(result => result.status === 'rejected')).toHaveLength(1);
+    expect(resumeEffects).toBe(1);
+    await reader.stopWorkers();
   });
 
   it('refreshes the full nested definition closure rather than retaining a stale child', async () => {

--- a/packages/core/src/mastra/dynamic-workflow-run-revisions.test.ts
+++ b/packages/core/src/mastra/dynamic-workflow-run-revisions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
+import { MastraError } from '../error';
 import { InMemoryStore } from '../storage';
 import { createWorkflow } from '../workflows/create';
 import type { DynamicWorkflowGraph } from '../workflows/dynamic';
@@ -208,9 +209,12 @@ describe('dynamic workflow run revisions', () => {
       },
     });
 
-    await expect(mastra.getWorkflow('campaign').createRun({ runId: 'legacy-run' })).rejects.toThrow(
-      /does not contain a pinned definition revision/,
-    );
+    const createLegacyRun = mastra.getWorkflow('campaign').createRun({ runId: 'legacy-run' });
+    await expect(createLegacyRun).rejects.toMatchObject({
+      id: 'MASTRA_DYNAMIC_WORKFLOW_RESUME_REVISION_MISSING',
+      details: { status: 409, workflowId: 'campaign', runId: 'legacy-run' },
+    });
+    await expect(createLegacyRun).rejects.toBeInstanceOf(MastraError);
   });
 
   it('restores a pinned revision from a raw JSON string snapshot', async () => {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -59,6 +59,7 @@ import { InMemoryStore } from '../storage';
 import { BackgroundTasksInMemory } from '../storage/domains/background-tasks/inmemory';
 import { InMemoryDB } from '../storage/domains/inmemory-db';
 import type { Schedule, ScheduleUpdate, SchedulesStorage } from '../storage/domains/schedules/base';
+import type { WorkflowDefinition } from '../storage/domains/workflow-definitions/base';
 import { WorkflowsInMemory } from '../storage/domains/workflows/inmemory';
 import { augmentWithInit } from '../storage/storageWithInit';
 import type { StorageResolvedPromptBlockType } from '../storage/types';
@@ -824,6 +825,9 @@ export class Mastra<
   // non-serializable AISpan, so it cannot ride the engine's pubsub events —
   // the event processor reads it from here, keyed by runId, instead.
   #runTracingContexts: Map<string, TracingContext> = new Map();
+  // Serializes storage-backed dynamic workflow materialization so concurrent
+  // run creation cannot publish partially refreshed dependency closures.
+  #dynamicWorkflowRefreshQueue: Promise<void> = Promise.resolve();
   // Server cache for temporary persistence and durable agent resumable streams
   #serverCache: MastraServerCache;
   // Cache for stored agents to allow in-memory modifications (like model changes) to persist across requests
@@ -4727,7 +4731,8 @@ export class Mastra<
     }
   }
 
-  #replaceDynamicWorkflow(workflow: AnyWorkflow, key: string): void {
+  #prepareDynamicWorkflow(workflow: AnyWorkflow, storageBackedAuthority: boolean): void {
+    workflow.dynamicStorageBacked = storageBackedAuthority;
     workflow.__registerMastra(this);
     workflow.__registerPrimitives({
       logger: this.getLogger(),
@@ -4736,10 +4741,152 @@ export class Mastra<
     if (!workflow.committed) {
       workflow.commit();
     }
+  }
 
+  #replaceDynamicWorkflow(workflow: AnyWorkflow, key: string): void {
+    this.#prepareDynamicWorkflow(workflow, true);
     (this.#workflows as Record<string, AnyWorkflow>)[key] = workflow;
     this.#hiddenWorkflowKeys.delete(key);
     this.registerStaticWorkflowScorers(workflow);
+  }
+
+  #workflowDefinitionToGraph(definition: WorkflowDefinition): DynamicWorkflowGraph {
+    return {
+      id: definition.id,
+      description: definition.description,
+      metadata: definition.metadata,
+      inputSchema: definition.inputSchema as DynamicWorkflowGraph['inputSchema'],
+      outputSchema: definition.outputSchema as DynamicWorkflowGraph['outputSchema'],
+      stateSchema: definition.stateSchema as DynamicWorkflowGraph['stateSchema'],
+      requestContextSchema: definition.requestContextSchema as DynamicWorkflowGraph['requestContextSchema'],
+      graph: definition.graph,
+    };
+  }
+
+  #orderDynamicDefinitionClosure(rootId: string, definitions: readonly DynamicWorkflowGraph[]): DynamicWorkflowGraph[] {
+    const byId = new Map(definitions.map(definition => [definition.id, definition] as const));
+    const ordered: DynamicWorkflowGraph[] = [];
+    const visiting = new Set<string>();
+    const visited = new Set<string>();
+
+    const visit = (id: string) => {
+      if (visited.has(id)) return;
+      if (visiting.has(id)) {
+        throw new Error(`Dynamic workflow revision has a circular nested-workflow dependency at "${id}".`);
+      }
+      const definition = byId.get(id);
+      if (!definition) return;
+      visiting.add(id);
+      for (const dependencyId of collectNestedWorkflowIds(definition.graph)) {
+        if (dependencyId === id) continue;
+        if (byId.has(dependencyId)) {
+          visit(dependencyId);
+          continue;
+        }
+        const registered = (this.#workflows as Record<string, AnyWorkflow>)[dependencyId];
+        if (registered?.origin === 'dynamic' && registered.dynamicStorageBacked) {
+          throw new Error(
+            `Dynamic workflow revision references inactive or missing stored workflow "${dependencyId}".`,
+          );
+        }
+      }
+      visiting.delete(id);
+      visited.add(id);
+      ordered.push(definition);
+    };
+
+    visit(rootId);
+    if (!visited.has(rootId)) {
+      throw new Error(`Dynamic workflow definition "${rootId}" is not available in storage.`);
+    }
+    return ordered;
+  }
+
+  async #materializeDynamicWorkflowRevision(
+    rootId: string,
+    definitions: readonly DynamicWorkflowGraph[],
+  ): Promise<{ root: AnyWorkflow; workflows: Map<string, AnyWorkflow> }> {
+    const ordered = this.#orderDynamicDefinitionClosure(rootId, definitions);
+    const workflows = new Map<string, AnyWorkflow>();
+
+    // Materialize every public registry member with its own dependency objects.
+    // A root run must keep the child instances from its pinned closure; sharing
+    // the public child object would let a later child refresh change that run.
+    for (const target of ordered) {
+      const closure = this.#orderDynamicDefinitionClosure(target.id, ordered);
+      const revisionMembers = new Map<string, AnyWorkflow>();
+      for (const definition of closure) {
+        const { workflow } = await rehydrateWorkflow(definition, this, {
+          resolveWorkflow: id => revisionMembers.get(id),
+        });
+        // Revision-local child objects must not refresh from storage when the
+        // pinned root executes them. They still need the owning Mastra instance
+        // and native primitives for run persistence and resume.
+        this.#prepareDynamicWorkflow(workflow as AnyWorkflow, false);
+        revisionMembers.set(definition.id, workflow as AnyWorkflow);
+      }
+      const workflow = revisionMembers.get(target.id)!;
+      workflow.__setDynamicWorkflowDefinitions?.(closure);
+      workflows.set(target.id, workflow);
+    }
+    return { root: workflows.get(rootId)!, workflows };
+  }
+
+  async #withDynamicWorkflowRefresh<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.#dynamicWorkflowRefreshQueue;
+    let release!: () => void;
+    this.#dynamicWorkflowRefreshQueue = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Resolve the immutable dynamic definition revision for a workflow run.
+   * New runs read the authoritative definition store. Existing runs prefer the
+   * exact definition closure persisted in their snapshot.
+   * @internal
+   */
+  public async __resolveDynamicWorkflowForRun(
+    workflow: AnyWorkflow,
+    runId?: string,
+  ): Promise<{ workflow: AnyWorkflow }> {
+    if (workflow.origin !== 'dynamic' || !workflow.dynamicStorageBacked) return { workflow };
+    const definitionStore = await this.#storage?.getStore('workflowDefinitions');
+    if (!definitionStore) return { workflow };
+
+    return this.#withDynamicWorkflowRefresh(async () => {
+      if (runId) {
+        const workflowStore = await this.#storage?.getStore('workflows');
+        const storedRun = await workflowStore?.getWorkflowRunById({ workflowName: workflow.id, runId });
+        const snapshot = storedRun?.snapshot;
+        if (snapshot && typeof snapshot !== 'string' && snapshot.dynamicWorkflowDefinitions?.length) {
+          const revision = await this.#materializeDynamicWorkflowRevision(
+            workflow.id,
+            snapshot.dynamicWorkflowDefinitions,
+          );
+          return { workflow: revision.root };
+        }
+        if (storedRun) {
+          throw new Error(
+            `Dynamic workflow run "${runId}" does not contain a pinned definition revision and cannot be resumed safely after the registered definition may have changed.`,
+          );
+        }
+      }
+
+      const { definitions } = await definitionStore.list({ status: 'active' });
+      const graphs = definitions.map(definition => this.#workflowDefinitionToGraph(definition));
+      const revision = await this.#materializeDynamicWorkflowRevision(workflow.id, graphs);
+      for (const [id, member] of revision.workflows) {
+        this.#replaceDynamicWorkflow(member, id);
+      }
+      return { workflow: revision.root };
+    });
   }
 
   /**
@@ -5001,6 +5148,7 @@ export class Mastra<
               onUnsupported: message => this.#logger?.warn?.(`Dynamic workflow "${def.id}": ${message}`),
             },
           );
+          (workflow as AnyWorkflow).dynamicStorageBacked = true;
           this.addWorkflow(workflow as AnyWorkflow, def.id);
           loaded.add(def.id);
         } catch (error) {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -73,7 +73,7 @@ import { readPositiveIntEnv } from '../utils';
 import type { MastraVector } from '../vector';
 import { OrchestrationWorker, SchedulerWorker, BackgroundTaskWorker } from '../worker';
 import type { MastraWorker, WorkerDeps } from '../worker';
-import type { AnyWorkflow, Workflow } from '../workflows';
+import type { AnyWorkflow, Workflow, WorkflowRunState } from '../workflows';
 import { normalizeWorkflowBuilderDefinition } from '../workflows/builder';
 import type { WorkflowBuilderDefinitionInput } from '../workflows/builder';
 import type { DynamicWorkflowGraph, WorkflowRegistryIndex, WorkflowRegistrySchemas } from '../workflows/dynamic';
@@ -825,9 +825,14 @@ export class Mastra<
   // non-serializable AISpan, so it cannot ride the engine's pubsub events —
   // the event processor reads it from here, keyed by runId, instead.
   #runTracingContexts: Map<string, TracingContext> = new Map();
-  // Serializes storage-backed dynamic workflow materialization so concurrent
-  // run creation cannot publish partially refreshed dependency closures.
-  #dynamicWorkflowRefreshQueue: Promise<void> = Promise.resolve();
+  // Each root owns its refresh queue. This prevents concurrent materialization
+  // of the same registry slot without coupling unrelated dynamic workflows.
+  #dynamicWorkflowRefreshQueues = new Map<string, Promise<void>>();
+  #dynamicWorkflowRevisionCache = new Map<string, { identity: string; root: AnyWorkflow }>();
+  // A suspended dynamic run must keep one revision-local Run instance across
+  // repeated createRun({ runId }) calls. The Run cleanup removes this entry
+  // once the execution reaches a terminal state.
+  #dynamicWorkflowRuns = new Map<string, ReturnType<AnyWorkflow['__createRunPinned']>>();
   // Server cache for temporary persistence and durable agent resumable streams
   #serverCache: MastraServerCache;
   // Cache for stored agents to allow in-memory modifications (like model changes) to persist across requests
@@ -4805,44 +4810,50 @@ export class Mastra<
   async #materializeDynamicWorkflowRevision(
     rootId: string,
     definitions: readonly DynamicWorkflowGraph[],
-  ): Promise<{ root: AnyWorkflow; workflows: Map<string, AnyWorkflow> }> {
+    definitionVersions?: ReadonlyMap<string, string>,
+  ): Promise<{ root: AnyWorkflow }> {
     const ordered = this.#orderDynamicDefinitionClosure(rootId, definitions);
-    const workflows = new Map<string, AnyWorkflow>();
-
-    // Materialize every public registry member with its own dependency objects.
-    // A root run must keep the child instances from its pinned closure; sharing
-    // the public child object would let a later child refresh change that run.
-    for (const target of ordered) {
-      const closure = this.#orderDynamicDefinitionClosure(target.id, ordered);
-      const revisionMembers = new Map<string, AnyWorkflow>();
-      for (const definition of closure) {
-        const { workflow } = await rehydrateWorkflow(definition, this, {
-          resolveWorkflow: id => revisionMembers.get(id),
-        });
-        // Revision-local child objects must not refresh from storage when the
-        // pinned root executes them. They still need the owning Mastra instance
-        // and native primitives for run persistence and resume.
-        this.#prepareDynamicWorkflow(workflow as AnyWorkflow, false);
-        revisionMembers.set(definition.id, workflow as AnyWorkflow);
-      }
-      const workflow = revisionMembers.get(target.id)!;
-      workflow.__setDynamicWorkflowDefinitions?.(closure);
-      workflows.set(target.id, workflow);
+    const identity = JSON.stringify(
+      ordered.map(definition => [definition.id, definitionVersions?.get(definition.id) ?? definition]),
+    );
+    const cached = this.#dynamicWorkflowRevisionCache.get(rootId);
+    if (cached?.identity === identity) {
+      return { root: cached.root };
     }
-    return { root: workflows.get(rootId)!, workflows };
+
+    // Materialize only the requested root and its dependency closure. Nested
+    // stored definitions stay revision-local; another member is published only
+    // when it is requested as a run root itself.
+    const revisionMembers = new Map<string, AnyWorkflow>();
+    const registry = this.#workflows as Record<string, AnyWorkflow>;
+    for (const definition of ordered) {
+      const { workflow } = await rehydrateWorkflow(definition, this, {
+        resolveWorkflow: id => revisionMembers.get(id) ?? registry[id],
+      });
+      this.#prepareDynamicWorkflow(workflow as AnyWorkflow, false);
+      revisionMembers.set(definition.id, workflow as AnyWorkflow);
+    }
+    const root = revisionMembers.get(rootId)!;
+    root.__setDynamicWorkflowDefinitions?.(ordered);
+    this.#dynamicWorkflowRevisionCache.set(rootId, { identity, root });
+    return { root };
   }
 
-  async #withDynamicWorkflowRefresh<T>(operation: () => Promise<T>): Promise<T> {
-    const previous = this.#dynamicWorkflowRefreshQueue;
+  async #withDynamicWorkflowRefresh<T>(rootId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.#dynamicWorkflowRefreshQueues.get(rootId) ?? Promise.resolve();
     let release!: () => void;
-    this.#dynamicWorkflowRefreshQueue = new Promise<void>(resolve => {
+    const current = new Promise<void>(resolve => {
       release = resolve;
     });
+    this.#dynamicWorkflowRefreshQueues.set(rootId, current);
     await previous;
     try {
       return await operation();
     } finally {
       release();
+      if (this.#dynamicWorkflowRefreshQueues.get(rootId) === current) {
+        this.#dynamicWorkflowRefreshQueues.delete(rootId);
+      }
     }
   }
 
@@ -4860,12 +4871,22 @@ export class Mastra<
     const definitionStore = await this.#storage?.getStore('workflowDefinitions');
     if (!definitionStore) return { workflow };
 
-    return this.#withDynamicWorkflowRefresh(async () => {
+    return this.#withDynamicWorkflowRefresh(workflow.id, async () => {
       if (runId) {
         const workflowStore = await this.#storage?.getStore('workflows');
         const storedRun = await workflowStore?.getWorkflowRunById({ workflowName: workflow.id, runId });
-        const snapshot = storedRun?.snapshot;
-        if (snapshot && typeof snapshot !== 'string' && snapshot.dynamicWorkflowDefinitions?.length) {
+        const storedSnapshot = storedRun?.snapshot;
+        let snapshot: WorkflowRunState | undefined;
+        if (typeof storedSnapshot === 'string') {
+          try {
+            snapshot = JSON.parse(storedSnapshot) as WorkflowRunState;
+          } catch (error) {
+            throw new Error(`Dynamic workflow run "${runId}" contains an invalid JSON snapshot.`, { cause: error });
+          }
+        } else {
+          snapshot = storedSnapshot;
+        }
+        if (snapshot?.dynamicWorkflowDefinitions?.length) {
           const revision = await this.#materializeDynamicWorkflowRevision(
             workflow.id,
             snapshot.dynamicWorkflowDefinitions,
@@ -4880,13 +4901,52 @@ export class Mastra<
       }
 
       const { definitions } = await definitionStore.list({ status: 'active' });
-      const graphs = definitions.map(definition => this.#workflowDefinitionToGraph(definition));
-      const revision = await this.#materializeDynamicWorkflowRevision(workflow.id, graphs);
-      for (const [id, member] of revision.workflows) {
-        this.#replaceDynamicWorkflow(member, id);
-      }
+      const registry = this.#workflows as Record<string, AnyWorkflow>;
+      const eligibleDefinitions = definitions.filter(
+        definition => definition.id === workflow.id || registry[definition.id]?.origin !== 'code',
+      );
+      const graphs = eligibleDefinitions.map(definition => this.#workflowDefinitionToGraph(definition));
+      const definitionVersions = new Map(
+        eligibleDefinitions.map(definition => [definition.id, new Date(definition.updatedAt).toISOString()] as const),
+      );
+      const revision = await this.#materializeDynamicWorkflowRevision(workflow.id, graphs, definitionVersions);
+      this.#replaceDynamicWorkflow(revision.root, workflow.id);
       return { workflow: revision.root };
     });
+  }
+
+  /** @internal Resolves and shares one revision-local Run for a persisted dynamic run id. */
+  public async __createDynamicWorkflowRun(
+    workflow: AnyWorkflow,
+    options?: Parameters<AnyWorkflow['__createRunPinned']>[0],
+  ): ReturnType<AnyWorkflow['__createRunPinned']> {
+    if (!options?.runId) {
+      const resolved = await this.__resolveDynamicWorkflowForRun(workflow);
+      return resolved.workflow.__createRunPinned(options);
+    }
+
+    const key = JSON.stringify([workflow.id, options.runId]);
+    const existing = this.#dynamicWorkflowRuns.get(key);
+    if (existing) return existing;
+
+    let pending!: ReturnType<AnyWorkflow['__createRunPinned']>;
+    pending = (async () => {
+      const resolved = await this.__resolveDynamicWorkflowForRun(workflow, options.runId);
+      return resolved.workflow.__createRunPinned(options, () => {
+        if (this.#dynamicWorkflowRuns.get(key) === pending) {
+          this.#dynamicWorkflowRuns.delete(key);
+        }
+      });
+    })();
+    this.#dynamicWorkflowRuns.set(key, pending);
+    try {
+      return await pending;
+    } catch (error) {
+      if (this.#dynamicWorkflowRuns.get(key) === pending) {
+        this.#dynamicWorkflowRuns.delete(key);
+      }
+      throw error;
+    }
   }
 
   /**

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -4777,7 +4777,15 @@ export class Mastra<
     const visit = (id: string) => {
       if (visited.has(id)) return;
       if (visiting.has(id)) {
-        throw new Error(`Dynamic workflow revision has a circular nested-workflow dependency at "${id}".`);
+        const error = new MastraError({
+          id: 'MASTRA_DYNAMIC_WORKFLOW_REVISION_CIRCULAR_DEPENDENCY',
+          domain: ErrorDomain.MASTRA,
+          category: ErrorCategory.USER,
+          text: `Dynamic workflow revision has a circular nested-workflow dependency at "${id}".`,
+          details: { status: 400, rootId, workflowId: id },
+        });
+        this.#logger?.trackException(error);
+        throw error;
       }
       const definition = byId.get(id);
       if (!definition) return;
@@ -4790,9 +4798,15 @@ export class Mastra<
         }
         const registered = (this.#workflows as Record<string, AnyWorkflow>)[dependencyId];
         if (registered?.origin === 'dynamic' && registered.dynamicStorageBacked) {
-          throw new Error(
-            `Dynamic workflow revision references inactive or missing stored workflow "${dependencyId}".`,
-          );
+          const error = new MastraError({
+            id: 'MASTRA_DYNAMIC_WORKFLOW_REVISION_STORED_WORKFLOW_NOT_FOUND',
+            domain: ErrorDomain.MASTRA,
+            category: ErrorCategory.USER,
+            text: `Dynamic workflow revision references inactive or missing stored workflow "${dependencyId}".`,
+            details: { status: 404, rootId, workflowId: dependencyId },
+          });
+          this.#logger?.trackException(error);
+          throw error;
         }
       }
       visiting.delete(id);
@@ -4802,7 +4816,15 @@ export class Mastra<
 
     visit(rootId);
     if (!visited.has(rootId)) {
-      throw new Error(`Dynamic workflow definition "${rootId}" is not available in storage.`);
+      const error = new MastraError({
+        id: 'MASTRA_DYNAMIC_WORKFLOW_REVISION_ROOT_NOT_FOUND',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: `Dynamic workflow definition "${rootId}" is not available in storage.`,
+        details: { status: 404, rootId },
+      });
+      this.#logger?.trackException(error);
+      throw error;
     }
     return ordered;
   }
@@ -4894,9 +4916,15 @@ export class Mastra<
           return { workflow: revision.root };
         }
         if (storedRun) {
-          throw new Error(
-            `Dynamic workflow run "${runId}" does not contain a pinned definition revision and cannot be resumed safely after the registered definition may have changed.`,
-          );
+          const error = new MastraError({
+            id: 'MASTRA_DYNAMIC_WORKFLOW_RESUME_REVISION_MISSING',
+            domain: ErrorDomain.MASTRA,
+            category: ErrorCategory.USER,
+            text: `Dynamic workflow run "${runId}" does not contain a pinned definition revision and cannot be resumed safely after the registered definition may have changed.`,
+            details: { status: 409, workflowId: workflow.id, runId },
+          });
+          this.#logger?.trackException(error);
+          throw error;
         }
       }
 

--- a/packages/core/src/workflows/dynamic/rehydrate.ts
+++ b/packages/core/src/workflows/dynamic/rehydrate.ts
@@ -50,10 +50,19 @@ export interface RehydratedWorkflow {
  */
 export type RehydrateWorkflowOptions = JsonSchemaToZodOptions;
 
+export interface RehydrateDynamicWorkflowOptions extends RehydrateWorkflowOptions {
+  /**
+   * Internal resolution seam used when materializing an immutable run revision.
+   * Dynamic nested workflows resolve from the revision bundle before falling
+   * back to the Mastra registry.
+   */
+  resolveWorkflow?: (id: string) => any | undefined;
+}
+
 export async function rehydrateWorkflow(
   def: DynamicWorkflowGraph,
   mastra: Mastra,
-  opts?: RehydrateWorkflowOptions,
+  opts?: RehydrateDynamicWorkflowOptions,
 ): Promise<RehydratedWorkflow> {
   const inputSchema = jsonSchemaToZod(def.inputSchema, opts);
   const outputSchema = jsonSchemaToZod(def.outputSchema, opts);
@@ -75,6 +84,7 @@ export async function rehydrateWorkflow(
   }
   const built: any = wf.commit();
   built.origin = 'dynamic';
+  built.__setDynamicWorkflowDefinitions?.([def]);
   return { workflow: built };
 }
 
@@ -82,7 +92,7 @@ function applyGraphEntry(
   wf: any,
   entry: ValidatableStepFlowEntry,
   mastra: Mastra,
-  schemaOpts?: JsonSchemaToZodOptions,
+  schemaOpts?: RehydrateDynamicWorkflowOptions,
 ): void {
   switch (entry.type) {
     case 'agent':
@@ -91,7 +101,7 @@ function applyGraphEntry(
       return;
     case 'mapping': {
       const cfg = parseMapConfig(entry.mapConfig, entry.id);
-      const live = rehydrateMapConfig(cfg, mastra);
+      const live = rehydrateMapConfig(cfg, mastra, schemaOpts?.resolveWorkflow);
       wf.map(live, { id: entry.id });
       return;
     }
@@ -145,7 +155,7 @@ function applyGraphEntry(
       return;
     }
     case 'workflow': {
-      const nested = assertWorkflowExists(mastra, entry.workflowId);
+      const nested = assertWorkflowExists(mastra, entry.workflowId, schemaOpts?.resolveWorkflow);
       // A nested workflow executes as its own `Workflow`, so the engine keys its
       // result by the workflow's intrinsic id. The portable definition addresses
       // it by the declared call-site id, which is what mappings, predicates and
@@ -218,7 +228,7 @@ function rebuildAgentOptions(
     outputSchema?: Record<string, any>;
     options?: SerializedStepOptions;
   },
-  schemaOpts?: JsonSchemaToZodOptions,
+  schemaOpts?: RehydrateDynamicWorkflowOptions,
 ): Record<string, any> | undefined {
   const opts: Record<string, any> = {};
   if (entry.outputSchema) {
@@ -251,7 +261,7 @@ function rebuildToolOptions(entry: { options?: SerializedStepOptions }): Record<
 function rehydrateSingleEntry(
   entry: SerializedSingleStepEntry,
   mastra: Mastra,
-  schemaOpts?: JsonSchemaToZodOptions,
+  schemaOpts?: RehydrateDynamicWorkflowOptions,
 ): SingleStepEntry {
   switch (entry.type) {
     case 'agent': {
@@ -296,7 +306,7 @@ function rehydrateSingleEntry(
       );
     }
     case 'workflow': {
-      const nested = assertWorkflowExists(mastra, entry.workflowId);
+      const nested = assertWorkflowExists(mastra, entry.workflowId, schemaOpts?.resolveWorkflow);
       // Same call-site identity rule as top-level nested workflows: run the
       // clone under the declared id so results are keyed the way the portable
       // definition addresses them.
@@ -314,7 +324,11 @@ function rehydrateSingleEntry(
  * Rebuild the object shape that `.map()` accepts. Step sources remain workflow-local
  * step IDs because mapping execution resolves them from the run's step results.
  */
-function rehydrateMapConfig(cfg: Record<string, any>, mastra: Mastra): Record<string, any> {
+function rehydrateMapConfig(
+  cfg: Record<string, any>,
+  mastra: Mastra,
+  resolveWorkflow?: (id: string) => any | undefined,
+): Record<string, any> {
   const out: Record<string, any> = {};
   for (const [key, source] of Object.entries(cfg)) {
     if (!source || typeof source !== 'object') {
@@ -328,7 +342,7 @@ function rehydrateMapConfig(cfg: Record<string, any>, mastra: Mastra): Record<st
     } else if ('requestContextPath' in source) {
       out[key] = { requestContextPath: source.requestContextPath };
     } else if ('initData' in source && typeof source.initData === 'string') {
-      const wf = mastra.getWorkflow?.(source.initData);
+      const wf = resolveWorkflow?.(source.initData) ?? mastra.getWorkflow?.(source.initData);
       if (!wf) {
         throw new Error(`Mapping references unknown workflow init-data "${source.initData}".`);
       }
@@ -392,8 +406,12 @@ function tryGetWorkflowById(mastra: Mastra, id: string): any | undefined {
   }
 }
 
-function assertWorkflowExists(mastra: Mastra, workflowId: string): any {
-  const wf = tryGetWorkflowById(mastra, workflowId);
+function assertWorkflowExists(
+  mastra: Mastra,
+  workflowId: string,
+  resolveWorkflow?: (id: string) => any | undefined,
+): any {
+  const wf = resolveWorkflow?.(workflowId) ?? tryGetWorkflowById(mastra, workflowId);
   if (!wf) {
     throw new Error(
       `Dynamic workflow references nested workflow "${workflowId}" which is not registered on this Mastra instance.`,

--- a/packages/core/src/workflows/dynamic/rehydrate.ts
+++ b/packages/core/src/workflows/dynamic/rehydrate.ts
@@ -12,6 +12,7 @@ import { createStepFromAgent, createStepFromTool } from '../step-factories';
 import type { SerializedSingleStepEntry, SerializedStepOptions, SingleStepEntry, StepFlowEntry } from '../types';
 import { getSingleStepEntryId } from '../utils';
 import { mapVariable, predicateToCondition } from '../workflow';
+import type { AnyWorkflow } from '../workflow';
 import { jsonSchemaToZod } from './json-schema-to-zod';
 import type { JsonSchema, JsonSchemaToZodOptions } from './json-schema-to-zod';
 import { parseMapConfig } from './mapping-config';
@@ -40,8 +41,10 @@ export interface DynamicWorkflowGraph {
  * Always destructure: `const { workflow } = await rehydrateWorkflow(...)`.
  */
 export interface RehydratedWorkflow {
-  workflow: any;
+  workflow: AnyWorkflow;
 }
+
+type ResolveWorkflow = (id: string) => AnyWorkflow | undefined;
 
 /**
  * Options controlling how `rehydrateWorkflow` handles unsupported JSON Schema
@@ -56,7 +59,7 @@ export interface RehydrateDynamicWorkflowOptions extends RehydrateWorkflowOption
    * Dynamic nested workflows resolve from the revision bundle before falling
    * back to the Mastra registry.
    */
-  resolveWorkflow?: (id: string) => any | undefined;
+  resolveWorkflow?: ResolveWorkflow;
 }
 
 export async function rehydrateWorkflow(
@@ -327,7 +330,7 @@ function rehydrateSingleEntry(
 function rehydrateMapConfig(
   cfg: Record<string, any>,
   mastra: Mastra,
-  resolveWorkflow?: (id: string) => any | undefined,
+  resolveWorkflow?: ResolveWorkflow,
 ): Record<string, any> {
   const out: Record<string, any> = {};
   for (const [key, source] of Object.entries(cfg)) {
@@ -389,7 +392,7 @@ function tryGetToolById(mastra: Mastra, id: string): any | undefined {
  * the key the workflow was registered under (`workflows: { greetingWorkflow }`
  * vs `id: 'greeting-workflow'`).
  */
-function tryGetWorkflowById(mastra: Mastra, id: string): any | undefined {
+function tryGetWorkflowById(mastra: Mastra, id: string): AnyWorkflow | undefined {
   if (!id) return undefined;
   if (typeof (mastra as any).getWorkflowById === 'function') {
     try {
@@ -406,11 +409,7 @@ function tryGetWorkflowById(mastra: Mastra, id: string): any | undefined {
   }
 }
 
-function assertWorkflowExists(
-  mastra: Mastra,
-  workflowId: string,
-  resolveWorkflow?: (id: string) => any | undefined,
-): any {
+function assertWorkflowExists(mastra: Mastra, workflowId: string, resolveWorkflow?: ResolveWorkflow): AnyWorkflow {
   const wf = resolveWorkflow?.(workflowId) ?? tryGetWorkflowById(mastra, workflowId);
   if (!wf) {
     throw new Error(

--- a/packages/core/src/workflows/execution-engine.ts
+++ b/packages/core/src/workflows/execution-engine.ts
@@ -6,6 +6,7 @@ import { RegisteredLogger } from '../logger';
 import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
 import type { Span, SpanType, TracingPolicy } from '../observability';
+import type { DynamicWorkflowGraph } from './dynamic';
 import type {
   OutputWriter,
   SerializedStepFlowEntry,
@@ -66,6 +67,8 @@ export interface ExecutionEngineOptions {
 export abstract class ExecutionEngine extends MastraBase {
   public mastra?: Mastra;
   public options: ExecutionEngineOptions;
+  /** Exact dynamic definition closure pinned to runs created by this engine. */
+  public dynamicWorkflowDefinitions?: readonly DynamicWorkflowGraph[];
   constructor({ mastra, options }: { mastra?: Mastra; options: ExecutionEngineOptions }) {
     super({ name: 'ExecutionEngine', component: RegisteredLogger.WORKFLOW });
     this.mastra = mastra;

--- a/packages/core/src/workflows/handlers/entry.ts
+++ b/packages/core/src/workflows/handlers/entry.ts
@@ -209,7 +209,7 @@ export async function persistStepUpdate(
       // Persist tracing context for span continuity on resume
       tracingContext,
       dynamicWorkflowDefinitions: engine.dynamicWorkflowDefinitions
-        ? structuredClone(Array.from(engine.dynamicWorkflowDefinitions))
+        ? Array.from(engine.dynamicWorkflowDefinitions)
         : undefined,
     };
 

--- a/packages/core/src/workflows/handlers/entry.ts
+++ b/packages/core/src/workflows/handlers/entry.ts
@@ -208,6 +208,9 @@ export async function persistStepUpdate(
       timestamp: Date.now(),
       // Persist tracing context for span continuity on resume
       tracingContext,
+      dynamicWorkflowDefinitions: engine.dynamicWorkflowDefinitions
+        ? structuredClone(Array.from(engine.dynamicWorkflowDefinitions))
+        : undefined,
     };
 
     const workflowsStore = await engine.mastra?.getStorage()?.getStore('workflows');

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -405,6 +405,11 @@ export interface WorkflowRunState {
    * as children of the original suspended span.
    */
   tracingContext?: WorkflowStateTracingContext;
+  /**
+   * Exact root and nested dynamic definitions used by this run. This keeps
+   * resume/restart revision-stable even after the registered definition changes.
+   */
+  dynamicWorkflowDefinitions?: import('./dynamic').DynamicWorkflowGraph[];
 }
 
 /**

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2535,6 +2535,11 @@ export class Workflow<
     /** Optional pubsub instance for streaming events. If not provided, a new EventEmitterPubSub is created. */
     pubsub?: PubSub;
   }): Promise<Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>> {
+    if (this.origin === 'dynamic' && this.dynamicStorageBacked && this.#mastra) {
+      return this.#mastra.__createDynamicWorkflowRun(this as AnyWorkflow, options) as Promise<
+        Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>
+      >;
+    }
     const resolved = await this.#mastra?.__resolveDynamicWorkflowForRun(this as any, options?.runId);
     if (resolved && resolved.workflow !== this) {
       return resolved.workflow.__createRunPinned(options);
@@ -2543,12 +2548,15 @@ export class Workflow<
   }
 
   /** @internal Creates a run from this already-resolved immutable workflow revision. */
-  async __createRunPinned(options?: {
-    runId?: string;
-    resourceId?: string;
-    disableScorers?: boolean;
-    pubsub?: PubSub;
-  }): Promise<Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>> {
+  async __createRunPinned(
+    options?: {
+      runId?: string;
+      resourceId?: string;
+      disableScorers?: boolean;
+      pubsub?: PubSub;
+    },
+    sharedCleanup?: () => void,
+  ): Promise<Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>> {
     if (this.stepFlow.length === 0) {
       throw new Error(
         'Execution flow of workflow is not defined. Add steps to the workflow via .then(), .branch(), etc.',
@@ -2583,7 +2591,11 @@ export class Workflow<
         retryConfig: this.retryConfig,
         serializedStepGraph: this.serializedStepGraph,
         disableScorers: options?.disableScorers,
-        cleanup: () => this.#runs.delete(runIdToUse),
+        cleanup: () => {
+          this.#runs.delete(runIdToUse);
+          sharedCleanup?.();
+        },
+        serializeResumes: this.origin === 'dynamic',
         tracingPolicy: this.#options?.tracingPolicy,
         workflowSteps: this.steps,
         validateInputs: this.#options?.validateInputs,
@@ -2634,7 +2646,7 @@ export class Workflow<
         error: undefined,
         timestamp: Date.now(),
         dynamicWorkflowDefinitions: this.dynamicWorkflowDefinitions
-          ? structuredClone(Array.from(this.dynamicWorkflowDefinitions))
+          ? Array.from(this.dynamicWorkflowDefinitions)
           : undefined,
       };
       await workflowsStore?.persistWorkflowSnapshot({
@@ -3323,6 +3335,8 @@ export class Run<
   protected requestContextSchema?: StandardSchemaWithJSON<any>;
 
   protected cleanup?: () => void;
+  protected serializeResumes: boolean;
+  #resumeQueue: Promise<void> = Promise.resolve();
 
   protected retryConfig?: {
     attempts?: number;
@@ -3344,6 +3358,7 @@ export class Run<
       delay?: number;
     };
     cleanup?: () => void;
+    serializeResumes?: boolean;
     serializedStepGraph: SerializedStepFlowEntry[];
     disableScorers?: boolean;
     tracingPolicy?: TracingPolicy;
@@ -3363,6 +3378,7 @@ export class Run<
     this.pubsub = params.pubsub ?? new EventEmitterPubSub();
     this.retryConfig = params.retryConfig;
     this.cleanup = params.cleanup;
+    this.serializeResumes = params.serializeResumes ?? false;
     this.disableScorers = params.disableScorers;
     this.tracingPolicy = params.tracingPolicy;
     this.workflowSteps = params.workflowSteps;
@@ -4247,6 +4263,26 @@ export class Run<
   }
 
   protected async _resume<TResume>(
+    params: Parameters<Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>['_resumeUnserialized']>[0],
+  ): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+    if (!this.serializeResumes) {
+      return this._resumeUnserialized(params);
+    }
+
+    const previous = this.#resumeQueue;
+    let release!: () => void;
+    this.#resumeQueue = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await this._resumeUnserialized(params);
+    } finally {
+      release();
+    }
+  }
+
+  protected async _resumeUnserialized<TResume>(
     params: {
       resumeData?: TResume;
       step?:

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -53,6 +53,7 @@ import type { ToolExecutionContext } from '../tools/types';
 import type { DynamicArgument } from '../types';
 import { PUBSUB_SYMBOL } from './constants';
 import { DefaultExecutionEngine } from './default';
+import type { DynamicWorkflowGraph } from './dynamic';
 import type { ExecutionEngine, ExecutionGraph } from './execution-engine';
 import { validateTemplate } from './mapping-template';
 import { derivePredicateLabel, evaluatePredicate } from './predicate';
@@ -1639,6 +1640,10 @@ export class Workflow<
   public type: WorkflowType = 'default';
   /** Where this workflow came from: 'code' for statically registered workflows, 'dynamic' for workflows rehydrated from storage. Set by rehydrateWorkflow; defaults to 'code'. */
   public origin: 'code' | 'dynamic' = 'code';
+  /** Whether this dynamic workflow is authoritative in WorkflowDefinitionsStorage. */
+  public dynamicStorageBacked = false;
+  /** Exact definition closure used to materialize this dynamic workflow revision. */
+  public dynamicWorkflowDefinitions?: readonly DynamicWorkflowGraph[];
   #nestedWorkflowInput?: TInput;
   public committed: boolean = false;
   protected stepFlow: StepFlowEntry<TEngineType>[];
@@ -1723,6 +1728,12 @@ export class Workflow<
 
   get options() {
     return this.#options;
+  }
+
+  /** @internal Pins the JSON-safe definition closure used by this workflow revision. */
+  __setDynamicWorkflowDefinitions(definitions: readonly DynamicWorkflowGraph[]) {
+    this.dynamicWorkflowDefinitions = structuredClone(definitions);
+    this.executionEngine.dynamicWorkflowDefinitions = this.dynamicWorkflowDefinitions;
   }
 
   __registerMastra(mastra: Mastra) {
@@ -2524,6 +2535,20 @@ export class Workflow<
     /** Optional pubsub instance for streaming events. If not provided, a new EventEmitterPubSub is created. */
     pubsub?: PubSub;
   }): Promise<Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>> {
+    const resolved = await this.#mastra?.__resolveDynamicWorkflowForRun(this as any, options?.runId);
+    if (resolved && resolved.workflow !== this) {
+      return resolved.workflow.__createRunPinned(options);
+    }
+    return this.__createRunPinned(options);
+  }
+
+  /** @internal Creates a run from this already-resolved immutable workflow revision. */
+  async __createRunPinned(options?: {
+    runId?: string;
+    resourceId?: string;
+    disableScorers?: boolean;
+    pubsub?: PubSub;
+  }): Promise<Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>> {
     if (this.stepFlow.length === 0) {
       throw new Error(
         'Execution flow of workflow is not defined. Add steps to the workflow via .then(), .branch(), etc.',
@@ -2608,6 +2633,9 @@ export class Workflow<
         result: undefined,
         error: undefined,
         timestamp: Date.now(),
+        dynamicWorkflowDefinitions: this.dynamicWorkflowDefinitions
+          ? structuredClone(Array.from(this.dynamicWorkflowDefinitions))
+          : undefined,
       };
       await workflowsStore?.persistWorkflowSnapshot({
         workflowName: this.id,


### PR DESCRIPTION
## Summary

- treat WorkflowDefinitionsStorage as the authority when a storage-backed dynamic workflow creates a new run, so independent replicas converge without an invalidation bus
- materialize an independent root-plus-nested dynamic definition closure for each revision
- persist that exact closure in native workflow run snapshots and restore it for resume/restart
- fail closed for legacy dynamic runs whose snapshots do not contain a pinned definition revision
- document the boundary: code-defined nested workflows still follow the host deployment

## Verification

- dynamic workflow revision tests: 5 passed, including two stale replicas, pre-update in-flight pinning, suspended resume after restart, legacy fail-closed, and nested child pinning
- combined dynamic workflow suites: 4 files, 70 tests passed, no type errors
- `@mastra/core` check: passed
- `@mastra/core` build: passed
- changed-file oxfmt, oxlint, and git diff check: passed

## Boundary

This guarantees storage-backed dynamic definition coherence and pinning. It does not snapshot arbitrary code-defined nested workflow implementations; those must remain resume-compatible across host deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

New workflow runs use the latest stored workflow definition. Existing runs keep the exact root and nested definitions used when they started, even after updates or restarts.

## Changes

- Use `WorkflowDefinitionsStorage` as the authority for storage-backed dynamic workflow runs.
- Pin root and nested dynamic workflow definitions to each run.
- Persist pinned definitions in workflow run snapshots.
- Restore pinned definitions during resume and restart.
- Fail closed for legacy runs without a pinned revision.
- Keep code-defined nested workflows tied to the host deployment.
- Detect missing, inactive, and circular nested definitions.
- Serialize concurrent dynamic workflow resumes.
- Share revision-pinned runs by run ID.
- Classify dynamic revision and unsafe resume failures with stable `MastraError` instances.
- Update documentation and add a `@mastra/core` patch changeset.
- Add comprehensive regression coverage for revision refresh, pinning, restart, resume, and nested workflows.

## Validation

- Dynamic workflow revision tests
- Combined dynamic workflow suites
- Type checking
- Build validation
- Formatting
- Linting
- Diff checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->