### PR TITLE
fix(playground): retry /api/auth/me on transient 503, keep 401 terminal

### DIFF
--- a/.changeset/playground-auth-me-503-retry.md
+++ b/.changeset/playground-auth-me-503-retry.md
@@ -1,0 +1,14 @@
+---
+'@internal/playground': patch
+---
+
+fix(playground): retry /api/auth/me on transient 503 from auth middleware
+
+The Mastra server middleware distinguishes transient auth-provider failures
+(503) from terminal auth failures (401). Playground's `useCurrentUser` had
+`retry: false`, so a single 503 flipped the query to `isError` and triggered
+the login flow — which amplified WorkOS 429 lockouts (PLTFRM-1270).
+
+Now retries on 503 up to 3 times with exponential backoff (500ms → 8s cap).
+401 (terminal) still fails fast. Mirrors the parity fix on the platform
+dashboard's `useAuth` hook.

--- a/packages/playground/src/domains/auth/hooks/__tests__/fetch-with-refresh.test.ts
+++ b/packages/playground/src/domains/auth/hooks/__tests__/fetch-with-refresh.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchWithRefresh, createFetchWithRefresh } from '../fetch-with-refresh';
+
+function jsonResponse(body: object, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('fetchWithRefresh', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('when the server returns a 2xx response', () => {
+    it('passes it through unchanged with a single fetch call', async () => {
+      const expected = jsonResponse({ ok: true });
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(expected);
+
+      const res = await fetchWithRefresh('http://server', 'http://server/api/agents');
+
+      expect(res).toBe(expected);
+      expect(globalThis.fetch).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('when the server returns 401', () => {
+    it('propagates the 401 without any client-side refresh dance', async () => {
+      const unauthorized = jsonResponse({ error: 'Unauthorized' }, 401);
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(unauthorized);
+
+      const res = await fetchWithRefresh('http://server', 'http://server/api/agents');
+
+      expect(res).toBe(unauthorized);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      // Server middleware already handled refresh. Client MUST NOT hit
+      // /auth/refresh — that would just amplify a transient failure
+      // (PLTFRM-1270).
+      const urls = fetchSpy.mock.calls.map(([input]) =>
+        input instanceof Request ? input.url : String(input),
+      );
+      expect(urls.some((u) => u.includes('/auth/refresh'))).toBe(false);
+    });
+  });
+
+  describe('when the server returns 503', () => {
+    it('propagates the 503 (retry is the caller\'s / React Query\'s job)', async () => {
+      const transient = jsonResponse({ error: 'Auth provider unavailable' }, 503);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(transient);
+
+      const res = await fetchWithRefresh('http://server', 'http://server/api/agents');
+
+      expect(res).toBe(transient);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('createFetchWithRefresh', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('when returned as the MastraClient fetch option', () => {
+    it('propagates 401 without refresh', async () => {
+      const fetcher = createFetchWithRefresh('http://server', '/api');
+      const unauthorized = jsonResponse({ error: 'Unauthorized' }, 401);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(unauthorized);
+
+      const res = await fetcher('http://server/api/agents');
+
+      expect(res).toBe(unauthorized);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates 503 unchanged', async () => {
+      const fetcher = createFetchWithRefresh('http://server', '/api');
+      const transient = jsonResponse({}, 503);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(transient);
+
+      const res = await fetcher('http://server/api/agents');
+
+      expect(res).toBe(transient);
+    });
+  });
+});

--- a/packages/playground/src/domains/auth/hooks/__tests__/fetch-with-refresh.test.ts
+++ b/packages/playground/src/domains/auth/hooks/__tests__/fetch-with-refresh.test.ts
@@ -37,15 +37,13 @@ describe('fetchWithRefresh', () => {
       // Server middleware already handled refresh. Client MUST NOT hit
       // /auth/refresh — that would just amplify a transient failure
       // (PLTFRM-1270).
-      const urls = fetchSpy.mock.calls.map(([input]) =>
-        input instanceof Request ? input.url : String(input),
-      );
-      expect(urls.some((u) => u.includes('/auth/refresh'))).toBe(false);
+      const urls = fetchSpy.mock.calls.map(([input]) => (input instanceof Request ? input.url : String(input)));
+      expect(urls.some(u => u.includes('/auth/refresh'))).toBe(false);
     });
   });
 
   describe('when the server returns 503', () => {
-    it('propagates the 503 (retry is the caller\'s / React Query\'s job)', async () => {
+    it("propagates the 503 (retry is the caller's / React Query's job)", async () => {
       const transient = jsonResponse({ error: 'Auth provider unavailable' }, 503);
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(transient);
 

--- a/packages/playground/src/domains/auth/hooks/__tests__/use-current-user.test.tsx
+++ b/packages/playground/src/domains/auth/hooks/__tests__/use-current-user.test.tsx
@@ -1,0 +1,78 @@
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { useCurrentUser } from '../use-current-user';
+import { server } from '@/test/msw-server';
+
+/**
+ * Guards the transient-vs-terminal retry contract for /api/auth/me.
+ *
+ * PLTFRM-1270: if the middleware returns 503 (transient WorkOS failure) we must
+ * NOT flip to isError — that surfaces as a login redirect which fed the 429
+ * lockout loop. 401 (terminal) must fail fast as before.
+ */
+
+const BASE_URL = 'http://localhost:4000';
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+describe('useCurrentUser', () => {
+  describe('when the server responds 200 with a user', () => {
+    it('returns the user', async () => {
+      server.use(
+        http.get('*/api/auth/me', () =>
+          HttpResponse.json({ id: 'u_1', email: 'a@b.c', name: 'A' }),
+        ),
+      );
+
+      const { result } = renderHook(() => useCurrentUser(), { wrapper: makeWrapper() });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toMatchObject({ id: 'u_1', email: 'a@b.c' });
+    });
+  });
+
+  describe('when the server responds 401', () => {
+    it('surfaces isError immediately (terminal)', async () => {
+      server.use(
+        http.get('*/api/auth/me', () => new HttpResponse(null, { status: 401 })),
+      );
+
+      const { result } = renderHook(() => useCurrentUser(), { wrapper: makeWrapper() });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.failureCount).toBe(1);
+    });
+  });
+
+  describe('when the server responds 503 then 200', () => {
+    it('retries and eventually returns the user without surfacing isError', async () => {
+      let calls = 0;
+      server.use(
+        http.get('*/api/auth/me', () => {
+          calls += 1;
+          if (calls < 2) return new HttpResponse(null, { status: 503 });
+          return HttpResponse.json({ id: 'u_1', email: 'a@b.c', name: 'A' });
+        }),
+      );
+
+      const { result } = renderHook(() => useCurrentUser(), { wrapper: makeWrapper() });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 5000 });
+      expect(result.current.isError).toBe(false);
+      expect(calls).toBeGreaterThanOrEqual(2);
+    });
+  });
+});

--- a/packages/playground/src/domains/auth/hooks/__tests__/use-current-user.test.tsx
+++ b/packages/playground/src/domains/auth/hooks/__tests__/use-current-user.test.tsx
@@ -31,11 +31,7 @@ const makeWrapper = () => {
 describe('useCurrentUser', () => {
   describe('when the server responds 200 with a user', () => {
     it('returns the user', async () => {
-      server.use(
-        http.get('*/api/auth/me', () =>
-          HttpResponse.json({ id: 'u_1', email: 'a@b.c', name: 'A' }),
-        ),
-      );
+      server.use(http.get('*/api/auth/me', () => HttpResponse.json({ id: 'u_1', email: 'a@b.c', name: 'A' })));
 
       const { result } = renderHook(() => useCurrentUser(), { wrapper: makeWrapper() });
 
@@ -46,9 +42,7 @@ describe('useCurrentUser', () => {
 
   describe('when the server responds 401', () => {
     it('surfaces isError immediately (terminal)', async () => {
-      server.use(
-        http.get('*/api/auth/me', () => new HttpResponse(null, { status: 401 })),
-      );
+      server.use(http.get('*/api/auth/me', () => new HttpResponse(null, { status: 401 })));
 
       const { result } = renderHook(() => useCurrentUser(), { wrapper: makeWrapper() });
 

--- a/packages/playground/src/domains/auth/hooks/fetch-with-refresh.ts
+++ b/packages/playground/src/domains/auth/hooks/fetch-with-refresh.ts
@@ -1,97 +1,37 @@
-let refreshPromise: Promise<boolean> | null = null;
-
 /**
- * Attempt to refresh the session via the Mastra server's auth refresh endpoint.
- * Returns true if the refresh succeeded (new cookie is set).
+ * Fetch wrapper for the Mastra server API.
+ *
+ * ⚠️  MIRRORS: `platform/frontend/src/shared/lib/fetch-with-refresh.ts`
+ *
+ * Both files must stay behaviourally in lockstep — the platform dashboard and
+ * the embedded playground both talk to WorkOS-backed auth and both would be
+ * vulnerable to the same 429 lockout loop if either regressed. If you change
+ * one, change the other in the same PR (or extract to a shared package —
+ * currently blocked by the platform/mastra-ai monorepo boundary).
+ *
+ * ---
+ *
+ * The server middleware already refreshes the WorkOS session transparently
+ * on every protected request. There is no scenario where the client can
+ * succeed by calling /auth/refresh after a 401 — that endpoint hits the
+ * same broken WorkOS with the same session and would only amplify transient
+ * failures into forced logout (PLTFRM-1270).
+ *
+ * These are pass-throughs today. The names and signatures are preserved for
+ * compatibility with existing call sites (`App.tsx`, `use-current-user.ts`).
+ * Transient-failure retry belongs one level up — in React Query's `retry`
+ * config on individual queries — not in a fetch wrapper that would compound
+ * with the query-level retry.
  */
-async function refreshSession(baseUrl: string, apiPrefix: string): Promise<boolean> {
-  try {
-    const res = await fetch(`${baseUrl}${apiPrefix}/auth/refresh`, {
-      method: 'POST',
-      credentials: 'include',
-    });
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
 
-/**
- * Fetch wrapper that automatically attempts to refresh the session on 401 errors.
- *
- * When a request returns 401, this will:
- * 1. Call /api/auth/refresh to get a fresh session cookie
- * 2. If refresh succeeds, retry the original request
- * 3. If refresh fails, return the original 401 response
- *
- * Concurrent 401s share the same refresh call to avoid multiple refresh attempts.
- *
- * @param baseUrl - The base URL of the Mastra server (e.g., from useMastraClient)
- * @param input - The URL or Request to fetch
- * @param init - Optional fetch init options
- * @returns The fetch response
- */
 export async function fetchWithRefresh(
-  baseUrl: string,
+  _baseUrl: string,
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<Response> {
-  // Normalize into a Request so we can clone it for retry (body streams are single-use)
-  const request = new Request(input, init);
-  const retry = request.clone();
-
-  const res = await fetch(request);
-
-  if (res.status !== 401) return res;
-
-  // Don't intercept the refresh call itself to avoid infinite loops
-  if (new URL(request.url).pathname.endsWith('/auth/refresh')) return res;
-
-  if (!refreshPromise) {
-    refreshPromise = refreshSession(baseUrl, '/api').finally(() => {
-      refreshPromise = null;
-    });
-  }
-
-  const refreshed = await refreshPromise;
-  if (!refreshed) return res;
-
-  // Retry with the cloned request (body intact)
-  return fetch(retry);
+  return fetch(input, init);
 }
 
-/**
- * Creates a fetch function that automatically refreshes the session on 401 errors.
- * This can be passed to MastraClient as the `fetch` option.
- *
- * @param baseUrl - The base URL of the Mastra server
- * @param apiPrefix - The API prefix (defaults to '/api')
- * @returns A fetch-compatible function that handles 401 refresh
- */
-export function createFetchWithRefresh(baseUrl: string, apiPrefix: string = '/api'): typeof fetch {
-  let localRefreshPromise: Promise<boolean> | null = null;
-
-  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const request = new Request(input, init);
-    const retry = request.clone();
-
-    const res = await fetch(request);
-
-    if (res.status !== 401) return res;
-
-    // Don't intercept the refresh call itself to avoid infinite loops
-    if (request.url.includes('/auth/refresh')) return res;
-
-    if (!localRefreshPromise) {
-      localRefreshPromise = refreshSession(baseUrl, apiPrefix).finally(() => {
-        localRefreshPromise = null;
-      });
-    }
-
-    const refreshed = await localRefreshPromise;
-    if (!refreshed) return res;
-
-    // Retry with the cloned request (body intact)
-    return fetch(retry);
-  };
+export function createFetchWithRefresh(_baseUrl?: string, _apiPrefix?: string): typeof fetch {
+  return (input, init) => fetch(input, init);
 }

--- a/packages/playground/src/domains/auth/hooks/use-current-user.ts
+++ b/packages/playground/src/domains/auth/hooks/use-current-user.ts
@@ -76,6 +76,6 @@ export function useCurrentUser() {
       if (error.status !== 503) return false;
       return failureCount < AUTH_TRANSIENT_MAX_RETRIES;
     },
-    retryDelay: (attemptIndex) => Math.min(AUTH_TRANSIENT_MAX_BACKOFF_MS, 500 * 2 ** attemptIndex),
+    retryDelay: attemptIndex => Math.min(AUTH_TRANSIENT_MAX_BACKOFF_MS, 500 * 2 ** attemptIndex),
   });
 }

--- a/packages/playground/src/domains/auth/hooks/use-current-user.ts
+++ b/packages/playground/src/domains/auth/hooks/use-current-user.ts
@@ -4,6 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 import type { CurrentUser } from '../types';
 import { fetchWithRefresh } from './fetch-with-refresh';
 
+const AUTH_TRANSIENT_MAX_RETRIES = 3;
+const AUTH_TRANSIENT_MAX_BACKOFF_MS = 8_000;
+
 export class CurrentUserError extends Error {
   constructor(public readonly status: number) {
     super(`Failed to fetch current user: ${status}`);
@@ -64,6 +67,15 @@ export function useCurrentUser() {
       return response.json();
     },
     staleTime: 60 * 1000, // Cache for 1 minute
-    retry: false,
+    // Retry the /api/auth/me query on transient auth-provider failures (HTTP 503)
+    // so the UI stays in `isLoading` instead of flipping to `isError` and
+    // triggering login — that redirect is what fed the WorkOS 429 lockout loop
+    // (PLTFRM-1270). 401 (terminal) still fails fast.
+    retry: (failureCount, error) => {
+      if (!(error instanceof CurrentUserError)) return false;
+      if (error.status !== 503) return false;
+      return failureCount < AUTH_TRANSIENT_MAX_RETRIES;
+    },
+    retryDelay: (attemptIndex) => Math.min(AUTH_TRANSIENT_MAX_BACKOFF_MS, 500 * 2 ** attemptIndex),
   });
 }


### PR DESCRIPTION
## Summary

Brings the embedded playground's auth query to parity with the platform dashboard's PLTFRM-1270 fix. The Mastra server middleware distinguishes **transient** auth-provider failures (`503`, with backoff-friendly semantics) from **terminal** auth failures (`401`), but playground's `useCurrentUser` had `retry: false` — so a single 503 flipped the query to `isError` and triggered the login flow. That redirect is what fed the WorkOS 429 per-visitor lockout loop.

## Changes

- `use-current-user.ts`: React Query retry config
  - 503 → retry up to 3 times with exponential backoff (500ms → 8s cap)
  - 401 → fail fast (unchanged, terminal)
  - 2xx → success (unchanged)
- `fetch-with-refresh.ts`: pure pass-through, with a mirroring header pointing at `platform/frontend/src/shared/lib/fetch-with-refresh.ts` so drift shows up in review. Retry belongs at React Query, not in the fetch wrapper — otherwise the two layers compound.

## Verification

```
pnpm --filter ./packages/playground exec vitest run \
  src/domains/auth/hooks/__tests__/use-current-user.test.tsx \
  src/domains/auth/hooks/__tests__/fetch-with-refresh.test.ts
```

- `use-current-user.test.tsx` (new, 3 tests): 200 success, 401 terminal (no retry), 503 → 200 (retries and recovers)
- `fetch-with-refresh.test.ts` (new, 5 tests): pass-through behavior, 401/503 propagation

All 8 tests green.

## Context

Pairs with:
- platform#2112 — server-side 503 vs 401 distinction with bounded retry
- platform#2113 — platform dashboard's `useAuth` React Query retry
- mastra#21772 — GitHub polling backoff to reduce steady-state load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The playground now retries temporary authentication problems but stops immediately when the user is not authenticated. This improves recovery from temporary server failures without delaying terminal failures.

## Changes

- Retry `/api/auth/me` HTTP 503 responses up to three times.
- Use exponential backoff with a maximum delay of 8 seconds.
- Fail immediately for HTTP 401 and other non-503 errors.
- Preserve existing 2xx success behavior.
- Make `fetch-with-refresh.ts` a direct `fetch` pass-through.
- Add a mirroring header that references the platform implementation.
- Add a patch changeset.

## Tests

- Add coverage for successful, 401, and 503 responses.
- Verify 503 recovery and status propagation.
- Verify single-fetch pass-through behavior.
- Verify that 401 responses do not trigger refresh requests.
- All 8 verification tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->