### PR TITLE
fix(core): skip resume on delegation without a suspended run

### DIFF
--- a/.changeset/tidy-owls-delegate.md
+++ b/.changeset/tidy-owls-delegate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix sub-agent and workflow delegation attempting to resume a non-existent snapshot when the model populates `resumeData` with no suspended run (issue #21608)

--- a/packages/core/src/agent/__tests__/agent-delegation-resume.test.ts
+++ b/packages/core/src/agent/__tests__/agent-delegation-resume.test.ts
@@ -1,0 +1,133 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { Agent } from '../agent';
+
+/**
+ * Regression tests for issue #21608: when a model fills the optional
+ * `resumeData` field on a sub-agent delegation tool call while no run is
+ * actually suspended, the delegation must not attempt a resume (there is no
+ * `suspendedToolRunId` to load, and resuming a non-existent snapshot throws
+ * AGENT_RESUME_NO_SNAPSHOT_FOUND, surfacing as an opaque delegation failure).
+ * It must fall back to a fresh stream.
+ */
+
+function makeSubAgent() {
+  const subAgentModel = new MockLanguageModelV2({
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'sub-id-0', modelId: 'mock', timestamp: new Date(0) },
+        { type: 'text-start', id: 'sub-text-1' },
+        { type: 'text-delta', id: 'sub-text-1', delta: 'sub-agent response' },
+        { type: 'text-end', id: 'sub-text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+        },
+      ]),
+    }),
+  });
+
+  return new Agent({
+    id: 'sub-agent',
+    name: 'sub-agent',
+    description: 'A sub-agent.',
+    instructions: 'You answer briefly.',
+    model: subAgentModel,
+  });
+}
+
+function makeSupervisorModelWithResumeData() {
+  let callCount = 0;
+  return new MockLanguageModelV2({
+    doStream: async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'sup-id-0', modelId: 'mock', timestamp: new Date(0) },
+            {
+              type: 'tool-call',
+              toolCallId: 'sup-call-1',
+              toolName: 'agent-subAgent',
+              // resumeData present, suspendedToolRunId absent -- the model
+              // invented resumeData because the schema always exposes it.
+              input: JSON.stringify({
+                prompt: 'do the thing',
+                resumeData: { someKey: 'someValue' },
+              }),
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+        };
+      }
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'sup-id-1', modelId: 'mock', timestamp: new Date(0) },
+          { type: 'text-start', id: 'sup-text-1' },
+          { type: 'text-delta', id: 'sup-text-1', delta: 'all done' },
+          { type: 'text-end', id: 'sup-text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+      };
+    },
+  });
+}
+
+describe('Sub-agent delegation: resumeData without a suspended run (issue #21608)', () => {
+  it('runs the sub-agent fresh instead of resuming a non-existent snapshot', async () => {
+    const subAgent = makeSubAgent();
+    const resumeSpy = vi.spyOn(subAgent, 'resumeStream').mockImplementation(
+      (() => Promise.reject(new Error('resumeStream must not be called'))) as never,
+    );
+    const streamSpy = vi.spyOn(subAgent, 'stream').mockImplementation(
+      (async () => {
+        const original = makeSubAgent();
+        return (original as any).stream('irrelevant');
+      }) as never,
+    );
+
+    const supervisor = new Agent({
+      id: 'supervisor',
+      name: 'supervisor',
+      instructions: 'You orchestrate sub-agents.',
+      model: makeSupervisorModelWithResumeData(),
+      agents: { subAgent },
+    });
+
+    new Mastra({
+      agents: { supervisor },
+      storage: new InMemoryStore(),
+    });
+
+    const stream = await supervisor.stream('Please delegate', { maxSteps: 5 });
+    for await (const _chunk of stream.fullStream) {
+      // drain
+    }
+
+    // The delegation fell back to a fresh stream instead of trying to resume
+    // a snapshot that does not exist (which would throw
+    // AGENT_RESUME_NO_SNAPSHOT_FOUND before the sub-agent ever runs).
+    expect(streamSpy).toHaveBeenCalled();
+    expect(resumeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5081,6 +5081,15 @@ export class Agent<
 
               const { resumeData, suspend } = context?.agent ?? {};
 
+              // Only resume when there is actually a suspended run to resume.
+              // resumeData is an optional field on the delegation tool schema
+              // and models fill it unprompted even when nothing is suspended;
+              // with no suspendedToolRunId the resume call has no run to load
+              // and throws AGENT_RESUME_NO_SNAPSHOT_FOUND, surfacing to the
+              // user as an opaque delegation failure (issue #21608). Fall
+              // through to the fresh generate/stream path in that case.
+              const shouldResume = Boolean(resumeData && suspendedToolRunId);
+
               // Apply messageFilter callback (runs after onDelegationStart so effectivePrompt
               // reflects any hook modifications). Falls back to full context on error.
               let filteredContextMessages = sanitizedMessages;
@@ -5170,7 +5179,7 @@ export class Agent<
                 (methodType === 'generate' || methodType === 'generateLegacy') &&
                 supportedLanguageModelSpecifications.includes(resolvedModelVersion)
               ) {
-                const generateResult = resumeData
+                const generateResult = shouldResume
                   ? await resolvedAgent.resumeGenerate(resumeData, {
                       runId: suspendedToolRunId,
                       requestContext: subAgentRequestContext,
@@ -5262,7 +5271,7 @@ export class Agent<
                 (methodType === 'stream' || methodType === 'streamLegacy') &&
                 supportedLanguageModelSpecifications.includes(resolvedModelVersion)
               ) {
-                const streamResult = resumeData
+                const streamResult = shouldResume
                   ? await resolvedAgent.resumeStream(resumeData, {
                       runId: suspendedToolRunId,
                       requestContext: subAgentRequestContext,
@@ -5713,10 +5722,17 @@ export class Agent<
               const run = await workflow.createRun({ runId: runIdToUse, resourceId });
               const { resumeData, suspend } = context?.agent ?? {};
 
+              // Same guard as the sub-agent delegation path (issue #21608):
+              // resumeData alone must not select the resume path when no
+              // suspended run exists -- runIdToUse is a fresh UUID in that
+              // case and resuming it would throw on a snapshot that never
+              // existed. Fall back to a fresh start.
+              const shouldResume = Boolean(resumeData && suspendedToolRunId);
+
               let result: WorkflowResult<any, any, any, any> | undefined = undefined;
 
               if (methodType === 'generate' || methodType === 'generateLegacy') {
-                if (resumeData) {
+                if (shouldResume) {
                   result = await run.resume({
                     resumeData,
                     requestContext,
@@ -5750,7 +5766,7 @@ export class Agent<
 
                 result = await streamResult.getWorkflowState();
               } else if (methodType === 'stream') {
-                const streamResult = resumeData
+                const streamResult = shouldResume
                   ? run.resumeStream({
                       resumeData,
                       requestContext,


### PR DESCRIPTION
## What & why

Closes #21608.

When a model populates `resumeData` on a sub-agent (or workflow) delegation tool call while **no run is suspended**, the delegation selects the resume path on `resumeData` alone. `suspendedToolRunId` comes from the tool-call input and is only injected by `tool-call-step` when a suspended tool actually exists in history; when the model invents `resumeData` unprompted (the field is always exposed on the `agent-*`/`workflow-*` schemas, while the instruction on how to use it is gated on real suspensions), the resume call gets `runId: undefined`, `#loadAgenticLoopSnapshotOrThrow` can never find a snapshot, and the delegation throws `AGENT_RESUME_NO_SNAPSHOT_FOUND` — surfacing to the user as an opaque `Failed agent tool execution for <subAgent>` that the supervisor then explains with made-up reasons.

Real production impact from the issue: a file-upload flow failed ~2 of every 3 delegations, with the assistant telling clinicians the file had the wrong format when it didn't.

### The fix

Only take the resume path when **both** `resumeData` and a `suspendedToolRunId` are present; otherwise fall through to the fresh `generate`/`stream` (or `run.start`/`run.stream`) path. Applied to all four delegation resume sites in `packages/core/src/agent/agent.ts`:

- sub-agent `generate` path (`resumeGenerate` vs `generate`)
- sub-agent `stream` path (`resumeStream` vs `stream`)
- workflow `generate` path (`run.resume` vs `run.start`)
- workflow `stream` path (`run.resumeStream` vs `run.stream`)

The workflow path had the same shape: `runIdToUse = suspendedToolRunId || randomUUID()` means a stray `resumeData` resumes a brand-new run that never suspended.

## Test plan

New `packages/core/src/agent/__tests__/agent-delegation-resume.test.ts`: a supervisor delegates to a sub-agent whose model emits `resumeData` with no `suspendedToolRunId`; spies assert the sub-agent's `stream` is called and `resumeStream` is **not** (without the fix the test fails — `resumeStream` is called and the snapshot lookup throws). Verified both directions locally.

- `vitest run src/agent/__tests__/agent-delegation-resume.test.ts` → pass
- Related agent suites (`agentic-loop-snapshot-lifecycle`, `supervisor-output-processor-stream`) → 12 pass
- `tsc --noEmit` on `@mastra/core` → clean
- The 32 failures in the full agent dir are all `workspace-tools-openai.e2e.test.ts` (needs a real OpenAI key; none in this environment) — pre-existing and unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a delegated agent receives resume information without an actual paused run, it now starts normally instead of trying to resume something that does not exist. This prevents delegation failures caused by missing snapshots.

## Changes

- Require both `resumeData` and `suspendedToolRunId` before using resume operations.
- Use fresh execution for sub-agent and workflow `generate` and `stream` calls when no suspended run exists.
- Preserve resume behavior for valid suspended runs.
- Add regression coverage for sub-agent streaming.
- Add a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->