### PR TITLE
feat(daytona): add computer use support

### DIFF
--- a/.changeset/slimy-windows-check.md
+++ b/.changeset/slimy-windows-check.md
@@ -1,0 +1,15 @@
+---
+'@mastra/daytona': minor
+---
+
+Added computer-use support to `DaytonaSandbox`. Workspaces backed by Daytona can now take screenshots, control the mouse and keyboard, inspect the display, and open a noVNC viewer through the standard computer tools.
+
+```typescript
+const sandbox = new DaytonaSandbox();
+await sandbox.start();
+
+await sandbox.computer.leftClick(100, 200);
+const screenshot = await sandbox.computer.screenshot();
+```
+
+Desktop services start lazily on the first computer operation. Set `computerUse: false` to disable the capability or `computerUse: { autoStart: false }` to manage those services directly.

--- a/.changeset/vast-adults-draw.md
+++ b/.changeset/vast-adults-draw.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': minor
+---
+
+Added an optional computer-use capability for workspace sandboxes. Providers can expose `SandboxComputer` to give agents screenshot, mouse, keyboard, screen information, and wait tools automatically.
+
+```typescript
+const workspace = new Workspace({ sandbox });
+
+if (supportsComputer(sandbox)) {
+  const screenshot = await sandbox.computer.screenshot();
+}
+```
+
+Computer action tools return a follow-up screenshot by default and support the existing workspace tool approval and enablement settings.

--- a/.changeset/vast-adults-draw.md
+++ b/.changeset/vast-adults-draw.md
@@ -2,7 +2,7 @@
 '@mastra/core': minor
 ---
 
-Added an optional computer-use capability for workspace sandboxes. Providers can expose `SandboxComputer` to give agents screenshot, mouse, keyboard, screen information, and wait tools automatically.
+Added an optional computer-use capability for workspace sandboxes. Providers can expose `SandboxComputer` to give agents screenshot, mouse, keyboard, screen information, and wait tools automatically when the workspace uses a static sandbox. Resolver-backed sandboxes do not register computer tools because their capabilities are unavailable when the tool list is constructed.
 
 ```typescript
 const workspace = new Workspace({ sandbox });

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -610,7 +610,7 @@ export interface WorkspaceActionAttributes extends AIBaseAttributes {
   /** Human-readable workspace name */
   workspaceName?: string;
   /** Action category */
-  category: 'filesystem' | 'sandbox' | 'search' | 'skill' | 'mount';
+  category: 'filesystem' | 'sandbox' | 'search' | 'skill' | 'mount' | 'computer';
   /** Sandbox provider name (e.g. 'e2b', 'docker', 'local') */
   sandboxProvider?: string;
   /** Filesystem provider name (e.g. 'local', 'agentfs', 's3') */

--- a/packages/core/src/workspace/constants/index.ts
+++ b/packages/core/src/workspace/constants/index.ts
@@ -30,6 +30,19 @@ export const WORKSPACE_TOOLS = {
     GET_PROCESS_OUTPUT: `${WORKSPACE_TOOLS_PREFIX}_get_process_output` as const,
     KILL_PROCESS: `${WORKSPACE_TOOLS_PREFIX}_kill_process` as const,
   },
+  COMPUTER: {
+    SCREENSHOT: `${WORKSPACE_TOOLS_PREFIX}_computer_screenshot` as const,
+    CLICK: `${WORKSPACE_TOOLS_PREFIX}_computer_click` as const,
+    DOUBLE_CLICK: `${WORKSPACE_TOOLS_PREFIX}_computer_double_click` as const,
+    RIGHT_CLICK: `${WORKSPACE_TOOLS_PREFIX}_computer_right_click` as const,
+    MOVE_MOUSE: `${WORKSPACE_TOOLS_PREFIX}_computer_move_mouse` as const,
+    DRAG: `${WORKSPACE_TOOLS_PREFIX}_computer_drag` as const,
+    TYPE: `${WORKSPACE_TOOLS_PREFIX}_computer_type` as const,
+    PRESS_KEY: `${WORKSPACE_TOOLS_PREFIX}_computer_press_key` as const,
+    SCROLL: `${WORKSPACE_TOOLS_PREFIX}_computer_scroll` as const,
+    GET_SCREEN_INFO: `${WORKSPACE_TOOLS_PREFIX}_computer_get_screen_info` as const,
+    WAIT: `${WORKSPACE_TOOLS_PREFIX}_computer_wait` as const,
+  },
   SEARCH: {
     SEARCH: `${WORKSPACE_TOOLS_PREFIX}_search` as const,
     INDEX: `${WORKSPACE_TOOLS_PREFIX}_index` as const,
@@ -46,4 +59,5 @@ export type WorkspaceToolName =
   | (typeof WORKSPACE_TOOLS.FILESYSTEM)[keyof typeof WORKSPACE_TOOLS.FILESYSTEM]
   | (typeof WORKSPACE_TOOLS.SEARCH)[keyof typeof WORKSPACE_TOOLS.SEARCH]
   | (typeof WORKSPACE_TOOLS.SANDBOX)[keyof typeof WORKSPACE_TOOLS.SANDBOX]
+  | (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER]
   | (typeof WORKSPACE_TOOLS.LSP)[keyof typeof WORKSPACE_TOOLS.LSP];

--- a/packages/core/src/workspace/errors.ts
+++ b/packages/core/src/workspace/errors.ts
@@ -47,7 +47,7 @@ export class SandboxNotAvailableError extends WorkspaceError {
 }
 
 export class SandboxFeatureNotSupportedError extends WorkspaceError {
-  constructor(feature: 'executeCommand' | 'installPackage' | 'processes') {
+  constructor(feature: 'executeCommand' | 'installPackage' | 'processes' | 'computer') {
     super(`Sandbox does not support ${feature}`, 'FEATURE_NOT_SUPPORTED');
     this.name = 'SandboxFeatureNotSupportedError';
   }

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -34,6 +34,7 @@ export {
   type WorkspaceToolConfig,
   type WorkspaceToolsConfig,
   type ExecuteCommandToolConfig,
+  type ComputerToolConfig,
   type BackgroundProcessConfig,
   type BackgroundProcessMeta,
   type BackgroundProcessExitMeta,
@@ -83,10 +84,14 @@ export type {
 export type { FilesystemMountConfig, MountResult, FilesystemIcon } from './filesystem';
 
 // Sandbox
-export { MountManager, supportsNetworking } from './sandbox';
+export { MountManager, supportsNetworking, supportsComputer } from './sandbox';
 export type {
   WorkspaceSandbox,
   SandboxNetworking,
+  SandboxComputer,
+  ComputerScreenshot,
+  ComputerScreenSize,
+  ComputerPosition,
   SandboxFileInput,
   SandboxCloneOptions,
   SandboxStartOutcome,

--- a/packages/core/src/workspace/sandbox/computer.test.ts
+++ b/packages/core/src/workspace/sandbox/computer.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Sandbox Computer Capability Tests
+ *
+ * Tests the optional `computer` (desktop) capability on WorkspaceSandbox /
+ * MastraSandbox, plus the `supportsComputer` type guard.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { ProviderStatus } from '../lifecycle';
+
+import { MastraSandbox } from './mastra-sandbox';
+import { supportsComputer } from './sandbox';
+import type { SandboxComputer, WorkspaceSandbox } from './sandbox';
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+function createComputer(): SandboxComputer {
+  return {
+    screenshot: async () => ({ data: PNG_BYTES, mediaType: 'image/png' }),
+    leftClick: async () => {},
+    rightClick: async () => {},
+    doubleClick: async () => {},
+    moveMouse: async () => {},
+    drag: async () => {},
+    scroll: async () => {},
+    type: async () => {},
+    press: async () => {},
+    getScreenSize: async () => ({ width: 1024, height: 768 }),
+    getCursorPosition: async () => ({ x: 0, y: 0 }),
+  };
+}
+
+class DesktopSandbox extends MastraSandbox {
+  readonly id = 'test-desktop-sandbox';
+  readonly name = 'DesktopSandbox';
+  readonly provider = 'test';
+  status: ProviderStatus = 'pending';
+
+  readonly computer: SandboxComputer = createComputer();
+
+  constructor() {
+    super({ name: 'DesktopSandbox' });
+  }
+
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async destroy(): Promise<void> {}
+}
+
+class PlainSandbox extends MastraSandbox {
+  readonly id = 'test-plain-sandbox';
+  readonly name = 'PlainSandbox';
+  readonly provider = 'test';
+  status: ProviderStatus = 'pending';
+
+  constructor() {
+    super({ name: 'PlainSandbox' });
+  }
+
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async destroy(): Promise<void> {}
+}
+
+describe('supportsComputer', () => {
+  it('returns true for a sandbox implementing the computer capability', () => {
+    const sandbox: WorkspaceSandbox = new DesktopSandbox();
+    expect(supportsComputer(sandbox)).toBe(true);
+  });
+
+  it('returns false for a sandbox without computer', () => {
+    const sandbox: WorkspaceSandbox = new PlainSandbox();
+    expect(supportsComputer(sandbox)).toBe(false);
+  });
+
+  it('returns false when computer is present but screenshot is not a function', () => {
+    const sandbox = new PlainSandbox() as WorkspaceSandbox & { computer?: unknown };
+    (sandbox as { computer?: unknown }).computer = {};
+    expect(supportsComputer(sandbox as WorkspaceSandbox)).toBe(false);
+  });
+
+  it('narrows the type so computer is non-optional', async () => {
+    const sandbox: WorkspaceSandbox = new DesktopSandbox();
+    if (supportsComputer(sandbox)) {
+      // No optional chaining needed after the guard
+      const shot = await sandbox.computer.screenshot();
+      expect(shot.mediaType).toBe('image/png');
+      expect(shot.data).toEqual(PNG_BYTES);
+    } else {
+      expect.unreachable('guard should have passed');
+    }
+  });
+});

--- a/packages/core/src/workspace/sandbox/computer.test.ts
+++ b/packages/core/src/workspace/sandbox/computer.test.ts
@@ -74,10 +74,29 @@ describe('supportsComputer', () => {
     expect(supportsComputer(sandbox)).toBe(false);
   });
 
-  it('returns false when computer is present but screenshot is not a function', () => {
+  it.each([
+    'screenshot',
+    'leftClick',
+    'rightClick',
+    'doubleClick',
+    'moveMouse',
+    'drag',
+    'scroll',
+    'type',
+    'press',
+    'getScreenSize',
+    'getCursorPosition',
+  ] satisfies Array<keyof SandboxComputer>)('returns false when computer.%s is not a function', method => {
     const sandbox = new PlainSandbox() as WorkspaceSandbox & { computer?: unknown };
-    (sandbox as { computer?: unknown }).computer = {};
+    const computer = { ...createComputer(), [method]: undefined };
+    (sandbox as { computer?: unknown }).computer = computer;
     expect(supportsComputer(sandbox as WorkspaceSandbox)).toBe(false);
+  });
+
+  it('does not require the optional streamUrl method', () => {
+    const sandbox: WorkspaceSandbox = new DesktopSandbox();
+    expect(sandbox.computer?.streamUrl).toBeUndefined();
+    expect(supportsComputer(sandbox)).toBe(true);
   });
 
   it('narrows the type so computer is non-optional', async () => {

--- a/packages/core/src/workspace/sandbox/mastra-sandbox.ts
+++ b/packages/core/src/workspace/sandbox/mastra-sandbox.ts
@@ -31,7 +31,7 @@ import type { ProviderStatus, SandboxStartOutcome, SandboxStartResult } from '..
 import { SandboxNotReadyError } from './errors';
 import { MountManager } from './mount-manager';
 import type { SandboxProcessManager } from './process-manager';
-import type { SandboxFileInput, SandboxNetworking, WorkspaceSandbox } from './sandbox';
+import type { SandboxComputer, SandboxFileInput, SandboxNetworking, WorkspaceSandbox } from './sandbox';
 import type { CommandResult, ExecuteCommandOptions, SandboxInfo } from './types';
 import { shellQuote } from './utils';
 
@@ -172,6 +172,9 @@ export abstract class MastraSandbox<THandle = unknown> extends MastraBase implem
 
   /** Optional networking capability - implement to expose public port URLs */
   readonly networking?: SandboxNetworking;
+
+  /** Optional computer-use (desktop) capability - implement to enable workspace computer tools */
+  readonly computer?: SandboxComputer;
 
   /**
    * Optional bulk file upload into the sandbox's own filesystem.

--- a/packages/core/src/workspace/sandbox/sandbox.ts
+++ b/packages/core/src/workspace/sandbox/sandbox.ts
@@ -183,7 +183,20 @@ export interface SandboxComputer {
 export function supportsComputer(
   sandbox: WorkspaceSandbox,
 ): sandbox is WorkspaceSandbox & { computer: SandboxComputer } {
-  return typeof sandbox.computer?.screenshot === 'function';
+  const computer = sandbox.computer;
+  return (
+    typeof computer?.screenshot === 'function' &&
+    typeof computer.leftClick === 'function' &&
+    typeof computer.rightClick === 'function' &&
+    typeof computer.doubleClick === 'function' &&
+    typeof computer.moveMouse === 'function' &&
+    typeof computer.drag === 'function' &&
+    typeof computer.scroll === 'function' &&
+    typeof computer.type === 'function' &&
+    typeof computer.press === 'function' &&
+    typeof computer.getScreenSize === 'function' &&
+    typeof computer.getCursorPosition === 'function'
+  );
 }
 
 // =============================================================================

--- a/packages/core/src/workspace/sandbox/sandbox.ts
+++ b/packages/core/src/workspace/sandbox/sandbox.ts
@@ -112,8 +112,11 @@ export interface ComputerPosition {
  *
  * Providers with a controllable display (Daytona Computer Use, E2B Desktop,
  * etc.) implement this to surface screenshot, mouse, and keyboard control
- * through the abstraction. When present, the workspace tools factory emits
- * the `mastra_workspace_computer_*` tools automatically.
+ * through the abstraction. When present on a statically configured workspace
+ * sandbox, the workspace tools factory emits the
+ * `mastra_workspace_computer_*` tools automatically. Resolver-backed sandboxes
+ * do not register these tools because their capabilities are unavailable when
+ * the tool list is constructed.
  *
  * Coordinates are in pixels from the top-left corner of the display.
  * Providers normalize their SDK semantics (key names, scroll units) onto

--- a/packages/core/src/workspace/sandbox/sandbox.ts
+++ b/packages/core/src/workspace/sandbox/sandbox.ts
@@ -83,6 +83,110 @@ export function supportsNetworking(
 }
 
 // =============================================================================
+// Computer (Desktop) Capability
+// =============================================================================
+
+/** A screenshot of the sandbox's desktop display. */
+export interface ComputerScreenshot {
+  /** Raw image bytes */
+  data: Uint8Array;
+  /** Image media type (providers normalize to PNG) */
+  mediaType: 'image/png';
+}
+
+/** Screen dimensions in pixels. */
+export interface ComputerScreenSize {
+  width: number;
+  height: number;
+}
+
+/** A position on the sandbox's desktop display, in pixels from the top-left corner. */
+export interface ComputerPosition {
+  x: number;
+  y: number;
+}
+
+/**
+ * Optional computer-use (desktop) capability for sandboxes that run a GUI
+ * desktop environment.
+ *
+ * Providers with a controllable display (Daytona Computer Use, E2B Desktop,
+ * etc.) implement this to surface screenshot, mouse, and keyboard control
+ * through the abstraction. When present, the workspace tools factory emits
+ * the `mastra_workspace_computer_*` tools automatically.
+ *
+ * Coordinates are in pixels from the top-left corner of the display.
+ * Providers normalize their SDK semantics (key names, scroll units) onto
+ * this surface and may expose richer native APIs via their own accessors.
+ */
+export interface SandboxComputer {
+  /** Capture the current display as a PNG image. */
+  screenshot(): Promise<ComputerScreenshot>;
+
+  /** Left-click at the given coordinates. */
+  leftClick(x: number, y: number): Promise<void>;
+
+  /** Right-click at the given coordinates. */
+  rightClick(x: number, y: number): Promise<void>;
+
+  /** Double-click (left button) at the given coordinates. */
+  doubleClick(x: number, y: number): Promise<void>;
+
+  /** Move the mouse cursor to the given coordinates without clicking. */
+  moveMouse(x: number, y: number): Promise<void>;
+
+  /** Press the left button at `from`, drag to `to`, and release. */
+  drag(from: ComputerPosition, to: ComputerPosition): Promise<void>;
+
+  /**
+   * Scroll the display.
+   *
+   * @param direction - Scroll direction
+   * @param amount - Scroll amount in provider-normalized ticks (positive integer)
+   */
+  scroll(direction: 'up' | 'down', amount: number): Promise<void>;
+
+  /** Type text into the focused element using the keyboard. */
+  type(text: string): Promise<void>;
+
+  /**
+   * Press a key or key combination.
+   *
+   * A single string presses one key (e.g. `'Enter'`, `'Tab'`, `'a'`).
+   * An array presses a chord/hotkey (e.g. `['ctrl', 's']`).
+   */
+  press(key: string | string[]): Promise<void>;
+
+  /** Get the display dimensions. */
+  getScreenSize(): Promise<ComputerScreenSize>;
+
+  /** Get the current mouse cursor position. */
+  getCursorPosition(): Promise<ComputerPosition>;
+
+  /**
+   * Get a URL for a live view of the desktop (e.g. noVNC), or null when
+   * unavailable. Optional — not all providers expose a viewer.
+   */
+  streamUrl?(): Promise<string | null>;
+}
+
+/**
+ * Type guard: does this sandbox support the computer-use (desktop) capability?
+ *
+ * @example
+ * ```typescript
+ * if (supportsComputer(sandbox)) {
+ *   const { data } = await sandbox.computer.screenshot();
+ * }
+ * ```
+ */
+export function supportsComputer(
+  sandbox: WorkspaceSandbox,
+): sandbox is WorkspaceSandbox & { computer: SandboxComputer } {
+  return typeof sandbox.computer?.screenshot === 'function';
+}
+
+// =============================================================================
 // Sandbox Derivation
 // =============================================================================
 
@@ -271,6 +375,23 @@ export interface WorkspaceSandbox extends SandboxLifecycle<SandboxInfo> {
    * ```
    */
   readonly networking?: SandboxNetworking;
