### PR TITLE
fix(factory): gate GitHub events on their real sender and deliver signals to the thread owner

### DIFF
--- a/.changeset/factory-app-identity.md
+++ b/.changeset/factory-app-identity.md
@@ -1,0 +1,20 @@
+---
+'@mastra/factory': patch
+---
+
+Stop Factory from waking itself on its own GitHub comments.
+
+Factory recognised its own writes by comparing the event sender against
+`GITHUB_APP_SLUG`. That variable names the deployment's own self-hosted GitHub
+App, which is a different App than the one a Platform deployment posts as — and
+on such a deployment it is legitimately unset, so the check compared against
+`undefined[bot]` and never matched. Every self-loop guard silently failed open.
+
+The visible result: triage published its handoff comment, that comment came back
+through ingress, re-invoked triage, and cancelled the run that had written it —
+leaving the public verdict stuck at "Pending" while both runs reported success.
+
+The Platform integration now names the App it actually posts as, overridable
+with `MASTRA_PLATFORM_GITHUB_APP_SLUG`, and identity resolution is centralised so
+an unresolved identity is reported as *unknown* rather than collapsing into
+"not Factory".

--- a/.changeset/factory-github-sender-gate.md
+++ b/.changeset/factory-github-sender-gate.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Check who sent a GitHub comment or review before letting it wake an agent, and ingest default-branch `push` events.
+
+The sender gate listed event kinds under names the webhook classifier never produces, so the identity check that keeps untrusted commenters from waking Factory agents was skipped for every comment and review event. The gate now names the kinds the classifier actually emits. Separately, `push` events were dropped by the event filter before ingestion; they are now ingested and forwarded to Factory's event pipeline so downstream consumers (such as the upcoming warm base-checkpoint refresh) can observe default-branch pushes.

--- a/.changeset/github-subscription-thread-ownership.md
+++ b/.changeset/github-subscription-thread-ownership.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Deliver GitHub pull request signals to the session that actually owns the subscribed thread, and skip subscriptions whose thread this deployment does not hold.
+
+A subscription records the Factory project as its resource, but an unscoped session registers under its own id, so delivery looked for the thread under a resource that did not own it and failed with "Thread not found" on every matching event. Delivery now reads the thread from storage to find its owning resource. A subscription naming a thread that is absent is skipped rather than failed, so a pull request's events reaching a deployment that never owned the thread no longer fabricate a session or retry in a loop.

--- a/mastracode/factory/src/integrations/github/app-identity.test.ts
+++ b/mastracode/factory/src/integrations/github/app-identity.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { GithubAppIdentity } from './app-identity.js';
+
+describe('GithubAppIdentity', () => {
+  it('recognises the App it was configured for', () => {
+    const identity = new GithubAppIdentity('mastra-platform');
+    expect(identity.known).toBe(true);
+    expect(identity.matches('mastra-platform[bot]')).toBe(true);
+  });
+
+  it('compares logins case-insensitively', () => {
+    const identity = new GithubAppIdentity('Mastra-Platform');
+    expect(identity.matches('mastra-platform[bot]')).toBe(true);
+    expect(identity.matches('MASTRA-PLATFORM[BOT]')).toBe(true);
+  });
+
+  it('does not mistake another App or a human for itself', () => {
+    const identity = new GithubAppIdentity('mastra-platform');
+    expect(identity.matches('dane-ai-mastra[bot]')).toBe(false);
+    expect(identity.matches('mastra-platform')).toBe(false);
+    expect(identity.matches('some-human')).toBe(false);
+  });
+
+  it('reports an unresolved identity as unknown rather than as "not Factory"', () => {
+    // The distinction is the whole point: an unset slug used to collapse into a
+    // `false` that silently disabled every self-loop guard. Callers that must
+    // not fail open have to be able to tell the two apart.
+    const identity = new GithubAppIdentity(undefined);
+    expect(identity.known).toBe(false);
+    expect(identity.login).toBeUndefined();
+    expect(identity.matches('mastra-platform[bot]')).toBe(false);
+  });
+
+  it('treats a blank slug as unresolved instead of building "[bot]"', () => {
+    expect(new GithubAppIdentity('   ').known).toBe(false);
+  });
+
+  it('learns its login from a write it made', () => {
+    const identity = new GithubAppIdentity(undefined);
+    identity.observeSelfAuthor('mastra-platform[bot]');
+    expect(identity.known).toBe(true);
+    expect(identity.matches('mastra-platform[bot]')).toBe(true);
+  });
+
+  it('prefers the observed login over the configured one', () => {
+    // Configuration is a claim about which App this is; the observed author is
+    // what GitHub actually attributed the write to.
+    const identity = new GithubAppIdentity('stale-app');
+    identity.observeSelfAuthor('mastra-platform[bot]');
+    expect(identity.matches('mastra-platform[bot]')).toBe(true);
+    expect(identity.matches('stale-app[bot]')).toBe(false);
+  });
+
+  it('ignores an empty observation rather than forgetting what it knew', () => {
+    const identity = new GithubAppIdentity('mastra-platform');
+    identity.observeSelfAuthor(null);
+    identity.observeSelfAuthor(undefined);
+    identity.observeSelfAuthor('  ');
+    expect(identity.matches('mastra-platform[bot]')).toBe(true);
+  });
+});

