### PR TITLE
feat: add Taskmarket integration (@mastra/taskmarket)

### DIFF
--- a/.changeset/taskmarket-integration.md
+++ b/.changeset/taskmarket-integration.md
@@ -1,0 +1,5 @@
+---
+"@mastra/taskmarket": minor
+---
+
+Added a Taskmarket integration with tools to browse, create, and manage onchain agent tasks (USDC on Base). Read-only tools call the public REST API; creating a task goes through the first-party CLI, requires explicit confirmation, and enforces the `TASKMARKET_MAX_SPEND_USDC` spending cap (default 10 USDC).

--- a/docs/src/content/en/integrations/sidebars.js
+++ b/docs/src/content/en/integrations/sidebars.js
@@ -551,6 +551,12 @@ const sidebars = {
           label: 'Tavily',
           customProps: { icon: '/img/integrations/tavily.svg', customCSS: 'dark:invert' },
         },
+        {
+          type: 'doc',
+          id: 'tools/taskmarket',
+          label: 'Taskmarket',
+          customProps: { icon: 'https://cdn.simpleicons.org/bitcoin?viewbox=auto&size=28' },
+        },
       ],
     },
     {

--- a/docs/src/content/en/integrations/tools/taskmarket.mdx
+++ b/docs/src/content/en/integrations/tools/taskmarket.mdx
@@ -1,0 +1,284 @@
+---
+title: "Taskmarket | Tools"
+description: "API reference for @mastra/taskmarket, which provides browse, create, and manage tools for Taskmarket, an onchain agent task marketplace paying USDC on Base."
+packages:
+  - "@mastra/taskmarket"
+---
+
+# Taskmarket
+
+The `@mastra/taskmarket` package lets Mastra agents browse, create, and manage tasks on [Taskmarket](https://taskmarket.dev), an onchain agent task marketplace where buyers escrow USDC on Base against one funded outcome and agents compete to deliver the accepted result.
+
+Read-only tools talk directly to the public Taskmarket REST API. The write path (`taskmarketCreateTask`) shells out to the first-party [`@lucid-agents/taskmarket`](https://www.npmjs.com/package/@lucid-agents/taskmarket) CLI, which owns the wallet, x402 payments, and signatures — this integration never handles private keys.
+
+## Installation
+
+```sh npm2yarn
+npm install @mastra/taskmarket
+```
+
+The write path additionally requires the first-party CLI:
+
+```bash
+npm install -g @lucid-agents/taskmarket
+taskmarket init
+```
+
+## Quick start
+
+Use `createTaskmarketTools()` to get all five tools:
+
+```typescript title="src/mastra/tools/index.ts"
+import { createTaskmarketTools } from '@mastra/taskmarket'
+
+const tools = createTaskmarketTools()
+// tools.taskmarketListOpenTasks
+// tools.taskmarketGetTask
+// tools.taskmarketTrackTask
+// tools.taskmarketCreateTask
+// tools.taskmarketListSubmissions
+```
+
+## `createTaskmarketTools()`
+
+Returns an object containing all five tools with a shared configuration.
+
+**Returns:** `{ taskmarketListOpenTasks, taskmarketGetTask, taskmarketTrackTask, taskmarketCreateTask, taskmarketListSubmissions }`
+
+## `createTaskmarketListTasksTool()`
+
+Lists open tasks on Taskmarket (Base network, USDC rewards), optionally filtered by mode and reward range.
+
+**Tool ID:** `taskmarket-list-open-tasks`
+
+### Input
+
+<PropertiesTable
+  content={[
+  {
+    name: 'limit',
+    type: 'number',
+    description: 'Maximum number of open tasks to return (1-100).',
+    isOptional: true,
+    defaultValue: '20',
+  },
+  {
+    name: 'minRewardUsdc',
+    type: 'number',
+    description: 'Only return tasks with a reward of at least this many USDC.',
+    isOptional: true,
+  },
+  {
+    name: 'maxRewardUsdc',
+    type: 'number',
+    description: 'Only return tasks with a reward of at most this many USDC.',
+    isOptional: true,
+  },
+  {
+    name: 'mode',
+    type: "'bounty' | 'claim' | 'pitch' | 'benchmark' | 'auction'",
+    description: 'Only return tasks of this mode.',
+    isOptional: true,
+  },
+]}
+/>
+
+### Output
+
+<PropertiesTable
+  content={[
+  {
+    name: 'network',
+    type: 'string',
+    description: "Payment network ('base').",
+  },
+  {
+    name: 'count',
+    type: 'number',
+    description: 'Number of tasks returned after filtering.',
+  },
+  {
+    name: 'tasks',
+    type: 'TaskmarketTask[]',
+    description: 'Array of open tasks with id, description, rewardUsdc, mode, status, submissionCount, expiryTime, tags, and requester fields.',
+  },
+]}
+/>
+
+## `createTaskmarketGetTaskTool()`
+
+Fetches the full details of a single task by ID.
+
+**Tool ID:** `taskmarket-get-task`
+
+### Input
+
+<PropertiesTable
+  content={[
+  {
+    name: 'taskId',
+    type: 'string',
+    description: 'Taskmarket task ID (0x-prefixed 32-byte hex string).',
+  },
+]}
+/>
+
+## `createTaskmarketTrackTaskTool()`
+
+Re-fetches a task and returns its live status, reward, expiry, and submission count. Use this to check a task you created.
+
+**Tool ID:** `taskmarket-track-task`
+
+## `createTaskmarketListSubmissionsTool()`
+
+Lists the submissions on a task and presents them for human review. It never accepts or rejects work automatically; a human requester decides.
+
+**Tool ID:** `taskmarket-list-submissions`
+
+### Output
+
+<PropertiesTable
+  content={[
+  {
+    name: 'taskId',
+    type: 'string',
+    description: 'The task ID.',
+  },
+  {
+    name: 'count',
+    type: 'number',
+    description: 'Number of submissions.',
+  },
+  {
+    name: 'submissions',
+    type: 'TaskmarketSubmission[]',
+    description: 'Submissions with id, workerAddress, submittedAt, deliverableUrl, and deliverableHash.',
+  },
+  {
+    name: 'reviewNote',
+    type: 'string',
+    description: 'Reminder to present submissions to a human requester.',
+  },
+]}
+/>
+
+## `createTaskmarketCreateTaskTool()`
+
+Creates a funded task on Taskmarket (Base, USDC) as a requester through the first-party taskmarket CLI. Requires explicit confirmation, shows the exact plan, and enforces the `TASKMARKET_MAX_SPEND_USDC` spending limit (default 10 USDC). The configured ceiling always wins over the per-call cap.
+
+**Tool ID:** `taskmarket-create-task`
+
+### Input
+
+<PropertiesTable
+  content={[
+  {
+    name: 'description',
+    type: 'string',
+    description: 'Exact task description the requester wants done.',
+  },
+  {
+    name: 'rewardUsdc',
+    type: 'number',
+    description: 'Reward in USDC, paid from the wallet managed by the taskmarket CLI.',
+  },
+  {
+    name: 'durationHours',
+    type: 'number',
+    description: 'Task duration in hours before it expires.',
+  },
+  {
+    name: 'maxSpendUsdc',
+    type: 'number',
+    description: 'Hard cap on the reward for this call. Cannot exceed TASKMARKET_MAX_SPEND_USDC; the configured ceiling always wins.',
+    isOptional: true,
+  },
+  {
+    name: 'confirmation',
+    type: 'boolean',
+    description: 'Must be true to create the task. Creating a task spends real USDC from the requester wallet, so this requires fresh explicit user authorization.',
+    isOptional: true,
+    defaultValue: 'false',
+  },
+]}
+/>
+
+### Output
+
+<PropertiesTable
+  content={[
+  {
+    name: 'status',
+    type: "'requires_confirmation' | 'submitted'",
+    description: 'requires_confirmation when confirmation is false; submitted when the task was created.',
+  },
+  {
+    name: 'taskId',
+    type: 'string',
+    description: 'The created task ID when status is submitted.',
+    isOptional: true,
+  },
+  {
+    name: 'plan',
+    type: 'object',
+    description: 'The exact plan (description, rewardUsdc, durationHours, network, maxSpendUsdc) shown before execution.',
+    isOptional: true,
+  },
+]}
+/>
+
+### Creating a task
+
+`taskmarketCreateTask` never spends money without fresh, explicit authorization:
+
+```typescript title="src/mastra/tools/index.ts"
+import { createTaskmarketTools } from '@mastra/taskmarket'
+
+const tools = createTaskmarketTools()
+
+// Step 1: see the exact plan
+const plan = await tools.taskmarketCreateTask.execute({
+  description: 'Write a source-cited market research brief on agent payment rails.',
+  rewardUsdc: 25,
+  durationHours: 48,
+})
+
+// Step 2: review plan.plan, then authorize
+const created = await tools.taskmarketCreateTask.execute({
+  description: 'Write a source-cited market research brief on agent payment rails.',
+  rewardUsdc: 25,
+  durationHours: 48,
+  confirmation: true,
+})
+```
+
+If the CLI reports a settlement whose status is unknown (`pending`), the tool throws and never retries the payment.
+
+## Agent example
+
+The following example demonstrates an agent that watches for low-competition research tasks:
+
+```typescript title="src/mastra/agents/index.ts"
+import { Agent } from '@mastra/core/agent'
+import { createTaskmarketTools } from '@mastra/taskmarket'
+
+const agent = new Agent({
+  id: 'taskmarket-watcher',
+  name: 'Taskmarket Watcher Agent',
+  model: '__GATEWAY_ANTHROPIC_MODEL_SONNET__',
+  instructions:
+    'You monitor Taskmarket for open research tasks under $60 USDC. Report the best opportunities with their reward, deadline, and submission count.',
+  tools: createTaskmarketTools(),
+})
+```
+
+## Environment variables
+
+| Variable | Description |
+| - | - |
+| `TASKMARKET_MAX_SPEND_USDC` | Hard ceiling on `taskmarketCreateTask` rewards (default 10 USDC). The configured value always wins over the per-call cap. |
+
+## Related
+
+- [`createTool()`](/reference/tools/create-tool)
+- [Taskmarket documentation](https://docs.taskmarket.dev)

--- a/integrations/taskmarket/README.md
+++ b/integrations/taskmarket/README.md
@@ -1,0 +1,76 @@
+# @mastra/taskmarket
+
+[Taskmarket](https://taskmarket.dev) tools for Mastra agents: browse, create, and manage onchain agent tasks (USDC on Base).
+
+Taskmarket is an onchain agent task marketplace where buyers escrow USDC against one funded outcome and autonomous agents compete to deliver the accepted result.
+
+## Install
+
+```bash
+npm install @mastra/taskmarket
+```
+
+The write path (`taskmarketCreateTask`) shells out to the first-party Taskmarket CLI, which owns the wallet, x402 payments, and signatures:
+
+```bash
+npm install -g @lucid-agents/taskmarket
+taskmarket init   # create and register an agent wallet
+```
+
+## Tools
+
+| Tool | Read/Write | Description |
+| --- | --- | --- |
+| `taskmarketListOpenTasks` | read | List open tasks, optionally filtered by mode and reward range |
+| `taskmarketGetTask` | read | Fetch full task details by ID |
+| `taskmarketTrackTask` | read | Live status, reward, expiry, and submission count for a task |
+| `taskmarketListSubmissions` | read | List submissions for human review (never auto-accepts) |
+| `taskmarketCreateTask` | write | Create a funded task via the first-party CLI with explicit confirmation and a hard spending cap |
+
+## Usage
+
+```ts
+import { Agent } from '@mastra/core';
+import { createTaskmarketTools } from '@mastra/taskmarket';
+
+const agent = new Agent({
+  name: 'market-watcher',
+  instructions: 'Find open research tasks under $60 and report the best one.',
+  model: { provider: 'OPEN_AI', name: 'gpt-4o' },
+  tools: createTaskmarketTools(),
+});
+```
+
+### Creating a task (write path)
+
+`taskmarketCreateTask` never spends money without fresh, explicit authorization:
+
+1. Call it with `confirmation: false` to see the exact plan (description, reward, duration, network, spending cap).
+2. Call it again with `confirmation: true` to execute. The reward must be at or below `TASKMARKET_MAX_SPEND_USDC` (default 10 USDC), and the configured ceiling always wins over the tool-call cap.
+
+```ts
+const tools = createTaskmarketTools();
+
+const plan = await tools.taskmarketCreateTask.execute({
+  description: 'Write a source-cited market research brief on AI agent payment rails.',
+  rewardUsdc: 25,
+  durationHours: 48,
+});
+
+// review plan.plan, then:
+const created = await tools.taskmarketCreateTask.execute({
+  description: 'Write a source-cited market research brief on AI agent payment rails.',
+  rewardUsdc: 25,
+  durationHours: 48,
+  confirmation: true,
+});
+```
+
+If the CLI reports a settlement whose status is unknown (`pending`), the tool throws and never retries the payment.
+
+## Safety
+
+- Writes go through the first-party CLI: the integration never handles private keys, seeds, or tokens.
+- The spending cap is a hard gate: `TASKMARKET_MAX_SPEND_USDC` (default 10) always wins over the per-call cap.
+- Submissions are presented for human review only; nothing is ever auto-accepted.
+- No payment is ever blindly retried.

--- a/integrations/taskmarket/eslint.config.js
+++ b/integrations/taskmarket/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/integrations/taskmarket/lint-staged.config.js
+++ b/integrations/taskmarket/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['oxlint --fix --deny-warnings', 'eslint --fix --max-warnings=0', 'oxfmt --no-error-on-unmatched-pattern'],
+  '*.{js,jsx}': ['oxfmt --no-error-on-unmatched-pattern'],
+  '*.{json,md,yml,yaml}': ['oxfmt --no-error-on-unmatched-pattern'],
+};

--- a/integrations/taskmarket/package.json
+++ b/integrations/taskmarket/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@mastra/taskmarket",
+  "version": "0.1.0",
+  "description": "Taskmarket tools for Mastra agents: browse, create, and manage onchain agent tasks (USDC on Base) with a hard spending cap and explicit confirmation.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsdown --silent --config tsdown.config.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "lint": "oxlint . && eslint .",
+    "lint:fix": "oxlint --fix . && eslint --fix .",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "mastra",
+    "taskmarket",
+    "usdc",
+    "base",
+    "bounties",
+    "tools",
+    "ai-agent"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "integrations/taskmarket"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "homepage": "https://mastra.ai",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "dependencies": {},
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "zod": ">=3.0.0 || >=4.0.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "tsdown": "0.22.9",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/integrations/taskmarket/src/__tests__/api.test.ts
+++ b/integrations/taskmarket/src/__tests__/api.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TaskmarketClient } from '../api.js';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('TaskmarketClient.listTasks', () => {
+  it('converts reward base units to USDC', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        tasks: [
+          {
+            id: '0x1',
+            reward: '64000000',
+            description: 'd',
+            mode: 'bounty',
+            status: 'open',
+            submissionCount: 2,
+            tags: [],
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const result = await new TaskmarketClient().listTasks();
+    expect(result.tasks[0]?.rewardUsdc).toBe(64);
+  });
+
+  it('rounds fractional minRewardUsdc to whole base units', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ tasks: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+    await new TaskmarketClient().listTasks({ minRewardUsdc: 0.3 });
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toContain('minReward=300000');
+    expect(url).not.toContain('299999');
+  });
+
+  it('passes mode and fetches a superset when any filter is active', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ tasks: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+    await new TaskmarketClient().listTasks({ mode: 'claim', minRewardUsdc: 1, limit: 5 });
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toContain('mode=claim');
+    expect(url).toContain('minReward=1000000');
+    expect(url).toContain('limit=100');
+  });
+
+  it('filters client-side by maxRewardUsdc and applies the limit', async () => {
+    const tasks = [
+      { id: 'a', reward: '5000000', description: 'd', mode: 'bounty', status: 'open', submissionCount: 0, tags: [] },
+      { id: 'b', reward: '2000000', description: 'd', mode: 'bounty', status: 'open', submissionCount: 0, tags: [] },
+    ];
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ tasks })));
+    const result = await new TaskmarketClient().listTasks({ maxRewardUsdc: 3, limit: 10 });
+    expect(result.tasks.map(t => t.id)).toEqual(['b']);
+  });
+
+  it('throws on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('nope', { status: 500 })));
+    await expect(new TaskmarketClient().listTasks()).rejects.toThrow('HTTP 500');
+  });
+});
+
+describe('TaskmarketClient.getTask / listSubmissions', () => {
+  it('compacts a task and keeps requester and pendingActions', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          id: '0x1',
+          requester: '0xabc',
+          requesterAgentId: '42',
+          pendingActions: [{ action: 'review' }],
+          reward: '1000000',
+          tags: [],
+        }),
+      ),
+    );
+    const { task } = await new TaskmarketClient().getTask('0x1');
+    expect(task.requester).toBe('0xabc');
+    expect(task.requesterAgentId).toBe('42');
+    expect(task.rewardUsdc).toBe(1);
+    expect(task.pendingActions).toEqual([{ action: 'review' }]);
+  });
+
+  it('returns submissions with a human-review note', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          submissions: [{ id: 'sub-1', workerAddress: '0x1', fileUrl: 'https://x/y.md' }],
+        }),
+      ),
+    );
+    const result = await new TaskmarketClient().listSubmissions('0x1');
+    expect(result.count).toBe(1);
+    expect(result.submissions[0]?.deliverableUrl).toBe('https://x/y.md');
+    expect(result.reviewNote).toContain('human requester');
+  });
+});

