### PR TITLE
fix(processors): propagate request context to detector inference

### DIFF
--- a/.changeset/bright-detectors-carry-context.md
+++ b/.changeset/bright-detectors-carry-context.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Propagate processor `RequestContext` through model-backed detector inference.

--- a/packages/core/src/processors/processors/detector-request-context.test.ts
+++ b/packages/core/src/processors/processors/detector-request-context.test.ts
@@ -1,0 +1,136 @@
+import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
+import { describe, expect, it, vi } from 'vitest';
+import type { MastraDBMessage } from '../../agent/message-list';
+import { RequestContext } from '../../request-context';
+import { LanguageDetector } from './language-detector';
+import { PIIDetector } from './pii-detector';
+import { PromptInjectionDetector } from './prompt-injection-detector';
+import { SystemPromptScrubber } from './system-prompt-scrubber';
+
+function createModel(result: unknown) {
+  return new MockLanguageModelV1({
+    defaultObjectGenerationMode: 'json',
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop',
+      usage: { promptTokens: 1, completionTokens: 1 },
+      text: JSON.stringify(result),
+    }),
+  });
+}
+
+function createMessage(role: 'user' | 'assistant', text: string): MastraDBMessage {
+  return {
+    id: `${role}-message`,
+    role,
+    content: { format: 2, parts: [{ type: 'text', text }] },
+    createdAt: new Date(),
+  };
+}
+
+function createDynamicModel(result: unknown) {
+  const model = createModel(result);
+  const resolver = vi.fn(() => model);
+  return { model: resolver as any, resolver };
+}
+
+function expectRequestContext(resolver: ReturnType<typeof vi.fn>, requestContext: RequestContext) {
+  expect(resolver).toHaveBeenCalled();
+  expect(resolver.mock.calls.every(([args]) => args.requestContext === requestContext)).toBe(true);
+}
+
+describe('model-backed detector RequestContext propagation', () => {
+  it('propagates RequestContext through LanguageDetector internal inference', async () => {
+    const { model, resolver } = createDynamicModel({ iso_code: null, confidence: null });
+    const detector = new LanguageDetector({ model, targetLanguages: ['English'] });
+    const requestContext = new RequestContext();
+
+    await detector.processInput({
+      messages: [createMessage('user', 'Hello from this request context')],
+      abort: vi.fn() as any,
+      requestContext,
+    });
+
+    expectRequestContext(resolver, requestContext);
+  });
+
+  it('propagates RequestContext through PromptInjectionDetector internal inference', async () => {
+    const { model, resolver } = createDynamicModel({ categories: null, reason: null });
+    const detector = new PromptInjectionDetector({ model });
+    const requestContext = new RequestContext();
+
+    await detector.processInput({
+      messages: [createMessage('user', 'A normal request for help')],
+      abort: vi.fn() as any,
+      requestContext,
+    });
+
+    expectRequestContext(resolver, requestContext);
+  });
+
+  it('propagates RequestContext through PIIDetector internal inference', async () => {
+    const { model, resolver } = createDynamicModel({ categories: null, detections: null, redacted_content: null });
+    const detector = new PIIDetector({ model });
+    const requestContext = new RequestContext();
+
+    await detector.processInput({
+      messages: [createMessage('user', 'A normal request without personal details')],
+      abort: vi.fn() as any,
+      requestContext,
+    });
+
+    expectRequestContext(resolver, requestContext);
+
+    resolver.mockClear();
+    await detector.processOutputResult({
+      messages: [createMessage('assistant', 'A normal response without personal details')],
+      abort: vi.fn() as any,
+      requestContext,
+    });
+    expectRequestContext(resolver, requestContext);
+
+    resolver.mockClear();
+    await detector.processOutputStream({
+      part: {
+        type: 'text-delta',
+        runId: 'test-run',
+        from: 'AGENT',
+        payload: { id: 'text-1', text: 'A normal complete sentence.' },
+      } as any,
+      streamParts: [],
+      state: {},
+      abort: vi.fn() as any,
+      requestContext,
+    });
+    expectRequestContext(resolver, requestContext);
+  });
+
+  it('propagates RequestContext through SystemPromptScrubber internal inference', async () => {
+    const { model, resolver } = createDynamicModel({ detections: null, reason: null, redacted_content: null });
+    const detector = new SystemPromptScrubber({ model });
+    const requestContext = new RequestContext();
+
+    await detector.processOutputResult({
+      messages: [createMessage('assistant', 'A normal assistant response')],
+      abort: vi.fn() as any,
+      requestContext,
+    });
+
+    expectRequestContext(resolver, requestContext);
+
+    resolver.mockClear();
+    await detector.processOutputStream({
+      part: {
+        type: 'text-delta',
+        runId: 'test-run',
+        from: 'AGENT',
+        payload: { id: 'text-1', text: 'A normal assistant stream part' },
+      } as any,
+      streamParts: [],
+      state: {},
+      abort: vi.fn() as any,
+      requestContext,
+    });
+    expectRequestContext(resolver, requestContext);
+  });
+});

