### PR TITLE
feat(editor): route Composio tools by invoker identity

### DIFF
--- a/.changeset/slick-worms-flow.md
+++ b/.changeset/slick-worms-flow.md
@@ -1,0 +1,23 @@
+---
+'@mastra/editor': minor
+---
+
+Added authenticated-user execution and deterministic connected-account routing to ComposioToolProvider. Invoker-bound connections execute as the authenticated Composio user against the exact stored connected account, including accounts shared through Composio ACLs.
+
+Use userIdResolver when application user IDs need mapping to Composio user IDs:
+
+```typescript
+import { MASTRA_USER_KEY } from '@mastra/server/auth';
+import { ComposioToolProvider } from '@mastra/editor/composio';
+
+const composio = new ComposioToolProvider({
+  apiKey: process.env.COMPOSIO_API_KEY!,
+  userIdResolver: ({ requestContext }) => {
+    const user = requestContext?.getRaw(MASTRA_USER_KEY);
+    if (!user || typeof user !== 'object' || !('id' in user) || typeof user.id !== 'string') return undefined;
+    return user.id;
+  },
+});
+```
+
+Pinned caller-supplied connections now route to their exact account instead of allowing Composio to auto-select one.

--- a/.changeset/yellow-toes-listen.md
+++ b/.changeset/yellow-toes-listen.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': minor
+---
+
+Added invoker-bound tool provider connections. Providers now receive the connection kind, toolkit, and live RequestContext so they can execute as the authenticated user without coupling provider identity to the Memory resource. The stored connection ID continues to select the exact provider account.
+
+```typescript
+async resolveToolsVNext({ kind, requestContext, connectionId }) {
+  if (kind === 'invoker') {
+    const userId = requestContext?.get('providerUserId');
+    return resolveForUser(userId, connectionId);
+  }
+}
+```

--- a/.changeset/yellow-toes-listen.md
+++ b/.changeset/yellow-toes-listen.md
@@ -5,10 +5,22 @@
 Added invoker-bound tool provider connections. Providers now receive the connection kind, toolkit, and live RequestContext so they can execute as the authenticated user without coupling provider identity to the Memory resource. The stored connection ID continues to select the exact provider account.
 
 ```typescript
-async resolveToolsVNext({ kind, requestContext, connectionId }) {
-  if (kind === 'invoker') {
-    const userId = requestContext?.get('providerUserId');
-    return resolveForUser(userId, connectionId);
-  }
-}
+import type { ToolProviders } from '@mastra/core/tool-provider';
+
+const toolProviders: ToolProviders = {
+  crm: {
+    tools: {
+      CREATE_LEAD: { toolkit: 'salesforce' },
+    },
+    connections: {
+      salesforce: [
+        {
+          kind: 'invoker',
+          toolkit: 'salesforce',
+          connectionId: 'connected-account-id',
+        },
+      ],
+    },
+  },
+};
 ```

