### PR TITLE
fix(core): scope per-step reasoning to the current step

### DIFF
--- a/.changeset/per-step-reasoning-accumulation.md
+++ b/.changeset/per-step-reasoning-accumulation.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': patch
+---
+
+Fixed per-step `reasoningText` and `reasoning` accumulating across steps for multi-step reasoning models.
+
+Each step result read the run-lifetime reasoning buffers, which are only cleared at the run boundary, so every step reported the combined reasoning of all prior steps. For a run with two reasoning steps, `steps[1].reasoningText` came back as step one's reasoning concatenated with step two's, and `steps[1].reasoning` contained both steps' reasoning entries. This corrupted `onStepFinish` callbacks, the `steps` array, and anything driven off per-step reasoning.
+
+Each step now reports only its own reasoning, matching how per-step `text` already worked.
+
+```ts
+const result = await agent.stream('...'); // reasoning model, multiple steps
+
+// Before: steps[1].reasoningText included step 0's reasoning too.
+// After:  each step's reasoningText and reasoning contain only that step's output.
+for (const step of await result.steps) {
+  console.log(step.reasoningText);
+}
+```

--- a/.changeset/per-step-reasoning-accumulation.md
+++ b/.changeset/per-step-reasoning-accumulation.md
@@ -4,9 +4,9 @@
 
 Fixed per-step `reasoningText` and `reasoning` accumulating across steps for multi-step reasoning models.
 
-Each step result read the run-lifetime reasoning buffers, which are only cleared at the run boundary, so every step reported the combined reasoning of all prior steps. For a run with two reasoning steps, `steps[1].reasoningText` came back as step one's reasoning concatenated with step two's, and `steps[1].reasoning` contained both steps' reasoning entries. This corrupted `onStepFinish` callbacks, the `steps` array, and anything driven off per-step reasoning.
+In a run with more than one reasoning step, each step reported the combined reasoning of all prior steps. For two reasoning steps, `steps[1].reasoningText` came back as step one's reasoning concatenated with step two's, and `steps[1].reasoning` contained both steps' entries. The same wrong values reached the `onStepFinish` callback.
 
