### PR TITLE
fix(memory): honor null-as-delete on first write in working memory merge

### DIFF
--- a/.changeset/tidy-working-memory-null-merge.md
+++ b/.changeset/tidy-working-memory-null-merge.md
@@ -1,0 +1,25 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed schema-based working memory persisting `null` placeholders as literal nulls.
+
+Strict-mode providers (such as OpenAI structured outputs) pad fields they are not updating with `null`, and the working memory merge treats `null` as "delete this field". That worked when the field already existed, but on a first write — or when a nested object was being created for the first time — the padded nulls were stored literally instead of being dropped. So a brand-new working memory could be saved as `{ "role": null }`, and new nested objects kept their `null` placeholders.
+
+Now `null` consistently deletes the field regardless of whether the target already existed, matching the tool's documented contract. The merge also no longer returns the caller's update object by reference on a first write.
+
+```ts
+import { deepMergeWorkingMemory } from '@mastra/memory';
+
+// Before: null placeholders survived when there was nothing to merge into
+deepMergeWorkingMemory(null, { name: 'Ada', role: null });
+// => { name: 'Ada', role: null }
+deepMergeWorkingMemory({ name: 'Ada' }, { work: { company: 'Acme', manager: null } });
+// => { name: 'Ada', work: { company: 'Acme', manager: null } }
+
+// After: null consistently deletes the field
+deepMergeWorkingMemory(null, { name: 'Ada', role: null });
+// => { name: 'Ada' }
+deepMergeWorkingMemory({ name: 'Ada' }, { work: { company: 'Acme', manager: null } });
+// => { name: 'Ada', work: { company: 'Acme' } }
+```

--- a/packages/memory/src/tools/working-memory.test.ts
+++ b/packages/memory/src/tools/working-memory.test.ts
@@ -97,6 +97,34 @@ describe('deepMergeWorkingMemory', () => {
 
       expect(result).toEqual({ a: 1, c: 3 });
     });
+
+    // Strict-mode providers (e.g. OpenAI) pad omitted fields with `null`. The merge
+    // treats `null` as "delete", but on a first write there is no existing object to
+    // merge into, so the padded nulls must be dropped rather than persisted as literal
+    // nulls. Otherwise the very first working-memory write stores `{ "field": null }`.
+    it('should drop null placeholders on a first write (existing is null)', () => {
+      const result = deepMergeWorkingMemory(null, { name: 'Charlie', role: null });
+
+      expect(result).toEqual({ name: 'Charlie' });
+      expect('role' in result).toBe(false);
+    });
+
+    it('should drop null placeholders on a first write (existing is undefined)', () => {
+      const result = deepMergeWorkingMemory(undefined, { status: 'active', archivedAt: null });
+
+      expect(result).toEqual({ status: 'active' });
+      expect('archivedAt' in result).toBe(false);
+    });
+
+    it('should not return the update object by reference on a first write', () => {
+      const update = { name: 'Charlie' };
+      const result = deepMergeWorkingMemory(null, update);
+
+      // A shared reference would let a later mutation of the stored memory leak back
+      // into the caller's object (and vice versa).
+      expect(result).not.toBe(update);
+      expect(result).toEqual({ name: 'Charlie' });
+    });
   });
 
   describe('nested object merging', () => {
@@ -153,6 +181,28 @@ describe('deepMergeWorkingMemory', () => {
         name: 'Alice',
         work: { company: 'Acme', role: 'Engineer' },
       });
+    });
+
+    // A brand-new nested object can also carry `null` placeholders from strict-mode
+    // providers. Since the property is being created, there is nothing to delete, so
+    // the nulls must be dropped instead of persisted inside the new object.
+    it('should drop null placeholders inside a brand-new nested object', () => {
+      const existing = { name: 'Alice' };
+      const update = { work: { company: 'Acme', role: 'Engineer', manager: null } };
+      const result = deepMergeWorkingMemory(existing, update);
+
+      expect(result).toEqual({
+        name: 'Alice',
+        work: { company: 'Acme', role: 'Engineer' },
+      });
+    });
+
+    it('should drop null placeholders when an object replaces a non-object value', () => {
+      const existing = { profile: 'unknown' };
+      const update = { profile: { name: 'Alice', nickname: null } };
+      const result = deepMergeWorkingMemory(existing, update);
+
+      expect(result).toEqual({ profile: { name: 'Alice' } });
     });
   });
 

