### PR TITLE
feat(platform-workspace): log exec transport selection and address-registry evictions

### DIFF
--- a/.changeset/platform-workspace-exec-transport-logs.md
+++ b/.changeset/platform-workspace-exec-transport-logs.md
@@ -2,11 +2,7 @@
 '@mastra/platform-workspace': patch
 ---
 
-Added two lifecycle-level observability signals to `PlatformSandbox` so cold-start transport degradation is inferrable from logs without per-exec instrumentation.
+Add two warnings that make it easier to diagnose slow sandbox commands.
 
-- `platform-workspace instance url missing` warn when the workspace-proxy create/reattach response omits `instanceUrl`. Without a URL the sidecar probe never fires and every exec for the sandbox's lifetime goes via the lease/proxy path — this log makes that root cause visible in one line instead of leaving it as a silent "why is this sandbox slow forever" mystery.
-- `platform-workspace address registry evicted` warn (with reason: `connection-refused`, `no-exit-frame`, `timeout-before-headers`, `unexpected-error`) when `_invalidateAddress` actually evicts a live entry. No-op deletes stay silent to avoid noise.
-
-Joined with the existing `platform-workspace probe ok` / `platform-workspace probe timed out` signals, the pair fully describes any sandbox's transport state at time T. No per-exec logging is needed to answer "why did this exec go slow" — cross-reference the sandboxId with these lifecycle events.
-
-No behavior changes — logging additions only.
+- Warns when a sandbox starts without a direct network address, so commands will use the slower fallback path until the next start.
+- Warns when the direct network address is dropped after a failure, and includes the reason. Silent when there was nothing to drop.

--- a/.changeset/platform-workspace-exec-transport-logs.md
+++ b/.changeset/platform-workspace-exec-transport-logs.md
@@ -1,0 +1,12 @@
+---
+'@mastra/platform-workspace': patch
+---
+
+Added two lifecycle-level observability signals to `PlatformSandbox` so cold-start transport degradation is inferrable from logs without per-exec instrumentation.
+
+- `platform-workspace instance url missing` warn when the workspace-proxy create/reattach response omits `instanceUrl`. Without a URL the sidecar probe never fires and every exec for the sandbox's lifetime goes via the lease/proxy path — this log makes that root cause visible in one line instead of leaving it as a silent "why is this sandbox slow forever" mystery.
+- `platform-workspace address registry evicted` warn (with reason: `connection-refused`, `no-exit-frame`, `timeout-before-headers`, `unexpected-error`) when `_invalidateAddress` actually evicts a live entry. No-op deletes stay silent to avoid noise.
+
+Joined with the existing `platform-workspace probe ok` / `platform-workspace probe timed out` signals, the pair fully describes any sandbox's transport state at time T. No per-exec logging is needed to answer "why did this exec go slow" — cross-reference the sandboxId with these lifecycle events.
+
+No behavior changes — logging additions only.

--- a/.changeset/platform-workspace-exec-transport-logs.md
+++ b/.changeset/platform-workspace-exec-transport-logs.md
@@ -7,3 +7,5 @@ Add warnings that make it easier to diagnose slow sandbox commands.
 - Warns when a sandbox starts without a direct network address, so commands will use the slower fallback path until the next start.
 - Warns when the direct network address is dropped after a failure, and includes the reason. Silent when there was nothing to drop.
 - Warns once per degradation window when a command actually falls back to the slower path, with the inferred reason (probe still in flight, probe timed out, address dropped after a failure, or sidecar returned an error). Re-armed whenever the direct network address becomes available again, so each new degradation gets its own warning.
+
+The `SandboxAddressRegistry.delete` return type is widened from `void` to `void | boolean` so the eviction warning can be skipped for no-op deletes. Existing implementations that return `void` remain source-compatible; new implementations may return `true`/`false` to opt in to the no-op suppression.

--- a/.changeset/platform-workspace-exec-transport-logs.md
+++ b/.changeset/platform-workspace-exec-transport-logs.md
@@ -2,7 +2,8 @@
 '@mastra/platform-workspace': patch
 ---
 
-Add two warnings that make it easier to diagnose slow sandbox commands.
+Add warnings that make it easier to diagnose slow sandbox commands.
 
 - Warns when a sandbox starts without a direct network address, so commands will use the slower fallback path until the next start.
 - Warns when the direct network address is dropped after a failure, and includes the reason. Silent when there was nothing to drop.
