### PR TITLE
feat(playground-ui): add destructive button variants

### DIFF
--- a/.changeset/better-bushes-make.md
+++ b/.changeset/better-bushes-make.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added filled and ghost destructive Button variants for dangerous actions.

--- a/packages/playground-ui/src/ds/components/Button/Button.tsx
+++ b/packages/playground-ui/src/ds/components/Button/Button.tsx
@@ -32,6 +32,10 @@ export const buttonVariants = cva(
           'border border-border2 bg-surface3 text-neutral6 hover:bg-surface5 hover:text-neutral6 active:bg-surface6',
         primary:
           'border border-transparent bg-neutral6 font-medium text-surface1 hover:bg-neutral6/90 active:bg-neutral6/80',
+        destructive:
+          'border border-transparent bg-accent2 font-medium text-white hover:bg-accent2/90 active:bg-accent2/80',
+        'destructive-ghost':
+          'border border-transparent bg-transparent text-accent2 hover:bg-accent2/10 hover:text-accent2 active:bg-accent2/15',
         ghost:
           'border border-transparent bg-transparent text-neutral4 hover:bg-neutral6/5 hover:text-neutral6 active:bg-neutral6/10',
         outline:

--- a/packages/playground-ui/src/ds/components/Button/button.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Button/button.stories.tsx
@@ -4,7 +4,7 @@ import { TooltipProvider } from '../Tooltip';
 import type { ButtonVariant } from './Button';
 import { Button } from './Button';
 
-const ALL_VARIANTS: ButtonVariant[] = ['default', 'primary', 'outline', 'ghost'];
+const ALL_VARIANTS: ButtonVariant[] = ['default', 'primary', 'destructive', 'destructive-ghost', 'outline', 'ghost'];
 
 const meta: Meta<typeof Button> = {
   title: 'Elements/Button',

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.test.tsx
@@ -109,11 +109,14 @@ describe('ButtonsGroup', () => {
     // ...and are EXCLUDED from the transparent-left-border rule, so a filled segment keeps
     // its own 1px border as the single seam (its opaque bg hides the neighbour's border).
     // The previous inset-shadow approach was 1px off the covered border → a 2px double line.
-    expect(cls).toContain(':not([data-variant=default]):not([data-variant=primary])');
+    expect(cls).toContain(':not([data-variant=default]):not([data-variant=primary]):not([data-variant=destructive])');
     expect(cls).not.toContain('[data-variant=default]:not([aria-hidden=true]):not(:first-child)]:shadow-[inset');
-    // `primary` is borderless-filled, so it (only) gets an inset-shadow divider.
+    // Borderless filled variants get an inset-shadow divider.
     expect(cls).toContain(
       '[&>[data-variant=primary]:not([aria-hidden=true]):not(:first-child)]:shadow-[inset_1px_0_0_0_var(--color-border1)]',
+    );
+    expect(cls).toContain(
+      '[&>[data-variant=destructive]:not([aria-hidden=true]):not(:first-child)]:shadow-[inset_1px_0_0_0_var(--color-border1)]',
     );
     // Anti-flicker: grouped segments only transition colour/background (border + ring snap).
     expect(cls).toContain(':transition-[color,background-color]');

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.tsx
@@ -49,14 +49,15 @@ const buttonsGroupVariants = cva(
           '[&>*:has(~_*:not([aria-hidden=true]):not([data-base-ui-focus-guard]):not([aria-owns]))]:rounded-r-none',
           '[&>*:not(:first-child):not([aria-hidden=true]):not([data-base-ui-focus-guard]):not([aria-owns])]:rounded-l-none',
           // One-line seam: `-ml-px` overlaps adjacent borders onto the same pixel. Filled
-          // segments (opaque bg: default/primary buttons, the text chip) keep their own
-          // border — the bg hides the neighbour's. Transparent/outline segments null their
-          // left border at rest (so the neighbour's shows without doubling) and reveal it on
-          // hover / keyboard-focus, where the z-10 lift paints the complete border on top.
+          // segments (opaque bg: default/primary/destructive buttons, the text chip) keep
+          // their own border — the bg hides the neighbour's. Transparent/outline segments
+          // null their left border at rest (so the neighbour's shows without doubling) and
+          // reveal it on hover / keyboard-focus, where the z-10 lift paints the complete border.
           '[&>*:not([data-slot=buttons-group-separator]):not([aria-hidden=true]):not([data-base-ui-focus-guard]):not([aria-owns]):not(:first-child)]:-ml-px',
-          '[&>*:not([data-slot=buttons-group-separator]):not([data-slot=buttons-group-text]):not([data-variant=default]):not([data-variant=primary]):not([aria-hidden=true]):not([data-base-ui-focus-guard]):not([aria-owns]):not(:first-child):not(:hover):not(:focus-visible):not(:has(:focus-visible))]:border-l-transparent',
-          // `primary` is filled but borderless — give it (only) an inset-shadow divider.
+          '[&>*:not([data-slot=buttons-group-separator]):not([data-slot=buttons-group-text]):not([data-variant=default]):not([data-variant=primary]):not([data-variant=destructive]):not([aria-hidden=true]):not([data-base-ui-focus-guard]):not([aria-owns]):not(:first-child):not(:hover):not(:focus-visible):not(:has(:focus-visible))]:border-l-transparent',
+          // Borderless filled variants get an inset-shadow divider.
           '[&>[data-variant=primary]:not([aria-hidden=true]):not(:first-child)]:shadow-[inset_1px_0_0_0_var(--color-border1)]',
+          '[&>[data-variant=destructive]:not([aria-hidden=true]):not(:first-child)]:shadow-[inset_1px_0_0_0_var(--color-border1)]',
           // Animate only colour/bg so the seam + ring snap (no fade desynced from the z-10 drop).
           '[&>*:not([data-slot=buttons-group-separator]):not([aria-hidden=true])]:transition-[color,background-color]',
           // Group owns sizing (no consumer width classes): fill on flex/InputGroup/input,
@@ -79,8 +80,9 @@ const buttonsGroupVariants = cva(
           '[&>:first-child]:rounded-t-xl',
           '[&>:last-child]:rounded-b-xl',
           '[&>*:not([data-slot=buttons-group-separator]):not(:first-child)]:-mt-px',
-          '[&>*:not([data-slot=buttons-group-separator]):not([data-slot=buttons-group-text]):not([data-variant=default]):not([data-variant=primary]):not(:first-child):not(:hover):not(:focus-visible):not(:has(:focus-visible))]:border-t-transparent',
+          '[&>*:not([data-slot=buttons-group-separator]):not([data-slot=buttons-group-text]):not([data-variant=default]):not([data-variant=primary]):not([data-variant=destructive]):not(:first-child):not(:hover):not(:focus-visible):not(:has(:focus-visible))]:border-t-transparent',
           '[&>[data-variant=primary]:not(:first-child)]:shadow-[inset_0_1px_0_0_var(--color-border1)]',
+          '[&>[data-variant=destructive]:not(:first-child)]:shadow-[inset_0_1px_0_0_var(--color-border1)]',
           '[&>*:not([data-slot=buttons-group-separator])]:transition-[color,background-color]',
         ),
       },
@@ -184,4 +186,5 @@ export const ButtonsGroupText = React.forwardRef<HTMLDivElement, ButtonsGroupTex
 );
 ButtonsGroupText.displayName = 'ButtonsGroupText';
 
+// eslint-disable-next-line react-refresh/only-export-components -- exported variant helper is part of ButtonsGroup's public API
 export { buttonsGroupVariants };


### PR DESCRIPTION
## Description

Adds filled `destructive` and lower-emphasis `destructive-ghost` variants to the playground UI Button component. The Storybook matrix covers both variants, and ButtonsGroup keeps the correct seams for filled destructive buttons.

Includes a minor changeset for `@mastra/playground-ui`.

## Related issue(s)

Fixes #21789

Platform adoption follow-up: https://linear.app/kepler-crm/issue/PLTFRM-1287/adopt-the-playground-ui-destructive-button-variant

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Button component now supports two destructive styles for actions that can cause harm. The update also shows these styles in Storybook and keeps grouped buttons visually connected.

## Changes

- Added `destructive` and `destructive-ghost` Button variants.
- Added both variants to the Button Storybook matrix.
- Updated `ButtonsGroup` seam styling for filled destructive buttons.
- Added tests for destructive button dividers in horizontal and vertical groups.
- Added a minor-release changeset for `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->