### PR TITLE
perf(core): stop persisting the system prompt echo in agent-loop snapshots

### DIFF
--- a/.changeset/smooth-squids-cry.md
+++ b/.changeset/smooth-squids-cry.md
@@ -2,8 +2,8 @@
 '@mastra/core': patch
 ---
 
-Reduced the size of persisted agent loop snapshots by dropping the copy of the agent's system prompt that was stored in every step's exported span data.
+Reduced how much durable agents write when persisting a run.
 
-Durable agents persist a run snapshot at every step boundary. Each step result carried `agentSpanData.attributes.instructions`, the agent's full system prompt, on both its input and its output side, so a long turn rewrote that prompt dozens of times. Nothing read those copies back: a resumed run rebuilds its agent span from the snapshot's initial input, which is left untouched, so traces are unaffected.
+A durable run saves its state at every step, and each of those saves re-serialized a copy of the agent's system prompt, so a long turn spent time writing the same prompt over and over. That copy is now left out. Snapshots are smaller, each step writes less, and resume and tracing behave exactly as before.
 
-Measured over 300 production snapshots, this removed 27.7 MB of 518.1 MB persisted, about 5% of all snapshot bytes written.
+Measured over 300 production snapshots, this removed about 5% of all persisted snapshot bytes.

--- a/.changeset/smooth-squids-cry.md
+++ b/.changeset/smooth-squids-cry.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Reduced the size of persisted agent loop snapshots by dropping the copy of the agent's system prompt that was stored in every step's exported span data.
+
+Durable agents persist a run snapshot at every step boundary. Each step result carried `agentSpanData.attributes.instructions`, the agent's full system prompt, on both its input and its output side, so a long turn rewrote that prompt dozens of times. Nothing read those copies back: a resumed run rebuilds its agent span from the snapshot's initial input, which is left untouched, so traces are unaffected.
+
+Measured over 300 production snapshots, this removed 27.7 MB of 518.1 MB persisted, about 5% of all snapshot bytes written.

--- a/packages/core/src/loop/workflows/prune-snapshot.test.ts
+++ b/packages/core/src/loop/workflows/prune-snapshot.test.ts
@@ -377,3 +377,129 @@ describe('pruneAgentLoopSnapshot terminal payload iteration state', () => {
     });
   });
 });
