### PR TITLE
fix(core): input-processor filtering no longer corrupts the persisted memory view

### DIFF
--- a/.changeset/fix-core-input-processor-persisted-view.md
+++ b/.changeset/fix-core-input-processor-persisted-view.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Stop input processors from corrupting the persisted memory view. An input processor that rewrites the message array (e.g. `ToolCallFilter`, which strips `tool-invocation` parts for the LLM prompt) was mutating the same `MessageList` that backs the persisted/remembered view, so stored `tool-invocation` parts were reported as their filtered copies. Remembered (memory-sourced) messages are now snapshotted as loaded from storage, and `getPersisted.remembered` serves that original snapshot — the LLM-input view still sees the processor's transforms, but the persisted view no longer does.
+Input processors no longer change what gets saved to memory. Previously, with memory enabled, a processor that rewrites messages for the model (such as `ToolCallFilter`) could also alter the remembered messages in storage, dropping stored tool-invocation data. Remembered messages are now kept as they were saved, while the model still sees the processor's filtered view.

--- a/.changeset/fix-core-input-processor-persisted-view.md
+++ b/.changeset/fix-core-input-processor-persisted-view.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Stop input processors from corrupting the persisted memory view. An input processor that rewrites the message array (e.g. `ToolCallFilter`, which strips `tool-invocation` parts for the LLM prompt) was mutating the same `MessageList` that backs the persisted/remembered view, so stored `tool-invocation` parts were reported as their filtered copies. Remembered (memory-sourced) messages are now snapshotted as loaded from storage, and `getPersisted.remembered` serves that original snapshot — the LLM-input view still sees the processor's transforms, but the persisted view no longer does.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -786,7 +786,14 @@ export class MessageList {
     },
   };
   private rememberedPersisted = {
-    db: () => this.all.db().filter(m => this.memoryMessagesPersisted.has(m)),
+    // Report remembered messages as they were loaded from storage. Input processors rewrite the
+    // live objects (e.g. ToolCallFilter strips tool-invocation parts for the LLM prompt); the
+    // persisted view must ignore those transient edits so memory/storage is never corrupted.
+    db: () =>
+      this.all
+        .db()
+        .filter(m => this.memoryMessagesPersisted.has(m))
+        .map(m => this.stateManager.getPersistedRemembered(m.id) ?? m),
     v1: () => convertToV1Messages(this.rememberedPersisted.db()),
 
     aiV5: {

--- a/packages/core/src/agent/message-list/state/MessageStateManager.ts
+++ b/packages/core/src/agent/message-list/state/MessageStateManager.ts
@@ -30,6 +30,12 @@ export class MessageStateManager {
   private newResponseMessagesPersisted = new Set<MastraDBMessage>();
   private userContextMessagesPersisted = new Set<MastraDBMessage>();
 
+  // Snapshot of remembered (memory-sourced) messages as they were loaded from storage,
+  // keyed by id. Input processors (e.g. ToolCallFilter) rewrite the live message objects
+  // to shape the LLM prompt; the persisted views must keep reporting the original stored
+  // message so those transforms never leak back into memory/storage.
+  private persistedRememberedById = new Map<string, MastraDBMessage>();
+
   /**
    * Add a message to the appropriate source set and persisted set
    */
@@ -38,6 +44,12 @@ export class MessageStateManager {
       case 'memory':
         this.memoryMessages.add(message);
         this.memoryMessagesPersisted.add(message);
+        // Capture the message as it was first loaded from storage. A later input processor
+        // may replace this object with a rewritten copy (same id) for the LLM prompt; the
+        // persisted views must still surface this original, so never overwrite an existing entry.
+        if (!this.persistedRememberedById.has(message.id)) {
+          this.persistedRememberedById.set(message.id, message);
+        }
         break;
       case 'response':
         // Promoting from memory (e.g. OM step prepare → merge step-2 text): keep a single
@@ -152,7 +164,18 @@ export class MessageStateManager {
   }
 
   /**
-   * Remove a message from all source sets
+   * Get the remembered (memory-sourced) message as it was originally loaded from storage.
+   * Returns undefined for messages that were never loaded from memory. Used by the persisted
+   * views so an input processor rewriting the live object cannot corrupt the stored record.
+   */
+  getPersistedRemembered(id: string): MastraDBMessage | undefined {
+    return this.persistedRememberedById.get(id);
+  }
+
+  /**
+   * Remove a message from all source sets. The persisted-remembered snapshot is intentionally
+   * left intact: an input processor removing/replacing a remembered message must not erase the
+   * record of what was actually stored.
    */
   removeMessage(message: MastraDBMessage): void {
     this.memoryMessages.delete(message);

--- a/packages/core/src/processors/processors/tool-call-filter.test.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.test.ts
@@ -1,17 +1,19 @@
 import { stepCountIs } from '@internal/ai-sdk-v5';
 import { convertArrayToReadableStream, mockValues, mockId } from '@internal/ai-sdk-v5/test';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { z } from 'zod/v4';
 
 import { Mastra } from '../..';
 import { MessageList } from '../../agent/message-list';
 import { EventEmitterPubSub } from '../../events';
+import type { IMastraLogger } from '../../logger';
 import { loop } from '../../loop/loop';
 import { MastraLanguageModelV2Mock } from '../../loop/test-utils/MastraLanguageModelV2Mock';
 import type { MastraDBMessage } from '../../memory/types';
 import { toolCallFilterProvider } from '../../processor-provider/providers';
 import { InMemoryStore } from '../../storage';
 import type { ProcessInputStepArgs } from '../index';
+import { ProcessorRunner } from '../runner';
 
 import { ToolCallFilter } from './tool-call-filter';
 
@@ -2003,6 +2005,110 @@ describe('ToolCallFilter', () => {
       expect(step4Prompt.some((msg: any) => msg.content?.some((p: any) => p.toolCallId === 'call-weather-3'))).toBe(
         true,
       );
+    });
+  });
+
+  // Regression: https://github.com/mastra-ai/mastra/issues/21631
+  // ToolCallFilter is an input-only processor: it strips tool calls from the LLM prompt but the
+  // filtered messages must "remain saved in memory". Running it through the shared ProcessorRunner
+  // used to rewrite the remembered (memory-sourced) messages in the persisted MessageList, so the
+  // stored tool-invocation parts were destroyed. The prompt view must be filtered while the
+  // persisted view keeps the original stored message intact.
+  describe('Issue #21631: input filtering must not mutate the persisted MessageList', () => {
+    const mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trackException: vi.fn(),
+      getTransports: vi.fn(() => new Map()),
+    } as unknown as IMastraLogger;
+
+    const hasToolInvocation = (message: MastraDBMessage | undefined): boolean => {
+      if (!message || typeof message.content === 'string' || !message.content?.parts) return false;
+      return message.content.parts.some((p: any) => p.type === 'tool-invocation');
+    };
+
+    // An assistant tool call made on a previous turn, loaded back from memory this turn.
+    const rememberedAssistantWithToolCall = (): MastraDBMessage => ({
+      id: 'remembered-assistant',
+      role: 'assistant',
+      content: {
+        format: 2,
+        parts: [
+          { type: 'text' as const, text: 'Let me look that up.' },
+          {
+            type: 'tool-invocation' as const,
+            toolInvocation: {
+              state: 'result' as const,
+              toolCallId: 'call-1',
+              toolName: 'search_documents',
+              args: { query: 'pricing' },
+              result: { documents: [{ title: 'Pricing', content: '$99' }] },
+            },
+          },
+        ],
+      },
+      createdAt: new Date(1000),
+      threadId: 'thread-21631',
+    });
+
+    const currentUserInput = (id: string, text: string): MastraDBMessage => ({
+      id,
+      role: 'user',
+      content: { format: 2, parts: [{ type: 'text' as const, text }] },
+      createdAt: new Date(2000),
+      threadId: 'thread-21631',
+    });
+
+    it('filters tool calls from the LLM prompt but keeps them in the persisted remembered messages', async () => {
+      const messageList = new MessageList({ threadId: 'thread-21631' });
+      messageList.add([rememberedAssistantWithToolCall()], 'memory');
+      messageList.add([currentUserInput('current-user', 'What is the price?')], 'input');
+
+      const runner = new ProcessorRunner({
+        inputProcessors: [new ToolCallFilter()],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await runner.runInputProcessors(messageList);
+
+      // LLM-input view is filtered (ToolCallFilter's documented behavior).
+      const promptRemembered = messageList.get.remembered.db();
+      expect(promptRemembered).toHaveLength(1);
+      expect(hasToolInvocation(promptRemembered[0])).toBe(false);
+
+      // Persisted/stored view still carries the original tool-invocation part.
+      const persistedRemembered = messageList.getPersisted.remembered.db();
+      expect(persistedRemembered).toHaveLength(1);
+      expect(hasToolInvocation(persistedRemembered[0])).toBe(true);
+
+      // The remembered message is not re-queued as an unsaved (new) message to be written back.
+      expect(messageList.drainUnsavedMessages().some(m => m.id === 'remembered-assistant')).toBe(false);
+    });
+
+    it('preserves the original stored tool result even with preserveModelOutput enabled', async () => {
+      const messageList = new MessageList({ threadId: 'thread-21631' });
+      messageList.add([rememberedAssistantWithToolCall()], 'memory');
+      messageList.add([currentUserInput('current-user-2', 'And in AUD?')], 'input');
+
+      const runner = new ProcessorRunner({
+        inputProcessors: [new ToolCallFilter({ preserveModelOutput: true })],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await runner.runInputProcessors(messageList);
+
+      const persisted = messageList.getPersisted.remembered.db()[0];
+      expect(hasToolInvocation(persisted)).toBe(true);
+      const invocation = (persisted.content as { parts: any[] }).parts.find(
+        (p: any) => p.type === 'tool-invocation',
+      );
+      expect(invocation.toolInvocation.result).toEqual({ documents: [{ title: 'Pricing', content: '$99' }] });
     });
   });
 });

--- a/packages/core/src/processors/processors/tool-call-filter.test.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.test.ts
@@ -2039,6 +2039,7 @@ describe('ToolCallFilter', () => {
           { type: 'text' as const, text: 'Let me look that up.' },
           {
             type: 'tool-invocation' as const,
+            providerMetadata: { mastra: { modelOutput: 'Found pricing: $99' } },
             toolInvocation: {
               state: 'result' as const,
               toolCallId: 'call-1',
@@ -2102,6 +2103,11 @@ describe('ToolCallFilter', () => {
       });
 
       await runner.runInputProcessors(messageList);
+
+      // With preserveModelOutput the LLM-input view keeps the model-facing text
+      // instead of dropping the tool result entirely, so this exercises that branch.
+      const promptContent = JSON.stringify(messageList.get.remembered.db()[0].content);
+      expect(promptContent).toContain('Found pricing: $99');
 
       const persisted = messageList.getPersisted.remembered.db()[0];
       expect(hasToolInvocation(persisted)).toBe(true);


### PR DESCRIPTION
## Description

`ToolCallFilter` is documented as input-only ("filtered messages remain saved in memory"), but with memory enabled its filtering leaked into the **persisted** view of the `MessageList`, so stored `tool-invocation` parts were reported as their stripped copies.

Root cause: `ProcessorRunner.runInputProcessors` applies an input processor's array return by `removeByIds()` + `add()` back onto the *same* `MessageList` that serves both the LLM prompt and the persisted/remembered view. `ToolCallFilter.processInput()` returns the whole history with `tool-invocation` parts removed, so the remembered messages in the shared list get replaced by rewritten copies. `getPersisted.remembered` (consumed by scorers) then reports the corrupted messages.

## Fix

A single `MessageList` must serve two views from one backing array: the filtered **LLM-input** view (needed for the prompt) and the **persisted** view (must reflect what's in storage). Rather than special-case each processor, the fix lives where the two views are defined:

- `MessageStateManager` snapshots each remembered (memory-sourced) message the first time it's loaded (`addToSource('memory')`), keyed by id, and never overwrites or clears it on `removeMessage`.
- `MessageList.rememberedPersisted.db()` serves that original snapshot (`getPersistedRemembered(id) ?? m`).

It's reference-preserving: an unmodified message returns the same object, so there's zero behavioural change unless an input processor actually replaced a remembered message.

## Testing

Added regression tests to `tool-call-filter.test.ts`: load a remembered `tool-invocation` message from memory, run it through `runInputProcessors([new ToolCallFilter()])`, and assert the prompt view is filtered while `getPersisted.remembered` still contains the `tool-invocation` (plus the reporter's `preserveModelOutput: true` case).

- Reverting the fix → both regression tests fail (`expected false to be true` on the persisted `tool-invocation`).
- With the fix → `message-list` + `processors` suites: 1714 passed, 2 skipped; `tsc --noEmit` clean.

## Note

On current `main` the save-queue only drains new user/response messages, so the DB rows aren't overwritten through that path the way the original report (on `@mastra/core@1.59.0`) described — the demonstrable defect here is the corruption of the in-memory **persisted view** that scorers read, which is the same documented invariant. One edge remains out of scope: the snapshot map isn't part of `serializeAll`/`deserializeAll`, so durable-agent flows that serialize a `MessageList` *between* input-processing and reading the persisted view aren't covered (that path was already corrupted pre-fix, so this isn't a regression).

Closes #21631


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The PR lets the model use filtered messages without changing the original messages saved for future conversations. Tool calls and their results remain available in persisted history.

## Changes

- Snapshot memory-sourced messages when `MessageStateManager` first loads them.
- Use original snapshots in `rememberedPersisted.db()`.
- Keep `ToolCallFilter` transformations limited to the current LLM prompt.
- Add regression tests for filtered `tool-invocation` messages with and without `preserveModelOutput: true`.
- Add a changeset documenting the fix.

## Validation

- 1,714 tests passed.
- 2 tests skipped.
- TypeScript compilation passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->