--- a/docs/src/content/en/reference/editor/tool-provider.mdx
+++ b/docs/src/content/en/reference/editor/tool-provider.mdx
@@ -244,7 +244,7 @@ type ComposioUserIdResolver = (
     name: 'requestContext',
     type: 'RequestContext',
     description:
-      'Live per-request context. Read server-populated identity fields with getRaw(). Clients can set arbitrary non-reserved entries.',
+      'Live per-request context. Client-provided non-reserved entries are untrusted. Derive identity and authorize connectedAccountId only from validated, server-populated fields such as MASTRA_USER_KEY, read with getRaw().',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/editor/tool-provider.mdx
+++ b/docs/src/content/en/reference/editor/tool-provider.mdx
@@ -174,6 +174,13 @@ const editor = new MastraEditor({
     isOptional: true,
     defaultValue: "'per-author'",
   },
+  {
+    name: 'userIdResolver',
+    type: 'ComposioUserIdResolver',
+    description:
+      'Server-side resolver that derives the effective Composio userId from authenticated context fields. Used for invoker and caller-supplied execution. The exact connected account always comes from the stored connection pin.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -184,6 +191,130 @@ Composio tools use uppercase slug format: `GITHUB_CREATE_ISSUE`, `SLACK_SEND_MES
 ### Authentication
 
 Connections use per-author scope by default. Set `defaultScope: 'caller-supplied'` to bucket authorization by the caller identity resolved from `MASTRA_RESOURCE_ID_KEY` in request context. Ensure each authenticated request provides a stable, unique resource ID. When using `MastraAuthWorkos`, configure `mapUserToResourceId` to set this value from the authenticated user.
+
+How the provider resolves the Composio user for a tool call depends on the connection:
+
+- **Author-bound connections** (`kind: 'author'`) execute as the agent author's user against the pinned connected account.
+- **Invoker-bound connections** (`kind: 'invoker'`) execute as the authenticated invoker against the exact pinned account, which may be an account another user shared with the invoker through Composio's access control list (ACL). The user ID comes from `userIdResolver` when configured, then the authenticated user, and never from the Memory `resourceId`. Invoker resolution fails when no authenticated user or resolver result exists.
+- **Caller-supplied scope** (`scope: 'caller-supplied'`) uses `userIdResolver` when configured. Otherwise, it falls back to the legacy `resourceId` from request context for backward compatibility. When a specific connected account is pinned, execution routes to that exact account. Otherwise, Composio auto-resolves within the user's bucket.
+
+### Execute with a shared account
+
+Bob needs to run a Salesforce tool with an account that Alice shared through Composio. Keep each identity separate:
+
+| Identity | Value |
+| - | - |
+| Memory resource | `project_123` |
+| Composio user ID | `bob` |
+| Connected account | `ca_alice_salesforce` |
+
+Register the provider normally. Mastra server authentication writes the authenticated user to request context, so most applications don't need a `userIdResolver`:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+import { MastraEditor } from '@mastra/editor'
+import { ComposioToolProvider } from '@mastra/editor/composio'
+
+const editor = new MastraEditor({
+  toolProviders: {
+    composio: new ComposioToolProvider({
+      apiKey: process.env.COMPOSIO_API_KEY!,
+    }),
+  },
+})
+
+export const mastra = new Mastra({ editor })
+```
+
+Configure the agent with an invoker connection pinned to `ca_alice_salesforce`. When Bob invokes the agent, Mastra sends `bob` as the Composio user and the pinned account ID as the exact connected account. The Memory resource stays `project_123`. Composio then checks whether the account's ACL permits Bob to execute it.
+
+### Map application users to Composio users
+
+Use `userIdResolver` when your Composio user IDs differ from the IDs returned by Mastra authentication, or when your application must authorize the stored account pin before execution.
+
+```typescript
+type ComposioUserIdResolver = (
+  input: ComposioUserIdResolverInput,
+) => Promise<string | undefined> | string | undefined
+```
+
+<PropertiesTable
+  content={[
+  {
+    name: 'requestContext',
+    type: 'RequestContext',
+    description:
+      'Live per-request context. Read server-populated identity fields with getRaw(). Clients can set arbitrary non-reserved entries.',
+    isOptional: true,
+  },
+  {
+    name: 'toolkit',
+    type: 'string',
+    description: 'Toolkit slug the identity is being resolved for, when known.',
+    isOptional: true,
+  },
+  {
+    name: 'connectedAccountId',
+    type: 'string',
+    description:
+      'Stored connection pin being resolved, when one exists. Use it to validate that the invoker may use this exact account.',
+    isOptional: true,
+  },
+]}
+/>
+
+The resolver returns the Composio user ID, or `undefined` to use the provider's default resolution. Returning an empty string throws instead of silently falling back. The resolver can't replace the connected account.
+
+This example namespaces the Composio user by organization and asks the application's authorization layer to approve the exact account pin:
+
+```typescript title="src/mastra/index.ts"
+import { MASTRA_USER_KEY } from '@mastra/server/auth'
+import { ComposioToolProvider } from '@mastra/editor/composio'
+import { canUseConnectedAccount } from './integration-authorization'
+
+type AuthenticatedUser = {
+  id: string
+  organizationId: string
+}
+
+function isAuthenticatedUser(value: unknown): value is AuthenticatedUser {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    typeof value.id === 'string' &&
+    'organizationId' in value &&
+    typeof value.organizationId === 'string'
+  )
+}
+
+const composio = new ComposioToolProvider({
+  apiKey: process.env.COMPOSIO_API_KEY!,
+  userIdResolver: async ({ requestContext, toolkit, connectedAccountId }) => {
+    const user = requestContext?.getRaw(MASTRA_USER_KEY)
+    if (!isAuthenticatedUser(user)) return undefined
+
+    if (connectedAccountId) {
+      const allowed = await canUseConnectedAccount({
+        actorId: user.id,
+        organizationId: user.organizationId,
+        provider: 'composio',
+        toolkit,
+        connectedAccountId,
+      })
+      if (!allowed) {
+        throw new Error('User cannot access this connected account')
+      }
+    }
+
+    return `${user.organizationId}:${user.id}`
+  },
+})
+```
+
+Use the same namespaced ID when creating Composio connections and shared-account ACL entries. For example, Bob's Composio user ID in this setup is `acme:bob`.
+
+Throw from `userIdResolver` to deny the request. During stored-agent resolution, Mastra logs the failure and omits tools associated with that connection, so no tool call reaches Composio. Other connections continue to resolve. When calling `resolveToolsVNext()` directly, the error is returned to the caller instead.
 
 ### Connection management tools
 

--- a/packages/core/src/tool-provider/base.ts
+++ b/packages/core/src/tool-provider/base.ts
@@ -1,3 +1,4 @@
+import { RequestContext } from '../request-context';
 import type { StorageToolConfig } from '../storage/types';
 import type { ToolAction } from '../tools/types';
 import type {
@@ -9,6 +10,7 @@ import type {
   ListToolkitsResult,
   ListToolsOpts,
   ListToolsResult,
+  ResolveToolProviderToolsOptions,
   ResolveToolsOpts,
   ToolProvider,
   ToolProviderCapabilities,
@@ -129,7 +131,7 @@ export abstract class BaseToolProvider implements ToolProvider {
   async resolveTools(
     toolSlugs: string[],
     toolConfigs?: Record<string, StorageToolConfig>,
-    options?: { userId?: string; requestContext?: Record<string, unknown>; [key: string]: unknown },
+    options?: ResolveToolProviderToolsOptions,
   ): Promise<Record<string, ToolAction<any, any, any>>> {
     return this.resolveToolsVNext({
       toolSlugs,
@@ -138,7 +140,7 @@ export abstract class BaseToolProvider implements ToolProvider {
       ),
       connectionId: '',
       authorId: options?.userId,
-      requestContext: options?.requestContext,
+      requestContext: options?.requestContext ? new RequestContext(Object.entries(options.requestContext)) : undefined,
     });
   }
 

--- a/packages/core/src/tool-provider/runtime.test.ts
+++ b/packages/core/src/tool-provider/runtime.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
-import { MASTRA_RESOURCE_ID_KEY } from '../request-context';
+import { MASTRA_RESOURCE_ID_KEY, RequestContext } from '../request-context';
 import { buildConnectionSuffix, resolveStoredToolProviders } from './runtime';
 import type { ResolveToolsOpts, ToolProvider, ToolProviderConnectionScope, ToolProviders } from './types';
 import { SHARED_BUCKET_ID } from './types';
+
+function requestContext(resourceId: string): RequestContext {
+  return new RequestContext([[MASTRA_RESOURCE_ID_KEY, resourceId]]);
+}
 
 function makeStubProvider(): {
   provider: ToolProvider;
@@ -48,7 +52,7 @@ describe('resolveStoredToolProviders — resolveConnectionAuthorId branches', ()
     const { provider, resolveToolsVNext } = makeStubProvider();
 
     await resolveStoredToolProviders(buildToolProviders('caller-supplied'), () => provider, {
-      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'user_abc' },
+      requestContext: requestContext('user_abc'),
       authorId: 'author_xyz',
     });
 
@@ -94,6 +98,68 @@ describe('resolveStoredToolProviders — resolveConnectionAuthorId branches', ()
     expect(resolveToolsVNext.mock.calls[0]![0].authorId).toBe('author_xyz');
     expect(resolveToolsVNext.mock.calls[0]![0].scope).toBe('per-author');
   });
+
+  it('forwards connection kind and toolkit to the provider', async () => {
+    const { provider, resolveToolsVNext } = makeStubProvider();
+
+    await resolveStoredToolProviders(buildToolProviders('per-author'), () => provider, {
+      authorId: 'author_xyz',
+    });
+
+    expect(resolveToolsVNext.mock.calls[0]![0].kind).toBe('author');
+    expect(resolveToolsVNext.mock.calls[0]![0].toolkit).toBe('gmail');
+  });
+});
+
+describe('resolveStoredToolProviders — invoker connections', () => {
+  function buildInvokerToolProviders(): ToolProviders {
+    return {
+      composio: {
+        tools: {
+          'salesforce.create_lead': { toolkit: 'salesforce' },
+        },
+        connections: {
+          salesforce: [
+            {
+              kind: 'invoker',
+              toolkit: 'salesforce',
+              connectionId: 'ca_alice_salesforce',
+            },
+          ],
+        },
+      },
+    };
+  }
+
+  it('never derives the user bucket from the Memory resource id', async () => {
+    const { provider, resolveToolsVNext } = makeStubProvider();
+
+    await resolveStoredToolProviders(buildInvokerToolProviders(), () => provider, {
+      requestContext: requestContext('project_123'),
+      authorId: 'author_xyz',
+    });
+
+    expect(resolveToolsVNext).toHaveBeenCalledTimes(1);
+    const opts = resolveToolsVNext.mock.calls[0]![0];
+    expect(opts.authorId).toBeUndefined();
+    expect(opts.kind).toBe('invoker');
+  });
+
+  it('passes the pinned connectionId and live RequestContext through unchanged', async () => {
+    const { provider, resolveToolsVNext } = makeStubProvider();
+    const context = requestContext('project_123');
+
+    await resolveStoredToolProviders(buildInvokerToolProviders(), () => provider, {
+      requestContext: context,
+      authorId: 'author_xyz',
+    });
+
+    const opts = resolveToolsVNext.mock.calls[0]![0];
+    expect(opts.connectionId).toBe('ca_alice_salesforce');
+    expect(opts.toolkit).toBe('salesforce');
+    expect(opts.requestContext).toBe(context);
+    expect(opts.requestContext?.getRaw(MASTRA_RESOURCE_ID_KEY)).toBe('project_123');
+  });
 });
 
 describe('resolveStoredToolProviders — connectionless caller-supplied tools', () => {
@@ -120,8 +186,9 @@ describe('resolveStoredToolProviders — connectionless caller-supplied tools', 
       },
     };
 
+    const context = requestContext('tenant-user-1');
     const resolved = await resolveStoredToolProviders(toolProviders, () => provider, {
-      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'tenant-user-1' },
+      requestContext: context,
       authorId: 'agent-author',
     });
 
@@ -133,7 +200,7 @@ describe('resolveStoredToolProviders — connectionless caller-supplied tools', 
         connectionId: 'tenant-user-1',
         authorId: 'tenant-user-1',
         scope: 'caller-supplied',
-        requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'tenant-user-1' },
+        requestContext: context,
       }),
     );
   });
@@ -162,7 +229,7 @@ describe('resolveStoredToolProviders — connectionless caller-supplied tools', 
     };
 
     const resolved = await resolveStoredToolProviders(toolProviders, () => provider, {
-      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'tenant-user-1' },
+      requestContext: requestContext('tenant-user-1'),
     });
 
     expect(resolved[legacyToolId]).toBeDefined();

--- a/packages/core/src/tool-provider/runtime.ts
+++ b/packages/core/src/tool-provider/runtime.ts
@@ -1,5 +1,6 @@
 import type { IMastraLogger } from '../logger';
 import { MASTRA_RESOURCE_ID_KEY } from '../request-context';
+import type { RequestContext } from '../request-context';
 import type { ToolAction } from '../tools/types';
 import type { ToolProvider, ToolProviderConnection, ToolProviders } from './types';
 import { SHARED_BUCKET_ID } from './types';
@@ -10,8 +11,8 @@ import { SHARED_BUCKET_ID } from './types';
 export type ToolProviderLookup = (providerId: string) => ToolProvider;
 
 export interface ResolveStoredToolProvidersOpts {
-  /** Per-request context plumbed to each `provider.resolveToolsVNext` call. */
-  requestContext?: Record<string, unknown>;
+  /** Live per-request context plumbed to each `provider.resolveToolsVNext` call. */
+  requestContext?: RequestContext;
   /**
    * Agent author's user id. Used as the provider user bucket for
    * `kind: 'author'` connections so pinned credentials work for any invoker.
@@ -146,6 +147,8 @@ export async function resolveStoredToolProviders(
               toolMeta: tools,
               connectionId: resolvedAuthorId,
               authorId: resolvedAuthorId,
+              kind: 'author',
+              toolkit,
               scope: 'caller-supplied',
               requestContext,
             });
@@ -212,6 +215,8 @@ export async function resolveStoredToolProviders(
             toolMeta: cfg.tools ?? {},
             connectionId: connection.connectionId,
             authorId: resolvedAuthorId,
+            kind: connection.kind,
+            toolkit,
             scope: connection.scope,
             requestContext,
           });
@@ -259,10 +264,14 @@ function warnDefaultBucketFallback(logger: IMastraLogger | undefined): void {
 /**
  * Resolve the provider user bucket for a pinned connection.
  *
- * - `kind !== 'author'` → undefined (invoker/platform are reserved for later phases).
+ * - `kind === 'invoker'` → undefined. The provider resolves the invoker's
+ *   user id from trusted request context (its identity resolver /
+ *   authenticated user), never from the Memory resource id. The pinned
+ *   `connectionId` is passed through unchanged as the exact account.
+ * - `kind === 'platform'` → undefined (reserved for later phases).
  * - `scope === 'shared'` → {@link SHARED_BUCKET_ID}.
- * - `scope === 'caller-supplied'` → `requestContext[MASTRA_RESOURCE_ID_KEY]` when
- *   present, otherwise falls back to the shared `'default'` bucket (matching legacy
+ * - `scope === 'caller-supplied'` → `requestContext.getRaw(MASTRA_RESOURCE_ID_KEY)`
+ *   when present, otherwise falls back to the shared `'default'` bucket (matching legacy
  *   `ComposioToolProvider` semantics on main). Multi-tenant deployments should wire
  *   `authConfig.mapUserToResourceId` to avoid cross-user bucket sharing.
  * - otherwise → the caller's resolved authorId.
@@ -270,7 +279,7 @@ function warnDefaultBucketFallback(logger: IMastraLogger | undefined): void {
 function resolveConnectionAuthorId(
   connection: ToolProviderConnection,
   callerAuthorId: string | undefined,
-  requestContext: Record<string, unknown> | undefined,
+  requestContext: RequestContext | undefined,
   logger: IMastraLogger | undefined,
 ): string | undefined {
   if (connection.kind !== 'author') return undefined;
@@ -282,13 +291,13 @@ function resolveConnectionAuthorId(
 }
 
 function resolveCallerSuppliedAuthorId(
-  requestContext: Record<string, unknown> | undefined,
+  requestContext: RequestContext | undefined,
   logger: IMastraLogger | undefined,
 ): string {
-  const resourceId = requestContext?.[MASTRA_RESOURCE_ID_KEY];
+  const resourceId = requestContext?.getRaw(MASTRA_RESOURCE_ID_KEY);
   if (typeof resourceId === 'string' && resourceId.length > 0) return resourceId;
   // Match legacy ComposioToolProvider behavior: when the host app has not
-  // wired requestContext[MASTRA_RESOURCE_ID_KEY] (e.g. via
+  // wired requestContext.getRaw(MASTRA_RESOURCE_ID_KEY) (e.g. via
   // authConfig.mapUserToResourceId), fall back to a shared 'default' bucket
   // so tools still resolve. Multi-tenant deployments must wire the resource
   // id explicitly to avoid cross-user bucket sharing.

--- a/packages/core/src/tool-provider/types.ts
+++ b/packages/core/src/tool-provider/types.ts
@@ -1,3 +1,4 @@
+import type { RequestContext } from '../request-context';
 import type { StorageToolConfig } from '../storage/types';
 import type { ToolAction } from '../tools/types';
 
@@ -78,7 +79,7 @@ export interface ToolProviderListResult<T> {
 export interface ResolveToolProviderToolsOptions {
   /** User ID for user-scoped tool execution (e.g., Composio) */
   userId?: string;
-  /** Per-request context (e.g., user-specific API keys, tenant IDs) */
+  /** Per-request context snapshot for the legacy resolver. */
   requestContext?: Record<string, unknown>;
   /** Additional provider-specific options */
   [key: string]: unknown;
@@ -135,7 +136,11 @@ export interface ToolProviderConnection {
    * Identity binding kind.
    *
    * - `'author'` — uses the agent author's connection (v1 default).
-   * - `'invoker'` — uses the end-user's connection (reserved).
+   * - `'invoker'` — executes as the authenticated end-user (invoker). The
+   *   pinned `connectionId` selects the exact provider account (which may be
+   *   an account another user shared with the invoker); the provider resolves
+   *   the invoker's user id from authenticated, server-populated context,
+   *   never from the Memory resource id.
    * - `'platform'` — uses a shared platform account (reserved).
    */
   kind: 'author' | 'invoker' | 'platform';
@@ -144,7 +149,8 @@ export interface ToolProviderConnection {
   /**
    * Provider-opaque identifier for the OAuth bucket.
    *
-   * Required for `'author'` and `'platform'`; reserved (empty) for `'invoker'`.
+   * Required for `'author'` and `'platform'`. For `'invoker'`, carries the
+   * exact provider account id the invoker selected (personal or shared).
    */
   connectionId: string;
   /**
@@ -246,13 +252,22 @@ export interface ResolveToolsOpts {
    */
   authorId?: string;
   /**
+   * Identity binding kind of the connection being resolved. Absent = treat
+   * as `'author'` (back-compat). For `'invoker'`, providers must resolve the
+   * user bucket from trusted, server-populated request context and route
+   * execution to the exact `connectionId`.
+   */
+  kind?: ToolProviderConnection['kind'];
+  /** Toolkit slug this resolution targets. Absent for legacy callers. */
+  toolkit?: string;
+  /**
    * Identity bucketing for this connection. Providers may use it to decide
    * whether to pin a specific account or let the backend auto-resolve within
    * the user bucket. Absent = treat as `'per-author'` (back-compat).
    */
   scope?: ToolProviderConnectionScope;
-  /** Per-request context (auth, tenant, currentUser, ...). */
-  requestContext?: Record<string, unknown>;
+  /** Live per-request context. Use its typed accessors instead of serializing it. */
+  requestContext?: RequestContext;
 }
 
 /**

--- a/packages/editor/src/apply-stored-overrides.test.ts
+++ b/packages/editor/src/apply-stored-overrides.test.ts
@@ -534,7 +534,9 @@ describe('applyStoredOverrides', () => {
     });
 
     const result = await editor.agent.applyStoredOverrides(codeAgent);
-    const tools = await result.listTools({ requestContext: new RequestContext() });
+    const requestContext = new RequestContext();
+    requestContext.setRaw('nonSerializable', () => 'preserved');
+    const tools = await result.listTools({ requestContext });
 
     expect(tools['code-tool']).toBeDefined();
     expect(tools['GITHUB_LIST_REPOSITORY_ISSUES']).toBeDefined();
@@ -547,5 +549,8 @@ describe('applyStoredOverrides', () => {
         authorId: 'author-1',
       }),
     );
+    const providerRequestContext = vi.mocked(stubProvider.resolveToolsVNext!).mock.calls[0]?.[0].requestContext;
+    expect(providerRequestContext).toBe(requestContext);
+    expect(providerRequestContext?.getRaw('nonSerializable')).toBe(requestContext.getRaw('nonSerializable'));
   });
 });

--- a/packages/editor/src/composio.ts
+++ b/packages/editor/src/composio.ts
@@ -1,2 +1,6 @@
 export { ComposioToolProvider } from './providers/composio';
-export type { ComposioToolProviderConfig } from './providers/composio';
+export type {
+  ComposioToolProviderConfig,
+  ComposioUserIdResolver,
+  ComposioUserIdResolverInput,
+} from './providers/composio';

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -645,7 +645,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
             resolvedToolProvidersConfig,
             (providerId: string) => this.editor.getToolProviderOrThrow(providerId),
             {
-              requestContext: ctx,
+              requestContext,
               authorId: storedConfig!.authorId,
               logger: this.logger,
             },
@@ -856,7 +856,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
           resolvedToolProvidersConfig,
           (providerId: string) => this.editor.getToolProviderOrThrow(providerId),
           {
-            requestContext: ctx,
+            requestContext,
             authorId: storedAgent.authorId,
             logger: this.logger,
           },

--- a/packages/editor/src/providers/composio.test.ts
+++ b/packages/editor/src/providers/composio.test.ts
@@ -601,8 +601,8 @@ describe('ComposioToolProvider — invoker identity', () => {
     ).rejects.toThrow('requires an authenticated user or a userIdResolver');
   });
 
-  it('lets the userIdResolver supply the userId while the stored pin routes the account', async () => {
-    const userIdResolver = vi.fn(async () => 'bob');
+  it('normalizes the userIdResolver result while the stored pin routes the account', async () => {
+    const userIdResolver = vi.fn(async () => '  bob  ');
     const integration = new ComposioToolProvider({ apiKey: 'k', userIdResolver });
 
     await integration

--- a/packages/editor/src/providers/composio.test.ts
+++ b/packages/editor/src/providers/composio.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
+import { MASTRA_RESOURCE_ID_KEY, RequestContext } from '@mastra/core/request-context';
+import { resolveStoredToolProviders } from '@mastra/core/tool-provider';
+import type { ToolProviders } from '@mastra/core/tool-provider';
 
 // ── module mocks ────────────────────────────────────────────────────────
 // `vi.hoisted` because the mock factory below is hoisted above all other
@@ -58,6 +60,9 @@ vi.mock('@composio/mastra', () => ({
 
 // Import after mocks are registered.
 import { ComposioToolProvider } from './composio';
+// Public entry-point surface (`@mastra/editor/composio`) — type-only imports
+// verify the resolver types are exported where consumers import them from.
+import type { ComposioUserIdResolver, ComposioUserIdResolverInput, ComposioToolProviderConfig } from '../composio';
 
 function getRawInstance(): FakeComposioInstance {
   return composioInstances.find(i => !i.hasProvider)!;
@@ -67,11 +72,24 @@ function getMastraInstance(): FakeComposioInstance {
   return composioInstances.find(i => i.hasProvider)!;
 }
 
+function createRequestContext(values: Record<string, unknown>): RequestContext {
+  return new RequestContext(Object.entries(values));
+}
+
 beforeEach(() => {
   composioInstances.length = 0;
 });
 
 describe('ComposioToolProvider — identity & capabilities', () => {
+  it('exports the user ID resolver types from the public composio entry point', () => {
+    const resolver: ComposioUserIdResolver = (input: ComposioUserIdResolverInput) => {
+      const user = input.requestContext?.get('user');
+      return typeof user === 'string' ? user : undefined;
+    };
+    const config: ComposioToolProviderConfig = { apiKey: 'k', userIdResolver: resolver };
+    expect(new ComposioToolProvider(config).info.id).toBe('composio');
+  });
+
   it('has literal id "composio" and full capabilities', () => {
     const integration = new ComposioToolProvider({ apiKey: 'k' });
     expect(integration.info.id).toBe('composio');
@@ -232,7 +250,7 @@ describe('ComposioToolProvider — resolveTools', () => {
       toolSlugs: ['gmail.fetch_emails'],
       toolMeta: { 'gmail.fetch_emails': { description: 'overridden' } },
       connectionId: 'ca_1',
-      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'user_42' },
+      requestContext: createRequestContext({ [MASTRA_RESOURCE_ID_KEY]: 'user_42' }),
     });
 
     expect(Object.keys(result)).toEqual(['gmail.fetch_emails']);
@@ -251,7 +269,7 @@ describe('ComposioToolProvider — resolveTools', () => {
     expect(params.connectedAccountId).toBe('ca_1');
   });
 
-  it('does not pin connectedAccountId under caller-supplied scope (lets Composio auto-resolve)', async () => {
+  it('pins connectedAccountId for pinned caller-supplied connections (deterministic routing)', async () => {
     const integration = new ComposioToolProvider({ apiKey: 'k' });
 
     await integration
@@ -265,11 +283,41 @@ describe('ComposioToolProvider — resolveTools', () => {
       toolSlugs: ['gmail.fetch_emails'],
       toolMeta: {},
       connectionId: 'ca_1',
+      authorId: 'tenant_7',
       scope: 'caller-supplied',
-      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'tenant_7' },
+      requestContext: createRequestContext({ [MASTRA_RESOURCE_ID_KEY]: 'tenant_7' }),
     });
 
-    // User bucket is the resolved resourceId, not the pinned connection id.
+    // User bucket is the resolved resourceId, and the pinned account routes
+    // execution deterministically.
+    expect(mastra.tools.get.mock.calls[0]![0]).toBe('tenant_7');
+    const modifiers = mastra.tools.get.mock.calls[0]![2] as {
+      beforeExecute: (a: { params: { connectedAccountId?: string } }) => unknown;
+    };
+    const params: { connectedAccountId?: string } = {};
+    modifiers.beforeExecute({ params });
+    expect(params.connectedAccountId).toBe('ca_1');
+  });
+
+  it('does not pin an account for unpinned caller-supplied bootstrap tools (connectionId === authorId)', async () => {
+    const integration = new ComposioToolProvider({ apiKey: 'k' });
+
+    await integration
+      .resolveToolsVNext({ toolSlugs: ['a'], toolMeta: {}, connectionId: 'ca_1' })
+      .catch(() => undefined);
+    const mastra = getMastraInstance();
+    mastra.tools.get.mockClear();
+    mastra.tools.get.mockResolvedValue({ 'gmail.fetch_emails': { id: 'gmail.fetch_emails' } });
+
+    await integration.resolveToolsVNext({
+      toolSlugs: ['gmail.fetch_emails'],
+      toolMeta: {},
+      connectionId: 'tenant_7',
+      authorId: 'tenant_7',
+      scope: 'caller-supplied',
+      requestContext: createRequestContext({ [MASTRA_RESOURCE_ID_KEY]: 'tenant_7' }),
+    });
+
     expect(mastra.tools.get.mock.calls[0]![0]).toBe('tenant_7');
     const modifiers = mastra.tools.get.mock.calls[0]![2] as {
       beforeExecute: (a: { params: { connectedAccountId?: string } }) => unknown;
@@ -312,7 +360,7 @@ describe('ComposioToolProvider — resolveTools', () => {
       toolSlugs: ['gmail.fetch_emails'],
       toolMeta: {},
       connectionId: 'ca_1',
-      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'author_99' },
+      requestContext: createRequestContext({ [MASTRA_RESOURCE_ID_KEY]: 'author_99' }),
     });
 
     expect(mastra.tools.get.mock.calls[0]![0]).toBe('author_99');
@@ -333,7 +381,7 @@ describe('ComposioToolProvider — resolveTools', () => {
       toolMeta: {},
       connectionId: 'ca_1',
       authorId: 'author_owner',
-      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'invoker_other' },
+      requestContext: createRequestContext({ [MASTRA_RESOURCE_ID_KEY]: 'invoker_other' }),
     });
 
     expect(mastra.tools.get.mock.calls[0]![0]).toBe('author_owner');
@@ -364,7 +412,7 @@ describe('ComposioToolProvider — resolveTools', () => {
       connectionId: 'tenant_7',
       authorId: 'agent_author_should_not_win',
       scope: 'caller-supplied',
-      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'tenant_7' },
+      requestContext: createRequestContext({ [MASTRA_RESOURCE_ID_KEY]: 'tenant_7' }),
     });
 
     expect(mastra.tools.get).not.toHaveBeenCalled();
@@ -403,7 +451,7 @@ describe('ComposioToolProvider — resolveTools', () => {
         connectionId: callerPrincipalId,
         authorId: callerPrincipalId,
         scope: 'caller-supplied',
-        requestContext: { [MASTRA_RESOURCE_ID_KEY]: callerPrincipalId },
+        requestContext: createRequestContext({ [MASTRA_RESOURCE_ID_KEY]: callerPrincipalId }),
       });
 
     const [callerATools, callerBTools] = await Promise.all([
@@ -496,6 +544,227 @@ describe('ComposioToolProvider — resolveTools', () => {
       }),
     ).rejects.toThrow('session unavailable');
     expect(mastra.tools.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('ComposioToolProvider — invoker identity', () => {
+  const MASTRA_USER_KEY = 'mastra__user';
+
+  function getBeforeExecute(mastra: FakeComposioInstance) {
+    return mastra.tools.get.mock.calls[0]![2] as {
+      beforeExecute: (a: { params: { connectedAccountId?: string } }) => unknown;
+    };
+  }
+
+  it('executes invoker connections as the authenticated user, never the Memory resource id', async () => {
+    const integration = new ComposioToolProvider({ apiKey: 'k' });
+
+    await integration
+      .resolveToolsVNext({ toolSlugs: ['a'], toolMeta: {}, connectionId: 'ca_1' })
+      .catch(() => undefined);
+    const mastra = getMastraInstance();
+    mastra.tools.get.mockClear();
+    mastra.tools.get.mockResolvedValue({});
+
+    await integration.resolveToolsVNext({
+      toolSlugs: ['salesforce.create_lead'],
+      toolMeta: {},
+      connectionId: 'ca_alice_salesforce',
+      kind: 'invoker',
+      toolkit: 'salesforce',
+      requestContext: createRequestContext({
+        [MASTRA_RESOURCE_ID_KEY]: 'project_123',
+        [MASTRA_USER_KEY]: { id: 'bob' },
+      }),
+    });
+
+    // User bucket = authenticated invoker, not the memory resource id.
+    expect(mastra.tools.get.mock.calls[0]![0]).toBe('bob');
+    // Execution routes to the exact pinned (shared) account.
+    const params: { connectedAccountId?: string } = {};
+    getBeforeExecute(mastra).beforeExecute({ params });
+    expect(params.connectedAccountId).toBe('ca_alice_salesforce');
+  });
+
+  it('rejects invoker connections without an authenticated user or identity resolver', async () => {
+    const integration = new ComposioToolProvider({ apiKey: 'k' });
+
+    await expect(
+      integration.resolveToolsVNext({
+        toolSlugs: ['gmail.fetch_emails'],
+        toolMeta: {},
+        connectionId: 'ca_1',
+        kind: 'invoker',
+        toolkit: 'gmail',
+        requestContext: createRequestContext({ [MASTRA_RESOURCE_ID_KEY]: 'project_123' }),
+      }),
+    ).rejects.toThrow('requires an authenticated user or a userIdResolver');
+  });
+
+  it('lets the userIdResolver supply the userId while the stored pin routes the account', async () => {
+    const userIdResolver = vi.fn(async () => 'bob');
+    const integration = new ComposioToolProvider({ apiKey: 'k', userIdResolver });
+
+    await integration
+      .resolveToolsVNext({ toolSlugs: ['a'], toolMeta: {}, connectionId: 'ca_1' })
+      .catch(() => undefined);
+    const mastra = getMastraInstance();
+    mastra.tools.get.mockClear();
+    mastra.tools.get.mockResolvedValue({});
+
+    const requestContext = createRequestContext({ [MASTRA_USER_KEY]: { id: 'someone_else' } });
+    await integration.resolveToolsVNext({
+      toolSlugs: ['salesforce.create_lead'],
+      toolMeta: {},
+      connectionId: 'ca_requested',
+      kind: 'invoker',
+      toolkit: 'salesforce',
+      requestContext,
+    });
+
+    expect(userIdResolver).toHaveBeenCalledWith({
+      requestContext,
+      toolkit: 'salesforce',
+      connectedAccountId: 'ca_requested',
+    });
+    expect(mastra.tools.get.mock.calls[0]![0]).toBe('bob');
+    const params: { connectedAccountId?: string } = {};
+    getBeforeExecute(mastra).beforeExecute({ params });
+    // The resolver cannot override the account — the stored pin routes it.
+    expect(params.connectedAccountId).toBe('ca_requested');
+  });
+
+  it('consults the userIdResolver with the live RequestContext', async () => {
+    const requestContext = createRequestContext({ [MASTRA_RESOURCE_ID_KEY]: 'tenant_7' });
+    const userIdResolver = vi.fn(async ({ requestContext: context }: ComposioUserIdResolverInput) => {
+      expect(context).toBe(requestContext);
+      expect(context?.getRaw(MASTRA_RESOURCE_ID_KEY)).toBe('tenant_7');
+      return 'bob';
+    });
+    const integration = new ComposioToolProvider({ apiKey: 'k', userIdResolver });
+
+    await integration
+      .resolveToolsVNext({ toolSlugs: ['a'], toolMeta: {}, connectionId: 'ca_1' })
+      .catch(() => undefined);
+    const mastra = getMastraInstance();
+    mastra.tools.get.mockClear();
+    mastra.tools.get.mockResolvedValue({});
+
+    await integration.resolveToolsVNext({
+      toolSlugs: ['gmail.fetch_emails'],
+      toolMeta: {},
+      connectionId: 'tenant_7',
+      authorId: 'tenant_7',
+      scope: 'caller-supplied',
+      toolkit: 'gmail',
+      requestContext,
+    });
+
+    expect(userIdResolver).toHaveBeenCalledWith({
+      requestContext,
+      toolkit: 'gmail',
+      connectedAccountId: undefined,
+    });
+    expect(mastra.tools.get.mock.calls[0]![0]).toBe('bob');
+    // No account pin exists — Composio auto-resolves within the bucket.
+    const params: { connectedAccountId?: string } = {};
+    getBeforeExecute(mastra).beforeExecute({ params });
+    expect(params.connectedAccountId).toBeUndefined();
+  });
+
+  it('falls back to the authenticated user when the userIdResolver returns undefined', async () => {
+    const userIdResolver = vi.fn(async () => undefined);
+    const integration = new ComposioToolProvider({ apiKey: 'k', userIdResolver });
+
+    await integration
+      .resolveToolsVNext({ toolSlugs: ['a'], toolMeta: {}, connectionId: 'ca_1' })
+      .catch(() => undefined);
+    const mastra = getMastraInstance();
+    mastra.tools.get.mockClear();
+    mastra.tools.get.mockResolvedValue({});
+
+    await integration.resolveToolsVNext({
+      toolSlugs: ['salesforce.create_lead'],
+      toolMeta: {},
+      connectionId: 'ca_alice_salesforce',
+      kind: 'invoker',
+      toolkit: 'salesforce',
+      requestContext: createRequestContext({ [MASTRA_USER_KEY]: { id: 'bob' } }),
+    });
+
+    expect(userIdResolver).toHaveBeenCalledOnce();
+    expect(mastra.tools.get.mock.calls[0]![0]).toBe('bob');
+  });
+
+  it('rejects a userIdResolver that returns an empty userId instead of silently falling back', async () => {
+    const userIdResolver = vi.fn(async () => '');
+    const integration = new ComposioToolProvider({ apiKey: 'k', userIdResolver });
+
+    await expect(
+      integration.resolveToolsVNext({
+        toolSlugs: ['gmail.fetch_emails'],
+        toolMeta: {},
+        connectionId: 'ca_1',
+        kind: 'invoker',
+        toolkit: 'gmail',
+        requestContext: createRequestContext({ [MASTRA_USER_KEY]: { id: 'bob' } }),
+      }),
+    ).rejects.toThrow('userIdResolver must return a non-empty string or undefined');
+  });
+});
+
+describe('ComposioToolProvider — stored-config runtime integration', () => {
+  const MASTRA_USER_KEY = 'mastra__user';
+
+  it('routes a stored invoker pin through the runtime fan-out as the authenticated user against the exact account', async () => {
+    const integration = new ComposioToolProvider({ apiKey: 'k' });
+
+    await integration
+      .resolveToolsVNext({ toolSlugs: ['a'], toolMeta: {}, connectionId: 'ca_1' })
+      .catch(() => undefined);
+    const mastra = getMastraInstance();
+    mastra.tools.get.mockClear();
+    mastra.tools.get.mockResolvedValue({
+      SALESFORCE_CREATE_LEAD: { id: 'SALESFORCE_CREATE_LEAD', description: 'Create a lead' },
+    });
+
+    // The stored agent config shape persisted by Agent Builder.
+    const stored: ToolProviders = {
+      composio: {
+        tools: { SALESFORCE_CREATE_LEAD: { toolkit: 'salesforce' } },
+        connections: {
+          salesforce: [
+            {
+              kind: 'invoker',
+              toolkit: 'salesforce',
+              connectionId: 'ca_alice_salesforce',
+              scope: 'per-author',
+            },
+          ],
+        },
+      },
+    };
+
+    const tools = await resolveStoredToolProviders(stored, () => integration, {
+      requestContext: createRequestContext({
+        [MASTRA_RESOURCE_ID_KEY]: 'project_123',
+        [MASTRA_USER_KEY]: { id: 'bob' },
+      }),
+      authorId: 'agent_author',
+    });
+
+    // The runtime fan-out reached Composio as the authenticated invoker —
+    // not the Memory resource id or the agent author.
+    expect(mastra.tools.get.mock.calls[0]![0]).toBe('bob');
+    // The materialised tool exists under its natural slug…
+    expect(tools['SALESFORCE_CREATE_LEAD']).toBeDefined();
+    // …and execution routes to the exact pinned (shared) account.
+    const modifiers = mastra.tools.get.mock.calls[0]![2] as {
+      beforeExecute: (a: { params: { connectedAccountId?: string } }) => unknown;
+    };
+    const params: { connectedAccountId?: string } = {};
+    modifiers.beforeExecute({ params });
+    expect(params.connectedAccountId).toBe('ca_alice_salesforce');
   });
 });
 

--- a/packages/editor/src/providers/composio.ts
+++ b/packages/editor/src/providers/composio.ts
@@ -17,6 +17,7 @@ import type {
 import { BaseToolProvider } from '@mastra/core/tool-provider';
 import type { ToolAction } from '@mastra/core/tools';
 import { MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
+import type { RequestContext } from '@mastra/core/request-context';
 
 import { Composio } from '@composio/core';
 import type {
@@ -31,7 +32,44 @@ import type { MastraToolCollection } from '@composio/mastra';
 export interface ComposioToolProviderConfig extends BaseToolProviderOptions {
   /** Composio API key. */
   apiKey: string;
+  /**
+   * Server-side resolver mapping request context to the Composio `userId` the
+   * call should execute as. Runs for `kind: 'invoker'` and `caller-supplied`
+   * resolution, so the host application (for example, its FGA layer) can
+   * derive and authorize the effective user before execution.
+   *
+   * Only server-populated fields within request context are trusted. When the
+   * resolver is absent (or returns `undefined`), invoker connections require
+   * the authenticated user (`MASTRA_USER_KEY`). Legacy `caller-supplied`
+   * connections retain their existing resource-id fallback.
+   *
+   * The exact `connectedAccountId` always comes from the stored connection
+   * pin — the resolver cannot override it.
+   */
+  userIdResolver?: ComposioUserIdResolver;
 }
+
+/** Inputs handed to {@link ComposioToolProviderConfig.userIdResolver}. */
+export interface ComposioUserIdResolverInput {
+  /** Live per-request context. Use `get()` for declared keys and `getRaw()` for reserved runtime keys. */
+  requestContext?: RequestContext;
+  /** Toolkit slug the identity is being resolved for, when known. */
+  toolkit?: string;
+  /**
+   * The stored connection pin being resolved, when one exists. Hosts can use
+   * it to validate that the invoker is allowed to use this exact account.
+   */
+  connectedAccountId?: string;
+}
+
+/**
+ * Server-side resolver returning the effective Composio `userId` for a
+ * request. Returning `undefined` falls back to the provider's default
+ * identity resolution. Must never trust client-supplied context values.
+ */
+export type ComposioUserIdResolver = (
+  input: ComposioUserIdResolverInput,
+) => Promise<string | undefined> | string | undefined;
 
 const COMPOSIO_PROVIDER_ID = 'composio' as const;
 const DEFAULT_INTERNAL_USER_ID = 'default';
@@ -65,6 +103,8 @@ export class ComposioToolProvider extends BaseToolProvider {
     supportsRevoke: true,
   };
 
+  readonly userIdResolver?: ComposioUserIdResolver;
+
   private readonly apiKey: string;
   private rawClient: Composio | null = null;
   private mastraClient: Composio<MastraProvider> | null = null;
@@ -76,6 +116,7 @@ export class ComposioToolProvider extends BaseToolProvider {
       defaultScope: config.defaultScope,
     });
     this.apiKey = config.apiKey;
+    this.userIdResolver = config.userIdResolver;
   }
 
   // ── client cache ──────────────────────────────────────────────────────
@@ -168,15 +209,7 @@ export class ComposioToolProvider extends BaseToolProvider {
   async resolveToolsVNext(opts: ResolveToolsOpts): Promise<Record<string, ToolAction<any, any, any>>> {
     if (opts.toolSlugs.length === 0) return {};
 
-    // Caller-supplied scope is always owned by the authenticated caller's
-    // resource id. Author-bound connections use the agent author's id so the
-    // same pin resolves for every invoker of that agent.
-    const callerPrincipalId =
-      opts.scope === 'caller-supplied'
-        ? resolveInternalUserId(opts.requestContext)
-        : opts.authorId && opts.authorId.length > 0
-          ? opts.authorId
-          : resolveInternalUserId(opts.requestContext);
+    const identity = await this.resolveExecutionIdentity(opts);
     const composio = this.getMastraClient();
     const sessionToolSlugs = opts.toolSlugs.filter(slug => COMPOSIO_CONNECTION_MANAGEMENT_TOOLS.has(slug));
     const directToolSlugs = opts.toolSlugs.filter(slug => !COMPOSIO_CONNECTION_MANAGEMENT_TOOLS.has(slug));
@@ -190,13 +223,8 @@ export class ComposioToolProvider extends BaseToolProvider {
         // into the API call. Mutating `params.connectedAccountId` routes
         // the call to a specific account.
         beforeExecute: ({ params }: { params: { connectedAccountId?: string; userId?: string } }) => {
-          // Under `caller-supplied` scope the user bucket (`callerPrincipalId`,
-          // resolved from the host app's resourceId) already scopes the call to
-          // the right tenant. Pinning a specific `connectedAccountId` would defeat
-          // Composio's per-user-bucket auto-resolve, so we let Composio pick the
-          // connected account within the bucket instead of forcing one.
-          if (opts.scope !== 'caller-supplied') {
-            params.connectedAccountId = opts.connectionId;
+          if (identity.connectionId) {
+            params.connectedAccountId = identity.connectionId;
           }
           return params;
         },
@@ -204,7 +232,7 @@ export class ComposioToolProvider extends BaseToolProvider {
 
       Object.assign(
         mastraTools,
-        (await composio.tools.get(callerPrincipalId, { tools: directToolSlugs }, modifiers)) as MastraToolCollection,
+        (await composio.tools.get(identity.userId, { tools: directToolSlugs }, modifiers)) as MastraToolCollection,
       );
     }
 
@@ -219,7 +247,7 @@ export class ComposioToolProvider extends BaseToolProvider {
             ),
         ),
       ];
-      const session = await composio.sessions.create(callerPrincipalId, {
+      const session = await composio.sessions.create(identity.userId, {
         ...(selectedToolkits.length > 0 ? { toolkits: selectedToolkits } : {}),
         manageConnections: { enable: true, waitForConnections: true },
         sandbox: { enable: false },
@@ -251,6 +279,73 @@ export class ComposioToolProvider extends BaseToolProvider {
     }
 
     return result;
+  }
+
+  /**
+   * Run the configured `userIdResolver` and validate its result. Returns
+   * the resolved user id, or `undefined` when no resolver is configured or
+   * the resolver declined (returned `undefined`). Throws when the resolver
+   * returns an empty or non-string value — an empty execution identity must
+   * fail closed instead of silently falling back.
+   */
+  private async runUserIdResolver(input: ComposioUserIdResolverInput): Promise<string | undefined> {
+    if (!this.userIdResolver) return undefined;
+    const resolved = await this.userIdResolver(input);
+    if (resolved === undefined) return undefined;
+    if (typeof resolved !== 'string' || resolved.trim().length === 0) {
+      throw new Error('[composio] userIdResolver must return a non-empty string or undefined');
+    }
+    return resolved;
+  }
+
+  /**
+   * Resolve the effective Composio execution identity for one
+   * `resolveToolsVNext` call: the `userId` bucket to fetch tools under and
+   * the exact `connectedAccountId` to route execution to (absent = let
+   * Composio auto-resolve within the bucket).
+   */
+  private async resolveExecutionIdentity(opts: ResolveToolsOpts): Promise<{ userId: string; connectionId?: string }> {
+    // The unpinned caller-supplied bootstrap fan-out passes the user bucket
+    // itself as `connectionId` (connectionId === authorId). That is not an
+    // account pin, so execution must stay on Composio's per-bucket
+    // auto-resolve.
+    const hasAccountPin = opts.connectionId !== opts.authorId;
+
+    if (opts.kind === 'invoker') {
+      const resolvedUserId = await this.runUserIdResolver({
+        requestContext: opts.requestContext,
+        toolkit: opts.toolkit,
+        connectedAccountId: opts.connectionId,
+      });
+      // Invoker connections execute as the authenticated user — never the
+      // Memory resource id — against the exact stored account pin (which may
+      // be an account another user shared with the invoker via Composio ACL).
+      return {
+        userId: resolvedUserId ?? resolveInvokerUserId(opts.requestContext),
+        connectionId: opts.connectionId,
+      };
+    }
+
+    if (opts.scope === 'caller-supplied') {
+      const resolvedUserId = await this.runUserIdResolver({
+        requestContext: opts.requestContext,
+        toolkit: opts.toolkit,
+        connectedAccountId: hasAccountPin ? opts.connectionId : undefined,
+      });
+      return {
+        userId: resolvedUserId ?? resolveInternalUserId(opts.requestContext),
+        connectionId: hasAccountPin ? opts.connectionId : undefined,
+      };
+    }
+
+    // Author-bound (and legacy) connections: the runtime fan-out passes the
+    // agent author's id explicitly. Use it as the Composio user bucket so the
+    // pin resolves for any invoker (not just the original author), and always
+    // route execution to the pinned account.
+    return {
+      userId: opts.authorId && opts.authorId.length > 0 ? opts.authorId : resolveInternalUserId(opts.requestContext),
+      connectionId: opts.connectionId,
+    };
   }
 
   // ── auth surface ──────────────────────────────────────────────────────
@@ -378,7 +473,7 @@ export class ComposioToolProvider extends BaseToolProvider {
       return { items: [], pagination: { page, perPage, hasMore: false } };
     }
 
-    // Composio SDK 0.6.x uses cursor-based pagination on the wire. We surface
+    // Composio SDK uses cursor-based pagination on the wire. We surface
     // page-based pagination to keep the Mastra contract consistent with every
     // other list API. For now we only fetch the first page (page=1); paginated
     // requests for page > 1 are a follow-up — the UI does not yet paginate.
@@ -537,13 +632,13 @@ const MASTRA_USER_KEY = 'mastra__user';
  * author id (or `'default'`) into `requestContext` under
  * {@link MASTRA_RESOURCE_ID_KEY}.
  */
-function resolveInternalUserId(requestContext?: Record<string, unknown>): string {
-  const resourceId = requestContext?.[MASTRA_RESOURCE_ID_KEY];
+function resolveInternalUserId(requestContext?: RequestContext): string {
+  const resourceId = requestContext?.getRaw(MASTRA_RESOURCE_ID_KEY);
   if (typeof resourceId === 'string' && resourceId.length > 0) {
     return resourceId;
   }
 
-  const user = requestContext?.[MASTRA_USER_KEY];
+  const user = requestContext?.getRaw(MASTRA_USER_KEY);
   if (user && typeof user === 'object' && 'id' in user) {
     const id = (user as { id: unknown }).id;
     if (typeof id === 'string' && id.length > 0) {
@@ -552,6 +647,23 @@ function resolveInternalUserId(requestContext?: Record<string, unknown>): string
   }
 
   return DEFAULT_INTERNAL_USER_ID;
+}
+
+/**
+ * Read the authenticated invoker's Composio `userId` from per-request
+ * context. Invoker connections must never fall back to the Memory resource id
+ * because a project or thread is not an authenticated connector principal.
+ */
+function resolveInvokerUserId(requestContext?: RequestContext): string {
+  const user = requestContext?.getRaw(MASTRA_USER_KEY);
+  if (user && typeof user === 'object' && 'id' in user) {
+    const id = (user as { id: unknown }).id;
+    if (typeof id === 'string' && id.length > 0) {
+      return id;
+    }
+  }
+
+  throw new Error('[composio] kind "invoker" requires an authenticated user or a userIdResolver result');
 }
 
 /**

--- a/packages/editor/src/providers/composio.ts
+++ b/packages/editor/src/providers/composio.ts
@@ -292,10 +292,14 @@ export class ComposioToolProvider extends BaseToolProvider {
     if (!this.userIdResolver) return undefined;
     const resolved = await this.userIdResolver(input);
     if (resolved === undefined) return undefined;
-    if (typeof resolved !== 'string' || resolved.trim().length === 0) {
+    if (typeof resolved !== 'string') {
       throw new Error('[composio] userIdResolver must return a non-empty string or undefined');
     }
-    return resolved;
+    const normalized = resolved.trim();
+    if (normalized.length === 0) {
+      throw new Error('[composio] userIdResolver must return a non-empty string or undefined');
+    }
+    return normalized;
   }
 
   /**

--- a/packages/editor/src/providers/composio.ts
+++ b/packages/editor/src/providers/composio.ts
@@ -629,6 +629,12 @@ function mapComposioStatus(status: string, isDisabled: boolean): ExistingConnect
 // reverse dependency from `editor` onto `server`.
 const MASTRA_USER_KEY = 'mastra__user';
 
+function readAuthenticatedUserId(requestContext?: RequestContext): string | undefined {
+  const user = requestContext?.getRaw(MASTRA_USER_KEY);
+  if (!user || typeof user !== 'object' || !('id' in user)) return undefined;
+  return typeof user.id === 'string' && user.id.length > 0 ? user.id : undefined;
+}
+
 /**
  * Read the internal user id (Composio `userId`) from per-request context.
  *
@@ -642,15 +648,7 @@ function resolveInternalUserId(requestContext?: RequestContext): string {
     return resourceId;
   }
 
-  const user = requestContext?.getRaw(MASTRA_USER_KEY);
-  if (user && typeof user === 'object' && 'id' in user) {
-    const id = (user as { id: unknown }).id;
-    if (typeof id === 'string' && id.length > 0) {
-      return id;
-    }
-  }
-
-  return DEFAULT_INTERNAL_USER_ID;
+  return readAuthenticatedUserId(requestContext) ?? DEFAULT_INTERNAL_USER_ID;
 }
 
 /**
@@ -659,14 +657,8 @@ function resolveInternalUserId(requestContext?: RequestContext): string {
  * because a project or thread is not an authenticated connector principal.
  */
 function resolveInvokerUserId(requestContext?: RequestContext): string {
-  const user = requestContext?.getRaw(MASTRA_USER_KEY);
-  if (user && typeof user === 'object' && 'id' in user) {
-    const id = (user as { id: unknown }).id;
-    if (typeof id === 'string' && id.length > 0) {
-      return id;
-    }
-  }
-
+  const userId = readAuthenticatedUserId(requestContext);
+  if (userId) return userId;
   throw new Error('[composio] kind "invoker" requires an authenticated user or a userIdResolver result');
 }
 

--- a/packages/editor/src/providers/index.ts
+++ b/packages/editor/src/providers/index.ts
@@ -1,4 +1,4 @@
 export { ComposioToolProvider } from './composio';
-export type { ComposioToolProviderConfig } from './composio';
+export type { ComposioToolProviderConfig, ComposioUserIdResolver, ComposioUserIdResolverInput } from './composio';
 export { ArcadeToolProvider } from './arcade';
 export type { ArcadeToolProviderConfig } from './arcade';


### PR DESCRIPTION
This separates Composio execution identity from Memory resource scoping. Invoker-bound connections now execute as the authenticated user against the exact connected account stored on the agent, while Composio continues to enforce access to personal or shared accounts.

Applications that map authenticated users to different Composio user IDs can use the new resolver without changing the stored account pin:

```ts
new ComposioToolProvider({
  apiKey: process.env.COMPOSIO_API_KEY!,
  userIdResolver: ({ requestContext }) => {
    const user = requestContext?.getRaw(MASTRA_USER_KEY)
    return isAuthenticatedUser(user) ? user.id : undefined
  },
})
```

The provider runtime now passes the connection kind, toolkit, and live RequestContext through tool resolution. This was covered by the core and editor test suites and verified against a live Composio shared account, including a denied unauthorized invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Composio now runs tools as the correct signed-in user while still using the exact account selected by the agent. Applications can map their users to Composio users without changing stored account selections.

## Changes

- Added optional `userIdResolver` support to `ComposioToolProvider`.
- Passed `kind`, `toolkit`, and the live `RequestContext` through tool-provider resolution.
- Enforced authenticated identity for invoker connections.
- Preserved exact connected-account routing for pinned connections.
- Rejected invalid or empty resolver results.
- Preserved shared-account and personal-account authorization checks.
- Updated public exports and documentation for resolver configuration and connection behavior.
- Added core and editor tests for identity routing, pinned accounts, request-context preservation, resolver behavior, and authorization failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->