### PR TITLE
chore: consolidate release metadata for memory updates

### DIFF
--- a/.changeset/quiet-rivers-build.md
+++ b/.changeset/quiet-rivers-build.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': minor
+'@mastra/memory': minor
+'@mastra/libsql': minor
+'@mastra/mongodb': minor
+'@mastra/mysql': minor
+'@mastra/pg': minor
+'@mastra/code-sdk': minor
+'@mastra/factory': minor
+'mastracode': minor
+---
+
+Added foundational support for an upcoming experimental memory capability across storage, runtime, and developer tooling.


### PR DESCRIPTION
## Summary

- adds one consolidated changeset for the completed storage, memory, adapter, and developer-tooling stack
- keeps release wording intentionally concise while the capability remains experimental

## Test plan

- `pnpm exec changeset status --since origin/feat/knowledge-graph-explorer`