### PR TITLE
Say which identity provider a Factory signs users in against

### DIFF
--- a/.changeset/better-places-add.md
+++ b/.changeset/better-places-add.md
@@ -1,0 +1,11 @@
+---
+'@mastra/factory': patch
+---
+
+Factory now names the identity provider it falls back to. With no `auth` passed, it installs the platform-backed provider and signs users in against Mastra's hosted platform — previously without saying so anywhere, which made a local dev server look self-contained while it was talking to production.
+
+```
+[factory] Identity defers to https://platform.mastra.ai/v1 (default). Pass `auth` for your own provider, `auth: null` to disable auth, or MASTRA_SHARED_API_URL to point elsewhere.
+```
+
+Behavior is unchanged — the default still works exactly as before, it is just no longer invisible.

--- a/.changeset/mighty-jars-flash.md
+++ b/.changeset/mighty-jars-flash.md
@@ -1,0 +1,10 @@
+---
+'@mastra/auth-studio': patch
+---
+
+Exposed the resolved shared API base as a public `sharedApiUrl` property on `MastraAuthStudio`, so callers can report which identity endpoint a deployment ended up talking to instead of re-deriving it from environment variables.
+
+```ts
+const auth = new MastraAuthStudio();
+console.log(auth.sharedApiUrl); // https://platform.mastra.ai/v1
+```

--- a/.changeset/olive-jars-listen.md
+++ b/.changeset/olive-jars-listen.md
@@ -1,0 +1,14 @@
+---
+'create-factory': patch
+---
+
+A new project now states which identity provider it resolved to at boot, instead of leaving it to be guessed. With no WorkOS variables set, sign-in defers to Mastra's hosted platform — that has always been the default, but nothing said so, so a local dev server looked self-contained while it was talking to production.
+
+```
+[factory] Identity defers to https://platform.mastra.ai/v1 (default).
+[Auth] WORKOS_CLIENT_ID is missing, so self-managed WorkOS sign-in is off and identity defers to the Mastra platform instead. Set both variables to use your own WorkOS.
+```
+
+The second line is the case that used to be invisible: setting only one of `WORKOS_API_KEY` / `WORKOS_CLIENT_ID` silently kept the platform default, so a project that had asked for self-managed WorkOS authenticated its users elsewhere and only failed later with an unrelated-looking redirect error.
+
+Behavior is unchanged in every case, and `.env.example` now spells out that "no WorkOS variables" is not the same thing as "auth disabled".

