### PR TITLE
fix(core): remove stale capability files when regenerating without capabilities

### DIFF
--- a/.changeset/tame-poets-arrive.md
+++ b/.changeset/tame-poets-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+`writeRegistryFiles()` now removes the previous `capabilities/` directory on every successful generation, even when the new capability maps are empty. Previously the cleanup only ran when at least one capability map contained data, so a later generation with empty capabilities left stale files on disk and could report model capabilities that no longer existed. Fixes #21530.

--- a/packages/core/src/llm/model/registry-generator.test.ts
+++ b/packages/core/src/llm/model/registry-generator.test.ts
@@ -88,4 +88,18 @@ describe('registry-generator', () => {
       await expect(fs.readFile(path.join(dir, 'capabilities', 'openai.json'), 'utf8')).resolves.toContain('gpt-4o');
     });
   });
+  it('removes the previous capabilities directory when the new generation has no capability data', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mastra-capabilities-'));
+    tempDirs.push(dir);
+    const jsonPath = path.join(dir, 'provider-registry.json');
+    const typesPath = path.join(dir, 'provider-types.generated.d.ts');
+
+    // First generation writes capability files
+    await writeRegistryFiles(jsonPath, typesPath, {}, {}, undefined, undefined, { openai: ['gpt-4o'] });
+    await expect(fs.readFile(path.join(dir, 'capabilities', 'openai.json'), 'utf8')).resolves.toContain('gpt-4o');
+
+    // Second generation returns empty capability maps - the old directory must not survive
+    await writeRegistryFiles(jsonPath, typesPath, {}, {}, {}, {}, {});
+    await expect(fs.stat(path.join(dir, 'capabilities'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
 });

--- a/packages/core/src/llm/model/registry-generator.ts
+++ b/packages/core/src/llm/model/registry-generator.ts
@@ -310,15 +310,19 @@ export async function writeRegistryFiles(
   await atomicWriteFile(typesPath, typeContent, 'utf-8');
 
   // 3. Write per-provider capability files into a capabilities/ directory
+  const capDir = path.join(jsonDir, 'capabilities');
+
+  // Replace the directory on every generation so stale files and legacy
+  // nested gateway paths are removed even when the new capability maps
+  // are empty - a later generation with no capability data must not leave
+  // the previous capabilities behind.
+  await fs.rm(capDir, { recursive: true, force: true });
+
   const hasCapabilities =
     (attachmentCapabilities && Object.keys(attachmentCapabilities).length > 0) ||
     (temperatureCapabilities && Object.keys(temperatureCapabilities).length > 0) ||
     (structuredOutputCapabilities && Object.keys(structuredOutputCapabilities).length > 0);
   if (hasCapabilities) {
-    const capDir = path.join(jsonDir, 'capabilities');
-
-    // Replace the directory so stale files and legacy nested gateway paths are removed.
-    await fs.rm(capDir, { recursive: true, force: true });
     await fs.mkdir(capDir, { recursive: true });
 
     // Build a merged capability object per provider


### PR DESCRIPTION
## Description

`writeRegistryFiles()` only removed the previous `capabilities/` directory when the newly generated registry actually contained capability data. If an earlier run wrote capability files and a later run came back with empty capability maps, the cleanup was skipped and the stale files stayed on disk — so a provider that no longer reports capabilities could still look like it supported them.

This moves the directory replacement out of the `hasCapabilities` branch: every successful generation now clears the old `capabilities/` directory first, then recreates it (with only the current files) when there's data to write. When the new maps are empty, the directory is simply removed.

**Before:**
1. generate a registry with capability data → `capabilities/` is created
2. regenerate with empty attachment/temperature/structured-output maps → old `capabilities/` files remain

**After:** the stale directory is gone, and a subsequent generation with data recreates it from scratch.

Verified with a regression test that fails on `main` (the stale directory survives the empty regeneration) and passes with this change.

## Related issue(s)

Fixes #21530

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the registry is generated again, old capability files are now removed first. This prevents outdated files from remaining when the new capability data is empty or has changed.

## Changes

- Updated `writeRegistryFiles()` to remove the existing `capabilities/` directory after each successful generation.
- Recreates `capabilities/` only when current capability data exists.
- Removes stale nested gateway paths and leaves the directory absent when all capability maps are empty.
- Added a regression test for regeneration with empty capability data.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->