### PR TITLE
feat(core): add computer use workspace tools

### DIFF
--- a/.changeset/vast-adults-draw.md
+++ b/.changeset/vast-adults-draw.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': minor
+---
+
+Added an optional computer-use capability for workspace sandboxes. Providers can expose `SandboxComputer` to give agents screenshot, mouse, keyboard, screen information, and wait tools automatically.
+
+```typescript
+const workspace = new Workspace({ sandbox });
+
+if (supportsComputer(sandbox)) {
+  const screenshot = await sandbox.computer.screenshot();
+}
+```
+
+Computer action tools return a follow-up screenshot by default and support the existing workspace tool approval and enablement settings.

--- a/.changeset/vast-adults-draw.md
+++ b/.changeset/vast-adults-draw.md
@@ -2,7 +2,7 @@
 '@mastra/core': minor
 ---
 
-Added an optional computer-use capability for workspace sandboxes. Providers can expose `SandboxComputer` to give agents screenshot, mouse, keyboard, screen information, and wait tools automatically.
+Added an optional computer-use capability for workspace sandboxes. Providers can expose `SandboxComputer` to give agents screenshot, mouse, keyboard, screen information, and wait tools automatically when the workspace uses a static sandbox. Resolver-backed sandboxes do not register computer tools because their capabilities are unavailable when the tool list is constructed.
 
 ```typescript
 const workspace = new Workspace({ sandbox });

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -610,7 +610,7 @@ export interface WorkspaceActionAttributes extends AIBaseAttributes {
   /** Human-readable workspace name */
   workspaceName?: string;
   /** Action category */
-  category: 'filesystem' | 'sandbox' | 'search' | 'skill' | 'mount';
+  category: 'filesystem' | 'sandbox' | 'search' | 'skill' | 'mount' | 'computer';
   /** Sandbox provider name (e.g. 'e2b', 'docker', 'local') */
   sandboxProvider?: string;
   /** Filesystem provider name (e.g. 'local', 'agentfs', 's3') */

--- a/packages/core/src/workspace/constants/index.ts
+++ b/packages/core/src/workspace/constants/index.ts
@@ -30,6 +30,19 @@ export const WORKSPACE_TOOLS = {
     GET_PROCESS_OUTPUT: `${WORKSPACE_TOOLS_PREFIX}_get_process_output` as const,
     KILL_PROCESS: `${WORKSPACE_TOOLS_PREFIX}_kill_process` as const,
   },
+  COMPUTER: {
+    SCREENSHOT: `${WORKSPACE_TOOLS_PREFIX}_computer_screenshot` as const,
+    CLICK: `${WORKSPACE_TOOLS_PREFIX}_computer_click` as const,
+    DOUBLE_CLICK: `${WORKSPACE_TOOLS_PREFIX}_computer_double_click` as const,
+    RIGHT_CLICK: `${WORKSPACE_TOOLS_PREFIX}_computer_right_click` as const,
+    MOVE_MOUSE: `${WORKSPACE_TOOLS_PREFIX}_computer_move_mouse` as const,
+    DRAG: `${WORKSPACE_TOOLS_PREFIX}_computer_drag` as const,
+    TYPE: `${WORKSPACE_TOOLS_PREFIX}_computer_type` as const,
+    PRESS_KEY: `${WORKSPACE_TOOLS_PREFIX}_computer_press_key` as const,
+    SCROLL: `${WORKSPACE_TOOLS_PREFIX}_computer_scroll` as const,
+    GET_SCREEN_INFO: `${WORKSPACE_TOOLS_PREFIX}_computer_get_screen_info` as const,
+    WAIT: `${WORKSPACE_TOOLS_PREFIX}_computer_wait` as const,
+  },
   SEARCH: {
     SEARCH: `${WORKSPACE_TOOLS_PREFIX}_search` as const,
     INDEX: `${WORKSPACE_TOOLS_PREFIX}_index` as const,
@@ -46,4 +59,5 @@ export type WorkspaceToolName =
   | (typeof WORKSPACE_TOOLS.FILESYSTEM)[keyof typeof WORKSPACE_TOOLS.FILESYSTEM]
   | (typeof WORKSPACE_TOOLS.SEARCH)[keyof typeof WORKSPACE_TOOLS.SEARCH]
   | (typeof WORKSPACE_TOOLS.SANDBOX)[keyof typeof WORKSPACE_TOOLS.SANDBOX]
+  | (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER]
   | (typeof WORKSPACE_TOOLS.LSP)[keyof typeof WORKSPACE_TOOLS.LSP];

--- a/packages/core/src/workspace/errors.ts
+++ b/packages/core/src/workspace/errors.ts
@@ -47,7 +47,7 @@ export class SandboxNotAvailableError extends WorkspaceError {
 }
 
 export class SandboxFeatureNotSupportedError extends WorkspaceError {
-  constructor(feature: 'executeCommand' | 'installPackage' | 'processes') {
+  constructor(feature: 'executeCommand' | 'installPackage' | 'processes' | 'computer') {
     super(`Sandbox does not support ${feature}`, 'FEATURE_NOT_SUPPORTED');
     this.name = 'SandboxFeatureNotSupportedError';
   }

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -34,6 +34,7 @@ export {
   type WorkspaceToolConfig,
   type WorkspaceToolsConfig,
   type ExecuteCommandToolConfig,
+  type ComputerToolConfig,
   type BackgroundProcessConfig,
   type BackgroundProcessMeta,
   type BackgroundProcessExitMeta,
@@ -83,10 +84,14 @@ export type {
 export type { FilesystemMountConfig, MountResult, FilesystemIcon } from './filesystem';
 
 // Sandbox
-export { MountManager, supportsNetworking } from './sandbox';
+export { MountManager, supportsNetworking, supportsComputer } from './sandbox';
 export type {
   WorkspaceSandbox,
   SandboxNetworking,
+  SandboxComputer,
+  ComputerScreenshot,
+  ComputerScreenSize,
+  ComputerPosition,
   SandboxFileInput,
   SandboxCloneOptions,
   SandboxStartOutcome,

--- a/packages/core/src/workspace/sandbox/computer.test.ts
+++ b/packages/core/src/workspace/sandbox/computer.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Sandbox Computer Capability Tests
+ *
+ * Tests the optional `computer` (desktop) capability on WorkspaceSandbox /
+ * MastraSandbox, plus the `supportsComputer` type guard.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { ProviderStatus } from '../lifecycle';
+
+import { MastraSandbox } from './mastra-sandbox';
+import { supportsComputer } from './sandbox';
+import type { SandboxComputer, WorkspaceSandbox } from './sandbox';
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+function createComputer(): SandboxComputer {
+  return {
+    screenshot: async () => ({ data: PNG_BYTES, mediaType: 'image/png' }),
+    leftClick: async () => {},
+    rightClick: async () => {},
+    doubleClick: async () => {},
+    moveMouse: async () => {},
+    drag: async () => {},
+    scroll: async () => {},
+    type: async () => {},
+    press: async () => {},
+    getScreenSize: async () => ({ width: 1024, height: 768 }),
+    getCursorPosition: async () => ({ x: 0, y: 0 }),
+  };
+}
+
+class DesktopSandbox extends MastraSandbox {
+  readonly id = 'test-desktop-sandbox';
+  readonly name = 'DesktopSandbox';
+  readonly provider = 'test';
+  status: ProviderStatus = 'pending';
+
+  readonly computer: SandboxComputer = createComputer();
+
+  constructor() {
+    super({ name: 'DesktopSandbox' });
+  }
+
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async destroy(): Promise<void> {}
+}
+
+class PlainSandbox extends MastraSandbox {
+  readonly id = 'test-plain-sandbox';
+  readonly name = 'PlainSandbox';
+  readonly provider = 'test';
+  status: ProviderStatus = 'pending';
+
+  constructor() {
+    super({ name: 'PlainSandbox' });
+  }
+
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async destroy(): Promise<void> {}
+}
+
+describe('supportsComputer', () => {
+  it('returns true for a sandbox implementing the computer capability', () => {
+    const sandbox: WorkspaceSandbox = new DesktopSandbox();
+    expect(supportsComputer(sandbox)).toBe(true);
+  });
+
+  it('returns false for a sandbox without computer', () => {
+    const sandbox: WorkspaceSandbox = new PlainSandbox();
+    expect(supportsComputer(sandbox)).toBe(false);
+  });
+
+  it('returns false when computer is present but screenshot is not a function', () => {
+    const sandbox = new PlainSandbox() as WorkspaceSandbox & { computer?: unknown };
+    (sandbox as { computer?: unknown }).computer = {};
+    expect(supportsComputer(sandbox as WorkspaceSandbox)).toBe(false);
+  });
+
+  it('narrows the type so computer is non-optional', async () => {
+    const sandbox: WorkspaceSandbox = new DesktopSandbox();
+    if (supportsComputer(sandbox)) {
+      // No optional chaining needed after the guard
+      const shot = await sandbox.computer.screenshot();
+      expect(shot.mediaType).toBe('image/png');
+      expect(shot.data).toEqual(PNG_BYTES);
+    } else {
+      expect.unreachable('guard should have passed');
+    }
+  });
+});

--- a/packages/core/src/workspace/sandbox/computer.test.ts
+++ b/packages/core/src/workspace/sandbox/computer.test.ts
@@ -74,10 +74,29 @@ describe('supportsComputer', () => {
     expect(supportsComputer(sandbox)).toBe(false);
   });
 
-  it('returns false when computer is present but screenshot is not a function', () => {
+  it.each([
+    'screenshot',
+    'leftClick',
+    'rightClick',
+    'doubleClick',
+    'moveMouse',
+    'drag',
+    'scroll',
+    'type',
+    'press',
+    'getScreenSize',
+    'getCursorPosition',
+  ] satisfies Array<keyof SandboxComputer>)('returns false when computer.%s is not a function', method => {
     const sandbox = new PlainSandbox() as WorkspaceSandbox & { computer?: unknown };
-    (sandbox as { computer?: unknown }).computer = {};
+    const computer = { ...createComputer(), [method]: undefined };
+    (sandbox as { computer?: unknown }).computer = computer;
     expect(supportsComputer(sandbox as WorkspaceSandbox)).toBe(false);
+  });
+
+  it('does not require the optional streamUrl method', () => {
+    const sandbox: WorkspaceSandbox = new DesktopSandbox();
+    expect(sandbox.computer?.streamUrl).toBeUndefined();
+    expect(supportsComputer(sandbox)).toBe(true);
   });
 
   it('narrows the type so computer is non-optional', async () => {

--- a/packages/core/src/workspace/sandbox/mastra-sandbox.ts
+++ b/packages/core/src/workspace/sandbox/mastra-sandbox.ts
@@ -31,7 +31,7 @@ import type { ProviderStatus, SandboxStartOutcome, SandboxStartResult } from '..
 import { SandboxNotReadyError } from './errors';
 import { MountManager } from './mount-manager';
 import type { SandboxProcessManager } from './process-manager';
-import type { SandboxFileInput, SandboxNetworking, WorkspaceSandbox } from './sandbox';
+import type { SandboxComputer, SandboxFileInput, SandboxNetworking, WorkspaceSandbox } from './sandbox';
 import type { CommandResult, ExecuteCommandOptions, SandboxInfo } from './types';
 import { shellQuote } from './utils';
 
@@ -172,6 +172,9 @@ export abstract class MastraSandbox<THandle = unknown> extends MastraBase implem
 
   /** Optional networking capability - implement to expose public port URLs */
   readonly networking?: SandboxNetworking;
+
+  /** Optional computer-use (desktop) capability - implement to enable workspace computer tools */
+  readonly computer?: SandboxComputer;
 
   /**
    * Optional bulk file upload into the sandbox's own filesystem.

--- a/packages/core/src/workspace/sandbox/sandbox.ts
+++ b/packages/core/src/workspace/sandbox/sandbox.ts
@@ -183,7 +183,20 @@ export interface SandboxComputer {
 export function supportsComputer(
   sandbox: WorkspaceSandbox,
 ): sandbox is WorkspaceSandbox & { computer: SandboxComputer } {
-  return typeof sandbox.computer?.screenshot === 'function';
+  const computer = sandbox.computer;
+  return (
+    typeof computer?.screenshot === 'function' &&
+    typeof computer.leftClick === 'function' &&
+    typeof computer.rightClick === 'function' &&
+    typeof computer.doubleClick === 'function' &&
+    typeof computer.moveMouse === 'function' &&
+    typeof computer.drag === 'function' &&
+    typeof computer.scroll === 'function' &&
+    typeof computer.type === 'function' &&
+    typeof computer.press === 'function' &&
+    typeof computer.getScreenSize === 'function' &&
+    typeof computer.getCursorPosition === 'function'
+  );
 }
 
 // =============================================================================

--- a/packages/core/src/workspace/sandbox/sandbox.ts
+++ b/packages/core/src/workspace/sandbox/sandbox.ts
@@ -112,8 +112,11 @@ export interface ComputerPosition {
  *
  * Providers with a controllable display (Daytona Computer Use, E2B Desktop,
  * etc.) implement this to surface screenshot, mouse, and keyboard control
- * through the abstraction. When present, the workspace tools factory emits
- * the `mastra_workspace_computer_*` tools automatically.
+ * through the abstraction. When present on a statically configured workspace
+ * sandbox, the workspace tools factory emits the
+ * `mastra_workspace_computer_*` tools automatically. Resolver-backed sandboxes
+ * do not register these tools because their capabilities are unavailable when
+ * the tool list is constructed.
  *
  * Coordinates are in pixels from the top-left corner of the display.
  * Providers normalize their SDK semantics (key names, scroll units) onto

--- a/packages/core/src/workspace/sandbox/sandbox.ts
+++ b/packages/core/src/workspace/sandbox/sandbox.ts
@@ -83,6 +83,110 @@ export function supportsNetworking(
 }
 
 // =============================================================================
+// Computer (Desktop) Capability
+// =============================================================================
+
+/** A screenshot of the sandbox's desktop display. */
+export interface ComputerScreenshot {
+  /** Raw image bytes */
+  data: Uint8Array;
+  /** Image media type (providers normalize to PNG) */
+  mediaType: 'image/png';
+}
+
+/** Screen dimensions in pixels. */
+export interface ComputerScreenSize {
+  width: number;
+  height: number;
+}
+
+/** A position on the sandbox's desktop display, in pixels from the top-left corner. */
+export interface ComputerPosition {
+  x: number;
+  y: number;
+}
+
+/**
+ * Optional computer-use (desktop) capability for sandboxes that run a GUI
+ * desktop environment.
+ *
+ * Providers with a controllable display (Daytona Computer Use, E2B Desktop,
+ * etc.) implement this to surface screenshot, mouse, and keyboard control
+ * through the abstraction. When present, the workspace tools factory emits
+ * the `mastra_workspace_computer_*` tools automatically.
+ *
+ * Coordinates are in pixels from the top-left corner of the display.
+ * Providers normalize their SDK semantics (key names, scroll units) onto
+ * this surface and may expose richer native APIs via their own accessors.
+ */
+export interface SandboxComputer {
+  /** Capture the current display as a PNG image. */
+  screenshot(): Promise<ComputerScreenshot>;
+
+  /** Left-click at the given coordinates. */
+  leftClick(x: number, y: number): Promise<void>;
+
+  /** Right-click at the given coordinates. */
+  rightClick(x: number, y: number): Promise<void>;
+
+  /** Double-click (left button) at the given coordinates. */
+  doubleClick(x: number, y: number): Promise<void>;
+
+  /** Move the mouse cursor to the given coordinates without clicking. */
+  moveMouse(x: number, y: number): Promise<void>;
+
+  /** Press the left button at `from`, drag to `to`, and release. */
+  drag(from: ComputerPosition, to: ComputerPosition): Promise<void>;
+
+  /**
+   * Scroll the display.
+   *
+   * @param direction - Scroll direction
+   * @param amount - Scroll amount in provider-normalized ticks (positive integer)
+   */
+  scroll(direction: 'up' | 'down', amount: number): Promise<void>;
+
+  /** Type text into the focused element using the keyboard. */
+  type(text: string): Promise<void>;
+
+  /**
+   * Press a key or key combination.
+   *
+   * A single string presses one key (e.g. `'Enter'`, `'Tab'`, `'a'`).
+   * An array presses a chord/hotkey (e.g. `['ctrl', 's']`).
+   */
+  press(key: string | string[]): Promise<void>;
+
+  /** Get the display dimensions. */
+  getScreenSize(): Promise<ComputerScreenSize>;
+
+  /** Get the current mouse cursor position. */
+  getCursorPosition(): Promise<ComputerPosition>;
+
+  /**
+   * Get a URL for a live view of the desktop (e.g. noVNC), or null when
+   * unavailable. Optional — not all providers expose a viewer.
+   */
+  streamUrl?(): Promise<string | null>;
+}
+
+/**
+ * Type guard: does this sandbox support the computer-use (desktop) capability?
+ *
+ * @example
+ * ```typescript
+ * if (supportsComputer(sandbox)) {
+ *   const { data } = await sandbox.computer.screenshot();
+ * }
+ * ```
+ */
+export function supportsComputer(
+  sandbox: WorkspaceSandbox,
+): sandbox is WorkspaceSandbox & { computer: SandboxComputer } {
+  return typeof sandbox.computer?.screenshot === 'function';
+}
+
+// =============================================================================
 // Sandbox Derivation
 // =============================================================================
 
@@ -271,6 +375,23 @@ export interface WorkspaceSandbox extends SandboxLifecycle<SandboxInfo> {
    * ```
    */
   readonly networking?: SandboxNetworking;
