### PR TITLE
chore(create-mastra): Remove unused dist files

### DIFF
--- a/.changeset/thirty-ears-know.md
+++ b/.changeset/thirty-ears-know.md
@@ -2,4 +2,4 @@
 'create-mastra': patch
 ---
 
-Reduced the create-mastra package by removing unused CLI development assets.
+Removed unused starter files and templates from the `create-mastra` package. The command-line tool still clones the starter repository.

--- a/.changeset/thirty-ears-know.md
+++ b/.changeset/thirty-ears-know.md
@@ -1,0 +1,5 @@
+---
+'create-mastra': patch
+---
+
+Reduced the create-mastra package by removing unused CLI development assets.

--- a/packages/create-mastra/rollup.config.js
+++ b/packages/create-mastra/rollup.config.js
@@ -1,6 +1,3 @@
-import * as fsPromises from 'node:fs/promises';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
@@ -36,18 +33,6 @@ export default defineConfig({
     }),
     nodeExternals(),
     commonjs(),
-    {
-      name: 'copy-starter-files',
-      buildEnd: async () => {
-        const mastraPath = path.dirname(fileURLToPath(import.meta.resolve('mastra/package.json')));
-
-        // Copy to dist directory instead of root
-        await fsPromises.cp(path.join(mastraPath, 'dist', 'starter-files'), './dist/starter-files', {
-          recursive: true,
-        });
-        await fsPromises.cp(path.join(mastraPath, 'dist', 'templates'), './dist/templates', { recursive: true });
-      },
-    },
   ],
   onwarn(warning, warn) {
     // Ignore specific warnings


### PR DESCRIPTION
## Description

Remove unused starter-files and templates from dist of create-mastra. The current CLI just clones a github repository

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The CLI now gets starter files from GitHub, so it does not need to package unused copies. This change removes those unused files from the build process.

## Changes

- Removed the `copy-starter-files` Rollup plugin from `create-mastra`.
- Removed unused filesystem, path, and URL imports.
- Added a patch changeset for `create-mastra`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->