### PR TITLE
fix(pg): make listWorkflowRuns status filter indexable on jsonb snapshots

### DIFF
--- a/.changeset/fix-pg-workflow-status-indexable.md
+++ b/.changeset/fix-pg-workflow-status-indexable.md
@@ -2,4 +2,4 @@
 '@mastra/pg': patch
 ---
 
-Fix `listWorkflowRuns` status filter so it stays indexable on `jsonb` snapshot columns. The filter previously wrapped the column in `regexp_replace(snapshot::text, …)::jsonb ->> 'status'`, which forces a sequential scan (the sanitization is a no-op on `jsonb`, where Postgres already rejects the offending escapes at insert time). The predicate is now chosen by the live column type: `jsonb` uses the plain, indexable `snapshot ->> 'status'`, while `json`/`text` columns keep the sanitizing form.
+Speed up `listWorkflowRuns` when filtering by `status`. On the default `jsonb` snapshot storage the status filter can now use an index instead of scanning every row, so filtered and paginated listings stay fast as run history grows. Existing `json`/`text` snapshot schemas keep working unchanged.

--- a/.changeset/fix-pg-workflow-status-indexable.md
+++ b/.changeset/fix-pg-workflow-status-indexable.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fix `listWorkflowRuns` status filter so it stays indexable on `jsonb` snapshot columns. The filter previously wrapped the column in `regexp_replace(snapshot::text, …)::jsonb ->> 'status'`, which forces a sequential scan (the sanitization is a no-op on `jsonb`, where Postgres already rejects the offending escapes at insert time). The predicate is now chosen by the live column type: `jsonb` uses the plain, indexable `snapshot ->> 'status'`, while `json`/`text` columns keep the sanitizing form.

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -604,6 +604,23 @@ export class PgDB extends MastraBase {
   }
 
   /**
+   * Returns the live SQL type of a column (`data_type` from `information_schema`,
+   * e.g. `jsonb`, `json`, `text`), or `null` when the column does not exist.
+   * Always probes the catalog because the init-window schema snapshot only tracks
+   * column names, not their types.
+   */
+  async getColumnType(table: string, column: string): Promise<string | null> {
+    const schema = this.schemaName || 'public';
+
+    const result = await this.client.oneOrNone(
+      `SELECT data_type FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND (column_name = $3 OR column_name = $4)`,
+      [schema, table, column, column.toLowerCase()],
+    );
+
+    return result ? String(result.data_type) : null;
+  }
+
+  /**
    * Prepares values for insertion, handling JSONB columns by stringifying them
    */
   private prepareValuesForInsert(record: Record<string, any>, tableName: TABLE_NAMES): any[] {

--- a/stores/pg/src/storage/domains/workflows/index.ts
+++ b/stores/pg/src/storage/domains/workflows/index.ts
@@ -24,6 +24,7 @@ import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import { PgDB, resolvePgConfig, generateTableSQL, generateIndexSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { runPrune, resolveTargets } from '../../retention';
+import { buildWorkflowStatusFilter } from './status-filter';
 
 function getSchemaName(schema?: string) {
   return schema ? `"${schema}"` : '"public"';
@@ -558,15 +559,13 @@ export class WorkflowsPG extends WorkflowsStorage {
       }
 
       if (status) {
-        // Use regexp_replace to strip problematic Unicode escape sequences before casting to jsonb.
-        // PostgreSQL's jsonb cast fails on:
-        // - \u0000 (null character) with error 22P05 "unsupported Unicode escape sequence"
-        // - \uD800-\uDFFF (unpaired surrogates) with "Unicode low surrogate must follow a high surrogate"
-        // The regex pattern matches \u0000 and all surrogate code points (D800-DFFF).
-        // See: https://github.com/mastra-ai/mastra/issues/11563
-        conditions.push(
-          `regexp_replace(snapshot::text, '\\\\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})', '', 'g')::jsonb ->> 'status' = $${paramIndex}`,
-        );
+        // When `snapshot` is `jsonb` (the store's default), read `status` directly so the
+        // predicate stays indexable. The regexp_replace sanitization is only needed on
+        // `json`/`text` columns, where a stored NUL or unpaired surrogate makes the
+        // `::jsonb` cast throw 22P05. See: https://github.com/mastra-ai/mastra/issues/11563
+        // Unknown/missing column type falls back to the safe sanitizing form.
+        const snapshotColumnType = await this.#db.getColumnType(TABLE_WORKFLOW_SNAPSHOT, 'snapshot');
+        conditions.push(buildWorkflowStatusFilter(snapshotColumnType === 'jsonb', paramIndex));
         values.push(status);
         paramIndex++;
       }

--- a/stores/pg/src/storage/domains/workflows/status-filter.test.ts
+++ b/stores/pg/src/storage/domains/workflows/status-filter.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { buildWorkflowStatusFilter } from './status-filter';
+
+// Regression for #21619: on a jsonb snapshot column the status predicate must be the
+// plain, indexable form. The regexp_replace sanitization is a no-op on jsonb (Postgres
+// rejects the bad escapes at insert time) and is the only reason the predicate cannot be
+// indexed, forcing a full table scan. It is kept only for json/text columns (the #11563 fix).
+describe('buildWorkflowStatusFilter', () => {
+  it('uses the plain, indexable predicate for jsonb columns', () => {
+    const sql = buildWorkflowStatusFilter(true, 3);
+    expect(sql).toBe(`snapshot ->> 'status' = $3`);
+    // No wrapping expression -> the planner can use a btree on (snapshot ->> 'status').
+    expect(sql).not.toContain('regexp_replace');
+    expect(sql).not.toContain('::jsonb');
+    expect(sql).not.toContain('::text');
+  });
+
+  it('keeps the sanitizing predicate for non-jsonb (json/text) columns', () => {
+    const sql = buildWorkflowStatusFilter(false, 2);
+    expect(sql).toContain('regexp_replace(snapshot::text');
+    // strips NUL and surrogate (D800-DFFF) escapes before the jsonb cast
+    expect(sql).toContain(`'\\\\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})'`);
+    expect(sql).toContain(`::jsonb ->> 'status' = $2`);
+  });
+
+  it('interpolates the parameter index into both branches', () => {
+    expect(buildWorkflowStatusFilter(true, 7)).toContain('$7');
+    expect(buildWorkflowStatusFilter(false, 9)).toContain('$9');
+  });
+});

--- a/stores/pg/src/storage/domains/workflows/status-filter.ts
+++ b/stores/pg/src/storage/domains/workflows/status-filter.ts
@@ -1,0 +1,23 @@
+/**
+ * Builds the `status` filter predicate used by `WorkflowsPG.listWorkflowRuns`.
+ *
+ * On a `jsonb` snapshot column the stored value is guaranteed to be valid JSON.
+ * Postgres rejects NUL and unpaired-surrogate escapes at insert time, so `status`
+ * is read directly. This keeps the predicate indexable (e.g. a btree on
+ * `(snapshot ->> 'status')`), avoiding the full table scan that the sanitizing
+ * form forces.
+ *
+ * On a `json`/`text` column those escapes can be stored and would make a `::jsonb`
+ * cast throw `22P05`, so they are stripped first. That path is not indexable but
+ * preserves the fix from https://github.com/mastra-ai/mastra/issues/11563.
+ *
+ * @param isJsonbSnapshot Whether the live `snapshot` column type is `jsonb`.
+ * @param paramIndex The 1-based positional parameter index for the status value.
+ */
+export function buildWorkflowStatusFilter(isJsonbSnapshot: boolean, paramIndex: number): string {
+  if (isJsonbSnapshot) {
+    return `snapshot ->> 'status' = $${paramIndex}`;
+  }
+
+  return `regexp_replace(snapshot::text, '\\\\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})', '', 'g')::jsonb ->> 'status' = $${paramIndex}`;
+}


### PR DESCRIPTION
## Description

`WorkflowsPG.listWorkflowRuns` builds its `status` filter as:

```sql
regexp_replace(snapshot::text, '\u(0000|[Dd][89A-Fa-f][0-9A-Fa-f]{2})', '', 'g')::jsonb ->> 'status' = $N
```

Wrapping the `snapshot` column in `regexp_replace(snapshot::text, …)::jsonb` makes the predicate **unindexable**, so every filtered `listWorkflowRuns` call does a sequential scan that serializes + regex-rewrites + reparses every snapshot row (paid twice under pagination via the companion `COUNT(*)`). On the store's default `jsonb` column that cost buys nothing: Postgres already rejects `` / unpaired surrogates at insert time, so no stored value can contain them, and the sanitization there is a no-op.

The sanitizing form is still needed on `json`/`text` columns, where a stored bad escape makes the `::jsonb` cast throw `22P05` — that was the point of #11563. So the fix keeps both paths and picks by the **live column type**.

## Fix

- Add `PgDB.getColumnType(table, column)` — a thin `information_schema.columns` probe (mirrors the existing `hasColumn`, schema-qualified).
- `listWorkflowRuns` now selects the predicate via a small pure helper `buildWorkflowStatusFilter(isJsonbSnapshot, paramIndex)`:
  - `jsonb` → `snapshot ->> 'status' = $N` (indexable),
  - `json` / `text` / unknown → the original sanitizing predicate, byte-for-byte unchanged.

No behaviour change to results — only the query shape on `jsonb`. The helper is extracted so it can be unit-tested without a live database.

## Testing

`pnpm --filter @mastra/pg exec vitest run …/status-filter.test.ts` → 3 passing: asserts the `jsonb` branch is the plain indexable predicate (no `regexp_replace`/`::jsonb`/`::text`), the non-`jsonb` branch is unchanged, and the parameter index interpolates in both.

## Note

This adds one `information_schema` lookup per `listWorkflowRuns` call that has a status filter — cheap, and a good trade for removing a full table scan, but happy to cache the column type if you'd prefer.

Closes #21619


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Workflow status searches now use a database index when the snapshot column supports it. The existing safety checks remain for older column types that can contain invalid data.

## Changes

- Added `PgDB.getColumnType()` to read the live PostgreSQL column type.
- Updated `listWorkflowRuns`:
  - Uses the indexable `snapshot ->> 'status'` predicate for `jsonb`.
  - Keeps the sanitizing predicate for `json`, `text`, and unknown types.
- Extracted `buildWorkflowStatusFilter()` for unit testing.
- Added tests for both predicate branches and parameter indexes.
- Added a changeset for `@mastra/pg`.

## Testing

- Added regression tests for predicate selection and parameter interpolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->