### PR TITLE
fix(create-mastra): remove unused pino runtime

### DIFF
--- a/.changeset/hip-states-wash.md
+++ b/.changeset/hip-states-wash.md
@@ -1,0 +1,5 @@
+---
+'create-mastra': patch
+---
+
+Reduced create-mastra's runtime dependencies while preserving project creation behavior.

--- a/.changeset/sweet-ravens-marry.md
+++ b/.changeset/sweet-ravens-marry.md
@@ -2,4 +2,4 @@
 'mastra': patch
 ---
 
-Improved template clone warnings to use the standard CLI output.
+Template cloning now reports package.json update failures as warnings and continues project creation.

--- a/.changeset/sweet-ravens-marry.md
+++ b/.changeset/sweet-ravens-marry.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Improved template clone warnings to use the standard CLI output.

--- a/packages/cli/src/utils/clone-template.test.ts
+++ b/packages/cli/src/utils/clone-template.test.ts
@@ -6,20 +6,15 @@ vi.mock('../commands/utils', () => ({
   getPackageManager: vi.fn(() => 'npm'),
 }));
 
+import * as p from '@clack/prompts';
 import { execa } from 'execa';
 import { vol } from 'memfs';
 import type * as MemfsModule from 'memfs';
 import yoctoSpinner from 'yocto-spinner';
 
