### PR TITLE
perf(code-sdk): fold containment check into sandbox filesystem read execs

### DIFF
--- a/.changeset/bumpy-jokes-taste.md
+++ b/.changeset/bumpy-jokes-taste.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+SandboxFilesystem read operations (stat, readFile, readdir) issue a single sandbox exec instead of two.

--- a/mastracode/sdk/src/agents/sandbox-filesystem.conformance.test.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.conformance.test.ts
@@ -9,12 +9,12 @@
  */
 
 import { execFile } from 'node:child_process';
-import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
+import { mkdtempSync, rmSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { createFilesystemTestSuite } from '@internal/workspace-test-utils';
-import { afterAll } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 import type { SandboxCommandResult, SandboxExec } from './sandbox-filesystem';
 import { SandboxFilesystem } from './sandbox-filesystem';
@@ -63,6 +63,24 @@ function createSandboxFilesystem(): SandboxFilesystem {
   tmpDirs.push(workdir);
   return new SandboxFilesystem({ sandbox: createLocalShellExec(), workdir });
 }
+
+// Real-shell containment coverage: the unit tests exercise the folded
+// containment scripts against scripted mock exit codes; these run the actual
+// prelude in a real `sh` against a real escaping symlink.
+describe('SandboxFilesystem containment (real shell)', () => {
+  it('rejects a symlink escaping the workspace root for readFile, stat, and readdir', async () => {
+    const workdir = realpathSync(mkdtempSync(join(tmpdir(), 'mastra-sandbox-fs-escape-')));
+    const outside = realpathSync(mkdtempSync(join(tmpdir(), 'mastra-sandbox-fs-outside-')));
+    tmpDirs.push(workdir, outside);
+    writeFileSync(join(outside, 'secret.txt'), 'secret');
+    symlinkSync(outside, join(workdir, 'link'));
+    const fs = new SandboxFilesystem({ sandbox: createLocalShellExec(), workdir });
+
+    await expect(fs.readFile('link/secret.txt')).rejects.toThrow(/escapes workspace root/);
+    await expect(fs.stat('link/secret.txt')).rejects.toThrow(/escapes workspace root/);
+    await expect(fs.readdir('link')).rejects.toThrow(/escapes workspace root/);
+  });
+});
 
 createFilesystemTestSuite({
   suiteName: 'SandboxFilesystem Conformance (local shell)',

--- a/mastracode/sdk/src/agents/sandbox-filesystem.test.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.test.ts
@@ -1,3 +1,4 @@
+import { FileNotFoundError, IsDirectoryError } from '@mastra/core/workspace';
 import { describe, expect, it } from 'vitest';
 import { SandboxFilesystem } from './sandbox-filesystem.js';
 import type { SandboxCommandResult, SandboxExec } from './sandbox-filesystem.js';
@@ -25,9 +26,14 @@ class FakeSandbox implements SandboxExec {
 
 const WORKDIR = '/workspace/repo';
 
-/** The realpath containment guard script starts by assigning the target path. */
+/**
+ * The STANDALONE realpath containment guard (write paths, move/copy sources)
+ * assigns the target path and prints root + realpath. Read ops fold their
+ * containment into the same script as the operation (identified by the
+ * `case "$rp"` comparison), so they no longer match here.
+ */
 function isContainmentCheck(script: string): boolean {
-  return script.startsWith('p=');
+  return script.startsWith('p=') && script.includes(`printf '%s\\n%s'`);
 }
 
 /** Containment guard output: canonicalized root on line 1, target realpath on line 2. */
@@ -51,11 +57,7 @@ describe('SandboxFilesystem', () => {
   it('reads a file via base64 and decodes it', async () => {
     const content = 'hello world';
     const b64 = Buffer.from(content, 'utf8').toString('base64');
-    const { sandbox, fs } = makeFs(script => {
-      // The realpath containment check runs first; resolve it inside the workdir.
-      if (isContainmentCheck(script)) return realpathResult(`${WORKDIR}/src/index.ts`);
-      return { exitCode: 0, stdout: b64, stderr: '' };
-    });
+    const { sandbox, fs } = makeFs(() => ({ exitCode: 0, stdout: b64, stderr: '' }));
 
     const result = await fs.readFile('/src/index.ts', { encoding: 'utf8' });
 
@@ -63,25 +65,76 @@ describe('SandboxFilesystem', () => {
     expect(sandbox.calls.some(c => c.includes(`base64 < '${WORKDIR}/src/index.ts'`))).toBe(true);
   });
 
+  // Read-op containment is folded into the op's own script: the shell exits
+  // with a sentinel code (escape / cannot-canonicalize) BEFORE the read runs.
+  const CONTAINMENT_ESCAPE = { exitCode: 23, stdout: '', stderr: '' };
+  const CANNOT_CANONICALIZE = { exitCode: 24, stdout: '', stderr: '' };
+
   it('rejects a symlink whose realpath escapes the workspace root', async () => {
-    const { fs } = makeFs(script => {
-      if (isContainmentCheck(script)) return realpathResult('/etc/passwd');
-      return { exitCode: 0, stdout: '', stderr: '' };
-    });
+    const { fs, sandbox } = makeFs(() => CONTAINMENT_ESCAPE);
 
     await expect(fs.readFile('/link')).rejects.toThrow(/escapes workspace root \(symlink\)/);
+    // The containment comparison runs inside the same script, before the read.
+    const script = sandbox.calls[0]!;
+    expect(script.indexOf('case "$rp"')).toBeGreaterThanOrEqual(0);
+    expect(script.indexOf('case "$rp"')).toBeLessThan(script.indexOf('base64 <'));
+  });
+
+  it('escaping symlinks are rejected by every read op', async () => {
+    const { fs } = makeFs(() => CONTAINMENT_ESCAPE);
+    await expect(fs.stat('/link')).rejects.toThrow(/escapes workspace root \(symlink\)/);
+    await expect(fs.readdir('/link')).rejects.toThrow(/escapes workspace root \(symlink\)/);
+    await expect(fs.readdir('/link', { recursive: true })).rejects.toThrow(/escapes workspace root \(symlink\)/);
   });
 
   it('fails closed when an existing path cannot be canonicalized', async () => {
     // If no canonicalization tool works, skipping the check would let a
     // symlink bypass containment — the operation must fail instead.
-    const { fs, sandbox } = makeFs(script => {
-      if (isContainmentCheck(script)) return { exitCode: 1, stdout: '', stderr: '' };
-      return { exitCode: 0, stdout: '', stderr: '' };
-    });
+    const { fs } = makeFs(() => CANNOT_CANONICALIZE);
 
     await expect(fs.readFile('/link')).rejects.toThrow(/Unable to verify path stays within workspace root/);
-    expect(sandbox.calls.some(c => c.includes('base64 <'))).toBe(false);
+    await expect(fs.stat('/link')).rejects.toThrow(/Unable to verify path stays within workspace root/);
+    await expect(fs.readdir('/link')).rejects.toThrow(/Unable to verify path stays within workspace root/);
+  });
+
+  it('preserves per-op error types with the folded scripts', async () => {
+    // readFile: missing -> FileNotFoundError, directory -> IsDirectoryError
+    const { fs: missingFs } = makeFs(() => ({ exitCode: 20, stdout: '', stderr: '' }));
+    await expect(missingFs.readFile('/gone.txt')).rejects.toBeInstanceOf(FileNotFoundError);
+
+    const { fs: dirFs } = makeFs(() => ({ exitCode: 21, stdout: '', stderr: '' }));
+    await expect(dirFs.readFile('/some-dir')).rejects.toBeInstanceOf(IsDirectoryError);
+
+    // stat: missing -> FileNotFoundError (stat itself exits 1)
+    const { fs: statFs } = makeFs(() => ({ exitCode: 1, stdout: '', stderr: '' }));
+    await expect(statFs.stat('/gone.txt')).rejects.toBeInstanceOf(FileNotFoundError);
+
+    // readdir: missing -> plain Error('Directory not found: <path>'), NOT FileNotFoundError
+    const { fs: dirlessFs } = makeFs(() => ({ exitCode: 1, stdout: '', stderr: '' }));
+    const readdirError = await dirlessFs.readdir('/gone').catch((e: unknown) => e);
+    expect(readdirError).toBeInstanceOf(Error);
+    expect(readdirError).not.toBeInstanceOf(FileNotFoundError);
+    expect((readdirError as Error).message).toBe('Directory not found: /gone');
+  });
+
+  it('issues exactly one exec per read op on the happy path', async () => {
+    const b64 = Buffer.from('x', 'utf8').toString('base64');
+    const { sandbox, fs } = makeFs(script => {
+      if (script.includes('stat -c')) return { exitCode: 0, stdout: 'regular file|1|1700000000|-1\n', stderr: '' };
+      if (script.includes('base64 <')) return { exitCode: 0, stdout: b64, stderr: '' };
+      return { exitCode: 0, stdout: 'f\ta.txt\n', stderr: '' };
+    });
+
+    await fs.stat('/a.txt');
+    expect(sandbox.calls.length).toBe(1);
+
+    sandbox.calls.length = 0;
+    await fs.readFile('/a.txt');
+    expect(sandbox.calls.length).toBe(1);
+
+    sandbox.calls.length = 0;
+    await fs.readdir('/');
+    expect(sandbox.calls.length).toBe(1);
   });
 
   it('rejects a write whose parent directory is a symlink escaping the workspace', async () => {
@@ -155,10 +208,7 @@ describe('SandboxFilesystem', () => {
   });
 
   it('lists a directory and parses type/name pairs', async () => {
-    const { sandbox, fs } = makeFs(script => {
-      if (isContainmentCheck(script)) return realpathResult(WORKDIR);
-      return { exitCode: 0, stdout: 'd\tsrc\nf\tREADME.md\n', stderr: '' };
-    });
+    const { sandbox, fs } = makeFs(() => ({ exitCode: 0, stdout: 'd\tsrc\nf\tREADME.md\n', stderr: '' }));
 
     const entries = await fs.readdir('/');
 
@@ -170,10 +220,7 @@ describe('SandboxFilesystem', () => {
   });
 
   it('stats a file and returns parsed metadata', async () => {
-    const { fs } = makeFs(script => {
-      if (isContainmentCheck(script)) return realpathResult(`${WORKDIR}/a.txt`);
-      return { exitCode: 0, stdout: 'regular file|42|1700000000|-1\n', stderr: '' };
-    });
+    const { fs } = makeFs(() => ({ exitCode: 0, stdout: 'regular file|42|1700000000|-1\n', stderr: '' }));
 
     const stat = await fs.stat('/a.txt');
 
@@ -200,10 +247,7 @@ describe('SandboxFilesystem', () => {
   });
 
   it('normalizes .. segments inside an absolute workdir path', async () => {
-    const { sandbox, fs } = makeFs(script => {
-      if (isContainmentCheck(script)) return realpathResult(`${WORKDIR}/notes.txt`);
-      return { exitCode: 0, stdout: '', stderr: '' };
-    });
+    const { sandbox, fs } = makeFs(() => ({ exitCode: 0, stdout: '', stderr: '' }));
 
     await fs.readFile(`${WORKDIR}/src/../notes.txt`);
     expect(sandbox.calls.some(c => c.includes(`base64 < '${WORKDIR}/notes.txt'`))).toBe(true);
@@ -211,7 +255,6 @@ describe('SandboxFilesystem', () => {
 
   it('falls back to BSD stat when GNU stat is unavailable', async () => {
     const { fs } = makeFs(script => {
-      if (isContainmentCheck(script)) return realpathResult(`${WORKDIR}/dir`);
       // Simulate macOS: the `stat -c || stat -f` compound runs BSD output.
       if (script.includes('stat -c')) {
         expect(script).toContain('stat -f');
@@ -225,10 +268,11 @@ describe('SandboxFilesystem', () => {
   });
 
   it('lists recursively without GNU find -printf', async () => {
-    const { sandbox, fs } = makeFs(script => {
-      if (isContainmentCheck(script)) return realpathResult(WORKDIR);
-      return { exitCode: 0, stdout: `d\t${WORKDIR}/src\nf\t${WORKDIR}/src/index.ts\n`, stderr: '' };
-    });
+    const { sandbox, fs } = makeFs(() => ({
+      exitCode: 0,
+      stdout: `d\t${WORKDIR}/src\nf\t${WORKDIR}/src/index.ts\n`,
+      stderr: '',
+    }));
 
     const entries = await fs.readdir('/', { recursive: true });
 

--- a/mastracode/sdk/src/agents/sandbox-filesystem.ts
+++ b/mastracode/sdk/src/agents/sandbox-filesystem.ts
@@ -36,6 +36,8 @@ import { FileExistsError, FileNotFoundError, IsDirectoryError } from '@mastra/co
 const EXIT_NOT_FOUND = 20;
 const EXIT_IS_DIRECTORY = 21;
 const EXIT_EXISTS = 22;
+const EXIT_CONTAINMENT_ESCAPE = 23;
+const EXIT_CANNOT_CANONICALIZE = 24;
 
 /** Minimal command result shape we depend on. */
 export interface SandboxCommandResult {
@@ -170,6 +172,46 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
   }
 
   /**
+   * Shell prelude with the same containment logic as assertContainedRealpath,
+   * for folding into a read op's script so the whole operation is ONE sandbox
+   * exec instead of two (containment round-trips dominate skills discovery
+   * over remote sandboxes).
+   *
+   * A missing path skips the check (nothing to canonicalize; the op body
+   * produces its own not-found error, matching the two-exec behavior).
+   * An existing path that cannot be canonicalized fails CLOSED with
+   * EXIT_CANNOT_CANONICALIZE; a realpath outside the canonicalized root exits
+   * EXIT_CONTAINMENT_ESCAPE. Map both with throwIfContainmentError.
+   */
+  private containedPrelude(abs: string): string {
+    return [
+      `p=${shellQuote(abs)}`,
+      `if [ -e "$p" ] || [ -L "$p" ]; then`,
+      // The workdir itself may contain symlinked components (/tmp on macOS),
+      // so canonicalize it as the comparison root.
+      `  root=$(cd ${shellQuote(this.basePath)} 2>/dev/null && pwd -P)`,
+      `  [ -n "$root" ] || exit ${EXIT_CANNOT_CANONICALIZE}`,
+      `  rp=$(realpath "$p" 2>/dev/null) || rp=$(readlink -f "$p" 2>/dev/null) || { [ -d "$p" ] && rp=$(cd "$p" 2>/dev/null && pwd -P); }`,
+      `  [ -n "$rp" ] || exit ${EXIT_CANNOT_CANONICALIZE}`,
+      `  case "$rp" in`,
+      `    "$root" | "$root"/*) ;;`,
+      `    *) exit ${EXIT_CONTAINMENT_ESCAPE} ;;`,
+      `  esac`,
+      `fi`,
+    ].join('\n');
+  }
+
+  /** Map the containedPrelude sentinel exit codes to the containment errors. */
+  private throwIfContainmentError(result: SandboxCommandResult, inputPath: string): void {
+    if (result.exitCode === EXIT_CONTAINMENT_ESCAPE) {
+      throw new Error(`Path escapes workspace root (symlink): ${inputPath}`);
+    }
+    if (result.exitCode === EXIT_CANNOT_CANONICALIZE) {
+      throw new Error(`Unable to verify path stays within workspace root: ${inputPath}`);
+    }
+  }
+
+  /**
    * Guard for write destinations. The lexical guard catches `..`, but a symlink
    * inside the workdir can redirect a write outside it. For an existing target
    * we check its realpath; for a not-yet-existing target we check the realpath
@@ -199,12 +241,13 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
 
   async readFile(path: string, options?: ReadOptions): Promise<string | Buffer> {
     const abs = this.resolve(path);
-    await this.assertContainedRealpath(abs, path);
+    // Containment is folded into the same script as the read (one exec).
     // Guard clauses first: redirecting from a directory "succeeds" with empty
     // output on some shells, so classify before reading.
     const result = await this.exec(
-      `if [ -d ${shellQuote(abs)} ]; then exit ${EXIT_IS_DIRECTORY}; elif [ ! -e ${shellQuote(abs)} ]; then exit ${EXIT_NOT_FOUND}; fi; base64 < ${shellQuote(abs)}`,
+      `${this.containedPrelude(abs)}\nif [ -d ${shellQuote(abs)} ]; then exit ${EXIT_IS_DIRECTORY}; elif [ ! -e ${shellQuote(abs)} ]; then exit ${EXIT_NOT_FOUND}; fi; base64 < ${shellQuote(abs)}`,
     );
+    this.throwIfContainmentError(result, path);
     if (result.exitCode === EXIT_IS_DIRECTORY) throw new IsDirectoryError(path);
     if (result.exitCode === EXIT_NOT_FOUND) throw new FileNotFoundError(path);
     if (result.exitCode !== 0) {
@@ -374,14 +417,15 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
 
   async readdir(path: string, options?: ListOptions): Promise<FileEntry[]> {
     const abs = this.resolve(path);
-    await this.assertContainedRealpath(abs, path);
+    // Containment is folded into the same script as the listing (one exec).
     if (options?.recursive) {
       // Recursive listing emitting "type\tpath". `find -printf` is GNU-only
       // (fails on macOS/BSD hosts backing a local sandbox), so classify each
       // entry with a portable shell loop instead.
       const result = await this.exec(
-        `test -d ${shellQuote(abs)} && find ${shellQuote(abs)} -mindepth 1 ${options.maxDepth ? `-maxdepth ${Number(options.maxDepth)} ` : ''}2>/dev/null | while IFS= read -r f; do if [ -d "$f" ]; then printf 'd\\t%s\\n' "$f"; else printf 'f\\t%s\\n' "$f"; fi; done`,
+        `${this.containedPrelude(abs)}\ntest -d ${shellQuote(abs)} && find ${shellQuote(abs)} -mindepth 1 ${options.maxDepth ? `-maxdepth ${Number(options.maxDepth)} ` : ''}2>/dev/null | while IFS= read -r f; do if [ -d "$f" ]; then printf 'd\\t%s\\n' "$f"; else printf 'f\\t%s\\n' "$f"; fi; done`,
       );
+      this.throwIfContainmentError(result, path);
       if (result.exitCode !== 0) throw new Error(`Directory not found: ${path}`);
       return this.parseFindOutput(result.stdout, abs, options);
     }
@@ -389,8 +433,9 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
     // not echo — bash-as-/bin/sh (macOS local sandboxes) does not expand \t
     // in echo arguments.
     const result = await this.exec(
-      `cd ${shellQuote(abs)} 2>/dev/null && for f in * .[!.]*; do [ -e "$f" ] || continue; if [ -d "$f" ]; then printf 'd\\t%s\\n' "$f"; else printf 'f\\t%s\\n' "$f"; fi; done`,
+      `${this.containedPrelude(abs)}\ncd ${shellQuote(abs)} 2>/dev/null && for f in * .[!.]*; do [ -e "$f" ] || continue; if [ -d "$f" ]; then printf 'd\\t%s\\n' "$f"; else printf 'f\\t%s\\n' "$f"; fi; done`,
     );
+    this.throwIfContainmentError(result, path);
     if (result.exitCode !== 0) throw new Error(`Directory not found: ${path}`);
     return this.parseListOutput(result.stdout, options);
   }
@@ -442,15 +487,16 @@ export class SandboxFilesystem implements WorkspaceFilesystem {
 
   async stat(path: string): Promise<FileStat> {
     const abs = this.resolve(path);
-    await this.assertContainedRealpath(abs, path);
+    // Containment is folded into the same script as the stat (one exec).
     // GNU stat: %F=type, %s=size, %Y=mtime (epoch seconds), %W=birth (or -1).
     // BSD/macOS stat (local sandbox hosts) rejects `-c`; fall back to its
     // `-f` format with the same field order (%HT=type, %z=size, %m=mtime,
     // %B=birth). Delimit with `|` — neither stat interprets `\t` escapes in
     // its format string.
     const result = await this.exec(
-      `stat -c '%F|%s|%Y|%W' ${shellQuote(abs)} 2>/dev/null || stat -f '%HT|%z|%m|%B' ${shellQuote(abs)}`,
+      `${this.containedPrelude(abs)}\nstat -c '%F|%s|%Y|%W' ${shellQuote(abs)} 2>/dev/null || stat -f '%HT|%z|%m|%B' ${shellQuote(abs)}`,
     );
+    this.throwIfContainmentError(result, path);
     if (result.exitCode !== 0) {
       throw new FileNotFoundError(path);
     }


### PR DESCRIPTION
## What

`SandboxFilesystem` read operations (`stat`, `readFile`, `readdir`) now issue a single sandbox exec instead of two. Previously every read ran a standalone symlink-containment check (`assertContainedRealpath`) as its own exec, then a second exec for the actual read. This PR folds the containment check into the same shell script as the read.

## Why

Every sandbox exec is a network round-trip on remote sandboxes (measured 500-800ms each in production; a skills-discovery pass over a 30-skill repo cost ~70 execs and showed up as a 93s turn-start block in prod traces). Halving the exec count for reads roughly halves that cost everywhere the filesystem is used, warm or cold. Shared context: this is one of three PRs splitting up the original combined branch; the others are #21555 (core: non-blocking skills discovery) and #21679 (factory: non-blocking turn-end capture).

## How it works

- The containment prelude (realpath resolution chain: `realpath` -> `readlink -f` -> `cd && pwd -P`, with the root canonicalized the same way) is prepended to each read op's script, and the prefix comparison happens in shell via a `case` statement.
- Two new sentinel exit codes distinguish a containment escape (23) from an existing-but-uncanonicalizable path (24, fail closed). The Node side maps them to the same error messages as before, byte for byte.
- Per-op error semantics are unchanged: `stat`/`readFile` throw `FileNotFoundError`, `readFile` throws `IsDirectoryError` on directories, `readdir` throws a plain `Error('Directory not found')`.
- Write paths keep the standalone containment guard (`assertContainedDest`); `exists` was already single-exec.
- Every interpolated path is shell-quoted.

## Review note

This is the security-sensitive piece of the split: the containment check that used to be a dedicated exec now rides inside each read's shell script. The containment-first ordering inside the folded script, the exit-code mapping, and the fail-closed behavior for uncanonicalizable paths deserve a careful read.

## Verification

- 81 tests pass in `sandbox-filesystem.test.ts` + `sandbox-filesystem.conformance.test.ts`, including new per-op tests for exec count (exactly 1), symlink escape, fail-closed canonicalization, and error semantics; the conformance suite runs against a real shell and includes a real symlink-escape test.
- `tsc --noEmit` clean.
- A latency-injected demo driving the real `SandboxFilesystem` over `sh -c` records exec counts stat=1 / readFile=1 / readdir=1 (2/2/2 before this change).

Related PRs from the same split: #21555 (core), #21679 (factory). Each stands alone and can merge in any order.
