### PR TITLE
fix(core): add opt-out and warning for delegation memory graft

### DIFF
--- a/.changeset/delegation-memory-graft-optout.md
+++ b/.changeset/delegation-memory-graft-optout.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': minor
+---
+
+Added `inheritMemory` to `DelegationConfig` and a one-time warning for the parent-memory graft onto memory-less sub-agents.
+
+When a supervisor delegates to a sub-agent with no memory of its own, the parent grafts its own `Memory` instance onto the sub-agent instance itself. Since Agent instances are commonly constructed once and shared across requests, this mutates shared state for the instance's lifetime — invisibly, and with no signal that it happened.
+
+Set `delegation: { inheritMemory: false }` to opt out; the sub-agent is left without memory instead of having the parent's grafted onto it. The graft still happens by default (`inheritMemory: true`), preserving current behavior exactly, but now emits a `logger.warn` naming both the parent and the sub-agent the first time it mutates a given sub-agent instance, so the graft is no longer silent.
+
+This is a minimal, compatibility-preserving fix. The deeper fix — resolving the effective memory per invocation instead of mutating the shared sub-agent instance, which would remove the race between concurrent delegations to the same memory-less sub-agent — is a larger architectural change and is left to a future PR.

--- a/packages/core/src/agent/__tests__/delegation-memory-graft-optout.test.ts
+++ b/packages/core/src/agent/__tests__/delegation-memory-graft-optout.test.ts
@@ -1,0 +1,183 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { Mastra } from '../../mastra';
+import { MockMemory } from '../../memory/mock';
+import { InMemoryStore } from '../../storage';
+import { Agent } from '../agent';
+
+/**
+ * Coverage for `DelegationConfig.inheritMemory`.
+ *
+ * When a supervisor delegates to a sub-agent with no memory of its own, the
+ * parent grafts its own `Memory` instance onto the (possibly shared/singleton)
+ * sub-agent instance via an internal setter. `inheritMemory: false` opts out
+ * of that graft, and a one-time `logger.warn` names both agents the first
+ * time a graft actually mutates a sub-agent instance.
+ *
+ * Related: https://github.com/mastra-ai/mastra/issues/21625
+ */
+
+/** Sub-agent with no memory of its own, answering directly with fixed text. */
+function buildMemorylessSubAgent(id = 'sub-agent', name = 'Sub Agent') {
+  const model = new MockLanguageModelV2({
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'sub-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'sub-t' },
+        { type: 'text-delta', id: 'sub-t', delta: 'Sub-agent result.' },
+        { type: 'text-end', id: 'sub-t' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+      ] as any),
+    }),
+  });
+
+  return new Agent({
+    id,
+    name,
+    description: 'Answers directly, no own memory.',
+    instructions: 'Answer directly.',
+    model,
+  });
+}
+
+/**
+ * Supervisor whose first turn delegates once to the sub-agent, then reports
+ * completion on the following turn once the delegation's tool result is seen.
+ */
+function buildSupervisor(subAgent: Agent, memory: MockMemory) {
+  let step = 0;
+  const model = new MockLanguageModelV2({
+    doStream: async () => {
+      step += 1;
+      const chunks =
+        step === 1
+          ? [
+              {
+                type: 'tool-call',
+                toolCallId: 'sup-tc-1',
+                toolName: 'agent-subAgent',
+                input: JSON.stringify({ prompt: 'Delegate this.' }),
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              },
+            ]
+          : [
+              { type: 'text-start', id: 'sup-final-t' },
+              { type: 'text-delta', id: 'sup-final-t', delta: 'Sub-agent result acknowledged.' },
+              { type: 'text-end', id: 'sup-final-t' },
+              { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+            ];
+
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: `sup-${step}`, modelId: 'mock-model-id', timestamp: new Date(0) },
+          ...chunks,
+        ] as any),
+      };
+    },
+  });
+
+  return new Agent({
+    id: 'supervisor',
+    name: 'Supervisor',
+    instructions: 'Delegate to the sub agent.',
+    model,
+    memory,
+    agents: { subAgent },
+  });
+}
+
+function buildSupervisorAgent(subAgent: Agent, memory: MockMemory, storage: InMemoryStore = new InMemoryStore()) {
+  const sup = buildSupervisor(subAgent, memory);
+  const mastra = new Mastra({ agents: { supervisor: sup }, logger: false, storage });
+  return mastra.getAgent('supervisor');
+}
+
+async function drain(stream: AsyncIterable<unknown>) {
+  for await (const _chunk of stream) {
+    // Drain the stream so the delegation runs to completion.
+  }
+}
+
+describe('DelegationConfig.inheritMemory', () => {
+  it('by default, the parent grafts its memory onto a memory-less sub-agent (existing behavior)', async () => {
+    const subAgent = buildMemorylessSubAgent();
+    expect(subAgent.hasOwnMemory()).toBe(false);
+
+    const memory = new MockMemory();
+    const supervisor = buildSupervisorAgent(subAgent, memory);
+
+    const stream = await supervisor.stream('Delegate this.', { maxSteps: 4 });
+    await drain(stream.fullStream);
+
+    expect(subAgent.hasOwnMemory()).toBe(true);
+  });
+
+  it('inheritMemory: false prevents the graft — the sub-agent stays memory-less', async () => {
+    const subAgent = buildMemorylessSubAgent();
+    expect(subAgent.hasOwnMemory()).toBe(false);
+
+    const memory = new MockMemory();
+    const supervisor = buildSupervisorAgent(subAgent, memory);
+
+    const stream = await supervisor.stream('Delegate this.', {
+      maxSteps: 4,
+      delegation: { inheritMemory: false },
+    });
+    await drain(stream.fullStream);
+
+    expect(subAgent.hasOwnMemory()).toBe(false);
+  });
+
+  it('emits a one-time warning naming both agents when a graft mutates the sub-agent', async () => {
+    const subAgent = buildMemorylessSubAgent('sub-agent', 'Sub Agent');
+    const memory = new MockMemory();
+    const supervisor = buildSupervisorAgent(subAgent, memory);
+    const warnSpy = vi.fn();
+    // @ts-expect-error - internal test hook into the Mastra logger for assertions
+    supervisor.logger.warn = warnSpy;
+
+    const stream = await supervisor.stream('Delegate this.', { maxSteps: 4 });
+    await drain(stream.fullStream);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message, meta] = warnSpy.mock.calls[0]!;
+    expect(message).toMatch(/grafted parent memory/i);
+    expect(meta).toMatchObject({ parentAgent: 'Supervisor', subAgent: 'Sub Agent' });
+  });
+
+  it('does not warn again on a second delegation to the same already-grafted sub-agent', async () => {
+    const subAgent = buildMemorylessSubAgent('sub-agent-repeat', 'Sub Agent Repeat');
+    const memory = new MockMemory();
+
+    // First supervisor delegates once and grafts memory onto the shared sub-agent instance.
+    const firstSupervisor = buildSupervisorAgent(subAgent, memory);
+    const warnSpy1 = vi.fn();
+    // @ts-expect-error - internal test hook into the Mastra logger for assertions
+    firstSupervisor.logger.warn = warnSpy1;
+    await drain((await firstSupervisor.stream('Delegate this.', { maxSteps: 4 })).fullStream);
+    expect(warnSpy1).toHaveBeenCalledTimes(1);
+
+    // Sub-agent already has memory now, so a second, independent supervisor
+    // delegating to the SAME sub-agent instance must not warn again — both
+    // because hasOwnMemory() is now true (no further graft happens) and
+    // because the one-time-per-instance guard would suppress it regardless.
+    const secondMemory = new MockMemory();
+    const secondSupervisor = buildSupervisorAgent(subAgent, secondMemory);
+    const warnSpy2 = vi.fn();
+    // @ts-expect-error - internal test hook into the Mastra logger for assertions
+    secondSupervisor.logger.warn = warnSpy2;
+    await drain((await secondSupervisor.stream('Delegate this.', { maxSteps: 4 })).fullStream);
+
+    expect(warnSpy2).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -240,6 +240,11 @@ interface StandaloneDurableWrapper {
   prepare: (...args: any[]) => any;
 }
 
+// Tracks sub-agent instances that have already had a parent's memory grafted
+// onto them via __setMemory, so the one-time graft warning below only fires
+// once per instance rather than on every delegation that reaches it.
+const delegationMemoryGraftWarned = new WeakSet<object>();
+
 const createSubAgentInputSchema = () =>
   z.object({
     prompt: z.string().describe('The prompt to send to the agent'),
@@ -4916,8 +4921,27 @@ export class Agent<
                 methodType === 'streamLegacy') &&
               supportedLanguageModelSpecifications.includes(resolvedModelVersion)
             ) {
-              if (!resolvedAgent.hasOwnMemory() && this.#memory) {
+              if (!resolvedAgent.hasOwnMemory() && this.#memory && delegation?.inheritMemory !== false) {
                 resolvedAgent.__setMemory(this.#memory as DynamicArgument<MastraMemory, TRequestContext>);
+
+                // Warn the first time this sub-agent instance is mutated by a
+                // memory graft. Agent instances are commonly constructed once
+                // and shared, so this mutation is otherwise invisible and
+                // permanent for the instance's lifetime.
+                if (!delegationMemoryGraftWarned.has(resolvedAgent)) {
+                  delegationMemoryGraftWarned.add(resolvedAgent);
+                  this.logger.warn(
+                    'Delegation grafted parent memory onto a memory-less sub-agent instance. ' +
+                      'This mutates the shared sub-agent instance for its lifetime; concurrent delegations ' +
+                      "to the same sub-agent from other parents can race on which parent's memory ends up " +
+                      "grafted. Set delegation.inheritMemory: false to opt out, or configure the sub-agent's " +
+                      'own memory to make this warning unnecessary.',
+                    {
+                      parentAgent: this.name,
+                      subAgent: resolvedAgent.name ?? resolvedAgent.id,
+                    },
+                  );
+                }
               }
             }
 

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -332,6 +332,25 @@ export interface DelegationConfig {
    * ```
    */
   messageFilter?: (context: MessageFilterContext) => MastraDBMessage[] | Promise<MastraDBMessage[]>;
+
+  /**
+   * Controls whether the parent agent grafts its own memory onto a delegated
+   * sub-agent that has no memory of its own configured.
+   *
+   * When a sub-agent has no own memory, the parent's memory instance is
+   * assigned onto the sub-agent instance itself (via an internal setter) so
+   * the delegated run can persist messages. Because Agent instances are
+   * commonly constructed once and shared across requests, this mutates
+   * shared state: concurrent delegations to the same memory-less sub-agent
+   * from supervisors bound to different callers can race on which parent's
+   * memory ends up grafted.
+   *
+   * Set to `false` to opt out — the sub-agent is left without memory instead
+   * of having the parent's memory grafted onto it.
+   *
+   * @default true
+   */
+  inheritMemory?: boolean;
 }
 /**
  * Configuration for the routing agent's behavior.


### PR DESCRIPTION
## Problem

When a supervisor delegates to a sub-agent that has no memory of its own configured, the parent grafts its own `Memory` instance onto the sub-agent **instance itself**, via an internal setter:

```js
if (!resolvedAgent.hasOwnMemory() && this.#memory) resolvedAgent.__setMemory(this.#memory)
```

Since Agent instances are commonly constructed once and shared (singleton composition roots are the norm), this mutates shared state for the instance's lifetime — invisibly, and with no signal that it happened. In a multi-user server, two concurrent turns delegating to the same memory-less sub-agent singleton from supervisors bound to different users/threads can race on which parent's memory ends up grafted (a cross-user memory-bleed hazard). Applications whose sub-agents happen to declare their own memory are safe today, but often by accident — removing that declaration later silently re-arms the hazard, with nothing failing loudly.

## Change

Minimal, compatibility-preserving fix in `packages/core/src/agent/agent.ts` and `agent.types.ts`:

- **`DelegationConfig.inheritMemory?: boolean` (default `true`)** — set to `false` to opt out of the graft; the sub-agent is left without memory instead of having the parent's grafted onto it. Placed alongside the config surface's other flat, colocated options (`includeSubAgentToolResultsInModelContext`, `messageFilter`, and this PR's sibling addition `hookErrorStrategy`).
- **One-time `logger.warn`** — the first time a graft actually mutates a given sub-agent instance (i.e. only when `__setMemory` is actually called, not on every delegation), a warning is logged naming both the parent and the sub-agent, guarded by a module-level `WeakSet` so it doesn't spam on repeated delegations to an already-grafted instance.

## Backward compatibility

Fully additive and opt-in. `inheritMemory` defaults to `true`, so the graft still happens exactly as before for all existing callers — the only new behavior for existing callers is the added warning log line, which is purely observational.

## Out of scope (deferred to maintainers)

The deeper, correct fix is resolving the effective memory **per invocation** (passed through the execution context) instead of mutating the shared instance at all — this would remove the race entirely rather than just making it visible/opt-outable. That's a larger architectural change than fits a minimal patch, so this PR does not attempt it; flagging it here for maintainer input on whether/when to take that on.

## Tests

Added `packages/core/src/agent/__tests__/delegation-memory-graft-optout.test.ts`, covering:
- Default behavior: the graft still happens when `inheritMemory` is unset (regression coverage for existing behavior).
- `inheritMemory: false` prevents the graft; the sub-agent stays memory-less.
- The warning is emitted once, naming both the parent and sub-agent by name.
- No duplicate warning on a second, independent delegation to the same already-grafted sub-agent instance.

`pnpm --filter @mastra/core typecheck`, `lint` (oxlint + eslint), and the full `@mastra/core` delegation-related test suite (198 files / 1757 tests) pass locally.

A changeset is included (`@mastra/core`, minor — additive config option).

Fixes #21625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Delegated agents can still share their parent agent’s memory by default. This change adds a switch to stop that sharing and warns users when it happens.

## Changes

- Added `DelegationConfig.inheritMemory`.
- Memory inheritance remains enabled by default.
- Setting `inheritMemory: false` prevents memory grafting.
- Added a one-time warning that identifies the parent and sub-agent.
- Prevented duplicate warnings with a `WeakSet`.
- Added tests for default behavior, opt-out behavior, warning contents, and duplicate-warning prevention.
- Added a minor `@mastra/core` changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->