--- a/packages/core/src/processors/processors/language-detector.ts
+++ b/packages/core/src/processors/processors/language-detector.ts
@@ -7,6 +7,7 @@ import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { MastraModelConfig } from '../../llm/model/shared.types';
 import type { ObservabilityContext } from '../../observability';
 import { InternalSpans, resolveObservabilityContext } from '../../observability';
+import type { RequestContext } from '../../request-context';
 import { standardSchemaToJSONSchema } from '../../schema';
 import type { Processor } from '../index';
 import { selectMessagesToCheck } from './message-selection';
@@ -208,10 +209,11 @@ export class LanguageDetector implements Processor<'language-detector'> {
     args: {
       messages: MastraDBMessage[];
       abort: (reason?: string) => never;
+      requestContext?: RequestContext;
     } & Partial<ObservabilityContext>,
   ): Promise<MastraDBMessage[]> {
     try {
-      const { messages, abort, ...rest } = args;
+      const { messages, abort, requestContext, ...rest } = args;
       const observabilityContext = resolveObservabilityContext(rest);
 
       if (messages.length === 0) {
@@ -235,7 +237,7 @@ export class LanguageDetector implements Processor<'language-detector'> {
           continue;
         }
 
-        const detectionResult = await this.detectLanguage(textContent, observabilityContext);
+        const detectionResult = await this.detectLanguage(textContent, observabilityContext, requestContext);
 
         // Check if confidence meets threshold
         if (detectionResult.confidence && detectionResult.confidence < this.threshold) {
@@ -287,11 +289,12 @@ export class LanguageDetector implements Processor<'language-detector'> {
   private async detectLanguage(
     content: string,
     observabilityContext?: ObservabilityContext,
+    requestContext?: RequestContext,
   ): Promise<LanguageDetectionResult> {
     const prompt = this.createDetectionPrompt(content);
 
     try {
-      const model = await this.detectionAgent.getModel();
+      const model = await this.detectionAgent.getModel({ requestContext });
 
       const baseSchema = z.object({
         iso_code: z.string().describe('ISO language code').nullable(),
@@ -316,6 +319,7 @@ export class LanguageDetector implements Processor<'language-detector'> {
           },
           providerOptions: this.providerOptions,
           ...observabilityContext,
+          requestContext,
         });
 
         result = response.object!;
@@ -325,6 +329,7 @@ export class LanguageDetector implements Processor<'language-detector'> {
           temperature: 0,
           providerOptions: this.providerOptions as SharedV2ProviderOptions,
           ...observabilityContext,
+          requestContext,
         });
 
         result = response.object as LanguageDetectionResult;

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -8,6 +8,7 @@ import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { MastraModelConfig } from '../../llm/model/shared.types';
 import type { ObservabilityContext } from '../../observability';
 import { InternalSpans, resolveObservabilityContext } from '../../observability';
+import type { RequestContext } from '../../request-context';
 import type { PublicSchema } from '../../schema';
 import { toStandardSchema, standardSchemaToJSONSchema } from '../../schema';
 import type { ChunkType } from '../../stream';
@@ -286,10 +287,11 @@ export class PIIDetector implements Processor<'pii-detector'> {
     args: {
       messages: MastraDBMessage[];
       abort: (reason?: string) => never;
+      requestContext?: RequestContext;
     } & Partial<ObservabilityContext>,
   ): Promise<MastraDBMessage[]> {
     try {
-      const { messages, abort, ...rest } = args;
+      const { messages, abort, requestContext, ...rest } = args;
       const observabilityContext = resolveObservabilityContext(rest);
 
       if (messages.length === 0) {
@@ -313,7 +315,7 @@ export class PIIDetector implements Processor<'pii-detector'> {
           continue;
         }
 
-        const detectionResult = await this.detectPII(textContent, observabilityContext);
+        const detectionResult = await this.detectPII(textContent, observabilityContext, requestContext);
         const flagged = this.isPIIFlagged(detectionResult);
         await this.emitDetection(textContent, detectionResult, flagged);
 
@@ -365,11 +367,15 @@ export class PIIDetector implements Processor<'pii-detector'> {
   /**
    * Detect PII using the internal agent
    */
-  private async detectPII(content: string, observabilityContext?: ObservabilityContext): Promise<PIIDetectionResult> {
+  private async detectPII(
+    content: string,
+    observabilityContext?: ObservabilityContext,
+    requestContext?: RequestContext,
+  ): Promise<PIIDetectionResult> {
     const prompt = this.createDetectionPrompt(content);
 
     try {
-      const model = await this.detectionAgent.getModel();
+      const model = await this.detectionAgent.getModel({ requestContext });
 
       const baseDetectionSchema = z.object({
         type: z.string().describe('Type of PII detected'),
@@ -427,6 +433,7 @@ export class PIIDetector implements Processor<'pii-detector'> {
           },
           providerOptions: this.providerOptions,
           ...observabilityContext,
+          requestContext,
         });
         if (!response.object) {
           throw new Error('Structured output returned no object');
@@ -439,6 +446,7 @@ export class PIIDetector implements Processor<'pii-detector'> {
           temperature: 0,
           providerOptions: this.providerOptions as SharedV2ProviderOptions,
           ...observabilityContext,
+          requestContext,
         });
 
         result = response.object as PIIDetectionResult;
@@ -800,6 +808,7 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
     state: Record<string, any>,
     abort: (reason?: string) => never,
     observabilityContext?: ObservabilityContext,
+    requestContext?: RequestContext,
   ): Promise<ChunkType | null> {
     const buffer: string = state._piiBuffer || '';
     const firstPayloadId: string = state._piiFirstPayloadId || 'text-0';
@@ -811,7 +820,7 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
 
     if (!buffer) return null;
 
-    const detectionResult = await this.detectPII(buffer, observabilityContext);
+    const detectionResult = await this.detectPII(buffer, observabilityContext, requestContext);
     const flagged = this.isPIIFlagged(detectionResult);
     await this.emitDetection(buffer, detectionResult, flagged);
 
@@ -852,15 +861,16 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
       state: Record<string, any>;
       abort: (reason?: string) => never;
       writer?: { custom: (data: ChunkType) => Promise<void> };
+      requestContext?: RequestContext;
     } & Partial<ObservabilityContext>,
   ): Promise<ChunkType | null> {
-    const { part, abort, state, writer, ...rest } = args;
+    const { part, abort, state, writer, requestContext, ...rest } = args;
     const observabilityContext = resolveObservabilityContext(rest);
     try {
       // Handle non-text chunks: flush any pending LLM buffer first
       if (part.type !== 'text-delta') {
         if (this.hasLLMOnlyTypes && state._piiBuffer) {
-          const flushed = await this.flushLLMBuffer(state, abort, observabilityContext);
+          const flushed = await this.flushLLMBuffer(state, abort, observabilityContext, requestContext);
           if (flushed) {
             // Two parts to emit: flushed buffer + this non-text part.
             // Use REPROCESS_PART_KEY so the runner re-drives the non-text part.
@@ -947,7 +957,7 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
               : textContent;
           // Check flush threshold
           if (state._piiBuffer.length >= this.bufferSize || /[.!?]\s*$/.test(state._piiBuffer)) {
-            return this.flushLLMBuffer(state, abort, observabilityContext);
+            return this.flushLLMBuffer(state, abort, observabilityContext, requestContext);
           }
           return null; // Hold back until flush
         }
@@ -970,7 +980,7 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
 
       // Flush on sentence boundary or size threshold
       if (state._piiBuffer.length >= this.bufferSize || /[.!?]\s*$/.test(state._piiBuffer)) {
-        return this.flushLLMBuffer(state, abort, observabilityContext);
+        return this.flushLLMBuffer(state, abort, observabilityContext, requestContext);
       }
 
       return null; // Hold back until flush
@@ -989,10 +999,12 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
   async processOutputResult({
     messages,
     abort,
+    requestContext,
     ...rest
   }: {
     messages: MastraDBMessage[];
     abort: (reason?: string) => never;
+    requestContext?: RequestContext;
   } & Partial<ObservabilityContext>): Promise<MastraDBMessage[]> {
     const observabilityContext = resolveObservabilityContext(rest);
     try {
@@ -1017,7 +1029,7 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
           continue;
         }
 
-        const detectionResult = await this.detectPII(textContent, observabilityContext);
+        const detectionResult = await this.detectPII(textContent, observabilityContext, requestContext);
         const flagged = this.isPIIFlagged(detectionResult);
         await this.emitDetection(textContent, detectionResult, flagged);
 

--- a/packages/core/src/processors/processors/prompt-injection-detector.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.ts
@@ -7,6 +7,7 @@ import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { MastraModelConfig } from '../../llm/model/shared.types';
 import { InternalSpans, resolveObservabilityContext } from '../../observability';
 import type { ObservabilityContext } from '../../observability';
+import type { RequestContext } from '../../request-context';
 import type { PublicSchema } from '../../schema';
 import { toStandardSchema, standardSchemaToJSONSchema } from '../../schema';
 import type { Processor } from '../index';
@@ -173,10 +174,11 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
     args: {
       messages: MastraDBMessage[];
       abort: (reason?: string) => never;
+      requestContext?: RequestContext;
     } & Partial<ObservabilityContext>,
   ): Promise<MastraDBMessage[]> {
     try {
-      const { messages, abort, ...rest } = args;
+      const { messages, abort, requestContext, ...rest } = args;
       const observabilityContext = resolveObservabilityContext(rest);
 
       if (messages.length === 0) {
@@ -201,7 +203,7 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
           continue;
         }
 
-        const detectionResult = await this.detectPromptInjection(textContent, observabilityContext);
+        const detectionResult = await this.detectPromptInjection(textContent, observabilityContext, requestContext);
         results.push(detectionResult);
         const flagged = this.isInjectionFlagged(detectionResult);
         await this.emitDetection(textContent, detectionResult, flagged);
@@ -256,10 +258,11 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
   private async detectPromptInjection(
     content: string,
     observabilityContext?: ObservabilityContext,
+    requestContext?: RequestContext,
   ): Promise<PromptInjectionResult> {
     const prompt = this.createDetectionPrompt(content);
     try {
-      const model = await this.detectionAgent.getModel();
+      const model = await this.detectionAgent.getModel({ requestContext });
 
       const baseSchema = z.object({
         categories: z
@@ -301,6 +304,7 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
           },
           providerOptions: this.providerOptions,
           ...observabilityContext,
+          requestContext,
         });
 
         if (!response.object) {
@@ -314,6 +318,7 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
           temperature: 0,
           providerOptions: this.providerOptions as SharedV2ProviderOptions,
           ...observabilityContext,
+          requestContext,
         });
 
         if (!response.object) {

--- a/packages/core/src/processors/processors/system-prompt-scrubber.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.ts
@@ -5,6 +5,7 @@ import { TripWire } from '../../agent/trip-wire';
 import type { MastraModelConfig } from '../../llm/model/shared.types';
 import type { ObservabilityContext } from '../../observability';
 import { InternalSpans, resolveObservabilityContext } from '../../observability';
+import type { RequestContext } from '../../request-context';
 import type { PublicSchema } from '../../schema';
 import { toStandardSchema, standardSchemaToJSONSchema } from '../../schema';
 import type { ChunkType } from '../../stream';
@@ -116,9 +117,10 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
       streamParts: ChunkType[];
       state: Record<string, any>;
       abort: (reason?: string) => never;
+      requestContext?: RequestContext;
     } & Partial<ObservabilityContext>,
   ): Promise<ChunkType | null> {
-    const { part, abort, ...rest } = args;
+    const { part, abort, requestContext, ...rest } = args;
     const observabilityContext = resolveObservabilityContext(rest);
 
     // Only process text-delta chunks
@@ -132,7 +134,7 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
     }
 
     try {
-      const detectionResult = await this.detectSystemPrompts(text, observabilityContext);
+      const detectionResult = await this.detectSystemPrompts(text, observabilityContext, requestContext);
 
       if (detectionResult.detections && detectionResult.detections.length > 0) {
         const detectedTypes = detectionResult.detections.map(detection => detection.type);
@@ -187,10 +189,12 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
   async processOutputResult({
     messages,
     abort,
+    requestContext,
     ...rest
   }: {
     messages: MastraDBMessage[];
     abort: (reason?: string) => never;
+    requestContext?: RequestContext;
   } & Partial<ObservabilityContext>): Promise<MastraDBMessage[]> {
     const observabilityContext = resolveObservabilityContext(rest);
     const processedMessages: MastraDBMessage[] = [];
@@ -214,7 +218,7 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
       }
 
       try {
-        const detectionResult = await this.detectSystemPrompts(textContent, observabilityContext);
+        const detectionResult = await this.detectSystemPrompts(textContent, observabilityContext, requestContext);
 
         if (detectionResult.detections && detectionResult.detections.length > 0) {
           const detectedTypes = detectionResult.detections.map(detection => detection.type);
@@ -267,9 +271,10 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
   private async detectSystemPrompts(
     text: string,
     observabilityContext?: ObservabilityContext,
+    requestContext?: RequestContext,
   ): Promise<SystemPromptDetectionResult> {
     try {
-      const model = await this.detectionAgent.getModel();
+      const model = await this.detectionAgent.getModel({ requestContext });
 
       const baseDetectionSchema = z.object({
         type: z.string().describe('Type of system prompt detected'),
@@ -306,6 +311,7 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
             schema,
           },
           ...observabilityContext,
+          requestContext,
         });
 
         if (!response.object) {
@@ -317,6 +323,7 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
         const response = await this.detectionAgent.generateLegacy(text, {
           output: standardSchemaToJSONSchema(standardSchema),
           ...observabilityContext,
+          requestContext,
         });
 
         result = response.object as SystemPromptDetectionResult;


### PR DESCRIPTION
Fixes #21583

Forwards ProcessorContext RequestContext through internal model resolution and inference for LanguageDetector, PromptInjectionDetector, PIIDetector, and SystemPromptScrubber, including PII stream and final paths. Includes a cross-path regression test and patch changeset.

Verification: 171 focused tests passed; core typecheck passed; lint passed; build passed.