### PR TITLE
fix(factory): stop the event worker from crashing when built before storage initialization

### DIFF
--- a/.changeset/factory-lazy-reconcile-storage.md
+++ b/.changeset/factory-lazy-reconcile-storage.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Stop the GitHub event worker from crashing when it is constructed before source-control storage is initialized.
+
+`workers()` dereferenced the integration's source-control storage eagerly while building the reconcile worker, but that storage is only attached later by `versionControl.initialize`. A deployment that constructs workers first crashed with "source-control storage has not been initialized". The worker now receives a lazy handle that resolves the storage slices at call time, once the worker is actually running.

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -734,7 +734,18 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         intervalMs: this.#pollingIntervalMs,
         pullRequestReconcileIntervalMs: this.#pullRequestReconcileIntervalMs,
         issueReconcileIntervalMs: this.#issueReconcileIntervalMs,
-        sourceControl: this.storage,
+        // Resolved lazily: workers are constructed before versionControl
+        // storage is initialized, and the worker only reads these slices once
+        // it is running.
+        sourceControl: {
+          projectRepositories: {
+            listConfiguredExternalKeys: () => this.storage.projectRepositories.listConfiguredExternalKeys(),
+            listByExternalRepository: args => this.storage.projectRepositories.listByExternalRepository(args),
+          },
+          repositories: {
+            findByExternalId: args => this.storage.repositories.findByExternalId(args),
+          },
+        },
       }),
     ];
   }

--- a/mastracode/factory/src/integrations/slack/slack.test.ts
+++ b/mastracode/factory/src/integrations/slack/slack.test.ts
@@ -803,10 +803,10 @@ describe('session start (onSessionStart)', () => {
       },
       model: { switch: vi.fn(async () => {}) },
       om: {
-        observer: { switchModel: vi.fn(async () => {}) },
-        reflector: { switchModel: vi.fn(async () => {}) },
+        observer: { modelId: vi.fn(() => 'initial/model'), switchModel: vi.fn(async () => {}) },
+        reflector: { modelId: vi.fn(() => 'initial/model'), switchModel: vi.fn(async () => {}) },
       },
-      state: { set: vi.fn(async () => {}) },
+      state: { get: vi.fn(() => ({})), set: vi.fn(async () => {}) },
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes the 3 test failures currently red on `main` (`integration.test.ts` ×2, `slack.test.ts` ×1), one of which is a real runtime bug:

- **Runtime fix:** `PlatformGithubIntegration.workers()` eagerly dereferenced source-control storage while constructing the reconcile worker, but that storage is only attached later by `versionControl.initialize` — constructing workers first threw "source-control storage has not been initialized". The worker now receives a lazy handle that resolves the storage slices at call time.
- **Test fix:** the slack session mock lacked the `om.<role>.modelId()` and `state.get()` surface that `applyStoredMemorySettings` reads; the resulting TypeError was swallowed by hydration's best-effort catch, so the observer model switch the test asserts on never ran. The mock now models the real session surface.

## Test plan

- `vitest run src/integrations/slack/slack.test.ts src/integrations/platform/github/integration.test.ts`: 80/80 pass (was 3 failing on main)
- `mastracode/factory` typecheck clean