### PR TITLE
feat(evals): support conversation context in prompt alignment scorer

### DIFF
--- a/.changeset/bright-bags-align.md
+++ b/.changeset/bright-bags-align.md
@@ -3,3 +3,15 @@
 ---
 
 Add opt-in conversation context to the Prompt Alignment scorer for multi-turn Agent evaluations.
+
+Usage example:
+
+```ts
+createPromptAlignmentScorerLLM({
+  model,
+  options: {
+    contextMode: 'conversation',
+    maxRememberedMessages: 10,
+  },
+});
+```

--- a/.changeset/bright-bags-align.md
+++ b/.changeset/bright-bags-align.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': minor
+---
+
+Add opt-in conversation context to the Prompt Alignment scorer for multi-turn Agent evaluations.

--- a/packages/evals/src/scorers/llm/prompt-alignment/index.ts
+++ b/packages/evals/src/scorers/llm/prompt-alignment/index.ts
@@ -6,14 +6,41 @@ import {
   getAssistantMessageFromRunOutput,
   getUserMessageFromRunInput,
   getCombinedSystemPrompt,
+  getTextContentFromMastraDBMessage,
+  isScorerRunInputForAgent,
   roundToTwoDecimals,
 } from '../../utils';
-import type { ScorerRunInputForLLMJudge, ScorerRunOutputForLLMJudge } from '../../utils';
+import type {
+  ScorerRunInputForAgent,
+  ScorerRunInputForLLMJudge,
+  ScorerRunOutputForLLMJudge,
+} from '../../utils';
 import { PROMPT_ALIGNMENT_INSTRUCTIONS, createAnalyzePrompt, createReasonPrompt } from './prompts';
 
 export interface PromptAlignmentOptions {
   scale?: number;
   evaluationMode?: 'user' | 'system' | 'both';
+  /**
+   * Controls whether Agent scorer runs include recent remembered messages.
+   * Defaults to the current user prompt only for backwards compatibility.
+   */
+  contextMode?: 'current' | 'conversation';
+  /**
+   * Maximum number of remembered messages included when contextMode is 'conversation'.
+   * Defaults to 10.
+   */
+  maxRememberedMessages?: number;
+}
+
+function formatConversationContext(input: ScorerRunInputForAgent, maxRememberedMessages: number) {
+  return input.rememberedMessages
+    .slice(-maxRememberedMessages)
+    .map(message => {
+      const text = getTextContentFromMastraDBMessage(message).trim();
+      return text ? `${message.role}: ${text}` : undefined;
+    })
+    .filter((message): message is string => Boolean(message))
+    .join(String.fromCharCode(10));
 }
 
 // Helper for score validation - uses refine() instead of min/max for Anthropic API compatibility
