### PR TITLE
fix(core): add opt-in error strategy for delegation lifecycle hooks

### DIFF
--- a/.changeset/delegation-hook-error-strategy.md
+++ b/.changeset/delegation-hook-error-strategy.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': minor
+---
+
+Added `hookErrorStrategy` to `DelegationConfig`, an opt-in strategy for how errors thrown by the `onDelegationStart` and `onDelegationComplete` delegation lifecycle hooks are handled.
+
+Previously, both hooks silently logged a thrown error and continued as if the hook had not thrown — a throwing `onDelegationStart` could never actually block a delegation, and a throwing `onDelegationComplete` left the delegation looking successful even though the hook's own result handling never ran. This default ("warn") behavior is unchanged.
+
+Setting `hookErrorStrategy: 'throw'` opts into fail-closed behavior: a throwing `onDelegationStart` now aborts the delegation before the sub-agent is invoked, and a throwing `onDelegationComplete` marks the delegation as failed, propagating the hook's error the same way a sub-agent execution failure would.

--- a/packages/core/src/agent/__tests__/delegation-hook-error-strategy.test.ts
+++ b/packages/core/src/agent/__tests__/delegation-hook-error-strategy.test.ts
@@ -1,0 +1,268 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { Agent } from '../agent';
+
+/**
+ * Coverage for `DelegationConfig.hookErrorStrategy`.
+ *
+ * Delegation lifecycle hooks (`onDelegationStart`, `onDelegationComplete`) run
+ * inside a try/catch that, by default, only logs a throwing hook and continues
+ * ("fail-open"). `hookErrorStrategy: 'throw'` opts into fail-closed behavior:
+ * a throwing `onDelegationStart` aborts the delegation, and a throwing
+ * `onDelegationComplete` marks the delegation as failed.
+ *
+ * Related: https://github.com/mastra-ai/mastra/issues/21624
+ */
+
+/** Sub-agent that immediately answers with fixed text, no tool calls. */
+function buildSubAgent() {
+  const model = new MockLanguageModelV2({
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'sub-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'sub-t' },
+        { type: 'text-delta', id: 'sub-t', delta: 'Sub-agent result.' },
+        { type: 'text-end', id: 'sub-t' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+      ] as any),
+    }),
+  });
+
+  return new Agent({
+    id: 'sub-agent',
+    name: 'Sub Agent',
+    description: 'Answers directly.',
+    instructions: 'Answer directly.',
+    model,
+  });
+}
+
+/** Sub-agent whose model call always fails, so the delegation itself fails. */
+function buildFailingSubAgent() {
+  const model = new MockLanguageModelV2({
+    doStream: async () => {
+      throw new Error('sub-agent model boom');
+    },
+  });
+
+  return new Agent({
+    id: 'sub-agent',
+    name: 'Sub Agent',
+    description: 'Always fails.',
+    instructions: 'Always fails.',
+    model,
+  });
+}
+
+/**
+ * Supervisor whose first turn delegates once to the sub-agent, then reports
+ * completion on the following turn once the delegation's tool result is seen.
+ */
+function buildSupervisor(subAgent: Agent) {
+  let step = 0;
+  const model = new MockLanguageModelV2({
+    doStream: async () => {
+      step += 1;
+      const chunks =
+        step === 1
+          ? [
+              {
+                type: 'tool-call',
+                toolCallId: 'sup-tc-1',
+                toolName: 'agent-subAgent',
+                input: JSON.stringify({ prompt: 'Delegate this.' }),
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              },
+            ]
+          : [
+              { type: 'text-start', id: 'sup-final-t' },
+              { type: 'text-delta', id: 'sup-final-t', delta: 'Sub-agent result acknowledged.' },
+              { type: 'text-end', id: 'sup-final-t' },
+              { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+            ];
+
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: `sup-${step}`, modelId: 'mock-model-id', timestamp: new Date(0) },
+          ...chunks,
+        ] as any),
+      };
+    },
+  });
+
+  return new Agent({
+    id: 'supervisor',
+    name: 'Supervisor',
+    instructions: 'Delegate to the sub agent.',
+    model,
+    agents: { subAgent },
+  });
+}
+
+function buildSupervisorAgent(subAgent: Agent, storage: InMemoryStore = new InMemoryStore()) {
+  const sup = buildSupervisor(subAgent);
+  const mastra = new Mastra({ agents: { supervisor: sup }, logger: false, storage });
+  return mastra.getAgent('supervisor');
+}
+
+describe('DelegationConfig.hookErrorStrategy', () => {
+  describe('default ("warn") — unchanged from pre-existing behavior', () => {
+    it('a throwing onDelegationStart is logged and the delegation still proceeds', async () => {
+      const subAgent = buildSubAgent();
+      const supervisor = buildSupervisorAgent(subAgent);
+      const errorSpy = vi.fn();
+      // @ts-expect-error - internal test hook into the Mastra logger for assertions
+      supervisor.logger.error = errorSpy;
+
+      const stream = await supervisor.stream('Delegate this.', {
+        maxSteps: 4,
+        delegation: {
+          onDelegationStart: () => {
+            throw new Error('start hook boom');
+          },
+        },
+      });
+
+      const text = await stream.text;
+      expect(text).toContain('Sub-agent result');
+      expect(errorSpy).toHaveBeenCalledWith('onDelegationStart hook error', expect.objectContaining({}));
+    });
+
+    it('a throwing onDelegationComplete is logged and the delegation result is still returned', async () => {
+      const subAgent = buildSubAgent();
+      const supervisor = buildSupervisorAgent(subAgent);
+      const errorSpy = vi.fn();
+      // @ts-expect-error - internal test hook into the Mastra logger for assertions
+      supervisor.logger.error = errorSpy;
+
+      const stream = await supervisor.stream('Delegate this.', {
+        maxSteps: 4,
+        delegation: {
+          onDelegationComplete: () => {
+            throw new Error('complete hook boom');
+          },
+        },
+      });
+
+      const text = await stream.text;
+      expect(text).toContain('Sub-agent result');
+      expect(errorSpy).toHaveBeenCalledWith('onDelegationComplete hook error', expect.objectContaining({}));
+    });
+  });
+
+  describe("'throw' strategy", () => {
+    it('a throwing onDelegationStart aborts the delegation instead of proceeding', async () => {
+      const subAgent = buildSubAgent();
+      const supervisor = buildSupervisorAgent(subAgent);
+
+      const stream = await supervisor.stream('Delegate this.', {
+        maxSteps: 4,
+        delegation: {
+          hookErrorStrategy: 'throw',
+          onDelegationStart: () => {
+            throw new Error('start hook boom');
+          },
+        },
+      });
+
+      // The delegation aborts before invoking the sub-agent: the tool call
+      // surfaces as a tool-error chunk instead of a successful tool-result.
+      const toolErrorChunks: any[] = [];
+      const toolResultChunks: any[] = [];
+      for await (const chunk of stream.fullStream) {
+        if (chunk.type === 'tool-error') toolErrorChunks.push(chunk);
+        if (chunk.type === 'tool-result') toolResultChunks.push(chunk);
+      }
+      expect(toolErrorChunks.length).toBeGreaterThan(0);
+      expect(toolErrorChunks[0].payload.error.message).toMatch(/onDelegationStart hook threw/i);
+      // The sub-agent's own tool-result must never appear: the abort happens
+      // before the sub-agent is invoked.
+      expect(toolResultChunks.some(c => c.payload?.toolName === 'agent-subAgent')).toBe(false);
+    });
+
+    it('a throwing onDelegationComplete marks the delegation as failed, propagating the hook error', async () => {
+      const subAgent = buildSubAgent();
+      const supervisor = buildSupervisorAgent(subAgent);
+
+      const stream = await supervisor.stream('Delegate this.', {
+        maxSteps: 4,
+        delegation: {
+          hookErrorStrategy: 'throw',
+          onDelegationComplete: () => {
+            throw new Error('complete hook boom');
+          },
+        },
+      });
+
+      const toolErrorChunks: any[] = [];
+      for await (const chunk of stream.fullStream) {
+        if (chunk.type === 'tool-error') toolErrorChunks.push(chunk);
+      }
+      expect(toolErrorChunks.length).toBeGreaterThan(0);
+      // The delegation is marked failed the same way a sub-agent execution
+      // failure would propagate: the top-level message is the generic
+      // "failed agent tool execution" text, with the hook's own error
+      // preserved down the cause chain.
+      const error = toolErrorChunks[0].payload.error;
+      expect(error.message).toMatch(/Failed agent tool execution/i);
+      expect(JSON.stringify(error)).toContain('complete hook boom');
+    });
+
+    it('does not invoke onDelegationComplete a second time when it already threw', async () => {
+      const subAgent = buildSubAgent();
+      const supervisor = buildSupervisorAgent(subAgent);
+      const completeSpy = vi.fn(() => {
+        throw new Error('complete hook boom');
+      });
+
+      const stream = await supervisor.stream('Delegate this.', {
+        maxSteps: 4,
+        delegation: {
+          hookErrorStrategy: 'throw',
+          onDelegationComplete: completeSpy,
+        },
+      });
+
+      for await (const _chunk of stream.fullStream) {
+        // Drain the stream so the delegation runs to completion.
+      }
+      expect(completeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('when the sub-agent itself fails AND onDelegationComplete throws, the hook error is surfaced instead of silently logged', async () => {
+      const failingSubAgent = buildFailingSubAgent();
+      const supervisor = buildSupervisorAgent(failingSubAgent);
+
+      const stream = await supervisor.stream('Delegate this.', {
+        maxSteps: 4,
+        delegation: {
+          hookErrorStrategy: 'throw',
+          onDelegationComplete: () => {
+            throw new Error('complete hook boom on failure path');
+          },
+        },
+      });
+
+      const toolErrorChunks: any[] = [];
+      for await (const chunk of stream.fullStream) {
+        if (chunk.type === 'tool-error') toolErrorChunks.push(chunk);
+      }
+      expect(toolErrorChunks.length).toBeGreaterThan(0);
+      // The hook's own error is preserved in the propagated failure instead
+      // of being silently logged and discarded.
+      expect(JSON.stringify(toolErrorChunks[0].payload.error)).toContain('complete hook boom on failure path');
+    });
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4870,6 +4870,26 @@ export class Agent<
               try {
                 startResult = await delegation.onDelegationStart(delegationStartContext);
               } catch (hookError) {
+                if (delegation.hookErrorStrategy === 'throw') {
+                  const mastraError = new MastraError(
+                    {
+                      id: 'AGENT_AGENT_TOOL_EXECUTION_FAILED',
+                      domain: ErrorDomain.AGENT,
+                      category: ErrorCategory.USER,
+                      details: {
+                        agentName: this.name,
+                        subAgentName: agent.name ?? agent.id,
+                        runId: runId || '',
+                        threadId: threadId || '',
+                        resourceId: resourceId || '',
+                      },
+                      text: `[Agent:${this.name}] - onDelegationStart hook threw for ${agentName}`,
+                    },
+                    hookError,
+                  );
+                  this.logger.trackException(mastraError);
+                  throw mastraError;
+                }
                 this.logger.error('onDelegationStart hook error', { agent: this.name, error: hookError });
                 // Continue with original values on hook error
               }
@@ -5065,6 +5085,11 @@ export class Agent<
                 }
               }
             }
+
+            // Set when onDelegationComplete itself throws under the 'throw'
+            // hookErrorStrategy, so the outer catch below does not invoke the
+            // hook a second time for an error the hook already raised.
+            let completeHookAlreadyRan = false;
 
             try {
               this.logger.debug('Executing agent as tool', {
@@ -5475,14 +5500,25 @@ export class Agent<
                     }
                   }
                 } catch (hookError) {
+                  if (delegation.hookErrorStrategy === 'throw') {
+                    // Mark the delegation failed, the same way a sub-agent execution
+                    // failure would, without re-invoking onDelegationComplete for an
+                    // error the hook itself just raised (see completeHookAlreadyRan
+                    // check below).
+                    completeHookAlreadyRan = true;
+                    throw hookError;
+                  }
                   this.logger.error('onDelegationComplete hook error', { agent: this.name, error: hookError });
                 }
               }
               return result;
             } catch (err) {
               let bailed = false;
-              // Call onDelegationComplete with error if hook is provided
-              if (delegation?.onDelegationComplete) {
+              // Call onDelegationComplete with error if hook is provided, unless the
+              // error originated from onDelegationComplete itself under the 'throw'
+              // strategy above — in that case the hook already ran for this
+              // delegation and must not be invoked a second time.
+              if (delegation?.onDelegationComplete && !completeHookAlreadyRan) {
                 try {
                   const delegationCompleteContext: DelegationCompleteContext = {
                     primitiveId: agent.id,
@@ -5543,6 +5579,31 @@ export class Agent<
                     }
                   }
                 } catch (hookError) {
+                  if (delegation.hookErrorStrategy === 'throw') {
+                    // The delegation already failed (we're handling a sub-agent
+                    // execution error). The hook itself also threw while reporting
+                    // that failure — surface the hook's error as the propagated
+                    // cause instead of silently logging it, same as a sub-agent
+                    // failure would propagate.
+                    const mastraError = new MastraError(
+                      {
+                        id: 'AGENT_AGENT_TOOL_EXECUTION_FAILED',
+                        domain: ErrorDomain.AGENT,
+                        category: ErrorCategory.USER,
+                        details: {
+                          agentName: this.name,
+                          subAgentName: agent.name ?? agent.id,
+                          runId: runId || '',
+                          threadId: threadId || '',
+                          resourceId: resourceId || '',
+                        },
+                        text: `[Agent:${this.name}] - onDelegationComplete hook threw while handling a failed delegation for ${agentName}`,
+                      },
+                      hookError,
+                    );
+                    this.logger.trackException(mastraError);
+                    throw mastraError;
+                  }
                   this.logger.error('onDelegationComplete hook error on failure', {
                     agent: this.name,
                     error: hookError,

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -332,6 +332,22 @@ export interface DelegationConfig {
    * ```
    */
   messageFilter?: (context: MessageFilterContext) => MastraDBMessage[] | Promise<MastraDBMessage[]>;
+
+  /**
+   * Controls how errors thrown by `onDelegationStart` and `onDelegationComplete`
+   * are handled.
+   *
+   * - `'warn'` (default): log the error and continue, preserving the delegation's
+   *   original behavior as if the hook had not thrown. This matches the behavior
+   *   prior to this option's introduction.
+   * - `'throw'`: a throwing `onDelegationStart` aborts the delegation before the
+   *   sub-agent is invoked, surfacing the hook's error as the tool call's error.
+   *   A throwing `onDelegationComplete` marks the delegation as failed, propagating
+   *   the hook's error the same way a failed sub-agent execution would.
+   *
+   * @default 'warn'
+   */
+  hookErrorStrategy?: 'warn' | 'throw';
 }
 /**
  * Configuration for the routing agent's behavior.


### PR DESCRIPTION
## Problem

All three sub-agent delegation lifecycle hook call sites (`onDelegationStart`, and `onDelegationComplete` on both its success and failure paths) wrap the user-supplied hook in a `try/catch` that only logs and continues:

```js
catch (hookError) { this.logger.error("onDelegationStart hook error", { agent: this.name, error: hookError, ... }); }
catch (hookError) { this.logger.error("onDelegationComplete hook error", { agent: this.name, error: hookError, ... }); }
catch (hookError) { this.logger.error("onDelegationComplete hook error on failure", { agent: this.name, error: hookError, ... }); }
```

This is fail-open: a throwing `onDelegationStart` cannot block a delegation (the documented way to block is returning `{ proceed: false }`, but an accidentally-buggy guard that throws instead is silently ignored, so the delegation proceeds anyway). A throwing `onDelegationComplete` leaves the delegation looking successful even though whatever result-handling the hook was responsible for never ran — if an application uses `onDelegationComplete` to collect/relay sub-agent results (common, since the result is otherwise not surfaced to the caller), a bug in that hook makes the delegation result silently vanish with only an easily-missed error log as a trace.

## Change

Adds an opt-in `hookErrorStrategy?: 'warn' | 'throw'` option to `DelegationConfig` (`packages/core/src/agent/agent.types.ts`), matching the flat, colocated-option shape already used by `DelegationConfig`'s other settings (`includeSubAgentToolResultsInModelContext`, `messageFilter`).

- **`'warn'` (default)** — unchanged: log and continue. This preserves current behavior exactly; nothing changes for existing callers.
- **`'throw'`** — fail-closed:
  - A throwing `onDelegationStart` aborts the delegation before the sub-agent is invoked, surfacing the hook's error as the tool call's error (instead of proceeding as if the hook had returned nothing).
  - A throwing `onDelegationComplete` marks the delegation as failed, propagating the hook's error the same way a sub-agent execution failure would (reuses the existing failure `MastraError` construction/propagation path rather than adding a parallel one). If the sub-agent itself already failed and `onDelegationComplete`'s failure-handling invocation *also* throws under `'throw'`, that error is surfaced too instead of being silently logged, without invoking the hook a second time.

## Backward compatibility

Fully additive and opt-in. The new field is optional; when unset, behavior is byte-for-byte the same as before this change (log + continue on hook errors).

## Tests

Added `packages/core/src/agent/__tests__/delegation-hook-error-strategy.test.ts`, covering:
- Default strategy: a throwing `onDelegationStart`/`onDelegationComplete` is still just logged, delegation continues and result is returned (regression coverage for existing behavior).
- `'throw'` strategy: a throwing `onDelegationStart` aborts the delegation before the sub-agent runs.
- `'throw'` strategy: a throwing `onDelegationComplete` (success path) marks the delegation failed, with the hook's error preserved down the cause chain.
- `'throw'` strategy: `onDelegationComplete` is not invoked a second time when it already threw.
- `'throw'` strategy: when the sub-agent itself fails *and* `onDelegationComplete` also throws while handling that failure, the hook's error is surfaced rather than silently logged.

`pnpm --filter @mastra/core typecheck`, `lint` (oxlint + eslint), and the full `@mastra/core` delegation-related test suite (113 files / 1250 tests) pass locally.

A changeset is included (`@mastra/core`, minor — additive config option).

Fixes #21624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Delegation hooks can now either log errors and continue, or stop the delegation and report the error. Existing behavior remains the default.

## Changes

- Added `DelegationConfig.hookErrorStrategy?: 'warn' | 'throw'`.
- Preserved `'warn'` as the default behavior.
- Added `'throw'` behavior:
  - `onDelegationStart` errors stop delegation before the sub-agent runs.
  - `onDelegationComplete` errors fail the delegation and propagate the hook error.
  - Prevented duplicate completion-hook calls on failure paths.
- Added delegation hook error-strategy tests.
- Added a `@mastra/core` changeset.

## Validation

- Typecheck passed.
- Lint passed.
- Delegation-related tests passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->