--- a/integrations/taskmarket/src/__tests__/cli.test.ts
+++ b/integrations/taskmarket/src/__tests__/cli.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+  execSync: vi.fn(() => 'C:\\global\\node_modules'),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: mocks.execFile,
+  execSync: mocks.execSync,
+}));
+
+import { createTask, taskmarketCliEntry } from '../cli.js';
+
+describe('taskmarketCliEntry', () => {
+  it('resolves the first-party CLI entry under npm global root', () => {
+    expect(taskmarketCliEntry()).toContain('@lucid-agents');
+    expect(taskmarketCliEntry()).toContain('taskmarket');
+    expect(taskmarketCliEntry()).toContain('index.js');
+  });
+});
+
+describe('createTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.TASKMARKET_MAX_SPEND_USDC;
+  });
+
+  afterEach(() => {
+    delete process.env.TASKMARKET_MAX_SPEND_USDC;
+  });
+
+  it('returns requires_confirmation without calling the CLI', async () => {
+    const result = await createTask({
+      description: 'd',
+      rewardUsdc: 5,
+      durationHours: 24,
+      confirmation: false,
+    });
+    expect(result.status).toBe('requires_confirmation');
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
+
+  it('enforces the env ceiling over the tool-call cap', async () => {
+    process.env.TASKMARKET_MAX_SPEND_USDC = '2';
+    const result = await createTask({
+      description: 'd',
+      rewardUsdc: 1,
+      durationHours: 24,
+      maxSpendUsdc: 100,
+      confirmation: false,
+    });
+    expect((result.plan as Record<string, unknown>).maxSpendUsdc).toBe(2);
+  });
+
+  it('throws when the reward exceeds the ceiling', async () => {
+    process.env.TASKMARKET_MAX_SPEND_USDC = '2';
+    await expect(
+      createTask({ description: 'd', rewardUsdc: 5, durationHours: 24, confirmation: true }),
+    ).rejects.toThrow('exceeds the spending limit');
+  });
+
+  it('parses the ok envelope and returns the task id', async () => {
+    mocks.execFile.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: (e: null, so: string, se: string) => void) =>
+      cb(null, JSON.stringify({ ok: true, data: { taskId: '0xabc' } }), ''),
+    );
+    const result = await createTask({
+      description: 'd',
+      rewardUsdc: 5,
+      durationHours: 24,
+      confirmation: true,
+    });
+    expect(result.status).toBe('submitted');
+    expect(result.taskId).toBe('0xabc');
+    const callArgs = mocks.execFile.mock.calls[0]?.[1] as string[];
+    expect(callArgs).toContain('task');
+    expect(callArgs).toContain('create');
+    expect(callArgs).toContain('--reward');
+  });
+
+  it('never retries a pending (unknown settlement) failure', async () => {
+    mocks.execFile.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: (e: null, so: string, se: string) => void) =>
+      cb(null, '', JSON.stringify({ ok: false, pending: true })),
+    );
+    await expect(
+      createTask({ description: 'd', rewardUsdc: 5, durationHours: 24, confirmation: true }),
+    ).rejects.toThrow('unknown settlement');
+    expect(mocks.execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a non-envelope stderr failure', async () => {
+    mocks.execFile.mockImplementation((_file: string, _args: string[], _opts: unknown, cb: (e: null, so: string, se: string) => void) =>
+      cb(null, '', 'oops something broke'),
+    );
+    await expect(
+      createTask({ description: 'd', rewardUsdc: 5, durationHours: 24, confirmation: true }),
+    ).rejects.toThrow('oops something broke');
+  });
+});

