### PR TITLE
fix(core): carry generated-file filenames through the stream and rebuilt messages

### DIFF
--- a/.changeset/hip-bears-film.md
+++ b/.changeset/hip-bears-film.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+File chunks now keep the filename from provider-generated files (e.g. Gemini) and preserve it when chunks are rebuilt into message parts.

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -524,6 +524,22 @@ describe('buildMessagesFromChunks', () => {
     expect(result[0]).toMatchObject({ type: 'file', data: 'base64data', mimeType: 'image/png' });
   });
 
+  it('should preserve the original filename on file parts', () => {
+    const result = parts([
+      {
+        type: 'file',
+        payload: { data: 'base64data', mimeType: 'application/pdf', filename: 'contract.pdf' },
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'file',
+      data: 'base64data',
+      mimeType: 'application/pdf',
+      filename: 'contract.pdf',
+    });
+  });
+
   // ── step-start insertion ────────────────────────────────────
 
   it('should insert step-start between tool-invocation and text', () => {

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -229,6 +229,7 @@ export function buildMessagesFromChunks({
           type: 'file' as const,
           data: p.data,
           mimeType: p.mimeType,
+          ...(p.filename ? { filename: p.filename } : {}),
           ...(p.providerMetadata ? { providerMetadata: p.providerMetadata } : {}),
         } as MastraMessagePart);
         break;

--- a/packages/core/src/stream/aisdk/v5/transform.test.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.test.ts
@@ -751,4 +751,52 @@ describe('convertFullStreamChunkToMastra', () => {
       }
     });
   });
+
+  describe('file chunk handling', () => {
+    it('should carry the original filename from a file part into the chunk payload', () => {
+      // The streamed file part type doesn't declare a filename, but providers
+      // send one at runtime — mirror the cast used in the transform itself.
+      const chunk: StreamPart & { filename: string } = {
+        type: 'file',
+        data: 'aGVsbG8gd29ybGQ=',
+        mediaType: 'application/pdf',
+        filename: 'contract.pdf',
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result).toEqual({
+        type: 'file',
+        runId: 'test-run-123',
+        from: ChunkFrom.AGENT,
+        payload: {
+          data: 'aGVsbG8gd29ybGQ=',
+          base64: 'aGVsbG8gd29ybGQ=',
+          mimeType: 'application/pdf',
+          filename: 'contract.pdf',
+        },
+      });
+    });
+
+    it('should omit filename from the payload when the file part has none', () => {
+      const chunk: StreamPart = {
+        type: 'file',
+        data: 'aGVsbG8gd29ybGQ=',
+        mediaType: 'text/plain',
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result).toEqual({
+        type: 'file',
+        runId: 'test-run-123',
+        from: ChunkFrom.AGENT,
+        payload: {
+          data: 'aGVsbG8gd29ybGQ=',
+          base64: 'aGVsbG8gd29ybGQ=',
+          mimeType: 'text/plain',
+        },
+      });
+    });
+  });
 });

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -209,6 +209,9 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
 
     case 'file': {
       const pm = (value as any).providerMetadata;
+      // The streamed file part type doesn't declare a filename, but providers
+      // (e.g. Gemini) do send one for generated files — keep it when present.
+      const filename = (value as { filename?: string }).filename;
       return {
         type: 'file',
         runId: ctx.runId,
@@ -218,6 +221,7 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
           // URL-backed generated files flatten to URL strings, which are not base64.
           base64: typeof value.data === 'string' && !isUrlString(value.data) ? value.data : undefined,
           mimeType: value.mediaType,
+          ...(filename ? { filename } : {}),
           ...(pm != null ? { providerMetadata: pm } : {}),
         },
       };


### PR DESCRIPTION
Completes the filename path for #20731. The channel layer fix landed in #21135 - this PR covers the two spots that still dropped the name before a chunk reaches it.

The stream transform now keeps the filename providers attach to generated files (Gemini does for generated docs/PDFs), so the name actually makes it into `FilePayload` instead of being lost at the model boundary. And when file chunks are rebuilt into message parts (agentic execution / workflows), the filename survives the round trip too.

```ts
// before: filename never reaches the chunk payload
payload: { data, base64, mimeType, ...(pm != null ? { providerMetadata: pm } : {}) }

// after: filename rides along when the provider sends one
payload: { data, base64, mimeType, ...(filename ? { filename } : {}), ... }
```

Chunks without a filename are unaffected.