### PR TITLE
feat(playground-ui): show task progress as a strip of bars in the header

### DIFF
--- a/.changeset/wise-worms-take.md
+++ b/.changeset/wise-worms-take.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Replaced the task list's progress bar and "2/4 completed" label with a compact status strip in the header. One bar per task, colored by state (green completed, orange in progress, grey pending), with the exact count on hover. Frees the vertical space the progress bar used to take.

--- a/.changeset/wise-worms-take.md
+++ b/.changeset/wise-worms-take.md
@@ -3,3 +3,20 @@
 ---
 
 Replaced the task list's progress bar and "2/4 completed" label with a compact status strip in the header. One bar per task, colored by state (green completed, orange in progress, grey pending), with the exact count on hover. Frees the vertical space the progress bar used to take.
+
+`<TaskList>` is unchanged, but the strip now derives everything from the tasks, so `TaskListCount` is gone and `TaskListProgress` takes the tasks instead of a completed/total pair:
+
+```tsx
+const tasks = [
+  { id: '1', content: 'Inspect code', activeForm: 'Inspecting code', status: 'completed' },
+  { id: '2', content: 'Add tests', activeForm: 'Adding tests', status: 'in_progress' },
+  { id: '3', content: 'Build package', activeForm: 'Building package', status: 'pending' },
+];
+
+// Before
+<TaskListCount completed={1} total={3} />
+<TaskListProgress completed={1} total={3} />
+
+// After
+<TaskListProgress tasks={tasks} />
+```

--- a/.changeset/wise-worms-take.md
+++ b/.changeset/wise-worms-take.md
@@ -1,10 +1,12 @@
 ---
-'@mastra/playground-ui': patch
+'@mastra/playground-ui': minor
 ---
 
 Replaced the task list's progress bar and "2/4 completed" label with a compact status strip in the header. One bar per task, colored by state (green completed, orange in progress, grey pending), with the exact count on hover. Frees the vertical space the progress bar used to take.
 