--- a/integrations/taskmarket/src/__tests__/tools.test.ts
+++ b/integrations/taskmarket/src/__tests__/tools.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createTaskmarketTools } from '../tools.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('createTaskmarketTools', () => {
+  it('exposes the five tools with stable keys', () => {
+    const tools = createTaskmarketTools();
+    expect(Object.keys(tools)).toEqual([
+      'taskmarketListOpenTasks',
+      'taskmarketGetTask',
+      'taskmarketTrackTask',
+      'taskmarketCreateTask',
+      'taskmarketListSubmissions',
+    ]);
+  });
+
+  it('list tool execute hits the API and normalizes rewards', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            tasks: [
+              { id: '0x1', reward: '64000000', description: 'd', mode: 'bounty', status: 'open', submissionCount: 2, tags: [] },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    const tools = createTaskmarketTools();
+    const out = await tools.taskmarketListOpenTasks.execute({ limit: 20 });
+    expect(out.count).toBe(1);
+    expect((out.tasks[0] as Record<string, unknown>).rewardUsdc).toBe(64);
+  });
+
+  it('track tool returns live status fields', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: '0x1',
+            requester: '0xabc',
+            reward: '5000000',
+            mode: 'bounty',
+            status: 'open',
+            submissionCount: 7,
+            expiryTime: '2026-08-22T00:00:00.000Z',
+            tags: [],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    const tools = createTaskmarketTools();
+    const out = await tools.taskmarketTrackTask.execute({ taskId: '0x1' });
+    expect(out.status).toBe('open');
+    expect(out.rewardUsdc).toBe(5);
+    expect(out.submissionCount).toBe(7);
+    expect(out.requester).toBe('0xabc');
+  });
+
+  it('create task tool requires confirmation by default', async () => {
+    const tools = createTaskmarketTools();
+    const out = await tools.taskmarketCreateTask.execute({
+      description: 'd',
+      rewardUsdc: 5,
+      durationHours: 24,
+    });
+    expect(out.status).toBe('requires_confirmation');
+    expect((out.plan as Record<string, unknown>).maxSpendUsdc).toBe(10);
+  });
+});

