### PR TITLE
fix(memory): log discarded degenerate observer output for diagnosis

### DIFF
--- a/.changeset/gold-pandas-report.md
+++ b/.changeset/gold-pandas-report.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Log discarded degenerate observer/reflector output so failures are diagnosable. When observational memory's degenerate-repetition detector trips, the raw model output was previously thrown away — the error "Observer produced degenerate output after retry" gave no way to tell a real repetition loop apart from a detector false-positive on legitimately repetitive content. Detection sites now log bounded diagnostics (length, duplicate-window ratio, most-repeated window, head/tail snippets) to the OM debug log, and the thrown observer errors include a compact version of the same diagnostics.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -43,6 +43,7 @@ import {
   extractCurrentTask,
   sanitizeObservationLines,
   detectDegenerateRepetition,
+  describeDegenerateOutput,
 } from '../observer-agent';
 import { ObserverRunner } from '../observer-runner';
 import { ObservationalMemoryProcessor } from '../processor';
@@ -3292,6 +3293,37 @@ User asked about </current-task> parsing and how it works
       const result = parseObserverOutput(text);
       expect(result.degenerate).toBe(true);
       expect(result.observations).toBe('');
+    });
+  });
+
+  describe('describeDegenerateOutput', () => {
+    it('reports length, duplicate stats, and the most-repeated window on one line', () => {
+      const block =
+        'getLanguageModel().doGenerate(options: LanguageModelV2CallOptions): PromiseLike<LanguageModelV2GenerateResult>, ';
+      const text = block.repeat(100);
+      const description = describeDegenerateOutput(text);
+      expect(description).toContain(`length=${text.length}`);
+      expect(description).toMatch(/duplicateRatio=0\.\d+/);
+      expect(description).toMatch(/topWindowCount=\d+/);
+      expect(description).toContain('topWindow="');
+      expect(description).toContain('head="');
+      expect(description).toContain('tail="');
+      expect(description).not.toContain('\n');
+    });
+
+    it('bounds snippets to the requested size', () => {
+      const text = 'x'.repeat(10_000);
+      const description = describeDegenerateOutput(text, 100);
+      const head = /head="(x+)"/.exec(description)?.[1];
+      const tail = /tail="(x+)"/.exec(description)?.[1];
+      expect(head?.length).toBe(100);
+      expect(tail?.length).toBe(100);
+    });
+
+    it('omits the tail when the text is short', () => {
+      const description = describeDegenerateOutput('short text', 400);
+      expect(description).toContain('head="short text"');
+      expect(description).not.toContain('tail=');
     });
   });
 });

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -1678,6 +1678,60 @@ export function detectDegenerateRepetition(text: string): boolean {
 }
 
 /**
+ * Build a single-line diagnostic description of output flagged by
+ * {@link detectDegenerateRepetition}. Used when logging or surfacing a
+ * degenerate-output failure so the discarded model output can be inspected —
+ * without it there is no way to tell a real repetition loop apart from a
+ * detector false-positive on legitimately repetitive content.
+ *
+ * Reuses the detector's sampling parameters (200-char windows, ~50 samples)
+ * so the reported duplicate ratio and most-repeated window match what
+ * triggered the detection. Snippets are JSON-escaped so the result stays on
+ * one line.
+ */
+export function describeDegenerateOutput(text: string, snippetChars = 400): string {
+  const windowSize = 200;
+  const step = Math.max(1, Math.floor(text.length / 50));
+  const seen = new Map<string, number>();
+  let duplicateWindows = 0;
+  let totalWindows = 0;
+  for (let i = 0; i + windowSize <= text.length; i += step) {
+    const window = text.slice(i, i + windowSize);
+    totalWindows++;
+    const count = (seen.get(window) ?? 0) + 1;
+    seen.set(window, count);
+    if (count > 1) duplicateWindows++;
+  }
+
+  let topWindow = '';
+  let topCount = 0;
+  for (const [window, count] of seen) {
+    if (count > topCount) {
+      topCount = count;
+      topWindow = window;
+    }
+  }
+
+  let longestLine = 0;
+  for (const line of text.split('\n')) {
+    if (line.length > longestLine) longestLine = line.length;
+  }
+
+  const duplicateRatio = totalWindows > 0 ? (duplicateWindows / totalWindows).toFixed(2) : 'n/a';
+  const parts = [
+    `length=${text.length}`,
+    `sampledWindows=${totalWindows}`,
+    `duplicateRatio=${duplicateRatio}`,
+    `longestLine=${longestLine}`,
+    `topWindowCount=${topCount}`,
+  ];
+  if (topCount > 1) parts.push(`topWindow=${JSON.stringify(topWindow)}`);
+  parts.push(`head=${JSON.stringify(text.slice(0, snippetChars))}`);
+  if (text.length > snippetChars * 2) parts.push(`tail=${JSON.stringify(text.slice(-snippetChars))}`);
+  return parts.join(' ');
+}
+
+/**
  * Check if observations contain a Current Task section.
  * Supports both XML format and legacy markdown format.
  */

--- a/packages/memory/src/processors/observational-memory/observer-runner.ts
+++ b/packages/memory/src/processors/observational-memory/observer-runner.ts
@@ -25,6 +25,7 @@ import {
   buildMultiThreadObserverHistoryMessage,
   parseObserverOutput,
   parseMultiThreadObserverOutput,
+  describeDegenerateOutput,
 } from './observer-agent';
 import { withRetry } from './retry';
 import { createTemporaryOmMemoryContext } from './temporary-memory';
