### PR TITLE
Improve playground route header layout and accessibility

### DIFF
--- a/packages/playground/src/components/layout.tsx
+++ b/packages/playground/src/components/layout.tsx
@@ -76,21 +76,19 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
         {shouldShowSidebar && <AppSidebar />}
         <div className="flex h-full min-h-0 flex-col">
           {shouldShowSidebar && <MobileNavbar />}
-          {shouldShowSidebar && (
-            <div className="mx-1.5 mt-1 shrink-0 lg:mx-2 lg:mt-1.5">
-              <RouteHeader />
-            </div>
-          )}
-          <PageHeadingContext.Provider value={pageHeading}>
+          <PageHeadingContext.Provider value={shouldShowSidebar ? undefined : pageHeading}>
             <div
               className={cn(
-                'ml-0 mx-1.5 mb-1.5 flex-1 min-h-0 overflow-y-auto [--studio-frame-radius:1.5rem] [--studio-frame-inset:0.5rem] rounded-studio-frame border border-border1 bg-surface2 shadow-main-frame lg:mx-2 lg:mb-2 lg:ml-0',
-                shouldShowSidebar ? 'mt-0' : 'mt-1.5 lg:mt-2 h-[calc(100%-1.5rem)]',
+                'bg-surface2 flex min-h-0 flex-1 flex-col overflow-hidden',
+                shouldShowSidebar && 'border-border1 lg:border-l',
               )}
             >
-              <AuthRequired>
-                <ErrorBoundary resetKeys={[pathname]}>{children}</ErrorBoundary>
-              </AuthRequired>
+              {shouldShowSidebar && <RouteHeader />}
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                <AuthRequired>
+                  <ErrorBoundary resetKeys={[pathname]}>{children}</ErrorBoundary>
+                </AuthRequired>
+              </div>
             </div>
           </PageHeadingContext.Provider>
         </div>

--- a/packages/playground/src/lib/route-header/__tests__/route-header-handles.test.tsx
+++ b/packages/playground/src/lib/route-header/__tests__/route-header-handles.test.tsx
@@ -117,7 +117,46 @@ function RouteHeaderOverrideProbe() {
   return <RouteHeaderCrumbs crumbs={[{ id: 'override', label: 'Override crumb' }]} />;
 }
 
