### PR TITLE
fix(core): don't resume a sub-agent run when none is suspended

### DIFF
--- a/.changeset/tame-donkeys-shave.md
+++ b/.changeset/tame-donkeys-shave.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Don't attempt a sub-agent resume when there is no suspended run to resume.
+
+The delegation step selected the resume path on `resumeData` alone and called `resumeStream`/`resumeGenerate` with `runId: suspendedToolRunId`, which is `undefined` when the suspended-run lookup finds nothing. That produced an unsatisfiable snapshot lookup and threw `AGENT_RESUME_NO_SNAPSHOT_FOUND` before the sub-agent ran.
+
+`resumeData` is an optional field on the generated sub-agent tool schema, so a model can populate it at any time — including on a first delegation, where nothing is suspended and the auto-resume system-message suffix was never injected. Both resume call sites now also require a non-empty `suspendedToolRunId`, falling through to a normal fresh run otherwise.

--- a/packages/core/src/agent/__tests__/subagent-resume-without-suspension.test.ts
+++ b/packages/core/src/agent/__tests__/subagent-resume-without-suspension.test.ts
@@ -1,0 +1,183 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { Agent } from '../agent';
+
+/**
+ * Regression tests for delegation crashing when the model authors `resumeData`
+ * but nothing is suspended.
+ *
+ * `resumeData` is an optional field on the generated sub-agent tool schema, so a
+ * model can populate it at any time — including on a first delegation, where no
+ * suspended run exists. The auto-resume system-message suffix is only injected
+ * when `suspendedTools.length > 0`, so in that situation the model was never
+ * even instructed to use it.
+ *
+ * The delegation step used to select the resume path on `resumeData` alone and
+ * call `resumeStream`/`resumeGenerate` with `runId: suspendedToolRunId`, which
+ * is `undefined` when the suspended-run lookup finds nothing. That resolves to
+ * an unsatisfiable snapshot lookup and throws AGENT_RESUME_NO_SNAPSHOT_FOUND
+ * before the sub-agent ever runs.
+ *
+ * Note this is distinct from resumeStream/resumeGenerate throwing when called
+ * directly with an explicit-but-unknown runId — that behaviour is correct and is
+ * covered by resume-stream-no-snapshot.test.ts. The bug is the delegation step
+ * *choosing* the resume path when it has no run id to resume.
+ */
+
+const DELEGATION_PROMPT = 'Bulk admit the patients in the attached file.';
+const SUB_AGENT_RESPONSE = 'Processing the attached file now.';
+
+function makeSubAgentModel(invocations: { count: number }) {
+  return new MockLanguageModelV2({
+    doGenerate: async () => {
+      invocations.count++;
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+        text: SUB_AGENT_RESPONSE,
+        content: [{ type: 'text' as const, text: SUB_AGENT_RESPONSE }],
+        warnings: [],
+      };
+    },
+    doStream: async () => {
+      invocations.count++;
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'sub-id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: SUB_AGENT_RESPONSE },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 } },
+        ]),
+      };
+    },
+  });
+}
+
+/**
+ * Emits a delegation tool call carrying `resumeData` and no `suspendedToolRunId`,
+ * exactly as an LLM does when it treats a follow-up message as resume input.
+ */
+function makeSupervisorModel() {
+  const delegationInput = JSON.stringify({
+    prompt: DELEGATION_PROMPT,
+    resumeData: { fileUrl: ['https://example.com/patients.csv'] },
+  });
+  let generateCallCount = 0;
+  let streamCallCount = 0;
+
+  return new MockLanguageModelV2({
+    doGenerate: async () => {
+      generateCallCount++;
+      if (generateCallCount === 1) {
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'tool-calls' as const,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          text: '',
+          content: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'supervisor-call-1',
+              toolName: 'agent-subAgent',
+              input: delegationInput,
+            },
+          ],
+          warnings: [],
+        };
+      }
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        text: 'Done',
+        content: [{ type: 'text' as const, text: 'Done' }],
+        warnings: [],
+      };
+    },
+    doStream: async () => {
+      streamCallCount++;
+      if (streamCallCount === 1) {
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            {
+              type: 'tool-call',
+              toolCallId: 'supervisor-call-1',
+              toolName: 'agent-subAgent',
+              input: delegationInput,
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+        };
+      }
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Done' },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+        ]),
+      };
+    },
+  });
+}
+
+function buildSupervisor(invocations: { count: number }) {
+  const subAgent = new Agent({
+    id: 'sub-agent-resume-without-suspension',
+    name: 'Sub Agent',
+    description: 'A sub-agent that starts work from a delegation prompt',
+    instructions: 'Do the work.',
+    model: makeSubAgentModel(invocations),
+  });
+
+  return new Agent({
+    id: 'supervisor-resume-without-suspension',
+    name: 'Supervisor',
+    instructions: 'Delegate to the sub-agent.',
+    model: makeSupervisorModel(),
+    agents: { subAgent },
+  });
+}
+
+describe('sub-agent delegation with model-authored resumeData and no suspended run', () => {
+  it('runs the sub-agent instead of attempting a resume (stream)', async () => {
+    const invocations = { count: 0 };
+    const supervisor = buildSupervisor(invocations);
+
+    const streamResult = await supervisor.stream(DELEGATION_PROMPT, { maxSteps: 3 });
+    const chunks: unknown[] = [];
+    for await (const chunk of streamResult.fullStream) {
+      chunks.push(chunk);
+    }
+
+    expect(invocations.count).toBeGreaterThan(0);
+    expect(JSON.stringify(chunks)).not.toContain('AGENT_RESUME_NO_SNAPSHOT_FOUND');
+  });
+
+  it('runs the sub-agent instead of attempting a resume (generate)', async () => {
+    const invocations = { count: 0 };
+    const supervisor = buildSupervisor(invocations);
+
+    const result = await supervisor.generate(DELEGATION_PROMPT, { maxSteps: 3 });
+
+    expect(invocations.count).toBeGreaterThan(0);
+    expect(JSON.stringify(result)).not.toContain('AGENT_RESUME_NO_SNAPSHOT_FOUND');
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5170,7 +5170,7 @@ export class Agent<
                 (methodType === 'generate' || methodType === 'generateLegacy') &&
                 supportedLanguageModelSpecifications.includes(resolvedModelVersion)
               ) {
-                const generateResult = resumeData
+                const generateResult = resumeData && suspendedToolRunId
                   ? await resolvedAgent.resumeGenerate(resumeData, {
                       runId: suspendedToolRunId,
                       requestContext: subAgentRequestContext,
@@ -5262,7 +5262,7 @@ export class Agent<
                 (methodType === 'stream' || methodType === 'streamLegacy') &&
                 supportedLanguageModelSpecifications.includes(resolvedModelVersion)
               ) {
-                const streamResult = resumeData
+                const streamResult = resumeData && suspendedToolRunId
                   ? await resolvedAgent.resumeStream(resumeData, {
                       runId: suspendedToolRunId,
                       requestContext: subAgentRequestContext,


### PR DESCRIPTION
Fixes #21608

## Problem

A sub-agent delegation throws `AGENT_RESUME_NO_SNAPSHOT_FOUND` — before the sub-agent runs — whenever the model populates `resumeData` while nothing is suspended.

The delegation step selects the resume path on `resumeData` alone and passes `runId: suspendedToolRunId`:

```ts
const suspendedToolRunId = (inputData as any).suspendedToolRunId;
...
const streamResult = resumeData
  ? await resolvedAgent.resumeStream(resumeData, { runId: suspendedToolRunId, ... })
  : await resolvedAgent.stream(...);
```

The upstream suspended-run lookup sets `args.suspendedToolRunId` **only when it finds a suspended tool in message history**. With nothing suspended it stays `undefined`, and `resumeStream` then performs a snapshot lookup that can never be satisfied.

This is reachable in ordinary use because `resumeData` is always exposed on the generated sub-agent tool schema, while the instruction describing it is gated on suspensions existing (`if (suspendedTools.length > 0)`). With nothing suspended the model is never told about `resumeData` — it fills the field unprompted, because it's in the schema and a follow-up message can look like resume input.

We saw this in production on `1.47.0`: ~2 of 3 delegations in a file-upload flow failed, 16 occurrences across 4 users, **every one with an empty `runId`**. Because it's model sampling it's nondeterministic — identical delegation prompts produced both outcomes.

## Fix

Require a non-empty `suspendedToolRunId` at both agent-tool resume call sites, so the delegation falls through to a normal fresh run:

```diff
-const generateResult = resumeData
+const generateResult = resumeData && suspendedToolRunId

-const streamResult = resumeData
+const streamResult = resumeData && suspendedToolRunId
```

Two lines. Deliberately scoped:

- **Real resumes are unaffected.** `suspendedToolRunId` is non-empty exactly when the lookup found a suspended run — the lookup runs under the same `resumeData && isAgentTool` condition as this guard.
- **Direct `resumeStream`/`resumeGenerate` calls are untouched.** Throwing on an explicit-but-unknown `runId` is correct and stays covered by `resume-stream-no-snapshot.test.ts`. The bug here is the delegation step *choosing* the resume path when it has no run id to resume.
- **The workflow-as-tool resume path is untouched.** It resumes a specific `run` object rather than by run id, so the same guard doesn't apply.
- The previously-taken branch was unconditionally fatal, so nothing that worked before changes behaviour.

## Test

`packages/core/src/agent/__tests__/subagent-resume-without-suspension.test.ts` drives a supervisor whose mock model emits a delegation tool call carrying `resumeData` and no `suspendedToolRunId`, for both `stream` and `generate`, and asserts the sub-agent actually runs.

Verified both directions against the published `@mastra/core` 1.47.0 with the same scenario:

| build | sub-agent invoked | `AGENT_RESUME_NO_SNAPSHOT_FOUND` |
| --- | --- | --- |
| unmodified | **0** | yes |
| with this guard | **1** | no |

## Note for reviewers

I could not get the full `packages/core` suite running locally — the workspace build chain wouldn't complete from a sparse checkout in my environment — so the new test has not been executed in-repo; the failing→passing verification above was done against the published package instead. CI on this PR is the real check for the vitest version. Happy to adjust it if it needs reshaping.

I also left `agent.ts` otherwise untouched: running Prettier over it reformats ~120 unrelated lines (the committed file isn't Prettier-clean under the root `.prettierrc`), so I kept the diff to the two changed lines.

## Possible follow-up

Gating the `resumeData`/`suspendedToolRunId` **schema fields** on the same condition as the instruction (`suspendedTools.length > 0`) would stop the model selecting a resume that cannot exist, rather than handling it after the fact. Happy to open that separately if you'd like it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a model provides resume information without a paused sub-agent run, the delegation now starts a new run instead of failing. Real paused-run resumes continue to work as before.

## Changes

- Require both `resumeData` and a non-empty `suspendedToolRunId` before using `resumeGenerate` or `resumeStream`.
- Start a fresh sub-agent run when no suspended run exists.
- Add regression tests for `stream` and `generate` delegations.
- Add a patch changeset for `@mastra/core`.
- Leave direct resume APIs and workflow-as-tool resume behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->