### PR TITLE
fix(ai-sdk): forward message metadata through chatRoute

### DIFF
--- a/.changeset/calm-chats-carry-metadata.md
+++ b/.changeset/calm-chats-carry-metadata.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Forward `messageMetadata` from `chatRoute` to the underlying AI SDK stream handler.

--- a/client-sdks/ai-sdk/src/__tests__/chat-route-message-metadata.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/chat-route-message-metadata.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { chatRoute } from '../chat-route';
+
+function createAgentStream() {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({
+        type: 'start',
+        runId: 'test-run-id',
+        payload: { id: 'test-message-id' },
+      });
+      controller.enqueue({
+        type: 'finish',
+        runId: 'test-run-id',
+        payload: {
+          stepResult: { reason: 'stop' },
+          output: {
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          },
+        },
+      });
+      controller.close();
+    },
+  });
+}
+
+function createRouteContext() {
+  const body = {
+    messages: [{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+  };
+  const agent = {
+    stream: vi.fn().mockResolvedValue({ fullStream: createAgentStream() }),
+  };
+  const mastra = {
+    getAgentById: vi.fn().mockReturnValue(agent),
+  };
+  const request = new Request('http://localhost/chat/test-agent', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  return {
+    req: {
+      raw: request,
+      json: () => Promise.resolve(body),
+      param: (name: string) => (name === 'agentId' ? 'test-agent' : undefined),
+      query: () => undefined,
+    },
+    get: (key: string) => (key === 'mastra' ? mastra : undefined),
+  };
+}
+
+async function invokeRoute(route: ReturnType<typeof chatRoute>): Promise<Response> {
+  if (!('handler' in route)) throw new Error('Expected chatRoute to return a route handler');
+  const response = await route.handler(createRouteContext() as never, async () => {});
+  if (!(response instanceof Response)) throw new Error('Expected chatRoute handler to return a Response');
+  await response.text();
+  return response;
+}
+
+describe('chatRoute messageMetadata', () => {
+  it.each(['v5', 'v6'] as const)('forwards messageMetadata to the %s stream handler', async version => {
+    const messageMetadata = vi.fn(({ part }: { part: { type: string } }) => ({
+      responseLanguage: 'ar',
+      partType: part.type,
+    }));
+
+    const route = chatRoute({
+      path: '/chat/:agentId',
+      version,
+      messageMetadata,
+    });
+
+    await invokeRoute(route);
+
+    expect(messageMetadata).toHaveBeenCalled();
+    expect(messageMetadata.mock.calls.some(([{ part }]) => part.type === 'start')).toBe(true);
+    expect(messageMetadata.mock.calls.some(([{ part }]) => part.type === 'finish')).toBe(true);
+  });
+});

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -417,7 +417,7 @@ export async function handleChatStream<OUTPUT = undefined>({
   }) as ReadableStream<any>;
 }
 
-export type chatRouteOptions<OUTPUT = undefined> = {
+export type chatRouteOptions<OUTPUT = undefined, UI_MESSAGE extends SupportedUIMessage = SupportedUIMessage> = {
   defaultOptions?: ChatStreamDefaultOptions<OUTPUT>;
   /** Experimental transforms applied before converting Mastra chunks to AI SDK UI chunks. */
   experimentalTransform?: MastraStreamTransformOptions<OUTPUT>;
@@ -440,6 +440,8 @@ export type chatRouteOptions<OUTPUT = undefined> = {
     /** Target interval for periodic SSE comment heartbeats. Values up to 0 disable heartbeats. `NaN`, positive infinity, and values above 2,147,483,647 throw a `RangeError`. */
     heartbeatMs?: number;
     onError?: (error: unknown) => string;
+    /** Metadata attached to start and finish message parts in the AI SDK stream. */
+    messageMetadata?: ChatStreamHandlerOptions<UI_MESSAGE, OUTPUT>['messageMetadata'];
   };
 
 /**
@@ -457,6 +459,7 @@ export type chatRouteOptions<OUTPUT = undefined> = {
  * @param {boolean} [options.sendSources=false] - Whether to include source citations in the stream
  * @param {number} [options.heartbeatMs] - Target interval for periodic SSE comment heartbeats. Already-buffered source events and stream lifecycle signals take priority. Values up to 0 disable heartbeats. `NaN`, positive infinity, and values above 2,147,483,647 throw a `RangeError`.
  * @param {(error: unknown) => string} [options.onError] - Custom error serializer streamed to the client. When omitted, errors are passed through a default serializer that strips sensitive fields (e.g. `APICallError.requestBodyValues`, which holds the system prompt) before they reach the client.
+ * @param {Function} [options.messageMetadata] - Maps stream parts to metadata attached to AI SDK start and finish message parts.
  *
  * @returns {ReturnType<typeof registerApiRoute>} A registered API route handler
  *
@@ -488,7 +491,7 @@ export type chatRouteOptions<OUTPUT = undefined> = {
  * - If both `agent` and `:agentId` are present, a warning is logged and the fixed `agent` takes precedence
  * - Request context from the incoming request overrides `defaultOptions.requestContext` if both are present
  */
-export function chatRoute<OUTPUT = undefined>({
+export function chatRoute<OUTPUT = undefined, UI_MESSAGE extends SupportedUIMessage = SupportedUIMessage>({
   path = '/chat/:agentId',
   agent,
   defaultOptions,
@@ -501,7 +504,8 @@ export function chatRoute<OUTPUT = undefined>({
   sendSources = false,
   heartbeatMs,
   onError,
-}: chatRouteOptions<OUTPUT>): ReturnType<typeof registerApiRoute> {
+  messageMetadata,
+}: chatRouteOptions<OUTPUT, UI_MESSAGE>): ReturnType<typeof registerApiRoute> {
   if (!agent && !path.includes('/:agentId')) {
     throw new Error('Path must include :agentId to route to the correct agent or pass the agent explicitly');
   }
@@ -706,10 +710,14 @@ export function chatRoute<OUTPUT = undefined>({
         const uiMessageStream = await handleChatStream({
           ...handlerOptions,
           version: 'v6',
+          messageMetadata: messageMetadata as UIMessageStreamOptionsV6<V6UIMessage>['messageMetadata'],
         });
         response = createUIMessageStreamResponseV6({ stream: uiMessageStream });
       } else {
-        const uiMessageStream = await handleChatStream(handlerOptions);
+        const uiMessageStream = await handleChatStream({
+          ...handlerOptions,
+          messageMetadata: messageMetadata as UIMessageStreamOptionsV5<V5UIMessage>['messageMetadata'],
+        });
         response = createUIMessageStreamResponseV5({ stream: uiMessageStream });
       }
 


### PR DESCRIPTION
Fixes #21579

Adds version-aware messageMetadata to chatRoute and forwards it unchanged to handleChatStream for AI SDK v5 and v6. Includes focused route regression coverage and a patch changeset.

Verification: 35 focused tests passed; package lint passed; package build passed.