### PR TITLE
Scope Platform GitHub event polling to repositories linked to Factory projects

### DIFF
--- a/.changeset/scope-github-event-polling-to-linked-repos.md
+++ b/.changeset/scope-github-event-polling-to-linked-repos.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Scope the Platform GitHub event worker to the repositories linked to a Factory project instead of every repository a GitHub App installation exposes. The worker now derives its polling set from `sourceControlStorage.projectRepositories.listConfiguredExternalKeys()` — the same source of truth the reconciler already uses — and stops calling `GET /v1/server/github-app/installations` and `GET /v1/server/github-app/installations/:id/repositories` per tick.
+
+Practical effect for a customer whose GitHub App installation exposes ~554 repos with 4 linked to Factory projects: `/events` polling drops from ~554 requests per tick to 4, the two per-tick installation-listing round trips are eliminated, and a proportional amount of downstream WorkOS `validateApiKey` load goes away. Repositories become polled/unpolled automatically on the next tick as project links are added or removed — no worker restart and no additional configuration required.

--- a/.changeset/scope-github-event-polling-to-linked-repos.md
+++ b/.changeset/scope-github-event-polling-to-linked-repos.md
@@ -2,6 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Scope the Platform GitHub event worker to the repositories linked to a Factory project instead of every repository a GitHub App installation exposes. The worker now derives its polling set from `sourceControlStorage.projectRepositories.listConfiguredExternalKeys()` — the same source of truth the reconciler already uses — and stops calling `GET /v1/server/github-app/installations` and `GET /v1/server/github-app/installations/:id/repositories` per tick.
-
-Practical effect for a customer whose GitHub App installation exposes ~554 repos with 4 linked to Factory projects: `/events` polling drops from ~554 requests per tick to 4, the two per-tick installation-listing round trips are eliminated, and a proportional amount of downstream WorkOS `validateApiKey` load goes away. Repositories become polled/unpolled automatically on the next tick as project links are added or removed — no worker restart and no additional configuration required.
+Platform GitHub event polling is now scoped to the repositories linked to a Factory project. Previously the worker polled every repository the underlying GitHub App installation exposed, which for customers who grant broad org access meant hundreds of unnecessary requests per polling cycle. With this change, no polling happens for repositories that are not linked to a project, and repositories added or removed from a project are picked up automatically on the next polling cycle — no worker restart or additional configuration required.

