### PR TITLE
fix(core): detect workflow tool steps via the shared tool marker

### DIFF
--- a/.changeset/perky-roses-joke.md
+++ b/.changeset/perky-roses-joke.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed createStep() and workflow step detection not recognizing tool copies. Tools that lose their class prototype — for example provider tools renamed by tool-provider resolution, or tools loaded twice in Vite SSR — are now detected via the shared tool marker, so createStep(tool) builds a proper tool step instead of misinterpreting the tool as a custom step and passing the wrong arguments to it. This applies to both the default createStep and the one exported from @mastra/core/workflows/evented.
+Fixed `createStep(tool)` sometimes misinterpreting a tool as a custom step. Copied or renamed tools — such as tools resolved through a tool provider — are now correctly detected and build a proper tool step. This applies to both the default `createStep` and the one exported from `@mastra/core/workflows/evented`.

--- a/.changeset/perky-roses-joke.md
+++ b/.changeset/perky-roses-joke.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed createStep() and workflow step detection not recognizing tool copies. Tools that lose their class prototype — for example provider tools renamed by tool-provider resolution, or tools loaded twice in Vite SSR — are now detected via the shared tool marker, so createStep(tool) builds a proper tool step instead of misinterpreting the tool as a custom step and passing the wrong arguments to it.
+Fixed createStep() and workflow step detection not recognizing tool copies. Tools that lose their class prototype — for example provider tools renamed by tool-provider resolution, or tools loaded twice in Vite SSR — are now detected via the shared tool marker, so createStep(tool) builds a proper tool step instead of misinterpreting the tool as a custom step and passing the wrong arguments to it. This applies to both the default createStep and the one exported from @mastra/core/workflows/evented.

--- a/.changeset/perky-roses-joke.md
+++ b/.changeset/perky-roses-joke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed createStep() and workflow step detection not recognizing tool copies. Tools that lose their class prototype — for example provider tools renamed by tool-provider resolution, or tools loaded twice in Vite SSR — are now detected via the shared tool marker, so createStep(tool) builds a proper tool step instead of misinterpreting the tool as a custom step and passing the wrong arguments to it.

--- a/packages/core/src/workflows/__tests__/declarative-step-entries.test.ts
+++ b/packages/core/src/workflows/__tests__/declarative-step-entries.test.ts
@@ -15,6 +15,7 @@ import { InMemoryStore } from '../../storage';
 import { createTool } from '../../tools';
 import { createWorkflow } from '../create';
 import { DefaultExecutionEngine } from '../default';
+import { createStep as createEventedStep } from '../evented/workflow';
 import type { SerializedStepFlowEntry } from '../types';
 import { getSingleStepEntryId, getStepIds, isSingleStepEntry } from '../utils';
 import { createStep } from '../workflow';
