### PR TITLE
fix(core): accept numeric strings for the tail param of the sandbox tools

### DIFF
--- a/.changeset/bright-lizards-speak.md
+++ b/.changeset/bright-lizards-speak.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the `tail` parameter of the workspace `execute_command` and `get_process_output` tools rejecting numeric strings. Models sometimes send number parameters as strings, for example `"10"` instead of `10`. The `timeout` parameter already tolerated this, but `tail` failed validation and the command never ran, wasting a turn. In observed cases the model then fabricated a success result instead of retrying. Numeric strings are now coerced to numbers for `tail` in both tools.

--- a/packages/core/src/workspace/tools/__tests__/sandbox-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/sandbox-tools.test.ts
@@ -213,6 +213,23 @@ describe('execute_command tool', () => {
         expect(result).toContain('line 500');
       });
 
+      it('accepts tail as a numeric string, like timeout', async () => {
+        const sandbox = createMockSandbox({
+          executeCommand: vi.fn().mockResolvedValue({
+            success: true,
+            exitCode: 0,
+            stdout: longOutput,
+            stderr: '',
+            executionTimeMs: 5,
+          }),
+        });
+        const ctx = createContext(sandbox);
+        const result = await executeCommandTool.execute({ command: 'seq 500', tail: '10' as any }, ctx);
+        expect(result).toContain('[showing last 10 of 500 lines]');
+        expect(result).toContain('line 491');
+        expect(result).toContain('line 500');
+      });
+
       it('tail applies to both stdout and stderr on failure', async () => {
         const longStderr = Array.from({ length: 50 }, (_, i) => `err ${i + 1}`).join('\n');
         const sandbox = createMockSandbox({
@@ -378,6 +395,25 @@ describe('get_process_output tool', () => {
     const ctx = createContext(sandbox);
     const result = await getProcessOutputTool.execute({ pid: 'session-abc' }, ctx);
     expect(result).toContain('string pid output');
+  });
+
+  it('accepts tail as a numeric string', async () => {
+    const handle = createMockHandle({
+      pid: '13',
+      stdout: Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join('\n'),
+      stderr: '',
+      exitCode: undefined,
+    });
+    const sandbox = createMockSandbox({
+      processes: {
+        get: vi.fn().mockResolvedValue(handle),
+      },
+    });
+    const ctx = createContext(sandbox);
+    const result = await getProcessOutputTool.execute({ pid: '13', tail: '5' as any }, ctx);
+    expect(result).toContain('[showing last 5 of 50 lines]');
+    expect(result).toContain('line 46');
+    expect(result).toContain('line 50');
   });
 
   it('returns output and exit code for already-exited process (no wait)', async () => {

--- a/packages/core/src/workspace/tools/execute-command.ts
+++ b/packages/core/src/workspace/tools/execute-command.ts
@@ -3,11 +3,9 @@ import { browserCliHandler } from '../../browser/cli-handler';
 import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { SandboxFeatureNotSupportedError } from '../errors';
-import { emitWorkspaceMetadata, requireSandbox } from './helpers';
+import { coerceNumericString, emitWorkspaceMetadata, requireSandbox } from './helpers';
 import { DEFAULT_TAIL_LINES, truncateOutput, sandboxToModelOutput } from './output-helpers';
 import { startWorkspaceSpan } from './tracing';
-
-const NUMERIC_TIMEOUT_STRING_REGEX = /^\d+(?:\.\d+)?$/;
 
 /**
  * Base input schema for execute_command (no background param).
@@ -18,18 +16,12 @@ export const executeCommandInputSchema = z.object({
     .string()
     .describe('The shell command to execute (e.g., "npm install", "ls -la src/", "cat file.txt | grep error")'),
   timeout: z
-    .preprocess(value => {
-      if (typeof value !== 'string') {
-        return value;
-      }
-      const trimmed = value.trim();
-      return NUMERIC_TIMEOUT_STRING_REGEX.test(trimmed) ? Number(trimmed) : value;
-    }, z.number())
+    .preprocess(coerceNumericString, z.number())
     .nullish()
     .describe('Maximum execution time in seconds. Example: 60 for 1 minute.'),
   cwd: z.string().nullish().describe('Working directory for the command'),
   tail: z
-    .number()
+    .preprocess(coerceNumericString, z.number())
     .nullish()
     .describe(
       `For foreground commands: limit output to the last N lines, similar to tail -n. Defaults to ${DEFAULT_TAIL_LINES}. Use 0 for no limit.`,

--- a/packages/core/src/workspace/tools/get-process-output.ts
+++ b/packages/core/src/workspace/tools/get-process-output.ts
@@ -2,7 +2,7 @@ import { z } from 'zod/v4';
 import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { SandboxFeatureNotSupportedError } from '../errors';
-import { emitWorkspaceMetadata, getDynamicSandboxCacheKeyHint, requireSandbox } from './helpers';
+import { coerceNumericString, emitWorkspaceMetadata, getDynamicSandboxCacheKeyHint, requireSandbox } from './helpers';
 import { DEFAULT_TAIL_LINES, truncateOutput, sandboxToModelOutput } from './output-helpers';
 import { startWorkspaceSpan } from './tracing';
 
@@ -16,7 +16,7 @@ Use this after starting a background command with execute_command (background: t
   inputSchema: z.object({
     pid: z.string().describe('The process ID returned when the background command was started'),
     tail: z
-      .number()
+      .preprocess(coerceNumericString, z.number())
       .optional()
       .describe(
         `Number of lines to return, similar to tail -n. Positive or negative returns last N lines from end. Defaults to ${DEFAULT_TAIL_LINES}. Use 0 for no limit.`,

--- a/packages/core/src/workspace/tools/helpers.ts
+++ b/packages/core/src/workspace/tools/helpers.ts
@@ -13,6 +13,22 @@ import type { LSPDiagnostic, DiagnosticSeverity } from '../lsp/types';
 import type { WorkspaceSandbox } from '../sandbox';
 import type { Workspace } from '../workspace';
 
+const NUMERIC_STRING_REGEX = /^-?\d+(?:\.\d+)?$/;
+
+/**
+ * Preprocessor for numeric tool params: models sometimes send numbers as
+ * strings (e.g. `"10"` instead of `10`), and a strict `z.number()` rejects
+ * the call outright. Coerce unambiguous numeric strings; anything else
+ * passes through unchanged so schema validation still reports it.
+ */
+export function coerceNumericString(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const trimmed = value.trim();
+  return NUMERIC_STRING_REGEX.test(trimmed) ? Number(trimmed) : value;
+}
+
 /**
  * Extract workspace from tool execution context.
  * Throws if workspace is not available.


### PR DESCRIPTION
## Description

Models sometimes send number params as JSON strings. The `timeout` param of `execute_command` already handles this with a preprocess that coerces numeric strings, but `tail` in the same schema (and in `get_process_output`) is a bare `z.number()`, so a call carrying `tail: "10"` is rejected before the command runs. In our eval runs this rejection happened in 2 of 5 runs for one model, and in one run the model then fabricated a successful result instead of retrying, so the strict schema turned an unambiguous value into a correctness failure.

The asymmetry, on current main:

`timeout` coerces numeric strings:
https://github.com/mastra-ai/mastra/blob/8e3f8a2fb9c17bf77ec6b5e3267090cef81fd66e/packages/core/src/workspace/tools/execute-command.ts#L20-L29

`tail` right below it is a bare `z.number()`:
https://github.com/mastra-ai/mastra/blob/8e3f8a2fb9c17bf77ec6b5e3267090cef81fd66e/packages/core/src/workspace/tools/execute-command.ts#L31-L36

`tail` in `get_process_output` is bare as well:
https://github.com/mastra-ai/mastra/blob/8e3f8a2fb9c17bf77ec6b5e3267090cef81fd66e/packages/core/src/workspace/tools/get-process-output.ts#L18-L23

Before:

```ts
await executeCommandTool.execute({ command: 'seq 500', tail: '10' }, ctx);
// rejected: tail: Invalid input: expected number, received string
```

After:

```ts
await executeCommandTool.execute({ command: 'seq 500', tail: '10' }, ctx);
// runs and returns the last 10 lines, same as tail: 10
```

The fix extracts the coercion `timeout` already used into a shared `coerceNumericString` helper and applies it to `tail` in both tools:

https://github.com/mastra-ai/mastra/blob/b1ed0f66f5b26895346c08bbde34e3a7e9d2b216/packages/core/src/workspace/tools/helpers.ts#L16-L30

Nonnumeric strings pass through untouched so normal schema errors still surface. Two new regression tests cover both tools, and the existing workspace suites stay green.

## Related issue(s)

Fixes #21492

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The sandbox tools now accept `"10"` for `tail` just like they accept `timeout` values. The tools convert numeric text to a number and still reject invalid text.

## Changes

- Added shared `coerceNumericString` helper.
- Applied numeric-string coercion to `tail` in:
  - `execute_command`
  - `get_process_output`
- Reused the helper for `timeout` in `execute_command`.
- Added regression tests for numeric-string `tail` values and output truncation.
- Added a patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