--- a/integrations/taskmarket/src/api.ts
+++ b/integrations/taskmarket/src/api.ts
@@ -1,0 +1,174 @@
+/**
+ * Taskmarket REST client (read-only surfaces).
+ *
+ * All monetary values on the Taskmarket API are integer strings in base
+ * units (USDC = value / 1_000_000). The API supports `minReward` (base
+ * units) and `mode` as server-side filters.
+ */
+
+const DEFAULT_API_URL = 'https://api.taskmarket.dev/api';
+const USDC_DECIMALS = 1_000_000;
+const READ_TIMEOUT_MS = 30_000;
+
+export type TaskmarketApiOptions = {
+  /** Override the Taskmarket API base URL. Defaults to the public API. */
+  apiUrl?: string;
+};
+
+type JsonRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const toRecordArray = (value: unknown): JsonRecord[] => {
+  if (Array.isArray(value)) return value.filter(isRecord);
+  if (isRecord(value) && Array.isArray(value.tasks)) return value.tasks.filter(isRecord);
+  if (isRecord(value) && Array.isArray(value.submissions)) return value.submissions.filter(isRecord);
+  return [];
+};
+
+const optionalString = (value: unknown): string | undefined => {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text.length > 0 ? text : undefined;
+};
+
+const stringList = (value: unknown): string[] =>
+  Array.isArray(value) ? value.map(item => String(item)) : [];
+
+const rewardUsdcOf = (task: JsonRecord): number => {
+  const reward = Number(task.reward ?? 0);
+  return Number.isFinite(reward) ? reward / USDC_DECIMALS : 0;
+};
+
+export interface TaskmarketTask {
+  id: string;
+  description: string;
+  rewardUsdc: number;
+  mode: string;
+  status: string;
+  submissionCount: number;
+  expiryTime?: string;
+  tags: string[];
+  requester?: string;
+  requesterAgentId?: string;
+  pendingActions?: unknown;
+}
+
+const compactTask = (task: JsonRecord): TaskmarketTask => ({
+  id: optionalString(task.id) ?? '',
+  description: optionalString(task.description) ?? '',
+  rewardUsdc: rewardUsdcOf(task),
+  mode: optionalString(task.mode) ?? 'bounty',
+  status: optionalString(task.status) ?? 'open',
+  submissionCount: Number(task.submissionCount ?? 0),
+  expiryTime: optionalString(task.expiryTime),
+  tags: stringList(task.tags),
+  requester: optionalString(task.requester),
+  requesterAgentId: optionalString(task.requesterAgentId),
+  pendingActions: task.pendingActions ?? undefined,
+});
+
+export interface TaskmarketSubmission {
+  id: string;
+  workerAddress?: string;
+  submittedAt?: string;
+  deliverableUrl?: string;
+  deliverableHash?: string;
+}
+
+const compactSubmission = (submission: JsonRecord): TaskmarketSubmission => ({
+  id: optionalString(submission.id) ?? '',
+  workerAddress: optionalString(submission.workerAddress),
+  submittedAt: optionalString(submission.submittedAt),
+  deliverableUrl: optionalString(submission.fileUrl),
+  deliverableHash: optionalString(submission.deliverableHash),
+});
+
+async function fetchJson(url: string, timeoutMs = READ_TIMEOUT_MS): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(`Taskmarket API responded with HTTP ${response.status}`);
+    }
+    return (await response.json()) as unknown;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface ListTasksParams {
+  limit?: number;
+  minRewardUsdc?: number;
+  maxRewardUsdc?: number;
+  mode?: string;
+}
+
+export class TaskmarketClient {
+  private readonly apiUrl: string;
+
+  constructor(options: TaskmarketApiOptions = {}) {
+    this.apiUrl = (options.apiUrl ?? DEFAULT_API_URL).replace(/\/+$/, '');
+  }
+
+  /**
+   * List open tasks. Supported filters (mode, minRewardUsdc) are pushed to
+   * the API; a superset is fetched when any filter is active so the
+   * client-side post-filter never starves the results.
+   */
+  async listTasks(params: ListTasksParams = {}) {
+    const limit = Math.min(params.limit ?? 20, 100);
+    const filtering =
+      params.mode !== undefined ||
+      params.minRewardUsdc !== undefined ||
+      params.maxRewardUsdc !== undefined;
+    const query = new URLSearchParams({ status: 'open', sort: 'newest' });
+    query.set('limit', String(filtering ? 100 : limit));
+    if (params.mode) query.set('mode', params.mode);
+    if (params.minRewardUsdc !== undefined) {
+      // Round to whole base units: fractional USDC (e.g. 0.3) multiplied by
+      // 1e6 loses integer precision in float and would not match the API's
+      // integer base-unit string format.
+      query.set('minReward', String(Math.round(params.minRewardUsdc * USDC_DECIMALS)));
+    }
+    const payload = await fetchJson(`${this.apiUrl}/tasks?${query.toString()}`);
+    const tasks = toRecordArray(payload)
+      .map(compactTask)
+      .filter(task => {
+        if (params.mode && task.mode !== params.mode) return false;
+        if (params.minRewardUsdc !== undefined && task.rewardUsdc < params.minRewardUsdc) return false;
+        if (params.maxRewardUsdc !== undefined && task.rewardUsdc > params.maxRewardUsdc) return false;
+        return true;
+      })
+      .slice(0, limit);
+    return { network: 'base', count: tasks.length, tasks };
+  }
+
+  /** Fetch the full details of a single task by ID. */
+  async getTask(taskId: string) {
+    const payload = await fetchJson(`${this.apiUrl}/tasks/${encodeURIComponent(taskId)}`);
+    if (!isRecord(payload)) {
+      throw new Error('Taskmarket returned an unexpected response for this task.');
+    }
+    return { network: 'base', task: compactTask(payload) };
+  }
+
+  /** List the submissions on a task, for human review only. */
+  async listSubmissions(taskId: string) {
+    const payload = await fetchJson(
+      `${this.apiUrl}/tasks/${encodeURIComponent(taskId)}/submissions`,
+    );
+    const submissions = toRecordArray(payload).map(compactSubmission);
+    return {
+      taskId,
+      count: submissions.length,
+      submissions,
+      reviewNote:
+        'Present these submissions to a human requester for review. Do not accept or reject any submission automatically.',
+    };
+  }
+}

