### PR TITLE
feat: chat follows the agent while it works

### DIFF
--- a/.changeset/empty-camels-admire.md
+++ b/.changeset/empty-camels-admire.md
@@ -2,11 +2,9 @@
 '@mastra/playground-ui': minor
 ---
 
-Chat transcripts now follow the stream. With `autoScroll` on, `MessageScroller` carries the reader with the newest output while they are attached to the end, and a new user turn re-attaches them there. Only the reader can detach it, by scrolling away — content growing under them cannot, which is what used to flash the jump-to-end button for a moment on every send and yank the view back up to the last user message on tool progress.
+Improved `MessageScroller` so chat transcripts follow the stream. With `autoScroll` on, the reader is carried with the newest output while they sit at the end, and a new user turn brings them back to it. Only scrolling away stops the following — content growing under the reader, or landing above them, no longer moves them or flashes the jump-to-end button.
 
-Content that lands above the reader mid-run (a temporal gap separator, a late tool row) no longer shifts what they are reading.
-
-A turn opening only animates the scroll for a reader who had scrolled away and has to be brought back. Someone already at the end is carried by whatever the turn grows under itself, so its transition — not a competing scroll animation — sets the pace:
+A turn opening animates the scroll only for a reader who had scrolled away. Someone already at the end is carried by whatever the turn grows under itself, so a surface can reserve room under a live turn and let its own transition set the pace:
 
 ```tsx
 <MessageScrollerProvider autoScroll>
@@ -18,5 +16,3 @@ A turn opening only animates the scroll for a reader who had scrolled away and h
   </MessageScrollerViewport>
 </MessageScrollerProvider>
 ```
-
-A surface that follows the stream can transition that min-height to `0` when the run ends, and the follow glides the transcript down with it instead of dropping it.

--- a/.changeset/empty-camels-admire.md
+++ b/.changeset/empty-camels-admire.md
@@ -1,0 +1,22 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Chat transcripts now follow the stream. With `autoScroll` on, `MessageScroller` carries the reader with the newest output while they are attached to the end, and a new user turn re-attaches them there. Only the reader can detach it, by scrolling away — content growing under them cannot, which is what used to flash the jump-to-end button for a moment on every send and yank the view back up to the last user message on tool progress.
+
+Content that lands above the reader mid-run (a temporal gap separator, a late tool row) no longer shifts what they are reading.
+
+A turn opening only animates the scroll for a reader who had scrolled away and has to be brought back. Someone already at the end is carried by whatever the turn grows under itself, so its transition — not a competing scroll animation — sets the pace:
+
+```tsx
+<MessageScrollerProvider autoScroll>
+  <MessageScrollerViewport>
+    <MessageScrollerContent>
+      {/* the viewport is a size container, so a live turn can reserve a share of it */}
+      <div className="min-h-[70cqh]">{liveTurn}</div>
+    </MessageScrollerContent>
+  </MessageScrollerViewport>
+</MessageScrollerProvider>
+```
+
+A surface that follows the stream can transition that min-height to `0` when the run ends, and the follow glides the transcript down with it instead of dropping it.

--- a/.changeset/olive-eggs-appear.md
+++ b/.changeset/olive-eggs-appear.md
@@ -1,0 +1,13 @@
+---
+'@mastra/factory': patch
+---
+
+The factory chat now follows the agent as it works. Sending a message scrolls once, parking your message near the top with room under it, and the view then stays on the newest output — tool progress, subagents, the streamed reply — instead of standing still or jumping back up to the message you just sent. Scroll up to read back and the chat stops following; return to the bottom and it picks the stream back up.
+
+That room is held open only while the agent works. It opens under the turn you just sent and closes when the run ends, both on the same eased curve, so a finished conversation settles against the composer instead of leaving most of the window blank — and a run that ends while the room is still opening reverses from wherever it got to rather than snapping. The thinking line fades in with it.
+
+Two things used to move the transcript a second time, a beat after sending. The run echoes your message back as its own signal row, which draws nothing on screen — it was still treated as a new turn, so the reserved room jumped from the message you can see to an empty group, closing under one and reopening under the other just as the reply started. A turn is now what you can see: only a drawn message opens one, and it keeps its room for the whole answer.
+
+A time separator like `24 minutes later` is written a moment after the message it introduces and belongs above it, which used to shove the whole transcript down a second after sending. It is now part of the turn it announces, so it lands inside that reserved room and nothing else moves.
+
+The jump-to-latest button also stops flickering on send: it now tracks whether you are attached to the stream rather than how far the end happens to be, so output arriving cannot make it appear while the chat is already carrying you there.

--- a/.changeset/olive-eggs-appear.md
+++ b/.changeset/olive-eggs-appear.md
@@ -2,12 +2,8 @@
 '@mastra/factory': patch
 ---
 
-The factory chat now follows the agent as it works. Sending a message scrolls once, parking your message near the top with room under it, and the view then stays on the newest output — tool progress, subagents, the streamed reply — instead of standing still or jumping back up to the message you just sent. Scroll up to read back and the chat stops following; return to the bottom and it picks the stream back up.
+Improved chat scrolling in the factory. Sending a message now scrolls once and parks it near the top with room under it, and the view stays on the agent's newest output — tool progress, subagents, the streamed reply — instead of standing still or jumping back up to what you just sent.
 
