### PR TITLE
fix(factory-ui): keep sandbox warm-up failures from blocking chat sessions

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerPreparingSession.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerPreparingSession.msw.test.tsx
@@ -7,34 +7,39 @@ import { waitForMutationsIdle } from '../../../../../../e2e/ui/render';
 import { releaseSession, renderThread, stubPreparingSession } from './composer-session-test-fixture';
 
 describe('Composer while a session prepares its workspace', () => {
-  it('blocks sandbox actions while /ensure is pending but keeps the textarea typable', async () => {
+  it('keeps the composer fully usable while /ensure is still pending', async () => {
     const session = stubPreparingSession({ ensurePending: true });
     const user = userEvent.setup();
     const { container, client } = renderThread();
 
+    // `/ensure` is only a background warm-up now — send and attach must come
+    // online as soon as session metadata resolves, without waiting for it.
     const message = () => screen.getByRole('textbox', { name: 'Message' });
     await waitFor(() => expect(message()).toBeEnabled());
+    await user.type(message(), 'go while warming');
+    // Send only enables once the draft is non-empty and chat preparation
+    // (metadata + message load) is done — /ensure is still pending here.
     const sendButton = screen.getByRole('button', { name: 'Send message' });
-    expect(sendButton).toBeDisabled();
-
-    await user.type(message(), 'draft while initializing');
-    expect(message()).toHaveValue('draft while initializing');
-    await user.keyboard('{Enter}');
-    expect(session.posted).toEqual([]);
+    await waitFor(() => expect(sendButton).toBeEnabled());
 
     const image = new File(['png'], 'shot.png', { type: 'image/png' });
     const form = container.querySelector('form');
     assert(form);
     fireEvent.drop(form, { dataTransfer: { files: [image] } });
-    fireEvent.paste(message(), { clipboardData: { files: [image] } });
-    expect(screen.queryByRole('button', { name: 'Remove image' })).not.toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Remove image' })).toBeInTheDocument();
+
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(session.posted).toEqual(['go while warming']));
+    expect(session.postedFiles).toHaveLength(1);
+    // Delivery still queues behind the workspace, not behind /ensure.
+    expect(session.delivered).toEqual([]);
+    // Warm-up fired exactly once for the session entry.
+    expect(session.ensureRequests).toBe(1);
 
     session.finishEnsure();
-    await waitFor(() => expect(sendButton).toBeEnabled());
-    expect(message()).toHaveValue('draft while initializing');
-
     session.finishWorkspace();
     await waitForMutationsIdle(client);
+    await waitFor(() => expect(session.delivered).toEqual(['go while warming']));
   });
 
   it('sends the message straight away and shows it while the workspace comes up', async () => {
@@ -185,13 +190,16 @@ describe('Composer while a session prepares its workspace', () => {
     const message = () => screen.getByRole('textbox', { name: 'Message' });
     await waitFor(() => expect(message()).toBeEnabled());
     await waitFor(() => expect(screen.getByText('Preparing workspace…')).toBeInTheDocument());
+    // Drops are ignored while the composer is still initializing (messages
+    // loading), so type first and wait for send to come online before attaching.
+    await user.type(message(), 'what is wrong here');
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Send message' })).toBeEnabled());
 
     const form = container.querySelector('form');
     assert(form);
     fireEvent.drop(form, { dataTransfer: { files: [new File(['png'], 'shot.png', { type: 'image/png' })] } });
     expect(await screen.findByRole('button', { name: 'Remove image' })).toBeInTheDocument();
 
-    await user.type(message(), 'what is wrong here');
     await user.keyboard('{Enter}');
 
     await waitFor(() => expect(session.posted).toEqual(['what is wrong here']));

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionContext.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionContext.ts
@@ -24,28 +24,35 @@ export interface ChatSessionContextApi {
    */
   resourceReady: boolean;
   /**
-   * `/ensure` has succeeded and runs can execute in the sandbox. Gate any
-   * write/run consumer on this flag.
+   * Session metadata resolved and runs can be sent. Does NOT wait on the
+   * `/ensure` warm-up — the server materializes sandboxes lazily on first use.
+   * Gate any write/run consumer on this flag.
    */
   sandboxReady: boolean;
   /**
-   * `/ensure` is in flight (or not yet started because deps aren't ready) for
-   * an in-session mount. UI should show a preparing affordance while true.
+   * Session metadata is still resolving for an in-session mount. UI should
+   * show a preparing affordance while true.
    */
   sandboxPreparing: boolean;
   /**
-   * Latest SSE progress event from `/ensure`, or `undefined` before the first
-   * event arrives or when no preparation is in progress.
+   * Latest SSE progress event from the background `/ensure` warm-up, or
+   * `undefined` before the first event arrives or when no warm-up is in
+   * progress. Informational only — never blocks the chat UI.
    */
   sandboxProgress: PrepareProgress | undefined;
   resourceEnabled: boolean;
   /**
-   * Failure while preparing the session's workspace (sandbox provision /
-   * repo materialization). While set, the session never becomes enabled, so
-   * surfaces must show this error instead of an eternal loading state.
+   * Failure resolving the session itself (denied/missing/errored session
+   * query). Fatal — the chat surface replaces its content with an error state.
    */
   sessionError?: Error;
-  /** Re-runs workspace preparation after a `sessionError`. */
+  /**
+   * Failure from the background workspace warm-up (`/ensure`). Non-fatal —
+   * the run path materializes lazily — so surfaces show it as a banner with a
+   * retry affordance rather than disabling the session.
+   */
+  warmupError?: Error;
+  /** Re-runs the failed session query and/or workspace warm-up. */
   retrySession?: () => void;
   projectPath?: string;
   /**

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -222,8 +222,8 @@ export function ChatMessageBoundary({ children }: { children: ReactNode }) {
   // A denied or missing session is fatal — replace the chat instead of
   // spinning on the preparing loader. A failed workspace warm-up is
   // non-fatal (the run path materializes lazily), so that stays a banner.
-  if (sessionError) return <ChatMessageFeedback error={sessionError} />;
-  const warmupBanner = warmupError ? <ChatMessageFeedback error={warmupError} /> : null;
+  if (sessionError) return <ChatMessageFeedback error={sessionError} source="session" />;
+  const warmupBanner = warmupError ? <ChatMessageFeedback error={warmupError} source="warmup" /> : null;
 
   // Any pre-transcript wait — session metadata resolution OR the initial
   // thread messages fetch — is shown as the step loader. Splitting these into
@@ -257,11 +257,13 @@ export function ChatMessageBoundary({ children }: { children: ReactNode }) {
   );
 }
 
-function ChatMessageFeedback({ error }: { error: Error }) {
+function ChatMessageFeedback({ error, source }: { error: Error; source: 'session' | 'warmup' }) {
   const { retrySession } = useChatSessionContext();
   // The server intentionally returns the same 404 for a missing session and a
-  // private one owned by someone else, so the message covers both.
-  const notFound = (error as { status?: number }).status === 404;
+  // private one owned by someone else, so the message covers both — but only
+  // for the session lookup itself. A warm-up (`/ensure`) 404 describes a
+  // missing repository or workspace, so it keeps its actual error details.
+  const notFound = source === 'session' && (error as { status?: number }).status === 404;
   return (
     <div className="flex flex-col items-stretch gap-4">
       <Notice variant="destructive">

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -50,8 +50,14 @@ export function ChatSessionConfigProvider({
   // happen when the caller actually enters a session. Every factory route mounts
   // this provider (the chat shell is the router layout), so an ungated /ensure
   // here provisioned a sandbox just for visiting the board, metrics or settings.
+  // In-session it runs as a background warm-up only — nothing below blocks on it.
   const inSession = Boolean(userScoped ? threadId : sessionId);
-  const ensureQuery = useEnsureMaterializedSandbox(inSession ? repository?.projectRepositoryId : undefined);
+  // Warm-up also waits for session metadata: before `storedSession` resolves
+  // the `repository` fallback is the factory's first repository, which in a
+  // multi-repository factory could warm the wrong workspace.
+  const ensureQuery = useEnsureMaterializedSandbox(
+    inSession && storedSession ? repository?.projectRepositoryId : undefined,
+  );
   const resolvingSession = inSession && sessionQuery.isPending;
   // Sessions and their threads are provisioned with the session's own id as the
   // memory resourceId and no scope (see FactoryStartCoordinator.prepare and
@@ -72,12 +78,17 @@ export function ChatSessionConfigProvider({
   const resourceOverride = userScoped
     ? null
     : new URLSearchParams(typeof window === 'undefined' ? '' : window.location.search).get('resourceId');
-  const sandboxReady = resourceOverride
-    ? Boolean(resourceOverride)
-    : ensureQuery.isSuccess && Boolean(storedSession) && !resolvingSession;
-  // A denied or missing session (404 from the session query) must surface the
-  // error state, not the eternal preparing loader.
-  const sessionError = ensureQuery.error ?? sessionQuery.error ?? undefined;
+  // `sandboxReady` — session metadata resolved; safe to run mutations. It does
+  // NOT wait on `/ensure`: the server materializes sandboxes lazily on first
+  // use (and revives dead ones), so the `/ensure` call above is only a
+  // background warm-up that usually wins the race against the first command.
+  const sandboxReady = resourceOverride ? Boolean(resourceOverride) : Boolean(storedSession) && !resolvingSession;
+  // A denied or missing session (404 from the session query) is fatal and must
+  // surface the error state, not the eternal preparing loader. A failed warm-up
+  // is surfaced non-fatally (banner + retry) — the run path no longer depends
+  // on `/ensure` — so the two errors are kept apart.
+  const sessionError = sessionQuery.error ?? undefined;
+  const warmupError = ensureQuery.error ?? undefined;
   // `resourceReady` — safe to address the agent-controller session by
   // `resourceId` for reads/streaming as soon as server-side session metadata
   // resolves. Does NOT wait on `/ensure` — the agent-controller endpoints are
@@ -86,17 +97,22 @@ export function ChatSessionConfigProvider({
   const resourceReady = userScoped
     ? Boolean(storedSession) && !resolvingSession
     : Boolean(resourceOverride) || (Boolean(storedSession) && !resolvingSession);
-  // `sandboxPreparing` — true only when we're actively inside a session and
-  // awaiting `/ensure`. Distinct from `!sandboxReady`, which is also false
-  // outside any session.
-  const sandboxPreparing = inSession && !sandboxReady && !sessionError;
+  // `sandboxPreparing` — true only while session metadata is still resolving
+  // for an in-session mount. Distinct from `!sandboxReady`, which is also
+  // false outside any session. Track the pending query (not `!sandboxReady`)
+  // so a denied/missing session cannot keep the preparing loader up forever.
+  const sandboxPreparing = resolvingSession && !resourceOverride;
   const sandboxProgressQuery = useEnsureProgress(inSession ? repository?.projectRepositoryId : undefined);
-  const sandboxProgress = sandboxPreparing ? sandboxProgressQuery.data : undefined;
+  // Warm-up progress is informational only — it never blocks the chat UI.
+  const sandboxWarming = inSession && !resourceOverride && ensureQuery.isPending;
+  const sandboxProgress = sandboxWarming ? sandboxProgressQuery.data : undefined;
   // Outside a session the factory resource is addressable straight away (its id
-  // is the factory project id); inside one we keep the original ordering and
-  // wait for the workspace so resource reads follow materialization.
+  // is the factory project id); inside one it becomes addressable as soon as
+  // session metadata resolves — same as `resourceReady`.
   const resourceAddressable =
-    userScoped || !inSession ? Boolean(resourceId) : Boolean(resourceOverride) || ensureQuery.isSuccess;
+    userScoped || !inSession
+      ? Boolean(resourceId)
+      : Boolean(resourceOverride) || (Boolean(storedSession) && !resolvingSession);
   const resourceEnabled = !isUserDraft && resourceAddressable;
   const value = {
     resourceId: resourceOverride ?? resourceId ?? '',
@@ -109,12 +125,14 @@ export function ChatSessionConfigProvider({
     sandboxProgress,
     resourceEnabled,
     sessionError,
-    retrySession: sessionError
-      ? () => {
-          void ensureQuery.refetch();
-          if (sessionQuery.isError) void sessionQuery.refetch();
-        }
-      : undefined,
+    warmupError,
+    retrySession:
+      sessionError || warmupError
+        ? () => {
+            if (ensureQuery.isError) void ensureQuery.refetch();
+            if (sessionQuery.isError) void sessionQuery.refetch();
+          }
+        : undefined,
     projectPath,
     sessionThreadId: storedSession?.sessionId,
     workspacePending: storedSession !== undefined && !storedSession.materializedAt,
@@ -199,33 +217,57 @@ export function ChatSessionBoundary({
 export function ChatMessageBoundary({ children }: { children: ReactNode }) {
   const value = useContext(ChatThreadMessagesContext);
   if (!value) throw new Error('ChatMessageBoundary must be used within a ChatSessionBoundary');
-  const { sessionError, sandboxPreparing } = useChatSessionContext();
+  const { sessionError, warmupError, sandboxPreparing } = useChatSessionContext();
 
-  // A failed workspace preparation keeps the session disabled — surface the
-  // real failure instead of an eternal skeleton or a partial-state loader.
-  if (sessionError) return <ChatMessageFeedback />;
+  // A denied or missing session is fatal — replace the chat instead of
+  // spinning on the preparing loader. A failed workspace warm-up is
+  // non-fatal (the run path materializes lazily), so that stays a banner.
+  if (sessionError) return <ChatMessageFeedback error={sessionError} />;
+  const warmupBanner = warmupError ? <ChatMessageFeedback error={warmupError} /> : null;
 
-  // One loader for both pre-transcript waits: a fast ensure followed by a slow
-  // messages fetch would otherwise flicker between two of them.
-  if (sandboxPreparing || value.isPending) return <SessionPrepareSteps />;
+  // Any pre-transcript wait — session metadata resolution OR the initial
+  // thread messages fetch — is shown as the step loader. Splitting these into
+  // two different loaders would flicker between them on cold visits; keeping
+  // them under one loader keeps the composer's spinning ring continuously
+  // meaningful through the whole preparing window.
+  const messagesInitializing = Boolean(value.threadId) && value.isPending;
+  if (sandboxPreparing || messagesInitializing) {
+    return (
+      <>
+        {warmupBanner}
+        <SessionPrepareSteps />
+      </>
+    );
+  }
 
-  if (value.threadId && value.error) return <ChatMessageFallback {...value} />;
+  if (value.threadId && value.error) {
+    return (
+      <>
+        {warmupBanner}
+        <ChatMessageFallback {...value} />
+      </>
+    );
+  }
 
-  return children;
+  return (
+    <>
+      {warmupBanner}
+      {children}
+    </>
+  );
 }
 
-function ChatMessageFeedback() {
-  const { sessionError, retrySession } = useChatSessionContext();
-  if (!sessionError) return null;
+function ChatMessageFeedback({ error }: { error: Error }) {
+  const { retrySession } = useChatSessionContext();
   // The server intentionally returns the same 404 for a missing session and a
   // private one owned by someone else, so the message covers both.
-  const notFound = (sessionError as { status?: number }).status === 404;
+  const notFound = (error as { status?: number }).status === 404;
   return (
     <div className="flex flex-col items-stretch gap-4">
       <Notice variant="destructive">
         {notFound
           ? 'This session was not found or is private to another user.'
-          : `Failed to prepare the workspace: ${sessionError.message}`}
+          : `Failed to prepare the workspace: ${error.message}`}
       </Notice>
       {retrySession && (
         <div>

--- a/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatSessionWarmup.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatSessionWarmup.msw.test.tsx
@@ -35,14 +35,22 @@ describe('workspace warm-up repository targeting', () => {
   it('warms the repository from the session metadata, never the factory fallback', async () => {
     stubPreparingSession({ materialized: true });
     const ensuredRepositories: string[] = [];
+    let connectionsServed = false;
+    // The session row is held open explicitly (not on a timer) so the test
+    // deterministically creates — and then closes — the window where the
+    // connections list is known but the session row is not. An ungated
+    // warm-up fired for repositories[0] inside exactly that window.
+    let releaseSession!: () => void;
+    const sessionGate = new Promise<void>(resolve => (releaseSession = resolve));
 
     server.use(
       // Two repositories: the factory's first repository is NOT the one the
       // session belongs to. Before the session row resolves, the provider's
       // `repository` fallback points at the first repository — warm-up must
       // wait for the session metadata instead of using that fallback.
-      http.get(`${TEST_BASE_URL}/web/factory/projects/:factoryProjectId/source-control-connections`, () =>
-        HttpResponse.json({
+      http.get(`${TEST_BASE_URL}/web/factory/projects/:factoryProjectId/source-control-connections`, () => {
+        connectionsServed = true;
+        return HttpResponse.json({
           connections: [
             {
               id: 'conn-1',
@@ -63,13 +71,10 @@ describe('workspace warm-up repository targeting', () => {
               ],
             },
           ],
-        }),
-      ),
+        });
+      }),
       http.get(`${TEST_BASE_URL}/web/user-sessions/:sessionId`, async () => {
-        // Resolve the session AFTER the repository list so the provider spends
-        // real time in the "connections known, session unknown" window — the
-        // exact window where an ungated warm-up fired for repositories[0].
-        await new Promise(resolve => setTimeout(resolve, 50));
+        await sessionGate;
         return HttpResponse.json({
           session: {
             id: 'row-1',
@@ -93,11 +98,25 @@ describe('workspace warm-up repository targeting', () => {
       }),
     );
 
-    renderSession();
+    const { client } = renderSession();
+
+    // Hold the "connections known, session unknown" window open until the
+    // repository list has definitely been served, then release the session.
+    await waitFor(() => expect(connectionsServed).toBe(true));
+    releaseSession();
 
     expect(await screen.findByTestId('chat-content')).toBeInTheDocument();
-    await waitFor(() => expect(ensuredRepositories.length).toBeGreaterThan(0));
-    expect(ensuredRepositories).toContain(SESSION_REPOSITORY_ID);
-    expect(ensuredRepositories).not.toContain(OTHER_REPOSITORY_ID);
+    // The warm-up is a mutation; wait until every mutation has settled — and
+    // stays settled across a macrotask gap — so a late warm-up request for
+    // the fallback repository cannot escape the assertion below. (Full
+    // query-idle is not usable here: the agent-controller connection-init
+    // queries in this fixture are long-lived by design.)
+    await waitFor(async () => {
+      expect(client.isMutating()).toBe(0);
+      expect(ensuredRepositories.length).toBeGreaterThan(0);
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(client.isMutating()).toBe(0);
+    });
+    expect(ensuredRepositories).toEqual([SESSION_REPOSITORY_ID]);
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatSessionWarmup.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/__tests__/ChatSessionWarmup.msw.test.tsx
@@ -1,0 +1,103 @@
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../e2e/ui/msw-server';
+import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
+import { FACTORY_ID, SESSION_ID, stubPreparingSession } from '../../components/__tests__/composer-session-test-fixture';
+import { ChatMessageBoundary } from '../ChatSessionProvider';
+import { ChatSessionTestProvider } from '../ChatSessionTestProvider';
+
+const OTHER_REPOSITORY_ID = 'repo-other';
+const SESSION_REPOSITORY_ID = 'repo-session';
+
+function renderSession() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[`/factories/${FACTORY_ID}/user/threads/${SESSION_ID}`]}>
+      <Routes>
+        <Route
+          path="/factories/:factoryId/user/threads/:threadId"
+          element={
+            <ChatSessionTestProvider threadId={SESSION_ID} userScoped deferUntilMessagesReady={false}>
+              <ChatMessageBoundary>
+                <div data-testid="chat-content">ready</div>
+              </ChatMessageBoundary>
+            </ChatSessionTestProvider>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('workspace warm-up repository targeting', () => {
+  it('warms the repository from the session metadata, never the factory fallback', async () => {
+    stubPreparingSession({ materialized: true });
+    const ensuredRepositories: string[] = [];
+
+    server.use(
+      // Two repositories: the factory's first repository is NOT the one the
+      // session belongs to. Before the session row resolves, the provider's
+      // `repository` fallback points at the first repository — warm-up must
+      // wait for the session metadata instead of using that fallback.
+      http.get(`${TEST_BASE_URL}/web/factory/projects/:factoryProjectId/source-control-connections`, () =>
+        HttpResponse.json({
+          connections: [
+            {
+              id: 'conn-1',
+              installationId: 'inst-1',
+              repositories: [
+                {
+                  id: OTHER_REPOSITORY_ID,
+                  branch: 'main',
+                  sandboxWorkdir: '/workspace/other',
+                  repository: { slug: 'octo/other', defaultBranch: 'main' },
+                },
+                {
+                  id: SESSION_REPOSITORY_ID,
+                  branch: 'main',
+                  sandboxWorkdir: '/workspace/session',
+                  repository: { slug: 'octo/session', defaultBranch: 'main' },
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/user-sessions/:sessionId`, async () => {
+        // Resolve the session AFTER the repository list so the provider spends
+        // real time in the "connections known, session unknown" window — the
+        // exact window where an ungated warm-up fired for repositories[0].
+        await new Promise(resolve => setTimeout(resolve, 50));
+        return HttpResponse.json({
+          session: {
+            id: 'row-1',
+            sessionId: SESSION_ID,
+            projectRepositoryId: SESSION_REPOSITORY_ID,
+            orgId: 'org-1',
+            userId: 'user-1',
+            branch: 'user/session-1',
+            baseBranch: 'main',
+            sandboxId: null,
+            sandboxWorkdir: null,
+            materializedAt: '2026-07-23T00:00:00.000Z',
+            createdAt: '2026-07-23T00:00:00.000Z',
+            updatedAt: '2026-07-23T00:00:00.000Z',
+          },
+        });
+      }),
+      http.post(`${TEST_BASE_URL}/web/github/projects/:projectRepositoryId/ensure`, ({ params }) => {
+        ensuredRepositories.push(String(params.projectRepositoryId));
+        return HttpResponse.json({ resourceId: SESSION_ID, sandboxId: null, sandboxWorkdir: '/workspace/session' });
+      }),
+    );
+
+    renderSession();
+
+    expect(await screen.findByTestId('chat-content')).toBeInTheDocument();
+    await waitFor(() => expect(ensuredRepositories.length).toBeGreaterThan(0));
+    expect(ensuredRepositories).toContain(SESSION_REPOSITORY_ID);
+    expect(ensuredRepositories).not.toContain(OTHER_REPOSITORY_ID);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsActivity.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsActivity.msw.test.tsx
@@ -26,6 +26,7 @@ function makeSession(
     projectRepositoryId,
     orgId: 'org-1',
     userId: 'user-1',
+    visibility: 'org' as const,
     baseBranch: 'main',
     sandboxId: null,
     sandboxWorkdir: null,

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceSidebarVisibility.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceSidebarVisibility.msw.test.tsx
@@ -22,6 +22,7 @@ function makeSession(index: number, overrides: Partial<FactoryUserSession> = {})
     projectRepositoryId,
     orgId: 'org-1',
     userId: 'user-1',
+    visibility: 'org' as const,
     branch: `factory/task-${index}`,
     baseBranch: 'main',
     sandboxId: null,

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageEagerRender.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageEagerRender.msw.test.tsx
@@ -2,9 +2,10 @@
  * Eager-render contract for a factory workspace thread route: the transcript
  * region, thread rail, header, and composer must all appear as soon as the
  * server-side session metadata resolves — *without* waiting for
- * `/web/github/projects/:id/ensure` to complete. During the ensure window the
- * transcript region shows the `<SessionPrepareSteps>` step loader driven by
- * the SSE progress phases, and the Send button stays disabled.
+ * `/web/github/projects/:id/ensure` to complete. `/ensure` is only a
+ * background warm-up: while it is still streaming, the composer must become
+ * fully usable (send enabled, attachments accepted) as soon as the initial
+ * messages request resolves. The only blocking window is message loading.
  */
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -13,7 +14,7 @@ import { createMemoryRouter, RouterProvider } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../../e2e/ui/msw-server';
-import { renderWithProviders, TEST_BASE_URL } from '../../../../e2e/ui/render';
+import { renderWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../../e2e/ui/render';
 import { createAppRoutes } from '../../router';
 
 const FACTORY_ID = 'fp-1';
@@ -37,6 +38,7 @@ const workspaceSession = {
 };
 
 interface ThreadRouteController {
+  readonly ensureRequests: () => number;
   emitProgress(phase: string, message: string): Promise<void>;
   completeEnsure(): Promise<void>;
   completeMessages(): void;
@@ -46,6 +48,7 @@ interface ThreadRouteController {
 function stubThreadRoute(): ThreadRouteController {
   const encoder = new TextEncoder();
   let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  let ensureRequests = 0;
   let resolveStreamReady = () => {};
   let resolveMessages = () => {};
   const streamReady = new Promise<void>(resolve => {
@@ -87,8 +90,9 @@ function stubThreadRoute(): ThreadRouteController {
       HttpResponse.json({ sessions: [workspaceSession] }),
     ),
     http.get(`${TEST_BASE_URL}/web/github/subscriptions`, () => HttpResponse.json({ subscriptions: [] })),
-    // The gated /ensure call — streams SSE progress under test control.
+    // The background /ensure warm-up — streams SSE progress under test control.
     http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () => {
+      ensureRequests += 1;
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {
           streamController = controller;
@@ -140,6 +144,7 @@ function stubThreadRoute(): ThreadRouteController {
   );
 
   return {
+    ensureRequests: () => ensureRequests,
     async emitProgress(phase, message) {
       await streamReady;
       const payload = JSON.stringify({ phase, message });
@@ -171,54 +176,43 @@ function renderThreadRoute() {
 }
 
 describe('ThreadPage eager render during /ensure', () => {
-  it('renders the composer, transcript region, and step loader before /ensure resolves', async () => {
+  it('becomes fully interactive while /ensure is still pending', async () => {
     const ensure = stubThreadRoute();
-    renderThreadRoute();
+    const { client } = renderThreadRoute();
 
     // Header + composer + transcript region should render right away.
     expect(await screen.findByRole('region', { name: 'Thread composer' })).toBeInTheDocument();
     expect(screen.getByRole('region', { name: 'Factory session' })).toBeInTheDocument();
 
-    // The step loader replaces the "Loading messages" skeleton entirely.
-    expect(await screen.findByRole('status', { name: 'Preparing session' })).toBeInTheDocument();
-    expect(screen.queryByLabelText('Loading messages')).not.toBeInTheDocument();
-
-    // Before any SSE event, the first group ("Preparing sandbox") is the
-    // active default with a "Starting…" secondary message.
-    expect(screen.getByText('Preparing sandbox')).toBeInTheDocument();
-    expect(screen.getByText('Starting…')).toBeInTheDocument();
-
-    // Send button is disabled during preparing. Phase 2 wires
-    // `sandboxPreparing` directly into `sendDisabled` — the more precise
-    // assertion (title attribute) lives in the second `it` block below.
+    // The only blocking window is initial message loading — the loader shows
+    // "Loading messages…" and Send stays disabled while it is held.
+    await waitFor(() => expect(screen.getByText('Loading messages…')).toBeInTheDocument());
     const sendButton = screen.getByRole('button', { name: 'Send message' });
     expect(sendButton).toBeDisabled();
 
-    // Advance through phases.
-    await ensure.emitProgress('provisioning', 'Provisioning a new sandbox…');
-    await waitFor(() => expect(screen.getByText('Provisioning…')).toBeInTheDocument());
-
-    await ensure.emitProgress('cloning', 'Cloning octo/hello…');
-    await waitFor(() => expect(screen.getByText('Cloning…')).toBeInTheDocument());
-    // The "Preparing sandbox" group is now complete → its short secondary
-    // message unmounts, the "Cloning repository" group is the active step.
-    await waitFor(() => expect(screen.queryByText('Provisioning…')).not.toBeInTheDocument());
-    expect(screen.queryByText('Cloning octo/hello…')).not.toBeInTheDocument();
-
-    // Resolve /ensure while messages are still held: the loader stays mounted,
-    // advances to its final step, and Send remains disabled.
-    await ensure.completeEnsure();
-    await waitFor(() => expect(screen.getByText('Loading messages…')).toBeInTheDocument());
-    expect(screen.getByRole('status', { name: 'Preparing session' })).toBeInTheDocument();
-    expect(sendButton).toBeDisabled();
-
+    // Messages resolve while /ensure is still streaming: the loader unmounts
+    // and the composer comes fully online without waiting for the warm-up.
     ensure.completeMessages();
     await waitFor(() => expect(screen.queryByRole('status', { name: 'Preparing session' })).not.toBeInTheDocument());
+
+    const user = userEvent.setup();
+    await user.type(screen.getByRole('textbox', { name: 'Message' }), 'ready before warm-up');
+    await waitFor(() => expect(sendButton).toBeEnabled());
+
+    // Warm-up progress may still stream in the background without re-blocking.
+    await ensure.emitProgress('cloning', 'Cloning acme/app…');
+    expect(sendButton).toBeEnabled();
+    expect(screen.queryByRole('status', { name: 'Preparing session' })).not.toBeInTheDocument();
+
+    // The warm-up fired exactly once for this session entry.
+    expect(ensure.ensureRequests()).toBe(1);
+    await ensure.completeEnsure();
+    await waitForMutationsIdle(client);
   });
 
-  it('keeps the textarea typable during preparing and preserves the draft after /ensure', async () => {
+  it('keeps the textarea typable during message loading and preserves the draft', async () => {
     const ensure = stubThreadRoute();
-    renderThreadRoute();
+    const { client } = renderThreadRoute();
 
     // Composer mounts eagerly.
     const composerRegion = await screen.findByRole('region', { name: 'Thread composer' });
@@ -231,7 +225,7 @@ describe('ThreadPage eager render during /ensure', () => {
     textarea.focus();
     expect(document.activeElement).toBe(textarea);
 
-    // Ring is spinning (data-busy="true") during preparing.
+    // Ring is spinning (data-busy="true") while messages load.
     const ring = composerRegion.querySelector<HTMLElement>('[data-slot="composer-ring"]');
     if (!ring) throw new Error('Composer ring not found');
     expect(ring).toHaveAttribute('data-busy', 'true');
@@ -239,8 +233,8 @@ describe('ThreadPage eager render during /ensure', () => {
     // Placeholder starts with the initializing prefix while empty.
     expect(textarea.placeholder.startsWith('Initializing work session')).toBe(true);
 
-    // Send and every image-attachment entry point stay disabled while /ensure
-    // is pending, without disabling text entry.
+    // Send and every image-attachment entry point stay disabled while the
+    // initial messages request is held, without disabling text entry.
     const sendButton = screen.getByRole('button', { name: 'Send message' });
     expect(sendButton).toBeDisabled();
     expect(sendButton).toHaveAttribute('title', 'Initializing session…');
@@ -249,23 +243,14 @@ describe('ThreadPage eager render during /ensure', () => {
     fireEvent.paste(textarea, { clipboardData: { files: [image] } });
     expect(screen.queryByRole('button', { name: 'Remove image' })).not.toBeInTheDocument();
 
-    // User types a draft during preparing.
+    // User types a draft while messages load.
     const user = userEvent.setup();
     await user.type(textarea, 'my draft prompt');
     expect(textarea.value).toBe('my draft prompt');
 
-    // Resolve /ensure first — the draft remains while the initial messages
-    // request is still held and the final loader step stays active.
-    await ensure.completeEnsure();
-    await waitFor(() => expect(screen.getByText('Loading messages…')).toBeInTheDocument());
-    expect(textarea.value).toBe('my draft prompt');
-    expect(sendButton).toBeDisabled();
-    fireEvent.drop(composerRegion.querySelector('form') ?? composerRegion, { dataTransfer: { files: [image] } });
-    fireEvent.paste(textarea, { clipboardData: { files: [image] } });
-    expect(screen.queryByRole('button', { name: 'Remove image' })).not.toBeInTheDocument();
-
-    // Once messages resolve, the loader unmounts, ring stops spinning,
-    // placeholder reverts, Send tooltip clears, and Send becomes enabled.
+    // Messages resolve while /ensure is still pending: the loader unmounts,
+    // ring stops spinning, placeholder reverts, Send tooltip clears, and Send
+    // becomes enabled — all without waiting for the warm-up.
     ensure.completeMessages();
     await waitFor(() => expect(screen.queryByRole('status', { name: 'Preparing session' })).not.toBeInTheDocument());
     // Draft survives the flag flip without remount.
@@ -274,5 +259,12 @@ describe('ThreadPage eager render during /ensure', () => {
     expect(textarea.placeholder).toBe('Ask Mastra Code…');
     expect(sendButton).not.toHaveAttribute('title', 'Initializing session…');
     await waitFor(() => expect(sendButton).not.toBeDisabled());
+
+    // Attachments now work while the warm-up is still streaming.
+    fireEvent.drop(composerRegion.querySelector('form') ?? composerRegion, { dataTransfer: { files: [image] } });
+    expect(await screen.findByRole('button', { name: 'Remove image' })).toBeInTheDocument();
+
+    await ensure.completeEnsure();
+    await waitForMutationsIdle(client);
   });
 });

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageEnsureError.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageEnsureError.msw.test.tsx
@@ -144,6 +144,16 @@ describe('ThreadPage workspace preparation failure', () => {
     ).toBeInTheDocument();
     const retry = screen.getByRole('button', { name: 'Retry' });
 
+    // The warm-up failure is a banner, not a wall: the composer stays mounted
+    // and usable while the error is visible, because the run path can still
+    // materialize the sandbox lazily.
+    const composer = await screen.findByRole('region', { name: 'Thread composer' });
+    expect(composer).toBeInTheDocument();
+    const input = screen.getByRole('textbox');
+    expect(input).toBeEnabled();
+    await userEvent.type(input, 'still usable');
+    expect(input).toHaveValue('still usable');
+
     // Retry re-runs preparation; on success the error clears and the thread mounts.
     await userEvent.click(retry);
     expect(await screen.findByRole('region', { name: 'Thread composer' })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Last slice of #21767 (5c). Factory-ui session UX only — no server changes; uses the existing \`/ensure\` endpoint, so this is independent of the #21802 → #21803 → #21805 stack and mergeable against main now.

- **Fatal vs. non-fatal errors separated**: a missing/denied session (\`sessionError\`) still blocks the chat, but a failed background sandbox warm-up (\`warmupError\`) now shows as a banner while the session stays usable. \`retrySession\` retries both.
- **Warm-up targets the right repository**: the \`/ensure\` warm-up now waits for the stored session to resolve instead of falling back to the project's first repository, which could warm (and bill) the wrong sandbox in multi-repository projects.

## Test plan

- New \`ChatSessionWarmup.msw.test.tsx\`: deterministic two-repository regression test — delays the session response so connections resolve first, asserts \`/ensure\` fires exactly once for the session's own repository (fails without the gate).
- Updated \`ComposerPreparingSession\`/\`ThreadPageEagerRender\` MSW tests for the new error split.
- \`test:msw\` 590 passed (121 files), \`test:unit\` 208 passed, typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Chat sessions can open while sandbox setup runs or fails. Users can start chatting sooner, see setup errors, and retry setup without losing the session.

## Changes

- Separated fatal `sessionError` failures from non-fatal `warmupError` failures.
- Allowed the composer, sending, and image attachments to become available before sandbox warm-up completes.
- Kept message delivery queued until the workspace is ready.
- Updated `retrySession` to retry session preparation and sandbox warm-up.
- Started warm-up only after session metadata resolves.
- Targeted the repository from the stored session instead of the first factory repository.
- Scoped 404 feedback to the relevant error source.
- Added deterministic two-repository warm-up targeting coverage.
- Updated MSW tests for background warm-up behavior, composer usability, mutation synchronization, and explicit session visibility.
- Reported validation: 590 MSW tests, 208 unit tests, 798 Factory UI tests, and clean typechecking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->