### PR TITLE
perf(auth-better-auth): make the org-cache sweep amortized O(1)

### DIFF
--- a/.changeset/better-auth-active-org.md
+++ b/.changeset/better-auth-active-org.md
@@ -4,4 +4,13 @@
 
 Resolve a default `activeOrganizationId` from the user's oldest existing membership when the stored better-auth session has no `activeOrganizationId` set. Nothing in a default sign-in flow calls the organization plugin's `setActive`, so the field was always null and org-scoped consumers saw users with no organization.
 
+```ts
+import { MastraAuthBetterAuth } from '@mastra/auth-better-auth';
+
+const mastraAuth = new MastraAuthBetterAuth({ auth });
+const user = await mastraAuth.authenticateToken(token, request);
+// Populated even when the sign-in flow never called `setActive`.
+console.log(user?.session.activeOrganizationId);
+```
+
 The resolution is read-only and best-effort: the session row is not mutated, users with no memberships still authenticate, and a failed lookup falls back to today's behavior. Caveats: the resolved value is an inferred default, not an explicit user selection, and a session whose active organization was deliberately cleared via `setActive` is indistinguishable from one that was never set, so it also receives the default. A membership removed by an administrator stops being applied to new sessions within about a minute.

--- a/auth/better-auth/src/index.ts
+++ b/auth/better-auth/src/index.ts
@@ -183,16 +183,19 @@ export class MastraAuthBetterAuth
   }
 
   /**
-   * Cache a resolved `userId → orgId` mapping. Sweeps expired entries first so
-   * users who never authenticate again do not accumulate in the map for the
-   * process lifetime: every write bounds the cache to entries touched within
-   * the last TTL window.
+   * Cache a resolved `userId → orgId` mapping. The map is kept in expiry
+   * order: writes delete-then-set so refreshed entries move to the back, and
+   * since every entry uses the same TTL, iteration order is ascending
+   * `expiresAt`. The sweep therefore stops at the first live entry, making
+   * each write amortized O(1) instead of a full scan.
    */
   #storeOrgId(userId: string, orgId: string): void {
     const now = Date.now();
     for (const [key, entry] of this.#orgCache) {
-      if (now >= entry.expiresAt) this.#orgCache.delete(key);
+      if (now < entry.expiresAt) break;
+      this.#orgCache.delete(key);
     }
+    this.#orgCache.delete(userId);
     this.#orgCache.set(userId, { orgId, expiresAt: now + ORG_CACHE_TTL_MS });
   }
 


### PR DESCRIPTION
## Summary

Split from #21767 (review feedback polish, PR 1 of 2 quick extractions).

Every `#storeOrgId` write swept the entire userId→orgId cache for expired entries — O(U²) work across U users authenticating within one TTL window. The map is now kept in expiry order (delete-then-set on refresh; a single shared TTL means insertion order is ascending `expiresAt`), so the sweep stops at the first live entry and each write is amortized O(1).

Also appends a short integrator-facing usage example to the pending `better-auth-active-org` changeset.

## Intentionally excluded

- All factory/core/workspaces changes remain on #21767.

## Test plan

- `auth/better-auth`: `tsc --noEmit` clean, 67/67 vitest tests pass (includes existing cache TTL/sweep coverage).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The organization cache now finds expired entries faster instead of checking every entry each time. The PR also adds an example that shows how to get the active organization after authentication.

## Changes

- Maintains organization cache entries in expiry order.
- Refreshes entries by deleting and reinserting them.
- Stops expiration checks at the first live entry.
- Adds an integrator-facing `MastraAuthBetterAuth.authenticateToken` example.
- Documents the default `activeOrganizationId`, including when sign-in does not call `setActive`.

## Validation

- `tsc --noEmit` passes.
- All 67 Vitest tests pass in `auth/better-auth`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->