### PR TITLE
feat(browser-firecrawl): expose session deletion receipts

### DIFF
--- a/.changeset/famous-emus-scream.md
+++ b/.changeset/famous-emus-scream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/browser-firecrawl': minor
+---
+
+Added a callback that exposes Firecrawl's provider receipt after a hosted browser session is deleted.

--- a/browser/firecrawl/src/firecrawl-browser.test.ts
+++ b/browser/firecrawl/src/firecrawl-browser.test.ts
@@ -1,0 +1,118 @@
+import type { Firecrawl } from 'firecrawl';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  browser: vi.fn(),
+  deleteBrowser: vi.fn(),
+  launch: vi.fn(),
+  close: vi.fn(),
+  getPage: vi.fn(() => ({ url: vi.fn(() => 'about:blank') })),
+}));
+
+vi.mock('firecrawl', () => ({
+  Firecrawl: class MockFirecrawl {
+    browser = mocks.browser;
+    deleteBrowser = mocks.deleteBrowser;
+  },
+}));
+
+vi.mock('agent-browser', () => ({
+  BrowserManager: class MockBrowserManager {
+    launch = mocks.launch;
+    close = mocks.close;
+    getPage = mocks.getPage;
+  },
+}));
+
+vi.mock('./resolve-cdp', () => ({
+  resolveCdpWebSocketUrl: vi.fn(async () => 'wss://browser.example'),
+}));
+
+import { FirecrawlBrowser } from './firecrawl-browser';
+import { FirecrawlAgentBrowserThreadManager } from './firecrawl-thread-manager';
+
+const receipt = {
+  success: true,
+  sessionDurationMs: 12_345,
+  creditsBilled: 0.42,
+};
+
+describe('Firecrawl session deletion receipts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.browser.mockResolvedValue({
+      success: true,
+      id: 'session-1',
+      cdpUrl: 'https://browser.example',
+    });
+    mocks.deleteBrowser.mockResolvedValue(receipt);
+    mocks.launch.mockResolvedValue(undefined);
+    mocks.close.mockResolvedValue(undefined);
+  });
+
+  it('emits the provider receipt when a shared session closes', async () => {
+    const onSessionDeleted = vi.fn();
+    const browser = new FirecrawlBrowser({
+      apiKey: 'test-key',
+      scope: 'shared',
+      onSessionDeleted,
+    });
+
+    await browser.launch();
+    await browser.close();
+
+    expect(mocks.deleteBrowser).toHaveBeenCalledWith('session-1');
+    expect(onSessionDeleted).toHaveBeenCalledWith({ sessionId: 'session-1', receipt });
+  });
+
+  it('emits the provider receipt with the thread ID when a thread session closes', async () => {
+    const onSessionDeleted = vi.fn();
+    const firecrawl = {
+      browser: mocks.browser,
+      deleteBrowser: mocks.deleteBrowser,
+    } as unknown as Firecrawl;
+    const manager = new FirecrawlAgentBrowserThreadManager({
+      scope: 'thread',
+      browserConfig: {},
+      firecrawl,
+      resolveWebSocketUrl: vi.fn(async () => 'wss://browser.example'),
+      onSessionDeleted,
+    });
+
+    await manager.getManagerForThread('thread-1');
+    await manager.destroySession('thread-1');
+
+    expect(onSessionDeleted).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      threadId: 'thread-1',
+      receipt,
+    });
+  });
+
+  it('emits the provider receipt during failed-launch cleanup without masking the launch error', async () => {
+    const onSessionDeleted = vi.fn();
+    mocks.launch.mockRejectedValueOnce(new Error('CDP launch failed'));
+    const browser = new FirecrawlBrowser({
+      apiKey: 'test-key',
+      scope: 'shared',
+      onSessionDeleted,
+    });
+
+    await expect(browser.launch()).rejects.toThrow('CDP launch failed');
+
+    expect(onSessionDeleted).toHaveBeenCalledWith({ sessionId: 'session-1', receipt });
+  });
+
+  it('keeps cleanup successful when the receipt callback throws', async () => {
+    const browser = new FirecrawlBrowser({
+      apiKey: 'test-key',
+      scope: 'shared',
+      onSessionDeleted: vi.fn().mockRejectedValue(new Error('observer unavailable')),
+    });
+
+    await browser.launch();
+    await expect(browser.close()).resolves.toBeUndefined();
+
+    expect(browser.status).toBe('closed');
+  });
+});

