### PR TITLE
docs: add Sentry to OpenTelemetry providers

### DIFF
--- a/docs/src/content/en/integrations/observability/opentelemetry.mdx
+++ b/docs/src/content/en/integrations/observability/opentelemetry.mdx
@@ -13,13 +13,13 @@ Mastra supports OpenTelemetry (OTEL) through an exporter for sending traces and 
 
 ## Exporter
 
-The OpenTelemetry exporter sends your traces and logs using standardized [OpenTelemetry Semantic Conventions for GenAI](https://opentelemetry.io/docs/specs/semconv/gen-ai/). This ensures broad compatibility with platforms like Datadog, New Relic, SigNoz, MLflow, Latitude, Dash0, Traceloop, Laminar, telemetry.dev, and more.
+The OpenTelemetry exporter sends your traces and logs using standardized [OpenTelemetry Semantic Conventions for GenAI](https://opentelemetry.io/docs/specs/semconv/gen-ai/). This ensures broad compatibility with platforms like Datadog, New Relic, Sentry, SigNoz, MLflow, Latitude, Dash0, Traceloop, Laminar, telemetry.dev, and more.
 
 ### Installation
 
 Each provider requires specific protocol packages. Install the base exporter plus the protocol package for your provider:
 
-#### For HTTP/Protobuf Providers (SigNoz, New Relic, Laminar, MLflow, Latitude, telemetry.dev)
+#### For HTTP/Protobuf Providers (SigNoz, New Relic, Sentry, Laminar, MLflow, Latitude, telemetry.dev)
 
 ```bash npm2yarn
 npm install @mastra/otel-exporter@latest @opentelemetry/exporter-trace-otlp-proto
@@ -50,6 +50,10 @@ All providers support zero-config setup via environment variables. Set the appro
 | Laminar | `LMNR_PROJECT_API_KEY` (required), `LAMINAR_ENDPOINT` (optional) |
 
 ### Provider configurations
+
+#### Sentry
+
+[Sentry](https://sentry.io/) accepts OpenTelemetry traces and logs through its OTLP endpoints. For Sentry-specific span mapping and AI monitoring attributes, use Mastra's dedicated [Sentry exporter](/integrations/observability/sentry).
 
 #### MLflow
 

--- a/docs/src/content/en/integrations/observability/opentelemetry.mdx
+++ b/docs/src/content/en/integrations/observability/opentelemetry.mdx
@@ -53,7 +53,30 @@ All providers support zero-config setup via environment variables. Set the appro
 
 #### Sentry
 
-[Sentry](https://sentry.io/) accepts OpenTelemetry traces and logs through its OTLP endpoints. For Sentry-specific span mapping and AI monitoring attributes, use Mastra's dedicated [Sentry exporter](/integrations/observability/sentry).
+[Sentry](https://sentry.io/) accepts OpenTelemetry traces and logs through its OTLP endpoints. In Sentry, open [**Project Settings** > **Client Keys (DSN)**](https://sentry.io/settings/projects/) and copy the OTLP traces endpoint and authentication header. Add both values to your environment:
+
+```bash title=".env"
+SENTRY_OTLP_ENDPOINT=https://o000000.ingest.sentry.io/api/0000000/integration/otlp/v1/traces
+SENTRY_OTLP_AUTH_HEADER="sentry sentry_key=..."
+```
+
+Use the `custom` provider with HTTP/Protobuf:
+
+```typescript title="src/mastra/index.ts"
+new OtelExporter({
+  provider: {
+    custom: {
+      endpoint: process.env.SENTRY_OTLP_ENDPOINT!,
+      protocol: 'http/protobuf',
+      headers: {
+        'x-sentry-auth': process.env.SENTRY_OTLP_AUTH_HEADER!,
+      },
+    },
+  },
+})
+```
+
+For Sentry-specific span mapping and AI monitoring attributes, use Mastra's dedicated [Sentry exporter](/integrations/observability/sentry).
 
 #### MLflow
 

--- a/docs/src/content/en/integrations/observability/opentelemetry.mdx
+++ b/docs/src/content/en/integrations/observability/opentelemetry.mdx
@@ -76,7 +76,12 @@ new OtelExporter({
 })
 ```
 
-For Sentry-specific span mapping and AI monitoring attributes, use Mastra's dedicated [Sentry exporter](/integrations/observability/sentry).
+See [Sentry's OTLP documentation](https://docs.sentry.io/concepts/otlp/) for endpoint setup, supported signals, and current ingestion limits.
+
+Choose an exporter based on your setup:
+
+- `OtelExporter`: Sends vendor-neutral traces and logs over OTLP. Use it with an existing OpenTelemetry pipeline or when you want backend portability.
+- [`SentryExporter`](/integrations/observability/sentry): Uses the Sentry SDK to map Mastra span types to Sentry operations, add AI monitoring attributes, and capture span errors as Sentry issues.
 
 #### MLflow
 


### PR DESCRIPTION
Adds Sentry to the generic OpenTelemetry compatibility and HTTP/Protobuf provider lists, and documents direct OTLP setup with the endpoint and `x-sentry-auth` header from Sentry project settings. The page links to Sentry's OTLP documentation and compares the portable OTLP path with the dedicated `@mastra/sentry` exporter's Sentry-specific mapping, AI attributes, and error capture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This update explains how to send observability data to Sentry. It also explains when to use generic OpenTelemetry or the dedicated `@mastra/sentry` exporter.

## Changes

- Added Sentry to the supported HTTP/Protobuf OpenTelemetry providers.
- Added a Sentry OTLP configuration example.
- Documented Sentry endpoint and `x-sentry-auth` environment variables.
- Linked to Sentry’s OTLP documentation.
- Compared generic OTLP with `@mastra/sentry`, including Sentry-specific span mapping, AI attributes, and error capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->