### PR TITLE
docs: Update MongoDB Rag Retrieval Docs

### DIFF
--- a/docs/src/content/en/reference/rag/retrieval.mdx
+++ b/docs/src/content/en/reference/rag/retrieval.mdx
@@ -16,6 +16,7 @@ packages:
   - "@mastra/s3vectors"
   - "@mastra/upstash"
   - "@mastra/vectorize"
+  - "@mastra/voyageai"
 ---
 
 import Tabs from "@theme/Tabs";
@@ -291,6 +292,23 @@ Vector store prompts define query patterns and filtering capabilities for each v
 When implementing filtering, these prompts are required in the agent's instructions to specify valid operators and syntax for each vector store implementation.
 
 <Tabs>
+  <TabItem value="mongodb" label="MongoDB">
+    ```ts title="vector-store.ts"
+    import { MONGODB_PROMPT } from '@mastra/mongodb'
+
+    export const ragAgent = new Agent({
+      id: 'rag-agent',
+      name: 'RAG Agent',
+      model: '__GATEWAY_OPENAI_MODEL__',
+      instructions: `
+      Process queries using the provided context. Structure responses to be concise and relevant.
+      ${MONGODB_PROMPT}
+      `,
+      tools: { vectorQueryTool },
+    })
+    ```
+  </TabItem>
+
   <TabItem value="pgvector" label="pgVector">
     ```ts
     import { PGVECTOR_PROMPT } from '@mastra/pg'
@@ -427,23 +445,6 @@ When implementing filtering, these prompts are required in the agent's instructi
     ```
   </TabItem>
 
-  <TabItem value="mongodb" label="MongoDB">
-    ```ts title="vector-store.ts"
-    import { MONGODB_PROMPT } from '@mastra/mongodb'
-
-    export const ragAgent = new Agent({
-      id: 'rag-agent',
-      name: 'RAG Agent',
-      model: '__GATEWAY_OPENAI_MODEL__',
-      instructions: `
-      Process queries using the provided context. Structure responses to be concise and relevant.
-      ${MONGODB_PROMPT}
-      `,
-      tools: { vectorQueryTool },
-    })
-    ```
-  </TabItem>
-
   <TabItem value="opensearch" label="OpenSearch">
     ```ts title="vector-store.ts"
     import { OPENSEARCH_PROMPT } from '@mastra/opensearch'
@@ -548,7 +549,11 @@ The weights control how different factors influence the final ranking:
 For semantic scoring to work properly during re-ranking, each result must include the text content in its `metadata.text` field.
 :::
 
-You can also use other relevance score providers like Cohere or ZeroEntropy:
+You can also use other relevance score providers like Voyage AI, Cohere, or ZeroEntropy:
+
+```ts
+const relevanceProvider = new VoyageRelevanceScorer({ model: 'rerank-2.5' })
+```
 
 ```ts
 const relevanceProvider = new CohereRelevanceScorer('rerank-v3.5')
@@ -557,6 +562,8 @@ const relevanceProvider = new CohereRelevanceScorer('rerank-v3.5')
 ```ts
 const relevanceProvider = new ZeroEntropyRelevanceScorer('zerank-1')
 ```
+
+Voyage AI provides dedicated reranking models: `rerank-2.5` and `rerank-2.5-lite` both support a 32,000-token context. `VoyageRelevanceScorer` reads `VOYAGE_API_KEY` from the environment, or accepts an `apiKey` in its config.
 
 The re-ranked results combine vector similarity with semantic understanding to improve retrieval quality.
 

--- a/docs/src/content/en/reference/rag/retrieval.mdx
+++ b/docs/src/content/en/reference/rag/retrieval.mdx
@@ -565,7 +565,7 @@ const relevanceProvider = new CohereRelevanceScorer('rerank-v3.5')
 const relevanceProvider = new ZeroEntropyRelevanceScorer('zerank-1')
 ```
 
-Voyage AI provides dedicated reranking models: `rerank-2.5` and `rerank-2.5-lite` both support a 32,000-token context. `VoyageRelevanceScorer` reads `VOYAGE_API_KEY` from the environment, or accepts an `apiKey` in its config.
+Voyage AI provides dedicated reranking models: `rerank-2.5` and `rerank-2.5-lite` both allow up to 32,000 tokens for the query and any single document combined, and up to 600,000 tokens across a request. `VoyageRelevanceScorer` reads `VOYAGE_API_KEY` from the environment, or accepts an `apiKey` in its config.
 
 The re-ranked results combine vector similarity with semantic understanding to improve retrieval quality.
 

--- a/docs/src/content/en/reference/rag/retrieval.mdx
+++ b/docs/src/content/en/reference/rag/retrieval.mdx
@@ -552,6 +552,8 @@ For semantic scoring to work properly during re-ranking, each result must includ
 You can also use other relevance score providers like Voyage AI, Cohere, or ZeroEntropy:
 
 ```ts
+import { VoyageRelevanceScorer } from '@mastra/voyageai'
+
 const relevanceProvider = new VoyageRelevanceScorer({ model: 'rerank-2.5' })
 ```
 


### PR DESCRIPTION
## Description

- Added "@mastra/voyageai" to the frontmatter packages list, immediately after "@mastra/vectorize".
- Moved the MongoDB TabItem to the top of the Vector Store Prompts <Tabs> group, ahead of the pgVector tab (no content changes).
- Updated the Re-ranking section's closing text to list Voyage AI alongside Cohere and ZeroEntropy.
- Added a VoyageRelevanceScorer({ model: 'rerank-2.5' }) code block before the existing Cohere and ZeroEntropy blocks.
- Added a paragraph noting rerank-2.5 and rerank-2.5-lite support a 32,000-token context, and that VoyageRelevanceScorer reads VOYAGE_API_KEY or accepts an apiKey in its config.

## Related issue(s)

N/A

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This update makes the MongoDB RAG retrieval guide easier to use. It also explains how to use Voyage AI to improve search result rankings.

## Changes

- Added `@mastra/voyageai` to the documented package list.
- Moved the MongoDB tab before the pgVector tab in the Vector Store Prompts section.
- Added Voyage AI to the re-ranking documentation.
- Added a `VoyageRelevanceScorer({ model: 'rerank-2.5' })` example and import.
- Documented 32,000-token context support for `rerank-2.5` and `rerank-2.5-lite`.
- Documented `VOYAGE_API_KEY` and the `apiKey` configuration option for `VoyageRelevanceScorer`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->