--- a/mastracode/factory/src/integrations/github/app-identity.ts
+++ b/mastracode/factory/src/integrations/github/app-identity.ts
@@ -1,0 +1,62 @@
+/**
+ * Factory's own GitHub identity.
+ *
+ * Factory must recognise its own writes, or it wakes itself: a handoff comment
+ * arrives back through ingress, fires the rule that authored it, and cancels the
+ * run mid-flight. Every self-loop guard depends on answering "is this me?".
+ *
+ * The answer is not free. On a Platform deployment the credentials that post as
+ * `mastra-platform[bot]` do not carry that login, and `GITHUB_APP_SLUG`
+ * describes a *different*, self-hosted App — so it is legitimately unset. A bare
+ * `login === `${slug}[bot]`` therefore compares against `undefined[bot]`, never
+ * matches, and silently disables every guard while looking correct.
+ *
+ * Two sources, in order of trust:
+ *
+ * 1. **Observed.** Every comment Factory creates comes back with its author.
+ *    That is authoritative, costs no extra request, and needs no configuration —
+ *    Factory learns its own name the first time it speaks.
+ * 2. **Configured.** `slug` from a self-hosted GitHub App, when present.
+ *
+ * When neither is available the identity is *unknown*, which is distinct from
+ * "not Factory". Callers must handle it explicitly rather than inherit a `false`.
+ */
+export class GithubAppIdentity {
+  #configuredLogin: string | undefined;
+  #observedLogin: string | undefined;
+
+  constructor(slug?: string) {
+    const trimmed = slug?.trim();
+    this.#configuredLogin = trimmed ? `${trimmed.toLowerCase()}[bot]` : undefined;
+  }
+
+  /** The login Factory posts as, or `undefined` when it cannot be determined. */
+  get login(): string | undefined {
+    return this.#observedLogin ?? this.#configuredLogin;
+  }
+
+  /** True once Factory can recognise its own writes. */
+  get known(): boolean {
+    return this.login !== undefined;
+  }
+
+  /**
+   * Record the author GitHub reported for a write Factory just made. Observed
+   * identity wins over configuration: it is what GitHub actually attributes the
+   * write to, whereas the slug is a claim about a possibly-different App.
+   */
+  observeSelfAuthor(login: string | null | undefined): void {
+    const trimmed = login?.trim().toLowerCase();
+    if (trimmed) this.#observedLogin = trimmed;
+  }
+
+  /**
+   * Whether `login` is Factory. Returns `false` when the identity is unknown —
+   * callers that must not fail open should check {@link known} first.
+   */
+  matches(login: string | null | undefined): boolean {
+    const self = this.login;
+    if (!self || !login) return false;
+    return login.trim().toLowerCase() === self;
+  }
+}

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -107,6 +107,7 @@ function projectRepositoryRow(row: Record<string, any>) {
     sandboxProvider: row.sandboxProvider ?? 'railway',
     sandboxWorkdir: row.sandboxWorkdir,
     setupCommand: row.setupCommand ?? null,
+    baseCheckpoint: row.baseCheckpoint ?? null,
     teardownCommand: row.teardownCommand ?? null,
     createdAt: now,
     updatedAt: now,
@@ -399,6 +400,7 @@ const ensureProjectSandbox = vi.fn(
     storage: SourceControlStorageInMemory['sandboxes'];
     token: string;
     onProgress?: (e: any) => void;
+    seedCheckpointName?: string;
   }) => {
     await opts.storage.setSandboxId({ id: opts.row.id, sandboxId: 'sb' });
     opts.onProgress?.({ phase: 'provisioning', message: 'Provisioning a new sandbox…' });
@@ -782,6 +784,9 @@ describe('webhook route', () => {
       sendNotificationSignal,
     };
     const controller = {
+      // Delivery confirms this deployment holds the subscribed thread and reads
+      // the resource that owns it; here that is the subscription's own resource.
+      queryThreadById: vi.fn(async ({ threadId }: { threadId: string }) => ({ id: threadId, resourceId: 'resource-1' })),
       getSessionByResource: vi.fn(async () => session),
       createSession: vi.fn(),
     } as unknown as NonNullable<Parameters<typeof buildGithubRoutes>[0]>['controller'];

--- a/mastracode/factory/src/integrations/github/webhook.test.ts
+++ b/mastracode/factory/src/integrations/github/webhook.test.ts
@@ -42,6 +42,23 @@ function parsed(event: string, action: string, extra: Record<string, unknown> = 
   };
 }
 
+/**
+ * Dispatch reads the subscribed thread from storage to decide whether this
+ * deployment owns it and which resource does. Tests that only care about
+ * delivery get a store where every thread exists under `resource-1`.
+ */
+function controllerStub(overrides: Record<string, unknown>, threads: Record<string, string> | 'all' = 'all') {
+  return {
+    queryThreadById: async ({ threadId }: { threadId: string }) =>
+      threads === 'all'
+        ? { id: threadId, resourceId: 'resource-1' }
+        : threads[threadId]
+          ? { id: threadId, resourceId: threads[threadId] }
+          : null,
+    ...overrides,
+  } as never;
+}
+
 function subscription(id: string, scope: string, threadId = `thread-${id}`): GithubSignalSubscriptionRow {
   return {
     id,
@@ -128,7 +145,7 @@ describe('dispatchGithubWebhook', () => {
       },
     );
 
-    expect(result).toEqual({ delivered: 0, failed: 0, ignored: true });
+    expect(result).toEqual({ delivered: 0, failed: 0, skipped: 0, ignored: true });
     expect(getRepositoryCollaboratorPermission).toHaveBeenCalledWith(7, 'octo/hello', 'ada', expect.any(AbortSignal));
     expect(listSubscriptions).not.toHaveBeenCalled();
   });
@@ -152,7 +169,7 @@ describe('dispatchGithubWebhook', () => {
 
       await vi.advanceTimersByTimeAsync(5_000);
 
-      await expect(result).resolves.toEqual({ delivered: 0, failed: 0, ignored: true });
+      await expect(result).resolves.toEqual({ delivered: 0, failed: 0, skipped: 0, ignored: true });
       expect(permissionSignal?.aborted).toBe(true);
       expect(listSubscriptions).not.toHaveBeenCalled();
     } finally {
@@ -174,6 +191,7 @@ describe('dispatchGithubWebhook', () => {
     ).resolves.toEqual({
       delivered: 0,
       failed: 0,
+      skipped: 0,
       ignored: true,
     });
     await expect(
@@ -181,9 +199,26 @@ describe('dispatchGithubWebhook', () => {
     ).resolves.toEqual({
       delivered: 0,
       failed: 0,
+      skipped: 0,
       ignored: false,
     });
     expect(listSubscriptions).toHaveBeenCalledTimes(1);
+    expect(getRepositoryCollaboratorPermission).not.toHaveBeenCalled();
+  });
+
+  it("admits Factory's own app login, which GitHub forces review verdicts through", async () => {
+    // GitHub refuses to let an app review its own pull request, so on
+    // Factory-authored PRs the verdict is posted as a comment under this login.
+    // Gating it out would strand the review handoff.
+    const listSubscriptions = vi.fn(async () => []);
+    const github = { ...githubWithSessionRow(null), slug: 'mastra-platform' };
+    const verdict = parsed('issue_comment', 'created', {
+      sender: { login: 'mastra-platform[bot]', type: 'Bot' },
+    });
+
+    await expect(dispatchGithubWebhook(verdict, { controller: {} as never, github, listSubscriptions })).resolves.toEqual(
+      { delivered: 0, failed: 0, skipped: 0, ignored: false },
+    );
     expect(getRepositoryCollaboratorPermission).not.toHaveBeenCalled();
   });
 
@@ -197,7 +232,7 @@ describe('dispatchGithubWebhook', () => {
 
     await expect(
       dispatchGithubWebhook(notification, { controller: {} as never, github, listSubscriptions }),
-    ).resolves.toEqual({ delivered: 0, failed: 0, ignored: false });
+    ).resolves.toEqual({ delivered: 0, failed: 0, skipped: 0, ignored: false });
     // The configured list extends the defaults rather than replacing them.
     await expect(
       dispatchGithubWebhook(
@@ -207,7 +242,7 @@ describe('dispatchGithubWebhook', () => {
         }),
         { controller: {} as never, github, listSubscriptions },
       ),
-    ).resolves.toEqual({ delivered: 0, failed: 0, ignored: false });
+    ).resolves.toEqual({ delivered: 0, failed: 0, skipped: 0, ignored: false });
     expect(getRepositoryCollaboratorPermission).not.toHaveBeenCalled();
   });
 
@@ -248,14 +283,14 @@ describe('dispatchGithubWebhook', () => {
         pull_request: undefined,
       }),
       {
-        controller: { getSessionByResource, createSession } as never,
+        controller: controllerStub({ getSessionByResource, createSession }),
         github: githubWithSessionRow({ userId: 'user-1', orgId: 'org-1' }, getBySessionId),
         listSubscriptions: async () => rows,
         isAuthorizedSender: async () => true,
       },
     );
 
-    expect(result).toEqual({ delivered: 2, failed: 0, ignored: false });
+    expect(result).toEqual({ delivered: 2, failed: 0, skipped: 0, ignored: false });
     expect(getSessionByResource).toHaveBeenCalledWith('resource-1', '/worktrees/a');
     expect(getBySessionId).toHaveBeenCalledOnce();
     expect(getBySessionId).toHaveBeenCalledWith('session-b');
@@ -299,14 +334,14 @@ describe('dispatchGithubWebhook', () => {
         pull_request: undefined,
       }),
       {
-        controller: { getSessionByResource: async () => undefined, createSession } as never,
+        controller: controllerStub({ getSessionByResource: async () => undefined, createSession }),
         github: githubWithSessionRow(null),
         listSubscriptions: async () => [subscription('a', '/worktrees/a')],
         isAuthorizedSender: async () => true,
       },
     );
 