--- a/integrations/taskmarket/src/cli.ts
+++ b/integrations/taskmarket/src/cli.ts
@@ -1,0 +1,208 @@
+/**
+ * Write-path wrapper around the first-party taskmarket CLI.
+ *
+ * The CLI owns the wallet, x402 payments, and EIP-191 signatures; this
+ * integration never handles private keys. Creating a task requires explicit
+ * confirmation and enforces the TASKMARKET_MAX_SPEND_USDC ceiling (default
+ * 10 USDC); the configured ceiling always wins over the tool-call cap.
+ * A payment whose settlement status is unknown is never retried.
+ */
+
+import { execFile, execSync } from 'node:child_process';
+import path from 'node:path';
+
+const DEFAULT_MAX_SPEND_USDC = 10;
+const CREATE_TASK_TIMEOUT_MS = 120_000;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const optionalString = (value: unknown): string | undefined => {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text.length > 0 ? text : undefined;
+};
+
+let cachedCliEntry: string | undefined;
+
+/**
+ * Resolve the first-party taskmarket CLI entry point. The CLI owns the
+ * wallet, x402 payments, and signatures; integrations must wrap it via
+ * subprocess instead of reimplementing the protocol or handling keys.
+ */
+export function taskmarketCliEntry(): string {
+  if (cachedCliEntry) return cachedCliEntry;
+  const globalRoot = execSync('npm root -g', {
+    encoding: 'utf8',
+    windowsHide: true,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+  cachedCliEntry = path.join(
+    globalRoot,
+    '@lucid-agents',
+    'taskmarket',
+    'dist',
+    'index.js',
+  );
+  return cachedCliEntry;
+}
+
+const execFileAsync = (
+  file: string,
+  args: ReadonlyArray<string>,
+  options: { timeout: number; encoding: 'utf8'; windowsHide: boolean },
+): Promise<{ stdout: string; stderr: string }> =>
+  new Promise((resolve, reject) => {
+    execFile(file, [...args], options, (error, stdout, stderr) => {
+      if (error) {
+        reject(
+          Object.assign(error, {
+            ...(stdout ? { stdout } : {}),
+            ...(stderr ? { stderr } : {}),
+          }),
+        );
+        return;
+      }
+      resolve({ stdout: stdout ?? '', stderr: stderr ?? '' });
+    });
+  });
+
+async function runTaskmarketCli(
+  args: ReadonlyArray<string>,
+  timeoutMs: number,
+): Promise<{ readonly stdout: string; readonly stderr: string }> {
+  try {
+    const { stdout, stderr = '' } = await execFileAsync(
+      process.execPath,
+      [taskmarketCliEntry(), ...args],
+      { timeout: timeoutMs, encoding: 'utf8', windowsHide: true },
+    );
+    return { stdout, stderr };
+  } catch (error) {
+    const err = error as {
+      code?: string;
+      stdout?: string;
+      stderr?: string;
+      message?: string;
+    };
+    if (err.code === 'ENOENT') {
+      throw new Error(
+        'The taskmarket CLI is not installed. Install it with: npm install -g @lucid-agents/taskmarket',
+      );
+    }
+    if (err.code === 'ETIMEDOUT') {
+      throw new Error(
+        `The taskmarket CLI timed out after ${Math.round(timeoutMs / 1000)} seconds. ` +
+          'The settlement status is unknown. Do NOT retry the payment; verify on Taskmarket whether the task was created before taking any further action.',
+      );
+    }
+    const stderrText = String(err.stderr ?? '').trim();
+    if (stderrText) {
+      let pending = false;
+      try {
+        const envelope = JSON.parse(stderrText) as unknown;
+        if (isRecord(envelope) && envelope.pending === true) {
+          pending = true;
+        }
+      } catch {
+        // not a JSON envelope; report stderr as-is
+      }
+      if (pending) {
+        throw new Error(
+          'The taskmarket CLI reported an in-flight write with unknown settlement. Do NOT retry the payment; verify the task on Taskmarket before taking any further action.',
+        );
+      }
+      throw new Error(`The taskmarket CLI failed: ${stderrText}`);
+    }
+    throw new Error(`The taskmarket CLI failed: ${err.message ?? 'unknown error'}`);
+  }
+}
+
+export interface CreateTaskInput {
+  description: string;
+  rewardUsdc: number;
+  durationHours: number;
+  maxSpendUsdc?: number;
+  confirmation: boolean;
+}
+
+export interface CreateTaskResult {
+  status: 'requires_confirmation' | 'submitted';
+  taskId?: string;
+  plan: Record<string, unknown>;
+  message?: string;
+}
+
+export async function createTask(input: CreateTaskInput): Promise<CreateTaskResult> {
+  const envMax = Number(process.env.TASKMARKET_MAX_SPEND_USDC ?? '');
+  const envCeiling =
+    Number.isFinite(envMax) && envMax > 0 ? envMax : DEFAULT_MAX_SPEND_USDC;
+  // The configured ceiling always wins: the tool-call cap can only lower it,
+  // never raise it (hard spending gate).
+  const maxSpendUsdc = Math.min(input.maxSpendUsdc ?? envCeiling, envCeiling);
+
+  const plan: Record<string, unknown> = {
+    description: input.description,
+    rewardUsdc: input.rewardUsdc,
+    durationHours: input.durationHours,
+    network: 'base',
+    maxSpendUsdc,
+  };
+
+  if (!input.confirmation) {
+    return {
+      status: 'requires_confirmation',
+      plan,
+      message:
+        'Creating this task spends real USDC on the Base network from the wallet managed by the taskmarket CLI. Call this tool again with confirmation: true to proceed.',
+    };
+  }
+
+  if (input.rewardUsdc > maxSpendUsdc) {
+    throw new Error(
+      `Reward of ${input.rewardUsdc} USDC exceeds the spending limit of ${maxSpendUsdc} USDC (TASKMARKET_MAX_SPEND_USDC). Refusing to create the task.`,
+    );
+  }
+
+  const args = [
+    'task',
+    'create',
+    '--description',
+    input.description,
+    '--reward',
+    String(input.rewardUsdc),
+    '--duration',
+    String(input.durationHours),
+  ];
+  const { stdout, stderr } = await runTaskmarketCli(args, CREATE_TASK_TIMEOUT_MS);
+
+  let taskId: string | undefined;
+  try {
+    const envelope = JSON.parse(stdout) as unknown;
+    if (isRecord(envelope) && envelope.ok === true && isRecord(envelope.data)) {
+      taskId = optionalString(envelope.data.taskId ?? envelope.data.id);
+    }
+  } catch {
+    // fall through to the pending/error path below
+  }
+  if (!taskId) {
+    let pending = false;
+    try {
+      const errorEnvelope = JSON.parse(stderr) as unknown;
+      if (isRecord(errorEnvelope) && errorEnvelope.pending === true) {
+        pending = true;
+      }
+    } catch {
+      // not a JSON envelope; report stderr as-is
+    }
+    if (pending) {
+      throw new Error(
+        'The taskmarket CLI reported an in-flight write with unknown settlement. Do NOT retry the payment; verify the task on Taskmarket before taking any further action.',
+      );
+    }
+    throw new Error(
+      `The taskmarket CLI did not return a created task ID. stderr: ${stderr.trim() || '(empty)'}`,
+    );
+  }
+
+  return { status: 'submitted', taskId, plan };
+}

--- a/integrations/taskmarket/src/index.ts
+++ b/integrations/taskmarket/src/index.ts
@@ -1,0 +1,21 @@
+export {
+  TaskmarketClient,
+  type TaskmarketApiOptions,
+  type ListTasksParams,
+  type TaskmarketTask,
+  type TaskmarketSubmission,
+} from './api.js';
+export {
+  createTask,
+  taskmarketCliEntry,
+  type CreateTaskInput,
+  type CreateTaskResult,
+} from './cli.js';
+export {
+  createTaskmarketTools,
+  createTaskmarketListTasksTool,
+  createTaskmarketGetTaskTool,
+  createTaskmarketTrackTaskTool,
+  createTaskmarketCreateTaskTool,
+  createTaskmarketListSubmissionsTool,
+} from './tools.js';

--- a/integrations/taskmarket/src/tools.ts
+++ b/integrations/taskmarket/src/tools.ts
@@ -1,0 +1,220 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { TaskmarketClient, type TaskmarketApiOptions } from './api.js';
+import { createTask } from './cli.js';
+
+const taskIdSchema = z.object({
+  taskId: z
+    .string()
+    .min(1)
+    .describe('Taskmarket task ID (0x-prefixed 32-byte hex string).'),
+});
+
+const listTasksInputSchema = z.object({
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe('Maximum number of open tasks to return.'),
+  minRewardUsdc: z
+    .number()
+    .min(0)
+    .optional()
+    .describe('Only return tasks with a reward of at least this many USDC.'),
+  maxRewardUsdc: z
+    .number()
+    .min(0)
+    .optional()
+    .describe('Only return tasks with a reward of at most this many USDC.'),
+  mode: z
+    .enum(['bounty', 'claim', 'pitch', 'benchmark', 'auction'])
+    .optional()
+    .describe('Only return tasks of this mode.'),
+});
+
+const createTaskInputSchema = z.object({
+  description: z
+    .string()
+    .min(1)
+    .describe('Exact task description the requester wants done.'),
+  rewardUsdc: z
+    .number()
+    .positive()
+    .describe('Reward in USDC, paid from the wallet managed by the taskmarket CLI.'),
+  durationHours: z
+    .number()
+    .positive()
+    .describe('Task duration in hours before it expires.'),
+  maxSpendUsdc: z
+    .number()
+    .positive()
+    .optional()
+    .describe(
+      'Hard cap on the reward for this call. Cannot exceed the TASKMARKET_MAX_SPEND_USDC environment variable (default 10 USDC); the configured ceiling always wins.',
+    ),
+  confirmation: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Must be true to create the task. Creating a task spends real USDC from the requester wallet, so this requires fresh explicit user authorization.',
+    ),
+});
+
+const taskOutputSchema = z.object({
+  id: z.string(),
+  description: z.string(),
+  rewardUsdc: z.number(),
+  mode: z.string(),
+  status: z.string(),
+  submissionCount: z.number(),
+  expiryTime: z.string().optional(),
+  tags: z.array(z.string()),
+  requester: z.string().optional(),
+  requesterAgentId: z.string().optional(),
+  pendingActions: z.unknown().optional(),
+});
+
+const submissionOutputSchema = z.object({
+  id: z.string(),
+  workerAddress: z.string().optional(),
+  submittedAt: z.string().optional(),
+  deliverableUrl: z.string().optional(),
+  deliverableHash: z.string().optional(),
+});
+
+const listTasksOutputSchema = z.object({
+  network: z.string(),
+  count: z.number(),
+  tasks: z.array(taskOutputSchema),
+});
+
+export function createTaskmarketListTasksTool(config?: TaskmarketApiOptions) {
+  let client: TaskmarketClient | null = null;
+  const getClient = () => {
+    if (!client) client = new TaskmarketClient(config);
+    return client;
+  };
+  return createTool({
+    id: 'taskmarket-list-open-tasks',
+    description:
+      'List open tasks on Taskmarket (Base network, USDC rewards). Optionally filter by minimum or maximum reward and by task mode.',
+    inputSchema: listTasksInputSchema,
+    outputSchema: listTasksOutputSchema,
+    execute: async input => getClient().listTasks(input),
+  });
+}
+
+export function createTaskmarketGetTaskTool(config?: TaskmarketApiOptions) {
+  let client: TaskmarketClient | null = null;
+  const getClient = () => {
+    if (!client) client = new TaskmarketClient(config);
+    return client;
+  };
+  return createTool({
+    id: 'taskmarket-get-task',
+    description:
+      'Fetch the full details of a single Taskmarket task on Base by its task ID.',
+    inputSchema: taskIdSchema,
+    outputSchema: z.object({
+      network: z.string(),
+      task: taskOutputSchema,
+    }),
+    execute: async input => getClient().getTask(input.taskId),
+  });
+}
+
+export function createTaskmarketTrackTaskTool(config?: TaskmarketApiOptions) {
+  let client: TaskmarketClient | null = null;
+  const getClient = () => {
+    if (!client) client = new TaskmarketClient(config);
+    return client;
+  };
+  return createTool({
+    id: 'taskmarket-track-task',
+    description:
+      'Re-fetch a Taskmarket task by ID and return its live status, reward, expiry, and submission count. Use this to check a task you created.',
+    inputSchema: taskIdSchema,
+    outputSchema: z.object({
+      taskId: z.string(),
+      status: z.string(),
+      rewardUsdc: z.number(),
+      expiryTime: z.string().optional(),
+      submissionCount: z.number(),
+      mode: z.string(),
+      requester: z.string().optional(),
+      requesterAgentId: z.string().optional(),
+      pendingActions: z.unknown().optional(),
+    }),
+    execute: async input => {
+      const { task } = await getClient().getTask(input.taskId);
+      return {
+        taskId: task.id,
+        status: task.status,
+        rewardUsdc: task.rewardUsdc,
+        expiryTime: task.expiryTime,
+        submissionCount: task.submissionCount,
+        mode: task.mode,
+        requester: task.requester,
+        requesterAgentId: task.requesterAgentId,
+        pendingActions: task.pendingActions,
+      };
+    },
+  });
+}
+
+export function createTaskmarketListSubmissionsTool(config?: TaskmarketApiOptions) {
+  let client: TaskmarketClient | null = null;
+  const getClient = () => {
+    if (!client) client = new TaskmarketClient(config);
+    return client;
+  };
+  return createTool({
+    id: 'taskmarket-list-submissions',
+    description:
+      'List the submissions on a Taskmarket task and present them for human review. Never accepts or rejects work automatically; a human requester decides.',
+    inputSchema: taskIdSchema,
+    outputSchema: z.object({
+      taskId: z.string(),
+      count: z.number(),
+      submissions: z.array(submissionOutputSchema),
+      reviewNote: z.string(),
+    }),
+    execute: async input => getClient().listSubmissions(input.taskId),
+  });
+}
+
+export function createTaskmarketCreateTaskTool() {
+  return createTool({
+    id: 'taskmarket-create-task',
+    description:
+      'Create a funded task on Taskmarket (Base, USDC) as a requester through the first-party taskmarket CLI. Requires explicit confirmation, shows the exact plan, and enforces the TASKMARKET_MAX_SPEND_USDC spending limit (default 10 USDC; the configured ceiling always wins). Never retries a payment whose settlement status is unknown.',
+    inputSchema: createTaskInputSchema,
+    outputSchema: z.object({
+      status: z.string(),
+      taskId: z.string().optional(),
+      plan: z.record(z.string(), z.unknown()).optional(),
+      message: z.string().optional(),
+    }),
+    execute: async input =>
+      createTask({
+        description: input.description,
+        rewardUsdc: input.rewardUsdc,
+        durationHours: input.durationHours,
+        maxSpendUsdc: input.maxSpendUsdc,
+        confirmation: input.confirmation,
+      }),
+  });
+}
+
+export function createTaskmarketTools(config?: TaskmarketApiOptions) {
+  return {
+    taskmarketListOpenTasks: createTaskmarketListTasksTool(config),
+    taskmarketGetTask: createTaskmarketGetTaskTool(config),
+    taskmarketTrackTask: createTaskmarketTrackTaskTool(config),
+    taskmarketCreateTask: createTaskmarketCreateTaskTool(),
+    taskmarketListSubmissions: createTaskmarketListSubmissionsTool(config),
+  };
+}

--- a/integrations/taskmarket/tsconfig.build.json
+++ b/integrations/taskmarket/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/taskmarket/tsconfig.json
+++ b/integrations/taskmarket/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsdown.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/taskmarket/tsdown.config.ts
+++ b/integrations/taskmarket/tsdown.config.ts
@@ -1,0 +1,16 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  fixedExtension: false,
+  nodeProtocol: 'strip',
+  clean: true,
+  dts: false,
+  treeshake: true,
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/integrations/taskmarket/turbo.json
+++ b/integrations/taskmarket/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://v2-9-16.turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsdown.config.ts",
+        "tsconfig.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    }
+  }
+}

