### PR TITLE
fix(editor): retain Composio-supplied output schemas so tool results are validated

### DIFF
--- a/.changeset/chubby-ways-fly.md
+++ b/.changeset/chubby-ways-fly.md
@@ -1,0 +1,5 @@
+---
+'@mastra/editor': patch
+---
+
+Fixed Composio tool results not being validated. Resolved Composio tools now keep the output schema supplied by Composio, so tool results are checked against it: real API responses (including null or extra fields) still pass, while structurally invalid output is rejected instead of being silently returned. This also lets Composio tools be used with APIs that require an output schema, like createStep(tool).

--- a/packages/editor/src/providers/composio-output-validation.test.ts
+++ b/packages/editor/src/providers/composio-output-validation.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { MastraProvider } from '@composio/mastra';
+import type { Tool } from '@mastra/core/tools';
+
+/**
+ * Regression tests for retaining Composio-supplied output schemas.
+ *
+ * `ComposioToolProvider` used to clear `outputSchema` on every resolved tool
+ * because early `@composio/mastra` versions passed Composio's strict API
+ * schemas straight through and real third-party responses failed validation.
+ * Current `@composio/mastra` relaxes the schema (nullable fields, extra
+ * properties allowed, `required` dropped) before converting it, so the schema
+ * can be kept: lenient enough for real payloads, while still rejecting
+ * structurally invalid output.
+ *
+ * These tests use the real `MastraProvider.wrapTool()` and the real
+ * `Tool.execute()` validation pipeline — no mocks, no network.
+ */
+
+// A strict Composio-style tool definition: required fields everywhere,
+// `additionalProperties: false`, non-nullable primitives.
+const strictComposioTool = {
+  slug: 'TEST_LIST_ITEMS',
+  name: 'Test list items',
+  description: 'Lists items',
+  toolkit: { slug: 'test', name: 'Test' },
+  inputParameters: {
+    type: 'object',
+    properties: { owner: { type: 'string' } },
+    required: ['owner'],
+    additionalProperties: false,
+  },
+  outputParameters: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['data', 'error', 'successful'],
+    properties: {
+      data: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['items'],
+        properties: {
+          items: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: ['name', 'assignee'],
+              properties: {
+                name: { type: 'string' },
+                assignee: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+      error: { type: 'string' },
+      successful: { type: 'boolean' },
+    },
+  },
+};
+
+function wrapWithResponse(response: unknown): Tool<any, any> {
+  const provider = new MastraProvider();
+  return (
+    provider as unknown as {
+      wrapTool: (tool: unknown, exec: (...args: unknown[]) => Promise<unknown>) => Tool<any, any>;
+    }
+  ).wrapTool(strictComposioTool, async () => response);
+}
+
+describe('Composio output schema retention', () => {
+  it('wrapTool supplies a Standard Schema outputSchema', () => {
+    const tool = wrapWithResponse({});
+    expect(tool.outputSchema).toBeDefined();
+    expect(tool.outputSchema && '~standard' in tool.outputSchema).toBe(true);
+  });
+
+  it('accepts a realistic lenient success response (nulls, missing and extra fields)', async () => {
+    const response = {
+      data: {
+        items: [
+          // extra property + null for a "required" non-nullable field
+          { name: 'one', assignee: null, extra_field: 42 },
+          // missing "required" field entirely
+          { name: 'two' },
+        ],
+      },
+      error: null,
+      successful: true,
+      // extra top-level key real APIs sometimes add
+      logId: 'log_123',
+    };
+
+    const tool = wrapWithResponse(response);
+    const result = await tool.execute!({ owner: 'mastra-ai' }, undefined as never);
+
+    expect(result).toEqual(response);
+  });
+
+  it('accepts the failure envelope', async () => {
+    const response = { data: {}, error: 'boom', successful: false };
+
+    const tool = wrapWithResponse(response);
+    const result = await tool.execute!({ owner: 'mastra-ai' }, undefined as never);
+
+    expect(result).toEqual(response);
+  });
+
+  it('rejects structurally invalid output', async () => {
+    const tool = wrapWithResponse(42);
+    const result = (await tool.execute!({ owner: 'mastra-ai' }, undefined as never)) as {
+      error?: boolean;
+      message?: string;
+    };
+
+    expect(result.error).toBe(true);
+    expect(result.message).toContain('Tool output validation failed');
+  });
+
+  it('rejects wrongly typed envelope fields', async () => {
+    const tool = wrapWithResponse({ data: 'not-an-object', error: 123, successful: 'yes' });
+    const result = (await tool.execute!({ owner: 'mastra-ai' }, undefined as never)) as {
+      error?: boolean;
+      message?: string;
+    };
+
+    expect(result.error).toBe(true);
+    expect(result.message).toContain('Tool output validation failed');
+  });
+});

--- a/packages/editor/src/providers/composio.test.ts
+++ b/packages/editor/src/providers/composio.test.ts
@@ -211,7 +211,7 @@ describe('ComposioToolProvider — resolveTools', () => {
     expect(composioInstances.length).toBe(0);
   });
 
-  it('injects connectedAccountId via beforeExecute, clears outputSchema, applies description override', async () => {
+  it('injects connectedAccountId via beforeExecute, retains outputSchema, applies description override', async () => {
     const integration = new ComposioToolProvider({ apiKey: 'k' });
 
     await integration
@@ -220,10 +220,11 @@ describe('ComposioToolProvider — resolveTools', () => {
     const mastra = getMastraInstance();
     mastra.tools.get.mockClear();
 
+    const outputSchema = { type: 'object' } as unknown;
     const tool = {
       id: 'gmail.fetch_emails',
       description: 'original',
-      outputSchema: { not: 'undefined' } as unknown,
+      outputSchema,
     };
     mastra.tools.get.mockResolvedValue({ 'gmail.fetch_emails': tool });
 
@@ -235,7 +236,9 @@ describe('ComposioToolProvider — resolveTools', () => {
     });
 
     expect(Object.keys(result)).toEqual(['gmail.fetch_emails']);
-    expect((result['gmail.fetch_emails'] as unknown as typeof tool).outputSchema).toBeUndefined();
+    // The outputSchema supplied by @composio/mastra is kept: it pre-relaxes
+    // Composio's strict schemas, so Mastra can validate results against it.
+    expect((result['gmail.fetch_emails'] as unknown as typeof tool).outputSchema).toBe(outputSchema);
     expect((result['gmail.fetch_emails'] as unknown as typeof tool).description).toBe('overridden');
 
     // beforeExecute modifier was passed and injects connectionId.
@@ -372,7 +375,9 @@ describe('ComposioToolProvider — resolveTools', () => {
     });
     expect(sessionTools).toHaveBeenCalledOnce();
     expect(Object.keys(result)).toEqual(['COMPOSIO_MANAGE_CONNECTIONS']);
-    expect((result.COMPOSIO_MANAGE_CONNECTIONS as unknown as typeof manageTool).outputSchema).toBeUndefined();
+    expect((result.COMPOSIO_MANAGE_CONNECTIONS as unknown as typeof manageTool).outputSchema).toEqual({
+      type: 'object',
+    });
   });
 
   it('creates distinct sessions for two callers using the same provider', async () => {
@@ -449,8 +454,8 @@ describe('ComposioToolProvider — resolveTools', () => {
       sandbox: { enable: false },
     });
     expect(Object.keys(result)).toEqual(['GMAIL_FETCH_EMAILS', 'COMPOSIO_WAIT_FOR_CONNECTIONS']);
-    expect(gmailTool).toMatchObject({ description: 'gmail override', outputSchema: undefined });
-    expect(waitTool).toMatchObject({ description: 'wait override', outputSchema: undefined });
+    expect(gmailTool).toMatchObject({ description: 'gmail override', outputSchema: {} });
+    expect(waitTool).toMatchObject({ description: 'wait override', outputSchema: {} });
 
     const modifiers = mastra.tools.get.mock.calls[0]![2] as {
       beforeExecute: (a: { params: { connectedAccountId?: string } }) => unknown;

--- a/packages/editor/src/providers/composio.ts
+++ b/packages/editor/src/providers/composio.ts
@@ -44,8 +44,10 @@ const COMPOSIO_CONNECTION_MANAGEMENT_TOOLS = new Set(['COMPOSIO_MANAGE_CONNECTIO
  * client. Runtime (`resolveToolsVNext`) uses {@link MastraProvider} so resolved
  * tools are already in `createTool()` shape. Ordinary tools use Composio's
  * direct-tools API, while connection-management tools use a caller-scoped
- * Tool Router session. `outputSchema` is cleared because Composio returns
- * union schemas that Mastra's runtime rejects.
+ * Tool Router session. Resolved tools keep the `outputSchema` supplied by
+ * `@composio/mastra`, which pre-relaxes Composio's strict API schemas
+ * (nullable fields, extra properties, no `required`) so real third-party
+ * responses validate while structurally invalid output is still rejected.
  *
  * Allowlist filtering is layered by {@link BaseToolProvider}; this class
  * never reads `allowedToolkits` / `allowedTools` directly.
@@ -235,16 +237,6 @@ export class ComposioToolProvider extends BaseToolProvider {
     for (const [key, tool] of Object.entries(mastraTools)) {
       if (!tool) continue;
       const slug = (tool as { id?: string }).id ?? key;
-
-      // Composio returns union output schemas (`successful: true | false`) that
-      // Mastra's runtime cannot validate; clearing avoids per-tool validation
-      // errors at execute time. The property may be non-writable on some SDK
-      // versions, so we swallow assignment errors.
-      try {
-        (tool as unknown as { outputSchema: unknown }).outputSchema = undefined;
-      } catch {
-        // ignore
-      }
 
       const descOverride = opts.toolMeta?.[slug]?.description;
       if (descOverride) {


### PR DESCRIPTION
ComposioToolProvider has been clearing `outputSchema` on every tool it resolves. That workaround dates back to when Composio returned union-style JSON Schemas that Mastra's schema conversion rejected — but `@composio/mastra@0.10.2` now ships a `relax-output-schema` layer that normalizes those schemas before we ever see them. So the workaround was only costing us: Composio tool results were never validated, and `createStepFromTool()` rejected Composio tools for missing an output schema.

Before:

```ts
const tools = await provider.resolveToolsVNext({ toolSlugs: ['GITHUB_LIST_REPOSITORY_ISSUES'], ... });
tools.GITHUB_LIST_REPOSITORY_ISSUES.outputSchema; // undefined — results never validated
```

After:

```ts
tools.GITHUB_LIST_REPOSITORY_ISSUES.outputSchema; // Composio-supplied schema, enforced by Tool.execute()
```

The change deletes the `outputSchema = undefined` mutation, flips the existing tests to assert retention, and adds a regression test file that runs real `@composio/mastra`-wrapped tools through the `Tool.execute()` validation pipeline (valid envelopes pass, structurally invalid output is rejected, union/nullable branches are tolerated).

Verified with the full editor test suite (518 passing), typecheck, and a live end-to-end run against the Composio API where a workflow executed `GITHUB_LIST_REPOSITORY_ISSUES` and the 30-issue response passed output validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Composio tools now keep the instructions that describe their results. This lets Mastra check tool results and use Composio tools with `createStepFromTool()`.

## Changes

- Preserve Composio-provided `outputSchema` values.
- Document that `@composio/mastra` supplies pre-relaxed schemas.
- Add tests for valid, invalid, union, nullable, and session-resolved tool outputs.
- Add a patch changeset for `@mastra/editor`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->