-// Mock the logger
-vi.mock('./logger', () => ({
-  logger: {
-    log: vi.fn(),
-    error: vi.fn(),
+vi.mock('@clack/prompts', () => ({
+  log: {
     warn: vi.fn(),
-    info: vi.fn(),
-    success: vi.fn(),
-    break: vi.fn(),
   },
 }));
 
@@ -239,23 +234,62 @@ describe('clone-template', () => {
       expect(packageJson.version).toBe('1.0.0'); // Should preserve other fields
     });
 
-    it('should handle missing package.json gracefully', async () => {
+    it('warns and succeeds when package.json is missing', async () => {
       const mockExec = vi.fn().mockImplementation(async () => {
         vol.fromJSON({ '/test-project/README.md': 'template' });
         return { stdout: '', stderr: '' };
       });
       vi.mocked(execa).mockImplementation(mockExec as never);
 
-      const { logger } = await import('./logger');
       const { cloneTemplate } = await import('./clone-template');
 
-      const result = await cloneTemplate({
-        template: mockTemplate,
-        projectName: 'test-project',
-      });
+      await expect(
+        cloneTemplate({
+          template: mockTemplate,
+          projectName: 'test-project',
+        }),
+      ).resolves.toBe('/test-project');
+      expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining('Could not update package.json:'));
+      expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining('ENOENT'));
+    });
 
-      expect(result).toBe('/test-project');
-      expect(logger.warn).toHaveBeenCalledWith('Could not update package.json', expect.any(Object));
+    it('warns and succeeds when package.json contains invalid JSON', async () => {
+      const mockExec = vi.fn().mockImplementation(async () => {
+        vol.fromJSON({ '/test-project/package.json': '{invalid json' });
+        return { stdout: '', stderr: '' };
+      });
+      vi.mocked(execa).mockImplementation(mockExec as never);
+
+      const { cloneTemplate } = await import('./clone-template');
+
+      await expect(
+        cloneTemplate({
+          template: mockTemplate,
+          projectName: 'test-project',
+        }),
+      ).resolves.toBe('/test-project');
+      expect(p.log.warn).toHaveBeenCalledWith(expect.stringContaining('Could not update package.json:'));
+      expect(p.log.warn).toHaveBeenCalledWith(expect.stringMatching(/JSON|Unexpected/));
+    });
+
+    it('warns and succeeds when package.json cannot be written', async () => {
+      const mockExec = vi.fn().mockImplementation(async () => {
+        vol.fromJSON({ '/test-project/package.json': JSON.stringify({ name: 'template' }) });
+        return { stdout: '', stderr: '' };
+      });
+      vi.mocked(execa).mockImplementation(mockExec as never);
+      const fs = await import('node:fs/promises');
+      vi.spyOn(fs.default, 'writeFile').mockRejectedValueOnce(new Error('disk full'));
+
+      const { cloneTemplate } = await import('./clone-template');
+
+      await expect(
+        cloneTemplate({
+          template: mockTemplate,
+          projectName: 'test-project',
+        }),
+      ).resolves.toBe('/test-project');
+      expect(p.log.warn).toHaveBeenCalledWith('Could not update package.json: disk full');
     });
 
     it('should throw error if directory already exists', async () => {

--- a/packages/cli/src/utils/clone-template.test.ts
+++ b/packages/cli/src/utils/clone-template.test.ts
@@ -292,6 +292,26 @@ describe('clone-template', () => {
       expect(p.log.warn).toHaveBeenCalledWith('Could not update package.json: disk full');
     });
 
+    it('includes non-Error rejection details in the warning', async () => {
+      const mockExec = vi.fn().mockImplementation(async () => {
+        vol.fromJSON({ '/test-project/package.json': JSON.stringify({ name: 'template' }) });
+        return { stdout: '', stderr: '' };
+      });
+      vi.mocked(execa).mockImplementation(mockExec as never);
+      const fs = await import('node:fs/promises');
+      vi.spyOn(fs.default, 'writeFile').mockRejectedValueOnce('disk full');
+
+      const { cloneTemplate } = await import('./clone-template');
+
+      await expect(
+        cloneTemplate({
+          template: mockTemplate,
+          projectName: 'test-project',
+        }),
+      ).resolves.toBe('/test-project');
+      expect(p.log.warn).toHaveBeenCalledWith('Could not update package.json: disk full');
+    });
+
     it('should throw error if directory already exists', async () => {
       vol.fromJSON({
         '/existing-project/some-file.txt': 'content',

--- a/packages/cli/src/utils/clone-template.test.ts
+++ b/packages/cli/src/utils/clone-template.test.ts
@@ -57,7 +57,7 @@ beforeEach(() => {
 });
 
 // Mock fs after importing vol
-vi.mock('fs/promises', async () => {
+vi.mock('node:fs/promises', async () => {
   const memfs = await vi.importActual<typeof MemfsModule>('memfs');
   return {
     default: memfs.fs.promises,

--- a/packages/cli/src/utils/clone-template.ts
+++ b/packages/cli/src/utils/clone-template.ts
@@ -1,11 +1,10 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import * as p from '@clack/prompts';
 import { execa } from 'execa';
 import yoctoSpinner from 'yocto-spinner';
 
 import { getPackageManager } from '../commands/utils';
-
-import { logger } from './logger';
 import type { PackageManager } from './package-manager';
 import type { Template } from './template-utils';
 
@@ -152,7 +151,7 @@ async function updatePackageJson(projectPath: string, projectName: string): Prom
     await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf-8');
   } catch (error) {
     // It's okay if package.json doesn't exist or can't be updated
-    logger.warn('Could not update package.json', { error: error instanceof Error ? error.message : 'Unknown error' });
+    p.log.warn(`Could not update package.json: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }
 

--- a/packages/cli/src/utils/clone-template.ts
+++ b/packages/cli/src/utils/clone-template.ts
@@ -151,7 +151,7 @@ async function updatePackageJson(projectPath: string, projectName: string): Prom
     await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf-8');
   } catch (error) {
     // It's okay if package.json doesn't exist or can't be updated
-    p.log.warn(`Could not update package.json: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    p.log.warn(`Could not update package.json: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 

--- a/packages/create-mastra/package.json
+++ b/packages/create-mastra/package.json
@@ -39,8 +39,6 @@
   ],
   "dependencies": {
     "commander": "^14.0.3",
-    "pino": "^10.3.1",
-    "pino-pretty": "^13.1.3",
     "posthog-node": "^5.46.1",
     "tinyexec": "^1.1.1"
   },

--- a/packages/create-mastra/rollup.config.js
+++ b/packages/create-mastra/rollup.config.js
@@ -9,7 +9,7 @@ import esbuild from 'rollup-plugin-esbuild';
 import nodeExternals from 'rollup-plugin-node-externals';
 import pkgJson from './package.json' with { type: 'json' };
 
-const external = ['commander', 'tinyexec', 'posthog-node', 'pino', 'pino-pretty'];
+const external = ['commander', 'tinyexec', 'posthog-node'];
 external.forEach(pkg => {
   if (!pkgJson.dependencies[pkg]) {
     throw new Error(`${pkg} is not in the dependencies of create-mastra`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4706,12 +4706,6 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
-      pino:
-        specifier: ^10.3.1
-        version: 10.3.1
-      pino-pretty:
-        specifier: ^13.1.3
-        version: 13.1.3
       posthog-node:
         specifier: ^5.46.1
         version: 5.48.0(rxjs@7.8.2)


### PR DESCRIPTION
This removes `pino` and `pino-pretty` from the published `create-mastra` runtime dependencies and Rollup externals. Template cloning now reports nonfatal `package.json` update failures through the existing Clack output, including the underlying error detail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

New projects no longer include unused logging packages. If a template cannot update `package.json`, project creation continues and displays the error details.

## Changes

- Removed `pino` and `pino-pretty` from `create-mastra` runtime dependencies and Rollup externals.
- Updated template cloning to warn through `@clack/prompts.log.warn` when `package.json` updates fail.
- Preserved details for both `Error` and non-`Error` failures.
- Added tests for missing, invalid, unwritable, and non-`Error` `package.json` update failures.
- Added patch changesets for `create-mastra` and `mastra`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->