### PR TITLE
fix(evals): score final assistant output

### DIFF
--- a/.changeset/loud-rockets-tap.md
+++ b/.changeset/loud-rockets-tap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fixed LLM scorers to evaluate the final assistant response when agent output includes multiple assistant messages.

--- a/packages/evals/src/scorers/utils.test.ts
+++ b/packages/evals/src/scorers/utils.test.ts
@@ -63,6 +63,15 @@ describe('Scorer Utils', () => {
       expect(result).toBe('Assistant response');
     });
 
+    it('should extract the final assistant response from multi-step output', () => {
+      const output: ScorerRunOutputForAgent = [
+        createTestMessage({ content: 'Intermediate assistant response', role: 'assistant' }),
+        createTestMessage({ content: 'Final assistant response', role: 'assistant' }),
+      ];
+
+      expect(getAssistantMessageFromRunOutput(output)).toBe('Final assistant response');
+    });
+
     it('should extract assistant text from workflow-style output', () => {
       expect(getAssistantMessageFromRunOutput({ text: 'Workflow response' })).toBe('Workflow response');
       expect(getAssistantMessageFromRunOutput({ content: 'Task response' })).toBe('Task response');

--- a/packages/evals/src/scorers/utils.ts
+++ b/packages/evals/src/scorers/utils.ts
@@ -394,7 +394,12 @@ export const getCombinedSystemPrompt = (input?: unknown): string => {
  */
 export const getAssistantMessageFromRunOutput = (output?: unknown) => {
   if (typeof output === 'string') return output;
-  if (Array.isArray(output)) return getTextFromMessages(output, 'assistant');
+  if (Array.isArray(output)) {
+    const finalAssistantMessage = [...output]
+      .reverse()
+      .find(message => isRecord(message) && getEffectiveMessageRole(message) === 'assistant');
+    return finalAssistantMessage ? getTextFromValue(finalAssistantMessage) : undefined;
+  }
   if (!isRecord(output)) return undefined;
 
   const isAssistantOutput = output.role === undefined || output.role === 'assistant';


### PR DESCRIPTION
Fixes #21645

## Summary

- select the final assistant message when a scorer run output contains multiple assistant messages
- add a regression test for multi-step agent output
- include a patch changeset for `@mastra/evals`

This lets built-in LLM scorers such as Prompt Alignment evaluate the final response without application-level scorer wrappers.

## Verification

- `pnpm -C packages/evals exec vitest run src/scorers/utils.test.ts`
- `pnpm -C packages/evals check`
- `pnpm -C packages/evals lint`