+
+/**
+ * Unit coverage for the `agentSpanData.attributes.instructions` strip. The
+ * exported agent span the loop carries forward holds the agent's entire system
+ * prompt, stored on both sides of every step result and rewritten at every
+ * step boundary. Resume rebuilds the span from `context.input`, which the
+ * pruner leaves whole, so the step-level copies are dead weight.
+ */
+function spanData() {
+  return {
+    id: 'span-1',
+    traceId: 'trace-1',
+    name: 'agent run',
+    attributes: {
+      agentId: 'weather',
+      instructions: 's'.repeat(4000),
+      maxSteps: 5,
+    },
+  };
+}
+
+/** Deep-scans a structure for surviving span instruction copies. */
+function countInstructionEchoes(value: unknown): number {
+  if (Array.isArray(value)) return value.reduce<number>((n, v) => n + countInstructionEchoes(v), 0);
+  if (value === null || typeof value !== 'object') return 0;
+  const record = value as Record<string, unknown>;
+  let n = 0;
+  const span = record.agentSpanData as Record<string, any> | undefined;
+  if (span && typeof span === 'object' && span.attributes && 'instructions' in span.attributes) n += 1;
+  for (const v of Object.values(record)) n += countInstructionEchoes(v);
+  return n;
+}
+
+describe('pruneAgentLoopSnapshot span instructions strip', () => {
+  it('strips the instructions echo from both sides of a terminal step', () => {
+    const pruned = pruneAgentLoopSnapshot({
+      snapshot: snapshotWith({
+        'durable-llm-execution': {
+          status: 'success',
+          payload: { agentSpanData: spanData() },
+          output: { agentSpanData: spanData() },
+        },
+      }),
+    });
+
+    const step = (pruned.context as Record<string, any>)['durable-llm-execution'];
+    expect(step.payload.agentSpanData.attributes).not.toHaveProperty('instructions');
+    expect(step.output.agentSpanData.attributes).not.toHaveProperty('instructions');
+  });
+
+  it('strips non-terminal steps too, since the snapshot persists at every step boundary', () => {
+    const pruned = pruneAgentLoopSnapshot({
+      snapshot: snapshotWith({
+        'durable-tool-call': {
+          status: 'running',
+          payload: { agentSpanData: spanData() },
+          output: { agentSpanData: spanData() },
+        },
+      }),
+    });
+
+    expect(countInstructionEchoes((pruned.context as Record<string, any>)['durable-tool-call'])).toBe(0);
+  });
+
+  it('keeps the span itself and every other attribute', () => {
+    const pruned = pruneAgentLoopSnapshot({
+      snapshot: snapshotWith({
+        step: { status: 'success', output: { agentSpanData: spanData() } },
+      }),
+    });
+
+    const span = (pruned.context as Record<string, any>).step.output.agentSpanData;
+    expect(span.id).toBe('span-1');
+    expect(span.traceId).toBe('trace-1');
+    expect(span.name).toBe('agent run');
+    expect(span.attributes).toEqual({ agentId: 'weather', maxSteps: 5 });
+  });
+
+  it('leaves the `context.input` copy intact, since resume rebuilds the span from it', () => {
+    const pruned = pruneAgentLoopSnapshot({
+      snapshot: {
+        context: {
+          input: { agentSpanData: spanData() },
+          step: { status: 'success', output: { agentSpanData: spanData() } },
+        },
+      } as unknown as WorkflowRunState,
+    });
+
+    const input = (pruned.context as Record<string, any>).input;
+    expect(input.agentSpanData.attributes.instructions).toBe('s'.repeat(4000));
+    expect(countInstructionEchoes((pruned.context as Record<string, any>).step)).toBe(0);
+  });
+
+  it('passes step results without span data through unchanged', () => {
+    const pruned = pruneAgentLoopSnapshot({
+      snapshot: snapshotWith({
+        'collect-tool-results': { status: 'success', output: { toolResults: [{ result: 'ok' }] } },
+      }),
+    });
+
+    expect((pruned.context as Record<string, any>)['collect-tool-results']).toMatchObject({
+      output: { toolResults: [{ result: 'ok' }] },
+    });
+  });
+
+  it('passes a span without an instructions attribute through unchanged', () => {
+    const span = { id: 'span-1', attributes: { agentId: 'weather' } };
+    const pruned = pruneAgentLoopSnapshot({
+      snapshot: snapshotWith({
+        step: { status: 'success', output: { agentSpanData: span } },
+      }),
+    });
+
+    expect((pruned.context as Record<string, any>).step.output.agentSpanData).toEqual(span);
+  });
+
+  it('is copy-on-write and does not mutate the caller snapshot', () => {
+    const snapshot = snapshotWith({
+      step: { status: 'success', payload: { agentSpanData: spanData() }, output: { agentSpanData: spanData() } },
+    });
+
+    pruneAgentLoopSnapshot({ snapshot });
+
+    expect(countInstructionEchoes(snapshot.context)).toBe(2);
+  });
+});

--- a/packages/core/src/loop/workflows/prune-snapshot.ts
+++ b/packages/core/src/loop/workflows/prune-snapshot.ts
@@ -191,6 +191,28 @@ function stripTerminalPayloadState<T>(value: T): T {
   return pruned as T;
 }
 
