### PR TITLE
Batch default index creation during PostgresStore first-run init

### DIFF
--- a/.changeset/quiet-moons-batch.md
+++ b/.changeset/quiet-moons-batch.md
@@ -1,0 +1,11 @@
+---
+'@mastra/pg': patch
+---
+
+Improved `PostgresStore` startup time on a database that has not been set up yet. Creating the schema for the first time issued one `CREATE INDEX CONCURRENTLY` per default index — 48 statements, each its own round trip on the single connection `init()` reserves. Indexes for tables that `init()` just created are now built in one batched statement without `CONCURRENTLY`, which is safe because those tables are brand new and empty. First-run init drops from 99 round trips to 49; against a Postgres with 25ms of latency that is roughly 4.2s down to 2.2s.
+
+Indexes added later to a table that already exists still use `CONCURRENTLY`, so a version upgrade that introduces an index never blocks writers on a populated table. An already-migrated database still initializes in 6 queries, unchanged. If one index fails to build, the rest are still created.
+
+`init()` also no longer releases its pinned connection while a storage domain is still setting up, so an init that fails partway can no longer leave DDL running on a separate pooled connection after it returns.
+
+Related to [#21676](https://github.com/mastra-ai/mastra/issues/21676).

--- a/stores/pg/src/storage/client.ts
+++ b/stores/pg/src/storage/client.ts
@@ -357,6 +357,14 @@ export class PinnedClientAdapter implements DbClient {
     );
   }
 
