### PR TITLE
fix(factory-ui): keep the transcript from duplicating content after a tab switch

### DIFF
--- a/.changeset/eight-seals-fly.md
+++ b/.changeset/eight-seals-fly.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the Factory chat transcript drawing the same content twice after coming back to a tab. While a run streams, leaving the tab drops the event stream and the transcript refetches on return: an assistant reply the server had persisted as its own step, and a steer whose live event was missed, both landed on screen a second time. The refetched window is now paired against what is already drawn — by message id, by tool call, then by the text itself — so it only inserts what is genuinely missing.
+
+Also fixed a tool call rendering as two half-filled cards when a steer interrupted it: live tool state followed the newest assistant message instead of staying with the call it belongs to.

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -44,6 +44,10 @@ function messageParts(entry: unknown): unknown[] {
   return isMessageEntry(entry) ? entry.message.content.parts : [];
 }
 
+function isToolInvocationPart(part: unknown): part is { toolInvocation: { toolCallId: string } } {
+  return typeof part === 'object' && part !== null && 'toolInvocation' in part;
+}
+
 function isMessageEntry(entry: unknown): entry is MessageEntryFixture {
   return (
     typeof entry === 'object' && entry !== null && 'kind' in entry && entry.kind === 'message' && 'message' in entry
@@ -438,6 +442,43 @@ describe('transcript reducer message entries', () => {
       },
     ]);
   });
+
+  it('keeps a tool call in one card when a steer rotates the assistant message mid-stream', () => {
+    // A steer closes the running assistant message and opens the next one while
+    // the tool arguments are still streaming; the remaining deltas belong to the
+    // call that started, not to whatever message is latest.
+    let state = transcriptReducer(initialTranscript, {
+      type: 'event',
+      event: {
+        type: 'message_start',
+        message: dbMessage('turn-1', 'assistant', [{ type: 'text', text: 'reviewing' }]),
+      },
+    });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: { type: 'tool_input_start', toolCallId: 'tool-1', toolName: 'submit_review' },
+    });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: { type: 'tool_input_delta', toolCallId: 'tool-1', argsTextDelta: 'the implementation reuses' },
+    });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: { type: 'message_start', message: dbMessage('turn-2', 'assistant', [{ type: 'text', text: '' }]) },
+    });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: { type: 'tool_input_delta', toolCallId: 'tool-1', argsTextDelta: ' the backing agent' },
+    });
+
+    const cards = state.entries.flatMap(entry =>
+      messageParts(entry).filter(part => isToolInvocationPart(part) && part.toolInvocation.toolCallId === 'tool-1'),
+    );
+    expect(cards).toHaveLength(1);
+    expect(state.entries[0]).toMatchObject({
+      runtimeTools: { 'tool-1': { argsText: 'the implementation reuses the backing agent' } },
+    });
+  });
 });
 
 describe('transcript reducer mergeWindow', () => {
@@ -804,6 +845,91 @@ describe('transcript reducer mergeWindow', () => {
       { type: 'text' },
       { toolInvocation: { state: 'result', result: 'ok' } },
     ]);
+  });
+
+  it('does not redraw the text of a turn the server persisted as its own step', () => {
+    // The stream carries one assistant message per run; the server persists one
+    // per step, so the trailing text comes back under an id the timeline never
+    // saw — and used to land on screen a second time on every revalidation.
+    let state = createInitialTranscript({ messages: [] });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('streamed-turn', 'assistant', [
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'result', toolCallId: 'tool-1', toolName: 'view', args: {}, result: 'ok' },
+          },
+          { type: 'text', text: 'Almost, but not approvable yet.' },
+        ]),
+      },
+    });
+
+    const next = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [
+        dbMessage('step-1', 'assistant', [
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'result', toolCallId: 'tool-1', toolName: 'view', args: {}, result: 'ok' },
+          },
+        ]),
+        dbMessage('step-2', 'assistant', [{ type: 'text', text: 'Almost, but not approvable yet.' }]),
+      ],
+    });
+
+    expect(next.entries).toHaveLength(1);
+  });
+
+  it('still inserts a window copy that extends what the gap left on screen', () => {
+    let state = createInitialTranscript({ messages: [] });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('streamed-turn', 'assistant', [{ type: 'text', text: 'Almost' }]),
+      },
+    });
+
+    const next = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [dbMessage('step-2', 'assistant', [{ type: 'text', text: 'Almost, but not approvable yet.' }])],
+    });
+
+    expect(next.entries).toHaveLength(2);
+  });
+
+  it('lets the persisted copy claim the local echo of a steer', () => {
+    // A steer sent while the tab is hidden loses its live signal event to the
+    // SSE gap: the reconnect refetch is the first time the timeline sees it, and
+    // the echo it belongs to carries a client-minted `local-…` id.
+    let state = createInitialTranscript({ messages: [], threadId: 't1' });
+    state = transcriptReducer(state, { type: 'localUser', text: 'stop and read the file', steer: true });
+
+    const next = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [signalMessage({ id: 'sig-1', type: 'user', tagName: 'user', text: 'stop and read the file' })],
+    });
+
+    expect(next.entries).toHaveLength(1);
+    expect(next.entries[0]).toMatchObject({ steer: true });
+  });
+
+  it('draws both when the same text is sent twice', () => {
+    let state = createInitialTranscript({ messages: [], threadId: 't1' });
+    state = transcriptReducer(state, { type: 'localUser', text: 'again' });
+    state = transcriptReducer(state, { type: 'localUser', text: 'again' });
+
+    const next = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [
+        signalMessage({ id: 'sig-1', type: 'user', tagName: 'user', text: 'again' }),
+        signalMessage({ id: 'sig-2', type: 'user', tagName: 'user', text: 'again' }),
+      ],
+    });
+
+    expect(next.entries).toHaveLength(2);
   });
 });
 

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -612,47 +612,23 @@ function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]):
   if (messages.length === 0) return state;
 
   const reconciled = reconcileToolResults(adoptCoveringWindowCopies(state, messages), messages);
