### PR TITLE
fix(factory): let the right GitHub events reach the rules engine

### DIFF
--- a/.changeset/factory-aborted-runs-are-retryable.md
+++ b/.changeset/factory-aborted-runs-are-retryable.md
@@ -1,0 +1,14 @@
+---
+'@internal/mastra-factory': patch
+---
+
+Resume a skill run that was aborted out from under it.
+
+An aborted run was recorded as a terminal failure on the assumption that an
+abort is deliberate. In practice the dominant cause is the process going away
+underneath the run — an operator restarting the server — and the run stream does
+not say which happened. Cards were dead-ending at attempt 1 with nothing on the
+board to press, needing a human to nudge each one by hand after every restart.
+
+Aborted runs are now retried like any other interrupted work, still bounded by
+the existing attempt cap.

--- a/.changeset/factory-app-identity.md
+++ b/.changeset/factory-app-identity.md
@@ -1,0 +1,20 @@
+---
+'@mastra/factory': patch
+---
+
+Stop Factory from waking itself on its own GitHub comments.
+
+Factory recognised its own writes by comparing the event sender against
+`GITHUB_APP_SLUG`. That variable names the deployment's own self-hosted GitHub
+App, which is a different App than the one a Platform deployment posts as — and
+on such a deployment it is legitimately unset, so the check compared against
+`undefined[bot]` and never matched. Every self-loop guard silently failed open.
+
+The visible result: triage published its handoff comment, that comment came back
+through ingress, re-invoked triage, and cancelled the run that had written it —
+leaving the public verdict stuck at "Pending" while both runs reported success.
+
+The Platform integration now names the App it actually posts as, overridable
+with `MASTRA_PLATFORM_GITHUB_APP_SLUG`, and identity resolution is centralised so
+an unresolved identity is reported as *unknown* rather than collapsing into
+"not Factory".

--- a/.changeset/factory-binding-role-rotation.md
+++ b/.changeset/factory-binding-role-rotation.md
@@ -1,0 +1,25 @@
+---
+'@mastra/factory': patch
+---
+
+Let a Factory run finish its stage when the previous role handed off in the same
+session.
+
+`factory_transition_work_item` re-checked its authority at execution time by
+comparing the live run binding against the binding row that existed when the
+tool was built, requiring the same row id. But handing the next role its turn in
+an existing session legitimately rotates that row: the previous role's binding is
+revoked and a new one is issued for the same session and the same work item.
+Tools built for the earlier role stay live across that rotation, so they were
+keyed to a row that the handoff itself had just replaced.
+
+The visible result: planning produced a complete plan, called its terminal
+transition to `execute`, and was refused with "Factory agent binding is
+unavailable, revoked, or no longer matches this session." The item stopped in
+Planning with the plan written but never advanced, and the decision that carried
+it reported success. Every leg that continues an item in an existing session —
+planning after triage, and the review-feedback wakes — failed the same way.
+
+Authority is now the work item the session is bound to rather than the
+individual binding row, so a rotation no longer strands the run it exists to
+start. Re-pointing a session at a *different* work item is still refused.

--- a/.changeset/factory-building-stage-runs.md
+++ b/.changeset/factory-building-stage-runs.md
@@ -1,0 +1,18 @@
+---
+'@internal/mastra-factory': patch
+---
+
+Start the implementation run when a work item enters Building.
+
+Building was the one stage on the Work board with no entry rule, so an item
+arriving there stopped: the plan was approved and nothing picked it up until
+somebody pressed Build by hand. Every other stage advances itself, which made
+Building the single manual step in an otherwise continuous path from intake to
+review.
+
+The run it starts carries a prompt rather than activating a skill. Skills exist
+here to define a handoff — a terminal message later rules match on to decide
+what happens next — and Building already has one: it ends by opening a pull
+request, which arrives as its own event and raises the Review card. Rules could
+previously only express "invoke this skill", so the decision vocabulary now
+accepts a prompt as the alternative to a skill name.

--- a/.changeset/factory-deliver-path-contract.md
+++ b/.changeset/factory-deliver-path-contract.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Stop reporting a skill kickoff as successful when it was queued onto a run that was already ending.
+
+Signals sent into an active session settle as `deliver`, which acknowledges routing but promises nothing about execution. If the in-flight run finished before draining its queue, the prompt was dropped: no turn started, no error surfaced, and the decision was marked succeeded while the work item sat in its new stage with nobody working on it. The dispatcher now confirms the signal actually landed in the thread and retries the decision when it did not, so the next attempt finds the session idle and takes the instrumented wake path.

--- a/.changeset/factory-dismiss-dead-proposals.md
+++ b/.changeset/factory-dismiss-dead-proposals.md
@@ -1,0 +1,5 @@
+---
+'@internal/factory': patch
+---
+
+Dismiss runs still parked on a work item when it reaches a terminal stage. A merged or closed pull request cannot answer a suggested run, so the card no longer keeps asking.

--- a/.changeset/factory-ingest-pull-request-opened.md
+++ b/.changeset/factory-ingest-pull-request-opened.md
@@ -1,0 +1,5 @@
+---
+'@internal/factory': patch
+---
+
+Ingest `pull_request.opened` from the Platform event poller so a newly opened pull request mints its Review card. The poller forwards an allow-list of events to the rules engine, and `opened` was missing from it — so on deployments without a direct webhook (the only path a local deployment has), a pull request the factory authored itself was never reviewed.

--- a/.changeset/factory-poller-review-feedback.md
+++ b/.changeset/factory-poller-review-feedback.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Deliver GitHub review feedback to the factory rules on the polling path. Submitted reviews and new pull request comments were dropped before the rules engine ran, so the agent that authored a branch was never woken when a reviewer asked for changes.

--- a/.changeset/factory-pr-comments-wake-work.md
+++ b/.changeset/factory-pr-comments-wake-work.md
@@ -1,0 +1,11 @@
+---
+'@mastra/factory': patch
+---
+
+Route pull request comments to the agent that authored the pull request, and stop provenance from branding commenters as Factory.
+
+Comments on a PR arrive as `issue_comment` with `issue.pull_request` set, and the ingress explicitly dropped them. That closed the most common feedback path of all: on a Factory-authored PR, GitHub refuses a formal `--approve`/`--request-changes` verdict from the account that opened it, so the review skill falls back to `gh pr comment` — which was discarded. External review bots leaving plain comments were dropped for the same reason.
+
+A new `pullRequestCommentCreated` rule event now carries those comments, reading the pull request from the `issue` payload so provenance binds the comment to the authoring Work item rather than mistaking the number for an issue's. The default rule sends a high-priority `sendMessage` to the `work` role, which wakes an idle session. Factory's own comments are ignored, because `factoryAuthored` cannot distinguish the Work role from the Review role and reacting to them would let an agent wake itself in a loop.
+
+Separately, `factoryAuthored` was derived from PR provenance for every event, which proves the *pull request* came from Factory, not the sender of the event. Any human or review bot commenting on a Factory-authored PR was therefore marked as Factory. Provenance-based attribution is now skipped for events whose sender is responding to the PR — comments, submitted reviews, and re-requested reviews — where only the app login identifies Factory.

--- a/.changeset/factory-redeliver-after-run-ends.md
+++ b/.changeset/factory-redeliver-after-run-ends.md
@@ -1,0 +1,16 @@
+---
+'@internal/mastra-factory': patch
+---
+
+Wait for the run that swallowed a kickoff, instead of racing it.
+
+A signal queued onto an already-running turn can be dropped when that turn ends
+before draining its queue. That case was detected correctly and then handed to
+the generic exponential backoff, which spends all five attempts inside about
+thirty seconds — while the run it is waiting on takes minutes. Every attempt
+landed on the same busy session and the card gave up roughly ten times too early.
+
+The dispatcher now waits for the in-flight run to end and redelivers into the
+freed session, which is the event that actually resolves the condition. The
+decision settles within its original lease without spending the retry budget, and
+a redelivery that is dropped again still goes back on the queue.

--- a/.changeset/factory-rereview-push-during-review.md
+++ b/.changeset/factory-rereview-push-during-review.md
@@ -1,0 +1,20 @@
+---
+'@internal/mastra-factory': patch
+---
+
+Re-review a pull request when a push lands while its card is still in Reviewing.
+
+A push to a card already sitting in Reviewing was dropped rather than deferred:
+the rule returned nothing, and once the in-flight pass finished it transitioned
+to Done having reviewed code that was no longer current, with no record that
+newer commits had arrived. That is the exact ordering the review loop produces —
+a review asks for changes, the authoring agent pushes a fix, and the fix lands
+before the card finishes leaving Reviewing.
+
+Only Intake now suppresses the re-review. A push during Reviewing re-enters the
+stage, which supersedes the stale pass: the stage rule already cancels the run
+in flight and selects the right skill for the entry it sees.
+
+Transition decisions carry a `reenter` flag for this, since a transition to the
+stage an item already holds is otherwise inert — the common case is a board
+being corrected into a state it already has, not work that needs restarting.

--- a/.changeset/factory-review-feedback-reaches-author.md
+++ b/.changeset/factory-review-feedback-reaches-author.md
@@ -1,0 +1,17 @@
+---
+'@internal/mastra-factory': patch
+---
+
+Carry pull request review feedback back to the agent that wrote the code.
+
+A `changes_requested` review is meant to wake the authoring work session, but
+when the pull request carried no provenance the event resolved to the pull
+request's own Review card. `addressReviewFeedback` deliberately refuses to act
+on the review board — a Review card reacting to its own posted review would loop
+the reviewer against itself — so the wake was dropped and the author never heard
+about the feedback.
+
+Review and pull request comment events now follow the linked card's
+`parentWorkItemId` back to the item that authored the pull request, so the
+existing guard becomes true for the right item instead of never. A pull request
+card with no authoring item still emits nothing.

--- a/.changeset/factory-review-feedback-wakes-work.md
+++ b/.changeset/factory-review-feedback-wakes-work.md
@@ -1,0 +1,9 @@
+---
+'@mastra/factory': patch
+---
+
+Close the work/review loop: a review that requests changes now wakes the agent that authored the pull request.
+
+`pull_request_review` webhooks were accepted and classified urgent, but no matching rule event existed, so the delivery was dropped after classification and the authoring agent was never told. PR subscriptions did not cover this — they sync PR activity into a thread's notification inbox for the agent to read on its *next* turn, but nothing starts that turn.
+
+A new `pullRequestReviewSubmitted` rule event maps `pull_request_review`/`submitted`, and the default rule sends a high-priority `sendMessage` to the `work` role, which wakes an idle session. Only `changes_requested` fires; `approved` and `commented` stay quiet, and the Review card that posted the review never reacts to its own output.

--- a/.changeset/factory-review-own-pull-requests.md
+++ b/.changeset/factory-review-own-pull-requests.md
@@ -1,0 +1,15 @@
+---
+'@internal/factory': patch
+---
+
+Send Factory's own pull requests straight to Review.
+
+A pull request entered Review only when its author passed a repository-collaborator
+permission check. A GitHub App bot is never a collaborator, so every pull request
+Factory opened itself scored as untrusted and parked in Intake, waiting on a human
+click — the exact opposite of the intent, since those are the pull requests whose
+provenance Factory knows best.
+
+Factory authorship is now its own trust signal for pull requests: the branch came
+from a Work run this Factory dispatched. Issues are deliberately unchanged, because
+auto-triaging an issue Factory opened is a self-loop with no upside.

--- a/.changeset/factory-review-verdict-wakes-work.md
+++ b/.changeset/factory-review-verdict-wakes-work.md
@@ -1,0 +1,18 @@
+---
+'@internal/mastra-factory': patch
+---
+
+Let a Factory review verdict reach the agent that authored the pull request.
+
+GitHub refuses to let an app review a pull request it authored, so on
+Factory-authored PRs `factory-review` falls back to posting its verdict as a
+plain comment under the Factory app's own login. That comment was dropped twice
+before it could reach the authoring agent: the ingress author gate only admits
+an explicit allow-list of bots, and the pull-request-comment rule ignores
+Factory's own comments so the Work agent cannot wake itself in a loop.
+
+Factory's own app login now clears the author gate, and the rule makes one
+exception to the self-loop guard: a comment whose first line carries the review
+handoff's `Verdict: request changes` line wakes the authoring Work agent. A
+verdict that approves, or one merely quoted further down a comment body, is
+still ignored.

--- a/.changeset/factory-run-outcomes.md
+++ b/.changeset/factory-run-outcomes.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Report what actually happened to a Factory run. A human dragging a card on the board now arms the item, so the run it asks for starts instead of parking for approval, and a run that dies mid-flight — a provider error, or a cancellation by the next decision — is recorded as failed on the decision instead of reported as a success.

--- a/.changeset/factory-supersede-parked-proposals.md
+++ b/.changeset/factory-supersede-parked-proposals.md
@@ -1,0 +1,10 @@
+---
+'@mastra/factory': patch
+---
+
+Retire a parked proposal when the run it asked for starts anyway. Approving a
+proposal mints a fresh decision rather than dispatching the parked one, so the
+original stayed `proposed` forever and the card kept asking to start a run that
+had already finished. The dispatcher now dismisses proposals for the same work
+item and role as any `invokeSkill` it dispatches, so the waiting badge only ever
+marks a loop that is genuinely stopped.

--- a/.changeset/github-subscription-thread-ownership.md
+++ b/.changeset/github-subscription-thread-ownership.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Deliver GitHub pull request signals to the session that actually owns the subscribed thread, and skip subscriptions whose thread this deployment does not hold.
+
+A subscription records the Factory project as its resource, but an unscoped session registers under its own id, so delivery looked for the thread under a resource that did not own it and failed with "Thread not found" on every matching event. Delivery now reads the thread from storage to find its owning resource. A subscription naming a thread that is absent is skipped rather than failed, so a pull request's events reaching a deployment that never owned the thread no longer fabricate a session or retry in a loop.

--- a/mastracode/factory/src/integrations/github/app-identity.test.ts
+++ b/mastracode/factory/src/integrations/github/app-identity.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { GithubAppIdentity } from './app-identity.js';
+
+describe('GithubAppIdentity', () => {
+  it('recognises the App it was configured for', () => {
+    const identity = new GithubAppIdentity('mastra-platform');
+    expect(identity.known).toBe(true);
+    expect(identity.matches('mastra-platform[bot]')).toBe(true);
+  });
+
+  it('compares logins case-insensitively', () => {
+    const identity = new GithubAppIdentity('Mastra-Platform');
+    expect(identity.matches('mastra-platform[bot]')).toBe(true);
+    expect(identity.matches('MASTRA-PLATFORM[BOT]')).toBe(true);
+  });
+
+  it('does not mistake another App or a human for itself', () => {
+    const identity = new GithubAppIdentity('mastra-platform');
+    expect(identity.matches('dane-ai-mastra[bot]')).toBe(false);
+    expect(identity.matches('mastra-platform')).toBe(false);
+    expect(identity.matches('some-human')).toBe(false);
+  });
+
+  it('reports an unresolved identity as unknown rather than as "not Factory"', () => {
+    // The distinction is the whole point: an unset slug used to collapse into a
+    // `false` that silently disabled every self-loop guard. Callers that must
+    // not fail open have to be able to tell the two apart.
+    const identity = new GithubAppIdentity(undefined);
+    expect(identity.known).toBe(false);
+    expect(identity.login).toBeUndefined();
+    expect(identity.matches('mastra-platform[bot]')).toBe(false);
+  });
+
+  it('treats a blank slug as unresolved instead of building "[bot]"', () => {
+    expect(new GithubAppIdentity('   ').known).toBe(false);
+  });
+
+  it('learns its login from a write it made', () => {
+    const identity = new GithubAppIdentity(undefined);
+    identity.observeSelfAuthor('mastra-platform[bot]');
+    expect(identity.known).toBe(true);
+    expect(identity.matches('mastra-platform[bot]')).toBe(true);
+  });
+
+  it('prefers the observed login over the configured one', () => {
+    // Configuration is a claim about which App this is; the observed author is
+    // what GitHub actually attributed the write to.
+    const identity = new GithubAppIdentity('stale-app');
+    identity.observeSelfAuthor('mastra-platform[bot]');
+    expect(identity.matches('mastra-platform[bot]')).toBe(true);
+    expect(identity.matches('stale-app[bot]')).toBe(false);
+  });
+
+  it('ignores an empty observation rather than forgetting what it knew', () => {
+    const identity = new GithubAppIdentity('mastra-platform');
+    identity.observeSelfAuthor(null);
+    identity.observeSelfAuthor(undefined);
+    identity.observeSelfAuthor('  ');
+    expect(identity.matches('mastra-platform[bot]')).toBe(true);
+  });
+});