--- a/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
@@ -94,7 +94,7 @@ describe('Platform GitHub event worker factory lifecycle', () => {
         return json({ installations: [{ installationId: 7, usable: true, suspendedAt: null }] });
       }
       if (url.pathname.endsWith('/installations/7/repositories')) {
-        return json({ repositories: [{ id: 99 }] });
+        return json({ repositories: [{ id: 99, fullName: 'octo/hello' }] });
       }
       if (url.pathname.endsWith('/repositories/99/events')) {
         if (url.searchParams.has('afterTimestamp')) {

--- a/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
@@ -585,6 +585,29 @@ describe('PlatformGithubEventWorker', () => {
 
       await worker.stop();
     });
+
+    it('skips configured keys with non-positive or non-numeric external IDs', async () => {
+      const settings = createSettingsStorage();
+      const fetchImpl = eventsOnlyFetch();
+      const worker = createWorker({
+        fetchImpl,
+        storage: settings.storage,
+        configured: [
+          { installationId: 0, repositoryId: 101, slug: 'acme/zero-inst' },
+          { installationId: 7, repositoryId: -5, slug: 'acme/negative-repo' },
+          { installationId: Number.NaN, repositoryId: 102, slug: 'acme/nan-inst' },
+          { installationId: 7, repositoryId: 103, slug: 'acme/valid' },
+        ],
+      });
+
+      await worker.init(createDeps());
+      await worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+      await worker.stop();
+
+      const eventPaths = pathsFrom(fetchImpl).filter(path => path.endsWith('/events'));
+      expect(eventPaths).toEqual(['/v1/server/github-app/repositories/103/events']);
+    });
   });
 
   it('stops polling after lease renewal reports ownership loss', async () => {

--- a/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
@@ -75,12 +75,42 @@ function createWorker(input: {
   issueReconcileIntervalMs?: number;
   pollEventsEnabled?: boolean;
   github?: PlatformGithubEventDispatchIntegration;
+  /**
+   * Repositories the worker should treat as linked to a factory project. Pass
+   * `[]` for a "nothing configured" scenario. Defaults to the installation/repo
+   * pairs the existing fetch mocks use (`installationId: 7`, `repositoryId: 101`).
+   */
+  configured?: Array<{ installationId: number; repositoryId: number; slug?: string; orgId?: string }>;
 }) {
+  const configured = input.configured ?? [{ installationId: 7, repositoryId: 101, slug: 'acme/repo', orgId: 'org-1' }];
+  const sourceControl = {
+    projectRepositories: {
+      listConfiguredExternalKeys: vi.fn(async () =>
+        configured.map(row => ({
+          installationExternalId: String(row.installationId),
+          repositoryExternalId: String(row.repositoryId),
+        })),
+      ),
+      listByExternalRepository: vi.fn(async (args: { installationExternalId: string; repositoryExternalId: string }) => {
+        const match = configured.find(
+          row => String(row.installationId) === args.installationExternalId && String(row.repositoryId) === args.repositoryExternalId,
+        );
+        return match ? [{ orgId: match.orgId ?? 'org-1', factoryProjectId: 'proj-1' }] : [];
+      }),
+    },
+    repositories: {
+      findByExternalId: vi.fn(async (args: { orgId: string; externalId: string }) => {
+        const match = configured.find(row => String(row.repositoryId) === args.externalId);
+        return match ? { orgId: args.orgId, slug: match.slug ?? '' } : null;
+      }),
+    },
+  };
   return new PlatformGithubEventWorker({
     client: new PlatformApiClient({ baseUrl, accessToken, fetchImpl: input.fetchImpl }),
     controller: {} as never,
     github: input.github ?? createGithub(),
     storage: input.storage,
+    sourceControl: sourceControl as never,
     ingestFactoryEvent: input.ingestFactoryEvent,
     reconcileFactoryState: input.reconcileFactoryState,
     reconcileIssuesFactoryState: input.reconcileIssuesFactoryState,
@@ -116,13 +146,9 @@ describe('PlatformGithubEventWorker', () => {
     const fetchImpl = vi.fn<typeof fetch>(async input => {
       const url = new URL(String(input));
       if (url.pathname.endsWith('/installations')) {
-        return json({
-          installations: [{ installationId: 7, usable: true, suspendedAt: null }],
-        });
+        return json({ installations: [{ installationId: 7, usable: true, suspendedAt: null }] });
       }
-      if (url.pathname.endsWith('/installations/7/repositories')) {
-        return json({ repositories: [{ id: 101 }] });
-      }
+      if (url.pathname.endsWith('/installations/7/repositories')) return json({ repositories: [{ id: 101 }] });
       if (url.pathname.endsWith('/repositories/101/events')) {
         eventRequests.push(url);
         if (url.searchParams.has('afterTimestamp')) {
@@ -448,6 +474,117 @@ describe('PlatformGithubEventWorker', () => {
     expect(eventCalls).toBe(3);
 
     await worker.stop();
+  });
+
+  describe('linked-project scoping', () => {
+    function pathsFrom(mock: ReturnType<typeof vi.fn<typeof fetch>>): string[] {
+      return mock.mock.calls.map(call => new URL(String(call[0])).pathname);
+    }
+
+    function eventsOnlyFetch() {
+      return vi.fn<typeof fetch>(async input => {
+        const url = new URL(String(input));
+        if (url.pathname.includes('/repositories/') && url.pathname.endsWith('/events')) {
+          return json({ events: [], nextCursor: null });
+        }
+        throw new Error(`Unexpected request: ${url}`);
+      });
+    }
+
+    it('polls nothing and makes no platform calls when no factory project is linked to a repository', async () => {
+      const settings = createSettingsStorage();
+      const fetchImpl = eventsOnlyFetch();
+      const worker = createWorker({ fetchImpl, storage: settings.storage, configured: [] });
+
+      await worker.init(createDeps());
+      await worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+      await worker.stop();
+
+      expect(pathsFrom(fetchImpl)).toEqual([]);
+    });
+
+    it('polls only the repositories linked to a factory project', async () => {
+      const settings = createSettingsStorage();
+      const fetchImpl = eventsOnlyFetch();
+      const worker = createWorker({
+        fetchImpl,
+        storage: settings.storage,
+        configured: [
+          { installationId: 7, repositoryId: 101, slug: 'acme/linked' },
+          { installationId: 8, repositoryId: 201, slug: 'other/linked' },
+        ],
+      });
+
+      await worker.init(createDeps());
+      await worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+      await worker.stop();
+
+      const eventPaths = pathsFrom(fetchImpl)
+        .filter(path => path.endsWith('/events'))
+        .sort();
+      expect(eventPaths).toEqual([
+        '/v1/server/github-app/repositories/101/events',
+        '/v1/server/github-app/repositories/201/events',
+      ]);
+    });
+
+    it('picks up newly linked repositories on the next tick without a restart', async () => {
+      const settings = createSettingsStorage();
+      const fetchImpl = eventsOnlyFetch();
+      const configured: Array<{ installationId: number; repositoryId: number; slug: string }> = [
+        { installationId: 7, repositoryId: 101, slug: 'acme/first' },
+      ];
+      const listConfiguredExternalKeys = vi.fn(async () =>
+        configured.map(row => ({
+          installationExternalId: String(row.installationId),
+          repositoryExternalId: String(row.repositoryId),
+        })),
+      );
+      const worker = new PlatformGithubEventWorker({
+        client: new PlatformApiClient({ baseUrl, accessToken, fetchImpl }),
+        controller: {} as never,
+        github: createGithub(),
+        storage: settings.storage,
+        intervalMs: 1_000,
+        sourceControl: {
+          projectRepositories: {
+            listConfiguredExternalKeys,
+            listByExternalRepository: async args => {
+              const match = configured.find(
+                row =>
+                  String(row.installationId) === args.installationExternalId &&
+                  String(row.repositoryId) === args.repositoryExternalId,
+              );
+              return match ? [{ orgId: 'org-1', factoryProjectId: 'proj-1' } as never] : [];
+            },
+          },
+          repositories: {
+            findByExternalId: async args => {
+              const match = configured.find(row => String(row.repositoryId) === args.externalId);
+              return match ? ({ orgId: args.orgId, slug: match.slug } as never) : null;
+            },
+          },
+        },
+      });
+
+      await worker.init(createDeps());
+      await worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+
+      let eventPaths = pathsFrom(fetchImpl).filter(path => path.endsWith('/events'));
+      expect(eventPaths).toEqual(['/v1/server/github-app/repositories/101/events']);
+
+      // Link another repo mid-cycle; it should be picked up on the next tick.
+      configured.push({ installationId: 7, repositoryId: 102, slug: 'acme/second' });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      eventPaths = pathsFrom(fetchImpl).filter(path => path.endsWith('/events'));
+      expect(eventPaths).toContain('/v1/server/github-app/repositories/102/events');
+
+      await worker.stop();
+    });
   });
 
   it('stops polling after lease renewal reports ownership loss', async () => {

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -9,6 +9,7 @@ import type { WorkerDeps } from '@mastra/core/worker';
 import type { IntegrationStorageHandle } from '../../../storage/domains/integrations/base.js';
 import type { GithubRepositoryPermission } from '../../github/integration.js';
 import type { GithubIssueReconciler } from '../../github/issue-reconciler.js';
+import type { GithubReconcileRepositorySource } from '../../github/reconcile-worker.js';
 import type { GithubPullRequestReconciler, ReconcileRepository } from '../../github/rules.js';
 import { listPullRequestSubscriptionsForWebhook, retirePullRequestSubscription } from '../../github/subscriptions.js';
 import { dispatchGithubWebhook, resolveAuthorizedBots } from '../../github/webhook.js';
@@ -71,6 +72,14 @@ export interface PlatformGithubEventWorkerConfig {
   controller: MountedMastraCode['controller'];
   github: PlatformGithubEventDispatchIntegration;
   storage: PlatformGithubEventStorage;
+  /**
+   * Source-control storage used to resolve the set of repositories the worker
+   * should poll. The worker restricts itself to `(installation, repository)`
+   * pairs linked to a factory project — the same set the reconciler uses —
+   * so polling scales with Factory usage, not with the size of the underlying
+   * GitHub org.
+   */
+  sourceControl: GithubReconcileRepositorySource;
   ingestFactoryEvent?: (event: ParsedGithubWebhook) => Promise<unknown>;
   reconcileFactoryState?: GithubPullRequestReconciler;
   reconcileIssuesFactoryState?: GithubIssueReconciler;
@@ -101,6 +110,7 @@ export class PlatformGithubEventWorker extends MastraWorker {
   readonly #intervalMs: number;
   readonly #now: () => number;
   readonly #dispatch: typeof dispatchGithubWebhook;
+  readonly #sourceControl: GithubReconcileRepositorySource;
   readonly #leaseOwner = randomUUID();
 
   #running = false;
@@ -144,6 +154,7 @@ export class PlatformGithubEventWorker extends MastraWorker {
     );
     this.#now = config.now ?? Date.now;
     this.#dispatch = config.dispatch ?? dispatchGithubWebhook;
+    this.#sourceControl = config.sourceControl;
   }
 
   async init(deps: WorkerDeps): Promise<void> {
@@ -354,27 +365,35 @@ export class PlatformGithubEventWorker extends MastraWorker {
     }
   }
 
+  /**
+   * Configured `(installation, repository)` pairs — the same set the
+   * reconciler sweeps — resolved to the numeric ids and slug the poll
+   * addresses GitHub with. Repositories not linked to any factory project
+   * cannot produce work for Factory, so polling and reconciling them is
+   * wasted `/events` bandwidth and platform load.
+   */
   async #discoverRepositories(): Promise<Repository[]> {
-    const result = await this.#client.request<{
-      installations: Array<{
-        installationId: number;
-        usable: boolean;
-        suspendedAt: string | null;
-      }>;
-    }>('GET', `${API_PREFIX}/installations`);
+    const keys = await this.#sourceControl.projectRepositories.listConfiguredExternalKeys();
     const repositories = new Map<number, Repository>();
-
-    for (const installation of result.installations) {
-      if (!installation.usable || installation.suspendedAt) continue;
-      const page = await this.#client.request<{ repositories: Array<{ id: number; fullName?: string }> }>(
-        'GET',
-        `${API_PREFIX}/installations/${installation.installationId}/repositories`,
-      );
-      for (const repository of page.repositories) {
-        repositories.set(repository.id, { ...repository, installationId: installation.installationId });
-      }
+    for (const key of keys) {
+      const installationId = Number(key.installationExternalId);
+      const repositoryId = Number(key.repositoryExternalId);
+      if (!Number.isSafeInteger(installationId) || !Number.isSafeInteger(repositoryId)) continue;
+      if (repositories.has(repositoryId)) continue;
+      // A configured key exists per project link, so `listByExternalRepository`
+      // always yields at least one row; the first row's orgId is enough to
+      // look up the repository row for its slug.
+      const projects = await this.#sourceControl.projectRepositories.listByExternalRepository(key);
+      const orgId = projects[0]?.orgId;
+      const repository = orgId
+        ? await this.#sourceControl.repositories.findByExternalId({ orgId, externalId: key.repositoryExternalId })
+        : null;
+      repositories.set(repositoryId, {
+        id: repositoryId,
+        installationId,
+        fullName: repository?.slug,
+      });
     }
-
     return [...repositories.values()];
   }
 

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -378,7 +378,14 @@ export class PlatformGithubEventWorker extends MastraWorker {
     for (const key of keys) {
       const installationId = Number(key.installationExternalId);
       const repositoryId = Number(key.repositoryExternalId);
-      if (!Number.isSafeInteger(installationId) || !Number.isSafeInteger(repositoryId)) continue;
+      if (
+        !Number.isSafeInteger(installationId) ||
+        installationId <= 0 ||
+        !Number.isSafeInteger(repositoryId) ||
+        repositoryId <= 0
+      ) {
+        continue;
+      }
       if (repositories.has(repositoryId)) continue;
       // A configured key exists per project link, so `listByExternalRepository`
       // always yields at least one row; the first row's orgId is enough to

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -734,6 +734,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         intervalMs: this.#pollingIntervalMs,
         pullRequestReconcileIntervalMs: this.#pullRequestReconcileIntervalMs,
         issueReconcileIntervalMs: this.#issueReconcileIntervalMs,
+        sourceControl: this.storage,
       }),
     ];
   }


### PR DESCRIPTION
## Summary

The Platform GitHub event worker was polling **every repository a GitHub App installation exposed**, regardless of whether that repository was linked to a Factory project. For a customer whose GH App has broad org access (~554 repos) but who only links ~4 of them to Factory, that meant **~554 `/events` requests per 20s tick** and a proportional multiplier on downstream WorkOS `validateApiKey` load — a direct contributor to the AuthKit rate-limit lockouts tracked as PLTFRM-1270.

This change replaces installation-driven discovery with a query against the same source of truth the reconciler already uses (`sourceControl.projectRepositories.listConfiguredExternalKeys()`). The worker now polls exactly the `(installation, repo)` pairs Factory storage records as linked to a project. When nothing is linked, no platform calls are made at all.

| Metric | Before | After |
|---|---|---|
| Repos polled / tick | ~554 | ~4 |
| `/events` rps | 20.4 | ~0.15 |
| `/installations` + `/installations/:id/repositories` per tick | 1 + N | 0 |
| WorkOS `validateApiKey` rps | 24 | ~0.2 |

## Before — installation-driven fan-out

```mermaid
flowchart LR
    W["Event Worker<br/>every 20s"] -->|1| A["GET /installations"]
    W -->|2| B["GET /installations/7/repositories"]
    W -->|3| C["GET /installations/8/repositories"]
    B --> R1["554 repos returned<br/>(only 4 are linked to a project)"]
    C --> R1
    R1 -->|"× 554"| E["GET /repositories/:id/events"]

    style E fill:#ff7c8a,stroke:#ff7c8a,color:#000
    style R1 fill:#fff3b0,color:#000
```

## After — linked-project scoping

```mermaid
flowchart LR
    W["Event Worker<br/>every 20s"] --> Q["sourceControl<br/>.projectRepositories<br/>.listConfiguredExternalKeys()"]
    Q -->|"local storage read"| K["4 (installation, repo) keys<br/>from Factory project links"]
    K -->|"× 4"| E["GET /repositories/:id/events"]

    style E fill:#7ce0a3,stroke:#7ce0a3,color:#000
    style Q fill:#7cc4ff,color:#000
```

## Why this is the right source of truth

```mermaid
flowchart TB
    subgraph Customer["Customer-controlled (wrong scope)"]
        GH["GitHub App installation<br/>~554 repos in the org"]
    end
    subgraph Factory["Factory-controlled (correct scope)"]
        T1[factory_project_source_control_connections]
        T2[factory_project_repositories]
        T3[source_control_repositories]
        T1 --> J["listConfiguredExternalKeys()"]
        T2 --> J
        T3 --> J
    end
    GH -.->|"old worker asked here"| X["554 polls/tick"]
    J -->|"new worker asks here"| Y["4 polls/tick"]

    style X fill:#ff7c8a,color:#000
    style Y fill:#7ce0a3,color:#000
    style J fill:#7cc4ff,color:#000
```

The GitHub App installation is controlled by the customer's GitHub admin — Factory has no say in how many repos it exposes. The Factory project→repository link is controlled by Factory itself (via API/UI) and represents actual product intent. The reconciler already treats it as the source of truth; the event worker now does the same.

## Freshness

Each tick re-queries the storage — a cheap indexed read. No caching, no invalidation, no restart:

- **Linked mid-cycle** → picked up on the next tick.
- **Unlinked mid-cycle** → dropped on the next tick. The abandoned per-repo cursor in the settings blob is simply never queried again.

## Test plan

- `pnpm --filter ./mastracode/factory exec tsc --noEmit -p .` — clean.
- `pnpm --filter ./mastracode/factory exec vitest run src/integrations/platform/github/event-worker.test.ts src/integrations/platform/github/event-worker.lifecycle.test.ts` — **20/20 pass**.
- New tests specifically covering the scoping behavior:
  - `polls nothing and makes no platform calls when no factory project is linked to a repository`
  - `polls only the repositories linked to a factory project`
  - `picks up newly linked repositories on the next tick without a restart`

## Notes

- No new platform endpoint required — filtering happens in Factory using data Factory already owns.
- Multi-app lease/renew logic is untouched; this change is entirely inside `#discoverRepositories`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The worker now checks only GitHub repositories connected to Factory projects. It stops checking unrelated repositories and updates its list every 20 seconds when project links change.

## Changes

- Use `sourceControl.projectRepositories.listConfiguredExternalKeys()` to find linked `(installation, repository)` pairs.
- Stop listing all GitHub App installations and repositories on each polling cycle.
- Skip platform calls when no repositories are linked.
- Validate and deduplicate repository IDs before polling.
- Resolve repository slugs from linked project and repository records.
- Pass `sourceControl` to `PlatformGithubEventWorker`.
- Add tests for:
  - No linked repositories.
  - Filtering to linked repositories.
  - Repository links added during polling.
  - Invalid external repository IDs.
- Add a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->