### PR TITLE
refactor(factory): centralize stage vocabulary

### DIFF
--- a/.changeset/nice-hands-cheat.md
+++ b/.changeset/nice-hands-cheat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved Factory stage handling so run routes and board columns stay aligned with the rule stage vocabulary.

--- a/mastracode/factory-ui/src/hooks/useStartFactoryRun.ts
+++ b/mastracode/factory-ui/src/hooks/useStartFactoryRun.ts
@@ -1,3 +1,4 @@
+import { isFactoryRuleStage } from '@mastra/factory/rules/types';
 import { toast } from '@mastra/playground-ui/components/Toaster';
 import { useMutation, useMutationState, useQueryClient } from '@tanstack/react-query';
 import { ExternalLink } from 'lucide-react';
@@ -99,7 +100,7 @@ export function useStartFactoryRun() {
       const userSession = await createUserSession(baseUrl, repository.projectRepositoryId, { branch });
       const sessionId = userSession.sessionId;
       const desiredStage = workItem.stages.length === 1 ? workItem.stages[0] : undefined;
-      if (!desiredStage) throw new Error('Factory runs require one exclusive destination stage');
+      if (!isFactoryRuleStage(desiredStage)) throw new Error('Factory runs require one exclusive destination stage');
 
       setPhase('kickoff');
       const prepared = await startFactoryRun(baseUrl, factoryId, {
@@ -114,7 +115,7 @@ export function useStartFactoryRun() {
                 arguments: `${invocation.arguments.trim()}\n\nPrepared workspace context:\n- Session: ${sessionId}\n- Branch: ${userSession.branch}`,
               }
             : invocation,
-        destinationStage: desiredStage as 'intake' | 'triage' | 'planning' | 'execute' | 'review' | 'done',
+        destinationStage: desiredStage,
         workItem: {
           id: workItem.id,
           role: workItem.role,

--- a/mastracode/factory-ui/src/hooks/useWorkItems.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkItems.ts
@@ -1,3 +1,5 @@
+import type { FactoryRuleStage } from '@mastra/factory/rules/types';
+import { isFactoryRuleStage } from '@mastra/factory/rules/types';
 import type { QueryClient, QueryKey } from '@tanstack/react-query';
 import {
   queryOptions,
@@ -21,7 +23,6 @@ import type {
   BoardSnapshot,
   CreateWorkItemInput,
   FactoryBoard,
-  FactoryStage,
   UpdateWorkItemInput,
   WorkItem,
 } from '../ui/domains/factory/services/workItems';
@@ -126,23 +127,8 @@ type TransitionWorkItemVariables = {
   cause?: string;
 };
 
-function isFactoryStage(stage: unknown): stage is FactoryStage {
-  switch (stage) {
-    case 'intake':
-    case 'triage':
-    case 'planning':
-    case 'execute':
-    case 'review':
-    case 'done':
-    case 'canceled':
-      return true;
-    default:
-      return false;
-  }
-}
-
-function requireFactoryStage(stage: string): FactoryStage {
-  if (!isFactoryStage(stage)) throw new Error(`Unsupported Factory stage: ${stage}`);
+function requireFactoryStage(stage: string): FactoryRuleStage {
+  if (!isFactoryRuleStage(stage)) throw new Error(`Unsupported Factory stage: ${stage}`);
   return stage;
 }
 
@@ -207,12 +193,12 @@ export function useTransitionWorkItemMutation(factoryProjectId: string | undefin
 
 interface PendingTransitionVariables {
   item: { id: string };
-  stage: FactoryStage;
+  stage: FactoryRuleStage;
 }
 
 function isPendingTransitionVariables(value: unknown): value is PendingTransitionVariables {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
-  if (!('stage' in value) || !isFactoryStage(value.stage)) return false;
+  if (!('stage' in value) || !isFactoryRuleStage(value.stage)) return false;
   if (!('item' in value) || typeof value.item !== 'object' || value.item === null || !('id' in value.item))
     return false;
   return typeof value.item.id === 'string';

--- a/mastracode/factory-ui/src/ui/domains/factory/boardStages.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardStages.test.ts
@@ -1,3 +1,5 @@
+import { FACTORY_RULE_STAGES } from '@mastra/factory/rules/types';
+
 import { describe, expect, it } from 'vitest';
 
 import { boardStages, currentItemStageLabel, itemAppearsInStage } from './boardStages';
@@ -23,6 +25,21 @@ function workItem(source: WorkItemSource, stages: string[]): WorkItem {
     updatedAt: '2026-07-01T00:00:00.000Z',
   };
 }
+
+describe('boardStages', () => {
+  it('uses the canonical stage order for the work board', () => {
+    expect(boardStages('work').map(stage => stage.id)).toEqual(FACTORY_RULE_STAGES);
+  });
+
+  it('selects and labels the review board columns', () => {
+    expect(boardStages('review')).toEqual([
+      { id: 'intake', label: 'Intake' },
+      { id: 'review', label: 'Reviewing' },
+      { id: 'done', label: 'Done' },
+      { id: 'canceled', label: 'Canceled' },
+    ]);
+  });
+});
 
 describe('currentItemStageLabel', () => {
   it('reads the furthest column the item sits in', () => {

--- a/mastracode/factory-ui/src/ui/domains/factory/boardStages.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardStages.ts
@@ -1,22 +1,25 @@
+import type { FactoryRuleBoard, FactoryRuleStage } from '@mastra/factory/rules/types';
+
 import type { WorkItem } from './services/workItems';
 import { BOARD_STAGES, stageLabel, stageOrder } from './stages';
-import type { BoardStageId } from './stages';
+import type { BoardStage, BoardStageId } from './stages';
 
-export type BoardKind = 'work' | 'review';
+export type BoardKind = FactoryRuleBoard;
 
-interface BoardStage {
-  id: BoardStageId;
-  label: string;
-}
+const REVIEW_BOARD_STAGE_VISIBILITY = {
+  intake: true,
+  triage: false,
+  planning: false,
+  execute: false,
+  review: true,
+  done: true,
+  canceled: true,
+} satisfies Record<FactoryRuleStage, boolean>;
 
-// Every stage a rule can send a pull request to needs a column here: without
-// one the card falls through to Intake, the queue of PRs still awaiting review.
-const REVIEW_BOARD_STAGES: ReadonlyArray<BoardStage> = [
-  { id: 'intake', label: 'Intake' },
-  { id: 'review', label: 'Reviewing' },
-  { id: 'done', label: 'Done' },
-  { id: 'canceled', label: 'Canceled' },
-];
+const REVIEW_BOARD_STAGES: ReadonlyArray<BoardStage> = BOARD_STAGES.flatMap(stage => {
+  if (!REVIEW_BOARD_STAGE_VISIBILITY[stage.id]) return [];
+  return [stage.id === 'review' ? { ...stage, label: 'Reviewing' } : stage];
+});
 
 export function boardStages(kind: BoardKind): ReadonlyArray<BoardStage> {
   return kind === 'review' ? REVIEW_BOARD_STAGES : BOARD_STAGES;

--- a/mastracode/factory-ui/src/ui/domains/factory/services/workItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/workItems.ts
@@ -6,6 +6,8 @@
  * org-wide, so every member of the org reads and moves the same cards.
  */
 
+import type { FactoryRuleStage } from '@mastra/factory/rules/types';
+
 import { requestJson } from './request';
 
 export type WorkItemSource = 'github-issue' | 'github-pr' | 'linear-issue' | 'slack-thread' | 'manual';
@@ -133,7 +135,6 @@ function fromWireWorkItem(item: WireWorkItem): WorkItem {
 }
 
 export type FactoryBoard = 'work' | 'review';
-export type FactoryStage = 'intake' | 'triage' | 'planning' | 'execute' | 'review' | 'done' | 'canceled';
 
 export type FactoryTransitionResult =
   | {
@@ -141,7 +142,7 @@ export type FactoryTransitionResult =
       transitionId: string;
       itemId: string;
       revision: number;
-      stage: FactoryStage;
+      stage: FactoryRuleStage;
       decisions: unknown[];
     }
   | { status: 'rejected'; transitionId: string; itemId: string; code: string; reason: string };
@@ -193,7 +194,7 @@ export async function transitionWorkItem(
   baseUrl: string,
   githubProjectId: string,
   id: string,
-  input: { board: FactoryBoard; stage: FactoryStage; expectedRevision: number; requestId: string; cause: string },
+  input: { board: FactoryBoard; stage: FactoryRuleStage; expectedRevision: number; requestId: string; cause: string },
 ): Promise<FactoryTransitionResult> {
   const res = await fetch(
     `${baseUrl}/web/factory/projects/${encodeURIComponent(githubProjectId)}/work-items/${encodeURIComponent(id)}/transition`,
@@ -224,7 +225,7 @@ export interface StartFactoryRunRequest {
   threadTags?: Record<string, string>;
   kickoffKey: string;
   invocation?: { type: 'prompt'; prompt: string } | { type: 'skill'; skillName: string; arguments: string };
-  destinationStage: FactoryStage;
+  destinationStage: FactoryRuleStage;
   workItem: {
     id?: string;
     role: string;

--- a/mastracode/factory-ui/src/ui/domains/factory/stages.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/stages.ts
@@ -1,19 +1,27 @@
-/**
- * The Factory board's stage vocabulary, shared by the Board (columns) and the
- * Metrics page (stage labels/ordering). Stages are plain strings server-side —
- * this is purely the UI's naming and ordering of them.
- */
-export const BOARD_STAGES = [
-  { id: 'intake', label: 'Intake' },
-  { id: 'triage', label: 'Triage' },
-  { id: 'planning', label: 'Planning' },
-  { id: 'execute', label: 'Building' },
-  { id: 'review', label: 'Review' },
-  { id: 'done', label: 'Done' },
-  { id: 'canceled', label: 'Canceled' },
-] as const;
+import type { FactoryRuleStage } from '@mastra/factory/rules/types';
+import { FACTORY_RULE_STAGES } from '@mastra/factory/rules/types';
 
-export type BoardStageId = (typeof BOARD_STAGES)[number]['id'];
+const BOARD_STAGE_LABELS = {
+  intake: 'Intake',
+  triage: 'Triage',
+  planning: 'Planning',
+  execute: 'Building',
+  review: 'Review',
+  done: 'Done',
+  canceled: 'Canceled',
+} satisfies Record<FactoryRuleStage, string>;
+
+export type BoardStageId = FactoryRuleStage;
+
+export interface BoardStage {
+  id: BoardStageId;
+  label: string;
+}
+
+export const BOARD_STAGES: ReadonlyArray<BoardStage> = FACTORY_RULE_STAGES.map(id => ({
+  id,
+  label: BOARD_STAGE_LABELS[id],
+}));
 
 /**
  * Stages that hold work in the pipeline, in column order — the board minus its
@@ -25,7 +33,7 @@ export type BoardStageId = (typeof BOARD_STAGES)[number]['id'];
  * live candidates in first, which needs its own age semantics (upstream open
  * date vs. time in stage).
  */
-export const PIPELINE_STAGES: BoardStageId[] = BOARD_STAGES.map(stage => stage.id).filter(
+export const PIPELINE_STAGES: BoardStageId[] = FACTORY_RULE_STAGES.filter(
   id => id !== 'intake' && id !== 'done' && id !== 'canceled',
 );
 

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -12,6 +12,7 @@ import type { FactoryBindingPreparationInput } from '../rules/dispatcher.js';
 import { FactoryStartCoordinator } from '../rules/start-coordinator.js';
 import { FactoryTransitionService } from '../rules/transition-service.js';
 import type { FactoryRules } from '../rules/types.js';
+import { isFactoryRuleStage } from '../rules/types.js';
 import type { SandboxFleet } from '../sandbox/fleet.js';
 import { ensureFactorySourceSession, resolveFactoryDefaultModelId } from '../session/factory-session.js';
 import { LiveSessions } from '../session/live-sessions.js';
@@ -181,7 +182,8 @@ export async function prepareFactoryRuleBinding(
     branch,
   });
   const destinationStage = input.item.stages.length === 1 ? input.item.stages[0] : undefined;
-  if (!destinationStage) throw new Error('Factory skill invocation requires one exclusive board stage.');
+  if (!isFactoryRuleStage(destinationStage))
+    throw new Error('Factory skill invocation requires one exclusive board stage.');
 
   await coordinator.prepare({
     orgId: input.record.orgId,
@@ -191,7 +193,7 @@ export async function prepareFactoryRuleBinding(
     defaultModelId: await resolveFactoryDefaultModelId(projects, input.record.factoryProjectId),
     threadTitle: `${input.role === 'review' ? 'PR' : 'Issue'}: ${input.item.title}`,
     kickoffKey: input.record.id,
-    destinationStage: destinationStage as 'intake' | 'triage' | 'planning' | 'execute' | 'review' | 'done',
+    destinationStage,
     workItem: {
       id: input.item.id,
       role: input.role,

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -18,8 +18,8 @@ import type {
 } from '../rules/start-coordinator.js';
 import { FactoryStartTransitionError } from '../rules/start-coordinator.js';
 import type { FactoryTransitionRequest, FactoryTransitionService } from '../rules/transition-service.js';
-import type { FactoryRuleBoard, FactoryRuleStage } from '../rules/types.js';
-import { FACTORY_RULE_BOARDS, FACTORY_RULE_STAGES } from '../rules/types.js';
+import type { FactoryRuleBoard } from '../rules/types.js';
+import { FACTORY_RULE_BOARDS, isFactoryRuleStage } from '../rules/types.js';
 import type { LiveSessions } from '../session/live-sessions.js';
 import type { AuditEmitter } from '../storage/domains/audit/domain.js';
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
@@ -219,9 +219,7 @@ function parseTransitionBody(
   const board = FACTORY_RULE_BOARDS.includes(body.board as FactoryRuleBoard)
     ? (body.board as FactoryRuleBoard)
     : undefined;
-  const stage = FACTORY_RULE_STAGES.includes(body.stage as FactoryRuleStage)
-    ? (body.stage as FactoryRuleStage)
-    : undefined;
+  const stage = isFactoryRuleStage(body.stage) ? body.stage : undefined;
   const requestId = boundedText(body.requestId, 256);
   const cause = boundedText(body.cause, 256);
   if (
@@ -270,9 +268,7 @@ function parseStartBody(
   const threadTitle = boundedText(body.threadTitle, 512);
   const kickoffKey = boundedText(body.kickoffKey, 256);
   const invocation = parseInvocation(body.invocation);
-  const destinationStage = FACTORY_RULE_STAGES.includes(body.destinationStage as FactoryRuleStage)
-    ? (body.destinationStage as FactoryRuleStage)
-    : undefined;
+  const destinationStage = isFactoryRuleStage(body.destinationStage) ? body.destinationStage : undefined;
   const role = boundedText(body.workItem.role, 32);
   const id = body.workItem.id === undefined ? undefined : boundedText(body.workItem.id, 64);
   if (body.workItem.id !== undefined && (!id || !UUID_RE.test(id))) return null;

--- a/mastracode/factory/src/rules/index.ts
+++ b/mastracode/factory/src/rules/index.ts
@@ -13,6 +13,7 @@ export {
   FACTORY_RULE_SOURCES,
   FACTORY_RULE_STAGES,
   factoryRuleSourceForWorkItem,
+  isFactoryRuleStage,
 } from './types.js';
 export type {
   FactoryBoardRuleLeaf,

--- a/mastracode/factory/src/rules/processor.ts
+++ b/mastracode/factory/src/rules/processor.ts
@@ -12,12 +12,13 @@ import type { FactoryRunBindingRecord, WorkItemsStorage, WorkItemRow } from '../
 import { getFactorySessionCoordinates } from './binding-context.js';
 import { resolveFactoryToolRule } from './resolve.js';
 import type { FactoryTransitionService } from './transition-service.js';
-import { FACTORY_RULE_STAGES } from './types.js';
+import { isFactoryRuleStage } from './types.js';
 import type {
   FactoryCommitDecision,
   FactoryRuleBoard,
   FactoryRuleDecision,
   FactoryRuleJsonValue,
+  FactoryRuleStage,
   FactoryRules,
   FactoryToolResultRuleContext,
 } from './types.js';
@@ -27,7 +28,7 @@ const STATE_ID = 'factory-phase';
 const RULE_TIMEOUT_MS = 5_000;
 const TRANSCRIPT_PAGE_SIZE = 50;
 const MAX_LINKED_ITEMS = 5;
-const PHASE_LABELS: Record<(typeof FACTORY_RULE_STAGES)[number], string> = {
+const PHASE_LABELS: Record<FactoryRuleStage, string> = {
   intake: 'Intake',
   triage: 'Investigating',
   planning: 'Planning',
@@ -261,7 +262,8 @@ export class FactoryPhaseStateProcessor implements Processor<'factory-phase'> {
     }
 
     const item = await this.options.storage.get({ orgId: binding.orgId, id: binding.workItemId });
-    if (!item || item.stages.length !== 1 || !FACTORY_RULE_STAGES.includes(item.stages[0] as never)) return;
+    const stage = item?.stages.length === 1 ? item.stages[0] : undefined;
+    if (!item || !isFactoryRuleStage(stage)) return;
     const allItems = await this.options.storage.list({
       orgId: binding.orgId,
       factoryProjectId: binding.factoryProjectId,
@@ -270,7 +272,6 @@ export class FactoryPhaseStateProcessor implements Processor<'factory-phase'> {
       .filter(candidate => candidate.parentWorkItemId === item.id || item.parentWorkItemId === candidate.id)
       .slice(0, MAX_LINKED_ITEMS);
     const board = boardForItem(item);
-    const stage = item.stages[0]!;
     const value: PhaseSnapshotValue = {
       status: 'active',
       bindingId: binding.id,
@@ -289,7 +290,7 @@ export class FactoryPhaseStateProcessor implements Processor<'factory-phase'> {
       ? `\nLinked items: ${linked.map(candidate => `${workItemSource(candidate)} ${candidate.title}`).join('; ')}`
       : '';
     const snapshotContents =
-      `Factory ${board} phase: ${PHASE_LABELS[stage as keyof typeof PHASE_LABELS]} (${escapeText(stage)})\n` +
+      `Factory ${board} phase: ${PHASE_LABELS[stage]} (${escapeText(stage)})\n` +
       `Work item: ${escapeText(item.title)} (${item.id})\n` +
       `Role: ${escapeText(binding.role)}\nRevision: ${item.revision}\nRules: ${escapeText(this.options.rules.version)}\n` +
       `Use factory_transition_work_item with expectedRevision ${item.revision} to request a phase change.${escapeText(linkedText)}`;
@@ -350,7 +351,7 @@ export class FactoryPhaseStateProcessor implements Processor<'factory-phase'> {
     toolCallIds?: ReadonlySet<string>,
   ): Promise<void> {
     const item = await this.options.storage.get({ orgId: binding.orgId, id: binding.workItemId });
-    if (!item || item.stages.length !== 1 || !FACTORY_RULE_STAGES.includes(item.stages[0] as never)) return;
+    if (!item || item.stages.length !== 1 || !isFactoryRuleStage(item.stages[0])) return;
     for (const message of messages) {
       for (const toolResult of completedToolResults(message)) {
         if (toolCallIds && !toolCallIds.has(toolResult.toolCallId)) continue;

--- a/mastracode/factory/src/rules/transition-service.ts
+++ b/mastracode/factory/src/rules/transition-service.ts
@@ -13,7 +13,7 @@ import type {
   FactoryStageRuleContext,
   FactoryTransitionResult,
 } from './types.js';
-import { FACTORY_RULE_STAGES, factoryRuleSourceForWorkItem } from './types.js';
+import { factoryRuleSourceForWorkItem, isFactoryRuleStage } from './types.js';
 import {
   MAX_FACTORY_RULE_CAUSAL_DEPTH,
   validateFactoryRuleDecision,
@@ -91,7 +91,7 @@ function actorId(actor: FactoryRuleActor): string {
 function currentStage(stages: readonly string[]): FactoryRuleStage | undefined {
   if (stages.length !== 1) return undefined;
   const stage = stages[0];
-  return FACTORY_RULE_STAGES.includes(stage as FactoryRuleStage) ? (stage as FactoryRuleStage) : undefined;
+  return isFactoryRuleStage(stage) ? stage : undefined;
 }
 
 function workItemSource(source: ExternalWorkItemSource | null) {

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -3,6 +3,10 @@ export type WorkItemSource = 'github-issue' | 'github-pr' | 'linear-issue' | 'ma
 export const FACTORY_RULE_STAGES = ['intake', 'triage', 'planning', 'execute', 'review', 'done', 'canceled'] as const;
 export type FactoryRuleStage = (typeof FACTORY_RULE_STAGES)[number];
 
+export function isFactoryRuleStage(value: unknown): value is FactoryRuleStage {
+  return typeof value === 'string' && FACTORY_RULE_STAGES.some(stage => stage === value);
+}
+
 export const FACTORY_RULE_BOARDS = ['work', 'review'] as const;
 export type FactoryRuleBoard = (typeof FACTORY_RULE_BOARDS)[number];
 


### PR DESCRIPTION
Factory stages now come from the rule-stage vocabulary instead of being re-declared across the server and board UI.

I added a shared runtime guard, derived board columns and labels from the canonical list, and made review-board membership exhaustive so adding a stage requires an explicit product decision. The existing Reviewing label remains local to the review board.

Verified with focused Factory route, processor, transition, board, service, and mutation tests; package typechecks and lint/format checks; the Factory distribution smoke test; and a production Factory UI build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory now uses one shared list of stages. This keeps server validation and board columns aligned when stages change.

## Changes

- Added the `isFactoryRuleStage` runtime type guard and exported it from `@mastra/factory/rules`.
- Updated Factory routes and rule services to validate stages with the shared guard.
- Derived board stages and pipeline stages from `FACTORY_RULE_STAGES`.
- Made review-board membership explicit for `intake`, `review`, `done`, and `canceled`.
- Kept the review-board label `Reviewing` local to the board UI.
- Replaced local `FactoryStage` types with `FactoryRuleStage`.
- Added board-stage coverage tests.
- Added a patch changeset for `@mastra/factory`.

## Verification

- Focused tests passed.
- Typechecks, lint, and formatting checks passed.
- Factory distribution smoke test passed.
- Production Factory UI build passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->