### PR TITLE
fix(playground): paginate agent message history

### DIFF
--- a/.changeset/calm-chats-scroll.md
+++ b/.changeset/calm-chats-scroll.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed Agent chat to load older message history while preserving live messages and the reader's scroll position.

--- a/.changeset/wise-singers-jog.md
+++ b/.changeset/wise-singers-jog.md
@@ -1,0 +1,6 @@
+---
+'@mastra/client-js': patch
+'@mastra/server': patch
+---
+
+Fixed memory message list responses to expose consistent pagination metadata and newest-page ordering.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -7418,6 +7418,10 @@ export type GetMemoryThreadsThreadIdMessages_QueryParams = {
 };
 
 export type GetMemoryThreadsThreadIdMessages_Response = {
+  total: number;
+  page: number;
+  perPage: number | false;
+  hasMore: boolean;
   messages: unknown[];
   uiMessages: unknown[] | null;
 };

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -791,7 +791,7 @@ export type ListMemoryThreadMessagesParams = Omit<StorageListMessagesInput, 'thr
   includeSystemReminders?: boolean;
 };
 
-export type ListMemoryThreadMessagesResponse = {
+export type ListMemoryThreadMessagesResponse = PaginationInfo & {
   messages: MastraDBMessage[];
 };
 

--- a/packages/playground/src/domains/agents/components/agent-chat.tsx
+++ b/packages/playground/src/domains/agents/components/agent-chat.tsx
@@ -53,7 +53,13 @@ export const AgentChat = ({
   const { settings } = useAgentSettings();
   const requestContext = useMergedRequestContext();
 
-  const { data, isLoading: isMessagesLoading } = useAgentMessages({
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isMessagesLoading,
+  } = useAgentMessages({
     agentId: agentId,
     threadId: isNewThread ? undefined : threadId!, // Prevent fetching when thread is new
     memory: memory ?? false,
@@ -84,7 +90,7 @@ export const AgentChat = ({
     emptyMessagesRef.current = { threadId, messages: [] };
   }
 
-  const messages = data?.messages ?? emptyMessagesRef.current.messages;
+  const initialMessages = data?.initialMessages ?? emptyMessagesRef.current.messages;
   const availableSuggestedPrompts = getAvailableSuggestedPrompts({
     suggestedPrompts,
     isNewThread,
@@ -99,7 +105,12 @@ export const AgentChat = ({
       agentVersionId={agentVersionId}
       supportsMemory={supportsMemory}
       threadId={threadId}
-      initialMessages={messages}
+      initialMessages={initialMessages}
+      history={{
+        hasMore: Boolean(hasNextPage),
+        isLoading: isFetchingNextPage,
+        load: async () => (await fetchNextPage()).data?.messages ?? [],
+      }}
       refreshThreadList={refreshThreadList}
       settings={settings}
       requestContext={requestContext}

--- a/packages/playground/src/hooks/__tests__/fixtures/agent-messages.ts
+++ b/packages/playground/src/hooks/__tests__/fixtures/agent-messages.ts
@@ -1,0 +1,65 @@
+import type { ListMemoryThreadMessagesResponse, RouteResponse } from '@mastra/client-js';
+
+export const authenticatedUser: RouteResponse<'GET /auth/me'> = { id: 'user-1' };
+
+export const authDisabled: RouteResponse<'GET /auth/capabilities'> = { enabled: false, login: null };
+
+export const emptyMemoryConfig: RouteResponse<'GET /memory/config'> = { config: {} };
+
+export const memoryDisabled: RouteResponse<'GET /memory/status'> = { result: false };
+
+export const emptyWorkingMemory: RouteResponse<'GET /memory/threads/:threadId/working-memory'> = {
+  workingMemory: null,
+  source: 'thread',
+  workingMemoryTemplate: null,
+  threadExists: true,
+};
+
+export const emptyObservationalMemory: RouteResponse<'GET /memory/observational-memory'> = { record: null };
+
+export const emptyAgentProviders: RouteResponse<'GET /agents/providers'> = { providers: [] };
+
+export const emptyVoiceSpeakers: RouteResponse<'GET /agents/:agentId/voice/speakers'> = [];
+
+export const builderDisabled: RouteResponse<'GET /editor/builder/settings'> = {
+  enabled: false,
+  modelPolicy: { active: false },
+};
+
+export const emptyBuilderModels: RouteResponse<'GET /editor/builder/models/available'> = { providers: [] };
+
+const makeMessage = (number: number): ListMemoryThreadMessagesResponse['messages'][number] => ({
+  id: `message-${String(number).padStart(3, '0')}`,
+  role: number % 2 === 0 ? 'assistant' : 'user',
+  createdAt: new Date(Date.UTC(2026, 7, 15, 0, number)),
+  threadId: 'thread-pagination',
+  resourceId: 'agent-pagination',
+  content: {
+    format: 2,
+    parts: [{ type: 'text', text: `Message ${number}` }],
+  },
+});
+
+export const latestAgentMessagesPage: ListMemoryThreadMessagesResponse = {
+  messages: Array.from({ length: 40 }, (_, index) => makeMessage(index + 40)),
+  total: 79,
+  page: 0,
+  perPage: 40,
+  hasMore: true,
+};
+
+export const olderAgentMessagesPage: ListMemoryThreadMessagesResponse = {
+  messages: Array.from({ length: 40 }, (_, index) => makeMessage(index + 1)),
+  total: 79,
+  page: 1,
+  perPage: 40,
+  hasMore: false,
+};
+
+export const refreshedLatestAgentMessagesPage: ListMemoryThreadMessagesResponse = {
+  messages: Array.from({ length: 40 }, (_, index) => makeMessage(index + 41)),
+  total: 80,
+  page: 0,
+  perPage: 40,
+  hasMore: true,
+};

--- a/packages/playground/src/hooks/__tests__/use-agent-messages.msw.test.tsx
+++ b/packages/playground/src/hooks/__tests__/use-agent-messages.msw.test.tsx
@@ -1,0 +1,277 @@
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useAgentMessages } from '../use-agent-messages';
+import {
+  authenticatedUser,
+  authDisabled,
+  builderDisabled,
+  emptyAgentProviders,
+  emptyBuilderModels,
+  emptyMemoryConfig,
+  emptyObservationalMemory,
+  emptyVoiceSpeakers,
+  emptyWorkingMemory,
+  latestAgentMessagesPage,
+  memoryDisabled,
+  olderAgentMessagesPage,
+  refreshedLatestAgentMessagesPage,
+} from './fixtures/agent-messages';
+import { WorkingMemoryProvider } from '@/domains/agents/context/agent-working-memory-context';
+import { BrowserSessionProvider } from '@/domains/agents/context/browser-session-provider';
+import { ThreadInputProvider } from '@/domains/conversation';
+import { useChatSend } from '@/lib/ai-ui/chat/chat-context';
+import { ChatProvider } from '@/lib/ai-ui/chat/chat-provider';
+import { Thread } from '@/lib/ai-ui/thread';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+const AGENT_ID = 'agent-pagination';
+const THREAD_ID = 'thread-pagination';
+
+const makeGate = () => {
+  let resolve = () => {};
+  const promise = new Promise<void>(release => {
+    resolve = release;
+  });
+  return { promise, resolve };
+};
+
+const finishStream = () =>
+  new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'finish', payload: {} })}\n\n`));
+      controller.close();
+    },
+  });
+
+const baseChatHandlers = () => [
+  http.get(`${BASE_URL}/api/auth/me`, () => HttpResponse.json(authenticatedUser)),
+  http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(authDisabled)),
+  http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json(emptyMemoryConfig)),
+  http.get(`${BASE_URL}/api/memory/status`, () => HttpResponse.json(memoryDisabled)),
+  http.get(`${BASE_URL}/api/memory/threads/:threadId/working-memory`, () => HttpResponse.json(emptyWorkingMemory)),
+  http.get(`${BASE_URL}/api/memory/observational-memory`, () => HttpResponse.json(emptyObservationalMemory)),
+  http.get(`${BASE_URL}/api/agents/providers`, () => HttpResponse.json(emptyAgentProviders)),
+  http.get(`${BASE_URL}/api/agents/:agentId/voice/speakers`, () => HttpResponse.json(emptyVoiceSpeakers)),
+  http.get(`${BASE_URL}/api/editor/builder/settings`, () => HttpResponse.json(builderDisabled)),
+  http.get(`${BASE_URL}/api/editor/builder/models/available`, () => HttpResponse.json(emptyBuilderModels)),
+];
+
+const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const MastraQueryProviders = ({ children, queryClient }: { children: ReactNode; queryClient: QueryClient }) => (
+  <MastraReactProvider baseUrl={BASE_URL}>
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  </MastraReactProvider>
+);
+
+const makeWrapper = () => {
+  const queryClient = createTestQueryClient();
+  return ({ children }: { children: ReactNode }) => (
+    <MastraQueryProviders queryClient={queryClient}>{children}</MastraQueryProviders>
+  );
+};
+
+const LiveTailButton = () => {
+  const send = useChatSend();
+  return <button onClick={() => send({ message: 'live tail' })}>Send live tail</button>;
+};
+
+const PaginatedThread = () => {
+  const query = useAgentMessages({ agentId: AGENT_ID, threadId: THREAD_ID, memory: true });
+
+  if (!query.data) return null;
+
+  return (
+    <ChatProvider
+      agentId={AGENT_ID}
+      threadId={THREAD_ID}
+      initialMessages={query.data.initialMessages}
+      supportsMemory
+      settings={{ modelSettings: { chatWithLegacyStream: true } }}
+      history={{
+        hasMore: Boolean(query.hasNextPage),
+        isLoading: query.isFetchingNextPage,
+        load: async () => (await query.fetchNextPage()).data?.messages ?? [],
+      }}
+    >
+      <LiveTailButton />
+      <button onClick={() => void query.refetch()}>Refresh history</button>
+      <Thread agentId={AGENT_ID} threadId={THREAD_ID} hasModelList />
+    </ChatProvider>
+  );
+};
+
+const renderPaginatedThread = () => {
+  const queryClient = createTestQueryClient();
+  return render(
+    <MastraQueryProviders queryClient={queryClient}>
+      <MemoryRouter>
+        <BrowserSessionProvider agentId={AGENT_ID} threadId={THREAD_ID} enabled={false}>
+          <WorkingMemoryProvider agentId={AGENT_ID} threadId={THREAD_ID} resourceId={AGENT_ID}>
+            <ThreadInputProvider>
+              <PaginatedThread />
+            </ThreadInputProvider>
+          </WorkingMemoryProvider>
+        </BrowserSessionProvider>
+      </MemoryRouter>
+    </MastraQueryProviders>,
+  );
+};
+
+const setScrollMetrics = (
+  element: HTMLElement,
+  metrics: { scrollHeight: number; clientHeight: number; scrollTop: number },
+) => {
+  Object.defineProperty(element, 'scrollHeight', { configurable: true, value: metrics.scrollHeight });
+  Object.defineProperty(element, 'clientHeight', { configurable: true, value: metrics.clientHeight });
+  element.scrollTop = metrics.scrollTop;
+};
+
+const renderStreamingHistoryScenario = () => {
+  const requestedPages = vi.fn<(page: string | null) => void>();
+  const olderMessagesGate = makeGate();
+  const streamGate = makeGate();
+  server.use(
+    ...baseChatHandlers(),
+    http.get(`${BASE_URL}/api/memory/threads/${THREAD_ID}/messages`, async ({ request }) => {
+      const page = new URL(request.url).searchParams.get('page');
+      requestedPages(page);
+      if (page === '1') await olderMessagesGate.promise;
+      return HttpResponse.json(page === '1' ? olderAgentMessagesPage : latestAgentMessagesPage);
+    }),
+    http.post(`${BASE_URL}/api/agents/${AGENT_ID}/stream`, async () => {
+      await streamGate.promise;
+      return new HttpResponse(finishStream(), {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    }),
+  );
+  renderPaginatedThread();
+  return { olderMessagesGate, requestedPages, streamGate };
+};
+
+const loadOlderHistoryAtStart = async (
+  scenario: ReturnType<typeof renderStreamingHistoryScenario>,
+): Promise<HTMLElement> => {
+  await screen.findByText('Message 79');
+  fireEvent.click(screen.getByRole('button', { name: 'Send live tail' }));
+  await screen.findByText('live tail');
+
+  const viewport = document.querySelector<HTMLElement>('[data-slot="message-scroller-viewport"]');
+  if (!viewport) throw new Error('Message scroller viewport was not rendered');
+
+  setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+  fireEvent.scroll(viewport);
+  setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 0 });
+  fireEvent.scroll(viewport);
+  await waitFor(() => expect(scenario.requestedPages.mock.calls.map(([page]) => page)).toEqual(['0', '1']));
+  Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1600 });
+  scenario.olderMessagesGate.resolve();
+  await screen.findByText('Message 1');
+  return viewport;
+};
+
+afterEach(() => cleanup());
+
+describe('useAgentMessages', () => {
+  describe('when an existing thread has an older page of persisted messages', () => {
+    it('returns one chronological message sequence', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/memory/threads/${THREAD_ID}/messages`, ({ request }) => {
+          const page = new URL(request.url).searchParams.get('page');
+          return HttpResponse.json(page === '1' ? olderAgentMessagesPage : latestAgentMessagesPage);
+        }),
+      );
+
+      const { result } = renderHook(() => useAgentMessages({ agentId: AGENT_ID, threadId: THREAD_ID, memory: true }), {
+        wrapper: makeWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.data?.messages).toHaveLength(40));
+
+      await act(async () => {
+        await result.current.fetchNextPage();
+      });
+
+      await waitFor(() => expect(result.current.data?.messages).toHaveLength(79));
+      expect(result.current.data?.messages.map(message => message.id)).toEqual(
+        Array.from({ length: 79 }, (_, index) => `message-${String(index + 1).padStart(3, '0')}`),
+      );
+    });
+  });
+
+  describe('when the reader returns to the start while a local message is still streaming', () => {
+    it('shows the older history', async () => {
+      const scenario = renderStreamingHistoryScenario();
+      try {
+        await loadOlderHistoryAtStart(scenario);
+        expect(screen.getByText('Message 1')).not.toBeNull();
+      } finally {
+        scenario.olderMessagesGate.resolve();
+        scenario.streamGate.resolve();
+      }
+    });
+
+    it('keeps the local tail visible', async () => {
+      const scenario = renderStreamingHistoryScenario();
+      try {
+        await loadOlderHistoryAtStart(scenario);
+        expect(screen.getByText('live tail')).not.toBeNull();
+      } finally {
+        scenario.olderMessagesGate.resolve();
+        scenario.streamGate.resolve();
+      }
+    });
+
+    it('preserves the reader position', async () => {
+      const scenario = renderStreamingHistoryScenario();
+      try {
+        const viewport = await loadOlderHistoryAtStart(scenario);
+        expect(viewport.scrollTop).toBe(600);
+      } finally {
+        scenario.olderMessagesGate.resolve();
+        scenario.streamGate.resolve();
+      }
+    });
+  });
+
+  describe('when the newest page refreshes after older history was loaded', () => {
+    it('keeps the loaded older history visible', async () => {
+      let latestPageRequests = 0;
+      server.use(
+        ...baseChatHandlers(),
+        http.get(`${BASE_URL}/api/memory/threads/${THREAD_ID}/messages`, ({ request }) => {
+          const page = new URL(request.url).searchParams.get('page');
+          if (page === '1') return HttpResponse.json(olderAgentMessagesPage);
+          latestPageRequests += 1;
+          return HttpResponse.json(latestPageRequests > 1 ? refreshedLatestAgentMessagesPage : latestAgentMessagesPage);
+        }),
+      );
+
+      renderPaginatedThread();
+
+      await screen.findByText('Message 79');
+      const viewport = document.querySelector<HTMLElement>('[data-slot="message-scroller-viewport"]');
+      if (!viewport) throw new Error('Message scroller viewport was not rendered');
+      setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+      fireEvent.scroll(viewport);
+      setScrollMetrics(viewport, { scrollHeight: 1000, clientHeight: 400, scrollTop: 0 });
+      fireEvent.scroll(viewport);
+      await screen.findByText('Message 1');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Refresh history' }));
+      await waitFor(() => expect(latestPageRequests).toBeGreaterThan(1));
+
+      expect(screen.getByText('Message 1')).not.toBeNull();
+    });
+  });
+});