+
+  // ---------------------------------------------------------------------------
+  // Computer Use (Optional)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Computer-use (desktop) capability for sandboxes with a GUI desktop.
+   * Optional - only available on providers with a controllable display.
+   * When present, workspace computer tools (screenshot/click/type/…) are
+   * emitted automatically.
+   *
+   * @example
+   * ```typescript
+   * const { data } = await sandbox.computer?.screenshot();
+   * ```
+   */
+  readonly computer?: SandboxComputer;
 
   // ---------------------------------------------------------------------------
   // File Upload (Optional)

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
 import { WORKSPACE_TOOLS } from '../../constants';
+import type { SandboxComputer, WorkspaceSandbox } from '../../sandbox';
 import { Workspace } from '../../workspace';
 import { computerScreenshotTool } from '../computer-screenshot';
 import { isMediaToolResult, mediaToModelOutput } from '../media';
@@ -25,50 +26,54 @@ const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a
 const ALL_COMPUTER_TOOL_NAMES = Object.values(WORKSPACE_TOOLS.COMPUTER);
 
 /** Create a mock SandboxComputer backed by vi.fn()s. */
-function createMockComputer(overrides: Record<string, any> = {}) {
+function createMockComputer(overrides: Partial<SandboxComputer> = {}): SandboxComputer {
   return {
-    screenshot: vi.fn().mockResolvedValue({ data: PNG_BYTES, mediaType: 'image/png' }),
-    leftClick: vi.fn().mockResolvedValue(undefined),
-    rightClick: vi.fn().mockResolvedValue(undefined),
-    doubleClick: vi.fn().mockResolvedValue(undefined),
-    moveMouse: vi.fn().mockResolvedValue(undefined),
-    drag: vi.fn().mockResolvedValue(undefined),
-    scroll: vi.fn().mockResolvedValue(undefined),
-    type: vi.fn().mockResolvedValue(undefined),
-    press: vi.fn().mockResolvedValue(undefined),
-    getScreenSize: vi.fn().mockResolvedValue({ width: 1024, height: 768 }),
-    getCursorPosition: vi.fn().mockResolvedValue({ x: 12, y: 34 }),
+    screenshot: vi.fn(async () => ({ data: PNG_BYTES, mediaType: 'image/png' as const })),
+    leftClick: vi.fn(async () => {}),
+    rightClick: vi.fn(async () => {}),
+    doubleClick: vi.fn(async () => {}),
+    moveMouse: vi.fn(async () => {}),
+    drag: vi.fn(async () => {}),
+    scroll: vi.fn(async () => {}),
+    type: vi.fn(async () => {}),
+    press: vi.fn(async () => {}),
+    getScreenSize: vi.fn(async () => ({ width: 1024, height: 768 })),
+    getCursorPosition: vi.fn(async () => ({ x: 12, y: 34 })),
     ...overrides,
   };
 }
 
 /** Create a mock sandbox, optionally with the computer capability. */
-function createMockSandbox(opts: { computer?: any } = {}) {
-  const sandbox: any = {
+function createMockSandbox(opts: { computer?: SandboxComputer } = {}): WorkspaceSandbox {
+  return {
     id: 'test-sandbox',
     name: 'Test Sandbox',
     provider: 'test',
     status: 'running',
-    getInfo: vi.fn().mockResolvedValue({
+    snapshot: vi.fn(async () => {}),
+    getInfo: vi.fn(async () => ({
       id: 'test-sandbox',
       name: 'Test Sandbox',
       provider: 'test',
-      status: 'running',
+      status: 'running' as const,
       createdAt: new Date(),
-    }),
-    executeCommand: vi.fn(),
+    })),
+    executeCommand: vi.fn(async () => ({
+      success: true,
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      executionTimeMs: 0,
+    })),
+    ...(opts.computer ? { computer: opts.computer } : {}),
   };
-  if (opts.computer) {
-    sandbox.computer = opts.computer;
-  }
-  return sandbox;
 }
 
 /**
  * Create a workspace with the mock sandbox + the emitted workspace tools.
  * `screenshotDelayMs: 0` is applied to all computer tools so tests don't sleep.
  */
-async function setup(computer: any, tools?: WorkspaceToolsConfig) {
+async function setup(computer: SandboxComputer, tools?: WorkspaceToolsConfig) {
   const toolsConfig: WorkspaceToolsConfig = { ...tools };
   for (const name of ALL_COMPUTER_TOOL_NAMES) {
     toolsConfig[name] = { screenshotDelayMs: 0, ...(tools?.[name] as object | undefined) };
@@ -102,9 +107,10 @@ describe('createWorkspaceTools computer gating', () => {
   });
 
   it('emits no computer tools when the computer capability is incomplete', async () => {
-    const workspace = new Workspace({
-      sandbox: createMockSandbox({ computer: createMockComputer({ drag: undefined }) }),
-    });
+    const incompleteComputer: unknown = { ...createMockComputer(), drag: undefined };
+    const sandbox = createMockSandbox();
+    (sandbox as { computer?: unknown }).computer = incompleteComputer;
+    const workspace = new Workspace({ sandbox });
     const tools = await createWorkspaceTools(workspace);
     for (const name of ALL_COMPUTER_TOOL_NAMES) {
       expect(tools[name], `expected ${name} to be absent`).toBeUndefined();

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -306,6 +306,19 @@ describe('computer action tools', () => {
     expect(computer.press).toHaveBeenCalledWith(['ctrl', 's']);
   });
 
+  it('press_key rejects empty key values before calling the capability', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.PRESS_KEY]: { screenshotAfterAction: false },
+    });
+    const tool = emitted[WORKSPACE_TOOLS.COMPUTER.PRESS_KEY];
+
+    for (const key of ['', [''], ['ctrl', '']]) {
+      await expect(tool.execute({ key }, { workspace })).resolves.toMatchObject({ error: true });
+    }
+    expect(computer.press).not.toHaveBeenCalled();
+  });
+
   it('scroll defaults the amount to 3', async () => {
     const computer = createMockComputer();
     const { workspace, emitted } = await setup(computer, {

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Workspace Computer (Desktop) Tools Tests
+ *
+ * Tests the `mastra_workspace_computer_*` tools: factory gating on the
+ * sandbox `computer` capability, delegation to the capability, media
+ * (screenshot) output with size caps, post-action screenshots, and
+ * approval config resolution.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { WORKSPACE_TOOLS } from '../../constants';
+import { Workspace } from '../../workspace';
+import { computerScreenshotTool } from '../computer-screenshot';
+import { isMediaToolResult, mediaToModelOutput } from '../media';
+import { createWorkspaceTools } from '../tools';
+import type { WorkspaceToolsConfig } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mock Helpers
+// ---------------------------------------------------------------------------
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const ALL_COMPUTER_TOOL_NAMES = Object.values(WORKSPACE_TOOLS.COMPUTER);
+
+/** Create a mock SandboxComputer backed by vi.fn()s. */
+function createMockComputer(overrides: Record<string, any> = {}) {
+  return {
+    screenshot: vi.fn().mockResolvedValue({ data: PNG_BYTES, mediaType: 'image/png' }),
+    leftClick: vi.fn().mockResolvedValue(undefined),
+    rightClick: vi.fn().mockResolvedValue(undefined),
+    doubleClick: vi.fn().mockResolvedValue(undefined),
+    moveMouse: vi.fn().mockResolvedValue(undefined),
+    drag: vi.fn().mockResolvedValue(undefined),
+    scroll: vi.fn().mockResolvedValue(undefined),
+    type: vi.fn().mockResolvedValue(undefined),
+    press: vi.fn().mockResolvedValue(undefined),
+    getScreenSize: vi.fn().mockResolvedValue({ width: 1024, height: 768 }),
+    getCursorPosition: vi.fn().mockResolvedValue({ x: 12, y: 34 }),
+    ...overrides,
+  };
+}
+
+/** Create a mock sandbox, optionally with the computer capability. */
+function createMockSandbox(opts: { computer?: any } = {}) {
+  const sandbox: any = {
+    id: 'test-sandbox',
+    name: 'Test Sandbox',
+    provider: 'test',
+    status: 'running',
+    getInfo: vi.fn().mockResolvedValue({
+      id: 'test-sandbox',
+      name: 'Test Sandbox',
+      provider: 'test',
+      status: 'running',
+      createdAt: new Date(),
+    }),
+    executeCommand: vi.fn(),
+  };
+  if (opts.computer) {
+    sandbox.computer = opts.computer;
+  }
+  return sandbox;
+}
+
+/**
+ * Create a workspace with the mock sandbox + the emitted workspace tools.
+ * `screenshotDelayMs: 0` is applied to all computer tools so tests don't sleep.
+ */
+async function setup(computer: any, tools?: WorkspaceToolsConfig) {
+  const toolsConfig: WorkspaceToolsConfig = { ...tools };
+  for (const name of ALL_COMPUTER_TOOL_NAMES) {
+    toolsConfig[name] = { screenshotDelayMs: 0, ...(tools?.[name] as object | undefined) };
+  }
+  const workspace = new Workspace({ sandbox: createMockSandbox({ computer }), tools: toolsConfig });
+  const emitted = await createWorkspaceTools(workspace);
+  return { workspace, emitted };
+}
+
+// ---------------------------------------------------------------------------
+// Factory gating
+// ---------------------------------------------------------------------------
+
+describe('createWorkspaceTools computer gating', () => {
+  it('emits all computer tools when the sandbox supports the capability', async () => {
+    const workspace = new Workspace({ sandbox: createMockSandbox({ computer: createMockComputer() }) });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be emitted`).toBeDefined();
+    }
+  });
+
+  it('emits no computer tools when the sandbox lacks the capability', async () => {
+    const workspace = new Workspace({ sandbox: createMockSandbox() });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be absent`).toBeUndefined();
+    }
+    // Sandbox tools are still emitted
+    expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]).toBeDefined();
+  });
+
+  it('emits no computer tools for dynamic sandbox resolvers', async () => {
+    const workspace = new Workspace({
+      sandbox: async () => createMockSandbox({ computer: createMockComputer() }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be absent`).toBeUndefined();
+    }
+  });
+
+  it('respects per-tool enabled config', async () => {
+    const { emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.TYPE]: { enabled: false },
+    });
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.TYPE]).toBeUndefined();
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT]).toBeDefined();
+  });
+
+  it('resolves static requireApproval onto the emitted tool', async () => {
+    const { emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.CLICK]: { requireApproval: true },
+    });
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].requireApproval).toBe(true);
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT].requireApproval).toBe(false);
+  });
+
+  it('supports dynamic arg-aware requireApproval', async () => {
+    const { emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.TYPE]: {
+        requireApproval: ({ args }) => (args.text as string).includes('rm -rf'),
+      },
+    });
+    const tool = emitted[WORKSPACE_TOOLS.COMPUTER.TYPE];
+    expect(tool.requireApproval).toBe(true);
+    await expect(tool.needsApprovalFn({ text: 'hello' })).resolves.toBe(false);
+    await expect(tool.needsApprovalFn({ text: 'rm -rf /' })).resolves.toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Screenshot tool
+// ---------------------------------------------------------------------------
+
+describe('computer_screenshot tool', () => {
+  it('returns a media result with base64 PNG data', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT].execute({}, { workspace });
+
+    expect(isMediaToolResult(result)).toBe(true);
+    if (isMediaToolResult(result)) {
+      expect(result.mediaType).toBe('image/png');
+      expect(result.data).toBe(Buffer.from(PNG_BYTES).toString('base64'));
+      expect(result.text).toContain('Screenshot');
+    }
+    expect(computer.screenshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to text when the screenshot exceeds maxMediaBytes', async () => {
+    const { workspace, emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.SCREENSHOT]: { maxMediaBytes: 4 },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT].execute({}, { workspace });
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('exceeds maxMediaBytes');
+  });
+
+  it('throws when the sandbox lacks the computer capability', async () => {
+    const workspace = new Workspace({ sandbox: createMockSandbox() });
+    await expect((computerScreenshotTool.execute as any)({}, { workspace })).rejects.toThrow(
+      'Sandbox does not support computer',
+    );
+  });
+
+  it('throws when the workspace has no sandbox', async () => {
+    const workspace = new Workspace({ filesystem: { provider: 'test', readOnly: false } as any });
+    await expect((computerScreenshotTool.execute as any)({}, { workspace })).rejects.toThrow(
+      'Workspace does not have a sandbox configured',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action tools
+// ---------------------------------------------------------------------------
+
+describe('computer action tools', () => {
+  it('click delegates to leftClick and attaches a post-action screenshot by default', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 5, y: 10 }, { workspace });
+
+    expect(computer.leftClick).toHaveBeenCalledWith(5, 10);
+    expect(isMediaToolResult(result)).toBe(true);
+    if (isMediaToolResult(result)) {
+      expect(result.text).toBe('Clicked at (5, 10)');
+      expect(result.mediaType).toBe('image/png');
+    }
+    expect(computer.screenshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the post-action screenshot when screenshotAfterAction is false', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.CLICK]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 5, y: 10 }, { workspace });
+
+    expect(result).toBe('Clicked at (5, 10)');
+    expect(computer.screenshot).not.toHaveBeenCalled();
+  });
+
+  it('does not fail the action when the post-action screenshot fails', async () => {
+    const computer = createMockComputer({
+      screenshot: vi.fn().mockRejectedValue(new Error('display gone')),
+    });
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 1, y: 2 }, { workspace });
+
+    expect(result).toBe('Clicked at (1, 2) (post-action screenshot failed)');
+  });
+
+  it('caps the post-action screenshot via maxMediaBytes', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.CLICK]: { maxMediaBytes: 4 },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 1, y: 2 }, { workspace });
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('Clicked at (1, 2)');
+    expect(result).toContain('exceeds maxMediaBytes');
+  });
+
+  it('double_click and right_click delegate to the capability', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK]: { screenshotAfterAction: false },
+      [WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK]: { screenshotAfterAction: false },
+    });
+
+    await expect(emitted[WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK].execute({ x: 3, y: 4 }, { workspace })).resolves.toBe(
+      'Double-clicked at (3, 4)',
+    );
+    expect(computer.doubleClick).toHaveBeenCalledWith(3, 4);
+
+    await expect(emitted[WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK].execute({ x: 7, y: 8 }, { workspace })).resolves.toBe(
+      'Right-clicked at (7, 8)',
+    );
+    expect(computer.rightClick).toHaveBeenCalledWith(7, 8);
+  });
+
+  it('move_mouse delegates to moveMouse', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE].execute({ x: 50, y: 60 }, { workspace });
+
+    expect(computer.moveMouse).toHaveBeenCalledWith(50, 60);
+    expect(result).toBe('Moved mouse to (50, 60)');
+  });
+
+  it('type delegates to type without echoing the text back', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.TYPE]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.TYPE].execute({ text: 'secret password' }, { workspace });
+
+    expect(computer.type).toHaveBeenCalledWith('secret password');
+    expect(result).toBe('Typed 15 characters');
+  });
+
+  it('press_key supports single keys and hotkey chords', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.PRESS_KEY]: { screenshotAfterAction: false },
+    });
+    const tool = emitted[WORKSPACE_TOOLS.COMPUTER.PRESS_KEY];
+
+    await expect(tool.execute({ key: 'Enter' }, { workspace })).resolves.toBe('Pressed Enter');
+    expect(computer.press).toHaveBeenCalledWith('Enter');
+
+    await expect(tool.execute({ key: ['ctrl', 's'] }, { workspace })).resolves.toBe('Pressed ctrl+s');
+    expect(computer.press).toHaveBeenCalledWith(['ctrl', 's']);
+  });
+
+  it('scroll defaults the amount to 3', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.SCROLL]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.SCROLL].execute({ direction: 'down' }, { workspace });
+
+    expect(computer.scroll).toHaveBeenCalledWith('down', 3);
+    expect(result).toBe('Scrolled down by 3');
+  });
+
+  it('drag maps flat coordinates to from/to positions', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.DRAG]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.DRAG].execute(
+      { startX: 1, startY: 2, endX: 3, endY: 4 },
+      { workspace },
+    );
+
+    expect(computer.drag).toHaveBeenCalledWith({ x: 1, y: 2 }, { x: 3, y: 4 });
+    expect(result).toBe('Dragged from (1, 2) to (3, 4)');
+  });
+
+  it('wait sleeps then reports', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.WAIT]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.WAIT].execute({ seconds: 0.1 }, { workspace });
+    expect(result).toBe('Waited 0.1s');
+  });
+
+  it('get_screen_info reports screen size and cursor position', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO].execute({}, { workspace });
+
+    expect(result).toBe('Screen size: 1024x768\nCursor position: (12, 34)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toModelOutput
+// ---------------------------------------------------------------------------
+
+describe('mediaToModelOutput', () => {
+  it('surfaces media results as text + media parts', () => {
+    const output = mediaToModelOutput({
+      __workspaceMedia: true,
+      text: 'Screenshot',
+      mediaType: 'image/png',
+      data: 'aGVsbG8=',
+    });
+    expect(output).toEqual({
+      type: 'content',
+      value: [
+        { type: 'text', text: 'Screenshot' },
+        { type: 'media', data: 'aGVsbG8=', mediaType: 'image/png' },
+      ],
+    });
+  });
+
+  it('returns undefined for plain string output', () => {
+    expect(mediaToModelOutput('Clicked at (1, 2)')).toBeUndefined();
+  });
+});

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -101,6 +101,16 @@ describe('createWorkspaceTools computer gating', () => {
     expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]).toBeDefined();
   });
 
+  it('emits no computer tools when the computer capability is incomplete', async () => {
+    const workspace = new Workspace({
+      sandbox: createMockSandbox({ computer: createMockComputer({ drag: undefined }) }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be absent`).toBeUndefined();
+    }
+  });
+
   it('emits no computer tools for dynamic sandbox resolvers', async () => {
     const workspace = new Workspace({
       sandbox: async () => createMockSandbox({ computer: createMockComputer() }),

--- a/packages/core/src/workspace/tools/computer-click.ts
+++ b/packages/core/src/workspace/tools/computer-click.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerClickTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.CLICK,
+  description:
+    'Left-click at pixel coordinates on the sandbox desktop. Coordinates are measured from the top-left corner of the screen — take a screenshot first to find the right position.',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.CLICK);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'click',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.leftClick(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.CLICK,
+        `Clicked at (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-double-click.ts
+++ b/packages/core/src/workspace/tools/computer-double-click.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerDoubleClickTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK,
+  description:
+    'Double-click (left button) at pixel coordinates on the sandbox desktop. Use for opening files, folders, and applications.',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'doubleClick',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.doubleClick(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK,
+        `Double-clicked at (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-drag.ts
+++ b/packages/core/src/workspace/tools/computer-drag.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerDragTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.DRAG,
+  description:
+    'Drag from one position to another on the sandbox desktop: presses the left button at the start coordinates, moves to the end coordinates, and releases. Use for moving windows, selecting text, and drag-and-drop.',
+  inputSchema: z.object({
+    startX: z.number().int().min(0).describe('X coordinate to start the drag from'),
+    startY: z.number().int().min(0).describe('Y coordinate to start the drag from'),
+    endX: z.number().int().min(0).describe('X coordinate to drag to'),
+    endY: z.number().int().min(0).describe('Y coordinate to drag to'),
+  }),
+  execute: async ({ startX, startY, endX, endY }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.DRAG);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'drag',
+      input: { startX, startY, endX, endY },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.drag({ x: startX, y: startY }, { x: endX, y: endY });
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.DRAG,
+        `Dragged from (${startX}, ${startY}) to (${endX}, ${endY})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-get-screen-info.ts
+++ b/packages/core/src/workspace/tools/computer-get-screen-info.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerGetScreenInfoTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO,
+  description:
+    'Get the sandbox desktop screen dimensions and current mouse cursor position. Use to understand the coordinate space before clicking.',
+  inputSchema: z.object({}),
+  execute: async (_input, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'getScreenInfo',
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      const [size, cursor] = await Promise.all([computer.getScreenSize(), computer.getCursorPosition()]);
+      span.end({ success: true });
+      return `Screen size: ${size.width}x${size.height}\nCursor position: (${cursor.x}, ${cursor.y})`;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+});

--- a/packages/core/src/workspace/tools/computer-helpers.ts
+++ b/packages/core/src/workspace/tools/computer-helpers.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared helpers for the workspace computer (desktop) tools.
+ *
+ * The computer tools delegate to the sandbox's optional `computer` capability
+ * (see SandboxComputer). These helpers extract the capability from the tool
+ * execution context and format screenshot results as media parts.
+ */
+
+import type { ToolExecutionContext } from '../../tools/types';
+import { WORKSPACE_TOOLS } from '../constants';
+import { SandboxFeatureNotSupportedError } from '../errors';
+import type { ComputerScreenshot, SandboxComputer, WorkspaceSandbox } from '../sandbox';
+import { supportsComputer } from '../sandbox';
+import type { Workspace } from '../workspace';
+import { requireSandbox } from './helpers';
+import type { MediaToolResult } from './media';
+import { DEFAULT_MAX_MEDIA_BYTES } from './media';
+import type { ComputerToolConfig } from './types';
+
+/** Default for ComputerToolConfig.screenshotAfterAction. */
+export const DEFAULT_SCREENSHOT_AFTER_ACTION = true;
+
+/** Default for ComputerToolConfig.screenshotDelayMs. */
+export const DEFAULT_SCREENSHOT_DELAY_MS = 500;
+
+type ComputerToolName = (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER];
+
+/**
+ * Extract the computer capability from the workspace sandbox in the tool
+ * execution context. Throws if the workspace has no sandbox or the sandbox
+ * doesn't support the computer capability.
+ */
+export function requireComputer(context: ToolExecutionContext): {
+  workspace: Workspace;
+  sandbox: WorkspaceSandbox;
+  computer: SandboxComputer;
+} {
+  const { workspace, sandbox } = requireSandbox(context);
+  if (!supportsComputer(sandbox)) {
+    throw new SandboxFeatureNotSupportedError('computer');
+  }
+  return { workspace, sandbox, computer: sandbox.computer };
+}
+
+/** Resolve the per-tool ComputerToolConfig from the workspace tools config. */
+export function getComputerToolConfig(
+  workspace: Workspace,
+  toolName: ComputerToolName,
+): ComputerToolConfig | undefined {
+  return workspace.getToolsConfig()?.[toolName];
+}
+
+/**
+ * Format a screenshot as a MediaToolResult, falling back to text-only output
+ * when the image exceeds the configured size cap (so huge base64 payloads
+ * don't blow up the model context or storage).
+ */
+export function screenshotToResult(
+  screenshot: ComputerScreenshot,
+  text: string,
+  maxMediaBytes: number,
+): MediaToolResult | string {
+  if (screenshot.data.byteLength > maxMediaBytes) {
+    return `${text} — screenshot (${screenshot.data.byteLength} bytes, ${screenshot.mediaType}) exceeds maxMediaBytes (${maxMediaBytes}). Returning text only; configure \`maxMediaBytes\` on the computer tool to raise this cap.`;
+  }
+  return {
+    __workspaceMedia: true,
+    text,
+    mediaType: screenshot.mediaType,
+    data: Buffer.from(screenshot.data).toString('base64'),
+  };
+}
+
+/**
+ * Finish a computer action tool: when `screenshotAfterAction` is enabled
+ * (default), wait briefly for the UI to react and attach a fresh screenshot
+ * to the result so computer-use loops see the resulting desktop state.
+ * Screenshot failures never fail the action itself.
+ */
+export async function finishComputerAction(
+  workspace: Workspace,
+  computer: SandboxComputer,
+  toolName: ComputerToolName,
+  text: string,
+): Promise<MediaToolResult | string> {
+  const config = getComputerToolConfig(workspace, toolName);
+  const screenshotAfterAction = config?.screenshotAfterAction ?? DEFAULT_SCREENSHOT_AFTER_ACTION;
+  if (!screenshotAfterAction) return text;
+
+  const delayMs = config?.screenshotDelayMs ?? DEFAULT_SCREENSHOT_DELAY_MS;
+  if (delayMs > 0) {
+    await new Promise(resolve => setTimeout(resolve, delayMs));
+  }
+
+  try {
+    const screenshot = await computer.screenshot();
+    const maxMediaBytes = config?.maxMediaBytes ?? DEFAULT_MAX_MEDIA_BYTES;
+    return screenshotToResult(screenshot, text, maxMediaBytes);
+  } catch {
+    return `${text} (post-action screenshot failed)`;
+  }
+}

--- a/packages/core/src/workspace/tools/computer-move-mouse.ts
+++ b/packages/core/src/workspace/tools/computer-move-mouse.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerMoveMouseTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE,
+  description:
+    'Move the mouse cursor to pixel coordinates on the sandbox desktop without clicking. Use for hover states (tooltips, dropdown menus).',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'moveMouse',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.moveMouse(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE,
+        `Moved mouse to (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-press-key.ts
+++ b/packages/core/src/workspace/tools/computer-press-key.ts
@@ -12,7 +12,7 @@ export const computerPressKeyTool = createTool({
     'Press a key or key combination on the sandbox desktop keyboard. Pass a single key (e.g. "Enter", "Tab", "Escape") or an array for a hotkey chord (e.g. ["ctrl", "s"]).',
   inputSchema: z.object({
     key: z
-      .union([z.string(), z.array(z.string()).min(1)])
+      .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
       .describe('A single key (e.g. "Enter") or an array of keys pressed together as a hotkey (e.g. ["ctrl", "c"])'),
   }),
   execute: async ({ key }, context) => {

--- a/packages/core/src/workspace/tools/computer-press-key.ts
+++ b/packages/core/src/workspace/tools/computer-press-key.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerPressKeyTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.PRESS_KEY,
+  description:
+    'Press a key or key combination on the sandbox desktop keyboard. Pass a single key (e.g. "Enter", "Tab", "Escape") or an array for a hotkey chord (e.g. ["ctrl", "s"]).',
+  inputSchema: z.object({
+    key: z
+      .union([z.string(), z.array(z.string()).min(1)])
+      .describe('A single key (e.g. "Enter") or an array of keys pressed together as a hotkey (e.g. ["ctrl", "c"])'),
+  }),
+  execute: async ({ key }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.PRESS_KEY);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'pressKey',
+      input: { key },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.press(key);
+      const label = Array.isArray(key) ? key.join('+') : key;
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.PRESS_KEY,
+        `Pressed ${label}`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-right-click.ts
+++ b/packages/core/src/workspace/tools/computer-right-click.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerRightClickTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK,
+  description: 'Right-click at pixel coordinates on the sandbox desktop. Use for opening context menus.',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'rightClick',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.rightClick(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK,
+        `Right-clicked at (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-screenshot.ts
+++ b/packages/core/src/workspace/tools/computer-screenshot.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { getComputerToolConfig, requireComputer, screenshotToResult } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { DEFAULT_MAX_MEDIA_BYTES, mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerScreenshotTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.SCREENSHOT,
+  description:
+    'Take a screenshot of the sandbox desktop display. Returns the current screen as an image. Use this to see the desktop state before and after interacting with it.',
+  inputSchema: z.object({}),
+  execute: async (_input, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.SCREENSHOT);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'screenshot',
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      const screenshot = await computer.screenshot();
+      const config = getComputerToolConfig(workspace, WORKSPACE_TOOLS.COMPUTER.SCREENSHOT);
+      const maxMediaBytes = config?.maxMediaBytes ?? DEFAULT_MAX_MEDIA_BYTES;
+      const result = screenshotToResult(
+        screenshot,
+        `Screenshot of the desktop (${screenshot.data.byteLength} bytes, ${screenshot.mediaType})`,
+        maxMediaBytes,
+      );
+      span.end({ success: true }, { bytesTransferred: screenshot.data.byteLength });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-scroll.ts
+++ b/packages/core/src/workspace/tools/computer-scroll.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerScrollTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.SCROLL,
+  description: 'Scroll the sandbox desktop display up or down.',
+  inputSchema: z.object({
+    direction: z.enum(['up', 'down']).describe('Scroll direction'),
+    amount: z.number().int().min(1).optional().describe('Scroll amount in ticks (default: 3)'),
+  }),
+  execute: async ({ direction, amount }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.SCROLL);
+
+    const effectiveAmount = amount ?? 3;
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'scroll',
+      input: { direction, amount: effectiveAmount },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.scroll(direction, effectiveAmount);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.SCROLL,
+        `Scrolled ${direction} by ${effectiveAmount}`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-type.ts
+++ b/packages/core/src/workspace/tools/computer-type.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerTypeTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.TYPE,
+  description:
+    'Type text into the focused element on the sandbox desktop using the keyboard. Click an input field first to focus it. Use the press-key tool for special keys (Enter, Tab, shortcuts).',
+  inputSchema: z.object({
+    text: z.string().describe('The text to type'),
+  }),
+  execute: async ({ text }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.TYPE);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'type',
+      input: { length: text.length },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.type(text);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.TYPE,
+        `Typed ${text.length} characters`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-wait.ts
+++ b/packages/core/src/workspace/tools/computer-wait.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerWaitTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.WAIT,
+  description:
+    'Wait for the sandbox desktop UI to settle (e.g. an application launching or a page loading) before the next action.',
+  inputSchema: z.object({
+    seconds: z.number().min(0.1).max(30).describe('How long to wait, in seconds (max 30)'),
+  }),
+  execute: async ({ seconds }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.WAIT);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'wait',
+      input: { seconds },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await new Promise(resolve => setTimeout(resolve, seconds * 1000));
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.WAIT,
+        `Waited ${seconds}s`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/index.ts
+++ b/packages/core/src/workspace/tools/index.ts
@@ -24,9 +24,22 @@ export { getProcessOutputTool } from './get-process-output';
 export { killProcessTool } from './kill-process';
 export { grepTool } from './grep';
 export { lspInspectTool } from './lsp-inspect';
+export { computerScreenshotTool } from './computer-screenshot';
+export { computerClickTool } from './computer-click';
+export { computerDoubleClickTool } from './computer-double-click';
+export { computerRightClickTool } from './computer-right-click';
+export { computerMoveMouseTool } from './computer-move-mouse';
+export { computerDragTool } from './computer-drag';
+export { computerTypeTool } from './computer-type';
+export { computerPressKeyTool } from './computer-press-key';
+export { computerScrollTool } from './computer-scroll';
+export { computerGetScreenInfoTool } from './computer-get-screen-info';
+export { computerWaitTool } from './computer-wait';
 
 // Helpers
 export { requireWorkspace, requireFilesystem, requireSandbox, emitWorkspaceMetadata } from './helpers';
+export { requireComputer } from './computer-helpers';
+export { isMediaToolResult, mediaToModelOutput, DEFAULT_MAX_MEDIA_BYTES, type MediaToolResult } from './media';
 export {
   applyTail,
   applyTokenLimit,

--- a/packages/core/src/workspace/tools/media.ts
+++ b/packages/core/src/workspace/tools/media.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared media-result helpers for workspace tools.
+ *
+ * Tools that surface binary media (read_file for media files, the computer
+ * screenshot tools) return a MediaToolResult so `toModelOutput` can present
+ * the media as a native image/file part while only the `text` header is kept
+ * in the stored/displayed result.
+ */
+
+/**
+ * Internal marker on the tool's result that signals to `toModelOutput`
+ * that the payload should be surfaced to the model as a media part (image or
+ * binary file) rather than as plain text. We attach this on a wrapper object
+ * but only the `text` field is shown to the model (via toModelOutput); the
+ * marker is stripped before it ever reaches the model.
+ *
+ * The shape is intentionally JSON-serialisable so it round-trips through
+ * storage layers that snapshot tool results.
+ */
+export type MediaToolResult = {
+  __workspaceMedia: true;
+  text: string;
+  mediaType: string;
+  data: string;
+};
+
+export function isMediaToolResult(value: unknown): value is MediaToolResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<string, unknown>).__workspaceMedia === true &&
+    typeof (value as Record<string, unknown>).text === 'string' &&
+    typeof (value as Record<string, unknown>).mediaType === 'string' &&
+    typeof (value as Record<string, unknown>).data === 'string'
+  );
+}
+
+/**
+ * Default cap (in bytes) on inline media results. Payloads larger than this
+ * fall back to text-only output instead of being fully base64-encoded into
+ * the model context (and persisted in storage on rehydration). 10 MiB is
+ * roughly aligned with provider per-image/per-pdf limits.
+ */
+export const DEFAULT_MAX_MEDIA_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Shared `toModelOutput` handler for tools that may return a MediaToolResult.
+ * Surfaces the media as a native part; returns undefined for plain string
+ * output so we don't store a duplicate copy on providerMetadata.
+ */
+export function mediaToModelOutput(output: unknown) {
+  if (isMediaToolResult(output)) {
+    return {
+      type: 'content' as const,
+      value: [
+        { type: 'text' as const, text: output.text },
+        { type: 'media' as const, data: output.data, mediaType: output.mediaType },
+      ],
+    };
+  }
+  return undefined;
+}

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -3,36 +3,10 @@ import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { extractLinesWithLimit, formatWithLineNumbers } from '../line-utils';
 import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
+import type { MediaToolResult } from './media';
+import { DEFAULT_MAX_MEDIA_BYTES, mediaToModelOutput } from './media';
 import { applyTokenLimit } from './output-helpers';
 import { startWorkspaceSpan } from './tracing';
-
-/**
- * Internal marker on the tool's text result that signals to `toModelOutput`
- * that the file should be surfaced to the model as a media part (image or
- * binary file) rather than as plain text. We attach this on a wrapper object
- * but only the `text` field is shown to the model (via toModelOutput); the
- * marker is stripped before it ever reaches the model.
- *
- * The shape is intentionally JSON-serialisable so it round-trips through
- * storage layers that snapshot tool results.
- */
-type MediaToolResult = {
-  __workspaceMedia: true;
-  text: string;
-  mediaType: string;
-  data: string;
-};
-
-function isMediaToolResult(value: unknown): value is MediaToolResult {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    (value as Record<string, unknown>).__workspaceMedia === true &&
-    typeof (value as Record<string, unknown>).text === 'string' &&
-    typeof (value as Record<string, unknown>).mediaType === 'string' &&
-    typeof (value as Record<string, unknown>).data === 'string'
-  );
-}
 
 /**
  * Default mime types surfaced to the model as media parts. The list is
@@ -42,14 +16,6 @@ function isMediaToolResult(value: unknown): value is MediaToolResult {
  * that some providers reject. Override `mediaTypes` to broaden this.
  */
 const DEFAULT_MEDIA_TYPES: string[] = ['image/png', 'image/jpeg', 'image/webp', 'application/pdf'];
-
-/**
- * Default cap (in bytes) on inline media reads. Files larger than this fall
- * back to metadata-only output instead of being fully base64-encoded into
- * the model context (and persisted in storage on rehydration). 10 MiB is
- * roughly aligned with provider per-image/per-pdf limits.
- */
-const DEFAULT_MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 
 /**
  * `application/*` mime types that are actually text content and safe to read
@@ -275,19 +241,8 @@ export const readFileTool = createTool({
       throw err;
     }
   },
-  toModelOutput: (output: unknown) => {
-    if (isMediaToolResult(output)) {
-      return {
-        type: 'content',
-        value: [
-          { type: 'text', text: output.text },
-          { type: 'media', data: output.data, mediaType: output.mediaType },
-        ],
-      };
-    }
-    // For plain string output, return undefined so we don't store a duplicate
-    // copy on providerMetadata.mastra.modelOutput — the original string result
-    // is already what the model sees.
-    return undefined;
-  },
+  // For plain string output, mediaToModelOutput returns undefined so we don't
+  // store a duplicate copy on providerMetadata.mastra.modelOutput — the
+  // original string result is already what the model sees.
+  toModelOutput: mediaToModelOutput,
 });

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -15,8 +15,20 @@ import { FileNotFoundError, FileReadRequiredError } from '../errors';
 import { InMemoryFileReadTracker, InMemoryFileWriteLock } from '../filesystem';
 import type { FileReadTracker, FileWriteLock, WorkspaceFilesystem } from '../filesystem';
 import type { WorkspaceSandbox } from '../sandbox';
+import { supportsComputer } from '../sandbox';
 import type { Workspace } from '../workspace';
 import { isAstGrepAvailable, astEditTool } from './ast-edit';
+import { computerClickTool } from './computer-click';
+import { computerDoubleClickTool } from './computer-double-click';
+import { computerDragTool } from './computer-drag';
+import { computerGetScreenInfoTool } from './computer-get-screen-info';
+import { computerMoveMouseTool } from './computer-move-mouse';
+import { computerPressKeyTool } from './computer-press-key';
+import { computerRightClickTool } from './computer-right-click';
+import { computerScreenshotTool } from './computer-screenshot';
+import { computerScrollTool } from './computer-scroll';
+import { computerTypeTool } from './computer-type';
+import { computerWaitTool } from './computer-wait';
 import { deleteFileTool } from './delete-file';
 import { editFileTool } from './edit-file';
 import { executeCommandTool, executeCommandWithBackgroundTool } from './execute-command';
@@ -543,6 +555,25 @@ export async function createWorkspaceTools(
     if (workspace.sandbox.processes) {
       await addTool(WORKSPACE_TOOLS.SANDBOX.GET_PROCESS_OUTPUT, getProcessOutputTool, { targets: { sandbox: true } });
       await addTool(WORKSPACE_TOOLS.SANDBOX.KILL_PROCESS, killProcessTool, { targets: { sandbox: true } });
+    }
+
+    // Computer (desktop) tools — only when the sandbox supports the computer
+    // capability. Not offered for dynamic sandbox resolvers (no static
+    // instance) since the capability can't be detected at tool-listing time.
+    if (supportsComputer(workspace.sandbox)) {
+      await addTool(WORKSPACE_TOOLS.COMPUTER.SCREENSHOT, computerScreenshotTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.CLICK, computerClickTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK, computerDoubleClickTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK, computerRightClickTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE, computerMoveMouseTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.DRAG, computerDragTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.TYPE, computerTypeTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.PRESS_KEY, computerPressKeyTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.SCROLL, computerScrollTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO, computerGetScreenInfoTool, {
+        targets: { sandbox: true },
+      });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.WAIT, computerWaitTool, { targets: { sandbox: true } });
     }
   } else if (hasSandboxConfig(workspace)) {
     await addTool(WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND, executeCommandWithBackgroundTool, {

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -247,6 +247,45 @@ export interface ReadFileToolConfig extends WorkspaceToolConfig {
   maxMediaBytes?: number;
 }
 
+/**
+ * Extended configuration for the computer (desktop) tools.
+ *
+ * Applies to the `mastra_workspace_computer_*` tools emitted when the
+ * workspace sandbox supports the computer capability.
+ *
+ * @example
+ * ```ts
+ * tools: {
+ *   // Don't attach a screenshot to click results
+ *   mastra_workspace_computer_click: { screenshotAfterAction: false },
+ *
+ *   // Require approval for typing on the desktop
+ *   mastra_workspace_computer_type: { requireApproval: true },
+ * }
+ * ```
+ */
+export interface ComputerToolConfig extends WorkspaceToolConfig {
+  /**
+   * For action tools (click/type/scroll/…): attach a fresh screenshot to the
+   * tool result after the action completes, so computer-use loops see the
+   * resulting desktop state without an extra screenshot call. Default: true.
+   * Ignored by the screenshot tool itself.
+   */
+  screenshotAfterAction?: boolean;
+  /**
+   * Delay (ms) between an action and its post-action screenshot, giving the
+   * UI time to react (menus, animations). Default: 500.
+   */
+  screenshotDelayMs?: number;
+  /**
+   * Maximum screenshot size (in bytes) to return inline as a media part.
+   * Larger screenshots fall back to text-only output rather than being
+   * fully base64-encoded into the model context and persisted in storage.
+   * Defaults to 10 MiB (10 * 1024 * 1024).
+   */
+  maxMediaBytes?: number;
+}
+
 // =============================================================================
 // Top-Level Tools Config
 // =============================================================================
@@ -316,11 +355,15 @@ export type WorkspaceToolsConfig = {
   [K in typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]?: ExecuteCommandToolConfig;
 } & {
   [K in typeof WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]?: ReadFileToolConfig;
+} & {
+  [K in (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER]]?: ComputerToolConfig;
 } & Partial<
     Record<
       Exclude<
         WorkspaceToolName,
-        typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND | typeof WORKSPACE_TOOLS.FILESYSTEM.READ_FILE
+        | typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND
+        | typeof WORKSPACE_TOOLS.FILESYSTEM.READ_FILE
+        | (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER]
       >,
       WorkspaceToolConfig
     >

--- a/workspaces/daytona/package.json
+++ b/workspaces/daytona/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.12.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.60.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/workspaces/daytona/src/sandbox/index.integration.test.ts
+++ b/workspaces/daytona/src/sandbox/index.integration.test.ts
@@ -835,6 +835,66 @@ describe.skipIf(!process.env.DAYTONA_API_KEY || !hasS3Credentials)('DaytonaSandb
 });
 
 /**
+ * Computer-use (desktop) smoke tests.
+ *
+ * Verifies the `computer` capability against a real Daytona sandbox:
+ * desktop processes start lazily, screenshots return PNG bytes, mouse input
+ * reaches the desktop, and the noVNC live view URL resolves.
+ */
+describe.skipIf(!process.env.DAYTONA_API_KEY)('DaytonaSandbox Computer Use', () => {
+  let sandbox: DaytonaSandbox;
+
+  beforeEach(() => {
+    sandbox = new DaytonaSandbox({
+      id: `test-computer-${Date.now()}`,
+      timeout: 60000,
+    });
+  });
+
+  afterEach(async () => {
+    if (sandbox) {
+      try {
+        await sandbox._destroy();
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it('captures a PNG screenshot and reports screen geometry', async () => {
+    await sandbox._start();
+
+    const shot = await sandbox.computer!.screenshot();
+    expect(shot.mediaType).toBe('image/png');
+    // PNG magic bytes: \x89 P N G
+    expect(Array.from(shot.data.slice(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47]);
+
+    const size = await sandbox.computer!.getScreenSize();
+    expect(size.width).toBeGreaterThan(0);
+    expect(size.height).toBeGreaterThan(0);
+  }, 300000);
+
+  it('mouse input reaches the desktop (move → cursor position round-trip)', async () => {
+    await sandbox._start();
+
+    await sandbox.computer!.moveMouse(101, 102);
+    const position = await sandbox.computer!.getCursorPosition();
+
+    expect(position.x).toBe(101);
+    expect(position.y).toBe(102);
+  }, 300000);
+
+  it('streamUrl resolves a live noVNC viewer URL', async () => {
+    await sandbox._start();
+
+    const url = await sandbox.computer!.streamUrl!();
+
+    expect(url).toBeTruthy();
+    expect(url).toMatch(/^https?:\/\//);
+  }, 300000);
+});
+
+/**
  * Shared sandbox conformance tests.
  */
 describe.skipIf(!process.env.DAYTONA_API_KEY)('DaytonaSandbox Conformance', () => {

--- a/workspaces/daytona/src/sandbox/index.test.ts
+++ b/workspaces/daytona/src/sandbox/index.test.ts
@@ -13,7 +13,13 @@
  */
 
 import { createSandboxLifecycleTests, createMountOperationsTests } from '@internal/workspace-test-utils';
-import { SandboxNotReadyError } from '@mastra/core/workspace';
+import {
+  SandboxNotReadyError,
+  WORKSPACE_TOOLS,
+  Workspace,
+  createWorkspaceTools,
+  supportsComputer,
+} from '@mastra/core/workspace';
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
 
 import { DaytonaSandbox } from './index';
@@ -46,6 +52,32 @@ const { mockSandbox, mockDaytona, resetMockDefaults, DaytonaError, DaytonaNotFou
       downloadFile: vi.fn().mockResolvedValue(Buffer.from('')),
     },
     getPreviewLink: vi.fn().mockResolvedValue({ url: 'https://4111-mock-sandbox-id.proxy.daytona.work', token: 't' }),
+    computerUse: {
+      start: vi.fn().mockResolvedValue({ message: 'started' }),
+      stop: vi.fn().mockResolvedValue({ message: 'stopped' }),
+      getStatus: vi.fn().mockResolvedValue({ status: 'running' }),
+      mouse: {
+        getPosition: vi.fn().mockResolvedValue({ x: 100, y: 200 }),
+        move: vi.fn().mockResolvedValue({ x: 0, y: 0 }),
+        click: vi.fn().mockResolvedValue({ x: 0, y: 0 }),
+        drag: vi.fn().mockResolvedValue({}),
+        scroll: vi.fn().mockResolvedValue(true),
+      },
+      keyboard: {
+        type: vi.fn().mockResolvedValue(undefined),
+        press: vi.fn().mockResolvedValue(undefined),
+        hotkey: vi.fn().mockResolvedValue(undefined),
+      },
+      screenshot: {
+        takeFullScreen: vi.fn().mockResolvedValue({ screenshot: Buffer.from('fake-png-bytes').toString('base64') }),
+      },
+      display: {
+        getInfo: vi
+          .fn()
+          .mockResolvedValue({ displays: [{ id: 0, x: 0, y: 0, width: 1920, height: 1080, isActive: true }] }),
+        getWindows: vi.fn().mockResolvedValue({ windows: [] }),
+      },
+    },
     start: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockResolvedValue(undefined),
     delete: vi.fn().mockResolvedValue(undefined),
@@ -80,6 +112,24 @@ const { mockSandbox, mockDaytona, resetMockDefaults, DaytonaError, DaytonaNotFou
       url: 'https://4111-mock-sandbox-id.proxy.daytona.work',
       token: 't',
     });
+    mockSandbox.computerUse.start.mockResolvedValue({ message: 'started' });
+    mockSandbox.computerUse.stop.mockResolvedValue({ message: 'stopped' });
+    mockSandbox.computerUse.getStatus.mockResolvedValue({ status: 'running' });
+    mockSandbox.computerUse.mouse.getPosition.mockResolvedValue({ x: 100, y: 200 });
+    mockSandbox.computerUse.mouse.move.mockResolvedValue({ x: 0, y: 0 });
+    mockSandbox.computerUse.mouse.click.mockResolvedValue({ x: 0, y: 0 });
+    mockSandbox.computerUse.mouse.drag.mockResolvedValue({});
+    mockSandbox.computerUse.mouse.scroll.mockResolvedValue(true);
+    mockSandbox.computerUse.keyboard.type.mockResolvedValue(undefined);
+    mockSandbox.computerUse.keyboard.press.mockResolvedValue(undefined);
+    mockSandbox.computerUse.keyboard.hotkey.mockResolvedValue(undefined);
+    mockSandbox.computerUse.screenshot.takeFullScreen.mockResolvedValue({
+      screenshot: Buffer.from('fake-png-bytes').toString('base64'),
+    });
+    mockSandbox.computerUse.display.getInfo.mockResolvedValue({
+      displays: [{ id: 0, x: 0, y: 0, width: 1920, height: 1080, isActive: true }],
+    });
+    mockSandbox.computerUse.display.getWindows.mockResolvedValue({ windows: [] });
     mockSandbox.state = 'started';
     mockSandbox.start.mockResolvedValue(undefined);
     mockSandbox.stop.mockResolvedValue(undefined);
@@ -1211,6 +1261,216 @@ describe('DaytonaSandbox', () => {
         { source: Buffer.from('hello'), destination: '/home/daytona/app/a.txt' },
         { source: Buffer.from([1, 2, 3]), destination: '/home/daytona/app/b.bin' },
       ]);
+    });
+  });
+
+  describe('Computer Use', () => {
+    it('exposes the computer capability by default', () => {
+      const sandbox = new DaytonaSandbox();
+
+      expect(sandbox.computer).toBeDefined();
+      expect(supportsComputer(sandbox)).toBe(true);
+    });
+
+    it('computerUse: false disables the capability', () => {
+      const sandbox = new DaytonaSandbox({ computerUse: false });
+
+      expect(sandbox.computer).toBeUndefined();
+      expect(supportsComputer(sandbox)).toBe(false);
+    });
+
+    it('starts desktop processes lazily on the first operation and memoizes', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+      expect(mockSandbox.computerUse.start).not.toHaveBeenCalled();
+
+      await sandbox.computer!.leftClick(10, 20);
+      await sandbox.computer!.type('hello');
+
+      expect(mockSandbox.computerUse.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('autoStart: false skips desktop process startup', async () => {
+      const sandbox = new DaytonaSandbox({ computerUse: { autoStart: false } });
+      await sandbox._start();
+
+      await sandbox.computer!.leftClick(10, 20);
+
+      expect(mockSandbox.computerUse.start).not.toHaveBeenCalled();
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenCalledWith(10, 20, 'left');
+    });
+
+    it('restarts desktop processes after the sandbox is stopped', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+      await sandbox.computer!.leftClick(1, 1);
+      expect(mockSandbox.computerUse.start).toHaveBeenCalledTimes(1);
+
+      await sandbox._stop();
+      await sandbox.computer!.leftClick(2, 2);
+
+      expect(mockSandbox.computerUse.start).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries lazy start after a startup failure', async () => {
+      mockSandbox.computerUse.start.mockRejectedValueOnce(new Error('no desktop'));
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await expect(sandbox.computer!.leftClick(1, 1)).rejects.toThrow('no desktop');
+      await sandbox.computer!.leftClick(2, 2);
+
+      expect(mockSandbox.computerUse.start).toHaveBeenCalledTimes(2);
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenCalledWith(2, 2, 'left');
+    });
+
+    it('screenshot decodes the base64 response to PNG bytes', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const shot = await sandbox.computer!.screenshot();
+
+      expect(mockSandbox.computerUse.screenshot.takeFullScreen).toHaveBeenCalled();
+      expect(shot.mediaType).toBe('image/png');
+      expect(Buffer.from(shot.data).toString()).toBe('fake-png-bytes');
+    });
+
+    it('screenshot throws on an empty response', async () => {
+      mockSandbox.computerUse.screenshot.takeFullScreen.mockResolvedValueOnce({});
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await expect(sandbox.computer!.screenshot()).rejects.toThrow(/empty screenshot/);
+    });
+
+    it('maps clicks to mouse.click with the right button semantics', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await sandbox.computer!.leftClick(10, 20);
+      await sandbox.computer!.rightClick(30, 40);
+      await sandbox.computer!.doubleClick(50, 60);
+
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenNthCalledWith(1, 10, 20, 'left');
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenNthCalledWith(2, 30, 40, 'right');
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenNthCalledWith(3, 50, 60, 'left', true);
+    });
+
+    it('maps moveMouse and drag', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await sandbox.computer!.moveMouse(5, 6);
+      await sandbox.computer!.drag({ x: 1, y: 2 }, { x: 3, y: 4 });
+
+      expect(mockSandbox.computerUse.mouse.move).toHaveBeenCalledWith(5, 6);
+      expect(mockSandbox.computerUse.mouse.drag).toHaveBeenCalledWith(1, 2, 3, 4);
+    });
+
+    it('scroll uses the current cursor position', async () => {
+      mockSandbox.computerUse.mouse.getPosition.mockResolvedValue({ x: 640, y: 360 });
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await sandbox.computer!.scroll('down', 3);
+
+      expect(mockSandbox.computerUse.mouse.scroll).toHaveBeenCalledWith(640, 360, 'down', 3);
+    });
+
+    it('maps type, single key press, and hotkey chords', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await sandbox.computer!.type('hello world');
+      await sandbox.computer!.press('Enter');
+      await sandbox.computer!.press(['ctrl', 's']);
+
+      expect(mockSandbox.computerUse.keyboard.type).toHaveBeenCalledWith('hello world');
+      expect(mockSandbox.computerUse.keyboard.press).toHaveBeenCalledWith('Enter');
+      expect(mockSandbox.computerUse.keyboard.hotkey).toHaveBeenCalledWith('ctrl+s');
+    });
+
+    it('getScreenSize prefers the active display', async () => {
+      mockSandbox.computerUse.display.getInfo.mockResolvedValueOnce({
+        displays: [
+          { id: 0, x: 0, y: 0, width: 800, height: 600, isActive: false },
+          { id: 1, x: 800, y: 0, width: 1920, height: 1080, isActive: true },
+        ],
+      });
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const size = await sandbox.computer!.getScreenSize();
+
+      expect(size).toEqual({ width: 1920, height: 1080 });
+    });
+
+    it('getScreenSize throws when no display info is returned', async () => {
+      mockSandbox.computerUse.display.getInfo.mockResolvedValueOnce({ displays: [] });
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await expect(sandbox.computer!.getScreenSize()).rejects.toThrow(/display information/);
+    });
+
+    it('getCursorPosition returns the mouse position', async () => {
+      mockSandbox.computerUse.mouse.getPosition.mockResolvedValue({ x: 12, y: 34 });
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const position = await sandbox.computer!.getCursorPosition();
+
+      expect(position).toEqual({ x: 12, y: 34 });
+    });
+
+    it('streamUrl resolves the noVNC preview link (default port 6080)', async () => {
+      mockSandbox.getPreviewLink.mockResolvedValue({ url: 'https://6080-mock.proxy.daytona.work', token: 't' });
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const url = await sandbox.computer!.streamUrl!();
+
+      expect(mockSandbox.computerUse.start).toHaveBeenCalledTimes(1);
+      expect(mockSandbox.getPreviewLink).toHaveBeenCalledWith(6080);
+      expect(url).toBe('https://6080-mock.proxy.daytona.work');
+    });
+
+    it('streamUrl uses a custom noVncPort', async () => {
+      const sandbox = new DaytonaSandbox({ computerUse: { noVncPort: 6901 } });
+      await sandbox._start();
+
+      await sandbox.computer!.streamUrl!();
+
+      expect(mockSandbox.getPreviewLink).toHaveBeenCalledWith(6901);
+    });
+
+    it('streamUrl returns null when the preview link fails', async () => {
+      mockSandbox.getPreviewLink.mockRejectedValueOnce(new Error('preview unavailable'));
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const url = await sandbox.computer!.streamUrl!();
+
+      expect(url).toBeNull();
+    });
+
+    it('operations start the sandbox automatically when not running', async () => {
+      const sandbox = new DaytonaSandbox();
+
+      await sandbox.computer!.leftClick(1, 2);
+
+      expect(mockDaytona.create).toHaveBeenCalledTimes(1);
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenCalledWith(1, 2, 'left');
+    });
+
+    it('emits exactly the workspace computer tool set', async () => {
+      const sandbox = new DaytonaSandbox();
+      const workspace = new Workspace({ sandbox });
+
+      const tools = await createWorkspaceTools(workspace);
+
+      const computerToolNames = Object.keys(tools).filter(name => name.startsWith('mastra_workspace_computer_'));
+      expect(computerToolNames.sort()).toEqual(Object.values(WORKSPACE_TOOLS.COMPUTER).sort());
     });
   });
 

--- a/workspaces/daytona/src/sandbox/index.ts
+++ b/workspaces/daytona/src/sandbox/index.ts
@@ -10,6 +10,7 @@
 
 import { Daytona, DaytonaNotFoundError, SandboxState } from '@daytonaio/sdk';
 import type {
+  ComputerUse,
   CreateSandboxFromImageParams,
   CreateSandboxFromSnapshotParams,
   Sandbox,
@@ -23,6 +24,9 @@ import type {
   MountResult,
   FilesystemMountConfig,
   MountManager,
+  CommandResult,
+  ExecuteCommandOptions,
+  SandboxComputer,
   SandboxNetworking,
   SandboxFileInput,
   SandboxCloneOptions,
@@ -74,6 +78,9 @@ function validateMountPath(mountPath: string): void {
 
 /** Allowlist for marker filenames from ls output — e.g. "mount-abc123" */
 const SAFE_MARKER_NAME = /^mount-[a-z0-9]+$/;
+
+/** Default port of the noVNC web viewer started by Daytona computer use. */
+const DEFAULT_NOVNC_PORT = 6080;
 
 /** Patterns indicating the sandbox is dead/gone (@daytonaio/sdk@0.143.0). */
 const SANDBOX_DEAD_PATTERNS: RegExp[] = [
@@ -178,6 +185,33 @@ export interface DaytonaSandboxOptions extends Omit<MastraSandboxOptions, 'proce
    * Secrets are created at the organization level (Daytona dashboard or SDK).
    */
   secrets?: Record<string, string>;
+  /**
+   * Computer-use (desktop) capability configuration.
+   *
+   * When enabled (the default), the sandbox exposes the `computer` capability
+   * and workspaces emit the `mastra_workspace_computer_*` tools. The desktop
+   * processes (Xvfb, xfce4, x11vnc, noVNC) are started lazily on the first
+   * computer operation.
+   *
+   * Set to `false` to disable the capability entirely.
+   */
+  computerUse?:
+    | boolean
+    | {
+        /**
+         * Automatically start the desktop processes on the first computer
+         * operation. Set to `false` if you manage
+         * `sandbox.daytona.computerUse.start()` yourself.
+         * @default true
+         */
+        autoStart?: boolean;
+        /**
+         * Port of the noVNC web viewer inside the sandbox, used by
+         * `computer.streamUrl()`.
+         * @default 6080
+         */
+        noVncPort?: number;
+      };
 }
 
 // =============================================================================
@@ -249,6 +283,16 @@ export class DaytonaSandbox extends MastraSandbox {
     },
   };
 
+  /**
+   * Computer-use (desktop) capability: screenshot, mouse, and keyboard control
+   * of the sandbox's desktop environment via Daytona's computer use API.
+   *
+   * `undefined` when the sandbox was constructed with `computerUse: false`.
+   * Desktop processes are started lazily on the first operation (unless
+   * `computerUse.autoStart` is `false`).
+   */
+  declare readonly computer?: SandboxComputer;
+
   status: ProviderStatus = 'pending';
 
   private _daytona: Daytona | null = null;
@@ -256,6 +300,9 @@ export class DaytonaSandbox extends MastraSandbox {
   private _createdAt: Date | null = null;
   private _workingDir: string | null = null;
   private _isRetrying = false;
+  private _computerUseStarted: Promise<void> | null = null;
+  private readonly computerUseAutoStart: boolean;
+  private readonly noVncPort: number;
 
   private readonly timeout: number;
   private readonly language: 'typescript' | 'javascript' | 'python';
@@ -315,6 +362,14 @@ export class DaytonaSandbox extends MastraSandbox {
       ...(options.target !== undefined && { target: options.target }),
     };
     this._constructorOptions = { ...options };
+
+    const computerUseOption = options.computerUse ?? true;
+    this.computerUseAutoStart = typeof computerUseOption === 'object' ? (computerUseOption.autoStart ?? true) : true;
+    this.noVncPort =
+      typeof computerUseOption === 'object' ? (computerUseOption.noVncPort ?? DEFAULT_NOVNC_PORT) : DEFAULT_NOVNC_PORT;
+    if (computerUseOption !== false) {
+      this.computer = this.createComputer();
+    }
   }
 
   private generateId(): string {
@@ -507,6 +562,7 @@ export class DaytonaSandbox extends MastraSandbox {
       }
     }
     this._sandbox = null;
+    this._computerUseStarted = null;
   }
 
   /**
@@ -537,6 +593,7 @@ export class DaytonaSandbox extends MastraSandbox {
     this._sandbox = null;
     this._daytonaSandboxId = undefined;
     this._daytona = null;
+    this._computerUseStarted = null;
     this.mounts?.clear();
   }
 
@@ -629,6 +686,112 @@ export class DaytonaSandbox extends MastraSandbox {
         destination: file.path,
       })),
     );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Computer Use
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Ensure the Daytona computer use processes (Xvfb, xfce4, x11vnc, noVNC)
+   * are running. Memoized per attached sandbox; the memo is reset when the
+   * sandbox stops, dies, or is destroyed so a fresh sandbox restarts them.
+   */
+  private async ensureComputerUseStarted(): Promise<void> {
+    if (!this.computerUseAutoStart) return;
+    if (!this._computerUseStarted) {
+      this._computerUseStarted = this.daytona.computerUse
+        .start()
+        .then(() => undefined)
+        .catch((error: unknown) => {
+          this._computerUseStarted = null;
+          throw error;
+        });
+    }
+    return this._computerUseStarted;
+  }
+
+  /**
+   * Build the {@link SandboxComputer} capability backed by Daytona's
+   * computer use API (`sandbox.computerUse`).
+   *
+   * Every operation ensures the sandbox is running and the desktop processes
+   * are started, and retries once if the sandbox died (mirroring command
+   * execution behavior).
+   */
+  private createComputer(): SandboxComputer {
+    const run = async <T>(fn: (computerUse: ComputerUse) => Promise<T>): Promise<T> => {
+      await this.ensureRunning();
+      return this.retryOnDead(async () => {
+        await this.ensureComputerUseStarted();
+        return fn(this.daytona.computerUse);
+      });
+    };
+
+    return {
+      screenshot: async () => {
+        const response = await run(computerUse => computerUse.screenshot.takeFullScreen());
+        if (!response.screenshot) {
+          throw new Error(`${LOG_PREFIX} Daytona returned an empty screenshot response`);
+        }
+        return {
+          data: new Uint8Array(Buffer.from(response.screenshot, 'base64')),
+          mediaType: 'image/png' as const,
+        };
+      },
+      leftClick: async (x, y) => {
+        await run(computerUse => computerUse.mouse.click(x, y, 'left'));
+      },
+      rightClick: async (x, y) => {
+        await run(computerUse => computerUse.mouse.click(x, y, 'right'));
+      },
+      doubleClick: async (x, y) => {
+        await run(computerUse => computerUse.mouse.click(x, y, 'left', true));
+      },
+      moveMouse: async (x, y) => {
+        await run(computerUse => computerUse.mouse.move(x, y));
+      },
+      drag: async (from, to) => {
+        await run(computerUse => computerUse.mouse.drag(from.x, from.y, to.x, to.y));
+      },
+      scroll: async (direction, amount) => {
+        // Daytona scrolls at explicit coordinates — use the current cursor position.
+        await run(async computerUse => {
+          const position = await computerUse.mouse.getPosition();
+          return computerUse.mouse.scroll(position.x ?? 0, position.y ?? 0, direction, amount);
+        });
+      },
+      type: async text => {
+        await run(computerUse => computerUse.keyboard.type(text));
+      },
+      press: async key => {
+        // Daytona's hotkey API takes a '+'-joined combination (e.g. 'ctrl+s').
+        await run(computerUse =>
+          Array.isArray(key) ? computerUse.keyboard.hotkey(key.join('+')) : computerUse.keyboard.press(key),
+        );
+      },
+      getScreenSize: async () => {
+        const info = await run(computerUse => computerUse.display.getInfo());
+        const display = info.displays?.find(d => d.isActive) ?? info.displays?.[0];
+        if (!display || display.width === undefined || display.height === undefined) {
+          throw new Error(`${LOG_PREFIX} Daytona did not return display information`);
+        }
+        return { width: display.width, height: display.height };
+      },
+      getCursorPosition: async () => {
+        const position = await run(computerUse => computerUse.mouse.getPosition());
+        return { x: position.x ?? 0, y: position.y ?? 0 };
+      },
+      streamUrl: async () => {
+        try {
+          // Ensure the desktop (and its noVNC process) is up before resolving the link.
+          const preview = await run(() => this.daytona.getPreviewLink(this.noVncPort));
+          return preview?.url ?? null;
+        } catch {
+          return null;
+        }
+      },
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -1210,6 +1373,7 @@ export class DaytonaSandbox extends MastraSandbox {
    */
   private handleSandboxTimeout(): void {
     this._sandbox = null;
+    this._computerUseStarted = null;
 
     // Reset mounted entries to pending so they get re-mounted on restart
     if (this.mounts) {


### PR DESCRIPTION
## Summary

This is PR 2 of 4 for workspace computer use and is stacked on #21700.

- adapts Daytona's computer-use API to the core `SandboxComputer` capability
- starts desktop services lazily and resets initialization across sandbox lifecycle changes
- supports screenshots, mouse and keyboard input, screen information, and noVNC preview URLs
- adds provider unit coverage and credential-gated integration smoke tests

## Intentionally excluded

- PR 3 adds E2B Desktop support
- PR 4 adds documentation and the agent example

## Test plan

- `pnpm --filter ./workspaces/daytona build`
- `pnpm --filter ./workspaces/daytona test:unit -- --reporter=dot --bail=1`
- `env -u DAYTONA_API_KEY pnpm --filter ./workspaces/daytona test -- --reporter=dot --bail=1`