--- a/browser/firecrawl/src/firecrawl-browser.ts
+++ b/browser/firecrawl/src/firecrawl-browser.ts
@@ -6,14 +6,18 @@ import { BrowserManager } from 'agent-browser';
 import { Firecrawl } from 'firecrawl';
 import { FirecrawlAgentBrowserThreadManager } from './firecrawl-thread-manager';
 import { resolveCdpWebSocketUrl } from './resolve-cdp';
-import type { FirecrawlBrowserConfig, FirecrawlBrowserSessionOptions } from './types';
+import type {
+  FirecrawlBrowserConfig,
+  FirecrawlBrowserSessionDeletedHook,
+  FirecrawlBrowserSessionOptions,
+} from './types';
 
 function pickSessionOpts(c: FirecrawlBrowserConfig): FirecrawlBrowserSessionOptions {
   return c.firecrawl ?? {};
 }
 
 function toBaseConfig(config: FirecrawlBrowserConfig): AgentBrowserConfig {
-  const { apiKey: _a, apiUrl: _u, firecrawl: _f, ...rest } = config;
+  const { apiKey: _a, apiUrl: _u, firecrawl: _f, onSessionDeleted: _d, ...rest } = config;
   return rest;
 }
 
@@ -30,6 +34,7 @@ export class FirecrawlBrowser extends AgentBrowser {
 
   private readonly firecrawl: Firecrawl;
   private readonly sessionOpts: FirecrawlBrowserSessionOptions;
+  private readonly onSessionDeleted?: FirecrawlBrowserSessionDeletedHook;
   private sharedFirecrawlSessionId?: string;
 
   constructor(config: FirecrawlBrowserConfig) {
@@ -48,10 +53,21 @@ export class FirecrawlBrowser extends AgentBrowser {
           firecrawl: fc,
           resolveWebSocketUrl: url => resolveCdpWebSocketUrl(url, opts.logger),
           sessionOptions: sessionOpts,
+          onSessionDeleted: config.onSessionDeleted,
         }),
     });
     this.firecrawl = fc;
     this.sessionOpts = sessionOpts;