--- a/packages/memory/src/tools/working-memory.ts
+++ b/packages/memory/src/tools/working-memory.ts
@@ -27,11 +27,15 @@ export function deepMergeWorkingMemory(
     return existing && typeof existing === 'object' ? { ...existing } : {};
   }
 
-  if (!existing || typeof existing !== 'object') {
-    return update;
-  }
-
-  const result: Record<string, unknown> = { ...existing };
+  // Start from a shallow copy of the existing object when there is one, or from
+  // an empty object on a first write / when the existing side is not a mergeable
+  // object. The update is always applied key-by-key below (rather than returned
+  // wholesale) so that `null` consistently deletes and nested objects are merged
+  // regardless of whether the target branch already existed. Returning the raw
+  // update here instead would persist its `null` placeholders as literal nulls
+  // and leak the caller's object by reference.
+  const result: Record<string, unknown> =
+    existing && typeof existing === 'object' && !Array.isArray(existing) ? { ...existing } : {};
 
   for (const key of Object.keys(update)) {
     const updateValue = update[key];
@@ -50,18 +54,15 @@ export function deepMergeWorkingMemory(
     else if (Array.isArray(updateValue)) {
       result[key] = updateValue;
     }
-    // Recursively merge nested objects
-    else if (
-      typeof updateValue === 'object' &&
-      updateValue !== null &&
-      typeof existingValue === 'object' &&
-      existingValue !== null &&
-      !Array.isArray(existingValue)
-    ) {
-      result[key] = deepMergeWorkingMemory(
-        existingValue as Record<string, unknown>,
-        updateValue as Record<string, unknown>,
-      );
+    // Recursively merge nested objects. Recurse even when there is no existing
+    // object to merge into, so `null` placeholders inside a brand-new nested
+    // object are deleted rather than persisted as literal nulls.
+    else if (typeof updateValue === 'object') {
+      const base =
+        existingValue && typeof existingValue === 'object' && !Array.isArray(existingValue)
+          ? (existingValue as Record<string, unknown>)
+          : undefined;
+      result[key] = deepMergeWorkingMemory(base, updateValue as Record<string, unknown>);
     }
     // Primitive values or new properties: just set them
     else {


### PR DESCRIPTION
## Description

Schema-based working memory merges partial updates into the stored object and treats `null` as "delete this field" — strict-mode providers (e.g. OpenAI structured outputs) pad the fields they aren't updating with `null`, so the merge has to drop them.

That contract was only honored when the target branch already existed. In `deepMergeWorkingMemory` (`packages/memory/src/tools/working-memory.ts`), when `existing` was `null`/`undefined` it did `return update` verbatim, and when a nested object had no existing counterpart the update object was assigned wholesale — so in both cases the per-key `null → delete` handling was skipped. As a result a first write could be stored as `{ "role": null }`, and brand-new nested objects kept their `null` placeholders. Returning `update` by reference also aliased the caller's object into stored memory.

**Fix:** apply the update key-by-key from an empty base in those cases and recurse into new nested objects, so `null` consistently deletes the field regardless of whether the target already existed, and the caller's `update` object is no longer returned by reference on a first write.

```ts
// Before
deepMergeWorkingMemory(null, { name: 'Ada', role: null });
// => { name: 'Ada', role: null }

// After
deepMergeWorkingMemory(null, { name: 'Ada', role: null });
// => { name: 'Ada' }
```

Existing behavior is unchanged when the field/branch already exists (`null` still deletes, arrays still replace entirely, omitted/`undefined` fields still preserve existing data).

**Tests:** added unit tests in `working-memory.test.ts` for first-write null padding (`existing` `null` and `undefined`), `null` placeholders inside a brand-new nested object, replacing a non-object value with an object carrying a padded `null`, and the no-shared-reference guarantee. Full file passes locally (`36 passed`), typecheck passes, and a `@mastra/memory` patch changeset is included.

## Related issue(s)

Fixes #21616

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When memory data uses `null` to mark fields for removal, the merge now removes those fields correctly, even during the first save or inside new objects. The saved result also stays separate from the caller’s input.

## Changes

- Updated `deepMergeWorkingMemory` to:
  - Apply updates key by key from an empty base.
  - Remove `null` placeholders during first writes.
  - Recursively process new nested objects.
  - Replace non-object values with objects when required.
  - Preserve array replacement behavior.
  - Prevent shared references between updates and merged results.
- Added tests for:
  - First-write null removal.
  - Nested null placeholders.
  - Nested object creation and replacement.
  - First-write reference isolation.
- Added a changeset for `@mastra/memory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->