-Each step now reports only its own reasoning, matching how per-step `text` already worked.
+Each step and its `onStepFinish` payload now report only that step's own reasoning, matching how per-step `text` already worked. The run-level `reasoningText` and `reasoning` on the final result stay cumulative across the whole run.
 
 ```ts
 const result = await agent.stream('...'); // reasoning model, multiple steps

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -1414,7 +1414,7 @@ describe('MastraModelOutput', () => {
     const reasoningEnd = (runId: string, id: string): ChunkType =>
       ({ type: 'reasoning-end', runId, from: ChunkFrom.AGENT, payload: { id } }) as ChunkType;
 
-    it('reports only the current step reasoning, not the cumulative reasoning of all prior steps', async () => {
+    it('reports only the current step reasoning to steps and onStepFinish, and keeps run-level reasoning cumulative', async () => {
       const runId = 'test-run';
       const messageList = new MessageList({ threadId: 'test-thread' });
 
@@ -1432,12 +1432,21 @@ describe('MastraModelOutput', () => {
         createFinishChunk(runId),
       ]);
 
+      const stepFinishReasoning: { text: string; ids: string[] }[] = [];
       const output = new MastraModelOutput({
         model: { modelId: 'test-model', provider: 'test', version: 'v3' },
         stream,
         messageList,
         messageId: 'msg-1',
-        options: { runId },
+        options: {
+          runId,
+          onStepFinish: async (payload: any) => {
+            stepFinishReasoning.push({
+              text: payload.reasoningText,
+              ids: payload.reasoning.map((r: any) => r.payload.id),
+            });
+          },
+        },
       });
 
       await output.consumeStream();
@@ -1452,6 +1461,58 @@ describe('MastraModelOutput', () => {
       expect(steps[1]!.reasoningText).toBe('STEP-TWO-THINKING');
       expect(steps[1]!.reasoning.map(r => r.payload.id)).toEqual(['rs2']);
       expect(steps[1]!.reasoning[0]!.payload.text).toBe('STEP-TWO-THINKING');
+
+      // onStepFinish sees the same step-local reasoning.
+      expect(stepFinishReasoning).toEqual([
+        { text: 'STEP-ONE-THINKING', ids: ['rs1'] },
+        { text: 'STEP-TWO-THINKING', ids: ['rs2'] },
+      ]);
+
+      // Run-level reasoning stays cumulative across the whole run.
+      expect(await output.reasoningText).toBe('STEP-ONE-THINKINGSTEP-TWO-THINKING');
+      expect((await output.reasoning).map(r => r.payload.id)).toEqual(['rs1', 'rs2']);
+    });
+
+    it('keeps the onStepFinish reasoning intact when a goal continuation truncates run-lifetime buffers before the step-finish', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      // In-process goal runs emit the continuation goal chunk BEFORE the judged
+      // turn's step-finish. That goal boundary clears the run-lifetime reasoning
+      // buffers (and drops the judged step from the run-end `steps`), but
+      // onStepFinish still fires for that step first. Reading the run-lifetime
+      // buffers there would surface empty reasoning; the per-step buffer must
+      // still carry it.
+      const stream = createChunkStream([
+        reasoningStart(runId, 'rs1'),
+        reasoningDelta(runId, 'rs1', 'JUDGED-TURN-THINKING'),
+        reasoningEnd(runId, 'rs1'),
+        createGoalChunk(runId, { shouldContinue: true }),
+        createStepFinishChunk(runId),
+        createGoalChunk(runId, { shouldContinue: false }),
+        createFinishChunk(runId),
+      ]);
+
+      const stepFinishReasoning: { text: string; ids: string[] }[] = [];
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+          onStepFinish: async (payload: any) => {
+            stepFinishReasoning.push({
+              text: payload.reasoningText,
+              ids: payload.reasoning.map((r: any) => r.payload.id),
+            });
+          },
+        },
+      });
+
+      await output.consumeStream();
+
+      expect(stepFinishReasoning).toEqual([{ text: 'JUDGED-TURN-THINKING', ids: ['rs1'] }]);
     });
 
     it('reports empty reasoning for a step that produced none', async () => {

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -1407,12 +1407,12 @@ describe('MastraModelOutput', () => {
   });
 
   describe('per-step reasoning', () => {
-    const reasoningStart = (runId: string, id: string): ChunkType =>
-      ({ type: 'reasoning-start', runId, from: ChunkFrom.AGENT, payload: { id } }) as ChunkType;
+    const reasoningStart = (runId: string, id: string, providerMetadata?: Record<string, unknown>): ChunkType =>
+      ({ type: 'reasoning-start', runId, from: ChunkFrom.AGENT, payload: { id, providerMetadata } }) as ChunkType;
     const reasoningDelta = (runId: string, id: string, text: string): ChunkType =>
       ({ type: 'reasoning-delta', runId, from: ChunkFrom.AGENT, payload: { id, text } }) as ChunkType;
-    const reasoningEnd = (runId: string, id: string): ChunkType =>
-      ({ type: 'reasoning-end', runId, from: ChunkFrom.AGENT, payload: { id } }) as ChunkType;
+    const reasoningEnd = (runId: string, id: string, providerMetadata?: Record<string, unknown>): ChunkType =>
+      ({ type: 'reasoning-end', runId, from: ChunkFrom.AGENT, payload: { id, providerMetadata } }) as ChunkType;
 
     it('reports only the current step reasoning to steps and onStepFinish, and keeps run-level reasoning cumulative', async () => {
       const runId = 'test-run';
@@ -1513,6 +1513,46 @@ describe('MastraModelOutput', () => {
       await output.consumeStream();
 
       expect(stepFinishReasoning).toEqual([{ text: 'JUDGED-TURN-THINKING', ids: ['rs1'] }]);
+    });
+
+    it('preserves per-step reasoning-start/end metadata and blocks with no text delta', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      const startMeta = { openai: { itemId: 'block-1' } };
+      const endMeta = { openai: { signature: 'sig-1' } };
+
+      // rsA carries providerMetadata only on start/end (never on a delta); rsB is a
+      // reasoning block with no text delta at all. Both must survive per step.
+      const stream = createChunkStream([
+        reasoningStart(runId, 'rsA', startMeta),
+        reasoningDelta(runId, 'rsA', 'THINKING'),
+        reasoningEnd(runId, 'rsA', endMeta),
+        reasoningStart(runId, 'rsB'),
+        reasoningEnd(runId, 'rsB'),
+        createStepFinishChunk(runId),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      await output.consumeStream();
+      const steps = await output.steps;
+
+      expect(steps).toHaveLength(1);
+      expect(steps[0]!.reasoning.map(r => r.payload.id)).toEqual(['rsA', 'rsB']);
+      // reasoning-end metadata wins over the start metadata for the same block.
+      expect(steps[0]!.reasoning[0]!.payload.providerMetadata).toEqual(endMeta);
+      expect(steps[0]!.reasoning[0]!.payload.text).toBe('THINKING');
+      // The delta-less block is still reported with empty text.
+      expect(steps[0]!.reasoning[1]!.payload.text).toBe('');
+      expect(steps[0]!.reasoningText).toBe('THINKING');
     });
 
     it('reports empty reasoning for a step that produced none', async () => {

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -1515,6 +1515,35 @@ describe('MastraModelOutput', () => {
       expect(stepFinishReasoning).toEqual([{ text: 'JUDGED-TURN-THINKING', ids: ['rs1'] }]);
     });
 
+    it('drops a judged step whose only reasoning is a delta-less block on goal continuation', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      // The judged turn's only in-flight content is a reasoning block with no text
+      // delta. That still marks the step as in flight, so the goal boundary must
+      // drop it from the run-end steps rather than leaking the judged turn.
+      const stream = createChunkStream([
+        reasoningStart(runId, 'rs1'),
+        reasoningEnd(runId, 'rs1'),
+        createGoalChunk(runId, { shouldContinue: true }),
+        createStepFinishChunk(runId),
+        createGoalChunk(runId, { shouldContinue: false }),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      await output.consumeStream();
+
+      expect(await output.steps).toHaveLength(0);
+    });
+
     it('preserves per-step reasoning-start/end metadata and blocks with no text delta', async () => {
       const runId = 'test-run';
       const messageList = new MessageList({ threadId: 'test-thread' });

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -1405,4 +1405,84 @@ describe('MastraModelOutput', () => {
       expect(output.status).toBe('failed');
     });
   });
+
+  describe('per-step reasoning', () => {
+    const reasoningStart = (runId: string, id: string): ChunkType =>
+      ({ type: 'reasoning-start', runId, from: ChunkFrom.AGENT, payload: { id } }) as ChunkType;
+    const reasoningDelta = (runId: string, id: string, text: string): ChunkType =>
+      ({ type: 'reasoning-delta', runId, from: ChunkFrom.AGENT, payload: { id, text } }) as ChunkType;
+    const reasoningEnd = (runId: string, id: string): ChunkType =>
+      ({ type: 'reasoning-end', runId, from: ChunkFrom.AGENT, payload: { id } }) as ChunkType;
+
+    it('reports only the current step reasoning, not the cumulative reasoning of all prior steps', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      // Two reasoning blocks in two steps. Each step-finish should carry only its
+      // own reasoning, mirroring how `text` is scoped per step.
+      const stream = createChunkStream([
+        reasoningStart(runId, 'rs1'),
+        reasoningDelta(runId, 'rs1', 'STEP-ONE-THINKING'),
+        reasoningEnd(runId, 'rs1'),
+        createStepFinishChunk(runId),
+        reasoningStart(runId, 'rs2'),
+        reasoningDelta(runId, 'rs2', 'STEP-TWO-THINKING'),
+        reasoningEnd(runId, 'rs2'),
+        createStepFinishChunk(runId),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      await output.consumeStream();
+      const steps = await output.steps;
+
+      expect(steps).toHaveLength(2);
+
+      expect(steps[0]!.reasoningText).toBe('STEP-ONE-THINKING');
+      expect(steps[0]!.reasoning.map(r => r.payload.id)).toEqual(['rs1']);
+
+      // The second step must not inherit the first step's reasoning.
+      expect(steps[1]!.reasoningText).toBe('STEP-TWO-THINKING');
+      expect(steps[1]!.reasoning.map(r => r.payload.id)).toEqual(['rs2']);
+      expect(steps[1]!.reasoning[0]!.payload.text).toBe('STEP-TWO-THINKING');
+    });
+
+    it('reports empty reasoning for a step that produced none', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      const stream = createChunkStream([
+        reasoningStart(runId, 'rs1'),
+        reasoningDelta(runId, 'rs1', 'ONLY-STEP-ONE'),
+        reasoningEnd(runId, 'rs1'),
+        createStepFinishChunk(runId),
+        // Second step has no reasoning at all.
+        createStepFinishChunk(runId),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      await output.consumeStream();
+      const steps = await output.steps;
+
+      expect(steps).toHaveLength(2);
+      expect(steps[0]!.reasoningText).toBe('ONLY-STEP-ONE');
+      expect(steps[1]!.reasoningText).toBe('');
+      expect(steps[1]!.reasoning).toEqual([]);
+    });
+  });
 });

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -742,21 +742,42 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               const stepText = stepTripwire ? '' : self.#bufferedByStep.text;
 
               // Per-step reasoning must not leak earlier steps. `#bufferedReasoning`