+function renderRouteHeader() {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: <RouteHeader />,
+        handle: {
+          crumbs: [
+            { id: 'agents', label: 'Agents', to: '/agents' },
+            { id: 'agent', label: 'Research assistant' },
+          ],
+        },
+      },
+    ],
+    { initialEntries: ['/'] },
+  );
+
+  render(<RouterProvider router={router} />);
+}
+
 describe('route header handles', () => {
+  describe('when a route provides breadcrumb data', () => {
+    it('renders the route heading for assistive technologies only', () => {
+      renderRouteHeader();
+
+      const heading = screen.getByRole('heading', { level: 1, name: 'Research assistant' });
+
+      expect(heading.classList.contains('sr-only')).toBe(true);
+    });
+
+    it('places the breadcrumb before the route heading', () => {
+      renderRouteHeader();
+
+      const breadcrumb = screen.getByRole('navigation', { name: 'Breadcrumb' });
+      const heading = screen.getByRole('heading', { level: 1, name: 'Research assistant' });
+
+      expect(breadcrumb.compareDocumentPosition(heading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+  });
+
   it('every page under RootLayout inherits or declares breadcrumb data', () => {
     // Scope: only routes nested in the main RootLayout subtree are covered.
     // MinimalRootLayout pages (e.g. /agents/:agentId/session) and unauthenticated
@@ -234,7 +273,7 @@ describe('route header handles', () => {
 
     render(<RouterProvider router={router} />);
 
-    await waitFor(() => expect(screen.getByText('Override crumb')).toBeTruthy());
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1, name: 'Override crumb' })).toBeTruthy());
     expect(screen.queryByText('Handle crumb')).toBeNull();
   });
 });

--- a/packages/playground/src/lib/route-header/route-header.tsx
+++ b/packages/playground/src/lib/route-header/route-header.tsx
@@ -7,6 +7,7 @@ import type { ReactNode } from 'react';
 import { Link } from 'react-router';
 import { RouteHeaderActionsSlot } from './route-header-actions';
 import { useRouteHeaderCrumbsOverride } from './route-header-crumbs-context';
+import { getRouteHeaderHeading } from './route-heading';
 import type { CrumbDef } from './types';
 import { useRouteHeader } from './use-route-header';
 
@@ -27,53 +28,58 @@ export function RouteHeader() {
   const override = useRouteHeaderCrumbsOverride();
   const crumbs = override ?? handleCrumbs;
   const lastIdx = crumbs.length - 1;
+  const heading = getRouteHeaderHeading(crumbs);
 
   return (
-    <Header border={false} className="h-10 min-h-10 gap-2 overflow-hidden px-2">
-      {crumbs.length > 0 && (
-        <Breadcrumb label="Breadcrumb" className="min-w-0 flex-1 overflow-hidden" listClassName="min-w-0">
-          {crumbs.map((def, i) => {
-            const isCurrent = i === lastIdx;
-            const linkable = !isCurrent && def.to;
-            const IconComponent = def.icon;
-            return (
-              <Crumb
-                key={def.id}
-                as={linkable ? Link : 'span'}
-                to={linkable ? def.to : undefined}
-                isCurrent={isCurrent}
-                className={isCurrent ? 'max-w-[28rem]' : 'max-w-[18rem]'}
-              >
-                {IconComponent && (
-                  <Icon>
-                    <IconComponent />
-                  </Icon>
-                )}
-                {routeHeaderCrumbContent(def)}
-              </Crumb>
-            );
-          })}
-        </Breadcrumb>
-      )}
-
-      <div className="ml-auto flex shrink-0 items-center gap-2 overflow-hidden">
-        <RouteHeaderActionsSlot className="contents" />
-        {docs && (
-          <Button
-            as="a"
-            href={docs.href}
-            target="_blank"
-            rel="noopener noreferrer"
-            variant="ghost"
-            size="sm"
-            aria-label={docs.label ?? 'Documentation'}
-            className="max-w-[14rem] min-w-0"
-          >
-            <DocsIcon />
-            <span className="min-w-0 truncate">{docs.label ?? 'Documentation'}</span>
-          </Button>
+    <Header border={false} className="h-auto min-h-0 flex-col items-stretch gap-1 overflow-visible px-6 pt-4 pb-2">
+      <div className="flex min-h-8 items-center gap-2 overflow-hidden">
+        {crumbs.length > 0 && (
+          <Breadcrumb label="Breadcrumb" className="min-w-0 flex-1 overflow-hidden" listClassName="min-w-0">
+            {crumbs.map((def, i) => {
+              const isCurrent = i === lastIdx;
+              const linkable = !isCurrent && def.to;
+              const IconComponent = def.icon;
+              return (
+                <Crumb
+                  key={def.id}
+                  as={linkable ? Link : 'span'}
+                  to={linkable ? def.to : undefined}
+                  isCurrent={isCurrent}
+                  className={isCurrent ? 'max-w-[28rem]' : 'max-w-[18rem]'}
+                >
+                  {IconComponent && (
+                    <Icon>
+                      <IconComponent />
+                    </Icon>
+                  )}
+                  {routeHeaderCrumbContent(def)}
+                </Crumb>
+              );
+            })}
+          </Breadcrumb>
         )}
+
+        <div className="ml-auto flex shrink-0 items-center gap-2 overflow-hidden">
+          <RouteHeaderActionsSlot className="contents" />
+          {docs && (
+            <Button
+              as="a"
+              href={docs.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="ghost"
+              size="sm"
+              aria-label={docs.label ?? 'Documentation'}
+              className="max-w-[14rem] min-w-0"
+            >
+              <DocsIcon />
+              <span className="min-w-0 truncate">{docs.label ?? 'Documentation'}</span>
+            </Button>
+          )}
+        </div>
       </div>
+
+      {heading && <h1 className="sr-only">{heading}</h1>}
     </Header>
   );
 }


### PR DESCRIPTION
## Summary

- Move the route header into the main content frame for sidebar layouts
- Restructure the header to place breadcrumbs and actions consistently
- Add a visually hidden route heading for assistive technologies
- Add coverage for heading presence, ordering, and breadcrumb overrides

## Testing

- Added and updated Vitest unit tests for route header accessibility and breadcrumb behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The route header now sits in the correct place on sidebar pages. It also includes a hidden page title so screen readers can understand the page structure.

## Changes

- Moved the route header into the main content area for sidebar layouts.
- Added a visually hidden `<h1>` using `getRouteHeaderHeading`.
- Reworked breadcrumb and action layout, spacing, and overflow behavior.
- Updated Vitest coverage for heading presence, order, and breadcrumb overrides.
- Preserved authentication gating and error-boundary reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->