--- a/mastracode/factory/src/integrations/github/app-identity.ts
+++ b/mastracode/factory/src/integrations/github/app-identity.ts
@@ -1,0 +1,62 @@
+/**
+ * Factory's own GitHub identity.
+ *
+ * Factory must recognise its own writes, or it wakes itself: a handoff comment
+ * arrives back through ingress, fires the rule that authored it, and cancels the
+ * run mid-flight. Every self-loop guard depends on answering "is this me?".
+ *
+ * The answer is not free. On a Platform deployment the credentials that post as
+ * `mastra-platform[bot]` do not carry that login, and `GITHUB_APP_SLUG`
+ * describes a *different*, self-hosted App — so it is legitimately unset. A bare
+ * `login === `${slug}[bot]`` therefore compares against `undefined[bot]`, never
+ * matches, and silently disables every guard while looking correct.
+ *
+ * Two sources, in order of trust:
+ *
+ * 1. **Observed.** Every comment Factory creates comes back with its author.
+ *    That is authoritative, costs no extra request, and needs no configuration —
+ *    Factory learns its own name the first time it speaks.
+ * 2. **Configured.** `slug` from a self-hosted GitHub App, when present.
+ *
+ * When neither is available the identity is *unknown*, which is distinct from
+ * "not Factory". Callers must handle it explicitly rather than inherit a `false`.
+ */
+export class GithubAppIdentity {
+  #configuredLogin: string | undefined;
+  #observedLogin: string | undefined;
+
+  constructor(slug?: string) {
+    const trimmed = slug?.trim();
+    this.#configuredLogin = trimmed ? `${trimmed.toLowerCase()}[bot]` : undefined;
+  }
+
+  /** The login Factory posts as, or `undefined` when it cannot be determined. */
+  get login(): string | undefined {
+    return this.#observedLogin ?? this.#configuredLogin;
+  }
+
+  /** True once Factory can recognise its own writes. */
+  get known(): boolean {
+    return this.login !== undefined;
+  }
+
+  /**
+   * Record the author GitHub reported for a write Factory just made. Observed
+   * identity wins over configuration: it is what GitHub actually attributes the
+   * write to, whereas the slug is a claim about a possibly-different App.
+   */
+  observeSelfAuthor(login: string | null | undefined): void {
+    const trimmed = login?.trim().toLowerCase();
+    if (trimmed) this.#observedLogin = trimmed;
+  }
+
+  /**
+   * Whether `login` is Factory. Returns `false` when the identity is unknown —
+   * callers that must not fail open should check {@link known} first.
+   */
+  matches(login: string | null | undefined): boolean {
+    const self = this.login;
+    if (!self || !login) return false;
+    return login.trim().toLowerCase() === self;
+  }
+}

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -784,6 +784,9 @@ describe('webhook route', () => {
       sendNotificationSignal,
     };
     const controller = {
+      // Delivery confirms this deployment holds the subscribed thread and reads
+      // the resource that owns it; here that is the subscription's own resource.
+      queryThreadById: vi.fn(async ({ threadId }: { threadId: string }) => ({ id: threadId, resourceId: 'resource-1' })),
       getSessionByResource: vi.fn(async () => session),
       createSession: vi.fn(),
     } as unknown as NonNullable<Parameters<typeof buildGithubRoutes>[0]>['controller'];

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -4,6 +4,7 @@ import { FactoryDecisionDispatcher } from '../../rules/dispatcher.js';
 import { FactoryStartCoordinator } from '../../rules/start-coordinator.js';
 import { FactoryTransitionService } from '../../rules/transition-service.js';
 import { createFactoryStorageForTests } from '../../storage/test-utils.js';
+import { GithubAppIdentity } from './app-identity.js';
 import type { GithubIntegration } from './integration.js';
 import { createGithubPullRequestReconciler, GithubRules } from './rules.js';
 import type { ReconcileIssueState, ReconcilePullRequestState } from './rules.js';
@@ -372,6 +373,68 @@ describe('GithubRules', () => {
     ).resolves.toEqual({ status: 'ignored' });
 
     expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual([]);
+  });
+
+  it('ignores its own handoff comment when only the resolved identity names the App', async () => {
+    // Regression: a Platform deployment has no configured slug, because that
+    // slug names a *different*, self-hosted App. Recognition therefore has to
+    // come from the resolved identity. Without it Factory's own handoff woke
+    // triage and cancelled the run that had just written it.
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    await createLinkedIssue(workItems, project.id);
+    const service = new GithubRules({
+      github: {
+        ...github,
+        slug: undefined,
+        identity: new GithubAppIdentity('mastra-platform'),
+      } as unknown as GithubIntegration,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await expect(
+      service.ingest(
+        issueComment('created', 'delivery-platform-handoff', {
+          sender: 'mastra-platform[bot]',
+          author: 'mastra-platform[bot]',
+          body: '<!-- mastra-factory-triage -->\nRoute: Pending',
+        }),
+      ),
+    ).resolves.toEqual({ status: 'ignored' });
+
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual([]);
+  });
+
+  it('still retriages a human handoff comment when the identity is resolved', async () => {
+    // The guard must key on authorship, not on the marker: a human quoting the
+    // marker to add a lead has to keep retriggering triage.
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    await createLinkedIssue(workItems, project.id);
+    const service = new GithubRules({
+      github: {
+        ...github,
+        slug: undefined,
+        identity: new GithubAppIdentity('mastra-platform'),
+      } as unknown as GithubIntegration,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await expect(
+      service.ingest(
+        issueComment('created', 'delivery-human-lead', {
+          body: '<!-- mastra-factory-triage -->\nNew investigation lead',
+        }),
+      ),
+    ).resolves.toEqual({ status: 'committed' });
+
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toHaveLength(1);
   });
 
   it('keeps trusted issues created before the Factory in Intake', async () => {
@@ -948,14 +1011,29 @@ describe('GithubRules', () => {
       cancelInFlight: true,
     });
 
-    // A follow-up push while the card is still Reviewing is a guarded no-op: no
-    // extra transition, no duplicate skill invocation.
+    // A follow-up push while the card is still Reviewing supersedes the pass it
+    // just started, which is now reading code the push replaced. Re-entering
+    // from `review` rather than `done` means there is no completed pass left to
+    // reconcile against, so the fresh run is a plain review.
     await expect(service.ingest(pullRequest('synchronize', 'delivery-push-2'))).resolves.toEqual({
       status: 'committed',
     });
+    await dispatcher.runOnce(new Date('2030-01-01T00:01:00Z'));
+
     const afterSecondPush = await workItems.listDeferredDecisions('org-1', project.id);
-    expect(afterSecondPush.filter(entry => entry.decision.type === 'transition')).toHaveLength(1);
-    expect(afterSecondPush.filter(entry => entry.decision.type === 'invokeSkill')).toHaveLength(1);
+    const transitions = afterSecondPush.filter(entry => entry.decision.type === 'transition');
+    expect(transitions).toHaveLength(2);
+    // Without this the transition is inert: the card is already in the stage it
+    // is being moved to, so the entry rule would never run.
+    expect(transitions.at(-1)!.decision).toMatchObject({ stage: 'review', reenter: true });
+    const reruns = afterSecondPush.filter(entry => entry.decision.type === 'invokeSkill');
+    expect(reruns).toHaveLength(2);
+    expect(reruns.at(-1)!.decision).toMatchObject({
+      type: 'invokeSkill',
+      skillName: 'factory-review',
+      role: 'review',
+      cancelInFlight: true,
+    });
   });
 
   it('ignores push events on PRs whose card has not yet completed a review pass', async () => {
@@ -1008,6 +1086,445 @@ describe('GithubRules', () => {
     await service.ingest(issueOpened(`delivery-${permission ?? 'missing'}`));
     expect(seen).toHaveBeenCalledWith(expect.objectContaining({ actor: expect.objectContaining({ trusted: false }) }));
     expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual([]);
+  });
+
+  it('routes a changes-requested review back to the Work item that authored the pull request', async () => {
+    // Reviews used to stop at the ingress: the webhook was accepted and
+    // classified urgent, but no rule event existed, so the authoring agent was
+    // never told and the work/review loop stayed open.
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('read');
+    const work = await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue',
+          externalId: 'github:10:issue:42',
+          url: 'https://github.com/acme/repo/issues/42',
+        },
+        title: 'Issue 42',
+        stages: ['execute'],
+        sessions: {},
+        metadata: {},
+      },
+    });
+    await integrationStorage.subscriptions.create({
+      orgId: 'org-1',
+      targetKey: 'factory-pr-provenance:10:17',
+      threadId: 'thread-1',
+      status: 'active',
+      data: { kind: 'factory-pr-provenance', workItemId: work.item.id },
+    });
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await service.ingest({
+      event: 'pull_request_review',
+      deliveryId: 'delivery-review-submitted',
+      payload: {
+        action: 'submitted',
+        installation: { id: 7 },
+        repository: { id: 10, full_name: 'acme/repo' },
+        sender: { login: 'reviewer' },
+        review: {
+          id: 99,
+          state: 'changes_requested',
+          html_url: 'https://github.com/acme/repo/pull/17#pullrequestreview-99',
+        },
+        pull_request: {
+          number: 17,
+          title: 'PR 17',
+          html_url: 'https://github.com/acme/repo/pull/17',
+          state: 'open',
+          merged: false,
+          head: { ref: 'feature' },
+          base: { ref: 'main' },
+        },
+      },
+    });
+
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workItemId: work.item.id,
+          decision: expect.objectContaining({ type: 'sendMessage', role: 'work', priority: 'high' }),
+        }),
+      ]),
+    );
+  });
+
+  it('routes a changes-requested review through the PR card to the work item that authored it', async () => {
+    // Provenance is the happy path, but it is not always there: a PR opened
+    // outside the tracked tool call records none, so the PR-number lookup wins
+    // and returns the PR's own Review card. `addressReviewFeedback` refuses to
+    // act on the review board, so the wake was dropped and the authoring agent
+    // never heard about the feedback. The linked card names its author, so the
+    // event has to be carried back across that link.
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('read');
+    const work = await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue',
+          externalId: 'github:10:issue:42',
+          url: 'https://github.com/acme/repo/issues/42',
+        },
+        title: 'Issue 42',
+        stages: ['execute'],
+        sessions: {},
+        metadata: {},
+      },
+    });
+    await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'pull-request',
+          externalId: 'github:10:pull-request:17',
+          url: 'https://github.com/acme/repo/pull/17',
+        },
+        parentWorkItemId: work.item.id,
+        title: 'PR 17',
+        stages: ['review'],
+        sessions: {},
+        metadata: {},
+      },
+    });
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await service.ingest({
+      event: 'pull_request_review',
+      deliveryId: 'delivery-review-through-pr-card',
+      payload: {
+        action: 'submitted',
+        installation: { id: 7 },
+        repository: { id: 10, full_name: 'acme/repo' },
+        sender: { login: 'reviewer' },
+        review: {
+          id: 99,
+          state: 'changes_requested',
+          html_url: 'https://github.com/acme/repo/pull/17#pullrequestreview-99',
+        },
+        pull_request: {
+          number: 17,
+          title: 'PR 17',
+          html_url: 'https://github.com/acme/repo/pull/17',
+          state: 'open',
+          merged: false,
+          head: { ref: 'feature' },
+          base: { ref: 'main' },
+        },
+      },
+    });
+
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workItemId: work.item.id,
+          decision: expect.objectContaining({ type: 'sendMessage', role: 'work', priority: 'high' }),
+        }),
+      ]),
+    );
+  });
+
+  it('ignores a changes-requested review on a pull request card with no authoring work item', async () => {
+    // The link is what makes the hop safe. Without one there is no agent that
+    // wrote this code, and waking the PR card's own review session would put
+    // the reviewer in a loop against itself.
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('read');
+    await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'pull-request',
+          externalId: 'github:10:pull-request:17',
+          url: 'https://github.com/acme/repo/pull/17',
+        },
+        title: 'PR 17',
+        stages: ['review'],
+        sessions: {},
+        metadata: {},
+      },
+    });
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await service.ingest({
+      event: 'pull_request_review',
+      deliveryId: 'delivery-review-orphan-pr-card',
+      payload: {
+        action: 'submitted',
+        installation: { id: 7 },
+        repository: { id: 10, full_name: 'acme/repo' },
+        sender: { login: 'reviewer' },
+        review: {
+          id: 99,
+          state: 'changes_requested',
+          html_url: 'https://github.com/acme/repo/pull/17#pullrequestreview-99',
+        },
+        pull_request: {
+          number: 17,
+          title: 'PR 17',
+          html_url: 'https://github.com/acme/repo/pull/17',
+          state: 'open',
+          merged: false,
+          head: { ref: 'feature' },
+          base: { ref: 'main' },
+        },
+      },
+    });
+
+    expect(
+      (await workItems.listDeferredDecisions('org-1', project.id)).filter(
+        record => record.decision.type === 'sendMessage',
+      ),
+    ).toEqual([]);
+  });
+
+  it('delivers a changes-requested review into the authoring agent session', async () => {
+    // The rule test above only proves a decision row of the right shape exists.
+    // This one runs the dispatcher over that row so the leg is exercised all the
+    // way to the message the authoring agent actually receives.
+    const { github, sourceControl, integrationStorage, workItems, projects, project, projectRepository } =
+      await setup('read');
+    const rules = builtInFactoryRules();
+    const transitionService = new FactoryTransitionService({ storage: workItems, rules });
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules,
+    });
+
+    const notifications: Array<{ threadId: string; summary: string; priority: string }> = [];
+    let threadId: string | undefined = 'thread-work';
+    const session = {
+      thread: {
+        list: vi.fn(async () => []),
+        create: vi.fn(async () => {
+          threadId = 'thread-work';
+          return { id: threadId };
+        }),
+        switch: vi.fn(async ({ threadId: next }: { threadId: string }) => {
+          threadId = next;
+        }),
+        setSetting: vi.fn(async () => {}),
+        rename: vi.fn(async () => {}),
+        requireId: vi.fn(() => {
+          if (!threadId) throw new Error('Thread was not persisted before binding creation.');
+          return threadId;
+        }),
+        listActiveMessages: vi.fn(async () => []),
+      },
+      getWorkspace: () => ({ skills: { maybeRefresh: vi.fn(async () => {}), get: vi.fn(async () => undefined) } }),
+      subscribe: vi.fn(() => () => {}),
+      state: { set: vi.fn(async () => {}) },
+      sendMessage: vi.fn(async () => {}),
+      sendSignal: vi.fn(() => ({ accepted: Promise.resolve({ accepted: true, action: 'wake' }) })),
+      sendNotificationSignal: vi.fn(
+        async (input: { summary: string; priority: string }) => (
+          notifications.push({ threadId: threadId!, summary: input.summary, priority: input.priority }),
+          {
+            persisted: Promise.resolve(),
+            accepted: Promise.resolve({ action: 'wake', output: { consumeStream: async () => {} } }),
+          }
+        ),
+      ),
+    };
+    const controller = {
+      createSession: vi.fn(async () => session),
+      getSessionByResource: vi.fn(async () => session),
+    };
+    await sourceControl.sessions.create({
+      sessionId: 'session-work-42',
+      projectRepositoryId: projectRepository.id,
+      orgId: 'org-1',
+      userId: 'user-1',
+      branch: 'factory/issue-42',
+      baseBranch: 'main',
+    });
+    const coordinator = new FactoryStartCoordinator(controller as never, workItems, transitionService, sourceControl);
+    const prepared = await coordinator.prepare({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      sessionId: 'session-work-42',
+      threadTitle: 'Issue 42',
+      kickoffKey: 'kickoff-work-42',
+      destinationStage: 'execute',
+      workItem: {
+        role: 'work',
+        input: {
+          externalSource: {
+            integrationId: 'github',
+            type: 'issue',
+            externalId: 'github:10:issue:42',
+            url: 'https://github.com/acme/repo/issues/42',
+          },
+          title: 'Issue 42',
+          stages: ['execute'],
+          sessions: {},
+          metadata: {},
+        },
+      },
+    });
+    await integrationStorage.subscriptions.create({
+      orgId: 'org-1',
+      targetKey: 'factory-pr-provenance:10:17',
+      threadId: 'thread-work',
+      status: 'active',
+      data: { kind: 'factory-pr-provenance', workItemId: prepared.workItemId },
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage: workItems,
+      isAutoRunEnabled: async () => true,
+      ownerId: 'worker-1',
+    });
+
+    await service.ingest({
+      event: 'pull_request_review',
+      deliveryId: 'delivery-review-dispatched',
+      payload: {
+        action: 'submitted',
+        installation: { id: 7 },
+        repository: { id: 10, full_name: 'acme/repo' },
+        sender: { login: 'reviewer' },
+        review: {
+          id: 99,
+          state: 'changes_requested',
+          body: 'This needs a null check.',
+          html_url: 'https://github.com/acme/repo/pull/17#pullrequestreview-99',
+        },
+        pull_request: {
+          number: 17,
+          title: 'PR 17',
+          html_url: 'https://github.com/acme/repo/pull/17',
+          state: 'open',
+          merged: false,
+          head: { ref: 'feature' },
+          base: { ref: 'main' },
+        },
+      },
+    });
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+
+    expect(notifications).toEqual([
+      expect.objectContaining({
+        threadId: 'thread-work',
+        priority: 'high',
+        summary: expect.stringContaining('https://github.com/acme/repo/pull/17'),
+      }),
+    ]);
+    const decisions = await workItems.listDeferredDecisions('org-1', project.id);
+    expect(decisions.filter(decision => decision.decision.type === 'sendMessage').map(decision => decision.status)).
+      toEqual(['succeeded']);
+  });
+
+  it('routes a comment on a pull request back to the Work item that authored it', async () => {
+    // Comments on a PR arrive as `issue_comment` and used to be dropped at the
+    // ingress, so review feedback left as a plain comment — the fallback the
+    // review skill takes on Factory-authored PRs, where GitHub refuses a formal
+    // verdict — never reached the author.
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('read');
+    const work = await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue',
+          externalId: 'github:10:issue:42',
+          url: 'https://github.com/acme/repo/issues/42',
+        },
+        title: 'Issue 42',
+        stages: ['execute'],
+        sessions: {},
+        metadata: {},
+      },
+    });
+    await integrationStorage.subscriptions.create({
+      orgId: 'org-1',
+      targetKey: 'factory-pr-provenance:10:17',
+      threadId: 'thread-1',
+      status: 'active',
+      data: { kind: 'factory-pr-provenance', workItemId: work.item.id },
+    });
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await service.ingest({
+      event: 'issue_comment',
+      deliveryId: 'delivery-pr-comment',
+      payload: {
+        action: 'created',
+        installation: { id: 7 },
+        repository: { id: 10, full_name: 'acme/repo' },
+        sender: { login: 'reviewer' },
+        comment: {
+          id: 555,
+          body: 'This needs a null check.',
+          html_url: 'https://github.com/acme/repo/pull/17#issuecomment-555',
+          user: { login: 'reviewer' },
+        },
+        issue: {
+          number: 17,
+          title: 'PR 17',
+          html_url: 'https://github.com/acme/repo/pull/17',
+          state: 'open',
+          pull_request: { url: 'https://api.github.com/repos/acme/repo/pulls/17' },
+        },
+      },
+    });
+
+    expect(await workItems.listDeferredDecisions('org-1', project.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workItemId: work.item.id,
+          decision: expect.objectContaining({ type: 'sendMessage', role: 'work', priority: 'high' }),
+        }),
+      ]),
+    );
   });
 
   it('uses verified Factory provenance to link an opened Review card and remind Work on merge', async () => {

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../storage/domains/source-control/base.js';
 import type { WorkItemRow, WorkItemsStorage } from '../../storage/domains/work-items/base.js';
 import type { IntegrationContext } from '../base.js';
+import type { GithubAppIdentity } from './app-identity.js';
 import type { GithubRepositoryPermission } from './integration.js';
 import { changeRequestTargetKey } from './subscriptions.js';
 import type { ParsedGithubWebhook } from './webhook.js';
@@ -80,7 +81,14 @@ function eventName(parsed: ParsedGithubWebhook): FactoryGithubEventName | undefi
   if (parsed.event === 'issues' && action === 'closed') return 'issueClosed';
   if (parsed.event === 'issue_comment') {
     const issue = object(parsed.payload.issue);
-    if (object(issue?.pull_request)) return undefined;
+    // A comment on a PR arrives as `issue_comment` with `issue.pull_request` set.
+    // It routes to the PR's own event so it binds to the authoring Work item via
+    // provenance instead of being mistaken for a comment on an issue of the same
+    // number. Only `created` matters: edits and deletions of an existing comment
+    // are not new feedback to act on.
+    if (object(issue?.pull_request)) {
+      return action === 'created' ? 'pullRequestCommentCreated' : undefined;
+    }
     if (action === 'created') return 'issueCommentCreated';
     if (action === 'edited') return 'issueCommentEdited';
     if (action === 'deleted') return 'issueCommentDeleted';
@@ -91,6 +99,7 @@ function eventName(parsed: ParsedGithubWebhook): FactoryGithubEventName | undefi
     return boolean(object(parsed.payload.pull_request)?.merged) ? 'pullRequestMerged' : 'pullRequestClosed';
   }
   if (parsed.event === 'pull_request' && action === 'review_requested') return 'pullRequestReviewRequested';
+  if (parsed.event === 'pull_request_review' && action === 'submitted') return 'pullRequestReviewSubmitted';
   return undefined;
 }
 
@@ -163,6 +172,13 @@ function pullRequestProvenance(data: Record<string, unknown> | undefined): Facto
 
 export interface GithubRulesIntegration {
   readonly slug?: string;
+  /**
+   * Factory's own GitHub login, used to ignore its own writes. Optional because
+   * not every integration can name itself; when absent, self-recognition falls
+   * back to the configured slug and, failing that, to content Factory stamps
+   * itself (see `FACTORY_TRIAGE_COMMENT_MARKER`).
+   */
+  readonly identity?: GithubAppIdentity;
   getRepositoryCollaboratorPermission(
     installationId: number,
     repoFullName: string,
@@ -182,6 +198,21 @@ export interface GithubRulesOptions {
 
 export class GithubRules {
   constructor(private readonly options: GithubRulesOptions) {}
+
+  /**
+   * Whether a login is Factory itself. Prefers the resolved identity, which is
+   * observed from Factory's own writes, and falls back to the configured slug.
+   * An unset slug must not silently answer "not Factory" — that is what
+   * disabled every self-loop guard.
+   */
+  #isFactoryLogin(login: string | undefined): boolean {
+    const identity = this.options.github.identity;
+    if (identity?.known) return identity.matches(login);
+    const slug = this.options.github.slug?.trim();
+    if (!slug || !login) return false;
+    return login.toLowerCase() === `${slug.toLowerCase()}[bot]`;
+  }
+
 
   async ingest(parsed: ParsedGithubWebhook): Promise<{ status: 'ignored' | 'committed' | 'replayed' | 'missing' }> {
     const event = eventName(parsed);
@@ -225,8 +256,13 @@ export class GithubRules {
     const issue = object(parsed.payload.issue);
     const issueComment = object(parsed.payload.comment);
     const changes = object(parsed.payload.changes);
-    const pullRequest = object(parsed.payload.pull_request);
-    const issueNumber = number(issue?.number);
+    // A comment on a PR carries the PR under `issue` (with `pull_request` set)
+    // and has no `pull_request` payload of its own. Read the PR from `issue` in
+    // that case so provenance and `context.pullRequest` behave as they do for
+    // every other PR event, and so the number is never treated as an issue's.
+    const commentOnPullRequest = object(parsed.payload.issue)?.pull_request !== undefined;
+    const pullRequest = object(parsed.payload.pull_request) ?? (commentOnPullRequest ? issue : undefined);
+    const issueNumber = commentOnPullRequest ? undefined : number(issue?.number);
     const pullRequestNumber = number(pullRequest?.number);
     const provenance = pullRequestNumber
       ? pullRequestProvenance(
@@ -243,6 +279,13 @@ export class GithubRules {
     // sender is whoever clicked re-request, so a Factory-authored PR must not
     // brand a human requester as factory-authored.
     const reviewRequested = event === 'pullRequestReviewRequested';
+    // Provenance proves the *pull request* came from Factory, which is not the
+    // same as the sender of this event. For events where the sender is whoever
+    // reacted to the PR — re-requesting review, commenting, submitting a review
+    // — branding them from provenance would mark every human and every review
+    // bot as Factory. Only the app login identifies Factory for those.
+    const senderIsResponder =
+      reviewRequested || event === 'pullRequestCommentCreated' || event === 'pullRequestReviewSubmitted';
     const reReviewEvent = reviewRequested || event === 'pullRequestUpdated';
     const requestedReviewer = string(object(parsed.payload.requested_reviewer)?.login);
     const relatedItem = await this.#relatedItem(
@@ -254,13 +297,19 @@ export class GithubRules {
       pullRequestNumber,
       string(object(pullRequest?.head)?.ref),
       reReviewEvent ? null : provenance,
+      senderIsResponder && !reviewRequested,
     );
     const actor = await githubActor(this.options.github, {
       installationId,
       repository: repositoryName,
       login,
-      factoryAuthored: (!reviewRequested && provenance !== null) || login === `${this.options.github.slug}[bot]`,
+      factoryAuthored: (!senderIsResponder && provenance !== null) || this.#isFactoryLogin(login),
     });
+    // A marked handoff comment is ignored only when Factory authored it: a
+    // human may quote the marker to add an investigation lead, and that must
+    // still retrigger triage. Recognising the author is therefore the whole
+    // guard — when identity cannot be resolved this fails open and Factory's
+    // own handoff cancels the run that wrote it.
     if (
       actor.type === 'github' &&
       actor.factoryAuthored &&
@@ -350,7 +399,7 @@ export class GithubRules {
         ? {
             reviewRequest: {
               reviewer: requestedReviewer,
-              factoryReviewer: requestedReviewer === `${this.options.github.slug}[bot]`,
+              factoryReviewer: this.#isFactoryLogin(requestedReviewer),
             },
           }
         : {}),
@@ -414,8 +463,40 @@ export class GithubRules {
     pullRequestNumber: number | undefined,
     pullRequestHeadBranch: string | undefined,
     provenance: FactoryPullRequestProvenanceData | null,
+    preferAuthoringItem = false,
   ): Promise<WorkItemRow | undefined> {
     const items = await this.options.storage.list({ orgId, factoryProjectId: projectId });
+    const resolved = this.#resolveItem(
+      items,
+      repositoryId,
+      repositoryFullName,
+      issueNumber,
+      pullRequestNumber,
+      pullRequestHeadBranch,
+      provenance,
+    );
+    // Feedback on a pull request has to reach the item that *wrote* the code.
+    // Provenance normally lands it there directly, but when provenance is
+    // missing the PR-number lookup wins and returns the PR's own Review card
+    // instead — a board the feedback rules deliberately refuse to act on, so
+    // the wake is silently dropped. The linked card records its author in
+    // `parentWorkItemId`, so follow that link back rather than relaxing the
+    // guard, which would let a Review card react to its own posted review.
+    if (preferAuthoringItem && resolved?.externalSource?.type === 'pull-request' && resolved.parentWorkItemId) {
+      return items.find(item => item.id === resolved.parentWorkItemId) ?? resolved;
+    }
+    return resolved;
+  }
+
+  #resolveItem(
+    items: WorkItemRow[],
+    repositoryId: number,
+    repositoryFullName: string,
+    issueNumber: number | undefined,
+    pullRequestNumber: number | undefined,
+    pullRequestHeadBranch: string | undefined,
+    provenance: FactoryPullRequestProvenanceData | null,
+  ): WorkItemRow | undefined {
     if (provenance) return items.find(item => item.id === provenance.workItemId);
     if (issueNumber) {
       return (

--- a/mastracode/factory/src/integrations/github/webhook.test.ts
+++ b/mastracode/factory/src/integrations/github/webhook.test.ts
@@ -42,6 +42,23 @@ function parsed(event: string, action: string, extra: Record<string, unknown> = 
   };
 }
 
+/**
+ * Dispatch reads the subscribed thread from storage to decide whether this
+ * deployment owns it and which resource does. Tests that only care about
+ * delivery get a store where every thread exists under `resource-1`.
+ */
+function controllerStub(overrides: Record<string, unknown>, threads: Record<string, string> | 'all' = 'all') {
+  return {
+    queryThreadById: async ({ threadId }: { threadId: string }) =>
+      threads === 'all'
+        ? { id: threadId, resourceId: 'resource-1' }
+        : threads[threadId]
+          ? { id: threadId, resourceId: threads[threadId] }
+          : null,
+    ...overrides,
+  } as never;
+}
+
 function subscription(id: string, scope: string, threadId = `thread-${id}`): GithubSignalSubscriptionRow {
   return {
     id,
@@ -128,7 +145,7 @@ describe('dispatchGithubWebhook', () => {
       },
     );
 
-    expect(result).toEqual({ delivered: 0, failed: 0, ignored: true });
+    expect(result).toEqual({ delivered: 0, failed: 0, skipped: 0, ignored: true });
     expect(getRepositoryCollaboratorPermission).toHaveBeenCalledWith(7, 'octo/hello', 'ada', expect.any(AbortSignal));
     expect(listSubscriptions).not.toHaveBeenCalled();
   });
@@ -152,7 +169,7 @@ describe('dispatchGithubWebhook', () => {
 
       await vi.advanceTimersByTimeAsync(5_000);
 
-      await expect(result).resolves.toEqual({ delivered: 0, failed: 0, ignored: true });
+      await expect(result).resolves.toEqual({ delivered: 0, failed: 0, skipped: 0, ignored: true });
       expect(permissionSignal?.aborted).toBe(true);
       expect(listSubscriptions).not.toHaveBeenCalled();
     } finally {
@@ -174,6 +191,7 @@ describe('dispatchGithubWebhook', () => {
     ).resolves.toEqual({
       delivered: 0,
       failed: 0,
+      skipped: 0,
       ignored: true,
     });
     await expect(
@@ -181,9 +199,26 @@ describe('dispatchGithubWebhook', () => {
     ).resolves.toEqual({
       delivered: 0,
       failed: 0,
+      skipped: 0,
       ignored: false,
     });
     expect(listSubscriptions).toHaveBeenCalledTimes(1);
+    expect(getRepositoryCollaboratorPermission).not.toHaveBeenCalled();
+  });
+
+  it("admits Factory's own app login, which GitHub forces review verdicts through", async () => {
+    // GitHub refuses to let an app review its own pull request, so on
+    // Factory-authored PRs the verdict is posted as a comment under this login.
+    // Gating it out would strand the review handoff.
+    const listSubscriptions = vi.fn(async () => []);
+    const github = { ...githubWithSessionRow(null), slug: 'mastra-platform' };
+    const verdict = parsed('issue_comment', 'created', {
+      sender: { login: 'mastra-platform[bot]', type: 'Bot' },
+    });
+
+    await expect(dispatchGithubWebhook(verdict, { controller: {} as never, github, listSubscriptions })).resolves.toEqual(
+      { delivered: 0, failed: 0, skipped: 0, ignored: false },
+    );
     expect(getRepositoryCollaboratorPermission).not.toHaveBeenCalled();
   });
 
@@ -197,7 +232,7 @@ describe('dispatchGithubWebhook', () => {
 
     await expect(
       dispatchGithubWebhook(notification, { controller: {} as never, github, listSubscriptions }),
-    ).resolves.toEqual({ delivered: 0, failed: 0, ignored: false });
+    ).resolves.toEqual({ delivered: 0, failed: 0, skipped: 0, ignored: false });
     // The configured list extends the defaults rather than replacing them.
     await expect(
       dispatchGithubWebhook(
@@ -207,7 +242,7 @@ describe('dispatchGithubWebhook', () => {
         }),
         { controller: {} as never, github, listSubscriptions },
       ),
-    ).resolves.toEqual({ delivered: 0, failed: 0, ignored: false });
+    ).resolves.toEqual({ delivered: 0, failed: 0, skipped: 0, ignored: false });
     expect(getRepositoryCollaboratorPermission).not.toHaveBeenCalled();
   });
 
@@ -248,14 +283,14 @@ describe('dispatchGithubWebhook', () => {
         pull_request: undefined,
       }),
       {
-        controller: { getSessionByResource, createSession } as never,
+        controller: controllerStub({ getSessionByResource, createSession }),
         github: githubWithSessionRow({ userId: 'user-1', orgId: 'org-1' }, getBySessionId),
         listSubscriptions: async () => rows,
         isAuthorizedSender: async () => true,
       },
     );
 
-    expect(result).toEqual({ delivered: 2, failed: 0, ignored: false });
+    expect(result).toEqual({ delivered: 2, failed: 0, skipped: 0, ignored: false });
     expect(getSessionByResource).toHaveBeenCalledWith('resource-1', '/worktrees/a');
     expect(getBySessionId).toHaveBeenCalledOnce();
     expect(getBySessionId).toHaveBeenCalledWith('session-b');
@@ -299,14 +334,14 @@ describe('dispatchGithubWebhook', () => {
         pull_request: undefined,
       }),
       {
-        controller: { getSessionByResource: async () => undefined, createSession } as never,
+        controller: controllerStub({ getSessionByResource: async () => undefined, createSession }),
         github: githubWithSessionRow(null),
         listSubscriptions: async () => [subscription('a', '/worktrees/a')],
         isAuthorizedSender: async () => true,
       },
     );
 
-    expect(result).toEqual({ delivered: 0, failed: 1, ignored: false });
+    expect(result).toEqual({ delivered: 0, failed: 1, skipped: 0, ignored: false });
     expect(createSession).not.toHaveBeenCalled();
   });
 
@@ -319,7 +354,7 @@ describe('dispatchGithubWebhook', () => {
     const session = { thread: { getId: () => currentThread, switch: switchThread }, sendNotificationSignal: send };
 
     await dispatchGithubWebhook(parsed('pull_request', 'synchronize'), {
-      controller: { getSessionByResource: async () => session, createSession: vi.fn() } as never,
+      controller: controllerStub({ getSessionByResource: async () => session, createSession: vi.fn() }),
       listSubscriptions: async () => [subscription('a', '/worktrees/a')],
     });
 
@@ -333,13 +368,13 @@ describe('dispatchGithubWebhook', () => {
     const updateStatus = vi.fn(async () => {});
 
     await dispatchGithubWebhook(parsed('pull_request', 'reopened'), {
-      controller: {
+      controller: controllerStub({
         getSessionByResource: async () => ({
           thread: { getId: () => 'thread-a', switch: vi.fn() },
           sendNotificationSignal: send,
         }),
         createSession: vi.fn(),
-      } as never,
+      }),
       listSubscriptions,
       retireSubscription: updateStatus,
     });
@@ -375,32 +410,74 @@ describe('dispatchGithubWebhook', () => {
     const result = await dispatchGithubWebhook(
       parsed('pull_request', 'closed', { pull_request: { number: 34, merged: true } }),
       {
-        controller: {
+        controller: controllerStub({
           getSessionByResource: async (_resourceId: string, scope?: string) =>
             scope === '/worktrees/a' ? success : failure,
           createSession: vi.fn(),
-        } as never,
+        }),
         listSubscriptions: async () => [subscription('a', '/worktrees/a'), subscription('b', '/worktrees/b')],
         retireSubscription: retire,
         onTargetError,
       },
     );
 
-    expect(result).toEqual({ delivered: 1, failed: 1, ignored: false });
+    expect(result).toEqual({ delivered: 1, failed: 1, skipped: 0, ignored: false });
     expect(retire).toHaveBeenCalledOnce();
     expect(retire).toHaveBeenCalledWith('a', 'merged');
     expect(order.at(-1)).toBe('retired:a');
     expect(onTargetError).toHaveBeenCalledWith(expect.objectContaining({ id: 'b' }), expect.any(Error));
   });
 
+  it('skips a subscription whose thread this deployment does not hold', async () => {
+    const getSessionByResource = vi.fn();
+    const createSession = vi.fn();
+    const onTargetSkipped = vi.fn();
+    const retire = vi.fn(async () => {});
+
+    const result = await dispatchGithubWebhook(parsed('pull_request', 'synchronize'), {
+      // The subscribed thread is absent from storage: the row points somewhere
+      // this deployment cannot reach.
+      controller: controllerStub({ getSessionByResource, createSession }, {}),
+      listSubscriptions: async () => [subscription('a', '/worktrees/a')],
+      retireSubscription: retire,
+      onTargetSkipped,
+    });
+
+    // Skipping is not a failure, so nothing is retried or reported as broken.
+    expect(result).toEqual({ delivered: 0, failed: 0, skipped: 1, ignored: false });
+    expect(onTargetSkipped).toHaveBeenCalledWith(expect.objectContaining({ id: 'a' }));
+    // Never fabricate a session for a thread we do not have...
+    expect(createSession).not.toHaveBeenCalled();
+    expect(getSessionByResource).not.toHaveBeenCalled();
+    // ...and leave the row alone, since the thread may live where it was made.
+    expect(retire).not.toHaveBeenCalled();
+  });
+
+  it('resolves the session by the resource that owns the thread, not the stored one', async () => {
+    const send = vi.fn(async () => ({ record: { id: 'n-1' }, decision: { action: 'deliver' } }));
+    const session = { thread: { getId: () => 'thread-a', switch: vi.fn() }, sendNotificationSignal: send };
+    const getSessionByResource = vi.fn(async () => session);
+
+    const result = await dispatchGithubWebhook(parsed('pull_request', 'synchronize'), {
+      // An unscoped session registers under its own id, so the subscription's
+      // stored 'resource-1' names a resource that does not own the thread.
+      controller: controllerStub({ getSessionByResource, createSession: vi.fn() }, { 'thread-a': 'session-a' }),
+      listSubscriptions: async () => [subscription('a', '/worktrees/a')],
+    });
+
+    expect(getSessionByResource).toHaveBeenCalledWith('session-a', '/worktrees/a');
+    expect(result).toEqual({ delivered: 1, failed: 0, skipped: 0, ignored: false });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
   it('does nothing when no subscription exists', async () => {
     const controller = { getSessionByResource: vi.fn(), createSession: vi.fn() };
     const result = await dispatchGithubWebhook(parsed('pull_request', 'edited'), {
-      controller: controller as never,
+      controller: controllerStub(controller),
       listSubscriptions: async () => [],
     });
 
-    expect(result).toEqual({ delivered: 0, failed: 0, ignored: false });
+    expect(result).toEqual({ delivered: 0, failed: 0, skipped: 0, ignored: false });
     expect(controller.getSessionByResource).not.toHaveBeenCalled();
   });
 });

--- a/mastracode/factory/src/integrations/github/webhook.ts
+++ b/mastracode/factory/src/integrations/github/webhook.ts
@@ -3,6 +3,7 @@ import type { MountedMastraCode } from '@mastra/code-sdk';
 import type { NotificationPriority } from '@mastra/core/notifications';
 import { RequestContext } from '@mastra/core/request-context';
 import type { Context } from 'hono';
+import { GithubAppIdentity } from './app-identity.js';
 import type { GithubIntegration, GithubRepositoryPermission } from './integration.js';
 import { listPullRequestSubscriptionsForWebhook, retirePullRequestSubscription } from './subscriptions.js';
 import type {
@@ -71,6 +72,14 @@ export type FactorySessionOwner = { userId: string; orgId: string };
  * much is common to both.
  */
 export interface GithubWebhookDispatchIntegration {
+  /** App slug, used to recognize Factory's own bot identity. */
+  readonly slug?: string;
+  /**
+   * Resolved identity of the App this integration posts as. Preferred over
+   * {@link slug}, which names the deployment's own self-hosted App and is unset
+   * on deployments that run against Platform's App.
+   */
+  readonly identity?: GithubAppIdentity;
   readonly integrationStorage: GithubSubscriptionStorage;
   /**
    * Extra bot logins this deployment authorizes to trigger author-gated
@@ -106,6 +115,8 @@ export interface GithubWebhookDispatchDependencies {
   /** Called when the sender gate drops a notification, so the drop is observable. */
   onSenderRejected?: (notification: GithubWebhookNotification) => void;
   onTargetError?: (subscription: GithubSignalSubscriptionRow, error: unknown) => void;
+  /** Called when a subscription names a thread this deployment does not hold. */
+  onTargetSkipped?: (subscription: GithubSignalSubscriptionRow) => void;
 }
 
 function normalizeHeader(value: string | undefined | null): string | null {
@@ -324,8 +335,23 @@ async function resolveSubscriptionSession(
   if (!sessionId || !resourceId || !threadId) {
     throw new Error(`GitHub subscription ${subscription.id} is missing its session binding.`);
   }
+  // Read the thread straight from storage before touching sessions. This answers
+  // two questions at once, and `queryThreadById` does it without constructing a
+  // session (so no workspace or sandbox is provisioned just to make the check).
+  //
+  // First: do we even have this thread? A pull request's events can reach a
+  // deployment that never owned the subscribed thread, and delivery must not
+  // fabricate a session for a thread that lives somewhere else.
+  //
+  // Second: which resource owns it? The subscription records the Factory project
+  // as its `resourceId`, but an unscoped session is registered under its own id,
+  // so the stored value routinely names a resource that does not own the thread.
+  // The thread row is the authoritative answer; the stored id is only a fallback.
+  const thread = await controller.queryThreadById({ threadId });
+  if (!thread) return undefined;
+  const ownerResourceId = thread.resourceId || resourceId;
   const scope = subscription.sessionScope || undefined;
-  let session = await controller.getSessionByResource(resourceId, scope);
+  let session = await controller.getSessionByResource(ownerResourceId, scope);
   if (!session) {
     const tags = {
       factoryProjectId: resourceId,
@@ -334,8 +360,9 @@ async function resolveSubscriptionSession(
     };
     // Creating the session resolves its workspace, which authorizes the caller
     // against the Factory session row — no signed-in user, so run as its owner.
-    // The controller resource is the Factory project for scoped sessions; the
-    // persisted Factory session is keyed by the subscription's session ID.
+    // The session is created under the resource that owns the thread, so the
+    // thread switch below resolves; the persisted Factory session is keyed by
+    // the subscription's session ID.
     const sessionRow = await github?.sourceControlStorage.sessions.getBySessionId(sessionId);
     if (!sessionRow) {
       throw new Error(`GitHub subscription ${subscription.id} has no Factory session ${sessionId} to run as.`);
@@ -345,7 +372,7 @@ async function resolveSubscriptionSession(
     session = await controller.createSession({
       id: sessionId,
       ownerId: sessionRow.userId,
-      resourceId,
+      resourceId: ownerResourceId,
       scope,
       tags,
       requestContext,
@@ -399,14 +426,33 @@ const AUTHOR_GATED_KINDS = new Set([
   'review-dismissed',
 ]);
 
+/**
+ * Recognizes Factory's own GitHub App identity. GitHub forbids an app from
+ * reviewing a pull request it authored, so `factory-review` falls back to
+ * posting its verdict as a comment under this login. Those comments have to
+ * clear the author gate for the review handoff to reach the authoring agent;
+ * the rules layer still decides which of them are worth acting on.
+ */
+export function isFactoryAppSender(sender: string | undefined, slug: string | undefined): boolean {
+  if (!sender || !slug) return false;
+  return sender.toLowerCase() === `${slug.toLowerCase()}[bot]`;
+}
+
 async function isAuthorizedGithubSender(
   notification: GithubWebhookNotification,
-  github: Pick<GithubWebhookDispatchIntegration, 'getRepositoryCollaboratorPermission' | 'authorizedBots'> | undefined,
+  github:
+    | Pick<
+        GithubWebhookDispatchIntegration,
+        'getRepositoryCollaboratorPermission' | 'slug' | 'identity' | 'authorizedBots'
+      >
+    | undefined,
 ): Promise<boolean> {
   if (!AUTHOR_GATED_KINDS.has(notification.kind)) return true;
   const sender = notification.metadata.sender;
   const repository = notification.metadata.repository;
   if (!sender || !repository) return false;
+  if (github?.identity?.matches(sender)) return true;
+  if (isFactoryAppSender(sender, github?.slug)) return true;
   const normalizedSender = sender.toLowerCase();
   if (notification.metadata.senderType?.toLowerCase() === 'bot' || normalizedSender.endsWith('[bot]')) {
     return resolveAuthorizedBots(github?.authorizedBots).has(normalizedSender);
@@ -440,15 +486,15 @@ async function isAuthorizedGithubSender(
 export async function dispatchGithubWebhook(
   parsed: ParsedGithubWebhook,
   dependencies: GithubWebhookDispatchDependencies,
-): Promise<{ delivered: number; failed: number; ignored: boolean }> {
+): Promise<{ delivered: number; failed: number; skipped: number; ignored: boolean }> {
   const notification = classifyGithubWebhook(parsed);
-  if (!notification) return { delivered: 0, failed: 0, ignored: true };
+  if (!notification) return { delivered: 0, failed: 0, skipped: 0, ignored: true };
   const isAuthorizedSender =
     dependencies.isAuthorizedSender ??
     ((n: GithubWebhookNotification) => isAuthorizedGithubSender(n, dependencies.github));
   if (!(await isAuthorizedSender(notification))) {
     dependencies.onSenderRejected?.(notification);
-    return { delivered: 0, failed: 0, ignored: true };
+    return { delivered: 0, failed: 0, skipped: 0, ignored: true };
   }
 
   const target = {
@@ -475,10 +521,20 @@ export async function dispatchGithubWebhook(
   const subscriptions = await listSubscriptions(target, { includeTerminal: notification.action === 'reopened' });
   let delivered = 0;
   let failed = 0;
+  let skipped = 0;
 
   for (const subscription of subscriptions) {
     try {
       const session = await resolveSubscriptionSession(dependencies.controller, subscription, dependencies.github);
+      // No session means this deployment does not hold the subscribed thread.
+      // That is not a delivery failure, so it must not be retried or counted as
+      // one; the subscription is left untouched because the thread may exist
+      // wherever the subscription was created.
+      if (!session) {
+        skipped += 1;
+        dependencies.onTargetSkipped?.(subscription);
+        continue;
+      }
       const result = await session.sendNotificationSignal({
         source: 'github',
         kind: notification.kind,
@@ -511,7 +567,7 @@ export async function dispatchGithubWebhook(
     }
   }
 
-  return { delivered, failed, ignored: false };
+  return { delivered, failed, skipped, ignored: false };
 }
 
 export async function handleGithubWebhook(

--- a/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
@@ -10,6 +10,9 @@ import { PlatformGithubIntegration } from './integration.js';
 
 const harness = vi.hoisted(() => {
   let mastra: Mastra | undefined;
+  // The resource that owns the subscribed thread. A scoped session is registered
+  // under its Factory project, so tests point this at the project under test.
+  let threadResourceId = 'resource-1';
   const sendNotificationSignal = vi.fn(async () => ({
     record: { id: 'notification-1' },
     decision: { action: 'deliver' as const },
@@ -25,6 +28,9 @@ const harness = vi.hoisted(() => {
       mastra = instance;
     }),
     getMastra: vi.fn(() => mastra),
+    // Delivery reads the subscribed thread first to confirm this deployment
+    // holds it and to learn which resource owns it.
+    queryThreadById: vi.fn(async ({ threadId }: { threadId: string }) => ({ id: threadId, resourceId: threadResourceId })),
     getSessionByResource: vi.fn<() => Promise<typeof session | undefined>>(async () => session),
     createSession: vi.fn(async (_input: { requestContext: { get(key: string): unknown } }) => session),
     onSessionCreated: vi.fn(),
@@ -35,8 +41,12 @@ const harness = vi.hoisted(() => {
   return {
     controller,
     sendNotificationSignal,
+    ownThreadWith(resourceId: string) {
+      threadResourceId = resourceId;
+    },
     reset() {
       mastra = undefined;
+      threadResourceId = 'resource-1';
       vi.clearAllMocks();
     },
   };
@@ -184,6 +194,9 @@ describe('Platform GitHub event worker factory lifecycle', () => {
         github.integrationStorage,
       );
 
+      // This subscription is scoped to a worktree, so its thread is owned by the
+      // Factory project resource that the session is created under below.
+      harness.ownThreadWith(factoryProject.id);
       harness.controller.getSessionByResource.mockResolvedValueOnce(undefined);
       const mastra = new Mastra(args);
       await factory.finalize();

--- a/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
@@ -109,6 +109,7 @@ describe('PlatformGithubEventWorker', () => {
     const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
       delivered: 1,
       failed: 0,
+      skipped: 0,
       ignored: false,
     });
     const ingestFactoryEvent = vi.fn(async () => ({ status: 'committed' }));
@@ -132,6 +133,12 @@ describe('PlatformGithubEventWorker', () => {
                 id: '1000-0',
                 deliveryId: 'delivery-opened',
                 event: 'issues',
+                payload: { action: 'opened' },
+              },
+              {
+                id: '1000-1',
+                deliveryId: 'delivery-pr-opened',
+                event: 'pull_request',
                 payload: { action: 'opened' },
               },
               {
@@ -172,6 +179,11 @@ describe('PlatformGithubEventWorker', () => {
     await worker.start();
     await vi.advanceTimersByTimeAsync(0);
 
+    const parsedPullRequestOpened = {
+      event: 'pull_request',
+      deliveryId: 'delivery-pr-opened',
+      payload: { action: 'opened' },
+    };
     const parsedSynchronize = {
       event: 'pull_request',
       deliveryId: 'delivery-sync',
@@ -193,14 +205,16 @@ describe('PlatformGithubEventWorker', () => {
       retireSubscription: expect.any(Function),
       isAuthorizedSender: expect.any(Function),
     });
-    // Synchronize and review_requested feed the re-review path; closed feeds
-    // the reconciler. opened is dispatched to subscribers but not ingested by
-    // the factory rules — the factory picks up new work through the reconciler.
-    expect(ingestFactoryEvent).toHaveBeenCalledTimes(3);
-    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(1, parsedSynchronize);
-    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(2, parsedReviewRequested);
-    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(3, parsedClosed);
-    expect(dispatch).toHaveBeenCalledTimes(4);
+    // A pull request being opened is what mints its Review card, so it has to
+    // reach the rules engine; synchronize and review_requested feed the
+    // re-review path, and closed feeds the reconciler. An opened *issue* is
+    // deliberately absent — the factory picks new issues up via the reconciler.
+    expect(ingestFactoryEvent).toHaveBeenCalledTimes(4);
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(1, parsedPullRequestOpened);
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(2, parsedSynchronize);
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(3, parsedReviewRequested);
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(4, parsedClosed);
+    expect(dispatch).toHaveBeenCalledTimes(5);
     expect(dispatch).toHaveBeenNthCalledWith(
       1,
       {
@@ -210,9 +224,10 @@ describe('PlatformGithubEventWorker', () => {
       },
       dispatchDependencies,
     );
-    expect(dispatch).toHaveBeenNthCalledWith(2, parsedSynchronize, dispatchDependencies);
-    expect(dispatch).toHaveBeenNthCalledWith(3, parsedReviewRequested, dispatchDependencies);
-    expect(dispatch).toHaveBeenNthCalledWith(4, parsedClosed, dispatchDependencies);
+    expect(dispatch).toHaveBeenNthCalledWith(2, parsedPullRequestOpened, dispatchDependencies);
+    expect(dispatch).toHaveBeenNthCalledWith(3, parsedSynchronize, dispatchDependencies);
+    expect(dispatch).toHaveBeenNthCalledWith(4, parsedReviewRequested, dispatchDependencies);
+    expect(dispatch).toHaveBeenNthCalledWith(5, parsedClosed, dispatchDependencies);
     expect(eventRequests[0]?.searchParams.get('afterTimestamp')).toBe('999');
     expect(eventRequests[1]?.searchParams.get('afterEventId')).toBe('1003-0');
     expect(settings.read()).toEqual({
@@ -232,12 +247,89 @@ describe('PlatformGithubEventWorker', () => {
     await resumed.stop();
   });
 
+  it('hands review feedback to the factory rules so the authoring agent is woken', async () => {
+    const settings = createSettingsStorage();
+    const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
+      delivered: 1,
+      failed: 0,
+      skipped: 0,
+      ignored: false,
+    });
+    const ingestFactoryEvent = vi.fn(async () => ({ status: 'committed' }));
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/installations')) {
+        return json({ installations: [{ installationId: 7, usable: true, suspendedAt: null }] });
+      }
+      if (url.pathname.endsWith('/installations/7/repositories')) {
+        return json({ repositories: [{ id: 101 }] });
+      }
+      if (url.pathname.endsWith('/repositories/101/events')) {
+        if (url.searchParams.has('afterTimestamp')) {
+          return json({
+            events: [
+              {
+                id: '2000-0',
+                deliveryId: 'delivery-review',
+                event: 'pull_request_review',
+                payload: { action: 'submitted' },
+              },
+              {
+                id: '2001-0',
+                deliveryId: 'delivery-comment',
+                event: 'issue_comment',
+                payload: { action: 'created' },
+              },
+              {
+                id: '2002-0',
+                deliveryId: 'delivery-comment-edited',
+                event: 'issue_comment',
+                payload: { action: 'edited' },
+              },
+            ],
+            nextCursor: '2002-0',
+          });
+        }
+        return json({ events: [], nextCursor: null });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const worker = createWorker({
+      fetchImpl,
+      storage: settings.storage,
+      now: () => 1_000,
+      dispatch,
+      ingestFactoryEvent,
+    });
+
+    await worker.init(createDeps());
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // A submitted review and a new pull-request comment are the two ways review
+    // feedback reaches the agent that authored the branch. Comment edits stay
+    // with the subscription dispatcher — re-waking on an edit would double-fire.
+    expect(ingestFactoryEvent).toHaveBeenCalledTimes(2);
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(1, {
+      event: 'pull_request_review',
+      deliveryId: 'delivery-review',
+      payload: { action: 'submitted' },
+    });
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(2, {
+      event: 'issue_comment',
+      deliveryId: 'delivery-comment',
+      payload: { action: 'created' },
+    });
+    expect(dispatch).toHaveBeenCalledTimes(3);
+    await worker.stop();
+  });
+
   it('advances the cursor when one subscription fails so the bad target does not poison later events', async () => {
     const settings = createSettingsStorage();
     const dispatch = vi
       .fn<typeof dispatchGithubWebhook>()
-      .mockResolvedValueOnce({ delivered: 1, failed: 1, ignored: false })
-      .mockResolvedValue({ delivered: 1, failed: 0, ignored: false });
+      .mockResolvedValueOnce({ delivered: 1, failed: 1, skipped: 0, ignored: false })
+      .mockResolvedValue({ delivered: 1, failed: 0, skipped: 0, ignored: false });
     const eventCursors: string[] = [];
     const fetchImpl = vi.fn<typeof fetch>(async input => {
       const url = new URL(String(input));
@@ -311,6 +403,7 @@ describe('PlatformGithubEventWorker', () => {
     const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
       delivered: 1,
       failed: 0,
+      skipped: 0,
       ignored: false,
     });
     const fetchImpl = vi.fn<typeof fetch>(async input => {
@@ -352,6 +445,7 @@ describe('PlatformGithubEventWorker', () => {
     const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
       delivered: 1,
       failed: 0,
+      skipped: 0,
       ignored: false,
     });
     const eventCursors: string[] = [];

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -11,7 +11,7 @@ import type { GithubRepositoryPermission } from '../../github/integration.js';
 import type { GithubIssueReconciler } from '../../github/issue-reconciler.js';
 import type { GithubPullRequestReconciler, ReconcileRepository } from '../../github/rules.js';
 import { listPullRequestSubscriptionsForWebhook, retirePullRequestSubscription } from '../../github/subscriptions.js';
-import { dispatchGithubWebhook, resolveAuthorizedBots } from '../../github/webhook.js';
+import { dispatchGithubWebhook, isFactoryAppSender, resolveAuthorizedBots } from '../../github/webhook.js';
 import type {
   GithubWebhookDispatchIntegration,
   GithubWebhookNotification,
@@ -438,6 +438,15 @@ export class PlatformGithubEventWorker extends MastraWorker {
             retirePullRequestSubscription(id, status, this.#github.integrationStorage),
           github: this.#github,
           isAuthorizedSender: notification => this.#isAuthorizedSender(notification),
+          onTargetSkipped: subscription => {
+            // Routine when a subscription's thread belongs to another
+            // deployment, so this stays at debug rather than warning on a loop.
+            this.deps?.logger.debug('Platform GitHub event skipped: thread is not held here', {
+              deliveryId: event.deliveryId,
+              subscriptionId: subscription.id,
+              threadId: subscription.threadId,
+            });
+          },
           onSenderRejected: notification => {
             this.deps?.logger.debug('Platform GitHub event dropped: sender not authorized', {
               deliveryId: event.deliveryId,
@@ -477,6 +486,13 @@ export class PlatformGithubEventWorker extends MastraWorker {
     const sender = notification.metadata.sender;
     const repository = notification.metadata.repository;
     if (!sender || !repository) return false;
+    // Factory's own app has to clear the gate before the bot rules below, which
+    // fail closed for every bot that is not explicitly allowlisted. GitHub
+    // forbids an app from reviewing its own pull request, so `factory-review`
+    // posts its verdict as a comment under this login and that comment is the
+    // handoff the authoring agent wakes on.
+    if (this.#github.identity?.matches(sender)) return true;
+    if (isFactoryAppSender(sender, this.#github.slug)) return true;
     const normalizedSender = sender.toLowerCase();
     const authorizedBots = resolveAuthorizedBots(this.#github.authorizedBots);
     if (authorizedBots.has(normalizedSender)) return true;
@@ -528,18 +544,25 @@ function normalizeSettings(value: PlatformGithubEventWorkerSettings | null): Pla
 
 // Events the polling worker forwards to the factory rules engine. Closures
 // let the reconciler finalize cards; `synchronize` and `review_requested` on a
-// pull request are the two triggers the review board's re-review path listens
-// for. Direct-webhook consumers ingest every parsed event; the platform path
-// gates because most other events (comments, reviews, edits) only interest the
-// subscription dispatcher, not the factory rules.
+// pull request are the triggers the review board's re-review path listens for;
+// submitted reviews and pull request comments are how review feedback reaches
+// the agent that authored the branch. Direct-webhook consumers ingest every
+// parsed event; the platform path gates because the remaining events (issue
+// edits, comment edits and deletions) only interest the subscription
+// dispatcher, not the factory rules.
 function isFactoryIngestedEvent(event: ParsedGithubWebhook): boolean {
   if ((event.event === 'issues' || event.event === 'pull_request') && event.payload.action === 'closed') {
     return true;
   }
   if (event.event === 'pull_request') {
     const action = event.payload.action;
-    if (action === 'synchronize' || action === 'review_requested') return true;
+    // `opened` is what mints the Review card for a pull request. Without it a
+    // factory-authored PR never gets reviewed on the polling path, which is the
+    // only path a local deployment has.
+    if (action === 'opened' || action === 'synchronize' || action === 'review_requested') return true;
   }
+  if (event.event === 'pull_request_review' && event.payload.action === 'submitted') return true;
+  if (event.event === 'issue_comment' && event.payload.action === 'created') return true;
   return false;
 }
 

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -45,6 +45,7 @@ import type {
   SourceControlStorageHandle,
 } from '../../../storage/domains/source-control/base.js';
 import type { FactoryIntegration, IntegrationContext, IntegrationTools } from '../../base.js';
+import { GithubAppIdentity } from '../../github/app-identity.js';
 import type { GithubIntegration, GithubRepositoryPermission, RepoSummary } from '../../github/integration.js';
 import { attachGithubIssueReconciler } from '../../github/issue-reconciler.js';
 import { reconcileInterval, reconciliationEnabled } from '../../github/reconciliation-config.js';
@@ -147,6 +148,13 @@ type GithubReviewComment = GithubComment & {
 const PAGE_SIZE = 30;
 const API_PREFIX = '/v1/server';
 /**
+ * Slug of the GitHub App this integration posts as. Platform credentials do not
+ * carry their own identity, so Factory cannot otherwise recognise its own
+ * writes — and failing to recognise them makes Factory wake itself. Override
+ * with `MASTRA_PLATFORM_GITHUB_APP_SLUG` when pointing at a non-production App.
+ */
+const PLATFORM_GITHUB_APP_SLUG = 'mastra-platform';
+/**
  * How long an installation's repository listing may be reused. The repos
  * route and token minting both call it — often several times within one UI
  * interaction — and each call is a full Platform round trip.
@@ -194,6 +202,12 @@ export class PlatformGithubIntegration implements FactoryIntegration {
   readonly #client: PlatformApiClient;
   readonly #endpointHost: string;
   readonly #slug: string | undefined;
+  /**
+   * Factory's own GitHub identity. Platform credentials do not carry the login
+   * they post as, so this starts from the configured slug (usually absent on a
+   * Platform deployment) and is corrected the first time Factory writes.
+   */
+  readonly identity: GithubAppIdentity;
   /**
    * Extra reviewer bot logins this deployment trusts for author-gated
    * notifications, merged over the built-in defaults.
@@ -466,6 +480,15 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     this.#client = new PlatformApiClient(config);
     this.#endpointHost = new URL(config.baseUrl).host;
     this.#slug = options.slug;
+    // Identity is deliberately NOT taken from `options.slug`. That slug names
+    // the deployment's own self-hosted GitHub App, which is a different App
+    // than the one this integration posts as — and on a Platform deployment it
+    // is legitimately unset. Borrowing it is what left every self-loop guard
+    // comparing against `undefined[bot]`. This integration *is* the Platform
+    // App, so it names itself, with an override for non-production Apps.
+    this.identity = new GithubAppIdentity(
+      process.env.MASTRA_PLATFORM_GITHUB_APP_SLUG?.trim() || PLATFORM_GITHUB_APP_SLUG,
+    );
     this.authorizedBots = parseAuthorizedBotsEnv(process.env.MASTRACODE_GITHUB_AUTHORIZED_BOTS) ?? [];
     this.#pollingEnabled = process.env.MASTRA_PLATFORM_GITHUB_POLLING_ENABLED?.trim().toLowerCase() !== 'false';
     this.#pollingIntervalMs = optionalPositiveIntegerEnv('MASTRA_PLATFORM_GITHUB_POLLING_INTERVAL_MS');
@@ -1053,6 +1076,16 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     }
   }
 
+  /**
+   * Learn Factory's own login from a write it just made. Skipped when the write
+   * was made on behalf of a user — that comment is authored by the human, and
+   * recording it would teach Factory to mistake a person for itself.
+   */
+  #observeSelfAuthor(comment: GithubComment, actingUserId: string | undefined): void {
+    if (actingUserId) return;
+    this.identity.observeSelfAuthor(comment.user?.login);
+  }
+
   async #createIssueComment(input: CreateIntakeCommentInput) {
     requireGithubConnection(input.connection);
     const repository = requireSource(input.sourceId, 'GitHub Intake requires a repository source.');
@@ -1064,6 +1097,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         { body: input.body },
         { actingUserId: input.actingUserId },
       );
+      this.#observeSelfAuthor(comment, input.actingUserId);
       return { id: String(comment.id), url: comment.htmlUrl };
     } catch (error) {
       if (isNotFound(error)) return null;
@@ -1162,6 +1196,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       { body: input.body },
       { actingUserId: input.actingUserId },
     );
+    this.#observeSelfAuthor(comment, input.actingUserId);
     return parseComment(comment);
   }
 

--- a/mastracode/factory/src/routes/work-items.test.ts
+++ b/mastracode/factory/src/routes/work-items.test.ts
@@ -445,6 +445,34 @@ describe('POST /web/factory/projects/:id/runs/start', () => {
     );
   });
 
+  it('arms the item so the runs that follow a person’s start need no further consent', async () => {
+    const created = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody());
+    const { workItem } = await created.json();
+    const prepare = vi.fn(async (input: any) => ({
+      workItemId: input.workItem.id,
+      bindingId: 'binding-1',
+      threadId: input.sessionId,
+      resourceId: input.sessionId,
+      sessionId: input.sessionId,
+      branch: 'factory/issue-42',
+      revision: 2,
+      kickoffStatus: 'pending',
+      replayed: false,
+    }));
+    const app = buildApp(orgUser, { prepare });
+
+    const res = await app.request(`/web/factory/projects/${PROJECT_ID}/runs/start`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(startBody(workItem.id)),
+    });
+
+    expect(res.status).toBe(202);
+    expect(await seed.workItems.get({ orgId: 'org1', id: workItem.id })).toMatchObject({
+      autonomyArmedAt: expect.any(Date),
+    });
+  });
+
   it('rejects a non-UUID kickoff identity before coordination', async () => {
     const prepare = vi.fn();
     const app = buildApp(orgUser, { prepare });

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -508,8 +508,15 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
         const decisionId = context.req.param('decisionId');
         if (!decisionId || !UUID_RE.test(decisionId)) return c.json({ error: 'invalid_decision_id' }, 422);
         await workItems.ensureReady();
-        const decision = await settle(resolved.orgId, resolved.factoryProjectId, decisionId, new Date());
+        const now = new Date();
+        const decision = await settle(resolved.orgId, resolved.factoryProjectId, decisionId, now);
         if (!decision) return c.json({ error: 'decision_not_proposed' }, 409);
+        // Releasing a proposal is a person taking the item on. What follows —
+        // the review of the branch this run pushes, the fix a review asks for —
+        // is the same request continuing, so it no longer waits to be approved.
+        if (verb === 'approve' && decision.workItemId) {
+          await workItems.armAutonomy({ orgId: resolved.orgId, id: decision.workItemId, now });
+        }
         await audit.emit({
           context,
           input: {
@@ -801,6 +808,10 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
             }
             throw error;
           }
+          // This route is only reached by a person pressing a run action, so
+          // reaching it is the commitment the approval gate is asking for. The
+          // runs that carry this item on to review are that request continuing.
+          await workItems.armAutonomy({ orgId: resolved.orgId, id: prepared.workItemId, now: new Date() });
           await audit.emit({
             context: loose(c),
             input: {

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -458,6 +458,34 @@ describe('defaultFactoryRules', () => {
     });
   });
 
+  it.each([
+    ['issue', 'github-issue'],
+    ['linearIssue', 'linear-issue'],
+    ['manual', 'manual'],
+  ] as const)('starts building a %s item from a prompt, with no skill to activate', async (source, itemSource) => {
+    // The approved plan is the specification, and opening the pull request is
+    // what signals the stage is done, so this run needs no skill contract.
+    const rule = defaultFactoryRules({ version: 'deployment-7' }).work.execute?.[source]?.onEnter;
+    const context = {
+      ...stageContext({ type: 'human', id: 'user-1' }, 'work'),
+      item: { ...item, source: itemSource },
+      source,
+      stage: 'execute',
+      fromStage: 'planning',
+      toStage: 'execute',
+    } as FactoryStageRuleContext;
+
+    const decision = await rule?.(context);
+    expect(decision).toMatchObject({
+      type: 'invokeSkill',
+      idempotencyKey: 'delivery-1:build',
+      role: 'work',
+      prompt:
+        'Implement the approved plan for https://github.test/acme/repo/issues/42. Open a pull request when the work is ready for review.',
+    });
+    expect(decision).not.toHaveProperty('skillName');
+  });
+
   it('keys the planning skill invocation once per ingress', async () => {
     const rule = defaultFactoryRules({ version: 'deployment-7' }).work.planning?.issue?.onEnter;
     const context = {
@@ -496,6 +524,145 @@ describe('defaultFactoryRules', () => {
     ]) {
       expect(await rule?.(context)).toBeUndefined();
     }
+  });
+
+  describe('pullRequestReviewSubmitted', () => {
+    function reviewContext(overrides: Partial<FactoryGithubRuleContext> = {}): FactoryGithubRuleContext {
+      return {
+        ...githubContext('pullRequestReviewSubmitted'),
+        item,
+        board: 'work',
+        itemRevision: 5,
+        review: {
+          id: 99,
+          state: 'changes_requested',
+          url: 'https://github.test/acme/repo/pull/17#pullrequestreview-99',
+        },
+        ...overrides,
+      };
+    }
+
+    it('wakes the authoring Work agent when changes are requested', async () => {
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewSubmitted?.onEvent;
+      const decision = await rule?.(reviewContext());
+      expect(decision).toMatchObject({
+        type: 'sendMessage',
+        idempotencyKey: 'delivery-1:address-review-feedback',
+        role: 'work',
+        priority: 'high',
+      });
+      // The message has to carry the review URL: the agent reads the individual
+      // line comments from its own PR subscription, not from this message.
+      expect((decision as { message: string }).message).toContain('#pullrequestreview-99');
+    });
+
+    it('stays quiet for reviews that are not asking for changes', async () => {
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewSubmitted?.onEvent;
+      for (const state of ['approved', 'commented', 'dismissed']) {
+        expect(
+          await rule?.(reviewContext({ review: { id: 99, state, url: 'https://github.test/r' } })),
+        ).toBeUndefined();
+      }
+    });
+
+    it('never fires on the Review card that posted the review', async () => {
+      // Only the PR's author can act on the feedback. Reacting on the Review
+      // card would loop the reviewer against its own output.
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestReviewSubmitted?.onEvent;
+      expect(await rule?.(reviewContext({ board: 'review' }))).toBeUndefined();
+      expect(await rule?.(reviewContext({ item: undefined, board: undefined }))).toBeUndefined();
+      expect(await rule?.(reviewContext({ review: undefined }))).toBeUndefined();
+    });
+  });
+
+  describe('pullRequestCommentCreated', () => {
+    function commentContext(overrides: Partial<FactoryGithubRuleContext> = {}): FactoryGithubRuleContext {
+      return {
+        ...githubContext('pullRequestCommentCreated'),
+        item,
+        board: 'work',
+        itemRevision: 5,
+        issueComment: {
+          id: 555,
+          body: 'This needs a null check.',
+          url: 'https://github.test/acme/repo/pull/17#issuecomment-555',
+          author: 'reviewer',
+        },
+        ...overrides,
+      };
+    }
+
+    it('wakes the authoring Work agent when someone comments on the pull request', async () => {
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestCommentCreated?.onEvent;
+      const decision = await rule?.(commentContext());
+      expect(decision).toMatchObject({
+        type: 'sendMessage',
+        idempotencyKey: 'delivery-1:address-pull-request-comment',
+        role: 'work',
+        priority: 'high',
+      });
+      expect((decision as { message: string }).message).toContain('#issuecomment-555');
+    });
+
+    it('ignores Factory-authored comments so the Work agent cannot wake itself', async () => {
+      // `factoryAuthored` cannot tell the Work role from the Review role, so
+      // reacting to Factory's own comments would let the Work agent's progress
+      // notes wake it in a loop.
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestCommentCreated?.onEvent;
+      expect(
+        await rule?.(
+          commentContext({
+            actor: { type: 'github', login: 'factory[bot]', trusted: true, factoryAuthored: true },
+          }),
+        ),
+      ).toBeUndefined();
+    });
+
+    it('stays quiet on the Review card and on pull requests that are no longer open', async () => {
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestCommentCreated?.onEvent;
+      expect(await rule?.(commentContext({ board: 'review' }))).toBeUndefined();
+      expect(await rule?.(commentContext({ issueComment: undefined }))).toBeUndefined();
+    });
+
+    it('wakes on the review verdict Factory had to post as a comment on its own pull request', async () => {
+      // GitHub refuses a self-review, so on Factory-authored PRs the verdict
+      // arrives as a comment under Factory's own login. It is the handoff, so it
+      // has to survive the self-loop guard.
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestCommentCreated?.onEvent;
+      const decision = await rule?.(
+        commentContext({
+          actor: { type: 'github', login: 'factory[bot]', trusted: true, factoryAuthored: true },
+          issueComment: {
+            id: 556,
+            body: '**Verdict: Request changes**\n\n## Findings\n\nThe retry loop never terminates.',
+            url: 'https://github.test/acme/repo/pull/17#issuecomment-556',
+            author: 'factory[bot]',
+          },
+        }),
+      );
+      expect(decision).toMatchObject({ type: 'sendMessage', role: 'work', priority: 'high' });
+    });
+
+    it('ignores a Factory verdict that approves, and a verdict only quoted in the body', async () => {
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestCommentCreated?.onEvent;
+      const factoryActor = { type: 'github', login: 'factory[bot]', trusted: true, factoryAuthored: true } as const;
+      expect(
+        await rule?.(
+          commentContext({
+            actor: factoryActor,
+            issueComment: { id: 557, body: '**Verdict: Approve**\n\nLooks good.', author: 'factory[bot]' },
+          }),
+        ),
+      ).toBeUndefined();
+      expect(
+        await rule?.(
+          commentContext({
+            actor: factoryActor,
+            issueComment: { id: 558, body: 'Pushed the fixes.\n\n> Verdict: request changes', author: 'factory[bot]' },
+          }),
+        ),
+      ).toBeUndefined();
+    });
   });
 
   describe('pullRequestReviewRequested', () => {
@@ -589,13 +756,23 @@ describe('defaultFactoryRules', () => {
       });
     });
 
-    it('does nothing when the PR is still in Intake or Reviewing, is unlinked, or is not on the Review board', async () => {
+    it('supersedes the pass in flight when a push lands on a card still in Reviewing', async () => {
+      // The push invalidates whatever the running pass is reading, so it has to
+      // start over on the new head. Re-entering the stage is how that pass gets
+      // cancelled; dropping the push would strand the review on stale code.
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestUpdated?.onEvent;
+      expect(await rule?.(pushContext({ item: { ...prItem, stages: ['review'] } }))).toMatchObject({
+        type: 'transition',
+        board: 'review',
+        stage: 'review',
+      });
+    });
+
+    it('does nothing when the PR is still in Intake, is unlinked, or is not on the Review board', async () => {
       const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestUpdated?.onEvent;
       for (const context of [
         // Card is still in intake — a review pass has not started yet.
         pushContext({ item: { ...prItem, stages: ['intake'] } }),
-        // Card is already back in review — waking the pending pass would double-fire.
-        pushContext({ item: { ...prItem, stages: ['review'] } }),
         // No linked Review card to move.
         pushContext({ item: undefined, board: undefined, itemRevision: undefined }),
         // Card exists but is bound to the Work board (not a PR review card).
@@ -639,12 +816,29 @@ describe('defaultFactoryRules', () => {
         type: 'upsertLinkedWorkItem',
         stage: 'intake',
       });
+      // A pull request Factory opened is the Work leg's own output: its
+      // provenance is known, so it advances to Review even though an App bot can
+      // never hold collaborator permission. An issue Factory opened gets no such
+      // pass — auto-triaging our own issue is a self-loop with no upside.
       expect(await rules.github[event]?.onEvent?.(factoryAuthored)).toMatchObject({
         type: 'upsertLinkedWorkItem',
-        stage: 'intake',
+        stage: event === 'pullRequestOpened' ? 'review' : 'intake',
       });
     },
   );
+
+  it('keeps a factory-authored pull request opened before the Factory in Intake', async () => {
+    const rules = defaultFactoryRules({ version: 'deployment-7' });
+    const older = {
+      ...githubContext('pullRequestOpened', '2026-05-01T00:00:00Z'),
+      actor: { type: 'github', login: 'factory-bot', trusted: false, factoryAuthored: true } as const,
+    };
+
+    expect(await rules.github.pullRequestOpened?.onEvent?.(older)).toMatchObject({
+      type: 'upsertLinkedWorkItem',
+      stage: 'intake',
+    });
+  });
 
   it.each(['issueOpened', 'pullRequestOpened'] as const)(
     'keeps trusted %s items created before the Factory in Intake',

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -95,6 +95,22 @@ function planWorkItem(context: FactoryStageRuleContext) {
   } as const;
 }
 
+/**
+ * Building carries a prompt rather than a skill. The approved plan is already
+ * the specification, so there is nothing for a skill document to add, and the
+ * handoff a skill would define is unnecessary here: Building ends by opening a
+ * pull request, which arrives as its own event and raises the Review card.
+ */
+function buildWorkItem(context: FactoryStageRuleContext) {
+  const subject = context.item.url ? `the approved plan for ${context.item.url}` : 'the approved plan';
+  return {
+    type: 'invokeSkill',
+    idempotencyKey: `${context.ingress.id}:build`,
+    role: 'work',
+    prompt: `Implement ${subject}. Open a pull request when the work is ready for review.`,
+  } as const;
+}
+
 function completeIssue(context: FactoryStageRuleContext) {
   return {
     type: 'invokeSkill',
@@ -212,6 +228,12 @@ function issueClosed(context: FactoryGithubRuleContext) {
 
 function pullRequestOpened(context: FactoryGithubRuleContext) {
   if (!context.pullRequest) return;
+  // Trust is a repository-collaborator permission lookup, and a GitHub App bot
+  // is never a collaborator — so a PR Factory opened itself scores as untrusted
+  // and parks in Intake, the one class of PR whose provenance we know best.
+  // Factory authorship is its own trust signal: the branch came from a Work run
+  // this Factory dispatched.
+  const factoryAuthored = context.actor.type === 'github' && context.actor.factoryAuthored;
   return {
     type: 'upsertLinkedWorkItem',
     idempotencyKey: `${context.ingress.id}:pull-request-intake`,
@@ -221,13 +243,14 @@ function pullRequestOpened(context: FactoryGithubRuleContext) {
     title: context.pullRequest.title,
     url: context.pullRequest.url,
     stage:
-      trustedGithubActor(context) && createdAfterFactory(context.pullRequest.createdAt, context.factory.createdAt)
+      (trustedGithubActor(context) || factoryAuthored) &&
+      createdAfterFactory(context.pullRequest.createdAt, context.factory.createdAt)
         ? 'review'
         : 'intake',
     metadata: {
       githubRepositoryId: context.repository.id,
       githubPullRequestNumber: context.pullRequest.number,
-      factoryAuthored: context.actor.type === 'github' && context.actor.factoryAuthored,
+      factoryAuthored,
       state: context.pullRequest.state,
       draft: context.pullRequest.draft,
       merged: context.pullRequest.merged,
@@ -272,6 +295,89 @@ function pullRequestMerged(context: FactoryGithubRuleContext) {
   } as const;
 }
 
+function addressReviewFeedback(context: FactoryGithubRuleContext) {
+  if (!context.item || !context.pullRequest || !context.review) return;
+  // Only the Work item that authored the PR can act on the feedback. Provenance
+  // binds the event there; a Review card seeing its own posted review must not
+  // react to it (that would loop the reviewer against itself).
+  if (context.board !== 'work') return;
+  // `approved` needs no work, and `commented` (a review body with no verdict)
+  // is how a reviewer leaves notes without blocking — only a verdict that asks
+  // for changes should pull the author back in.
+  if (context.review.state.toLowerCase() !== 'changes_requested') return;
+  // The authoring thread is already subscribed to this PR (`gh pr create`
+  // subscribes automatically), so it can read the individual line comments
+  // from its own notification inbox — the message only has to wake it and
+  // point at the review.
+  return {
+    type: 'sendMessage',
+    idempotencyKey: `${context.ingress.id}:address-review-feedback`,
+    role: 'work',
+    priority: 'high',
+    message:
+      `Changes were requested on pull request #${context.pullRequest.number} (${context.review.url}). ` +
+      'Read the review comments on this PR, address the ones you agree with, and push the fixes to the PR branch. ' +
+      'Reply on GitHub to anything you are deliberately not changing, explaining why.',
+  } as const;
+}
+
+/**
+ * Detects the `factory-review` handoff verdict in a comment body.
+ *
+ * GitHub forbids an app from reviewing a pull request it authored, so on
+ * Factory-authored PRs the review skill falls back to posting its verdict as a
+ * plain comment. That comment is the only signal the authoring agent gets, so
+ * it has to be readable back out. The skill's handoff contract puts the verdict
+ * on the first line (`Verdict: request changes`), so only that line is
+ * inspected — a verdict quoted later in the findings must not count.
+ */
+function requestsChangesVerdict(body: string | undefined): boolean {
+  const firstLine = body
+    ?.split('\n')
+    .map(line => line.trim())
+    .find(line => line.length > 0);
+  if (!firstLine) return false;
+  // Tolerate the markdown the skill wraps the line in (`**Verdict: ...**`).
+  const normalized = firstLine
+    .replaceAll(/[*_`#>\s]+/g, ' ')
+    .trim()
+    .toLowerCase();
+  if (!normalized.startsWith('verdict:')) return false;
+  return normalized.includes('request changes') || normalized.includes('changes requested');
+}
+
+function addressPullRequestComment(context: FactoryGithubRuleContext) {
+  if (!context.item || !context.pullRequest || !context.issueComment) return;
+  // Provenance binds the comment to the Work item that authored the PR — the
+  // only session that can act on it. A Review card must not react to comments
+  // on the PR it is reviewing.
+  if (context.board !== 'work') return;
+  if (context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
+  // `factoryAuthored` is one bit for the whole Factory, so Factory's own
+  // comments are indistinguishable between roles — waking on all of them would
+  // let the Work agent's own progress comments wake itself in a loop. The one
+  // exception is the review verdict the Review run had to post as a comment
+  // because GitHub refused a self-review: that is the handoff, and it only ever
+  // asks for changes once per review, so it cannot sustain a loop.
+  if (
+    context.actor.type === 'github' &&
+    context.actor.factoryAuthored &&
+    !requestsChangesVerdict(context.issueComment.body)
+  ) {
+    return;
+  }
+  return {
+    type: 'sendMessage',
+    idempotencyKey: `${context.ingress.id}:address-pull-request-comment`,
+    role: 'work',
+    priority: 'high',
+    message:
+      `${context.issueComment.author ?? 'Someone'} commented on pull request #${context.pullRequest.number} ` +
+      `(${context.issueComment.url ?? context.pullRequest.url}). Read the comment, address it if you agree, and push ` +
+      'the fixes to the PR branch. Reply on GitHub to anything you are deliberately not changing, explaining why.',
+  } as const;
+}
+
 function pullRequestClosed(context: FactoryGithubRuleContext) {
   if (!context.item || !context.pullRequest || context.pullRequest.merged) return;
   if (context.board !== 'review') return;
@@ -313,14 +419,22 @@ function reReviewRequestedPullRequest(context: FactoryGithubRuleContext) {
 function reReviewUpdatedPullRequest(context: FactoryGithubRuleContext) {
   if (!context.item || context.board !== 'review') return;
   if (!context.pullRequest || context.pullRequest.state !== 'open' || context.pullRequest.merged) return;
-  // Intake and Reviewing have not completed a review pass yet. Only a push to a
-  // card that already left Reviewing should start a fresh pass.
-  if (context.item.stages.some(stage => stage === 'intake' || stage === 'review')) return;
+  // Intake has not started a review pass yet, so a push there is just more of
+  // the code the first pass will read. A push to a card sitting in Reviewing is
+  // different: it invalidates whatever that pass is reading, so re-enter the
+  // stage to supersede it. `reviewPullRequest` cancels the stale run and picks
+  // the right skill for the entry it sees.
+  if (context.item.stages.some(stage => stage === 'intake')) return;
+  const alreadyReviewing = context.item.stages.some(stage => stage === 'review');
   return {
     type: 'transition',
     idempotencyKey: `${context.ingress.id}:re-review-updated`,
     board: 'review',
     stage: 'review',
+    // Re-entry is the point when the card is already Reviewing: the stage's
+    // entry rule is what cancels the superseded pass and starts one on the code
+    // that just landed.
+    ...(alreadyReviewing ? { reenter: true } : {}),
   } as const;
 }
 
@@ -382,6 +496,11 @@ const BUILT_IN_DEFAULTS: FactoryRulesOverrides = {
       linearIssue: { onEnter: planWorkItem },
       manual: { onEnter: planWorkItem },
     },
+    execute: {
+      issue: { onEnter: buildWorkItem },
+      linearIssue: { onEnter: buildWorkItem },
+      manual: { onEnter: buildWorkItem },
+    },
     done: {
       issue: { onEnter: completeIssue },
     },
@@ -397,7 +516,9 @@ const BUILT_IN_DEFAULTS: FactoryRulesOverrides = {
     issueCommentDeleted: { onEvent: retriageGithubIssue },
     pullRequestOpened: { onEvent: pullRequestOpened },
     pullRequestUpdated: { onEvent: reReviewUpdatedPullRequest },
+    pullRequestCommentCreated: { onEvent: addressPullRequestComment },
     pullRequestReviewRequested: { onEvent: reReviewRequestedPullRequest },
+    pullRequestReviewSubmitted: { onEvent: addressReviewFeedback },
     pullRequestMerged: { onEvent: pullRequestMerged },
     pullRequestClosed: { onEvent: pullRequestClosed },
   },

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
-import { defaultFactoryRules } from './defaults.js';
+import { builtInFactoryRules, defaultFactoryRules } from './defaults.js';
 import { FACTORY_DISPATCH_CONSTANTS, FactoryDecisionDispatcher } from './dispatcher.js';
 import { FactoryStartCoordinator } from './start-coordinator.js';
 import { FactoryTransitionService } from './transition-service.js';
@@ -32,17 +32,25 @@ function createSession(
   options?: {
     signalAccepted?: Promise<{ accepted: true; action?: string }>;
     emitAgentEndDuringSignal?: boolean;
+    agentEndReason?: 'complete' | 'aborted' | 'error' | 'suspended';
+    /** Models a signal queued onto an in-flight run that ends before draining it. */
+    dropDeliveredSignal?: boolean;
+    /** The run that swallowed the dropped signal ends, freeing the session. */
+    endRunAfterDroppedSignal?: boolean;
+    /** Once the session is free, a redelivered signal wakes it and lands. */
+    acceptRedeliveredSignal?: boolean;
   },
 ) {
   let threadId = 'thread-1';
   const consumeStream = vi.fn(async () => {});
   const notificationAccepted = accepted ?? Promise.resolve({ action: 'wake', output: { consumeStream } });
-  const agentEndListeners = new Set<(event: { type: string }) => void>();
-  const emitAgentEnd = () => {
+  const agentEndListeners = new Set<(event: { type: string; reason?: string }) => void>();
+  const emitAgentEnd = (reason = options?.agentEndReason) => {
     for (const listener of agentEndListeners) {
-      listener({ type: 'agent_end' });
+      listener({ type: 'agent_end', reason });
     }
   };
+  let signalSends = 0;
   const deliveredKeys = new Set<string>();
   const deliveredSignals = new Set<string>();
   const delivered: string[] = [];
@@ -78,13 +86,22 @@ function createSession(
     state: { set: vi.fn(async () => {}) },
     sendMessage: vi.fn(async () => {}),
     sendSignal: vi.fn((input: { id: string }, _options: { requestContext: { get(key: string): unknown } }) => {
-      deliveredSignals.add(input.id);
-      if (options?.emitAgentEndDuringSignal) {
-        emitAgentEnd();
+      signalSends += 1;
+      // The first send is the one queued onto the busy run; anything after it is
+      // a redelivery into a session the dispatcher waited for.
+      const redelivered = signalSends > 1 && options?.acceptRedeliveredSignal === true;
+      if (!options?.dropDeliveredSignal || redelivered) deliveredSignals.add(input.id);
+      if (options?.emitAgentEndDuringSignal || redelivered) {
+        emitAgentEnd(redelivered ? 'complete' : undefined);
+      } else if (options?.endRunAfterDroppedSignal) {
+        // The busy run finishes without ever answering the queued prompt, which
+        // is the moment the session becomes free to take it again.
+        queueMicrotask(() => emitAgentEnd('complete'));
       }
+      if (redelivered) return { accepted: Promise.resolve({ accepted: true as const, action: 'wake' }) };
       return { accepted: options?.signalAccepted ?? Promise.resolve({ accepted: true, action: 'deliver' }) };
     }),
-    subscribe: vi.fn((listener: (event: { type: string }) => void) => {
+    subscribe: vi.fn((listener: (event: { type: string; reason?: string }) => void) => {
       agentEndListeners.add(listener);
       return () => agentEndListeners.delete(listener);
     }),
@@ -424,6 +441,51 @@ describe('FactoryDecisionDispatcher', () => {
       status: 'succeeded',
       attempts: 1,
     });
+  });
+
+  it('delivers the built-in build prompt into the work session when a card enters Building', async () => {
+    // Building is the one leg of the loop that has never run for real, and it
+    // carries a prompt rather than a skill. Drive the shipped rules through the
+    // dispatcher so the prompt an agent would actually receive is asserted.
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    await bindWorkRun(storage, item.id);
+    const bound = await storage.get({ orgId: 'org-1', id: item.id });
+    const transitionService = new FactoryTransitionService({ storage, rules: builtInFactoryRules() });
+    const transitioned = await transitionService.transition({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      board: 'work',
+      stage: 'execute',
+      expectedRevision: bound!.revision,
+      actor: { type: 'human', id: 'user-1' },
+      ingress: { type: 'human', identity: 'move-build-1' },
+      cause: 'board_drag',
+    });
+    expect(transitioned.status).toBe('accepted');
+    const { controller, session } = createSession(undefined, {
+      emitAgentEndDuringSignal: true,
+      agentEndReason: 'complete',
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      isAutoRunEnabled: async () => true,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+
+    expect(session.sendSignal).toHaveBeenCalledTimes(1);
+    expect(session.sendSignal.mock.calls[0]?.[0]).toMatchObject({
+      contents: expect.stringContaining('Open a pull request when the work is ready for review.'),
+    });
+    const buildDecisions = (await storage.listDeferredDecisions('org-1', PROJECT_ID)).filter(
+      decision => decision.decision.type === 'invokeSkill',
+    );
+    expect(buildDecisions.map(decision => decision.status)).toEqual(['succeeded']);
   });
 
   it('prepares a binding, delivers to active sessions, and consumes idle wake streams for an urgent stage transition', async () => {
@@ -1067,6 +1129,175 @@ describe('FactoryDecisionDispatcher', () => {
     expect(getAgentEndListenerCount()).toBe(0);
   });
 
+  it.each([
+    { reason: 'error' as const, key: 'skill-run-error', message: 'ended in error' },
+    // An abort reads as deliberate, but the stream never says who aborted, and
+    // the usual cause is the process going away underneath the run. Ending the
+    // card at attempt 1 with no button leaves a human to nudge it by hand.
+    { reason: 'aborted' as const, key: 'skill-run-aborted', message: 'was aborted' },
+  ])('retries a run that ended $reason instead of reporting success', async ({ reason, key, message }) => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { item, transitionService } = await queueDecision(storage, {
+      type: 'invokeSkill',
+      role: 'work',
+      skillName: 'understand-issue',
+      arguments: 'Issue 42',
+      idempotencyKey: key,
+    });
+    await storage.prepareRunStart({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: PROJECT_ID,
+      workItem: {
+        id: item.id,
+        input: {
+          externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:1' },
+          title: 'Fix issue',
+          stages: ['execute'],
+          sessions: {},
+          metadata: {},
+        },
+      },
+      role: 'work',
+      session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-1' },
+      resourceId: PROJECT_ID,
+      kickoffKey: 'kickoff-null',
+      kickoffMessage: null,
+    });
+    const { controller, getAgentEndListenerCount } = createSession(undefined, {
+      signalAccepted: Promise.resolve({ accepted: true, action: 'wake' }),
+      emitAgentEndDuringSignal: true,
+      agentEndReason: reason,
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      isAutoRunEnabled: async () => true,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+
+    const [decision] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(decision?.status).toBe('retry');
+    expect(decision?.lastError).toContain(message);
+    // `retry` only helps if the row can actually be picked up again.
+    expect(decision?.availableAt).toBeTruthy();
+    expect(getAgentEndListenerCount()).toBe(0);
+  });
+
+  it('retries a kickoff that was queued onto an ending run instead of reporting success', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { item, transitionService } = await queueDecision(storage, {
+      type: 'invokeSkill',
+      role: 'work',
+      skillName: 'understand-issue',
+      arguments: 'Issue 42',
+      idempotencyKey: 'skill-delivered-onto-dying-run',
+    });
+    await storage.prepareRunStart({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: PROJECT_ID,
+      workItem: {
+        id: item.id,
+        input: {
+          externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:1' },
+          title: 'Fix issue',
+          stages: ['execute'],
+          sessions: {},
+          metadata: {},
+        },
+      },
+      role: 'work',
+      session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-1' },
+      resourceId: PROJECT_ID,
+      kickoffKey: 'kickoff-null',
+      kickoffMessage: null,
+    });
+    // The session is mid-turn, so the signal is delivered onto the in-flight
+    // run; that run then ends without ever persisting or answering the prompt,
+    // and the redelivery is swallowed the same way. Nothing here can be waited
+    // out, so the decision has to go back on the queue.
+    const { controller, getAgentEndListenerCount } = createSession(undefined, {
+      signalAccepted: Promise.resolve({ accepted: true, action: 'deliver' }),
+      dropDeliveredSignal: true,
+      endRunAfterDroppedSignal: true,
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      isAutoRunEnabled: async () => true,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+
+    const [decision] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(decision?.status).toBe('retry');
+    expect(decision?.lastError).toContain('never reached the agent');
+    expect(getAgentEndListenerCount()).toBe(0);
+  });
+
+  it('redelivers a kickoff dropped onto an ending run once that run finishes', async () => {
+    // The condition that frees the session is the in-flight run ending, which
+    // takes as long as a turn takes. Retrying on the generic backoff spends all
+    // five attempts inside half a minute, so every one lands on the same busy
+    // run and the card dies of impatience rather than of anything being wrong.
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { item, transitionService } = await queueDecision(storage, {
+      type: 'invokeSkill',
+      role: 'work',
+      skillName: 'understand-issue',
+      arguments: 'Issue 42',
+      idempotencyKey: 'skill-redelivered-after-run-ends',
+    });
+    await storage.prepareRunStart({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: PROJECT_ID,
+      workItem: {
+        id: item.id,
+        input: {
+          externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:1' },
+          title: 'Fix issue',
+          stages: ['execute'],
+          sessions: {},
+          metadata: {},
+        },
+      },
+      role: 'work',
+      session: { sessionId: 'session-1', branch: 'factory/issue-1', threadId: 'thread-1' },
+      resourceId: PROJECT_ID,
+      kickoffKey: 'kickoff-null',
+      kickoffMessage: null,
+    });
+    const { controller, session, getAgentEndListenerCount } = createSession(undefined, {
+      signalAccepted: Promise.resolve({ accepted: true, action: 'deliver' }),
+      dropDeliveredSignal: true,
+      endRunAfterDroppedSignal: true,
+      acceptRedeliveredSignal: true,
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      isAutoRunEnabled: async () => true,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+
+    const [decision] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(decision?.status).toBe('succeeded');
+    // Settled inside the one lease, without spending the card's retry budget.
+    expect(decision?.attempts).toBe(1);
+    expect(session.sendSignal).toHaveBeenCalledTimes(2);
+    expect(getAgentEndListenerCount()).toBe(0);
+  });
+
   it('retries the skill kickoff when the wake signal is rejected instead of marking it succeeded', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const { item, transitionService } = await queueDecision(storage, {
@@ -1160,6 +1391,49 @@ describe('FactoryDecisionDispatcher', () => {
     expect((await storage.listDeferredDecisions('org-1', PROJECT_ID))[0]?.status).toBe('succeeded');
   });
 
+  it('runs without approval on an item a person already started, even with automatic runs off', async () => {
+    // Withholding automatic runs decides what the Factory picks up on its own.
+    // Once a person hands it an item, the runs that carry that item to review
+    // are the same request continuing, not new work to consent to.
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { item, transitionService } = await queueDecision(storage, {
+      type: 'invokeSkill',
+      role: 'work',
+      skillName: 'understand-issue',
+      idempotencyKey: 'skill-on-armed-item',
+    });
+    await bindWorkRun(storage, item.id);
+    await storage.armAutonomy({ orgId: 'org-1', id: item.id, now: new Date('2030-01-01T00:00:00Z') });
+    const { controller, session } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+      isAutoRunEnabled: async () => false,
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:01:00Z'));
+
+    expect(session.sendSignal).toHaveBeenCalledTimes(1);
+    expect((await storage.listDeferredDecisions('org-1', PROJECT_ID))[0]?.status).toBe('succeeded');
+  });
+
+  it('arms an item once, so the first commitment is the one that counts', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { item } = await queueDecision(storage, {
+      type: 'invokeSkill',
+      role: 'work',
+      skillName: 'understand-issue',
+      idempotencyKey: 'skill-arm-once',
+    });
+    const armed = new Date('2030-01-01T00:00:00Z');
+    await storage.armAutonomy({ orgId: 'org-1', id: item.id, now: armed });
+    await storage.armAutonomy({ orgId: 'org-1', id: item.id, now: new Date('2030-06-01T00:00:00Z') });
+
+    expect(await storage.get({ orgId: 'org-1', id: item.id })).toMatchObject({ autonomyArmedAt: armed });
+  });
+
   it('never runs a dismissed proposal', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const { transitionService } = await queueDecision(storage, {
@@ -1195,6 +1469,76 @@ describe('FactoryDecisionDispatcher', () => {
     expect(
       await storage.approveDeferredDecision('org-1', PROJECT_ID, parked!.id, new Date('2030-01-01T00:03:00Z')),
     ).toBeNull();
+  });
+
+  it('retires a parked proposal once the run it asked for is starting anyway', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    // First drag, before the item is armed: the run parks as a question.
+    const { item } = await queueDecision(storage, {
+      type: 'invokeSkill',
+      role: 'work',
+      skillName: 'understand-issue',
+      idempotencyKey: 'skill-parked',
+    });
+    const { controller, session, emitAgentEnd } = createSession();
+    const transitionService = new FactoryTransitionService({
+      storage,
+      rules: defaultFactoryRules({
+        version: 'rules-v1',
+        overrides: {
+          work: {
+            execute: {
+              issue: {
+                onEnter: () => ({
+                  type: 'invokeSkill',
+                  role: 'work',
+                  skillName: 'understand-issue',
+                  idempotencyKey: 'skill-approved',
+                }),
+              },
+            },
+          },
+        },
+      }),
+    });
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+      isAutoRunEnabled: async () => false,
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+    const [parked] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(parked).toMatchObject({ status: 'proposed' });
+
+    // The person answers by taking the item on, which arms it and emits a
+    // second copy of the same run. The parked question is now moot.
+    await storage.armAutonomy({ orgId: 'org-1', id: item.id, now: new Date('2030-01-01T00:01:00Z') });
+    await bindWorkRun(storage, item.id);
+    const current = await storage.get({ orgId: 'org-1', id: item.id });
+    await transitionService.transition({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      board: 'work',
+      stage: 'execute',
+      expectedRevision: current!.revision,
+      actor: { type: 'human', id: 'user-1' },
+      ingress: { type: 'human', identity: 'move-2' },
+      cause: 'test',
+      reenter: true,
+    });
+
+    const dispatched = dispatcher.runOnce(new Date('2030-01-01T00:02:00Z'));
+    await vi.waitFor(() => expect(session.sendSignal).toHaveBeenCalled());
+    emitAgentEnd();
+    await dispatched;
+
+    const decisions = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(decisions.find(entry => entry.id === parked!.id)?.status).toBe('dismissed');
+    expect(decisions.find(entry => entry.id !== parked!.id)?.status).toBe('succeeded');
   });
 
   it('still moves cards for external facts while automatic runs are off', async () => {

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -4,7 +4,7 @@ import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentController, AgentControllerEventListener } from '@mastra/core/agent-controller';
 import { RequestContext } from '@mastra/core/request-context';
 
-import { resolveSkillInvocation } from '../skills/service.js';
+import { resolvePromptInvocation, resolveSkillInvocation } from '../skills/service.js';
 import type { SkillSession } from '../skills/service.js';
 import type {
   FactoryDeferredDecisionRecord,
@@ -329,6 +329,7 @@ export class FactoryDecisionDispatcher {
         if (!proposed) throw new Error('Factory decision lease was lost before approval could be requested.');
         return;
       }
+      await this.#supersedeProposals(record, decision);
       await this.#withLease(
         async leaseExpiresAt =>
           this.#storage.renewDeferredDecisionLease(leaseIdentity(record, this.#ownerId), leaseExpiresAt),
@@ -348,10 +349,38 @@ export class FactoryDecisionDispatcher {
     }
   }
 
+  /**
+   * A proposal is a question: "should this run start?" Once that run is
+   * starting anyway — because a person approved a later copy, or armed the item
+   * — the question has been answered and the card must stop asking it. Left
+   * alone the badge outlives the work it describes, and the one affordance that
+   * means "the loop is stopped, answer this" cries wolf.
+   */
+  async #supersedeProposals(record: FactoryDeferredDecisionRecord, decision: FactoryCommitDecision): Promise<void> {
+    if (decision.type !== 'invokeSkill' || !record.workItemId) return;
+    try {
+      await this.#storage.dismissProposalsForWorkItem({
+        orgId: record.orgId,
+        factoryProjectId: record.factoryProjectId,
+        workItemId: record.workItemId,
+        role: decision.role,
+        dismissedAt: new Date(),
+      });
+    } catch (error) {
+      // Best-effort: a stale badge is not worth failing the run it describes.
+      console.error('Factory proposal supersede failed', sanitizeDispatchError(error));
+    }
+  }
+
   /** Starting an agent run spends the project's compute and executes its code — the one effect a human owns. */
   async #needsApproval(record: FactoryDeferredDecisionRecord, decision: FactoryCommitDecision): Promise<boolean> {
     if (decision.type !== 'invokeSkill' || record.approvedAt !== null) return false;
-    return !(await this.#isAutoRunEnabled({ orgId: record.orgId, factoryProjectId: record.factoryProjectId }));
+    if (await this.#isAutoRunEnabled({ orgId: record.orgId, factoryProjectId: record.factoryProjectId })) return false;
+    // Withholding auto-run decides what the Factory may pick up on its own, not
+    // whether it may finish work a person already handed it. Once someone starts
+    // an item, the runs that carry it to review are that same request continuing.
+    const item = record.workItemId ? await this.#storage.get({ orgId: record.orgId, id: record.workItemId }) : null;
+    return item?.autonomyArmedAt == null;
   }
 
   async #executeDecision(record: FactoryDeferredDecisionRecord, decision: FactoryCommitDecision): Promise<void> {
@@ -375,6 +404,7 @@ export class FactoryDecisionDispatcher {
           ingress: { type: 'rule', identity: `decision:${record.idempotencyKey}` },
           cause: 'rule_decision',
           causalChain: nextChain,
+          ...(decision.reenter ? { reenter: true } : {}),
         });
         if (result.status === 'rejected') throw new Error(`${result.code}: ${result.reason}`);
         if (!decision.message) return;
@@ -423,11 +453,17 @@ export class FactoryDecisionDispatcher {
         await this.#primeCredentials?.({ orgId: record.orgId, userId: startedBy });
         const requestContext = new RequestContext();
         requestContext.set('user', { workosId: startedBy, organizationId: record.orgId });
-        const resolved = await resolveSkillInvocation(this.#controller, {
-          resourceId: binding.resourceId,
-          name: decision.skillName,
-          arguments: decision.arguments,
-        });
+        const resolved =
+          decision.skillName === undefined
+            ? await resolvePromptInvocation(this.#controller, {
+                resourceId: binding.resourceId,
+                prompt: decision.prompt,
+              })
+            : await resolveSkillInvocation(this.#controller, {
+                resourceId: binding.resourceId,
+                name: decision.skillName,
+                arguments: decision.arguments,
+              });
         const session = resolved.session as DispatcherSession;
         await this.#switchThread(session, binding);
         const delivered = await session.thread.listActiveMessages();
@@ -454,16 +490,29 @@ export class FactoryDecisionDispatcher {
           );
         }
         let resolveAgentEnd!: () => void;
-        const agentEnd = new Promise<void>(resolve => {
-          resolveAgentEnd = resolve;
-        });
+        let agentEnd!: Promise<void>;
+        // The run's own verdict, not the delivery's. A signal can reach the
+        // agent perfectly and the run still die on a provider error or be
+        // cancelled mid-flight; without this the decision reports success and
+        // the break is invisible on the card.
+        let endReason: 'complete' | 'aborted' | 'error' | 'suspended' | undefined;
+        // Re-armed before a redelivery so the second send waits on its own run's
+        // ending rather than seeing the one that already resolved.
+        const armAgentEnd = () => {
+          endReason = undefined;
+          agentEnd = new Promise<void>(resolve => {
+            resolveAgentEnd = resolve;
+          });
+        };
+        armAgentEnd();
         const unsubscribe = session.subscribe(event => {
           if (event.type === 'agent_end') {
+            endReason = event.reason;
             resolveAgentEnd();
           }
         });
 
-        try {
+        const sendKickoff = async () => {
           const result = session.sendSignal(
             {
               id: record.id,
@@ -484,6 +533,37 @@ export class FactoryDecisionDispatcher {
             // a success.
             throw new Error(`Factory skill invocation signal did not reach the agent (${String(settled.action)}).`);
           }
+          return settled;
+        };
+
+        try {
+          let settled = await sendKickoff();
+          if (settled.action === 'deliver') {
+            // `deliver` means the signal was queued onto a run that was already
+            // in flight. If that run ends before draining its queue the prompt
+            // is dropped silently: no turn starts, no error surfaces, and the
+            // decision reports success while the card sits in its new stage with
+            // nobody working. Signals persist under their own id (the same
+            // identity the replay guard above reads), so confirm the message
+            // actually landed in the thread rather than trusting the ack.
+            const landed = await session.thread.listActiveMessages();
+            if (!landed.some(message => message.id === record.id)) {
+              // The condition that resolves this is the in-flight run ending, so
+              // wait for exactly that and redeliver into the idle session. A
+              // backoff cannot work here: retries are sized in seconds and a turn
+              // takes minutes, so every attempt lands on the same busy run and
+              // the card burns its whole budget without the session ever having
+              // had a chance to be free.
+              if (!(await waitForAgentEndOrTimeout(agentEnd))) {
+                throw new Error('Factory skill invocation is waiting on a run that has not ended.');
+              }
+              armAgentEnd();
+              settled = await sendKickoff();
+              if (settled.action !== 'wake') {
+                throw new Error('Factory skill invocation was queued onto an ending run and never reached the agent.');
+              }
+            }
+          }
           if (settled.action === 'wake') {
             const observed = await waitForAgentEndOrTimeout(agentEnd);
             if (!observed) {
@@ -491,6 +571,17 @@ export class FactoryDecisionDispatcher {
                 decisionId: record.id,
                 runId: settled.runId,
               });
+            } else if (endReason === 'error') {
+              throw new Error('Factory skill run ended in error.');
+            } else if (endReason === 'aborted') {
+              // Retryable, though an abort reads as deliberate. The stream does
+              // not say who aborted, and in practice the dominant cause is the
+              // process going away underneath the run — an operator restarting
+              // the server — not anyone deciding this work should stop. Treating
+              // that as terminal dead-ends the card at attempt 1 with nothing on
+              // the board to press. A spurious retry is bounded by MAX_ATTEMPTS;
+              // a dead card costs a human a manual nudge.
+              throw new Error('Factory skill run was aborted before it finished.');
             }
           }
         } finally {

--- a/mastracode/factory/src/rules/resolve.ts
+++ b/mastracode/factory/src/rules/resolve.ts
@@ -26,9 +26,10 @@ export function resolveFactoryStageRules(
     fromStage: FactoryRuleStage;
     toStage: FactoryRuleStage;
     initialEntry?: boolean;
+    reenter?: boolean;
   },
 ): ResolvedFactoryStageRule[] {
-  if (input.fromStage === input.toStage && !input.initialEntry) return [];
+  if (input.fromStage === input.toStage && !input.initialEntry && !input.reenter) return [];
   const boardRules = rules[input.board];
   const resolved: ResolvedFactoryStageRule[] = [];
   const onExit = input.initialEntry ? undefined : boardRules[input.fromStage]?.[input.source]?.onExit;

--- a/mastracode/factory/src/rules/terminal-cleanup.test.ts
+++ b/mastracode/factory/src/rules/terminal-cleanup.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import { defaultFactoryRules } from './defaults.js';
 import { createTerminalStageCleanup } from './terminal-cleanup.js';
+import { FactoryTransitionService } from './transition-service.js';
 
 const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
 
@@ -95,12 +97,58 @@ describe('createTerminalStageCleanup', () => {
     ]);
   });
 
+  it('dismisses the runs still parked on the item, since a finished item cannot answer them', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const prepared = await prepareBinding(storage);
+    const rules = defaultFactoryRules({
+      version: 'rules-v1',
+      overrides: {
+        work: {
+          execute: {
+            issue: {
+              onEnter: () => ({ type: 'invokeSkill', role: 'work', skillName: 'factory-plan', idempotencyKey: 'p-1' }),
+            },
+          },
+        },
+      },
+    });
+    await new FactoryTransitionService({ storage, rules }).transition({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: prepared.item.id,
+      board: 'work',
+      stage: 'execute',
+      expectedRevision: prepared.item.revision,
+      actor: { type: 'human', id: 'user-1' },
+      ingress: { type: 'human', identity: 'move-1' },
+      cause: 'test',
+    });
+    const now = new Date('2030-01-01T00:00:00Z');
+    const [claimed] = await storage.claimDeferredDecisions({
+      ownerId: 'dispatcher',
+      now,
+      leaseExpiresAt: new Date(now.getTime() + 30_000),
+      limit: 1,
+    });
+    await storage.proposeDeferredDecision(
+      { id: claimed!.id, orgId: 'org-1', factoryProjectId: PROJECT_ID, ownerId: 'dispatcher' },
+      now,
+    );
+
+    const cleanup = createTerminalStageCleanup({ workItems: storage });
+    await cleanup({ orgId: 'org-1', factoryProjectId: PROJECT_ID, workItemId: prepared.item.id });
+
+    const decisions = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(decisions).toEqual([expect.objectContaining({ id: claimed!.id, status: 'dismissed' })]);
+  });
+
   it('never throws and still releases sandboxes when revocation fails', async () => {
     const releaseSandboxes = vi.fn(async () => {});
     const cleanup = createTerminalStageCleanup({
       workItems: {
         listRunBindings: vi.fn().mockRejectedValue(new Error('storage down')),
         revokeRunBindingsForWorkItem: vi.fn(),
+        dismissProposalsForWorkItem: vi.fn().mockRejectedValue(new Error('storage down')),
       },
       releaseSandboxes,
     });

--- a/mastracode/factory/src/rules/terminal-cleanup.ts
+++ b/mastracode/factory/src/rules/terminal-cleanup.ts
@@ -1,7 +1,7 @@
 import type { FactoryRunBindingRecord, WorkItemsStorage } from '../storage/domains/work-items/base.js';
 
 export interface TerminalStageCleanupOptions {
-  workItems: Pick<WorkItemsStorage, 'listRunBindings' | 'revokeRunBindingsForWorkItem'>;
+  workItems: Pick<WorkItemsStorage, 'listRunBindings' | 'revokeRunBindingsForWorkItem' | 'dismissProposalsForWorkItem'>;
   /** Final ingest of trailing tool results before the binding is revoked. */
   reconcileBinding?: (binding: FactoryRunBindingRecord) => Promise<void>;
   /** Release the item's session sandboxes back to the reuse pool. */
@@ -18,9 +18,9 @@ export interface TerminalStageCleanupArgs {
  * Terminal-stage cleanup for a work item: ingest any trailing tool results
  * from the item's bound threads, revoke its active run bindings so completed
  * items leave the reconcile walk (the active set otherwise grows forever),
- * then release its sandboxes. Every step is best-effort — a committed
- * transition never fails on cleanup; leaked bindings are drained by the
- * staleness sweep.
+ * dismiss the runs still parked on it, then release its sandboxes. Every step
+ * is best-effort — a committed transition never fails on cleanup; leaked
+ * bindings are drained by the staleness sweep.
  */
 export function createTerminalStageCleanup(options: TerminalStageCleanupOptions) {
   return async (args: TerminalStageCleanupArgs): Promise<void> => {
@@ -40,6 +40,18 @@ export function createTerminalStageCleanup(options: TerminalStageCleanupOptions)
       });
     } catch {
       // Best-effort; the staleness sweep retries later.
+    }
+    try {
+      // A merged pull request answers its own parked runs: there is nothing
+      // left for them to do, so they should stop asking to be started.
+      await options.workItems.dismissProposalsForWorkItem({
+        orgId: args.orgId,
+        factoryProjectId: args.factoryProjectId,
+        workItemId: args.workItemId,
+        dismissedAt: new Date(),
+      });
+    } catch {
+      // Best-effort; a stranded proposal is still dismissible from the card.
     }
     await options.releaseSandboxes?.(args);
   };

--- a/mastracode/factory/src/rules/tools.test.ts
+++ b/mastracode/factory/src/rules/tools.test.ts
@@ -206,6 +206,98 @@ describe('factory_transition_work_item', () => {
     ).rejects.toThrow(/binding is unavailable, revoked, or no longer matches/);
   });
 
+  it('keeps working when the next role takes its turn in the same session', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const prepared = await prepareBoundItem(storage);
+    const transition = vi.fn(async () => ({
+      status: 'accepted' as const,
+      transitionId: 'transition-2',
+      itemId: prepared.item.id,
+      revision: 2,
+      stage: 'execute' as const,
+      decisions: [],
+    }));
+    const context = requestContext();
+    const tools = await createFactoryTransitionTools({
+      requestContext: context,
+      storage,
+      transitionService: { transition },
+    });
+
+    // Handing planning its turn in the live session rotates the binding row.
+    const rotated = await storage.prepareRunStart({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: PROJECT_ID,
+      workItem: {
+        id: prepared.item.id,
+        input: {
+          externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:1' },
+          title: 'Factory item',
+          stages: ['planning'],
+          sessions: {},
+          metadata: {},
+        },
+      },
+      role: 'plan',
+      session: { sessionId: 'resource-1', branch: 'factory/item', threadId: 'thread-1' },
+      resourceId: 'resource-1',
+      kickoffKey: 'kickoff-2',
+      kickoffMessage: null,
+    });
+    expect(rotated.binding.id).not.toBe(prepared.binding.id);
+
+    await expect(
+      execute(tools.factory_transition_work_item as ExecutableTool, context, {
+        stage: 'execute',
+        expectedRevision: 1,
+        rationale: 'The plan is ready to build.',
+      }),
+    ).resolves.toMatchObject({ status: 'accepted' });
+    expect(transition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workItemId: prepared.item.id,
+        actor: expect.objectContaining({ bindingId: rotated.binding.id }),
+      }),
+    );
+  });
+
+  it('rejects a session that has been re-pointed at a different work item', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    await prepareBoundItem(storage);
+    const service = new FactoryTransitionService({ storage, rules: defaultFactoryRules({ version: 'rules-v1' }) });
+    const context = requestContext();
+    const tools = await createFactoryTransitionTools({ requestContext: context, storage, transitionService: service });
+
+    await storage.prepareRunStart({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: PROJECT_ID,
+      workItem: {
+        input: {
+          externalSource: { integrationId: 'github', type: 'issue', externalId: 'github-issue:2' },
+          title: 'A different item',
+          stages: ['intake'],
+          sessions: {},
+          metadata: {},
+        },
+      },
+      role: 'work',
+      session: { sessionId: 'resource-1', branch: 'factory/other', threadId: 'thread-1' },
+      resourceId: 'resource-1',
+      kickoffKey: 'kickoff-3',
+      kickoffMessage: null,
+    });
+
+    await expect(
+      execute(tools.factory_transition_work_item as ExecutableTool, context, {
+        stage: 'planning',
+        expectedRevision: 1,
+        rationale: 'Continue.',
+      }),
+    ).rejects.toThrow(/binding is unavailable, revoked, or no longer matches/);
+  });
+
   it('returns canonical stale and rule rejection results from transition authority', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     await prepareBoundItem(storage);

--- a/mastracode/factory/src/rules/tools.ts
+++ b/mastracode/factory/src/rules/tools.ts
@@ -66,7 +66,13 @@ export async function createFactoryTransitionTools(options: {
           throw new Error('Factory transitions require an authenticated bound agent tool call.');
         }
         const binding = await options.storage.findActiveRunBinding(currentAddress);
-        if (!binding || binding.id !== availableBinding.id) {
+        // Authority is the work item this session is bound to, not the individual
+        // binding row. Handing the next role its turn in an existing session
+        // rotates the binding, and tools built for the previous role stay live
+        // across that rotation; keying on row identity would strand the run that
+        // the rotation exists to start. Re-pointing a session at a different item
+        // is the hijack this guards against.
+        if (!binding || binding.workItemId !== availableBinding.workItemId) {
           throw new Error('Factory agent binding is unavailable, revoked, or no longer matches this session.');
         }
         const item = await options.storage.get({ orgId: binding.orgId, id: binding.workItemId });

--- a/mastracode/factory/src/rules/transition-service.test.ts
+++ b/mastracode/factory/src/rules/transition-service.test.ts
@@ -165,6 +165,40 @@ describe('FactoryTransitionService', () => {
     expect(onTerminalStage).toHaveBeenCalledOnce();
   });
 
+  it('arms autonomy when a person moves a card, so its follow-up runs instead of parking', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage, { stages: ['intake'] });
+    const service = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.autonomyArmedAt).toBeNull();
+
+    const result = await service.transition({ ...request(item, { stage: 'triage' }), cause: 'board_drag' });
+
+    expect(result.status).toBe('accepted');
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.autonomyArmedAt).toBeInstanceOf(Date);
+  });
+
+  it('leaves autonomy unarmed when the mover is not a person', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage, { stages: ['intake'] });
+    const service = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+
+    const result = await service.transition({
+      ...request(item, { stage: 'triage' }),
+      actor: { type: 'system', id: 'reconciler' },
+      ingress: { type: 'rule', identity: 'rule-1' },
+      cause: 'board_drag',
+    });
+
+    expect(result.status).toBe('accepted');
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.autonomyArmedAt).toBeNull();
+  });
+
   it('queues an urgent wake-up when a board drag has no skill follow-up', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const item = await createItem(storage, { stages: ['triage'] });
@@ -174,7 +208,7 @@ describe('FactoryTransitionService', () => {
     });
 
     const result = await service.transition({
-      ...request(item, { stage: 'execute' }),
+      ...request(item, { stage: 'canceled' }),
       cause: 'board_drag',
     });
 
@@ -184,7 +218,7 @@ describe('FactoryTransitionService', () => {
         {
           type: 'sendMessage',
           role: 'work',
-          message: 'This work was moved from the triage stage to the execute stage.',
+          message: 'This work was moved from the triage stage to the canceled stage.',
           priority: 'urgent',
           idleBehavior: 'wake',
           prepareBinding: true,

--- a/mastracode/factory/src/rules/transition-service.ts
+++ b/mastracode/factory/src/rules/transition-service.ts
@@ -42,6 +42,8 @@ export interface FactoryTransitionRequest {
   causalChain?: readonly FactoryRuleCausalEntry[];
   /** Internal materialization path: evaluate only the destination onEnter leaf even when already at that stage. */
   initialEntry?: boolean;
+  /** Re-runs the stage's entry rules when the item already holds that stage, to restart work the entry invalidated. */
+  reenter?: boolean;
 }
 
 export interface FactoryTransitionServiceOptions {
@@ -195,6 +197,9 @@ export class FactoryTransitionService {
       );
     }
 
+    const humanBoardDrag =
+      request.actor.type === 'human' && request.cause === 'board_drag' && fromStage !== request.stage;
+
     const contextBase = {
       tenant: { orgId: request.orgId, projectId: request.factoryProjectId },
       actor: request.actor,
@@ -233,6 +238,7 @@ export class FactoryTransitionService {
             fromStage,
             toStage: request.stage,
             initialEntry: request.initialEntry,
+            reenter: request.reenter,
           })) {
             const context: FactoryStageRuleContext = Object.freeze({
               ...contextBase,
@@ -247,7 +253,7 @@ export class FactoryTransitionService {
             decisions.push(decision);
           }
           const validated = validateFactoryRuleDecisions(decisions);
-          if (request.actor.type === 'human' && request.cause === 'board_drag' && fromStage !== request.stage) {
+          if (humanBoardDrag) {
             const message = stageTransitionMessage(fromStage, request.stage);
             const skill = validated.find(decision => decision.type === 'invokeSkill');
             if (skill) {
@@ -277,6 +283,13 @@ export class FactoryTransitionService {
           ? { code: 'timeout' as const, reason: 'Factory rule evaluation timed out.' }
           : ruleFailure(error);
       evaluation = { outcome: 'rejected', ...failed };
+    }
+    // Moving a card by hand is itself the request to do the work. Arm the item
+    // before the decisions this transition emits become visible to the
+    // dispatcher, so they run instead of parking as proposals a person would
+    // only have to approve again.
+    if (evaluation.outcome === 'accepted' && humanBoardDrag) {
+      await this.#storage.armAutonomy({ orgId: request.orgId, id: request.workItemId, now: new Date() });
     }
     return this.#commit(request, transitionId, evaluation);
   }

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -22,7 +22,9 @@ export const FACTORY_GITHUB_EVENTS = [
   'issueCommentDeleted',
   'pullRequestOpened',
   'pullRequestUpdated',
+  'pullRequestCommentCreated',
   'pullRequestReviewRequested',
+  'pullRequestReviewSubmitted',
   'pullRequestMerged',
   'pullRequestClosed',
 ] as const;
@@ -144,6 +146,8 @@ export interface FactoryGithubRuleContext extends FactoryRuleContextBase {
   };
   /** Present on `pullRequestReviewRequested`: who review was (re-)requested from. */
   reviewRequest?: { reviewer: string; factoryReviewer: boolean };
+  /** Present on `pullRequestReviewSubmitted`: the review that was just posted. */
+  review?: { id: number; state: string; url: string };
 }
 
 export interface FactoryLinearRuleContext extends FactoryRuleContextBase {
@@ -240,6 +244,14 @@ export interface FactoryTransitionDecision extends FactoryCommitDecisionBase {
    * informational messages never fail the transition.
    */
   message?: { text: string; role?: string };
+  /**
+   * Runs the stage's entry rules even when the item is already in that stage.
+   * A transition to the current stage is normally inert, because most callers
+   * are correcting a board into a state it already holds. Re-entry is for the
+   * opposite case: the stage's work is in flight and has been invalidated, so
+   * it has to start over.
+   */
+  reenter?: boolean;
 }
 
 export interface FactoryUpsertLinkedWorkItemDecision extends FactoryCommitDecisionBase {
@@ -253,14 +265,23 @@ export interface FactoryUpsertLinkedWorkItemDecision extends FactoryCommitDecisi
   metadata?: Record<string, FactoryRuleJsonValue>;
 }
 
-export interface FactoryInvokeSkillDecision extends FactoryCommitDecisionBase {
+interface FactoryInvokeSkillDecisionBase extends FactoryCommitDecisionBase {
   type: 'invokeSkill';
   role: string;
-  skillName: string;
   arguments?: string;
   precedingMessage?: string;
   cancelInFlight?: boolean;
 }
+
+/**
+ * Starting an agent run. Most runs activate a skill, because the skill carries
+ * the handoff contract later rules match on. A run whose completion is already
+ * signalled some other way — Building finishes by opening a pull request, which
+ * arrives as its own event — needs no contract, so it can carry a plain prompt
+ * instead of an otherwise empty skill.
+ */
+export type FactoryInvokeSkillDecision = FactoryInvokeSkillDecisionBase &
+  ({ skillName: string; prompt?: never } | { prompt: string; skillName?: never });
 
 export interface FactorySendMessageDecision extends FactoryCommitDecisionBase {
   type: 'sendMessage';

--- a/mastracode/factory/src/rules/validation.test.ts
+++ b/mastracode/factory/src/rules/validation.test.ts
@@ -148,6 +148,30 @@ describe('Factory rule validation', () => {
     expect(String(error)).not.toContain(secret);
   });
 
+  it('takes a prompt in place of a skill, but never both and never neither', () => {
+    expect(
+      validateFactoryRuleDecision({
+        type: 'invokeSkill',
+        idempotencyKey: 'build-1',
+        role: 'work',
+        prompt: 'Implement the approved plan.',
+      }),
+    ).toEqual({
+      type: 'invokeSkill',
+      idempotencyKey: 'build-1',
+      role: 'work',
+      prompt: 'Implement the approved plan.',
+    });
+    // Both are ways of authoring the same kickoff message, so accepting both
+    // would leave the dispatcher to pick a winner.
+    for (const invalid of [
+      { type: 'invokeSkill', idempotencyKey: 'build-2', role: 'work', skillName: 'factory-plan', prompt: 'Build it.' },
+      { type: 'invokeSkill', idempotencyKey: 'build-3', role: 'work' },
+    ]) {
+      expect(() => validateFactoryRuleDecision(invalid)).toThrow(/exactly one of skillName or prompt/);
+    }
+  });
+
   it('accepts and normalizes the optional cancelInFlight flag on invokeSkill decisions', () => {
     expect(
       validateFactoryRuleDecision({

--- a/mastracode/factory/src/rules/validation.ts
+++ b/mastracode/factory/src/rules/validation.ts
@@ -220,7 +220,14 @@ export function validateFactoryRuleDecision(value: unknown, causalDepth = 0): Fa
       };
     }
     case 'transition': {
-      assertExactKeys(value, ['type', 'idempotencyKey', 'board', 'stage', 'message'], 'Factory transition decision');
+      assertExactKeys(
+        value,
+        ['type', 'idempotencyKey', 'board', 'stage', 'message', 'reenter'],
+        'Factory transition decision',
+      );
+      if (value.reenter !== undefined && typeof value.reenter !== 'boolean') {
+        throw new FactoryRuleValidationError('Factory transition reenter must be a boolean.');
+      }
       let message: { text: string; role?: string } | undefined;
       if (value.message !== undefined) {
         if (!isPlainObject(value.message)) {
@@ -242,6 +249,7 @@ export function validateFactoryRuleDecision(value: unknown, causalDepth = 0): Fa
         board: enumValue(value.board, FACTORY_RULE_BOARDS, 'Factory transition board'),
         stage: enumValue(value.stage, FACTORY_RULE_STAGES, 'Factory transition stage'),
         ...(message ? { message } : {}),
+        ...(value.reenter === true ? { reenter: true } : {}),
       };
     }
     case 'upsertLinkedWorkItem': {
@@ -270,9 +278,15 @@ export function validateFactoryRuleDecision(value: unknown, causalDepth = 0): Fa
     case 'invokeSkill': {
       assertExactKeys(
         value,
-        ['type', 'idempotencyKey', 'role', 'skillName', 'arguments', 'precedingMessage', 'cancelInFlight'],
+        ['type', 'idempotencyKey', 'role', 'skillName', 'prompt', 'arguments', 'precedingMessage', 'cancelInFlight'],
         'Factory invoke skill decision',
       );
+      // A run activates a skill or carries a prompt, never both: they are two
+      // ways to author the same kickoff message, so accepting both would leave
+      // the dispatcher picking a winner.
+      if ((value.skillName === undefined) === (value.prompt === undefined)) {
+        throw new FactoryRuleValidationError('Factory skill invocation needs exactly one of skillName or prompt.');
+      }
       const args = optionalBoundedString(value.arguments, 'Factory skill arguments', MAX_ARGUMENTS_LENGTH);
       const precedingMessage = optionalBoundedString(
         value.precedingMessage,
@@ -286,7 +300,9 @@ export function validateFactoryRuleDecision(value: unknown, causalDepth = 0): Fa
         type,
         ...commonCommitFields(value),
         role: boundedString(value.role, 'Factory skill role', MAX_ROLE_LENGTH, IDENTIFIER_RE),
-        skillName: boundedString(value.skillName, 'Factory skill name', MAX_SKILL_NAME_LENGTH, SKILL_NAME_RE),
+        ...(value.skillName === undefined
+          ? { prompt: boundedString(value.prompt, 'Factory skill prompt', MAX_MESSAGE_LENGTH) }
+          : { skillName: boundedString(value.skillName, 'Factory skill name', MAX_SKILL_NAME_LENGTH, SKILL_NAME_RE) }),
         ...(args ? { arguments: args } : {}),
         ...(precedingMessage ? { precedingMessage } : {}),
         ...(value.cancelInFlight === true ? { cancelInFlight: true } : {}),

--- a/mastracode/factory/src/skills/service.ts
+++ b/mastracode/factory/src/skills/service.ts
@@ -47,6 +47,16 @@ function escapeSkillBoundary(value: string): string {
   return value.replaceAll('</skill>', '&lt;/skill&gt;');
 }
 
+/** Kicks a run off from a plain prompt, for runs that activate no skill. */
+export async function resolvePromptInvocation(
+  controller: Pick<AgentController<MastraCodeState>, 'getSessionByResource'>,
+  input: { resourceId: string; scope?: SkillInvocationInput['scope']; prompt: string },
+): Promise<{ session: SkillSession; message: string }> {
+  const session = (await controller.getSessionByResource(input.resourceId, input.scope)) as SkillSession | undefined;
+  if (!session) throw new SkillInvocationError('session_not_found', 'Agent controller session not found.');
+  return { session, message: input.prompt };
+}
+
 export async function resolveSkillInvocation(
   controller: Pick<AgentController<MastraCodeState>, 'getSessionByResource'>,
   input: SkillInvocationInput,

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -315,6 +315,13 @@ export interface WorkItemRow {
   stageHistory: WorkItemStageEntry[];
   sessions: WorkItemSessions;
   metadata: Record<string, unknown> | null;
+  /**
+   * When a person first committed this item to the Factory, by starting a run
+   * on it or releasing one that was proposed. Projects that withhold auto-run
+   * are asking to decide what the Factory picks up, not to approve each step of
+   * work they already asked for, so runs on an armed item skip the gate.
+   */
+  autonomyArmedAt: Date | null;
   revision: number;
   createdBy: string;
   createdAt: Date;
@@ -363,6 +370,7 @@ export const WORK_ITEMS_SCHEMA: CollectionSchema = {
     stage_history: { type: 'json' },
     sessions: { type: 'json' },
     metadata: { type: 'json', nullable: true },
+    autonomy_armed_at: { type: 'timestamp', nullable: true },
     revision: { type: 'integer', default: 1 },
     created_by: { type: 'text' },
     created_at: { type: 'timestamp' },
@@ -398,6 +406,7 @@ interface WorkItemDbRow extends Record<string, unknown> {
   stage_history: WorkItemStageEntry[];
   sessions: WorkItemSessions;
   metadata: Record<string, unknown> | null;
+  autonomy_armed_at: Date | null;
   revision: number;
   created_by: string;
   created_at: Date;
@@ -420,6 +429,7 @@ function toWorkItem(row: WorkItemDbRow): WorkItemRow {
     stageHistory: row.stage_history,
     sessions: row.sessions,
     metadata: row.metadata,
+    autonomyArmedAt: row.autonomy_armed_at ?? null,
     revision: row.revision,
     createdBy: row.created_by,
     createdAt: row.created_at,
@@ -1356,6 +1366,37 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     );
   }
 
+  /**
+   * Retire proposals parked on a work item. A merged pull request (or an item
+   * closed out any other way) leaves its queued runs with nothing left to do,
+   * and they would otherwise sit on the card forever asking to be answered.
+   *
+   * Pass `role` to retire only the proposals a run now starting has overtaken:
+   * a parked "start triage" is moot the moment triage is actually running.
+   */
+  async dismissProposalsForWorkItem(input: {
+    orgId: string;
+    factoryProjectId: string;
+    workItemId: string;
+    role?: string;
+    dismissedAt: Date;
+  }): Promise<FactoryDeferredDecisionRecord[]> {
+    const rows = await this.#db.findMany<GovernanceDbRow>('factory_deferred_decisions', {
+      org_id: input.orgId,
+      factory_project_id: input.factoryProjectId,
+      work_item_id: input.workItemId,
+      status: 'proposed',
+    });
+    const dismissed: FactoryDeferredDecisionRecord[] = [];
+    for (const row of rows) {
+      if (input.role !== undefined && toDeferredDecision(row).decision.role !== input.role) continue;
+      // Re-settled atomically: an approval racing this sweep keeps the run.
+      const record = await this.dismissDeferredDecision(input.orgId, input.factoryProjectId, row.id, input.dismissedAt);
+      if (record) dismissed.push(record);
+    }
+    return dismissed;
+  }
+
   async #settleProposedDecision(
     { orgId, factoryProjectId, decisionId }: { orgId: string; factoryProjectId: string; decisionId: string },
     patch: Partial<GovernanceDbRow>,
@@ -1891,6 +1932,18 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     const candidate = await this.#db.findOne<WorkItemDbRow>('work_items', { org_id: orgId, id });
     if (!candidate) return null;
     return this.#withProjectRelationTransaction(orgId, candidate.factory_project_id, run);
+  }
+
+  /**
+   * Record that a person committed this item to the Factory. Only the first
+   * time counts: the timestamp marks when the item stopped needing permission,
+   * so later runs must not push it forward. Bumps no revision, because arming
+   * is not a change anyone is editing against.
+   */
+  async armAutonomy({ orgId, id, now }: { orgId: string; id: string; now: Date }): Promise<void> {
+    await this.#db.updateAtomic<WorkItemDbRow>('work_items', { org_id: orgId, id }, current =>
+      current.autonomy_armed_at ? null : { autonomy_armed_at: now },
+    );
   }
 
   /**

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -308,8 +308,11 @@ export const factory = new MastraFactory({
   vector,
   pubsub,
   platform: {
-    // Platform's GitHub App identity is not included in the Platform credentials.
-    // Reuse the deployment's configured App slug to ignore Factory's own handoff writes.
+    // The deployment's own self-hosted App slug, when one is configured. It is
+    // NOT Platform's identity: Platform posts as its own App, which names
+    // itself. Reusing this value for that purpose left self-recognition
+    // comparing against `undefined[bot]` on every Platform deployment, where
+    // this is legitimately unset.
     githubAppSlug,
   },
   // Browser-facing origin. On the platform the SPA is hosted separately, so


### PR DESCRIPTION
> Stacked on #21767. Review that one first; this diff is only the ingestion layer.

## What this changes

Several rules in the autonomous loop had never fired a single time. In every case
the rule itself was right — the event never reached it.

**The poller's ingest gate was too narrow.** It forwarded `closed`, `synchronize`
and `review_requested`, and dropped everything else. Submitted reviews and issue
comments never made it to the rules engine, which made every feedback rule
unreachable on the polling path. `pull_request.opened` was missing too, so a pull
request the factory opened itself never produced a review.

**Signals were delivered by thread id alone.** Nothing checked which session owned
that thread, so a subscription belonging to a deleted thread could deliver into
the wrong session.

**The factory could not reliably recognize itself.** Self-loop guards compared a
sender login against a configured app slug, and that slug was optional. With it
unset the comparison became `login === 'undefined[bot]'` — never true — so every
guard silently degraded to off. That is exactly how the factory's own triage
comment came back through the poller, re-triggered triage, and cancelled the run
that had just posted it. The card was left in Intake with its public comment
frozen at "Route: Pending".

Identity now resolves in three ordered steps — configured slug, then a login
learned from observed GitHub API responses, then unknown — and an unknown identity
refuses to claim authorship instead of returning a confident wrong answer.

## Test plan

- `pnpm --filter ./mastracode/factory test` — 1601 passing, 89 files
- `pnpm --filter ./mastracode/factory check` — clean
- Every gate widening has a test asserting the event reaches the rules engine
  through the poller, not just through webhooks.
- Mutation check: reverting identity resolution to the slug-only comparison fails
  the self-loop guard test.

## Notes for review

Deliberately scoped to ingestion and identity. The rules and dispatcher changes
that consume these events are the next PR in the stack.
