### PR TITLE
docs: Update MongoDB Metadata Filter Documentation

### DIFF
--- a/docs/src/content/en/reference/rag/metadata-filters.mdx
+++ b/docs/src/content/en/reference/rag/metadata-filters.mdx
@@ -166,7 +166,7 @@ const results = await store.query({
   {
     name: '$size',
     description: 'Array length check',
-    example: '{ tags: { $size: 3 } }',
+    example: '{ tags: { $size: { $gt: 2 } } } — MongoDB requires an integer instead: { tags: { $size: 3 } }',
     supportedBy: ['Astra', 'libSQL', 'PgVector', 'MongoDB', 'OracleDB'],
   },
   {
@@ -329,13 +329,21 @@ const results = await store.query({
 
 ### MongoDB
 
-- Full support for MongoDB/Sift query syntax for metadata filters
-- Supports all standard comparison, array, logical, and element operators
-- Supports nested fields and arrays in metadata
-- Filtering can be applied to both `metadata` and the original document content using the `filter` and `documentFilter` options, respectively
-- `filter` applies to the metadata object; `documentFilter` applies to the original document fields
-- No artificial limits on filter size or complexity (subject to MongoDB query limits)
-- Indexing metadata fields is recommended for optimal performance
+- Requires MongoDB Atlas or a deployment with MongoDB Vector Search enabled; the store queries with the `$vectorSearch` aggregation stage.
+- Uses MongoDB query syntax directly for metadata filters, including nested fields and arrays in metadata.
+- Supports the comparison, array, logical, and element operators in the tables above, plus `$regex` and `$size`. `$size` takes an integer, as in `{ tags: { $size: 3 } }`.
+- Use `filter` to match fields in the metadata object and `documentFilter` to match the original document text. You can combine them in a single query.
+- Declare the metadata fields you filter on in `filterFields` when you create the index. Mastra passes filters that use only declared fields and the operators MongoDB Vector Search accepts (`$and`, `$or`, `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`) directly to `$vectorSearch`:
+
+```typescript
+await store.createIndex({
+  indexName: 'my_index',
+  dimension: 1536,
+  filterFields: ['category', 'price'],
+})
+```
+
+- Filters that reference an undeclared field or use another operator still work, but Mastra pre-filters the collection and passes the matching document IDs to `$vectorSearch`. On large collections, that pre-filter can exceed the 16 MB BSON document limit, so declare your filter fields for selective queries over large data sets.
 
 ### Couchbase
 

--- a/docs/src/content/en/reference/rag/metadata-filters.mdx
+++ b/docs/src/content/en/reference/rag/metadata-filters.mdx
@@ -343,7 +343,7 @@ await store.createIndex({
 })
 ```
 
-- Filters that reference an undeclared field or use another operator still work, but Mastra pre-filters the collection and passes the matching document IDs to `$vectorSearch`. On large collections, that pre-filter can exceed the 16 MB BSON document limit, so declare your filter fields for selective queries over large data sets.
+- Filters that reference an undeclared field or use another operator take a fallback path: Mastra pre-filters the collection and passes the matching document IDs to `$vectorSearch`. This works only while the ID set fits within MongoDB's 16 MB BSON document limit. On large collections the query fails once that limit is exceeded, so declare your filter fields for selective queries over large data sets.
 
 ### Couchbase
 

--- a/docs/src/content/en/reference/rag/metadata-filters.mdx
+++ b/docs/src/content/en/reference/rag/metadata-filters.mdx
@@ -329,7 +329,7 @@ const results = await store.query({
 
 ### MongoDB
 
-- Requires MongoDB Atlas or a deployment with MongoDB Vector Search enabled; the store queries with the `$vectorSearch` aggregation stage.
+- Requires MongoDB Atlas or a deployment with MongoDB Vector Search enabled. The store queries with the `$vectorSearch` aggregation stage.
 - Uses MongoDB query syntax directly for metadata filters, including nested fields and arrays in metadata.
 - Supports the comparison, array, logical, and element operators in the tables above, plus `$regex` and `$size`. `$size` takes an integer, as in `{ tags: { $size: 3 } }`.
 - Use `filter` to match fields in the metadata object and `documentFilter` to match the original document text. You can combine them in a single query.

--- a/docs/src/content/en/reference/rag/retrieval.mdx
+++ b/docs/src/content/en/reference/rag/retrieval.mdx
@@ -98,6 +98,65 @@ For detailed information about available operators and syntax, see the [Metadata
 
 Basic filtering examples:
 
+<Tabs>
+  <TabItem value="mongodb" label="MongoDB">
+```ts
+// Simple equality filter
+const results = await mongoVector.query({
+  indexName: 'embeddings',
+  queryVector: embedding,
+  topK: 10,
+  filter: {
+    source: 'article1.txt',
+  },
+})
+
+// Numeric comparison
+const results = await mongoVector.query({
+  indexName: 'embeddings',
+  queryVector: embedding,
+  topK: 10,
+  filter: {
+    price: { $gt: 100 },
+  },
+})
+
+// Multiple conditions
+const results = await mongoVector.query({
+  indexName: 'embeddings',
+  queryVector: embedding,
+  topK: 10,
+  filter: {
+    category: 'electronics',
+    price: { $lt: 1000 },
+    inStock: true,
+  },
+})
+
+// Array operations
+const results = await mongoVector.query({
+  indexName: 'embeddings',
+  queryVector: embedding,
+  topK: 10,
+  filter: {
+    tags: { $in: ['sale', 'new'] },
+  },
+})
+
+// Logical operators
+const results = await mongoVector.query({
+  indexName: 'embeddings',
+  queryVector: embedding,
+  topK: 10,
+  filter: {
+    $or: [{ category: 'electronics' }, { category: 'accessories' }],
+    $and: [{ price: { $gt: 50 } }, { price: { $lt: 200 } }],
+  },
+})
+```
+  </TabItem>
+
+  <TabItem value="pgvector" label="pgVector">
 ```ts
 // Simple equality filter
 const results = await pgVector.query({
@@ -152,6 +211,8 @@ const results = await pgVector.query({
   },
 })
 ```
+  </TabItem>
+</Tabs>
 
 Common use cases for metadata filtering:
 
@@ -161,6 +222,44 @@ Common use cases for metadata filtering:
 - Filter by numerical ranges (e.g., price, rating)
 - Combine multiple conditions for precise querying
 - Filter by document attributes (e.g., language, author)
+
+### Where the filter is applied
+
+Vector stores differ in _when_ they apply a metadata filter, which affects how filtered queries scale.
+
+MongoDB can evaluate the filter inside the vector index itself, so a filtered query stays about as fast as an unfiltered one. This requires declaring the fields you filter on in `filterFields` when you create the index:
+
+```ts
+// Declare the metadata fields you want to filter on
+await mongoVector.createIndex({
+  indexName: 'embeddings',
+  dimension: 1536,
+  filterFields: ['source'],
+})
+
+// The filter is applied during the index search
+const results = await mongoVector.query({
+  indexName: 'embeddings',
+  queryVector: embedding,
+  topK: 10,
+  filter: { source: 'article1.txt' },
+})
+```
+
+Mastra passes the filter to the index only when every field it references is declared in `filterFields` and every operator is one the index accepts: `$and`, `$or`, `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, and `$nin`. A filter that uses an undeclared field or any other operator still returns correct results, but Mastra matches the collection first and passes the matching document IDs into the vector search. On large collections, the results can exceed MongoDB's 16 MB document limit, so declare your filter fields when you expect selective filters over large data sets.
+
+pgVector applies the filter as an ordinary query condition:
+
+```ts
+const results = await pgVector.query({
+  indexName: 'embeddings',
+  queryVector: embedding,
+  topK: 10,
+  filter: { source: 'article1.txt' },
+})
+```
+
+Postgres vector indexes (HNSW and IVFFlat) can't restrict that search to rows matching a condition. So when a filter is present, pgVector computes distances across the matching rows, sorts them, and returns the top `topK`. Results are exact, but the work grows with the number of rows the filter matches. Indexing the metadata column speeds up row retrieval; the distance comparisons still happen per row.
 
 ### Vector Query Tool
 

--- a/docs/src/content/en/reference/rag/retrieval.mdx
+++ b/docs/src/content/en/reference/rag/retrieval.mdx
@@ -101,8 +101,16 @@ Basic filtering examples:
 <Tabs>
   <TabItem value="mongodb" label="MongoDB">
     ```ts
+    import { MongoDBVector } from '@mastra/mongodb'
+
+    const mongoVector = new MongoDBVector({
+      id: 'mongodb-vector',
+      uri: process.env.MONGODB_URI,
+      dbName: process.env.MONGODB_DB_NAME,
+    })
+
     // Simple equality filter
-    const results = await mongoVector.query({
+    const equalityResults = await mongoVector.query({
       indexName: 'embeddings',
       queryVector: embedding,
       topK: 10,
@@ -112,7 +120,7 @@ Basic filtering examples:
     })
 
     // Numeric comparison
-    const results = await mongoVector.query({
+    const priceResults = await mongoVector.query({
       indexName: 'embeddings',
       queryVector: embedding,
       topK: 10,
@@ -122,7 +130,7 @@ Basic filtering examples:
     })
 
     // Multiple conditions
-    const results = await mongoVector.query({
+    const compoundResults = await mongoVector.query({
       indexName: 'embeddings',
       queryVector: embedding,
       topK: 10,
@@ -134,7 +142,7 @@ Basic filtering examples:
     })
 
     // Array operations
-    const results = await mongoVector.query({
+    const tagResults = await mongoVector.query({
       indexName: 'embeddings',
       queryVector: embedding,
       topK: 10,
@@ -144,7 +152,7 @@ Basic filtering examples:
     })
 
     // Logical operators
-    const results = await mongoVector.query({
+    const categoryResults = await mongoVector.query({
       indexName: 'embeddings',
       queryVector: embedding,
       topK: 10,
@@ -159,7 +167,7 @@ Basic filtering examples:
   <TabItem value="pgvector" label="pgVector">
     ```ts
     // Simple equality filter
-    const results = await pgVector.query({
+    const equalityResults = await pgVector.query({
       indexName: 'embeddings',
       queryVector: embedding,
       topK: 10,
@@ -169,7 +177,7 @@ Basic filtering examples:
     })
 
     // Numeric comparison
-    const results = await pgVector.query({
+    const priceResults = await pgVector.query({
       indexName: 'embeddings',
       queryVector: embedding,
       topK: 10,
@@ -179,7 +187,7 @@ Basic filtering examples:
     })
 
     // Multiple conditions
-    const results = await pgVector.query({
+    const compoundResults = await pgVector.query({
       indexName: 'embeddings',
       queryVector: embedding,
       topK: 10,
@@ -191,7 +199,7 @@ Basic filtering examples:
     })
 
     // Array operations
-    const results = await pgVector.query({
+    const tagResults = await pgVector.query({
       indexName: 'embeddings',
       queryVector: embedding,
       topK: 10,
@@ -201,7 +209,7 @@ Basic filtering examples:
     })
 
     // Logical operators
-    const results = await pgVector.query({
+    const categoryResults = await pgVector.query({
       indexName: 'embeddings',
       queryVector: embedding,
       topK: 10,
@@ -246,7 +254,7 @@ const results = await mongoVector.query({
 })
 ```
 
-Mastra passes the filter to the index only when every field it references is declared in `filterFields` and every operator is one the index accepts: `$and`, `$or`, `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, and `$nin`. A filter that uses an undeclared field or any other operator still returns correct results, but Mastra matches the collection first and passes the matching document IDs into the vector search. On large collections, the results can exceed MongoDB's 16 MB document limit, so declare your filter fields when you expect selective filters over large data sets.
+Mastra passes the filter to the index only when every field it references is declared in `filterFields` and every operator is one the index accepts: `$and`, `$or`, `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, and `$nin`. A filter that uses an undeclared field or any other operator takes a fallback path: Mastra matches the collection first and passes the matching document IDs into the vector search. That fallback holds only while the ID set fits within MongoDB's 16 MB BSON document limit. On large collections the query fails once that limit is exceeded, so declare your filter fields when you expect selective filters over large data sets.
 
 pgVector applies the filter as an ordinary query condition:
 

--- a/docs/src/content/en/reference/rag/retrieval.mdx
+++ b/docs/src/content/en/reference/rag/retrieval.mdx
@@ -100,117 +100,117 @@ Basic filtering examples:
 
 <Tabs>
   <TabItem value="mongodb" label="MongoDB">
-```ts
-// Simple equality filter
-const results = await mongoVector.query({
-  indexName: 'embeddings',
-  queryVector: embedding,
-  topK: 10,
-  filter: {
-    source: 'article1.txt',
-  },
-})
+    ```ts
+    // Simple equality filter
+    const results = await mongoVector.query({
+      indexName: 'embeddings',
+      queryVector: embedding,
+      topK: 10,
+      filter: {
+        source: 'article1.txt',
+      },
+    })
 
-// Numeric comparison
-const results = await mongoVector.query({
-  indexName: 'embeddings',
-  queryVector: embedding,
-  topK: 10,
-  filter: {
-    price: { $gt: 100 },
-  },
-})
+    // Numeric comparison
+    const results = await mongoVector.query({
+      indexName: 'embeddings',
+      queryVector: embedding,
+      topK: 10,
+      filter: {
+        price: { $gt: 100 },
+      },
+    })
 
-// Multiple conditions
-const results = await mongoVector.query({
-  indexName: 'embeddings',
-  queryVector: embedding,
-  topK: 10,
-  filter: {
-    category: 'electronics',
-    price: { $lt: 1000 },
-    inStock: true,
-  },
-})
+    // Multiple conditions
+    const results = await mongoVector.query({
+      indexName: 'embeddings',
+      queryVector: embedding,
+      topK: 10,
+      filter: {
+        category: 'electronics',
+        price: { $lt: 1000 },
+        inStock: true,
+      },
+    })
 
-// Array operations
-const results = await mongoVector.query({
-  indexName: 'embeddings',
-  queryVector: embedding,
-  topK: 10,
-  filter: {
-    tags: { $in: ['sale', 'new'] },
-  },
-})
+    // Array operations
+    const results = await mongoVector.query({
+      indexName: 'embeddings',
+      queryVector: embedding,
+      topK: 10,
+      filter: {
+        tags: { $in: ['sale', 'new'] },
+      },
+    })
 
-// Logical operators
-const results = await mongoVector.query({
-  indexName: 'embeddings',
-  queryVector: embedding,
-  topK: 10,
-  filter: {
-    $or: [{ category: 'electronics' }, { category: 'accessories' }],
-    $and: [{ price: { $gt: 50 } }, { price: { $lt: 200 } }],
-  },
-})
-```
+    // Logical operators
+    const results = await mongoVector.query({
+      indexName: 'embeddings',
+      queryVector: embedding,
+      topK: 10,
+      filter: {
+        $or: [{ category: 'electronics' }, { category: 'accessories' }],
+        $and: [{ price: { $gt: 50 } }, { price: { $lt: 200 } }],
+      },
+    })
+    ```
   </TabItem>
 
   <TabItem value="pgvector" label="pgVector">
-```ts
-// Simple equality filter
-const results = await pgVector.query({
-  indexName: 'embeddings',
-  queryVector: embedding,
-  topK: 10,
-  filter: {
-    source: 'article1.txt',
-  },
-})
+    ```ts
+    // Simple equality filter
+    const results = await pgVector.query({
+      indexName: 'embeddings',
+      queryVector: embedding,
+      topK: 10,
+      filter: {
+        source: 'article1.txt',
+      },
+    })
 
-// Numeric comparison
-const results = await pgVector.query({
-  indexName: 'embeddings',
-  queryVector: embedding,
-  topK: 10,
-  filter: {
-    price: { $gt: 100 },
-  },
-})
+    // Numeric comparison
+    const results = await pgVector.query({
+      indexName: 'embeddings',
+      queryVector: embedding,
+      topK: 10,
+      filter: {
+        price: { $gt: 100 },
+      },
+    })
 
-// Multiple conditions
-const results = await pgVector.query({
-  indexName: 'embeddings',
-  queryVector: embedding,
-  topK: 10,
-  filter: {
-    category: 'electronics',
-    price: { $lt: 1000 },
-    inStock: true,
-  },
-})
+    // Multiple conditions
+    const results = await pgVector.query({
+      indexName: 'embeddings',
+      queryVector: embedding,
+      topK: 10,
+      filter: {
+        category: 'electronics',
+        price: { $lt: 1000 },
+        inStock: true,
+      },
+    })
 
-// Array operations
-const results = await pgVector.query({
-  indexName: 'embeddings',
-  queryVector: embedding,
-  topK: 10,
-  filter: {
-    tags: { $in: ['sale', 'new'] },
-  },
-})
+    // Array operations
+    const results = await pgVector.query({
+      indexName: 'embeddings',
+      queryVector: embedding,
+      topK: 10,
+      filter: {
+        tags: { $in: ['sale', 'new'] },
+      },
+    })
 
-// Logical operators
-const results = await pgVector.query({
-  indexName: 'embeddings',
-  queryVector: embedding,
-  topK: 10,
-  filter: {
-    $or: [{ category: 'electronics' }, { category: 'accessories' }],
-    $and: [{ price: { $gt: 50 } }, { price: { $lt: 200 } }],
-  },
-})
-```
+    // Logical operators
+    const results = await pgVector.query({
+      indexName: 'embeddings',
+      queryVector: embedding,
+      topK: 10,
+      filter: {
+        $or: [{ category: 'electronics' }, { category: 'accessories' }],
+        $and: [{ price: { $gt: 50 } }, { price: { $lt: 200 } }],
+      },
+    })
+    ```
   </TabItem>
 </Tabs>
 
@@ -227,7 +227,7 @@ Common use cases for metadata filtering:
 
 Vector stores differ in _when_ they apply a metadata filter, which affects how filtered queries scale.
 
-MongoDB can evaluate the filter inside the vector index itself, so a filtered query stays about as fast as an unfiltered one. This requires declaring the fields you filter on in `filterFields` when you create the index:
+MongoDB can evaluate the filter inside the vector index itself. This keeps the query on a single round trip to `$vectorSearch`, so it avoids the pre-filter pass that collects matching document IDs and the 16 MB BSON limit that pass is subject to. Declaring the fields you filter on in `filterFields` when you create the index is what enables it:
 
 ```ts
 // Declare the metadata fields you want to filter on
@@ -259,7 +259,7 @@ const results = await pgVector.query({
 })
 ```
 
-Postgres vector indexes (HNSW and IVFFlat) can't restrict that search to rows matching a condition. So when a filter is present, pgVector computes distances across the matching rows, sorts them, and returns the top `topK`. Results are exact, but the work grows with the number of rows the filter matches. Indexing the metadata column speeds up row retrieval; the distance comparisons still happen per row.
+Postgres vector indexes (HNSW and IVFFlat) can't restrict that search to rows matching a condition. When a filter is present, pgVector instead compares the query vector against every matching row and returns the closest `topK`. Results are exact, but the work grows with the number of rows the filter matches. Indexing the metadata column speeds up row retrieval. The distance comparisons still happen per row.
 
 ### Vector Query Tool
 

--- a/docs/src/content/en/reference/rag/retrieval.mdx
+++ b/docs/src/content/en/reference/rag/retrieval.mdx
@@ -242,7 +242,7 @@ MongoDB can evaluate the filter inside the vector index itself. This keeps the q
 await mongoVector.createIndex({
   indexName: 'embeddings',
   dimension: 1536,
-  filterFields: ['source'],
+  filterFields: ['source', 'price', 'category', 'inStock', 'tags'],
 })
 
 // The filter is applied during the index search

--- a/docs/src/content/en/reference/rag/retrieval.mdx
+++ b/docs/src/content/en/reference/rag/retrieval.mdx
@@ -245,6 +245,9 @@ await mongoVector.createIndex({
   filterFields: ['source', 'price', 'category', 'inStock', 'tags'],
 })
 
+// createIndex() returns before the index finishes building
+await mongoVector.waitForIndexReady({ indexName: 'embeddings' })
+
 // The filter is applied during the index search
 const results = await mongoVector.query({
   indexName: 'embeddings',


### PR DESCRIPTION
## Description

docs/src/content/en/reference/rag/metadata-filters.mdx
- Replaced the 7 old bullets in the ### MongoDB section with the new 6-bullet version: Atlas/$vectorSearch requirement, MongoDB query syntax, supported operators (incl. $regex and integer-only $size), filter vs documentFilter, and filterFields declaration.
- Added a createIndex code example with filterFields: ['category', 'price'] inside that section.
- Added the closing bullet about undeclared fields/other operators falling back to a pre-filter that can hit the 16 MB BSON limit.
- Updated the $size row ile to note MongoDB requires an integer.

docs/src/content/en/reference/rag/retrieval.mdx
- Wrapped the "Basic filt in <Tabs> with two tabs:MongoDB (new, using mongoVector) and pgVector (the existing examples).
- Added a new ### Where ton after thecommon-use-cases list and before ### Vector Query Tool, covering:
  - MongoDB filtering ins a createIndex + queryexample.
  - The operator/field coiltering and the fallbackbehavior.
  - pgVector applying thery condition, with anexample and an explanation of why HNSW/IVFFlat can't restrict the search.

## Related issue(s)

N/A

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR explains how MongoDB and pgVector filter search results. It adds examples, required settings, fallback behavior, and filtering limits.

## Changes

- Updated MongoDB metadata filter documentation:
  - Added Atlas `$vectorSearch` requirements.
  - Documented query syntax, supported operators, `filter`, `documentFilter`, and `filterFields`.
  - Added a `createIndex` example that waits for the MongoDB index to be ready.
  - Explained native filter pushdown and the candidate-ID fallback path.
  - Documented the potential 16 MB BSON limit.
  - Clarified that MongoDB requires an integer for `$size`.

- Updated retrieval documentation:
  - Added MongoDB and pgVector tabs for common metadata filters.
  - Added a “Where to filter” section.
  - Documented MongoDB filtering requirements and fallback behavior.
  - Documented pgVector filtering limitations with HNSW and IVFFlat.
  - Clarified pgVector filtering and distance-computation behavior.

- Validation:
  - Vale checks pass.
  - MDX formatting checks pass.
  - `git diff --check` passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->