### PR TITLE
fix(factory-ui): announce session owners to screen readers and settle test query chains

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatSessionDenied.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatSessionDenied.msw.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../../../../e2e/ui/msw-server';
-import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
+import { TEST_BASE_URL, renderWithProviders, waitForMutationsIdle } from '../../../../../../e2e/ui/render';
 import { FACTORY_ID, SESSION_ID, stubPreparingSession } from '../../components/__tests__/composer-session-test-fixture';
 import { ChatMessageBoundary } from '../ChatSessionProvider';
 import { ChatSessionTestProvider } from '../ChatSessionTestProvider';
@@ -39,7 +39,8 @@ describe('denied or missing session', () => {
       ),
     );
 
-    renderDeniedSession();
+    const { client } = renderDeniedSession();
+    await waitForMutationsIdle(client);
 
     expect(await screen.findByText('This session was not found or is private to another user.')).toBeInTheDocument();
     expect(screen.queryByTestId('chat-content')).not.toBeInTheDocument();

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -63,7 +63,7 @@ export function SessionNavRow({
     <button
       type="button"
       aria-current={active ? 'page' : undefined}
-      aria-label={name}
+      aria-label={owner ? `${name}, started by ${owner}` : name}
       disabled={disabled || loading}
       onClick={onSelect}
       title={preview ? undefined : title}
@@ -71,7 +71,7 @@ export function SessionNavRow({
       <GitBranch />
       <MainSidebar.NavLabel className="flex-initial">{name}</MainSidebar.NavLabel>
       {owner ? (
-        <Txt as="span" variant="ui-xs" className="text-icon3 shrink-0 truncate" aria-label={`Started by ${owner}`}>
+        <Txt as="span" variant="ui-xs" className="text-icon3 shrink-0 truncate">
           {owner}
         </Txt>
       ) : null}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsAttribution.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsAttribution.msw.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../../../../e2e/ui/msw-server';
-import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
+import { TEST_BASE_URL, renderWithProviders, waitForMutationsIdle } from '../../../../../../e2e/ui/render';
 import type { FactoryUserSession } from '../../services/github';
 import { UserSessionsSection } from '../UserSessionsSection';
 
@@ -84,19 +84,25 @@ describe('user session attribution', () => {
       'user-viewer-9',
     );
 
-    renderSection();
+    const { client } = renderSection();
+    await waitForMutationsIdle(client);
 
-    const rows = [await screen.findByRole('button', { name: 'mine' }), screen.getByRole('button', { name: 'alpha' })];
+    // The non-owned session carries its owner in the accessible name; the
+    // viewer's own does not.
+    const mine = await screen.findByRole('button', { name: 'mine' });
+    const other = screen.getByRole('button', { name: 'alpha, started by user-owner-1' });
+    expect(mine).toBeInTheDocument();
+    expect(other).toBeInTheDocument();
+
     const labels = screen
       .getAllByRole('button')
       .map(button => button.getAttribute('aria-label'))
-      .filter(label => label === 'mine' || label === 'alpha');
-    expect(labels).toEqual(['mine', 'alpha']);
+      .filter(label => label === 'mine' || label === 'alpha, started by user-owner-1');
+    expect(labels).toEqual(['mine', 'alpha, started by user-owner-1']);
 
-    // The non-owned session carries its owner marker; the viewer's own does not.
-    expect(rows[0]).toBeInTheDocument();
-    expect(screen.getByLabelText('Started by user-owner-1')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Started by user-viewer-9')).not.toBeInTheDocument();
+    // The owner is still shown as visible text on the non-owned row only.
+    expect(screen.getByText('user-owner-1')).toBeInTheDocument();
+    expect(screen.queryByText('user-viewer-9')).not.toBeInTheDocument();
   });
 
   it('offers delete only on the viewer-owned session', async () => {
@@ -111,7 +117,8 @@ describe('user session attribution', () => {
       'user-viewer-9',
     );
 
-    renderSection();
+    const { client } = renderSection();
+    await waitForMutationsIdle(client);
     const user = userEvent.setup();
 
     await user.click(await screen.findByRole('button', { name: 'Session actions for alpha' }));


### PR DESCRIPTION
## Summary

Follow-up addressing the two actionable CodeRabbit findings from #21460 (org-visible sessions), which merged before they were applied.

- **A11y**: the session row button's accessible name only contained the session name; the "started by" owner text lived in a nested span's `aria-label`, which does not extend the button's accessible name, so screen readers never heard the owner. The owner is now part of the button's `aria-label` (`"<name>, started by <owner>"`), and the visible owner text is unchanged.
- **Test robustness**: the two session-visibility MSW tests now `await waitForMutationsIdle` after render before asserting, per the package's testing guidelines, so assertions cannot race the auth -> project -> repository -> sessions query chain.

No changeset: `@internal/factory-ui` is a private package.

## Test plan

- `vitest run --config e2e/ui/vitest.config.ts` on both touched test files: 3 passed
- Typecheck: 0 errors
- oxfmt clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Session rows now tell screen readers who started each session. The related tests also wait for updates to finish before checking results, which prevents timing failures.

## Changes

- Add `started by <owner>` to the session row button’s accessible name.
- Keep the owner text unchanged visually.
- Remove the owner text’s separate `aria-label`.
- Add `await waitForMutationsIdle` to session visibility tests.
- Update attribution assertions to use accessible button names and visible text.

## Validation

- 3 tests pass.
- Typechecking succeeds.
- Formatting passes.
- No changeset added because `@internal/factory-ui` is private.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->