### PR TITLE
fix(core): validate model config routing fields

### DIFF
--- a/.changeset/tidy-model-configs-fail.md
+++ b/.changeset/tidy-model-configs-fail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Reject malformed model routing fields before they reach the model router, so invalid configurations produce Mastra's standard error instead of an internal runtime exception.

--- a/packages/core/src/llm/model/resolve-model.test.ts
+++ b/packages/core/src/llm/model/resolve-model.test.ts
@@ -82,6 +82,34 @@ describe('resolveModelConfig', () => {
     await expect(resolveModelConfig(null as any)).rejects.toThrow('Invalid model configuration provided');
   });
 
+  describe('routing field validation', () => {
+    it('should reject a non-string id', async () => {
+      const config = { id: 123 } as any;
+
+      expect(isOpenAICompatibleObjectConfig(config)).toBe(false);
+      await expect(resolveModelConfig(config)).rejects.toThrow('Invalid model configuration provided');
+    });
+
+    it.each([
+      { providerId: 123, modelId: 'model' },
+      { providerId: 'provider', modelId: 123 },
+    ])('should reject non-string provider/model routing fields', async config => {
+      expect(isOpenAICompatibleObjectConfig(config as any)).toBe(false);
+      await expect(resolveModelConfig(config as any)).rejects.toThrow('Invalid model configuration provided');
+    });
+
+    it('should validate provider/model fields when both are present', async () => {
+      const config = {
+        id: 'fallback/model',
+        providerId: 123,
+        modelId: 'model',
+      } as any;
+
+      expect(isOpenAICompatibleObjectConfig(config)).toBe(false);
+      await expect(resolveModelConfig(config)).rejects.toThrow('Invalid model configuration provided');
+    });
+  });
+
   describe('v4 (LanguageModelV4 / AI SDK v7) handling', () => {
     it('should wrap a v4 model in AISDKV7LanguageModel', async () => {
       const model = {

--- a/packages/core/src/llm/model/resolve-model.ts
+++ b/packages/core/src/llm/model/resolve-model.ts
@@ -37,8 +37,10 @@ export function isOpenAICompatibleObjectConfig(
   // 1. 'id' field (but NOT 'model' - that's ModelWithRetries)
   // 2. Both 'providerId' and 'modelId' fields
   if (!('model' in modelConfig)) {
-    if ('id' in modelConfig) return true;
-    if ('providerId' in modelConfig && 'modelId' in modelConfig) return true;
+    if ('providerId' in modelConfig && 'modelId' in modelConfig) {
+      return typeof modelConfig.providerId === 'string' && typeof modelConfig.modelId === 'string';
+    }
+    if ('id' in modelConfig) return typeof modelConfig.id === 'string';
   }
   return false;
 }


### PR DESCRIPTION
## Description

Fixes malformed model-routing configurations being accepted by `isOpenAICompatibleObjectConfig()` based only on property presence.

Previously, configurations containing non-string `id`, `providerId`, or `modelId` values could pass the type guard and reach model-router code that expects those fields to be strings. This could produce an internal JavaScript error or silently coerce invalid routing values.

This change validates routing-field types before constructing `ModelRouterLanguageModel`, allowing invalid configurations to reach Mastra’s existing controlled error:

```text
Invalid model configuration provided
```

FIXES #21588 

## Changes

- Require `providerId` and `modelId` to both be strings when both properties are present.
- Require `id` to be a string when using the `id` configuration form.
- Preserve the router’s precedence when both provider/model fields and `id` are present.
- Preserve the existing null, object, `specificationVersion`, and `model` guards.
- Leave optional `url`, `apiKey`, and `headers` validation unchanged.
- Add regression tests for malformed routing-field values.
- Add an `@mastra/core` patch changeset.
- Make no public API, export, or documentation changes.

## Test plan

The regression tests verify that:

1. `{ id: 123 }` is rejected by the type guard.
2. Resolving `{ id: 123 }` produces `Invalid model configuration provided`.
3. Non-string `providerId` and `modelId` values are rejected by both the type guard and resolver.
4. Provider/model fields control validation when both they and `id` are present.
5. Existing valid `id` and `providerId`/`modelId` configurations continue resolving successfully.

Validation completed:

- [x] Focused `resolve-model.test.ts` suite — 27 tests passed
- [x] Focused Vitest typecheck — no type errors
- [x] Core build TypeScript check
- [x] ESLint
- [x] Oxlint
- [x] Formatting check
- [x] `git diff --check`

The full package declaration-test check currently reports unrelated existing `RequestContext` errors involving `getRaw`, `setRaw`, `hasRaw`, and `deleteRaw`. The changed resolver and tests are not involved in those failures.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue in the description above
- [x] I have added tests that prove the fix is effective
- [x] I have added the required changeset
- [x] I have run the relevant focused tests and static checks
- [x] No documentation changes are required because this does not change the public API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The model router now rejects invalid configuration values before they cause internal errors. Valid model configurations continue to work as before.

## Changes

- Validate that `id`, `providerId`, and `modelId` values are strings.
- Reject malformed configurations with `Invalid model configuration provided`.
- Preserve existing routing precedence, guards, optional-field validation, and public APIs.
- Add regression tests for invalid routing fields and mixed fallback configurations.
- Add a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->