-              // and `#bufferedReasoningDetails` are run-lifetime buffers (cleared only
-              // at the run/goal boundary in `#truncateRunBuffers`), so reading them
-              // here made every step report the cumulative reasoning of all prior
-              // steps. Mirror how `stepText` uses the per-step `#bufferedByStep`
-              // buffer: take this step's reasoning deltas, and narrow the id-keyed
-              // details map to just the ids seen this step.
+              // and `#bufferedReasoningDetails` are run-lifetime buffers, so reading
+              // them here made every step report the cumulative reasoning of all
+              // prior steps. Rebuild this step's reasoning from the per-step
+              // `#bufferedByStep.reasoning` buffer instead, mirroring how `stepText`
+              // uses `#bufferedByStep.text`. Aggregating the details from the per-step
+              // deltas (rather than filtering the run-lifetime details map) also keeps
+              // this correct when a goal continuation clears the run-lifetime buffers
+              // via `#truncateRunBuffers` before this step-finish lands, since the
+              // per-step buffer is untouched by that boundary. Text is joined from the
+              // deltas and details are aggregated per reasoning id, matching the
+              // run-level reasoning fields.
               const stepReasoningText = self.#bufferedByStep.reasoning
                 .map(reasoningPart => reasoningPart.payload.text)
                 .join('');