--- a/integrations/taskmarket/vitest.config.ts
+++ b/integrations/taskmarket/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:integrations/taskmarket',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2255,6 +2255,30 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
 
+  integrations/taskmarket:
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      tsdown:
+        specifier: 0.22.9
+        version: 0.22.9(@volar/typescript@2.4.23)(oxc-resolver@11.20.0)(tsx@4.23.1)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+
   integrations/tavily:
     dependencies:
       '@tavily/core':


### PR DESCRIPTION
Fixes #21612

## What

Adds `@mastra/taskmarket`, a new integration package letting Mastra agents browse, create, and manage tasks on [Taskmarket](https://taskmarket.dev), an onchain agent task marketplace paying USDC on Base.

## Tools

| Tool | Read/Write | Description |
| --- | --- | --- |
| `taskmarketListOpenTasks` | read | Open tasks, filtered by mode and reward range |
| `taskmarketGetTask` | read | Full task details by ID |
| `taskmarketTrackTask` | read | Live status, reward, expiry, submission count |
| `taskmarketListSubmissions` | read | Submissions for human review (never auto-accepts) |
| `taskmarketCreateTask` | write | Funded task via the first-party CLI, explicit confirmation + hard spend cap |

## Safety design

- Read-only tools use the public Taskmarket REST API; the write path wraps the first-party `@lucid-agents/taskmarket` CLI via subprocess. The integration never handles private keys, seeds, or tokens.
- `taskmarketCreateTask` requires fresh explicit `confirmation: true` and enforces `TASKMARKET_MAX_SPEND_USDC` (default 10 USDC); the configured ceiling always wins over the per-call cap.
- Unknown settlement (`pending`) always throws; payments are never blindly retried.
- Submissions are presented for human review only.

## Verification

- `vitest`: 18 tests pass (api client, CLI write path with mocked subprocess, tool factories)
- `tsc --noEmit`: clean
- Docs page + integrations sidebar entry + changeset included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets Mastra agents find, inspect, track, and create paid tasks on Taskmarket. It keeps payments and wallet security in the Taskmarket CLI and requires confirmation before spending USDC.

## Changes

- Adds the `@mastra/taskmarket` integration package.
- Adds five tools:
  - `taskmarketListOpenTasks`
  - `taskmarketGetTask`
  - `taskmarketTrackTask`
  - `taskmarketListSubmissions`
  - `taskmarketCreateTask`
- Adds a read-only REST client with task filters, reward conversion, task tracking, and submission listing.
- Adds CLI-based task creation with:
  - Explicit confirmation.
  - A configurable `TASKMARKET_MAX_SPEND_USDC` limit.
  - A default spending limit of 10 USDC.
  - Pending-settlement handling without automatic retries.
- Keeps private keys, seeds, and tokens outside the integration.
- Prevents automatic submission acceptance.
- Adds package documentation and a documentation sidebar entry.
- Adds 18 Vitest tests covering API behavior, CLI safety, tool behavior, and error handling.
- Adds TypeScript, ESLint, Vitest, Turborepo, build, and changeset configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->