+    this.onSessionDeleted = config.onSessionDeleted;
+  }
+
+  private async deleteSession(sessionId: string): Promise<void> {
+    const receipt = await this.firecrawl.deleteBrowser(sessionId);
+    try {
+      await this.onSessionDeleted?.({ sessionId, receipt });
+    } catch (error) {
+      this.logger?.warn?.(`Firecrawl onSessionDeleted(${sessionId}) failed: ${error}`);
+    }
   }
 
   protected override async doLaunch(): Promise<void> {
@@ -75,7 +91,7 @@ export class FirecrawlBrowser extends AgentBrowser {
       const err = new Error(`Firecrawl browser(): ${msg}`);
       if (createRes.id) {
         try {
-          await this.firecrawl.deleteBrowser(createRes.id);
+          await this.deleteSession(createRes.id);
         } catch (cleanupErr) {
           this.logger?.warn?.(`Firecrawl deleteBrowser(${createRes.id}) after failed browser(): ${cleanupErr}`);
         }
@@ -112,7 +128,7 @@ export class FirecrawlBrowser extends AgentBrowser {
         this.logger?.warn?.(`BrowserManager.close() after failed shared launch: ${closeErr}`);
       }
       try {
-        await this.firecrawl.deleteBrowser(sessionId);
+        await this.deleteSession(sessionId);
       } catch (delErr) {
         this.logger?.warn?.(`Firecrawl deleteBrowser(${sessionId}) after failed shared launch: ${delErr}`);
       }
@@ -127,7 +143,7 @@ export class FirecrawlBrowser extends AgentBrowser {
     await super.doClose();
     if (sid) {
       try {
-        await this.firecrawl.deleteBrowser(sid);
+        await this.deleteSession(sid);
       } catch (err) {
         this.logger?.warn?.(`Firecrawl deleteBrowser(${sid}) failed: ${err}`);
       }

--- a/browser/firecrawl/src/firecrawl-thread-manager.ts
+++ b/browser/firecrawl/src/firecrawl-thread-manager.ts
@@ -4,7 +4,7 @@ import { resolveViewportSize, DEFAULT_BROWSER_VIEWPORT } from '@mastra/core/brow
 import type { BrowserLaunchOptions } from 'agent-browser';
 import { BrowserManager } from 'agent-browser';
 import type { Firecrawl } from 'firecrawl';
-import type { FirecrawlBrowserSessionOptions } from './types';
+import type { FirecrawlBrowserSessionDeletedHook, FirecrawlBrowserSessionOptions } from './types';
 
 /**
  * Thread session with Firecrawl sandbox id for cleanup.
@@ -19,6 +19,8 @@ export interface FirecrawlAgentBrowserThreadManagerConfig extends AgentBrowserTh
   resolveWebSocketUrl: (url: string) => Promise<string>;
   /** Options for each `firecrawl.browser()` call (thread scope = one call per thread). */
   sessionOptions?: FirecrawlBrowserSessionOptions;
+  /** Callback invoked with Firecrawl's response after a hosted session is deleted. */
+  onSessionDeleted?: FirecrawlBrowserSessionDeletedHook;
 }
 
 /**
@@ -28,12 +30,23 @@ export class FirecrawlAgentBrowserThreadManager extends AgentBrowserThreadManage
   private readonly firecrawl: Firecrawl;
   private readonly resolveWebSocketUrl: (url: string) => Promise<string>;
   private readonly sessionOptions: FirecrawlBrowserSessionOptions;
+  private readonly onSessionDeleted?: FirecrawlBrowserSessionDeletedHook;
 
   constructor(config: FirecrawlAgentBrowserThreadManagerConfig) {
     super(config);
     this.firecrawl = config.firecrawl;
     this.resolveWebSocketUrl = config.resolveWebSocketUrl;
     this.sessionOptions = config.sessionOptions ?? {};
+    this.onSessionDeleted = config.onSessionDeleted;
+  }
+
+  private async deleteSession(sessionId: string, threadId: string): Promise<void> {
+    const receipt = await this.firecrawl.deleteBrowser(sessionId);
+    try {
+      await this.onSessionDeleted?.({ sessionId, threadId, receipt });
+    } catch (error) {
+      this.logger?.warn?.(`Firecrawl onSessionDeleted(${sessionId}) failed: ${error}`);
+    }
   }
 
   protected override async createSession(threadId: string): Promise<FirecrawlAgentBrowserSession> {
@@ -60,7 +73,7 @@ export class FirecrawlAgentBrowserThreadManager extends AgentBrowserThreadManage
         const err = new Error(`Firecrawl browser(): ${msg}`);
         if (createRes.id) {
           try {
-            await this.firecrawl.deleteBrowser(createRes.id);
+            await this.deleteSession(createRes.id, threadId);
           } catch (cleanupErr) {
             this.logger?.warn?.(`Firecrawl deleteBrowser(${createRes.id}) after failed browser(): ${cleanupErr}`);
           }
@@ -92,7 +105,7 @@ export class FirecrawlAgentBrowserThreadManager extends AgentBrowserThreadManage
           // ignore
         }
         try {
-          await this.firecrawl.deleteBrowser(createRes.id);
+          await this.deleteSession(createRes.id, threadId);
         } catch {
           // ignore
         }
@@ -118,7 +131,7 @@ export class FirecrawlAgentBrowserThreadManager extends AgentBrowserThreadManage
         }
         if (session.firecrawlSessionId) {
           try {
-            await this.firecrawl.deleteBrowser(session.firecrawlSessionId);
+            await this.deleteSession(session.firecrawlSessionId, threadId);
           } catch {
             // ignore
           }
@@ -142,7 +155,7 @@ export class FirecrawlAgentBrowserThreadManager extends AgentBrowserThreadManage
 
     if (session.firecrawlSessionId) {
       try {
-        await this.firecrawl.deleteBrowser(session.firecrawlSessionId);
+        await this.deleteSession(session.firecrawlSessionId, session.threadId);
       } catch {
         // ignore
       }

--- a/browser/firecrawl/src/index.ts
+++ b/browser/firecrawl/src/index.ts
@@ -5,4 +5,9 @@ export type {
   FirecrawlAgentBrowserThreadManagerConfig,
 } from './firecrawl-thread-manager';
 export { resolveCdpWebSocketUrl } from './resolve-cdp';
-export type { FirecrawlBrowserConfig, FirecrawlBrowserSessionOptions } from './types';
+export type {
+  FirecrawlBrowserConfig,
+  FirecrawlBrowserSessionDeletedEvent,
+  FirecrawlBrowserSessionDeletedHook,
+  FirecrawlBrowserSessionOptions,
+} from './types';

--- a/browser/firecrawl/src/types.ts
+++ b/browser/firecrawl/src/types.ts
@@ -1,4 +1,18 @@
 import type { AgentBrowserConfig } from '@mastra/agent-browser';
+import type { BrowserDeleteResponse } from 'firecrawl';
+
+/** Details emitted after Firecrawl confirms that a hosted browser session was deleted. */
+export interface FirecrawlBrowserSessionDeletedEvent {
+  /** Firecrawl browser session identifier. */
+  sessionId: string;
+  /** Mastra thread identifier for thread-scoped sessions. */
+  threadId?: string;
+  /** Firecrawl's response, including provider-reported duration and credits when available. */
+  receipt: BrowserDeleteResponse;
+}
+
+/** Callback invoked after Firecrawl confirms that a hosted browser session was deleted. */
+export type FirecrawlBrowserSessionDeletedHook = (event: FirecrawlBrowserSessionDeletedEvent) => void | Promise<void>;
 
 /**
  * Options passed to Firecrawl `POST /v2/browser` (see Firecrawl JS SDK `browser()`).
@@ -38,4 +52,6 @@ export type FirecrawlBrowserConfig = AgentBrowserConfig & {
    * (local Playwright profile path): see {@link FirecrawlBrowserSessionOptions.profile}.
    */
   firecrawl?: FirecrawlBrowserSessionOptions;
+  /** Observe Firecrawl's provider receipt after a hosted browser session is deleted. */
+  onSessionDeleted?: FirecrawlBrowserSessionDeletedHook;
 };

--- a/docs/src/content/en/reference/browser/firecrawl-browser.mdx
+++ b/docs/src/content/en/reference/browser/firecrawl-browser.mdx
@@ -22,6 +22,14 @@ const browser = new FirecrawlBrowser({
   firecrawl: {
     ttl: 600,
   },
+  onSessionDeleted: ({ sessionId, threadId, receipt }) => {
+    console.log({
+      sessionId,
+      threadId,
+      duration: receipt.sessionDurationMs,
+      credits: receipt.creditsBilled,
+    })
+  },
 })
 
 export const browserAgent = new Agent({
@@ -51,6 +59,13 @@ then interact with elements using their refs (e.g., @e5).`,
     name: 'apiUrl',
     type: 'string',
     description: 'Base URL for a self-hosted Firecrawl API.',
+    isOptional: true,
+  },
+  {
+    name: 'onSessionDeleted',
+    type: '(event: FirecrawlBrowserSessionDeletedEvent) => void | Promise<void>',
+    description:
+      'Callback invoked after Firecrawl confirms a hosted session was deleted. The event includes the session ID, the thread ID for thread-scoped sessions, and Firecrawl\'s deletion response with provider-reported sessionDurationMs and creditsBilled when available.',
     isOptional: true,
   },
   {
@@ -114,6 +129,8 @@ Session provisioning depends on the `scope` option inherited from `AgentBrowser`
 - `'shared'`: One Firecrawl sandbox session is created when the browser launches and shared across all threads. The session is deleted when the browser closes.
 
 In both cases, `FirecrawlBrowser` deletes the remote Firecrawl session when the browser closes, including when session creation or connection fails partway through.
+
+Use `onSessionDeleted` to observe Firecrawl's deletion response. The callback runs only after Firecrawl successfully deletes the hosted session, including cleanup after a failed launch. Errors thrown by the callback are logged and do not prevent browser cleanup.
 
 ## Tools
 


### PR DESCRIPTION
## Summary
- expose Firecrawl's deletion response through a typed `onSessionDeleted` callback
- emit the receipt for shared and thread-scoped sessions, including failed-launch cleanup
- document the callback and export its public event/hook types

## Verification
- `pnpm --filter @mastra/browser-firecrawl lint`
- `pnpm --filter @mastra/browser-firecrawl test` (4 tests passed)
- `pnpm --filter @mastra/browser-firecrawl build`