### PR TITLE
feat(factory): add issue completion skill

### DIFF
--- a/.changeset/full-knives-float.md
+++ b/.changeset/full-knives-float.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory completion so moving a GitHub issue to Done removes its remaining triage status labels.

--- a/.changeset/full-knives-float.md
+++ b/.changeset/full-knives-float.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed Factory completion so moving a GitHub issue to Done marks it as done and removes its remaining triage status labels.
+Fixed Factory completion so moving a GitHub issue to Done marks it as pending close and removes its remaining triage status labels.

--- a/.changeset/full-knives-float.md
+++ b/.changeset/full-knives-float.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed Factory completion so moving a GitHub issue to Done removes its remaining triage status labels.
+Fixed Factory completion so moving a GitHub issue to Done marks it as done and removes its remaining triage status labels.

--- a/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
@@ -12,6 +12,7 @@ Parse the issue URL or number from `$ARGUMENTS`, then read its current labels. R
 - `status: needs triage`
 - `status: auto-triaged`
 - `status: needs approval`
+- `status: pending-close`
 
 Use `gh issue edit <issue> --remove-label <label>` for each present label. Then post this comment unless the issue already has it:
 

--- a/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
@@ -7,14 +7,14 @@ description: Mark a GitHub issue as done and update its status labels
 
 Mark the GitHub issue behind a completed Factory work item as done and update its status labels.
 
-Parse the issue URL or number from `$ARGUMENTS`, then read its current labels. Remove any of these labels that are present:
+Parse the issue URL or number from `$ARGUMENTS`, then read its current state and labels. Remove any of these labels that are present:
 
 - `status: needs triage`
 - `status: auto-triaged`
 - `status: needs approval`
 
-Use `gh issue edit <issue> --remove-label <label>` for each present label, then add `status: pending-close` if it is not already present. Then post this comment unless the issue already has it:
+Use `gh issue edit` to remove the listed triage labels and, if the issue is open, add `status: pending-close` when it is not already present. Do not add `status: pending-close` if the issue is already closed, and do not modify any other labels or issue fields. Then post this comment unless the issue already has it:
 
 > This issue has now been marked as done.
 
-Do not add or remove any other labels, close, reopen, assign, or edit the issue, and do not request another Factory transition.
+Do not close, reopen, or assign the issue, and do not request another Factory transition.

--- a/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: factory-complete-issue
+description: Remove Factory triage labels when a GitHub issue is moved to Done
+---
+
+# Factory Complete Issue
+
+Clean up the GitHub issue behind a Factory work item that was moved to Done.
+
+Parse the issue URL or number from `$ARGUMENTS`, then read its current labels. Remove any of these labels that are present:
+
+- `status: needs triage`
+- `status: auto-triaged`
+- `status: needs approval`
+
+Use `gh issue edit <issue> --remove-label <label>` for each present label. Do not add or remove any other labels. Do not comment, close, reopen, assign, or edit the issue, and do not request another Factory transition.

--- a/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
@@ -1,20 +1,19 @@
 ---
 name: factory-complete-issue
-description: Mark a GitHub issue as done and remove its triage labels
+description: Mark a GitHub issue as done and update its status labels
 ---
 
 # Factory Complete Issue
 
-Mark the GitHub issue behind a completed Factory work item as done and clean up its triage labels.
+Mark the GitHub issue behind a completed Factory work item as done and update its status labels.
 
 Parse the issue URL or number from `$ARGUMENTS`, then read its current labels. Remove any of these labels that are present:
 
 - `status: needs triage`
 - `status: auto-triaged`
 - `status: needs approval`
-- `status: pending-close`
 
-Use `gh issue edit <issue> --remove-label <label>` for each present label. Then post this comment unless the issue already has it:
+Use `gh issue edit <issue> --remove-label <label>` for each present label, then add `status: pending-close` if it is not already present. Then post this comment unless the issue already has it:
 
 > This issue has now been marked as done.
 

--- a/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: factory-complete-issue
-description: Remove Factory triage labels when a GitHub issue is moved to Done
+description: Mark a GitHub issue as done and remove its triage labels
 ---
 
 # Factory Complete Issue
 
-Clean up the GitHub issue behind a Factory work item that was moved to Done.
+Mark the GitHub issue behind a completed Factory work item as done and clean up its triage labels.
 
 Parse the issue URL or number from `$ARGUMENTS`, then read its current labels. Remove any of these labels that are present:
 
@@ -13,4 +13,8 @@ Parse the issue URL or number from `$ARGUMENTS`, then read its current labels. R
 - `status: auto-triaged`
 - `status: needs approval`
 
-Use `gh issue edit <issue> --remove-label <label>` for each present label. Do not add or remove any other labels. Do not comment, close, reopen, assign, or edit the issue, and do not request another Factory transition.
+Use `gh issue edit <issue> --remove-label <label>` for each present label. Then post this comment unless the issue already has it:
+
+> This issue has now been marked as done.
+
+Do not add or remove any other labels, close, reopen, assign, or edit the issue, and do not request another Factory transition.

--- a/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-complete-issue/SKILL.md
@@ -13,8 +13,10 @@ Parse the issue URL or number from `$ARGUMENTS`, then read its current state and
 - `status: auto-triaged`
 - `status: needs approval`
 
