### PR TITLE
fix(core): persist completed tool results when a client tool is pending

### DIFF
--- a/.changeset/fixed-calls-flush.md
+++ b/.changeset/fixed-calls-flush.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Flush completed server-side tool results in `llm-mapping-step` before bailing for a pending client-side tool in the same step. Mixed execute + client/toolset turns now stream and persist `tool-result` for the finished call instead of leaving it in `call` state. Fixes #21637.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -191,31 +191,57 @@ describe('createLLMMappingStep HITL behavior', () => {
     );
   });
 
-  it('should bail when SOME tools have results and SOME do not (mixed scenario)', async () => {
-    // Arrange: One tool with execute, one without (the bug scenario)
+  it('should flush completed results then bail when SOME tools have results and SOME do not (#21637)', async () => {
+    // Mixed step: server-side execute() completed + client/HITL tool still pending.
+    // Ending the turn is correct (the client tool handshake), but the completed
+    // sibling must be streamed and persisted first — otherwise it stays in `call`
+    // state and AI SDK clients deadlock waiting for output-available.
     const inputData: ToolCallOutput[] = [
       {
         toolCallId: 'call-1',
         toolName: 'updateTitle',
         args: { title: 'test' },
-        result: { success: true }, // Has result (has execute function)
+        result: { success: true },
       },
       {
         toolCallId: 'call-2',
         toolName: 'updateSummary',
         args: { summary: 'test' },
-        result: undefined, // No result (HITL, no execute function)
+        result: undefined,
       },
     ];
 
-    // Act
     const result = await llmMappingStep.execute(createExecuteParams(inputData));
 
-    // Assert: Should bail (suspend execution) because updateSummary needs HITL
     expect(bail).toHaveBeenCalled();
     expect(result.stepResult.isContinued).toBe(false);
-    // Should NOT emit tool-result chunks
-    expect(controller.enqueue).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'tool-result' }));
+    expect(controller.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-result',
+        payload: expect.objectContaining({
+          toolCallId: 'call-1',
+          toolName: 'updateTitle',
+          result: { success: true },
+        }),
+      }),
+    );
+    expect(messageList.updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-invocation',
+        toolInvocation: expect.objectContaining({
+          state: 'result',
+          toolCallId: 'call-1',
+          toolName: 'updateTitle',
+          result: { success: true },
+        }),
+      }),
+    );
+    expect(controller.enqueue).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-result',
+        payload: expect.objectContaining({ toolCallId: 'call-2' }),
+      }),
+    );
   });
 
   it('should enqueue tool-output-denied when a requireApproval tool is declined (#20880)', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -469,99 +469,100 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
           tc => tc.result === undefined && !tc.error && !tc.aborted && !tc.providerExecuted && !isDeniedApproval(tc),
         );
 
