### PR TITLE
fix(factory-ui): keep label search visible

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardRelevanceFilters.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardRelevanceFilters.msw.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BOARD_RELEVANCE_TYPES } from '../boardRelevance';
+import { BoardRelevanceFilters } from './BoardRelevanceFilters';
+
+function renderFilters() {
+  render(
+    <BoardRelevanceFilters
+      kind="work"
+      participants={[]}
+      selectedTypes={new Set(BOARD_RELEVANCE_TYPES)}
+      availableLabels={['bug', 'documentation', '@mastra/core']}
+      selectedLabels={new Set()}
+      onParticipantChange={vi.fn()}
+      onTypeChange={vi.fn()}
+      onLabelChange={vi.fn()}
+      onReset={vi.fn()}
+    />,
+  );
+}
+
+describe('BoardRelevanceFilters', () => {
+  describe('when a user searches the available labels', () => {
+    it('keeps the search focused and filters the selectable labels', async () => {
+      const user = userEvent.setup();
+      renderFilters();
+
+      await user.click(screen.getByRole('button', { name: 'Filter by labels' }));
+      const search = await screen.findByRole('searchbox', { name: 'Search labels' });
+      await user.click(search);
+      await user.type(search, 'core');
+
+      expect(search).toHaveFocus();
+      const menu = screen.getByRole('menu');
+      expect(within(menu).getByText('@mastra/core')).toBeInTheDocument();
+      expect(within(menu).queryByText('bug')).not.toBeInTheDocument();
+      expect(within(menu).queryByText('documentation')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardRelevanceFilters.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardRelevanceFilters.tsx
@@ -121,33 +121,38 @@ export function BoardRelevanceFilters({
             <span className="max-w-48 truncate">{labelButtonText}</span>
           </Button>
         </DropdownMenu.Trigger>
-        <DropdownMenu.Content align="start" className="max-h-80 min-w-56 overflow-y-auto">
-          <DropdownMenu.Label>Labels</DropdownMenu.Label>
-          <div className="px-2 pb-1">
-            <input
-              type="search"
-              value={labelSearch}
-              onChange={event => setLabelSearch(event.target.value)}
-              placeholder="Search labels..."
-              aria-label="Search labels"
-              className="border-border-1 bg-surface-3 focus:border-border-2 w-full rounded-md border px-2 py-1 text-xs outline-none"
-            />
-          </div>
-          {visibleLabels.length === 0 && (
-            <div className="text-icon3 px-3 py-1.5 text-xs">
-              {availableLabels.length === 0 ? 'No labels available.' : 'No labels match.'}
+        <DropdownMenu.Content align="start" className="flex max-h-80 min-w-56 flex-col overflow-hidden">
+          <div className="shrink-0">
+            <DropdownMenu.Label>Labels</DropdownMenu.Label>
+            <div className="px-2 pb-1">
+              <input
+                type="search"
+                value={labelSearch}
+                onChange={event => setLabelSearch(event.target.value)}
+                onKeyDown={event => event.stopPropagation()}
+                placeholder="Search labels..."
+                aria-label="Search labels"
+                className="border-border-1 bg-surface-3 focus:border-border-2 w-full rounded-md border px-2 py-1 text-xs outline-none"
+              />
             </div>
-          )}
-          {visibleLabels.map(label => (
-            <DropdownMenu.CheckboxItem
-              key={label}
-              checked={selectedLabels.has(label)}
-              onCheckedChange={checked => onLabelChange(label, checked === true)}
-              onSelect={event => event.preventDefault()}
-            >
-              {label}
-            </DropdownMenu.CheckboxItem>
-          ))}
+          </div>
+          <div className="min-h-0 overflow-y-auto">
+            {visibleLabels.length === 0 && (
+              <div className="text-icon3 px-3 py-1.5 text-xs">
+                {availableLabels.length === 0 ? 'No labels available.' : 'No labels match.'}
+              </div>
+            )}
+            {visibleLabels.map(label => (
+              <DropdownMenu.CheckboxItem
+                key={label}
+                checked={selectedLabels.has(label)}
+                onCheckedChange={checked => onLabelChange(label, checked === true)}
+                onSelect={event => event.preventDefault()}
+              >
+                {label}
+              </DropdownMenu.CheckboxItem>
+            ))}
+          </div>
         </DropdownMenu.Content>
       </DropdownMenu>
 


### PR DESCRIPTION
The Factory label filter currently lets dropdown keyboard navigation intercept search input, and the search field shares the result list's scrolling area. Typing can scroll the search field out of view and make filtering appear broken.

This keeps keyboard events from reaching dropdown typeahead, pins the search controls above a separately scrolling result list, and adds interaction coverage that verifies focus and filtered results.

Test plan:
- Run the focused BoardRelevanceFilters MSW interaction test
- Run Factory UI typecheck
- Build Factory UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The label search stays available while users filter labels. The search field keeps focus, and only matching labels appear in the scrollable results list.

## Changes

- Separated the label search area from the scrollable label results list.
- Prevented dropdown keyboard events from intercepting search input events.
- Kept empty-state messages inside the label results list.
- Added interaction coverage for search focus and filtered results.

## Test Plan

- Run the focused `BoardRelevanceFilters` MSW interaction test.
- Run the Factory UI typecheck.
- Run the Factory UI build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->