### PR TITLE
Address CodeRabbit review on #21332: dedup metadata helpers, preserve non-plain metadata

### DIFF
--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -41,41 +41,8 @@ import { emitAutoExtractedMetrics, emitTokenMetricsForUsage } from '../metrics/a
 import { CardinalityFilter } from '../metrics/cardinality';
 import { resolveModelId } from '../model-id';
 import { NoOpSpan } from '../spans';
+import { isPlainRecord, mergeMetadata } from '../spans/metadata';
 import { addUsageStats } from '../usage';
-
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return false;
-  }
-
-  try {
-    const prototype = Object.getPrototypeOf(value);
-    return prototype === Object.prototype || prototype === null;
-  } catch {
-    return false;
-  }
-}
-
-function mergeMetadata(parentMetadata: unknown, metadata: unknown): Record<string, any> | undefined {
-  if (!parentMetadata) {
-    return metadata as Record<string, any> | undefined;
-  }
-  if (!metadata) {
-    return parentMetadata as Record<string, any> | undefined;
-  }
-  if (!isPlainRecord(parentMetadata) || !isPlainRecord(metadata)) {
-    return metadata as Record<string, any>;
-  }
-
-  try {
-    const merged: Record<string, unknown> = {};
-    Object.defineProperties(merged, Object.getOwnPropertyDescriptors(parentMetadata));
-    Object.defineProperties(merged, Object.getOwnPropertyDescriptors(metadata));
-    return merged;
-  } catch {
-    return metadata as Record<string, any>;
-  }
-}
 
 function hasMetadataKey(metadata: unknown, key: string): boolean {
   if (!metadata || typeof metadata !== 'object') {
@@ -95,6 +62,13 @@ function injectEnvironmentMetadata(
 ): Record<string, any> | undefined {
   if (environment === undefined || hasMetadataKey(metadata, 'environment')) {
     return metadata as Record<string, any> | undefined;
+  }
+
+  // Only plain records can be merged without losing the original value's shape.
+  // A Map, Date, or class instance would otherwise be replaced by `{ environment }`,
+  // discarding all user-provided metadata.
+  if (metadata && !isPlainRecord(metadata)) {
+    return metadata as Record<string, any>;
   }
 
   return mergeMetadata(metadata, { environment });

--- a/observability/mastra/src/spans/base.ts
+++ b/observability/mastra/src/spans/base.ts
@@ -20,6 +20,7 @@ import type {
 } from '@mastra/core/observability';
 
 import { ModelSpanTracker } from '../model-tracing';
+import { isPlainRecord, mergeMetadata as mergeSpanMetadata } from './metadata';
 import { deepClean, mergeSerializationOptions } from './serialization';
 import type { DeepCleanOptions } from './serialization';
 
@@ -71,40 +72,6 @@ function isSpanInternal(spanType: SpanType, flags?: InternalSpans): boolean {
     // Default: never internal
     default:
       return false;
-  }
-}
-
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return false;
-  }
-
-  try {
-    const prototype = Object.getPrototypeOf(value);
-    return prototype === Object.prototype || prototype === null;
-  } catch {
-    return false;
-  }
-}
-
-function mergeSpanMetadata(parentMetadata: unknown, metadata: unknown): unknown {
-  if (!parentMetadata) {
-    return metadata;
-  }
-  if (!metadata) {
-    return parentMetadata;
-  }
-  if (!isPlainRecord(parentMetadata) || !isPlainRecord(metadata)) {
-    return metadata;
-  }
-
-  try {
-    const merged: Record<string, unknown> = {};
-    Object.defineProperties(merged, Object.getOwnPropertyDescriptors(parentMetadata));
-    Object.defineProperties(merged, Object.getOwnPropertyDescriptors(metadata));
-    return merged;
-  } catch {
-    return metadata;
   }
 }
 