+  const onScreenIndex = claimOnScreenEntries(reconciled.entries, messages);
 
-  // Streamed turns adopt the loop's persisted message id (#21185), so window
-  // copies normally match by id; the shared-toolCallId fallback covers paths
-  // that can still diverge (retries, resume, older servers) — inserting such a
-  // window message would duplicate a turn reconcileToolResults heals in place.
-  const entryToolCallIds = reconciled.entries.map(entry =>
-    entry.kind === 'message' && entry.message.role === 'assistant'
-      ? new Set(toolCallIdsOf(entry.message.content.parts))
-      : undefined,
-  );
-  const matchesEntry = (entryIndex: number, message: MastraDBMessage): boolean => {
-    const entry = reconciled.entries[entryIndex];
-    if (entry.kind !== 'message') return false;
-    if (entry.id === message.id) return true;
-    if (message.role !== 'assistant') return false;
-    const toolCallIds = entryToolCallIds[entryIndex];
-    if (!toolCallIds || toolCallIds.size === 0) return false;
-    return toolCallIdsOf(message.content.parts).some(toolCallId => toolCallIds.has(toolCallId));
-  };
-  const onScreenIndexFor = (message: MastraDBMessage, from: number): number => {
-    for (let entryIndex = from; entryIndex < reconciled.entries.length; entryIndex++) {
-      if (matchesEntry(entryIndex, message)) return entryIndex;
-    }
-    return -1;
-  };
-
-  if (messages.every(message => onScreenIndexFor(message, 0) !== -1)) return reconciled;
+  if (messages.every(message => onScreenIndex.has(message))) return reconciled;
 
   const entries: TimelineEntry[] = [];
   let cursor = 0;
   let missing: MastraDBMessage[] = [];
 
   for (const message of messages) {
-    if (onScreenIndexFor(message, 0) === -1) {
+    const anchorIndex = onScreenIndex.get(message);
+    if (anchorIndex === undefined) {
       missing.push(message);
       continue;
     }
     // Out-of-order anchor (the window disagrees with the timeline): leave it
     // where the timeline put it rather than moving rendered content around.
-    const anchorIndex = onScreenIndexFor(message, cursor);
-    if (anchorIndex === -1) continue;
+    if (anchorIndex < cursor) continue;
     entries.push(...reconciled.entries.slice(cursor, anchorIndex), ...messagesToEntries(missing));
     missing = [];
     cursor = anchorIndex;
@@ -660,6 +636,77 @@ function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]):
   entries.push(...reconciled.entries.slice(cursor), ...messagesToEntries(missing));
 
   return { ...reconciled, entries };
