### PR TITLE
fix(core): remove stale capability files

### DIFF
--- a/.changeset/clean-capabilities-vanish.md
+++ b/.changeset/clean-capabilities-vanish.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Removed obsolete generated capability files after registry refreshes.

--- a/packages/core/src/llm/model/registry-generator.test.ts
+++ b/packages/core/src/llm/model/registry-generator.test.ts
@@ -87,5 +87,22 @@ describe('registry-generator', () => {
       await expect(fs.stat(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' });
       await expect(fs.readFile(path.join(dir, 'capabilities', 'openai.json'), 'utf8')).resolves.toContain('gpt-4o');
     });
+
+    it('removes capability files when regenerated without capability data', async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mastra-capabilities-'));
+      tempDirs.push(dir);
+      const jsonPath = path.join(dir, 'provider-registry.json');
+      const typesPath = path.join(dir, 'provider-types.generated.d.ts');
+      const capabilityDir = path.join(dir, 'capabilities');
+      const capabilityPath = path.join(capabilityDir, 'openai.json');
+
+      await writeRegistryFiles(jsonPath, typesPath, {}, {}, undefined, undefined, { openai: ['gpt-4o'] });
+      await expect(fs.readFile(capabilityPath, 'utf8')).resolves.toContain('gpt-4o');
+
+      await writeRegistryFiles(jsonPath, typesPath, {}, {}, {}, {}, {});
+
+      await expect(fs.stat(capabilityPath)).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.stat(capabilityDir)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
   });
 });

--- a/packages/core/src/llm/model/registry-generator.ts
+++ b/packages/core/src/llm/model/registry-generator.ts
@@ -310,15 +310,16 @@ export async function writeRegistryFiles(
   await atomicWriteFile(typesPath, typeContent, 'utf-8');
 
   // 3. Write per-provider capability files into a capabilities/ directory
+  const capDir = path.join(jsonDir, 'capabilities');
   const hasCapabilities =
     (attachmentCapabilities && Object.keys(attachmentCapabilities).length > 0) ||
     (temperatureCapabilities && Object.keys(temperatureCapabilities).length > 0) ||
     (structuredOutputCapabilities && Object.keys(structuredOutputCapabilities).length > 0);
-  if (hasCapabilities) {
-    const capDir = path.join(jsonDir, 'capabilities');
 
-    // Replace the directory so stale files and legacy nested gateway paths are removed.
-    await fs.rm(capDir, { recursive: true, force: true });
+  // Remove stale files even when the latest registry has no capability data.
+  await fs.rm(capDir, { recursive: true, force: true });
+
+  if (hasCapabilities) {
     await fs.mkdir(capDir, { recursive: true });
 
     // Build a merged capability object per provider


### PR DESCRIPTION
## Description

Fixes stale generated capability files remaining on disk when a registry refresh no longer returns capability data.

Previously, the existing `capabilities/` directory was removed only when the new registry contained at least one capability entry. If all capability maps became empty, the cleanup was skipped and files from an earlier generation remained available to registry consumers.

This change clears the previous capability output on every successful registry generation, then recreates the directory only when new capability data exists.

FIXES #21530 

## Changes

- Moved capability-directory cleanup outside the `hasCapabilities` condition.
- Always removes the previous generated `capabilities/` directory.
- Recreates the directory only when the latest registry contains capability data.
- Preserves keyed empty arrays such as `{ openai: [] }` as meaningful provider capability data.
- Added a regression test covering consecutive generations where capability data becomes empty.
- Added an `@mastra/core` patch changeset.

## Test plan

The regression test verifies that:

1. Registry generation with capability data creates the expected provider file.
2. A subsequent generation with empty attachment, temperature, and structured-output capability maps removes the old provider file.
3. The empty `capabilities/` directory is not left behind.

Validation completed:

- [x] Focused `registry-generator.test.ts` suite — 6 tests passed
- [x] `@mastra/core` TypeScript check
- [x] ESLint
- [x] Oxlint
- [x] Formatting check
- [x] `git diff --check`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue in the description above
- [x] I have added tests that prove the fix is effective
- [x] I have added the required changeset
- [x] I have run the relevant tests and static checks
- [x] No documentation changes are required because this does not change the public API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The registry generator now removes old capability files before writing new ones. This prevents outdated files from remaining when the latest registry has no capability data.

## Changes

- Remove the existing `capabilities/` directory on every successful `writeRegistryFiles()` call.
- Recreate and write the directory only when the latest registry contains capability data.
- Add a regression test for consecutive generations where capability data becomes empty.
- Add an `@mastra/core` patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->