--- a/packages/playground/src/hooks/use-agent-messages.ts
+++ b/packages/playground/src/hooks/use-agent-messages.ts
@@ -1,6 +1,31 @@
+import type { ListMemoryThreadMessagesResponse } from '@mastra/client-js';
 import { useMastraClient } from '@mastra/react';
-import { useQuery } from '@tanstack/react-query';
+import { skipToken, useInfiniteQuery } from '@tanstack/react-query';
+import { useRef } from 'react';
 import { usePlaygroundStore } from '@/store/playground-store';
+
+const MESSAGE_PAGE_SIZE = 40;
+
+const mergeMessagePages = (pages: ListMemoryThreadMessagesResponse[]) => {
+  const newestMessageById = new Map<string, ListMemoryThreadMessagesResponse['messages'][number]>();
+  const mergedMessages: ListMemoryThreadMessagesResponse['messages'] = [];
+
+  for (let pageIndex = pages.length - 1; pageIndex >= 0; pageIndex--) {
+    const page = pages[pageIndex];
+    if (!page) continue;
+    for (const message of page.messages) newestMessageById.set(message.id, message);
+  }
+
+  for (let pageIndex = pages.length - 1; pageIndex >= 0; pageIndex--) {
+    const page = pages[pageIndex];
+    if (!page) continue;
+    for (const message of page.messages) {
+      if (newestMessageById.get(message.id) === message) mergedMessages.push(message);
+    }
+  }
+
+  return mergedMessages;
+};
 
 export interface UseAgentMessagesProps {
   threadId?: string;
@@ -11,21 +36,51 @@ export const useAgentMessages = ({ threadId, agentId, memory }: UseAgentMessages
   const client = useMastraClient();
   const { requestContext } = usePlaygroundStore();
 
-  return useQuery({
-    queryKey: ['memory', 'messages', threadId, agentId, 'requestContext'],
-    queryFn: async () => {
-      if (!threadId) return null;
-      const result = await client.listThreadMessages(threadId, {
-        agentId,
-        requestContext,
-        includeSystemReminders: true,
-      });
-      return result;
-    },
+  const query = useInfiniteQuery({
+    queryKey: ['memory', 'messages', threadId, agentId, requestContext],
+    queryFn: threadId
+      ? ({ pageParam }) =>
+          client.getMemoryThread({ threadId, agentId }).listMessages({
+            page: pageParam,
+            perPage: MESSAGE_PAGE_SIZE,
+            requestContext,
+            includeSystemReminders: true,
+          })
+      : skipToken,
+    initialPageParam: 0,
+    getNextPageParam: lastPage => (lastPage.hasMore ? lastPage.page + 1 : undefined),
+    select: data => ({
+      initialMessages: data.pages[0]?.messages ?? [],
+      messages: mergeMessagePages(data.pages),
+    }),
     enabled: memory && Boolean(threadId),
     staleTime: 0,
     gcTime: 0,
     retry: false,
     refetchOnWindowFocus: false,
   });
+
+  const initialMessagesRef = useRef<{
+    agentId: string;
+    messages?: ListMemoryThreadMessagesResponse['messages'];
+    requestContext: typeof requestContext;
+    threadId?: string;
+  }>({ agentId, requestContext, threadId });
+  const queryChanged =
+    initialMessagesRef.current.agentId !== agentId ||
+    initialMessagesRef.current.requestContext !== requestContext ||
+    initialMessagesRef.current.threadId !== threadId;
+
+  if (queryChanged) initialMessagesRef.current = { agentId, requestContext, threadId };
+  initialMessagesRef.current.messages ??= query.data?.initialMessages;
+
+  return {
+    ...query,
+    data: query.data
+      ? {
+          ...query.data,
+          initialMessages: initialMessagesRef.current.messages ?? [],
+        }
+      : undefined,
+  };
 };

--- a/packages/playground/src/lib/ai-ui/chat/chat-context.ts
+++ b/packages/playground/src/lib/ai-ui/chat/chat-context.ts
@@ -40,6 +40,12 @@ export interface TasksContextValue {
   tasks: TaskItem[];
 }
 
+export interface HistoryContextValue {
+  hasMore: boolean;
+  isLoading: boolean;
+  load: () => void | Promise<void>;
+}
+
 // NOTE: Tool/network approvals are NOT exposed here. The badge approval buttons
 // consume the existing `ToolCallProvider` (`@/services/tool-call-provider`),
 // which `ChatProvider` renders directly with `useChat`'s handlers — identical to
@@ -54,8 +60,14 @@ export const ChatRunningContext = createContext<RunningContextValue>({
 });
 export const ChatSendContext = createContext<SendContextValue>({ send: () => {} });
 export const ChatTasksContext = createContext<TasksContextValue>({ tasks: [] });
+export const ChatHistoryContext = createContext<HistoryContextValue>({
+  hasMore: false,
+  isLoading: false,
+  load: () => {},
+});
 
 export const useChatMessages = (): MastraDBMessage[] => useContext(ChatMessagesContext).messages;
 export const useChatRunning = (): RunningContextValue => useContext(ChatRunningContext);
 export const useChatSend = (): SendContextValue['send'] => useContext(ChatSendContext).send;
 export const useChatTasks = (): TaskItem[] => useContext(ChatTasksContext).tasks;
+export const useChatHistory = (): HistoryContextValue => useContext(ChatHistoryContext);

--- a/packages/playground/src/lib/ai-ui/chat/chat-provider.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/chat-provider.tsx
@@ -7,8 +7,20 @@ import { useChat, useMastraClient } from '@mastra/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
-import { ChatMessagesContext, ChatRunningContext, ChatSendContext, ChatTasksContext } from './chat-context';
-import type { MessagesContextValue, RunningContextValue, SendContextValue, TasksContextValue } from './chat-context';
+import {
+  ChatHistoryContext,
+  ChatMessagesContext,
+  ChatRunningContext,
+  ChatSendContext,
+  ChatTasksContext,
+} from './chat-context';
+import type {
+  HistoryContextValue,
+  MessagesContextValue,
+  RunningContextValue,
+  SendContextValue,
+  TasksContextValue,
+} from './chat-context';
 import { useChatSendHandler } from './use-chat-send-handler';
 import { useObservationalMemoryContext } from '@/domains/agents/context';
 import { useWorkingMemory } from '@/domains/agents/context/agent-working-memory-context';
@@ -48,7 +60,16 @@ export function ChatProvider({
   modelVersion,
   agentVersionId,
   supportsMemory,
-}: Readonly<{ children: ReactNode }> & ChatProps) {
+  history,
+}: Readonly<{
+  children: ReactNode;
+  history?: {
+    hasMore: boolean;
+    isLoading: boolean;
+    load: () => Promise<MastraDBMessage[]>;
+  };
+}> &
+  ChatProps) {
   const { settings: tracingSettings } = useTracingSettings();
   const modelOverride = usePlaygroundModelOptional()?.modelOverride;
 
@@ -324,8 +345,17 @@ export function ChatProvider({
   );
   const sendValue = useMemo<SendContextValue>(() => ({ send }), [send]);
   const tasksValue = useMemo<TasksContextValue>(() => ({ tasks }), [tasks]);
+  const loadHistory = async () => {
+    if (!history?.hasMore || history.isLoading) return;
 
-  return (
+    const persistedMessages = await history.load();
+    setMessages(currentMessages => {
+      const currentMessageIds = new Set(currentMessages.map(message => message.id));
+      const olderMessages = persistedMessages.filter(message => !currentMessageIds.has(message.id));
+      return olderMessages.length > 0 ? [...olderMessages, ...currentMessages] : currentMessages;
+    });
+  };
+  const chat = (
     <ChatRunningContext.Provider value={runningValue}>
       <ChatMessagesContext.Provider value={messagesValue}>
         <ChatTasksContext.Provider value={tasksValue}>
@@ -348,4 +378,13 @@ export function ChatProvider({
       </ChatMessagesContext.Provider>
     </ChatRunningContext.Provider>
   );
+
+  if (!history) return chat;
+
+  const historyValue: HistoryContextValue = {
+    hasMore: history.hasMore,
+    isLoading: history.isLoading,
+    load: loadHistory,
+  };
+  return <ChatHistoryContext.Provider value={historyValue}>{chat}</ChatHistoryContext.Provider>;
 }

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -30,7 +30,7 @@ import { startTransition, useEffect, useMemo, useRef, useState } from 'react';
 import { AttachFilePopover } from './attachments/attach-file-popover';
 import { ComposerAttachments as ChatComposerAttachments } from './attachments/attachment';
 import { ComposerAttachmentsProvider, useComposerAttachments } from './attachments/composer-attachments';
-import { useChatMessages, useChatRunning, useChatSend } from './chat/chat-context';
+import { useChatHistory, useChatMessages, useChatRunning, useChatSend } from './chat/chat-context';
 import { useReadAloud } from './chat/use-read-aloud';
 import { BracketOverlay } from './components/bracket-overlay';
 import './thread.css';
@@ -132,6 +132,7 @@ export const Thread = ({
   const messagesContainerRef = useRef<HTMLDivElement>(null);
 
   const messages = useChatMessages();
+  const history = useChatHistory();
   const { isRunning } = useChatRunning();
   const { requestContext } = usePlaygroundStore();
   const { isSpeaking, readAloud, stop: stopSpeaking } = useReadAloud(agentId, requestContext);
@@ -162,7 +163,11 @@ export const Thread = ({
 
   return (
     <ComposerAttachmentsProvider>
-      <MessageScrollerProvider defaultScrollPosition="last-anchor">
+      <MessageScrollerProvider
+        defaultScrollPosition="last-anchor"
+        onReachStart={history.hasMore && !history.isLoading ? history.load : undefined}
+        preserveScrollOnPrepend={history.hasMore}
+      >
         <div className="group/thread grid h-full grid-rows-[1fr_auto] overflow-y-auto" data-testid="thread-wrapper">
           <MessageScroller>
             <MessageScrollerViewport className="h-full overflow-y-scroll" style={{ overflowAnchor: 'none' }}>

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -1287,6 +1287,54 @@ describe('Memory Handlers', () => {
       });
     });
 
+    it('should return the newest storage fallback page in chronological order', async () => {
+      const threadId = 'storage-pagination-thread';
+      const resourceId = 'storage-pagination-resource';
+      const memoryStore = await storage.getStore('memory');
+      if (!memoryStore) throw new Error('Memory store not initialized');
+
+      await memoryStore.saveThread({ thread: createThread({ id: threadId, resourceId }) });
+      await memoryStore.saveMessages({
+        messages: [
+          {
+            id: 'message-oldest',
+            role: 'user',
+            createdAt: new Date('2026-08-15T00:00:00Z'),
+            threadId,
+            resourceId,
+            content: { format: 2, parts: [{ type: 'text', text: 'Oldest' }] },
+          },
+          {
+            id: 'message-middle',
+            role: 'assistant',
+            createdAt: new Date('2026-08-15T00:01:00Z'),
+            threadId,
+            resourceId,
+            content: { format: 2, parts: [{ type: 'text', text: 'Middle' }] },
+          },
+          {
+            id: 'message-newest',
+            role: 'user',
+            createdAt: new Date('2026-08-15T00:02:00Z'),
+            threadId,
+            resourceId,
+            content: { format: 2, parts: [{ type: 'text', text: 'Newest' }] },
+          },
+        ],
+      });
+      const mastra = new Mastra({ logger: false, storage });
+
+      const result = await LIST_MESSAGES_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        threadId,
+        resourceId,
+        page: 0,
+        perPage: 2,
+      });
+
+      expect(result.messages.map(message => message.id)).toEqual(['message-middle', 'message-newest']);
+    });
+
     it('should reject metadata filters for gateway agents', async () => {
       vi.stubEnv('MASTRA_GATEWAY_API_KEY', 'test-gateway-key');
       vi.stubEnv('MASTRA_GATEWAY_URL', 'https://gateway.example.test');
@@ -1321,6 +1369,91 @@ describe('Memory Handlers', () => {
         fetchMock.mockRestore();
         vi.unstubAllEnvs();
       }
+    });
+
+    it('should return pagination metadata for gateway messages', async () => {
+      vi.stubEnv('MASTRA_GATEWAY_API_KEY', 'test-gateway-key');
+      vi.stubEnv('MASTRA_GATEWAY_URL', 'https://gateway.example.test');
+      const gatewayAgent = new Agent({
+        id: 'paginated-gateway-agent',
+        name: 'paginated-gateway-agent',
+        instructions: 'test-instructions',
+        model: 'mastra/openai/gpt-5-mini',
+      });
+      const mastra = new Mastra({ logger: false, agents: { 'paginated-gateway-agent': gatewayAgent } });
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              thread: {
+                id: 'gateway-thread',
+                projectId: 'project-1',
+                resourceId: 'resource-1',
+                title: null,
+                metadata: null,
+                createdAt: '2026-08-15T00:00:00Z',
+                updatedAt: '2026-08-15T00:02:00Z',
+              },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              messages: [
+                {
+                  id: 'message-newest',
+                  threadId: 'gateway-thread',
+                  role: 'user',
+                  content: { format: 2, parts: [{ type: 'text', text: 'Newest' }] },
+                  type: 'text',
+                  createdAt: '2026-08-15T00:02:00Z',
+                },
+                {
+                  id: 'message-middle',
+                  threadId: 'gateway-thread',
+                  role: 'assistant',
+                  content: { format: 2, parts: [{ type: 'text', text: 'Middle' }] },
+                  type: 'text',
+                  createdAt: '2026-08-15T00:01:00Z',
+                },
+              ],
+              total: 3,
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        );
+
+      try {
+        const result = await LIST_MESSAGES_ROUTE.handler({
+          ...createTestServerContext({ mastra }),
+          agentId: 'paginated-gateway-agent',
+          threadId: 'gateway-thread',
+          resourceId: 'resource-1',
+          page: 0,
+          perPage: 2,
+        });
+
+        expect(result).toMatchObject({ total: 3, page: 0, perPage: 2, hasMore: true });
+      } finally {
+        fetchMock.mockRestore();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should return pagination metadata when memory is not configured', async () => {
+      const mastra = new Mastra({ logger: false });
+      vi.spyOn(mastra, 'getStorage').mockReturnValue(undefined);
+      const result = await LIST_MESSAGES_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        threadId: 'empty-thread',
+        page: 0,
+        perPage: 40,
+      });
+
+      expect(result).toMatchObject({ messages: [], total: 0, page: 0, perPage: 40, hasMore: false });
     });
 
     it('should preserve custom metadata in messages when loading messages with metadata', async () => {

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -1128,17 +1128,24 @@ export const LIST_MESSAGES_ROUTE = createRoute({
           const effectivePage = page ?? 0;
           const effectivePerPage = perPage ?? 100;
           const offset = effectivePage * effectivePerPage;
+          const shouldGetNewestAndReverse = !orderBy;
           const result = await gwClient.listMessages(effectiveThreadId, {
             limit: effectivePerPage,
             offset,
-            order: orderBy?.direction?.toLowerCase(),
+            order: orderBy?.direction?.toLowerCase() ?? 'desc',
           });
           if (!result) {
             throw new HTTPException(404, { message: 'Thread not found' });
           }
+          const messages = result.messages.map(toLocalMessage);
+          const orderedMessages = shouldGetNewestAndReverse ? messages.toReversed() : messages;
           return {
-            messages: result.messages.map(toLocalMessage),
-            uiMessages: result.messages.map(toLocalMessage),
+            messages: orderedMessages,
+            uiMessages: orderedMessages,
+            total: result.total,
+            page: effectivePage,
+            perPage: effectivePerPage,
+            hasMore: offset + result.messages.length < result.total,
           };
         }
       }
@@ -1192,17 +1199,19 @@ export const LIST_MESSAGES_ROUTE = createRoute({
             effectiveResourceId,
           });
 
+          const shouldGetNewestAndReverse = !orderBy;
           const result = await memoryStore.listMessages({
             threadId: effectiveThreadId,
             resourceId: effectiveResourceId,
             perPage,
             page,
-            orderBy,
+            orderBy: orderBy ?? { field: 'createdAt', direction: 'DESC' },
             include,
             filter,
           });
           return {
             ...result,
+            messages: shouldGetNewestAndReverse ? result.messages.toReversed() : result.messages,
             uiMessages: null,
           };
         }
@@ -1210,7 +1219,14 @@ export const LIST_MESSAGES_ROUTE = createRoute({
 
       // Return empty messages when memory is not configured (Issue #11765)
       // This allows the playground UI to gracefully handle agents without memory
-      return { messages: [], uiMessages: [] };
+      return {
+        messages: [],
+        uiMessages: [],
+        total: 0,
+        page: page ?? 0,
+        perPage: perPage ?? 40,
+        hasMore: false,
+      };
     } catch (error) {
       return handleError(error, 'Error getting messages');
     }

--- a/packages/server/src/server/schemas/memory.ts
+++ b/packages/server/src/server/schemas/memory.ts
@@ -513,7 +513,7 @@ export const getThreadByIdResponseSchema = threadSchema;
 /**
  * Response for GET /memory/threads/:threadId/messages
  */
-export const listMessagesResponseSchema = z.object({
+export const listMessagesResponseSchema = paginationInfoSchema.extend({
   messages: z.array(messageSchema),
   uiMessages: z.array(z.unknown()).nullable(), // Converted messages in UI format
 });


### PR DESCRIPTION
Agent Studio currently loads only the first page of persisted messages, so older history cannot be reached in long conversations. This updates the message hook to fetch older pages when the reader reaches the start, prepend them without duplicating messages, and preserve both the live tail and viewport position.

Before this change, scrolling to the start left the transcript truncated. After this change, older pages load progressively while active streamed messages remain in place. The server and client response contract now also exposes consistent pagination metadata and newest-page ordering across local, storage fallback, and gateway memory paths.

Regression coverage uses the real client SDK and React Query through typed MSW fixtures, alongside server handler tests for pagination metadata and ordering.

Fixes #21349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Agent Studio can now load older chat messages when you scroll to the top. It adds older messages without duplicates and keeps live messages and your current scroll position.

## Changes

- Added paginated message loading with `useInfiniteQuery`.
- Added chat history context and scroll-triggered loading.
- Preserved active streamed messages and viewport position when older messages are prepended.
- Standardized pagination metadata and newest-page ordering across storage, gateway, and empty-memory responses.
- Updated client and server pagination schemas and types.
- Added React Query, MSW, client SDK, and server regression tests.
- Added patch release changesets for `@internal/playground`, `@mastra/client-js`, and `@mastra/server`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->