@@ -80,6 +107,8 @@ export function createPromptAlignmentScorerLLM({
 }) {
   const scale = options?.scale || 1;
   const evaluationMode = options?.evaluationMode || 'both';
+  const contextMode = options?.contextMode || 'current';
+  const maxRememberedMessages = Math.max(1, options?.maxRememberedMessages || 10);
 
   return createScorer<ScorerRunInputForLLMJudge, ScorerRunOutputForLLMJudge>({
     id: 'prompt-alignment-scorer',
@@ -97,6 +126,10 @@ export function createPromptAlignmentScorerLLM({
         const userPrompt = getUserMessageFromRunInput(run.input) ?? '';
         const systemPrompt = getCombinedSystemPrompt(run.input) ?? '';
         const agentResponse = getAssistantMessageFromRunOutput(run.output) ?? '';
+        const conversationContext =
+          contextMode === 'conversation' && isScorerRunInputForAgent(run.input)
+            ? formatConversationContext(run.input, maxRememberedMessages)
+            : undefined;
 
         // Validation based on evaluation mode
         if (evaluationMode === 'user' && !userPrompt) {
@@ -117,6 +150,7 @@ export function createPromptAlignmentScorerLLM({
           systemPrompt,
           agentResponse,
           evaluationMode,
+          conversationContext,
         });
       },
     })

--- a/packages/evals/src/scorers/llm/prompt-alignment/index.ts
+++ b/packages/evals/src/scorers/llm/prompt-alignment/index.ts
@@ -108,7 +108,7 @@ export function createPromptAlignmentScorerLLM({
   const scale = options?.scale || 1;
   const evaluationMode = options?.evaluationMode || 'both';
   const contextMode = options?.contextMode || 'current';
-  const maxRememberedMessages = Math.max(1, options?.maxRememberedMessages || 10);
+  const maxRememberedMessages = Math.max(1, options?.maxRememberedMessages ?? 10);
 
   return createScorer<ScorerRunInputForLLMJudge, ScorerRunOutputForLLMJudge>({
     id: 'prompt-alignment-scorer',

--- a/packages/evals/src/scorers/llm/prompt-alignment/prompts.test.ts
+++ b/packages/evals/src/scorers/llm/prompt-alignment/prompts.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { createAnalyzePrompt } from './prompts';
+
+describe('Prompt Alignment prompts', () => {
+  it('includes conversation context when provided', () => {
+    const prompt = createAnalyzePrompt({
+      userPrompt: 'A',
+      systemPrompt: '',
+      agentResponse: 'Confirmed option A.',
+      evaluationMode: 'user',
+      conversationContext: 'assistant: Please choose option A or option B.',
+    });
+
+    expect(prompt).toContain('Conversation Context:');
+    expect(prompt).toContain('assistant: Please choose option A or option B.');
+    expect(prompt).toContain('User Prompt:\nA');
+  });
+
+  it('keeps the current prompt format when context is omitted', () => {
+    const prompt = createAnalyzePrompt({
+      userPrompt: 'What is 2+2?',
+      systemPrompt: '',
+      agentResponse: '4',
+      evaluationMode: 'user',
+    });
+
+    expect(prompt).not.toContain('Conversation Context:');
+    expect(prompt).toContain('User Prompt:\nWhat is 2+2?');
+  });
+});

--- a/packages/evals/src/scorers/llm/prompt-alignment/prompts.ts
+++ b/packages/evals/src/scorers/llm/prompt-alignment/prompts.ts
@@ -13,6 +13,7 @@ Evaluation Guidelines:
 - Assess whether the response fully addresses the prompt or leaves gaps
 - Evaluate if the response format and tone are appropriate for the request
 - Be objective and focus on alignment rather than response quality
+- When conversation context is provided, use it to resolve short replies such as A, B, yes, and confirm against the preceding conversation.
 
 Score each dimension from 0.0 (completely misaligned) to 1.0 (perfectly aligned).`;
 
@@ -26,21 +27,29 @@ export function createAnalyzePrompt({
   systemPrompt?: string;
   agentResponse: string;
   evaluationMode: 'user' | 'system' | 'both';
+  conversationContext?: string;
 }) {
   // Build the prompt based on evaluation mode
+  const conversationSection =
+    conversationContext
+      ? `Conversation Context:
+${conversationContext}
+
+`
+      : '';
   let promptContext = '';
   let evaluationTarget = '';
 
   if (evaluationMode === 'user') {
-    promptContext = `User Prompt:
+    promptContext = `${conversationSection}User Prompt:
 ${userPrompt}`;
     evaluationTarget = "the user's prompt";
   } else if (evaluationMode === 'system') {
-    promptContext = `System Prompt:
+    promptContext = `${conversationSection}System Prompt:
 ${systemPrompt}`;
     evaluationTarget = "the system's behavioral guidelines and constraints";
   } else {
-    promptContext = `User Prompt:
+    promptContext = `${conversationSection}User Prompt:
 ${userPrompt}
 
 System Prompt:


### PR DESCRIPTION
Fixes #21638

## Problem
The prebuilt Prompt Alignment scorer only evaluates the current user prompt. For multi-turn Agent runs, short replies such as `A`, `yes`, and `confirm` depend on `rememberedMessages`, which are currently ignored.

## Solution
- Add opt-in `contextMode: "conversation"` support.
- Add `maxRememberedMessages` with a default of 10.
- Include recent remembered messages in the analysis prompt.
- Instruct the Judge to resolve short replies against preceding conversation.
- Preserve the existing single-turn behavior by default.
- Add prompt-generation tests and a package changeset.

## Validation
- Added deterministic tests for conversation-context prompt generation.
- The equivalent Mastra-native contextual scorer test in the VinkClaw integration passed locally: 6 tests passed.
- The full upstream monorepo test suite still needs to run in GitHub CI because direct GitHub repository cloning was unavailable in the local environment.

This is intentionally an opt-in API to avoid changing existing score semantics for current users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The scorer can now read recent messages from a conversation when you enable conversation mode. This helps it understand short replies such as “yes” or “confirm” without changing the default single-turn behavior.

## Changes

- Added `contextMode: 'current' | 'conversation'` to `PromptAlignmentOptions`.
- Added `maxRememberedMessages`, which defaults to 10.
- Added Agent-shaped input support with recent `rememberedMessages`.
- Included conversation context in the Judge analysis prompt when enabled.
- Instructed the Judge to resolve short replies using preceding messages.
- Preserved current-prompt-only behavior by default.
- Added deterministic prompt-generation tests for included and omitted context.
- Added a minor-release changeset for `@mastra/evals`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->