### PR TITLE
fix(core): keep array textStream valid when the first chunk has elements

### DIFF
--- a/.changeset/giant-rabbits-ask.md
+++ b/.changeset/giant-rabbits-ask.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed array textStream output so it always stays valid JSON, even when the first streamed chunk already includes elements

--- a/packages/core/src/stream/base/output-format-handlers.test.ts
+++ b/packages/core/src/stream/base/output-format-handlers.test.ts
@@ -6,7 +6,11 @@ import { convertArrayToReadableStream, convertAsyncIterableToArray } from '../..
 import type { PublicSchema } from '../../schema';
 import type { ChunkType } from '../types';
 import { ChunkFrom } from '../types';
-import { createObjectStreamTransformer, escapeUnescapedControlCharsInJsonStrings } from './output-format-handlers';
+import {
+  createJsonTextStreamTransformer,
+  createObjectStreamTransformer,
+  escapeUnescapedControlCharsInJsonStrings,
+} from './output-format-handlers';
 
 describe('escapeUnescapedControlCharsInJsonStrings', () => {
   it('should escape newlines inside JSON strings', () => {
@@ -1235,6 +1239,66 @@ Want to work on challenging problems"}`;
       const objectResultChunk = chunks.find(c => c?.type === 'object-result');
       expect(objectResultChunk).toBeDefined();
       expect(objectResultChunk?.object).toEqual(fallbackValue);
+    });
+  });
+
+  describe('createJsonTextStreamTransformer', () => {
+    const objectChunk = (object: unknown): ChunkType<unknown> => ({
+      type: 'object',
+      runId: 'test-run',
+      from: ChunkFrom.AGENT,
+      object: object as any,
+    });
+
+    const arraySchema = z.array(z.object({ a: z.number() }));
+
+    it('keeps array textStream valid when the first object chunk already has elements', async () => {
+      // Regression test for #18758: coarse/batched provider deltas deliver the
+      // array-so-far as the first object chunk, so the transformer must not
+      // close the array until it knows the stream has actually ended.
+      const transformer = createJsonTextStreamTransformer(arraySchema);
+      // @ts-expect-error - web/stream readable stream type error
+      const stream = convertArrayToReadableStream([
+        objectChunk([{ a: 1 }]),
+        objectChunk([{ a: 1 }, { a: 2 }]),
+        objectChunk([{ a: 1 }, { a: 2 }, { a: 3 }]),
+      ]).pipeThrough(transformer);
+      const chunks = await convertAsyncIterableToArray(stream);
+
+      const text = chunks.join('');
+      expect(text).toBe('[{"a":1},{"a":2},{"a":3}]');
+      expect(JSON.parse(text)).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }]);
+    });
+
+    it('emits a complete single-chunk array as one closed JSON string', async () => {
+      const transformer = createJsonTextStreamTransformer(arraySchema);
+      // @ts-expect-error - web/stream readable stream type error
+      const stream = convertArrayToReadableStream([objectChunk([{ a: 1 }, { a: 2 }])]).pipeThrough(transformer);
+      const chunks = await convertAsyncIterableToArray(stream);
+
+      expect(chunks).toEqual(['[{"a":1},{"a":2}]']);
+    });
+
+    it('emits a well-formed empty array for a single empty chunk', async () => {
+      const transformer = createJsonTextStreamTransformer(arraySchema);
+      // @ts-expect-error - web/stream readable stream type error
+      const stream = convertArrayToReadableStream([objectChunk([])]).pipeThrough(transformer);
+      const chunks = await convertAsyncIterableToArray(stream);
+
+      expect(chunks).toEqual(['[]']);
+    });
+
+    it('streams fine-grained array chunks incrementally', async () => {
+      const transformer = createJsonTextStreamTransformer(arraySchema);
+      // @ts-expect-error - web/stream readable stream type error
+      const stream = convertArrayToReadableStream([
+        objectChunk([]),
+        objectChunk([{ a: 1 }]),
+        objectChunk([{ a: 1 }, { a: 2 }]),
+      ]).pipeThrough(transformer);
+      const chunks = await convertAsyncIterableToArray(stream);
+
+      expect(chunks).toEqual(['[', '{"a":1}', ',{"a":2}', ']']);
     });
   });
 });

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -758,7 +758,14 @@ export function createObjectStreamTransformer<OUTPUT = undefined>({
 export function createJsonTextStreamTransformer<OUTPUT = undefined>(schema?: StandardSchemaWithJSON<OUTPUT>) {
   let previousArrayLength = 0;
   let hasStartedArray = false;
-  let chunkCount = 0;
+  // The first array chunk is held back instead of being emitted immediately.
+  // A single object chunk may already contain the complete array (coarse or
+  // batched provider deltas), in which case it should be emitted as one closed
+  // JSON string. But the same first chunk can also be the first slice of a
+  // longer incremental sequence, so we can only decide once the next chunk
+  // arrives or the stream ends. Emitting it closed too early produced invalid
+  // JSON like a closed array followed by more elements (see #18758).
+  let pendingFirstArrayChunk: unknown[] | undefined;
   const outputSchema = getTransformedSchema(schema);
 
   return new TransformStream<ChunkType<OUTPUT>, string>({
@@ -768,24 +775,21 @@ export function createJsonTextStreamTransformer<OUTPUT = undefined>(schema?: Sta
       }
 
       if (outputSchema?.outputFormat === 'array' && Array.isArray(chunk.object)) {
-        chunkCount++;
-
-        // If this is the first chunk, decide between complete vs incremental streaming
-        if (chunkCount === 1) {
-          // If the first chunk already has multiple elements or is complete,
-          // emit as single JSON string
-          if (chunk.object.length > 0) {
-            controller.enqueue(JSON.stringify(chunk.object));
-            previousArrayLength = chunk.object.length;
-            hasStartedArray = true;
-            return;
-          }
-        }
-
-        // Incremental streaming mode (multiple chunks)
-        if (!hasStartedArray) {
+        if (pendingFirstArrayChunk !== undefined) {
+          // A second chunk arrived, so the buffered chunk was only the first
+          // slice. Switch to incremental mode and replay the buffered elements.
           controller.enqueue('[');
           hasStartedArray = true;
+          for (let i = 0; i < pendingFirstArrayChunk.length; i++) {
+            const elementJson = JSON.stringify(pendingFirstArrayChunk[i]);
+            controller.enqueue(i > 0 ? ',' + elementJson : elementJson);
+          }
+          previousArrayLength = pendingFirstArrayChunk.length;
+          pendingFirstArrayChunk = undefined;
+        } else if (!hasStartedArray) {
+          // First chunk -- buffer it and wait to see whether the stream ends here.
+          pendingFirstArrayChunk = chunk.object;
+          return;
         }
 
         // Emit new elements that were added
@@ -804,8 +808,18 @@ export function createJsonTextStreamTransformer<OUTPUT = undefined>(schema?: Sta
       }
     },
     flush(controller) {
-      // Close the array when the stream ends (only for incremental streaming)
-      if (hasStartedArray && outputSchema?.outputFormat === 'array' && chunkCount > 1) {
+      if (outputSchema?.outputFormat !== 'array') {
+        return;
+      }
+      if (pendingFirstArrayChunk !== undefined) {
+        // The stream ended after a single array chunk: it was the complete
+        // array, so emit it as one closed JSON string. An empty single chunk
+        // still needs a well-formed '[]'.
+        const firstChunk = pendingFirstArrayChunk;
+        pendingFirstArrayChunk = undefined;
+        controller.enqueue(firstChunk.length > 0 ? JSON.stringify(firstChunk) : '[]');
+      } else if (hasStartedArray) {
+        // Close the incrementally-streamed array.
         controller.enqueue(']');
       }
     },


### PR DESCRIPTION
## Description

`createJsonTextStreamTransformer` produced invalid JSON for an array `textStream` whenever the first `object` chunk already contained elements. Coarse or batched provider deltas deliver the array-so-far as the first chunk, and the transformer's first-chunk fast path emitted a fully-closed array (`[{\"a\":1}]`) that later chunks then appended to:

```
chunks: [{a:1}]  [{a:1},{a:2}]  [{a:1},{a:2},{a:3}]
output: [{"a":1}],{"a":2},{"a":3}]   // JSON.parse throws
```

This fix holds the first array chunk back and only decides at flush time:
- if a second chunk arrives, the buffered chunk was just the first slice, so it switches to incremental streaming;
- if the stream ends after one chunk, it emits the complete array as a single closed JSON string.

That keeps the existing single-chunk `textStream` contract (one complete array in one chunk) intact, fixes the multi-chunk case, and also makes a lone empty chunk emit `[]` instead of a bare `[`.

```
after:  [{"a":1},{"a":2},{"a":3}]   // valid
```

## Related issue(s)

Fixes #18758

Note: #18759 targets the same bug with an always-incremental approach that changes single-chunk chunk boundaries and currently fails an existing loop test. This PR keeps those boundaries untouched instead.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This fix keeps streamed array data as one valid JSON array. It handles both multi-chunk streams and streams that contain only one chunk.

## Changes

- Buffer the first array chunk in `createJsonTextStreamTransformer`.
- Stream buffered elements incrementally when later chunks arrive.
- Emit a complete JSON array when the stream ends after one chunk.
- Emit `[]` for a lone empty chunk.
- Add tests for batched, single-chunk, empty, and incremental array output.
- Add a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->