### PR TITLE
fix(core): cancel live stream source during history replay

### DIFF
--- a/.changeset/tidy-streams-cancel.md
+++ b/.changeset/tidy-streams-cancel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed replay stream cancellation so disconnects during history replay also cancel the live source.

--- a/packages/core/src/stream/__tests__/caching-transform-stream.test.ts
+++ b/packages/core/src/stream/__tests__/caching-transform-stream.test.ts
@@ -289,6 +289,32 @@ describe('createReplayStream', () => {
 
     expect(cancelled).toBe(true);
   });
+
+  it('should cancel the live source during history replay', async () => {
+    let cancellationCount = 0;
+    let cancellationReason: unknown;
+
+    const liveSource = new ReadableStream<string>({
+      cancel(reason) {
+        cancellationCount++;
+        cancellationReason = reason;
+      },
+    });
+
+    const stream = createReplayStream({
+      history: ['history-1', 'history-2'],
+      liveSource,
+    });
+
+    const reader = stream.getReader();
+    await expect(reader.read()).resolves.toEqual({ done: false, value: 'history-1' });
+
+    const reason = 'client disconnected';
+    await reader.cancel(reason);
+
+    expect(cancellationCount).toBe(1);
+    expect(cancellationReason).toBe(reason);
+  });
 });
 
 describe('withStreamCaching', () => {

--- a/packages/core/src/stream/caching-transform-stream.ts
+++ b/packages/core/src/stream/caching-transform-stream.ts
@@ -181,10 +181,12 @@ export function createReplayStream<T>(options: {
       }
     },
 
-    cancel() {
+    cancel(reason) {
       if (liveReader) {
-        void liveReader.cancel();
+        return liveReader.cancel(reason);
       }
+
+      return liveSource.cancel(reason);
     },
   });
 }


### PR DESCRIPTION
Fixes replay-stream cancellation when the consumer disconnects during cached-history replay.

Previously, `createReplayStream()` only cancelled `liveReader`. Since `liveReader` is created lazily after history replay completes, cancellation during history replay did not reach the underlying live source.

This could leave the live stream running after the consumer disconnected.

FIXES #21543 

## Changes

- Forward the cancellation reason to `liveReader.cancel(reason)` when the live reader exists.
- Cancel `liveSource` directly when cancellation occurs during history replay.
- Return the underlying cancellation promise.
- Preserve lazy live-reader creation.
- Added a regression test using multiple history chunks.
- Added an `@mastra/core` patch changeset.

## Test plan

The regression test verifies that:

1. The first cached history chunk is emitted.
2. The replay reader is cancelled before the remaining history is consumed.
3. The live source cancellation handler runs exactly once.
4. The cancellation reason is forwarded correctly.

Validation completed:

- [x] Focused `caching-transform-stream.test.ts` suite — 13 tests passed
- [x] ESLint
- [x] Oxlint
- [x] Formatting check
- [x] `git diff --check`
- [ ] `@mastra/core` TypeScript check — currently reports unrelated existing `RequestContext` declaration-test errors

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue in the description above
- [x] I have added tests that prove the fix is effective
- [x] I have added the required changeset
- [x] I have run the relevant tests and static checks
- [x] No documentation changes are required because this does not change the public API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a user disconnects during replay of saved data, the stream now stops the live connection too. This prevents unnecessary work and forwards the cancellation reason correctly.

## Changes

- Cancel the active `liveReader` when it exists.
- Cancel `liveSource` directly when history replay occurs before `liveReader` creation.
- Forward the cancellation reason and return the cancellation promise.
- Preserve lazy `liveReader` creation.
- Add a regression test with multiple history chunks.
- Add an `@mastra/core` patch changeset.

## Validation

- Focused tests, linting, formatting, and diff checks passed.
- TypeScript checks report existing unrelated `RequestContext` declaration-test errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->