### PR TITLE
fix(factory): persist model pack defaults for interactive chats

### DIFF
--- a/.changeset/ripe-houses-follow.md
+++ b/.changeset/ripe-houses-follow.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Improved Factory model-pack controls so settings can choose or clear the default for new chats, while each chat can select its own pack from the composer status line.

--- a/.changeset/sour-cougars-mate.md
+++ b/.changeset/sour-cougars-mate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed model packs so each user can set a default for new interactive Factory chats while preserving thread-specific pack and model choices, refreshing edited packs, and leaving Factory work runs unaffected.

--- a/mastracode/factory-ui/src/api/keys.ts
+++ b/mastracode/factory-ui/src/api/keys.ts
@@ -60,7 +60,8 @@ export const queryKeys = {
   availableModels: () => ['available-models'] as const,
   customProviders: () => ['custom-providers'] as const,
   modelPacksAll: () => ['model-packs'] as const,
-  modelPacks: (resourceId: string | undefined) => [...queryKeys.modelPacksAll(), resourceId ?? null] as const,
+  modelPacks: (resourceId: string | undefined, scope: string | undefined) =>
+    [...queryKeys.modelPacksAll(), resourceId ?? null, scope ?? null] as const,
   om: (resourceId: string | undefined) => ['om', resourceId ?? null] as const,
   thinkingConfig: () => ['thinking-config'] as const,
   factorySkills: () => ['factory', 'skills'] as const,

--- a/mastracode/factory-ui/src/api/keys.ts
+++ b/mastracode/factory-ui/src/api/keys.ts
@@ -1,10 +1,10 @@
 /**
  * Stable, scoped React Query keys for the settings API.
  *
- * Resource-scoped lists (model packs, OM) include the `resourceId` so switching
+ * Resource-scoped lists such as OM include the `resourceId` so switching
  * factories yields a distinct cache entry instead of leaking another factory's
- * data. Keeping every key in one place makes invalidation in the mutation hooks
- * unambiguous.
+ * data. Personal settings such as model packs use one user-scoped key. Keeping
+ * every key in one place makes mutation invalidation unambiguous.
  */
 /**
  * Initial (and grow-step) size of the bounded transcript window. Opening a long
@@ -59,9 +59,8 @@ export const queryKeys = {
   providers: () => ['providers'] as const,
   availableModels: () => ['available-models'] as const,
   customProviders: () => ['custom-providers'] as const,
-  modelPacks: (resourceId: string | undefined) => ['model-packs', resourceId ?? null] as const,
-  /** Prefix that matches every `modelPacks(*)` entry — pack CRUD is global, so it invalidates all of them. */
   modelPacksAll: () => ['model-packs'] as const,
+  modelPacks: (resourceId: string | undefined) => [...queryKeys.modelPacksAll(), resourceId ?? null] as const,
   om: (resourceId: string | undefined) => ['om', resourceId ?? null] as const,
   thinkingConfig: () => ['thinking-config'] as const,
   factorySkills: () => ['factory', 'skills'] as const,

--- a/mastracode/factory-ui/src/api/types.ts
+++ b/mastracode/factory-ui/src/api/types.ts
@@ -72,6 +72,7 @@ export interface CustomProvidersResponse {
 export interface ModelPacksResponse {
   packs: ModelPackInfo[];
   activePackId: string | null;
+  sessionPackId: string | null;
 }
 
 export interface OMResponse {
@@ -126,7 +127,9 @@ export interface SaveModelPackBody {
 }
 
 export interface ActivateModelPackBody {
-  resourceId: string;
+  target: 'default' | 'session';
+  resourceId?: string;
+  scope?: string;
 }
 
 export interface UpdateOMModelBody {
@@ -173,7 +176,7 @@ export type OAuthPollResponse =
 
 export interface ActivateModelPackResponse {
   ok: true;
-  activePackId: string;
+  activePackId: string | null;
 }
 
 export interface UpdateOMResponse {

--- a/mastracode/factory-ui/src/api/types.ts
+++ b/mastracode/factory-ui/src/api/types.ts
@@ -174,9 +174,13 @@ export type OAuthPollResponse =
   | { status: 'complete' }
   | { status: 'failed'; error: string };
 
-export interface ActivateModelPackResponse {
+export type ActivateModelPackResponse =
+  | { ok: true; target: 'default'; activePackId: string }
+  | { ok: true; target: 'session'; sessionPackId: string };
+
+export interface ClearDefaultModelPackResponse {
   ok: true;
-  activePackId: string | null;
+  activePackId: null;
 }
 
 export interface UpdateOMResponse {

--- a/mastracode/factory-ui/src/hooks/__tests__/fixtures/model-packs.ts
+++ b/mastracode/factory-ui/src/hooks/__tests__/fixtures/model-packs.ts
@@ -18,12 +18,16 @@ export const customPack: ModelPackInfo = {
   active: false,
 };
 
-export function packsResponse(activePackId: string | null = null): ModelPacksResponse {
+export function packsResponse(
+  activePackId: string | null = null,
+  sessionPackId: string | null = null,
+): ModelPacksResponse {
   return {
     packs: [
       { ...builtinPack, active: builtinPack.id === activePackId },
       { ...customPack, active: customPack.id === activePackId },
     ],
     activePackId,
+    sessionPackId,
   };
 }

--- a/mastracode/factory-ui/src/hooks/__tests__/use-model-packs.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/use-model-packs.msw.test.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import { waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { act } from 'react';
@@ -5,52 +6,37 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { server } from '../../../e2e/ui/msw-server';
 import { TEST_BASE_URL, renderHookWithProviders, waitForMutationsIdle } from '../../../e2e/ui/render';
+import { queryKeys } from '../../api/keys';
+import { AGENT_CONTROLLER_ID } from '../../ui/domains/chat/services/constants';
 import { useActivateModelPack, useModelPacksQuery, useRemoveModelPack, useSaveModelPack } from '../use-model-packs';
 import { packsResponse } from './fixtures/model-packs';
 
 const URL = `${TEST_BASE_URL}/web/config/model-packs`;
 
 describe('useModelPacksQuery', () => {
-  describe('when no resourceId is provided', () => {
-    it('still loads packs but without a resourceId query param', async () => {
+  describe('when packs are loaded', () => {
+    it('returns the personal active pack without session-scoped query parameters', async () => {
       let seenUrl = '';
       server.use(
         http.get(URL, ({ request }) => {
           seenUrl = request.url;
-          return HttpResponse.json(packsResponse(null));
-        }),
-      );
-
-      const { result } = renderHookWithProviders(() => useModelPacksQuery(undefined));
-
-      await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(result.current.data?.packs).toHaveLength(2);
-      expect(new global.URL(seenUrl).searchParams.has('resourceId')).toBe(false);
-    });
-  });
-
-  describe('when a resourceId is provided', () => {
-    it('passes resourceId and returns the active pack', async () => {
-      let seenResource: string | null = null;
-      server.use(
-        http.get(URL, ({ request }) => {
-          seenResource = new global.URL(request.url).searchParams.get('resourceId');
           return HttpResponse.json(packsResponse('builtin:balanced'));
         }),
       );
 
-      const { result } = renderHookWithProviders(() => useModelPacksQuery('res-1'));
+      const { result } = renderHookWithProviders(() => useModelPacksQuery());
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(seenResource).toBe('res-1');
+      expect(result.current.data?.packs).toHaveLength(2);
       expect(result.current.data?.activePackId).toBe('builtin:balanced');
+      expect(new globalThis.URL(seenUrl).search).toBe('');
     });
   });
 });
 
 describe('useActivateModelPack', () => {
   describe('when a pack is activated', () => {
-    it('POSTs resourceId and invalidates the resource-scoped list', async () => {
+    it('sets the personal default without changing the current session', async () => {
       let activeId: string | null = null;
       let activateBody: unknown;
       server.use(
@@ -63,19 +49,48 @@ describe('useActivateModelPack', () => {
       );
 
       const { result, client } = renderHookWithProviders(() => ({
-        query: useModelPacksQuery('res-1'),
+        query: useModelPacksQuery(),
         activate: useActivateModelPack('res-1'),
       }));
 
       await waitFor(() => expect(result.current.query.data?.activePackId).toBe(null));
 
       await act(async () => {
-        await result.current.activate.mutateAsync({ id: 'builtin:balanced' });
+        await result.current.activate.mutateAsync({ id: 'builtin:balanced', target: 'default' });
       });
       await waitForMutationsIdle(client);
 
-      expect(activateBody).toEqual({ resourceId: 'res-1' });
+      expect(activateBody).toEqual({ target: 'default' });
       await waitFor(() => expect(result.current.query.data?.activePackId).toBe('builtin:balanced'));
+    });
+
+    it('refreshes the active session model after applying a thread pack', async () => {
+      let modelId = 'p/build';
+      const readState = vi.fn(async () => ({ modelId }));
+      server.use(
+        http.post(`${URL}/${encodeURIComponent('mine')}/activate`, async () => {
+          modelId = 'p/build-2';
+          return HttpResponse.json({ ok: true, activePackId: 'mine' });
+        }),
+      );
+
+      const { result, client } = renderHookWithProviders(() => ({
+        state: useQuery({
+          queryKey: queryKeys.agentControllerConnectionState(AGENT_CONTROLLER_ID, 'res-1', '/tmp/res-1'),
+          queryFn: readState,
+          staleTime: Infinity,
+        }),
+        activate: useActivateModelPack('res-1', '/tmp/res-1'),
+      }));
+
+      await waitFor(() => expect(result.current.state.data?.modelId).toBe('p/build'));
+      await act(async () => {
+        await result.current.activate.mutateAsync({ id: 'mine', target: 'session' });
+      });
+      await waitForMutationsIdle(client);
+
+      expect(readState).toHaveBeenCalledTimes(2);
+      expect(result.current.state.data?.modelId).toBe('p/build-2');
     });
   });
 });
@@ -94,7 +109,7 @@ describe('useSaveModelPack', () => {
       );
 
       const { result, client } = renderHookWithProviders(() => ({
-        query: useModelPacksQuery('res-1'),
+        query: useModelPacksQuery(),
         save: useSaveModelPack(),
       }));
 
@@ -129,7 +144,7 @@ describe('useRemoveModelPack', () => {
       );
 
       const { result, client } = renderHookWithProviders(() => ({
-        query: useModelPacksQuery('res-1'),
+        query: useModelPacksQuery(),
         remove: useRemoveModelPack(),
       }));
 

--- a/mastracode/factory-ui/src/hooks/__tests__/use-model-packs.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/use-model-packs.msw.test.tsx
@@ -44,7 +44,7 @@ describe('useActivateModelPack', () => {
         http.post(`${URL}/${encodeURIComponent('builtin:balanced')}/activate`, async ({ request }) => {
           activateBody = await request.json();
           activeId = 'builtin:balanced';
-          return HttpResponse.json({ ok: true, activePackId: 'builtin:balanced' });
+          return HttpResponse.json({ ok: true, target: 'default', activePackId: 'builtin:balanced' });
         }),
       );
 
@@ -70,7 +70,7 @@ describe('useActivateModelPack', () => {
       server.use(
         http.post(`${URL}/${encodeURIComponent('mine')}/activate`, async () => {
           modelId = 'p/build-2';
-          return HttpResponse.json({ ok: true, activePackId: 'mine' });
+          return HttpResponse.json({ ok: true, target: 'session', sessionPackId: 'mine' });
         }),
       );
 

--- a/mastracode/factory-ui/src/hooks/use-model-packs.ts
+++ b/mastracode/factory-ui/src/hooks/use-model-packs.ts
@@ -19,7 +19,7 @@ import type {
 export function useModelPacksQuery(resourceId?: string, scope?: string) {
   const { client } = useApiConfig();
   return useQuery<ModelPacksResponse>({
-    queryKey: queryKeys.modelPacks(resourceId),
+    queryKey: queryKeys.modelPacks(resourceId, scope),
     queryFn: () => {
       const params = new URLSearchParams();
       if (resourceId) params.set('resourceId', resourceId);

--- a/mastracode/factory-ui/src/hooks/use-model-packs.ts
+++ b/mastracode/factory-ui/src/hooks/use-model-packs.ts
@@ -2,17 +2,21 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
-import type { ActivateModelPackResponse, ModelPacksResponse, OkResponse, SaveModelPackBody } from '../api/types';
+import { AGENT_CONTROLLER_ID } from '../ui/domains/chat/services/constants';
+import type {
+  ActivateModelPackBody,
+  ActivateModelPackResponse,
+  ModelPacksResponse,
+  OkResponse,
+  SaveModelPackBody,
+} from '../api/types';
 
 /**
- * Model packs (mirrors the TUI `/models-pack` command). Listing + custom-pack
- * CRUD are global; activation is session-scoped and needs the active factory's
- * `resourceId`. The list is keyed by `resourceId` so switching factories yields a
- * distinct cache entry (active-pack state differs per session). The query stays
- * enabled without a `resourceId` — it just returns packs with no active flag,
- * matching the current component which loads the catalog either way.
+ * Model-pack definitions are organization-scoped. The active pack is the
+ * user's default for new interactive chats; a resourceId reads the pack
+ * selected specifically for that thread.
  */
-export function useModelPacksQuery(resourceId: string | undefined, scope?: string) {
+export function useModelPacksQuery(resourceId?: string, scope?: string) {
   const { client } = useApiConfig();
   return useQuery<ModelPacksResponse>({
     queryKey: queryKeys.modelPacks(resourceId),
@@ -20,26 +24,43 @@ export function useModelPacksQuery(resourceId: string | undefined, scope?: strin
       const params = new URLSearchParams();
       if (resourceId) params.set('resourceId', resourceId);
       if (resourceId && scope) params.set('scope', scope);
-      const qs = params.size ? `?${params.toString()}` : '';
-      return client.get<ModelPacksResponse>(`/web/config/model-packs${qs}`);
+      const query = params.size ? `?${params.toString()}` : '';
+      return client.get<ModelPacksResponse>(`/web/config/model-packs${query}`);
     },
   });
 }
 
 export interface ActivateModelPackArgs {
   id: string;
+  target: ActivateModelPackBody['target'];
 }
 
 export function useActivateModelPack(resourceId: string | undefined, scope?: string) {
   const { client } = useApiConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ id }: ActivateModelPackArgs) =>
+    mutationFn: ({ id, target }: ActivateModelPackArgs) =>
       client.post<ActivateModelPackResponse>(`/web/config/model-packs/${encodeURIComponent(id)}/activate`, {
-        resourceId,
-        scope,
-      }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.modelPacks(resourceId) }),
+        target,
+        ...(target === 'session' ? { resourceId, scope } : {}),
+      } satisfies ActivateModelPackBody),
+    onSuccess: async (_, { target }) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.modelPacksAll() });
+      if (target === 'session' && resourceId) {
+        await queryClient.invalidateQueries({
+          queryKey: queryKeys.agentControllerConnectionState(AGENT_CONTROLLER_ID, resourceId, scope),
+        });
+      }
+    },
+  });
+}
+
+export function useClearDefaultModelPack() {
+  const { client } = useApiConfig();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => client.del<ActivateModelPackResponse>('/web/config/model-packs/active'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.modelPacksAll() }),
   });
 }
 

--- a/mastracode/factory-ui/src/hooks/use-model-packs.ts
+++ b/mastracode/factory-ui/src/hooks/use-model-packs.ts
@@ -6,6 +6,7 @@ import { AGENT_CONTROLLER_ID } from '../ui/domains/chat/services/constants';
 import type {
   ActivateModelPackBody,
   ActivateModelPackResponse,
+  ClearDefaultModelPackResponse,
   ModelPacksResponse,
   OkResponse,
   SaveModelPackBody,
@@ -59,7 +60,7 @@ export function useClearDefaultModelPack() {
   const { client } = useApiConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => client.del<ActivateModelPackResponse>('/web/config/model-packs/active'),
+    mutationFn: () => client.del<ClearDefaultModelPackResponse>('/web/config/model-packs/active'),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.modelPacksAll() }),
   });
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/ActiveModelPack.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/ActiveModelPack.tsx
@@ -1,0 +1,58 @@
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@mastra/playground-ui/components/Select';
+import { toast } from '@mastra/playground-ui/components/Toaster';
+import { useState } from 'react';
+
+import { useActivateModelPack, useModelPacksQuery } from '../../../../../hooks/use-model-packs';
+import { useChatConnection } from '../../context/useChatConnection';
+import { useChatSessionContext } from '../../context/useChatSessionContext';
+
+export function ActiveModelPack() {
+  const { resourceId, projectPath, draftSessionId, kind } = useChatSessionContext();
+  const { status } = useChatConnection();
+  const packsQuery = useModelPacksQuery(resourceId, projectPath);
+  const activateMutation = useActivateModelPack(resourceId, projectPath);
+  const [pendingPackId, setPendingPackId] = useState<string>();
+
+  const selectedPackId = pendingPackId ?? packsQuery.data?.sessionPackId ?? undefined;
+  const selectedPack = packsQuery.data?.packs.find(pack => pack.id === selectedPackId);
+
+  if (kind !== 'user' || draftSessionId || status !== 'ready' || !packsQuery.data?.packs.length) return null;
+
+  return (
+    <Select
+      value={selectedPackId}
+      disabled={Boolean(pendingPackId)}
+      onValueChange={packId => {
+        if (pendingPackId || packId === packsQuery.data.sessionPackId) return;
+        setPendingPackId(packId);
+        void activateMutation.mutateAsync({ id: packId, target: 'session' }).then(
+          () => {
+            setPendingPackId(undefined);
+          },
+          (cause: unknown) => {
+            setPendingPackId(undefined);
+            toast.error(cause instanceof Error ? cause.message : 'Failed to apply model pack');
+          },
+        );
+      }}
+    >
+      <SelectTrigger
+        variant="ghost"
+        size="xs"
+        aria-label="Thread model pack"
+        aria-busy={Boolean(pendingPackId)}
+        className="text-neutral3 w-auto"
+        title={selectedPack?.name}
+      >
+        <span>Pack · {selectedPack?.name ?? 'Choose'}</span>
+      </SelectTrigger>
+      <SelectContent>
+        {packsQuery.data.packs.map(pack => (
+          <SelectItem key={pack.id} value={pack.id}>
+            {pack.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/StatusLine.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/StatusLine.tsx
@@ -5,6 +5,7 @@ import { useWorkItemsQuery } from '../../../../../hooks/useWorkItems';
 import { useChatSessionContext } from '../../context/useChatSessionContext';
 import { PullRequestLinks } from '../PullRequestLinks';
 import { ActiveModel } from './ActiveModel';
+import { ActiveModelPack } from './ActiveModelPack';
 import { ConnectionActivity } from './ConnectionActivity';
 import { GoalStatus } from './GoalStatus';
 import { ModesSelection } from './ModesSelection';
@@ -18,7 +19,7 @@ import { RuntimeActivity } from './RuntimeActivity';
  */
 export function StatusLine() {
   const { factoryId, threadId } = useParams<{ factoryId: string; threadId: string }>();
-  const { projectPath, factorySessionState } = useChatSessionContext();
+  const { projectPath, factorySessionState, kind, resourceReady } = useChatSessionContext();
   const { data: factory } = useFactoryQuery(factoryId);
   const repository = factory?.repositories.find(
     repo => repo.projectRepositoryId === factorySessionState?.projectRepositoryId,
@@ -40,6 +41,7 @@ export function StatusLine() {
     >
       <ModesSelection />
       <ActiveModel />
+      {kind === 'user' && resourceReady ? <ActiveModelPack /> : null}
       <OperationalMemoryStatus />
       <RuntimeActivity />
       <ConnectionActivity />

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ActiveModelPack.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ActiveModelPack.msw.test.tsx
@@ -55,7 +55,7 @@ describe('ActiveModelPack', () => {
       http.post(`${TEST_BASE_URL}/web/config/model-packs/mine/activate`, async ({ request }) => {
         activateBody = await request.json();
         sessionPackId = 'mine';
-        return HttpResponse.json({ ok: true, activePackId: 'mine' });
+        return HttpResponse.json({ ok: true, target: 'session', sessionPackId: 'mine' });
       }),
     );
 

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ActiveModelPack.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ActiveModelPack.msw.test.tsx
@@ -4,7 +4,7 @@ import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../../../../../e2e/ui/msw-server';
-import { TEST_BASE_URL, renderWithProviders } from '../../../../../../../e2e/ui/render';
+import { TEST_BASE_URL, renderWithProviders, waitForMutationsIdle } from '../../../../../../../e2e/ui/render';
 import { ChatConnectionContext } from '../../../context/ChatConnectionContext';
 import { ChatSessionContext } from '../../../context/ChatSessionContext';
 import type { ChatSessionContextApi } from '../../../context/ChatSessionContext';
@@ -60,7 +60,7 @@ describe('ActiveModelPack', () => {
     );
 
     const user = userEvent.setup();
-    renderWithProviders(
+    const { client } = renderWithProviders(
       <ChatSessionContext.Provider value={session}>
         <ChatConnectionContext.Provider value={{ status: 'ready' }}>
           <ActiveModelPack />
@@ -83,6 +83,7 @@ describe('ActiveModelPack', () => {
         scope: '/tmp/session-1',
       }),
     );
-    await waitFor(() => expect(trigger).toHaveTextContent('Pack · Mine'));
+    await waitForMutationsIdle(client);
+    expect(trigger).toHaveTextContent('Pack · Mine');
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ActiveModelPack.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ActiveModelPack.msw.test.tsx
@@ -1,0 +1,88 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../../e2e/ui/msw-server';
+import { TEST_BASE_URL, renderWithProviders } from '../../../../../../../e2e/ui/render';
+import { ChatConnectionContext } from '../../../context/ChatConnectionContext';
+import { ChatSessionContext } from '../../../context/ChatSessionContext';
+import type { ChatSessionContextApi } from '../../../context/ChatSessionContext';
+import { ActiveModelPack } from '../ActiveModelPack';
+
+const session: ChatSessionContextApi = {
+  resourceId: 'session-1',
+  sessionEnabled: true,
+  resourceReady: true,
+  sandboxReady: true,
+  sandboxPreparing: false,
+  sandboxProgress: undefined,
+  resourceEnabled: true,
+  projectPath: '/tmp/session-1',
+  baseUrl: TEST_BASE_URL,
+  kind: 'user',
+};
+
+const packs = [
+  {
+    id: 'balanced',
+    name: 'Balanced',
+    description: '',
+    models: { build: 'p/build', plan: 'p/plan', fast: 'p/fast' },
+    custom: false,
+    active: true,
+  },
+  {
+    id: 'mine',
+    name: 'Mine',
+    description: '',
+    models: { build: 'p/build-2', plan: 'p/plan-2', fast: 'p/fast-2' },
+    custom: true,
+    active: false,
+  },
+];
+
+describe('ActiveModelPack', () => {
+  it('applies a different pack only to the current chat', async () => {
+    let sessionPackId = 'balanced';
+    let listUrl = '';
+    let activateBody: unknown;
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/config/model-packs`, ({ request }) => {
+        listUrl = request.url;
+        return HttpResponse.json({ packs, activePackId: 'balanced', sessionPackId });
+      }),
+      http.post(`${TEST_BASE_URL}/web/config/model-packs/mine/activate`, async ({ request }) => {
+        activateBody = await request.json();
+        sessionPackId = 'mine';
+        return HttpResponse.json({ ok: true, activePackId: 'mine' });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ChatSessionContext.Provider value={session}>
+        <ChatConnectionContext.Provider value={{ status: 'ready' }}>
+          <ActiveModelPack />
+        </ChatConnectionContext.Provider>
+      </ChatSessionContext.Provider>,
+    );
+
+    const trigger = await screen.findByLabelText('Thread model pack');
+    expect(trigger).toHaveTextContent('Pack · Balanced');
+    expect(new URL(listUrl).searchParams.get('resourceId')).toBe('session-1');
+    expect(new URL(listUrl).searchParams.get('scope')).toBe('/tmp/session-1');
+
+    await user.click(trigger);
+    await user.click(await screen.findByRole('option', { name: 'Mine' }));
+
+    await waitFor(() =>
+      expect(activateBody).toEqual({
+        target: 'session',
+        resourceId: 'session-1',
+        scope: '/tmp/session-1',
+      }),
+    );
+    await waitFor(() => expect(trigger).toHaveTextContent('Pack · Mine'));
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatModelsProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatModelsProvider.tsx
@@ -37,7 +37,7 @@ function DraftChatModelsProvider({ children }: ChatModelsProviderProps) {
       : undefined;
   const value: ChatModelsApi = {
     activeModelId: draftModelId ?? packModelId ?? factoryProjectQuery.data?.defaultModelId ?? undefined,
-    isLoading: factoryProjectQuery.isPending,
+    isLoading: factoryProjectQuery.isPending || modelPacksQuery.isPending,
     error: factoryProjectQuery.error ?? undefined,
     setModel: modelId => {
       setDraftModelId(modelId);

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatModelsProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatModelsProvider.tsx
@@ -2,11 +2,13 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import { useFactoryProjectQuery } from '../../../../hooks/useFactoryDefaultModel';
+import { useModelPacksQuery } from '../../../../hooks/use-model-packs';
 import { useSwitchAgentControllerModelMutation } from '../../../../hooks/useAgentControllerStateMutations';
 import { AGENT_CONTROLLER_ID } from '../services/constants';
 import { ChatModelsContext } from './ChatModelsContext';
 import type { ChatModelsApi } from './ChatModelsContext';
 import { useChatConnection } from './useChatConnection';
+import { useChatModes } from './useChatModes';
 import { useChatSessionContext } from './useChatSessionContext';
 
 interface ChatModelsProviderProps {
@@ -24,10 +26,17 @@ export function ChatModelsProvider({ children }: ChatModelsProviderProps) {
 
 function DraftChatModelsProvider({ children }: ChatModelsProviderProps) {
   const { factorySessionState } = useChatSessionContext();
+  const { activeModeId } = useChatModes();
   const factoryProjectQuery = useFactoryProjectQuery(factorySessionState?.factoryProjectId);
+  const modelPacksQuery = useModelPacksQuery();
   const [draftModelId, setDraftModelId] = useState<string>();
+  const activePack = modelPacksQuery.data?.packs.find(pack => pack.id === modelPacksQuery.data.activePackId);
+  const packModelId =
+    activeModeId === 'build' || activeModeId === 'plan' || activeModeId === 'fast'
+      ? activePack?.models[activeModeId]
+      : undefined;
   const value: ChatModelsApi = {
-    activeModelId: draftModelId ?? factoryProjectQuery.data?.defaultModelId ?? undefined,
+    activeModelId: draftModelId ?? packModelId ?? factoryProjectQuery.data?.defaultModelId ?? undefined,
     isLoading: factoryProjectQuery.isPending,
     error: factoryProjectQuery.error ?? undefined,
     setModel: modelId => {

--- a/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatModelsProvider.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatModelsProvider.msw.test.tsx
@@ -1,0 +1,117 @@
+import { screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../e2e/ui/msw-server';
+import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
+import { ChatModelsProvider } from '../ChatModelsProvider';
+import { ChatModesContext } from '../ChatModesContext';
+import { ChatSessionContext } from '../ChatSessionContext';
+import type { ChatSessionContextApi } from '../ChatSessionContext';
+import { useChatModels } from '../useChatModels';
+
+const draftSession: ChatSessionContextApi = {
+  resourceId: 'draft-1',
+  sessionEnabled: false,
+  resourceReady: false,
+  sandboxReady: false,
+  sandboxPreparing: false,
+  sandboxProgress: undefined,
+  resourceEnabled: false,
+  projectPath: undefined,
+  baseUrl: TEST_BASE_URL,
+  kind: 'user',
+  draftSessionId: 'draft-1',
+  factorySessionState: {
+    factoryProjectId: 'factory-1',
+    projectRepositoryId: 'repository-1',
+  },
+};
+
+function ActiveModelProbe() {
+  const { activeModelId } = useChatModels();
+  return <div>{activeModelId}</div>;
+}
+
+describe('ChatModelsProvider', () => {
+  it('uses the personal default pack for a new interactive chat', async () => {
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/factory/projects/factory-1`, () =>
+        HttpResponse.json({ project: { id: 'factory-1', defaultModelId: 'openrouter/fable-5' } }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/config/model-packs`, () =>
+        HttpResponse.json({
+          packs: [
+            {
+              id: 'mix',
+              name: 'Mix',
+              description: '',
+              models: {
+                build: 'anthropic/claude-opus-4-1',
+                plan: 'anthropic/claude-sonnet-4',
+                fast: 'anthropic/claude-haiku-3-5',
+              },
+              custom: true,
+              active: true,
+            },
+          ],
+          activePackId: 'mix',
+          sessionPackId: null,
+        }),
+      ),
+    );
+
+    renderWithProviders(
+      <ChatSessionContext.Provider value={draftSession}>
+        <ChatModesContext.Provider
+          value={{
+            modes: [],
+            activeMode: undefined,
+            activeModeId: 'build',
+            isLoading: false,
+            error: undefined,
+            setMode: async () => {},
+          }}
+        >
+          <ChatModelsProvider>
+            <ActiveModelProbe />
+          </ChatModelsProvider>
+        </ChatModesContext.Provider>
+      </ChatSessionContext.Provider>,
+    );
+
+    expect(await screen.findByText('anthropic/claude-opus-4-1')).toBeVisible();
+  });
+
+  it('falls back to the Factory model when personal pack loading fails', async () => {
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/factory/projects/factory-1`, () =>
+        HttpResponse.json({ project: { id: 'factory-1', defaultModelId: 'openrouter/fable-5' } }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/config/model-packs`, () =>
+        HttpResponse.json({ error: 'model_packs_unavailable' }, { status: 503 }),
+      ),
+    );
+
+    renderWithProviders(
+      <ChatSessionContext.Provider value={draftSession}>
+        <ChatModesContext.Provider
+          value={{
+            modes: [],
+            activeMode: undefined,
+            activeModeId: 'build',
+            isLoading: false,
+            error: undefined,
+            setMode: async () => {},
+          }}
+        >
+          <ChatModelsProvider>
+            <ActiveModelProbe />
+          </ChatModelsProvider>
+        </ChatModesContext.Provider>
+      </ChatSessionContext.Provider>,
+    );
+
+    expect(await screen.findByText('openrouter/fable-5')).toBeVisible();
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatModelsProvider.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatModelsProvider.msw.test.tsx
@@ -33,6 +33,11 @@ function ActiveModelProbe() {
   return <div>{activeModelId}</div>;
 }
 
+function LoadingProbe() {
+  const { isLoading } = useChatModels();
+  return <div>{isLoading ? 'loading' : 'ready'}</div>;
+}
+
 describe('ChatModelsProvider', () => {
   it('uses the personal default pack for a new interactive chat', async () => {
     server.use(
@@ -81,6 +86,45 @@ describe('ChatModelsProvider', () => {
     );
 
     expect(await screen.findByText('anthropic/claude-opus-4-1')).toBeVisible();
+  });
+
+  it('keeps a new chat loading until the personal default pack resolves', async () => {
+    let resolvePacks = () => {};
+    const packsPending = new Promise<void>(resolve => {
+      resolvePacks = resolve;
+    });
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/factory/projects/factory-1`, () =>
+        HttpResponse.json({ project: { id: 'factory-1', defaultModelId: 'openrouter/fable-5' } }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/config/model-packs`, async () => {
+        await packsPending;
+        return HttpResponse.json({ packs: [], activePackId: null, sessionPackId: null });
+      }),
+    );
+
+    renderWithProviders(
+      <ChatSessionContext.Provider value={draftSession}>
+        <ChatModesContext.Provider
+          value={{
+            modes: [],
+            activeMode: undefined,
+            activeModeId: 'build',
+            isLoading: false,
+            error: undefined,
+            setMode: async () => {},
+          }}
+        >
+          <ChatModelsProvider>
+            <LoadingProbe />
+          </ChatModelsProvider>
+        </ChatModesContext.Provider>
+      </ChatSessionContext.Provider>,
+    );
+
+    expect(await screen.findByText('loading')).toBeVisible();
+    resolvePacks();
+    expect(await screen.findByText('ready')).toBeVisible();
   });
 
   it('falls back to the Factory model when personal pack loading fails', async () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatModelsProvider.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatModelsProvider.msw.test.tsx
@@ -3,7 +3,7 @@ import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../../../../e2e/ui/msw-server';
-import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
+import { TEST_BASE_URL, renderWithProviders, waitForMutationsIdle } from '../../../../../../e2e/ui/render';
 import { ChatModelsProvider } from '../ChatModelsProvider';
 import { ChatModesContext } from '../ChatModesContext';
 import { ChatSessionContext } from '../ChatSessionContext';
@@ -103,7 +103,7 @@ describe('ChatModelsProvider', () => {
       }),
     );
 
-    renderWithProviders(
+    const { client } = renderWithProviders(
       <ChatSessionContext.Provider value={draftSession}>
         <ChatModesContext.Provider
           value={{
@@ -124,7 +124,8 @@ describe('ChatModelsProvider', () => {
 
     expect(await screen.findByText('loading')).toBeVisible();
     resolvePacks();
-    expect(await screen.findByText('ready')).toBeVisible();
+    await waitForMutationsIdle(client);
+    expect(screen.getByText('ready')).toBeVisible();
   });
 
   it('falls back to the Factory model when personal pack loading fails', async () => {

--- a/mastracode/factory-ui/src/ui/domains/settings/components/FactoryDefaultModelSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/FactoryDefaultModelSection.tsx
@@ -10,9 +10,9 @@ import { SettingsRow } from './SettingsCard';
 import { SharedCredentialNotice } from './SharedCredentialNotice';
 
 /**
- * Factory default model. Persisted on the Factory project itself; factory
- * runs (issue triage, board work items) and new chats start on it. The
- * setting is mandatory — it can be changed but not cleared.
+ * Factory default model. Persisted on the Factory project itself; Factory
+ * runs use it, and new chats fall back to it when the user has no default
+ * model pack. The setting is mandatory and can be changed but not cleared.
  */
 export function FactoryDefaultModelSection({ models }: { models: AvailableModelOption[] }) {
   const { factoryId } = useParams<{ factoryId: string }>();

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ModelPacksSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ModelPacksSection.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react';
 
 import {
   useActivateModelPack,
+  useClearDefaultModelPack,
   useModelPacksQuery,
   useRemoveModelPack,
   useSaveModelPack,
@@ -60,23 +61,14 @@ function ModelAssignment({ description, icon: Icon, label, model }: ModelAssignm
 }
 
 /**
- * Model packs. Mirrors the TUI's `/models-pack` command: a pack assigns a model
- * to each mode (build / plan / fast). Built-in packs are gated by provider
- * access; custom packs are user-defined. Activating a pack seeds the current
- * session's per-mode models — so it needs the active factory's resourceId (and
- * the session scope the web chat session was registered under).
+ * Personal model-pack defaults for interactive chats. A pack assigns a model to
+ * each mode (build / plan / fast). Thread-specific choices live in the chat UI;
+ * Factory work runs are unaffected.
  */
-export function ModelPacksSection({
-  resourceId,
-  scope,
-  models,
-}: {
-  resourceId?: string;
-  scope?: string;
-  models: AvailableModelOption[];
-}) {
-  const packsQuery = useModelPacksQuery(resourceId, scope);
-  const activateMutation = useActivateModelPack(resourceId, scope);
+export function ModelPacksSection({ models }: { models: AvailableModelOption[] }) {
+  const packsQuery = useModelPacksQuery();
+  const activateMutation = useActivateModelPack(undefined);
+  const clearDefaultMutation = useClearDefaultModelPack();
   const removeMutation = useRemoveModelPack();
   const saveMutation = useSaveModelPack();
 
@@ -85,18 +77,24 @@ export function ModelPacksSection({
 
   const packs = packsQuery.data?.packs ?? [];
   const loading = packsQuery.isPending;
-  const busy = activateMutation.isPending || removeMutation.isPending || saveMutation.isPending;
+  const busy =
+    activateMutation.isPending || clearDefaultMutation.isPending || removeMutation.isPending || saveMutation.isPending;
   const queryError = packsQuery.error instanceof Error ? packsQuery.error.message : null;
   const error = draftError ?? queryError;
 
   const activate = async (id: string) => {
-    if (!resourceId) {
-      setDraftError('Open a factory first to activate a pack.');
-      return;
-    }
     setDraftError(null);
     try {
-      await activateMutation.mutateAsync({ id });
+      await activateMutation.mutateAsync({ id, target: 'default' });
+    } catch (e) {
+      setDraftError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const clearDefault = async () => {
+    setDraftError(null);
+    try {
+      await clearDefaultMutation.mutateAsync();
     } catch (e) {
       setDraftError(e instanceof Error ? e.message : String(e));
     }
@@ -133,11 +131,10 @@ export function ModelPacksSection({
 
   return (
     <div className="flex flex-col gap-3">
-      {!resourceId && (
-        <Txt as="p" variant="ui-sm" className="text-icon3">
-          Open a factory to activate a pack on its session.
-        </Txt>
-      )}
+      <Txt as="p" variant="ui-sm" className="text-icon3">
+        Set your default for new interactive chats. Choose a different pack from within a specific chat. Factory work
+        runs continue to use the Factory default model.
+      </Txt>
       {error && (
         <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg">
           {error}
@@ -206,7 +203,7 @@ export function ModelPacksSection({
                   {p.custom && <Badge size="sm">Custom</Badge>}
                   {p.active && (
                     <Badge size="sm" variant="success">
-                      Active
+                      Default
                     </Badge>
                   )}
                 </div>
@@ -232,9 +229,13 @@ export function ModelPacksSection({
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                {!p.active && (
-                  <Button size="sm" disabled={busy || !resourceId} onClick={() => void activate(p.id)}>
-                    Activate
+                {p.active ? (
+                  <Button size="sm" disabled={busy} onClick={() => void clearDefault()}>
+                    Clear default
+                  </Button>
+                ) : (
+                  <Button size="sm" disabled={busy} onClick={() => void activate(p.id)}>
+                    Set default
                   </Button>
                 )}
                 {p.custom && (

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.tsx
@@ -116,11 +116,11 @@ export function SettingsPanel() {
               </SettingsCard>
             </SettingsSubsection>
             <SettingsSubsection
-              title="Model packs"
-              description="A pack sets a model for each mode (build / plan / fast)."
+              title="Chat model packs"
+              description="Set your personal Build, Plan and Fast defaults for interactive chats. Factory work runs are unaffected."
             >
               <SettingsCard className="p-4">
-                <ModelPacksSection resourceId={sessionResourceId} scope={sessionScope} models={models} />
+                <ModelPacksSection models={models} />
               </SettingsCard>
             </SettingsSubsection>
             <SettingsSubsection

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ModelPacksSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ModelPacksSection.msw.test.tsx
@@ -89,7 +89,7 @@ describe('ModelPacksSection', () => {
         http.get(PACKS_URL, () => packsResponse([builtinPack])),
         http.post(activateUrl('builtin'), async ({ request }) => {
           activateBody = await request.json();
-          return HttpResponse.json({ ok: true, activePackId: 'builtin' });
+          return HttpResponse.json({ ok: true, target: 'default', activePackId: 'builtin' });
         }),
       );
 
@@ -112,7 +112,7 @@ describe('ModelPacksSection', () => {
         http.post(activateUrl('builtin'), async ({ request }) => {
           activateBody = await request.json();
           packs[0] = { ...builtinPack, active: true };
-          return HttpResponse.json({ ok: true, activePackId: 'builtin' });
+          return HttpResponse.json({ ok: true, target: 'default', activePackId: 'builtin' });
         }),
       );
 

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ModelPacksSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ModelPacksSection.msw.test.tsx
@@ -13,15 +13,17 @@ const PACKS_URL = `${TEST_BASE_URL}/web/config/model-packs`;
 const activateUrl = (id: string) => `${PACKS_URL}/${encodeURIComponent(id)}/activate`;
 const itemUrl = (id: string) => `${PACKS_URL}/${encodeURIComponent(id)}`;
 
-const RESOURCE_ID = 'res-1';
-
 const models: AgentControllerAvailableModel[] = [
   { id: 'openai/gpt-x', provider: 'openai' } as AgentControllerAvailableModel,
   { id: 'anthropic/claude-x', provider: 'anthropic' } as AgentControllerAvailableModel,
 ];
 
-function packsResponse(packs: ModelPackInfo[], activePackId: string | null = null) {
-  return HttpResponse.json({ packs, activePackId });
+function packsResponse(
+  packs: ModelPackInfo[],
+  activePackId: string | null = null,
+  sessionPackId: string | null = null,
+) {
+  return HttpResponse.json({ packs, activePackId, sessionPackId });
 }
 
 /** Open a searchable combobox and pick an option (Base UI selects on pointer events). */
@@ -59,7 +61,7 @@ describe('ModelPacksSection', () => {
         }),
       );
 
-      renderWithProviders(<ModelPacksSection resourceId={RESOURCE_ID} models={models} />);
+      renderWithProviders(<ModelPacksSection models={models} />);
 
       expect(await screen.findByRole('status', { name: 'Loading model packs' })).toBeInTheDocument();
       expect(screen.queryByText(/Loading model packs/)).not.toBeInTheDocument();
@@ -73,36 +75,36 @@ describe('ModelPacksSection', () => {
     it('renders the available packs', async () => {
       server.use(http.get(PACKS_URL, () => packsResponse([builtinPack])));
 
-      renderWithProviders(<ModelPacksSection resourceId={RESOURCE_ID} models={models} />);
-
-      expect(await screen.findByText('Builtin Pack')).toBeInTheDocument();
-    });
-  });
-
-  describe('when there is no resourceId', () => {
-    it('still lists the catalog but disables Activate and shows the open-project hint', async () => {
-      let queryString: string | null = null;
-      server.use(
-        http.get(PACKS_URL, ({ request }) => {
-          queryString = new URL(request.url).search;
-          return packsResponse([builtinPack]);
-        }),
-      );
-
       renderWithProviders(<ModelPacksSection models={models} />);
 
       expect(await screen.findByText('Builtin Pack')).toBeInTheDocument();
-      expect(screen.getByText(/Open a factory to activate/)).toBeInTheDocument();
-      // No resourceId means the request is unscoped.
-      expect(queryString).toBe('');
-
-      const row = await rowFor('Builtin Pack');
-      expect(within(row).getByRole('button', { name: 'Activate' })).toBeDisabled();
+      expect(screen.queryByRole('button', { name: 'Use in this chat' })).not.toBeInTheDocument();
     });
   });
 
-  describe('when a pack is activated', () => {
-    it('POSTs the resourceId and session scope and refetches so the pack shows active', async () => {
+  describe('when setting the chat default', () => {
+    it('selects a default pack for future chats', async () => {
+      let activateBody: unknown;
+      server.use(
+        http.get(PACKS_URL, () => packsResponse([builtinPack])),
+        http.post(activateUrl('builtin'), async ({ request }) => {
+          activateBody = await request.json();
+          return HttpResponse.json({ ok: true, activePackId: 'builtin' });
+        }),
+      );
+
+      const user = userEvent.setup();
+      renderWithProviders(<ModelPacksSection models={models} />);
+
+      const row = await rowFor('Builtin Pack');
+      await user.click(within(row).getByRole('button', { name: 'Set default' }));
+
+      await waitFor(() => expect(activateBody).toEqual({ target: 'default' }));
+    });
+  });
+
+  describe('when a default pack is selected', () => {
+    it('updates the personal default without changing the current chat', async () => {
       const packs: ModelPackInfo[] = [builtinPack];
       let activateBody: unknown;
       server.use(
@@ -115,15 +117,32 @@ describe('ModelPacksSection', () => {
       );
 
       const user = userEvent.setup();
-      renderWithProviders(<ModelPacksSection resourceId={RESOURCE_ID} scope="/tmp/worktree" models={models} />);
+      renderWithProviders(<ModelPacksSection models={models} />);
 
       const row = await rowFor('Builtin Pack');
-      await user.click(within(row).getByRole('button', { name: 'Activate' }));
+      await user.click(within(row).getByRole('button', { name: 'Set default' }));
 
-      // The session registers under (resourceId, scope), so activation must
-      // forward both or the server-side lookup misses.
-      await waitFor(() => expect(activateBody).toEqual({ resourceId: RESOURCE_ID, scope: '/tmp/worktree' }));
-      await waitFor(() => expect(within(row).getByText('Active')).toBeInTheDocument());
+      await waitFor(() => expect(activateBody).toEqual({ target: 'default' }));
+      await waitFor(() => expect(within(row).getByText('Default')).toBeInTheDocument());
+    });
+
+    it('clears the personal default', async () => {
+      let active = true;
+      server.use(
+        http.get(PACKS_URL, () => packsResponse([{ ...builtinPack, active }], active ? 'builtin' : null)),
+        http.delete(`${PACKS_URL}/active`, () => {
+          active = false;
+          return HttpResponse.json({ ok: true, activePackId: null });
+        }),
+      );
+
+      const user = userEvent.setup();
+      renderWithProviders(<ModelPacksSection models={models} />);
+
+      const row = await rowFor('Builtin Pack');
+      await user.click(within(row).getByRole('button', { name: 'Clear default' }));
+
+      await waitFor(() => expect(within(row).getByRole('button', { name: 'Set default' })).toBeInTheDocument());
     });
   });
 
@@ -148,7 +167,7 @@ describe('ModelPacksSection', () => {
       );
 
       const user = userEvent.setup();
-      renderWithProviders(<ModelPacksSection resourceId={RESOURCE_ID} models={models} />);
+      renderWithProviders(<ModelPacksSection models={models} />);
 
       await user.click(await screen.findByRole('button', { name: 'New pack' }));
       await user.type(screen.getByPlaceholderText('e.g. my-pack'), 'My Pack');
@@ -183,7 +202,7 @@ describe('ModelPacksSection', () => {
       );
 
       const user = userEvent.setup();
-      renderWithProviders(<ModelPacksSection resourceId={RESOURCE_ID} models={models} />);
+      renderWithProviders(<ModelPacksSection models={models} />);
 
       const row = await rowFor('My Pack');
       await user.click(within(row).getByRole('button', { name: 'Remove' }));

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -195,10 +195,11 @@ describe('MastraFactory.prepare', () => {
     const factory = new MastraFactory({ storage });
     await factory.prepare();
 
-    const blockingCall = controllerMock.onSessionCreated.mock.calls.find(
+    const blockingCalls = controllerMock.onSessionCreated.mock.calls.filter(
       call => (call[1] as { blocking?: boolean } | undefined)?.blocking === true,
     );
-    expect(blockingCall).toBeDefined();
+    expect(blockingCalls).toHaveLength(2);
+    const blockingCall = blockingCalls[0];
 
     // Seed the owner's web session row and stored memory settings through the
     // same storage domains the factory registered.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -67,6 +67,7 @@ import { observeSessionFilesystem } from './session/filesystem-capture.js';
 import { observeSessionFirstExec } from './session/first-exec-capture.js';
 import { observeSessionFirstMessage } from './session/first-message-capture.js';
 import { hydrateSessionMemorySettings } from './session/memory-settings-hydration.js';
+import { hydrateSessionModelPack } from './session/model-pack-hydration.js';
 import { createSpaStaticMiddleware, resolveUiDistDir } from './spa-static.js';
 import { createStateSigner } from './state-signing.js';
 import { observeAgentGitAction } from './storage/domains/audit/agent-audit.js';
@@ -836,6 +837,18 @@ export class MastraFactory {
         hydrateSessionMemorySettings(session, {
           sourceControl: sourceControlStorage.forIntegration('github'),
           memorySettings: memorySettingsStorage,
+        }),
+      { blocking: true },
+    );
+
+    // Personal model packs seed interactive user sessions only. Active Factory
+    // run bindings are excluded and continue to use the project default model.
+    prepared.base.controller.onSessionCreated(
+      session =>
+        hydrateSessionModelPack(session, {
+          sourceControl: sourceControlStorage.forIntegration('github'),
+          workItems: workItemsStorage,
+          modelPacks: modelPacksStorage,
         }),
       { blocking: true },
     );

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -691,6 +691,23 @@ describe('model pack routes with a tenant', () => {
     expect(sessionController.getSessionByResource).not.toHaveBeenCalled();
   });
 
+  it('fails closed when session authorization storage is unavailable', async () => {
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('factoryAuthUser' as never, userA as never);
+      await next();
+    });
+    mountApiRoutes(
+      app as any,
+      new ConfigRoutes({ auth: fakeRouteAuth(), controller, modelPacks: seed.modelPacks }).routes(),
+    );
+
+    const response = await app.request('/web/config/model-packs?resourceId=session-1');
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: 'session_authorization_unavailable' });
+  });
+
   it('keeps packs invisible across organizations', async () => {
     await postPack(buildApp(userA), packBody);
 

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -598,6 +598,7 @@ describe('model pack routes with a tenant', () => {
     });
 
     expect(activated.status).toBe(200);
+    expect(await activated.json()).toEqual({ ok: true, target: 'default', activePackId: pack.id });
     expect(await seed.modelPacks.getActive({ orgId: 'org1', userId: 'user-a' })).toMatchObject({
       packId: pack.id,
       models: packBody.models,
@@ -664,6 +665,7 @@ describe('model pack routes with a tenant', () => {
     );
 
     expect(activated.status).toBe(200);
+    expect(await activated.json()).toEqual({ ok: true, target: 'session', sessionPackId: pack.id });
     expect(modelSwitch).toHaveBeenCalledExactlyOnceWith({ modelId: packBody.models.build });
     expect(setSetting).toHaveBeenCalledWith({ key: 'activeModelPackId', value: pack.id });
     expect(await seed.modelPacks.getActive({ orgId: 'org1', userId: 'user-a' })).toBeNull();

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -7,6 +7,7 @@ import { DEFAULT_OM_MODEL_ID } from '@mastra/code-sdk/constants';
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { SourceControlSession } from '../storage/domains/source-control/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
 import { buildProviderAccess, ConfigRoutes, listProviders } from './config.js';
@@ -462,11 +463,32 @@ describe('GET /web/config/models', () => {
 
 describe('model pack routes with a tenant', () => {
   let seed: FactoryStorageTestSeed;
+
+  function sourceSession(sessionId: string): SourceControlSession {
+    const now = new Date();
+    return {
+      id: `row-${sessionId}`,
+      sessionId,
+      projectRepositoryId: 'repo-1',
+      orgId: 'org1',
+      userId: 'user-a',
+      branch: `user/${sessionId}`,
+      title: null,
+      baseBranch: 'main',
+      sandboxId: null,
+      sandboxWorkdir: null,
+      materializedAt: null,
+      firstMessageAt: null,
+      firstMeaningfulExecAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
   const controller = makeAgentController([
     { provider: 'anthropic', hasApiKey: true, apiKeyEnvVar: 'ANTHROPIC_API_KEY' },
   ]);
 
-  function buildApp(user: { workosId: string; organizationId?: string } | null) {
+  function buildApp(user: { workosId: string; organizationId?: string } | null, routeController = controller) {
     const app = new Hono();
     app.use('*', async (c, next) => {
       if (user) c.set('factoryAuthUser' as never, user as never);
@@ -474,12 +496,20 @@ describe('model pack routes with a tenant', () => {
     });
     mountApiRoutes(
       app as any,
-      new ConfigRoutes({ auth: fakeRouteAuth(), controller, modelPacks: seed.modelPacks }).routes(),
+      new ConfigRoutes({
+        auth: fakeRouteAuth(),
+        controller: routeController,
+        modelPacks: seed.modelPacks,
+        sourceControlSessions: {
+          getBySessionId: vi.fn(async sessionId => (sessionId === 'session-1' ? sourceSession(sessionId) : null)),
+        },
+      }).routes(),
     );
     return app;
   }
 
   const userA = { workosId: 'user-a', organizationId: 'org1' };
+  const userB = { workosId: 'user-b', organizationId: 'org1' };
   const userOtherOrg = { workosId: 'user-c', organizationId: 'org2' };
   const packBody = {
     name: 'Team pack',
@@ -556,6 +586,109 @@ describe('model pack routes with a tenant', () => {
     const listed = await buildApp(userA).request('/web/config/model-packs');
     const { packs } = await listed.json();
     expect(packs.find((p: { id: string }) => p.id === pack.id)).toMatchObject({ custom: true, active: false });
+  });
+
+  it('persists one personal active pack without requiring an open session', async () => {
+    const created = await postPack(buildApp(userA), packBody);
+    const { pack } = await created.json();
+    const activated = await buildApp(userA).request(`/web/config/model-packs/${encodeURIComponent(pack.id)}/activate`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(activated.status).toBe(200);
+    expect(await seed.modelPacks.getActive({ orgId: 'org1', userId: 'user-a' })).toMatchObject({
+      packId: pack.id,
+      models: packBody.models,
+    });
+
+    const userAList = await buildApp(userA).request('/web/config/model-packs');
+    const userBList = await buildApp(userB).request('/web/config/model-packs');
+    expect((await userAList.json()).activePackId).toBe(pack.id);
+    expect((await userBList.json()).activePackId).toBeNull();
+  });
+
+  it('clears a personal default pack', async () => {
+    const created = await postPack(buildApp(userA), packBody);
+    const { pack } = await created.json();
+    await buildApp(userA).request(`/web/config/model-packs/${encodeURIComponent(pack.id)}/activate`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target: 'default' }),
+    });
+
+    const cleared = await buildApp(userA).request('/web/config/model-packs/active', { method: 'DELETE' });
+
+    expect(cleared.status).toBe(200);
+    expect(await cleared.json()).toEqual({ ok: true, activePackId: null });
+    expect(await seed.modelPacks.getActive({ orgId: 'org1', userId: 'user-a' })).toBeNull();
+  });
+
+  it('rejects unknown activation targets', async () => {
+    const response = await buildApp(userA).request('/web/config/model-packs/anthropic/activate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target: 'factory' }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'target must be "default" or "session"' });
+  });
+
+  it('applies a pack to one session without changing the personal default', async () => {
+    const created = await postPack(buildApp(userA), packBody);
+    const { pack } = await created.json();
+    const modelSwitch = vi.fn().mockResolvedValue(undefined);
+    let sessionPackId: string | null = null;
+    const setSetting = vi.fn(async ({ key, value }: { key: string; value: unknown }) => {
+      if (key === 'activeModelPackId' && typeof value === 'string') sessionPackId = value;
+    });
+    const sessionController = {
+      ...controller,
+      getSessionByResource: vi.fn().mockResolvedValue({
+        mode: { get: () => 'build' },
+        model: { switch: modelSwitch },
+        subagents: { model: { set: vi.fn().mockResolvedValue(undefined) } },
+        thread: { getId: () => 'session-1', getSetting: vi.fn().mockImplementation(() => sessionPackId), setSetting },
+      }),
+    };
+
+    const activated = await buildApp(userA, sessionController).request(
+      `/web/config/model-packs/${encodeURIComponent(pack.id)}/activate`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ target: 'session', resourceId: 'session-1' }),
+      },
+    );
+
+    expect(activated.status).toBe(200);
+    expect(modelSwitch).toHaveBeenCalledExactlyOnceWith({ modelId: packBody.models.build });
+    expect(setSetting).toHaveBeenCalledWith({ key: 'activeModelPackId', value: pack.id });
+    expect(await seed.modelPacks.getActive({ orgId: 'org1', userId: 'user-a' })).toBeNull();
+
+    const listed = await buildApp(userA, sessionController).request('/web/config/model-packs?resourceId=session-1');
+    expect(await listed.json()).toMatchObject({ activePackId: null, sessionPackId: pack.id });
+  });
+
+  it("does not expose or mutate another user's session pack", async () => {
+    const sessionController = {
+      ...controller,
+      getSessionByResource: vi.fn().mockResolvedValue({}),
+    };
+    const app = buildApp(userB, sessionController);
+
+    const listed = await app.request('/web/config/model-packs?resourceId=session-1');
+    const activated = await app.request('/web/config/model-packs/anthropic/activate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target: 'session', resourceId: 'session-1' }),
+    });
+
+    expect(listed.status).toBe(404);
+    expect(activated.status).toBe(404);
+    expect(sessionController.getSessionByResource).not.toHaveBeenCalled();
   });
 
   it('keeps packs invisible across organizations', async () => {

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -475,8 +475,8 @@ describe('model pack routes with a tenant', () => {
       branch: `user/${sessionId}`,
       title: null,
       baseBranch: 'main',
-      sandboxId: null,
-      sandboxWorkdir: null,
+      sandboxId: 'sandbox-1',
+      sandboxWorkdir: `/tmp/${sessionId}`,
       materializedAt: null,
       firstMessageAt: null,
       firstMeaningfulExecAt: null,
@@ -659,7 +659,7 @@ describe('model pack routes with a tenant', () => {
       {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ target: 'session', resourceId: 'session-1' }),
+        body: JSON.stringify({ target: 'session', resourceId: 'session-1', scope: '/tmp/session-1' }),
       },
     );
 
@@ -668,7 +668,9 @@ describe('model pack routes with a tenant', () => {
     expect(setSetting).toHaveBeenCalledWith({ key: 'activeModelPackId', value: pack.id });
     expect(await seed.modelPacks.getActive({ orgId: 'org1', userId: 'user-a' })).toBeNull();
 
-    const listed = await buildApp(userA, sessionController).request('/web/config/model-packs?resourceId=session-1');
+    const listed = await buildApp(userA, sessionController).request(
+      '/web/config/model-packs?resourceId=session-1&scope=%2Ftmp%2Fsession-1',
+    );
     expect(await listed.json()).toMatchObject({ activePackId: null, sessionPackId: pack.id });
   });
 
@@ -679,15 +681,31 @@ describe('model pack routes with a tenant', () => {
     };
     const app = buildApp(userB, sessionController);
 
-    const listed = await app.request('/web/config/model-packs?resourceId=session-1');
+    const listed = await app.request('/web/config/model-packs?resourceId=session-1&scope=%2Ftmp%2Fsession-1');
     const activated = await app.request('/web/config/model-packs/anthropic/activate', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ target: 'session', resourceId: 'session-1' }),
+      body: JSON.stringify({ target: 'session', resourceId: 'session-1', scope: '/tmp/session-1' }),
     });
 
     expect(listed.status).toBe(404);
     expect(activated.status).toBe(404);
+    expect(sessionController.getSessionByResource).not.toHaveBeenCalled();
+  });
+
+  it('rejects a valid resource with a different session scope', async () => {
+    const sessionController = {
+      ...controller,
+      getSessionByResource: vi.fn().mockResolvedValue({}),
+    };
+
+    const response = await buildApp(userA, sessionController).request('/web/config/model-packs/anthropic/activate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target: 'session', resourceId: 'session-1', scope: '/tmp/other-session' }),
+    });
+
+    expect(response.status).toBe(404);
     expect(sessionController.getSessionByResource).not.toHaveBeenCalled();
   });
 
@@ -702,7 +720,7 @@ describe('model pack routes with a tenant', () => {
       new ConfigRoutes({ auth: fakeRouteAuth(), controller, modelPacks: seed.modelPacks }).routes(),
     );
 
-    const response = await app.request('/web/config/model-packs?resourceId=session-1');
+    const response = await app.request('/web/config/model-packs?resourceId=session-1&scope=%2Ftmp%2Fsession-1');
 
     expect(response.status).toBe(503);
     expect(await response.json()).toEqual({ error: 'session_authorization_unavailable' });

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -1076,10 +1076,12 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
                 packId: pack.id,
                 models: pack.models,
               });
-            } else if (session) {
+              return c.json({ ok: true, target, activePackId: pack.id });
+            }
+            if (session) {
               await applyActiveModelPack(session, { packId: pack.id, models: pack.models });
             }
-            return c.json({ ok: true, activePackId: pack.id });
+            return c.json({ ok: true, target, sessionPackId: pack.id });
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);
           }

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -406,18 +406,26 @@ async function authorizePackSession({
   sessions,
   packContext,
   resourceId,
+  scope,
 }: {
   c: Context;
   auth: RouteAuth;
   sessions?: Pick<SourceControlStorageHandle['sessions'], 'getBySessionId'>;
   packContext: PackContext;
   resourceId: string;
+  scope: string | undefined;
 }): Promise<Response | null> {
   if (!auth.enabled()) return null;
   if (!sessions) return c.json({ error: 'session_authorization_unavailable' }, 503);
 
   const sourceSession = await sessions.getBySessionId(resourceId);
-  if (!sourceSession || sourceSession.orgId !== packContext.orgId || sourceSession.userId !== packContext.userId) {
+  if (
+    !sourceSession ||
+    sourceSession.orgId !== packContext.orgId ||
+    sourceSession.userId !== packContext.userId ||
+    !scope ||
+    sourceSession.sandboxWorkdir !== scope
+  ) {
     return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
   }
   return null;
@@ -913,6 +921,7 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
                 sessions: options.sourceControlSessions,
                 packContext,
                 resourceId,
+                scope,
               });
               if (unauthorized) return unauthorized;
             }
@@ -1036,6 +1045,7 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
                 sessions: options.sourceControlSessions,
                 packContext,
                 resourceId,
+                scope,
               });
               if (unauthorized) return unauthorized;
             }

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -8,7 +8,6 @@ import {
   loadSettings,
   saveSettings,
   THINKING_LEVEL_VALUES,
-  THREAD_ACTIVE_MODEL_PACK_ID_KEY,
 } from '@mastra/code-sdk/onboarding/settings';
 import type { CustomProviderSetting, ThinkingLevelSetting } from '@mastra/code-sdk/onboarding/settings';
 import type { ApiRoute } from '@mastra/core/server';
@@ -20,6 +19,7 @@ import {
   DEFAULT_OBSERVATION_THRESHOLD,
   DEFAULT_REFLECTION_THRESHOLD,
 } from '../session/memory-settings-hydration.js';
+import { applyActiveModelPack } from '../session/model-pack-hydration.js';
 import type {
   CredentialRecord,
   LoginSessionKind,
@@ -33,6 +33,7 @@ import type {
   MemorySettingsStorage,
 } from '../storage/domains/memory-settings/base.js';
 import type { ModelPackRecord, ModelPacksStorage } from '../storage/domains/model-packs/base.js';
+import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 import {
   getAuthProviderId,
   listTenantCredentialsForRequest,
@@ -97,8 +98,8 @@ interface PackSession {
   subagents: { model: { set: (args: { modelId: string; agentType: string }) => Promise<void> } };
   thread: {
     getId: () => string | null;
+    getSetting: (args: { key: string }) => Promise<unknown>;
     setSetting: (args: { key: string; value: unknown }) => Promise<void>;
-    list: () => Promise<Array<{ id: string; metadata?: Record<string, unknown> }>>;
   };
 }
 
@@ -399,6 +400,29 @@ async function resolvePackContext({
   };
 }
 
+async function authorizePackSession({
+  c,
+  auth,
+  sessions,
+  packContext,
+  resourceId,
+}: {
+  c: Context;
+  auth: RouteAuth;
+  sessions?: Pick<SourceControlStorageHandle['sessions'], 'getBySessionId'>;
+  packContext: PackContext;
+  resourceId: string;
+}): Promise<Response | null> {
+  if (!auth.enabled()) return null;
+  if (!sessions) return c.json({ error: 'session_authorization_unavailable' }, 503);
+
+  const sourceSession = await sessions.getBySessionId(resourceId);
+  if (!sourceSession || sourceSession.orgId !== packContext.orgId || sourceSession.userId !== packContext.userId) {
+    return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
+  }
+  return null;
+}
+
 /** DB row → the `ModePack` shape the packs list and activation flow consume. */
 function recordToModePack(record: ModelPackRecord): ModePack {
   return { id: `custom:${record.id}`, name: record.name, description: 'Saved custom pack', models: record.models };
@@ -407,8 +431,8 @@ function recordToModePack(record: ModelPackRecord): ModePack {
 /**
  * List available model packs (built-in, gated by provider access, plus saved
  * custom packs from the request's pack context). Drops the synthetic
- * "New Custom" placeholder — the web client has its own create flow. `active`
- * is set from the given session's thread when a resourceId is supplied.
+ * "New Custom" placeholder because the web client has its own create flow.
+ * `active` marks the user's default pack for new interactive chats.
  */
 export async function listModelPacks({
   controller,
@@ -437,55 +461,10 @@ export async function listModelPacks({
     }));
 }
 
-/** Resolve the active pack id for a session by reading its current thread. */
-async function resolveActivePackId(session: PackSession | undefined): Promise<string | null> {
-  if (!session) return null;
-  const threadId = session.thread.getId();
-  if (!threadId) return null;
-  const thread = (await session.thread.list()).find(t => t.id === threadId);
-  const value = thread?.metadata?.[THREAD_ACTIVE_MODEL_PACK_ID_KEY];
+async function resolveSessionModelPackId(session: PackSession | undefined): Promise<string | null> {
+  if (!session?.thread.getId()) return null;
+  const value = await session.thread.getSetting({ key: 'activeModelPackId' });
   return typeof value === 'string' ? value : null;
-}
-
-/**
- * Apply a pack to a session: seed each mode's default model, switch the current
- * mode's model, set per-subagent models, and tag the thread with the active
- * pack id. Mirrors the TUI `applyPack` orchestration.
- */
-async function applyPackToSession({
-  controller,
-  session,
-  pack,
-}: {
-  controller: ModelCatalog;
-  session: PackSession;
-  pack: ModePack;
-}): Promise<void> {
-  const modes = controller.listModes?.() ?? [];
-  const packModels = pack.models as Record<string, string>;
-
-  for (const mode of modes) {
-    const modelId = packModels[mode.id];
-    if (modelId) {
-      mode.defaultModelId = modelId;
-      await session.thread.setSetting({ key: `modeModelId_${mode.id}`, value: modelId });
-    }
-  }
-
-  const currentModeModel = packModels[session.mode.get()];
-  if (currentModeModel) {
-    await session.model.switch({ modelId: currentModeModel });
-  }
-
-  const subagentModeMap: Record<string, string> = { explore: 'fast', plan: 'plan', execute: 'build' };
-  for (const [agentType, modeId] of Object.entries(subagentModeMap)) {
-    const saModelId = packModels[modeId];
-    if (saModelId) {
-      await session.subagents.model.set({ modelId: saModelId, agentType });
-    }
-  }
-
-  await session.thread.setSetting({ key: THREAD_ACTIVE_MODEL_PACK_ID_KEY, value: pack.id });
 }
 
 // ── Observational memory ────────────────────────────────────────────────────
@@ -611,6 +590,8 @@ export interface ConfigRoutesDeps extends RouteDependencies {
   modelCredentials?: ModelCredentialsStorage;
   /** Tenant model-packs domain handle; absent in local (no-DB) mode. */
   modelPacks?: ModelPacksStorage;
+  /** Source-control sessions used to authorize session-scoped model-pack access. */
+  sourceControlSessions?: Pick<SourceControlStorageHandle['sessions'], 'getBySessionId'>;
   /** Tenant memory-settings domain handle; absent in local (no-DB) mode. */
   memorySettings?: MemorySettingsStorage;
   /** Custom-providers domain handle; absent when the app database is missing. */
@@ -907,10 +888,9 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
       }),
 
       // ── Model packs ─────────────────────────────────────────────────────────
-      // Mirrors the TUI's /models-pack command. Custom-pack CRUD lives in the
-      // model-packs storage domain (org-scoped, sentinel `local` org in no-auth
-      // mode — never settings.json); activation is session-scoped and resolves
-      // the session from the controller registry by resourceId.
+      // Custom pack definitions are organization-scoped. Each user can choose a
+      // default for new interactive chats, while a thread-specific activation
+      // takes precedence. Factory work sessions use the project default model.
 
       registerApiRoute('/web/config/model-packs', {
         method: 'GET',
@@ -921,8 +901,23 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           const resourceId = c.req.query('resourceId');
           const scope = c.req.query('scope') || undefined;
           try {
+            const activePack = await packContext.storage.getActive({
+              orgId: packContext.orgId,
+              userId: packContext.userId,
+            });
+            const activePackId = activePack?.packId ?? null;
+            if (resourceId) {
+              const unauthorized = await authorizePackSession({
+                c: loose(c),
+                auth,
+                sessions: options.sourceControlSessions,
+                packContext,
+                resourceId,
+              });
+              if (unauthorized) return unauthorized;
+            }
             const session = resourceId ? await controller.getSessionByResource?.(resourceId, scope) : undefined;
-            const activePackId = await resolveActivePackId(session);
+            const sessionPackId = await resolveSessionModelPackId(session);
             const tenantCredentials = await listTenantCredentialsForRequest({
               c: loose(c),
               auth,
@@ -937,6 +932,7 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
                 activePackId,
               }),
               activePackId,
+              sessionPackId,
             });
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);
@@ -978,6 +974,21 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
         },
       }),
 
+      registerApiRoute('/web/config/model-packs/active', {
+        method: 'DELETE',
+        requiresAuth: false,
+        handler: async c => {
+          const packContext = await resolvePackContext({ c: loose(c), auth, modelPacks: options.modelPacks });
+          if ('response' in packContext) return packContext.response;
+          try {
+            await packContext.storage.clearActive({ orgId: packContext.orgId, userId: packContext.userId });
+            return c.json({ ok: true, activePackId: null });
+          } catch (error) {
+            return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);
+          }
+        },
+      }),
+
       registerApiRoute('/web/config/model-packs/:id', {
         method: 'DELETE',
         requiresAuth: false,
@@ -1002,18 +1013,39 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           const packContext = await resolvePackContext({ c: loose(c), auth, modelPacks: options.modelPacks });
           if ('response' in packContext) return packContext.response;
           const id = decodeURIComponent(c.req.param('id'));
-          let body: { resourceId?: unknown; scope?: unknown };
+          let body: { resourceId?: unknown; scope?: unknown; target?: unknown };
           try {
             body = await c.req.json();
           } catch {
             return c.json({ error: 'Invalid JSON body' }, 400);
           }
-          const resourceId = typeof body.resourceId === 'string' ? body.resourceId : '';
+          const target = body.target ?? 'default';
+          if (target !== 'default' && target !== 'session') {
+            return c.json({ error: 'target must be "default" or "session"' }, 400);
+          }
+          const resourceId = typeof body.resourceId === 'string' && body.resourceId ? body.resourceId : undefined;
           const scope = typeof body.scope === 'string' && body.scope ? body.scope : undefined;
-          if (!resourceId) return c.json({ error: 'Missing required field: resourceId' }, 400);
+          if (target === 'session' && !resourceId) {
+            return c.json({ error: 'Missing required field for session activation: resourceId' }, 400);
+          }
           try {
-            const session = await controller.getSessionByResource?.(resourceId, scope);
-            if (!session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
+            if (target === 'session' && resourceId) {
+              const unauthorized = await authorizePackSession({
+                c: loose(c),
+                auth,
+                sessions: options.sourceControlSessions,
+                packContext,
+                resourceId,
+              });
+              if (unauthorized) return unauthorized;
+            }
+            const session =
+              target === 'session' && resourceId
+                ? await controller.getSessionByResource?.(resourceId, scope)
+                : undefined;
+            if (target === 'session' && !session) {
+              return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
+            }
             const tenantCredentials = await listTenantCredentialsForRequest({
               c: loose(c),
               auth,
@@ -1027,7 +1059,16 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
             });
             const pack = packs.find(p => p.id === id);
             if (!pack) return c.json({ error: `Unknown pack "${id}"` }, 404);
-            await applyPackToSession({ controller, session, pack });
+            if (target === 'default') {
+              await packContext.storage.setActive({
+                orgId: packContext.orgId,
+                userId: packContext.userId,
+                packId: pack.id,
+                models: pack.models,
+              });
+            } else if (session) {
+              await applyActiveModelPack(session, { packId: pack.id, models: pack.models });
+            }
             return c.json({ ok: true, activePackId: pack.id });
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -414,6 +414,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
       authStorage: deps.authStorage,
       modelCredentials: deps.domains.modelCredentials,
       modelPacks: deps.domains.modelPacks,
+      sourceControlSessions: deps.sourceControlStorage.forIntegration('github').sessions,
       memorySettings: deps.domains.memorySettings,
       customProviders: deps.domains.customProviders,
       onCredentialsChanged: invalidateTenantCredentialSnapshots,

--- a/mastracode/factory/src/session/model-pack-hydration.test.ts
+++ b/mastracode/factory/src/session/model-pack-hydration.test.ts
@@ -125,6 +125,18 @@ describe('hydrateSessionModelPack', () => {
     expect(session.thread.setSetting).not.toHaveBeenCalled();
   });
 
+  it('does not apply a user pack when thread settings cannot be read', async () => {
+    const session = createSession();
+    delete (session.thread as { getSetting?: ModelPackHydrationSession['thread']['getSetting'] }).getSetting;
+    const dependencies = createDependencies();
+
+    await hydrateSessionModelPack(session, dependencies);
+
+    expect(dependencies.sourceControl.sessions.getBySessionId).not.toHaveBeenCalled();
+    expect(dependencies.modelPacks.getActive).not.toHaveBeenCalled();
+    expect(session.model.switch).not.toHaveBeenCalled();
+  });
+
   it('does not apply a user pack to Factory work sessions', async () => {
     const session = createSession({ factoryProjectId: 'factory-1' });
     const dependencies = createDependencies();

--- a/mastracode/factory/src/session/model-pack-hydration.test.ts
+++ b/mastracode/factory/src/session/model-pack-hydration.test.ts
@@ -125,6 +125,18 @@ describe('hydrateSessionModelPack', () => {
     expect(session.thread.setSetting).not.toHaveBeenCalled();
   });
 
+  it('does not apply a user pack to Factory work sessions', async () => {
+    const session = createSession({ factoryProjectId: 'factory-1' });
+    const dependencies = createDependencies();
+
+    await hydrateSessionModelPack(session, dependencies);
+
+    expect(dependencies.sourceControl.sessions.getBySessionId).not.toHaveBeenCalled();
+    expect(dependencies.workItems.findActiveRunBindingByThread).not.toHaveBeenCalled();
+    expect(dependencies.modelPacks.getActive).not.toHaveBeenCalled();
+    expect(session.model.switch).not.toHaveBeenCalled();
+  });
+
   it('does not apply a user pack to Factory work sessions before their state is seeded', async () => {
     const session = createSession();
     const dependencies = createDependencies();

--- a/mastracode/factory/src/session/model-pack-hydration.test.ts
+++ b/mastracode/factory/src/session/model-pack-hydration.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ActiveModelPackRecord } from '../storage/domains/model-packs/base.js';
+import type { SourceControlSession } from '../storage/domains/source-control/base.js';
+import {
+  applyActiveModelPack,
+  hydrateSessionModelPack,
+  type ModelPackHydrationDependencies,
+  type ModelPackHydrationSession,
+} from './model-pack-hydration.js';
+
+const models = {
+  build: 'anthropic/claude-opus-5',
+  plan: 'openai/gpt-5.6-sol',
+  fast: 'anthropic/claude-sonnet-5',
+};
+
+function activePack(): ActiveModelPackRecord {
+  return {
+    orgId: 'org-1',
+    userId: 'user-1',
+    packId: 'custom:pack-1',
+    models,
+    updatedAt: new Date(),
+  };
+}
+
+function sourceControlRow(): SourceControlSession {
+  return {
+    id: 'row-1',
+    sessionId: 'session-1',
+    projectRepositoryId: 'repo-1',
+    orgId: 'org-1',
+    userId: 'user-1',
+    branch: 'user/session-1',
+    title: null,
+    baseBranch: 'main',
+    sandboxId: null,
+    sandboxWorkdir: null,
+    materializedAt: null,
+    firstMessageAt: null,
+    firstMeaningfulExecAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function createSession(
+  state: Record<string, unknown> = {},
+  mode = 'build',
+  threadPackId?: string,
+): ModelPackHydrationSession {
+  return {
+    identity: { getResourceId: () => 'session-1' },
+    mode: { get: () => mode },
+    model: { switch: vi.fn().mockResolvedValue(undefined) },
+    state: { get: () => state },
+    subagents: { model: { set: vi.fn().mockResolvedValue(undefined) } },
+    thread: {
+      getId: () => 'session-1',
+      getSetting: vi.fn().mockResolvedValue(threadPackId),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
+function createDependencies(pack: ActiveModelPackRecord | null = activePack()): ModelPackHydrationDependencies {
+  return {
+    sourceControl: { sessions: { getBySessionId: vi.fn().mockResolvedValue(sourceControlRow()) } },
+    workItems: { findActiveRunBindingByThread: vi.fn().mockResolvedValue(null) },
+    modelPacks: { getActive: vi.fn().mockResolvedValue(pack) },
+  };
+}
+
+describe('applyActiveModelPack', () => {
+  it('sets every chat mode, current model, subagent model, and active pack marker', async () => {
+    const session = createSession({}, 'plan');
+
+    await applyActiveModelPack(session, activePack());
+
+    expect(session.thread.setSetting).toHaveBeenCalledWith({ key: 'modeModelId_build', value: models.build });
+    expect(session.thread.setSetting).toHaveBeenCalledWith({ key: 'modeModelId_plan', value: models.plan });
+    expect(session.thread.setSetting).toHaveBeenCalledWith({ key: 'modeModelId_fast', value: models.fast });
+    expect(session.thread.setSetting).toHaveBeenCalledWith({ key: 'activeModelPackId', value: 'custom:pack-1' });
+    expect(session.model.switch).toHaveBeenCalledExactlyOnceWith({ modelId: models.plan });
+    expect(session.subagents.model.set).toHaveBeenCalledWith({ modelId: models.fast, agentType: 'explore' });
+    expect(session.subagents.model.set).toHaveBeenCalledWith({ modelId: models.plan, agentType: 'plan' });
+    expect(session.subagents.model.set).toHaveBeenCalledWith({ modelId: models.build, agentType: 'execute' });
+  });
+});
+
+describe('hydrateSessionModelPack', () => {
+  it('applies the user active pack to a new interactive session', async () => {
+    const session = createSession();
+    const dependencies = createDependencies();
+
+    await hydrateSessionModelPack(session, dependencies);
+
+    expect(dependencies.modelPacks.getActive).toHaveBeenCalledExactlyOnceWith({ orgId: 'org-1', userId: 'user-1' });
+    expect(session.model.switch).toHaveBeenCalledExactlyOnceWith({ modelId: models.build });
+  });
+
+  it('preserves an existing thread-specific pack when the session is recreated', async () => {
+    const session = createSession({}, 'build', 'custom:thread-pack');
+    const dependencies = createDependencies();
+
+    await hydrateSessionModelPack(session, dependencies);
+
+    expect(dependencies.modelPacks.getActive).not.toHaveBeenCalled();
+    expect(session.model.switch).not.toHaveBeenCalled();
+    expect(session.thread.setSetting).not.toHaveBeenCalled();
+  });
+
+  it('preserves manual thread model choices when the session is recreated', async () => {
+    const session = createSession();
+    vi.mocked(session.thread.getSetting!).mockImplementation(async ({ key }) =>
+      key === 'modeModelId_build' ? 'anthropic/claude-haiku-4-5' : undefined,
+    );
+    const dependencies = createDependencies();
+
+    await hydrateSessionModelPack(session, dependencies);
+
+    expect(dependencies.modelPacks.getActive).not.toHaveBeenCalled();
+    expect(session.model.switch).not.toHaveBeenCalled();
+    expect(session.thread.setSetting).not.toHaveBeenCalled();
+  });
+
+  it('does not apply a user pack to Factory work sessions before their state is seeded', async () => {
+    const session = createSession();
+    const dependencies = createDependencies();
+    vi.mocked(dependencies.workItems.findActiveRunBindingByThread).mockResolvedValue({} as never);
+
+    await hydrateSessionModelPack(session, dependencies);
+
+    expect(dependencies.workItems.findActiveRunBindingByThread).toHaveBeenCalledExactlyOnceWith({
+      orgId: 'org-1',
+      threadId: 'session-1',
+      resourceId: 'session-1',
+      sessionId: 'session-1',
+    });
+    expect(dependencies.modelPacks.getActive).not.toHaveBeenCalled();
+    expect(session.model.switch).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/factory/src/session/model-pack-hydration.ts
+++ b/mastracode/factory/src/session/model-pack-hydration.ts
@@ -1,0 +1,93 @@
+import type { ActiveModelPackRecord, ModelPacksStorage } from '../storage/domains/model-packs/base.js';
+import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+
+export interface ModelPackApplicableSession {
+  mode: { get(): string };
+  model: { switch(args: { modelId: string }): Promise<unknown> };
+  subagents: { model: { set(args: { modelId: string; agentType: string }): Promise<unknown> } };
+  thread: {
+    getSetting?(args: { key: string }): Promise<unknown>;
+    setSetting(args: { key: string; value: unknown }): Promise<unknown>;
+  };
+}
+
+export interface ModelPackHydrationSession extends ModelPackApplicableSession {
+  readonly identity: { getResourceId(): string };
+  state: { get(): Record<string, unknown> | undefined };
+  thread: ModelPackApplicableSession['thread'] & { getId(): string | null | undefined };
+}
+
+export async function applyActiveModelPack(
+  session: ModelPackApplicableSession,
+  activePack: Pick<ActiveModelPackRecord, 'packId' | 'models'>,
+): Promise<void> {
+  for (const [modeId, modelId] of Object.entries(activePack.models)) {
+    await session.thread.setSetting({ key: `modeModelId_${modeId}`, value: modelId });
+  }
+
+  const currentMode = session.mode.get();
+  const currentModeModel =
+    currentMode === 'build' || currentMode === 'plan' || currentMode === 'fast'
+      ? activePack.models[currentMode]
+      : undefined;
+  if (currentModeModel) {
+    await session.model.switch({ modelId: currentModeModel });
+  }
+
+  const subagentModels = [
+    ['explore', activePack.models.fast],
+    ['plan', activePack.models.plan],
+    ['execute', activePack.models.build],
+  ] as const;
+  for (const [agentType, modelId] of subagentModels) {
+    await session.subagents.model.set({ modelId, agentType });
+  }
+
+  await session.thread.setSetting({ key: 'activeModelPackId', value: activePack.packId });
+}
+
+export interface ModelPackHydrationDependencies {
+  sourceControl: {
+    sessions: Pick<SourceControlStorageHandle['sessions'], 'getBySessionId'>;
+  };
+  workItems: Pick<WorkItemsStorage, 'findActiveRunBindingByThread'>;
+  modelPacks: Pick<ModelPacksStorage, 'getActive'>;
+}
+
+/** Seed the user's default pack unless the interactive thread already selected its own pack. */
+export async function hydrateSessionModelPack(
+  session: ModelPackHydrationSession,
+  { sourceControl, workItems, modelPacks }: ModelPackHydrationDependencies,
+): Promise<void> {
+  const resourceId = session.identity.getResourceId();
+  if (session.state.get()?.factoryProjectId) return;
+  try {
+    const sourceSession = await sourceControl.sessions.getBySessionId(resourceId);
+    if (!sourceSession) return;
+    const threadId = session.thread.getId();
+    if (
+      threadId &&
+      (await workItems.findActiveRunBindingByThread({
+        orgId: sourceSession.orgId,
+        threadId,
+        resourceId,
+        sessionId: resourceId,
+      }))
+    ) {
+      return;
+    }
+    const existingThreadSettings = await Promise.all([
+      session.thread.getSetting?.({ key: 'activeModelPackId' }),
+      session.thread.getSetting?.({ key: 'modeModelId_build' }),
+      session.thread.getSetting?.({ key: 'modeModelId_plan' }),
+      session.thread.getSetting?.({ key: 'modeModelId_fast' }),
+    ]);
+    if (existingThreadSettings.some(setting => typeof setting === 'string')) return;
+
+    const activePack = await modelPacks.getActive({ orgId: sourceSession.orgId, userId: sourceSession.userId });
+    if (activePack) await applyActiveModelPack(session, activePack);
+  } catch (error) {
+    console.warn('[Factory model-pack hydration] Unable to apply the active model pack.', error);
+  }
+}

--- a/mastracode/factory/src/session/model-pack-hydration.ts
+++ b/mastracode/factory/src/session/model-pack-hydration.ts
@@ -15,7 +15,10 @@ export interface ModelPackApplicableSession {
 export interface ModelPackHydrationSession extends ModelPackApplicableSession {
   readonly identity: { getResourceId(): string };
   state: { get(): Record<string, unknown> | undefined };
-  thread: ModelPackApplicableSession['thread'] & { getId(): string | null | undefined };
+  thread: ModelPackApplicableSession['thread'] & {
+    getId(): string | null | undefined;
+    getSetting(args: { key: string }): Promise<unknown>;
+  };
 }
 
 export async function applyActiveModelPack(
@@ -61,7 +64,7 @@ export async function hydrateSessionModelPack(
   { sourceControl, workItems, modelPacks }: ModelPackHydrationDependencies,
 ): Promise<void> {
   const resourceId = session.identity.getResourceId();
-  if (session.state.get()?.factoryProjectId) return;
+  if (session.state.get()?.factoryProjectId || typeof session.thread.getSetting !== 'function') return;
   try {
     const sourceSession = await sourceControl.sessions.getBySessionId(resourceId);
     if (!sourceSession) return;
@@ -78,10 +81,10 @@ export async function hydrateSessionModelPack(
       return;
     }
     const existingThreadSettings = await Promise.all([
-      session.thread.getSetting?.({ key: 'activeModelPackId' }),
-      session.thread.getSetting?.({ key: 'modeModelId_build' }),
-      session.thread.getSetting?.({ key: 'modeModelId_plan' }),
-      session.thread.getSetting?.({ key: 'modeModelId_fast' }),
+      session.thread.getSetting({ key: 'activeModelPackId' }),
+      session.thread.getSetting({ key: 'modeModelId_build' }),
+      session.thread.getSetting({ key: 'modeModelId_plan' }),
+      session.thread.getSetting({ key: 'modeModelId_fast' }),
     ]);
     if (existingThreadSettings.some(setting => typeof setting === 'string')) return;
 

--- a/mastracode/factory/src/storage/domains/model-packs/base.test.ts
+++ b/mastracode/factory/src/storage/domains/model-packs/base.test.ts
@@ -70,17 +70,73 @@ describe('ModelPacksStorage', () => {
     expect(otherOrg.id).not.toBe(first.id);
   });
 
+  it('stores one active pack snapshot per organization and user', async () => {
+    const seed = await createFactoryStorageForTests();
+    const firstModels = { build: 'openai/gpt-5.6', plan: 'openai/gpt-5.6', fast: 'openai/gpt-5.4-mini' };
+    const secondModels = {
+      build: 'anthropic/claude-opus-5',
+      plan: 'anthropic/claude-fable-5',
+      fast: 'anthropic/claude-haiku-4-5',
+    };
+
+    await seed.modelPacks.setActive({ orgId: 'org-1', userId: 'user-1', packId: 'openai', models: firstModels });
+    await seed.modelPacks.setActive({ orgId: 'org-1', userId: 'user-1', packId: 'anthropic', models: secondModels });
+
+    expect(await seed.modelPacks.getActive({ orgId: 'org-1', userId: 'user-1' })).toMatchObject({
+      packId: 'anthropic',
+      models: secondModels,
+    });
+    expect(await seed.modelPacks.getActive({ orgId: 'org-1', userId: 'user-2' })).toBeNull();
+  });
+
+  it('updates active snapshots when a custom pack changes and allows clearing the default', async () => {
+    const seed = await createFactoryStorageForTests();
+    const originalModels = { build: 'openai/gpt-5.5', plan: 'openai/gpt-5.5', fast: 'openai/gpt-5.4-mini' };
+    const updatedModels = { build: 'openai/gpt-5.6', plan: 'openai/gpt-5.6', fast: 'openai/gpt-5.4-mini' };
+    const pack = await seed.modelPacks.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      input: { name: 'Default', models: originalModels },
+    });
+    await seed.modelPacks.setActive({
+      orgId: 'org-1',
+      userId: 'user-1',
+      packId: `custom:${pack.id}`,
+      models: originalModels,
+    });
+
+    await seed.modelPacks.upsert({
+      orgId: 'org-1',
+      userId: 'user-2',
+      input: { name: 'Default', models: updatedModels },
+    });
+
+    expect(await seed.modelPacks.getActive({ orgId: 'org-1', userId: 'user-1' })).toMatchObject({
+      models: updatedModels,
+    });
+    expect(await seed.modelPacks.clearActive({ orgId: 'org-1', userId: 'user-1' })).toBe(true);
+    expect(await seed.modelPacks.getActive({ orgId: 'org-1', userId: 'user-1' })).toBeNull();
+    expect(await seed.modelPacks.clearActive({ orgId: 'org-1', userId: 'user-1' })).toBe(false);
+  });
+
   it('lists packs alphabetically and deletes only within the org', async () => {
     const seed = await createFactoryStorageForTests();
 
     const models = { build: 'openai/gpt-5.6', plan: 'openai/gpt-5.6', fast: 'openai/gpt-5.4-mini' };
     await seed.modelPacks.upsert({ orgId: 'org-1', userId: 'user-1', input: { name: 'Zeta', models } });
     const alpha = await seed.modelPacks.upsert({ orgId: 'org-1', userId: 'user-1', input: { name: 'Alpha', models } });
+    await seed.modelPacks.setActive({
+      orgId: 'org-1',
+      userId: 'user-1',
+      packId: `custom:${alpha.id}`,
+      models,
+    });
 
     expect((await seed.modelPacks.list({ orgId: 'org-1' })).map(pack => pack.name)).toEqual(['Alpha', 'Zeta']);
 
     expect(await seed.modelPacks.delete({ orgId: 'org-2', id: alpha.id })).toBe(false);
     expect(await seed.modelPacks.delete({ orgId: 'org-1', id: alpha.id })).toBe(true);
     expect((await seed.modelPacks.list({ orgId: 'org-1' })).map(pack => pack.name)).toEqual(['Zeta']);
+    expect(await seed.modelPacks.getActive({ orgId: 'org-1', userId: 'user-1' })).toBeNull();
   });
 });

--- a/mastracode/factory/src/storage/domains/model-packs/base.ts
+++ b/mastracode/factory/src/storage/domains/model-packs/base.ts
@@ -1,4 +1,4 @@
-import { FactoryStorageDomain } from '@mastra/core/storage';
+import { FactoryStorageDomain, UniqueViolationError } from '@mastra/core/storage';
 import type { CollectionSchema, FactoryStorageOps } from '@mastra/core/storage';
 
 /** A saved custom model pack: one model per mode (build / plan / fast). */
@@ -17,6 +17,14 @@ export interface UpsertModelPackInput {
   models: { build: string; plan: string; fast: string };
 }
 
+export interface ActiveModelPackRecord {
+  orgId: string;
+  userId: string;
+  packId: string;
+  models: { build: string; plan: string; fast: string };
+  updatedAt: Date;
+}
+
 export const MODEL_PACKS_SCHEMA: CollectionSchema = {
   name: 'model_packs',
   columns: {
@@ -33,6 +41,21 @@ export const MODEL_PACKS_SCHEMA: CollectionSchema = {
   indexes: [{ name: 'model_packs_org_name_idx', columns: ['org_id', 'name'] }],
 };
 
+export const ACTIVE_MODEL_PACKS_SCHEMA: CollectionSchema = {
+  name: 'active_model_packs',
+  columns: {
+    id: { type: 'uuid-pk' },
+    org_id: { type: 'text' },
+    user_id: { type: 'text' },
+    pack_id: { type: 'text' },
+    build_model_id: { type: 'text' },
+    plan_model_id: { type: 'text' },
+    fast_model_id: { type: 'text' },
+    updated_at: { type: 'timestamp' },
+  },
+  uniqueIndexes: [{ name: 'active_model_packs_org_user_key', columns: ['org_id', 'user_id'] }],
+};
+
 interface ModelPackDbRow extends Record<string, unknown> {
   id: string;
   org_id: string;
@@ -42,6 +65,17 @@ interface ModelPackDbRow extends Record<string, unknown> {
   plan_model_id: string;
   fast_model_id: string;
   created_at: Date;
+  updated_at: Date;
+}
+
+interface ActiveModelPackDbRow extends Record<string, unknown> {
+  id: string;
+  org_id: string;
+  user_id: string;
+  pack_id: string;
+  build_model_id: string;
+  plan_model_id: string;
+  fast_model_id: string;
   updated_at: Date;
 }
 
@@ -57,16 +91,27 @@ function toModelPack(row: ModelPackDbRow): ModelPackRecord {
   };
 }
 
+function toActiveModelPack(row: ActiveModelPackDbRow): ActiveModelPackRecord {
+  return {
+    orgId: row.org_id,
+    userId: row.user_id,
+    packId: row.pack_id,
+    models: { build: row.build_model_id, plan: row.plan_model_id, fast: row.fast_model_id },
+    updatedAt: row.updated_at,
+  };
+}
+
 export class ModelPacksStorage extends FactoryStorageDomain {
   constructor() {
     super('model-packs');
   }
 
   async init(): Promise<void> {
-    await this.ensureCollections([MODEL_PACKS_SCHEMA]);
+    await this.ensureCollections([MODEL_PACKS_SCHEMA, ACTIVE_MODEL_PACKS_SCHEMA]);
   }
 
   async dangerouslyClearAll(): Promise<void> {
+    await this.ops.deleteMany('active_model_packs', {});
     await this.ops.deleteMany('model_packs', {});
   }
 
@@ -97,6 +142,16 @@ export class ModelPacksStorage extends FactoryStorageDomain {
           updated_at: now,
         }),
       );
+      await this.#db.updateMany(
+        'active_model_packs',
+        { org_id: orgId, pack_id: `custom:${existing.id}` },
+        {
+          build_model_id: input.models.build,
+          plan_model_id: input.models.plan,
+          fast_model_id: input.models.fast,
+          updated_at: now,
+        },
+      );
       return toModelPack(row ?? existing);
     }
     const row = await this.#db.insertOne<ModelPackDbRow>('model_packs', {
@@ -126,7 +181,68 @@ export class ModelPacksStorage extends FactoryStorageDomain {
     return row ? toModelPack(row) : null;
   }
 
+  async setActive({
+    orgId,
+    userId,
+    packId,
+    models,
+  }: {
+    orgId: string;
+    userId: string;
+    packId: string;
+    models: ActiveModelPackRecord['models'];
+  }): Promise<ActiveModelPackRecord> {
+    const now = new Date();
+    const values = {
+      pack_id: packId,
+      build_model_id: models.build,
+      plan_model_id: models.plan,
+      fast_model_id: models.fast,
+      updated_at: now,
+    };
+    const updateExisting = () =>
+      this.#db.updateAtomic<ActiveModelPackDbRow>(
+        'active_model_packs',
+        { org_id: orgId, user_id: userId },
+        () => values,
+      );
+
+    const updated = await updateExisting();
+    if (updated) return toActiveModelPack(updated);
+
+    try {
+      return toActiveModelPack(
+        await this.#db.insertOne<ActiveModelPackDbRow>('active_model_packs', {
+          org_id: orgId,
+          user_id: userId,
+          ...values,
+        }),
+      );
+    } catch (error) {
+      if (!(error instanceof UniqueViolationError)) throw error;
+      const row = await updateExisting();
+      if (!row) throw error;
+      return toActiveModelPack(row);
+    }
+  }
+
+  async getActive({ orgId, userId }: { orgId: string; userId: string }): Promise<ActiveModelPackRecord | null> {
+    const row = await this.#db.findOne<ActiveModelPackDbRow>('active_model_packs', {
+      org_id: orgId,
+      user_id: userId,
+    });
+    return row ? toActiveModelPack(row) : null;
+  }
+
+  async clearActive({ orgId, userId }: { orgId: string; userId: string }): Promise<boolean> {
+    return (await this.#db.deleteMany('active_model_packs', { org_id: orgId, user_id: userId })) > 0;
+  }
+
   async delete({ orgId, id }: { orgId: string; id: string }): Promise<boolean> {
-    return (await this.#db.deleteMany('model_packs', { org_id: orgId, id })) > 0;
+    const deleted = (await this.#db.deleteMany('model_packs', { org_id: orgId, id })) > 0;
+    if (deleted) {
+      await this.#db.deleteMany('active_model_packs', { org_id: orgId, pack_id: `custom:${id}` });
+    }
+    return deleted;
   }
 }


### PR DESCRIPTION
Model pack activation in Factory settings currently applies only to the open chat, even though the setting reads like a personal default. New chats therefore fall back to the Factory model, and changing packs can leave the displayed active model stale.

This persists one personal default pack per organization and user, applies it only when a new interactive chat has no thread-specific model configuration, and keeps Factory work sessions on the project default model. Settings now manage the personal default, while the chat status line applies a pack to the current thread. The routes validate session ownership, edited custom packs refresh active snapshots, and users can clear their default.

Verified with focused Factory storage, hydration, route, and registration tests; Factory UI MSW tests for settings, chat activation, draft fallback, and model refresh; Factory and Factory UI typechecks, lint, formatting, and production builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Users can choose a personal model pack for new Factory chats. Each chat keeps its own model pack, while Factory work sessions continue to use the project default model.

## Changes

- Persist one default model pack per organization and user.
- Apply the personal default only when a chat has no thread-specific model settings.
- Preserve thread-specific packs and manual model selections.
- Keep Factory work sessions on the project default model.
- Validate session ownership for session-scoped model-pack activation.
- Refresh active model-pack snapshots when custom packs change.
- Allow users to clear their personal default.
- Add chat status controls for selecting a model pack for the current thread.
- Update settings to manage “Chat model packs” separately from Factory configuration.
- Scope model-pack query caches by session.
- Wait for model-pack loading before submitting draft chats.
- Add API types, hooks, route handling, hydration logic, UI updates, storage changes, MSW coverage, focused tests, and changesets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->