@@ -300,13 +301,17 @@ export class ObserverRunner {
     let retriedDueToDegenerate = false;
 
     if (parsed.degenerate) {
-      omDebug(`[OM:callObserver] degenerate repetition detected, retrying once`);
+      omDebug(
+        `[OM:callObserver] degenerate repetition detected, retrying once. ${describeDegenerateOutput(result.text, 2000)}`,
+      );
       result = await doGenerate();
       parsed = parseObserverOutput(result.text, activeExtractors);
       retriedDueToDegenerate = true;
       if (parsed.degenerate) {
-        omDebug(`[OM:callObserver] degenerate repetition on retry, failing`);
-        throw new Error('Observer produced degenerate output after retry');
+        omDebug(
+          `[OM:callObserver] degenerate repetition on retry, failing. ${describeDegenerateOutput(result.text, 2000)}`,
+        );
+        throw new Error(`Observer produced degenerate output after retry. ${describeDegenerateOutput(result.text)}`);
       }
     }
 
@@ -525,13 +530,19 @@ export class ObserverRunner {
     let retriedDueToDegenerate = false;
 
     if (parsed.degenerate) {
-      omDebug(`[OM:callMultiThreadObserver] degenerate repetition detected, retrying once`);
+      omDebug(
+        `[OM:callMultiThreadObserver] degenerate repetition detected, retrying once. ${describeDegenerateOutput(result.text, 2000)}`,
+      );
       result = await doGenerate();
       parsed = parseMultiThreadObserverOutput(result.text, activeExtractors);
       retriedDueToDegenerate = true;
       if (parsed.degenerate) {
-        omDebug(`[OM:callMultiThreadObserver] degenerate repetition on retry, failing`);
-        throw new Error('Multi-thread observer produced degenerate output after retry');
+        omDebug(
+          `[OM:callMultiThreadObserver] degenerate repetition on retry, failing. ${describeDegenerateOutput(result.text, 2000)}`,
+        );
+        throw new Error(
+          `Multi-thread observer produced degenerate output after retry. ${describeDegenerateOutput(result.text)}`,
+        );
       }
     }
 

--- a/packages/memory/src/processors/observational-memory/reflector-runner.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-runner.ts
@@ -37,6 +37,7 @@ import {
 import { getObservableMessages } from './message-utils';
 import type { ModelByInputTokens } from './model-by-input-tokens';
 import { didProviderChange } from './model-context';
+import { describeDegenerateOutput } from './observer-agent';
 import { registerOp, unregisterOp, isOpActiveInProcess } from './operation-registry';
 import {
   buildReflectorSystemPrompt,
@@ -471,7 +472,7 @@ export class ReflectorRunner {
 
       if (parsed.degenerate) {
         omDebug(
-          `[OM:callReflector] attempt #${attemptNumber}: degenerate repetition detected, treating as compression failure`,
+          `[OM:callReflector] attempt #${attemptNumber}: degenerate repetition detected, treating as compression failure. ${describeDegenerateOutput(result.text, 2000)}`,
         );
         reflectedTokens = originalTokens;
       } else {


### PR DESCRIPTION
## Summary

When observational memory's degenerate-repetition detector trips, the raw model output is discarded — the only signal is the error `Observer produced degenerate output after retry`, with no way to tell a real repetition loop apart from a detector false-positive on legitimately repetitive content (e.g. observing dozens of identically formatted knowledge history entries). This has been killing Alexandria's knowledge CI goal runs with no diagnosable trail.

This PR makes the discarded output inspectable:

- New `describeDegenerateOutput()` helper (next to `detectDegenerateRepetition()` in `observer-agent.ts`) builds a single-line diagnostic: output length, sampled duplicate-window ratio, the most-repeated 200-char window, and JSON-escaped head/tail snippets. It reuses the detector's sampling parameters so the reported stats match what triggered detection.
- `callObserver` / `callMultiThreadObserver` log the diagnostics via `omDebug` on both the first detection and the failing retry, and the thrown errors now carry a compact version — so the output is visible in plain CI logs even without `OM_DEBUG`.
- `callReflector` logs the diagnostics when it treats degenerate output as a compression failure.

## Test plan

- New unit tests for `describeDegenerateOutput` (stats + top window reported, snippets bounded, tail omitted for short text) in `observational-memory.test.ts`
- `pnpm vitest run src/processors/observational-memory/__tests__/observational-memory.test.ts` — 472 passed
- `pnpm --filter ./packages/memory check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the system sees repetitive or unusable model output, it now records clear details about what happened. These details help identify repetition loops and false positives in CI logs.

## Changes

- Added `describeDegenerateOutput()` to report:
  - Output length.
  - Duplicate-window ratio.
  - Most-repeated 200-character window.
  - Longest line length.
  - JSON-escaped head and tail snippets.
- Added bounded diagnostics to observer, multi-thread observer, and reflector detection paths.
- Included compact diagnostic details in observer errors.
- Added tests for diagnostic statistics, repeated windows, bounded snippets, single-line formatting, and short text.
- Added a patch changeset for `@mastra/memory`.

## Validation

- 472 tests passed.
- The memory package check completed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->