### PR TITLE
docs: document computer-use sandboxes and add an agent example

### DIFF
--- a/.changeset/odd-moments-kick.md
+++ b/.changeset/odd-moments-kick.md
@@ -1,0 +1,12 @@
+---
+'@mastra/e2b-desktop': minor
+---
+
+Added `@mastra/e2b-desktop`, a computer-use sandbox provider backed by E2B Desktop. It combines E2B command, process, file, and reconnection support with screenshot, mouse, keyboard, screen information, and authenticated noVNC tools.
+
+```typescript
+const sandbox = new E2BDesktopSandbox({ resolution: [1280, 720] });
+const workspace = new Workspace({ sandbox });
+```
+
+The provider also exports the underlying desktop SDK through `sandbox.desktop` for desktop-specific operations.

--- a/.changeset/six-times-clean.md
+++ b/.changeset/six-times-clean.md
@@ -1,0 +1,5 @@
+---
+'@mastra/e2b': patch
+---
+
+Improved `E2BSandbox` extensibility by adding protected SDK creation, connection, and template resolution hooks. Providers built on E2B can now select a specialized SDK sandbox without changing existing E2B behavior.

--- a/.changeset/slimy-windows-check.md
+++ b/.changeset/slimy-windows-check.md
@@ -1,0 +1,15 @@
+---
+'@mastra/daytona': minor
+---
+
+Added computer-use support to `DaytonaSandbox`. Workspaces backed by Daytona can now take screenshots, control the mouse and keyboard, inspect the display, and open a noVNC viewer through the standard computer tools.
+
+```typescript
+const sandbox = new DaytonaSandbox();
+await sandbox.start();
+
+await sandbox.computer.leftClick(100, 200);
+const screenshot = await sandbox.computer.screenshot();
+```
+
+Desktop services start lazily on the first computer operation. Set `computerUse: false` to disable the capability or `computerUse: { autoStart: false }` to manage those services directly.

--- a/.changeset/vast-adults-draw.md
+++ b/.changeset/vast-adults-draw.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': minor
+---
+
+Added an optional computer-use capability for workspace sandboxes. Providers can expose `SandboxComputer` to give agents screenshot, mouse, keyboard, screen information, and wait tools automatically.
+
+```typescript
+const workspace = new Workspace({ sandbox });
+
+if (supportsComputer(sandbox)) {
+  const screenshot = await sandbox.computer.screenshot();
+}
+```
+
+Computer action tools return a follow-up screenshot by default and support the existing workspace tool approval and enablement settings.

--- a/.changeset/vast-adults-draw.md
+++ b/.changeset/vast-adults-draw.md
@@ -2,7 +2,7 @@
 '@mastra/core': minor
 ---
 
-Added an optional computer-use capability for workspace sandboxes. Providers can expose `SandboxComputer` to give agents screenshot, mouse, keyboard, screen information, and wait tools automatically.
+Added an optional computer-use capability for workspace sandboxes. Providers can expose `SandboxComputer` to give agents screenshot, mouse, keyboard, screen information, and wait tools automatically when the workspace uses a static sandbox. Resolver-backed sandboxes do not register computer tools because their capabilities are unavailable when the tool list is constructed.
 
 ```typescript
 const workspace = new Workspace({ sandbox });

--- a/docs/src/content/en/docs/sandbox/overview.mdx
+++ b/docs/src/content/en/docs/sandbox/overview.mdx
@@ -88,6 +88,48 @@ Set `{ enabled: false }` on one tool to remove it, or set the top-level `enabled
 
 See the [sandbox tools reference](/reference/workspace/workspace-class#sandbox-tools) for all generated tools and the [tool configuration reference](/reference/workspace/workspace-class#tool-configuration) for approvals, output limits, and hooks.
 
+### Computer-use tools
+
+Sandboxes that run a desktop environment can expose screenshot, mouse, and keyboard control. The workspace registers these tools when a statically configured sandbox supports the computer capability:
+
+| Tool | Does |
+| - | - |
+| `computer_screenshot` | Captures the desktop as a PNG image and returns it to the model as native media. |
+| `computer_click` | Presses and releases the left mouse button at pixel coordinates. |
+| `computer_double_click` | Presses the left mouse button twice at pixel coordinates. |
+| `computer_right_click` | Presses and releases the right mouse button at pixel coordinates. |
+| `computer_move_mouse` | Moves the cursor to pixel coordinates without pressing a button. |
+| `computer_drag` | Presses, drags, and releases between two points. |
+| `computer_type` | Types text into the focused element. |
+| `computer_press_key` | Presses a key or key combination, such as `Enter` or `ctrl+s`. |
+| `computer_scroll` | Scrolls up or down. |
+| `computer_get_screen_info` | Gets the screen dimensions and cursor position. |
+| `computer_wait` | Waits for the interface to settle. |
+
+[`DaytonaSandbox`](/integrations/sandboxes/daytona) and [`E2BDesktopSandbox`](/integrations/sandboxes/e2b-desktop) support this capability. Other sandbox backends don't register the computer tools. Resolver-backed sandboxes don't register them because the workspace can't inspect the resolved sandbox's capabilities when it creates the tool list.
+
+Action tools take a screenshot after each action by default. Configure the screenshot behavior for each tool:
+
+```typescript title="src/mastra/workspaces.ts"
+import { Workspace, WORKSPACE_TOOLS } from '@mastra/core/workspace'
+import { E2BDesktopSandbox } from '@mastra/e2b-desktop'
+
+const workspace = new Workspace({
+  sandbox: new E2BDesktopSandbox(),
+  tools: {
+    [WORKSPACE_TOOLS.COMPUTER.CLICK]: {
+      screenshotAfterAction: true,
+      screenshotDelayMs: 1000,
+    },
+    [WORKSPACE_TOOLS.COMPUTER.TYPE]: {
+      requireApproval: true,
+    },
+  },
+})
+```
+
+Computer tools accept the same per-tool `enabled` and `requireApproval` configuration as other workspace tools.
+
 {/* vale ai-tells.VerbTricolon = NO */}
 
 Authored runtime functions, including tools and workflow steps, can get the live sandbox from their execution context. Use it to execute commands, install dependencies, process files, or spawn a long-running process.

--- a/docs/src/content/en/integrations/sandboxes/daytona.mdx
+++ b/docs/src/content/en/integrations/sandboxes/daytona.mdx
@@ -288,6 +288,36 @@ const workspace = new Workspace({
 
 Inside the sandbox, the environment variable holds an opaque placeholder. Daytona's egress proxy substitutes the real value into HTTPS request headers toward the Secret's allowed hosts, so the raw credential never enters the sandbox. Secrets are applied at sandbox creation and are preserved by `clone()`.
 
+### Computer use (desktop)
+
+`DaytonaSandbox` exposes the [computer capability](/docs/sandbox/overview#computer-use-tools): screenshot, mouse, and keyboard control of a desktop environment inside the sandbox. When the sandbox is used in a workspace, agents automatically get the `mastra_workspace_computer_*` tools.
+
+The desktop processes (Xvfb, xfce4, x11vnc, noVNC) are started lazily on the first computer operation:
+
+```typescript
+const sandbox = new DaytonaSandbox()
+await sandbox.start()
+
+await sandbox.computer.leftClick(100, 200)
+await sandbox.computer.type('hello')
+const { data } = await sandbox.computer.screenshot() // PNG bytes
+
+// Live desktop view via the noVNC preview link
+const url = await sandbox.computer.streamUrl()
+```
+
+Disable the capability, or manage the desktop processes yourself, with the `computerUse` option:
+
+```typescript
+// No computer capability, no computer tools
+new DaytonaSandbox({ computerUse: false })
+
+// Capability stays on, but you call sandbox.daytona.computerUse.start() yourself
+new DaytonaSandbox({ computerUse: { autoStart: false } })
+```
+
+For Daytona-specific desktop APIs (regions, compressed screenshots, screen recording, accessibility tree), use the [direct SDK access](#direct-sdk-access) escape hatch: `sandbox.daytona.computerUse`.
+
 ## Constructor parameters
 
 <PropertiesTable
@@ -447,6 +477,14 @@ Inside the sandbox, the environment variable holds an opaque placeholder. Dayton
       "Daytona Secrets to expose inside the sandbox, mapping environment variable names to Daytona Secret names. The env var holds an opaque placeholder; the real value is substituted into HTTPS request headers at egress toward the Secret's allowed hosts.",
     isOptional: true,
   },
+  {
+    name: 'computerUse',
+    type: 'boolean | { autoStart?: boolean; noVncPort?: number }',
+    description:
+      'Computer-use (desktop) capability configuration. Set to false to disable the capability. Set autoStart to false to manage the desktop processes yourself. noVncPort sets the noVNC viewer port used by computer.streamUrl().',
+    isOptional: true,
+    defaultValue: 'true',
+  },
 ]}
 />
 
@@ -485,6 +523,12 @@ Inside the sandbox, the environment variable holds an opaque placeholder. Dayton
     type: 'DaytonaProcessManager',
     description:
       'Background process manager. See [SandboxProcessManager reference](/reference/workspace/process-manager).',
+  },
+  {
+    name: 'computer',
+    type: 'SandboxComputer | undefined',
+    description:
+      'Computer-use capability: screenshot, mouse, keyboard, and stream URL. Undefined when constructed with computerUse: false. See [SandboxComputer reference](/reference/workspace/sandbox#computer-capability).',
   },
 ]}
 />

--- a/docs/src/content/en/integrations/sandboxes/e2b-desktop.mdx
+++ b/docs/src/content/en/integrations/sandboxes/e2b-desktop.mdx
@@ -1,0 +1,145 @@
+---
+title: "E2B Desktop | Sandbox"
+description: "Documentation for the E2BDesktopSandbox provider for cloud desktop (computer-use) environments."
+packages:
+  - "@mastra/e2b-desktop"
+---
+
+# E2B Desktop
+
+Runs a full Linux desktop environment in an isolated [E2B](https://e2b.dev) cloud sandbox with screenshot, mouse, and keyboard control. `E2BDesktopSandbox` extends [`E2BSandbox`](/integrations/sandboxes/e2b), so everything the base provider supports (command execution, background processes, file upload, pause/resume reconnection) works against the same desktop machine. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/e2b-desktop
+```
+
+Set your E2B API key with the `E2B_API_KEY` environment variable or the `apiKey` option.
+
+## Usage
+
+Add an `E2BDesktopSandbox` to a workspace and assign it to an agent. Because the sandbox supports the [computer capability](/docs/sandbox/overview#computer-use-tools), the workspace registers the `mastra_workspace_computer_*` tools alongside the shell and process tools:
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { Workspace } from '@mastra/core/workspace'
+import { E2BDesktopSandbox } from '@mastra/e2b-desktop'
+
+const workspace = new Workspace({
+  sandbox: new E2BDesktopSandbox({
+    resolution: [1280, 720],
+  }),
+})
+
+const agent = new Agent({
+  id: 'desktop-agent',
+  name: 'Desktop Agent',
+  instructions: 'You can control a Linux desktop and run shell commands.',
+  model: '__GATEWAY_ANTHROPIC_MODEL_SONNET__',
+  workspace,
+})
+
+const response = await agent.generate(
+  'Take a screenshot, then create /tmp/hello.txt with the text "hello" and cat it.',
+)
+```
+
+The agent can mix desktop actions (click, type, screenshot) with shell commands. Both surfaces operate on the same machine.
+
+### Direct desktop control
+
+Use the `computer` capability programmatically without an agent:
+
+```typescript
+const sandbox = new E2BDesktopSandbox()
+await sandbox.start()
+
+await sandbox.computer.leftClick(100, 200)
+await sandbox.computer.type('hello')
+const { data } = await sandbox.computer.screenshot() // PNG bytes
+
+const size = await sandbox.computer.getScreenSize()
+console.log(size) // { width: 1024, height: 768 }
+```
+
+### Live desktop view
+
+`streamUrl()` starts an authenticated noVNC stream inside the sandbox and returns a viewer URL. Open it in a browser to watch the agent work:
+
+```typescript
+const url = await sandbox.computer.streamUrl()
+// https://6080-<sandbox-id>.e2b.app/vnc.html?...&password=<auth-key>
+```
+
+### Desktop SDK escape hatch
+
+Desktop-only APIs such as `launch`, `open`, window helpers, and custom stream control are available on the underlying [`@e2b/desktop`](https://github.com/e2b-dev/desktop) sandbox:
+
+```typescript
+await sandbox.desktop.launch('xfce4-terminal')
+await sandbox.desktop.open('https://mastra.ai')
+```
+
+## Constructor parameters
+
+Accepts all [`E2BSandbox` options](/integrations/sandboxes/e2b#constructor-parameters) plus:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'resolution',
+    type: '[number, number]',
+    description: 'Desktop display resolution as [width, height] in pixels. Applies to newly created sandboxes only.',
+    isOptional: true,
+  },
+  {
+    name: 'dpi',
+    type: 'number',
+    description: 'Desktop display DPI. Applies to newly created sandboxes only.',
+    isOptional: true,
+  },
+]}
+/>
+
+When no `template` is provided, the E2B-hosted `desktop` template is used instead of the base provider's mountable template.
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'computer',
+    type: 'SandboxComputer',
+    description:
+      'Computer-use capability: screenshot, mouse, keyboard, and stream URL. See [SandboxComputer reference](/reference/workspace/sandbox#computer-capability).',
+  },
+  {
+    name: 'desktop',
+    type: 'Sandbox',
+    description:
+      'The underlying @e2b/desktop SDK sandbox for desktop-only APIs. Throws if the sandbox has not started.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: "Provider name ('E2BDesktopSandbox')",
+  },
+  {
+    name: 'provider',
+    type: 'string',
+    description: "Provider identifier ('e2b-desktop')",
+  },
+]}
+/>
+
+## Cloud storage mounting
+
+The default `desktop` template has no FUSE tooling, so [cloud storage mounting](/integrations/sandboxes/e2b#mounting-cloud-storage) requires a custom desktop template with `s3fs` or `gcsfuse` installed. Pass it with the `template` option.
+
+## Related
+
+- [Computer-use tools](/docs/sandbox/overview#computer-use-tools)
+- [`E2BSandbox` reference](/integrations/sandboxes/e2b)
+- [`WorkspaceSandbox` interface](/reference/workspace/sandbox)
+- [Sandbox](/docs/sandbox/overview)

--- a/docs/src/content/en/integrations/sidebars.js
+++ b/docs/src/content/en/integrations/sidebars.js
@@ -208,6 +208,12 @@ const sidebars = {
           customProps: { icon: '/img/integrations/e2b.svg', customCSS: 'dark:invert' },
         },
         {
+          type: 'doc',
+          id: 'sandboxes/e2b-desktop',
+          label: 'E2B Desktop',
+          customProps: { icon: '/img/integrations/e2b.svg', customCSS: 'dark:invert' },
+        },
+        {
           type: 'link',
           label: 'Mastra',
           href: '/reference/workspace/platform-sandbox',

--- a/docs/src/content/en/reference/workspace/sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/sandbox.mdx
@@ -22,6 +22,13 @@ The `WorkspaceSandbox` interface defines how workspaces execute commands and man
       "Background process manager. If not implemented, process management tools won't be available. See SandboxProcessManager reference.",
     isOptional: true,
   },
+  {
+    name: 'computer',
+    type: 'SandboxComputer',
+    description:
+      "Computer-use (desktop) capability. If not implemented, computer tools won't be available. See [Computer capability](#computer-capability).",
+    isOptional: true,
+  },
 ]}
 />
 
@@ -279,6 +286,92 @@ const instructions = sandbox.getInstructions?.()
 />
 
 **Returns:** `string`