-        if (errorResults?.length > 0 && !hasPendingHITL) {
-          // Process any successful tool results from this turn before continuing.
-          // In a mixed turn (e.g., one valid tool + one hallucinated), the successful
-          // results need their chunks emitted and messages added to the messageList.
-          const successfulResults = inputData.filter(tc => tc.result !== undefined);
-          if (successfulResults.length) {
-            const stepNumber = (initialResult?.output?.steps?.length ?? 0) as number;
-            const steps = (initialResult?.output?.steps ?? []) as Array<StepResult<ToolSet>>;
-            for (const toolCall of successfulResults) {
-              // Compute modelOutput before emitting the chunk so consumers (e.g. harness)
-              // can access it on the chunk's providerMetadata.mastra.modelOutput.
-              // getProviderMetadataWithModelOutput already returns the fully-merged providerMetadata.
-              const providerMetadata = !toolCall.providerExecuted
-                ? await getProviderMetadataWithModelOutput(toolCall)
-                : undefined;
-              const chunkProviderMetadata = (providerMetadata ?? toolCall.providerMetadata) as
-                | ProviderMetadata
-                | undefined;
+        // Flush completed results before deciding continue vs bail. A pending
+        // client/HITL tool in the same step must still suspend the turn (#21637),
+        // but a sibling server-side execute() that already finished must stream
+        // and persist — otherwise the call stays in `call` state with no result.
+        const successfulResults = inputData.filter(tc => tc.result !== undefined);
+        if (successfulResults.length) {
+          const stepNumber = (initialResult?.output?.steps?.length ?? 0) as number;
+          const steps = (initialResult?.output?.steps ?? []) as Array<StepResult<ToolSet>>;
+          for (const toolCall of successfulResults) {
+            // Compute modelOutput before emitting the chunk so consumers (e.g. harness)
+            // can access it on the chunk's providerMetadata.mastra.modelOutput.
+            // getProviderMetadataWithModelOutput already returns the fully-merged providerMetadata.
+            const providerMetadata = !toolCall.providerExecuted
+              ? await getProviderMetadataWithModelOutput(toolCall)
+              : undefined;
+            const chunkProviderMetadata = (providerMetadata ?? toolCall.providerMetadata) as
+              | ProviderMetadata
+              | undefined;
 
-              const chunk = await transformToolChunk(
-                {
-                  type: 'tool-result',
-                  runId: rest.runId,
-                  from: ChunkFrom.AGENT,
-                  payload: {
-                    args: toolCall.args,
-                    toolCallId: toolCall.toolCallId,
-                    toolName: toolCall.toolName,
-                    result: toolCall.result,
-                    providerMetadata: chunkProviderMetadata,
-                    providerExecuted: toolCall.providerExecuted,
-                  },
+            const chunk = await transformToolChunk(
+              {
+                type: 'tool-result',
+                runId: rest.runId,
+                from: ChunkFrom.AGENT,
+                payload: {
+                  args: toolCall.args,
+                  toolCallId: toolCall.toolCallId,
+                  toolName: toolCall.toolName,
+                  result: toolCall.result,
+                  providerMetadata: chunkProviderMetadata,
+                  providerExecuted: toolCall.providerExecuted,
                 },
-                toolCall,
-                'output-available',
-              );
+              },
+              toolCall,
+              'output-available',
+            );
 
-              // Run processToolResult BEFORE the raw result is committed to messageList.
-              // This honors the documented "before the result is added to the message
-              // list" guarantee — on tripwire the raw value never reaches history.
-              // A processor that redacts via messageList.updateToolInvocation has its
-              // value synced back into chunk.payload.result, which the commit below uses.
-              const trResult = await runToolResultProcessors({
-                chunk: chunk as ChunkType<OUTPUT> & {
-                  payload: {
-                    toolCallId: string;
-                    toolName: string;
-                    args?: unknown;
-                    result?: unknown;
-                    providerExecuted?: boolean;
-                  };
-                },
-                stepNumber,
-                steps,
-              });
-              if (!trResult.ok) {
-                emitTripwireChunk(trResult.tripwire);
-                continue;
-              }
-
-              if (!toolCall.providerExecuted) {
-                // Update tool invocations from state:'call' to state:'result' for successful client tools.
-                // Provider-executed tools are handled by llm-execution-step.
-                rest.messageList.updateToolInvocation({
-                  type: 'tool-invocation' as const,
-                  toolInvocation: {
-                    state: 'result' as const,
-                    toolCallId: toolCall.toolCallId,
-                    toolName: sanitizeToolName(toolCall.toolName),
-                    args: toolCall.args,
-                    result: (chunk as { payload: { result: unknown } }).payload.result,
-                    // Preserve the approval decision for an approved approval-gated tool in a mixed
-                    // turn (one tool errored, another approved) so it round-trips on recall too.
-                    ...(toolCall.approval ? { approval: toolCall.approval } : {}),
-                  },
-                  ...(withToolPayloadTransformProviderMetadata(providerMetadata, chunk.metadata)
-                    ? {
-                        providerMetadata: withToolPayloadTransformProviderMetadata(
-                          providerMetadata,
-                          chunk.metadata,
-                        ) as ProviderMetadata,
-                      }
-                    : {}),
-                });
-              }
-
-              const processed = await processAndEnqueueChunk(chunk);
-              if (processed) await rest.options?.onChunk?.(processed);
+            // Run processToolResult BEFORE the raw result is committed to messageList.
+            // This honors the documented "before the result is added to the message
+            // list" guarantee — on tripwire the raw value never reaches history.
+            // A processor that redacts via messageList.updateToolInvocation has its
+            // value synced back into chunk.payload.result, which the commit below uses.
+            const trResult = await runToolResultProcessors({
+              chunk: chunk as ChunkType<OUTPUT> & {
+                payload: {
+                  toolCallId: string;
+                  toolName: string;
+                  args?: unknown;
+                  result?: unknown;
+                  providerExecuted?: boolean;
+                };
+              },
+              stepNumber,
+              steps,
+            });
+            if (!trResult.ok) {
+              emitTripwireChunk(trResult.tripwire);
+              continue;
             }
-          }
 
-          // Continue the loop — the error messages are already in the messageList,
-          // so the model will see them and can retry with correct tool names
+            if (!toolCall.providerExecuted) {
+              // Update tool invocations from state:'call' to state:'result' for successful client tools.
+              // Provider-executed tools are handled by llm-execution-step.
+              rest.messageList.updateToolInvocation({
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: toolCall.toolCallId,
+                  toolName: sanitizeToolName(toolCall.toolName),
+                  args: toolCall.args,
+                  result: (chunk as { payload: { result: unknown } }).payload.result,
+                  // Preserve the approval decision for an approved approval-gated tool in a mixed
+                  // turn (one tool errored, another approved) so it round-trips on recall too.
+                  ...(toolCall.approval ? { approval: toolCall.approval } : {}),
+                },
+                ...(withToolPayloadTransformProviderMetadata(providerMetadata, chunk.metadata)
+                  ? {
+                      providerMetadata: withToolPayloadTransformProviderMetadata(
+                        providerMetadata,
+                        chunk.metadata,
+                      ) as ProviderMetadata,
+                    }
+                  : {}),
+              });
+            }
+
+            const processed = await processAndEnqueueChunk(chunk);
+            if (processed) await rest.options?.onChunk?.(processed);
+          }
+        }
+
+        if (errorResults?.length > 0 && !hasPendingHITL) {
+          // Continue the loop — the error messages (and any flushed successful
+          // results) are already in the messageList, so the model can retry.
           initialResult.stepResult.isContinued = true;
           initialResult.stepResult.reason = 'tool-calls';
           return {


### PR DESCRIPTION
## Description

When a single assistant step contains both a server-side tool (`createTool({ execute })`) that **already finished** and a client-side tool (`toolsets` / schema-only, no `execute`) that is still pending, `llm-mapping-step` bailed without flushing the completed result. The stream never emitted `tool-result`, `messageList` stayed in `call` state, and AI SDK v5 / assistant-ui clients waiting on `lastAssistantMessageIsCompleteWithToolCalls` deadlock.

This is the completed-result sibling of #17995 / #18034. Ending the turn for the pending client tool is still correct. The change only runs the existing successful-result emit/persist loop whenever there are completed results, then bails if HITL is still pending.

## Related issue(s)

Fixes #21637

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test plan

- [x] `pnpm --filter @mastra/core exec vitest run src/loop/workflows/agentic-execution/llm-mapping-step.test.ts` — 32 passed, including mixed completed + pending client tool now expecting a `tool-result` flush then bail
- [ ] Confirm existing abort + pending-client and error + pending-HITL cases still bail without fabricating aborted results

Soft CTA for teams shipping mixed server/client tool steps who need a Gate/Prove review of expected vs actual tool results: Instant Audit ($499) at https://a2zsoc.com/productized-services#instant-audit-tripwire or https://a2zsoc.com/consultation.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When one tool finishes and another tool still waits for the user, the finished result is now saved and sent immediately. The waiting tool still pauses the turn.

## Changes

- Flush and persist completed server-side tool results before handling pending client-side tools.
- Stream completed results as `tool-result` chunks.
- Keep pending HITL tools from producing result chunks.
- Preserve existing error and tripwire handling.
- Add regression coverage for mixed completed and pending tools.
- Add a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->