### PR TITLE
fix(code-sdk): ignore node_modules during command discovery

### DIFF
--- a/.changeset/cuddly-socks-drop.md
+++ b/.changeset/cuddly-socks-drop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed custom command discovery loading Markdown files from node_modules.

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -478,7 +478,7 @@ Review my current git diff. Look for bugs, security issues,
 and violations of the project's coding standards.
 ```
 
-The filename (or directory structure) determines the command name. For example, `git/commit.md` becomes `/git:commit`.
+The filename (or directory structure) determines the command name. For example, `git/commit.md` becomes `/git:commit`. Mastra Code scans nested command directories but ignores directories named `node_modules`.
 
 Commands support variables like `$ARGUMENTS` for positional args, `@filename` for file content injection, and `!command` for shell command output.
 

--- a/mastracode/sdk/src/utils/__tests__/slash-command-loader.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/slash-command-loader.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -38,6 +38,51 @@ describe('slash command loader', () => {
 
     expect(commands).toHaveLength(1);
     expect(commands[0]).toMatchObject({ name: 'review', goal: true });
+  });
+
+  it('ignores node_modules while preserving nested commands', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'mastracode-project-'));
+    const commandsDir = join(projectDir, '.mastracode', 'commands');
+    const presentationDir = join(commandsDir, 'presentation');
+    const dependencyDir = join(
+      presentationDir,
+      'node_modules',
+      '.pnpm',
+      'example@1.0.0',
+      'node_modules',
+      'dependency-readme-sentinel',
+    );
+    const symlinkSourceDir = join(projectDir, '.mastracode', 'command-sources', 'dependencies');
+    const symlinkNamespaceDir = join(commandsDir, 'linked');
+    await mkdir(presentationDir, { recursive: true });
+    await mkdir(dependencyDir, { recursive: true });
+    await mkdir(symlinkSourceDir, { recursive: true });
+    await mkdir(symlinkNamespaceDir, { recursive: true });
+    await writeFile(join(presentationDir, 'review.md'), 'Review the presentation\n');
+    await writeFile(join(dependencyDir, 'README.md'), 'Dependency README\n');
+    await writeFile(join(symlinkSourceDir, 'README.md'), 'Symlinked dependency README\n');
+    await symlink(symlinkSourceDir, join(symlinkNamespaceDir, 'node_modules'));
+
+    const commands = await loadCustomCommands(projectDir);
+
+    expect(commands.find(command => command.name === 'presentation:review')).toMatchObject({
+      sourcePath: join(presentationDir, 'review.md'),
+    });
+    expect(commands.every(command => !command.name.includes('node_modules'))).toBe(true);
+    expect(commands.every(command => !command.sourcePath.split(sep).includes('node_modules'))).toBe(true);
+  });
+
+  it('loads an explicitly configured command root beneath node_modules', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'mastracode-project-'));
+    const commandsDir = join(projectDir, 'node_modules', 'example-plugin', 'commands');
+    await mkdir(commandsDir, { recursive: true });
+    await writeFile(join(commandsDir, 'review.md'), 'Review the plugin\n');
+
+    const commands = await loadCustomCommands(projectDir, '.mastracode', [commandsDir]);
+
+    expect(commands.find(command => command.name === 'review')).toMatchObject({
+      sourcePath: join(commandsDir, 'review.md'),
+    });
   });
 
   it('loads individually symlinked command files', async () => {

--- a/mastracode/sdk/src/utils/slash-command-loader.ts
+++ b/mastracode/sdk/src/utils/slash-command-loader.ts
@@ -129,6 +129,8 @@ export async function scanCommandDirectory(
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
 
     for (const entry of entries) {
+      if (entry.name === 'node_modules') continue;
+
       const fullPath = path.join(dirPath, entry.name);
       const stats = entry.isSymbolicLink() ? await fs.stat(fullPath).catch(() => null) : entry;
       if (!stats) continue;

--- a/mastracode/tui/e2e/fixtures/custom-slash-command.json
+++ b/mastracode/tui/e2e/fixtures/custom-slash-command.json
@@ -19,6 +19,16 @@
       "response": {
         "content": "MC review command response"
       }
+    },
+    {
+      "match": {
+        "userMessage": "Present the review findings.",
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat"
+      },
+      "response": {
+        "content": "MC presentation command response"
+      }
     }
   ]
 }

--- a/mastracode/tui/e2e/tui/custom-slash-command.ts
+++ b/mastracode/tui/e2e/tui/custom-slash-command.ts
@@ -2,16 +2,19 @@ import { mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect } from './expect.js';
 import type { McE2eScenario } from './types.js';
+import { typeTextSlowly } from './typing-utils.js';
 
 const DEPLOY_CONTENT = 'Deploy using the standard checklist.';
 const DEPLOY_ARGS = 'ARGUMENTS: prod blue';
 const REVIEW_CONTENT = 'Review src/index.ts src/main.ts';
 const REVIEW_DUPLICATE_CONTENT = 'ARGUMENTS: src/index.ts src/main.ts';
+const PRESENTATION_CONTENT = 'Present the review findings.';
+const DEPENDENCY_SENTINEL = 'dependency-readme-sentinel';
 
 export const customSlashCommandScenario: McE2eScenario = {
   name: 'custom-slash-command',
   description: 'Run custom slash commands through the real TUI and verify processed arguments reach the model request.',
-  testName: 'preserves custom slash command arguments in real TUI model requests',
+  testName: 'excludes dependency READMEs while preserving custom slash commands in the real TUI',
   projectFixture: 'long-branch',
   useOpenAIModel: true,
   aimockFixture: 'custom-slash-command.json',
@@ -26,6 +29,23 @@ export const customSlashCommandScenario: McE2eScenario = {
     );
     symlinkSync(join(commandSourcesDir, 'deploy.md'), join(commandsDir, 'deploy.md'));
     writeFileSync(join(commandsDir, 'review.md'), `---\ndescription: Review changed files\n---\nReview $1+\n`);
+
+    const presentationDir = join(commandsDir, 'presentation');
+    const dependencyReadmeDir = join(
+      presentationDir,
+      'node_modules',
+      '.pnpm',
+      'x',
+      'node_modules',
+      DEPENDENCY_SENTINEL,
+    );
+    mkdirSync(presentationDir, { recursive: true });
+    mkdirSync(dependencyReadmeDir, { recursive: true });
+    writeFileSync(
+      join(presentationDir, 'review.md'),
+      `---\ndescription: Review presentation\n---\n${PRESENTATION_CONTENT}\n`,
+    );
+    writeFileSync(join(dependencyReadmeDir, 'README.md'), 'Dependency README must not become a command.\n');
   },
   async run({ terminal, runtime }) {
     runtime.startLiveOutput(terminal);
@@ -36,6 +56,15 @@ export const customSlashCommandScenario: McE2eScenario = {
     ).toBeVisible();
     runtime.printScreen('after startup', terminal);
 
+    await terminal.flushInput?.();
+    await typeTextSlowly(terminal, '/presentation:');
+    await runtime.waitForScreenText(/\/presentation:review/i, terminal, 10_000);
+    runtime.printScreen('nested command autocomplete', terminal);
+    expect(terminal.serialize().view).not.toContain(DEPENDENCY_SENTINEL);
+    terminal.write('\x1b');
+    terminal.write('\x15');
+    await terminal.flushInput?.();
+
     terminal.submit('//deploy prod blue');
     await runtime.waitForScreenText(/MC deploy command response/i, terminal);
     runtime.printScreen('after deploy command', terminal);
@@ -43,6 +72,10 @@ export const customSlashCommandScenario: McE2eScenario = {
     terminal.submit('//review src/index.ts src/main.ts');
     await runtime.waitForScreenText(/MC review command response/i, terminal);
     runtime.printScreen('after review command', terminal);
+
+    terminal.submit('//presentation:review');
+    await runtime.waitForScreenText(/MC presentation command response/i, terminal);
+    runtime.printScreen('after nested presentation command', terminal);
 
     terminal.keyCtrlC();
     runtime.printScreen('after Ctrl-C', terminal);
@@ -53,5 +86,7 @@ export const customSlashCommandScenario: McE2eScenario = {
     expect(body).toContain(DEPLOY_ARGS);
     expect(body).toContain(REVIEW_CONTENT);
     expect(body).not.toContain(REVIEW_DUPLICATE_CONTENT);
+    expect(body).toContain(PRESENTATION_CONTENT);
+    expect(body).not.toContain(DEPENDENCY_SENTINEL);
   },
 };


### PR DESCRIPTION
Mastra Code recursively scanned every nested directory in custom command roots, so Markdown files from dependency trees could appear as slash commands and autocomplete entries.

Before:
```ts
for (const entry of entries) {
  const fullPath = path.join(dir, entry.name);
```

After:
```ts
for (const entry of entries) {
  if (entry.name === 'node_modules') continue;
  const fullPath = path.join(dir, entry.name);
```

This prunes descendant `node_modules` entries before stat or recursion while preserving explicit roots beneath package-manager paths, nested commands, and symlink behavior. It includes focused SDK coverage, a real-TUI autocomplete and dispatch regression test, documentation, and a patch changeset for `@mastra/code-sdk`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Mastra Code no longer treats dependency files in `node_modules` as slash commands. It still finds nested commands and supports explicitly configured paths.

## Changes

- Skip `node_modules` during recursive custom command scans.
- Preserve symlink behavior and explicit paths under `node_modules`.
- Add SDK tests for nested directories, symlinks, and explicit command roots.
- Add a real-TUI regression test for autocomplete and command dispatch.
- Update custom slash command documentation.
- Add a patch changeset for `@mastra/code-sdk`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->