### PR TITLE
fix(factory-ui): make the work board say what is actually happening

### DIFF
--- a/.changeset/factory-ui-board-tells-the-truth.md
+++ b/.changeset/factory-ui-board-tells-the-truth.md
@@ -1,5 +1,5 @@
 ---
-'@internal/factory-ui': patch
+'@mastra/factory': patch
 ---
 
 Make the board honest about runs it is waiting on, and about clicks that fail.

--- a/.changeset/factory-ui-board-tells-the-truth.md
+++ b/.changeset/factory-ui-board-tells-the-truth.md
@@ -1,0 +1,17 @@
+---
+'@internal/factory-ui': patch
+---
+
+Make the board honest about runs it is waiting on, and about clicks that fail.
+
+Four gaps closed on the work board:
+
+- A card click that failed while refreshing workspaces before starting a run did
+  nothing at all — no run, no error. It now surfaces the failure instead of
+  swallowing it, so an expired session reads as an expired session.
+- A run a rule proposed could not be approved from the card. The card menu now
+  offers it.
+- After a plan was approved, the Building run became unreachable from the card,
+  leaving the item stranded mid-loop.
+- A card with a proposed run looked idle. It now says it is waiting on someone,
+  with the approval inline.

--- a/.changeset/factory-ui-replayed-decisions-are-not-failures.md
+++ b/.changeset/factory-ui-replayed-decisions-are-not-failures.md
@@ -1,0 +1,14 @@
+---
+'@internal/factory-ui': patch
+---
+
+Stop showing "Linked card could not be filed" when nothing failed.
+
+A linked-card decision that already succeeded is deliberately reset to `retry`
+when its card is rematerialized, so the card gets re-filed. The board read any
+`retry` as "already failed at least once" and put an error on the card, so a
+routine replay looked like a broken automation — 16 cards were showing a failure
+nobody caused.
+
+A card now reports an error only when the effect has actually been attempted or
+left an error behind. A replay reads as what it is: the work it is doing.

--- a/.changeset/factory-ui-replayed-decisions-are-not-failures.md
+++ b/.changeset/factory-ui-replayed-decisions-are-not-failures.md
@@ -1,5 +1,5 @@
 ---
-'@internal/factory-ui': patch
+'@mastra/factory': patch
 ---
 
 Stop showing "Linked card could not be filed" when nothing failed.

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
@@ -4,6 +4,7 @@
  * thread gets a kickoff message instead of an empty "What can I help you
  * build?" session. Only cards with no run spec fall back to a plain session.
  */
+import { Toaster } from '@mastra/playground-ui/components/Toaster';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
@@ -200,5 +201,36 @@ describe('Board card click starts the default run', () => {
       invocation: { type: 'skill', skillName: 'factory-triage' },
       workItem: { role: 'triage' },
     });
+  });
+
+  // Card clicks refetch worktrees before deciding what to do. When that
+  // refetch fails (e.g. the auth cookie expired overnight), the click used to
+  // die silently — no run, no toast, nothing. It must surface an error.
+  it('shows an error toast instead of failing silently when the pre-start refetch fails', async () => {
+    const { startRequests } = stubBoardEndpoints();
+    // First sessions read (board load) succeeds; later refetches 401 like an
+    // expired session would.
+    let sessionsCalls = 0;
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () => {
+        sessionsCalls += 1;
+        if (sessionsCalls === 1) return HttpResponse.json({ sessions: [] });
+        return HttpResponse.json({ error: 'unauthorized' }, { status: 401 });
+      }),
+    );
+    const user = userEvent.setup();
+    // The Toaster normally mounts in main.tsx, above the router.
+    const router = createMemoryRouter(createAppRoutes(), { initialEntries: [`/factories/${FACTORY_ID}/work`] });
+    renderWithProviders(
+      <>
+        <RouterProvider router={router} />
+        <Toaster position="bottom-right" />
+      </>,
+    );
+
+    await user.click(await screen.findByRole('button', { name: 'Investigate Fix login bug' }));
+
+    await waitFor(() => expect(screen.getByText(/failed to (list sessions|refresh)/i)).toBeInTheDocument());
+    expect(startRequests).toHaveLength(0);
   });
 });

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageProposedRun.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageProposedRun.msw.test.tsx
@@ -97,14 +97,29 @@ const buildingWorkItem = {
   },
 };
 
