### PR TITLE
fix(mysql): stop warm init re-running 107 doomed ALTER TABLE statements every boot

### DIFF
--- a/.changeset/mysql-alter-column-probe.md
+++ b/.changeset/mysql-alter-column-probe.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mysql': patch
+---
+
+Fix the alterTable existing-column probe reading the wrong information_schema field casing. MySQL returns result fields with uppercase keys through mysql2, so the probe's existing-column set was always empty and every warm boot re-ran 107 ALTER TABLE ADD COLUMN statements that failed with ER_DUP_FIELDNAME and were silently swallowed, taking metadata locks on production tables for nothing. The probe now reads whichever key casing is present. Measured on docker mysql:9.7: warm init drops from 324 to 109 client-server round trips and issues zero ALTER statements.

--- a/.changeset/mysql-alter-column-probe.md
+++ b/.changeset/mysql-alter-column-probe.md
@@ -2,4 +2,4 @@
 '@mastra/mysql': patch
 ---
 
-Fix the alterTable existing-column probe reading the wrong information_schema field casing. MySQL returns result fields with uppercase keys through mysql2, so the probe's existing-column set was always empty and every warm boot re-ran 107 ALTER TABLE ADD COLUMN statements that failed with ER_DUP_FIELDNAME and were silently swallowed, taking metadata locks on production tables for nothing. The probe now reads whichever key casing is present. Measured on docker mysql:9.7: warm init drops from 324 to 109 client-server round trips and issues zero ALTER statements.
+Fix the alterTable existing-column probe reading the wrong information_schema field casing. MySQL returns result fields with uppercase keys through mysql2, so the probe's existing-column set was always empty and every warm boot re-ran 107 ALTER TABLE ADD COLUMN statements that failed with ER_DUP_FIELDNAME and were silently swallowed, taking metadata locks on production tables for nothing. The probe now reads whichever key casing is present. Measured on docker mysql:9.7: warm init drops from 326 to 109 client-server round trips and issues zero ALTER statements.

--- a/stores/mysql/src/storage/domains/operations/alter-table.unit.test.ts
+++ b/stores/mysql/src/storage/domains/operations/alter-table.unit.test.ts
@@ -1,0 +1,74 @@
+import type { Pool } from 'mysql2/promise';
+import { describe, expect, it } from 'vitest';
+import { StoreOperationsMySQL } from './index';
+
+// MySQL returns information_schema result fields with uppercase keys through mysql2
+// (proven by execution on mysql:9.7: Object.keys(rows[0]) -> ['COLUMN_NAME']).
+// The probe read must be casing agnostic because identifier casing can vary with
+// server settings, so both key shapes are covered here.
+function createPoolStub(columnRows: Record<string, unknown>[]) {
+  const executed: string[] = [];
+  const pool = {
+    execute: async (sql: string) => {
+      executed.push(sql);
+      if (sql.includes('information_schema.tables')) {
+        return [[{ count: 1 }], []];
+      }
+      if (sql.includes('information_schema.columns')) {
+        return [columnRows, []];
+      }
+      return [[], []];
+    },
+    query: async () => [[{ db: 'mastra' }], []],
+  } as unknown as Pool;
+  return { pool, executed };
+}
+
+const schema = {
+  resourceId: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+} as const;
+
+describe('alterTable existing-column probe casing', () => {
+  it('issues no ALTER when existing columns come back with uppercase keys (MySQL real behavior)', async () => {
+    const { pool, executed } = createPoolStub([{ COLUMN_NAME: 'resourceId' }, { COLUMN_NAME: 'createdAt' }]);
+    const ops = new StoreOperationsMySQL({ pool, database: 'mastra' });
+
+    await ops.alterTable({
+      tableName: 'mastra_workflow_snapshot' as any,
+      schema: schema as any,
+      ifNotExists: ['resourceId', 'createdAt'],
+    });
+
+    const alters = executed.filter(sql => sql.startsWith('ALTER TABLE'));
+    expect(alters).toEqual([]);
+  });
+
+  it('issues no ALTER when existing columns come back with lowercase keys (casing agnostic)', async () => {
+    const { pool, executed } = createPoolStub([{ column_name: 'resourceId' }, { column_name: 'createdAt' }]);
+    const ops = new StoreOperationsMySQL({ pool, database: 'mastra' });
+
+    await ops.alterTable({
+      tableName: 'mastra_workflow_snapshot' as any,
+      schema: schema as any,
+      ifNotExists: ['resourceId', 'createdAt'],
+    });
+
+    expect(executed.filter(sql => sql.startsWith('ALTER TABLE'))).toEqual([]);
+  });
+
+  it('still adds a column that is genuinely missing', async () => {
+    const { pool, executed } = createPoolStub([{ COLUMN_NAME: 'createdAt' }]);
+    const ops = new StoreOperationsMySQL({ pool, database: 'mastra' });
+
+    await ops.alterTable({
+      tableName: 'mastra_workflow_snapshot' as any,
+      schema: schema as any,
+      ifNotExists: ['resourceId', 'createdAt'],
+    });
+
+    const alters = executed.filter(sql => sql.startsWith('ALTER TABLE'));
+    expect(alters).toHaveLength(1);
+    expect(alters[0]).toContain('`resourceId`');
+  });
+});

