### PR TITLE
fix(server): resolve public origin from X-Mastra-Public-Host

### DIFF
--- a/.changeset/tidy-pugs-repeat.md
+++ b/.changeset/tidy-pugs-repeat.md
@@ -1,0 +1,7 @@
+---
+'@mastra/server': patch
+---
+
+Resolve the public origin from `X-Mastra-Public-Host` when present, ahead of `X-Forwarded-Host`.
+
+Gateways that overwrite `X-Forwarded-Host` with their own internal domain (Railway's does) left `getPublicOrigin()` resolving an internal hostname, so deployed apps built OAuth callback URIs like `https://my-project-qa-qa.up.railway.app/api/auth/sso/callback` and sign-in failed against providers that validate the redirect URI. The same mis-resolved origin also failed the same-origin check on `redirect_uri`, silently collapsing the post-login landing page to `/`.

--- a/packages/server/src/server/constants.ts
+++ b/packages/server/src/server/constants.ts
@@ -37,6 +37,18 @@ export type MastraAuthMode = 'studio' | 'server';
 
 export const MASTRA_CLIENT_TYPE_HEADER = 'x-mastra-client-type';
 
+/**
+ * Browser-facing host, set by a trusted proxy whose own `X-Forwarded-Host` does
+ * not survive the hop to the app. Railway's gateway, for example, overwrites
+ * `X-Forwarded-Host` with its internal domain, so an edge in front of it has no
+ * other way to tell the app which hostname the user actually typed.
+ *
+ * Read by `getPublicOrigin()` ahead of `X-Forwarded-Host`. Carries the same
+ * trust assumption as the other forwarded headers: meaningful only behind a
+ * proxy that sets it, and it must be stripped from untrusted client requests.
+ */
+export const MASTRA_PUBLIC_HOST_HEADER = 'x-mastra-public-host';
+
 export const MASTRA_STUDIO_CLIENT_TYPE = 'studio';
 
 const RESERVED_CONTEXT_KEYS = new Set([

--- a/packages/server/src/server/handlers/auth.test.ts
+++ b/packages/server/src/server/handlers/auth.test.ts
@@ -162,6 +162,83 @@ describe('GET /auth/sso/login — callback URI prefix', () => {
 });
 
 // =============================================================================
+// Public host behind a gateway that rewrites X-Forwarded-Host
+// =============================================================================
+
+describe('GET /auth/sso/login — public host behind a rewriting gateway', () => {
+  // Railway's gateway overwrites X-Forwarded-Host with its own internal domain,
+  // so the edge in front of it forwards the browser-facing host in
+  // X-Mastra-Public-Host. Resolving the origin from X-Forwarded-Host instead
+  // produced an internal *.up.railway.app callback that the platform's OAuth
+  // redirect_uri allowlist rejected outright.
+  const gatewayHeaders = {
+    'x-mastra-public-host': 'my-project--qa.studio.example.com',
+    'x-forwarded-host': 'my-project-qa-qa.up.railway.app',
+  };
+
+  it('should build the OAuth callback URI from the public host, not the gateway host', async () => {
+    const mockAuth = createMockSSOProvider();
+    const mastra = createMastraWithAuth(mockAuth);
+
+    const request = new Request('http://internal-hostname:8080/api/auth/sso/login', {
+      headers: new Headers(gatewayHeaders),
+    });
+    const ctx = {
+      ...createTestServerContext({ mastra }),
+      request,
+      redirect_uri: undefined,
+    };
+
+    await GET_SSO_LOGIN_ROUTE.handler(ctx as any);
+
+    const callbackUri = (mockAuth.getLoginUrl as any).mock.calls[0][0];
+    expect(callbackUri).toBe('https://my-project--qa.studio.example.com/api/auth/sso/callback');
+  });
+
+  it('should treat the public host as same-origin when validating the post-login redirect', async () => {
+    const mockAuth = createMockSSOProvider();
+    const mastra = createMastraWithAuth(mockAuth);
+
+    const request = new Request('http://internal-hostname:8080/api/auth/sso/login', {
+      headers: new Headers(gatewayHeaders),
+    });
+    const ctx = {
+      ...createTestServerContext({ mastra }),
+      request,
+      redirect_uri: 'https://my-project--qa.studio.example.com/agents',
+    };
+
+    await GET_SSO_LOGIN_ROUTE.handler(ctx as any);
+
+    // Resolving the origin as the gateway host makes this fail the same-origin
+    // check and silently collapse to '/', dropping the user's landing page.
+    const stateArg = (mockAuth.getLoginUrl as any).mock.calls[0][1] as string;
+    const [, encodedRedirect] = stateArg.split('|', 2);
+    expect(decodeURIComponent(encodedRedirect)).toBe('https://my-project--qa.studio.example.com/agents');
+  });
+
+  it('should still reject an external redirect_uri when a public host is set', async () => {
+    const mockAuth = createMockSSOProvider();
+    const mastra = createMastraWithAuth(mockAuth);
+
+    const request = new Request('http://internal-hostname:8080/api/auth/sso/login', {
+      headers: new Headers(gatewayHeaders),
+    });
+    const ctx = {
+      ...createTestServerContext({ mastra }),
+      request,
+      redirect_uri: 'https://evil.com/phish',
+    };
+
+    await GET_SSO_LOGIN_ROUTE.handler(ctx as any);
+
+    const stateArg = (mockAuth.getLoginUrl as any).mock.calls[0][1] as string;
+    const [, encodedRedirect] = stateArg.split('|', 2);
+    expect(decodeURIComponent(encodedRedirect)).toBe('/');
+  });
+});
+
+// =============================================================================
 // Issue #4: SSO callback rejects cross-origin post-login redirects
 // =============================================================================
 

--- a/packages/server/src/server/handlers/auth.ts
+++ b/packages/server/src/server/handlers/auth.ts
@@ -20,7 +20,12 @@ import type { IMastraAuthProvider } from '@mastra/core/server';
 
 import { z } from 'zod/v4';
 import { supportsSessionRefresh } from '../auth/helpers';
-import { MASTRA_USER_PERMISSIONS_KEY, MASTRA_CLIENT_TYPE_HEADER, isStudioClientTypeHeader } from '../constants';
+import {
+  MASTRA_USER_PERMISSIONS_KEY,
+  MASTRA_CLIENT_TYPE_HEADER,
+  MASTRA_PUBLIC_HOST_HEADER,
+  isStudioClientTypeHeader,
+} from '../constants';
 import { HTTPException } from '../http-exception';
 import {
   capabilitiesResponseSchema,
@@ -118,15 +123,26 @@ function isStudioRequest(request: Request): boolean {
  * and must be validated upstream.
  *
  * Priority:
- * 1. X-Forwarded-Host (traditional reverse proxy) → always HTTPS. Knative's
+ * 1. X-Mastra-Public-Host (proxy chain that rewrites X-Forwarded-Host) → always
+ *    HTTPS. Some platform gateways — Railway's among them — overwrite
+ *    X-Forwarded-Host with their own internal domain, which would otherwise
+ *    leave the app resolving an internal hostname it must never hand to an
+ *    OAuth provider. An edge that knows the browser-facing host sets this
+ *    header so it survives that rewrite.
+ * 2. X-Forwarded-Host (traditional reverse proxy) → always HTTPS. Knative's
  *    queue-proxy overwrites X-Forwarded-Proto based on the internal HTTP
  *    connection, so X-Forwarded-Proto is ignored here.
- * 2. Host header with X-Forwarded-Proto (AWS ALB, some proxies) → respect proto.
- * 3. Host header alone → use the scheme from request.url (covers both direct
+ * 3. Host header with X-Forwarded-Proto (AWS ALB, some proxies) → respect proto.
+ * 4. Host header alone → use the scheme from request.url (covers both direct
  *    HTTP access and proxies that preserve Host but don't set a proto header).
- * 4. No Host header → fall back to request.url.origin (local dev / direct access).
+ * 5. No Host header → fall back to request.url.origin (local dev / direct access).
  */
 export function getPublicOrigin(request: Request): string {
+  const publicHost = request.headers.get(MASTRA_PUBLIC_HOST_HEADER)?.split(',')[0]?.trim();
+  if (publicHost) {
+    return `https://${publicHost}`;
+  }
+
   const forwardedHost = request.headers.get('x-forwarded-host')?.split(',')[0]?.trim();
   if (forwardedHost) {
     return `https://${forwardedHost}`;

--- a/packages/server/src/server/handlers/get-public-origin.test.ts
+++ b/packages/server/src/server/handlers/get-public-origin.test.ts
@@ -2,6 +2,7 @@
  * Tests for getPublicOrigin helper function.
  *
  * Covers reverse proxy header resolution for:
+ * - X-Mastra-Public-Host (proxies whose X-Forwarded-Host is rewritten downstream)
  * - X-Forwarded-Host (traditional reverse proxies)
  * - Host header (AWS ALB with Preserve Host Header)
  * - X-Forwarded-Proto (protocol detection)
@@ -13,6 +14,69 @@ import { describe, it, expect } from 'vitest';
 import { getPublicOrigin } from './auth';
 
 describe('getPublicOrigin — reverse proxy header resolution', () => {
+  it('should use X-Mastra-Public-Host when present', () => {
+    const headers = new Headers({
+      'x-mastra-public-host': 'my-project--qa.studio.example.com',
+      host: 'internal-hostname',
+    });
+    const request = new Request('http://internal-hostname:3000/api/auth/sso/login', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://my-project--qa.studio.example.com');
+  });
+
+  it('should prefer X-Mastra-Public-Host over an X-Forwarded-Host rewritten by the gateway', () => {
+    // Railway's gateway overwrites X-Forwarded-Host with its own internal domain,
+    // so the edge sends the browser-facing host in X-Mastra-Public-Host. Trusting
+    // X-Forwarded-Host here is what produced a *.up.railway.app OAuth redirect_uri.
+    const headers = new Headers({
+      'x-mastra-public-host': 'my-project--qa.studio.example.com',
+      'x-forwarded-host': 'my-project-qa-qa.up.railway.app',
+    });
+    const request = new Request('http://internal:3000/api/auth/sso/login', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://my-project--qa.studio.example.com');
+  });
+
+  it('should prefer X-Mastra-Public-Host over the Host header', () => {
+    const headers = new Headers({
+      'x-mastra-public-host': 'my-project.studio.example.com',
+      host: 'my-project-qa-qa.up.railway.app',
+      'x-forwarded-proto': 'https',
+    });
+    const request = new Request('https://my-project-qa-qa.up.railway.app/api/auth/sso/login', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://my-project.studio.example.com');
+  });
+
+  it('should always use HTTPS with X-Mastra-Public-Host (ignore X-Forwarded-Proto)', () => {
+    const headers = new Headers({
+      'x-mastra-public-host': 'my-project.studio.example.com',
+      'x-forwarded-proto': 'http',
+    });
+    const request = new Request('http://internal:3000/some-path', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://my-project.studio.example.com');
+  });
+
+  it('should handle comma-separated X-Mastra-Public-Host by using the first value', () => {
+    const headers = new Headers({
+      'x-mastra-public-host': '  my-project.studio.example.com  , other.example.com',
+    });
+    const request = new Request('http://internal:3000/some-path', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://my-project.studio.example.com');
+  });
+
+  it('should fall through to X-Forwarded-Host when X-Mastra-Public-Host is empty', () => {
+    const headers = new Headers({
+      'x-mastra-public-host': '',
+      'x-forwarded-host': 'api.example.com',
+    });
+    const request = new Request('http://internal:3000/some-path', { headers });
+
+    expect(getPublicOrigin(request)).toBe('https://api.example.com');
+  });
+
   it('should use X-Forwarded-Host when present (reverse proxy)', () => {
     const headers = new Headers({
       'x-forwarded-host': 'api.example.com',


### PR DESCRIPTION
## Problem

`getPublicOrigin()` trusts `X-Forwarded-Host` as its highest-priority signal. Some platform gateways — Railway's among them — overwrite that header with their own internal domain before the request reaches the app, so a deployed Mastra server resolves its public origin to an internal hostname.

Two things break as a result, both on `GET /auth/sso/login`:

1. The OAuth callback URI is built on the internal host, e.g. `https://my-project-qa-qa.up.railway.app/api/auth/sso/callback`. Any provider that validates the redirect URI against an allowlist rejects it outright.
2. The `redirect_uri` same-origin check compares the user's real (public) URL against the internal origin, fails, and silently collapses `post_login_redirect` to `/` — so even a successful sign-in loses the landing page.

Observed against a deployed Studio: the login URL came back with `redirect_uri=https%3A%2F%2F...up.railway.app%2Fapi%2Fauth%2Fsso%2Fcallback&post_login_redirect=%2F`, and the platform's auth service answered `400 redirect_uri host not allowed`.

## Fix

An edge sitting in front of such a gateway already knows the browser-facing host and can forward it in a header the gateway does not rewrite. This reads `X-Mastra-Public-Host` ahead of `X-Forwarded-Host`, under the same trusted-proxy assumption the function already documents for the other forwarded headers, and always resolves it as HTTPS (matching the existing `X-Forwarded-Host` branch).

Nothing changes for deployments that don't set the header — every existing priority rule keeps its behavior and its tests.

### Why not fix this in middleware

The header-to-`X-Forwarded-Host` copy can be done in server middleware, and that is how the Mastra platform's deploy wrapper has been doing it. That approach is fragile: since #20989 the deployer wraps all user middleware in `skipIfFrameworkPublic()`, which no-ops it on framework-public routes — and `/auth/sso/login`, `/auth/sso/callback` and `/auth/logout` are all `createPublicRoute`. The middleware therefore gets skipped on precisely the three routes that need the public origin. Resolving the header inside `getPublicOrigin()` removes the dependency on middleware ordering and gating entirely.

## Test plan

- `packages/server/src/server/handlers/get-public-origin.test.ts` — new header wins over a rewritten `X-Forwarded-Host` and over `Host`; always HTTPS regardless of `X-Forwarded-Proto`; comma-separated/whitespace handling; empty value falls through to the existing chain.
- `packages/server/src/server/handlers/auth.test.ts` — end-to-end through `GET_SSO_LOGIN_ROUTE`: the callback URI is built on the public host, the post-login redirect survives the same-origin check, and an external `redirect_uri` is still rejected.
- All 7 behavior-changing tests fail without the fix and pass with it; the 31 existing tests in those two files are unchanged.
- `pnpm vitest run src/server/handlers` in `packages/server`: 44/45 files pass. The one failure, `agent-controller.test.ts` (8 tests), reproduces on a clean checkout of `main` and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a gateway changes the server address, login redirects can point to the wrong place. This change lets the gateway provide the correct public address and keeps login redirects safe.

## Changes

- Added the trusted `X-Mastra-Public-Host` header.
- Updated `getPublicOrigin()` to:
  - Prefer `X-Mastra-Public-Host`.
  - Use the first comma-separated, trimmed value.
  - Force the resolved origin to HTTPS.
  - Fall back to the existing origin-resolution chain when the header is absent or empty.
- Updated origin-precedence documentation.
- Added tests for:
  - Public-origin precedence.
  - HTTPS resolution.
  - Comma-separated header values.
  - Fallback to `X-Forwarded-Host`.
  - SSO callback URLs.
  - Same-origin redirect handling.
  - Rejection of external redirects.
- Added a `@mastra/server` changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->