### PR TITLE
docs: prioritize MCP in connections

### DIFF
--- a/docs/src/content/en/docs/connections/overview.mdx
+++ b/docs/src/content/en/docs/connections/overview.mdx
@@ -17,10 +17,10 @@ import TabItem from "@theme/TabItem";
 
 Connections let Mastra work with remote agents, coding agents, provider software development kit (SDK) runtimes, and external tools and resources. Choose a connection type based on which system owns the agent runtime and what you need to exchange.
 
+- [**Model Context Protocol (MCP)**](/docs/connections/mcp): Connect agents to external tools and resources, or expose Mastra agents, tools, workflows, prompts, and resources to MCP-compatible systems.
 - [**Agent-to-Agent (A2A)**](/docs/connections/a2a): Expose or consume remote agents across service, framework, vendor, and language boundaries.
 - [**Agent Client Protocol (ACP)**](/docs/connections/acp): Run compatible coding-agent processes as Mastra tools or subagents.
 - [**SDK agents**](/docs/connections/sdk-agents): Register Claude, Cursor, or OpenAI SDK-backed agents while the provider SDK retains control of the runtime, tools, permissions, and agent loop.
-- [**Model Context Protocol (MCP)**](/docs/connections/mcp): Connect agents to external tools and resources, or expose Mastra agents, tools, workflows, prompts, and resources to MCP-compatible systems.
 
 ## When to use connections
 

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -311,6 +311,11 @@ const sidebars = {
           items: [
             {
               type: 'doc',
+              id: 'connections/mcp',
+              label: 'MCP',
+            },
+            {
+              type: 'doc',
               id: 'connections/a2a',
               label: 'A2A',
             },
@@ -323,11 +328,6 @@ const sidebars = {
               type: 'doc',
               id: 'connections/sdk-agents',
               label: 'SDK Agents',
-            },
-            {
-              type: 'doc',
-              id: 'connections/mcp',
-              label: 'MCP',
             },
           ],
         },


### PR DESCRIPTION
## Summary
- move MCP directly beneath Overview in the Connections sidebar
- list MCP first on the Connections overview page

## Testing
- `pnpm lint:prose`
- `git diff --check`

## Validation note
- `pnpm validate` passes frontmatter, sidebar sorting, and sidebar coverage, but the aggregate command reports an unrelated stale `new` tag for `mastra-platform/regions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes MCP easier to find in the Connections documentation. It places MCP first in both the sidebar and the overview page.

## Changes

- Moved MCP directly below Overview in the Connections sidebar.
- Listed MCP before A2A, ACP, and SDK Agents on the Connections overview page.

## Validation

- `pnpm lint:prose` passed.
- `git diff --check` passed.
- `pnpm validate` passed frontmatter, sidebar sorting, and sidebar coverage checks.
- `pnpm validate` reported an unrelated stale `new` tag for `mastra-platform/regions`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->