+/**
+ * Drops `agentSpanData.attributes.instructions`: the agent's entire system
+ * prompt, exported into the span payload the loop carries forward and stored
+ * on BOTH sides of every step result, rewritten at every step boundary. The
+ * copies are never read back. The two `rebuildSpan` call sites that resume a
+ * run's agent span (`create-durable-agentic-workflow.ts`, `tool-call.ts`)
+ * both read `initData.agentSpanData`, i.e. `context.input`, which the pruner
+ * leaves whole, so a resumed run still rebuilds its span from a complete
+ * copy and the trace loses nothing. The live span was already exported with
+ * its attributes while the run was streaming. Measured over 300 real
+ * production snapshots it was 27.7 MB of 518.1 MB persisted, about 5% of
+ * everything written, and 2250 step-level copies went to 0 with the
+ * `context.input` copy retained.
+ */
+function stripSpanInstructions<T>(value: T): T {
+  if (!isPlainObject(value) || !isPlainObject(value.agentSpanData)) return value;
+  const span = value.agentSpanData;
+  if (!isPlainObject(span.attributes) || !('instructions' in span.attributes)) return value;
+  const { instructions: _instructions, ...attributes } = span.attributes;
+  return { ...value, agentSpanData: { ...span, attributes } } as T;
+}
+
 /** Applies the pruning rules to a single serialized step result. */
 function pruneStepResult(
   result: Record<string, any>,
@@ -201,6 +223,8 @@ function pruneStepResult(
   const pruned: Record<string, any> = { ...result };
   pruned.payload = stripStepResultRequest(pruned.payload);
   if ('output' in pruned) pruned.output = stripStepResultRequest(pruned.output);
+  pruned.payload = stripSpanInstructions(pruned.payload);
+  if ('output' in pruned) pruned.output = stripSpanInstructions(pruned.output);
   pruned.payload = stripHeavyIterationFields(pruned.payload);
   if ('prevOutput' in pruned) pruned.prevOutput = stripHeavyIterationFields(pruned.prevOutput);
 


### PR DESCRIPTION
## Description

`pruneAgentLoopSnapshot` drops `agentSpanData.attributes.instructions` from step payloads and outputs. That member is the agent's entire system prompt.

### Where the copies live

The exported agent-run span travels inside the durable loop's iteration state, so it is stored on **both** sides of every step result, and the durable path re-persists the whole snapshot at **every step boundary**. A turn with N steps therefore holds `1 + 2N` copies of the same system prompt in a single snapshot, and rewrites all of them on every boundary.

```text
one persisted snapshot, six step turn          system prompt copies
context
├── input .................................... 1   kept: resume rebuilds the span from here
├── llm-execution      payload ............... 1   removed
│                      output ................ 1   removed
├── tool-call          payload ............... 1   removed
│                      output ................ 1   removed
└── ... four more steps ...................... 8   removed
                                              ────
                                    before      13
                                     after       1
```

### Measured

300 real snapshots from a production durable-agent deployment, taken after the pruning already in main (so this is the marginal cost of this one field):

| | copies of the system prompt | bytes in the corpus | share of everything persisted |
| --- | --- | --- | --- |
| before | 2250 | 27.7 MB of 518.1 MB | 5.3% |
| after | 300, one per snapshot | 0 | 0 |

The share understates the effect on latency, because of where the cost lands. Instrumenting a single 170 second turn on the same deployment: 443 snapshot writes totalling 44.3s of write work, of which the finalization tail held only 2.6s. 94% of the snapshot write cost happens **between steps**, where it stalls the visible stream rather than a background flush.

### Why this is safe

Nothing reads the step-level copies back. There are exactly two `rebuildSpan` call sites that restore a run's agent span, and both resolve it from `initData.agentSpanData`, which is `context.input`:

https://github.com/mastra-ai/mastra/blob/f905520c75ca01d805dbaefd8aa1f247b6c61fd0/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts#L681-L695

https://github.com/mastra-ai/mastra/blob/f905520c75ca01d805dbaefd8aa1f247b6c61fd0/packages/core/src/agent/durable/workflows/steps/tool-call.ts#L298-L308

The pruner deliberately leaves `context.input` whole, so a resumed run still rebuilds its span from a complete copy. The live span was already exported with its attributes while the run was streaming, so the emitted trace is unchanged as well. The span object and every other attribute stay in place; only that one member is removed.

## Related issue(s)

Fixes #21773. Same root cause as #18647.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Test plan

`packages/core/src/loop/workflows/prune-snapshot.test.ts` gains seven cases: both sides of a terminal step, non-terminal steps, the span and its other attributes surviving, the `context.input` copy surviving, pass-through for step results with no span data, pass-through for a span with no `instructions` attribute, and copy-on-write.

We have been running this strip as a local dist patch in production since core 1.57, currently on 1.58.0, with the suspend/resume and tool-approval surface fully exercised. Resumed runs still rebuild their spans.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR stops saving the full system prompt twice for every agent step. This reduces snapshot size while keeping resume and tracing behavior unchanged.

## Changes

- Remove `agentSpanData.attributes.instructions` from step payloads and outputs.
- Preserve `context.input`, the span, and all other span attributes.
- Apply pruning to terminal and non-terminal steps.
- Preserve copy-on-write behavior and pass-through behavior.
- Add tests for pruning, preservation, and missing data cases.
- Add a `@mastra/core` changeset.

This reduces repeated snapshot data and write overhead. The measured reduction was approximately 5% across 300 production snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->