### PR TITLE
fix(vectorize): preserve IDs across update and delete

### DIFF
--- a/.changeset/cute-swans-obey.md
+++ b/.changeset/cute-swans-obey.md
@@ -1,0 +1,5 @@
+---
+'@mastra/vectorize': patch
+---
+
+Fixed Vectorize updates to preserve caller IDs and added ID-based bulk deletion.

--- a/stores/vectorize/src/vector/index.lifecycle.test.ts
+++ b/stores/vectorize/src/vector/index.lifecycle.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CloudflareVector } from './index';
+
+function createVectorStore() {
+  return new CloudflareVector({ id: 'test', accountId: 'account', apiToken: 'token' });
+}
+
+describe('CloudflareVector lifecycle contracts', () => {
+  it('preserves the caller-provided id when updating a vector', async () => {
+    const vector = createVectorStore();
+    const upsert = vi.spyOn(vector, 'upsert').mockResolvedValue(['vector-1']);
+
+    await vector.updateVector({
+      indexName: 'index',
+      id: 'vector-1',
+      update: { vector: [0.1, 0.2], metadata: { version: 2 } },
+    });
+
+    expect(upsert).toHaveBeenCalledWith({
+      indexName: 'index',
+      vectors: [[0.1, 0.2]],
+      metadata: [{ version: 2 }],
+      ids: ['vector-1'],
+    });
+  });
+
+  it('deletes multiple vectors by id through the Cloudflare API', async () => {
+    const vector = createVectorStore();
+    const deleteByIds = vi.spyOn(vector.client.vectorize.indexes, 'deleteByIds').mockResolvedValue({
+      mutationId: 'mutation-1',
+    });
+
+    await vector.deleteVectors({ indexName: 'index', ids: ['vector-1', 'vector-2'] });
+
+    expect(deleteByIds).toHaveBeenCalledWith('index', {
+      account_id: 'account',
+      ids: ['vector-1', 'vector-2'],
+    });
+  });
+
+  it('treats an empty id list as a successful no-op', async () => {
+    const vector = createVectorStore();
+    const deleteByIds = vi.spyOn(vector.client.vectorize.indexes, 'deleteByIds');
+
+    await expect(vector.deleteVectors({ indexName: 'index', ids: [] })).resolves.toBeUndefined();
+    expect(deleteByIds).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a metadata-filter deletion is requested', async () => {
+    const vector = createVectorStore();
+
+    await expect(vector.deleteVectors({ indexName: 'index', filter: { tenantId: 'tenant-a' } })).rejects.toThrow(
+      'Deleting Vectorize vectors by metadata filter is not supported',
+    );
+  });
+
+  it('rejects requests that provide both ids and a metadata filter', async () => {
+    const vector = createVectorStore();
+
+    await expect(
+      vector.deleteVectors({
+        indexName: 'index',
+        ids: ['vector-1'],
+        filter: { tenantId: 'tenant-a' },
+      }),
+    ).rejects.toThrow('ids and filter are mutually exclusive for Vectorize deleteVectors');
+  });
+
+  it('rejects requests without ids or a metadata filter', async () => {
+    const vector = createVectorStore();
+
+    await expect(vector.deleteVectors({ indexName: 'index' })).rejects.toThrow(
+      'ids are required for Vectorize deleteVectors',
+    );
+  });
+});

--- a/stores/vectorize/src/vector/index.ts
+++ b/stores/vectorize/src/vector/index.ts
@@ -340,7 +340,12 @@ export class CloudflareVector extends MastraVector<VectorizeVectorFilter> {
         updatePayload.metadata = [update.metadata];
       }
 
-      await this.upsert({ indexName: indexName, vectors: updatePayload.vectors, metadata: updatePayload.metadata });
+      await this.upsert({
+        indexName,
+        vectors: updatePayload.vectors,
+        metadata: updatePayload.metadata,
+        ids: [id],
+      });
     } catch (error) {
       throw new MastraError(
         {
@@ -387,16 +392,55 @@ export class CloudflareVector extends MastraVector<VectorizeVectorFilter> {
   }
 
   async deleteVectors({ indexName, filter, ids }: DeleteVectorsParams): Promise<void> {
-    throw new MastraError({
-      id: createVectorErrorId('VECTORIZE', 'DELETE_VECTORS', 'NOT_SUPPORTED'),
-      text: 'deleteVectors is not yet implemented for Vectorize vector store',
-      domain: ErrorDomain.STORAGE,
-      category: ErrorCategory.SYSTEM,
-      details: {
-        indexName,
-        ...(filter && { filter: JSON.stringify(filter) }),
-        ...(ids && { idsCount: ids.length }),
-      },
-    });
+    if (ids !== undefined && filter !== undefined) {
+      throw new MastraError({
+        id: createVectorErrorId('VECTORIZE', 'DELETE_VECTORS', 'INVALID_ARGS'),
+        text: 'ids and filter are mutually exclusive for Vectorize deleteVectors',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName, idsCount: ids.length, filter: JSON.stringify(filter) },
+      });
+    }
+
+    if (filter !== undefined) {
+      throw new MastraError({
+        id: createVectorErrorId('VECTORIZE', 'DELETE_VECTORS', 'FILTER_NOT_SUPPORTED'),
+        text: 'Deleting Vectorize vectors by metadata filter is not supported',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.SYSTEM,
+        details: { indexName, filter: JSON.stringify(filter) },
+      });
+    }
+
+    if (ids === undefined) {
+      throw new MastraError({
+        id: createVectorErrorId('VECTORIZE', 'DELETE_VECTORS', 'INVALID_ARGS'),
+        text: 'ids are required for Vectorize deleteVectors',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
+    if (ids.length === 0) {
+      return;
+    }
+
+    try {
+      await this.client.vectorize.indexes.deleteByIds(indexName, {
+        ids,
+        account_id: this.accountId,
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createVectorErrorId('VECTORIZE', 'DELETE_VECTORS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { indexName, idsCount: ids.length },
+        },
+        error,
+      );
+    }
   }
 }


### PR DESCRIPTION
Fixes #21582

Preserves caller-supplied IDs during updates, implements ID-batch deletion through the Cloudflare SDK, fails closed for unsupported metadata-filter deletion, and adds focused lifecycle tests plus a patch changeset.

Verification: 6 focused tests passed; TypeScript check passed; package lint passed; dependency build including @mastra/vectorize passed.