### PR TITLE
Require responsive screenshots for playground UI changes

### DIFF
--- a/packages/playground-ui/AGENTS.md
+++ b/packages/playground-ui/AGENTS.md
@@ -27,5 +27,7 @@ journey. Run e2e-frontend-validation for frontend changes before merging when
 applicable.
 
 This package needs both component validation and realistic UI validation.
+Always include mobile, tablet, and desktop screenshots when handing off any UI
+modification.
 Preserve design-system consistency and existing component APIs where possible.
 Do not add new `asChild` usage; prefer Base UI's native `render` prop for stronger type safety.

--- a/packages/playground/AGENTS.md
+++ b/packages/playground/AGENTS.md
@@ -29,4 +29,7 @@ types (no inline types, no `as any`). MSW is wired in `vitest.setup.ts`.
 Use Playwright E2E (`e2e-tests-studio`) only when MSW can't model the journey
 (multi-page, real server, streaming, real browser concerns).
 
+Always include mobile, tablet, and desktop screenshots when handing off any UI
+modification.
+
 Coordinate with packages/playground-ui for cross-boundary changes.


### PR DESCRIPTION
## Summary

- Require mobile, tablet, and desktop screenshots when handing off UI modifications in `playground` and `playground-ui`.

## Testing

Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When someone changes the playground UI, they must provide screenshots for phones, tablets, and desktop computers. This helps reviewers see how the change works on different screen sizes.

## Changes

- Added the screenshot handoff requirement to `packages/playground-ui/AGENTS.md`.
- Added the screenshot handoff requirement to `packages/playground/AGENTS.md`.

## Testing

- Not run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->