--- a/observability/mastra/src/spans/metadata.ts
+++ b/observability/mastra/src/spans/metadata.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared span-metadata helpers.
+ *
+ * Used by both the observability instance (`instances/base.ts`) and the span
+ * base class (`spans/base.ts`) so the plain-record check and the
+ * descriptor-preserving merge stay in a single place. Both feed the same span
+ * metadata pipeline, so keeping one implementation avoids divergence.
+ */
+
+/**
+ * Returns true only for plain object records (prototype is `Object.prototype`
+ * or `null`). Maps, Dates, class instances, and arrays return false so callers
+ * can preserve their original shape instead of shallow-copying them into `{}`.
+ */
+export function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  try {
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Merges two metadata values while preserving property descriptors (so getters
+ * are copied as accessors rather than eagerly invoked). Only plain records are
+ * merged; if either side is non-plain the second argument is returned as-is,
+ * matching the previous per-module behavior.
+ */
+export function mergeMetadata(parentMetadata: unknown, metadata: unknown): Record<string, any> | undefined {
+  if (!parentMetadata) {
+    return metadata as Record<string, any> | undefined;
+  }
+  if (!metadata) {
+    return parentMetadata as Record<string, any> | undefined;
+  }
+  if (!isPlainRecord(parentMetadata) || !isPlainRecord(metadata)) {
+    return metadata as Record<string, any>;
+  }
+
+  try {
+    const merged: Record<string, unknown> = {};
+    Object.defineProperties(merged, Object.getOwnPropertyDescriptors(parentMetadata));
+    Object.defineProperties(merged, Object.getOwnPropertyDescriptors(metadata));
+    return merged;
+  } catch {
+    return metadata as Record<string, any>;
+  }
+}

--- a/observability/mastra/src/tracing.test.ts
+++ b/observability/mastra/src/tracing.test.ts
@@ -2604,6 +2604,37 @@ describe('Tracing', () => {
       expect(span.getCorrelationContext().environment).toBe('production');
     });
 
+    it('preserves non-plain metadata instead of replacing it with the injected environment', () => {
+      const observability = new DefaultObservabilityInstance({
+        serviceName: 'test-service',
+        name: 'test',
+        exporters: [testExporter],
+      });
+
+      class SpanMetadata {
+        tenantId = 'tenant-1';
+        region = 'us-east-1';
+      }
+
+      observability.__setMastraEnvironment('production');
+
+      const span = observability.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'test-agent',
+        attributes: { agentId: 'agent-1' },
+        tracingOptions: { metadata: new SpanMetadata() },
+      });
+
+      // The class-instance metadata must not be discarded in favor of
+      // `{ environment: 'production' }`; user fields are retained.
+      expect(span.metadata).toMatchObject({
+        tenantId: 'tenant-1',
+        region: 'us-east-1',
+      });
+
+      span.end();
+    });
+
     it('lets per-span metadata.environment override the Mastra-pushed environment', () => {
       const observability = new DefaultObservabilityInstance({
         serviceName: 'test-service',


### PR DESCRIPTION
Follow-up to #21332 addressing the two unresolved CodeRabbit review comments. This PR targets the `esp/fix_deepclean` branch so it merges into the existing PR.

## Changes

**1. Deduplicate plain-record and metadata-merge helpers** ([comment](https://github.com/mastra-ai/mastra/pull/21332#discussion_r3782050582))

`isPlainRecord` and the descriptor-preserving metadata merge were defined identically in both `instances/base.ts` and `spans/base.ts`. Both copies feed the same span metadata pipeline, so any future fix had to be applied twice. Extracted them into a new shared internal module `observability/mastra/src/spans/metadata.ts` and imported them in both files, removing the two local copies.

**2. Preserve non-plain span metadata during environment injection** ([comment](https://github.com/mastra-ai/mastra/pull/21332#discussion_r3782050588))

`mergeMetadata` returns only its second argument when either side is not a plain record. `injectEnvironmentMetadata` called `mergeMetadata(metadata, { environment })`, so if a caller passed metadata as a `Map`, `Date`, or class instance while `#mastraEnvironment` was set, the root span metadata became `{ environment }` and all user metadata was lost. `hasMetadataKey` did not prevent this since a `Map` never has an own `environment` key.

Added a guard so non-plain metadata is returned unchanged instead of being replaced, and added a regression test that starts a root span with class-instance metadata while `__setMastraEnvironment` is set.

## Validation

- `pnpm turbo build --filter ./observability/mastra` — succeeds
- `pnpm --filter ./observability/mastra exec vitest run src/tracing.test.ts src/spans/base.test.ts` — 141 passed
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tky3a3XLacnrvJ7if8b3ox)_