@@ -145,6 +146,21 @@ describe('declarative step entries - construction & serialized graph shape', () 
     const entry = wf.serializedStepGraph[0] as Extract<SerializedStepFlowEntry, { type: 'tool' }>;
     expect(entry.type).toBe('tool');
     expect(entry.id).toBe('renamed-double');
+  });
+
+  it('the evented module createStep() also detects spread-copied tools', async () => {
+    // `@mastra/core/workflows/evented` exports its own `createStep` with a
+    // duplicate set of guards, so it needs the same marker-based detection.
+    const spreadCopy = { ...doubleTool, id: 'evented-renamed-double' } as unknown as typeof doubleTool;
+    const step = createEventedStep(spreadCopy);
+
+    expect(step.component).toBe('TOOL');
+    expect(step.id).toBe('evented-renamed-double');
+
+    // Without marker detection this falls through to the StepParams branch,
+    // whose execute hands the whole params object to the tool as its input.
+    const output = await step.execute({ inputData: { value: 5 } } as any);
+    expect(output).toEqual({ doubled: 10 });
   });
 
   it('agent/tool nested in .parallel() serialize as declarative child entries', () => {

--- a/packages/core/src/workflows/__tests__/declarative-step-entries.test.ts
+++ b/packages/core/src/workflows/__tests__/declarative-step-entries.test.ts
@@ -130,6 +130,23 @@ describe('declarative step entries - construction & serialized graph shape', () 
     expect(wf.serializedStepGraph[0]!.type).toBe('tool');
   });
 
+  it('.then(createStep(tool)) detects spread-copied tools via the marker symbol', () => {
+    // `resolveStoredToolProviders` renames tools with `{ ...tool, id }`, which
+    // loses the Tool prototype; the shared marker symbol must still be honored.
+    const spreadCopy = { ...doubleTool, id: 'renamed-double' } as unknown as typeof doubleTool;
+    const wf = createWorkflow({
+      id: 'wf-then-spread-tool',
+      inputSchema: z.object({ value: z.number() }),
+      outputSchema: z.any(),
+    })
+      .then(createStep(spreadCopy))
+      .commit();
+
+    const entry = wf.serializedStepGraph[0] as Extract<SerializedStepFlowEntry, { type: 'tool' }>;
+    expect(entry.type).toBe('tool');
+    expect(entry.id).toBe('renamed-double');
+  });
+
   it('agent/tool nested in .parallel() serialize as declarative child entries', () => {
     const agent = textAgent('par-agent', 'hi');
     const wf = createWorkflow({
@@ -256,6 +273,28 @@ describe.each(ENGINES)('declarative step runtime ($name engine)', ({ evented }) 
     expect(result.status).toBe('success');
     if (result.status === 'success') {
       expect((result.steps['double-tool'] as any).output).toEqual({ doubled: 10 });
+    }
+  });
+
+  it('createStep() of a spread-copied tool executes with (inputData, context)', async () => {
+    // Without marker-based detection the spread copy falls through to the
+    // StepParams branch, whose execute passes the whole params object as the
+    // tool input — the tool then fails input validation.
+    const spreadCopy = { ...doubleTool, id: 'renamed-double' } as unknown as typeof doubleTool;
+    const wf = createWorkflow({
+      id: 'rt-spread-tool',
+      inputSchema: z.object({ value: z.number() }),
+      outputSchema: z.any(),
+    })
+      .then(createStep(spreadCopy))
+      .commit();
+    bind(wf);
+
+    const run = await wf.createRun();
+    const result = await run.start({ inputData: { value: 5 } });
+    expect(result.status).toBe('success');
+    if (result.status === 'success') {
+      expect((result.steps['renamed-double'] as any).output).toEqual({ doubled: 10 });
     }
   });
 

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -47,7 +47,8 @@ import type { InferPublicSchema, InferStandardSchemaOutput, PublicSchema, Standa
 import { WorkflowRunOutput } from '../../stream/RunOutput';
 import type { ChunkType, LanguageModelUsage, ProviderMetadata } from '../../stream/types';
 import { ChunkFrom } from '../../stream/types';
-import { Tool } from '../../tools/tool';
+import type { Tool } from '../../tools/tool';
+import { isMastraTool } from '../../tools/toolchecks';
 import type { ToolExecutionContext } from '../../tools/types';
 import type { DynamicArgument } from '../../types';
 import type { ExecutionEngine, ExecutionGraph } from '../../workflows/execution-engine';
@@ -140,7 +141,10 @@ export function cloneStep<TStepId extends string>(
 // ============================================
 
 function isToolStep(input: unknown): input is ToolStep<any, any, any, any, any> {
-  return input instanceof Tool;
+  // `isMastraTool` also recognizes tools by their shared marker symbol, which
+  // survives module duplication (Vite SSR) and spread copies — e.g. tools
+  // renamed by `resolveStoredToolProviders` — where `instanceof` fails.
+  return isMastraTool(input);
 }
 
 /**
@@ -160,7 +164,7 @@ function isStepParams(input: unknown): input is StepParams<any, any, any, any, a
     'id' in input &&
     'execute' in input &&
     !isAgent(input) &&
-    !(input instanceof Tool)
+    !isMastraTool(input)
   );
 }
 
@@ -175,7 +179,7 @@ function isProcessor(obj: unknown): obj is Processor {
     'id' in obj &&
     typeof (obj as any).id === 'string' &&
     !isAgent(obj) &&
-    !(obj instanceof Tool) &&
+    !isMastraTool(obj) &&
     (typeof (obj as any).processInput === 'function' ||
       typeof (obj as any).processInputStep === 'function' ||
       typeof (obj as any).processOutputStream === 'function' ||

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -48,7 +48,8 @@ import type { StorageListWorkflowRunsInput } from '../storage';
 import { WorkflowRunOutput } from '../stream/RunOutput';
 import type { ChunkType, LanguageModelUsage, ProviderMetadata } from '../stream/types';
 import { ChunkFrom } from '../stream/types';
-import { Tool } from '../tools/tool';
+import type { Tool } from '../tools/tool';
+import { isMastraTool } from '../tools/toolchecks';
 import type { ToolExecutionContext } from '../tools/types';
 import type { DynamicArgument } from '../types';
 import { PUBSUB_SYMBOL } from './constants';
@@ -210,7 +211,10 @@ export function mapVariable(config: any): any {
 // ============================================
 
 function isToolStep(input: unknown): input is ToolStep<any, any, any, any, any> {
-  return input instanceof Tool;
+  // `isMastraTool` also recognizes tools by their shared marker symbol, which
+  // survives module duplication (Vite SSR) and spread copies — e.g. tools
+  // renamed by `resolveStoredToolProviders` — where `instanceof` fails.
+  return isMastraTool(input);
 }
 
 /**
@@ -219,7 +223,7 @@ function isToolStep(input: unknown): input is ToolStep<any, any, any, any, any> 
  * Uses the `component` discriminator from MastraBase instead of instanceof.
  */
 function isAgentOrTool(input: unknown): boolean {
-  if (input instanceof Tool) return true;
+  if (isMastraTool(input)) return true;
   const base = input as MastraBase;
   if (base && base.component === RegisteredLogger.AGENT) return true;
   return false;


### PR DESCRIPTION
Workflow step detection (`isToolStep` / `isAgentOrTool`) used `input instanceof Tool`, which fails for tools that lost their class prototype. That happens in practice: `resolveStoredToolProviders` renames provider tools with `{ ...tool, id }` (a spread copy), and Vite SSR can load the Tool class twice. Those tools fell through to the custom-step branch, so `createStep(tool)` built a step whose execute received the whole params object as the tool input — and the tool then failed its own input validation.

Before:

```ts
const renamed = { ...myTool, id: 'renamed' }; // e.g. what tool-provider resolution produces
createStep(renamed); // misdetected as a custom step → wrong execute args → input validation error
```

After:

```ts
createStep(renamed); // detected via the shared tool marker symbol → proper tool step
```

The fix switches both checks to `isMastraTool()`, which already existed for exactly this purpose (it falls back to the `Symbol.for` marker that survives spread copies and module duplication). Adds regression tests for spread-copied tools at both construction and runtime, across both execution engines.

Verified with the declarative step entries suite (40 passing incl. new tests), full workflows suite, typecheck, and lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Workflows now recognize tools after they are copied or loaded more than once. This ensures copied tools run as tool steps and receive the correct input.

## What changed

- Replaced `instanceof Tool` checks with the shared `isMastraTool()` marker.
- Updated standard and evented workflow tool-step detection.
- Kept `Tool` as a type-only import.
- Added regression tests for copied tools during serialization, direct evented execution, and end-to-end execution.
- Added a patch changeset for `@mastra/core` and `@mastra/core/workflows/evented`.

## Verification

- 1,219 tests passed.
- 9 tests skipped.
- Typecheck passed.
- Lint and core package checks passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->