-`<TaskList>` is unchanged, but the strip now derives everything from the tasks, so `TaskListCount` is gone and `TaskListProgress` takes the tasks instead of a completed/total pair:
+`<TaskList>` is unchanged. The strip now derives everything from the tasks, so `TaskListCount` and `TaskListCountProps` are removed, and `TaskListProgress` takes the tasks instead of a completed/total pair. Both were reachable from `@mastra/playground-ui/components/ai/task-list`.
+
+There is no replacement for `TaskListCount` — the count lives in the strip's tooltip. Callers of `TaskListProgress` pass the tasks they already render:
 
 ```tsx
 const tasks = [

--- a/packages/playground-ui/src/ds/components/ai/task-list/task-list.test.tsx
+++ b/packages/playground-ui/src/ds/components/ai/task-list/task-list.test.tsx
@@ -20,17 +20,21 @@ describe('TaskList', () => {
   });
 
   describe('when tasks have mixed statuses', () => {
-    it('renders the completion count', () => {
-      render(<TaskList tasks={mixedTasks} />);
-
-      expect(screen.getByText('1/3 completed')).toBeTruthy();
-    });
-
     it('renders progress for the completed tasks', () => {
       render(<TaskList tasks={mixedTasks} />);
 
       expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('1');
       expect(screen.getByRole('progressbar').getAttribute('aria-valuemax')).toBe('3');
+    });
+
+    it('renders one progress bar per task, colored by status', () => {
+      render(<TaskList tasks={mixedTasks} />);
+
+      const bars = Array.from(screen.getByRole('progressbar').children).map(bar => bar.className);
+      expect(bars).toHaveLength(3);
+      expect(bars[0]).toContain('bg-positive1');
+      expect(bars[1]).toContain('bg-warning1');
+      expect(bars[2]).toContain('bg-surface6');
     });
 
     it('renders the active form instead of the task content', () => {
@@ -73,13 +77,13 @@ describe('TaskList', () => {
   describe('when the list is collapsed', () => {
     const collapse = () => fireEvent.click(screen.getByRole('button'));
 
-    it('hides the tasks while keeping the completion count', () => {
+    it('hides the tasks while keeping the progress bars', () => {
       render(<TaskList tasks={mixedTasks} />);
       collapse();
 
       expect(screen.queryByText('Inspect code')).toBeNull();
       expect(screen.queryByText('Build package')).toBeNull();
-      expect(screen.getByText('1/3 completed')).toBeTruthy();
+      expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('1');
     });
 
     it('summarizes the active task in place of the title', () => {
@@ -134,18 +138,18 @@ describe('TaskList', () => {
   });
 
   describe('when empty lists are configured to remain visible', () => {
-    it('renders an empty completion count', () => {
+    it('renders no progress bar', () => {
       render(<TaskList tasks={[]} hideWhenEmpty={false} />);
 
-      expect(screen.getByText('0/0 completed')).toBeTruthy();
+      expect(screen.getByRole('progressbar').children).toHaveLength(0);
     });
   });
 
   describe('when completed lists are configured to remain visible', () => {
-    it('renders the completed task count', () => {
+    it('renders every bar as completed', () => {
       render(<TaskList tasks={completedTasks} hideWhenComplete={false} />);
 
-      expect(screen.getByText('3/3 completed')).toBeTruthy();
+      expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('3');
     });
   });
 });

--- a/packages/playground-ui/src/ds/components/ai/task-list/task-list.test.tsx
+++ b/packages/playground-ui/src/ds/components/ai/task-list/task-list.test.tsx
@@ -37,6 +37,14 @@ describe('TaskList', () => {
       expect(bars[2]).toContain('bg-surface6');
     });
 
+    it('reveals the exact count on hover', async () => {
+      render(<TaskList tasks={mixedTasks} />);
+
+      fireEvent.mouseEnter(screen.getByRole('progressbar'));
+
+      expect((await screen.findByRole('tooltip')).textContent).toBe('1/3 completed');
+    });
+
     it('renders the active form instead of the task content', () => {
       render(<TaskList tasks={mixedTasks} />);
 
@@ -83,6 +91,7 @@ describe('TaskList', () => {
 
       expect(screen.queryByText('Inspect code')).toBeNull();
       expect(screen.queryByText('Build package')).toBeNull();
+      expect(screen.getByRole('progressbar').children).toHaveLength(3);
       expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('1');
     });
 

--- a/packages/playground-ui/src/ds/components/ai/task-list/task-list.tsx
+++ b/packages/playground-ui/src/ds/components/ai/task-list/task-list.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import type { ComponentProps, ReactNode } from 'react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/ds/components/Collapsible';
 import { ScrollArea } from '@/ds/components/ScrollArea';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/ds/components/Tooltip';
 import { cn } from '@/lib/utils';
 
 export type TaskListItem = TaskItem;
@@ -19,43 +20,50 @@ export const TaskListHeader = ({ className, ...props }: ComponentProps<typeof Co
   />
 );
 
-export interface TaskListCountProps extends ComponentProps<'span'> {
-  completed: number;
-  total: number;
+const barColors: Record<TaskListItem['status'], string> = {
+  completed: 'bg-positive1',
+  in_progress: 'bg-warning1',
+  pending: 'bg-surface6',
+};
+
+export interface TaskListProgressProps extends Omit<ComponentProps<'span'>, 'children'> {
+  tasks: TaskListItem[];
 }
 
-export const TaskListCount = ({ completed, total, className, ...props }: TaskListCountProps) => (
-  <span className={cn('ml-auto shrink-0 text-ui-xs text-neutral4 tabular-nums', className)} {...props}>
-    {completed}/{total} completed
-  </span>
-);
-
-export interface TaskListProgressProps extends Omit<ComponentProps<'div'>, 'children'> {
-  completed: number;
-  total: number;
-}
-
-export const TaskListProgress = ({ completed, total, className, ...props }: TaskListProgressProps) => {
-  const percentage = total === 0 ? 0 : (completed / total) * 100;
+export const TaskListProgress = ({ tasks, className, ...props }: TaskListProgressProps) => {
+  const completed = tasks.filter(task => task.status === 'completed').length;
   return (
-    <div
-      role="progressbar"
-      aria-label="Task completion"
-      aria-valuemin={0}
-      aria-valuemax={total}
-      aria-valuenow={completed}
-      className={cn('mt-2 mb-2.5 h-1 w-full rounded-full bg-surface4', className)}
-      {...props}
-    >
-      <div className="bg-accent6 h-full rounded-full transition-all duration-300" style={{ width: `${percentage}%` }} />
-    </div>
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span
+              role="progressbar"
+              aria-label="Task completion"
+              aria-valuemin={0}
+              aria-valuemax={tasks.length}
+              aria-valuenow={completed}
+              className={cn('ml-auto flex h-4 w-fit max-w-40 shrink-0 items-center gap-1 overflow-hidden', className)}
+              {...props}
+            >
+              {tasks.map(task => (
+                <span key={task.id} className={cn('h-full w-1 min-w-px shrink rounded-full', barColors[task.status])} />
+              ))}
+            </span>
+          }
+        />
+        <TooltipContent>
+          {completed}/{tasks.length} completed
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };
 
 const icons: Record<TaskListItem['status'], ReactNode> = {
-  completed: <CheckCircle2 className="text-positive1 size-3.5 shrink-0" />,
-  in_progress: <Loader2 className="text-warning1 size-3.5 shrink-0 motion-safe:animate-spin" />,
-  pending: <Circle className="text-neutral4 size-3.5 shrink-0" />,
+  completed: <CheckCircle2 className="size-3.5 shrink-0 text-positive1" />,
+  in_progress: <Loader2 className="size-3.5 shrink-0 text-warning1 motion-safe:animate-spin" />,
+  pending: <Circle className="size-3.5 shrink-0 text-neutral4" />,
 };
 
 const statusLabels: Record<TaskListItem['status'], string> = {
@@ -102,8 +110,8 @@ const TaskListSummary = ({ task }: { task: TaskListItem }) => (
 
 const TaskListTitle = ({ title }: { title: ReactNode }) => (
   <span className="flex min-w-0 flex-1 items-center gap-2">
-    <ListChecks className="text-accent6 size-4 shrink-0" />
-    <span className="text-ui-sm leading-ui-sm text-neutral6 truncate font-medium">{title}</span>
+    <ListChecks className="size-4 shrink-0 text-accent6" />
+    <span className="truncate text-ui-sm leading-ui-sm font-medium text-neutral6">{title}</span>
   </span>
 );
 
@@ -143,11 +151,10 @@ export const TaskList = ({
         <TaskListHeader>
           <ChevronRight className="size-3.5 shrink-0" />
           {open || !summaryTask ? <TaskListTitle title={title} /> : <TaskListSummary task={summaryTask} />}
-          <TaskListCount completed={completed} total={total} />
+          <TaskListProgress tasks={tasks} />
         </TaskListHeader>
         <CollapsibleContent>
-          <TaskListProgress completed={completed} total={total} />
-          <ScrollArea maxHeight="8rem" viewPortClassName="pr-1">
+          <ScrollArea maxHeight="8rem" viewPortClassName="pr-1" className="mt-1">
             <ul className="space-y-1">
               {tasks.map(task => (
                 <TaskListRow

--- a/packages/playground-ui/src/ds/components/ai/task-list/task-list.tsx
+++ b/packages/playground-ui/src/ds/components/ai/task-list/task-list.tsx
@@ -61,9 +61,9 @@ export const TaskListProgress = ({ tasks, className, ...props }: TaskListProgres
 };
 
 const icons: Record<TaskListItem['status'], ReactNode> = {
-  completed: <CheckCircle2 className="size-3.5 shrink-0 text-positive1" />,
-  in_progress: <Loader2 className="size-3.5 shrink-0 text-warning1 motion-safe:animate-spin" />,
-  pending: <Circle className="size-3.5 shrink-0 text-neutral4" />,
+  completed: <CheckCircle2 className="text-positive1 size-3.5 shrink-0" />,
+  in_progress: <Loader2 className="text-warning1 size-3.5 shrink-0 motion-safe:animate-spin" />,
+  pending: <Circle className="text-neutral4 size-3.5 shrink-0" />,
 };
 
 const statusLabels: Record<TaskListItem['status'], string> = {
@@ -110,8 +110,8 @@ const TaskListSummary = ({ task }: { task: TaskListItem }) => (
 
 const TaskListTitle = ({ title }: { title: ReactNode }) => (
   <span className="flex min-w-0 flex-1 items-center gap-2">
-    <ListChecks className="size-4 shrink-0 text-accent6" />
-    <span className="truncate text-ui-sm leading-ui-sm font-medium text-neutral6">{title}</span>
+    <ListChecks className="text-accent6 size-4 shrink-0" />
+    <span className="text-ui-sm leading-ui-sm text-neutral6 truncate font-medium">{title}</span>
   </span>
 );
 

--- a/packages/playground-ui/src/ds/components/ai/task-list/task-list.tsx
+++ b/packages/playground-ui/src/ds/components/ai/task-list/task-list.tsx
@@ -47,7 +47,10 @@ export const TaskListProgress = ({ tasks, className, ...props }: TaskListProgres
               {...props}
             >
               {tasks.map(task => (
-                <span key={task.id} className={cn('h-full w-1 min-w-px shrink rounded-full', barColors[task.status])} />
+                <span
+                  key={task.id}
+                  className={cn('h-full w-0.5 min-w-px shrink rounded-full', barColors[task.status])}
+                />
               ))}
             </span>
           }


### PR DESCRIPTION
The task list no longer spends a whole row on a progress bar, and no longer shows the raw "2/4 completed" count.

Before, the header carried a `2/4 completed` label and, once expanded, a full-width bar sat between the header and the tasks — a row of vertical space to say something the list itself already showed. Now the top-right of the header holds one small bar per task, colored by state: green for completed, orange for in progress, grey for pending. It reads as a count and as progress at the same time, and it stays visible when the list is collapsed. Hovering it shows the exact `2/4 completed`, instantly — the tooltip is the precise number, the strip is the glance.

The strip is `w-fit` with a `max-w-40` cap and bars that shrink before they clip, so a long list narrows instead of pushing the title around. I kept `role="progressbar"` with `aria-valuenow`/`aria-valuemax` on the strip so screen readers still get the count, and rendered the trigger as a `span` so the header stays a single button. `TaskListCount` is gone and `TaskListProgress` now takes the tasks directly; nothing outside this file consumed either.

One trap worth writing down: two-decimal spacing utilities (`gap-0.75`, `basis-1.25`) generate no CSS in playground-ui, because `theme.css` resets `--spacing-*` and only redeclares integer keys. My first pass used them and the bars silently rendered 1px wide with no gap. Integer steps only here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The task list now uses small colored bars to show progress. The bars remain visible when the list is collapsed, and hovering shows the exact completion count.

## Changes

- Replaced the `2/4 completed` label and full-width progress bar with a compact segmented status strip.
- Colored segments by task state:
  - Green for completed tasks.
  - Orange for in-progress tasks.
  - Grey for pending tasks.
- Added hover text with the completed-task count.
- Constrained the strip with `w-fit` and `max-w-40`.
- Preserved accessibility with `role="progressbar"`, `aria-valuenow`, and `aria-valuemax`.
- Kept the strip visible in the collapsed task-list header.
- Rendered the trigger as a `span` so the header remains one button.
- Updated `TaskListProgress` to receive `tasks` directly.
- Removed `TaskListCount`.
- Set status bars to 2px thickness.
- Used integer spacing utilities supported by `playground-ui`.
- Added tests for task states, hover counts, collapsed lists, empty lists, and fully completed lists.
- Added a minor changeset for `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->