### PR TITLE
fix(memory): deliver passive reminders through a structured tool

### DIFF
--- a/.changeset/remind-send-reminder-tool.md
+++ b/.changeset/remind-send-reminder-tool.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Improve experimental Subconscious reminder delivery.

--- a/packages/memory/integration-tests/src/subconscious-libsql.test.ts
+++ b/packages/memory/integration-tests/src/subconscious-libsql.test.ts
@@ -236,16 +236,42 @@ describe('Subconscious LibSQL integration', () => {
     const model = new MockLanguageModelV2({
       doStream: async () => {
         streamCall += 1;
-        const text =
-          streamCall === 1 ? '<observations>\n- The user is scheduling Project Atlas.\n</observations>' : reminder;
+        const events =
+          streamCall === 1
+            ? [
+                { type: 'text-start' as const, id: 'observation-text' },
+                {
+                  type: 'text-delta' as const,
+                  id: 'observation-text',
+                  delta: '<observations>\n- The user is scheduling Project Atlas.\n</observations>',
+                },
+                { type: 'text-end' as const, id: 'observation-text' },
+              ]
+            : streamCall === 2
+              ? [
+                  { type: 'tool-input-start' as const, id: 'send-reminder', toolName: 'send_reminder' },
+                  {
+                    type: 'tool-input-delta' as const,
+                    id: 'send-reminder',
+                    delta: JSON.stringify({ reminder, sourceIds: ['record-atlas-launch'] }),
+                  },
+                  { type: 'tool-input-end' as const, id: 'send-reminder' },
+                ]
+              : [
+                  { type: 'text-start' as const, id: 'private-text' },
+                  { type: 'text-delta' as const, id: 'private-text', delta: 'Sent.' },
+                  { type: 'text-end' as const, id: 'private-text' },
+                ];
         return {
           stream: convertArrayToReadableStream([
             { type: 'stream-start', warnings: [] },
             { type: 'response-metadata', id: `remind-${streamCall}`, modelId: 'aimock', timestamp: new Date() },
-            { type: 'text-start', id: `text-${streamCall}` },
-            { type: 'text-delta', id: `text-${streamCall}`, delta: text },
-            { type: 'text-end', id: `text-${streamCall}` },
-            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 } },
+            ...events,
+            {
+              type: 'finish',
+              finishReason: streamCall === 2 ? 'tool-calls' : 'stop',
+              usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 },
+            },
           ]),
           rawCall: { rawPrompt: null, rawSettings: {} },
           warnings: [],
@@ -307,9 +333,9 @@ describe('Subconscious LibSQL integration', () => {
 
     expect(result.observed).toBe(true);
     expect(getModel).not.toHaveBeenCalled();
-    // The observation pass and native reminder conversation each stream through the configured model.
-    expect(streamCall).toBe(2);
-    expect(generateCall).toBe(0);
+    // The observation pass streams, and the reminder lane adds one tool-call step plus one final
+    // step, so passive reminders now cost exactly three model stream calls.
+    expect(streamCall).toBe(3);
     expect(sendSignal).toHaveBeenCalledOnce();
     expect(sendSignal).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'reactive', tagName: 'remembered', contents: expect.stringContaining(reminder) }),
@@ -333,15 +359,42 @@ describe('Subconscious LibSQL integration', () => {
     const model = new MockLanguageModelV2({
       doStream: async () => {
         streamCall += 1;
-        const text = streamCall === 1 ? `<observations>${observations}</observations>` : reminder;
+        const events =
+          streamCall === 1
+            ? [
+                { type: 'text-start' as const, id: 'resource-observation-text' },
+                {
+                  type: 'text-delta' as const,
+                  id: 'resource-observation-text',
+                  delta: `<observations>${observations}</observations>`,
+                },
+                { type: 'text-end' as const, id: 'resource-observation-text' },
+              ]
+            : streamCall === 2
+              ? [
+                  { type: 'tool-input-start' as const, id: 'resource-send-reminder', toolName: 'send_reminder' },
+                  {
+                    type: 'tool-input-delta' as const,
+                    id: 'resource-send-reminder',
+                    delta: JSON.stringify({ reminder, sourceIds: ['record-atlas-resource-launch'] }),
+                  },
+                  { type: 'tool-input-end' as const, id: 'resource-send-reminder' },
+                ]
+              : [
+                  { type: 'text-start' as const, id: 'resource-private-text' },
+                  { type: 'text-delta' as const, id: 'resource-private-text', delta: 'Sent.' },
+                  { type: 'text-end' as const, id: 'resource-private-text' },
+                ];
         return {
           stream: convertArrayToReadableStream([
             { type: 'stream-start', warnings: [] },
             { type: 'response-metadata', id: `resource-${streamCall}`, modelId: 'aimock', timestamp: new Date() },
-            { type: 'text-start', id: `resource-text-${streamCall}` },
-            { type: 'text-delta', id: `resource-text-${streamCall}`, delta: text },
-            { type: 'text-end', id: `resource-text-${streamCall}` },
-            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 } },
+            ...events,
+            {
+              type: 'finish',
+              finishReason: streamCall === 2 ? 'tool-calls' : 'stop',
+              usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 },
+            },
           ]),
           rawCall: { rawPrompt: null, rawSettings: {} },
           warnings: [],
@@ -410,7 +463,8 @@ describe('Subconscious LibSQL integration', () => {
 
     expect(result.observed).toBe(true);
     expect(getModel).not.toHaveBeenCalled();
-    expect(streamCall).toBe(2);
+    // Observation stream, reminder tool-call step, reminder final step.
+    expect(streamCall).toBe(3);
     expect(agentSignal).toHaveBeenCalledOnce();
     expect(agentSignal).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -38,6 +38,76 @@ function createModel(response: string) {
   });
 }
 
+function createReminderCallModel(toolInput: { reminder: string; sourceIds: string[] }) {
+  let generateCalls = 0;
+  let streamCalls = 0;
+  return new MockLanguageModelV2({
+    doGenerate: async () => {
+      generateCalls++;
+      if (generateCalls === 1) {
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'tool-calls' as const,
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+          warnings: [],
+          content: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'send-reminder-1',
+              toolName: 'send_reminder',
+              input: JSON.stringify(toolInput),
+            },
+          ],
+        };
+      }
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        warnings: [],
+        content: [{ type: 'text' as const, text: 'Sent.' }],
+      };
+    },
+    doStream: async () => {
+      streamCalls++;
+      if (streamCalls === 1) {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start' as const, warnings: [] },
+            { type: 'response-metadata' as const, id: 'remind-1', modelId: 'remind-model', timestamp: new Date() },
+            { type: 'tool-input-start' as const, id: 'send-reminder-1', toolName: 'send_reminder' },
+            { type: 'tool-input-delta' as const, id: 'send-reminder-1', delta: JSON.stringify(toolInput) },
+            { type: 'tool-input-end' as const, id: 'send-reminder-1' },
+            {
+              type: 'finish' as const,
+              finishReason: 'tool-calls' as const,
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      }
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start' as const, warnings: [] },
+          { type: 'response-metadata' as const, id: 'remind-2', modelId: 'remind-model', timestamp: new Date() },
+          { type: 'text-start' as const, id: 'text-1' },
+          { type: 'text-delta' as const, id: 'text-1', delta: 'Sent.' },
+          { type: 'text-end' as const, id: 'text-1' },
+          {
+            type: 'finish' as const,
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+          },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      };
+    },
+  });
+}
+
 function createContext(response: string) {
   const requestContext = new RequestContext();
   requestContext.set('organizationId', 'acme');
@@ -119,7 +189,7 @@ describe('Subconscious remind', () => {
       defaultScope: ['org:acme', 'resource:user-42'],
     });
     context.mainAgent.getModel = vi.fn(async () =>
-      createModel(`Project Atlas launches January 15. Source: ${record.id}`),
+      createReminderCallModel({ reminder: 'Project Atlas launches January 15.', sourceIds: [record.id] }),
     );
 
     const result = await applyExtractorHooks({
@@ -145,6 +215,221 @@ describe('Subconscious remind', () => {
       }),
     );
   });
+
+  it('keeps send_reminder reserved when the first delivery rejects', async () => {
+    const extractor = new SubconsciousRemindExtractor({ name: 'remind', maxSteps: 3, builtIn: true });
+    const context = createContext('unused');
+    const store = await context.memory.storage.getStore('knowledge');
+    const node = await store.createNode({
+      name: 'Project Atlas',
+      kind: 'project',
+      scope: ['org:acme', 'resource:user-42'],
+    });
+    const item = await store.appendKnowledge({
+      node: node.id,
+      text: 'Project Atlas launches January 15.',
+      scope: ['org:acme', 'resource:user-42'],
+      sourceThreadId: 'beta',
+      resolutionScope: ['org:acme', 'resource:user-42', 'thread:beta'],
+      defaultScope: ['org:acme', 'resource:user-42'],
+    });
+    // One turn, two grounded tool calls: the second must be refused by the once-per-run guard.
+    let streamCalls = 0;
+    const doubleCallModel = new MockLanguageModelV2({
+      doStream: async () => {
+        streamCalls++;
+        if (streamCalls === 1) {
+          const firstInput = JSON.stringify({ reminder: 'Atlas launches January 15.', sourceIds: [item.id] });
+          const secondInput = JSON.stringify({ reminder: 'Atlas launches January 15, again.', sourceIds: [item.id] });
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start' as const, warnings: [] },
+              {
+                type: 'response-metadata' as const,
+                id: 'double-remind-1',
+                modelId: 'remind-model',
+                timestamp: new Date(),
+              },
+              { type: 'tool-input-start' as const, id: 'send-reminder-1', toolName: 'send_reminder' },
+              { type: 'tool-input-delta' as const, id: 'send-reminder-1', delta: firstInput },
+              { type: 'tool-input-end' as const, id: 'send-reminder-1' },
+              { type: 'tool-input-start' as const, id: 'send-reminder-2', toolName: 'send_reminder' },
+              { type: 'tool-input-delta' as const, id: 'send-reminder-2', delta: secondInput },
+              { type: 'tool-input-end' as const, id: 'send-reminder-2' },
+              {
+                type: 'finish' as const,
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+            ]),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          };
+        }
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start' as const, warnings: [] },
+            {
+              type: 'response-metadata' as const,
+              id: 'double-remind-2',
+              modelId: 'remind-model',
+              timestamp: new Date(),
+            },
+            { type: 'text-start' as const, id: 'double-text' },
+            { type: 'text-delta' as const, id: 'double-text', delta: 'Sent.' },
+            { type: 'text-end' as const, id: 'double-text' },
+            {
+              type: 'finish' as const,
+              finishReason: 'stop' as const,
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+    context.mainAgent.getModel = vi.fn(async () => doubleCallModel);
+    context.sendSignal.mockRejectedValueOnce(new Error('delivery outcome unknown'));
+
+    const result = await applyExtractorHooks({
+      source: 'observer',
+      extractors: [extractor],
+      rawObservations: 'The user is scheduling Project Atlas.',
+      ...context,
+    });
+
+    expect(result.failures).toBeUndefined();
+    expect(context.sendSignal).toHaveBeenCalledOnce();
+  });
+
+  it('lets the agent correct a rejected id and still deliver the reminder', async () => {
+    const extractor = new SubconsciousRemindExtractor({ name: 'remind', maxSteps: 3, builtIn: true });
+    const context = createContext('unused');
+    const store = await context.memory.storage.getStore('knowledge');
+    const node = await store.createNode({
+      name: 'Project Atlas',
+      kind: 'project',
+      scope: ['org:acme', 'resource:user-42'],
+    });
+    const item = await store.appendKnowledge({
+      node: node.id,
+      text: 'Project Atlas launches January 15.',
+      scope: ['org:acme', 'resource:user-42'],
+      sourceThreadId: 'beta',
+      resolutionScope: ['org:acme', 'resource:user-42', 'thread:beta'],
+      defaultScope: ['org:acme', 'resource:user-42'],
+    });
+    // Turn 1 cites an invented id (rejected), turn 2 corrects it with the real id.
+    let streamCalls = 0;
+    const correctingModel = new MockLanguageModelV2({
+      doStream: async () => {
+        streamCalls++;
+        if (streamCalls <= 2) {
+          const toolCallId = `send-reminder-${streamCalls}`;
+          const input = JSON.stringify({
+            reminder: 'Atlas launches January 15.',
+            sourceIds: [streamCalls === 1 ? 'invented-item-id' : item.id],
+          });
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start' as const, warnings: [] },
+              {
+                type: 'response-metadata' as const,
+                id: `correct-${streamCalls}`,
+                modelId: 'remind-model',
+                timestamp: new Date(),
+              },
+              { type: 'tool-input-start' as const, id: toolCallId, toolName: 'send_reminder' },
+              { type: 'tool-input-delta' as const, id: toolCallId, delta: input },
+              { type: 'tool-input-end' as const, id: toolCallId },
+              {
+                type: 'finish' as const,
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+            ]),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          };
+        }
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start' as const, warnings: [] },
+            { type: 'response-metadata' as const, id: 'correct-3', modelId: 'remind-model', timestamp: new Date() },
+            { type: 'text-start' as const, id: 'correct-text' },
+            { type: 'text-delta' as const, id: 'correct-text', delta: 'Sent.' },
+            { type: 'text-end' as const, id: 'correct-text' },
+            {
+              type: 'finish' as const,
+              finishReason: 'stop' as const,
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+    context.mainAgent.getModel = vi.fn(async () => correctingModel);
+
+    const result = await applyExtractorHooks({
+      source: 'observer',
+      extractors: [extractor],
+      rawObservations: 'The user is scheduling Project Atlas.',
+      ...context,
+    });
+
+    expect(result.failures).toBeUndefined();
+    expect(context.sendSignal).toHaveBeenCalledOnce();
+    expect(context.sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({ contents: expect.stringContaining(item.id) }),
+    );
+  });
+
+  it.each(['prose without a tool call', 'a tool call citing an invented id'])(
+    'suppresses an ungrounded reminder delivered as %s',
+    async mode => {
+      const extractor = new SubconsciousRemindExtractor({
+        name: 'remind',
+        maxSteps: 3,
+        builtIn: true,
+      });
+      const context = createContext('unused');
+      context.mainAgent.getModel = vi.fn(async () =>
+        mode === 'prose without a tool call'
+          ? createModel('Project Atlas launches January 15. Source: invented-item-id')
+          : createReminderCallModel({
+              reminder: 'Project Atlas launches January 15.',
+              sourceIds: ['invented-item-id'],
+            }),
+      );
+      const store = await context.memory.storage.getStore('knowledge');
+      const node = await store.createNode({
+        name: 'Project Atlas',
+        kind: 'project',
+        scope: ['org:acme', 'resource:user-42'],
+      });
+      await store.appendKnowledge({
+        node: node.id,
+        text: 'Project Atlas launches January 15.',
+        scope: ['org:acme', 'resource:user-42'],
+        sourceThreadId: 'alpha',
+        resolutionScope: ['org:acme', 'resource:user-42', 'thread:alpha'],
+        defaultScope: ['org:acme', 'resource:user-42'],
+      });
+
+      const result = await applyExtractorHooks({
+        source: 'observer',
+        extractors: [extractor],
+        rawObservations: 'The user is scheduling Project Atlas.',
+        ...context,
+      });
+
+      expect(result.failures).toBeUndefined();
+      expect(context.sendSignal).not.toHaveBeenCalled();
+    },
+  );
 
   it.each(['Project Atlas launches January 15.', 'Project Atlas launches January 15. Source: invented-record-id'])(
     'suppresses an ungrounded reminder: %s',
@@ -204,7 +489,7 @@ describe('Subconscious remind', () => {
     const recordId = 'item-atlas-launch';
     const extractor = new SubconsciousRemindExtractor(
       { name: 'remind', maxSteps: 3, builtIn: true },
-      createModel(`Project Atlas launches January 15. Source KnowledgeRecord: ${recordId}.`) as any,
+      createReminderCallModel({ reminder: 'Project Atlas launches January 15.', sourceIds: [recordId] }) as any,
     );
     const context = createContext('unused');
     delete (context as any).mainAgent;
@@ -307,7 +592,7 @@ describe('Subconscious remind', () => {
   });
 
   it("still reminds about the thread's own older items once they age past the fresh window", async () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ['Date'] });
     try {
       const extractor = new SubconsciousRemindExtractor({
         name: 'remind',
@@ -329,7 +614,9 @@ describe('Subconscious remind', () => {
         resolutionScope: ['org:acme', 'resource:user-42', 'thread:alpha'],
         defaultScope: ['org:acme', 'resource:user-42'],
       });
-      context.mainAgent.getModel = vi.fn(async () => createModel(`The launch happens January 15. Source: ${item.id}`));
+      context.mainAgent.getModel = vi.fn(async () =>
+        createReminderCallModel({ reminder: 'The launch happens January 15.', sourceIds: [item.id] }),
+      );
 
       vi.advanceTimersByTime(31 * 60 * 1000);
 
@@ -657,34 +944,59 @@ describe('Subconscious remind', () => {
       // way a process restart reconstructs Memory around surviving storage.
       const sharedStorage = new InMemoryStore();
       const prompts: unknown[] = [];
-      const recordingModel = (response: string) =>
-        new MockLanguageModelV2({
-          doGenerate: async options => {
-            prompts.push(options.prompt);
-            return {
-              rawCall: { rawPrompt: null, rawSettings: {} },
-              finishReason: 'stop' as const,
-              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-              warnings: [],
-              content: [{ type: 'text' as const, text: response }],
-            };
-          },
+      const recordingModel = (response: string, sourceId: string) => {
+        let streamCalls = 0;
+        return new MockLanguageModelV2({
           doStream: async options => {
             prompts.push(options.prompt);
+            streamCalls++;
+            if (response === '<no-reminder />' || streamCalls > 1) {
+              return {
+                stream: convertArrayToReadableStream([
+                  { type: 'stream-start' as const, warnings: [] },
+                  {
+                    type: 'response-metadata' as const,
+                    id: `remind-${streamCalls}`,
+                    modelId: 'remind-model',
+                    timestamp: new Date(),
+                  },
+                  { type: 'text-start' as const, id: `text-${streamCalls}` },
+                  {
+                    type: 'text-delta' as const,
+                    id: `text-${streamCalls}`,
+                    delta: response === '<no-reminder />' ? response : 'Sent.',
+                  },
+                  { type: 'text-end' as const, id: `text-${streamCalls}` },
+                  {
+                    type: 'finish' as const,
+                    finishReason: 'stop' as const,
+                    usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                  },
+                ]),
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                warnings: [],
+              };
+            }
+            const input = JSON.stringify({ reminder: response, sourceIds: [sourceId] });
             return {
               stream: convertArrayToReadableStream([
-                { type: 'stream-start', warnings: [] },
-                { type: 'response-metadata', id: 'remind-1', modelId: 'remind-model', timestamp: new Date() },
-                { type: 'text-start', id: 'text-1' },
-                { type: 'text-delta', id: 'text-1', delta: response },
-                { type: 'text-end', id: 'text-1' },
-                { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+                { type: 'stream-start' as const, warnings: [] },
+                { type: 'response-metadata' as const, id: 'remind-1', modelId: 'remind-model', timestamp: new Date() },
+                { type: 'tool-input-start' as const, id: 'send-reminder-1', toolName: 'send_reminder' },
+                { type: 'tool-input-delta' as const, id: 'send-reminder-1', delta: input },
+                { type: 'tool-input-end' as const, id: 'send-reminder-1' },
+                {
+                  type: 'finish' as const,
+                  finishReason: 'tool-calls' as const,
+                  usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                },
               ]),
               rawCall: { rawPrompt: null, rawSettings: {} },
               warnings: [],
             };
           },
         });
+      };
 
       const runOnce = async (response: string) => {
         const extractor = new SubconsciousRemindExtractor({ name: 'remind', maxSteps: 3, builtIn: true }, undefined, {
@@ -692,7 +1004,9 @@ describe('Subconscious remind', () => {
         });
         const context = createContext('unused');
         const item = await seedRelevantItem(context);
-        context.mainAgent.getModel = vi.fn(async () => recordingModel(response.replace('{itemId}', item.id))) as any;
+        context.mainAgent.getModel = vi.fn(async () =>
+          recordingModel(response.replace('{itemId}', item.id), item.id),
+        ) as any;
         const result = await applyExtractorHooks({
           source: 'observer',
           extractors: [extractor],
@@ -1674,19 +1988,15 @@ describe('Subconscious remind ask conversation', () => {
     // reminders that reference no candidate, and this test is about signal shape.
     // Both entry points use sendMessage on the shared reminder conversation. Passive work owns its
     // output; question work is accepted immediately and can only answer through the bound reply tool.
+    context.mainAgent.getModel = vi.fn(async () =>
+      createReminderCallModel({ reminder: 'Atlas ships mid January, worth checking.', sourceIds: [item.id] }),
+    );
+    const originalSendMessage = Agent.prototype.sendMessage;
     const sendSpy = vi.spyOn(Agent.prototype, 'sendMessage' as any);
     sendSpy.mockImplementation(function (_input: any, opts: any) {
       const input = _input as { metadata?: Record<string, unknown> } | string;
       if (typeof input === 'string') {
-        return {
-          accepted: Promise.resolve({
-            action: 'wake',
-            output: {
-              consumeStream: vi.fn(async () => {}),
-              getFullOutput: vi.fn(async () => ({ text: `Atlas ships mid January, worth checking. (${item.id})` })),
-            },
-          }),
-        };
+        return originalSendMessage.call(this, _input, opts);
       }
       void pendingAsk.then(async answer => {
         const processor = createReplyToolProcessor(registry, {

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -25,8 +25,10 @@ const DEFAULT_INSTRUCTIONS = `Review the current observations and use the knowle
 
 Be selective. Treat future-dated items as relevant when their time is imminent or useful to the current task. When the observations show whether an earlier reminder was used, tune your selectivity accordingly without storing hit/miss counters.
 Never remind about knowledge that is already visible in the current observations or recent messages — a reminder is only valuable for knowledge the agent can no longer see. Echoing back what was just said or just captured is noise.
-If nothing is relevant, respond with exactly ${NO_REMINDER} and nothing else.
-If knowledge is relevant, return one concise reminder that explains why it matters and includes source node or item IDs. Do not invent knowledge and do not expose knowledge outside the tools' scoped results.`;
+For explicit questions, follow the reply tool instructions supplied for that turn. For passive reminder evaluation, follow the send_reminder tool instructions supplied for that turn. Do not invent knowledge and do not expose knowledge outside the tools' scoped results.`;
+
+const REMIND_TOOL_INSTRUCTIONS = `If knowledge is relevant, call send_reminder exactly once with one concise reminder explaining why it matters and the source node or item IDs it uses. Text outside the tool is private conversation residue and is never surfaced.
+If nothing is relevant, do not call send_reminder; no tool call means no reminder.`;
 
 /** Own-thread records younger than this are treated as still-in-context and excluded from reminder candidates. */
 const FRESH_OWN_RECORD_WINDOW_MS = 30 * 60 * 1000;
@@ -555,6 +557,7 @@ function createReminderAgent(args: {
   registry: RemindRequestRegistry;
   replyCapabilities: ReplyCapabilityRegistry;
   remindMemory?: Memory;
+  extraTools?: Record<string, ToolAction<any, any, any, any, any, any, any>>;
 }): Agent {
   return new Agent({
     id: `subconscious-remind-${args.parentThreadId}`,
@@ -562,7 +565,10 @@ function createReminderAgent(args: {
     instructions: args.instructions,
     model: args.model,
     ...(args.remindMemory ? { memory: args.remindMemory } : {}),
-    tools: createKnowledgeTools(args.memory, args.scope),
+    tools: {
+      ...createKnowledgeTools(args.memory, args.scope),
+      ...args.extraTools,
+    },
     inputProcessors: [
       createReplyToolProcessor(args.registry, args.conversation, args.replyCapabilities),
       new ReminderResearchBudgetProcessor(args.registry, args.conversation),
@@ -942,6 +948,53 @@ function fallbackRegistry(): RemindRequestRegistry {
   return (fallback ??= new RemindRequestRegistry());
 }
 
+function createSendReminderTool(deps: {
+  candidateIds: ReadonlySet<string>;
+  sendSignal: NonNullable<import('../extractor').ExtractorOnExtractedContext['sendSignal']>;
+  threadId: string;
+}) {
+  const state = { sent: false };
+  return createTool({
+    id: 'send_reminder',
+    description:
+      'Surface one source-linked reminder to the main agent. Call this at most once. Text outside this tool stays private.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        reminder: { type: 'string', minLength: 1 },
+        sourceIds: { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 5 },
+      },
+      required: ['reminder', 'sourceIds'],
+      additionalProperties: false,
+    } satisfies JSONSchema7,
+    execute: async input => {
+      const { reminder, sourceIds } = input as { reminder: string; sourceIds: string[] };
+      if (state.sent) return { ok: false, error: 'A reminder was already sent this run.' };
+      const text = reminder.trim();
+      const groundedIds = [...new Set(sourceIds)];
+      if (!text) return { ok: false, error: 'The reminder text is empty.' };
+      const unknown = groundedIds.filter(id => !deps.candidateIds.has(id));
+      if (unknown.length > 0) return { ok: false, error: `Unknown source ids: ${unknown.join(', ')}.` };
+      state.sent = true;
+      await deps.sendSignal({
+        id: `__subconscious_remembered_${crypto.randomUUID()}`,
+        type: 'reactive',
+        tagName: 'remembered',
+        contents: `${text}\n\nSources: ${groundedIds.join(', ')}`,
+        createdAt: new Date(),
+        metadata: { origin: 'subconscious' },
+        attributes: {
+          source: 'subconscious',
+          sourceIds: groundedIds.join(','),
+          agent: 'remind',
+          threadId: deps.threadId,
+        },
+      });
+      return { ok: true };
+    },
+  });
+}
+
 /** A configuration gap rather than a failure — reported as an explicit unavailable result. */
 class ReminderUnavailableError extends Error {}
 
@@ -977,7 +1030,9 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
             context.threadId,
           );
           if (sources.length === 0) return;
-          const instructions = [DEFAULT_INSTRUCTIONS, config.instructions?.trim()].filter(Boolean).join('\n\n');
+          const instructions = [DEFAULT_INSTRUCTIONS, REMIND_TOOL_INSTRUCTIONS, config.instructions?.trim()]
+            .filter(Boolean)
+            .join('\n\n');
           const recentMessagesSection = context.recentMessages?.trim()
             ? `\n\nRecent conversation messages (already visible to the agent — never remind about anything present here):\n${context.recentMessages}`
             : '';
@@ -1011,6 +1066,9 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
           ) {
             remindMemory = undefined;
           }
+          const candidateIds = new Set(
+            sources.flatMap(source => [source.id, source.recordId]).filter((id): id is string => Boolean(id)),
+          );
           const agent = createReminderAgent({
             parentThreadId: context.threadId,
             conversation: {
@@ -1026,8 +1084,15 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
             registry,
             replyCapabilities: resolveReplyCapabilities(registry),
             remindMemory,
+            extraTools: {
+              send_reminder: createSendReminderTool({
+                candidateIds,
+                sendSignal: context.sendSignal,
+                threadId: context.threadId,
+              }),
+            },
           });
-          const reminder = await runReminderConversationTurn({
+          await runReminderConversationTurn({
             agent,
             parentThreadId: context.threadId,
             resourceId: conversationResourceId,
@@ -1037,30 +1102,6 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
             // The passive evaluation stops waiting when its calling turn aborts. The reminder turn
             // itself may still complete and persist in causal order.
             abortSignal: context.abortSignal,
-          });
-          if (!reminder || /^<no-reminder\s*\/>$/i.test(reminder)) {
-            return;
-          }
-
-          const candidateIds = [...new Set(sources.flatMap(source => [source.id, source.recordId]))];
-          const sourceIds = candidateIds.filter(id => reminder.includes(id)).slice(0, 5);
-          if (sourceIds.length === 0) {
-            return;
-          }
-          const contents = `${reminder}\n\nSources: ${sourceIds.join(', ')}`;
-          await context.sendSignal({
-            id: `__subconscious_remembered_${crypto.randomUUID()}`,
-            type: 'reactive',
-            tagName: 'remembered',
-            contents,
-            createdAt: new Date(),
-            metadata: { origin: 'subconscious' },
-            attributes: {
-              source: 'subconscious',
-              sourceIds: sourceIds.join(','),
-              agent: 'remind',
-              threadId: context.threadId,
-            },
           });
         } catch (error) {
           await context.writer?.custom({


### PR DESCRIPTION
## Summary

Replace passive reminder prose parsing with a structured `send_reminder` tool. The reminder agent now emits a reactive signal only through a validated tool call; text outside the tool remains private conversation residue. The legacy no-reminder sentinel remains only for the explicit ask path.

## Root cause

The previous passive path treated model prose as a transport protocol. Silence depended on a literal sentinel, and grounding depended on source IDs appearing as substrings in generated text. This was fragile, difficult to correct within a model turn, and different from the native signal transport used by explicit reminder questions.

## What changed

- Add a passive-only `send_reminder` tool with structured reminder text and source IDs.
- Validate non-empty reminder text and one to five deduplicated source node or record IDs.
- Reject IDs outside the retrieved candidate set with a correctable tool error.
- Latch the per-run delivery reservation before awaiting `sendSignal()`, enforcing at most one delivery attempt per passive run.
- Keep the reservation latched after rejected or ambiguous delivery so a second tool call cannot duplicate the reminder.
- Treat no tool call as silence and keep all ordinary model prose private.
- Update unit and LibSQL integration mocks to exercise streamed structured tool calls rather than prose parsing.

## Design notes

The contract is at most one attempt, not guaranteed delivery. A transport failure consumes the passive run's reservation to avoid duplicate signals after an ambiguous enqueue result. Candidate validation proves that cited IDs were available to the reminder agent; it does not semantically prove every word of the reminder text.

The PR inherits the repaired ask stack's behavior: resource-less passive evaluations run statelessly without persistent reminder memory, while checkpoint and partial-delivery tradeoffs remain owned by #22515.

## Lineage

This PR is cleanly rebuilt on the repaired #22515 head. Its own diff contains only the structured passive reminder transport, its focused tests, the LibSQL integration mock update, and the minimal experimental patch changeset.

## Test plan

From `packages/memory`:

```bash
pnpm exec vitest run src/processors/observational-memory/__tests__/remind-request-state.test.ts src/processors/observational-memory/__tests__/subconscious-remind.test.ts src/processors/observational-memory/__tests__/remind-async-ux.test.ts --reporter=dot --bail=1
pnpm check
pnpm lint
git diff --check
```

From `packages/memory/integration-tests`:

```bash
pnpm exec vitest run src/subconscious-libsql.test.ts --reporter=dot --bail=1
```

Results on the reviewed and restacked head `f2435bc729a16abfa991100a303d42c107ed7639`:

- Focused reminder suites: 108 passed
- TypeScript check: passed
- Lint: 0 warnings and 0 errors across 199 files
- LibSQL Subconscious integration: 5 passed
- Diff check: passed

The PR includes a patch changeset for `@mastra/memory`. It is intentionally minimal because Subconscious remains experimental.