-              const stepReasoningIds = new Set(
-                self.#bufferedByStep.reasoning.map(reasoningPart => reasoningPart.payload.id),
-              );
-              const stepReasoning = Object.values(self.#bufferedReasoningDetails).filter(detail =>
-                stepReasoningIds.has(detail.payload.id),
-              );
+              const stepReasoningDetailsById = new Map<string, LLMStepResult<OUTPUT>['reasoning'][number]>();
+              for (const reasoningPart of self.#bufferedByStep.reasoning) {
+                let detail = stepReasoningDetailsById.get(reasoningPart.payload.id);
+                if (!detail) {
+                  detail = {
+                    type: 'reasoning',
+                    runId: reasoningPart.runId,
+                    from: reasoningPart.from,
+                    payload: {
+                      id: reasoningPart.payload.id,
+                      text: '',
+                      providerMetadata: reasoningPart.payload.providerMetadata,
+                    },
+                  };
+                  stepReasoningDetailsById.set(reasoningPart.payload.id, detail);
+                }
+                detail.payload.text += reasoningPart.payload.text;
+                if (reasoningPart.payload.providerMetadata) {
+                  detail.payload.providerMetadata = reasoningPart.payload.providerMetadata;
+                }
+              }
+              const stepReasoning = Array.from(stepReasoningDetailsById.values());
 
               const stepResult: LLMStepResult<OUTPUT> = {
                 stepType: self.#bufferedSteps.length === 0 ? 'initial' : 'tool-result',

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -741,6 +741,23 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               // If step has tripwire, text should be empty (rejected response)
               const stepText = stepTripwire ? '' : self.#bufferedByStep.text;
 
+              // Per-step reasoning must not leak earlier steps. `#bufferedReasoning`
+              // and `#bufferedReasoningDetails` are run-lifetime buffers (cleared only
+              // at the run/goal boundary in `#truncateRunBuffers`), so reading them
+              // here made every step report the cumulative reasoning of all prior
+              // steps. Mirror how `stepText` uses the per-step `#bufferedByStep`
+              // buffer: take this step's reasoning deltas, and narrow the id-keyed
+              // details map to just the ids seen this step.
+              const stepReasoningText = self.#bufferedByStep.reasoning
+                .map(reasoningPart => reasoningPart.payload.text)
+                .join('');
+              const stepReasoningIds = new Set(
+                self.#bufferedByStep.reasoning.map(reasoningPart => reasoningPart.payload.id),
+              );
+              const stepReasoning = Object.values(self.#bufferedReasoningDetails).filter(detail =>
+                stepReasoningIds.has(detail.payload.id),
+              );
+
               const stepResult: LLMStepResult<OUTPUT> = {
                 stepType: self.#bufferedSteps.length === 0 ? 'initial' : 'tool-result',
                 sources: self.#bufferedByStep.sources,
@@ -757,8 +774,8 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 text: stepText,
                 // Include tripwire data if present
                 tripwire: stepTripwire,
-                reasoningText: self.#bufferedReasoning.map(reasoningPart => reasoningPart.payload.text).join(''),
-                reasoning: Object.values(self.#bufferedReasoningDetails),
+                reasoningText: stepReasoningText,
+                reasoning: stepReasoning,
                 get staticToolCalls() {
                   return self.#bufferedByStep.toolCalls.filter(
                     part => part.type === 'tool-call' && part.payload?.dynamic === false,

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -205,6 +205,12 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
   #emitter = new EventEmitter();
   #bufferedSteps: LLMStepResult<OUTPUT>[] = [];
   #bufferedReasoningDetails: Record<string, LLMStepResult<OUTPUT>['reasoning'][number]> = {};
+  // Per-step mirror of `#bufferedReasoningDetails`. Populated across
+  // reasoning-start/delta/end so a step reports its own reasoning (including
+  // start/end-only metadata and blocks with no text delta), and reset each step.
+  // Unlike the run-lifetime map it is not cleared by `#truncateRunBuffers`, so a
+  // goal continuation that truncates before a step-finish cannot drop it.
+  #bufferedByStepReasoningDetails: Record<string, LLMStepResult<OUTPUT>['reasoning'][number]> = {};
   #bufferedByStep: LLMStepResult<OUTPUT> = {
     text: '',
     reasoning: [],
@@ -648,6 +654,16 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                   text: '',
                 },
               };
+              self.#bufferedByStepReasoningDetails[chunk.payload.id] = {
+                type: 'reasoning',
+                runId: chunk.runId,
+                from: chunk.from,
+                payload: {
+                  id: chunk.payload.id,
+                  providerMetadata: chunk.payload.providerMetadata,
+                  text: '',
+                },
+              };
               break;
             case 'reasoning-delta': {
               self.#bufferedReasoning.push({
@@ -663,20 +679,24 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 payload: chunk.payload,
               });
 