+
+## Computer capability
+
+Sandboxes with a controllable desktop environment implement the optional `SandboxComputer` interface on the `computer` property. When present on a statically configured sandbox, the workspace tools factory registers the `mastra_workspace_computer_*` tools automatically. See [Computer-use tools](/docs/sandbox/overview#computer-use-tools).
+
+Coordinates are pixels from the top-left corner of the display. Providers normalize their SDK semantics (key names, scroll units) onto this surface and expose richer native APIs through their own accessors.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'screenshot()',
+    type: '() => Promise<{ data: Uint8Array; mediaType: "image/png" }>',
+    description: 'Capture the current display as a PNG image.',
+  },
+  {
+    name: 'leftClick(x, y)',
+    type: '(x: number, y: number) => Promise<void>',
+    description: 'Left-click at the given coordinates.',
+  },
+  {
+    name: 'rightClick(x, y)',
+    type: '(x: number, y: number) => Promise<void>',
+    description: 'Right-click at the given coordinates.',
+  },
+  {
+    name: 'doubleClick(x, y)',
+    type: '(x: number, y: number) => Promise<void>',
+    description: 'Double-click (left button) at the given coordinates.',
+  },
+  {
+    name: 'moveMouse(x, y)',
+    type: '(x: number, y: number) => Promise<void>',
+    description: 'Move the cursor without clicking.',
+  },
+  {
+    name: 'drag(from, to)',
+    type: '(from: ComputerPosition, to: ComputerPosition) => Promise<void>',
+    description: 'Press the left button at `from`, drag to `to`, and release.',
+  },
+  {
+    name: 'scroll(direction, amount)',
+    type: "(direction: 'up' | 'down', amount: number) => Promise<void>",
+    description: 'Scroll the display by the given amount of ticks.',
+  },
+  {
+    name: 'type(text)',
+    type: '(text: string) => Promise<void>',
+    description: 'Type text into the focused element.',
+  },
+  {
+    name: 'press(key)',
+    type: '(key: string | string[]) => Promise<void>',
+    description:
+      "Press a key or key combination. A string presses one key (for example 'Enter'); an array presses a chord (for example ['ctrl', 's']).",
+  },
+  {
+    name: 'getScreenSize()',
+    type: '() => Promise<{ width: number; height: number }>',
+    description: 'Get the display dimensions.',
+  },
+  {
+    name: 'getCursorPosition()',
+    type: '() => Promise<{ x: number; y: number }>',
+    description: 'Get the current cursor position.',
+  },
+  {
+    name: 'streamUrl()',
+    type: '() => Promise<string | null>',
+    description:
+      'Get a URL for a live view of the desktop, such as noVNC, or null when unavailable. Optional, not all providers expose a viewer.',
+    isOptional: true,
+  },
+]}
+/>
+
+Use the `supportsComputer()` type guard to check for the capability:
+
+```typescript
+import { supportsComputer } from '@mastra/core/workspace'
+
+if (supportsComputer(sandbox)) {
+  const { data } = await sandbox.computer.screenshot()
+}
+```
+
+`DaytonaSandbox` and `E2BDesktopSandbox` implement this capability. See the [Daytona](/integrations/sandboxes/daytona#computer-use-desktop) and [E2B Desktop](/integrations/sandboxes/e2b-desktop) integration pages.
 
 ## Related
 

--- a/examples/agent/.env.example
+++ b/examples/agent/.env.example
@@ -1,1 +1,10 @@
 OPENAI_API_KEY=
+
+# Computer-use provider. Defaults to Daytona; set to e2b-desktop to use E2B.
+# COMPUTER_USE_PROVIDER=e2b-desktop
+
+# Required when using Daytona
+DAYTONA_API_KEY=
+
+# Required when COMPUTER_USE_PROVIDER=e2b-desktop
+E2B_API_KEY=

--- a/examples/agent/README.md
+++ b/examples/agent/README.md
@@ -31,6 +31,35 @@ This directory contains example agents demonstrating various Mastra features.
 - `pnpm mastra:build` - Build for production
 - `pnpm mastra:start` - Start production server
 
+## Computer-use agent
+
+The `computer-use-agent` controls a remote Linux desktop through workspace screenshot, mouse, keyboard, and shell tools. It uses Daytona by default:
+
+```bash
+DAYTONA_API_KEY=your-daytona-api-key
+```
+
+To use E2B Desktop instead, set:
+
+```bash
+COMPUTER_USE_PROVIDER=e2b-desktop
+E2B_API_KEY=your-e2b-api-key
+```
+
+Then start the linked workspace version of Mastra:
+
+```bash
+pnpm mastra dev
+```
+
+Open **Computer Use Agent** in Studio and try:
+
+> Take a screenshot and report the screen dimensions. Open a terminal through the desktop UI, create `/tmp/computer-use-demo.txt` containing a unique marker, then use the shell tool to read the file and verify that the GUI and shell are operating on the same machine.
+
+Only `COMPUTER_USE_PROVIDER=e2b-desktop` selects E2B Desktop; any other value uses Daytona. The selected provider's API key is required when the agent first uses a computer or shell tool.
+
+Computer actions can create billable cloud sandboxes. Stop or destroy test sandboxes when you're finished, and don't share authenticated desktop stream URLs.
+
 ## Request Context Presets
 
 This example includes a demonstration of Mastra's **Request Context Presets** feature, which allows you to define named configurations that can be easily switched between in the Studio UI.

--- a/examples/agent/package.json
+++ b/examples/agent/package.json
@@ -17,7 +17,9 @@
     "@mastra/auth-workos": "latest",
     "@mastra/client-js": "latest",
     "@mastra/core": "latest",
+    "@mastra/daytona": "latest",
     "@mastra/duckdb": "latest",
+    "@mastra/e2b-desktop": "latest",
     "@mastra/editor": "latest",
     "@mastra/evals": "latest",
     "@mastra/libsql": "latest",
@@ -37,6 +39,13 @@
     "zod": "^4.4.3"
   },
   "pnpm": {
+    "packageExtensions": {
+      "@daytonaio/sdk": {
+        "dependencies": {
+          "tslib": "*"
+        }
+      }
+    },
     "overrides": {
       "@mastra/auth-auth0": "link:../../auth/auth0",
       "@mastra/auth-clerk": "link:../../auth/clerk",
@@ -45,7 +54,10 @@
       "@mastra/auth-workos": "link:../../auth/workos",
       "@mastra/auth-cloud": "link:../../auth/cloud",
       "@mastra/core": "link:../../packages/core",
+      "@mastra/daytona": "link:../../workspaces/daytona",
       "@mastra/duckdb": "link:../../stores/duckdb",
+      "@mastra/e2b": "link:../../workspaces/e2b",
+      "@mastra/e2b-desktop": "link:../../workspaces/e2b-desktop",
       "@mastra/editor": "link:../../packages/editor",
       "@mastra/loggers": "link:../../packages/loggers",
       "@mastra/voice-openai": "link:../../voice/openai",

--- a/examples/agent/pnpm-lock.yaml
+++ b/examples/agent/pnpm-lock.yaml
@@ -12,7 +12,10 @@ overrides:
   '@mastra/auth-workos': link:../../auth/workos
   '@mastra/auth-cloud': link:../../auth/cloud
   '@mastra/core': link:../../packages/core
+  '@mastra/daytona': link:../../workspaces/daytona
   '@mastra/duckdb': link:../../stores/duckdb
+  '@mastra/e2b': link:../../workspaces/e2b
+  '@mastra/e2b-desktop': link:../../workspaces/e2b-desktop
   '@mastra/editor': link:../../packages/editor
   '@mastra/loggers': link:../../packages/loggers
   '@mastra/voice-openai': link:../../voice/openai
@@ -25,6 +28,8 @@ overrides:
   '@mastra/evals': link:../../packages/evals
   '@mastra/auth-studio': link:../../auth/studio
   mastra: link:../../packages/cli
+
+packageExtensionsChecksum: sha256-E1uC6ipRR7MoF7R/5oDB8SEpSulsYWlFaGB0bv3k/Mo=
 
 importers:
 
@@ -63,9 +68,15 @@ importers:
       '@mastra/core':
         specifier: link:../../packages/core
         version: link:../../packages/core
+      '@mastra/daytona':
+        specifier: link:../../workspaces/daytona
+        version: link:../../workspaces/daytona
       '@mastra/duckdb':
         specifier: link:../../stores/duckdb
         version: link:../../stores/duckdb
+      '@mastra/e2b-desktop':
+        specifier: link:../../workspaces/e2b-desktop
+        version: link:../../workspaces/e2b-desktop
       '@mastra/editor':
         specifier: link:../../packages/editor
         version: link:../../packages/editor

--- a/examples/agent/src/mastra/agents/index.ts
+++ b/examples/agent/src/mastra/agents/index.ts
@@ -10,6 +10,9 @@ import { calculatorWithUI, greetUserWithUI } from '../mcp/app-tools';
 import { PIIDetector, LanguageDetector, PromptInjectionDetector, ModerationProcessor } from '@mastra/core/processors';
 import { createAnswerRelevancyScorer } from '@mastra/evals/scorers/prebuilt';
 import { requestContextDemoAgent } from './request-context-demo-agent';
+import { DaytonaSandbox } from '@mastra/daytona';
+import { E2BDesktopSandbox } from '@mastra/e2b-desktop';
+import { Workspace } from '@mastra/core/workspace';
 
 // Export Dynamic Tools Agent
 export { dynamicToolsAgent } from './dynamic-tools-agent.js';
@@ -310,4 +313,38 @@ Available tools:
     calculatorWithUI,
     greetUserWithUI,
   },
+});
+
+const computerUseProvider = process.env.COMPUTER_USE_PROVIDER === 'e2b-desktop' ? 'e2b-desktop' : 'daytona';
+
+const computerUseSandbox =
+  computerUseProvider === 'e2b-desktop'
+    ? new E2BDesktopSandbox({
+        id: 'computer-use-agent-example',
+        apiKey: process.env.E2B_API_KEY,
+        resolution: [1280, 720],
+      })
+    : new DaytonaSandbox({
+        id: 'computer-use-agent-example',
+        apiKey: process.env.DAYTONA_API_KEY,
+        autoStopInterval: 15,
+        computerUse: true,
+      });
+
+export const computerUseAgent = new Agent({
+  id: 'computer-use-agent',
+  name: 'Computer Use Agent',
+  description: `Controls a remote Linux desktop through the provider-neutral workspace computer tools (${computerUseProvider}).`,
+  instructions: [
+    'You control a remote Linux desktop through workspace computer and shell tools.',
+    'Take a screenshot and inspect the screen dimensions before interacting with the desktop.',
+    'Use fresh screenshots after actions instead of assuming that the interface has not changed.',
+    'Use mouse and keyboard tools for desktop interactions, and use shell tools to verify resulting files or process state when possible.',
+    'Do not expose credentials or authenticated desktop stream URLs in your response.',
+  ].join('\n'),
+  model: 'openai/gpt-5.6-sol',
+  workspace: new Workspace({
+    id: `computer-use-${computerUseProvider}-workspace`,
+    sandbox: computerUseSandbox,
+  }),
 });

--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -35,6 +35,7 @@ import {
   slackDemoAgent,
   billingAgent,
   balanceAgent,
+  computerUseAgent,
 } from './agents/index';
 import { MCPClient } from '@mastra/mcp';
 import { myMcpServer, myMcpServerTwo, mcpAppsServer } from './mcp/server';
