### PR TITLE
fix(code-sdk): stop an unread hook stdin from crashing the host process

### DIFF
--- a/.changeset/hooks-epipe-crash.md
+++ b/.changeset/hooks-epipe-crash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Stop an unread hook stdin from crashing the host process. A hook command that exits without reading its stdin closes the pipe mid-write, and the resulting EPIPE arrived as an unhandled socket error rather than a throw, so the surrounding `try/catch` never saw it and Node tore the process down. The socket error is now absorbed; the hook's real outcome still comes from its exit code.

--- a/mastracode/sdk/src/hooks/executor.test.ts
+++ b/mastracode/sdk/src/hooks/executor.test.ts
@@ -12,10 +12,15 @@ vi.mock('node:child_process', () => ({
 
 const { executeHook } = await import('./executor.js');
 
+class FakeStdin extends EventEmitter {
+  write = vi.fn();
+  end = vi.fn();
+}
+
 class FakeChildProcess extends EventEmitter {
   stdout = new EventEmitter();
   stderr = new EventEmitter();
-  stdin = { write: vi.fn(), end: vi.fn() };
+  stdin = new FakeStdin();
   kill = vi.fn();
 }
 
@@ -70,5 +75,31 @@ describe('executeHook Windows argument handling', () => {
 
     const callOptions = spawnMock.mock.calls[0]?.[2] as Record<string, unknown>;
     expect(callOptions).not.toHaveProperty('windowsVerbatimArguments');
+  });
+});
+
+describe('executeHook stdin failures', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it('survives an EPIPE when the hook closes stdin without reading it', async () => {
+    const fakeChild = new FakeChildProcess();
+    const epipe = Object.assign(new Error('write EPIPE'), { code: 'EPIPE', errno: -32 });
+
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        // An EventEmitter with no 'error' listener rethrows on emit, which is
+        // exactly how this used to take the whole host process down.
+        fakeChild.stdin.emit('error', epipe);
+        fakeChild.emit('close', 0);
+      });
+      return fakeChild;
+    });
+
+    const result = await executeHook(makeHook('echo ignoring-stdin'), makeStdin());
+
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
   });
 });

--- a/mastracode/sdk/src/hooks/executor.ts
+++ b/mastracode/sdk/src/hooks/executor.ts
@@ -89,11 +89,18 @@ export async function executeHook(hook: HookDefinition, stdinPayload: HookStdin)
       });
     });
 
+    // A hook that never reads stdin (or exits before we finish writing) closes
+    // the pipe under us. That surfaces asynchronously as an EPIPE 'error' event
+    // on the socket, which Node escalates to an unhandled error — taking the
+    // whole host process down — unless something is listening. The hook's real
+    // outcome still arrives via 'close', so absorb it.
+    child.stdin?.on('error', () => {});
+
     try {
       child.stdin?.write(JSON.stringify(stdinPayload));
       child.stdin?.end();
     } catch {
-      // stdin write failure — process continues
+      // Synchronous stdin write failure — process continues
     }
   });
 }


### PR DESCRIPTION
## Summary

Split from #21767 (PR 2 of 2 quick extractions).

A hook command that exits without reading its stdin closes the pipe while we're writing the payload. The resulting EPIPE surfaces asynchronously as an `'error'` event on the stdin socket — not a synchronous throw — so the existing `try/catch` never saw it and Node escalated it to an unhandled error that took the whole host process down. An error listener now absorbs it; the hook's real outcome still comes from its exit code via `'close'`.

Includes a scoped `@mastra/code-sdk` patch changeset and a regression test that emits EPIPE on a listener-less fake stdin (the exact crash mode).

## Intentionally excluded

- All factory/core/workspaces changes remain on #21767.

## Test plan

- `mastracode/sdk`: `tsc --noEmit` clean, executor tests 3/3 pass (new EPIPE regression test included).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

If a hook command closes its input before reading it, the host process no longer crashes. The hook result still uses the command’s exit code.

## Changes

- Added an `error` listener for asynchronous `EPIPE` errors from hook stdin.
- Kept hook outcome handling based on the `close` event and exit code.
- Added a regression test for `EPIPE` with listener-less fake stdin.
- Added a patch changeset for `@mastra/code-sdk`.
- TypeScript checks pass, and all three executor tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->