-    expect(result).toEqual({ delivered: 0, failed: 1, ignored: false });
+    expect(result).toEqual({ delivered: 0, failed: 1, skipped: 0, ignored: false });
     expect(createSession).not.toHaveBeenCalled();
   });
 
@@ -319,7 +354,7 @@ describe('dispatchGithubWebhook', () => {
     const session = { thread: { getId: () => currentThread, switch: switchThread }, sendNotificationSignal: send };
 
     await dispatchGithubWebhook(parsed('pull_request', 'synchronize'), {
-      controller: { getSessionByResource: async () => session, createSession: vi.fn() } as never,
+      controller: controllerStub({ getSessionByResource: async () => session, createSession: vi.fn() }),
       listSubscriptions: async () => [subscription('a', '/worktrees/a')],
     });
 
@@ -333,13 +368,13 @@ describe('dispatchGithubWebhook', () => {
     const updateStatus = vi.fn(async () => {});
 
     await dispatchGithubWebhook(parsed('pull_request', 'reopened'), {
-      controller: {
+      controller: controllerStub({
         getSessionByResource: async () => ({
           thread: { getId: () => 'thread-a', switch: vi.fn() },
           sendNotificationSignal: send,
         }),
         createSession: vi.fn(),
-      } as never,
+      }),
       listSubscriptions,
       retireSubscription: updateStatus,
     });
@@ -375,32 +410,74 @@ describe('dispatchGithubWebhook', () => {
     const result = await dispatchGithubWebhook(
       parsed('pull_request', 'closed', { pull_request: { number: 34, merged: true } }),
       {
-        controller: {
+        controller: controllerStub({
           getSessionByResource: async (_resourceId: string, scope?: string) =>
             scope === '/worktrees/a' ? success : failure,
           createSession: vi.fn(),
-        } as never,
+        }),
         listSubscriptions: async () => [subscription('a', '/worktrees/a'), subscription('b', '/worktrees/b')],
         retireSubscription: retire,
         onTargetError,
       },
     );
 
-    expect(result).toEqual({ delivered: 1, failed: 1, ignored: false });
+    expect(result).toEqual({ delivered: 1, failed: 1, skipped: 0, ignored: false });
     expect(retire).toHaveBeenCalledOnce();
     expect(retire).toHaveBeenCalledWith('a', 'merged');
     expect(order.at(-1)).toBe('retired:a');
     expect(onTargetError).toHaveBeenCalledWith(expect.objectContaining({ id: 'b' }), expect.any(Error));
   });
 
+  it('skips a subscription whose thread this deployment does not hold', async () => {
+    const getSessionByResource = vi.fn();
+    const createSession = vi.fn();
+    const onTargetSkipped = vi.fn();
+    const retire = vi.fn(async () => {});
+
+    const result = await dispatchGithubWebhook(parsed('pull_request', 'synchronize'), {
+      // The subscribed thread is absent from storage: the row points somewhere
+      // this deployment cannot reach.
+      controller: controllerStub({ getSessionByResource, createSession }, {}),
+      listSubscriptions: async () => [subscription('a', '/worktrees/a')],
+      retireSubscription: retire,
+      onTargetSkipped,
+    });
+
+    // Skipping is not a failure, so nothing is retried or reported as broken.
+    expect(result).toEqual({ delivered: 0, failed: 0, skipped: 1, ignored: false });
+    expect(onTargetSkipped).toHaveBeenCalledWith(expect.objectContaining({ id: 'a' }));
+    // Never fabricate a session for a thread we do not have...
+    expect(createSession).not.toHaveBeenCalled();
+    expect(getSessionByResource).not.toHaveBeenCalled();
+    // ...and leave the row alone, since the thread may live where it was made.
+    expect(retire).not.toHaveBeenCalled();
+  });
+
+  it('resolves the session by the resource that owns the thread, not the stored one', async () => {
+    const send = vi.fn(async () => ({ record: { id: 'n-1' }, decision: { action: 'deliver' } }));
+    const session = { thread: { getId: () => 'thread-a', switch: vi.fn() }, sendNotificationSignal: send };
+    const getSessionByResource = vi.fn(async () => session);
+
+    const result = await dispatchGithubWebhook(parsed('pull_request', 'synchronize'), {
+      // An unscoped session registers under its own id, so the subscription's
+      // stored 'resource-1' names a resource that does not own the thread.
+      controller: controllerStub({ getSessionByResource, createSession: vi.fn() }, { 'thread-a': 'session-a' }),
+      listSubscriptions: async () => [subscription('a', '/worktrees/a')],
+    });
+
+    expect(getSessionByResource).toHaveBeenCalledWith('session-a', '/worktrees/a');
+    expect(result).toEqual({ delivered: 1, failed: 0, skipped: 0, ignored: false });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
   it('does nothing when no subscription exists', async () => {
     const controller = { getSessionByResource: vi.fn(), createSession: vi.fn() };
     const result = await dispatchGithubWebhook(parsed('pull_request', 'edited'), {
-      controller: controller as never,
+      controller: controllerStub(controller),
       listSubscriptions: async () => [],
     });
 
-    expect(result).toEqual({ delivered: 0, failed: 0, ignored: false });
+    expect(result).toEqual({ delivered: 0, failed: 0, skipped: 0, ignored: false });
     expect(controller.getSessionByResource).not.toHaveBeenCalled();
   });
 });

--- a/mastracode/factory/src/integrations/github/webhook.ts
+++ b/mastracode/factory/src/integrations/github/webhook.ts
@@ -3,6 +3,7 @@ import type { MountedMastraCode } from '@mastra/code-sdk';
 import type { NotificationPriority } from '@mastra/core/notifications';
 import { RequestContext } from '@mastra/core/request-context';
 import type { Context } from 'hono';
+import { GithubAppIdentity } from './app-identity.js';
 import type { GithubIntegration, GithubRepositoryPermission } from './integration.js';
 import { listPullRequestSubscriptionsForWebhook, retirePullRequestSubscription } from './subscriptions.js';
 import type {
@@ -23,6 +24,9 @@ const SUPPORTED_GITHUB_WEBHOOK_EVENTS = new Set([
   'pull_request',
   'pull_request_review',
   'pull_request_review_comment',
+  // Direct pushes to the default branch drive base-checkpoint rebuilds. The
+  // rules engine and subscription dispatcher both ignore push events.
+  'push',
 ]);
 
 export interface GithubWebhookMetadata {
@@ -68,6 +72,14 @@ export type FactorySessionOwner = { userId: string; orgId: string };
  * much is common to both.
  */
 export interface GithubWebhookDispatchIntegration {
+  /** App slug, used to recognize Factory's own bot identity. */
+  readonly slug?: string;
+  /**
+   * Resolved identity of the App this integration posts as. Preferred over
+   * {@link slug}, which names the deployment's own self-hosted App and is unset
+   * on deployments that run against Platform's App.
+   */
+  readonly identity?: GithubAppIdentity;
   readonly integrationStorage: GithubSubscriptionStorage;
   /**
    * Extra bot logins this deployment authorizes to trigger author-gated
@@ -103,6 +115,8 @@ export interface GithubWebhookDispatchDependencies {
   /** Called when the sender gate drops a notification, so the drop is observable. */
   onSenderRejected?: (notification: GithubWebhookNotification) => void;
   onTargetError?: (subscription: GithubSignalSubscriptionRow, error: unknown) => void;
+  /** Called when a subscription names a thread this deployment does not hold. */
+  onTargetSkipped?: (subscription: GithubSignalSubscriptionRow) => void;
 }
 
 function normalizeHeader(value: string | undefined | null): string | null {
@@ -321,8 +335,23 @@ async function resolveSubscriptionSession(
   if (!sessionId || !resourceId || !threadId) {
     throw new Error(`GitHub subscription ${subscription.id} is missing its session binding.`);
   }
+  // Read the thread straight from storage before touching sessions. This answers
+  // two questions at once, and `queryThreadById` does it without constructing a
+  // session (so no workspace or sandbox is provisioned just to make the check).
+  //
+  // First: do we even have this thread? A pull request's events can reach a
+  // deployment that never owned the subscribed thread, and delivery must not
+  // fabricate a session for a thread that lives somewhere else.
+  //
+  // Second: which resource owns it? The subscription records the Factory project
+  // as its `resourceId`, but an unscoped session is registered under its own id,
+  // so the stored value routinely names a resource that does not own the thread.
+  // The thread row is the authoritative answer; the stored id is only a fallback.
+  const thread = await controller.queryThreadById({ threadId });
+  if (!thread) return undefined;
+  const ownerResourceId = thread.resourceId || resourceId;
   const scope = subscription.sessionScope || undefined;
-  let session = await controller.getSessionByResource(resourceId, scope);
+  let session = await controller.getSessionByResource(ownerResourceId, scope);
   if (!session) {
     const tags = {
       factoryProjectId: resourceId,
@@ -331,8 +360,9 @@ async function resolveSubscriptionSession(
     };
     // Creating the session resolves its workspace, which authorizes the caller
     // against the Factory session row — no signed-in user, so run as its owner.
-    // The controller resource is the Factory project for scoped sessions; the
-    // persisted Factory session is keyed by the subscription's session ID.
+    // The session is created under the resource that owns the thread, so the
+    // thread switch below resolves; the persisted Factory session is keyed by
+    // the subscription's session ID.
     const sessionRow = await github?.sourceControlStorage.sessions.getBySessionId(sessionId);
     if (!sessionRow) {
       throw new Error(`GitHub subscription ${subscription.id} has no Factory session ${sessionId} to run as.`);
@@ -342,7 +372,7 @@ async function resolveSubscriptionSession(
     session = await controller.createSession({
       id: sessionId,
       ownerId: sessionRow.userId,
-      resourceId,
+      resourceId: ownerResourceId,
       scope,
       tags,
       requestContext,
@@ -396,14 +426,33 @@ const AUTHOR_GATED_KINDS = new Set([
   'review-dismissed',
 ]);
 
+/**
+ * Recognizes Factory's own GitHub App identity. GitHub forbids an app from
+ * reviewing a pull request it authored, so `factory-review` falls back to
+ * posting its verdict as a comment under this login. Those comments have to
+ * clear the author gate for the review handoff to reach the authoring agent;
+ * the rules layer still decides which of them are worth acting on.
+ */
+export function isFactoryAppSender(sender: string | undefined, slug: string | undefined): boolean {
+  if (!sender || !slug) return false;
+  return sender.toLowerCase() === `${slug.toLowerCase()}[bot]`;
+}
+
 async function isAuthorizedGithubSender(
   notification: GithubWebhookNotification,
-  github: Pick<GithubWebhookDispatchIntegration, 'getRepositoryCollaboratorPermission' | 'authorizedBots'> | undefined,
+  github:
+    | Pick<
+        GithubWebhookDispatchIntegration,
+        'getRepositoryCollaboratorPermission' | 'slug' | 'identity' | 'authorizedBots'
+      >
+    | undefined,
 ): Promise<boolean> {
   if (!AUTHOR_GATED_KINDS.has(notification.kind)) return true;
   const sender = notification.metadata.sender;
   const repository = notification.metadata.repository;
   if (!sender || !repository) return false;
+  if (github?.identity?.matches(sender)) return true;
+  if (isFactoryAppSender(sender, github?.slug)) return true;
   const normalizedSender = sender.toLowerCase();
   if (notification.metadata.senderType?.toLowerCase() === 'bot' || normalizedSender.endsWith('[bot]')) {
     return resolveAuthorizedBots(github?.authorizedBots).has(normalizedSender);
@@ -437,15 +486,15 @@ async function isAuthorizedGithubSender(
 export async function dispatchGithubWebhook(
   parsed: ParsedGithubWebhook,
   dependencies: GithubWebhookDispatchDependencies,
-): Promise<{ delivered: number; failed: number; ignored: boolean }> {
+): Promise<{ delivered: number; failed: number; skipped: number; ignored: boolean }> {
   const notification = classifyGithubWebhook(parsed);
-  if (!notification) return { delivered: 0, failed: 0, ignored: true };
+  if (!notification) return { delivered: 0, failed: 0, skipped: 0, ignored: true };
   const isAuthorizedSender =
     dependencies.isAuthorizedSender ??
     ((n: GithubWebhookNotification) => isAuthorizedGithubSender(n, dependencies.github));
   if (!(await isAuthorizedSender(notification))) {
     dependencies.onSenderRejected?.(notification);
-    return { delivered: 0, failed: 0, ignored: true };
+    return { delivered: 0, failed: 0, skipped: 0, ignored: true };
   }
 
   const target = {
@@ -472,10 +521,20 @@ export async function dispatchGithubWebhook(
   const subscriptions = await listSubscriptions(target, { includeTerminal: notification.action === 'reopened' });
   let delivered = 0;
   let failed = 0;
+  let skipped = 0;
 
   for (const subscription of subscriptions) {
     try {
       const session = await resolveSubscriptionSession(dependencies.controller, subscription, dependencies.github);
+      // No session means this deployment does not hold the subscribed thread.
+      // That is not a delivery failure, so it must not be retried or counted as
+      // one; the subscription is left untouched because the thread may exist
+      // wherever the subscription was created.
+      if (!session) {
+        skipped += 1;
+        dependencies.onTargetSkipped?.(subscription);
+        continue;
+      }
       const result = await session.sendNotificationSignal({
         source: 'github',
         kind: notification.kind,
@@ -508,7 +567,7 @@ export async function dispatchGithubWebhook(
     }
   }
 
-  return { delivered, failed, ignored: false };
+  return { delivered, failed, skipped, ignored: false };
 }
 
 export async function handleGithubWebhook(

--- a/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
@@ -10,6 +10,9 @@ import { PlatformGithubIntegration } from './integration.js';
 
 const harness = vi.hoisted(() => {
   let mastra: Mastra | undefined;
+  // The resource that owns the subscribed thread. A scoped session is registered
+  // under its Factory project, so tests point this at the project under test.
+  let threadResourceId = 'resource-1';
   const sendNotificationSignal = vi.fn(async () => ({
     record: { id: 'notification-1' },
     decision: { action: 'deliver' as const },
@@ -25,6 +28,9 @@ const harness = vi.hoisted(() => {
       mastra = instance;
     }),
     getMastra: vi.fn(() => mastra),
+    // Delivery reads the subscribed thread first to confirm this deployment
+    // holds it and to learn which resource owns it.
+    queryThreadById: vi.fn(async ({ threadId }: { threadId: string }) => ({ id: threadId, resourceId: threadResourceId })),
     getSessionByResource: vi.fn<() => Promise<typeof session | undefined>>(async () => session),
     createSession: vi.fn(async (_input: { requestContext: { get(key: string): unknown } }) => session),
     onSessionCreated: vi.fn(),
@@ -35,8 +41,12 @@ const harness = vi.hoisted(() => {
   return {
     controller,
     sendNotificationSignal,
+    ownThreadWith(resourceId: string) {
+      threadResourceId = resourceId;
+    },
     reset() {
       mastra = undefined;
+      threadResourceId = 'resource-1';
       vi.clearAllMocks();
     },
   };
@@ -184,6 +194,9 @@ describe('Platform GitHub event worker factory lifecycle', () => {
         github.integrationStorage,
       );
 
+      // This subscription is scoped to a worktree, so its thread is owned by the
+      // Factory project resource that the session is created under below.
+      harness.ownThreadWith(factoryProject.id);
       harness.controller.getSessionByResource.mockResolvedValueOnce(undefined);
       const mastra = new Mastra(args);
       await factory.finalize();

--- a/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
@@ -139,6 +139,7 @@ describe('PlatformGithubEventWorker', () => {
     const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
       delivered: 1,
       failed: 0,
+      skipped: 0,
       ignored: false,
     });
     const ingestFactoryEvent = vi.fn(async () => ({ status: 'committed' }));
@@ -161,6 +162,12 @@ describe('PlatformGithubEventWorker', () => {
                 payload: { action: 'opened' },
               },
               {
+                id: '1000-1',
+                deliveryId: 'delivery-pr-opened',
+                event: 'pull_request',
+                payload: { action: 'opened' },
+              },
+              {
                 id: '1001-0',
                 deliveryId: 'delivery-sync',
                 event: 'pull_request',
@@ -178,8 +185,14 @@ describe('PlatformGithubEventWorker', () => {
                 event: 'pull_request',
                 payload: { action: 'closed' },
               },
+              {
+                id: '1004-0',
+                deliveryId: 'delivery-push',
+                event: 'push',
+                payload: { ref: 'refs/heads/main' },
+              },
             ],
-            nextCursor: '1003-0',
+            nextCursor: '1004-0',
           });
         }
         return json({ events: [], nextCursor: null });
@@ -198,6 +211,11 @@ describe('PlatformGithubEventWorker', () => {
     await worker.start();
     await vi.advanceTimersByTimeAsync(0);
 
+    const parsedPullRequestOpened = {
+      event: 'pull_request',
+      deliveryId: 'delivery-pr-opened',
+      payload: { action: 'opened' },
+    };
     const parsedSynchronize = {
       event: 'pull_request',
       deliveryId: 'delivery-sync',
@@ -213,20 +231,29 @@ describe('PlatformGithubEventWorker', () => {
       deliveryId: 'delivery-1',
       payload: { action: 'closed' },
     };
+    const parsedPush = {
+      event: 'push',
+      deliveryId: 'delivery-push',
+      payload: { ref: 'refs/heads/main' },
+    };
     const dispatchDependencies = expect.objectContaining({
       controller: expect.anything(),
       listSubscriptions: expect.any(Function),
       retireSubscription: expect.any(Function),
       isAuthorizedSender: expect.any(Function),
     });
-    // Synchronize and review_requested feed the re-review path; closed feeds
-    // the reconciler. opened is dispatched to subscribers but not ingested by
-    // the factory rules — the factory picks up new work through the reconciler.
-    expect(ingestFactoryEvent).toHaveBeenCalledTimes(3);
-    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(1, parsedSynchronize);
-    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(2, parsedReviewRequested);
-    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(3, parsedClosed);
-    expect(dispatch).toHaveBeenCalledTimes(4);
+    // A pull request being opened is what mints its Review card, so it has to
+    // reach the rules engine; synchronize and review_requested feed the
+    // re-review path, and closed feeds the reconciler. An opened *issue* is
+    // deliberately absent — the factory picks new issues up via the reconciler.
+    // Pushes feed the base-checkpoint trigger wrapped around the ingest.
+    expect(ingestFactoryEvent).toHaveBeenCalledTimes(5);
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(1, parsedPullRequestOpened);
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(2, parsedSynchronize);
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(3, parsedReviewRequested);
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(4, parsedClosed);
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(5, parsedPush);
+    expect(dispatch).toHaveBeenCalledTimes(6);
     expect(dispatch).toHaveBeenNthCalledWith(
       1,
       {
@@ -236,14 +263,16 @@ describe('PlatformGithubEventWorker', () => {
       },
       dispatchDependencies,
     );
-    expect(dispatch).toHaveBeenNthCalledWith(2, parsedSynchronize, dispatchDependencies);
-    expect(dispatch).toHaveBeenNthCalledWith(3, parsedReviewRequested, dispatchDependencies);
-    expect(dispatch).toHaveBeenNthCalledWith(4, parsedClosed, dispatchDependencies);
+    expect(dispatch).toHaveBeenNthCalledWith(2, parsedPullRequestOpened, dispatchDependencies);
+    expect(dispatch).toHaveBeenNthCalledWith(3, parsedSynchronize, dispatchDependencies);
+    expect(dispatch).toHaveBeenNthCalledWith(4, parsedReviewRequested, dispatchDependencies);
+    expect(dispatch).toHaveBeenNthCalledWith(5, parsedClosed, dispatchDependencies);
+    expect(dispatch).toHaveBeenNthCalledWith(6, parsedPush, dispatchDependencies);
     expect(eventRequests[0]?.searchParams.get('afterTimestamp')).toBe('999');
-    expect(eventRequests[1]?.searchParams.get('afterEventId')).toBe('1003-0');
+    expect(eventRequests[1]?.searchParams.get('afterEventId')).toBe('1004-0');
     expect(settings.read()).toEqual({
       version: 1,
-      repositories: { '101': { afterEventId: '1003-0' } },
+      repositories: { '101': { afterEventId: '1004-0' } },
     });
     await worker.stop();
 
@@ -253,17 +282,94 @@ describe('PlatformGithubEventWorker', () => {
     await resumed.start();
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(eventRequests[0]?.searchParams.get('afterEventId')).toBe('1003-0');
+    expect(eventRequests[0]?.searchParams.get('afterEventId')).toBe('1004-0');
     expect(eventRequests[0]?.searchParams.has('afterTimestamp')).toBe(false);
     await resumed.stop();
+  });
+
+  it('hands review feedback to the factory rules so the authoring agent is woken', async () => {
+    const settings = createSettingsStorage();
+    const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
+      delivered: 1,
+      failed: 0,
+      skipped: 0,
+      ignored: false,
+    });
+    const ingestFactoryEvent = vi.fn(async () => ({ status: 'committed' }));
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/installations')) {
+        return json({ installations: [{ installationId: 7, usable: true, suspendedAt: null }] });
+      }
+      if (url.pathname.endsWith('/installations/7/repositories')) {
+        return json({ repositories: [{ id: 101 }] });
+      }
+      if (url.pathname.endsWith('/repositories/101/events')) {
+        if (url.searchParams.has('afterTimestamp')) {
+          return json({
+            events: [
+              {
+                id: '2000-0',
+                deliveryId: 'delivery-review',
+                event: 'pull_request_review',
+                payload: { action: 'submitted' },
+              },
+              {
+                id: '2001-0',
+                deliveryId: 'delivery-comment',
+                event: 'issue_comment',
+                payload: { action: 'created' },
+              },
+              {
+                id: '2002-0',
+                deliveryId: 'delivery-comment-edited',
+                event: 'issue_comment',
+                payload: { action: 'edited' },
+              },
+            ],
+            nextCursor: '2002-0',
+          });
+        }
+        return json({ events: [], nextCursor: null });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const worker = createWorker({
+      fetchImpl,
+      storage: settings.storage,
+      now: () => 1_000,
+      dispatch,
+      ingestFactoryEvent,
+    });
+
+    await worker.init(createDeps());
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // A submitted review and a new pull-request comment are the two ways review
+    // feedback reaches the agent that authored the branch. Comment edits stay
+    // with the subscription dispatcher — re-waking on an edit would double-fire.
+    expect(ingestFactoryEvent).toHaveBeenCalledTimes(2);
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(1, {
+      event: 'pull_request_review',
+      deliveryId: 'delivery-review',
+      payload: { action: 'submitted' },
+    });
+    expect(ingestFactoryEvent).toHaveBeenNthCalledWith(2, {
+      event: 'issue_comment',
+      deliveryId: 'delivery-comment',
+      payload: { action: 'created' },
+    });
+    expect(dispatch).toHaveBeenCalledTimes(3);
+    await worker.stop();
   });
 
   it('advances the cursor when one subscription fails so the bad target does not poison later events', async () => {
     const settings = createSettingsStorage();
     const dispatch = vi
       .fn<typeof dispatchGithubWebhook>()
-      .mockResolvedValueOnce({ delivered: 1, failed: 1, ignored: false })
-      .mockResolvedValue({ delivered: 1, failed: 0, ignored: false });
+      .mockResolvedValueOnce({ delivered: 1, failed: 1, skipped: 0, ignored: false })
+      .mockResolvedValue({ delivered: 1, failed: 0, skipped: 0, ignored: false });
     const eventCursors: string[] = [];
     const fetchImpl = vi.fn<typeof fetch>(async input => {
       const url = new URL(String(input));
@@ -337,6 +443,7 @@ describe('PlatformGithubEventWorker', () => {
     const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
       delivered: 1,
       failed: 0,
+      skipped: 0,
       ignored: false,
     });
     const fetchImpl = vi.fn<typeof fetch>(async input => {
@@ -378,6 +485,7 @@ describe('PlatformGithubEventWorker', () => {
     const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
       delivered: 1,
       failed: 0,
+      skipped: 0,
       ignored: false,
     });
     const eventCursors: string[] = [];
@@ -882,9 +990,9 @@ describe('PlatformGithubEventWorker', () => {
   });
 
   describe('sender gate', () => {
-    function notification(sender: string, senderType = 'Bot') {
+    function notification(sender: string, senderType = 'Bot', kind = 'review-changes-requested') {
       return {
-        kind: 'pull-request-review',
+        kind,
         metadata: {
           sender,
           senderType,
@@ -900,6 +1008,7 @@ describe('PlatformGithubEventWorker', () => {
       const dispatch = vi.fn<typeof dispatchGithubWebhook>().mockResolvedValue({
         delivered: 1,
         failed: 0,
+        skipped: 0,
         ignored: false,
       });
       const fetchImpl = vi.fn<typeof fetch>(async input => {
@@ -965,6 +1074,29 @@ describe('PlatformGithubEventWorker', () => {
       expect(github.getRepositoryCollaboratorPermission).not.toHaveBeenCalled();
     });
 
+    it('gates the kinds the webhook classifier actually emits', async () => {
+      const github = createGithub();
+      const { dependencies } = await captureGate(github);
+
+      // Sender-authored kinds emitted by classifyGithubWebhook must hit the gate.
+      for (const kind of [
+        'issue-comment-created',
+        'review-comment-created',
+        'review-approved',
+        'review-changes-requested',
+        'review-submitted',
+        'review-dismissed',
+      ]) {
+        await expect(dependencies.isAuthorizedSender?.(notification('other-reviewer[bot]', 'Bot', kind))).resolves.toBe(
+          false,
+        );
+      }
+      // Non-authored lifecycle kinds bypass the gate.
+      await expect(
+        dependencies.isAuthorizedSender?.(notification('other-reviewer[bot]', 'Bot', 'pull-request-merged')),
+      ).resolves.toBe(true);
+    });
+
     it('still permission-checks human senders', async () => {
       const github = createGithub();
       const { dependencies } = await captureGate(github);
@@ -985,7 +1117,7 @@ describe('PlatformGithubEventWorker', () => {
 
       expect(deps.logger.debug).toHaveBeenCalledWith(
         'Platform GitHub event dropped: sender not authorized',
-        expect.objectContaining({ sender: 'openswebot', repository: 'acme/repo', kind: 'pull-request-review' }),
+        expect.objectContaining({ sender: 'openswebot', repository: 'acme/repo', kind: 'review-changes-requested' }),
       );
     });
   });

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -12,7 +12,7 @@ import type { GithubIssueReconciler } from '../../github/issue-reconciler.js';
 import type { GithubReconcileRepositorySource } from '../../github/reconcile-worker.js';
 import type { GithubPullRequestReconciler, ReconcileRepository } from '../../github/rules.js';
 import { listPullRequestSubscriptionsForWebhook, retirePullRequestSubscription } from '../../github/subscriptions.js';
-import { dispatchGithubWebhook, resolveAuthorizedBots } from '../../github/webhook.js';
+import { dispatchGithubWebhook, isFactoryAppSender, resolveAuthorizedBots } from '../../github/webhook.js';
 import type {
   GithubWebhookDispatchIntegration,
   GithubWebhookNotification,
@@ -34,12 +34,19 @@ const SUPPORTED_EVENTS = new Set([
   'pull_request',
   'pull_request_review',
   'pull_request_review_comment',
+  // Pushes never reach the subscription dispatcher; they feed the factory
+  // ingest path so base checkpoints rebuild on default-branch updates.
+  'push',
 ]);
+// Kinds emitted by `classifyGithubWebhook` that carry untrusted sender-authored
+// content and must pass the sender authorization gate below.
 const AUTHOR_GATED_KINDS = new Set([
-  'issue-comment',
-  'pull-request-comment',
-  'pull-request-review',
-  'pull-request-review-comment',
+  'issue-comment-created',
+  'review-comment-created',
+  'review-approved',
+  'review-changes-requested',
+  'review-submitted',
+  'review-dismissed',
 ]);
 const AUTHORIZED_PERMISSIONS = new Set<GithubRepositoryPermission>(['admin', 'maintain', 'write']);
 const PERMISSION_CHECK_TIMEOUT_MS = 5_000;
@@ -83,6 +90,8 @@ export interface PlatformGithubEventWorkerConfig {
   ingestFactoryEvent?: (event: ParsedGithubWebhook) => Promise<unknown>;
   reconcileFactoryState?: GithubPullRequestReconciler;
   reconcileIssuesFactoryState?: GithubIssueReconciler;
+  /** Base-checkpoint freshness sweep, run after the reconcilers within the lease. */
+  sweepBaseCheckpoints?: () => Promise<void>;
   /** When false the worker skips event tailing and only runs enabled reconciliation sweeps. */
   pollEventsEnabled?: boolean;
   intervalMs?: number;
@@ -104,6 +113,7 @@ export class PlatformGithubEventWorker extends MastraWorker {
   readonly #ingestFactoryEvent: ((event: ParsedGithubWebhook) => Promise<unknown>) | undefined;
   readonly #reconcileFactoryState: GithubPullRequestReconciler | undefined;
   readonly #reconcileIssuesFactoryState: GithubIssueReconciler | undefined;
+  readonly #sweepBaseCheckpoints: (() => Promise<void>) | undefined;
   readonly #pollEventsEnabled: boolean;
   readonly #pullRequestReconcileIntervalMs: number;
   readonly #issueReconcileIntervalMs: number;
@@ -134,6 +144,7 @@ export class PlatformGithubEventWorker extends MastraWorker {
     this.#ingestFactoryEvent = config.ingestFactoryEvent;
     this.#reconcileFactoryState = config.reconcileFactoryState;
     this.#reconcileIssuesFactoryState = config.reconcileIssuesFactoryState;
+    this.#sweepBaseCheckpoints = config.sweepBaseCheckpoints;
     this.#pollEventsEnabled = config.pollEventsEnabled ?? true;
     const legacyReconcileIntervalMs = config.reconcileIntervalMs ?? DEFAULT_RECONCILE_INTERVAL_MS;
     this.#pullRequestReconcileIntervalMs = config.pullRequestReconcileIntervalMs ?? legacyReconcileIntervalMs;
@@ -363,6 +374,16 @@ export class PlatformGithubEventWorker extends MastraWorker {
         });
       }
     }
+
+    if (this.#sweepBaseCheckpoints && this.#hasLease) {
+      try {
+        await this.#sweepBaseCheckpoints();
+      } catch (error) {
+        this.deps?.logger.warn('Platform GitHub base-checkpoint freshness sweep failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
   }
 
   /**
@@ -450,6 +471,15 @@ export class PlatformGithubEventWorker extends MastraWorker {
             retirePullRequestSubscription(id, status, this.#github.integrationStorage),
           github: this.#github,
           isAuthorizedSender: notification => this.#isAuthorizedSender(notification),
+          onTargetSkipped: subscription => {
+            // Routine when a subscription's thread belongs to another
+            // deployment, so this stays at debug rather than warning on a loop.
+            this.deps?.logger.debug('Platform GitHub event skipped: thread is not held here', {
+              deliveryId: event.deliveryId,
+              subscriptionId: subscription.id,
+              threadId: subscription.threadId,
+            });
+          },
           onSenderRejected: notification => {
             this.deps?.logger.debug('Platform GitHub event dropped: sender not authorized', {
               deliveryId: event.deliveryId,
@@ -489,6 +519,13 @@ export class PlatformGithubEventWorker extends MastraWorker {
     const sender = notification.metadata.sender;
     const repository = notification.metadata.repository;
     if (!sender || !repository) return false;
+    // Factory's own app has to clear the gate before the bot rules below, which
+    // fail closed for every bot that is not explicitly allowlisted. GitHub
+    // forbids an app from reviewing its own pull request, so `factory-review`
+    // posts its verdict as a comment under this login and that comment is the
+    // handoff the authoring agent wakes on.
+    if (this.#github.identity?.matches(sender)) return true;
+    if (isFactoryAppSender(sender, this.#github.slug)) return true;
     const normalizedSender = sender.toLowerCase();
     const authorizedBots = resolveAuthorizedBots(this.#github.authorizedBots);
     if (authorizedBots.has(normalizedSender)) return true;
@@ -540,18 +577,28 @@ function normalizeSettings(value: PlatformGithubEventWorkerSettings | null): Pla
 
 // Events the polling worker forwards to the factory rules engine. Closures
 // let the reconciler finalize cards; `synchronize` and `review_requested` on a
-// pull request are the two triggers the review board's re-review path listens
-// for. Direct-webhook consumers ingest every parsed event; the platform path
-// gates because most other events (comments, reviews, edits) only interest the
-// subscription dispatcher, not the factory rules.
+// pull request are the triggers the review board's re-review path listens for;
+// submitted reviews and pull request comments are how review feedback reaches
+// the agent that authored the branch. Direct-webhook consumers ingest every
+// parsed event; the platform path gates because the remaining events (issue
+// edits, comment edits and deletions) only interest the subscription
+// dispatcher, not the factory rules.
 function isFactoryIngestedEvent(event: ParsedGithubWebhook): boolean {
   if ((event.event === 'issues' || event.event === 'pull_request') && event.payload.action === 'closed') {
     return true;
   }
   if (event.event === 'pull_request') {
     const action = event.payload.action;
-    if (action === 'synchronize' || action === 'review_requested') return true;
+    // `opened` is what mints the Review card for a pull request. Without it a
+    // factory-authored PR never gets reviewed on the polling path, which is the
+    // only path a local deployment has.
+    if (action === 'opened' || action === 'synchronize' || action === 'review_requested') return true;
   }
+  if (event.event === 'pull_request_review' && event.payload.action === 'submitted') return true;
+  if (event.event === 'issue_comment' && event.payload.action === 'created') return true;
+  // Default-branch pushes drive base-checkpoint rebuilds
+  // (`withBaseCheckpointWebhookTrigger` wraps the ingest callback).
+  if (event.event === 'push') return true;
   return false;
 }
 

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -308,8 +308,11 @@ export const factory = new MastraFactory({
   vector,
   pubsub,
   platform: {
-    // Platform's GitHub App identity is not included in the Platform credentials.
-    // Reuse the deployment's configured App slug to ignore Factory's own handoff writes.
+    // The deployment's own self-hosted App slug, when one is configured. It is
+    // NOT Platform's identity: Platform posts as its own App, which names
+    // itself. Reusing this value for that purpose left self-recognition
+    // comparing against `undefined[bot]` on every Platform deployment, where
+    // this is legitimately unset.
     githubAppSlug,
   },
   // Browser-facing origin. On the platform the SPA is hosted separately, so


### PR DESCRIPTION
## Summary

Split from #21767 (part 4a of the stack; follows #21795, #21796, #21798).

Four related fixes to how Factory receives and trusts GitHub events:

- **Sender gate actually fires (security).** `AUTHOR_GATED_KINDS` listed event kinds under names the webhook classifier never produces, so the identity check that keeps untrusted commenters and reviewers from waking Factory agents was silently skipped for every comment/review event. The gate now names the kinds `classifyGithubWebhook` actually emits.
- **Factory stops waking itself.** Factory recognised its own writes by comparing the sender against the deployment's self-hosted `GITHUB_APP_SLUG`, which doesn't match Platform-managed App logins. App identity is now resolved properly (`app-identity.ts`), so Factory's own comments no longer re-trigger its agents.
- **Signals reach the session that owns the thread.** Subscription delivery looked up the thread under the subscription's resource, which an unscoped session doesn't own — every matching event failed with "Thread not found" and could fabricate sessions in a retry loop. Delivery now reads the thread from storage to find its owning resource, and skips subscriptions whose thread this deployment doesn't hold.
- **`push` events are ingested.** They were dropped by the event filter before ingestion; downstream consumers (e.g. the upcoming warm base-checkpoint refresh) can now observe default-branch pushes.

## Test plan

- `mastracode/factory` typecheck clean
- `vitest run src/integrations`: 642 passed; the 4 remaining failures (`integration.test.ts` ×2, `slack.test.ts` ×1, plus one flaky) are pre-existing on `main` — fix PR coming separately
- New/updated coverage: sender-gate kinds regression test, push-event ingestion test, app-identity tests, thread-ownership delivery tests