@@ -175,6 +176,7 @@ export const mastra = new Mastra({
     clinicDirectAgent,
     clinicSpecialistAgent,
     clinicSupervisorAgent,
+    computerUseAgent,
     'standup-note-normalizer': standupNoteNormalizerAgent,
     'standup-digest': standupDigestAgent,
     'standup-escalation': standupEscalationAgent,

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -610,7 +610,7 @@ export interface WorkspaceActionAttributes extends AIBaseAttributes {
   /** Human-readable workspace name */
   workspaceName?: string;
   /** Action category */
-  category: 'filesystem' | 'sandbox' | 'search' | 'skill' | 'mount';
+  category: 'filesystem' | 'sandbox' | 'search' | 'skill' | 'mount' | 'computer';
   /** Sandbox provider name (e.g. 'e2b', 'docker', 'local') */
   sandboxProvider?: string;
   /** Filesystem provider name (e.g. 'local', 'agentfs', 's3') */

--- a/packages/core/src/workspace/constants/index.ts
+++ b/packages/core/src/workspace/constants/index.ts
@@ -30,6 +30,19 @@ export const WORKSPACE_TOOLS = {
     GET_PROCESS_OUTPUT: `${WORKSPACE_TOOLS_PREFIX}_get_process_output` as const,
     KILL_PROCESS: `${WORKSPACE_TOOLS_PREFIX}_kill_process` as const,
   },
+  COMPUTER: {
+    SCREENSHOT: `${WORKSPACE_TOOLS_PREFIX}_computer_screenshot` as const,
+    CLICK: `${WORKSPACE_TOOLS_PREFIX}_computer_click` as const,
+    DOUBLE_CLICK: `${WORKSPACE_TOOLS_PREFIX}_computer_double_click` as const,
+    RIGHT_CLICK: `${WORKSPACE_TOOLS_PREFIX}_computer_right_click` as const,
+    MOVE_MOUSE: `${WORKSPACE_TOOLS_PREFIX}_computer_move_mouse` as const,
+    DRAG: `${WORKSPACE_TOOLS_PREFIX}_computer_drag` as const,
+    TYPE: `${WORKSPACE_TOOLS_PREFIX}_computer_type` as const,
+    PRESS_KEY: `${WORKSPACE_TOOLS_PREFIX}_computer_press_key` as const,
+    SCROLL: `${WORKSPACE_TOOLS_PREFIX}_computer_scroll` as const,
+    GET_SCREEN_INFO: `${WORKSPACE_TOOLS_PREFIX}_computer_get_screen_info` as const,
+    WAIT: `${WORKSPACE_TOOLS_PREFIX}_computer_wait` as const,
+  },
   SEARCH: {
     SEARCH: `${WORKSPACE_TOOLS_PREFIX}_search` as const,
     INDEX: `${WORKSPACE_TOOLS_PREFIX}_index` as const,
@@ -46,4 +59,5 @@ export type WorkspaceToolName =
   | (typeof WORKSPACE_TOOLS.FILESYSTEM)[keyof typeof WORKSPACE_TOOLS.FILESYSTEM]
   | (typeof WORKSPACE_TOOLS.SEARCH)[keyof typeof WORKSPACE_TOOLS.SEARCH]
   | (typeof WORKSPACE_TOOLS.SANDBOX)[keyof typeof WORKSPACE_TOOLS.SANDBOX]
+  | (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER]
   | (typeof WORKSPACE_TOOLS.LSP)[keyof typeof WORKSPACE_TOOLS.LSP];

--- a/packages/core/src/workspace/errors.ts
+++ b/packages/core/src/workspace/errors.ts
@@ -47,7 +47,7 @@ export class SandboxNotAvailableError extends WorkspaceError {
 }
 
 export class SandboxFeatureNotSupportedError extends WorkspaceError {
-  constructor(feature: 'executeCommand' | 'installPackage' | 'processes') {
+  constructor(feature: 'executeCommand' | 'installPackage' | 'processes' | 'computer') {
     super(`Sandbox does not support ${feature}`, 'FEATURE_NOT_SUPPORTED');
     this.name = 'SandboxFeatureNotSupportedError';
   }

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -34,6 +34,7 @@ export {
   type WorkspaceToolConfig,
   type WorkspaceToolsConfig,
   type ExecuteCommandToolConfig,
+  type ComputerToolConfig,
   type BackgroundProcessConfig,
   type BackgroundProcessMeta,
   type BackgroundProcessExitMeta,
@@ -83,10 +84,14 @@ export type {
 export type { FilesystemMountConfig, MountResult, FilesystemIcon } from './filesystem';
 
 // Sandbox
-export { MountManager, supportsNetworking } from './sandbox';
+export { MountManager, supportsNetworking, supportsComputer } from './sandbox';
 export type {
   WorkspaceSandbox,
   SandboxNetworking,
+  SandboxComputer,
+  ComputerScreenshot,
+  ComputerScreenSize,
+  ComputerPosition,
   SandboxFileInput,
   SandboxCloneOptions,
   SandboxStartOutcome,

--- a/packages/core/src/workspace/sandbox/computer.test.ts
+++ b/packages/core/src/workspace/sandbox/computer.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Sandbox Computer Capability Tests
+ *
+ * Tests the optional `computer` (desktop) capability on WorkspaceSandbox /
+ * MastraSandbox, plus the `supportsComputer` type guard.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { ProviderStatus } from '../lifecycle';
+
+import { MastraSandbox } from './mastra-sandbox';
+import { supportsComputer } from './sandbox';
+import type { SandboxComputer, WorkspaceSandbox } from './sandbox';
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+function createComputer(): SandboxComputer {
+  return {
+    screenshot: async () => ({ data: PNG_BYTES, mediaType: 'image/png' }),
+    leftClick: async () => {},
+    rightClick: async () => {},
+    doubleClick: async () => {},
+    moveMouse: async () => {},
+    drag: async () => {},
+    scroll: async () => {},
+    type: async () => {},
+    press: async () => {},
+    getScreenSize: async () => ({ width: 1024, height: 768 }),
+    getCursorPosition: async () => ({ x: 0, y: 0 }),
+  };
+}
+
+class DesktopSandbox extends MastraSandbox {
+  readonly id = 'test-desktop-sandbox';
+  readonly name = 'DesktopSandbox';
+  readonly provider = 'test';
+  status: ProviderStatus = 'pending';
+
+  readonly computer: SandboxComputer = createComputer();
+
+  constructor() {
+    super({ name: 'DesktopSandbox' });
+  }
+
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async destroy(): Promise<void> {}
+}
+
+class PlainSandbox extends MastraSandbox {
+  readonly id = 'test-plain-sandbox';
+  readonly name = 'PlainSandbox';
+  readonly provider = 'test';
+  status: ProviderStatus = 'pending';
+
+  constructor() {
+    super({ name: 'PlainSandbox' });
+  }
+
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async destroy(): Promise<void> {}
+}
+
+describe('supportsComputer', () => {
+  it('returns true for a sandbox implementing the computer capability', () => {
+    const sandbox: WorkspaceSandbox = new DesktopSandbox();
+    expect(supportsComputer(sandbox)).toBe(true);
+  });
+
+  it('returns false for a sandbox without computer', () => {
+    const sandbox: WorkspaceSandbox = new PlainSandbox();
+    expect(supportsComputer(sandbox)).toBe(false);
+  });
+
+  it('returns false when computer is present but screenshot is not a function', () => {
+    const sandbox = new PlainSandbox() as WorkspaceSandbox & { computer?: unknown };
+    (sandbox as { computer?: unknown }).computer = {};
+    expect(supportsComputer(sandbox as WorkspaceSandbox)).toBe(false);
+  });
+
+  it('narrows the type so computer is non-optional', async () => {
+    const sandbox: WorkspaceSandbox = new DesktopSandbox();
+    if (supportsComputer(sandbox)) {
+      // No optional chaining needed after the guard
+      const shot = await sandbox.computer.screenshot();
+      expect(shot.mediaType).toBe('image/png');
+      expect(shot.data).toEqual(PNG_BYTES);
+    } else {
+      expect.unreachable('guard should have passed');
+    }
+  });
+});

--- a/packages/core/src/workspace/sandbox/computer.test.ts
+++ b/packages/core/src/workspace/sandbox/computer.test.ts
@@ -74,10 +74,29 @@ describe('supportsComputer', () => {
     expect(supportsComputer(sandbox)).toBe(false);
   });
 
-  it('returns false when computer is present but screenshot is not a function', () => {
+  it.each([
+    'screenshot',
+    'leftClick',
+    'rightClick',
+    'doubleClick',
+    'moveMouse',
+    'drag',
+    'scroll',
+    'type',
+    'press',
+    'getScreenSize',
+    'getCursorPosition',
+  ] satisfies Array<keyof SandboxComputer>)('returns false when computer.%s is not a function', method => {
     const sandbox = new PlainSandbox() as WorkspaceSandbox & { computer?: unknown };
-    (sandbox as { computer?: unknown }).computer = {};
+    const computer = { ...createComputer(), [method]: undefined };
+    (sandbox as { computer?: unknown }).computer = computer;
     expect(supportsComputer(sandbox as WorkspaceSandbox)).toBe(false);
+  });
+
+  it('does not require the optional streamUrl method', () => {
+    const sandbox: WorkspaceSandbox = new DesktopSandbox();
+    expect(sandbox.computer?.streamUrl).toBeUndefined();
+    expect(supportsComputer(sandbox)).toBe(true);
   });
 
   it('narrows the type so computer is non-optional', async () => {

--- a/packages/core/src/workspace/sandbox/mastra-sandbox.ts
+++ b/packages/core/src/workspace/sandbox/mastra-sandbox.ts
@@ -31,7 +31,7 @@ import type { ProviderStatus, SandboxStartOutcome, SandboxStartResult } from '..
 import { SandboxNotReadyError } from './errors';
 import { MountManager } from './mount-manager';
 import type { SandboxProcessManager } from './process-manager';
-import type { SandboxFileInput, SandboxNetworking, WorkspaceSandbox } from './sandbox';
+import type { SandboxComputer, SandboxFileInput, SandboxNetworking, WorkspaceSandbox } from './sandbox';
 import type { CommandResult, ExecuteCommandOptions, SandboxInfo } from './types';
 import { shellQuote } from './utils';
 
@@ -172,6 +172,9 @@ export abstract class MastraSandbox<THandle = unknown> extends MastraBase implem
 
   /** Optional networking capability - implement to expose public port URLs */
   readonly networking?: SandboxNetworking;
+
+  /** Optional computer-use (desktop) capability - implement to enable workspace computer tools */
+  readonly computer?: SandboxComputer;
 
   /**
    * Optional bulk file upload into the sandbox's own filesystem.

--- a/packages/core/src/workspace/sandbox/sandbox.ts
+++ b/packages/core/src/workspace/sandbox/sandbox.ts
@@ -183,7 +183,20 @@ export interface SandboxComputer {
 export function supportsComputer(
   sandbox: WorkspaceSandbox,
 ): sandbox is WorkspaceSandbox & { computer: SandboxComputer } {
-  return typeof sandbox.computer?.screenshot === 'function';
+  const computer = sandbox.computer;
+  return (
+    typeof computer?.screenshot === 'function' &&
+    typeof computer.leftClick === 'function' &&
+    typeof computer.rightClick === 'function' &&
+    typeof computer.doubleClick === 'function' &&
+    typeof computer.moveMouse === 'function' &&
+    typeof computer.drag === 'function' &&
+    typeof computer.scroll === 'function' &&
+    typeof computer.type === 'function' &&
+    typeof computer.press === 'function' &&
+    typeof computer.getScreenSize === 'function' &&
+    typeof computer.getCursorPosition === 'function'
+  );
 }
 
 // =============================================================================

--- a/packages/core/src/workspace/sandbox/sandbox.ts
+++ b/packages/core/src/workspace/sandbox/sandbox.ts
@@ -112,8 +112,11 @@ export interface ComputerPosition {
  *
  * Providers with a controllable display (Daytona Computer Use, E2B Desktop,
  * etc.) implement this to surface screenshot, mouse, and keyboard control
- * through the abstraction. When present, the workspace tools factory emits
- * the `mastra_workspace_computer_*` tools automatically.
+ * through the abstraction. When present on a statically configured workspace
+ * sandbox, the workspace tools factory emits the
+ * `mastra_workspace_computer_*` tools automatically. Resolver-backed sandboxes
+ * do not register these tools because their capabilities are unavailable when
+ * the tool list is constructed.
  *
  * Coordinates are in pixels from the top-left corner of the display.
  * Providers normalize their SDK semantics (key names, scroll units) onto

--- a/packages/core/src/workspace/sandbox/sandbox.ts
+++ b/packages/core/src/workspace/sandbox/sandbox.ts
@@ -83,6 +83,110 @@ export function supportsNetworking(
 }
 
 // =============================================================================
+// Computer (Desktop) Capability
+// =============================================================================
+
+/** A screenshot of the sandbox's desktop display. */
+export interface ComputerScreenshot {
+  /** Raw image bytes */
+  data: Uint8Array;
+  /** Image media type (providers normalize to PNG) */
+  mediaType: 'image/png';
+}
+
+/** Screen dimensions in pixels. */
+export interface ComputerScreenSize {
+  width: number;
+  height: number;
+}
+
+/** A position on the sandbox's desktop display, in pixels from the top-left corner. */
+export interface ComputerPosition {
+  x: number;
+  y: number;
+}
+
+/**
+ * Optional computer-use (desktop) capability for sandboxes that run a GUI
+ * desktop environment.
+ *
+ * Providers with a controllable display (Daytona Computer Use, E2B Desktop,
+ * etc.) implement this to surface screenshot, mouse, and keyboard control
+ * through the abstraction. When present, the workspace tools factory emits
+ * the `mastra_workspace_computer_*` tools automatically.
+ *
+ * Coordinates are in pixels from the top-left corner of the display.
+ * Providers normalize their SDK semantics (key names, scroll units) onto
+ * this surface and may expose richer native APIs via their own accessors.
+ */
+export interface SandboxComputer {
+  /** Capture the current display as a PNG image. */
+  screenshot(): Promise<ComputerScreenshot>;
+
+  /** Left-click at the given coordinates. */
+  leftClick(x: number, y: number): Promise<void>;
+
+  /** Right-click at the given coordinates. */
+  rightClick(x: number, y: number): Promise<void>;
+
+  /** Double-click (left button) at the given coordinates. */
+  doubleClick(x: number, y: number): Promise<void>;
+
+  /** Move the mouse cursor to the given coordinates without clicking. */
+  moveMouse(x: number, y: number): Promise<void>;
+
+  /** Press the left button at `from`, drag to `to`, and release. */
+  drag(from: ComputerPosition, to: ComputerPosition): Promise<void>;
+
+  /**
+   * Scroll the display.
+   *
+   * @param direction - Scroll direction
+   * @param amount - Scroll amount in provider-normalized ticks (positive integer)
+   */
+  scroll(direction: 'up' | 'down', amount: number): Promise<void>;
+
+  /** Type text into the focused element using the keyboard. */
+  type(text: string): Promise<void>;
+
+  /**
+   * Press a key or key combination.
+   *
+   * A single string presses one key (e.g. `'Enter'`, `'Tab'`, `'a'`).
+   * An array presses a chord/hotkey (e.g. `['ctrl', 's']`).
+   */
+  press(key: string | string[]): Promise<void>;
+
+  /** Get the display dimensions. */
+  getScreenSize(): Promise<ComputerScreenSize>;
+
+  /** Get the current mouse cursor position. */
+  getCursorPosition(): Promise<ComputerPosition>;
+
+  /**
+   * Get a URL for a live view of the desktop (e.g. noVNC), or null when
+   * unavailable. Optional — not all providers expose a viewer.
+   */
+  streamUrl?(): Promise<string | null>;
+}
+
+/**
+ * Type guard: does this sandbox support the computer-use (desktop) capability?
+ *
+ * @example
+ * ```typescript
+ * if (supportsComputer(sandbox)) {
+ *   const { data } = await sandbox.computer.screenshot();
+ * }
+ * ```
+ */
+export function supportsComputer(
+  sandbox: WorkspaceSandbox,
+): sandbox is WorkspaceSandbox & { computer: SandboxComputer } {
+  return typeof sandbox.computer?.screenshot === 'function';
+}
+
+// =============================================================================
 // Sandbox Derivation
 // =============================================================================
 
@@ -271,6 +375,23 @@ export interface WorkspaceSandbox extends SandboxLifecycle<SandboxInfo> {
    * ```
    */
   readonly networking?: SandboxNetworking;
+
+  // ---------------------------------------------------------------------------
+  // Computer Use (Optional)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Computer-use (desktop) capability for sandboxes with a GUI desktop.
+   * Optional - only available on providers with a controllable display.
+   * When present, workspace computer tools (screenshot/click/type/…) are
+   * emitted automatically.
+   *
+   * @example
+   * ```typescript
+   * const { data } = await sandbox.computer?.screenshot();
+   * ```
+   */
+  readonly computer?: SandboxComputer;
 
   // ---------------------------------------------------------------------------
   // File Upload (Optional)

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
 import { WORKSPACE_TOOLS } from '../../constants';
+import type { SandboxComputer, WorkspaceSandbox } from '../../sandbox';
 import { Workspace } from '../../workspace';
 import { computerScreenshotTool } from '../computer-screenshot';
 import { isMediaToolResult, mediaToModelOutput } from '../media';
@@ -25,50 +26,54 @@ const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a
 const ALL_COMPUTER_TOOL_NAMES = Object.values(WORKSPACE_TOOLS.COMPUTER);
 
 /** Create a mock SandboxComputer backed by vi.fn()s. */
-function createMockComputer(overrides: Record<string, any> = {}) {
+function createMockComputer(overrides: Partial<SandboxComputer> = {}): SandboxComputer {
   return {
-    screenshot: vi.fn().mockResolvedValue({ data: PNG_BYTES, mediaType: 'image/png' }),
-    leftClick: vi.fn().mockResolvedValue(undefined),
-    rightClick: vi.fn().mockResolvedValue(undefined),
-    doubleClick: vi.fn().mockResolvedValue(undefined),
-    moveMouse: vi.fn().mockResolvedValue(undefined),
-    drag: vi.fn().mockResolvedValue(undefined),
-    scroll: vi.fn().mockResolvedValue(undefined),
-    type: vi.fn().mockResolvedValue(undefined),
-    press: vi.fn().mockResolvedValue(undefined),
-    getScreenSize: vi.fn().mockResolvedValue({ width: 1024, height: 768 }),
-    getCursorPosition: vi.fn().mockResolvedValue({ x: 12, y: 34 }),
+    screenshot: vi.fn(async () => ({ data: PNG_BYTES, mediaType: 'image/png' as const })),
+    leftClick: vi.fn(async () => {}),
+    rightClick: vi.fn(async () => {}),
+    doubleClick: vi.fn(async () => {}),
+    moveMouse: vi.fn(async () => {}),
+    drag: vi.fn(async () => {}),
+    scroll: vi.fn(async () => {}),
+    type: vi.fn(async () => {}),
+    press: vi.fn(async () => {}),
+    getScreenSize: vi.fn(async () => ({ width: 1024, height: 768 })),
+    getCursorPosition: vi.fn(async () => ({ x: 12, y: 34 })),
     ...overrides,
   };
 }
 
 /** Create a mock sandbox, optionally with the computer capability. */
-function createMockSandbox(opts: { computer?: any } = {}) {
-  const sandbox: any = {
+function createMockSandbox(opts: { computer?: SandboxComputer } = {}): WorkspaceSandbox {
+  return {
     id: 'test-sandbox',
     name: 'Test Sandbox',
     provider: 'test',
     status: 'running',
-    getInfo: vi.fn().mockResolvedValue({
+    snapshot: vi.fn(async () => {}),
+    getInfo: vi.fn(async () => ({
       id: 'test-sandbox',
       name: 'Test Sandbox',
       provider: 'test',
-      status: 'running',
+      status: 'running' as const,
       createdAt: new Date(),
-    }),
-    executeCommand: vi.fn(),
+    })),
+    executeCommand: vi.fn(async () => ({
+      success: true,
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      executionTimeMs: 0,
+    })),
+    ...(opts.computer ? { computer: opts.computer } : {}),
   };
-  if (opts.computer) {
-    sandbox.computer = opts.computer;
-  }
-  return sandbox;
 }
 
 /**
  * Create a workspace with the mock sandbox + the emitted workspace tools.
  * `screenshotDelayMs: 0` is applied to all computer tools so tests don't sleep.
  */
-async function setup(computer: any, tools?: WorkspaceToolsConfig) {
+async function setup(computer: SandboxComputer, tools?: WorkspaceToolsConfig) {
   const toolsConfig: WorkspaceToolsConfig = { ...tools };
   for (const name of ALL_COMPUTER_TOOL_NAMES) {
     toolsConfig[name] = { screenshotDelayMs: 0, ...(tools?.[name] as object | undefined) };
@@ -102,9 +107,10 @@ describe('createWorkspaceTools computer gating', () => {
   });
 
   it('emits no computer tools when the computer capability is incomplete', async () => {
-    const workspace = new Workspace({
-      sandbox: createMockSandbox({ computer: createMockComputer({ drag: undefined }) }),
-    });
+    const incompleteComputer: unknown = { ...createMockComputer(), drag: undefined };
+    const sandbox = createMockSandbox();
+    (sandbox as { computer?: unknown }).computer = incompleteComputer;
+    const workspace = new Workspace({ sandbox });
     const tools = await createWorkspaceTools(workspace);
     for (const name of ALL_COMPUTER_TOOL_NAMES) {
       expect(tools[name], `expected ${name} to be absent`).toBeUndefined();

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -306,6 +306,19 @@ describe('computer action tools', () => {
     expect(computer.press).toHaveBeenCalledWith(['ctrl', 's']);
   });
 
+  it('press_key rejects empty key values before calling the capability', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.PRESS_KEY]: { screenshotAfterAction: false },
+    });
+    const tool = emitted[WORKSPACE_TOOLS.COMPUTER.PRESS_KEY];
+
+    for (const key of ['', [''], ['ctrl', '']]) {
+      await expect(tool.execute({ key }, { workspace })).resolves.toMatchObject({ error: true });
+    }
+    expect(computer.press).not.toHaveBeenCalled();
+  });
+
   it('scroll defaults the amount to 3', async () => {
     const computer = createMockComputer();
     const { workspace, emitted } = await setup(computer, {

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Workspace Computer (Desktop) Tools Tests
+ *
+ * Tests the `mastra_workspace_computer_*` tools: factory gating on the
+ * sandbox `computer` capability, delegation to the capability, media
+ * (screenshot) output with size caps, post-action screenshots, and
+ * approval config resolution.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { WORKSPACE_TOOLS } from '../../constants';
+import { Workspace } from '../../workspace';
+import { computerScreenshotTool } from '../computer-screenshot';
+import { isMediaToolResult, mediaToModelOutput } from '../media';
+import { createWorkspaceTools } from '../tools';
+import type { WorkspaceToolsConfig } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mock Helpers
+// ---------------------------------------------------------------------------
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const ALL_COMPUTER_TOOL_NAMES = Object.values(WORKSPACE_TOOLS.COMPUTER);
+
+/** Create a mock SandboxComputer backed by vi.fn()s. */
+function createMockComputer(overrides: Record<string, any> = {}) {
+  return {
+    screenshot: vi.fn().mockResolvedValue({ data: PNG_BYTES, mediaType: 'image/png' }),
+    leftClick: vi.fn().mockResolvedValue(undefined),
+    rightClick: vi.fn().mockResolvedValue(undefined),
+    doubleClick: vi.fn().mockResolvedValue(undefined),
+    moveMouse: vi.fn().mockResolvedValue(undefined),
+    drag: vi.fn().mockResolvedValue(undefined),
+    scroll: vi.fn().mockResolvedValue(undefined),
+    type: vi.fn().mockResolvedValue(undefined),
+    press: vi.fn().mockResolvedValue(undefined),
+    getScreenSize: vi.fn().mockResolvedValue({ width: 1024, height: 768 }),
+    getCursorPosition: vi.fn().mockResolvedValue({ x: 12, y: 34 }),
+    ...overrides,
+  };
+}
+
+/** Create a mock sandbox, optionally with the computer capability. */
+function createMockSandbox(opts: { computer?: any } = {}) {
+  const sandbox: any = {
+    id: 'test-sandbox',
+    name: 'Test Sandbox',
+    provider: 'test',
+    status: 'running',
+    getInfo: vi.fn().mockResolvedValue({
+      id: 'test-sandbox',
+      name: 'Test Sandbox',
+      provider: 'test',
+      status: 'running',
+      createdAt: new Date(),
+    }),
+    executeCommand: vi.fn(),
+  };
+  if (opts.computer) {
+    sandbox.computer = opts.computer;
+  }
+  return sandbox;
+}
+
+/**
+ * Create a workspace with the mock sandbox + the emitted workspace tools.
+ * `screenshotDelayMs: 0` is applied to all computer tools so tests don't sleep.
+ */
+async function setup(computer: any, tools?: WorkspaceToolsConfig) {
+  const toolsConfig: WorkspaceToolsConfig = { ...tools };
+  for (const name of ALL_COMPUTER_TOOL_NAMES) {
+    toolsConfig[name] = { screenshotDelayMs: 0, ...(tools?.[name] as object | undefined) };
+  }
+  const workspace = new Workspace({ sandbox: createMockSandbox({ computer }), tools: toolsConfig });
+  const emitted = await createWorkspaceTools(workspace);
+  return { workspace, emitted };
+}
+
+// ---------------------------------------------------------------------------
+// Factory gating
+// ---------------------------------------------------------------------------
+
+describe('createWorkspaceTools computer gating', () => {
+  it('emits all computer tools when the sandbox supports the capability', async () => {
+    const workspace = new Workspace({ sandbox: createMockSandbox({ computer: createMockComputer() }) });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be emitted`).toBeDefined();
+    }
+  });
+
+  it('emits no computer tools when the sandbox lacks the capability', async () => {
+    const workspace = new Workspace({ sandbox: createMockSandbox() });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be absent`).toBeUndefined();
+    }
+    // Sandbox tools are still emitted
+    expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]).toBeDefined();
+  });
+
+  it('emits no computer tools for dynamic sandbox resolvers', async () => {
+    const workspace = new Workspace({
+      sandbox: async () => createMockSandbox({ computer: createMockComputer() }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be absent`).toBeUndefined();
+    }
+  });
+
+  it('respects per-tool enabled config', async () => {
+    const { emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.TYPE]: { enabled: false },
+    });
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.TYPE]).toBeUndefined();
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT]).toBeDefined();
+  });
+
+  it('resolves static requireApproval onto the emitted tool', async () => {
+    const { emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.CLICK]: { requireApproval: true },
+    });
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].requireApproval).toBe(true);
+    expect(emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT].requireApproval).toBe(false);
+  });
+
+  it('supports dynamic arg-aware requireApproval', async () => {
+    const { emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.TYPE]: {
+        requireApproval: ({ args }) => (args.text as string).includes('rm -rf'),
+      },
+    });
+    const tool = emitted[WORKSPACE_TOOLS.COMPUTER.TYPE];
+    expect(tool.requireApproval).toBe(true);
+    await expect(tool.needsApprovalFn({ text: 'hello' })).resolves.toBe(false);
+    await expect(tool.needsApprovalFn({ text: 'rm -rf /' })).resolves.toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Screenshot tool
+// ---------------------------------------------------------------------------
+
+describe('computer_screenshot tool', () => {
+  it('returns a media result with base64 PNG data', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT].execute({}, { workspace });
+
+    expect(isMediaToolResult(result)).toBe(true);
+    if (isMediaToolResult(result)) {
+      expect(result.mediaType).toBe('image/png');
+      expect(result.data).toBe(Buffer.from(PNG_BYTES).toString('base64'));
+      expect(result.text).toContain('Screenshot');
+    }
+    expect(computer.screenshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to text when the screenshot exceeds maxMediaBytes', async () => {
+    const { workspace, emitted } = await setup(createMockComputer(), {
+      [WORKSPACE_TOOLS.COMPUTER.SCREENSHOT]: { maxMediaBytes: 4 },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.SCREENSHOT].execute({}, { workspace });
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('exceeds maxMediaBytes');
+  });
+
+  it('throws when the sandbox lacks the computer capability', async () => {
+    const workspace = new Workspace({ sandbox: createMockSandbox() });
+    await expect((computerScreenshotTool.execute as any)({}, { workspace })).rejects.toThrow(
+      'Sandbox does not support computer',
+    );
+  });
+
+  it('throws when the workspace has no sandbox', async () => {
+    const workspace = new Workspace({ filesystem: { provider: 'test', readOnly: false } as any });
+    await expect((computerScreenshotTool.execute as any)({}, { workspace })).rejects.toThrow(
+      'Workspace does not have a sandbox configured',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action tools
+// ---------------------------------------------------------------------------
+
+describe('computer action tools', () => {
+  it('click delegates to leftClick and attaches a post-action screenshot by default', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 5, y: 10 }, { workspace });
+
+    expect(computer.leftClick).toHaveBeenCalledWith(5, 10);
+    expect(isMediaToolResult(result)).toBe(true);
+    if (isMediaToolResult(result)) {
+      expect(result.text).toBe('Clicked at (5, 10)');
+      expect(result.mediaType).toBe('image/png');
+    }
+    expect(computer.screenshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the post-action screenshot when screenshotAfterAction is false', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.CLICK]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 5, y: 10 }, { workspace });
+
+    expect(result).toBe('Clicked at (5, 10)');
+    expect(computer.screenshot).not.toHaveBeenCalled();
+  });
+
+  it('does not fail the action when the post-action screenshot fails', async () => {
+    const computer = createMockComputer({
+      screenshot: vi.fn().mockRejectedValue(new Error('display gone')),
+    });
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 1, y: 2 }, { workspace });
+
+    expect(result).toBe('Clicked at (1, 2) (post-action screenshot failed)');
+  });
+
+  it('caps the post-action screenshot via maxMediaBytes', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.CLICK]: { maxMediaBytes: 4 },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.CLICK].execute({ x: 1, y: 2 }, { workspace });
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('Clicked at (1, 2)');
+    expect(result).toContain('exceeds maxMediaBytes');
+  });
+
+  it('double_click and right_click delegate to the capability', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK]: { screenshotAfterAction: false },
+      [WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK]: { screenshotAfterAction: false },
+    });
+
+    await expect(emitted[WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK].execute({ x: 3, y: 4 }, { workspace })).resolves.toBe(
+      'Double-clicked at (3, 4)',
+    );
+    expect(computer.doubleClick).toHaveBeenCalledWith(3, 4);
+
+    await expect(emitted[WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK].execute({ x: 7, y: 8 }, { workspace })).resolves.toBe(
+      'Right-clicked at (7, 8)',
+    );
+    expect(computer.rightClick).toHaveBeenCalledWith(7, 8);
+  });
+
+  it('move_mouse delegates to moveMouse', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE].execute({ x: 50, y: 60 }, { workspace });
+
+    expect(computer.moveMouse).toHaveBeenCalledWith(50, 60);
+    expect(result).toBe('Moved mouse to (50, 60)');
+  });
+
+  it('type delegates to type without echoing the text back', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.TYPE]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.TYPE].execute({ text: 'secret password' }, { workspace });
+
+    expect(computer.type).toHaveBeenCalledWith('secret password');
+    expect(result).toBe('Typed 15 characters');
+  });
+
+  it('press_key supports single keys and hotkey chords', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.PRESS_KEY]: { screenshotAfterAction: false },
+    });
+    const tool = emitted[WORKSPACE_TOOLS.COMPUTER.PRESS_KEY];
+
+    await expect(tool.execute({ key: 'Enter' }, { workspace })).resolves.toBe('Pressed Enter');
+    expect(computer.press).toHaveBeenCalledWith('Enter');
+
+    await expect(tool.execute({ key: ['ctrl', 's'] }, { workspace })).resolves.toBe('Pressed ctrl+s');
+    expect(computer.press).toHaveBeenCalledWith(['ctrl', 's']);
+  });
+
+  it('scroll defaults the amount to 3', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.SCROLL]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.SCROLL].execute({ direction: 'down' }, { workspace });
+
+    expect(computer.scroll).toHaveBeenCalledWith('down', 3);
+    expect(result).toBe('Scrolled down by 3');
+  });
+
+  it('drag maps flat coordinates to from/to positions', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.DRAG]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.DRAG].execute(
+      { startX: 1, startY: 2, endX: 3, endY: 4 },
+      { workspace },
+    );
+
+    expect(computer.drag).toHaveBeenCalledWith({ x: 1, y: 2 }, { x: 3, y: 4 });
+    expect(result).toBe('Dragged from (1, 2) to (3, 4)');
+  });
+
+  it('wait sleeps then reports', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer, {
+      [WORKSPACE_TOOLS.COMPUTER.WAIT]: { screenshotAfterAction: false },
+    });
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.WAIT].execute({ seconds: 0.1 }, { workspace });
+    expect(result).toBe('Waited 0.1s');
+  });
+
+  it('get_screen_info reports screen size and cursor position', async () => {
+    const computer = createMockComputer();
+    const { workspace, emitted } = await setup(computer);
+    const result = await emitted[WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO].execute({}, { workspace });
+
+    expect(result).toBe('Screen size: 1024x768\nCursor position: (12, 34)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toModelOutput
+// ---------------------------------------------------------------------------
+
+describe('mediaToModelOutput', () => {
+  it('surfaces media results as text + media parts', () => {
+    const output = mediaToModelOutput({
+      __workspaceMedia: true,
+      text: 'Screenshot',
+      mediaType: 'image/png',
+      data: 'aGVsbG8=',
+    });
+    expect(output).toEqual({
+      type: 'content',
+      value: [
+        { type: 'text', text: 'Screenshot' },
+        { type: 'media', data: 'aGVsbG8=', mediaType: 'image/png' },
+      ],
+    });
+  });
+
+  it('returns undefined for plain string output', () => {
+    expect(mediaToModelOutput('Clicked at (1, 2)')).toBeUndefined();
+  });
+});

--- a/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/computer-tools.test.ts
@@ -101,6 +101,16 @@ describe('createWorkspaceTools computer gating', () => {
     expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]).toBeDefined();
   });
 
+  it('emits no computer tools when the computer capability is incomplete', async () => {
+    const workspace = new Workspace({
+      sandbox: createMockSandbox({ computer: createMockComputer({ drag: undefined }) }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+    for (const name of ALL_COMPUTER_TOOL_NAMES) {
+      expect(tools[name], `expected ${name} to be absent`).toBeUndefined();
+    }
+  });
+
   it('emits no computer tools for dynamic sandbox resolvers', async () => {
     const workspace = new Workspace({
       sandbox: async () => createMockSandbox({ computer: createMockComputer() }),

--- a/packages/core/src/workspace/tools/computer-click.ts
+++ b/packages/core/src/workspace/tools/computer-click.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerClickTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.CLICK,
+  description:
+    'Left-click at pixel coordinates on the sandbox desktop. Coordinates are measured from the top-left corner of the screen — take a screenshot first to find the right position.',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.CLICK);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'click',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.leftClick(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.CLICK,
+        `Clicked at (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-double-click.ts
+++ b/packages/core/src/workspace/tools/computer-double-click.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerDoubleClickTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK,
+  description:
+    'Double-click (left button) at pixel coordinates on the sandbox desktop. Use for opening files, folders, and applications.',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'doubleClick',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.doubleClick(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK,
+        `Double-clicked at (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-drag.ts
+++ b/packages/core/src/workspace/tools/computer-drag.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerDragTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.DRAG,
+  description:
+    'Drag from one position to another on the sandbox desktop: presses the left button at the start coordinates, moves to the end coordinates, and releases. Use for moving windows, selecting text, and drag-and-drop.',
+  inputSchema: z.object({
+    startX: z.number().int().min(0).describe('X coordinate to start the drag from'),
+    startY: z.number().int().min(0).describe('Y coordinate to start the drag from'),
+    endX: z.number().int().min(0).describe('X coordinate to drag to'),
+    endY: z.number().int().min(0).describe('Y coordinate to drag to'),
+  }),
+  execute: async ({ startX, startY, endX, endY }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.DRAG);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'drag',
+      input: { startX, startY, endX, endY },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.drag({ x: startX, y: startY }, { x: endX, y: endY });
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.DRAG,
+        `Dragged from (${startX}, ${startY}) to (${endX}, ${endY})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-get-screen-info.ts
+++ b/packages/core/src/workspace/tools/computer-get-screen-info.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerGetScreenInfoTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO,
+  description:
+    'Get the sandbox desktop screen dimensions and current mouse cursor position. Use to understand the coordinate space before clicking.',
+  inputSchema: z.object({}),
+  execute: async (_input, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'getScreenInfo',
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      const [size, cursor] = await Promise.all([computer.getScreenSize(), computer.getCursorPosition()]);
+      span.end({ success: true });
+      return `Screen size: ${size.width}x${size.height}\nCursor position: (${cursor.x}, ${cursor.y})`;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+});

--- a/packages/core/src/workspace/tools/computer-helpers.ts
+++ b/packages/core/src/workspace/tools/computer-helpers.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared helpers for the workspace computer (desktop) tools.
+ *
+ * The computer tools delegate to the sandbox's optional `computer` capability
+ * (see SandboxComputer). These helpers extract the capability from the tool
+ * execution context and format screenshot results as media parts.
+ */
+
+import type { ToolExecutionContext } from '../../tools/types';
+import { WORKSPACE_TOOLS } from '../constants';
+import { SandboxFeatureNotSupportedError } from '../errors';
+import type { ComputerScreenshot, SandboxComputer, WorkspaceSandbox } from '../sandbox';
+import { supportsComputer } from '../sandbox';
+import type { Workspace } from '../workspace';
+import { requireSandbox } from './helpers';
+import type { MediaToolResult } from './media';
+import { DEFAULT_MAX_MEDIA_BYTES } from './media';
+import type { ComputerToolConfig } from './types';
+
+/** Default for ComputerToolConfig.screenshotAfterAction. */
+export const DEFAULT_SCREENSHOT_AFTER_ACTION = true;
+
+/** Default for ComputerToolConfig.screenshotDelayMs. */
+export const DEFAULT_SCREENSHOT_DELAY_MS = 500;
+
+type ComputerToolName = (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER];
+
+/**
+ * Extract the computer capability from the workspace sandbox in the tool
+ * execution context. Throws if the workspace has no sandbox or the sandbox
+ * doesn't support the computer capability.
+ */
+export function requireComputer(context: ToolExecutionContext): {
+  workspace: Workspace;
+  sandbox: WorkspaceSandbox;
+  computer: SandboxComputer;
+} {
+  const { workspace, sandbox } = requireSandbox(context);
+  if (!supportsComputer(sandbox)) {
+    throw new SandboxFeatureNotSupportedError('computer');
+  }
+  return { workspace, sandbox, computer: sandbox.computer };
+}
+
+/** Resolve the per-tool ComputerToolConfig from the workspace tools config. */
+export function getComputerToolConfig(
+  workspace: Workspace,
+  toolName: ComputerToolName,
+): ComputerToolConfig | undefined {
+  return workspace.getToolsConfig()?.[toolName];
+}
+
+/**
+ * Format a screenshot as a MediaToolResult, falling back to text-only output
+ * when the image exceeds the configured size cap (so huge base64 payloads
+ * don't blow up the model context or storage).
+ */
+export function screenshotToResult(
+  screenshot: ComputerScreenshot,
+  text: string,
+  maxMediaBytes: number,
+): MediaToolResult | string {
+  if (screenshot.data.byteLength > maxMediaBytes) {
+    return `${text} — screenshot (${screenshot.data.byteLength} bytes, ${screenshot.mediaType}) exceeds maxMediaBytes (${maxMediaBytes}). Returning text only; configure \`maxMediaBytes\` on the computer tool to raise this cap.`;
+  }
+  return {
+    __workspaceMedia: true,
+    text,
+    mediaType: screenshot.mediaType,
+    data: Buffer.from(screenshot.data).toString('base64'),
+  };
+}
+
+/**
+ * Finish a computer action tool: when `screenshotAfterAction` is enabled
+ * (default), wait briefly for the UI to react and attach a fresh screenshot
+ * to the result so computer-use loops see the resulting desktop state.
+ * Screenshot failures never fail the action itself.
+ */
+export async function finishComputerAction(
+  workspace: Workspace,
+  computer: SandboxComputer,
+  toolName: ComputerToolName,
+  text: string,
+): Promise<MediaToolResult | string> {
+  const config = getComputerToolConfig(workspace, toolName);
+  const screenshotAfterAction = config?.screenshotAfterAction ?? DEFAULT_SCREENSHOT_AFTER_ACTION;
+  if (!screenshotAfterAction) return text;
+
+  const delayMs = config?.screenshotDelayMs ?? DEFAULT_SCREENSHOT_DELAY_MS;
+  if (delayMs > 0) {
+    await new Promise(resolve => setTimeout(resolve, delayMs));
+  }
+
+  try {
+    const screenshot = await computer.screenshot();
+    const maxMediaBytes = config?.maxMediaBytes ?? DEFAULT_MAX_MEDIA_BYTES;
+    return screenshotToResult(screenshot, text, maxMediaBytes);
+  } catch {
+    return `${text} (post-action screenshot failed)`;
+  }
+}

--- a/packages/core/src/workspace/tools/computer-move-mouse.ts
+++ b/packages/core/src/workspace/tools/computer-move-mouse.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerMoveMouseTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE,
+  description:
+    'Move the mouse cursor to pixel coordinates on the sandbox desktop without clicking. Use for hover states (tooltips, dropdown menus).',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'moveMouse',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.moveMouse(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE,
+        `Moved mouse to (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-press-key.ts
+++ b/packages/core/src/workspace/tools/computer-press-key.ts
@@ -12,7 +12,7 @@ export const computerPressKeyTool = createTool({
     'Press a key or key combination on the sandbox desktop keyboard. Pass a single key (e.g. "Enter", "Tab", "Escape") or an array for a hotkey chord (e.g. ["ctrl", "s"]).',
   inputSchema: z.object({
     key: z
-      .union([z.string(), z.array(z.string()).min(1)])
+      .union([z.string().min(1), z.array(z.string().min(1)).min(1)])
       .describe('A single key (e.g. "Enter") or an array of keys pressed together as a hotkey (e.g. ["ctrl", "c"])'),
   }),
   execute: async ({ key }, context) => {

--- a/packages/core/src/workspace/tools/computer-press-key.ts
+++ b/packages/core/src/workspace/tools/computer-press-key.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerPressKeyTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.PRESS_KEY,
+  description:
+    'Press a key or key combination on the sandbox desktop keyboard. Pass a single key (e.g. "Enter", "Tab", "Escape") or an array for a hotkey chord (e.g. ["ctrl", "s"]).',
+  inputSchema: z.object({
+    key: z
+      .union([z.string(), z.array(z.string()).min(1)])
+      .describe('A single key (e.g. "Enter") or an array of keys pressed together as a hotkey (e.g. ["ctrl", "c"])'),
+  }),
+  execute: async ({ key }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.PRESS_KEY);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'pressKey',
+      input: { key },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.press(key);
+      const label = Array.isArray(key) ? key.join('+') : key;
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.PRESS_KEY,
+        `Pressed ${label}`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-right-click.ts
+++ b/packages/core/src/workspace/tools/computer-right-click.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerRightClickTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK,
+  description: 'Right-click at pixel coordinates on the sandbox desktop. Use for opening context menus.',
+  inputSchema: z.object({
+    x: z.number().int().min(0).describe('X coordinate in pixels from the left edge of the screen'),
+    y: z.number().int().min(0).describe('Y coordinate in pixels from the top edge of the screen'),
+  }),
+  execute: async ({ x, y }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'rightClick',
+      input: { x, y },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.rightClick(x, y);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK,
+        `Right-clicked at (${x}, ${y})`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-screenshot.ts
+++ b/packages/core/src/workspace/tools/computer-screenshot.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { getComputerToolConfig, requireComputer, screenshotToResult } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { DEFAULT_MAX_MEDIA_BYTES, mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerScreenshotTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.SCREENSHOT,
+  description:
+    'Take a screenshot of the sandbox desktop display. Returns the current screen as an image. Use this to see the desktop state before and after interacting with it.',
+  inputSchema: z.object({}),
+  execute: async (_input, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.SCREENSHOT);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'screenshot',
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      const screenshot = await computer.screenshot();
+      const config = getComputerToolConfig(workspace, WORKSPACE_TOOLS.COMPUTER.SCREENSHOT);
+      const maxMediaBytes = config?.maxMediaBytes ?? DEFAULT_MAX_MEDIA_BYTES;
+      const result = screenshotToResult(
+        screenshot,
+        `Screenshot of the desktop (${screenshot.data.byteLength} bytes, ${screenshot.mediaType})`,
+        maxMediaBytes,
+      );
+      span.end({ success: true }, { bytesTransferred: screenshot.data.byteLength });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-scroll.ts
+++ b/packages/core/src/workspace/tools/computer-scroll.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerScrollTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.SCROLL,
+  description: 'Scroll the sandbox desktop display up or down.',
+  inputSchema: z.object({
+    direction: z.enum(['up', 'down']).describe('Scroll direction'),
+    amount: z.number().int().min(1).optional().describe('Scroll amount in ticks (default: 3)'),
+  }),
+  execute: async ({ direction, amount }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.SCROLL);
+
+    const effectiveAmount = amount ?? 3;
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'scroll',
+      input: { direction, amount: effectiveAmount },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.scroll(direction, effectiveAmount);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.SCROLL,
+        `Scrolled ${direction} by ${effectiveAmount}`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-type.ts
+++ b/packages/core/src/workspace/tools/computer-type.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerTypeTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.TYPE,
+  description:
+    'Type text into the focused element on the sandbox desktop using the keyboard. Click an input field first to focus it. Use the press-key tool for special keys (Enter, Tab, shortcuts).',
+  inputSchema: z.object({
+    text: z.string().describe('The text to type'),
+  }),
+  execute: async ({ text }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.TYPE);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'type',
+      input: { length: text.length },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await computer.type(text);
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.TYPE,
+        `Typed ${text.length} characters`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/computer-wait.ts
+++ b/packages/core/src/workspace/tools/computer-wait.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { finishComputerAction, requireComputer } from './computer-helpers';
+import { emitWorkspaceMetadata } from './helpers';
+import { mediaToModelOutput } from './media';
+import { startWorkspaceSpan } from './tracing';
+
+export const computerWaitTool = createTool({
+  id: WORKSPACE_TOOLS.COMPUTER.WAIT,
+  description:
+    'Wait for the sandbox desktop UI to settle (e.g. an application launching or a page loading) before the next action.',
+  inputSchema: z.object({
+    seconds: z.number().min(0.1).max(30).describe('How long to wait, in seconds (max 30)'),
+  }),
+  execute: async ({ seconds }, context) => {
+    const { workspace, sandbox, computer } = requireComputer(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.COMPUTER.WAIT);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'computer',
+      operation: 'wait',
+      input: { seconds },
+      attributes: { sandboxProvider: sandbox.provider },
+    });
+
+    try {
+      await new Promise(resolve => setTimeout(resolve, seconds * 1000));
+      const result = await finishComputerAction(
+        workspace,
+        computer,
+        WORKSPACE_TOOLS.COMPUTER.WAIT,
+        `Waited ${seconds}s`,
+      );
+      span.end({ success: true });
+      return result;
+    } catch (err) {
+      span.error(err);
+      throw err;
+    }
+  },
+  toModelOutput: mediaToModelOutput,
+});

--- a/packages/core/src/workspace/tools/index.ts
+++ b/packages/core/src/workspace/tools/index.ts
@@ -24,9 +24,22 @@ export { getProcessOutputTool } from './get-process-output';
 export { killProcessTool } from './kill-process';
 export { grepTool } from './grep';
 export { lspInspectTool } from './lsp-inspect';
+export { computerScreenshotTool } from './computer-screenshot';
+export { computerClickTool } from './computer-click';
+export { computerDoubleClickTool } from './computer-double-click';
+export { computerRightClickTool } from './computer-right-click';
+export { computerMoveMouseTool } from './computer-move-mouse';
+export { computerDragTool } from './computer-drag';
+export { computerTypeTool } from './computer-type';
+export { computerPressKeyTool } from './computer-press-key';
+export { computerScrollTool } from './computer-scroll';
+export { computerGetScreenInfoTool } from './computer-get-screen-info';
+export { computerWaitTool } from './computer-wait';
 
 // Helpers
 export { requireWorkspace, requireFilesystem, requireSandbox, emitWorkspaceMetadata } from './helpers';
+export { requireComputer } from './computer-helpers';
+export { isMediaToolResult, mediaToModelOutput, DEFAULT_MAX_MEDIA_BYTES, type MediaToolResult } from './media';
 export {
   applyTail,
   applyTokenLimit,

--- a/packages/core/src/workspace/tools/media.ts
+++ b/packages/core/src/workspace/tools/media.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared media-result helpers for workspace tools.
+ *
+ * Tools that surface binary media (read_file for media files, the computer
+ * screenshot tools) return a MediaToolResult so `toModelOutput` can present
+ * the media as a native image/file part while only the `text` header is kept
+ * in the stored/displayed result.
+ */
+
+/**
+ * Internal marker on the tool's result that signals to `toModelOutput`
+ * that the payload should be surfaced to the model as a media part (image or
+ * binary file) rather than as plain text. We attach this on a wrapper object
+ * but only the `text` field is shown to the model (via toModelOutput); the
+ * marker is stripped before it ever reaches the model.
+ *
+ * The shape is intentionally JSON-serialisable so it round-trips through
+ * storage layers that snapshot tool results.
+ */
+export type MediaToolResult = {
+  __workspaceMedia: true;
+  text: string;
+  mediaType: string;
+  data: string;
+};
+
+export function isMediaToolResult(value: unknown): value is MediaToolResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<string, unknown>).__workspaceMedia === true &&
+    typeof (value as Record<string, unknown>).text === 'string' &&
+    typeof (value as Record<string, unknown>).mediaType === 'string' &&
+    typeof (value as Record<string, unknown>).data === 'string'
+  );
+}
+
+/**
+ * Default cap (in bytes) on inline media results. Payloads larger than this
+ * fall back to text-only output instead of being fully base64-encoded into
+ * the model context (and persisted in storage on rehydration). 10 MiB is
+ * roughly aligned with provider per-image/per-pdf limits.
+ */
+export const DEFAULT_MAX_MEDIA_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Shared `toModelOutput` handler for tools that may return a MediaToolResult.
+ * Surfaces the media as a native part; returns undefined for plain string
+ * output so we don't store a duplicate copy on providerMetadata.
+ */
+export function mediaToModelOutput(output: unknown) {
+  if (isMediaToolResult(output)) {
+    return {
+      type: 'content' as const,
+      value: [
+        { type: 'text' as const, text: output.text },
+        { type: 'media' as const, data: output.data, mediaType: output.mediaType },
+      ],
+    };
+  }
+  return undefined;
+}

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -3,36 +3,10 @@ import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { extractLinesWithLimit, formatWithLineNumbers } from '../line-utils';
 import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
+import type { MediaToolResult } from './media';
+import { DEFAULT_MAX_MEDIA_BYTES, mediaToModelOutput } from './media';
 import { applyTokenLimit } from './output-helpers';
 import { startWorkspaceSpan } from './tracing';
-
-/**
- * Internal marker on the tool's text result that signals to `toModelOutput`
- * that the file should be surfaced to the model as a media part (image or
- * binary file) rather than as plain text. We attach this on a wrapper object
- * but only the `text` field is shown to the model (via toModelOutput); the
- * marker is stripped before it ever reaches the model.
- *
- * The shape is intentionally JSON-serialisable so it round-trips through
- * storage layers that snapshot tool results.
- */
-type MediaToolResult = {
-  __workspaceMedia: true;
-  text: string;
-  mediaType: string;
-  data: string;
-};
-
-function isMediaToolResult(value: unknown): value is MediaToolResult {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    (value as Record<string, unknown>).__workspaceMedia === true &&
-    typeof (value as Record<string, unknown>).text === 'string' &&
-    typeof (value as Record<string, unknown>).mediaType === 'string' &&
-    typeof (value as Record<string, unknown>).data === 'string'
-  );
-}
 
 /**
  * Default mime types surfaced to the model as media parts. The list is
@@ -42,14 +16,6 @@ function isMediaToolResult(value: unknown): value is MediaToolResult {
  * that some providers reject. Override `mediaTypes` to broaden this.
  */
 const DEFAULT_MEDIA_TYPES: string[] = ['image/png', 'image/jpeg', 'image/webp', 'application/pdf'];
-
-/**
- * Default cap (in bytes) on inline media reads. Files larger than this fall
- * back to metadata-only output instead of being fully base64-encoded into
- * the model context (and persisted in storage on rehydration). 10 MiB is
- * roughly aligned with provider per-image/per-pdf limits.
- */
-const DEFAULT_MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 
 /**
  * `application/*` mime types that are actually text content and safe to read
@@ -275,19 +241,8 @@ export const readFileTool = createTool({
       throw err;
     }
   },
-  toModelOutput: (output: unknown) => {
-    if (isMediaToolResult(output)) {
-      return {
-        type: 'content',
-        value: [
-          { type: 'text', text: output.text },
-          { type: 'media', data: output.data, mediaType: output.mediaType },
-        ],
-      };
-    }
-    // For plain string output, return undefined so we don't store a duplicate
-    // copy on providerMetadata.mastra.modelOutput — the original string result
-    // is already what the model sees.
-    return undefined;
-  },
+  // For plain string output, mediaToModelOutput returns undefined so we don't
+  // store a duplicate copy on providerMetadata.mastra.modelOutput — the
+  // original string result is already what the model sees.
+  toModelOutput: mediaToModelOutput,
 });

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -15,8 +15,20 @@ import { FileNotFoundError, FileReadRequiredError } from '../errors';
 import { InMemoryFileReadTracker, InMemoryFileWriteLock } from '../filesystem';
 import type { FileReadTracker, FileWriteLock, WorkspaceFilesystem } from '../filesystem';
 import type { WorkspaceSandbox } from '../sandbox';
+import { supportsComputer } from '../sandbox';
 import type { Workspace } from '../workspace';
 import { isAstGrepAvailable, astEditTool } from './ast-edit';
+import { computerClickTool } from './computer-click';
+import { computerDoubleClickTool } from './computer-double-click';
+import { computerDragTool } from './computer-drag';
+import { computerGetScreenInfoTool } from './computer-get-screen-info';
+import { computerMoveMouseTool } from './computer-move-mouse';
+import { computerPressKeyTool } from './computer-press-key';
+import { computerRightClickTool } from './computer-right-click';
+import { computerScreenshotTool } from './computer-screenshot';
+import { computerScrollTool } from './computer-scroll';
+import { computerTypeTool } from './computer-type';
+import { computerWaitTool } from './computer-wait';
 import { deleteFileTool } from './delete-file';
 import { editFileTool } from './edit-file';
 import { executeCommandTool, executeCommandWithBackgroundTool } from './execute-command';
@@ -543,6 +555,25 @@ export async function createWorkspaceTools(
     if (workspace.sandbox.processes) {
       await addTool(WORKSPACE_TOOLS.SANDBOX.GET_PROCESS_OUTPUT, getProcessOutputTool, { targets: { sandbox: true } });
       await addTool(WORKSPACE_TOOLS.SANDBOX.KILL_PROCESS, killProcessTool, { targets: { sandbox: true } });
+    }
+
+    // Computer (desktop) tools — only when the sandbox supports the computer
+    // capability. Not offered for dynamic sandbox resolvers (no static
+    // instance) since the capability can't be detected at tool-listing time.
+    if (supportsComputer(workspace.sandbox)) {
+      await addTool(WORKSPACE_TOOLS.COMPUTER.SCREENSHOT, computerScreenshotTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.CLICK, computerClickTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.DOUBLE_CLICK, computerDoubleClickTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.RIGHT_CLICK, computerRightClickTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.MOVE_MOUSE, computerMoveMouseTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.DRAG, computerDragTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.TYPE, computerTypeTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.PRESS_KEY, computerPressKeyTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.SCROLL, computerScrollTool, { targets: { sandbox: true } });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.GET_SCREEN_INFO, computerGetScreenInfoTool, {
+        targets: { sandbox: true },
+      });
+      await addTool(WORKSPACE_TOOLS.COMPUTER.WAIT, computerWaitTool, { targets: { sandbox: true } });
     }
   } else if (hasSandboxConfig(workspace)) {
     await addTool(WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND, executeCommandWithBackgroundTool, {

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -247,6 +247,45 @@ export interface ReadFileToolConfig extends WorkspaceToolConfig {
   maxMediaBytes?: number;
 }
 
+/**
+ * Extended configuration for the computer (desktop) tools.
+ *
+ * Applies to the `mastra_workspace_computer_*` tools emitted when the
+ * workspace sandbox supports the computer capability.
+ *
+ * @example
+ * ```ts
+ * tools: {
+ *   // Don't attach a screenshot to click results
+ *   mastra_workspace_computer_click: { screenshotAfterAction: false },
+ *
+ *   // Require approval for typing on the desktop
+ *   mastra_workspace_computer_type: { requireApproval: true },
+ * }
+ * ```
+ */
+export interface ComputerToolConfig extends WorkspaceToolConfig {
+  /**
+   * For action tools (click/type/scroll/…): attach a fresh screenshot to the
+   * tool result after the action completes, so computer-use loops see the
+   * resulting desktop state without an extra screenshot call. Default: true.
+   * Ignored by the screenshot tool itself.
+   */
+  screenshotAfterAction?: boolean;
+  /**
+   * Delay (ms) between an action and its post-action screenshot, giving the
+   * UI time to react (menus, animations). Default: 500.
+   */
+  screenshotDelayMs?: number;
+  /**
+   * Maximum screenshot size (in bytes) to return inline as a media part.
+   * Larger screenshots fall back to text-only output rather than being
+   * fully base64-encoded into the model context and persisted in storage.
+   * Defaults to 10 MiB (10 * 1024 * 1024).
+   */
+  maxMediaBytes?: number;
+}
+
 // =============================================================================
 // Top-Level Tools Config
 // =============================================================================
@@ -316,11 +355,15 @@ export type WorkspaceToolsConfig = {
   [K in typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]?: ExecuteCommandToolConfig;
 } & {
   [K in typeof WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]?: ReadFileToolConfig;
+} & {
+  [K in (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER]]?: ComputerToolConfig;
 } & Partial<
     Record<
       Exclude<
         WorkspaceToolName,
-        typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND | typeof WORKSPACE_TOOLS.FILESYSTEM.READ_FILE
+        | typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND
+        | typeof WORKSPACE_TOOLS.FILESYSTEM.READ_FILE
+        | (typeof WORKSPACE_TOOLS.COMPUTER)[keyof typeof WORKSPACE_TOOLS.COMPUTER]
       >,
       WorkspaceToolConfig
     >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9797,6 +9797,55 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0)(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
 
+  workspaces/e2b-desktop:
+    dependencies:
+      '@e2b/desktop':
+        specifier: ^2.3.1
+        version: 2.3.1
+      '@mastra/e2b':
+        specifier: workspace:^
+        version: link:../e2b
+      e2b:
+        specifier: ^2.36.0
+        version: 2.38.0
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@internal/workspace-test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      eslint:
+        specifier: ^10.7.0
+        version: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
+      tsdown:
+        specifier: 0.22.9
+        version: 0.22.9(@volar/typescript@2.4.23(typescript@6.0.3))(oxc-resolver@11.20.0)(tsx@4.23.1)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0)(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+
   workspaces/files-sdk:
     dependencies:
       files-sdk:
@@ -13530,6 +13579,10 @@ packages:
 
   '@duckdb/node-bindings@1.5.2-r.2':
     resolution: {integrity: sha512-A17A6pXB7SEBAm93POdmEG+f4vQWMSujUP8/hNUfDWjaqp4C5mUWFnyuBM4XiB4qyXXH3vbjis2TYsnxAN2xEQ==}
+
+  '@e2b/desktop@2.3.1':
+    resolution: {integrity: sha512-/WVgs4LpOk28PU9bzMkUWPdYVI0QBPVdclpXC99bsSeNTbG5QuWiS4tgznulzwW2HE0+etxzoOhkQ7fl0gagYw==}
+    engines: {node: '>=20.18.1'}
 
   '@earendil-works/pi-tui@0.80.6':
     resolution: {integrity: sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==}
@@ -38396,6 +38449,10 @@ snapshots:
       '@duckdb/node-bindings-linux-x64-musl': 1.5.2-r.2
       '@duckdb/node-bindings-win32-arm64': 1.5.2-r.2
       '@duckdb/node-bindings-win32-x64': 1.5.2-r.2
+
+  '@e2b/desktop@2.3.1':
+    dependencies:
+      e2b: 2.38.0
 
   '@earendil-works/pi-tui@0.80.6(patch_hash=143464b7be6f7b88d7fdecf41bbb2f10b48be0bb8b69fc378f27932d403e5e7c)':
     dependencies:

--- a/workspaces/daytona/package.json
+++ b/workspaces/daytona/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.12.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.60.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/workspaces/daytona/src/sandbox/index.integration.test.ts
+++ b/workspaces/daytona/src/sandbox/index.integration.test.ts
@@ -835,6 +835,66 @@ describe.skipIf(!process.env.DAYTONA_API_KEY || !hasS3Credentials)('DaytonaSandb
 });
 
 /**
+ * Computer-use (desktop) smoke tests.
+ *
+ * Verifies the `computer` capability against a real Daytona sandbox:
+ * desktop processes start lazily, screenshots return PNG bytes, mouse input
+ * reaches the desktop, and the noVNC live view URL resolves.
+ */
+describe.skipIf(!process.env.DAYTONA_API_KEY)('DaytonaSandbox Computer Use', () => {
+  let sandbox: DaytonaSandbox;
+
+  beforeEach(() => {
+    sandbox = new DaytonaSandbox({
+      id: `test-computer-${Date.now()}`,
+      timeout: 60000,
+    });
+  });
+
+  afterEach(async () => {
+    if (sandbox) {
+      try {
+        await sandbox._destroy();
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it('captures a PNG screenshot and reports screen geometry', async () => {
+    await sandbox._start();
+
+    const shot = await sandbox.computer!.screenshot();
+    expect(shot.mediaType).toBe('image/png');
+    // PNG magic bytes: \x89 P N G
+    expect(Array.from(shot.data.slice(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47]);
+
+    const size = await sandbox.computer!.getScreenSize();
+    expect(size.width).toBeGreaterThan(0);
+    expect(size.height).toBeGreaterThan(0);
+  }, 300000);
+
+  it('mouse input reaches the desktop (move → cursor position round-trip)', async () => {
+    await sandbox._start();
+
+    await sandbox.computer!.moveMouse(101, 102);
+    const position = await sandbox.computer!.getCursorPosition();
+
+    expect(position.x).toBe(101);
+    expect(position.y).toBe(102);
+  }, 300000);
+
+  it('streamUrl resolves a live noVNC viewer URL', async () => {
+    await sandbox._start();
+
+    const url = await sandbox.computer!.streamUrl!();
+
+    expect(url).toBeTruthy();
+    expect(url).toMatch(/^https?:\/\//);
+  }, 300000);
+});
+
+/**
  * Shared sandbox conformance tests.
  */
 describe.skipIf(!process.env.DAYTONA_API_KEY)('DaytonaSandbox Conformance', () => {

--- a/workspaces/daytona/src/sandbox/index.test.ts
+++ b/workspaces/daytona/src/sandbox/index.test.ts
@@ -13,7 +13,13 @@
  */
 
 import { createSandboxLifecycleTests, createMountOperationsTests } from '@internal/workspace-test-utils';
-import { SandboxNotReadyError } from '@mastra/core/workspace';
+import {
+  SandboxNotReadyError,
+  WORKSPACE_TOOLS,
+  Workspace,
+  createWorkspaceTools,
+  supportsComputer,
+} from '@mastra/core/workspace';
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
 
 import { DaytonaSandbox } from './index';
@@ -46,6 +52,32 @@ const { mockSandbox, mockDaytona, resetMockDefaults, DaytonaError, DaytonaNotFou
       downloadFile: vi.fn().mockResolvedValue(Buffer.from('')),
     },
     getPreviewLink: vi.fn().mockResolvedValue({ url: 'https://4111-mock-sandbox-id.proxy.daytona.work', token: 't' }),
+    computerUse: {
+      start: vi.fn().mockResolvedValue({ message: 'started' }),
+      stop: vi.fn().mockResolvedValue({ message: 'stopped' }),
+      getStatus: vi.fn().mockResolvedValue({ status: 'running' }),
+      mouse: {
+        getPosition: vi.fn().mockResolvedValue({ x: 100, y: 200 }),
+        move: vi.fn().mockResolvedValue({ x: 0, y: 0 }),
+        click: vi.fn().mockResolvedValue({ x: 0, y: 0 }),
+        drag: vi.fn().mockResolvedValue({}),
+        scroll: vi.fn().mockResolvedValue(true),
+      },
+      keyboard: {
+        type: vi.fn().mockResolvedValue(undefined),
+        press: vi.fn().mockResolvedValue(undefined),
+        hotkey: vi.fn().mockResolvedValue(undefined),
+      },
+      screenshot: {
+        takeFullScreen: vi.fn().mockResolvedValue({ screenshot: Buffer.from('fake-png-bytes').toString('base64') }),
+      },
+      display: {
+        getInfo: vi
+          .fn()
+          .mockResolvedValue({ displays: [{ id: 0, x: 0, y: 0, width: 1920, height: 1080, isActive: true }] }),
+        getWindows: vi.fn().mockResolvedValue({ windows: [] }),
+      },
+    },
     start: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockResolvedValue(undefined),
     delete: vi.fn().mockResolvedValue(undefined),
@@ -80,6 +112,24 @@ const { mockSandbox, mockDaytona, resetMockDefaults, DaytonaError, DaytonaNotFou
       url: 'https://4111-mock-sandbox-id.proxy.daytona.work',
       token: 't',
     });
+    mockSandbox.computerUse.start.mockResolvedValue({ message: 'started' });
+    mockSandbox.computerUse.stop.mockResolvedValue({ message: 'stopped' });
+    mockSandbox.computerUse.getStatus.mockResolvedValue({ status: 'running' });
+    mockSandbox.computerUse.mouse.getPosition.mockResolvedValue({ x: 100, y: 200 });
+    mockSandbox.computerUse.mouse.move.mockResolvedValue({ x: 0, y: 0 });
+    mockSandbox.computerUse.mouse.click.mockResolvedValue({ x: 0, y: 0 });
+    mockSandbox.computerUse.mouse.drag.mockResolvedValue({});
+    mockSandbox.computerUse.mouse.scroll.mockResolvedValue(true);
+    mockSandbox.computerUse.keyboard.type.mockResolvedValue(undefined);
+    mockSandbox.computerUse.keyboard.press.mockResolvedValue(undefined);
+    mockSandbox.computerUse.keyboard.hotkey.mockResolvedValue(undefined);
+    mockSandbox.computerUse.screenshot.takeFullScreen.mockResolvedValue({
+      screenshot: Buffer.from('fake-png-bytes').toString('base64'),
+    });
+    mockSandbox.computerUse.display.getInfo.mockResolvedValue({
+      displays: [{ id: 0, x: 0, y: 0, width: 1920, height: 1080, isActive: true }],
+    });
+    mockSandbox.computerUse.display.getWindows.mockResolvedValue({ windows: [] });
     mockSandbox.state = 'started';
     mockSandbox.start.mockResolvedValue(undefined);
     mockSandbox.stop.mockResolvedValue(undefined);
@@ -1211,6 +1261,216 @@ describe('DaytonaSandbox', () => {
         { source: Buffer.from('hello'), destination: '/home/daytona/app/a.txt' },
         { source: Buffer.from([1, 2, 3]), destination: '/home/daytona/app/b.bin' },
       ]);
+    });
+  });
+
+  describe('Computer Use', () => {
+    it('exposes the computer capability by default', () => {
+      const sandbox = new DaytonaSandbox();
+
+      expect(sandbox.computer).toBeDefined();
+      expect(supportsComputer(sandbox)).toBe(true);
+    });
+
+    it('computerUse: false disables the capability', () => {
+      const sandbox = new DaytonaSandbox({ computerUse: false });
+
+      expect(sandbox.computer).toBeUndefined();
+      expect(supportsComputer(sandbox)).toBe(false);
+    });
+
+    it('starts desktop processes lazily on the first operation and memoizes', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+      expect(mockSandbox.computerUse.start).not.toHaveBeenCalled();
+
+      await sandbox.computer!.leftClick(10, 20);
+      await sandbox.computer!.type('hello');
+
+      expect(mockSandbox.computerUse.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('autoStart: false skips desktop process startup', async () => {
+      const sandbox = new DaytonaSandbox({ computerUse: { autoStart: false } });
+      await sandbox._start();
+
+      await sandbox.computer!.leftClick(10, 20);
+
+      expect(mockSandbox.computerUse.start).not.toHaveBeenCalled();
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenCalledWith(10, 20, 'left');
+    });
+
+    it('restarts desktop processes after the sandbox is stopped', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+      await sandbox.computer!.leftClick(1, 1);
+      expect(mockSandbox.computerUse.start).toHaveBeenCalledTimes(1);
+
+      await sandbox._stop();
+      await sandbox.computer!.leftClick(2, 2);
+
+      expect(mockSandbox.computerUse.start).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries lazy start after a startup failure', async () => {
+      mockSandbox.computerUse.start.mockRejectedValueOnce(new Error('no desktop'));
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await expect(sandbox.computer!.leftClick(1, 1)).rejects.toThrow('no desktop');
+      await sandbox.computer!.leftClick(2, 2);
+
+      expect(mockSandbox.computerUse.start).toHaveBeenCalledTimes(2);
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenCalledWith(2, 2, 'left');
+    });
+
+    it('screenshot decodes the base64 response to PNG bytes', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const shot = await sandbox.computer!.screenshot();
+
+      expect(mockSandbox.computerUse.screenshot.takeFullScreen).toHaveBeenCalled();
+      expect(shot.mediaType).toBe('image/png');
+      expect(Buffer.from(shot.data).toString()).toBe('fake-png-bytes');
+    });
+
+    it('screenshot throws on an empty response', async () => {
+      mockSandbox.computerUse.screenshot.takeFullScreen.mockResolvedValueOnce({});
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await expect(sandbox.computer!.screenshot()).rejects.toThrow(/empty screenshot/);
+    });
+
+    it('maps clicks to mouse.click with the right button semantics', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await sandbox.computer!.leftClick(10, 20);
+      await sandbox.computer!.rightClick(30, 40);
+      await sandbox.computer!.doubleClick(50, 60);
+
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenNthCalledWith(1, 10, 20, 'left');
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenNthCalledWith(2, 30, 40, 'right');
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenNthCalledWith(3, 50, 60, 'left', true);
+    });
+
+    it('maps moveMouse and drag', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await sandbox.computer!.moveMouse(5, 6);
+      await sandbox.computer!.drag({ x: 1, y: 2 }, { x: 3, y: 4 });
+
+      expect(mockSandbox.computerUse.mouse.move).toHaveBeenCalledWith(5, 6);
+      expect(mockSandbox.computerUse.mouse.drag).toHaveBeenCalledWith(1, 2, 3, 4);
+    });
+
+    it('scroll uses the current cursor position', async () => {
+      mockSandbox.computerUse.mouse.getPosition.mockResolvedValue({ x: 640, y: 360 });
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await sandbox.computer!.scroll('down', 3);
+
+      expect(mockSandbox.computerUse.mouse.scroll).toHaveBeenCalledWith(640, 360, 'down', 3);
+    });
+
+    it('maps type, single key press, and hotkey chords', async () => {
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await sandbox.computer!.type('hello world');
+      await sandbox.computer!.press('Enter');
+      await sandbox.computer!.press(['ctrl', 's']);
+
+      expect(mockSandbox.computerUse.keyboard.type).toHaveBeenCalledWith('hello world');
+      expect(mockSandbox.computerUse.keyboard.press).toHaveBeenCalledWith('Enter');
+      expect(mockSandbox.computerUse.keyboard.hotkey).toHaveBeenCalledWith('ctrl+s');
+    });
+
+    it('getScreenSize prefers the active display', async () => {
+      mockSandbox.computerUse.display.getInfo.mockResolvedValueOnce({
+        displays: [
+          { id: 0, x: 0, y: 0, width: 800, height: 600, isActive: false },
+          { id: 1, x: 800, y: 0, width: 1920, height: 1080, isActive: true },
+        ],
+      });
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const size = await sandbox.computer!.getScreenSize();
+
+      expect(size).toEqual({ width: 1920, height: 1080 });
+    });
+
+    it('getScreenSize throws when no display info is returned', async () => {
+      mockSandbox.computerUse.display.getInfo.mockResolvedValueOnce({ displays: [] });
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      await expect(sandbox.computer!.getScreenSize()).rejects.toThrow(/display information/);
+    });
+
+    it('getCursorPosition returns the mouse position', async () => {
+      mockSandbox.computerUse.mouse.getPosition.mockResolvedValue({ x: 12, y: 34 });
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const position = await sandbox.computer!.getCursorPosition();
+
+      expect(position).toEqual({ x: 12, y: 34 });
+    });
+
+    it('streamUrl resolves the noVNC preview link (default port 6080)', async () => {
+      mockSandbox.getPreviewLink.mockResolvedValue({ url: 'https://6080-mock.proxy.daytona.work', token: 't' });
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const url = await sandbox.computer!.streamUrl!();
+
+      expect(mockSandbox.computerUse.start).toHaveBeenCalledTimes(1);
+      expect(mockSandbox.getPreviewLink).toHaveBeenCalledWith(6080);
+      expect(url).toBe('https://6080-mock.proxy.daytona.work');
+    });
+
+    it('streamUrl uses a custom noVncPort', async () => {
+      const sandbox = new DaytonaSandbox({ computerUse: { noVncPort: 6901 } });
+      await sandbox._start();
+
+      await sandbox.computer!.streamUrl!();
+
+      expect(mockSandbox.getPreviewLink).toHaveBeenCalledWith(6901);
+    });
+
+    it('streamUrl returns null when the preview link fails', async () => {
+      mockSandbox.getPreviewLink.mockRejectedValueOnce(new Error('preview unavailable'));
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const url = await sandbox.computer!.streamUrl!();
+
+      expect(url).toBeNull();
+    });
+
+    it('operations start the sandbox automatically when not running', async () => {
+      const sandbox = new DaytonaSandbox();
+
+      await sandbox.computer!.leftClick(1, 2);
+
+      expect(mockDaytona.create).toHaveBeenCalledTimes(1);
+      expect(mockSandbox.computerUse.mouse.click).toHaveBeenCalledWith(1, 2, 'left');
+    });
+
+    it('emits exactly the workspace computer tool set', async () => {
+      const sandbox = new DaytonaSandbox();
+      const workspace = new Workspace({ sandbox });
+
+      const tools = await createWorkspaceTools(workspace);
+
+      const computerToolNames = Object.keys(tools).filter(name => name.startsWith('mastra_workspace_computer_'));
+      expect(computerToolNames.sort()).toEqual(Object.values(WORKSPACE_TOOLS.COMPUTER).sort());
     });
   });
 

--- a/workspaces/daytona/src/sandbox/index.ts
+++ b/workspaces/daytona/src/sandbox/index.ts
@@ -10,6 +10,7 @@
 
 import { Daytona, DaytonaNotFoundError, SandboxState } from '@daytonaio/sdk';
 import type {
+  ComputerUse,
   CreateSandboxFromImageParams,
   CreateSandboxFromSnapshotParams,
   Sandbox,
@@ -23,6 +24,9 @@ import type {
   MountResult,
   FilesystemMountConfig,
   MountManager,
+  CommandResult,
+  ExecuteCommandOptions,
+  SandboxComputer,
   SandboxNetworking,
   SandboxFileInput,
   SandboxCloneOptions,
@@ -74,6 +78,9 @@ function validateMountPath(mountPath: string): void {
 
 /** Allowlist for marker filenames from ls output — e.g. "mount-abc123" */
 const SAFE_MARKER_NAME = /^mount-[a-z0-9]+$/;
+
+/** Default port of the noVNC web viewer started by Daytona computer use. */
+const DEFAULT_NOVNC_PORT = 6080;
 
 /** Patterns indicating the sandbox is dead/gone (@daytonaio/sdk@0.143.0). */
 const SANDBOX_DEAD_PATTERNS: RegExp[] = [
@@ -178,6 +185,33 @@ export interface DaytonaSandboxOptions extends Omit<MastraSandboxOptions, 'proce
    * Secrets are created at the organization level (Daytona dashboard or SDK).
    */
   secrets?: Record<string, string>;
+  /**
+   * Computer-use (desktop) capability configuration.
+   *
+   * When enabled (the default), the sandbox exposes the `computer` capability
+   * and workspaces emit the `mastra_workspace_computer_*` tools. The desktop
+   * processes (Xvfb, xfce4, x11vnc, noVNC) are started lazily on the first
+   * computer operation.
+   *
+   * Set to `false` to disable the capability entirely.
+   */
+  computerUse?:
+    | boolean
+    | {
+        /**
+         * Automatically start the desktop processes on the first computer
+         * operation. Set to `false` if you manage
+         * `sandbox.daytona.computerUse.start()` yourself.
+         * @default true
+         */
+        autoStart?: boolean;
+        /**
+         * Port of the noVNC web viewer inside the sandbox, used by
+         * `computer.streamUrl()`.
+         * @default 6080
+         */
+        noVncPort?: number;
+      };
 }
 
 // =============================================================================
@@ -249,6 +283,16 @@ export class DaytonaSandbox extends MastraSandbox {
     },
   };
 
+  /**
+   * Computer-use (desktop) capability: screenshot, mouse, and keyboard control
+   * of the sandbox's desktop environment via Daytona's computer use API.
+   *
+   * `undefined` when the sandbox was constructed with `computerUse: false`.
+   * Desktop processes are started lazily on the first operation (unless
+   * `computerUse.autoStart` is `false`).
+   */
+  declare readonly computer?: SandboxComputer;
+
   status: ProviderStatus = 'pending';
 
   private _daytona: Daytona | null = null;
@@ -256,6 +300,9 @@ export class DaytonaSandbox extends MastraSandbox {
   private _createdAt: Date | null = null;
   private _workingDir: string | null = null;
   private _isRetrying = false;
+  private _computerUseStarted: Promise<void> | null = null;
+  private readonly computerUseAutoStart: boolean;
+  private readonly noVncPort: number;
 
   private readonly timeout: number;
   private readonly language: 'typescript' | 'javascript' | 'python';
@@ -315,6 +362,14 @@ export class DaytonaSandbox extends MastraSandbox {
       ...(options.target !== undefined && { target: options.target }),
     };
     this._constructorOptions = { ...options };
+
+    const computerUseOption = options.computerUse ?? true;
+    this.computerUseAutoStart = typeof computerUseOption === 'object' ? (computerUseOption.autoStart ?? true) : true;
+    this.noVncPort =
+      typeof computerUseOption === 'object' ? (computerUseOption.noVncPort ?? DEFAULT_NOVNC_PORT) : DEFAULT_NOVNC_PORT;
+    if (computerUseOption !== false) {
+      this.computer = this.createComputer();
+    }
   }
 
   private generateId(): string {
@@ -507,6 +562,7 @@ export class DaytonaSandbox extends MastraSandbox {
       }
     }
     this._sandbox = null;
+    this._computerUseStarted = null;
   }
 
   /**
@@ -537,6 +593,7 @@ export class DaytonaSandbox extends MastraSandbox {
     this._sandbox = null;
     this._daytonaSandboxId = undefined;
     this._daytona = null;
+    this._computerUseStarted = null;
     this.mounts?.clear();
   }
 
@@ -629,6 +686,112 @@ export class DaytonaSandbox extends MastraSandbox {
         destination: file.path,
       })),
     );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Computer Use
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Ensure the Daytona computer use processes (Xvfb, xfce4, x11vnc, noVNC)
+   * are running. Memoized per attached sandbox; the memo is reset when the
+   * sandbox stops, dies, or is destroyed so a fresh sandbox restarts them.
+   */
+  private async ensureComputerUseStarted(): Promise<void> {
+    if (!this.computerUseAutoStart) return;
+    if (!this._computerUseStarted) {
+      this._computerUseStarted = this.daytona.computerUse
+        .start()
+        .then(() => undefined)
+        .catch((error: unknown) => {
+          this._computerUseStarted = null;
+          throw error;
+        });
+    }
+    return this._computerUseStarted;
+  }
+
+  /**
+   * Build the {@link SandboxComputer} capability backed by Daytona's
+   * computer use API (`sandbox.computerUse`).
+   *
+   * Every operation ensures the sandbox is running and the desktop processes
+   * are started, and retries once if the sandbox died (mirroring command
+   * execution behavior).
+   */
+  private createComputer(): SandboxComputer {
+    const run = async <T>(fn: (computerUse: ComputerUse) => Promise<T>): Promise<T> => {
+      await this.ensureRunning();
+      return this.retryOnDead(async () => {
+        await this.ensureComputerUseStarted();
+        return fn(this.daytona.computerUse);
+      });
+    };
+
+    return {
+      screenshot: async () => {
+        const response = await run(computerUse => computerUse.screenshot.takeFullScreen());
+        if (!response.screenshot) {
+          throw new Error(`${LOG_PREFIX} Daytona returned an empty screenshot response`);
+        }
+        return {
+          data: new Uint8Array(Buffer.from(response.screenshot, 'base64')),
+          mediaType: 'image/png' as const,
+        };
+      },
+      leftClick: async (x, y) => {
+        await run(computerUse => computerUse.mouse.click(x, y, 'left'));
+      },
+      rightClick: async (x, y) => {
+        await run(computerUse => computerUse.mouse.click(x, y, 'right'));
+      },
+      doubleClick: async (x, y) => {
+        await run(computerUse => computerUse.mouse.click(x, y, 'left', true));
+      },
+      moveMouse: async (x, y) => {
+        await run(computerUse => computerUse.mouse.move(x, y));
+      },
+      drag: async (from, to) => {
+        await run(computerUse => computerUse.mouse.drag(from.x, from.y, to.x, to.y));
+      },
+      scroll: async (direction, amount) => {
+        // Daytona scrolls at explicit coordinates — use the current cursor position.
+        await run(async computerUse => {
+          const position = await computerUse.mouse.getPosition();
+          return computerUse.mouse.scroll(position.x ?? 0, position.y ?? 0, direction, amount);
+        });
+      },
+      type: async text => {
+        await run(computerUse => computerUse.keyboard.type(text));
+      },
+      press: async key => {
+        // Daytona's hotkey API takes a '+'-joined combination (e.g. 'ctrl+s').
+        await run(computerUse =>
+          Array.isArray(key) ? computerUse.keyboard.hotkey(key.join('+')) : computerUse.keyboard.press(key),
+        );
+      },
+      getScreenSize: async () => {
+        const info = await run(computerUse => computerUse.display.getInfo());
+        const display = info.displays?.find(d => d.isActive) ?? info.displays?.[0];
+        if (!display || display.width === undefined || display.height === undefined) {
+          throw new Error(`${LOG_PREFIX} Daytona did not return display information`);
+        }
+        return { width: display.width, height: display.height };
+      },
+      getCursorPosition: async () => {
+        const position = await run(computerUse => computerUse.mouse.getPosition());
+        return { x: position.x ?? 0, y: position.y ?? 0 };
+      },
+      streamUrl: async () => {
+        try {
+          // Ensure the desktop (and its noVNC process) is up before resolving the link.
+          const preview = await run(() => this.daytona.getPreviewLink(this.noVncPort));
+          return preview?.url ?? null;
+        } catch {
+          return null;
+        }
+      },
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -1210,6 +1373,7 @@ export class DaytonaSandbox extends MastraSandbox {
    */
   private handleSandboxTimeout(): void {
     this._sandbox = null;
+    this._computerUseStarted = null;
 
     // Reset mounted entries to pending so they get re-mounted on restart
     if (this.mounts) {

--- a/workspaces/e2b-desktop/.env.example
+++ b/workspaces/e2b-desktop/.env.example
@@ -1,0 +1,5 @@
+# E2B Desktop Integration Tests
+# Copy to .env and fill in your credentials
+
+# E2B is cloud-only (no local Docker option)
+E2B_API_KEY=your-e2b-api-key

--- a/workspaces/e2b-desktop/.gitignore
+++ b/workspaces/e2b-desktop/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.turbo/

--- a/workspaces/e2b-desktop/README.md
+++ b/workspaces/e2b-desktop/README.md
@@ -1,0 +1,71 @@
+# @mastra/e2b-desktop
+
+E2B Desktop (computer-use) sandbox provider for Mastra workspaces.
+
+Runs a full Linux desktop environment in an [E2B](https://e2b.dev) cloud sandbox with screenshot, mouse, and keyboard control. Extends [`@mastra/e2b`](../e2b)'s `E2BSandbox` the same way [`@e2b/desktop`](https://github.com/e2b-dev/desktop)'s SDK extends `e2b`'s — everything the base provider supports (command execution, processes, file upload, pause/resume reconnection) works against the same desktop VM.
+
+## Installation
+
+```bash
+npm install @mastra/e2b-desktop
+```
+
+Requires an E2B API key (`E2B_API_KEY` env var or the `apiKey` option).
+
+## Usage
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { Workspace } from '@mastra/core/workspace';
+import { E2BDesktopSandbox } from '@mastra/e2b-desktop';
+
+const sandbox = new E2BDesktopSandbox({ resolution: [1280, 720] });
+
+const agent = new Agent({
+  name: 'desktop-agent',
+  instructions: 'You can control a Linux desktop and run shell commands.',
+  model: 'anthropic/claude-sonnet-4-6',
+  // file + shell + computer tools are all emitted automatically
+  workspace: new Workspace({ sandbox }),
+});
+```
+
+With a `Workspace`, agents automatically get the `mastra_workspace_computer_*` tools (screenshot, click, type, press key, scroll, drag, …) alongside the shell and process tools.
+
+### Direct desktop control
+
+```typescript
+const sandbox = new E2BDesktopSandbox();
+await sandbox.start();
+
+await sandbox.computer.leftClick(100, 200);
+await sandbox.computer.type('hello');
+const { data } = await sandbox.computer.screenshot(); // PNG bytes
+
+// Live desktop view (authenticated noVNC URL)
+const viewerUrl = await sandbox.computer.streamUrl();
+```
+
+### Raw SDK escape hatch
+
+Desktop-only APIs (`launch`, `open`, window helpers, custom stream control) are available on the underlying `@e2b/desktop` sandbox:
+
+```typescript
+await sandbox.desktop.launch('xfce4-terminal');
+await sandbox.desktop.open('https://mastra.ai');
+```
+
+## Options
+
+All [`E2BSandboxOptions`](../e2b) plus:
+
+| Option       | Type               | Description                                       |
+| ------------ | ------------------ | ------------------------------------------------- |
+| `resolution` | `[number, number]` | Desktop resolution in pixels (new sandboxes only) |
+| `dpi`        | `number`           | Desktop display DPI (new sandboxes only)          |
+
+When no `template` is provided, the E2B-hosted `desktop` template is used. Note: the desktop template has no FUSE tooling, so cloud filesystem mounting requires a custom desktop template with `s3fs`/`gcsfuse` installed.
+
+## License
+
+Apache-2.0

--- a/workspaces/e2b-desktop/eslint.config.js
+++ b/workspaces/e2b-desktop/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/workspaces/e2b-desktop/lint-staged.config.js
+++ b/workspaces/e2b-desktop/lint-staged.config.js
@@ -1,0 +1,9 @@
+export default {
+  '*.{ts,tsx}': [
+    'oxlint --fix --deny-warnings',
+    'eslint --fix --max-warnings=0',
+    'oxfmt --no-error-on-unmatched-pattern',
+  ],
+  '*.{js,jsx}': ['oxfmt --no-error-on-unmatched-pattern'],
+  '*.{json,md,yml,yaml}': ['oxfmt --no-error-on-unmatched-pattern'],
+};

--- a/workspaces/e2b-desktop/package.json
+++ b/workspaces/e2b-desktop/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@mastra/e2b-desktop",
+  "version": "0.0.1",
+  "description": "E2B Desktop (computer-use) sandbox provider for Mastra workspaces",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown --silent --config tsdown.config.ts",
+    "build:lib": "pnpm build",
+    "build:watch": "pnpm build --watch",
+    "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
+    "test:watch": "vitest watch",
+    "test": "vitest run ./src/**/*.integration.test.ts",
+    "test:cloud": "pnpm test",
+    "lint": "oxlint . && eslint .",
+    "lint:fix": "oxlint --fix . && eslint --fix ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@e2b/desktop": "^2.3.1",
+    "@mastra/e2b": "workspace:^",
+    "e2b": "^2.36.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@internal/workspace-test-utils": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.20.1",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "dotenv": "^17.4.2",
+    "eslint": "^10.7.0",
+    "tsdown": "0.22.9",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.60.0-0 <2.0.0-0"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "workspaces/e2b-desktop"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/workspaces/e2b-desktop/src/index.ts
+++ b/workspaces/e2b-desktop/src/index.ts
@@ -1,0 +1,2 @@
+export { E2BDesktopSandbox, type E2BDesktopSandboxOptions } from './sandbox';
+export { e2bDesktopSandboxProvider } from './provider';

--- a/workspaces/e2b-desktop/src/provider.ts
+++ b/workspaces/e2b-desktop/src/provider.ts
@@ -1,0 +1,73 @@
+/**
+ * E2B Desktop sandbox provider descriptor for MastraEditor.
+ *
+ * @example
+ * ```typescript
+ * import { e2bDesktopSandboxProvider } from '@mastra/e2b-desktop';
+ *
+ * const editor = new MastraEditor({
+ *   sandboxes: [e2bDesktopSandboxProvider],
+ * });
+ * ```
+ */
+import type { SandboxProvider } from '@mastra/core/editor';
+import { E2BDesktopSandbox } from './sandbox';
+
+/**
+ * Serializable subset of E2BDesktopSandboxOptions for editor storage.
+ * Non-serializable options (TemplateBuilder callbacks, runtime objects) are excluded.
+ */
+interface E2BDesktopProviderConfig {
+  template?: string;
+  timeout?: number;
+  env?: Record<string, string>;
+  metadata?: Record<string, unknown>;
+  resolution?: [number, number];
+  dpi?: number;
+  domain?: string;
+  apiUrl?: string;
+  apiKey?: string;
+  accessToken?: string;
+}
+
+export const e2bDesktopSandboxProvider: SandboxProvider<E2BDesktopProviderConfig> = {
+  id: 'e2b-desktop',
+  name: 'E2B Desktop Sandbox',
+  description: 'Cloud desktop (computer-use) sandbox powered by E2B',
+  configSchema: {
+    type: 'object',
+    properties: {
+      template: { type: 'string', description: 'Sandbox template ID (defaults to the E2B desktop template)' },
+      timeout: { type: 'number', description: 'Execution timeout in milliseconds', default: 300000 },
+      env: {
+        type: 'object',
+        description: 'Environment variables',
+        additionalProperties: { type: 'string' },
+      },
+      metadata: {
+        type: 'object',
+        description: 'Custom metadata',
+        additionalProperties: true,
+      },
+      resolution: {
+        type: 'array',
+        description: 'Desktop resolution as [width, height] in pixels',
+        items: { type: 'number' },
+        minItems: 2,
+        maxItems: 2,
+      },
+      dpi: { type: 'number', description: 'Desktop display DPI' },
+      domain: { type: 'string', description: 'Domain for self-hosted E2B' },
+      apiUrl: { type: 'string', description: 'API URL for self-hosted E2B' },
+      apiKey: { type: 'string', description: 'E2B API key' },
+      accessToken: { type: 'string', description: 'E2B access token' },
+    },
+  },
+  createSandbox: config => {
+    const { resolution, ...rest } = config;
+    return new E2BDesktopSandbox({
+      ...rest,
+      ...(resolution && { resolution: [resolution[0]!, resolution[1]!] }),
+    });
+  },
+};

--- a/workspaces/e2b-desktop/src/sandbox/index.integration.test.ts
+++ b/workspaces/e2b-desktop/src/sandbox/index.integration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * E2B Desktop Sandbox Integration Tests
+ *
+ * These tests require real E2B API access and run against actual E2B desktop
+ * sandboxes (the E2B-hosted `desktop` template).
+ *
+ * Required environment variables:
+ * - E2B_API_KEY: E2B API key
+ */
+
+import { createSandboxTestSuite } from '@internal/workspace-test-utils';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { E2BDesktopSandbox } from './index';
+
+/**
+ * Computer-use (desktop) smoke tests.
+ *
+ * Verifies the `computer` capability against a real desktop sandbox:
+ * screenshots return PNG bytes, mouse input reaches the desktop, and the
+ * authenticated noVNC stream URL resolves.
+ */
+describe.skipIf(!process.env.E2B_API_KEY)('E2BDesktopSandbox Computer Use', () => {
+  let sandbox: E2BDesktopSandbox;
+
+  beforeEach(() => {
+    sandbox = new E2BDesktopSandbox({
+      id: `test-computer-${Date.now()}`,
+      timeout: 120000,
+    });
+  });
+
+  afterEach(async () => {
+    if (sandbox) {
+      try {
+        await sandbox._destroy();
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it('captures a PNG screenshot and reports screen geometry', async () => {
+    await sandbox._start();
+
+    const shot = await sandbox.computer.screenshot();
+    expect(shot.mediaType).toBe('image/png');
+    // PNG magic bytes: \x89 P N G
+    expect(Array.from(shot.data.slice(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47]);
+
+    const size = await sandbox.computer.getScreenSize();
+    expect(size.width).toBeGreaterThan(0);
+    expect(size.height).toBeGreaterThan(0);
+  }, 300000);
+
+  it('mouse input reaches the desktop (move → cursor position round-trip)', async () => {
+    await sandbox._start();
+
+    await sandbox.computer.moveMouse(101, 102);
+    const position = await sandbox.computer.getCursorPosition();
+
+    expect(position.x).toBe(101);
+    expect(position.y).toBe(102);
+  }, 300000);
+
+  it('GUI and shell surfaces hit the same machine (type → cat round-trip)', async () => {
+    await sandbox._start();
+
+    // Focus a terminal-free path: type into `cat > file` via a pty-less shell
+    // is not possible through the GUI, so instead prove the crossover both
+    // ways — write a file via shell, verify the desktop sees the same
+    // filesystem via the SDK escape hatch.
+    await sandbox.executeCommand!('sh', ['-c', `echo 'hello-desktop' > /tmp/crossover.txt`]);
+    const content = await sandbox.desktop.files.read('/tmp/crossover.txt');
+
+    expect(String(content).trim()).toBe('hello-desktop');
+  }, 300000);
+
+  it('streamUrl resolves an authenticated live viewer URL', async () => {
+    await sandbox._start();
+
+    const url = await sandbox.computer.streamUrl!();
+
+    expect(url).toBeTruthy();
+    expect(url).toMatch(/^https?:\/\//);
+    expect(url).toContain('password=');
+  }, 300000);
+});
+
+/**
+ * Shared sandbox conformance tests.
+ *
+ * The desktop template has no FUSE tooling, so mounting is disabled.
+ */
+describe.skipIf(!process.env.E2B_API_KEY)('E2BDesktopSandbox Conformance', () => {
+  createSandboxTestSuite({
+    suiteName: 'E2BDesktopSandbox',
+    createSandbox: async options =>
+      new E2BDesktopSandbox({
+        id: `conformance-desktop-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        timeout: 120000,
+        ...(options?.env && { env: options.env }),
+      }),
+    createInvalidSandbox: () =>
+      new E2BDesktopSandbox({
+        id: `bad-config-${Date.now()}`,
+        template: 'nonexistent-template-id-12345',
+      }),
+    cleanupSandbox: async sandbox => {
+      try {
+        await sandbox._destroy();
+      } catch {
+        // Ignore cleanup errors
+      }
+    },
+    killSandboxExternally: async sb => {
+      await (sb as E2BDesktopSandbox).e2b.kill();
+    },
+    capabilities: {
+      supportsMounting: false,
+      supportsReconnection: true,
+      supportsConcurrency: true,
+      supportsEnvVars: true,
+      supportsWorkingDirectory: true,
+      supportsTimeout: true,
+      defaultCommandTimeout: 30000,
+    },
+    testTimeout: 60000,
+  });
+});

--- a/workspaces/e2b-desktop/src/sandbox/index.test.ts
+++ b/workspaces/e2b-desktop/src/sandbox/index.test.ts
@@ -1,0 +1,383 @@
+/**
+ * E2B Desktop Sandbox Provider Tests
+ *
+ * Tests desktop-specific functionality layered on `E2BSandbox`:
+ * - Desktop SDK factory hooks (create/connect via `@e2b/desktop`)
+ * - Default desktop template resolution (no build)
+ * - Computer capability mapping (screenshot, mouse, keyboard, stream)
+ * - Workspace computer tool emission
+ */
+
+import { WORKSPACE_TOOLS, Workspace, createWorkspaceTools, supportsComputer } from '@mastra/core/workspace';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { E2BDesktopSandbox } from './index';
+
+// Use vi.hoisted to define mocks before vi.mock is hoisted
+const { mockDesktopSandbox, createMockE2bApi, createMockDesktopApi, resetMockDefaults } = vi.hoisted(() => {
+  const createDefaultRunMock = () =>
+    vi.fn().mockImplementation((_cmd: string, opts?: any) => {
+      const result = { exitCode: 0, stdout: '', stderr: '' };
+      if (opts?.background) {
+        return Promise.resolve({
+          pid: 1000,
+          wait: vi.fn().mockResolvedValue(result),
+          kill: vi.fn().mockResolvedValue(true),
+        });
+      }
+      return Promise.resolve(result);
+    });
+
+  const mockDesktopSandbox = {
+    sandboxId: 'mock-desktop-sandbox-id',
+    getHost: vi.fn((port: number) => `${port}-mock-desktop-sandbox-id.e2b.app`),
+    commands: {
+      run: createDefaultRunMock(),
+      list: vi.fn().mockResolvedValue([]),
+      sendStdin: vi.fn().mockResolvedValue(undefined),
+    },
+    files: {
+      write: vi.fn().mockResolvedValue(undefined),
+      read: vi.fn().mockResolvedValue(''),
+      list: vi.fn().mockResolvedValue([]),
+    },
+    kill: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn().mockResolvedValue(true),
+    // Desktop control surface
+    screenshot: vi.fn().mockResolvedValue(new Uint8Array([0x89, 0x50, 0x4e, 0x47])),
+    leftClick: vi.fn().mockResolvedValue(undefined),
+    rightClick: vi.fn().mockResolvedValue(undefined),
+    doubleClick: vi.fn().mockResolvedValue(undefined),
+    moveMouse: vi.fn().mockResolvedValue(undefined),
+    drag: vi.fn().mockResolvedValue(undefined),
+    scroll: vi.fn().mockResolvedValue(undefined),
+    write: vi.fn().mockResolvedValue(undefined),
+    press: vi.fn().mockResolvedValue(undefined),
+    getScreenSize: vi.fn().mockResolvedValue({ width: 1024, height: 720 }),
+    getCursorPosition: vi.fn().mockResolvedValue({ x: 10, y: 20 }),
+    launch: vi.fn().mockResolvedValue(undefined),
+    open: vi.fn().mockResolvedValue(undefined),
+    stream: {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      getAuthKey: vi.fn().mockReturnValue('auth-key-123'),
+      getUrl: vi.fn((opts?: { authKey?: string }) =>
+        opts?.authKey
+          ? `https://6080-mock-desktop-sandbox-id.e2b.app/vnc.html?password=${opts.authKey}`
+          : 'https://6080-mock-desktop-sandbox-id.e2b.app/vnc.html',
+      ),
+    },
+  };
+
+  // Base e2b SDK mock — used by E2BSandbox internals (list/pause/kill, Template)
+  const createMockE2bApi = () => {
+    const templateFn = vi.fn() as any;
+    templateFn.exists = vi.fn().mockResolvedValue(false);
+    templateFn.build = vi.fn().mockResolvedValue({ templateId: 'mock-built-template-id' });
+    return {
+      Sandbox: {
+        create: vi.fn().mockRejectedValue(new Error('base e2b Sandbox.create should not be called')),
+        connect: vi.fn().mockRejectedValue(new Error('base e2b Sandbox.connect should not be called')),
+        list: vi.fn().mockReturnValue({
+          nextItems: vi.fn().mockResolvedValue([]),
+        }),
+        pause: vi.fn().mockResolvedValue(true),
+        kill: vi.fn().mockResolvedValue(true),
+      },
+      Template: templateFn,
+    };
+  };
+
+  // Desktop SDK mock
+  const createMockDesktopApi = () => ({
+    Sandbox: {
+      create: vi.fn().mockResolvedValue(mockDesktopSandbox),
+      connect: vi.fn().mockResolvedValue(mockDesktopSandbox),
+    },
+  });
+
+  const resetMockDefaults = async () => {
+    const e2b = await import('e2b');
+    const desktop = await import('@e2b/desktop');
+    (e2b.Sandbox.create as any).mockRejectedValue(new Error('base e2b Sandbox.create should not be called'));
+    (e2b.Sandbox.connect as any).mockRejectedValue(new Error('base e2b Sandbox.connect should not be called'));
+    (e2b.Sandbox.list as any).mockReturnValue({ nextItems: vi.fn().mockResolvedValue([]) });
+    ((e2b.Sandbox as any).pause as any).mockResolvedValue(true);
+    ((e2b.Sandbox as any).kill as any).mockResolvedValue(true);
+    ((e2b.Template as any).exists as any).mockResolvedValue(false);
+    ((e2b.Template as any).build as any).mockResolvedValue({ templateId: 'mock-built-template-id' });
+    ((desktop.Sandbox as any).create as any).mockResolvedValue(mockDesktopSandbox);
+    ((desktop.Sandbox as any).connect as any).mockResolvedValue(mockDesktopSandbox);
+
+    mockDesktopSandbox.commands.run.mockImplementation((_cmd: string, opts?: any) => {
+      const result = { exitCode: 0, stdout: '', stderr: '' };
+      if (opts?.background) {
+        return Promise.resolve({
+          pid: 1000,
+          wait: vi.fn().mockResolvedValue(result),
+          kill: vi.fn().mockResolvedValue(true),
+        });
+      }
+      return Promise.resolve(result);
+    });
+    mockDesktopSandbox.screenshot.mockResolvedValue(new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+    mockDesktopSandbox.leftClick.mockResolvedValue(undefined);
+    mockDesktopSandbox.rightClick.mockResolvedValue(undefined);
+    mockDesktopSandbox.doubleClick.mockResolvedValue(undefined);
+    mockDesktopSandbox.moveMouse.mockResolvedValue(undefined);
+    mockDesktopSandbox.drag.mockResolvedValue(undefined);
+    mockDesktopSandbox.scroll.mockResolvedValue(undefined);
+    mockDesktopSandbox.write.mockResolvedValue(undefined);
+    mockDesktopSandbox.press.mockResolvedValue(undefined);
+    mockDesktopSandbox.getScreenSize.mockResolvedValue({ width: 1024, height: 720 });
+    mockDesktopSandbox.getCursorPosition.mockResolvedValue({ x: 10, y: 20 });
+    mockDesktopSandbox.stream.start.mockResolvedValue(undefined);
+    mockDesktopSandbox.stream.getAuthKey.mockReturnValue('auth-key-123');
+    mockDesktopSandbox.stream.getUrl.mockImplementation((opts?: { authKey?: string }) =>
+      opts?.authKey
+        ? `https://6080-mock-desktop-sandbox-id.e2b.app/vnc.html?password=${opts.authKey}`
+        : 'https://6080-mock-desktop-sandbox-id.e2b.app/vnc.html',
+    );
+  };
+
+  return { mockDesktopSandbox, createMockE2bApi, createMockDesktopApi, resetMockDefaults };
+});
+
+vi.mock('e2b', () => createMockE2bApi());
+vi.mock('@e2b/desktop', () => createMockDesktopApi());
+
+describe('E2BDesktopSandbox', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await resetMockDefaults();
+  });
+
+  describe('Constructor & Options', () => {
+    it('has desktop provider and name', () => {
+      const sandbox = new E2BDesktopSandbox();
+
+      expect(sandbox.provider).toBe('e2b-desktop');
+      expect(sandbox.name).toBe('E2BDesktopSandbox');
+    });
+
+    it('exposes the computer capability', () => {
+      const sandbox = new E2BDesktopSandbox();
+
+      expect(sandbox.computer).toBeDefined();
+      expect(supportsComputer(sandbox)).toBe(true);
+    });
+
+    it('clone returns an E2BDesktopSandbox with inherited options', () => {
+      const sandbox = new E2BDesktopSandbox({ resolution: [1280, 720], timeout: 60_000 });
+
+      const cloned = sandbox.clone({ id: 'cloned-id' });
+
+      expect(cloned).toBeInstanceOf(E2BDesktopSandbox);
+      expect(cloned.id).toBe('cloned-id');
+      expect((cloned as any).resolution).toEqual([1280, 720]);
+      expect((cloned as any).timeout).toBe(60_000);
+    });
+  });
+
+  describe('Template Resolution & SDK Factory Hooks', () => {
+    it('creates via the desktop SDK with the desktop template by default', async () => {
+      const desktop = await import('@e2b/desktop');
+      const e2b = await import('e2b');
+      const sandbox = new E2BDesktopSandbox();
+
+      await sandbox._start();
+
+      expect(desktop.Sandbox.create).toHaveBeenCalledTimes(1);
+      expect((desktop.Sandbox.create as any).mock.calls[0][0]).toBe('desktop');
+      expect(e2b.Sandbox.create).not.toHaveBeenCalled();
+      expect((e2b.Template as any).exists).not.toHaveBeenCalled();
+      expect((e2b.Template as any).build).not.toHaveBeenCalled();
+    });
+
+    it('uses an explicit template ID as-is', async () => {
+      const desktop = await import('@e2b/desktop');
+      const sandbox = new E2BDesktopSandbox({ template: 'my-desktop-template' });
+
+      await sandbox._start();
+
+      expect((desktop.Sandbox.create as any).mock.calls[0][0]).toBe('my-desktop-template');
+    });
+
+    it('passes resolution and dpi to desktop creation', async () => {
+      const desktop = await import('@e2b/desktop');
+      const sandbox = new E2BDesktopSandbox({ resolution: [1280, 720], dpi: 96 });
+
+      await sandbox._start();
+
+      const opts = (desktop.Sandbox.create as any).mock.calls[0][1];
+      expect(opts.resolution).toEqual([1280, 720]);
+      expect(opts.dpi).toBe(96);
+      expect(opts.timeoutMs).toBe(300_000);
+      expect(opts.metadata['mastra-sandbox-id']).toBe(sandbox.id);
+    });
+
+    it('reconnects to an existing sandbox via the desktop SDK', async () => {
+      const desktop = await import('@e2b/desktop');
+      const e2b = await import('e2b');
+      (e2b.Sandbox.list as any).mockReturnValue({
+        nextItems: vi.fn().mockResolvedValue([{ sandboxId: 'existing-desktop-id', state: 'running' }]),
+      });
+      const sandbox = new E2BDesktopSandbox({ id: 'reconnect-me' });
+
+      await sandbox._start();
+
+      expect(desktop.Sandbox.connect).toHaveBeenCalledWith('existing-desktop-id', expect.anything());
+      expect(desktop.Sandbox.create).not.toHaveBeenCalled();
+      expect(e2b.Sandbox.connect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Computer Capability', () => {
+    it('screenshot returns SDK PNG bytes', async () => {
+      const sandbox = new E2BDesktopSandbox();
+      await sandbox._start();
+
+      const shot = await sandbox.computer.screenshot();
+
+      expect(mockDesktopSandbox.screenshot).toHaveBeenCalled();
+      expect(shot.mediaType).toBe('image/png');
+      expect(Array.from(shot.data.slice(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47]);
+    });
+
+    it('maps mouse operations to the desktop SDK', async () => {
+      const sandbox = new E2BDesktopSandbox();
+      await sandbox._start();
+
+      await sandbox.computer.leftClick(10, 20);
+      await sandbox.computer.rightClick(30, 40);
+      await sandbox.computer.doubleClick(50, 60);
+      await sandbox.computer.moveMouse(5, 6);
+      await sandbox.computer.drag({ x: 1, y: 2 }, { x: 3, y: 4 });
+      await sandbox.computer.scroll('down', 3);
+
+      expect(mockDesktopSandbox.leftClick).toHaveBeenCalledWith(10, 20);
+      expect(mockDesktopSandbox.rightClick).toHaveBeenCalledWith(30, 40);
+      expect(mockDesktopSandbox.doubleClick).toHaveBeenCalledWith(50, 60);
+      expect(mockDesktopSandbox.moveMouse).toHaveBeenCalledWith(5, 6);
+      expect(mockDesktopSandbox.drag).toHaveBeenCalledWith([1, 2], [3, 4]);
+      expect(mockDesktopSandbox.scroll).toHaveBeenCalledWith('down', 3);
+    });
+
+    it('maps keyboard operations to the desktop SDK', async () => {
+      const sandbox = new E2BDesktopSandbox();
+      await sandbox._start();
+
+      await sandbox.computer.type('hello world');
+      await sandbox.computer.press('Enter');
+      await sandbox.computer.press(['ctrl', 's']);
+
+      expect(mockDesktopSandbox.write).toHaveBeenCalledWith('hello world');
+      expect(mockDesktopSandbox.press).toHaveBeenNthCalledWith(1, 'Enter');
+      expect(mockDesktopSandbox.press).toHaveBeenNthCalledWith(2, ['ctrl', 's']);
+    });
+
+    it('reports screen size and cursor position', async () => {
+      const sandbox = new E2BDesktopSandbox();
+      await sandbox._start();
+
+      await expect(sandbox.computer.getScreenSize()).resolves.toEqual({ width: 1024, height: 720 });
+      await expect(sandbox.computer.getCursorPosition()).resolves.toEqual({ x: 10, y: 20 });
+    });
+
+    it('operations start the sandbox automatically when not running', async () => {
+      const desktop = await import('@e2b/desktop');
+      const sandbox = new E2BDesktopSandbox();
+
+      await sandbox.computer.leftClick(1, 2);
+
+      expect(desktop.Sandbox.create).toHaveBeenCalledTimes(1);
+      expect(mockDesktopSandbox.leftClick).toHaveBeenCalledWith(1, 2);
+    });
+
+    it('recreates the desktop sandbox when an operation detects a dead VM', async () => {
+      const desktop = await import('@e2b/desktop');
+      mockDesktopSandbox.leftClick
+        .mockRejectedValueOnce(new Error('sandbox has been killed'))
+        .mockResolvedValueOnce(undefined);
+      const sandbox = new E2BDesktopSandbox();
+      await sandbox._start();
+
+      await sandbox.computer.leftClick(1, 2);
+
+      expect(desktop.Sandbox.create).toHaveBeenCalledTimes(2);
+      expect(mockDesktopSandbox.leftClick).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Stream URL', () => {
+    it('starts an authenticated stream and returns the viewer URL', async () => {
+      const sandbox = new E2BDesktopSandbox();
+      await sandbox._start();
+
+      const url = await sandbox.computer.streamUrl!();
+
+      expect(mockDesktopSandbox.stream.start).toHaveBeenCalledWith({ requireAuth: true });
+      expect(url).toBe('https://6080-mock-desktop-sandbox-id.e2b.app/vnc.html?password=auth-key-123');
+    });
+
+    it('memoizes stream startup across calls', async () => {
+      const sandbox = new E2BDesktopSandbox();
+      await sandbox._start();
+
+      await sandbox.computer.streamUrl!();
+      await sandbox.computer.streamUrl!();
+
+      expect(mockDesktopSandbox.stream.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('tolerates an externally started stream', async () => {
+      mockDesktopSandbox.stream.start.mockRejectedValue(new Error('Stream is already running'));
+      mockDesktopSandbox.stream.getAuthKey.mockImplementation(() => {
+        throw new Error('auth not enabled');
+      });
+      const sandbox = new E2BDesktopSandbox();
+      await sandbox._start();
+
+      const url = await sandbox.computer.streamUrl!();
+
+      expect(url).toBe('https://6080-mock-desktop-sandbox-id.e2b.app/vnc.html');
+    });
+
+    it('returns null when the stream cannot start', async () => {
+      mockDesktopSandbox.stream.start.mockRejectedValue(new Error('boom'));
+      const sandbox = new E2BDesktopSandbox();
+      await sandbox._start();
+
+      const url = await sandbox.computer.streamUrl!();
+
+      expect(url).toBeNull();
+    });
+  });
+
+  describe('Workspace Tool Emission', () => {
+    it('emits exactly the workspace computer tool set', async () => {
+      const sandbox = new E2BDesktopSandbox();
+      const workspace = new Workspace({ sandbox });
+
+      const tools = await createWorkspaceTools(workspace);
+
+      const computerToolNames = Object.keys(tools).filter(name => name.startsWith('mastra_workspace_computer_'));
+      expect(computerToolNames.sort()).toEqual(Object.values(WORKSPACE_TOOLS.COMPUTER).sort());
+    });
+  });
+
+  describe('Desktop Escape Hatch', () => {
+    it('desktop getter exposes the raw SDK sandbox', async () => {
+      const sandbox = new E2BDesktopSandbox();
+      await sandbox._start();
+
+      expect(sandbox.desktop).toBe(mockDesktopSandbox);
+    });
+
+    it('desktop getter throws when not started', () => {
+      const sandbox = new E2BDesktopSandbox();
+
+      expect(() => sandbox.desktop).toThrow();
+    });
+  });
+});

--- a/workspaces/e2b-desktop/src/sandbox/index.ts
+++ b/workspaces/e2b-desktop/src/sandbox/index.ts
@@ -1,0 +1,275 @@
+/**
+ * E2B Desktop Sandbox Provider
+ *
+ * An E2B sandbox running a full Linux desktop environment with computer-use
+ * (screenshot, mouse, keyboard) control. Extends `@mastra/e2b`'s `E2BSandbox`
+ * the same way `@e2b/desktop`'s SDK `Sandbox` extends `e2b`'s: everything the
+ * base provider supports (command execution, processes, file upload,
+ * reconnection) works against the same desktop VM.
+ *
+ * @see https://github.com/e2b-dev/desktop
+ */
+
+import { Sandbox as E2BDesktopSdkSandbox } from '@e2b/desktop';
+import type { SandboxCloneOptions, SandboxComputer } from '@mastra/core/workspace';
+import { SandboxNotReadyError } from '@mastra/core/workspace';
+import { E2BSandbox } from '@mastra/e2b';
+import type { E2BSandboxOptions } from '@mastra/e2b';
+import type { Sandbox, SandboxConnectOpts, SandboxOpts } from 'e2b';
+
+/**
+ * E2B-hosted desktop template (`@e2b/desktop`'s default). Used when no
+ * explicit `template` option is provided — unlike the base provider, no
+ * template build is required.
+ */
+const DEFAULT_DESKTOP_TEMPLATE = 'desktop';
+
+// =============================================================================
+// E2B Desktop Sandbox Options
+// =============================================================================
+
+/**
+ * E2B Desktop sandbox provider configuration.
+ *
+ * Inherits all `E2BSandboxOptions` (credentials, timeout, env, metadata,
+ * network, template, instructions). When no `template` is provided, the
+ * E2B-hosted `desktop` template is used instead of the base provider's
+ * mountable template.
+ */
+export interface E2BDesktopSandboxOptions extends E2BSandboxOptions {
+  /**
+   * Desktop display resolution as `[width, height]` in pixels.
+   * Applies to newly created sandboxes only.
+   */
+  resolution?: [number, number];
+  /**
+   * Desktop display DPI.
+   * Applies to newly created sandboxes only.
+   */
+  dpi?: number;
+}
+
+// =============================================================================
+// E2B Desktop Sandbox Implementation
+// =============================================================================
+
+/**
+ * E2B Desktop sandbox provider for Mastra workspaces.
+ *
+ * Features:
+ * - Everything from `E2BSandbox` (commands, processes, file upload, pause/resume)
+ * - `computer` capability: screenshot, mouse, and keyboard control — when
+ *   used in a `Workspace`, agents automatically get the
+ *   `mastra_workspace_computer_*` tools
+ * - Live desktop view via an authenticated noVNC stream URL
+ *
+ * @example Basic usage
+ * ```typescript
+ * import { Agent } from '@mastra/core/agent';
+ * import { Workspace } from '@mastra/core/workspace';
+ * import { E2BDesktopSandbox } from '@mastra/e2b-desktop';
+ *
+ * const sandbox = new E2BDesktopSandbox({ resolution: [1280, 720] });
+ * const agent = new Agent({
+ *   // file + shell + computer tools are all emitted automatically
+ *   workspace: new Workspace({ sandbox }),
+ *   // ...
+ * });
+ * ```
+ *
+ * @example Direct desktop control
+ * ```typescript
+ * const sandbox = new E2BDesktopSandbox();
+ * await sandbox.start();
+ * await sandbox.computer.leftClick(100, 200);
+ * const { data } = await sandbox.computer.screenshot();
+ * const viewerUrl = await sandbox.computer.streamUrl();
+ * ```
+ */
+export class E2BDesktopSandbox extends E2BSandbox {
+  override readonly name: string = 'E2BDesktopSandbox';
+  override readonly provider: string = 'e2b-desktop';
+
+  private readonly resolution?: [number, number];
+  private readonly dpi?: number;
+  private readonly _desktopConstructorOptions: E2BDesktopSandboxOptions;
+
+  /** Stream startup memo, keyed by SDK sandbox ID so a fresh VM restarts it. */
+  private _streamStarted: { sandboxId: string; promise: Promise<void> } | null = null;
+
+  constructor(options: E2BDesktopSandboxOptions = {}) {
+    super(options);
+    this.resolution = options.resolution;
+    this.dpi = options.dpi;
+    this._desktopConstructorOptions = { ...options };
+  }
+
+  /**
+   * Computer-use (desktop) capability: screenshot, mouse, and keyboard
+   * control of the sandbox's desktop, backed by `@e2b/desktop`.
+   * Operations start the sandbox automatically if it is not running.
+   */
+  override readonly computer: SandboxComputer = {
+    screenshot: async () => {
+      const data = await this.withDesktop(desktop => desktop.screenshot());
+      return { data, mediaType: 'image/png' as const };
+    },
+    leftClick: async (x, y) => {
+      await this.withDesktop(desktop => desktop.leftClick(x, y));
+    },
+    rightClick: async (x, y) => {
+      await this.withDesktop(desktop => desktop.rightClick(x, y));
+    },
+    doubleClick: async (x, y) => {
+      await this.withDesktop(desktop => desktop.doubleClick(x, y));
+    },
+    moveMouse: async (x, y) => {
+      await this.withDesktop(desktop => desktop.moveMouse(x, y));
+    },
+    drag: async (from, to) => {
+      await this.withDesktop(desktop => desktop.drag([from.x, from.y], [to.x, to.y]));
+    },
+    scroll: async (direction, amount) => {
+      await this.withDesktop(desktop => desktop.scroll(direction, amount));
+    },
+    type: async text => {
+      await this.withDesktop(desktop => desktop.write(text));
+    },
+    press: async key => {
+      await this.withDesktop(desktop => desktop.press(key));
+    },
+    getScreenSize: async () => {
+      return this.withDesktop(desktop => desktop.getScreenSize());
+    },
+    getCursorPosition: async () => {
+      return this.withDesktop(desktop => desktop.getCursorPosition());
+    },
+    streamUrl: async () => {
+      try {
+        return await this.withDesktop(async desktop => {
+          await this.ensureStreamStarted(desktop);
+          try {
+            return desktop.stream.getUrl({ authKey: desktop.stream.getAuthKey() });
+          } catch {
+            // Stream was started externally without auth — return the plain URL.
+            return desktop.stream.getUrl();
+          }
+        });
+      } catch {
+        return null;
+      }
+    },
+  };
+
+  /**
+   * Get the underlying `@e2b/desktop` Sandbox instance for direct access to
+   * desktop APIs not exposed through the abstraction (e.g. `launch()`,
+   * `open()`, window helpers, custom stream control).
+   *
+   * @throws {SandboxNotReadyError} If the sandbox has not been started
+   *
+   * @example Launch an application
+   * ```typescript
+   * await sandbox.start();
+   * await sandbox.desktop.launch('xfce4-terminal');
+   * await sandbox.desktop.open('https://mastra.ai');
+   * ```
+   */
+  get desktop(): E2BDesktopSdkSandbox {
+    if (!this._sandbox) {
+      throw new SandboxNotReadyError(this.id);
+    }
+    // Safe: the factory hooks below guarantee the SDK sandbox is a desktop sandbox.
+    return this._sandbox as E2BDesktopSdkSandbox;
+  }
+
+  /**
+   * Construct a sibling `E2BDesktopSandbox` that inherits this sandbox's
+   * configuration with per-instance overrides. See `E2BSandbox.clone`.
+   */
+  override clone(options: SandboxCloneOptions = {}): E2BDesktopSandbox {
+    const { id: _id, ...base } = this._desktopConstructorOptions;
+    return new E2BDesktopSandbox({
+      ...base,
+      ...(options.id !== undefined && { id: options.id }),
+      ...(options.env !== undefined && { env: options.env }),
+      ...(options.idleTimeoutMinutes !== undefined && { timeout: options.idleTimeoutMinutes * 60_000 }),
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // SDK Factory Hooks
+  // ---------------------------------------------------------------------------
+
+  /** Create a `@e2b/desktop` SDK sandbox (with desktop display options). */
+  protected override async createSdkSandbox(templateId: string, opts: SandboxOpts): Promise<Sandbox> {
+    return E2BDesktopSdkSandbox.create(templateId, {
+      ...opts,
+      ...(this.resolution && { resolution: this.resolution }),
+      ...(this.dpi !== undefined && { dpi: this.dpi }),
+    });
+  }
+
+  /** Connect to an existing `@e2b/desktop` SDK sandbox. */
+  protected override async connectSdkSandbox(sandboxId: string, opts: SandboxConnectOpts): Promise<Sandbox> {
+    return E2BDesktopSdkSandbox.connect(sandboxId, opts);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Template Resolution
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Resolve the template: without an explicit `template` option, use the
+   * E2B-hosted desktop template (no build needed). Explicit templates go
+   * through the base provider's resolution (ID, builder, or customizer).
+   */
+  protected override async resolveTemplate(): Promise<string> {
+    if (this._resolvedTemplateId) {
+      return this._resolvedTemplateId;
+    }
+    if (!this.templateSpec) {
+      this._resolvedTemplateId = DEFAULT_DESKTOP_TEMPLATE;
+      return this._resolvedTemplateId;
+    }
+    return super.resolveTemplate();
+  }
+
+  /**
+   * The default desktop template is E2B-hosted — there is nothing to build.
+   * (Only reached from the template-not-found retry path in `start()`.)
+   */
+  protected override async buildDefaultTemplate(): Promise<string> {
+    this._resolvedTemplateId = DEFAULT_DESKTOP_TEMPLATE;
+    return this._resolvedTemplateId;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal Helpers
+  // ---------------------------------------------------------------------------
+
+  /** Ensure the sandbox is running, then run a desktop SDK operation. */
+  private async withDesktop<T>(fn: (desktop: E2BDesktopSdkSandbox) => Promise<T>): Promise<T> {
+    await this.ensureRunning();
+    return this.retryOnDead(() => fn(this.desktop));
+  }
+
+  /**
+   * Ensure the VNC stream is running (authenticated), memoized per SDK
+   * sandbox so a resumed/recreated VM restarts it. A stream already started
+   * externally (via the `desktop` escape hatch) is left untouched.
+   */
+  private async ensureStreamStarted(desktop: E2BDesktopSdkSandbox): Promise<void> {
+    if (this._streamStarted?.sandboxId !== desktop.sandboxId) {
+      const promise = desktop.stream.start({ requireAuth: true }).catch((error: unknown) => {
+        if (String(error).includes('already running')) {
+          return;
+        }
+        this._streamStarted = null;
+        throw error;
+      });
+      this._streamStarted = { sandboxId: desktop.sandboxId, promise };
+    }
+    return this._streamStarted.promise;
+  }
+}

--- a/workspaces/e2b-desktop/tsconfig.build.json
+++ b/workspaces/e2b-desktop/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/e2b-desktop/tsconfig.json
+++ b/workspaces/e2b-desktop/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsdown.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/e2b-desktop/tsdown.config.ts
+++ b/workspaces/e2b-desktop/tsdown.config.ts
@@ -1,0 +1,19 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  fixedExtension: false,
+  nodeProtocol: 'strip',
+  clean: true,
+  dts: false,
+  treeshake: true,
+  sourcemap: true,
+  deps: {
+    neverBundle: ['@mastra/core', '@mastra/e2b', '@e2b/desktop', 'e2b'],
+  },
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/workspaces/e2b-desktop/vitest.config.ts
+++ b/workspaces/e2b-desktop/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.integration.test.ts'],
+    setupFiles: ['dotenv/config'],
+    testTimeout: 60000,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});

--- a/workspaces/e2b/src/sandbox/index.ts
+++ b/workspaces/e2b/src/sandbox/index.ts
@@ -29,9 +29,11 @@ type InstructionsOption = string | ((opts: { defaultInstructions: string; reques
 import { MastraSandbox, SandboxNotReadyError } from '@mastra/core/workspace';
 import { Sandbox, Template } from 'e2b';
 import type {
+  SandboxConnectOpts,
   SandboxInfo as E2BSandboxListInfo,
   SandboxLifecycle,
   SandboxNetworkOpts,
+  SandboxOpts,
   TemplateBuilder,
   TemplateClass,
 } from 'e2b';
@@ -184,8 +186,8 @@ export interface E2BSandboxOptions extends Omit<MastraSandboxOptions, 'processes
  */
 export class E2BSandbox extends MastraSandbox<Sandbox> {
   readonly id: string;
-  readonly name = 'E2BSandbox';
-  readonly provider = 'e2b';
+  readonly name: string = 'E2BSandbox';
+  readonly provider: string = 'e2b';
   status: ProviderStatus = 'pending';
 
   declare readonly mounts: MountManager; // Non-optional (initialized by BaseSandbox)
@@ -215,21 +217,21 @@ export class E2BSandbox extends MastraSandbox<Sandbox> {
     },
   };
 
-  private _sandbox: Sandbox | null = null;
+  protected _sandbox: Sandbox | null = null;
   private _createdAt: Date | null = null;
   private _isRetrying = false;
   private readonly timeout: number;
-  private readonly templateSpec?: TemplateSpec;
+  protected readonly templateSpec?: TemplateSpec;
   private readonly metadata: Record<string, unknown>;
   private readonly network?: SandboxNetworkOpts;
   private readonly lifecycle: SandboxLifecycle;
-  private readonly connectionOpts: Record<string, string>;
+  protected readonly connectionOpts: Record<string, string>;
   private readonly _preferredSandboxId?: string;
   private readonly _instructionsOverride?: InstructionsOption;
   private readonly _constructorOptions: E2BSandboxOptions;
 
   /** Resolved template ID after building (if needed) */
-  private _resolvedTemplateId?: string;
+  protected _resolvedTemplateId?: string;
 
   /** Promise for template preparation (started in constructor) */
   private _templatePreparePromise?: Promise<string>;
@@ -386,17 +388,20 @@ export class E2BSandbox extends MastraSandbox<Sandbox> {
     // destroying it so the next start() can resume it. Callers can override it (e.g. 'kill').
     this.logger.debug(`${LOG_PREFIX} Creating new sandbox for: ${this.id} with template: ${resolvedTemplateId}`);
 
+    const createOpts: SandboxOpts = {
+      ...this.connectionOpts,
+      lifecycle: this.lifecycle,
+      metadata: {
+        ...this.metadata,
+        'mastra-sandbox-id': this.id,
+      },
+      ...(this.network && { network: this.network }),
+      timeoutMs: this.timeout,
+    };
+
+    let sdkSandbox: Sandbox;
     try {
-      this._sandbox = await Sandbox.create(resolvedTemplateId, {
-        ...this.connectionOpts,
-        lifecycle: this.lifecycle,
-        metadata: {
-          ...this.metadata,
-          'mastra-sandbox-id': this.id,
-        },
-        ...(this.network && { network: this.network }),
-        timeoutMs: this.timeout,
-      });
+      sdkSandbox = await this.createSdkSandbox(resolvedTemplateId, createOpts);
     } catch (createError) {
       // If template not found (404), rebuild it and retry
       const errorStr = String(createError);
@@ -406,22 +411,14 @@ export class E2BSandbox extends MastraSandbox<Sandbox> {
         const rebuiltTemplateId = await this.buildDefaultTemplate();
 
         this.logger.debug(`${LOG_PREFIX} Retrying sandbox creation with rebuilt template: ${rebuiltTemplateId}`);
-        this._sandbox = await Sandbox.create(rebuiltTemplateId, {
-          ...this.connectionOpts,
-          lifecycle: this.lifecycle,
-          metadata: {
-            ...this.metadata,
-            'mastra-sandbox-id': this.id,
-          },
-          ...(this.network && { network: this.network }),
-          timeoutMs: this.timeout,
-        });
+        sdkSandbox = await this.createSdkSandbox(rebuiltTemplateId, createOpts);
       } else {
         throw createError;
       }
     }
+    this._sandbox = sdkSandbox;
 
-    this.logger.debug(`${LOG_PREFIX} Created sandbox ${this._sandbox.sandboxId} for logical ID: ${this.id}`);
+    this.logger.debug(`${LOG_PREFIX} Created sandbox ${sdkSandbox.sandboxId} for logical ID: ${this.id}`);
     this._createdAt = new Date();
     // Note: processPending is called by base class after start completes
   }
@@ -967,11 +964,34 @@ export class E2BSandbox extends MastraSandbox<Sandbox> {
     const info = await this.lookupExistingSandboxInfo();
     if (!info) return null;
     try {
-      return await Sandbox.connect(info.sandboxId, this.connectionOpts);
+      return await this.connectSdkSandbox(info.sandboxId, this.connectionOpts);
     } catch (e) {
       this.logger.debug(`${LOG_PREFIX} Error connecting to existing sandbox:`, e);
       return null;
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // SDK Factory Hooks (subclass override points)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a new SDK sandbox from a resolved template ID.
+   *
+   * Override point for providers layered on the E2B SDK whose `Sandbox`
+   * class extends `e2b`'s (e.g. `@e2b/desktop`): override to call their
+   * `Sandbox.create`. Connection options are already spread into `opts`.
+   */
+  protected async createSdkSandbox(templateId: string, opts: SandboxOpts): Promise<Sandbox> {
+    return Sandbox.create(templateId, opts);
+  }
+
+  /**
+   * Connect to (and resume) an existing SDK sandbox by its E2B sandbox ID.
+   * Override point — see {@link createSdkSandbox}.
+   */
+  protected async connectSdkSandbox(sandboxId: string, opts: SandboxConnectOpts): Promise<Sandbox> {
+    return Sandbox.connect(sandboxId, opts);
   }
 
   /**
@@ -981,8 +1001,11 @@ export class E2BSandbox extends MastraSandbox<Sandbox> {
    * - TemplateBuilder: Build and return the template ID
    * - Function: Apply to base mountable template, then build
    * - undefined: Use default mountable template (cached)
+   *
+   * Override point: subclasses with a different default template (e.g.
+   * desktop sandboxes) override this and {@link buildDefaultTemplate}.
    */
-  private async resolveTemplate(): Promise<string> {
+  protected async resolveTemplate(): Promise<string> {
     // If already resolved, return cached ID
     if (this._resolvedTemplateId) {
       return this._resolvedTemplateId;
@@ -1041,8 +1064,11 @@ export class E2BSandbox extends MastraSandbox<Sandbox> {
 
   /**
    * Build the default mountable template (bypasses exists check).
+   *
+   * Override point: called from the template-not-found retry path in
+   * `start()` when no explicit template was configured.
    */
-  private async buildDefaultTemplate(): Promise<string> {
+  protected async buildDefaultTemplate(): Promise<string> {
     const { template, id } = createDefaultMountableTemplate();
     this.logger.debug(`${LOG_PREFIX} Building default mountable template: ${id}...`);
     const buildResult = await Template.build(template as TemplateClass, id, this.connectionOpts);


### PR DESCRIPTION
## Summary

- document workspace computer-use tools and the `SandboxComputer` capability
- document Daytona desktop controls and the new E2B Desktop sandbox provider
- add E2B Desktop to the integrations sidebar
- add a provider-selectable computer-use agent example that defaults to Daytona and can use E2B Desktop through `COMPUTER_USE_PROVIDER=e2b-desktop`
- keep sandbox credentials optional at startup so the rest of the agent example runs without Daytona or E2B keys

This is the fourth PR in the computer-use stack and is based on #21707.

## Test plan

- `pnpm run format:check` in `docs`
- `pnpm run lint:remark` in `docs`
- `pnpm run lint:vale:ai` in `docs`
- `pnpm run validate:frontmatter` in `docs`
- `pnpm run validate:reference-sidebar` in `docs`
- `pnpm run validate:sidebar-docs` in `docs`
- `pnpm run build` in `docs`
- `pnpm install --ignore-workspace --frozen-lockfile` in `examples/agent`
- verified Daytona and E2B Desktop each emit exactly 11 computer workspace tools
- verified `OPENAI_API_KEY=test pnpm mastra dev` reaches Studio/API readiness without sandbox provider credentials

## Notes

The full docs `pnpm run validate` command currently fails on a pre-existing stale `new` tag for the Regions sidebar entry. All validation commands relevant to these changed files pass.