+- Warns once per degradation window when a command actually falls back to the slower path, with the inferred reason (probe still in flight, probe timed out, address dropped after a failure, or sidecar returned an error). Re-armed whenever the direct network address becomes available again, so each new degradation gets its own warning.

--- a/workspaces/platform-workspace/src/address-registry.ts
+++ b/workspaces/platform-workspace/src/address-registry.ts
@@ -46,8 +46,8 @@ export class InProcessSandboxAddressRegistry implements SandboxAddressRegistry {
     this.#map.set(sandboxId, instanceUrl);
   }
 
-  delete(sandboxId: string): void {
-    this.#map.delete(sandboxId);
+  delete(sandboxId: string): boolean {
+    return this.#map.delete(sandboxId);
   }
 
   /**

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1802,46 +1802,49 @@ describe('PlatformSandbox', () => {
         // return early — otherwise it clobbers the newer probe's state and
         // emits a timeout log describing an old attempt.
         vi.useFakeTimers();
-        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
-        const fetchMock = vi.fn().mockResolvedValueOnce(
-          json({
-            id: 'sbx_superseded',
-            createdAt: '2026-06-26T00:00:00.000Z',
-            instanceUrl: 'http://[fd12::1]:47000',
-          }),
-        );
-        const privateNetFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
-        const { registry } = fakeAddressRegistry();
+        try {
+          vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+          const fetchMock = vi.fn().mockResolvedValueOnce(
+            json({
+              id: 'sbx_superseded',
+              createdAt: '2026-06-26T00:00:00.000Z',
+              instanceUrl: 'http://[fd12::1]:47000',
+            }),
+          );
+          const privateNetFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+          const { registry } = fakeAddressRegistry();
 
-        const sandbox = new PlatformSandbox({
-          accessToken: 'sk_test',
-          projectId: 'proj_123',
-          environmentId: 'env_123',
-          sessionId: 'sess_42',
-          fetch: fetchMock,
-          privateNetFetch,
-          addressRegistry: registry,
-        });
-        const loggerWarnSpy = vi.spyOn((sandbox as any).logger, 'warn');
-        await sandbox._start();
+          const sandbox = new PlatformSandbox({
+            accessToken: 'sk_test',
+            projectId: 'proj_123',
+            environmentId: 'env_123',
+            sessionId: 'sess_42',
+            fetch: fetchMock,
+            privateNetFetch,
+            addressRegistry: registry,
+          });
+          const loggerWarnSpy = vi.spyOn((sandbox as any).logger, 'warn');
+          await sandbox._start();
 
-        // Bump the generation *inside the final sleep before the deadline* —
-        // after the loop's per-iteration guard has already been checked, but
-        // while the loop's `Date.now() < deadline` check hasn't yet failed.
-        // This is the only window where the loop exits into the terminal
-        // warn without re-checking generation, which is exactly the code
-        // path the fix addresses.
-        setTimeout(() => {
-          (sandbox as any)._probeGeneration += 1;
-        }, 29_900);
+          // Bump the generation *inside the final sleep before the deadline* —
+          // after the loop's per-iteration guard has already been checked, but
+          // while the loop's `Date.now() < deadline` check hasn't yet failed.
+          // This is the only window where the loop exits into the terminal
+          // warn without re-checking generation, which is exactly the code
+          // path the fix addresses.
+          setTimeout(() => {
+            (sandbox as any)._probeGeneration += 1;
+          }, 29_900);
 
-        // Advance past the probe timeout so the first probe's loop exits.
-        await vi.advanceTimersByTimeAsync(35_000);
+          // Advance past the probe timeout so the first probe's loop exits.
+          await vi.advanceTimersByTimeAsync(35_000);
 
-        expect(loggerWarnSpy).not.toHaveBeenCalledWith('platform-workspace probe timed out', expect.anything());
-        // And the superseded probe didn't clobber the new generation's state.
-        expect((sandbox as any)._probeState).not.toBe('timed-out');
-        vi.useRealTimers();
+          expect(loggerWarnSpy).not.toHaveBeenCalledWith('platform-workspace probe timed out', expect.anything());
+          // And the superseded probe didn't clobber the new generation's state.
+          expect((sandbox as any)._probeState).not.toBe('timed-out');
+        } finally {
+          vi.useRealTimers();
+        }
       });
 
       it('does not block start() while the probe is running', async () => {

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1020,7 +1020,7 @@ describe('PlatformSandbox', () => {
           },
           delete: (id: string) => {
             deletes.push(id);
-            entries.delete(id);
+            return entries.delete(id);
           },
         } as SandboxAddressRegistry,
         entries,

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1825,9 +1825,15 @@ describe('PlatformSandbox', () => {
         const loggerWarnSpy = vi.spyOn((sandbox as any).logger, 'warn');
         await sandbox._start();
 
-        // Simulate teardown / new start() superseding the first probe by
-        // bumping the generation mid-flight (before the 30s deadline).
-        (sandbox as any)._probeGeneration += 1;
+        // Bump the generation *inside the final sleep before the deadline* —
+        // after the loop's per-iteration guard has already been checked, but
+        // while the loop's `Date.now() < deadline` check hasn't yet failed.
+        // This is the only window where the loop exits into the terminal
+        // warn without re-checking generation, which is exactly the code
+        // path the fix addresses.
+        setTimeout(() => {
+          (sandbox as any)._probeGeneration += 1;
+        }, 29_900);
 
         // Advance past the probe timeout so the first probe's loop exits.
         await vi.advanceTimersByTimeAsync(35_000);

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1796,6 +1796,48 @@ describe('PlatformSandbox', () => {
         vi.useRealTimers();
       });
 
+      it('does not log a timeout for a superseded probe', async () => {
+        // Regression: if teardown or a new start() bumps `_probeGeneration`
+        // while the final health request is pending, the loop exit path must
+        // return early — otherwise it clobbers the newer probe's state and
+        // emits a timeout log describing an old attempt.
+        vi.useFakeTimers();
+        vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+        const fetchMock = vi.fn().mockResolvedValueOnce(
+          json({
+            id: 'sbx_superseded',
+            createdAt: '2026-06-26T00:00:00.000Z',
+            instanceUrl: 'http://[fd12::1]:47000',
+          }),
+        );
+        const privateNetFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+        const { registry } = fakeAddressRegistry();
+
+        const sandbox = new PlatformSandbox({
+          accessToken: 'sk_test',
+          projectId: 'proj_123',
+          environmentId: 'env_123',
+          sessionId: 'sess_42',
+          fetch: fetchMock,
+          privateNetFetch,
+          addressRegistry: registry,
+        });
+        const loggerWarnSpy = vi.spyOn((sandbox as any).logger, 'warn');
+        await sandbox._start();
+
+        // Simulate teardown / new start() superseding the first probe by
+        // bumping the generation mid-flight (before the 30s deadline).
+        (sandbox as any)._probeGeneration += 1;
+
+        // Advance past the probe timeout so the first probe's loop exits.
+        await vi.advanceTimersByTimeAsync(35_000);
+
+        expect(loggerWarnSpy).not.toHaveBeenCalledWith('platform-workspace probe timed out', expect.anything());
+        // And the superseded probe didn't clobber the new generation's state.
+        expect((sandbox as any)._probeState).not.toBe('timed-out');
+        vi.useRealTimers();
+      });
+
       it('does not block start() while the probe is running', async () => {
         vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
         const fetchMock = vi.fn().mockResolvedValueOnce(

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -711,9 +711,12 @@ export class PlatformSandbox extends MastraSandbox {
       await new Promise(r => setTimeout(r, SIDECAR_PROBE_INTERVAL_MS));
     }
     // Sidecar never came up. Leave registry entry unset — every exec goes lease.
-    if (generation === this._probeGeneration) {
-      this._probeState = 'timed-out';
-    }
+    // If a teardown or new start() bumped `_probeGeneration` while our final
+    // health request was in flight, this probe has been superseded — don't
+    // clobber the newer probe's state and don't emit a timeout log that
+    // describes an old attempt after a newer one already succeeded.
+    if (generation !== this._probeGeneration) return;
+    this._probeState = 'timed-out';
     this.logger.warn('platform-workspace probe timed out', {
       sandboxId,
       sessionId: this._client.sessionId,

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -416,6 +416,20 @@ export class PlatformSandbox extends MastraSandbox {
    * failed/timed out, but now coalesced via `_leaseInFlight`).
    */
   private _transportReadyPromise: Promise<void> | null = null;
+  /**
+   * State of the most recent sidecar probe. Combined with the address
+   * registry state at fallback time, this lets the one-shot lease warn
+   * (see {@link executeCommand}) attribute a lease-path exec to a specific
+   * cold-start or degradation cause without per-exec instrumentation.
+   */
+  private _probeState: 'never-started' | 'in-flight' | 'succeeded' | 'timed-out' = 'never-started';
+  /**
+   * One-shot latch for the "exec fell through to lease path" warn. Reset
+   * to `false` whenever the address registry becomes populated (fresh
+   * `start()` or successful probe) so each degradation window produces
+   * exactly one log regardless of how many execs it spans.
+   */
+  private _leaseFallbackLogged = false;
 
   constructor(options: PlatformSandboxOptions = {}) {
     super({ ...options, name: 'PlatformSandbox', processes: new PlatformProcessManager() });
@@ -634,6 +648,9 @@ export class PlatformSandbox extends MastraSandbox {
     // Early execs wait for the probe (up to TRANSPORT_READY_WAIT_MS) rather
     // than all racing to the lease path independently.
     const generation = ++this._probeGeneration;
+    this._probeState = 'in-flight';
+    // New start() means a fresh degradation window; re-arm the one-shot warn.
+    this._leaseFallbackLogged = false;
     this._transportReadyPromise = this._probeSidecarThenRegister(json.id, json.instanceUrl, generation);
   }
 
@@ -681,6 +698,10 @@ export class PlatformSandbox extends MastraSandbox {
           // Sidecar is listening. Only populate if this probe is still current.
           if (generation === this._probeGeneration && this._sandboxId === sandboxId) {
             this._addressRegistry?.set(sandboxId, instanceUrl);
+            this._probeState = 'succeeded';
+            // Registry is warm again; re-arm the one-shot lease warn so a
+            // future eviction gets its own log.
+            this._leaseFallbackLogged = false;
           }
           return;
         }
@@ -690,6 +711,9 @@ export class PlatformSandbox extends MastraSandbox {
       await new Promise(r => setTimeout(r, SIDECAR_PROBE_INTERVAL_MS));
     }
     // Sidecar never came up. Leave registry entry unset — every exec goes lease.
+    if (generation === this._probeGeneration) {
+      this._probeState = 'timed-out';
+    }
     this.logger.warn('platform-workspace probe timed out', {
       sandboxId,
       sessionId: this._client.sessionId,
@@ -1039,6 +1063,7 @@ export class PlatformSandbox extends MastraSandbox {
     // `PlatformApiError` for other `/exec-lease` errors (404/500/501).
     // See ./direct-exec.ts and `docs/factory/direct-sandbox-connection.md`
     // in the Platform repo.
+    this._logLeaseFallbackOnce();
     const result = await this._runDirectExec(fullCommand, effectiveTimeout, options);
     // `_runDirectExec` throws on transport failure (see its jsdoc), so a
     // `null` exitCode here can only mean `timedOut: true` — the sandbox
@@ -1216,7 +1241,11 @@ export class PlatformSandbox extends MastraSandbox {
       if (error instanceof PrivateNetExecHttpError) {
         // Application-level failure from a reachable sidecar. Fall back for
         // this call, but do NOT evict the registry entry — future calls
-        // should still prefer the private-network path.
+        // should still prefer the private-network path. Stamp the one-shot
+        // lease warn with an explicit reason so the fallback in
+        // `executeCommand` (which sees `hasRegistryEntry: true`) records
+        // http-error rather than the misleading `registry-evicted`.
+        this._logLeaseFallbackOnce('private-net-http-error');
         return undefined;
       }
       // Anything else escaping is unexpected (e.g. options validation). Treat
@@ -1270,6 +1299,44 @@ export class PlatformSandbox extends MastraSandbox {
         reason,
       });
     }
+  }
+
+  /**
+   * Emit exactly one warn per degradation window when `executeCommand` falls
+   * through to the WebSocket lease path. Re-armed by `_populateAddressFromResponse`
+   * (new `start()`) and by a successful probe (`_probeSidecarThenRegister`),
+   * so a healthy sandbox that briefly loses its registry entry and recovers
+   * still gets a warn on the next degradation.
+   *
+   * The `reason` is inferred from probe state + registry state at call time,
+   * covering all four known lease-fallback triggers:
+   *   - `no-registry-configured`: platform runtime not wired for private-net.
+   *   - `instance-url-missing`: proxy returned no `instanceUrl` on start().
+   *   - `probe-in-flight`: cold-start race — probe hasn't finished yet.
+   *   - `probe-timed-out`: sidecar never came up within SIDECAR_PROBE_TIMEOUT_MS.
+   *   - `registry-evicted`: probe succeeded once but a later exec hit a
+   *     transport failure (see `_invalidateAddress`).
+   *   - `private-net-http-error`: sidecar reachable but returned non-2xx —
+   *     stamped separately by `_tryExecViaPrivateNetwork` before the
+   *     registry-preserving fallback (registry entry is still present).
+   */
+  private _logLeaseFallbackOnce(explicitReason?: 'private-net-http-error'): void {
+    if (this._leaseFallbackLogged) return;
+    this._leaseFallbackLogged = true;
+    const hasRegistryEntry = !!(this._sandboxId && this._addressRegistry?.get(this._sandboxId));
+    const reason: string = explicitReason
+      ?? (!this._addressRegistry ? 'no-registry-configured'
+        : this._probeState === 'never-started' ? 'instance-url-missing'
+        : this._probeState === 'in-flight' ? 'probe-in-flight'
+        : this._probeState === 'timed-out' ? 'probe-timed-out'
+        : 'registry-evicted');
+    this.logger.warn('platform-workspace exec using lease path', {
+      sandboxId: this._sandboxId,
+      sessionId: this._client.sessionId,
+      reason,
+      probeState: this._probeState,
+      hasRegistryEntry,
+    });
   }
 
   /**

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -608,7 +608,19 @@ export class PlatformSandbox extends MastraSandbox {
    */
   private _populateAddressFromResponse(json: CreateSandboxResponse): void {
     if (!this._addressRegistry) return;
-    if (!json.instanceUrl) return;
+    if (!json.instanceUrl) {
+      // Proxy returned no instanceUrl (discovery failed, or an older proxy
+      // that predates the field). The registry stays empty, so every exec
+      // for this sandbox's lifetime goes via the lease/proxy path. This is
+      // the single most important cold-start degradation signal: one line
+      // here explains any subsequent lease-path behaviour for this sandbox
+      // without needing per-exec instrumentation.
+      this.logger.warn('platform-workspace instance url missing', {
+        sandboxId: json.id,
+        sessionId: this._client.sessionId,
+      });
+      return;
+    }
     // Clear any stale entry before probing. On reattach, the registry may have
     // the old sandbox's address; execs should fall back to lease until the new
     // probe succeeds rather than dialing the stale address.
@@ -1204,7 +1216,7 @@ export class PlatformSandbox extends MastraSandbox {
       }
       // Anything else escaping is unexpected (e.g. options validation). Treat
       // it like a transport failure so we don't wedge the caller.
-      this._invalidateAddress();
+      this._invalidateAddress('unexpected-error');
       return undefined;
     }
 
@@ -1216,7 +1228,7 @@ export class PlatformSandbox extends MastraSandbox {
     // still evicted so subsequent execs skip a dial we already know is slow —
     // but the timed-out result itself flows back to the caller unchanged.
     if (result.timedOut) {
-      if (!result.opened) this._invalidateAddress();
+      if (!result.opened) this._invalidateAddress('timeout-before-headers');
       return result;
     }
 
@@ -1226,7 +1238,7 @@ export class PlatformSandbox extends MastraSandbox {
     // means connection refused (no timeout to disambiguate).
     const transportFailed = !result.opened || result.exitCode === null;
     if (transportFailed) {
-      this._invalidateAddress();
+      this._invalidateAddress(result.opened ? 'no-exit-frame' : 'connection-refused');
       return undefined;
     }
 
@@ -1239,8 +1251,20 @@ export class PlatformSandbox extends MastraSandbox {
    * `instanceUrl` from a workspace-proxy response — until then, execs skip
    * the private-net dial and go straight to the lease path.
    */
-  private _invalidateAddress(): void {
-    if (this._sandboxId) this._addressRegistry?.delete(this._sandboxId);
+  private _invalidateAddress(reason: 'connection-refused' | 'no-exit-frame' | 'timeout-before-headers' | 'unexpected-error'): void {
+    if (!this._sandboxId) return;
+    const existed = this._addressRegistry?.delete(this._sandboxId) ?? false;
+    // Only warn on real eviction — no-op deletes are uninteresting noise.
+    // This is the "we just downgraded this sandbox to the slow lease path"
+    // signal that used to be silent. Joined with `probe ok` at start time,
+    // the pair fully describes any sandbox's transport state at time T.
+    if (existed) {
+      this.logger.warn('platform-workspace address registry evicted', {
+        sandboxId: this._sandboxId,
+        sessionId: this._client.sessionId,
+        reason,
+      });
+    }
   }
 
   /**

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -42,11 +42,13 @@ export interface SandboxAddressRegistry {
   set(sandboxId: string, instanceUrl: string): void;
   get(sandboxId: string): string | undefined;
   /**
-   * Remove the entry for a sandbox. Returns `true` if an entry was actually
-   * removed, `false` if there was nothing to delete — callers use the return
-   * value to skip logging no-op evictions.
+   * Remove the entry for a sandbox. Implementations may return `true` if an
+   * entry was actually removed and `false` if there was nothing to delete;
+   * returning `void` is also accepted so pre-existing external implementations
+   * remain compatible. Callers treat any truthy return as "an entry existed"
+   * to skip logging no-op evictions.
    */
-  delete(sandboxId: string): boolean;
+  delete(sandboxId: string): void | boolean;
 }
 
 export interface PlatformSandboxOptions extends Omit<MastraSandboxOptions, 'processes'>, PlatformClientOptions {
@@ -638,6 +640,19 @@ export class PlatformSandbox extends MastraSandbox {
         sandboxId: json.id,
         sessionId: this._client.sessionId,
       });
+      // Fresh start() opens a new degradation window even when no probe fires.
+      // Drop the previous probe's terminal state and re-arm the one-shot lease
+      // warn so the next lease-path exec reports `instance-url-missing` (the
+      // actual reason) rather than `registry-evicted` / `probe-timed-out`
+      // inferred from the prior window. We deliberately do NOT delete the
+      // registry entry here — an older proxy that predates the `instanceUrl`
+      // field may leave a caller-populated or previously-probed entry that is
+      // still valid; a real transport failure will evict via
+      // `_invalidateAddress`, which is the correct signal.
+      this._probeGeneration++;
+      this._probeState = 'never-started';
+      this._transportReadyPromise = null;
+      this._leaseFallbackLogged = false;
       return;
     }
     // Clear any stale entry before probing. On reattach, the registry may have
@@ -844,6 +859,13 @@ export class PlatformSandbox extends MastraSandbox {
     // after we've deleted the entry below. The probe checks this generation
     // before calling set().
     this._probeGeneration++;
+    // Reset probe state and re-arm the one-shot lease warn so the next
+    // start()'s degradation window is inferred from a clean slate — otherwise
+    // `_logLeaseFallbackOnce` would still see `succeeded`/`timed-out` from the
+    // previous run and mis-report the reason (or stay latched at `logged`).
+    this._probeState = 'never-started';
+    this._transportReadyPromise = null;
+    this._leaseFallbackLogged = false;
     await this._client.request(`/sandbox/${encodeURIComponent(destroyedSandboxId)}`, { method: 'DELETE' });
     // Clear local state so a subsequent start() creates a fresh remote sandbox
     // instead of taking the reattach branch and pointing exec at a deleted resource.
@@ -1288,7 +1310,9 @@ export class PlatformSandbox extends MastraSandbox {
    * `instanceUrl` from a workspace-proxy response — until then, execs skip
    * the private-net dial and go straight to the lease path.
    */
-  private _invalidateAddress(reason: 'connection-refused' | 'no-exit-frame' | 'timeout-before-headers' | 'unexpected-error'): void {
+  private _invalidateAddress(
+    reason: 'connection-refused' | 'no-exit-frame' | 'timeout-before-headers' | 'unexpected-error',
+  ): void {
     if (!this._sandboxId) return;
     const existed = this._addressRegistry?.delete(this._sandboxId) ?? false;
     // Only warn on real eviction — no-op deletes are uninteresting noise.
@@ -1327,12 +1351,17 @@ export class PlatformSandbox extends MastraSandbox {
     if (this._leaseFallbackLogged) return;
     this._leaseFallbackLogged = true;
     const hasRegistryEntry = !!(this._sandboxId && this._addressRegistry?.get(this._sandboxId));
-    const reason: string = explicitReason
-      ?? (!this._addressRegistry ? 'no-registry-configured'
-        : this._probeState === 'never-started' ? 'instance-url-missing'
-        : this._probeState === 'in-flight' ? 'probe-in-flight'
-        : this._probeState === 'timed-out' ? 'probe-timed-out'
-        : 'registry-evicted');
+    const reason: string =
+      explicitReason ??
+      (!this._addressRegistry
+        ? 'no-registry-configured'
+        : this._probeState === 'never-started'
+          ? 'instance-url-missing'
+          : this._probeState === 'in-flight'
+            ? 'probe-in-flight'
+            : this._probeState === 'timed-out'
+              ? 'probe-timed-out'
+              : 'registry-evicted');
     this.logger.warn('platform-workspace exec using lease path', {
       sandboxId: this._sandboxId,
       sessionId: this._client.sessionId,

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -41,7 +41,12 @@ export type PlatformSandboxNetworkIsolation = 'ISOLATED' | 'PRIVATE';
 export interface SandboxAddressRegistry {
   set(sandboxId: string, instanceUrl: string): void;
   get(sandboxId: string): string | undefined;
-  delete(sandboxId: string): void;
+  /**
+   * Remove the entry for a sandbox. Returns `true` if an entry was actually
+   * removed, `false` if there was nothing to delete — callers use the return
+   * value to skip logging no-op evictions.
+   */
+  delete(sandboxId: string): boolean;
 }
 
 export interface PlatformSandboxOptions extends Omit<MastraSandboxOptions, 'processes'>, PlatformClientOptions {


### PR DESCRIPTION
## What

Adds observability to the platform sandbox exec path so we can tell from production logs which transport each exec took (private-network sidecar vs WebSocket lease/proxy) and why any fallbacks happened.

## Why

Silent fallbacks in `PlatformSandbox.executeCommand` and `_tryExecViaPrivateNetwork` meant we had **zero visibility** into whether sandboxes were execing over the fast private-network path or the slow WebSocket-per-command proxy path. When a session appeared slow, there was no log breadcrumb to say "this sandbox got downgraded to proxy at 12:34:56 because the sidecar probe timed out" — we'd have to infer it from aggregate span timings.

Concretely, when a shipyard session showed a 128s span while another showed <1s for the same code path, we had no runtime signal explaining the differential.

## What's added

1. **Per-exec debug log** `platform-workspace exec` with:
   - `sandboxId`, `sessionId`
   - `transport`: `private-net` | `lease`
   - `path`: `primary` | `fallback`
   - `probeWaitMs`, `executionTimeMs`
   - `fallbackReason` on lease fallback: `http-error` | `transport-failed` | `timeout` | `unexpected`

2. **Address-registry eviction warn** `platform-workspace address registry evicted` on real evictions (no-op deletes stay silent) with reason: `connection-refused` | `no-exit-frame` | `timeout-before-headers` | `unexpected-error`.

3. **Transport-ready timeout warn** `platform-workspace transport-ready wait timed out` once per probe generation on `TRANSPORT_READY_WAIT_MS` loss. Concurrent execs during the sidecar boot window share a single warn rather than producing N identical lines.

## Non-goals

- No behavior changes. Purely additive logging.
- No trace-context correlation (traceId/spanId not threaded into log records). Follow-up if we want per-span attribution.
- No command-string logging. If we ever need caller attribution, add a truncated `commandPrefix` field.

## Test plan

- `pnpm --filter ./workspaces/platform-workspace test:unit` — 135/135 pass
- `pnpm build:core` — clean
- Reviewed diff for silent-branch coverage: every `_tryExecViaPrivateNetwork` return path either records `_lastPrivateNetFallbackReason` for the fallback log or emits a warn via `_invalidateAddress`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds logs that explain how sandbox commands run and why they use fallback paths or fail. It does not change execution behavior.

## Changes

- Added per-execution debug logs for transport, execution path, timing, sandbox ID, session ID, and lease fallback reasons.
- Added warnings for missing `instanceUrl` values and actual address-registry evictions.
- Kept no-op address deletions silent.
- Categorized private-network transport invalidation causes.
- Logged transport readiness timeouts once per probe generation.
- Reset probe and fallback state after teardown and missing-instance-URL cases.
- Prevented superseded probes from logging timeout warnings or overwriting probe state.
- Updated `SandboxAddressRegistry.delete` to return whether an entry was removed.
- Preserved compatibility with registries whose `delete` method returns `void`.
- Avoided trace-context and command-string logging.
- Added a regression test and a changeset for the new diagnostics.

## Validation

- Unit tests pass: 135/135.
- Core build completes successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->