+/** A Review card whose pull request has since closed: its parked run is moot. */
+const closedPullRequestWorkItem = {
+  ...workItem,
+  externalSource: { ...workItem.externalSource, type: 'pull-request', externalId: 'github-pr:1' },
+  stages: ['review'],
+  metadata: { number: 1, state: 'closed' },
+};
+
 function stubBoardEndpoints({
   withLiveSession = false,
   building = false,
-}: { withLiveSession?: boolean; building?: boolean } = {}) {
+  closedPullRequest = false,
+}: { withLiveSession?: boolean; building?: boolean; closedPullRequest?: boolean } = {}) {
   const settled: string[] = [];
   const startRequests: unknown[] = [];
   let status: 'proposed' | 'pending' | 'dismissed' = 'proposed';
-  const item = building ? buildingWorkItem : withLiveSession ? liveSessionWorkItem : workItem;
+  const item = closedPullRequest
+    ? closedPullRequestWorkItem
+    : building
+      ? buildingWorkItem
+      : withLiveSession
+        ? liveSessionWorkItem
+        : workItem;
   const sessions = withLiveSession || building ? [userSession] : [];
 
   server.use(
@@ -188,9 +203,13 @@ function stubBoardEndpoints({
   return { settled, startRequests };
 }
 
-function renderWorkBoard() {
-  const router = createMemoryRouter(createAppRoutes(), { initialEntries: [`/factories/${FACTORY_ID}/work`] });
+function renderBoard(board: 'work' | 'review' = 'work') {
+  const router = createMemoryRouter(createAppRoutes(), { initialEntries: [`/factories/${FACTORY_ID}/${board}`] });
   renderWithProviders(<RouterProvider router={router} />);
+}
+
+function renderWorkBoard() {
+  renderBoard('work');
 }
 
 describe('Board card with a proposed run', () => {
@@ -232,6 +251,36 @@ describe('Board card with a proposed run', () => {
 
     await waitFor(() => expect(settled).toEqual(['approve']));
     expect(startRequests).toHaveLength(0);
+  });
+
+  it('says a run is waiting on a card that would otherwise look idle', async () => {
+    const { settled, startRequests } = stubBoardEndpoints({ withLiveSession: true });
+    const user = userEvent.setup();
+    renderWorkBoard();
+
+    // Without the badge this card reads as a plain link to its session, so the
+    // parked run is only discoverable by opening the menu on a hunch.
+    const card = await screen.findByRole('article', { name: 'Fix login bug' });
+    expect(await within(card).findByText('Suggested: Build')).toBeVisible();
+
+    await user.click(within(card).getByRole('button', { name: 'Start suggested run: Build' }));
+
+    await waitFor(() => expect(settled).toEqual(['approve']));
+    expect(startRequests).toHaveLength(0);
+  });
+
+  it('stops asking about a run parked on a pull request that already closed', async () => {
+    const { settled } = stubBoardEndpoints({ closedPullRequest: true });
+    const user = userEvent.setup();
+    renderBoard('review');
+
+    const card = await screen.findByRole('article', { name: 'Fix login bug' });
+    expect(within(card).queryByText(/^Suggested:/)).toBeNull();
+
+    // Still reachable from the menu so the dead run can be cleared away.
+    await user.click(within(card).getByRole('button', { name: 'Actions for Fix login bug' }));
+    await user.click(await screen.findByRole('menuitem', { name: 'Dismiss suggested run' }));
+    await waitFor(() => expect(settled).toEqual(['dismiss']));
   });
 
   it('still offers the Building run when the plan already filled the work session slot', async () => {

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageProposedRun.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageProposedRun.msw.test.tsx
@@ -58,10 +58,38 @@ function decision(status: 'proposed' | 'pending' | 'dismissed') {
   };
 }
 
-function stubBoardEndpoints() {
+const SESSION_ID = 'sess-1';
+
+const liveSessionWorkItem = {
+  ...workItem,
+  stages: ['planning'],
+  sessions: {
+    triage: { sessionId: SESSION_ID, branch: 'factory/issue-1', threadId: 'thread-1', startedBy: 'user-1' },
+  },
+};
+
+const userSession = {
+  id: 'us-1',
+  sessionId: SESSION_ID,
+  projectRepositoryId: REPO_ID,
+  orgId: 'org-1',
+  userId: 'user-1',
+  title: 'Fix login bug',
+  branch: 'factory/issue-1',
+  baseBranch: 'main',
+  sandboxId: null,
+  sandboxWorkdir: null,
+  materializedAt: null,
+  createdAt: '2026-08-10T00:00:00.000Z',
+  updatedAt: '2026-08-10T00:00:00.000Z',
+};
+
+function stubBoardEndpoints({ withLiveSession = false }: { withLiveSession?: boolean } = {}) {
   const settled: string[] = [];
   const startRequests: unknown[] = [];
   let status: 'proposed' | 'pending' | 'dismissed' = 'proposed';
+  const item = withLiveSession ? liveSessionWorkItem : workItem;
+  const sessions = withLiveSession ? [userSession] : [];
 
   server.use(
     http.get(`${TEST_BASE_URL}/auth/me`, () =>
@@ -89,7 +117,7 @@ function stubBoardEndpoints() {
       }),
     ),
     http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
-      HttpResponse.json({ workItems: [workItem] }),
+      HttpResponse.json({ workItems: [item] }),
     ),
     http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions`, () =>
       HttpResponse.json({ decisions: [decision(status)] }),
@@ -122,7 +150,7 @@ function stubBoardEndpoints() {
     http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/issues`, () =>
       HttpResponse.json({ issues: [], nextPage: null }),
     ),
-    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () => HttpResponse.json({ sessions: [] })),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () => HttpResponse.json({ sessions })),
     http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () => HttpResponse.json({ ok: true })),
   );
 
@@ -157,6 +185,21 @@ describe('Board card with a proposed run', () => {
     await user.click(await screen.findByRole('menuitem', { name: 'Dismiss suggested run' }));
 
     await waitFor(() => expect(settled).toEqual(['dismiss']));
+    expect(startRequests).toHaveLength(0);
+  });
+
+  it('releases the proposal from the menu when the card already links to a session', async () => {
+    const { settled, startRequests } = stubBoardEndpoints({ withLiveSession: true });
+    const user = userEvent.setup();
+    renderWorkBoard();
+
+    // The card body is a link to the existing session, so the primary action
+    // button never renders — the menu must still offer the suggested run.
+    const card = await screen.findByRole('article', { name: 'Fix login bug' });
+    await user.click(within(card).getByRole('button', { name: 'Actions for Fix login bug' }));
+    await user.click(await screen.findByRole('menuitem', { name: 'Start suggested run' }));
+
+    await waitFor(() => expect(settled).toEqual(['approve']));
     expect(startRequests).toHaveLength(0);
   });
 });

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageProposedRun.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageProposedRun.msw.test.tsx
@@ -84,12 +84,28 @@ const userSession = {
   updatedAt: '2026-08-10T00:00:00.000Z',
 };
 
-function stubBoardEndpoints({ withLiveSession = false }: { withLiveSession?: boolean } = {}) {
+/**
+ * An approved plan transitions the card to Building and writes the `work`
+ * session ref itself — no run ever started, but the slot looks used.
+ */
+const buildingWorkItem = {
+  ...workItem,
+  stages: ['execute'],
+  sessions: {
+    triage: { sessionId: SESSION_ID, branch: 'factory/issue-1', threadId: 'thread-1', startedBy: 'user-1' },
+    work: { sessionId: SESSION_ID, branch: 'factory/issue-1', threadId: 'thread-1', startedBy: 'user-1' },
+  },
+};
+
+function stubBoardEndpoints({
+  withLiveSession = false,
+  building = false,
+}: { withLiveSession?: boolean; building?: boolean } = {}) {
   const settled: string[] = [];
   const startRequests: unknown[] = [];
   let status: 'proposed' | 'pending' | 'dismissed' = 'proposed';
-  const item = withLiveSession ? liveSessionWorkItem : workItem;
-  const sessions = withLiveSession ? [userSession] : [];
+  const item = building ? buildingWorkItem : withLiveSession ? liveSessionWorkItem : workItem;
+  const sessions = withLiveSession || building ? [userSession] : [];
 
   server.use(
     http.get(`${TEST_BASE_URL}/auth/me`, () =>
@@ -120,7 +136,10 @@ function stubBoardEndpoints({ withLiveSession = false }: { withLiveSession?: boo
       HttpResponse.json({ workItems: [item] }),
     ),
     http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions`, () =>
-      HttpResponse.json({ decisions: [decision(status)] }),
+      HttpResponse.json({ decisions: building ? [] : [decision(status)] }),
+    ),
+    http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+      HttpResponse.json({ session: userSession }),
     ),
     http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions/${DECISION_ID}/approve`, () => {
       settled.push('approve');
@@ -134,7 +153,19 @@ function stubBoardEndpoints({ withLiveSession = false }: { withLiveSession?: boo
     }),
     http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/runs/start`, async ({ request }) => {
       startRequests.push(await request.json());
-      return HttpResponse.json({});
+      return HttpResponse.json({
+        prepared: {
+          workItemId: ITEM_ID,
+          bindingId: 'binding-1',
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          sessionId: SESSION_ID,
+          branch: 'factory/issue-1',
+          revision: 2,
+          kickoffStatus: 'queued',
+          replayed: false,
+        },
+      });
     }),
     http.get(`${TEST_BASE_URL}/web/intake/config`, () =>
       HttpResponse.json({
@@ -201,5 +232,17 @@ describe('Board card with a proposed run', () => {
 
     await waitFor(() => expect(settled).toEqual(['approve']));
     expect(startRequests).toHaveLength(0);
+  });
+
+  it('still offers the Building run when the plan already filled the work session slot', async () => {
+    const { startRequests } = stubBoardEndpoints({ building: true });
+    const user = userEvent.setup();
+    renderWorkBoard();
+
+    const card = await screen.findByRole('article', { name: 'Fix login bug' });
+    await user.click(within(card).getByRole('button', { name: 'Actions for Fix login bug' }));
+    await user.click(await screen.findByRole('menuitem', { name: 'Build' }));
+
+    await waitFor(() => expect(startRequests).toHaveLength(1));
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.test.ts
@@ -68,6 +68,28 @@ describe('boardCardStatus', () => {
     });
   });
 
+  it('does not call a replayed linked-card effect a failure', () => {
+    // A linked-card decision that already succeeded is reset to `retry` when its
+    // card is rematerialized, so the card gets re-filed. Nothing failed: no
+    // attempt was spent and no error was left. Calling that an error is how the
+    // board ends up showing failures nobody caused.
+    expect(
+      boardCardStatus({
+        idle: IDLE,
+        decision: decision({ type: 'upsertLinkedWorkItem', status: 'retry', attempts: 0, lastError: null }),
+      }),
+    ).toEqual({ kind: 'busy', label: 'Filing a linked card…' });
+  });
+
+  it('still reports an effect that has actually been tried and failed', () => {
+    expect(
+      boardCardStatus({
+        idle: IDLE,
+        decision: decision({ type: 'upsertLinkedWorkItem', status: 'retry', attempts: 2, lastError: null }),
+      }),
+    ).toEqual({ kind: 'error', label: 'Linked card could not be filed — retrying…', detail: undefined });
+  });
+
   it('describes a queued rule effect in terms of what it does, not the queue', () => {
     expect(boardCardStatus({ idle: IDLE, decision: decision({ type: 'transition', status: 'pending' }) })).toEqual({
       kind: 'busy',

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.test.ts
@@ -75,6 +75,25 @@ describe('boardCardStatus', () => {
     });
   });
 
+  it('asks for the parked run once nothing is moving on its own', () => {
+    expect(
+      boardCardStatus({
+        idle: { label: 'Open session', affordance: 'open' },
+        proposal: { label: 'Re-review', decisionId: 'decision-9' },
+      }),
+    ).toEqual({ kind: 'waiting', label: 'Re-review', decisionId: 'decision-9' });
+  });
+
+  it('lets an effect the server is already working through outrank the parked run', () => {
+    expect(
+      boardCardStatus({
+        idle: IDLE,
+        proposal: { label: 'Re-review', decisionId: 'decision-9' },
+        decision: decision({ type: 'transition', status: 'pending' }),
+      }),
+    ).toEqual({ kind: 'busy', label: 'Moving this card automatically…' });
+  });
+
   it('falls back to the click affordance when nothing is in flight', () => {
     expect(boardCardStatus({ idle: { label: 'Open session', affordance: 'open' } })).toEqual({
       kind: 'idle',

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.ts
@@ -5,12 +5,15 @@ import type { FactoryDecisionSummary } from './services/decisions';
 /** A card has one status row, so every announcement it could make resolves to one of these. */
 export type BoardCardStatus =
   | { kind: 'idle'; label: string; affordance: 'open' | 'run' }
+  | { kind: 'waiting'; label: string; decisionId: string }
   | { kind: 'busy'; label: string }
   | { kind: 'error'; label: string; detail?: string; retryDecisionId?: string };
 
 export interface BoardCardStatusInput {
   /** What clicking the card does when nothing is happening. */
   idle: { label: string; affordance: 'open' | 'run' };
+  /** Run a rule parked on this card, held until someone releases it. */
+  proposal?: { label: string; decisionId: string };
   /** Destination of an in-flight stage move. */
   moving?: { stage: string; label: string };
   /** Runs whose start mutation is in flight, newest intent first. */
@@ -73,5 +76,9 @@ export function boardCardStatus(input: BoardCardStatusInput): BoardCardStatus {
     };
   }
   if (decision) return { kind: 'busy', label: automationCopy(decision.type).busy };
+  // Nothing is moving on its own, so a parked run is the card's live question.
+  if (input.proposal) {
+    return { kind: 'waiting', label: input.proposal.label, decisionId: input.proposal.decisionId };
+  }
   return { kind: 'idle', ...input.idle };
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.ts
@@ -67,8 +67,13 @@ export function boardCardStatus(input: BoardCardStatusInput): BoardCardStatus {
       detail: decision.lastError ?? undefined,
     };
   }
-  // Already failed at least once; the server retries on its own, so no button.
-  if (decision?.status === 'retry') {
+  // `retry` alone does not mean anything went wrong: a linked-card decision that
+  // already succeeded is deliberately reset to `retry` when its card is
+  // rematerialized, so the card gets re-filed. That replay has no attempt behind
+  // it and no error, and calling it a failure makes the board cry wolf. A real
+  // failure has been tried at least once, or left an error to show. The server
+  // retries either on its own, so neither offers a button.
+  if (decision?.status === 'retry' && (decision.attempts > 0 || decision.lastError)) {
     return {
       kind: 'error',
       label: `${automationCopy(decision.type).failed} — retrying…`,

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardCardParts.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardCardParts.tsx
@@ -2,7 +2,7 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { MessageSquare, Play, TriangleAlert } from 'lucide-react';
+import { MessageSquare, Play, Sparkles, TriangleAlert } from 'lucide-react';
 import type { ReactElement } from 'react';
 
 import type { BoardCardStatus } from '../boardCardStatus';
@@ -71,15 +71,48 @@ export function CardIdleOverlay({ status }: { status: IdleBoardCardStatus }) {
 /** The card's one status row: a hover hint when idle, a live region once something is happening. */
 export function CardStatus({
   status,
+  onApprove,
+  approving,
   onRetry,
   retrying,
 }: {
   status: BoardCardStatus;
+  /** Releases the parked run; omitted when nothing is waiting. */
+  onApprove?: () => void;
+  approving?: boolean;
   /** Re-queues the failed rule effect; omitted when nothing is retryable. */
   onRetry?: () => void;
   retrying?: boolean;
 }) {
   if (status.kind === 'idle') return <IdleCardStatus status={status} />;
+
+  // A parked run is the one idle state the card cannot whisper: it needs the
+  // user, so it stays lit without a hover and carries its own button. The
+  // button sits above the card's click overlay so a card that already links to
+  // a session can still release it.
+  if (status.kind === 'waiting') {
+    return (
+      <div className="flex w-full items-center justify-between gap-2">
+        <span role="status" aria-live="polite" className="text-ui-xs text-accent6 flex min-w-0 items-center gap-1.5">
+          <Sparkles size={11} aria-hidden className="shrink-0" />
+          <span className="truncate">Suggested: {status.label}</span>
+        </span>
+        {onApprove && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="relative z-20 shrink-0"
+            disabled={approving}
+            aria-label={`Start suggested run: ${status.label}`}
+            onClick={onApprove}
+          >
+            {approving ? 'Starting…' : 'Start'}
+          </Button>
+        )}
+      </div>
+    );
+  }
 
   if (status.kind === 'busy') {
     return (

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -155,6 +155,14 @@ export function WorkItemCard({
     runSpec !== undefined
       ? runSpec.actions.find(action => action.role === 'review' && action.role in sessions)
       : undefined;
+  // A card can land in a lane without its run ever starting — an approved plan
+  // transitions to Building and writes the `work` session ref itself, so the
+  // slot looks used and `runActions` filters Build out. Offer the lane's own
+  // run from the menu so the card is never a dead end.
+  const laneAction =
+    runSpec !== undefined && reReviewAction === undefined
+      ? runSpec.actions.find(action => action.stage === columnStage && action.role in sessions)
+      : undefined;
   const primaryAction = cardPrimaryAction({
     item,
     runSpec,
@@ -263,6 +271,15 @@ export function WorkItemCard({
                 >
                   {actionIcon(reReviewAction.label)}
                   <span>{pendingRunRoles.has(reReviewAction.role) ? 'Starting…' : 'Re-review'}</span>
+                </DropdownMenu.Item>
+              )}
+              {runSpec !== undefined && laneAction !== undefined && (
+                <DropdownMenu.Item
+                  disabled={runDisabled || pendingRunRoles.has(laneAction.role)}
+                  onClick={() => onRestartRun(runSpec, laneAction)}
+                >
+                  {actionIcon(laneAction.label)}
+                  <span>{pendingRunRoles.has(laneAction.role) ? 'Starting…' : laneAction.label}</span>
                 </DropdownMenu.Item>
               )}
               {/* Once the card has a live session it renders as a link, so the

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -173,6 +173,18 @@ export function WorkItemCard({
     onCreateSession,
   });
   const threadSession = itemThreadSession(sessions);
+  const proposedRunLabel =
+    proposal === undefined
+      ? undefined
+      : (runSpec?.actions.find(action => action.role === proposal.role)?.label ??
+        defaultRunAction?.label ??
+        'Start run');
+  // A run parked on a PR that has since closed or merged is dead work nobody
+  // needs to answer. It stays in the menu so it can still be dismissed, but it
+  // does not get to claim the status row and ask for a decision.
+  const proposalNeedsAnswer =
+    proposal !== undefined &&
+    (item.source !== 'github-pr' || ['open', 'draft'].includes(pullRequestStatusForItem(item)));
 
   const relatedItems = relatedWorkItems(item, allItems);
   const labels = metadataLabels(item.metadata);
@@ -182,6 +194,10 @@ export function WorkItemCard({
       threadSession !== undefined
         ? { label: 'Open session', affordance: 'open' }
         : { label: primaryAction.label, affordance: 'run' },
+    proposal:
+      proposal === undefined || proposedRunLabel === undefined || !proposalNeedsAnswer
+        ? undefined
+        : { label: proposedRunLabel, decisionId: proposal.id },
     moving:
       evaluatingStage === undefined
         ? undefined
@@ -289,7 +305,7 @@ export function WorkItemCard({
                   disabled={runDisabled || approvingDecisionId === proposal.id}
                   onClick={() => onApproveProposal(proposal.id)}
                 >
-                  {actionIcon(runSpec?.actions.find(action => action.role === proposal.role)?.label ?? 'Start run')}
+                  {actionIcon(proposedRunLabel ?? 'Start run')}
                   <span>{approvingDecisionId === proposal.id ? 'Starting…' : 'Start suggested run'}</span>
                 </DropdownMenu.Item>
               )}
@@ -384,6 +400,10 @@ export function WorkItemCard({
             {status.kind !== 'idle' && (
               <CardStatus
                 status={status}
+                onApprove={
+                  status.kind === 'waiting' && !runDisabled ? () => onApproveProposal(status.decisionId) : undefined
+                }
+                approving={status.kind === 'waiting' && approvingDecisionId === status.decisionId}
                 onRetry={retryDecisionId === undefined ? undefined : () => onRetryDecision(retryDecisionId)}
                 retrying={retryDecisionId !== undefined && retryDecisionId === retryingDecisionId}
               />

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -165,6 +165,7 @@ export function WorkItemCard({
     onCreateSession,
   });
   const threadSession = itemThreadSession(sessions);
+
   const relatedItems = relatedWorkItems(item, allItems);
   const labels = metadataLabels(item.metadata);
   const activity = workItemActivity(item, activityPage);
@@ -262,6 +263,17 @@ export function WorkItemCard({
                 >
                   {actionIcon(reReviewAction.label)}
                   <span>{pendingRunRoles.has(reReviewAction.role) ? 'Starting…' : 'Re-review'}</span>
+                </DropdownMenu.Item>
+              )}
+              {/* Once the card has a live session it renders as a link, so the
+                  menu is the only place left to release a proposed run. */}
+              {proposal !== undefined && (
+                <DropdownMenu.Item
+                  disabled={runDisabled || approvingDecisionId === proposal.id}
+                  onClick={() => onApproveProposal(proposal.id)}
+                >
+                  {actionIcon(runSpec?.actions.find(action => action.role === proposal.role)?.label ?? 'Start run')}
+                  <span>{approvingDecisionId === proposal.id ? 'Starting…' : 'Start suggested run'}</span>
                 </DropdownMenu.Item>
               )}
               {proposal !== undefined && (

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardRuns.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardRuns.ts
@@ -1,3 +1,4 @@
+import { toast } from '@mastra/playground-ui/components/Toaster';
 import { useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 
@@ -70,11 +71,20 @@ export function useBoardRuns({
     navigate(`/factories/${factoryProjectId}/workspaces/${session.sessionId}/threads/${session.threadId}`);
   };
 
+  // Refetch failures here used to be silent: an expired auth cookie made every
+  // board click a no-op with no feedback. Toast so the click never dies quietly.
   const refreshItemAndWorktrees = async (itemId: string) => {
     const [refreshedWorkspaces, refreshedItems] = await Promise.all([workspaces.refetch(), refetchItems()]);
-    if (!refreshedWorkspaces.isSuccess || !refreshedItems.isSuccess) return;
+    if (!refreshedWorkspaces.isSuccess || !refreshedItems.isSuccess) {
+      const cause = refreshedWorkspaces.error ?? refreshedItems.error;
+      toast.error(cause instanceof Error ? cause.message : 'Failed to refresh the board — try reloading the page');
+      return;
+    }
     const item = refreshedItems.data.find(candidate => candidate.id === itemId);
-    if (!item) return;
+    if (!item) {
+      toast.error('This card no longer exists — the board may be out of date');
+      return;
+    }
     return {
       item,
       paths: new Set(refreshedWorkspaces.data.workspaces.map(workspace => workspace.sessionId)),
@@ -145,7 +155,10 @@ export function useBoardRuns({
     }
     const spec = itemRunSpec(refreshed.item);
     const action = spec?.actions.find(candidate => candidate.role === role);
-    if (!spec || !action) return;
+    if (!spec || !action) {
+      toast.error(`This card can't start a ${role} run from its current state`);
+      return;
+    }
     await start.mutateAsync({
       branch: spec.branch,
       threadTitle: spec.threadTitle,


### PR DESCRIPTION
## What this changes

Four ways the work board misrepresented what was happening, all in the same
surface: the card.

**A failed click looked like no click.** Starting a run refreshes workspaces
first. When that refresh failed — an expired auth cookie returning 401 is the
common case — the handler returned early and nothing else happened. No run
started, and nothing said why. The failure is now surfaced, so an expired session
reads as an expired session instead of a dead button.

**A proposed run could not be approved from the card.** Rules propose runs that
wait for a human to release them. The card had no way to do that, so the only
path was elsewhere in the UI. The card menu now offers it.

**Building became unreachable after a plan was approved.** Once planning
completed, the action that starts the build run disappeared from the card,
stranding the item mid-loop with no affordance to continue.

**A card waiting on a person looked idle.** A proposed run rendered as nothing at
all. It now says it is waiting, with the approval inline.

**A replay looked like a failure.** A linked-card decision that already succeeded
is deliberately reset to `retry` when its card is rematerialized, so the card gets
re-filed. The board read any `retry` as "already failed at least once" and drew an
error — 16 cards were showing a failure nobody caused. A card now reports an error
only when the effect was actually attempted or left an error behind.

## Test plan

- `pnpm --filter ./mastracode/factory-ui test:unit` — 162 passing
- `pnpm --filter ./mastracode/factory-ui test:msw` — 575 passing
- `pnpm --filter ./mastracode/factory-ui typecheck` — clean
- Each behaviour has an MSW test driving the real client + React Query stack, and
  each was mutation-checked: reverting the fix fails its test. For the replay
  case specifically, dropping the `attempts`/`lastError` predicate makes a
  never-attempted decision render as an error again.

## Notes for review

This is one of several PRs split out of #21487. It touches only `factory-ui` and
shares no files with the others, so it stands alone and can land in any order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The work board now shows the real state of each run. It reports refresh errors, provides approval actions, keeps valid Build actions available, and avoids showing errors for runs that never started.

## Changes

- Show error toasts when workspace refreshes, missing cards, or invalid run states prevent a run from starting.
- Add approval and dismissal actions for proposed runs in card menus.
- Keep the Build action available when an approved plan has an existing work session.
- Show pending approval states inline with a Start button.
- Hide stale proposals for closed or merged pull requests while keeping them dismissible.
- Treat replayed, unattempted decisions as busy instead of failed.
- Add unit and MSW regression coverage for board actions, refresh failures, approval states, and replay behavior.
- Add separate patch changesets for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->