-              const bufferedReasoning = self.#bufferedReasoningDetails[chunk.payload.id];
-              if (bufferedReasoning) {
-                bufferedReasoning.payload.text += chunk.payload.text;
-                if (chunk.payload.providerMetadata) {
-                  bufferedReasoning.payload.providerMetadata = chunk.payload.providerMetadata;
+              for (const details of [self.#bufferedReasoningDetails, self.#bufferedByStepReasoningDetails]) {
+                const bufferedReasoning = details[chunk.payload.id];
+                if (bufferedReasoning) {
+                  bufferedReasoning.payload.text += chunk.payload.text;
+                  if (chunk.payload.providerMetadata) {
+                    bufferedReasoning.payload.providerMetadata = chunk.payload.providerMetadata;
+                  }
                 }
               }
               break;
             }
 
             case 'reasoning-end': {
-              const bufferedReasoning = self.#bufferedReasoningDetails[chunk.payload.id];
-              if (chunk.payload.providerMetadata && bufferedReasoning) {
-                bufferedReasoning.payload.providerMetadata = chunk.payload.providerMetadata;
+              for (const details of [self.#bufferedReasoningDetails, self.#bufferedByStepReasoningDetails]) {
+                const bufferedReasoning = details[chunk.payload.id];
+                if (chunk.payload.providerMetadata && bufferedReasoning) {
+                  bufferedReasoning.payload.providerMetadata = chunk.payload.providerMetadata;
+                }
               }
               break;
             }
@@ -744,40 +764,14 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               // Per-step reasoning must not leak earlier steps. `#bufferedReasoning`
               // and `#bufferedReasoningDetails` are run-lifetime buffers, so reading
               // them here made every step report the cumulative reasoning of all
-              // prior steps. Rebuild this step's reasoning from the per-step
-              // `#bufferedByStep.reasoning` buffer instead, mirroring how `stepText`
-              // uses `#bufferedByStep.text`. Aggregating the details from the per-step
-              // deltas (rather than filtering the run-lifetime details map) also keeps
-              // this correct when a goal continuation clears the run-lifetime buffers
-              // via `#truncateRunBuffers` before this step-finish lands, since the
-              // per-step buffer is untouched by that boundary. Text is joined from the
-              // deltas and details are aggregated per reasoning id, matching the
-              // run-level reasoning fields.
-              const stepReasoningText = self.#bufferedByStep.reasoning
-                .map(reasoningPart => reasoningPart.payload.text)
-                .join('');
-              const stepReasoningDetailsById = new Map<string, LLMStepResult<OUTPUT>['reasoning'][number]>();
-              for (const reasoningPart of self.#bufferedByStep.reasoning) {
-                let detail = stepReasoningDetailsById.get(reasoningPart.payload.id);
-                if (!detail) {
-                  detail = {
-                    type: 'reasoning',
-                    runId: reasoningPart.runId,
-                    from: reasoningPart.from,
-                    payload: {
-                      id: reasoningPart.payload.id,
-                      text: '',
-                      providerMetadata: reasoningPart.payload.providerMetadata,
-                    },
-                  };
-                  stepReasoningDetailsById.set(reasoningPart.payload.id, detail);
-                }
-                detail.payload.text += reasoningPart.payload.text;
-                if (reasoningPart.payload.providerMetadata) {
-                  detail.payload.providerMetadata = reasoningPart.payload.providerMetadata;
-                }
-              }
-              const stepReasoning = Array.from(stepReasoningDetailsById.values());
+              // prior steps. Read this step's reasoning from the per-step details map
+              // instead, mirroring how `stepText` uses `#bufferedByStep.text`. That
+              // map is built across reasoning-start/delta/end (so start/end-only
+              // metadata and blocks with no text delta are preserved) and, unlike the
+              // run-lifetime map, is untouched by `#truncateRunBuffers`, so a goal
+              // continuation that truncates before this step-finish cannot drop it.
+              const stepReasoning = Object.values(self.#bufferedByStepReasoningDetails);
+              const stepReasoningText = stepReasoning.map(detail => detail.payload.text).join('');
 
               const stepResult: LLMStepResult<OUTPUT> = {
                 stepType: self.#bufferedSteps.length === 0 ? 'initial' : 'tool-result',
@@ -879,6 +873,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 providerMetadata: undefined,
                 finishReason: undefined,
               };
+              self.#bufferedByStepReasoningDetails = {};
 
               // A continuing goal evaluation arrived while this step was still
               // in flight (in-process chunk ordering): this step-finish belongs
@@ -2068,6 +2063,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
       bufferedSteps: steps,
       bufferedStepRequests: requests,
       bufferedReasoningDetails: this.#bufferedReasoningDetails,
+      bufferedByStepReasoningDetails: this.#bufferedByStepReasoningDetails,
       bufferedByStep: this.#bufferedByStep,
       bufferedText: this.#bufferedText,
       bufferedTextChunks: this.#bufferedTextChunks,
@@ -2093,6 +2089,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     this.#status = state.status;
     this.#bufferedSteps = rehydrateStepRequests(state.bufferedSteps, state.bufferedStepRequests);
     this.#bufferedReasoningDetails = state.bufferedReasoningDetails;
+    this.#bufferedByStepReasoningDetails = state.bufferedByStepReasoningDetails ?? {};
     this.#bufferedByStep = state.bufferedByStep;
     this.#bufferedText = state.bufferedText;
     this.#bufferedTextChunks = state.bufferedTextChunks;

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -1254,6 +1254,10 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                   byStep.text.length > 0 ||
                   byStep.toolCalls.length > 0 ||
                   byStep.reasoning.length > 0 ||
+                  // A reasoning block with only start/end (no text delta) lives in
+                  // the per-step details map but not in `byStep.reasoning`, so check
+                  // it too, otherwise such a judged step would leak into run-end steps.
+                  Object.keys(self.#bufferedByStepReasoningDetails).length > 0 ||
                   byStep.sources.length > 0 ||
                   byStep.files.length > 0
                 ) {


### PR DESCRIPTION
## What

Fixes per-step `reasoningText` and `reasoning` accumulating across steps for multi-step reasoning models.

Closes #21594.

## Root cause

In `MastraModelOutput`, the `step-finish` handler built each step's reasoning from the run-lifetime buffers `#bufferedReasoning` and `#bufferedReasoningDetails`. Those are only cleared at the run/goal boundary (`#truncateRunBuffers`), never at `step-finish`, so every step reported the combined reasoning of all prior steps. The sibling `text` field is already scoped correctly by reading the per-step `#bufferedByStep.text` (reset each step), and the class even maintains a per-step reasoning buffer (`#bufferedByStep.reasoning`) that the step result never consumed.

## Fix

Derive the step's reasoning from per-step state at `step-finish`:

- `reasoningText` from this step's reasoning deltas (`#bufferedByStep.reasoning`).
- `reasoning` by narrowing the id-keyed details map to just the ids seen this step, which keeps the fully-accumulated text per reasoning block without pulling in earlier steps.

The run-level reasoning on the final output is unchanged (still the full concatenation across steps).

## Test

Added two tests to `output.test.ts`:

- Two reasoning blocks across two steps: each step now reports only its own reasoning. Fails before the fix with `expected 'STEP-ONE-THINKINGSTEP-TWO-THINKING' to be 'STEP-TWO-THINKING'`.
- A step that produced no reasoning reports empty `reasoningText` and `reasoning` instead of inheriting the previous step's.

Full `output.test.ts` (31) and the surrounding `stream/base` suite (102) pass, along with the agent reasoning suites (durable and non-durable) that exercise the serialized path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Each step now reports only the reasoning created during that step. The final result still includes reasoning from the full run.

## Changes

- Scoped per-step `reasoningText` and `reasoning` to the current step.
- Preserved reasoning metadata and blocks without text deltas.
- Preserved cumulative run-level reasoning.
- Preserved step reasoning across goal continuation and buffer truncation.
- Included per-step reasoning state in serialized output state.
- Added tests for:
  - Separate reasoning across steps.
  - Steps without reasoning.
  - `steps` results and `onStepFinish` payloads.
  - Goal-continuation ordering.
  - Metadata-only reasoning blocks.
  - Cumulative run-level reasoning.
- Added a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->