+}
+
+/**
+ * Pair each window message with the entry that already draws it — one anchor per
+ * message, so whatever stays unpaired is exactly what the timeline is missing.
+ *
+ * Identity widens from the persisted id to a shared tool call to the drawn text,
+ * because ids alone cannot carry the two shapes the transcript actually sees:
+ * the stream sends one assistant message per run while the server persists one
+ * per step, and the composer's optimistic echo lives under a `local-…` id the
+ * server never confirms (`sendMessage`/`steer` answer nothing). A text pairing
+ * is consumed once per entry, so sending the same words twice still draws two
+ * bubbles.
+ */
+function claimOnScreenEntries(entries: TimelineEntry[], messages: MastraDBMessage[]): Map<MastraDBMessage, number> {
+  const onScreen = entries.map(indexMessageEntry);
+  const anchors = new Map<MastraDBMessage, number>();
+  const claimedEntries = new Set<number>();
+  const claimedTexts = new Set<string>();
+
+  for (const message of messages) {
+    const displayed = toMessageEntry(message).message;
+    const toolCallIds = toolCallIdsOf(displayed.content.parts);
+    const texts = drawableTexts(displayed);
+    const textClaim = (index: number) => `${index} ${texts.join('\n')}`;
+
+    for (const [index, candidate] of onScreen.entries()) {
+      if (!candidate) continue;
+      const sameMessage =
+        candidate.entry.id === message.id || toolCallIds.some(toolCallId => candidate.toolCallIds.has(toolCallId));
+      // Whole text parts have to match: a window copy that extends what an SSE
+      // gap left on screen still needs inserting for its tail to appear at all.
+      const alreadyDrawn =
+        toolCallIds.length === 0 &&
+        texts.length > 0 &&
+        candidate.entry.message.role === displayed.role &&
+        texts.every(text => candidate.texts.has(text));
+
+      const claimsIdentity = sameMessage && !claimedEntries.has(index);
+      const claimsText = alreadyDrawn && !claimedTexts.has(textClaim(index));
+      if (!claimsIdentity && !claimsText) continue;
+
+      anchors.set(message, index);
+      claimedEntries.add(index);
+      if (texts.length > 0) claimedTexts.add(textClaim(index));
+      break;
+    }
+  }
+
+  return anchors;
+}
+
+interface OnScreenMessage {
+  entry: MessageEntry;
+  toolCallIds: Set<string>;
+  texts: Set<string>;
+}
+
+function indexMessageEntry(entry: TimelineEntry): OnScreenMessage | undefined {
+  if (entry.kind !== 'message') return undefined;
+  return {
+    entry,
+    toolCallIds: new Set(toolCallIdsOf(entry.message.content.parts)),
+    texts: new Set(drawableTexts(entry.message)),
+  };
+}
+
+function drawableTexts(message: MastraDBMessage): string[] {
+  return message.content.parts.flatMap(part =>
+    part.type === 'text' && part.text.trim().length > 0 ? [part.text.trim()] : [],
+  );
 }
 
 function toolCallIdsOf(parts: MastraMessagePart[]): string[] {
@@ -951,6 +998,22 @@ function hasAssistantText(state: TranscriptState): boolean {
   );
 }
 
+/**
+ * The entry a tool event belongs to: the one already holding that call, else the
+ * latest assistant entry. A run rotates its assistant message on a steer or a
+ * goal boundary, so the latest entry alone would move mid-call and split the
+ * card in two — one holding the args streamed before the rotation, one after.
+ */
+function toolAnchorIndex(entries: TimelineEntry[], toolCallId: string): number {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry.kind !== 'message') continue;
+    if (entry.runtimeTools?.[toolCallId]) return i;
+    if (entry.message.content.parts.some(part => toolCallIdForPart(part) === toolCallId)) return i;
+  }
+  return latestAssistantIndex(entries);
+}
+
 /** Find the latest assistant entry, creating one if none exists. */
 function latestAssistantIndex(entries: TimelineEntry[]): number {
   for (let i = entries.length - 1; i >= 0; i--) {
@@ -967,7 +1030,7 @@ function withTool(
   seed?: Partial<ToolCall>,
 ): TranscriptState {
   const entries = [...state.entries];
-  let idx = latestAssistantIndex(entries);
+  let idx = toolAnchorIndex(entries, toolCallId);
   if (idx === -1) {
     const message: MastraDBMessage = {
       id: `assistant-tools-${Date.now()}`,


### PR DESCRIPTION
Coming back to a tab while a run is streaming no longer redraws content that is already on screen, and a tool call interrupted by a steer stays in one card.

Leaving the tab drops the event stream, so the transcript refetches its message window on return. That window was reconciled by message id only, and ids cannot line up here: the engine streams one assistant message per run while the server persists one per step, and the composer's optimistic echo lives under a `local-` id the server never confirms. So the persisted copy of a reply, and of a steer whose live event was missed, both landed on screen a second time. The window is now paired one-to-one against what is already drawn, first by id, then by tool call, then by the drawn text itself, and only what is genuinely missing gets inserted.

The split tool card had its own cause: live tool state was anchored on the newest assistant entry, and a steer rotates that entry mid-stream, so the deltas arriving after the rotation opened a second part with the same `toolCallId`. It now anchors on the entry that already holds the call.

The first bug is really born in core, in the divergence between the streamed and the persisted message identity, and I fixed it in the client on purpose so the transcript heals whatever the server sends. One tradeoff worth knowing: if the agent sends exactly the same text twice and the earlier copy has scrolled out of the refetched window, the second one can be swallowed until the next remount. I took that over a duplicate that never goes away. Verified with reducer unit tests, 718 factory-ui tests green, not in a browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you switch tabs during a streaming chat, the app now avoids showing the same message twice when you return. It also keeps interrupted tool calls in the correct chat card.

## Changes

- Reconciled refetched messages with displayed messages by:
  - Message ID
  - Shared tool-call ID
  - Matching text
- Inserted only genuinely missing transcript content.
- Preserved distinct duplicate user messages.
- Anchored tool events to the assistant entry that already contains the tool call.
- Added regression tests for transcript deduplication and interrupted tool calls.
- Added a patch changeset for `@mastra/factory`.

## Testing

- 718 factory-ui tests passed.
- Reducer unit tests passed.
- Browser testing was not performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->