+
+  // ---------------------------------------------------------------------------
+  // Computer Use (Optional)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Computer-use (desktop) capability for sandboxes with a GUI desktop.
+   * Optional - only available on providers with a controllable display.
+   * When present, workspace computer tools (screenshot/click/type/…) are
+   * emitted automatically.
+   *
+   * @example
+   * ```typescript
+   * const { data } = await sandbox.computer?.screenshot();
+   * ```
+   */
+  readonly computer?: SandboxComputer;
 
   // ---------------------------------------------------------------------------
   // File Upload (Optional)

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
 import { WORKSPACE_TOOLS } from '../../constants';
+import type { SandboxComputer, WorkspaceSandbox } from '../../sandbox';
 import { Workspace } from '../../workspace';
 import { computerScreenshotTool } from '../computer-screenshot';
 import { isMediaToolResult, mediaToModelOutput } from '../media';
@@ -25,50 +26,54 @@ const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a
 const ALL_COMPUTER_TOOL_NAMES = Object.values(WORKSPACE_TOOLS.COMPUTER);
 
 /** Create a mock SandboxComputer backed by vi.fn()s. */
-function createMockComputer(overrides: Record<string, any> = {}) {
+function createMockComputer(overrides: Partial<SandboxComputer> = {}): SandboxComputer {
   return {
-    screenshot: vi.fn().mockResolvedValue({ data: PNG_BYTES, mediaType: 'image/png' }),
-    leftClick: vi.fn().mockResolvedValue(undefined),
-    rightClick: vi.fn().mockResolvedValue(undefined),
-    doubleClick: vi.fn().mockResolvedValue(undefined),
-    moveMouse: vi.fn().mockResolvedValue(undefined),
-    drag: vi.fn().mockResolvedValue(undefined),
-    scroll: vi.fn().mockResolvedValue(undefined),
-    type: vi.fn().mockResolvedValue(undefined),
-    press: vi.fn().mockResolvedValue(undefined),
-    getScreenSize: vi.fn().mockResolvedValue({ width: 1024, height: 768 }),
-    getCursorPosition: vi.fn().mockResolvedValue({ x: 12, y: 34 }),
+    screenshot: vi.fn(async () => ({ data: PNG_BYTES, mediaType: 'image/png' as const })),
+    leftClick: vi.fn(async () => {}),
+    rightClick: vi.fn(async () => {}),
+    doubleClick: vi.fn(async () => {}),
+    moveMouse: vi.fn(async () => {}),
+    drag: vi.fn(async () => {}),
+    scroll: vi.fn(async () => {}),
+    type: vi.fn(async () => {}),
+    press: vi.fn(async () => {}),
+    getScreenSize: vi.fn(async () => ({ width: 1024, height: 768 })),
+    getCursorPosition: vi.fn(async () => ({ x: 12, y: 34 })),
     ...overrides,
   };
 }
 
 /** Create a mock sandbox, optionally with the computer capability. */
-function createMockSandbox(opts: { computer?: any } = {}) {
-  const sandbox: any = {
+function createMockSandbox(opts: { computer?: SandboxComputer } = {}): WorkspaceSandbox {
+  return {
     id: 'test-sandbox',
     name: 'Test Sandbox',
     provider: 'test',
     status: 'running',
-    getInfo: vi.fn().mockResolvedValue({
+    snapshot: vi.fn(async () => {}),
+    getInfo: vi.fn(async () => ({
       id: 'test-sandbox',
       name: 'Test Sandbox',
       provider: 'test',
-      status: 'running',
+      status: 'running' as const,
       createdAt: new Date(),
-    }),
-    executeCommand: vi.fn(),
+    })),
+    executeCommand: vi.fn(async () => ({
+      success: true,
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      executionTimeMs: 0,
+    })),
+    ...(opts.computer ? { computer: opts.computer } : {}),
   };
-  if (opts.computer) {
-    sandbox.computer = opts.computer;
-  }
-  return sandbox;
 }
 
 /**
  * Create a workspace with the mock sandbox + the emitted workspace tools.
  * `screenshotDelayMs: 0` is applied to all computer tools so tests don't sleep.
  */
-async function setup(computer: any, tools?: WorkspaceToolsConfig) {
+async function setup(computer: SandboxComputer, tools?: WorkspaceToolsConfig) {
   const toolsConfig: WorkspaceToolsConfig = { ...tools };
   for (const name of ALL_COMPUTER_TOOL_NAMES) {
     toolsConfig[name] = { screenshotDelayMs: 0, ...(tools?.[name] as object | undefined) };
@@ -102,9 +107,10 @@ describe('createWorkspaceTools computer gating', () => {
   });
 
   it('emits no computer tools when the computer capability is incomplete', async () => {
-    const workspace = new Workspace({
-      sandbox: createMockSandbox({ computer: createMockComputer({ drag: undefined }) }),
-    });
+    const incompleteComputer: unknown = { ...createMockComputer(), drag: undefined };
+    const sandbox = createMockSandbox();
+    (sandbox as { computer?: unknown }).computer = incompleteComputer;
+    const workspace = new Workspace({ sandbox });
     const tools = await createWorkspaceTools(workspace);
     for (const name of ALL_COMPUTER_TOOL_NAMES) {
       expect(tools[name], `expected ${name} to be absent`).toBeUndefined();

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -306,6 +306,19 @@ describe('computer action tools', () => {
     expect(computer.press).toHaveBeenCalledWith(['ctrl', 's']);
   });
 
+  it('press_key rejects empty key values before calling the capability', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.PRESS_KEY]: { screenshotAfterAction: false },
+    });
+    const tool = emitted[WORKSPACE_TOOLS.COMPUTER.PRESS_KEY];
+
+    for (const key of ['', [''], ['ctrl', '']]) {
+      await expect(tool.execute({ key }, { workspace })).resolves.toMatchObject({ error: true });
+    }
+    expect(computer.press).not.toHaveBeenCalled();
+  });
+
   it('scroll defaults the amount to 3', async () => {
     const computer = createMockComputer();
     const { workspace, emitted } = await setup(computer, {

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Workspace Computer (Desktop) Tools Tests
+ *
+ * Tests the `mastra_workspace_computer_*` tools: factory gating on the
+ * sandbox `computer` capability, delegation to the capability, media
+ * (screenshot) output with size caps, post-action screenshots, and
+ * approval config resolution.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { WORKSPACE_TOOLS } from '../../constants';
+import { Workspace } from '../../workspace';
+import { computerScreenshotTool } from '../computer-screenshot';
+import { isMediaToolResult, mediaToModelOutput } from '../media';
+import { createWorkspaceTools } from '../tools';
+import type { WorkspaceToolsConfig } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mock Helpers
+// ---------------------------------------------------------------------------
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const ALL_COMPUTER_TOOL_NAMES = Object.values(WORKSPACE_TOOLS.COMPUTER);
+
+/** Create a mock SandboxComputer backed by vi.fn()s. */
+function createMockComputer(overrides: Record<string, any> = {}) {
+  return {
+    screenshot: vi.fn().mockResolvedValue({ data: PNG_BYTES, mediaType: 'image/png' }),
+    leftClick: vi.fn().mockResolvedValue(undefined),
+    rightClick: vi.fn().mockResolvedValue(undefined),
+    doubleClick: vi.fn().mockResolvedValue(undefined),
+    moveMouse: vi.fn().mockResolvedValue(undefined),
+    drag: vi.fn().mockResolvedValue(undefined),
+    scroll: vi.fn().mockResolvedValue(undefined),
+    type: vi.fn().mockResolvedValue(undefined),
+    press: vi.fn().mockResolvedValue(undefined),
+    getScreenSize: vi.fn().mockResolvedValue({ width: 1024, height: 768 }),
+    getCursorPosition: vi.fn().mockResolvedValue({ x: 12, y: 34 }),
+    ...overrides,
+  };
+}
+
+/** Create a mock sandbox, optionally with the computer capability. */
+function createMockSandbox(opts: { computer?: any } = {}) {
+  const sandbox: any = {
+    id: 'test-sandbox',
+    name: 'Test Sandbox',
+    provider: 'test',
+    status: 'running',
+    getInfo: vi.fn().mockResolvedValue({
+      id: 'test-sandbox',
+      name: 'Test Sandbox',
+      provider: 'test',
+      status: 'running',
+      createdAt: new Date(),
+    }),
+    executeCommand: vi.fn(),
+  };
+  if (opts.computer) {
+    sandbox.computer = opts.computer;
+  }
+  return sandbox;
+}
+
+/**
+ * Create a workspace with the mock sandbox + the emitted workspace tools.
+ * `screenshotDelayMs: 0` is applied to all computer tools so tests don't sleep.
+ */
+async function setup(computer: any, tools?: WorkspaceToolsConfig) {
+  const toolsConfig: WorkspaceToolsConfig = { ...tools };
+  for (const name of ALL_COMPUTER_TOOL_NAMES) {
+    toolsConfig[name] = { screenshotDelayMs: 0, ...(tools?.[name] as object | undefined) };
+  }
+  const workspace = new Workspace({ sandbox: createMockSandbox({ computer }), tools: toolsConfig });
+  const emitted = await createWorkspaceTools(workspace);
+  return { workspace, emitted };
+}
+
+// ---------------------------------------------------------------------------
+// Factory gating
+// ---------------------------------------------------------------------------
+
+describe('createWorkspaceTools computer gating', () => {
+  it('emits all computer tools when the sandbox supports the capability', async () => {
+    const workspace = new Workspace({ sandbox: createMockSandbox({ computer: createMockComputer() }) });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be emitted`).toBeDefined();
+    }
+  });
+
+  it('emits no computer tools when the sandbox lacks the capability', async () => {
+    const workspace = new Workspace({ sandbox: createMockSandbox() });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be absent`).toBeUndefined();
+    }
+    // Sandbox tools are still emitted
+    expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]).toBeDefined();
+  });
+
+  it('emits no computer tools for dynamic sandbox resolvers', async () => {
+    const workspace = new Workspace({
+      sandbox: async () => createMockSandbox({ computer: createMockComputer() }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be absent`).toBeUndefined();
+    }
+  });
+
+  it('respects per-tool enabled config', async () => {
+    const { emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.TYPE]: { enabled: false },
+    });
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.TYPE]).toBeUndefined();
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT]).toBeDefined();
+  });
+
+  it('resolves static requireApproval onto the emitted tool', async () => {
+    const { emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.CLICK]: { requireApproval: true },
+    });
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].requireApproval).toBe(true);
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT].requireApproval).toBe(false);
+  });
+
+  it('supports dynamic arg-aware requireApproval', async () => {
+    const { emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.TYPE]: {
+        requireApproval: ({ args }) => (args.text as string).includes('rm -rf'),
+      },
+    });
+    const tool = emitted[WORKSPACE_TOOLS.COMPUTER.TYPE];
+    expect(tool.requireApproval).toBe(true);
+    await expect(tool.needsApprovalFn({ text: 'hello' })).resolves.toBe(false);
+    await expect(tool.needsApprovalFn({ text: 'rm -rf /' })).resolves.toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Screenshot tool
+// ---------------------------------------------------------------------------
+
+describe('computer_screenshot tool', () => {
+  it('returns a media result with base64 PNG data', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT].execute({}, { workspace });
+
+    expect(isMediaToolResult(result)).toBe(true);
+    if (isMediaToolResult(result)) {
+      expect(result.mediaType).toBe('image/png');
+      expect(result.data).toBe(Buffer.from(PNG_BYTES).toString('base64'));
+      expect(result.text).toContain('Screenshot');
+    }
+    expect(computer.screenshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to text when the screenshot exceeds maxMediaBytes', async () => {
+    const { workspace, emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.SCREENSHOT]: { maxMediaBytes: 4 },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT].execute({}, { workspace });
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('exceeds maxMediaBytes');
+  });
+
+  it('throws when the sandbox lacks the computer capability', async () => {
+    const workspace = new Workspace({ sandbox: createMockSandbox() });
+    await expect((computerScreenshotTool.execute as any)({}, { workspace })).rejects.toThrow(
+      'Sandbox does not support computer',
+    );
+  });
+
+  it('throws when the workspace has no sandbox', async () => {
+    const workspace = new Workspace({ filesystem: { provider: 'test', readOnly: false } as any });
+    await expect((computerScreenshotTool.execute as any)({}, { workspace })).rejects.toThrow(
+      'Workspace does not have a sandbox configured',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action tools
+// ---------------------------------------------------------------------------
+
+describe('computer action tools', () => {
+  it('click delegates to leftClick and attaches a post-action screenshot by default', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 5, y: 10 }, { workspace });
+
+    expect(computer.leftClick).toHaveBeenCalledWith(5, 10);
+    expect(isMediaToolResult(result)).toBe(true);
+    if (isMediaToolResult(result)) {
+      expect(result.text).toBe('Clicked at (5, 10)');
+      expect(result.mediaType).toBe('image/png');
+    }
+    expect(computer.screenshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the post-action screenshot when screenshotAfterAction is false', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.CLICK]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 5, y: 10 }, { workspace });
+
+    expect(result).toBe('Clicked at (5, 10)');
+    expect(computer.screenshot).not.toHaveBeenCalled();
+  });
+
+  it('does not fail the action when the post-action screenshot fails', async () => {
+    const computer = createMockComputer({
+      screenshot: vi.fn().mockRejectedValue(new Error('display gone')),
+    });
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 1, y: 2 }, { workspace });
+
+    expect(result).toBe('Clicked at (1, 2) (post-action screenshot failed)');
+  });
+
+  it('caps the post-action screenshot via maxMediaBytes', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.CLICK]: { maxMediaBytes: 4 },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 1, y: 2 }, { workspace });
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('Clicked at (1, 2)');
+    expect(result).toContain('exceeds maxMediaBytes');
+  });
+
+  it('double_click and right_click delegate to the capability', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK]: { screenshotAfterAction: false },
+      [WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK]: { screenshotAfterAction: false },
+    });
+
+    await expect(emitted[WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK].execute({ x: 3, y: 4 }, { workspace })).resolves.toBe(
+      'Double-clicked at (3, 4)',
+    );
+    expect(computer.doubleClick).toHaveBeenCalledWith(3, 4);
+
+    await expect(emitted[WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK].execute({ x: 7, y: 8 }, { workspace })).resolves.toBe(
+      'Right-clicked at (7, 8)',
+    );
+    expect(computer.rightClick).toHaveBeenCalledWith(7, 8);
+  });
+
+  it('move_mouse delegates to moveMouse', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE].execute({ x: 50, y: 60 }, { workspace });
+
+    expect(computer.moveMouse).toHaveBeenCalledWith(50, 60);
+    expect(result).toBe('Moved mouse to (50, 60)');
+  });
+
+  it('type delegates to type without echoing the text back', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.TYPE]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.TYPE].execute({ text: 'secret password' }, { workspace });
+
+    expect(computer.type).toHaveBeenCalledWith('secret password');
+    expect(result).toBe('Typed 15 characters');
+  });
+
+  it('press_key supports single keys and hotkey chords', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.PRESS_KEY]: { screenshotAfterAction: false },
+    });
+    const tool = emitted[WORKSPACE_TOOLS.COMPUTER.PRESS_KEY];
+
+    await expect(tool.execute({ key: 'Enter' }, { workspace })).resolves.toBe('Pressed Enter');
+    expect(computer.press).toHaveBeenCalledWith('Enter');
+
+    await expect(tool.execute({ key: ['ctrl', 's'] }, { workspace })).resolves.toBe('Pressed ctrl+s');
+    expect(computer.press).toHaveBeenCalledWith(['ctrl', 's']);
+  });
+
+  it('scroll defaults the amount to 3', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.SCROLL]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.SCROLL].execute({ direction: 'down' }, { workspace });
+
+    expect(computer.scroll).toHaveBeenCalledWith('down', 3);
+    expect(result).toBe('Scrolled down by 3');
+  });
+
+  it('drag maps flat coordinates to from/to positions', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.DRAG]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.DRAG].execute(
+      { startX: 1, startY: 2, endX: 3, endY: 4 },
+      { workspace },
+    );
+
+    expect(computer.drag).toHaveBeenCalledWith({ x: 1, y: 2 }, { x: 3, y: 4 });
+    expect(result).toBe('Dragged from (1, 2) to (3, 4)');
+  });
+
+  it('wait sleeps then reports', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.WAIT]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.WAIT].execute({ seconds: 0.1 }, { workspace });
+    expect(result).toBe('Waited 0.1s');
+  });
+
+  it('get_screen_info reports screen size and cursor position', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO].execute({}, { workspace });
+
+    expect(result).toBe('Screen size: 1024x768\nCursor position: (12, 34)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toModelOutput
+// ---------------------------------------------------------------------------
+
+describe('mediaToModelOutput', () => {
+  it('surfaces media results as text + media parts', () => {
+    const output = mediaToModelOutput({
+      __workspaceMedia: true,
+      text: 'Screenshot',
+      mediaType: 'image/png',
+      data: 'aGVsbG8=',
+    });
+    expect(output).toEqual({
+      type: 'content',
+      value: [
+        { type: 'text', text: 'Screenshot' },
+        { type: 'media', data: 'aGVsbG8=', mediaType: 'image/png' },
+      ],
+    });
+  });
+
+  it('returns undefined for plain string output', () => {
+    expect(mediaToModelOutput('Clicked at (1, 2)')).toBeUndefined();
+  });
+});

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -101,6 +101,16 @@ describe('createWorkspaceTools computer gating', () => {
     expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]).toBeDefined();
   });
 
+  it('emits no computer tools when the computer capability is incomplete', async () => {
+    const workspace = new Workspace({
+      sandbox: createMockSandbox({ computer: createMockComputer({ drag: undefined }) }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be absent`).toBeUndefined();
+    }
+  });
+
   it('emits no computer tools for dynamic sandbox resolvers', async () => {
     const workspace = new Workspace({
       sandbox: async () => createMockSandbox({ computer: createMockComputer() }),

--- a/packages/core/src/workspace/tools/computer-click.ts
+++ b/packages/core/src/workspace/tools/computer-click.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerClickTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.CLICK,
+  description:
+    'Left-click at pixel coordinates on the sandbox desktop. Coordinates are measured from the top-left corner of the screen — take a screenshot first to find the right position.',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.CLICK);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'click',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.leftClick(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.CLICK,
+        `Clicked at (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-double-click.ts
+++ b/packages/core/src/workspace/tools/computer-double-click.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerDoubleClickTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK,
+  description:
+    'Double-click (left button) at pixel coordinates on the sandbox desktop. Use for opening files, folders, and applications.',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'doubleClick',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.doubleClick(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK,
+        `Double-clicked at (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-drag.ts
+++ b/packages/core/src/workspace/tools/computer-drag.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerDragTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.DRAG,
+  description:
+    'Drag from one position to another on the sandbox desktop: presses the left button at the start coordinates, moves to the end coordinates, and releases. Use for moving windows, selecting text, and drag-and-drop.',
+  inputSchema: z.object({
+    startX: z.number().int().min(0).describe('X coordinate to start the drag from'),
+    startY: z.number().int().min(0).describe('Y coordinate to start the drag from'),
+    endX: z.number().int().min(0).describe('X coordinate to drag to'),
+    endY: z.number().int().min(0).describe('Y coordinate to drag to'),
+  }),
+  execute: async ({ startX, startY, endX, endY }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.DRAG);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'drag',
+      input: { startX, startY, endX, endY },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.drag({ x: startX, y: startY }, { x: endX, y: endY });
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.DRAG,
+        `Dragged from (${startX}, ${startY}) to (${endX}, ${endY})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-get-screen-info.ts
+++ b/packages/core/src/workspace/tools/computer-get-screen-info.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerGetScreenInfoTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO,
+  description:
+    'Get the sandbox desktop screen dimensions and current mouse cursor position. Use to understand the coordinate space before clicking.',
+  inputSchema: z.object({}),
+  execute: async (_input, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'getScreenInfo',
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      const [size, cursor] = await Promise.all([computer.getScreenSize(), computer.getCursorPosition()]);
+      span.end({ success: true });
+      return `Screen size: ${size.width}x${size.height}\nCursor position: (${cursor.x}, ${cursor.y})`;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+});

--- a/packages/core/src/workspace/tools/computer-helpers.ts
+++ b/packages/core/src/workspace/tools/computer-helpers.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared helpers for the workspace computer (desktop) tools.
+ *
+ * The computer tools delegate to the sandbox's optional `computer` capability
+ * (see SandboxComputer). These helpers extract the capability from the tool
+ * execution context and format screenshot results as media parts.
+ */
+
+import type { ToolExecutionContext } from '../../tools/types';
+import { WORKSPACE_TOOLS } from '../constants';
+import { SandboxFeatureNotSupportedError } from '../errors';
+import type { ComputerScreenshot, SandboxComputer, WorkspaceSandbox } from '../sandbox';
+import { supportsComputer } from '../sandbox';
+import type { Workspace } from '../workspace';
+import { requireSandbox } from './helpers';
+import type { MediaToolResult } from './media';
+import { DEFAULT_MAX_MEDIA_BYTES } from './media';
+import type { ComputerToolConfig } from './types';
+
+/** Default for ComputerToolConfig.screenshotAfterAction. */
+export const DEFAULT_SCREENSHOT_AFTER_ACTION = true;
+
+/** Default for ComputerToolConfig.screenshotDelayMs. */
+export const DEFAULT_SCREENSHOT_DELAY_MS = 500;
+
+type ComputerToolName = (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER];
+
+/**
+ * Extract the computer capability from the workspace sandbox in the tool
+ * execution context. Throws if the workspace has no sandbox or the sandbox
+ * doesn't support the computer capability.
+ */
+export function requireComputer(context: ToolExecutionContext): {
+  workspace: Workspace;
+  sandbox: WorkspaceSandbox;
+  computer: SandboxComputer;
+} {
+  const { workspace, sandbox } = requireSandbox(context);
+  if (!supportsComputer(sandbox)) {
+    throw new SandboxFeatureNotSupportedError('computer');
+  }
+  return { workspace, sandbox, computer: sandbox.computer };
+}
+
+/** Resolve the per-tool ComputerToolConfig from the workspace tools config. */
+export function getComputerToolConfig(
+  workspace: Workspace,
+  toolName: ComputerToolName,
+): ComputerToolConfig | undefined {
+  return workspace.getToolsConfig()?.[toolName];
+}
+
+/**
+ * Format a screenshot as a MediaToolResult, falling back to text-only output
+ * when the image exceeds the configured size cap (so huge base64 payloads
+ * don't blow up the model context or storage).
+ */
+export function screenshotToResult(
+  screenshot: ComputerScreenshot,
+  text: string,
+  maxMediaBytes: number,
+): MediaToolResult | string {
+  if (screenshot.data.byteLength > maxMediaBytes) {
+    return `${text} — screenshot (${screenshot.data.byteLength} bytes, ${screenshot.mediaType}) exceeds maxMediaBytes (${maxMediaBytes}). Returning text only; configure \`maxMediaBytes\` on the computer tool to raise this cap.`;
+  }
+  return {
+    __workspaceMedia: true,
+    text,
+    mediaType: screenshot.mediaType,
+    data: Buffer.from(screenshot.data).toString('base64'),
+  };
+}
+
+/**
+ * Finish a computer action tool: when `screenshotAfterAction` is enabled
+ * (default), wait briefly for the UI to react and attach a fresh screenshot
+ * to the result so computer-use loops see the resulting desktop state.
+ * Screenshot failures never fail the action itself.
+ */
+export async function finishComputerAction(
+  workspace: Workspace,
+  computer: SandboxComputer,
+  toolName: ComputerToolName,
+  text: string,
+): Promise<MediaToolResult | string> {
+  const config = getComputerToolConfig(workspace, toolName);
+  const screenshotAfterAction = config?.screenshotAfterAction ?? DEFAULT_SCREENSHOT_AFTER_ACTION;
+  if (!screenshotAfterAction) return text;
+
+  const delayMs = config?.screenshotDelayMs ?? DEFAULT_SCREENSHOT_DELAY_MS;
+  if (delayMs > 0) {
+    await new Promise(resolve => setTimeout(resolve, delayMs));
+  }
+
+  try {
+    const screenshot = await computer.screenshot();
+    const maxMediaBytes = config?.maxMediaBytes ?? DEFAULT_MAX_MEDIA_BYTES;
+    return screenshotToResult(screenshot, text, maxMediaBytes);
+  } catch {
+    return `${text} (post-action screenshot failed)`;
+  }
+}

--- a/packages/core/src/workspace/tools/computer-move-mouse.ts
+++ b/packages/core/src/workspace/tools/computer-move-mouse.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerMoveMouseTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE,
+  description:
+    'Move the mouse cursor to pixel coordinates on the sandbox desktop without clicking. Use for hover states (tooltips, dropdown menus).',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'moveMouse',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.moveMouse(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE,
+        `Moved mouse to (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-press-key.ts
+++ b/packages/core/src/workspace/tools/computer-press-key.ts
@@ -12,7 +12,7 @@ export const computerPressKeyTool = createTool({
     'Press a key or key combination on the sandbox desktop keyboard. Pass a single key (e.g. "Enter", "Tab", "Escape") or an array for a hotkey chord (e.g. ["ctrl", "s"]).',
   inputSchema: z.object({
     key: z
-      .union([z.string(), z.array(z.string()).min(1)])
+      .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
       .describe('A single key (e.g. "Enter") or an array of keys pressed together as a hotkey (e.g. ["ctrl", "c"])'),
   }),
   execute: async ({ key }, context) => {

--- a/packages/core/src/workspace/tools/computer-press-key.ts
+++ b/packages/core/src/workspace/tools/computer-press-key.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerPressKeyTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.PRESS_KEY,
+  description:
+    'Press a key or key combination on the sandbox desktop keyboard. Pass a single key (e.g. "Enter", "Tab", "Escape") or an array for a hotkey chord (e.g. ["ctrl", "s"]).',
+  inputSchema: z.object({
+    key: z
+      .union([z.string(), z.array(z.string()).min(1)])
+      .describe('A single key (e.g. "Enter") or an array of keys pressed together as a hotkey (e.g. ["ctrl", "c"])'),
+  }),
+  execute: async ({ key }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.PRESS_KEY);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'pressKey',
+      input: { key },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.press(key);
+      const label = Array.isArray(key) ? key.join('+') : key;
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.PRESS_KEY,
+        `Pressed ${label}`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-right-click.ts
+++ b/packages/core/src/workspace/tools/computer-right-click.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerRightClickTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK,
+  description: 'Right-click at pixel coordinates on the sandbox desktop. Use for opening context menus.',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'rightClick',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.rightClick(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK,
+        `Right-clicked at (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-screenshot.ts
+++ b/packages/core/src/workspace/tools/computer-screenshot.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { getComputerToolConfig, requireComputer, screenshotToResult } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { DEFAULT_MAX_MEDIA_BYTES, mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerScreenshotTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.SCREENSHOT,
+  description:
+    'Take a screenshot of the sandbox desktop display. Returns the current screen as an image. Use this to see the desktop state before and after interacting with it.',
+  inputSchema: z.object({}),
+  execute: async (_input, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.SCREENSHOT);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'screenshot',
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      const screenshot = await computer.screenshot();
+      const config = getComputerToolConfig(workspace, WORKSPACE_TOOLS.COMPUTER.SCREENSHOT);
+      const maxMediaBytes = config?.maxMediaBytes ?? DEFAULT_MAX_MEDIA_BYTES;
+      const result = screenshotToResult(
+        screenshot,
+        `Screenshot of the desktop (${screenshot.data.byteLength} bytes, ${screenshot.mediaType})`,
+        maxMediaBytes,
+      );
+      span.end({ success: true }, { bytesTransferred: screenshot.data.byteLength });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-scroll.ts
+++ b/packages/core/src/workspace/tools/computer-scroll.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerScrollTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.SCROLL,
+  description: 'Scroll the sandbox desktop display up or down.',
+  inputSchema: z.object({
+    direction: z.enum(['up', 'down']).describe('Scroll direction'),
+    amount: z.number().int().min(1).optional().describe('Scroll amount in ticks (default: 3)'),
+  }),
+  execute: async ({ direction, amount }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.SCROLL);
+
+    const effectiveAmount = amount ?? 3;
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'scroll',
+      input: { direction, amount: effectiveAmount },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.scroll(direction, effectiveAmount);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.SCROLL,
+        `Scrolled ${direction} by ${effectiveAmount}`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-type.ts
+++ b/packages/core/src/workspace/tools/computer-type.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerTypeTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.TYPE,
+  description:
+    'Type text into the focused element on the sandbox desktop using the keyboard. Click an input field first to focus it. Use the press-key tool for special keys (Enter, Tab, shortcuts).',
+  inputSchema: z.object({
+    text: z.string().describe('The text to type'),
+  }),
+  execute: async ({ text }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.TYPE);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'type',
+      input: { length: text.length },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.type(text);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.TYPE,
+        `Typed ${text.length} characters`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-wait.ts
+++ b/packages/core/src/workspace/tools/computer-wait.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerWaitTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.WAIT,
+  description:
+    'Wait for the sandbox desktop UI to settle (e.g. an application launching or a page loading) before the next action.',
+  inputSchema: z.object({
+    seconds: z.number().min(0.1).max(30).describe('How long to wait, in seconds (max 30)'),
+  }),
+  execute: async ({ seconds }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.WAIT);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'wait',
+      input: { seconds },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await new Promise(resolve => setTimeout(resolve, seconds * 1000));
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.WAIT,
+        `Waited ${seconds}s`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/index.ts
+++ b/packages/core/src/workspace/tools/index.ts
@@ -24,9 +24,22 @@ export { getProcessOutputTool } from './get-process-output';
 export { killProcessTool } from './kill-process';
 export { grepTool } from './grep';
 export { lspInspectTool } from './lsp-inspect';
+export { computerScreenshotTool } from './computer-screenshot';
+export { computerClickTool } from './computer-click';
+export { computerDoubleClickTool } from './computer-double-click';
+export { computerRightClickTool } from './computer-right-click';
+export { computerMoveMouseTool } from './computer-move-mouse';
+export { computerDragTool } from './computer-drag';
+export { computerTypeTool } from './computer-type';
+export { computerPressKeyTool } from './computer-press-key';
+export { computerScrollTool } from './computer-scroll';
+export { computerGetScreenInfoTool } from './computer-get-screen-info';
+export { computerWaitTool } from './computer-wait';
 
 // Helpers
 export { requireWorkspace, requireFilesystem, requireSandbox, emitWorkspaceMetadata } from './helpers';
+export { requireComputer } from './computer-helpers';
+export { isMediaToolResult, mediaToModelOutput, DEFAULT_MAX_MEDIA_BYTES, type MediaToolResult } from './media';
 export {
   applyTail,
   applyTokenLimit,

--- a/packages/core/src/workspace/tools/media.ts
+++ b/packages/core/src/workspace/tools/media.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared media-result helpers for workspace tools.
+ *
+ * Tools that surface binary media (read_file for media files, the computer
+ * screenshot tools) return a MediaToolResult so `toModelOutput` can present
+ * the media as a native image/file part while only the `text` header is kept
+ * in the stored/displayed result.
+ */
+
+/**
+ * Internal marker on the tool's result that signals to `toModelOutput`
+ * that the payload should be surfaced to the model as a media part (image or
+ * binary file) rather than as plain text. We attach this on a wrapper object
+ * but only the `text` field is shown to the model (via toModelOutput); the
+ * marker is stripped before it ever reaches the model.
+ *
+ * The shape is intentionally JSON-serialisable so it round-trips through
+ * storage layers that snapshot tool results.
+ */
+export type MediaToolResult = {
+  __workspaceMedia: true;
+  text: string;
+  mediaType: string;
+  data: string;
+};
+
+export function isMediaToolResult(value: unknown): value is MediaToolResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<string, unknown>).__workspaceMedia === true &&
+    typeof (value as Record<string, unknown>).text === 'string' &&
+    typeof (value as Record<string, unknown>).mediaType === 'string' &&
+    typeof (value as Record<string, unknown>).data === 'string'
+  );
+}
+
+/**
+ * Default cap (in bytes) on inline media results. Payloads larger than this
+ * fall back to text-only output instead of being fully base64-encoded into
+ * the model context (and persisted in storage on rehydration). 10 MiB is
+ * roughly aligned with provider per-image/per-pdf limits.
+ */
+export const DEFAULT_MAX_MEDIA_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Shared `toModelOutput` handler for tools that may return a MediaToolResult.
+ * Surfaces the media as a native part; returns undefined for plain string
+ * output so we don't store a duplicate copy on providerMetadata.
+ */
+export function mediaToModelOutput(output: unknown) {
+  if (isMediaToolResult(output)) {
+    return {
+      type: 'content' as const,
+      value: [
+        { type: 'text' as const, text: output.text },
+        { type: 'media' as const, data: output.data, mediaType: output.mediaType },
+      ],
+    };
+  }
+  return undefined;
+}

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -3,36 +3,10 @@ import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { extractLinesWithLimit, formatWithLineNumbers } from '../line-utils';
 import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
+import type { MediaToolResult } from './media';
+import { DEFAULT_MAX_MEDIA_BYTES, mediaToModelOutput } from './media';
 import { applyTokenLimit } from './output-helpers';
 import { startWorkspaceSpan } from './tracing';
-
-/**
- * Internal marker on the tool's text result that signals to `toModelOutput`
- * that the file should be surfaced to the model as a media part (image or
- * binary file) rather than as plain text. We attach this on a wrapper object
- * but only the `text` field is shown to the model (via toModelOutput); the
- * marker is stripped before it ever reaches the model.
- *
- * The shape is intentionally JSON-serialisable so it round-trips through
- * storage layers that snapshot tool results.
- */
-type MediaToolResult = {
-  __workspaceMedia: true;
-  text: string;
-  mediaType: string;
-  data: string;
-};
-
-function isMediaToolResult(value: unknown): value is MediaToolResult {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    (value as Record<string, unknown>).__workspaceMedia === true &&
-    typeof (value as Record<string, unknown>).text === 'string' &&
-    typeof (value as Record<string, unknown>).mediaType === 'string' &&
-    typeof (value as Record<string, unknown>).data === 'string'
-  );
-}
 
 /**
  * Default mime types surfaced to the model as media parts. The list is
@@ -42,14 +16,6 @@ function isMediaToolResult(value: unknown): value is MediaToolResult {
  * that some providers reject. Override `mediaTypes` to broaden this.
  */
 const DEFAULT_MEDIA_TYPES: string[] = ['image/png', 'image/jpeg', 'image/webp', 'application/pdf'];
-
-/**
- * Default cap (in bytes) on inline media reads. Files larger than this fall
- * back to metadata-only output instead of being fully base64-encoded into
- * the model context (and persisted in storage on rehydration). 10 MiB is
- * roughly aligned with provider per-image/per-pdf limits.
- */
-const DEFAULT_MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 
 /**
  * `application/*` mime types that are actually text content and safe to read
@@ -275,19 +241,8 @@ export const readFileTool = createTool({
       throw err;
     }
   },
-  toModelOutput: (output: unknown) => {
-    if (isMediaToolResult(output)) {
-      return {
-        type: 'content',
-        value: [
-          { type: 'text', text: output.text },
-          { type: 'media', data: output.data, mediaType: output.mediaType },
-        ],
-      };
-    }
-    // For plain string output, return undefined so we don't store a duplicate
-    // copy on providerMetadata.mastra.modelOutput — the original string result
-    // is already what the model sees.
-    return undefined;
-  },
+  // For plain string output, mediaToModelOutput returns undefined so we don't
+  // store a duplicate copy on providerMetadata.mastra.modelOutput — the
+  // original string result is already what the model sees.
+  toModelOutput: mediaToModelOutput,
 });

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -15,8 +15,20 @@ import { FileNotFoundError, FileReadRequiredError } from '../errors';
 import { InMemoryFileReadTracker, InMemoryFileWriteLock } from '../filesystem';
 import type { FileReadTracker, FileWriteLock, WorkspaceFilesystem } from '../filesystem';
 import type { WorkspaceSandbox } from '../sandbox';
+import { supportsComputer } from '../sandbox';
 import type { Workspace } from '../workspace';
 import { isAstGrepAvailable, astEditTool } from './ast-edit';
+import { computerClickTool } from './computer-click';
+import { computerDoubleClickTool } from './computer-double-click';
+import { computerDragTool } from './computer-drag';
+import { computerGetScreenInfoTool } from './computer-get-screen-info';
+import { computerMoveMouseTool } from './computer-move-mouse';
+import { computerPressKeyTool } from './computer-press-key';
+import { computerRightClickTool } from './computer-right-click';
+import { computerScreenshotTool } from './computer-screenshot';
+import { computerScrollTool } from './computer-scroll';
+import { computerTypeTool } from './computer-type';
+import { computerWaitTool } from './computer-wait';
 import { deleteFileTool } from './delete-file';
 import { editFileTool } from './edit-file';
 import { executeCommandTool, executeCommandWithBackgroundTool } from './execute-command';
@@ -543,6 +555,25 @@ export async function createWorkspaceTools(
     if (workspace.sandbox.processes) {
       await addTool(WORKSPACE_TOOLS.SANDBOX.GET_PROCESS_OUTPUT, getProcessOutputTool, { targets: { sandbox: true } });
       await addTool(WORKSPACE_TOOLS.SANDBOX.KILL_PROCESS, killProcessTool, { targets: { sandbox: true } });
+    }
+
+    // Computer (desktop) tools — only when the sandbox supports the computer
+    // capability. Not offered for dynamic sandbox resolvers (no static
+    // instance) since the capability can't be detected at tool-listing time.
+    if (supportsComputer(workspace.sandbox)) {
+      await addTool(WORKSPACE_TOOLS.COMPUTER.SCREENSHOT, computerScreenshotTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.CLICK, computerClickTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK, computerDoubleClickTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK, computerRightClickTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE, computerMoveMouseTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.DRAG, computerDragTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.TYPE, computerTypeTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.PRESS_KEY, computerPressKeyTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.SCROLL, computerScrollTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO, computerGetScreenInfoTool, {
+        targets: { sandbox: true },
+      });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.WAIT, computerWaitTool, { targets: { sandbox: true } });
     }
   } else if (hasSandboxConfig(workspace)) {
     await addTool(WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND, executeCommandWithBackgroundTool, {

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -247,6 +247,45 @@ export interface ReadFileToolConfig extends WorkspaceToolConfig {
   maxMediaBytes?: number;
 }
 
+/**
+ * Extended configuration for the computer (desktop) tools.
+ *
+ * Applies to the `mastra_workspace_computer_*` tools emitted when the
+ * workspace sandbox supports the computer capability.
+ *
+ * @example
+ * ```ts
+ * tools: {
+ *   // Don't attach a screenshot to click results
+ *   mastra_workspace_computer_click: { screenshotAfterAction: false },
+ *
+ *   // Require approval for typing on the desktop
+ *   mastra_workspace_computer_type: { requireApproval: true },
+ * }
+ * ```
+ */
+export interface ComputerToolConfig extends WorkspaceToolConfig {
+  /**
+   * For action tools (click/type/scroll/…): attach a fresh screenshot to the
+   * tool result after the action completes, so computer-use loops see the
+   * resulting desktop state without an extra screenshot call. Default: true.
+   * Ignored by the screenshot tool itself.
+   */
+  screenshotAfterAction?: boolean;
+  /**
+   * Delay (ms) between an action and its post-action screenshot, giving the
+   * UI time to react (menus, animations). Default: 500.
+   */
+  screenshotDelayMs?: number;
+  /**
+   * Maximum screenshot size (in bytes) to return inline as a media part.
+   * Larger screenshots fall back to text-only output rather than being
+   * fully base64-encoded into the model context and persisted in storage.
+   * Defaults to 10 MiB (10 * 1024 * 1024).
+   */
+  maxMediaBytes?: number;
+}
+
 // =============================================================================
 // Top-Level Tools Config
 // =============================================================================
@@ -316,11 +355,15 @@ export type WorkspaceToolsConfig = {
   [K in typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]?: ExecuteCommandToolConfig;
 } & {
   [K in typeof WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]?: ReadFileToolConfig;
+} & {
+  [K in (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER]]?: ComputerToolConfig;
 } & Partial<
     Record<
       Exclude<
         WorkspaceToolName,
-        typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND | typeof WORKSPACE_TOOLS.FILESYSTEM.READ_FILE
+        | typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND
+        | typeof WORKSPACE_TOOLS.FILESYSTEM.READ_FILE
+        | (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER]
       >,
       WorkspaceToolConfig
     >


### PR DESCRIPTION
## Summary

This is PR 1 of 4 for workspace computer use.

- adds the optional `SandboxComputer` capability to workspace sandboxes
- emits 11 `mastra_workspace_computer_*` tools for supported sandboxes
- returns screenshots as native model media and shares media handling with `read_file`
- covers capability gating, tool delegation, configuration, approvals, screenshots, and type narrowing

## Intentionally excluded

- PR 2 adds Daytona support
- PR 3 adds E2B Desktop support
- PR 4 adds documentation and the agent example

## Test plan

- `pnpm build:core`
- `pnpm --filter ./packages/core exec vitest run src/workspace/sandbox/computer.test.ts src/workspace/tools/__tests__/computer-tools.test.ts src/workspace/tools/__tests__/read-file.test.ts --reporter=dot --bail=1`
- `pnpm --filter ./packages/core exec vitest run src/workspace --reporter=dot --bail=1`
- `pnpm --filter ./packages/core check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Supported workspace sandboxes can now control a computer. Agents can take screenshots, click, type, scroll, inspect the screen, and wait. The tools can return screenshots directly to the model.

## Changes

- Added optional `SandboxComputer` support to workspace sandboxes.
- Added 11 computer tools for screenshots, mouse actions, keyboard input, scrolling, screen information, and waiting.
- Added capability detection and unsupported-feature errors.
- Registered computer tools only for supported static sandboxes.
- Added per-tool configuration for follow-up screenshots, screenshot delay, and maximum media size.
- Added workspace approval and enablement support for computer actions.
- Added shared native media handling for computer tools and `read_file`.
- Added tracing support for the `computer` workspace action category.
- Added public types and exports for computer capabilities, screenshots, screen size, cursor positions, and tool configuration.
- Added validation for coordinates, wait durations, scroll inputs, text, and key names.
- Added tests for capability gating, tool registration, delegation, approvals, validation, screenshots, media limits, failures, and type narrowing.
- Added a changeset for `@mastra/core`.

Daytona support, E2B Desktop support, documentation, and the agent example remain out of scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->