### PR TITLE
fix(factory): make session materialized_at write-once

### DIFF
--- a/.changeset/busy-crabs-go.md
+++ b/.changeset/busy-crabs-go.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed `source_control_sessions.materialized_at` being overwritten on every session resume. It is now write-once, so the initial-materialize baseline used for TTFME/materialize timing is no longer corrupted when a session is resumed after Railway idle-reap, checkpoint restore, or sandbox recreate.
+Fixed session materialization timing being overwritten when sessions resume. The initial-materialize timestamp is now recorded once and preserved across idle-reap, checkpoint restore, and sandbox recreation, so time-to-first-materialize measurements reflect the true initial cost. Historical metrics captured before this fix are not backfilled.

--- a/.changeset/busy-crabs-go.md
+++ b/.changeset/busy-crabs-go.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed `source_control_sessions.materialized_at` being overwritten on every session resume. It is now write-once, so the initial-materialize baseline used for TTFME/materialize timing is no longer corrupted when a session is resumed after Railway idle-reap, checkpoint restore, or sandbox recreate.

--- a/mastracode/factory/src/storage/domains/source-control/base.test.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.test.ts
@@ -494,6 +494,33 @@ describe('SourceControlStorage', () => {
     await expect(github.sessions.markFirstMeaningfulExec({ sessionId: 'missing-session' })).resolves.toBeUndefined();
   });
 
+  it('records materialized_at write-once via sessions.markMaterialized', async () => {
+    const project = await createProject();
+    const link = await linkRepository({ factoryProjectId: project.id });
+    const session = await github.sessions.create({
+      sessionId: '00000000-0000-4000-8000-000000000005',
+      projectRepositoryId: link.id,
+      orgId: 'org-1',
+      userId: 'user-1',
+      branch: 'user/session-00000000-0000-4000-8000-000000000005',
+      baseBranch: 'main',
+    });
+    expect(session.materializedAt).toBeNull();
+
+    await github.sessions.markMaterialized({ id: session.id });
+    const marked = await github.sessions.getBySessionId(session.sessionId);
+    expect(marked?.materializedAt).toBeInstanceOf(Date);
+
+    // A resume (second markMaterialized call) must not move the timestamp:
+    // the guarded update only matches rows where the column is still NULL.
+    // Without this, `materialize_s = materialized_at - created_at` counts the
+    // entire idle-and-resume duration as initial-materialize latency.
+    await new Promise(resolve => setTimeout(resolve, 5));
+    await github.sessions.markMaterialized({ id: session.id });
+    const again = await github.sessions.getBySessionId(session.sessionId);
+    expect(again?.materializedAt?.getTime()).toBe(marked!.materializedAt!.getTime());
+  });
+
   it('clears every owned source-control collection', async () => {
     const project = await createProject();
     const link = await linkRepository({ factoryProjectId: project.id });

--- a/mastracode/factory/src/storage/domains/source-control/base.test.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { FactoryProjectsStorage } from '../projects/base.js';
 import { SourceControlStorage } from './base.js';
 import type { ProjectRepository, SourceControlStorageHandle } from './base.js';
+import { SourceControlStorageInMemory } from './inmemory.js';
 
 const repositoryInput = {
   externalId: 'repository-34',
@@ -537,5 +538,29 @@ describe('SourceControlStorage', () => {
 
     expect(await github.installations.list({ orgId: 'org-1' })).toEqual([]);
     expect(await github.projectRepositories.get({ orgId: 'org-1', id: link.id })).toBeNull();
+  });
+});
+
+describe('SourceControlStorageInMemory sessions.markMaterialized', () => {
+  it('records materialized_at write-once', async () => {
+    const store = new SourceControlStorageInMemory();
+    const session = await store.sessions.create({
+      sessionId: '00000000-0000-4000-8000-00000000aaaa',
+      projectRepositoryId: 'proj-1',
+      orgId: 'org-1',
+      userId: 'user-1',
+      branch: 'user/session-00000000-0000-4000-8000-00000000aaaa',
+      baseBranch: 'main',
+    });
+    expect(session.materializedAt).toBeNull();
+
+    await store.sessions.markMaterialized({ id: session.id });
+    const first = await store.sessions.getBySessionId(session.sessionId);
+    expect(first?.materializedAt).toBeInstanceOf(Date);
+
+    await new Promise(resolve => setTimeout(resolve, 5));
+    await store.sessions.markMaterialized({ id: session.id });
+    const second = await store.sessions.getBySessionId(session.sessionId);
+    expect(second?.materializedAt?.getTime()).toBe(first!.materializedAt!.getTime());
   });
 });

--- a/mastracode/factory/src/storage/domains/source-control/base.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.ts
@@ -479,6 +479,13 @@ export interface SourceControlStorageHandle {
     }): Promise<SourceControlSession | null>;
     create(input: CreateSourceControlSessionInput): Promise<SourceControlSession>;
     setSandbox(args: { id: string; sandboxId: string | null; sandboxWorkdir: string }): Promise<void>;
