### PR TITLE
Re-enable Studio playground analytics on all hosts

### DIFF
--- a/.changeset/playground-posthog-all-hosts.md
+++ b/.changeset/playground-posthog-all-hosts.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Re-enabled Studio playground analytics on all hosts. Playground telemetry was previously limited to Mastra Cloud domains, which stopped usage reporting from locally run and self-hosted Studio instances. Opt-outs via `MASTRA_TELEMETRY_DISABLED` and Brave browser detection are unchanged.

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -1773,6 +1773,8 @@ When a server started with `mastra dev` or `mastra start` has observability metr
 
 At server startup, Mastra also sends an anonymous project-surface snapshot: counts of registered agents, agent controllers, workflows, tools, processors, vector stores, scorers, workspaces, MCP servers, gateways, and channels, plus booleans for memory, voice, editor, and observability usage and the coarse storage backend category. It doesn't send names or identifiers. You can read the [source code](https://github.com/mastra-ai/mastra/blob/main/packages/core/src/telemetry/feature-telemetry.ts) to check what's collected.
 
+The Studio UI also collects anonymous browser-side usage analytics, such as page views and UI interactions. You can read the [source code](https://github.com/mastra-ai/mastra/blob/main/packages/playground/src/lib/analytics.tsx) to check what's collected. Setting `MASTRA_TELEMETRY_DISABLED` disables this too: the value is injected into the served page, so it applies to `mastra dev` and self-hosted builds alike.
+
 You can opt out of all CLI and usage analytics by setting an environment variable:
 
 ```bash

--- a/packages/playground/src/lib/analytics.test.tsx
+++ b/packages/playground/src/lib/analytics.test.tsx
@@ -45,8 +45,8 @@ afterEach(() => {
 });
 
 describe('PostHogProvider', () => {
-  it('initializes PostHog on the mastra.cloud apex', async () => {
-    setHostname('mastra.cloud');
+  it('initializes PostHog on localhost', async () => {
+    setHostname('localhost');
 
     render(
       <PostHogProvider>
@@ -62,34 +62,8 @@ describe('PostHogProvider', () => {
     expect(posthogMock.register).toHaveBeenCalledWith({ mastraSource: 'playground' });
   });
 
-  it('initializes PostHog on a mastra.cloud subdomain', async () => {
-    setHostname('foo.mastra.cloud');
-
-    render(
-      <PostHogProvider>
-        <div>Playground</div>
-      </PostHogProvider>,
-    );
-
-    await waitFor(() => expect(posthogMock.init).toHaveBeenCalledTimes(1));
-    expect(posthogMock.register).toHaveBeenCalledWith({ mastraSource: 'playground' });
-  });
-
-  it('initializes PostHog on a nested mastra.cloud subdomain', async () => {
-    setHostname('staging.foo.mastra.cloud');
-
-    render(
-      <PostHogProvider>
-        <div>Playground</div>
-      </PostHogProvider>,
-    );
-
-    await waitFor(() => expect(posthogMock.init).toHaveBeenCalledTimes(1));
-    expect(posthogMock.register).toHaveBeenCalledWith({ mastraSource: 'playground' });
-  });
-
-  it('does not initialize PostHog on disallowed hosts', async () => {
-    for (const hostname of ['localhost', 'foo.example.com', 'evil.notmastra.cloud']) {
+  it('initializes PostHog regardless of hostname', async () => {
+    for (const hostname of ['mastra.cloud', 'foo.mastra.cloud', 'foo.example.com', 'self-hosted.internal']) {
       setHostname(hostname);
 
       const { unmount } = render(
@@ -98,16 +72,15 @@ describe('PostHogProvider', () => {
         </PostHogProvider>,
       );
 
-      await waitFor(() => expect(posthogMock.init).not.toHaveBeenCalled());
-      expect(posthogMock.register).not.toHaveBeenCalled();
+      await waitFor(() => expect(posthogMock.init).toHaveBeenCalledTimes(1));
+      expect(posthogMock.register).toHaveBeenCalledWith({ mastraSource: 'playground' });
       unmount();
       posthogMock.init.mockReset();
       posthogMock.register.mockReset();
     }
   });
 
-  it('does not initialize PostHog when telemetry is disabled on an allowed host', async () => {
-    setHostname('foo.mastra.cloud');
+  it('does not initialize PostHog when telemetry is disabled', async () => {
     window.MASTRA_TELEMETRY_DISABLED = 'true';
 
     render(
@@ -120,8 +93,7 @@ describe('PostHogProvider', () => {
     expect(posthogMock.register).not.toHaveBeenCalled();
   });
 
-  it('does not initialize PostHog in Brave on an allowed host', async () => {
-    setHostname('foo.mastra.cloud');
+  it('does not initialize PostHog in Brave', async () => {
     setBrave({});
 
     render(

--- a/packages/playground/src/lib/analytics.tsx
+++ b/packages/playground/src/lib/analytics.tsx
@@ -4,7 +4,6 @@ import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 
 const TRUTHY_DISABLED_VALUES = ['1', 'true', 'yes'];
-const POSTHOG_ALLOWED_HOSTNAME = /(?:^|\.)mastra\.cloud$/;
 
 function isTelemetryDisabled(): boolean {
   const value = window.MASTRA_TELEMETRY_DISABLED;
@@ -12,10 +11,6 @@ function isTelemetryDisabled(): boolean {
     return false;
   }
   return TRUTHY_DISABLED_VALUES.includes(value.trim().toLowerCase());
-}
-
-function isPostHogAllowedHost(hostname: string): boolean {
-  return POSTHOG_ALLOWED_HOSTNAME.test(hostname.toLowerCase());
 }
 
 export function PostHogProvider({ children }: { children: ReactNode }) {
@@ -27,11 +22,6 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
 
     if (isTelemetryDisabled()) {
       console.info('[Analytics]: Telemetry is disabled.');
-      return;
-    }
-
-    if (!isPostHogAllowedHost(window.location.hostname)) {
-      console.info('[Analytics]: Telemetry is disabled for this host.');
       return;
     }
 


### PR DESCRIPTION
## Summary

- Removes the hostname allowlist added in #17485 that limited Playground PostHog analytics to `*.mastra.cloud` domains
- Studio usage telemetry now initializes on any host again (localhost, self-hosted, and Mastra Cloud), restoring the usage data that silently dropped off when #17485 shipped
- Existing opt-outs are unchanged: `MASTRA_TELEMETRY_DISABLED` and Brave browser detection still disable telemetry
- `mastraSource: 'playground'` super-property registration is unchanged
- Updates the analytics test suite to cover host-agnostic initialization plus both opt-out paths, and adds a patch changeset for `@internal/playground`

## Why

Usage dashboards showed an unexplained drop in Playground events. Root cause was #17485 (merged 2026-06-03) gating PostHog init to Mastra Cloud hostnames, which stopped all reporting from locally run Studio instances. This restores pre-#17485 collection behavior.

## Test plan

- ✅ `pnpm --filter ./packages/playground test:run src/lib/analytics.test.tsx` (4 tests pass)
- ✅ `eslint` clean on both changed files
- ⚠️ `pnpm --filter ./packages/playground typecheck` fails only on pre-existing unrelated errors elsewhere in the package (same state documented in #17485); no analytics-related type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Studio Playground analytics now works on localhost, self-hosted instances, and Mastra Cloud. Users can still disable telemetry with the existing environment variable or Brave browser settings.

## Changes

- Removed the `*.mastra.cloud` hostname allowlist from PostHog initialization.
- Kept `MASTRA_TELEMETRY_DISABLED`, Brave browser opt-outs, and `mastraSource: 'playground'` unchanged.
- Updated analytics tests for host-independent initialization and both opt-out paths.
- Documented Studio browser-side analytics in the CLI telemetry reference.
- Added a patch changeset for `@internal/playground`.
- Four analytics tests pass. ESLint is clean.
- Package typechecking still reports unrelated pre-existing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->