### PR TITLE
feat(studio): show usage in trace details

### DIFF
--- a/.changeset/empty-snakes-dress.md
+++ b/.changeset/empty-snakes-dress.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added token and estimated cost totals to full trace details in Studio. Opening a trace now shows input tokens, output tokens, and estimated cost in both the trace side panel and the dedicated trace page, including when the trace is opened from a direct link outside the loaded list. Subtrace panels omit these values because they represent totals for the full trace.

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -40,6 +40,52 @@ describe('TraceDataPanelView — Add tool mocks to item', () => {
   });
 });
 
+describe('TraceDataPanelView — trace usage summary', () => {
+  it('renders token and cost rows when usage is provided', () => {
+    render(
+      <TraceDataPanelView
+        {...baseProps}
+        usage={{ inputTokens: 1200, outputTokens: 300, estimatedCost: 0.0042, costUnit: 'usd' }}
+      />,
+    );
+
+    expect(screen.getByText('Trace input tokens')).not.toBeNull();
+    expect(screen.getByText('1.2K')).not.toBeNull();
+    expect(screen.getByText('Trace output tokens')).not.toBeNull();
+    expect(screen.getByText('300')).not.toBeNull();
+    expect(screen.getByText('Trace est. cost')).not.toBeNull();
+    expect(screen.getByText('$0.0042')).not.toBeNull();
+  });
+
+  it('renders a placeholder when the store produced no cost for the trace', () => {
+    render(<TraceDataPanelView {...baseProps} usage={{ inputTokens: 1200, outputTokens: 300 }} />);
+
+    expect(screen.getByText('Trace est. cost')).not.toBeNull();
+    expect(screen.getByText('—')).not.toBeNull();
+  });
+
+  it('renders no usage rows when the prop is omitted', () => {
+    render(<TraceDataPanelView {...baseProps} />);
+
+    expect(screen.queryByText('Trace est. cost')).toBeNull();
+    expect(screen.queryByText('Trace input tokens')).toBeNull();
+  });
+
+  it('does not render full-trace usage for a subtrace anchor', () => {
+    render(
+      <TraceDataPanelView
+        {...baseProps}
+        spans={nestedSpanFixture}
+        anchorSpanId="child"
+        usage={{ inputTokens: 12_500, outputTokens: 405, estimatedCost: 0.01, costUnit: 'usd' }}
+      />,
+    );
+
+    expect(screen.queryByText('Trace est. cost')).toBeNull();
+    expect(screen.queryByText('12.5K')).toBeNull();
+  });
+});
+
 describe('TraceDataPanelView — span selected from the URL', () => {
   describe('when the trace is still loading', () => {
     it('keeps the requested span instead of clearing it', () => {

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -12,6 +12,7 @@ import {
 import { useEffect, useMemo, useState } from 'react';
 import { getAllSpanIds } from '../hooks/get-all-span-ids';
 import { useDownloadTraceJson } from '../hooks/use-download-trace-json';
+import type { TraceUsageSummary } from '../trace-list-columns';
 import { formatHierarchicalSpans } from './format-hierarchical-spans';
 import { TraceKeysAndValues } from './trace-keys-and-values';
 import { TraceTimeline } from './trace-timeline';
@@ -29,6 +30,12 @@ export interface TraceDataPanelViewProps {
   traceId: string;
   /** Lightweight spans for the trace. Caller fetches via useTraceLightSpans. */
   spans: LightSpanRecord[] | undefined;
+  /**
+   * Token and estimated-cost totals for the trace (from `useTraceUsage`).
+   * Rendered in the trace summary when the panel is in the list side-panel
+   * placement; the trace page renders its own `TraceKeysAndValues` instead.
+   */
+  usage?: TraceUsageSummary;
   isLoading?: boolean;
   onClose: () => void;
   onSpanSelect?: (spanId: string | undefined) => void;
@@ -66,6 +73,7 @@ export interface TraceDataPanelViewProps {
 export function TraceDataPanelView({
   traceId,
   spans,
+  usage,
   isLoading,
   onClose,
   onSpanSelect,
@@ -131,6 +139,7 @@ export function TraceDataPanelView({
     () => (anchorSpanId ? spans?.find(s => s.spanId === anchorSpanId) : spans?.find(s => s.parentSpanId == null)),
     [spans, anchorSpanId],
   );
+  const isSubtrace = anchorSpanId !== undefined && rootSpan?.parentSpanId != null;
 
   const handleSpanClick = (id: string) => {
     const newId = selectedSpanId === id ? undefined : id;
@@ -210,7 +219,9 @@ export function TraceDataPanelView({
           <DataPanel.NoData>No spans found for this trace.</DataPanel.NoData>
         ) : (
           <DataPanel.Content>
-            {!isOnTracePage && rootSpan && <TraceKeysAndValues rootSpan={rootSpan} className="mb-6" />}
+            {!isOnTracePage && rootSpan && (
+              <TraceKeysAndValues rootSpan={rootSpan} usage={isSubtrace ? undefined : usage} className="mb-6" />
+            )}
 
             {!isOnTracePage && (onEvaluateTrace || onSaveAsDatasetItem || onAddTraceMocksToItem) && (
               <div className="mb-6 flex flex-wrap items-center justify-between gap-4">

--- a/packages/playground-ui/src/domains/traces/components/trace-keys-and-values.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-keys-and-values.tsx
@@ -1,4 +1,6 @@
 import { format } from 'date-fns';
+import type { TraceUsageSummary } from '../trace-list-columns';
+import { formatCompact, formatCost } from '@/domains/metrics/components/metrics-utils';
 import { DataKeysAndValues } from '@/ds/components/DataKeysAndValues';
 
 enum TraceStatus {
@@ -25,11 +27,18 @@ type RootSpanSummary = {
 
 export interface TraceKeysAndValuesProps {
   rootSpan: RootSpanSummary;
+  /**
+   * Token and estimated-cost totals aggregated across the trace's model spans
+   * (from `useTraceUsage`). When provided, token and cost rows are rendered —
+   * with `—` for values the metrics store couldn't produce (e.g. no pricing
+   * match or mixed cost units).
+   */
+  usage?: TraceUsageSummary;
   numOfCol?: 1 | 2 | 3;
   className?: string;
 }
 
-export function TraceKeysAndValues({ rootSpan, numOfCol = 2, className }: TraceKeysAndValuesProps) {
+export function TraceKeysAndValues({ rootSpan, usage, numOfCol = 2, className }: TraceKeysAndValuesProps) {
   const startedAt = rootSpan.startedAt ? new Date(rootSpan.startedAt) : null;
   const endedAt = rootSpan.endedAt ? new Date(rootSpan.endedAt) : null;
   const status = computeTraceStatus(rootSpan);
@@ -69,6 +78,22 @@ export function TraceKeysAndValues({ rootSpan, numOfCol = 2, className }: TraceK
         <>
           <DataKeysAndValues.Key>Ended at</DataKeysAndValues.Key>
           <DataKeysAndValues.Value>{format(endedAt, 'MMM dd, h:mm:ss.SSS aaa')}</DataKeysAndValues.Value>
+        </>
+      )}
+      {usage && (
+        <>
+          <DataKeysAndValues.Key>Trace input tokens</DataKeysAndValues.Key>
+          <DataKeysAndValues.Value>
+            {usage.inputTokens === undefined ? '—' : formatCompact(usage.inputTokens)}
+          </DataKeysAndValues.Value>
+          <DataKeysAndValues.Key>Trace output tokens</DataKeysAndValues.Key>
+          <DataKeysAndValues.Value>
+            {usage.outputTokens === undefined ? '—' : formatCompact(usage.outputTokens)}
+          </DataKeysAndValues.Value>
+          <DataKeysAndValues.Key>Trace est. cost</DataKeysAndValues.Key>
+          <DataKeysAndValues.Value>
+            {usage.estimatedCost === undefined ? '—' : formatCost(usage.estimatedCost, usage.costUnit)}
+          </DataKeysAndValues.Value>
         </>
       )}
     </DataKeysAndValues>

--- a/packages/playground/src/pages/traces/__tests__/fixtures/traces.ts
+++ b/packages/playground/src/pages/traces/__tests__/fixtures/traces.ts
@@ -5,6 +5,9 @@ import { TraceStatus } from '@mastra/core/storage';
 type ListTracesResponse = Awaited<ReturnType<MastraClient['listTraces']>>;
 type ListBranchesResponse = Awaited<ReturnType<MastraClient['listBranches']>>;
 type MetricBreakdownResponse = Awaited<ReturnType<MastraClient['getMetricBreakdown']>>;
+type GetTraceLightResponse = Awaited<ReturnType<MastraClient['getTraceLight']>>;
+type GetBranchResponse = Awaited<ReturnType<MastraClient['getBranch']>>;
+type ListFeedbackResponse = Awaited<ReturnType<MastraClient['listFeedback']>>;
 
 const baseSystemPackages: GetSystemPackagesResponse = {
   packages: [],
@@ -43,8 +46,18 @@ export const traceList: ListTracesResponse = {
   pagination: { total: 1, page: 0, perPage: 25, hasMore: false },
 };
 
+export const traceListWithTwoTraces: ListTracesResponse = {
+  spans: [trace, { ...trace, traceId: 'trace-b', spanId: 'span-b' }],
+  pagination: { total: 2, page: 0, perPage: 25, hasMore: false },
+};
+
 export const branchList: ListBranchesResponse = {
   branches: [{ ...trace, parentSpanId: 'root-span' }],
+  pagination: { total: 1, page: 0, perPage: 25, hasMore: false },
+};
+
+export const rootBranchList: ListBranchesResponse = {
+  branches: [{ ...trace, parentSpanId: null }],
   pagination: { total: 1, page: 0, perPage: 25, hasMore: false },
 };
 
@@ -57,6 +70,26 @@ export const traceUsageBreakdown: MetricBreakdownResponse = {
       costUnit: 'usd',
     },
   ],
+};
+
+export const traceLightSpans: GetTraceLightResponse = {
+  traceId: 'trace-a',
+  spans: [{ ...trace, parentSpanId: null }],
+};
+
+export const rootBranchSpans: GetBranchResponse = {
+  traceId: 'trace-a',
+  spans: [{ ...trace, parentSpanId: null }],
+};
+
+export const subtraceBranchSpans: GetBranchResponse = {
+  traceId: 'trace-a',
+  spans: [{ ...trace, parentSpanId: 'root-span' }],
+};
+
+export const emptyFeedback: ListFeedbackResponse = {
+  feedback: [],
+  pagination: { total: 0, page: 0, perPage: 10, hasMore: false },
 };
 
 export const emptyScorers: GetScoresScorers_Response = {};

--- a/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
+++ b/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
@@ -1,6 +1,6 @@
 import type { GetSystemPackagesResponse } from '@mastra/client-js';
 import { serializeTraceColumnPreferences } from '@mastra/playground-ui/domains/traces/trace-list-columns';
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import TracesPage from '..';
@@ -8,12 +8,18 @@ import {
   branchList,
   emptyEntityNames,
   emptyEnvironments,
+  emptyFeedback,
   emptyScorers,
   emptyServiceNames,
   emptyTags,
   metricsCapableSystemPackages,
   metricsUnavailableSystemPackages,
+  rootBranchList,
+  rootBranchSpans,
+  subtraceBranchSpans,
+  traceLightSpans,
   traceList,
+  traceListWithTwoTraces,
   traceUsageBreakdown,
 } from './fixtures/traces';
 import { TestLinkProvider } from '@/test/link-provider';
@@ -87,6 +93,22 @@ describe('Traces page usage columns', () => {
       await waitFor(() => expect(queryClient.isFetching()).toBe(0));
       expect(screen.getByText('Input tokens')).not.toBeNull();
     });
+
+    it('reuses list usage data for a selected trace', async () => {
+      setTracePageHandlers(metricsCapableSystemPackages);
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/observability/traces`, () => HttpResponse.json(traceListWithTwoTraces)),
+        http.get(`${TEST_BASE_URL}/api/observability/traces/light`, () => HttpResponse.json(traceListWithTwoTraces)),
+        http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a/light`, () => HttpResponse.json(traceLightSpans)),
+        http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
+      );
+
+      const { queryClient } = renderPage('/traces?traceId=trace-a');
+
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+      expect(onBreakdownRequest).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Trace est. cost')).not.toBeNull();
+    });
   });
 
   describe('when the observability store does not support metrics', () => {
@@ -101,7 +123,50 @@ describe('Traces page usage columns', () => {
     });
   });
 
+  describe('when a trace is opened from a direct link', () => {
+    it('shows the trace cost when the trace is outside the loaded list', async () => {
+      window.localStorage.setItem(
+        TRACE_COLUMN_STORAGE_KEY,
+        serializeTraceColumnPreferences({ visibleColumns: [], metadataKeys: [] }),
+      );
+      setTracePageHandlers(metricsCapableSystemPackages);
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/observability/traces`, () =>
+          HttpResponse.json({ ...traceList, spans: [], pagination: { ...traceList.pagination, total: 0 } }),
+        ),
+        http.get(`${TEST_BASE_URL}/api/observability/traces/light`, () =>
+          HttpResponse.json({ ...traceList, spans: [], pagination: { ...traceList.pagination, total: 0 } }),
+        ),
+        http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a/light`, () => HttpResponse.json(traceLightSpans)),
+        http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
+      );
+
+      renderPage('/traces?traceId=trace-a');
+
+      await waitFor(() => expect(onBreakdownRequest).toHaveBeenCalled());
+      expect(await screen.findByText('Trace est. cost')).not.toBeNull();
+      expect(await screen.findByText('$0.0010')).not.toBeNull();
+    });
+  });
+
   describe('when Branches mode is selected', () => {
+    it('shows trace totals for a root trace panel', async () => {
+      setTracePageHandlers(metricsCapableSystemPackages);
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/observability/branches`, () => HttpResponse.json(rootBranchList)),
+        http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a/branches/span-a`, () =>
+          HttpResponse.json(rootBranchSpans),
+        ),
+        http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
+      );
+
+      renderPage('/traces?listMode=branches&traceId=trace-a&anchorSpanId=span-a');
+
+      await waitFor(() => expect(onBreakdownRequest).toHaveBeenCalled());
+      expect(await screen.findByText('Trace est. cost')).not.toBeNull();
+      expect(await screen.findByText('$0.0010')).not.toBeNull();
+    });
+
     it('suppresses usage columns and metric requests', async () => {
       setTracePageHandlers(metricsCapableSystemPackages);
 
@@ -109,6 +174,30 @@ describe('Traces page usage columns', () => {
 
       await waitFor(() => expect(queryClient.isFetching()).toBe(0));
       expect(screen.queryByText('Input tokens')).toBeNull();
+      expect(onBreakdownRequest).not.toHaveBeenCalled();
+    });
+
+    it('does not show cached trace totals in a subtrace panel', async () => {
+      setTracePageHandlers(metricsCapableSystemPackages);
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a/branches/span-a`, () =>
+          HttpResponse.json(subtraceBranchSpans),
+        ),
+        http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
+      );
+
+      const { queryClient } = renderPage('/traces?listMode=branches&traceId=trace-a&anchorSpanId=span-a');
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+
+      act(() => {
+        queryClient.setQueryData(
+          ['trace-usage', `${TEST_BASE_URL}:/api`, ['trace-a']],
+          new Map([['trace-a', { inputTokens: 12_500, outputTokens: 405, estimatedCost: 0.01, costUnit: 'usd' }]]),
+        );
+      });
+
+      expect(screen.queryByText('Trace est. cost')).toBeNull();
+      expect(screen.queryByText('12.5K')).toBeNull();
       expect(onBreakdownRequest).not.toHaveBeenCalled();
     });
   });

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -219,12 +219,35 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
         visibleColumns: traceColumns.preferences.visibleColumns.filter(column => !isTraceUsageColumn(column)),
       }
     : traceColumns.preferences;
+  const selectedBranchAnchor =
+    url.listMode === 'branches' && anchorSpanId ? lightSpans?.find(span => span.spanId === anchorSpanId) : undefined;
+  const canShowSelectedTraceUsage =
+    url.listMode === 'traces' || (selectedBranchAnchor !== undefined && selectedBranchAnchor.parentSpanId == null);
+  const listUsageEnabled =
+    !usageColumnsUnavailable && !observabilityCapabilities.isLoading && hasTraceUsageColumn(displayedColumnPreferences);
   const traceUsage = useTraceUsage({
     traceIds: traces.map(trace => trace.traceId),
+    enabled: listUsageEnabled,
+    autoRefetch: autoRefetchTraces,
+  });
+  const selectedTraceId = url.traceIdParam;
+  const selectedTraceCoveredByListUsage =
+    canShowSelectedTraceUsage &&
+    selectedTraceId !== undefined &&
+    listUsageEnabled &&
+    traces.some(trace => trace.traceId === selectedTraceId);
+  const selectedTraceUsageFromList = selectedTraceId ? traceUsage.data?.get(selectedTraceId) : undefined;
+  const selectedTraceNeedsOwnQuery =
+    canShowSelectedTraceUsage &&
+    selectedTraceId !== undefined &&
+    (!selectedTraceCoveredByListUsage ||
+      (!traceUsage.isFetching && traceUsage.data !== undefined && !traceUsage.data.has(selectedTraceId)));
+  // Fetch independently when the list query cannot supply the selected trace,
+  // such as when usage columns are hidden or a direct link is outside the loaded page.
+  const selectedTraceUsage = useTraceUsage({
+    traceIds: selectedTraceNeedsOwnQuery && selectedTraceId ? [selectedTraceId] : [],
     enabled:
-      !usageColumnsUnavailable &&
-      !observabilityCapabilities.isLoading &&
-      hasTraceUsageColumn(displayedColumnPreferences),
+      selectedTraceNeedsOwnQuery && !observabilityCapabilities.isLoading && observabilityCapabilities.supportsMetrics,
     autoRefetch: autoRefetchTraces,
   });
 
@@ -416,7 +439,7 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
 
   const contentFiltersApplied = !!url.selectedEntityOption || !!url.selectedStatus || url.filterTokens.length > 0;
 
-  if (traces.length === 0 && !isTracesLoading && !contentFiltersApplied) {
+  if (traces.length === 0 && !isTracesLoading && !contentFiltersApplied && !url.traceIdParam) {
     return (
       <PageLayout width="wide" height="full">
         {pageTopArea}
@@ -475,6 +498,11 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
             <TraceDataPanelView
               traceId={url.traceIdParam}
               spans={lightSpans}
+              usage={
+                canShowSelectedTraceUsage
+                  ? (selectedTraceUsageFromList ?? selectedTraceUsage.data?.get(url.traceIdParam))
+                  : undefined
+              }
               anchorSpanId={anchorSpanId}
               isLoading={isLoadingLightSpans}
               onClose={url.handleTraceClose}

--- a/packages/playground/src/pages/traces/trace/index.tsx
+++ b/packages/playground/src/pages/traces/trace/index.tsx
@@ -10,11 +10,13 @@ import { TracesErrorContent } from '@mastra/playground-ui/domains/traces/compone
 import { useSpanDetail } from '@mastra/playground-ui/domains/traces/hooks/use-span-detail';
 import { useTraceLightSpans } from '@mastra/playground-ui/domains/traces/hooks/use-trace-light-spans';
 import { useTraceSpanNavigation } from '@mastra/playground-ui/domains/traces/hooks/use-trace-span-navigation';
+import { useTraceUsage } from '@mastra/playground-ui/domains/traces/hooks/use-trace-usage';
 import type { SpanTab } from '@mastra/playground-ui/domains/traces/types';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { CircleGaugeIcon, SaveIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
+import { useObservabilityStorageCapabilities } from '@/domains/configuration/hooks/use-observability-storage-capabilities';
 import { TraceAsItemDialog } from '@/domains/observability/components/trace-as-item-dialog';
 import { useScorers } from '@/domains/scores';
 import { useTraceSpanScores } from '@/domains/scores/hooks/use-trace-span-scores';
@@ -44,6 +46,13 @@ export default function TracePage() {
   const { data: traceLight, isLoading: isTraceLoading, error: traceError } = useTraceLightSpans(traceId);
   const lightSpans = useMemo(() => traceLight?.spans ?? [], [traceLight?.spans]);
   const rootSpan = useMemo(() => lightSpans.find(s => s.parentSpanId == null), [lightSpans]);
+
+  const observabilityCapabilities = useObservabilityStorageCapabilities();
+  const traceUsage = useTraceUsage({
+    traceIds: [traceId],
+    enabled: !observabilityCapabilities.isLoading && observabilityCapabilities.supportsMetrics,
+    autoRefetch: false,
+  });
 
   const { data: spanDetailData, isLoading: isLoadingSpanDetail } = useSpanDetail(traceId, featuredSpanId ?? '');
 
@@ -177,7 +186,7 @@ export default function TracePage() {
   const traceTopAreaSharedContent = rootSpan ? (
     <PageLayout.Row>
       <PageLayout.Column>
-        <TraceKeysAndValues rootSpan={rootSpan} numOfCol={3} />
+        <TraceKeysAndValues rootSpan={rootSpan} usage={traceUsage.data?.get(traceId)} numOfCol={3} />
       </PageLayout.Column>
     </PageLayout.Row>
   ) : null;


### PR DESCRIPTION
Display trace-wide token totals and estimated cost in trace summaries, including direct links and root rows in subtrace mode. Keep aggregate usage hidden for nested subtraces and reuse list metrics data to avoid duplicate requests.

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Studio now shows the total tokens and estimated cost for a trace. It uses data already loaded when possible, so it avoids extra requests. Nested subtraces do not show these totals.

## Changes

- Added input token, output token, and estimated cost values to trace summaries.
- Added em-dash placeholders for unavailable metrics.
- Reused list usage data for selected traces when available.
- Added separate usage loading when the selected trace is not in the loaded list.
- Displayed usage for direct links and root rows in subtrace mode.
- Suppressed usage for nested subtraces and unsupported branch roots.
- Added tests and fixtures for usage rendering, cost handling, direct links, root traces, and subtrace behavior.
- Added a `@mastra/playground-ui` changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->