+  async drain(): Promise<void> {
+    let seen: Promise<unknown> | undefined;
+    while (seen !== this.#tail) {
+      seen = this.#tail;
+      await seen.catch(() => undefined);
+    }
+  }
+
   none(query: string, values?: QueryValues): Promise<null> {
     return this.#enqueue(async () => {
       await this.pinnedClient.query(query, values);

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -936,6 +936,7 @@ export class PgDB extends MastraBase {
 
         if (snapshot) {
           snapshot.tables.add(tableName);
+          snapshot.createdTables.add(tableName);
           // generateTableSQL emits the declared columns plus a `Z` twin for
           // every timestamp column; record both so the alterTable pass below
           // and later domains don't re-probe for them.
@@ -1605,8 +1606,9 @@ export class PgDB extends MastraBase {
         }
       }
 
+      const deferTo = snapshot?.createdTables.has(table) ? snapshot : null;
       const uniqueStr = unique ? 'UNIQUE ' : '';
-      const concurrentStr = concurrent ? 'CONCURRENTLY ' : '';
+      const concurrentStr = concurrent && !deferTo ? 'CONCURRENTLY ' : '';
       const methodStr = method !== 'btree' ? `USING ${method} ` : '';
 
       const columnsStr = columns
@@ -1637,6 +1639,12 @@ export class PgDB extends MastraBase {
 
       const quotedIndexName = `"${parseSqlIdentifier(name, 'index name')}"`;
       const sql = `CREATE ${uniqueStr}INDEX ${concurrentStr}${quotedIndexName} ON ${fullTableName} ${methodStr}(${columnsStr})${withStr}${tablespaceStr}${whereStr}`;
+
+      if (deferTo) {
+        deferTo.pendingIndexes.push(sql);
+        deferTo.indexes.add(name);
+        return;
+      }
 
       await this.client.none(sql);
       snapshot?.indexes.add(name);
@@ -1674,8 +1682,13 @@ export class PgDB extends MastraBase {
     const snapshot = this.schemaSnapshot;
     if (snapshot?.indexes.has(indexName)) return;
 
+    if (snapshot) {
+      snapshot.pendingIndexes.push(sql);
+      snapshot.indexes.add(indexName);
+      return;
+    }
+
     await this.client.none(sql);
-    snapshot?.indexes.add(indexName);
   }
 
   async dropIndex(indexName: string): Promise<void> {

--- a/stores/pg/src/storage/db/schema-snapshot.test.ts
+++ b/stores/pg/src/storage/db/schema-snapshot.test.ts
@@ -421,3 +421,131 @@ describe('init catalog snapshot', () => {
     expect(versionColumns.has('instructions')).toBe(true);
   }, 60000);
 });
+
+const CONCURRENT_INDEX = /CREATE (UNIQUE )?INDEX CONCURRENTLY/i;
+
+function shortSchema(prefix: string): string {
+  const name = `${prefix}${Date.now().toString(36).slice(-5)}${Math.random().toString(36).slice(2, 6)}`;
+  schemasToDrop.push(name);
+  return name;
+}
+
+async function droppableIndexesIn(schemaName: string): Promise<string[]> {
+  const rows = await admin(
+    `SELECT c.relname AS indexname
+       FROM pg_catalog.pg_index i
+       JOIN pg_catalog.pg_class c ON c.oid = i.indexrelid
+       JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = $1
+        AND NOT i.indisprimary
+        AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_constraint k WHERE k.conindid = i.indexrelid)
+      ORDER BY c.relname`,
+    [schemaName],
+  );
+  return rows.map(r => r.indexname);
+}
+
+describe('init index batching', () => {
+  it('creates every default index in one statement, without CONCURRENTLY, on a cold schema', async () => {
+    const schema = shortSchema('idxcold');
+    await admin(`CREATE SCHEMA "${schema}"`);
+    const store = new PostgresStore({ ...TEST_CONFIG, id: `idx-${schema}`, schemaName: schema });
+    storesToClose.push(store);
+
+    const statements = await captureStatements(() => store.init());
+
+    expect(count(statements, CONCURRENT_INDEX)).toBe(0);
+    expect(count(statements, CREATE_INDEX)).toBe(1);
+    expect(await indexesIn(schema)).toContain(`${schema}_mastra_threads_resourceid_createdat_idx`);
+  }, 60000);
+
+  it('produces the same indexes as the per-statement path', async () => {
+    const schema = shortSchema('idxsame');
+    await admin(`CREATE SCHEMA "${schema}"`);
+    const batched = new PostgresStore({ ...TEST_CONFIG, id: `idx-${schema}-a`, schemaName: schema });
+    storesToClose.push(batched);
+    await batched.init();
+    const batchedIndexes = await indexesIn(schema);
+
+    for (const indexName of await droppableIndexesIn(schema)) {
+      await admin(`DROP INDEX "${schema}"."${indexName}"`);
+    }
+
+    const rebuilt = new PostgresStore({ ...TEST_CONFIG, id: `idx-${schema}-b`, schemaName: schema });
+    storesToClose.push(rebuilt);
+    const statements = await captureStatements(() => rebuilt.init());
+
+    expect(count(statements, CONCURRENT_INDEX)).toBeGreaterThan(0);
+    expect(await indexesIn(schema)).toEqual(batchedIndexes);
+  }, 90000);
+
+  it('keeps CONCURRENTLY for an index added to a table that already existed', async () => {
+    const schema = shortSchema('idxexist');
+    await admin(`CREATE SCHEMA "${schema}"`);
+    const cold = new PostgresStore({ ...TEST_CONFIG, id: `idx-${schema}-a`, schemaName: schema });
+    storesToClose.push(cold);
+    await cold.init();
+
+    const dropped = `${schema}_mastra_threads_resourceid_createdat_idx`;
+    await admin(`DROP INDEX "${schema}"."${dropped}"`);
+
+    const warm = new PostgresStore({ ...TEST_CONFIG, id: `idx-${schema}-b`, schemaName: schema });
+    storesToClose.push(warm);
+    const statements = await captureStatements(() => warm.init());
+
+    expect(count(statements, CONCURRENT_INDEX)).toBe(1);
+    expect(await indexesIn(schema)).toContain(dropped);
+  }, 90000);
+
+  it('creates the remaining indexes when one index in the batch fails', async () => {
+    const schema = shortSchema('idxpart');
+    await admin(`CREATE SCHEMA "${schema}"`);
+    const store = new PostgresStore({
+      ...TEST_CONFIG,
+      id: `idx-${schema}`,
+      schemaName: schema,
+      indexes: [{ name: `${schema}_broken`, table: 'mastra_threads', columns: ['column_that_does_not_exist'] }],
+    });
+    storesToClose.push(store);
+
+    await expect(store.init()).resolves.toBeUndefined();
+
+    const indexes = await indexesIn(schema);
+    expect(indexes).not.toContain(`${schema}_broken`);
+    expect(indexes).toContain(`${schema}_mastra_threads_resourceid_createdat_idx`);
+    expect(indexes).toContain(`${schema}_mastra_messages_thread_id_createdat_idx`);
+  }, 90000);
+
+  it('creates a valid custom index on a cold schema', async () => {
+    const schema = shortSchema('idxcust');
+    await admin(`CREATE SCHEMA "${schema}"`);
+    const store = new PostgresStore({
+      ...TEST_CONFIG,
+      id: `idx-${schema}`,
+      schemaName: schema,
+      indexes: [{ name: `${schema}_custom`, table: 'mastra_threads', columns: ['resourceId'] }],
+    });
+    storesToClose.push(store);
+
+    await store.init();
+
+    expect(await indexesIn(schema)).toContain(`${schema}_custom`);
+  }, 90000);
+
+  it('creates no default indexes when skipDefaultIndexes is set', async () => {
+    const schema = shortSchema('idxskip');
+    await admin(`CREATE SCHEMA "${schema}"`);
+    const store = new PostgresStore({
+      ...TEST_CONFIG,
+      id: `idx-${schema}`,
+      schemaName: schema,
+      skipDefaultIndexes: true,
+    });
+    storesToClose.push(store);
+
+    const statements = await captureStatements(() => store.init());
+
+    expect(count(statements, CONCURRENT_INDEX)).toBe(0);
+    expect(await indexesIn(schema)).not.toContain(`${schema}_mastra_threads_resourceid_createdat_idx`);
+  }, 60000);
+});

--- a/stores/pg/src/storage/db/schema-snapshot.ts
+++ b/stores/pg/src/storage/db/schema-snapshot.ts
@@ -35,6 +35,8 @@ export interface SchemaSnapshot {
   readonly schemaName: string;
   /** Unqualified names of tables present in the schema. */
   tables: Set<string>;
+  createdTables: Set<string>;
+  pendingIndexes: string[];
   /** table name -> column names present on that table. */
   columns: Map<string, Set<string>>;
   /** table name -> column name -> Postgres type name (`jsonb`, `text`, ...). */
@@ -143,6 +145,8 @@ export async function loadSchemaSnapshot(client: DbClient, schemaName: string | 
   return {
     schemaName: schema,
     tables: new Set(tableRows.map(r => r.tablename)),
+    createdTables: new Set(),
+    pendingIndexes: [],
     columns,
     columnTypes,
     indexes,

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -18,6 +18,7 @@ import type { DbClient, PoolClient } from './client';
 import type { PgDomainClientConfig } from './db';
 import { getSchemaName } from './db';
 import { loadSchemaSnapshot } from './db/schema-snapshot';
+import type { SchemaSnapshot } from './db/schema-snapshot';
 import { AgentsPG } from './domains/agents';
 import { BackgroundTasksPG } from './domains/background-tasks';
 import { BlobsPG } from './domains/blobs';
@@ -340,17 +341,20 @@ export class PostgresStore extends MastraCompositeStore {
     // blip during boot) is caught below and resets #initPromise, keeping
     // init() retryable instead of permanently rejecting.
     let pinnedClient: PoolClient | undefined;
+    let pinned: PinnedClientAdapter | undefined;
 
     try {
       pinnedClient = await this.#pool.connect();
-      const pinned = new PinnedClientAdapter(this.#pool, pinnedClient);
+      pinned = new PinnedClientAdapter(this.#pool, pinnedClient);
       this.#db.pin(pinned);
       // Read the schema's catalog once, up front, so the domains below can
       // answer "does this table/column/index already exist?" locally instead of
       // asking the server ~350 times over this one serialized connection.
       // Cleared in the finally: the snapshot never outlives init().
-      this.#db.setSchemaSnapshot(await loadSchemaSnapshot(pinned, this.schema));
+      const snapshot = await loadSchemaSnapshot(pinned, this.schema);
+      this.#db.setSchemaSnapshot(snapshot);
       await super.init();
+      await this.#flushPendingIndexes(pinned, snapshot);
       // Only mark initialized after schema creation actually finishes so a
       // racing second init() caller can't return early and issue runtime
       // queries against tables that aren't yet created.
@@ -373,6 +377,9 @@ export class PostgresStore extends MastraCompositeStore {
         error,
       );
     } finally {
+      if (pinned) {
+        await pinned.drain();
+      }
       // Drop the snapshot unconditionally — including when loading it or
       // super.init() threw — so no code path can read a stale catalog picture
       // after init returns.
@@ -382,6 +389,25 @@ export class PostgresStore extends MastraCompositeStore {
       if (pinnedClient) {
         this.#db.unpin();
         pinnedClient.release();
+      }
+    }
+  }
+
+  async #flushPendingIndexes(client: DbClient, snapshot: SchemaSnapshot): Promise<void> {
+    const pending = snapshot.pendingIndexes.splice(0);
+    if (pending.length === 0) {
+      return;
+    }
+
+    try {
+      await client.none(pending.join(';\n'));
+    } catch {
+      for (const sql of pending) {
+        try {
+          await client.none(sql);
+        } catch (error) {
+          this.logger?.warn?.(`Failed to create index: ${sql}`, error);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

Setting up a fresh schema issued one `CREATE INDEX CONCURRENTLY` per default index. Every domain's init is serialized onto the single connection `init()` pins, so those 48 statements were 48 sequential round trips the dominant cost of a first-run init on a remote Postgres.

`CONCURRENTLY` exists to avoid blocking writers on a populated table, which cannot apply to a table this same init just created: it is brand new and empty. It is also what prevented batching, since `CREATE INDEX CONCURRENTLY` cannot run inside the implicit transaction of a multi-statement query.

The init snapshot now records which tables init created, and indexes targeting those tables are collected and issued as one statement after the domains converge. Indexes on tables that already existed keep `CONCURRENTLY` and their own round trip, so a version upgrade that adds an index still never blocks writers. If the batch fails, each statement is retried individually so one bad index cannot lose the rest.

**First-run init drops from 99 round trips to 49; against a Postgres with 25ms of latency that is ~4.2s to ~2.2s.** An already-converged schema still initializes in 6 queries, unchanged.

This also drains the pinned client before releasing it. `super.init()` runs the domains under `Promise.all`, so a rejection left siblings still running while the `finally` block unpinned and released the connection; their remaining DDL then escaped onto arbitrary pool connections after init returned. Draining keeps that work on the pinned client, which is the invariant the pinning was introduced for.

## Related issue(s)

Related to #21676

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

PostgresStore now creates many indexes together when a database is set up for the first time. This reduces setup time while keeping safe concurrent index creation for existing tables.

## Changes

- Batch default index creation for tables created during initialization.
- Keep `CREATE INDEX CONCURRENTLY` for indexes on existing tables.
- Retry indexes individually if the batch operation fails.
- Continue index creation after individual failures and log warnings.
- Keep the pinned client active through domain initialization.
- Drain pending initialization work before releasing the client.
- Add integration tests for batching, retries, custom indexes, and disabled default indexes.
- Add a changeset for the initialization improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->