--- a/stores/mysql/src/storage/domains/operations/index.ts
+++ b/stores/mysql/src/storage/domains/operations/index.ts
@@ -641,7 +641,11 @@ export class StoreOperationsMySQL extends StoreOperations {
       params.push(db);
     }
     const [rows] = await this.pool.execute<RowDataPacket[]>(sql, params);
-    const existing = new Set((rows || []).map((row: RowDataPacket) => String(row.column_name).toLowerCase()));
+    // MySQL returns information_schema fields with uppercase keys through mysql2, but the
+    // casing can vary with server settings, so read whichever key shape is present.
+    const existing = new Set(
+      (rows || []).map((row: RowDataPacket) => String(row.column_name ?? row.COLUMN_NAME).toLowerCase()),
+    );
 
     for (const columnName of ifNotExists) {
       if (existing.has(columnName.toLowerCase())) {


### PR DESCRIPTION
## What this fixes

Every `@mastra/mysql` boot against an already-converged schema re-runs 107 distinct `ALTER TABLE ... ADD COLUMN` statements. Each one executes on the server, fails with `ER_DUP_FIELDNAME`, and is silently swallowed. Real DDL attempts take metadata locks on production tables on every startup, with no schema change to make.

Root cause: `alterTable` probes existing columns with `SELECT column_name FROM information_schema.columns ...` and then reads `row.column_name`. MySQL returns `information_schema` result fields with uppercase keys through mysql2 (`Object.keys(rows[0])` yields `['COLUMN_NAME']` on mysql:9.7), so the existing-column set was always empty and every column looked missing. The bug has been present since the adapter's first commit (#13638). The correct read already existed elsewhere in the same file: `createIndex`'s column-metadata query reads `row.COLUMN_NAME`.

The fix reads whichever key casing is present (`row.column_name ?? row.COLUMN_NAME`), because identifier casing of `information_schema` results can vary with server settings. The `ER_DUP_FIELDNAME` swallow stays untouched as the concurrent-boot safety net; the point is that the doomed statements stop being issued.

## Measured impact

Counted server-side via `mysql.general_log` (log_output=TABLE) across the `Query`, `Prepare`, and `Execute` command types, since mysql2 uses prepared statements and each Prepare and Execute is its own client-server round trip (hence 107 distinct ALTERs appearing as 214 round trips). Docker mysql:9.7, the package's own compose image, measured at this branch's base commit (f969067f56) and at the fix commit.

| | Before | After |
|---|---|---|
| Warm init total round trips | 326 | 109 |
| ALTER TABLE round trips (107 distinct statements) | 214 | 0 |

The remaining 109 are almost entirely per-table and per-index existence probes (plus one harness statement and one warm `CREATE INDEX` attempt from the memory domain's raw index DDL, a Prepare plus Execute pair), the same shape `@mastra/pg` eliminated with an init-scoped schema snapshot in #20394. A stacked PR ports that design.

## Tests

- New `alter-table.unit.test.ts`: feeds uppercase-keyed rows (MySQL's real behavior) to the probe and asserts no ALTER is issued; fails before the fix, passes after. Also covers the lowercase key shape and the genuinely-missing-column case.
- Full docker-backed suite: 628 passed, 2 skipped. Unit, typecheck, and lint all clean.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

MySQL was checking the same database columns repeatedly because it did not recognize the column names returned by the driver. This fix recognizes both name formats, so warm initialization avoids unnecessary table changes.

## Changes

- Updated `alterTable` to read both `row.column_name` and `row.COLUMN_NAME`.
- Preserved duplicate-column error handling for concurrent boots.
- Added tests for uppercase keys, lowercase keys, and missing columns.
- Added a patch changeset for `@mastra/mysql`.
- Corrected the documented warm-init baseline from 324 to 326 round trips.

## Results

- Warm-init round trips decreased from 326 to 109.
- `ALTER TABLE` round trips decreased from 214 to 0.
- Docker-backed tests pass: 628 passed, 2 skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->