### PR TITLE
perf(factory): stop gating agent_end on the turn-end filesystem capture

### DIFF
--- a/.changeset/polite-worlds-sink.md
+++ b/.changeset/polite-worlds-sink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The turn-end filesystem capture no longer blocks agent turn completion.

--- a/.changeset/polite-worlds-sink.md
+++ b/.changeset/polite-worlds-sink.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-The turn-end filesystem capture no longer blocks agent turn completion.
+The turn-end filesystem capture no longer blocks agent turn completion. Readers of the persisted workspace file listing wait for the in-flight capture (bounded) so they still observe the just-ended turn's files.

--- a/.changeset/polite-worlds-sink.md
+++ b/.changeset/polite-worlds-sink.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-The turn-end filesystem capture no longer blocks agent turn completion. Readers of the persisted workspace file listing wait for the in-flight capture (bounded) so they still observe the just-ended turn's files.
+The turn-end filesystem capture no longer blocks agent turn completion. Readers of the persisted workspace file listing wait up to 10 seconds for the in-flight capture to observe the just-ended turn's files; if a capture takes longer, a reader can temporarily receive the previous listing.

--- a/mastracode/factory/src/routes/fs.ts
+++ b/mastracode/factory/src/routes/fs.ts
@@ -9,6 +9,7 @@ import type { ApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
 
 import type { MaterializationSandbox, SandboxFleet } from '../sandbox/fleet.js';
+import { waitForPendingFilesystemCapture } from '../session/filesystem-capture.js';
 import type { FilesystemStorage } from '../storage/domains/filesystem/base.js';
 import type { SourceControlSession } from '../storage/domains/source-control/base.js';
 import type { RouteAuth } from './route.js';
@@ -457,6 +458,11 @@ export async function listSessionFilesystemFiles(
 ): Promise<WorkspaceFilesListing> {
   const safeThreadId = threadId.trim();
   if (!safeThreadId) throw new Error('Missing required query param: threadId');
+
+  // The turn-end capture no longer gates agent_end, so a reader refetching on
+  // run completion could otherwise race it and serve the previous turn's
+  // listing. Await the in-flight capture (bounded) before reading.
+  await waitForPendingFilesystemCapture(session.sessionId);
 
   return {
     workspacePath: session.sessionId,

--- a/mastracode/factory/src/session/filesystem-capture.test.ts
+++ b/mastracode/factory/src/session/filesystem-capture.test.ts
@@ -172,7 +172,9 @@ describe('observeSessionFilesystem', () => {
   it('does not gate the agent-end listener on slow capture execs', async () => {
     // The sandbox exec never resolves: the listener must still settle
     // immediately, because agent_end must not wait on the capture I/O.
-    const { session, listeners } = createSession();
+    // Unique resource id: this chain never settles and must not leak into
+    // other tests through the shared resource-level chain map.
+    const { session, listeners } = createSession(undefined, 'resource-never-settles');
     const gatedExec = new Promise<never>(() => {});
     session.getWorkspace = () => ({
       sandbox: { executeCommand: vi.fn(() => gatedExec) } as any,
@@ -190,7 +192,7 @@ describe('observeSessionFilesystem', () => {
   it('still persists the capture after the listener returns', async () => {
     // Gate the exec, release it after the listener has already settled, and
     // verify the capture completes in the background.
-    const { session, listeners } = createSession();
+    const { session, listeners } = createSession(undefined, 'resource-background-persist');
     let releaseExec: ((value: ReturnType<typeof commandResult>) => void) | undefined;
     const gate = new Promise<ReturnType<typeof commandResult>>(resolve => {
       releaseExec = resolve;
@@ -212,7 +214,10 @@ describe('observeSessionFilesystem', () => {
   });
 
   it('serializes captures when terminal events arrive before the prior capture finishes', async () => {
-    const { session, listeners } = createSession([commandResult(), commandResult(), commandResult(), commandResult()]);
+    const { session, listeners } = createSession(
+      [commandResult(), commandResult(), commandResult(), commandResult()],
+      'resource-serialize',
+    );
     let completeFirstCapture: (() => void) | undefined;
     const dependencies = createDependencies();
     dependencies.filesystem.replaceFiles = vi.fn(
@@ -235,10 +240,42 @@ describe('observeSessionFilesystem', () => {
     completeFirstCapture?.();
   });
 
+  it('serializes captures across sessions observing the same resource', async () => {
+    // Sessions are deduplicated by (resourceId, scope), so two scoped
+    // sessions can observe the same resource; their captures must extend one
+    // shared chain instead of interleaving through independent ones.
+    const first = createSession(undefined, 'resource-shared');
+    const second = createSession(undefined, 'resource-shared');
+    let releaseExec: ((value: ReturnType<typeof commandResult>) => void) | undefined;
+    const gate = new Promise<ReturnType<typeof commandResult>>(resolve => {
+      releaseExec = resolve;
+    });
+    const firstExec = vi
+      .fn()
+      .mockImplementationOnce(() => gate)
+      .mockImplementation(async () => commandResult());
+    first.session.getWorkspace = () => ({ sandbox: { executeCommand: firstExec } as any });
+    const dependencies = createDependencies();
+    observeSessionFilesystem(first.session, dependencies);
+    observeSessionFilesystem(second.session, dependencies);
+
+    first.listeners[0]!({ type: 'agent_end', reason: 'complete' });
+    second.listeners[0]!({ type: 'agent_end', reason: 'complete' });
+    await vi.waitFor(() => expect(firstExec).toHaveBeenCalledTimes(1));
+
+    // The second session's capture waits on the first session's gated exec.
+    expect(second.executeCommand).not.toHaveBeenCalled();
+    expect(dependencies.filesystem.replaceFiles).not.toHaveBeenCalled();
+
+    releaseExec?.(commandResult());
+    await vi.waitFor(() => expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(2));
+    expect(second.executeCommand).toHaveBeenCalled();
+  });
+
   it('disposing the listener does not cancel an in-flight capture', async () => {
     // A final-turn capture may still be running when the session tears the
     // listener down; the chain must run to completion and persist.
-    const { session, listeners } = createSession();
+    const { session, listeners } = createSession(undefined, 'resource-dispose');
     let releaseExec: ((value: ReturnType<typeof commandResult>) => void) | undefined;
     const gate = new Promise<ReturnType<typeof commandResult>>(resolve => {
       releaseExec = resolve;

--- a/mastracode/factory/src/session/filesystem-capture.test.ts
+++ b/mastracode/factory/src/session/filesystem-capture.test.ts
@@ -5,6 +5,7 @@ import {
   captureSessionFilesystem,
   observeSessionFilesystem,
   parseFilesystemCaptureFiles,
+  waitForPendingFilesystemCapture,
   type FilesystemCaptureDependencies,
   type FilesystemCaptureSession,
 } from './filesystem-capture.js';
@@ -20,11 +21,11 @@ function commandResult(overrides: Partial<{ exitCode: number; stdout: string; st
   };
 }
 
-function createSession(results = [commandResult(), commandResult()]) {
+function createSession(results = [commandResult(), commandResult()], resourceId = 'resource-1') {
   const executeCommand = vi.fn(async () => results.shift() ?? commandResult());
   const listeners: SessionBeforeAgentEndListener[] = [];
   const session: FilesystemCaptureSession = {
-    identity: { getResourceId: () => 'resource-1' },
+    identity: { getResourceId: () => resourceId },
     thread: { requireId: () => 'thread-1' },
     getWorkspace: () => ({
       sandbox: {
@@ -232,5 +233,84 @@ describe('observeSessionFilesystem', () => {
     completeFirstCapture?.();
     await vi.waitFor(() => expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(2));
     completeFirstCapture?.();
+  });
+
+  it('disposing the listener does not cancel an in-flight capture', async () => {
+    // A final-turn capture may still be running when the session tears the
+    // listener down; the chain must run to completion and persist.
+    const { session, listeners } = createSession();
+    let releaseExec: ((value: ReturnType<typeof commandResult>) => void) | undefined;
+    const gate = new Promise<ReturnType<typeof commandResult>>(resolve => {
+      releaseExec = resolve;
+    });
+    const executeCommand = vi
+      .fn()
+      .mockImplementationOnce(() => gate)
+      .mockImplementation(async () => commandResult());
+    session.getWorkspace = () => ({ sandbox: { executeCommand } as any });
+    const dependencies = createDependencies();
+    const dispose = observeSessionFilesystem(session, dependencies);
+
+    listeners[0]!({ type: 'agent_end', reason: 'complete' });
+    await vi.waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(1));
+
+    dispose();
+    expect(listeners).toHaveLength(0);
+
+    releaseExec?.(commandResult());
+    await vi.waitFor(() => expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe('waitForPendingFilesystemCapture', () => {
+  it('resolves immediately when the session has no capture in flight', async () => {
+    await expect(waitForPendingFilesystemCapture('no-such-resource')).resolves.toBeUndefined();
+  });
+
+  it('a reader awaiting the pending capture observes the persisted listing (agent_end contract)', async () => {
+    // The contract this module alters: agent_end no longer waits on the
+    // capture, so a reader refetching at agent_end must await the pending
+    // capture to see this turn's listing rather than the previous one.
+    const { session, listeners } = createSession(undefined, 'resource-wait-fresh');
+    let releaseExec: ((value: ReturnType<typeof commandResult>) => void) | undefined;
+    const gate = new Promise<ReturnType<typeof commandResult>>(resolve => {
+      releaseExec = resolve;
+    });
+    const executeCommand = vi
+      .fn()
+      .mockImplementationOnce(() => gate)
+      .mockImplementation(async () => commandResult());
+    session.getWorkspace = () => ({ sandbox: { executeCommand } as any });
+    const dependencies = createDependencies();
+    observeSessionFilesystem(session, dependencies);
+
+    listeners[0]!({ type: 'agent_end', reason: 'complete' });
+    await vi.waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(1));
+
+    let waitSettled = false;
+    const wait = waitForPendingFilesystemCapture('resource-wait-fresh').then(() => {
+      waitSettled = true;
+    });
+    await Promise.resolve();
+    expect(waitSettled).toBe(false);
+    expect(dependencies.filesystem.replaceFiles).not.toHaveBeenCalled();
+
+    releaseExec?.(commandResult());
+    await wait;
+    // The persist happened before the reader's wait resolved.
+    expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds the wait so a stuck capture cannot block readers', async () => {
+    const { session, listeners } = createSession(undefined, 'resource-wait-stuck');
+    session.getWorkspace = () => ({
+      sandbox: { executeCommand: vi.fn(() => new Promise<never>(() => {})) } as any,
+    });
+    const dependencies = createDependencies();
+    observeSessionFilesystem(session, dependencies);
+
+    listeners[0]!({ type: 'agent_end', reason: 'complete' });
+
+    await expect(waitForPendingFilesystemCapture('resource-wait-stuck', 20)).resolves.toBeUndefined();
   });
 });

--- a/mastracode/factory/src/session/filesystem-capture.test.ts
+++ b/mastracode/factory/src/session/filesystem-capture.test.ts
@@ -160,11 +160,55 @@ describe('observeSessionFilesystem', () => {
       const dependencies = createDependencies();
       observeSessionFilesystem(session, dependencies);
 
-      await listeners[0]!({ type: 'agent_end', reason });
+      // The listener no longer returns the capture chain; the capture still
+      // runs and persists in the background.
+      listeners[0]!({ type: 'agent_end', reason });
 
-      expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(1));
     },
   );
+
+  it('does not gate the agent-end listener on slow capture execs', async () => {
+    // The sandbox exec never resolves: the listener must still settle
+    // immediately, because agent_end must not wait on the capture I/O.
+    const { session, listeners } = createSession();
+    const gatedExec = new Promise<never>(() => {});
+    session.getWorkspace = () => ({
+      sandbox: { executeCommand: vi.fn(() => gatedExec) } as any,
+    });
+    const dependencies = createDependencies();
+    observeSessionFilesystem(session, dependencies);
+
+    const listenerResult = listeners[0]!({ type: 'agent_end', reason: 'complete' });
+
+    // Resolves without waiting on the never-resolving exec.
+    await expect(Promise.resolve(listenerResult)).resolves.toBeUndefined();
+    expect(dependencies.filesystem.replaceFiles).not.toHaveBeenCalled();
+  });
+
+  it('still persists the capture after the listener returns', async () => {
+    // Gate the exec, release it after the listener has already settled, and
+    // verify the capture completes in the background.
+    const { session, listeners } = createSession();
+    let releaseExec: ((value: ReturnType<typeof commandResult>) => void) | undefined;
+    const gate = new Promise<ReturnType<typeof commandResult>>(resolve => {
+      releaseExec = resolve;
+    });
+    const executeCommand = vi
+      .fn()
+      .mockImplementationOnce(() => gate)
+      .mockImplementation(async () => commandResult());
+    session.getWorkspace = () => ({ sandbox: { executeCommand } as any });
+    const dependencies = createDependencies();
+    observeSessionFilesystem(session, dependencies);
+
+    listeners[0]!({ type: 'agent_end', reason: 'complete' });
+    await vi.waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(1));
+    expect(dependencies.filesystem.replaceFiles).not.toHaveBeenCalled();
+
+    releaseExec?.(commandResult());
+    await vi.waitFor(() => expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(1));
+  });
 
   it('serializes captures when terminal events arrive before the prior capture finishes', async () => {
     const { session, listeners } = createSession([commandResult(), commandResult(), commandResult(), commandResult()]);
@@ -178,17 +222,15 @@ describe('observeSessionFilesystem', () => {
     );
     observeSessionFilesystem(session, dependencies);
 
-    const first = listeners[0]!({ type: 'agent_end', reason: 'complete' });
+    listeners[0]!({ type: 'agent_end', reason: 'complete' });
     await vi.waitFor(() => expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(1));
 
-    const second = listeners[0]!({ type: 'agent_end', reason: 'complete' });
+    listeners[0]!({ type: 'agent_end', reason: 'complete' });
     await Promise.resolve();
     expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(1);
 
     completeFirstCapture?.();
-    await first;
     await vi.waitFor(() => expect(dependencies.filesystem.replaceFiles).toHaveBeenCalledTimes(2));
     completeFirstCapture?.();
-    await second;
   });
 });

--- a/mastracode/factory/src/session/filesystem-capture.ts
+++ b/mastracode/factory/src/session/filesystem-capture.ts
@@ -91,10 +91,12 @@ export async function captureSessionFilesystem(
 }
 
 /**
- * In-flight capture chains keyed by session resource id, so readers of the
- * persisted file listing (the /web/workspace routes) can await the capture
- * for the turn that just ended instead of racing it. In-process only: the
- * factory server that runs the session controller also serves those routes.
+ * In-flight capture chains keyed by session resource id. Serves two purposes:
+ * readers of the persisted file listing (the /web/workspace routes) await the
+ * capture for the turn that just ended instead of racing it, and captures for
+ * the same resource stay sequential (last write wins) even when multiple
+ * scoped sessions observe the same resource id. In-process only: the factory
+ * server that runs the session controller also serves those routes.
  */
 const pendingCaptures = new Map<string, Promise<void>>();
 
@@ -124,7 +126,7 @@ export function observeSessionFilesystem(
   session: FilesystemCaptureSession,
   dependencies: FilesystemCaptureDependencies,
 ): () => void {
-  let capture = Promise.resolve();
+  let fallbackChain = Promise.resolve();
   return session.onBeforeAgentEnd(() => {
     // Chain so captures stay sequential (last write wins), but do NOT return
     // the chain: finishAgentRun awaits every listener before emitting
@@ -135,16 +137,21 @@ export function observeSessionFilesystem(
     // leak an unhandled rejection: captureSessionFilesystem's entire body
     // runs inside its own try/catch, and disposal of this listener does not
     // cancel an in-flight chain, so a final turn's capture still persists.
-    capture = capture.then(() => captureSessionFilesystem(session, dependencies));
-
     let resourceId: string | undefined;
     try {
       resourceId = session.identity.getResourceId();
     } catch {
-      // No resource id means no route can address this session's listing.
+      // No resource id means no route can address this session's listing;
+      // keep a per-observer chain so captures still run sequentially.
+      fallbackChain = fallbackChain.then(() => captureSessionFilesystem(session, dependencies));
       return;
     }
-    const chain = capture;
+    // Extend the resource-level chain rather than a per-session one: sessions
+    // are deduplicated by (resourceId, scope), so multiple scoped sessions can
+    // observe the same resource, and their captures must not interleave.
+    const chain = (pendingCaptures.get(resourceId) ?? Promise.resolve()).then(() =>
+      captureSessionFilesystem(session, dependencies),
+    );
     pendingCaptures.set(resourceId, chain);
     void chain.finally(() => {
       if (pendingCaptures.get(resourceId) === chain) {

--- a/mastracode/factory/src/session/filesystem-capture.ts
+++ b/mastracode/factory/src/session/filesystem-capture.ts
@@ -96,7 +96,13 @@ export function observeSessionFilesystem(
 ): () => void {
   let capture = Promise.resolve();
   return session.onBeforeAgentEnd(() => {
+    // Chain so captures stay sequential (last write wins), but do NOT return
+    // the chain: finishAgentRun awaits every listener before emitting
+    // agent_end, and the capture's sandbox execs (git status + artifacts
+    // find, 30s timeouts each) must not gate turn completion - parity with
+    // the checkpoint listener in checkpoint-capture.ts. The un-returned
+    // chain cannot leak an unhandled rejection: captureSessionFilesystem's
+    // entire body runs inside its own try/catch.
     capture = capture.then(() => captureSessionFilesystem(session, dependencies));
-    return capture;
   });
 }

--- a/mastracode/factory/src/session/filesystem-capture.ts
+++ b/mastracode/factory/src/session/filesystem-capture.ts
@@ -90,6 +90,36 @@ export async function captureSessionFilesystem(
   }
 }
 
+/**
+ * In-flight capture chains keyed by session resource id, so readers of the
+ * persisted file listing (the /web/workspace routes) can await the capture
+ * for the turn that just ended instead of racing it. In-process only: the
+ * factory server that runs the session controller also serves those routes.
+ */
+const pendingCaptures = new Map<string, Promise<void>>();
+
+/**
+ * Resolve once the session's in-flight filesystem capture (if any) has
+ * persisted, or after `timeoutMs` so a reader that arrives mid-capture is
+ * never blocked by the execs' worst-case 30s timeouts. Never rejects: the
+ * capture body is fully try/catch contained.
+ */
+export async function waitForPendingFilesystemCapture(resourceId: string, timeoutMs = 10_000): Promise<void> {
+  const pending = pendingCaptures.get(resourceId);
+  if (!pending) return;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      pending,
+      new Promise<void>(resolve => {
+        timer = setTimeout(resolve, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export function observeSessionFilesystem(
   session: FilesystemCaptureSession,
   dependencies: FilesystemCaptureDependencies,
@@ -99,10 +129,27 @@ export function observeSessionFilesystem(
     // Chain so captures stay sequential (last write wins), but do NOT return
     // the chain: finishAgentRun awaits every listener before emitting
     // agent_end, and the capture's sandbox execs (git status + artifacts
-    // find, 30s timeouts each) must not gate turn completion - parity with
-    // the checkpoint listener in checkpoint-capture.ts. The un-returned
-    // chain cannot leak an unhandled rejection: captureSessionFilesystem's
-    // entire body runs inside its own try/catch.
+    // find, 30s timeouts each) must not gate turn completion. Readers that
+    // need the fresh listing await the pending capture through
+    // waitForPendingFilesystemCapture instead. The un-returned chain cannot
+    // leak an unhandled rejection: captureSessionFilesystem's entire body
+    // runs inside its own try/catch, and disposal of this listener does not
+    // cancel an in-flight chain, so a final turn's capture still persists.
     capture = capture.then(() => captureSessionFilesystem(session, dependencies));
+
+    let resourceId: string | undefined;
+    try {
+      resourceId = session.identity.getResourceId();
+    } catch {
+      // No resource id means no route can address this session's listing.
+      return;
+    }
+    const chain = capture;
+    pendingCaptures.set(resourceId, chain);
+    void chain.finally(() => {
+      if (pendingCaptures.get(resourceId) === chain) {
+        pendingCaptures.delete(resourceId);
+      }
+    });
   });
 }


### PR DESCRIPTION
## What

The turn-end filesystem capture in factory sessions no longer gates `agent_end`. The `observeSessionFilesystem` listener keeps chaining captures sequentially (last write wins) but stops returning the capture promise, so `finishAgentRun` no longer awaits it before emitting `agent_end`. To keep readers fresh, the persisted file-listing routes now await the session's in-flight capture (bounded) before reading.

## Why

The capture runs `git status --porcelain` plus a `find .artifacts` listing through the sandbox, each with a 30s timeout. Returning the chain from the listener made every turn's `agent_end` wait on those execs (measured 1.3-1.8s per turn on a small repo, worst case a minute on big workdirs). Shared context: this is one of three PRs splitting up the original combined branch; the others are #21555 (core: non-blocking skills discovery) and #21678 (code-sdk: single-exec reads).

Note: an earlier revision of this description claimed parity with the checkpoint listener; that was wrong. `checkpoint-capture.ts` still returns its chain and continues to gate `agent_end` today, unchanged by this PR.

## How it works

- The listener body no longer returns the capture chain. Sequential chaining is preserved, so captures never interleave, and disposing the listener does not cancel an in-flight chain (a final turn's capture still persists).
- Freshness contract: the UI invalidates its workspace-files queries exactly at run completion, which now races the un-awaited capture. `filesystem-capture.ts` keeps an in-process registry of pending capture chains per session; `listSessionFilesystemFiles` (the single read path behind `/web/workspace/files` and the thread-scoped `/web/workspace/file` check) awaits the pending capture via `waitForPendingFilesystemCapture` before reading, bounded at 10s so a stuck capture cannot block readers. The run-completion refetch therefore observes the just-ended turn's listing.
- `captureSessionFilesystem` already runs its entire body inside try/catch, so the un-awaited chain cannot produce an unhandled rejection.
- What is captured, when it runs, the exec commands, and the DB write are all unchanged. `checkpoint-capture.ts` is untouched.

## Verification

- 15 tests pass in `filesystem-capture.test.ts`, including: the listener settles immediately even with a never-resolving exec; the capture still persists after the listener returns; contract-level coverage that a reader awaiting the pending capture observes the persisted listing (persist happens before the wait resolves); teardown coverage that disposing the listener does not drop an in-flight capture; and the bounded wait resolves even when the capture is stuck.
- 45 route tests pass in `routes/fs.test.ts`.
- `tsc --noEmit` clean.
- Validated live in an instrumented rig against a real Railway sandbox: turn-end wait dropped from ~1300ms to ~1ms while the capture still persisted in the background (`replaceFiles` confirmed after `agent_end`).

Related PRs from the same split: #21555 (core), #21678 (code-sdk). Each stands alone and can merge in any order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The agent can finish its turn without waiting for filesystem saves. Saves still run in order. File readers wait up to 10 seconds for pending saves so they can read the latest files.

## Changes

- Made `agent_end` filesystem capture non-blocking.
- Preserved sequential captures and “last write wins” behavior across sessions sharing a resource.
- Added `waitForPendingFilesystemCapture` with a 10-second timeout.
- Updated file-listing readers to wait for pending captures.
- Kept capture errors internal to the background capture chain.
- Ensured listener disposal does not cancel in-flight captures.
- Added a patch changeset for `@mastra/factory`.

## Tests

- Added coverage for listener settlement, persistence ordering, cross-session serialization, bounded waits, and teardown behavior.
- Verified 15 filesystem-capture tests pass.
- Verified 45 filesystem route tests pass.
- Verified `tsc --noEmit` passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->