--- a/auth/studio/src/index.ts
+++ b/auth/studio/src/index.ts
@@ -75,7 +75,8 @@ export class MastraAuthStudio
 {
   readonly isMastraCloudAuth = true;
 
-  private sharedApiUrl: string;
+  /** Public so callers can report which identity endpoint they resolved to. */
+  readonly sharedApiUrl: string;
   private organizationId: string | undefined;
   private useProductionCookies: boolean;
   private cookieDomain: string | undefined;

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -251,9 +251,16 @@ function resolveSandboxWorkdirBase(machine: WorkspaceSandbox, configuredWorkdir?
  *   4. otherwise host-only (no `Domain=`), which is correct for `localhost`.
  */
 function buildDefaultStudioAuth(publicUrl: string): IMastraAuthProvider {
-  return new MastraAuthStudio({
+  const provider = new MastraAuthStudio({
     cookieDomain: parentDomainFromPublicUrl(publicUrl),
   });
+  // Nobody chose this identity target, so name it. Log, not warn: the default
+  // is supported — it just must not be invisible.
+  console.log(
+    `[factory] Identity defers to ${provider.sharedApiUrl} (default). ` +
+      'Pass `auth` for your own provider, `auth: null` to disable auth, or MASTRA_SHARED_API_URL to point elsewhere.',
+  );
+  return provider;
 }
 
 /**

--- a/mastracode/web/.env.schema
+++ b/mastracode/web/.env.schema
@@ -130,6 +130,12 @@ MASTRA_PLATFORM_GITHUB_RECONCILE_ENABLED=
 # When WORKOS_API_KEY and WORKOS_CLIENT_ID are set, every route requires a
 # signed-in user (hosted login + encrypted session). This is a prerequisite
 # for the GitHub projects feature below.
+#
+# When NEITHER both of them nor MASTRA_SHARED_API_URL is set, identity is not
+# disabled — it defers to Mastra's hosted platform (production), which owns
+# the WorkOS credentials. Setting only one of the pair lands there too. Set
+# MASTRACODE_AUTH_DISABLED=1 for an auth-less instance, or
+# MASTRA_SHARED_API_URL to point at another platform.
 # ---------------------------------------------------------------------------
 
 WORKOS_API_KEY=

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -97,21 +97,32 @@ if (redisUrl) {
 //      credential (sandboxes, GitHub/Linear slots), not an identity signal —
 //      platform compute plus self-managed sign-in is a supported combination.
 //   4. Nothing configured — leave undefined and MastraFactory installs its
-//      platform-backed default provider.
+//      platform-backed default provider, which names its target at boot.
 const authDisabled = process.env.MASTRACODE_AUTH_DISABLED === '1';
-const workosConfigured = Boolean(process.env.WORKOS_API_KEY?.trim() && process.env.WORKOS_CLIENT_ID?.trim());
+const workosApiKey = process.env.WORKOS_API_KEY?.trim();
+const workosClientId = process.env.WORKOS_CLIENT_ID?.trim();
+const workosConfigured = Boolean(workosApiKey && workosClientId);
+const sharedApiUrl = process.env.MASTRA_SHARED_API_URL?.trim();
 let auth: IMastraAuthProvider | null | undefined;
 
 if (authDisabled) {
   auth = null;
-} else if (process.env.MASTRA_SHARED_API_URL?.trim()) {
-  if (workosConfigured) {
+  console.warn('[Auth] MASTRACODE_AUTH_DISABLED=1 — auth is off and every route is open.');
+} else if (sharedApiUrl) {
+  if (workosApiKey || workosClientId) {
     console.warn(
       '[Auth] WORKOS_API_KEY/WORKOS_CLIENT_ID are set but ignored: MASTRA_SHARED_API_URL takes precedence, so sign-in defers to the platform. Unset MASTRA_SHARED_API_URL to use self-managed WorkOS auth.',
     );
   }
+  console.log(`[Auth] Identity defers to the Mastra platform at ${sharedApiUrl}.`);
 } else if (workosConfigured) {
   auth = new MastraAuthWorkos({ fetchMemberships: true });
+  console.log(`[Auth] Self-managed WorkOS sign-in (client ${workosClientId}).`);
+} else if (workosApiKey || workosClientId) {
+  console.warn(
+    `[Auth] ${workosApiKey ? 'WORKOS_CLIENT_ID' : 'WORKOS_API_KEY'} is missing, so self-managed WorkOS sign-in is off ` +
+      'and identity defers to the Mastra platform instead. Set both variables to use your own WorkOS.',
+  );
 }
 
 // Direct GitHub App fallback: when the platform-backed integration isn't in


### PR DESCRIPTION
A Factory with no auth configured signs users in against Mastra's hosted platform, and nothing anywhere said so.

Before, `dev:ui` with an empty `.env` booted silently and looked entirely self-contained, while sign-in was 302-ing to `platform.mastra.ai` — production, with real orgs created behind it. That is what Marvin ran into: no WorkOS secret, no client id, and no way to tell what it was resolving to. Now each auth branch names its target at boot: the platform default, an explicit `MASTRA_SHARED_API_URL`, self-managed WorkOS, or auth disabled entirely.

The case worth looking at is a half-configured pair. Setting only `WORKOS_API_KEY` or only `WORKOS_CLIENT_ID` falls through to the platform default, so a deployment that asked for its own WorkOS authenticates its users somewhere else and only fails later with a redirect error that points at nothing useful. I considered making that a boot error — varlock already declares the rule in one direction, and `MastraAuthWorkos` refuses the incomplete pair anyway — but that turns a lost env var into an outage for a deployment that is currently running, so I kept it to a warning that names the missing variable. Worth deciding as a team rather than in this diff.

No auth flow changes destination, no test changed, and a freshly scaffolded project is unaffected: it ships both WorkOS variables commented out, keeps the platform default, and gets one extra line at boot. `.env.example` now spells out that "no WorkOS variables" is not the same thing as "auth disabled". The one thing that is not pure observability is `sharedApiUrl` becoming a public `readonly` on `MastraAuthStudio` — additive, but a published surface — which is what lets the factory name its target instead of re-deriving the hardcoded default from env.

I checked the failures in `mastracode/web/src/mastra/index.test.ts` against a clean HEAD before blaming the diff: the same tests fail without these changes, and two consecutive runs of the same code gave 7 and 3 failures, so the file is order-flaky on current main. The one constant failure is an upstream `stateSecret` requirement.
