### PR TITLE
fix(deps): repair broken lockfile blocking all CI jobs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9335,16 +9335,16 @@ importers:
         version: 17.4.2
       eslint:
         specifier: ^10.7.0
-        version: 10.7.0(jiti@2.7.0)
+        version: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
       tsdown:
         specifier: 0.22.9
-        version: 0.22.9(@volar/typescript@2.4.23)(oxc-resolver@11.20.0)(tsx@4.23.1)(typescript@6.0.3)
+        version: 0.22.9(@volar/typescript@2.4.23(typescript@6.0.3))(oxc-resolver@11.20.0)(tsx@4.23.1)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0)(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
 
   workspaces/daytona:
     dependencies:


### PR DESCRIPTION
CI is currently red on every open PR. Every job that runs the shared `Setup pnpm and Node.js` step fails before it does any real work:

```
[ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY] Broken lockfile: no entry for
'eslint@10.7.0(jiti@2.7.0)' in pnpm-lock.yaml
```

## What is going on

pnpm records each dependency in the lockfile under a key that includes its resolved peer context. The `workspaces/cloudflare-sandbox` importer added in #21596 recorded three of its versions with that peer context truncated:

| dependency | recorded | expected |
| --- | --- | --- |
| eslint | `10.7.0(jiti@2.7.0)` | `10.7.0(jiti@2.7.0)(supports-color@10.2.2)` |
| tsdown | `...(@volar/typescript@2.4.23)...` | `...(@volar/typescript@2.4.23(typescript@6.0.3))...` |
| vitest | `...(jsdom@27.4.0(...)(bufferutil@4.1.0))...` | `...(jsdom@27.4.0(...)(bufferutil@4.1.0)(supports-color@10.2.2))...` |

148 of the 149 importers that depend on eslint pin the full key. This one did not, and no snapshot exists under the short key — so `--frozen-lockfile` refuses to install.

Because install is the first step of the shared setup action, this takes out **every** job on **every** PR no matter what that PR touches. It shows up as unrelated failures in Lint, Docs E2E, Validate build outputs, Detect affected tests, and others.

## The fix

Regenerated the lockfile with `pnpm install --no-frozen-lockfile`, which is the repair pnpm recommends in the error message itself. The result is a 3-line diff confined to that one importer. No dependency versions change — only the peer-context keys are completed.

## Test plan

Reproduced and verified locally against `main`:

- **Before:** `pnpm install --frozen-lockfile` fails with the exact `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` error above
- **After:** `pnpm install --frozen-lockfile` succeeds (`Already up to date`)
- `grep -cE "version: 10\.7\.0\(jiti@2\.7\.0\)$" pnpm-lock.yaml` returns `0` — no truncated pins remain
- `pnpm --filter ./workspaces/cloudflare-sandbox exec eslint --version` resolves correctly (`v10.7.0`)

CI on this PR is itself the proof: if the setup step gets past install, the lockfile is repaired.