### PR TITLE
fix(ci): stop the deployer E2E gate from blocking the Changesets release PR

### DIFF
--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -48,10 +48,15 @@ jobs:
           # Deployer changes must include monorepo E2E coverage. This rule runs
           # before the no-test exemptions below so it applies to all contributors.
           # Keep this list separate from /tmp/changed-files so deleted tests are
-          # not restored from FETCH_HEAD. The package instructions are exempt.
-          if grep -q '^packages/deployer/' /tmp/changed-coverage-files \
+          # not restored from FETCH_HEAD. The package instructions and the
+          # generated changelog are exempt, and the automated Changesets release
+          # PR is skipped entirely: it only bumps versions and changelogs, so it
+          # can never add the E2E coverage this rule asks for.
+          if [ "${HEAD_REF#changeset-release/}" != "$HEAD_REF" ]; then
+            echo "Skipping deployer E2E coverage rule for the Changesets release PR."
+          elif grep -q '^packages/deployer/' /tmp/changed-coverage-files \
             && ! grep -q '^e2e-tests/monorepo/' /tmp/changed-coverage-files \
-            && awk '$0 ~ /^packages\/deployer\// && $0 != "packages/deployer/AGENTS.md" { found=1; exit } END { exit(found ? 0 : 1) }' \
+            && awk '$0 ~ /^packages\/deployer\// && $0 != "packages/deployer/AGENTS.md" && $0 != "packages/deployer/CHANGELOG.md" { found=1; exit } END { exit(found ? 0 : 1) }' \
               /tmp/changed-coverage-files; then
             first_deployer_file="$(
               awk '$0 ~ /^packages\/deployer\// && $0 != "packages/deployer/AGENTS.md" { print; exit }' \
@@ -100,6 +105,7 @@ jobs:
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           BASE_REPOSITORY: ${{ github.repository }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
           HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -51,15 +51,18 @@ jobs:
           # not restored from FETCH_HEAD. The package instructions and the
           # generated changelog are exempt, and the automated Changesets release
           # PR is skipped entirely: it only bumps versions and changelogs, so it
-          # can never add the E2E coverage this rule asks for.
-          if [ "${HEAD_REF#changeset-release/}" != "$HEAD_REF" ]; then
+          # can never add the E2E coverage this rule asks for. The branch name
+          # alone is not a trusted signal, since a fork can pick any name, so the
+          # skip also requires the head to live in this repository.
+          if [ "$HEAD_REPO_FULL_NAME" = "$BASE_REPOSITORY" ] \
+            && [ "${HEAD_REF#changeset-release/}" != "$HEAD_REF" ]; then
             echo "Skipping deployer E2E coverage rule for the Changesets release PR."
           elif grep -q '^packages/deployer/' /tmp/changed-coverage-files \
             && ! grep -q '^e2e-tests/monorepo/' /tmp/changed-coverage-files \
             && awk '$0 ~ /^packages\/deployer\// && $0 != "packages/deployer/AGENTS.md" && $0 != "packages/deployer/CHANGELOG.md" { found=1; exit } END { exit(found ? 0 : 1) }' \
               /tmp/changed-coverage-files; then
             first_deployer_file="$(
-              awk '$0 ~ /^packages\/deployer\// && $0 != "packages/deployer/AGENTS.md" { print; exit }' \
+              awk '$0 ~ /^packages\/deployer\// && $0 != "packages/deployer/AGENTS.md" && $0 != "packages/deployer/CHANGELOG.md" { print; exit }' \
                 /tmp/changed-coverage-files
             )"
             escaped_deployer_file="${first_deployer_file//%/%25}"


### PR DESCRIPTION
## What's broken

The automated Changesets release PR (#21597) fails the `changed-tests` check, and will keep failing on every release:

```
This PR changes packages/deployer/ but has no corresponding changes under
e2e-tests/monorepo/. Deployer unit tests alone do not validate generated
monorepo applications — add or update a monorepo E2E test.
```

The release PR touches 53 files, and every one of them is a `package.json`, a `CHANGELOG.md`, or a `.changeset/` entry — there is no source change anywhere in it. But because the version bump includes `packages/deployer/package.json`, the deployer coverage rule added in #21241 reads it as a deployer change and demands a monorepo E2E test. A version-bump PR can never satisfy that, so the gate is permanently red on releases.

## The fix

Two narrow changes to `.github/workflows/changed-test-gate.yml`:

1. Skip the deployer coverage rule for `changeset-release/*` head branches. These are generated by the Changesets action and only ever bump versions and changelogs.
2. Exempt `packages/deployer/CHANGELOG.md` from counting as a deployer change, the same way `AGENTS.md` already is. Generated changelog entries are never behavior.

The rule is deliberately **not** relaxed for `package.json` in general — a human PR editing `packages/deployer/package.json` still requires E2E coverage, since deployer dependencies do affect generated apps.

The job still runs and reports success on release PRs rather than being skipped at the job level, so it can stay a required check without leaving PRs stuck pending.

## Test plan

Extracted the rule verbatim into a harness and ran it against the real file list from #21597 plus regression cases:

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| 1 | #21597's real 53-file list on `changeset-release/main` | pass | pass |
| 2 | Same list on a normal branch | fail | fail |
| 3 | Deployer source change, no E2E | fail | fail |
| 4 | Deployer source change with E2E | pass | pass |
| 5 | Deployer `CHANGELOG.md` only | pass | pass |
| 6 | Deployer `AGENTS.md` only | pass | pass |

Case 2 is the important one: it confirms the gate was not blanket-loosened for `package.json`. Cases 3, 4 and 6 confirm #21241's original behavior is intact.

Also validated the workflow YAML parses and the modified step passes `bash -n`.

Fixes the red check on #21597.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Changesets release PRs update versions and changelogs. This change prevents those generated updates from failing the deployer E2E coverage check while keeping the check active for normal and fork pull requests.

## Changes

- Skip the deployer E2E coverage rule for same-repository `changeset-release/*` branches.
- Require the head repository to match the base repository for the release-branch bypass.
- Exclude `packages/deployer/CHANGELOG.md` from deployer-change detection and error annotations.
- Continue checking deployer changes on normal and fork pull requests.
- Pass the pull request head branch through `HEAD_REF`.
- Keep the workflow running and reporting success for release pull requests.

## Validation

- Confirmed same-repository release pull requests skip the gate.
- Confirmed fork branches cannot bypass the gate by using the `changeset-release/` prefix.
- Confirmed normal deployer changes still require E2E coverage.
- Confirmed changelog-only and unrelated changes pass.
- Validated YAML parsing and shell syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->