### PR TITLE
fix(core): keep evented conditional restart path at correct depth

### DIFF
--- a/.changeset/evented-conditional-restart-path.md
+++ b/.changeset/evented-conditional-restart-path.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fixed evented workflows corrupting the execution path when restarting a run that failed inside a conditional (`.branch()`) step.
+
+On restart the execution path is restored as the full branch path `[conditionalIndex, branchIndex]`. The conditional handler appended the re-resolved branch index onto that path instead of replacing the last segment, producing a phantom third level `[conditionalIndex, branchIndex, index]`. The branch step then ran at the wrong depth, and branch-result aggregation (which resolves the parent conditional via `executionPath.slice(0, -1)`) pointed at a level that does not exist, so the conditional's results never aggregated and the restarted run could hang or return the wrong output.
+
+Restarts of failed conditional branches now resolve to the correct branch at the correct depth, matching the parallel handler, which already handled this case.

--- a/.changeset/evented-conditional-restart-path.md
+++ b/.changeset/evented-conditional-restart-path.md
@@ -2,8 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed evented workflows corrupting the execution path when restarting a run that failed inside a conditional (`.branch()`) step.
-
-On restart the execution path is restored as the full branch path `[conditionalIndex, branchIndex]`. The conditional handler appended the re-resolved branch index onto that path instead of replacing the last segment, producing a phantom third level `[conditionalIndex, branchIndex, index]`. The branch step then ran at the wrong depth, and branch-result aggregation (which resolves the parent conditional via `executionPath.slice(0, -1)`) pointed at a level that does not exist, so the conditional's results never aggregated and the restarted run could hang or return the wrong output.
-
-Restarts of failed conditional branches now resolve to the correct branch at the correct depth, matching the parallel handler, which already handled this case.
+Fixed restarting an evented workflow that failed inside a conditional (`.branch()`) step. The restart could hang or return the wrong result because the conditional branch was re-run at the wrong position and its output never aggregated back. Restarts of failed conditional branches now resume the correct branch and complete reliably, matching how parallel steps already behaved.

--- a/packages/core/src/workflows/evented/workflow-event-processor/conditional-restart.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/conditional-restart.test.ts
@@ -59,6 +59,64 @@ describe('processWorkflowConditional restart execution path depth', () => {
     expect(runs[0].data.activeStepsPath['C']).toEqual([0, 2]);
   });
 