+    /**
+     * Record when the session's workspace was first materialized. Write-once:
+     * the guarded update only lands while the column is still NULL, so resumes
+     * (Railway idle-reap, checkpoint restore, sandbox recreate) do not overwrite
+     * the initial-materialize baseline that `materialize_s = materialized_at -
+     * created_at` depends on.
+     */
     markMaterialized(args: { id: string }): Promise<void>;
     /**
      * Record when the session's agent received its first user message.
@@ -1276,7 +1283,15 @@ export class SourceControlStorage extends FactoryStorageDomain {
           );
         },
         markMaterialized: async ({ id }) => {
-          await db().updateMany(SESSIONS, { id }, { materialized_at: new Date(), updated_at: new Date() });
+          // `materialized_at: null` in the filter compiles to `IS NULL`, making
+          // this a write-once update: session resumes (idle-reap, checkpoint
+          // restore, sandbox recreate) match zero rows and cannot overwrite the
+          // initial-materialize timestamp that `materialize_s` is derived from.
+          await db().updateMany(
+            SESSIONS,
+            { id, materialized_at: null },
+            { materialized_at: new Date(), updated_at: new Date() },
+          );
         },
         markFirstMessage: async ({ sessionId }) => {
           // `first_message_at: null` in the filter compiles to `IS NULL`, making

--- a/mastracode/factory/src/storage/domains/source-control/inmemory.ts
+++ b/mastracode/factory/src/storage/domains/source-control/inmemory.ts
@@ -515,7 +515,7 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
     },
     markMaterialized: async ({ id }: { id: string }) => {
       const row = this.sessionsRows.find(candidate => candidate.id === id);
-      if (row) Object.assign(row, { materializedAt: new Date(), updatedAt: new Date() });
+      if (row && row.materializedAt === null) Object.assign(row, { materializedAt: new Date(), updatedAt: new Date() });
     },
     markFirstMessage: async ({ sessionId }: { sessionId: string }) => {
       const row = this.sessionsRows.find(candidate => candidate.sessionId === sessionId);


### PR DESCRIPTION
## Summary

`source_control_sessions.materialized_at` was re-stamped on every session resume (Railway idle-reap, checkpoint restore, sandbox recreate) because the session materialize path issued an unconditional `UPDATE ... SET materialized_at = now()`. That silently corrupted the initial-materialize baseline: `materialize_s = materialized_at - created_at` counted the entire idle-and-resume duration as materialize latency, and every TTFME percentile computed for resumed sessions was inflated.

Evidence from Aug 13 sessions showed `materialized_at` landing 1–3 hours after `first_message_at`, which is causally impossible for an initial materialize.

## Change

- Guard `sessions.markMaterialized` on `materialized_at IS NULL`, using the same write-once pattern already used by `markFirstMessage` and `markFirstMeaningfulExec`.
- Mirror the guard in the in-memory storage.
- Document the write-once contract on the storage interface.

## Test plan

- New regression test in `base.test.ts`: a second `markMaterialized` call does not move the timestamp.
- `pnpm --filter ./mastracode/factory exec vitest run src/storage/domains/source-control` — 16 tests pass.
- `pnpm --filter ./mastracode/factory check` and `lint` — clean.

## Verification for existing data

Per the issue, post-fix:
- Sessions created after this change should never have `materialized_at > first_message_at`.
- Historical baselines can be recomputed using `LEAST(materialized_at, first_message_at) - created_at` as a corrective proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The system now records the first time a session is materialized and keeps that time unchanged. This prevents session resumes from making materialization latency metrics appear higher than they are.

## Changes

- Made `source_control_sessions.materialized_at` write-once.
- Added a `materialized_at IS NULL` guard to `sessions.markMaterialized`.
- Applied the same guard to in-memory storage.
- Documented the write-once contract on the storage interface.
- Added regression tests for repeated `markMaterialized` calls in both storage implementations.
- Added a patch changeset for `@mastra/factory`.
- Documented that historical metrics are not backfilled.

## Validation

- Specified storage tests pass.
- Checks and lint pass.
- Historical baselines can use `LEAST(materialized_at, first_message_at) - created_at`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->