-That room is held open only while the agent works. It opens under the turn you just sent and closes when the run ends, both on the same eased curve, so a finished conversation settles against the composer instead of leaving most of the window blank — and a run that ends while the room is still opening reverses from wherever it got to rather than snapping. The thinking line fades in with it.
+Scroll up to read back and the chat stops following. Return to the bottom and it picks the stream up again. The jump-to-latest button no longer flickers when you send a message.
 
-Two things used to move the transcript a second time, a beat after sending. The run echoes your message back as its own signal row, which draws nothing on screen — it was still treated as a new turn, so the reserved room jumped from the message you can see to an empty group, closing under one and reopening under the other just as the reply started. A turn is now what you can see: only a drawn message opens one, and it keeps its room for the whole answer.
-
-A time separator like `24 minutes later` is written a moment after the message it introduces and belongs above it, which used to shove the whole transcript down a second after sending. It is now part of the turn it announces, so it lands inside that reserved room and nothing else moves.
-
-The jump-to-latest button also stops flickering on send: it now tracks whether you are attached to the stream rather than how far the end happens to be, so output arriving cannot make it appear while the chat is already carrying you there.
+The room under the live turn is released when the run ends, so a finished conversation settles against the composer instead of leaving most of the window blank.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ActivityLine.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ActivityLine.tsx
@@ -62,7 +62,12 @@ export function ActivityLine() {
   if (!busy || !awaitingFirstOutput(transcript.entries)) return null;
 
   return (
-    <Txt as="p" variant="ui-sm" aria-hidden className="text-icon3 px-1.5 py-1">
+    <Txt
+      as="p"
+      variant="ui-sm"
+      aria-hidden
+      className="text-icon3 motion-safe:animate-in fade-in-0 slide-in-from-bottom-1 px-1.5 py-1"
+    >
       <Shimmer>Thinking</Shimmer>
     </Txt>
   );

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -501,7 +501,7 @@ function SignalRow({ kind, label, message }: { kind: string; label: string; mess
 
 export function Transcript({ tail }: { tail?: ReactNode }) {
   const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
-  const { transcript, resolvePrompt } = useChatTranscript();
+  const { transcript, resolvePrompt, busy } = useChatTranscript();
   const hookArgs = {
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
@@ -527,6 +527,7 @@ export function Transcript({ tail }: { tail?: ReactNode }) {
       isSubmitting={approveMutation.isPending || respondMutation.isPending}
       onApprove={onApprove}
       onRespond={onRespond}
+      running={busy}
       tail={tail}
     />
   );
@@ -537,12 +538,15 @@ export function TranscriptEntries({
   isSubmitting = false,
   onApprove,
   onRespond,
+  running = false,
   tail,
 }: {
   entries: TimelineEntry[];
   isSubmitting?: boolean;
   onApprove: (toolCallId: string, approved: boolean, promptId: string) => void;
   onRespond: (toolCallId: string, resumeData: string | string[] | PlanResume, promptId: string) => void;
+  /** Holds the room open under the live turn, and releases it when the agent stops. */
+  running?: boolean;
   /** Rendered inside the live turn (the activity line), so the reserved room stays under it. */
   tail?: ReactNode;
 }) {
@@ -584,22 +588,38 @@ export function TranscriptEntries({
     }
   };
 
+  // A turn is what you can see: the run echoes the message you sent back as a signal
+  // that draws nothing, and letting that open a turn would take the room off your bubble.
+  const drawsContent = (entry: MessageEntry): boolean =>
+    entry.message.content.parts.some(part => isRenderablePart(part, suspensions, entry.runtimeTools));
+  const opensTurn = (entry: TimelineEntry): boolean =>
+    entry.kind === 'message' && startsUserTurn(entry.message) && drawsContent(entry);
+
   const turnGroups: { key: string; entries: TimelineEntry[]; opensTurn: boolean }[] = [];
   for (const entry of entries) {
-    const opensTurn = entry.kind === 'message' && startsUserTurn(entry.message);
-    if (opensTurn || turnGroups.length === 0) turnGroups.push({ key: entry.id, entries: [], opensTurn });
-    turnGroups.at(-1)?.entries.push(entry);
+    const opens = opensTurn(entry);
+    if (!opens && turnGroups.length > 0) {
+      turnGroups.at(-1)?.entries.push(entry);
+      continue;
+    }
+    // A gap sorts above the turn it introduces but arrives after it: inside that turn the
+    // room absorbs its height, outside it shifts the transcript a beat later.
+    const previous = turnGroups.at(-1);
+    const introduction = previous && isTimeGap(previous.entries.at(-1)) ? previous.entries.splice(-1) : [];
+    turnGroups.push({ key: entry.id, entries: [...introduction, entry], opensTurn: opens });
   }
 
   return (
     <>
       {turnGroups.map((group, index) => {
         const isLiveTurn = index === turnGroups.length - 1;
+        // Every turn keeps `turn-room`: the one handing the room over closes on its curve.
+        const holdsRoom = isLiveTurn && group.opensTurn && running;
         return (
-          // The room a fresh turn scrolls up into is this min-height: pure layout,
-          // filled by the streaming reply. It stays after the run — collapsing it
-          // would shift the reader — and moves to the next turn with the anchor scroll.
-          <div key={group.key} className={cn('flex flex-col', isLiveTurn && group.opensTurn && 'min-h-[50cqh]')}>
+          <div
+            key={group.key}
+            className={cn('flex flex-col', group.opensTurn && 'turn-room', holdsRoom && 'turn-room-open')}
+          >
             {group.entries.map(entry => {
               const rendered = renderEntry(entry);
               if (!rendered) return null;
@@ -608,7 +628,7 @@ export function TranscriptEntries({
                 <MessageScrollerItem
                   key={entry.id}
                   messageId={entry.id}
-                  scrollAnchor={entry.kind === 'message' && startsUserTurn(entry.message)}
+                  scrollAnchor={opensTurn(entry)}
                   // Estimated off-screen heights would make the prepend anchor restore
                   // the wrong offset — measure the real thing.
                   className="[content-visibility:visible]"
@@ -1072,6 +1092,11 @@ function signalRowView(entry: MessageEntry): SignalRowView | undefined {
   if (signal.type === 'reactive' && tagName === 'system-reminder') return { kind: reminderKind, text };
   if (signal.type === 'reactive') return { kind: 'reactive', tagName, text };
   return undefined;
+}
+
+/** The `24 minutes later` separator, written a millisecond before the turn it introduces. */
+function isTimeGap(entry: TimelineEntry | undefined): boolean {
+  return entry?.kind === 'message' && signalRowView(entry)?.kind === 'gap';
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
@@ -7,6 +7,8 @@ import type { TimelineEntry } from '../../services/transcript';
 import { TranscriptEntries } from '../Transcript';
 
 const CREATED_AT = new Date('2026-07-15T10:00:00.000Z');
+const ROOM_CLASS = 'turn-room-open';
+const ROOM_SELECTOR = `.${ROOM_CLASS}`;
 
 function textEntry(id: string, role: 'user' | 'assistant', text: string): TimelineEntry {
   const message: MastraDBMessage = {
@@ -14,6 +16,39 @@ function textEntry(id: string, role: 'user' | 'assistant', text: string): Timeli
     role,
     createdAt: CREATED_AT,
     content: { format: 2, parts: [{ type: 'text', text }] },
+  };
+  return { kind: 'message', id, message };
+}
+
+function gapEntry(id: string): TimelineEntry {
+  const message: MastraDBMessage = {
+    id,
+    role: 'signal',
+    createdAt: CREATED_AT,
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text: '24 minutes later — 07/15/2026, 10:00 AM GMT+2' }],
+      metadata: {
+        signal: {
+          id,
+          type: 'reactive',
+          tagName: 'system-reminder',
+          createdAt: CREATED_AT.toISOString(),
+          attributes: { type: 'temporal-gap' },
+        },
+      },
+    },
+  };
+  return { kind: 'message', id, message };
+}
+
+/** The run's own copy of what you typed: a user row carrying a data part, which draws nothing. */
+function echoEntry(id: string, text: string): TimelineEntry {
+  const message: MastraDBMessage = {
+    id,
+    role: 'user',
+    createdAt: CREATED_AT,
+    content: { format: 2, parts: [{ type: 'data-user-message', data: { contents: text } }] },
   };
   return { kind: 'message', id, message };
 }
@@ -31,15 +66,16 @@ describe('TranscriptEntries turn groups', () => {
         entries={entries}
         onApprove={() => {}}
         onRespond={() => {}}
+        running
         tail={<div data-testid="tail" />}
       />,
     );
 
     const liveGroup = screen.getByTestId('tail').parentElement;
-    expect(liveGroup).toHaveClass('min-h-[50cqh]');
+    expect(liveGroup).toHaveClass(ROOM_CLASS);
     expect(liveGroup).toBeInstanceOf(HTMLElement);
     if (liveGroup) expect(within(liveGroup).getByText('second question')).toBeInTheDocument();
-    expect(screen.getByText('first question').closest('.min-h-\\[50cqh\\]')).toBeNull();
+    expect(screen.getByText('first question').closest(ROOM_SELECTOR)).toBeNull();
 
     rerender(
       <TranscriptEntries
@@ -50,11 +86,80 @@ describe('TranscriptEntries turn groups', () => {
         ]}
         onApprove={() => {}}
         onRespond={() => {}}
+        running
         tail={<div data-testid="tail" />}
       />,
     );
-    expect(screen.getByTestId('tail').parentElement).toHaveClass('min-h-[50cqh]');
-    expect(screen.getByText('second question').closest('.min-h-\\[50cqh\\]')).toBeNull();
+    expect(screen.getByTestId('tail').parentElement).toHaveClass(ROOM_CLASS);
+    // Closes as the new turn opens instead of vanishing under the reader.
+    const handedOver = screen.getByText('second question').closest('.turn-room');
+    expect(handedOver).not.toBeNull();
+    expect(handedOver).not.toHaveClass(ROOM_CLASS);
+    // One room, whatever the turn count: two would stack into a double gap.
+    expect(document.querySelectorAll(ROOM_SELECTOR)).toHaveLength(1);
+  });
+
+  it('releases the room through a transition once the agent stops', () => {
+    const { rerender } = renderWithProviders(
+      <TranscriptEntries
+        entries={entries}
+        onApprove={() => {}}
+        onRespond={() => {}}
+        running
+        tail={<div data-testid="tail" />}
+      />,
+    );
+
+    rerender(
+      <TranscriptEntries
+        entries={entries}
+        onApprove={() => {}}
+        onRespond={() => {}}
+        tail={<div data-testid="tail" />}
+      />,
+    );
+
+    const liveGroup = screen.getByTestId('tail').parentElement;
+    expect(liveGroup).not.toHaveClass(ROOM_CLASS);
+    // Kept: it carries the transition the room closes on.
+    expect(liveGroup).toHaveClass('turn-room');
+  });
+
+  it('keeps the room on the message you sent when the run echoes it back undrawn', () => {
+    const { rerender } = renderWithProviders(
+      <TranscriptEntries entries={[entries[0]]} onApprove={() => {}} onRespond={() => {}} running />,
+    );
+    const room = screen.getByText('first question').closest(ROOM_SELECTOR);
+    expect(room).toBeInstanceOf(HTMLElement);
+
+    rerender(
+      <TranscriptEntries
+        entries={[entries[0], echoEntry('echo-1', 'first question'), entries[1]]}
+        onApprove={() => {}}
+        onRespond={() => {}}
+        running
+      />,
+    );
+
+    // The same node, so the room does not close and reopen under the reply.
+    expect(screen.getByText('first question').closest(ROOM_SELECTOR)).toBe(room);
+    expect(screen.getByText('first answer').closest(ROOM_SELECTOR)).toBe(room);
+    expect(document.querySelectorAll(ROOM_SELECTOR)).toHaveLength(1);
+  });
+
+  it('takes the gap that introduces a turn into that turn, where the room absorbs it', () => {
+    renderWithProviders(
+      <TranscriptEntries
+        entries={[entries[0], entries[1], gapEntry('gap-1'), entries[2]]}
+        onApprove={() => {}}
+        onRespond={() => {}}
+        running
+      />,
+    );
+
+    const room = screen.getByText('second question').closest<HTMLElement>(ROOM_SELECTOR);
+    expect(room).toBeInstanceOf(HTMLElement);
+    if (room) expect(within(room).getByRole('separator')).toBeInTheDocument();
   });
 
   it('gives no room to a group no user turn opens', () => {
@@ -63,10 +168,11 @@ describe('TranscriptEntries turn groups', () => {
         entries={[textEntry('assistant-only', 'assistant', 'orphan answer')]}
         onApprove={() => {}}
         onRespond={() => {}}
+        running
       />,
     );
 
-    expect(screen.getByText('orphan answer').closest('.min-h-\\[50cqh\\]')).toBeNull();
+    expect(screen.getByText('orphan answer').closest(ROOM_SELECTOR)).toBeNull();
   });
 
   it('still shows the tail while the transcript is empty', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/chat-enter.css
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/chat-enter.css
@@ -46,9 +46,34 @@
   }
 }
 
+/* The scroller stays pinned to the end while this opens and closes, so these
+ * curves — not a scroll animation — are what carry the transcript. Opening
+ * answers a keypress; closing is the conversation settling, so it drifts. */
+.turn-room {
+  min-height: 0;
+  transition: min-height 1500ms cubic-bezier(0.3, 0, 0.2, 1);
+}
+
+.turn-room-open {
+  min-height: 70cqh;
+  transition: min-height 440ms cubic-bezier(0.2, 0, 0.2, 1);
+}
+
+/* A turn mounts with its room already due, and a transition alone has nothing to move from. */
+@starting-style {
+  .turn-room-open {
+    min-height: 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .chat-surface-enter,
   .composer-enter {
     animation: none;
+  }
+
+  .turn-room,
+  .turn-room-open {
+    transition: none;
   }
 }

--- a/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
@@ -152,6 +152,7 @@ function ThreadShell({
     <ChatShell
       className={threadShellClass}
       scroller={{
+        autoScroll: true,
         defaultScrollPosition: 'last-anchor',
         preserveScrollOnPrepend: true,
         onReachStart: canLoadMore ? loadMore.load : undefined,

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
@@ -11,6 +11,7 @@ import {
   MessageScrollerProvider,
   MessageScrollerViewport,
 } from './message-scroller';
+import type { MessageScrollerDefaultScrollPosition } from './message-scroller';
 
 if (!Element.prototype.getAnimations) {
   Object.defineProperty(Element.prototype, 'getAnimations', { configurable: true, value: () => [] });
@@ -394,19 +395,33 @@ const installScrollTo = (element: HTMLElement) => {
 
 const HistoryHarness = ({
   autoScroll = false,
+  defaultScrollPosition,
   messageIds,
   onReachStart,
+  replyIds = [],
 }: {
   autoScroll?: boolean;
+  defaultScrollPosition?: MessageScrollerDefaultScrollPosition;
   messageIds: string[];
   onReachStart?: () => void;
+  replyIds?: string[];
 }) => (
-  <MessageScrollerProvider autoScroll={autoScroll} preserveScrollOnPrepend onReachStart={onReachStart}>
+  <MessageScrollerProvider
+    autoScroll={autoScroll}
+    defaultScrollPosition={defaultScrollPosition}
+    preserveScrollOnPrepend
+    onReachStart={onReachStart}
+  >
     <MessageScrollerViewport data-testid="history-viewport">
       <MessageScrollerContent>
         {messageIds.map(messageId => (
           <MessageScrollerItem key={messageId} messageId={messageId} scrollAnchor>
             <div>{messageId}</div>
+          </MessageScrollerItem>
+        ))}
+        {replyIds.map(replyId => (
+          <MessageScrollerItem key={replyId} messageId={replyId}>
+            <div>{replyId}</div>
           </MessageScrollerItem>
         ))}
       </MessageScrollerContent>
@@ -742,6 +757,30 @@ describe('MessageScroller autoScroll', () => {
     });
 
     expect(scrollTo).toHaveBeenLastCalledWith({ top: 1800, behavior: 'auto' });
+  });
+
+  it('leaves a reopened thread on the turn it restored instead of following the stream', () => {
+    stubLayout({ 'message-1': 0, 'message-2': 300 });
+    const { rerender } = render(
+      <HistoryHarness autoScroll defaultScrollPosition="last-anchor" messageIds={['message-1', 'message-2']} />,
+    );
+
+    const viewport = screen.getByTestId('history-viewport');
+    const scrollTo = installScrollTo(viewport);
+    setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 300 });
+
+    // Rows registering after the restore must not be read as the reader riding the stream.
+    Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1400 });
+    rerender(
+      <HistoryHarness
+        autoScroll
+        defaultScrollPosition="last-anchor"
+        messageIds={['message-1', 'message-2']}
+        replyIds={['reply-1']}
+      />,
+    );
+
+    expect(scrollTo).not.toHaveBeenCalled();
   });
 
   it('lets the turn itself carry a reader who is already at the end', () => {

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
@@ -783,6 +783,51 @@ describe('MessageScroller autoScroll', () => {
     expect(scrollTo).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { defaultScrollPosition: 'start', landsOn: 0 },
+    { defaultScrollPosition: 'last-anchor', landsOn: 550 },
+  ] as const)(
+    'opens an asynchronously loaded transcript at its $defaultScrollPosition before following anything',
+    ({ defaultScrollPosition, landsOn }) => {
+      const frames: FrameRequestCallback[] = [];
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => frames.push(callback));
+      stubLayout({ 'message-1': 0, 'message-2': 300 });
+      const { rerender } = render(
+        <HistoryHarness autoScroll defaultScrollPosition={defaultScrollPosition} messageIds={[]} />,
+      );
+
+      const viewport = screen.getByTestId('history-viewport');
+      const scrollTo = installScrollTo(viewport);
+      setScrollMetrics(viewport, { scrollHeight: 1200, clientHeight: 400, scrollTop: 250 });
+
+      rerender(
+        <HistoryHarness
+          autoScroll
+          defaultScrollPosition={defaultScrollPosition}
+          messageIds={['message-1', 'message-2']}
+        />,
+      );
+      expect(scrollTo).not.toHaveBeenCalled();
+
+      act(() => frames.shift()?.(0));
+      act(() => frames.shift()?.(16));
+      expect(scrollTo).toHaveBeenLastCalledWith({ top: landsOn, behavior: 'auto' });
+
+      scrollTo.mockClear();
+      Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1600 });
+      rerender(
+        <HistoryHarness
+          autoScroll
+          defaultScrollPosition={defaultScrollPosition}
+          messageIds={['message-1', 'message-2']}
+          replyIds={['reply-1']}
+        />,
+      );
+
+      expect(scrollTo).not.toHaveBeenCalled();
+    },
+  );
+
   it('lets the turn itself carry a reader who is already at the end', () => {
     stubLayout({ 'message-2': 300 });
     const { rerender } = render(<HistoryHarness autoScroll messageIds={['message-1']} />);

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.test.tsx
@@ -374,6 +374,15 @@ const setScrollMetrics = (
   element.scrollTop = metrics.scrollTop;
 };
 
+// Only a scroll back up detaches a reader, so detaching one takes two moves: end, then up.
+const scrollReaderTo = (
+  element: HTMLElement,
+  metrics: { scrollHeight: number; clientHeight: number; scrollTop: number },
+) => {
+  setScrollMetrics(element, metrics);
+  fireEvent.scroll(element);
+};
+
 const installScrollTo = (element: HTMLElement) => {
   const scrollTo = vi.fn((options?: ScrollToOptions | number) => {
     if (typeof options === 'object' && typeof options.top === 'number') element.scrollTop = options.top;
@@ -395,6 +404,25 @@ const HistoryHarness = ({
   <MessageScrollerProvider autoScroll={autoScroll} preserveScrollOnPrepend onReachStart={onReachStart}>
     <MessageScrollerViewport data-testid="history-viewport">
       <MessageScrollerContent>
+        {messageIds.map(messageId => (
+          <MessageScrollerItem key={messageId} messageId={messageId} scrollAnchor>
+            <div>{messageId}</div>
+          </MessageScrollerItem>
+        ))}
+      </MessageScrollerContent>
+    </MessageScrollerViewport>
+  </MessageScrollerProvider>
+);
+
+const MarkerHarness = ({ markerIds = [], messageIds }: { markerIds?: string[]; messageIds: string[] }) => (
+  <MessageScrollerProvider autoScroll>
+    <MessageScrollerViewport data-testid="marker-viewport">
+      <MessageScrollerContent>
+        {markerIds.map(markerId => (
+          <MessageScrollerItem key={markerId} messageId={markerId}>
+            <div>{markerId}</div>
+          </MessageScrollerItem>
+        ))}
         {messageIds.map(messageId => (
           <MessageScrollerItem key={messageId} messageId={messageId} scrollAnchor>
             <div>{messageId}</div>
@@ -688,14 +716,157 @@ describe('MessageScroller autoScroll', () => {
     expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'auto' });
   });
 
+  it('stays attached when a scroll lands behind a reply that is still growing', async () => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    render(<HistoryHarness autoScroll messageIds={['message-1']} />);
+
+    const viewport = screen.getByTestId('history-viewport');
+    installScrollTo(viewport);
+    scrollReaderTo(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+
+    const { content, observer } = contentResizeObserver();
+    Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1400 });
+    await act(async () => {
+      observer.trigger([{ target: content }]);
+    });
+
+    // The follow lands on the end of the frame it measured, and the scroll event
+    // for it arrives once the reply has already grown past that.
+    Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1800 });
+    fireEvent.scroll(viewport);
+
+    const scrollTo = installScrollTo(viewport);
+    Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 2200 });
+    await act(async () => {
+      observer.trigger([{ target: content }]);
+    });
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1800, behavior: 'auto' });
+  });
+
+  it('lets the turn itself carry a reader who is already at the end', () => {
+    stubLayout({ 'message-2': 300 });
+    const { rerender } = render(<HistoryHarness autoScroll messageIds={['message-1']} />);
+
+    const viewport = screen.getByTestId('history-viewport');
+    installScrollTo(viewport);
+    setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+    fireEvent.scroll(viewport);
+
+    const scrollTo = installScrollTo(viewport);
+    Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1400 });
+    rerender(<HistoryHarness autoScroll messageIds={['message-1', 'message-2']} />);
+
+    // `auto`: the turn's own curve is the motion, pinning to the end each frame rides it.
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'auto' });
+  });
+
+  it('brings a reader who left back to the end when they open a turn', () => {
+    stubLayout({ 'message-2': 300 });
+    const { rerender } = render(<HistoryHarness autoScroll messageIds={['message-1']} />);
+
+    const viewport = screen.getByTestId('history-viewport');
+    installScrollTo(viewport);
+    scrollReaderTo(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+    scrollReaderTo(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 200 });
+
+    const scrollTo = installScrollTo(viewport);
+    Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1400 });
+    rerender(<HistoryHarness autoScroll messageIds={['message-1', 'message-2']} />);
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'smooth' });
+  });
+
+  it('holds the reading position when a marker lands above the reader', async () => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    const { rerender } = render(<MarkerHarness messageIds={['message-1']} />);
+
+    const viewport = screen.getByTestId('marker-viewport');
+    installScrollTo(viewport);
+    setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+    fireEvent.scroll(viewport);
+
+    const scrollTo = installScrollTo(viewport);
+    // A temporal marker persisted mid-run lands above the turn the reader is on:
+    // the transcript gets taller without them having moved.
+    Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1040 });
+    rerender(<MarkerHarness markerIds={['marker-1']} messageIds={['message-1']} />);
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 640, behavior: 'auto' });
+  });
+
+  it('keeps carrying the reader while a smooth scroll is still travelling', async () => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    const { rerender } = render(<HistoryHarness autoScroll messageIds={['message-1']} />);
+
+    const viewport = screen.getByTestId('history-viewport');
+    installScrollTo(viewport);
+    scrollReaderTo(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+    scrollReaderTo(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 200 });
+
+    // A real smooth scroll spends frames travelling, so the position stays
+    // behind the end while the reply already grows into it.
+    const scrollTo = vi.fn();
+    viewport.scrollTo = scrollTo;
+    Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1400 });
+    rerender(<HistoryHarness autoScroll messageIds={['message-1', 'message-2']} />);
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'smooth' });
+
+    const { content, observer } = contentResizeObserver();
+    Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1800 });
+    await act(async () => {
+      observer.trigger([{ target: content }]);
+    });
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1400, behavior: 'smooth' });
+  });
+
+  it('never offers to jump to an end it is already carrying the reader to', () => {
+    const { rerender } = render(<HistoryHarness autoScroll messageIds={['message-1']} />);
+
+    const viewport = screen.getByTestId('history-viewport');
+    installScrollTo(viewport);
+    setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+    fireEvent.scroll(viewport);
+
+    // The turn opens and the reply grows into a smooth scroll still in flight: the
+    // end sits far below, but the reader is already on their way to it.
+    viewport.scrollTo = vi.fn();
+    Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1400 });
+    rerender(<HistoryHarness autoScroll messageIds={['message-1', 'message-2']} />);
+
+    expect(viewport.getAttribute('data-scrollable')).toBe('start');
+
+    setScrollMetrics(viewport, { scrollHeight: 1400, clientHeight: 400, scrollTop: 200 });
+    fireEvent.scroll(viewport);
+
+    expect(viewport.getAttribute('data-scrollable')).toBe('start end');
+  });
+
+  it('takes the button back in the same frame a new turn re-attaches the reader', () => {
+    const { rerender } = render(<HistoryHarness autoScroll messageIds={['message-1']} />);
+
+    const viewport = screen.getByTestId('history-viewport');
+    installScrollTo(viewport);
+    scrollReaderTo(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+    scrollReaderTo(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 200 });
+    expect(viewport.getAttribute('data-scrollable')).toBe('start end');
+
+    viewport.scrollTo = vi.fn();
+    Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1400 });
+    rerender(<HistoryHarness autoScroll messageIds={['message-1', 'message-2']} />);
+
+    expect(viewport.getAttribute('data-scrollable')).toBe('start');
+  });
+
   it('leaves the reader alone once they have scrolled away from the end', async () => {
     vi.stubGlobal('ResizeObserver', MockResizeObserver);
     render(<HistoryHarness autoScroll messageIds={['message-1']} />);
 
     const viewport = screen.getByTestId('history-viewport');
     installScrollTo(viewport);
-    setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 200 });
-    fireEvent.scroll(viewport);
+    scrollReaderTo(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+    scrollReaderTo(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 200 });
 
     const { content, observer } = contentResizeObserver();
     const scrollTo = installScrollTo(viewport);

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
@@ -555,6 +555,9 @@ export function MessageScrollerProvider({
 
     const applyDefaultScroll = () => {
       const lastAnchorId = getLastAnchorId();
+      // Where a thread opens decides whether it starts attached: a restored reading
+      // position has the stream below it. `scrollToEnd` takes this back when it lands.
+      followingRef.current = false;
       let didScroll = false;
       if (defaultScrollPosition === 'start') {
         didScroll = scrollToStart({ behavior: 'auto' });

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.tsx
@@ -168,6 +168,7 @@ const getCurrentAnchorId = ({
 };
 
 export interface MessageScrollerProviderProps {
+  /** Carry the reader with the stream, re-attaching on a new turn. Off parks a new turn at the top instead. */
   autoScroll?: boolean;
   children?: React.ReactNode;
   defaultScrollPosition?: MessageScrollerDefaultScrollPosition;
@@ -218,6 +219,13 @@ export function MessageScrollerProvider({
   const [scrollable, setScrollable] = React.useState<MessageScrollerScrollable>(DEFAULT_SCROLLABLE);
   const [visibility, setVisibility] = React.useState<MessageScrollerVisibility>(DEFAULT_VISIBILITY);
   const atEndRef = React.useRef(true);
+  // Attachment is a mode, not a measurement: a growing reply moves the end away
+  // without the reader having moved, so only the reader detaches it.
+  const followingRef = React.useRef(true);
+  // Sampled mid-flight, a smooth trip reads as a reader who left. It only heads
+  // for the end, so a position going backwards is what calls it off.
+  const travellingToEndRef = React.useRef(false);
+  const lastScrollTopRef = React.useRef(0);
   // Mount sits at scrollTop 0 before the default scroll lands, indistinguishable
   // from a reader asking for older history. Arms only once settled at the end.
   const reachStartArmedRef = React.useRef(false);
@@ -253,20 +261,33 @@ export function MessageScrollerProvider({
     setVisibility(current => (visibilityMatches(current, nextVisibility) ? current : nextVisibility));
   }, []);
 
-  const updateScrollable = React.useCallback(() => {
-    if (!viewportElement) {
-      atEndRef.current = true;
-      publishScrollable(DEFAULT_SCROLLABLE);
-      return;
-    }
+  const updateScrollable = React.useCallback(
+    ({ fromScroll = false }: { fromScroll?: boolean } = {}) => {
+      if (!viewportElement) {
+        atEndRef.current = true;
+        publishScrollable(DEFAULT_SCROLLABLE);
+        return;
+      }
 
-    const remainingScroll = viewportElement.scrollHeight - viewportElement.scrollTop - viewportElement.clientHeight;
-    atEndRef.current = remainingScroll < AUTO_SCROLL_ATTACH_THRESHOLD;
-    publishScrollable({
-      start: viewportElement.scrollTop > scrollEdgeThreshold,
-      end: remainingScroll > scrollEdgeThreshold,
-    });
-  }, [publishScrollable, scrollEdgeThreshold, viewportElement]);
+      const { clientHeight, scrollHeight, scrollTop } = viewportElement;
+      const remainingScroll = scrollHeight - scrollTop - clientHeight;
+      const wentBack = scrollTop < lastScrollTopRef.current;
+      atEndRef.current = remainingScroll < AUTO_SCROLL_ATTACH_THRESHOLD;
+      if (atEndRef.current || wentBack) travellingToEndRef.current = false;
+      lastScrollTopRef.current = scrollTop;
+      // Scrolling back is the only way out of the stream, the end the only way back in:
+      // a position merely left behind by a growing reply is us chasing it, not them leaving.
+      if (fromScroll && !travellingToEndRef.current && (wentBack || atEndRef.current)) {
+        followingRef.current = atEndRef.current;
+      }
+
+      publishScrollable({
+        start: scrollTop > scrollEdgeThreshold,
+        end: remainingScroll > scrollEdgeThreshold && !(autoScroll && followingRef.current),
+      });
+    },
+    [autoScroll, publishScrollable, scrollEdgeThreshold, viewportElement],
+  );
 
   // Registration is mount order, not document order, once history is prepended.
   const getOrderedItems = React.useCallback(() => {
@@ -345,7 +366,8 @@ export function MessageScrollerProvider({
 
   const notifyScroll = React.useCallback(() => {
     const wasScrollable = Boolean(viewportElement && viewportElement.scrollHeight > viewportElement.clientHeight);
-    syncAfterScroll();
+    updateScrollable({ fromScroll: true });
+    updateVisibility();
     if (!viewportElement) return;
 
     if (atEndRef.current && wasScrollable) reachStartArmedRef.current = true;
@@ -368,15 +390,15 @@ export function MessageScrollerProvider({
       };
     }
     onReachStartRef.current();
-  }, [preserveScrollOnPrepend, reachStartThreshold, syncAfterScroll, viewportElement]);
+  }, [preserveScrollOnPrepend, reachStartThreshold, updateScrollable, updateVisibility, viewportElement]);
 
   const notifyContentResize = React.useCallback(() => {
-    const followEnd = autoScroll && defaultScrollAppliedRef.current && atEndRef.current && viewportElement;
+    const followEnd = autoScroll && defaultScrollAppliedRef.current && followingRef.current && viewportElement;
     if (followEnd) {
       scrollViewportTo(
         viewportElement,
         Math.max(0, viewportElement.scrollHeight - viewportElement.clientHeight),
-        'auto',
+        travellingToEndRef.current ? 'smooth' : 'auto',
       );
     }
     syncAfterScroll();
@@ -424,11 +446,15 @@ export function MessageScrollerProvider({
   const scrollToEnd = React.useCallback(
     ({ behavior = 'auto' }: MessageScrollerScrollOptions = {}) => {
       if (!viewportElement) return false;
+      followingRef.current = true;
+      travellingToEndRef.current = behavior === 'smooth';
       scrollViewportTo(
         viewportElement,
         Math.max(0, viewportElement.scrollHeight - viewportElement.clientHeight),
         behavior,
       );
+      // Published now, not next frame: a button that hears about the trip late flashes.
+      syncAfterScroll();
       scheduleScrollSync(syncAfterScroll);
       return true;
     },
@@ -574,10 +600,12 @@ export function MessageScrollerProvider({
     viewportElement,
   ]);
 
+  // Following has one target, the end: a turn opening re-attaches the reader there,
+  // and from then on nothing the run appends — or slips in above them — moves it.
   React.useLayoutEffect(() => {
     const lastAnchorId = getLastAnchorId();
     const lastAnchor = lastAnchorId ? itemsRegistry.get(lastAnchorId) : undefined;
-    const shouldAnchorNewTurn =
+    const opensTurn =
       turnAnchoringArmedRef.current &&
       lastAnchorId !== undefined &&
       lastAnchor !== undefined &&
@@ -591,13 +619,25 @@ export function MessageScrollerProvider({
     }
     turnAnchoringArmedRef.current = defaultScrollAppliedRef.current;
 
-    if (!shouldAnchorNewTurn || !lastAnchorId) return;
-    scrollToMessage(lastAnchorId, { align: 'start', behavior: 'smooth' });
+    if (!autoScroll) {
+      if (opensTurn && lastAnchorId) scrollToMessage(lastAnchorId, { align: 'start', behavior: 'smooth' });
+      return;
+    }
+
+    // Whatever the turn opens under itself already carries a reader who is riding the
+    // stream; animating on top of that is a competing motion. Only a return trip travels.
+    const wasFollowing = followingRef.current;
+    if (opensTurn) followingRef.current = true;
+    if (!defaultScrollAppliedRef.current || !followingRef.current) return;
+    const catchingUp = (opensTurn && !wasFollowing) || travellingToEndRef.current;
+    scrollToEnd({ behavior: catchingUp ? 'smooth' : 'auto' });
   }, [
+    autoScroll,
     getLastAnchorId,
     getOrderedItems,
     itemsRegistry,
     itemsVersion,
+    scrollToEnd,
     scrollToMessage,
     seenAnchorElements,
     seenAnchorIds,
@@ -622,11 +662,6 @@ export function MessageScrollerProvider({
     const grownBy = viewportElement.scrollHeight - anchor.scrollHeight;
     if (grownBy > 0) viewportElement.scrollTop = anchor.scrollTop + grownBy;
   }, [contentElement, itemsVersion, viewportElement]);
-
-  React.useLayoutEffect(() => {
-    if (!autoScroll || !defaultScrollAppliedRef.current || !atEndRef.current) return;
-    scrollToEnd({ behavior: 'auto' });
-  }, [autoScroll, itemsVersion, scrollToEnd]);
 
   const actionsContextValue = React.useMemo<MessageScrollerActionsContextValue>(
     () => ({


### PR DESCRIPTION
The factory chat now stays on the agent's newest output while it works, instead of standing still or jumping back up to the message you just sent.

Before, sending scrolled twice — once for your message, then again a beat later — and during the answer the view held still, so tool progress and subagents ran off the bottom edge. The jump-to-latest button also flashed on every send, because it was measuring how far the end was while the scroll was still on its way there. Now sending scrolls once and parks your message near the top with room under it, the view rides the stream from there, scrolling up detaches it, and coming back to the end re-attaches.

Both extra movements turned out to be the same thing: something that draws nothing was being treated as a new turn. The run echoes your message back as a signal row carrying only a data part, and a `24 minutes later` separator is stamped a millisecond before the message it introduces, so it arrives late and sorts above it. A turn is now what you can see — only a drawn message opens one — and a separator joins the turn it announces, where the reserved room absorbs its height. That room is a min-height on the live turn: it opens fast on send and drifts closed over 1.5s when the run ends, so a finished conversation settles against the composer. The scroller stays pinned to the end throughout, so that transition is what carries the transcript, and it only animates a scroll for a reader who had left and has to be brought back — otherwise the two motions compete.

One thing I removed while reviewing: I had exposed the room size as a `--scroller-room` custom property on the scroller viewport, and it doesn't work. Tailwind orders same-element arbitrary properties by value, not by class order, so the design system's default would have silently beaten a consumer's override. The viewport is already a size container, so each surface just writes `cqh` itself and the knob is gone.

No screenshot: this is a motion change and I'd rather not stage one. Damien is checking it live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The chat follows the agent’s latest work while it responds. If a reader scrolls up, the chat stops following until the reader returns to the end.

## Changes

- Improved `MessageScroller` auto-scroll behavior:
  - Follows streamed output.
  - Detaches when the reader scrolls away.
  - Re-attaches at the end.
  - Preserves restored-thread positions.
  - Supports `start` and `last-anchor` initial positions.
  - Animates only during re-attachment.
- Updated turn grouping so only rendered messages start turns.
- Grouped echoed signal rows and time separators with the correct turn.
- Added reserved space for active turns. The space closes over 1.5 seconds when the run ends.
- Added motion-safe activity and turn-room animations.
- Enabled automatic scrolling for the factory thread shell with `defaultScrollPosition="last-anchor"`.
- Expanded tests for asynchronous transcript loading, configured starting positions, streaming, restored threads, turn insertion, re-attachment, detached readers, echoed messages, and time separators.
- Added changesets for `@mastra/factory` and `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->