-Use `gh issue edit` to remove the listed triage labels and, if the issue is open, add `status: pending-close` when it is not already present. Do not add `status: pending-close` if the issue is already closed, and do not modify any other labels or issue fields. Then post this comment unless the issue already has it:
+Use `gh issue edit` to remove the listed triage labels. If the issue is open, add `status: pending-close` when it is not already present and post this comment unless the issue already has it:
 
 > This issue has now been marked as done.
+
+If the issue is already closed, do not add `status: pending-close` or post the comment. Do not modify any other labels or issue fields.
 
 Do not close, reopen, or assign the issue, and do not request another Factory transition.

--- a/mastracode/factory/src/routes/skills.test.ts
+++ b/mastracode/factory/src/routes/skills.test.ts
@@ -462,6 +462,7 @@ describe('factory skills catalog route', () => {
     const names = skills.map(s => s.name);
     expect(names).toContain('factory-triage');
     expect(names).toContain('factory-plan');
+    expect(names).toContain('factory-complete-issue');
     const triage = skills.find(s => s.name === 'factory-triage')!;
     expect(triage.description.length).toBeGreaterThan(0);
     expect(triage.content).toContain('# Factory Triage');

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -133,6 +133,7 @@ describe('defaultFactoryRules', () => {
     expect(rules.version).toBe('deployment-7');
     expect(rules.work.intake?.issue?.onEnter).toBeUndefined();
     expect(rules.work.triage?.issue?.onEnter).toBeTypeOf('function');
+    expect(rules.work.done?.issue?.onEnter).toBeTypeOf('function');
     expect(rules.review.intake?.pullRequest?.onEnter).toBeUndefined();
     expect(rules.review.review?.pullRequest?.onEnter).toBeTypeOf('function');
     expect(rules.tools.submit_plan?.onResult).toBeTypeOf('function');
@@ -352,6 +353,28 @@ describe('defaultFactoryRules', () => {
       type: 'invokeSkill',
       role: 'triage',
       skillName: 'factory-triage',
+    });
+  });
+
+  it('cleans up triage labels whenever a GitHub issue moves to Done', async () => {
+    const rule = defaultFactoryRules({ version: 'deployment-7' }).work.done?.issue?.onEnter;
+    const context = {
+      ...stageContext({ type: 'human', id: 'user-1' }, 'work'),
+      cause: 'board_drag',
+      stage: 'done',
+      fromStage: 'intake',
+      toStage: 'done',
+    } as FactoryStageRuleContext;
+
+    expect(await rule?.(context)).toMatchObject({
+      type: 'invokeSkill',
+      role: 'triage',
+      skillName: 'factory-complete-issue',
+      arguments: 'GitHub issue (https://github.test/acme/repo/issues/42)',
+    });
+    expect(await rule?.({ ...context, fromStage: 'triage' })).toMatchObject({
+      type: 'invokeSkill',
+      skillName: 'factory-complete-issue',
     });
   });
 

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -95,6 +95,16 @@ function planWorkItem(context: FactoryStageRuleContext) {
   } as const;
 }
 
+function completeIssue(context: FactoryStageRuleContext) {
+  return {
+    type: 'invokeSkill',
+    idempotencyKey: `${context.ingress.id}:factory-complete-issue`,
+    role: 'triage',
+    skillName: 'factory-complete-issue',
+    arguments: context.item.url ? `GitHub issue (${context.item.url})` : context.item.title,
+  } as const;
+}
+
 function reviewPullRequest(context: FactoryStageRuleContext) {
   // A re-entry into Review (from any post-intake stage) supersedes whichever
   // review pass previously ran on this card: cancel any in-flight run before
@@ -371,6 +381,9 @@ const BUILT_IN_DEFAULTS: FactoryRulesOverrides = {
       issue: { onEnter: planWorkItem },
       linearIssue: { onEnter: planWorkItem },
       manual: { onEnter: planWorkItem },
+    },
+    done: {
+      issue: { onEnter: completeIssue },
     },
   },
   review: { review: { pullRequest: { onEnter: reviewPullRequest } } },

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -271,6 +271,7 @@ describe('getFactoryWorkspace', () => {
 
     expect(assetNames).toEqual([
       'configure-factory-rules',
+      'factory-complete-issue',
       'factory-plan',
       'factory-rereview',
       'factory-review',

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -50,6 +50,7 @@ export const FACTORY_SKILLS_SOURCE_PATH =
 const FACTORY_SKILLS_MOUNT = path.resolve(path.parse(process.cwd()).root, '__mastracode_factory_skills__');
 export const FACTORY_SKILL_NAMES = new Set([
   'configure-factory-rules',
+  'factory-complete-issue',
   'factory-plan',
   'factory-rereview',
   'factory-review',


### PR DESCRIPTION
## Summary
- add a `factory-complete-issue` skill for GitHub issues entering Done
- comment that the issue has now been marked as done
- add `status: pending-close` and remove active triage status labels
- register and invoke the skill from the default Done-stage rule

## Test plan
- `pnpm exec vitest run src/rules/defaults.test.ts src/routes/skills.test.ts --reporter=dot --bail 1`
- `pnpm check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a GitHub issue moves to Done, Factory marks it as ready to close. It adds a completion comment, removes active triage labels, and adds `status: pending-close` only if the issue remains open.

## Changes

- Added and registered the `factory-complete-issue` skill.
- Skipped `status: pending-close` for already closed issues.
- Added a Work `done` rule for GitHub issues.
- Added coverage for Intake and Triage completion transitions.
- Added tests for skill registration and workspace packaging.
- Added a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->