+  it('keeps skipped-branch step.end paths at 2 levels on restart', async () => {
+    const published: any[] = [];
+    const pubsub = {
+      publish: async (_topic: string, event: any) => {
+        published.push(event);
+      },
+    } as any;
+
+    // Only branch C(2) is truthy on restart; A(0) and B(1) are skipped and emit
+    // step.end. Every path, run and end alike, must stay at 2 levels so the
+    // conditional aggregates instead of drilling into a phantom third level.
+    const step = makeConditionalStep(['A', 'B', 'C']);
+    const args = makeArgs({
+      executionPath: [0, 2],
+      restart: { activeStepsPath: { C: [0, 2] }, isParallelOrConditionalRestarted: false },
+    });
+
+    await processWorkflowConditional(args, { pubsub, stepExecutor: makeStepExecutor([2]), step });
+
+    const runs = published.filter(e => e.type === 'workflow.step.run');
+    const ends = published.filter(e => e.type === 'workflow.step.end');
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].data.executionPath).toEqual([0, 2]);
+
+    // Skipped branches A and B: paths [0, 0] and [0, 1], not [0, 2, 0] / [0, 2, 1].
+    expect(ends.map(e => e.data.executionPath).sort()).toEqual([
+      [0, 0],
+      [0, 1],
+    ]);
+    expect(ends.every(e => e.data.executionPath.length === 2)).toBe(true);
+  });
+
+  it('keeps the perStep branch path at 2 levels on restart', async () => {
+    const published: any[] = [];
+    const pubsub = {
+      publish: async (_topic: string, event: any) => {
+        published.push(event);
+      },
+    } as any;
+
+    // perStep mode publishes only the single active branch. On restart it must
+    // still resolve to the 2-level path, not append onto the restored one.
+    const step = makeConditionalStep(['A', 'B', 'C']);
+    const args = makeArgs({
+      executionPath: [0, 2],
+      perStep: true,
+      restart: { activeStepsPath: { C: [0, 2] }, isParallelOrConditionalRestarted: false },
+    });
+
+    await processWorkflowConditional(args, { pubsub, stepExecutor: makeStepExecutor([2]), step });
+
+    const runs = published.filter(e => e.type === 'workflow.step.run');
+    expect(runs).toHaveLength(1);
+    expect(runs[0].data.executionPath).toEqual([0, 2]);
+    expect(runs[0].data.activeStepsPath['C']).toEqual([0, 2]);
+  });
+
   it('appends the branch index normally on the first (non-restart) pass', async () => {
     const published: any[] = [];
     const pubsub = {

--- a/packages/core/src/workflows/evented/workflow-event-processor/conditional-restart.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/conditional-restart.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { processWorkflowConditional } from './parallel';
+
+function makeConditionalStep(ids: string[]) {
+  return {
+    type: 'conditional' as const,
+    steps: ids.map(id => ({ type: 'step' as const, step: { id } })),
+    conditions: ids.map(() => async () => true),
+    serializedConditions: ids.map((_, i) => ({ id: `cond-${i}`, fn: 'true' })),
+  };
+}
+
+function makeArgs(overrides: Record<string, any> = {}) {
+  return {
+    workflowId: 'wf',
+    runId: 'run-1',
+    executionPath: [0],
+    stepResults: {},
+    activeStepsPath: {},
+    resumeSteps: [],
+    prevResult: { status: 'success', output: {} },
+    requestContext: {},
+    state: {},
+    ...overrides,
+  } as any;
+}
+
+function makeStepExecutor(truthyIdxs: number[]) {
+  return {
+    evaluateConditions: async () => truthyIdxs,
+  } as any;
+}
+
+describe('processWorkflowConditional restart execution path depth', () => {
+  it('keeps the branch path at 2 levels on restart instead of growing a third level', async () => {
+    const published: any[] = [];
+    const pubsub = {
+      publish: async (_topic: string, event: any) => {
+        published.push(event);
+      },
+    } as any;
+
+    // Conditional with branches A(0), B(1), C(2). The run failed inside branch C,
+    // so restart restores executionPath = [conditionalIdx, branchIdx] = [0, 2].
+    // Re-running C must publish the path [0, 2], not [0, 2, 2].
+    const step = makeConditionalStep(['A', 'B', 'C']);
+    const args = makeArgs({
+      executionPath: [0, 2],
+      restart: { activeStepsPath: { C: [0, 2] }, isParallelOrConditionalRestarted: false },
+    });
+
+    await processWorkflowConditional(args, { pubsub, stepExecutor: makeStepExecutor([2]), step });
+
+    const runs = published.filter(e => e.type === 'workflow.step.run');
+    expect(runs).toHaveLength(1);
+    expect(runs[0].data.executionPath).toEqual([0, 2]);
+    // activeStepsPath entries must stay at the same depth so aggregation resolves
+    // the conditional container via executionPath.slice(0, -1) === [0].
+    expect(runs[0].data.activeStepsPath['C']).toEqual([0, 2]);
+  });
+
+  it('appends the branch index normally on the first (non-restart) pass', async () => {
+    const published: any[] = [];
+    const pubsub = {
+      publish: async (_topic: string, event: any) => {
+        published.push(event);
+      },
+    } as any;
+
+    const step = makeConditionalStep(['A', 'B', 'C']);
+    const args = makeArgs({
+      executionPath: [0],
+      restart: undefined,
+    });
+
+    await processWorkflowConditional(args, { pubsub, stepExecutor: makeStepExecutor([1]), step });
+
+    const runs = published.filter(e => e.type === 'workflow.step.run');
+    expect(runs).toHaveLength(1);
+    expect(runs[0].data.executionPath).toEqual([0, 1]);
+  });
+});

--- a/packages/core/src/workflows/evented/workflow-event-processor/parallel.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/parallel.ts
@@ -119,6 +119,15 @@ export async function processWorkflowConditional(
   // Create a proper RequestContext from the plain object passed in ProcessorArgs
   const reqContext = new RequestContext(Object.entries(requestContext ?? {}) as any);
 
+  // On restart, `executionPath` is already the branch path ([conditionalIdx, branchIdx])
+  // restored from the persisted active paths, so the re-resolved branch index has to
+  // replace the last segment instead of being appended. Appending grows a phantom
+  // third level ([conditionalIdx, branchIdx, idx]); the branch step then runs at the
+  // wrong depth and aggregateBranchResults resolves its parent via
+  // executionPath.slice(0, -1) to a level that does not exist, so the conditional's
+  // branch results never aggregate. Mirrors processWorkflowParallel above.
+  const branchPath = (idx: number) => (restart ? executionPath.slice(0, -1) : executionPath).concat([idx]);
+
   const idxs = await stepExecutor.evaluateConditions({
     workflowId,
     step,
@@ -145,14 +154,14 @@ export async function processWorkflowConditional(
   if (onlyStepToRun) {
     const onlyStepToRunId = getSingleStepEntryId(onlyStepToRun);
     const stepIndex = step.steps.findIndex(child => getSingleStepEntryId(child) === onlyStepToRunId);
-    activeStepsPath[onlyStepToRunId] = executionPath.concat([stepIndex]);
+    activeStepsPath[onlyStepToRunId] = branchPath(stepIndex);
     await pubsub.publish('workflows', {
       type: 'workflow.step.run',
       runId,
       data: {
         workflowId,
         runId,
-        executionPath: executionPath.concat([stepIndex]),
+        executionPath: branchPath(stepIndex),
         resumeSteps,
         stepResults,
         timeTravel,
@@ -172,7 +181,7 @@ export async function processWorkflowConditional(
       step.steps.map(async (child, idx) => {
         if (truthyIdxs[idx]) {
           if (child) {
-            activeStepsPath[getSingleStepEntryId(child)] = executionPath.concat([idx]);
+            activeStepsPath[getSingleStepEntryId(child)] = branchPath(idx);
           }
           return pubsub.publish('workflows', {
             type: 'workflow.step.run',
@@ -180,7 +189,7 @@ export async function processWorkflowConditional(
             data: {
               workflowId,
               runId,
-              executionPath: executionPath.concat([idx]),
+              executionPath: branchPath(idx),
               resumeSteps,
               stepResults,
               timeTravel,
@@ -202,7 +211,7 @@ export async function processWorkflowConditional(
             data: {
               workflowId,
               runId,
-              executionPath: executionPath.concat([idx]),
+              executionPath: branchPath(idx),
               resumeSteps,
               stepResults,
               prevResult: { status: 'skipped' },


### PR DESCRIPTION
## What

Fixes the evented workflow engine corrupting the execution path when a run is restarted after failing inside a conditional (`.branch()`) step.

Closes #21592.

## Root cause

On restart, `executionPath` is restored as the full branch path `[conditionalIndex, branchIndex]`. `processWorkflowConditional` built each branch's path with `executionPath.concat([index])`, which appends onto that already-complete path and produces a phantom third level `[conditionalIndex, branchIndex, index]`. The branch step then runs one level too deep, and branch-result aggregation (which resolves the parent conditional via `executionPath.slice(0, -1)`) points at a level that does not exist, so the conditional's results never aggregate and the restarted run can hang or return the wrong output.

The parallel handler in the same file already handles this: on restart it replaces the last segment with `executionPath.slice(0, -1).concat([idx])` instead of appending. The conditional handler was simply never given the same treatment.

## Fix

Add a small restart-aware `branchPath` helper to `processWorkflowConditional` that replaces the last path segment on restart and appends on the first pass, mirroring `processWorkflowParallel`, and use it at every `workflow.step.run` / `workflow.step.end` publish and every `activeStepsPath` write.

## Test

Added `conditional-restart.test.ts` (alongside the existing `parallel-restart.test.ts`) driving `processWorkflowConditional` directly with a mock pubsub and stepExecutor:

- On restart with `executionPath = [0, 2]`, the branch is published at `[0, 2]` (not `[0, 2, 2]`), and the `activeStepsPath` entry stays at the same depth. Fails before the fix with `expected [0, 2, 2] to deeply equal [0, 2]`.
- On the first (non-restart) pass, the branch index is appended normally (`[0]` becomes `[0, 1]`).

## Notes

Change is scoped to the conditional handler's path arithmetic; no behavior change on the first pass. The default engine already runs conditional restarts correctly, so this only affects the evented engine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a workflow restarts inside a conditional branch, it now returns to the correct branch instead of adding an extra path level. This lets the workflow finish and collect its results correctly.

## Changes

- Replaced the final execution-path segment during conditional restarts.
- Preserved the correct path format: `[conditionalIndex, branchIndex]`.
- Applied the corrected path to branch publications, `activeStepsPath`, and skipped-branch completion events.
- Added tests for restart, first-pass, per-step, and skipped-branch behavior.
- Added a patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->