### PR TITLE
fix: scope Subconscious knowledge capture to the real organization on every session path

### DIFF
--- a/.changeset/olive-orgs-stay-closed.md
+++ b/.changeset/olive-orgs-stay-closed.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Factory-hosted sessions now start with `factoryOrgUnresolved: true`, so a session whose organization seeding fails refuses knowledge capture instead of writing to the local knowledge graph. Successful org seeding still clears the marker and a resolved organization still takes precedence.

--- a/.changeset/user-session-org-seed.md
+++ b/.changeset/user-session-org-seed.md
@@ -1,5 +1,13 @@
 ---
 '@mastra/factory': patch
+'@mastra/code-sdk': patch
 ---
 
-Fix organization scoping for user chat sessions in the factory.
+Fix organization scoping for Subconscious knowledge capture.
+
+Every factory session-creation path now seeds the authoritative organization id into
+session state, and a path that cannot resolve one marks the session unresolved. The code
+SDK no longer promotes a session owner id into the organization slot: a factory-owned
+session with no resolvable organization disables knowledge capture and logs once instead
+of writing into a scope the read path can never resolve, and local (TUI/studio) use
+captures under an explicit local scope.

--- a/.changeset/user-session-org-seed.md
+++ b/.changeset/user-session-org-seed.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Seed the tenant org on user chat sessions so subconscious knowledge capture is scoped to the tenant instead of the controller id.
+Fix organization scoping for user chat sessions in the factory.

--- a/.changeset/user-session-org-seed.md
+++ b/.changeset/user-session-org-seed.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Seed the tenant org on user chat sessions so subconscious knowledge capture is scoped to the tenant instead of the controller id.

--- a/.changeset/user-session-org-seed.md
+++ b/.changeset/user-session-org-seed.md
@@ -3,11 +3,10 @@
 '@mastra/code-sdk': patch
 ---
 
-Fix organization scoping for Subconscious knowledge capture.
+Fix knowledge captured in factory sessions being stored in the wrong tenant.
 
-Every factory session-creation path now seeds the authoritative organization id into
-session state, and a path that cannot resolve one marks the session unresolved. The code
-SDK no longer promotes a session owner id into the organization slot: a factory-owned
-session with no resolvable organization disables knowledge capture and logs once instead
-of writing into a scope the read path can never resolve, and local (TUI/studio) use
-captures under an explicit local scope.
+Knowledge captured during a factory session is now always stored under the organization
+that owns the session, so it is visible in that organization's knowledge graph. A session
+whose organization cannot be determined no longer stores knowledge somewhere it could
+never be read back from; it stops capturing and reports why. Local (TUI/studio) use is
+unaffected and captures under a dedicated local scope.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -482,7 +482,7 @@ describe('MastraFactory.prepare', () => {
     // On the controller, not per session — `createSession` clones
     // `initialState` on every path, webhook recreation included.
     const config = await prepareFactory({ storage: fakeStorage() });
-    expect(config.initialState).toMatchObject({ skipGlobalInstructions: true });
+    expect(config.initialState).toMatchObject({ skipGlobalInstructions: true, factoryOrgUnresolved: true });
     expect(config.disableSettingsOmSeed).toBe(true);
   });
 

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -705,7 +705,11 @@ export class MastraFactory {
         // A factory reads the repository it works on and its skill, never the
         // ~/.claude instructions of whoever hosts the process. On the controller
         // rather than per session, so webhook-recreated sessions keep it too.
-        initialState: { skipGlobalInstructions: true },
+        // Factory sessions start fail-closed on org classification: the
+        // unresolved marker is set at birth, a successful org seed clears it,
+        // and a resolved `factoryOrgId` always takes precedence — so a failed
+        // (best-effort) seed can never leave a session classified as local.
+        initialState: { skipGlobalInstructions: true, factoryOrgUnresolved: true },
         storage: storage.getMastraStorage(),
         ...(mastraStorageBackend ? { storageBackend: mastraStorageBackend } : {}),
         ...(factoryProcessor ? { inputProcessors: [factoryProcessor] } : {}),

--- a/mastracode/factory/src/integrations/github/webhook.test.ts
+++ b/mastracode/factory/src/integrations/github/webhook.test.ts
@@ -532,6 +532,25 @@ describe('dispatchGithubWebhook org seeding', () => {
     expect(state.factoryOrgId).toBe('org-1');
   });
 
+  it('clears a stale unresolved marker on a session that already has its org', async () => {
+    // An earlier failed resolution left the marker behind. Nothing re-seeds a
+    // session after its start hook, so the marker would refuse capture forever.
+    const state: Record<string, unknown> = {
+      factoryProjectId: 'resource-1',
+      factoryOrgId: 'org-1',
+      factoryOrgUnresolved: true,
+    };
+    const session = liveSession(state);
+    const getBySessionId = vi.fn(async () => ({ userId: 'user-1', orgId: 'org-other' }));
+
+    const result = await deliver(session, getBySessionId as never);
+
+    expect(result.delivered).toBe(1);
+    expect(getBySessionId).not.toHaveBeenCalled();
+    expect(state.factoryOrgId).toBe('org-1');
+    expect(state.factoryOrgUnresolved).toBe(false);
+  });
+
   it.each([
     ['the row lookup rejects', async () => { throw new Error('storage down'); }],
     ['the row is gone', async () => null],

--- a/mastracode/factory/src/integrations/github/webhook.test.ts
+++ b/mastracode/factory/src/integrations/github/webhook.test.ts
@@ -521,6 +521,19 @@ describe('dispatchGithubWebhook org seeding', () => {
     expect(state.factoryOrgUnresolved).toBe(false);
   });
 
+  it('heals a session whose stored org is blank', async () => {
+    // Not every seam routes its seed through seedSessionOrg, so a blank org can
+    // reach state. Capture trims before deciding, so a truthiness check here
+    // would call it resolved while capture refuses, and nothing would repair it.
+    const state: Record<string, unknown> = { factoryProjectId: 'resource-1', factoryOrgId: '   ' };
+    const session = liveSession(state);
+
+    const result = await deliver(session, (async () => ({ userId: 'user-1', orgId: 'org-1' })) as never);
+
+    expect(result.delivered).toBe(1);
+    expect(state.factoryOrgId).toBe('org-1');
+  });
+
   it('leaves an already-seeded session untouched, costing no storage read', async () => {
     const state: Record<string, unknown> = { factoryProjectId: 'resource-1', factoryOrgId: 'org-1' };
     const session = liveSession(state);

--- a/mastracode/factory/src/integrations/github/webhook.test.ts
+++ b/mastracode/factory/src/integrations/github/webhook.test.ts
@@ -292,8 +292,10 @@ describe('dispatchGithubWebhook', () => {
 
     expect(result).toEqual({ delivered: 2, failed: 0, skipped: 0, ignored: false });
     expect(getSessionByResource).toHaveBeenCalledWith('resource-1', '/worktrees/a');
-    expect(getBySessionId).toHaveBeenCalledOnce();
-    expect(getBySessionId).toHaveBeenCalledWith('session-b');
+    // 'session-b' is the row the new session is built from. 'session-a' is the
+    // heal: a live session carrying no org gets one recovered from its row
+    // rather than refusing to capture for the rest of its life.
+    expect(getBySessionId.mock.calls.map(call => call[0])).toEqual(['session-a', 'session-b']);
     // Owner and identity both come from the Factory session row, not from the
     // subscription's `ownerId` ('owner-1'), which matches no user.
     expect(createSession).toHaveBeenCalledWith({
@@ -479,5 +481,69 @@ describe('dispatchGithubWebhook', () => {
 
     expect(result).toEqual({ delivered: 0, failed: 0, skipped: 0, ignored: false });
     expect(controller.getSessionByResource).not.toHaveBeenCalled();
+  });
+});
+
+describe('dispatchGithubWebhook org seeding', () => {
+  const liveSession = (state: Record<string, unknown>) => {
+    const set = vi.fn(async (patch: Record<string, unknown>) => void Object.assign(state, patch));
+    return {
+      state: { get: () => state, set },
+      thread: { getId: () => 'thread-a', switch: vi.fn() },
+      sendNotificationSignal: vi.fn(async () => ({ record: { id: 'n-a' }, decision: { action: 'deliver' } })),
+    };
+  };
+
+  const deliver = async (session: ReturnType<typeof liveSession>, getBySessionId: () => Promise<never>) =>
+    dispatchGithubWebhook(
+      parsed('issue_comment', 'created', {
+        issue: { number: 34, pull_request: { url: 'https://api.github.test/pr/34' } },
+        comment: { html_url: 'https://github.com/octo/hello/pull/34#issuecomment-123' },
+        pull_request: undefined,
+      }),
+      {
+        controller: controllerStub({ getSessionByResource: async () => session }),
+        github: githubWithSessionRow(null, getBySessionId as never),
+        listSubscriptions: async () => [subscription('a', '/worktrees/a')],
+        isAuthorizedSender: async () => true,
+      },
+    );
+
+  it('heals a session created before the org seed existed', async () => {
+    const state: Record<string, unknown> = { factoryProjectId: 'resource-1', factoryOrgUnresolved: true };
+    const session = liveSession(state);
+
+    const result = await deliver(session, (async () => ({ userId: 'user-1', orgId: 'org-1' })) as never);
+
+    expect(result.delivered).toBe(1);
+    expect(state.factoryOrgId).toBe('org-1');
+    // The recovered org also clears the marker; nothing else would ever clear it.
+    expect(state.factoryOrgUnresolved).toBe(false);
+  });
+
+  it('leaves an already-seeded session untouched, costing no storage read', async () => {
+    const state: Record<string, unknown> = { factoryProjectId: 'resource-1', factoryOrgId: 'org-1' };
+    const session = liveSession(state);
+    const getBySessionId = vi.fn(async () => ({ userId: 'user-1', orgId: 'org-other' }));
+
+    await deliver(session, getBySessionId as never);
+
+    expect(getBySessionId).not.toHaveBeenCalled();
+    expect(state.factoryOrgId).toBe('org-1');
+  });
+
+  it.each([
+    ['the row lookup rejects', async () => { throw new Error('storage down'); }],
+    ['the row is gone', async () => null],
+    ['the row carries an empty org', async () => ({ userId: 'user-1', orgId: '' })],
+  ])('marks the session unresolved and still delivers when %s', async (_label, getBySessionId) => {
+    const state: Record<string, unknown> = { factoryProjectId: 'resource-1' };
+    const session = liveSession(state);
+
+    const result = await deliver(session, getBySessionId as never);
+
+    expect(result.delivered).toBe(1);
+    expect(state.factoryOrgUnresolved).toBe(true);
+    expect(state.factoryOrgId).toBeUndefined();
   });
 });

--- a/mastracode/factory/src/integrations/github/webhook.ts
+++ b/mastracode/factory/src/integrations/github/webhook.ts
@@ -395,6 +395,12 @@ async function resolveSubscriptionSession(
       console.warn('[GitHub webhook] Unable to resolve the session organization.', error);
       await seedSessionOrg(session, undefined);
     }
+  } else if (session.state?.get()?.factoryOrgUnresolved) {
+    // The org is present, so an earlier failed resolution left a stale marker
+    // behind. Clear it without a storage read — nothing else re-seeds a session
+    // once the start hook has run, so the marker would otherwise outlive its
+    // cause.
+    await seedSessionOrg(session, session.state.get()?.factoryOrgId);
   }
   if (session.thread.getId() !== threadId) {
     await session.thread.switch({ threadId, emitEvent: false });

--- a/mastracode/factory/src/integrations/github/webhook.ts
+++ b/mastracode/factory/src/integrations/github/webhook.ts
@@ -3,7 +3,7 @@ import type { MountedMastraCode } from '@mastra/code-sdk';
 import type { NotificationPriority } from '@mastra/core/notifications';
 import { RequestContext } from '@mastra/core/request-context';
 import type { Context } from 'hono';
-import { seedSessionOrg } from '../../session/org-seed.js';
+import { hasResolvedOrg, seedSessionOrg } from '../../session/org-seed.js';
 import { GithubAppIdentity } from './app-identity.js';
 import type { GithubIntegration, GithubRepositoryPermission } from './integration.js';
 import { listPullRequestSubscriptionsForWebhook, retirePullRequestSubscription } from './subscriptions.js';
@@ -379,7 +379,7 @@ async function resolveSubscriptionSession(
       requestContext,
     });
     await seedSessionOrg(session, sessionRow.orgId);
-  } else if (!session.state?.get()?.factoryOrgId) {
+  } else if (!hasResolvedOrg(session.state?.get()?.factoryOrgId)) {
     // A session created before the org seed existed carries the project tag and
     // no org, so capture would refuse for the rest of its life even though the
     // org is recoverable. Heal it — but only here, and only when it is missing:

--- a/mastracode/factory/src/integrations/github/webhook.ts
+++ b/mastracode/factory/src/integrations/github/webhook.ts
@@ -3,6 +3,7 @@ import type { MountedMastraCode } from '@mastra/code-sdk';
 import type { NotificationPriority } from '@mastra/core/notifications';
 import { RequestContext } from '@mastra/core/request-context';
 import type { Context } from 'hono';
+import { seedSessionOrg } from '../../session/org-seed.js';
 import { GithubAppIdentity } from './app-identity.js';
 import type { GithubIntegration, GithubRepositoryPermission } from './integration.js';
 import { listPullRequestSubscriptionsForWebhook, retirePullRequestSubscription } from './subscriptions.js';
@@ -377,6 +378,23 @@ async function resolveSubscriptionSession(
       tags,
       requestContext,
     });
+    await seedSessionOrg(session, sessionRow.orgId);
+  } else if (!session.state?.get()?.factoryOrgId) {
+    // A session created before the org seed existed carries the project tag and
+    // no org, so capture would refuse for the rest of its life even though the
+    // org is recoverable. Heal it — but only here, and only when it is missing:
+    // hoisting the row fetch above would make an existing-session delivery throw
+    // on a missing row where it previously succeeded, and fetching it every time
+    // would add a storage read to every delivery. A row that is missing or a
+    // lookup that throws leaves the session marked unresolved, and delivery
+    // continues either way.
+    try {
+      const sessionRow = await github?.sourceControlStorage.sessions.getBySessionId(sessionId);
+      await seedSessionOrg(session, sessionRow?.orgId);
+    } catch (error) {
+      console.warn('[GitHub webhook] Unable to resolve the session organization.', error);
+      await seedSessionOrg(session, undefined);
+    }
   }
   if (session.thread.getId() !== threadId) {
     await session.thread.switch({ threadId, emitEvent: false });

--- a/mastracode/factory/src/integrations/slack/slack.test.ts
+++ b/mastracode/factory/src/integrations/slack/slack.test.ts
@@ -871,6 +871,68 @@ describe('session start (onSessionStart)', () => {
     expect(session.state.set).toHaveBeenCalledWith({ factoryProjectId: 'fp-1', factoryOrgId: 'org-1' });
   });
 
+  // The org rung knowledge capture scopes on. `gateDispatch` stamps it on the
+  // request context before the session exists, so it is in hand above every
+  // guard below — and seeding it must not cost a storage read.
+  const orgContext = (organizationId: unknown) => ({
+    get: (key: string) => (key === 'user' ? { id: 'user-1', organizationId } : undefined),
+  });
+
+  it('seeds the organization on a chat-only thread, which reaches no other seam', async () => {
+    const deps = makeStartDeps();
+    const session = makeSession();
+
+    await createChannelSessionStartHook(deps as any)({
+      ...startArgs(session, 'channel:slack:C-1:1700.42'),
+      requestContext: orgContext('org-1'),
+    } as any);
+
+    expect(session.state.set).toHaveBeenCalledWith({ factoryOrgId: 'org-1' });
+    expect(deps.sourceControl.sessions.getBySessionId).not.toHaveBeenCalled();
+  });
+
+  it('still seeds the organization when a mode model is already persisted', async () => {
+    const deps = makeStartDeps();
+    const session = makeSession({ persistedModeModel: 'anthropic/claude-fable-5' });
+
+    await createChannelSessionStartHook(deps as any)({
+      ...startArgs(session),
+      requestContext: orgContext('org-1'),
+    } as any);
+
+    expect(session.state.set).toHaveBeenCalledWith({ factoryOrgId: 'org-1' });
+    // The guard still holds, and the seed still took the request-context route.
+    expect(session.model.switch).not.toHaveBeenCalled();
+    expect(deps.sourceControl.sessions.getBySessionId).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['no request context at all', undefined],
+    ['a context whose user carries no org', orgContext(null)],
+  ])('marks the session unresolved given %s', async (_label, requestContext) => {
+    const deps = makeStartDeps();
+    const session = makeSession();
+
+    await createChannelSessionStartHook(deps as any)({
+      ...startArgs(session, 'channel:slack:C-1:1700.42'),
+      requestContext,
+    } as any);
+
+    expect(session.state.set).toHaveBeenCalledWith({ factoryOrgUnresolved: true });
+    expect(session.state.set).not.toHaveBeenCalledWith(expect.objectContaining({ factoryOrgId: expect.anything() }));
+  });
+
+  it('marks the session unresolved when the channel dependencies are absent', async () => {
+    const session = makeSession();
+
+    await createChannelSessionStartHook({} as any)({
+      ...startArgs(session),
+      requestContext: undefined,
+    } as any);
+
+    expect(session.state.set).toHaveBeenCalledWith({ factoryOrgUnresolved: true });
+  });
+
   it('skips chat-only threads, whose resourceId names no project', async () => {
     const deps = makeStartDeps();
     const session = makeSession();

--- a/mastracode/factory/src/integrations/slack/slack.test.ts
+++ b/mastracode/factory/src/integrations/slack/slack.test.ts
@@ -868,7 +868,21 @@ describe('session start (onSessionStart)', () => {
     expect(session.model.switch).not.toHaveBeenCalled();
     // The factory stamp still lands: org-first credential resolution keys off
     // controller state even when the model choice is already persisted.
-    expect(session.state.set).toHaveBeenCalledWith({ factoryProjectId: 'fp-1', factoryOrgId: 'org-1' });
+    expect(session.state.set).toHaveBeenCalledWith({ factoryProjectId: 'fp-1' });
+    expect(session.state.set).toHaveBeenCalledWith(expect.objectContaining({ factoryOrgId: 'org-1' }));
+  });
+
+  // An ungated dispatch marks the session unresolved above every guard. Owner
+  // recovery is the resolution, so it has to take the marker down with it —
+  // otherwise capture refuses for the life of the session over a stale flag.
+  it('clears the unresolved marker when owner recovery resolves the organization', async () => {
+    const deps = makeStartDeps();
+    const session = makeSession();
+    session.state.get = vi.fn(() => ({ factoryOrgUnresolved: true })) as any;
+
+    await createChannelSessionStartHook(deps as any)(startArgs(session) as any);
+
+    expect(session.state.set).toHaveBeenCalledWith({ factoryOrgId: 'org-1', factoryOrgUnresolved: false });
   });
 
   // The org rung knowledge capture scopes on. `gateDispatch` stamps it on the

--- a/mastracode/factory/src/integrations/slack/slack.test.ts
+++ b/mastracode/factory/src/integrations/slack/slack.test.ts
@@ -901,9 +901,8 @@ describe('session start (onSessionStart)', () => {
     } as any);
 
     expect(session.state.set).toHaveBeenCalledWith({ factoryOrgId: 'org-1' });
-    // The guard still holds, and the seed still took the request-context route.
+    // The guard still holds: the persisted mode model is left alone.
     expect(session.model.switch).not.toHaveBeenCalled();
-    expect(deps.sourceControl.sessions.getBySessionId).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/mastracode/factory/src/integrations/slack/slack.ts
+++ b/mastracode/factory/src/integrations/slack/slack.ts
@@ -415,7 +415,11 @@ export function createChannelSessionStartHook(deps: SlackChannelDeps): ChannelSe
     // Repo-backed Slack sessions are factory sessions: stamp the owning
     // project onto controller state so downstream reads (org-first credential
     // resolution, authority gates) recognize them, same as board runs.
-    await session.state.set({ factoryProjectId: owner.factoryProjectId, factoryOrgId: owner.orgId });
+    await session.state.set({ factoryProjectId: owner.factoryProjectId });
+    // Route the org through the seed helper rather than stamping it directly:
+    // an ungated dispatch marked this session unresolved above, and owner
+    // recovery is the resolution that has to clear that marker with it.
+    await seedSessionOrg(session, owner.orgId);
 
     const modeModelKey = `modeModelId_${session.mode.get()}`;
     if (await session.thread.getSetting({ key: modeModelKey })) return;

--- a/mastracode/factory/src/integrations/slack/slack.ts
+++ b/mastracode/factory/src/integrations/slack/slack.ts
@@ -19,6 +19,7 @@ import {
   resolveFactoryProjectForSession,
   resolveFactorySourceRepository,
 } from '../../session/factory-session.js';
+import { readRequestContextOrgId, seedSessionOrg } from '../../session/org-seed.js';
 import type {
   ChannelAccountLink,
   ChannelAccountLinkKey,
@@ -396,7 +397,15 @@ export const resolveChannelThreadId: ResolveThreadId = ({ resourceId, defaultThr
  */
 export function createChannelSessionStartHook(deps: SlackChannelDeps): ChannelSessionStart {
   const { projects, sourceControl, memorySettings } = deps;
-  return async ({ session, thread }) => {
+  return async ({ session, thread, requestContext }) => {
+    // Seed the tenant org above every guard below. `gateDispatch` stamps it on
+    // the message's request context before the session exists, so this needs no
+    // storage read — which matters, because the guards below deliberately skip
+    // storage on a restarted session. A channel-only thread and a thread whose
+    // dispatch was ungated both land here with no org and are marked unresolved
+    // rather than being left to look like a local session.
+    await seedSessionOrg(session, readRequestContextOrgId(requestContext));
+
     if (!projects || !sourceControl) return;
     if (thread.resourceId.startsWith('channel:')) return;
 

--- a/mastracode/factory/src/session/factory-session.test.ts
+++ b/mastracode/factory/src/session/factory-session.test.ts
@@ -196,6 +196,9 @@ describe('hydrateFactorySession', () => {
     await hydrateFactorySession(session, { orgId: 'org-1', factoryProjectId: 'proj-1' });
 
     expect(double.model.switch).not.toHaveBeenCalled();
+    // The org seed is the one state write that always happens: knowledge
+    // capture scopes on it, and it must land even when nothing else does.
+    expect(double.state.set).toHaveBeenCalledWith({ factoryOrgId: 'org-1' });
   });
 
   it('resets to the built-in memory defaults when memory settings are omitted', async () => {
@@ -209,6 +212,15 @@ describe('hydrateFactorySession', () => {
       observationThreshold: DEFAULT_OBSERVATION_THRESHOLD,
       reflectionThreshold: DEFAULT_REFLECTION_THRESHOLD,
     });
+  });
+
+  it('marks the session unresolved when the caller has no organization', async () => {
+    const { session, double } = createSessionDouble();
+
+    await hydrateFactorySession(session, { orgId: '  ', factoryProjectId: 'proj-1' });
+
+    expect(double.state.set).toHaveBeenCalledWith({ factoryOrgUnresolved: true });
+    expect(double.state.set).not.toHaveBeenCalledWith(expect.objectContaining({ factoryOrgId: expect.anything() }));
   });
 
   it('keeps going when the default model is unknown', async () => {

--- a/mastracode/factory/src/session/factory-session.ts
+++ b/mastracode/factory/src/session/factory-session.ts
@@ -9,6 +9,7 @@ import type { MemorySettingsStorage } from '../storage/domains/memory-settings/b
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 import { applyStoredMemorySettings } from './memory-settings-hydration.js';
+import { seedSessionOrg } from './org-seed.js';
 
 type FactorySession = Awaited<ReturnType<AgentController<MastraCodeState>['createSession']>>;
 
@@ -237,6 +238,9 @@ export interface HydrateFactorySessionArgs {
  * default it was created with, and the reason is logged.
  */
 export async function hydrateFactorySession(session: FactorySession, args: HydrateFactorySessionArgs): Promise<void> {
+  // The org rung knowledge capture scopes on. Seeded first so it lands even if
+  // a later best-effort step fails; an empty org marks the session unresolved.
+  await seedSessionOrg(session, args.orgId);
   try {
     const record =
       args.memorySettings && args.factoryProjectId

--- a/mastracode/factory/src/session/memory-settings-hydration.test.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.test.ts
@@ -235,6 +235,17 @@ describe('hydrateSessionMemorySettings', () => {
     expect(session.state.set).toHaveBeenCalledWith({ factoryOrgUnresolved: true });
   });
 
+  it('re-resolves a tagged session whose stored org is blank', async () => {
+    // The coordinator-hydrated early return has to agree with the capture side,
+    // which trims: a blank org is unresolved, so this session still needs a seed.
+    const session = createSession({ factoryProjectId: 'project-1', factoryOrgId: '   ' });
+    const dependencies = createDependencies({ row: { orgId: 'org-1', userId: 'user-1' } as never });
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.state.set).toHaveBeenCalledWith(expect.objectContaining({ factoryOrgId: 'org-1' }));
+  });
+
   it('marks the session unresolved when the row lookup rejects', async () => {
     const session = createSession();
     const dependencies = createDependencies();

--- a/mastracode/factory/src/session/memory-settings-hydration.test.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.test.ts
@@ -213,14 +213,36 @@ describe('hydrateSessionMemorySettings', () => {
     expect(session.state.set).toHaveBeenCalledWith({ factoryOrgId: 'org-1' });
   });
 
-  it('writes nothing and does not throw when the session has no source-control row', async () => {
+  it('marks the session unresolved and does not throw when it has no source-control row', async () => {
+    // No row means no org. Staying silent here is what let a Factory session be
+    // mistaken for a local one and filed under a scope nothing can read.
     const session = createSession();
     const dependencies = createDependencies({ row: null });
 
     await hydrateSessionMemorySettings(session, dependencies);
 
-    expect(session.state.set).not.toHaveBeenCalled();
+    expect(session.state.set).toHaveBeenCalledWith({ factoryOrgUnresolved: true });
+    expect(session.state.set).not.toHaveBeenCalledWith(expect.objectContaining({ factoryOrgId: expect.anything() }));
     expect(dependencies.memorySettings.get).not.toHaveBeenCalled();
+  });
+
+  it('marks the session unresolved when the row carries an empty org', async () => {
+    const session = createSession();
+    const dependencies = createDependencies({ row: { orgId: '  ', userId: 'user-1' } as never });
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.state.set).toHaveBeenCalledWith({ factoryOrgUnresolved: true });
+  });
+
+  it('marks the session unresolved when the row lookup rejects', async () => {
+    const session = createSession();
+    const dependencies = createDependencies();
+    dependencies.sourceControl.sessions.getBySessionId.mockRejectedValueOnce(new Error('storage down'));
+
+    await expect(hydrateSessionMemorySettings(session, dependencies)).resolves.toBeUndefined();
+
+    expect(session.state.set).toHaveBeenCalledWith({ factoryOrgUnresolved: true });
   });
 
   it('seeds the org on a tagged session that never went through the coordinator', async () => {

--- a/mastracode/factory/src/session/memory-settings-hydration.test.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.test.ts
@@ -152,7 +152,9 @@ describe('hydrateSessionMemorySettings', () => {
   });
 
   it('applies stored thresholds and attachment preferences to session state', async () => {
-    const session = createSession();
+    // Org pre-seeded: the seed has its own cases, and these assert the exact
+    // settings write.
+    const session = createSession({ factoryOrgId: 'org-1' });
     const dependencies = createDependencies({
       settings: memorySettingsRow({ observationThreshold: 12_000, observeAttachments: false }),
     });
@@ -168,7 +170,7 @@ describe('hydrateSessionMemorySettings', () => {
 
   it('resets stale session state when the stored row has null knobs', async () => {
     const session = createSession(
-      { observationThreshold: 99_000 },
+      { observationThreshold: 99_000, factoryOrgId: 'org-1' },
       { observer: 'google/gemini-3.5-flash', reflector: 'google/gemini-3.5-flash' },
     );
     const dependencies = createDependencies();
@@ -181,13 +183,68 @@ describe('hydrateSessionMemorySettings', () => {
     });
   });
 
-  it('skips factory-run sessions, which hydrate through the start coordinator', async () => {
+  it('seeds the tenant org from the session row so knowledge capture is scoped to it', async () => {
+    // Without this seed the capture side falls back to the session owner id —
+    // the controller's own id for web chat sessions — and every captured node
+    // lands under an org rung the knowledge reader never queries.
+    const session = createSession();
+    const dependencies = createDependencies();
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.state.set).toHaveBeenCalledWith({ factoryOrgId: 'org-1' });
+  });
+
+  it('does not rewrite an org that already matches the row', async () => {
+    const session = createSession({ factoryOrgId: 'org-1' });
+    const dependencies = createDependencies();
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.state.set).not.toHaveBeenCalledWith({ factoryOrgId: 'org-1' });
+  });
+
+  it('overwrites a stale org with the row org, since the row is authoritative', async () => {
+    const session = createSession({ factoryOrgId: 'stale-org' });
+    const dependencies = createDependencies();
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.state.set).toHaveBeenCalledWith({ factoryOrgId: 'org-1' });
+  });
+
+  it('writes nothing and does not throw when the session has no source-control row', async () => {
+    const session = createSession();
+    const dependencies = createDependencies({ row: null });
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
+    expect(session.state.set).not.toHaveBeenCalled();
+    expect(dependencies.memorySettings.get).not.toHaveBeenCalled();
+  });
+
+  it('seeds the org on a tagged session that never went through the coordinator', async () => {
+    // A web chat session persists `factoryProjectId` from its browser seed, so on
+    // resume it carries the tag with no org. Skipping on the tag alone would leave
+    // it mis-scoped forever. Settings still belong to the coordinator.
     const session = createSession({ factoryProjectId: 'project-1' });
     const dependencies = createDependencies();
 
     await hydrateSessionMemorySettings(session, dependencies);
 
+    expect(session.state.set).toHaveBeenCalledExactlyOnceWith({ factoryOrgId: 'org-1' });
+    expect(dependencies.memorySettings.get).not.toHaveBeenCalled();
+    expect(session.om.observer.switchModel).not.toHaveBeenCalled();
+  });
+
+  it('skips fully hydrated factory-run sessions, which the start coordinator owns', async () => {
+    const session = createSession({ factoryProjectId: 'project-1', factoryOrgId: 'org-1' });
+    const dependencies = createDependencies();
+
+    await hydrateSessionMemorySettings(session, dependencies);
+
     expect(dependencies.sourceControl.sessions.getBySessionId).not.toHaveBeenCalled();
+    expect(session.state.set).not.toHaveBeenCalled();
     expect(session.om.observer.switchModel).not.toHaveBeenCalled();
   });
 
@@ -205,7 +262,7 @@ describe('hydrateSessionMemorySettings', () => {
     // A missing row must behave like the settings routes: stale persisted
     // session values reset to the built-in defaults instead of surviving.
     const session = createSession(
-      { observationThreshold: 99_000 },
+      { observationThreshold: 99_000, factoryOrgId: 'org-1' },
       { observer: 'openai/gpt-5-mini', reflector: 'openai/gpt-5-mini' },
     );
     const dependencies = createDependencies({ settings: null });

--- a/mastracode/factory/src/session/memory-settings-hydration.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.ts
@@ -2,7 +2,7 @@ import { DEFAULT_OM_MODEL_ID } from '@mastra/code-sdk/constants';
 
 import type { MemorySettingsRecord, MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
-import { seedSessionOrg } from './org-seed.js';
+import { hasResolvedOrg, seedSessionOrg } from './org-seed.js';
 
 /** Default thresholds mirror the TUI `/om` fallbacks. */
 export const DEFAULT_OBSERVATION_THRESHOLD = 30_000;
@@ -117,7 +117,7 @@ export async function hydrateSessionMemorySettings(
   const state = session.state.get() ?? {};
   const isFactoryRun = Boolean(state.factoryProjectId);
   // A coordinator-hydrated run already carries both halves. Nothing to add.
-  if (isFactoryRun && state.factoryOrgId) return;
+  if (isFactoryRun && hasResolvedOrg(state.factoryOrgId)) return;
   try {
     const record = await sourceControl.sessions.getBySessionId(session.identity.getResourceId());
     // No row, or a row whose org is blank, leaves the session with no tenant.

--- a/mastracode/factory/src/session/memory-settings-hydration.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.ts
@@ -94,10 +94,11 @@ export interface MemorySettingsHydrationDependencies {
  * start a run.
  *
  * The org seed matters beyond settings. Subconscious knowledge capture scopes
- * every node and record on `factoryOrgId`; without it the capture side falls
- * back to the session owner id, which for web chat sessions is the agent
- * controller's own id rather than a tenant, so captured knowledge lands under an
- * org rung no reader ever queries. Same rule as the start coordinator: the org
+ * every node and record on `factoryOrgId`; before the SDK refusal guard,
+ * missing it made capture substitute the session owner id. For web chat sessions
+ * that is the agent controller's own id rather than a tenant, so captured
+ * knowledge landed under an org rung no reader ever queries. Same rule as the
+ * start coordinator: the org
  * comes from the row the session was created from, never improvised from an
  * owner id.
  *

--- a/mastracode/factory/src/session/memory-settings-hydration.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.ts
@@ -2,6 +2,7 @@ import { DEFAULT_OM_MODEL_ID } from '@mastra/code-sdk/constants';
 
 import type { MemorySettingsRecord, MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
+import { seedSessionOrg } from './org-seed.js';
 
 /** Default thresholds mirror the TUI `/om` fallbacks. */
 export const DEFAULT_OBSERVATION_THRESHOLD = 30_000;
@@ -118,14 +119,19 @@ export async function hydrateSessionMemorySettings(
   if (isFactoryRun && state.factoryOrgId) return;
   try {
     const record = await sourceControl.sessions.getBySessionId(session.identity.getResourceId());
+    // No row, or a row whose org is blank, leaves the session with no tenant.
+    // Mark it rather than returning silently: an unmarked projectless factory
+    // session is indistinguishable from a local one, and capture would file it
+    // under the local scope — the same bug wearing a different rung.
+    await seedSessionOrg(session, record?.orgId);
     if (!record) return;
-    if (state.factoryOrgId !== record.orgId) {
-      await session.state.set({ factoryOrgId: record.orgId });
-    }
     if (isFactoryRun) return;
     const settings = await memorySettings.get({ orgId: record.orgId, userId: record.userId });
     await applyStoredMemorySettings(session, settings);
   } catch (error) {
     console.warn('[Factory memory-settings hydration] Unable to apply stored memory settings.', error);
+    // A failed lookup is an unresolved org, not an absent one — unless the seed
+    // already landed and a later step is what threw.
+    if (!session.state.get()?.factoryOrgId) await seedSessionOrg(session, undefined);
   }
 }

--- a/mastracode/factory/src/session/memory-settings-hydration.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.ts
@@ -24,6 +24,7 @@ interface OMStateWrites {
   observationThreshold?: number;
   reflectionThreshold?: number;
   observeAttachments?: 'auto' | boolean;
+  factoryOrgId?: string;
 }
 
 /** The slice of a session needed to apply stored observational-memory settings. */
@@ -86,24 +87,42 @@ export interface MemorySettingsHydrationDependencies {
 }
 
 /**
- * Seed a freshly created controller session's observational-memory settings
- * from the owner's stored `memory-settings` row. Registered as a blocking
- * session-created listener so the seed lands before the caller can start a run.
+ * Seed a freshly created controller session's tenant org and its
+ * observational-memory settings from the owner's source-control row. Registered
+ * as a blocking session-created listener so the seed lands before the caller can
+ * start a run.
  *
- * Sessions tagged `factoryProjectId` (work/review runs, created with that tag)
- * hydrate through the start coordinator; sessions without a GitHub
- * source-control row (e.g. chat-only channel sessions) hydrate through
- * `hydrateFactorySession` with their own resolved tenant. Both are skipped
- * here. Best-effort: failures are logged, never thrown.
+ * The org seed matters beyond settings. Subconscious knowledge capture scopes
+ * every node and record on `factoryOrgId`; without it the capture side falls
+ * back to the session owner id, which for web chat sessions is the agent
+ * controller's own id rather than a tenant, so captured knowledge lands under an
+ * org rung no reader ever queries. Same rule as the start coordinator: the org
+ * comes from the row the session was created from, never improvised from an
+ * owner id.
+ *
+ * Memory settings for sessions tagged `factoryProjectId` (work/review runs) are
+ * owned by the start coordinator, and sessions without a GitHub source-control
+ * row (e.g. chat-only channel sessions) hydrate through `hydrateFactorySession`
+ * with their own resolved tenant; both are skipped here. The org seed is not
+ * skipped on the tag alone: a web chat session persists `factoryProjectId` from
+ * its browser seed, so on resume it carries the tag without ever having been
+ * through the coordinator. Best-effort: failures are logged, never thrown.
  */
 export async function hydrateSessionMemorySettings(
   session: MemorySettingsHydrationSession,
   { sourceControl, memorySettings }: MemorySettingsHydrationDependencies,
 ): Promise<void> {
-  if (session.state.get()?.factoryProjectId) return;
+  const state = session.state.get() ?? {};
+  const isFactoryRun = Boolean(state.factoryProjectId);
+  // A coordinator-hydrated run already carries both halves. Nothing to add.
+  if (isFactoryRun && state.factoryOrgId) return;
   try {
     const record = await sourceControl.sessions.getBySessionId(session.identity.getResourceId());
     if (!record) return;
+    if (state.factoryOrgId !== record.orgId) {
+      await session.state.set({ factoryOrgId: record.orgId });
+    }
+    if (isFactoryRun) return;
     const settings = await memorySettings.get({ orgId: record.orgId, userId: record.userId });
     await applyStoredMemorySettings(session, settings);
   } catch (error) {

--- a/mastracode/factory/src/session/org-seed-fail-open.test.ts
+++ b/mastracode/factory/src/session/org-seed-fail-open.test.ts
@@ -1,0 +1,114 @@
+import { getDynamicMemory } from '@mastra/code-sdk/agents/memory';
+import { LibSQLFactoryStorage } from '@mastra/libsql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MastraFactory } from '../factory.js';
+import { seedSessionOrg } from './org-seed.js';
+
+/**
+ * Wire regression for the org-classification fail-open (PR #21823 review):
+ * a projectless Factory-hosted session whose org-state write REJECTS must
+ * refuse knowledge capture, never fall through to the `local` org.
+ *
+ * The chain under test is real end to end: the Factory controller's actual
+ * `initialState` (captured off the mocked SDK mount) -> session state built
+ * the way `Session` builds it -> `seedSessionOrg` with a rejecting
+ * `state.set` -> the REAL SDK classification in `getDynamicMemory` (deep
+ * import; the bare-specifier mock below does not touch it). `@mastra/memory`
+ * is NOT mocked — the sdk dist resolves its own (externalized) copy, so the
+ * refusal is asserted through its two real observables: the deduped
+ * "Knowledge capture disabled" error (fired iff capture is refused) and the
+ * request context never being classified.
+ *
+ * Without `factoryOrgUnresolved: true` in the controller's `initialState`,
+ * the failed seed leaves neither marker and classification falls to `local`.
+ */
+
+// Bare-specifier mock: captures the controller mount config. Does NOT
+// intercept the deep import `@mastra/code-sdk/agents/memory` (vitest mocks by
+// specifier), so `getDynamicMemory` stays real — which is the point.
+const prepareMock = vi.fn(async (config: Record<string, unknown>) => ({
+  base: { controller: { onSessionCreated: vi.fn(), setChannels: vi.fn() } },
+  mastraArgs: {},
+  finalize: vi.fn(async () => {}),
+}));
+
+vi.mock('@mastra/code-sdk', () => ({
+  prepareAgentControllerMount: (config: Record<string, unknown>) => prepareMock(config),
+}));
+
+describe('org-classification fail-open (projectless factory session, rejecting org-state write)', () => {
+  const envBefore = process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS;
+
+  beforeEach(() => {
+    prepareMock.mockClear();
+    process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = '1';
+  });
+
+  afterEach(() => {
+    if (envBefore === undefined) delete process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS;
+    else process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = envBefore;
+  });
+
+  it('refuses capture and never classifies as local when the org seed write rejects', async () => {
+    // 1. The controller's REAL initialState, captured off the factory mount.
+    const storage = new LibSQLFactoryStorage({ url: ':memory:', id: 'org-seed-fail-open-test' });
+    const factory = new MastraFactory({ storage });
+    await factory.prepare();
+    expect(prepareMock).toHaveBeenCalledOnce();
+    const capturedInitialState = (prepareMock.mock.calls[0]![0] as { initialState: Record<string, unknown> })
+      .initialState;
+
+    // 2. Session state as the controller builds it: schema defaults merged
+    //    with the cloned initialState (session.ts merge order).
+    const schemaDefaults: Record<string, unknown> = {};
+    const sessionState = { ...schemaDefaults, ...structuredClone(capturedInitialState) };
+
+    // 3. Tyler's exact scenario: a projectless session whose org-state write
+    //    REJECTS. seedSessionOrg swallows the failure by contract, so the
+    //    write leaves no trace in session state.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sessionDouble = {
+      state: {
+        get: () => sessionState,
+        set: () => Promise.reject(new Error('session state write failed')),
+      },
+    };
+    await seedSessionOrg(sessionDouble, undefined);
+    warnSpy.mockRestore();
+
+    // 4. The real SDK classification over that state.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const getState = () => sessionState;
+      const values = new Map<string, unknown>([
+        [
+          'controller',
+          {
+            getState,
+            session: { id: 'session-fail-open', ownerId: 'factory-controller', state: { get: getState } },
+          },
+        ],
+      ]);
+      const requestContext = {
+        get: vi.fn((key: string) => values.get(key)),
+        set: vi.fn((key: string, value: unknown) => values.set(key, value)),
+      };
+
+      getDynamicMemory(
+        { storage: true } as never,
+        { vector: true } as never,
+      )({ requestContext: requestContext as never });
+
+      // Capture refused: the fail-closed refusal is the ONLY path that emits
+      // this error, and it is exactly the path where capture stays disabled
+      // (`captureEnabled = subconsciousEnabled && !orgUnresolvedRefusal`).
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(String(errorSpy.mock.calls[0]?.[0])).toContain('Knowledge capture disabled');
+      // And the session was never classified — in particular never as 'local'.
+      expect(requestContext.set).not.toHaveBeenCalledWith('organizationId', expect.anything());
+      expect(requestContext.get('organizationId')).toBeUndefined();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/mastracode/factory/src/session/org-seed-fail-open.test.ts
+++ b/mastracode/factory/src/session/org-seed-fail-open.test.ts
@@ -58,23 +58,24 @@ describe('org-classification fail-open (projectless factory session, rejecting o
     const capturedInitialState = (prepareMock.mock.calls[0]![0] as { initialState: Record<string, unknown> })
       .initialState;
 
-    // 2. Session state as the controller builds it: schema defaults merged
-    //    with the cloned initialState (session.ts merge order).
-    const schemaDefaults: Record<string, unknown> = {};
-    const sessionState = { ...schemaDefaults, ...structuredClone(capturedInitialState) };
+    // 2. Session state as the controller builds it: the cloned initialState.
+    //    `factoryOrgUnresolved` is declared optional with NO schema default
+    //    (sdk/src/schema.ts), so the schema merge cannot clobber the value.
+    const sessionState = { ...structuredClone(capturedInitialState) };
 
-    // 3. Tyler's exact scenario: a projectless session whose org-state write
-    //    REJECTS. seedSessionOrg swallows the failure by contract, so the
-    //    write leaves no trace in session state.
+    // 3. A projectless session whose org-state write REJECTS. Without the
+    //    fail-closed default, seedSessionOrg attempts to write the unresolved
+    //    marker, the write rejects, is swallowed by contract, and the state
+    //    stays unmarked — the exact fail-open. With the default present, the
+    //    marker is already true and seedSessionOrg short-circuits without
+    //    writing, which the `stateSet` assertion below pins.
+    const stateSet = vi.fn(() => Promise.reject(new Error('session state write failed')));
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const sessionDouble = {
-      state: {
-        get: () => sessionState,
-        set: () => Promise.reject(new Error('session state write failed')),
-      },
-    };
-    await seedSessionOrg(sessionDouble, undefined);
-    warnSpy.mockRestore();
+    try {
+      await seedSessionOrg({ state: { get: () => sessionState, set: stateSet } }, undefined);
+    } finally {
+      warnSpy.mockRestore();
+    }
 
     // 4. The real SDK classification over that state.
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -107,6 +108,10 @@ describe('org-classification fail-open (projectless factory session, rejecting o
       // And the session was never classified — in particular never as 'local'.
       expect(requestContext.set).not.toHaveBeenCalledWith('organizationId', expect.anything());
       expect(requestContext.get('organizationId')).toBeUndefined();
+      // Fail-closed default present -> the seed short-circuits and never
+      // needs the (rejecting) write. Without the default, the write IS
+      // attempted (and rejects) — so this also reddens on the base.
+      expect(stateSet).not.toHaveBeenCalled();
     } finally {
       errorSpy.mockRestore();
     }

--- a/mastracode/factory/src/session/org-seed.ts
+++ b/mastracode/factory/src/session/org-seed.ts
@@ -54,6 +54,19 @@ export function readRequestContextOrgId(requestContext: OrgBearingRequestContext
 }
 
 /**
+ * Whether a session state value counts as a resolved organization.
+ *
+ * The capture side trims before deciding (`sdk/src/agents/memory.ts`), so the
+ * recovery guards have to agree with it: a whitespace-only value that reads as
+ * truthy here would look resolved to a heal path while capture still refuses,
+ * and nothing would ever repair it. Not every seam routes its seed through
+ * `seedSessionOrg`, so this cannot be assumed away.
+ */
+export function hasResolvedOrg(orgId: unknown): boolean {
+  return typeof orgId === 'string' && orgId.trim().length > 0;
+}
+
+/**
  * Seed the session's organization, or mark it unresolved when there is none.
  *
  * An absent, empty, or whitespace-only org is a refusal, not a fallback: a

--- a/mastracode/factory/src/session/org-seed.ts
+++ b/mastracode/factory/src/session/org-seed.ts
@@ -1,0 +1,87 @@
+/**
+ * The tenant organization a session's knowledge is scoped to.
+ *
+ * Subconscious knowledge capture scopes every node and record on
+ * `factoryOrgId`. A session that reaches the capture seam without one used to
+ * fall back to the session owner id — for factory sessions the agent
+ * controller's own id — so the knowledge landed under an org rung no reader
+ * ever queries. The write succeeded and the read could never see it.
+ *
+ * The fix is that every session-creation path seeds the org it already holds,
+ * and a path that cannot resolve one marks the session `factoryOrgUnresolved`
+ * so the capture side refuses loudly instead of inventing an identity. "No
+ * project id" is not a proxy for "not a factory session" — chat sessions and
+ * Slack channel sessions are factory-owned and carry no project id — which is
+ * why the unresolved case needs its own explicit marker.
+ */
+
+/**
+ * Session-state fields org seeding writes. The index signatures mirror
+ * `MastraCodeState` so a concrete `Session.state.set(Partial<MastraCodeState>)`
+ * stays assignable to this minimal surface (contravariant parameter check).
+ */
+export interface OrgSeedStateWrites {
+  [key: string]: unknown;
+  [key: `subagentModelId_${string}`]: string | undefined;
+  factoryOrgId?: string;
+  factoryOrgUnresolved?: boolean;
+}
+
+/** The slice of a session needed to seed its organization. */
+export interface OrgSeedableSession {
+  state: {
+    get: () => Record<string, unknown> | undefined;
+    set: (updates: OrgSeedStateWrites) => Promise<void> | void;
+  };
+}
+
+/**
+ * A request context carrying the tenant on its `user` key. Slack stamps
+ * `{ id, organizationId }` and the GitHub webhook `{ workosId, organizationId }`,
+ * so only the shared `organizationId` field may be read here.
+ */
+export interface OrgBearingRequestContext {
+  get: (key: string) => unknown;
+}
+
+/** Read the tenant org off a request context's `user` key, if there is one. */
+export function readRequestContextOrgId(requestContext: OrgBearingRequestContext | undefined): string | undefined {
+  if (!requestContext) return undefined;
+  const user = requestContext.get('user');
+  if (!user || typeof user !== 'object') return undefined;
+  const orgId = (user as { organizationId?: unknown }).organizationId;
+  return typeof orgId === 'string' ? orgId : undefined;
+}
+
+/**
+ * Seed the session's organization, or mark it unresolved when there is none.
+ *
+ * An absent, empty, or whitespace-only org is a refusal, not a fallback: a
+ * blank org rung is not something canonicalization can save. A successful
+ * resolve also clears a stale marker, because the session-start hook runs at
+ * most once per session per process and nothing else would ever clear it.
+ *
+ * Best-effort by contract — every caller is a session-created listener that
+ * must not sink a run that is otherwise ready.
+ */
+export async function seedSessionOrg(session: OrgSeedableSession, orgId: string | null | undefined): Promise<void> {
+  const resolved = typeof orgId === 'string' ? orgId.trim() : '';
+  // Some session shapes (approval stubs, lightweight doubles) carry no state at
+  // all. There is nothing to seed and nothing to mark, so this is not a warning.
+  if (typeof session.state?.get !== 'function' || typeof session.state?.set !== 'function') return;
+  try {
+    const state = session.state.get() ?? {};
+    if (!resolved) {
+      if (state.factoryOrgUnresolved !== true) {
+        await session.state.set({ factoryOrgUnresolved: true });
+      }
+      return;
+    }
+    const updates: OrgSeedStateWrites = {};
+    if (state.factoryOrgId !== resolved) updates.factoryOrgId = resolved;
+    if (state.factoryOrgUnresolved) updates.factoryOrgUnresolved = false;
+    if (Object.keys(updates).length > 0) await session.state.set(updates);
+  } catch (error) {
+    console.warn('[Factory org seed] Unable to record the session organization.', error);
+  }
+}

--- a/mastracode/sdk/src/agents/memory.test.ts
+++ b/mastracode/sdk/src/agents/memory.test.ts
@@ -274,6 +274,32 @@ describe('getDynamicMemory', () => {
     }
   });
 
+  it('logs the refusal once per session even across separate request contexts', async () => {
+    // The controller is read off the request context on every resolution, so it
+    // is a fresh object per request. Dedupe has to key on the session id, or a
+    // long-lived refusing session logs once per run forever.
+    process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = '1';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      vi.resetModules();
+      getOmScopeMock.mockReturnValue('thread');
+      const { getDynamicMemory } = await import('./memory.js');
+      const resolve = getDynamicMemory({ storage: true } as never, { vector: true } as never);
+      const state = { projectPath: '/tmp/project', factoryProjectId: 'project-1' };
+
+      resolve({ requestContext: createRequestContext(state, 'session-same') as never });
+      resolve({ requestContext: createRequestContext(state, 'session-same') as never });
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      // A genuinely different session still gets its own error.
+      resolve({ requestContext: createRequestContext(state, 'session-other') as never });
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it.each([
     ['refusing first', ['refusing', 'healthy']],
     ['healthy first', ['healthy', 'refusing']],

--- a/mastracode/sdk/src/agents/memory.test.ts
+++ b/mastracode/sdk/src/agents/memory.test.ts
@@ -74,14 +74,14 @@ type RequestContextStub = {
   set: (key: string, value: unknown) => void;
 };
 
-function createRequestContext(state: Record<string, unknown>): RequestContextStub {
+function createRequestContext(state: Record<string, unknown>, sessionId = 'session-1'): RequestContextStub {
   const getState = () => state;
   const values = new Map<string, unknown>([
     [
       'controller',
       {
         getState,
-        session: { ownerId: 'mastracode-owner', state: { get: getState } },
+        session: { id: sessionId, ownerId: 'mastracode-owner', state: { get: getState } },
       },
     ],
   ]);
@@ -186,7 +186,7 @@ describe('getDynamicMemory', () => {
       maxScope: 'resource',
       pins: true,
     });
-    expect(requestContext.get('organizationId')).toBe('mastracode-owner');
+    expect(requestContext.get('organizationId')).toBe('local');
     // Outside the factory there is no project id, so the knowledge scope is untouched.
     expect(requestContext.get('knowledgeResourceId')).toBeUndefined();
   });
@@ -206,10 +206,108 @@ describe('getDynamicMemory', () => {
     expect(requestContext.get('organizationId')).toBe('org-real');
   });
 
-  it('falls back to the session owner for organizationId when no factory org id exists', async () => {
+  it('captures local (TUI/studio) knowledge under the explicit local scope, never the session owner', async () => {
     process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = '1';
+    const { getDynamicMemory, LOCAL_KNOWLEDGE_ORG_ID } = await import('./memory.js');
+    expect(LOCAL_KNOWLEDGE_ORG_ID).toBe('local');
+
     const { requestContext } = await createMemoryConfig({ projectPath: '/tmp/project' }, 'thread', { vector: true });
-    expect(requestContext.get('organizationId')).toBe('mastracode-owner');
+    const org = requestContext.get('organizationId');
+    expect(org).toBe('local');
+    expect(org).not.toBe('mastracode-owner');
+    expect(org).not.toBe('mastra-code');
+    expect(typeof getDynamicMemory).toBe('function');
+  });
+
+  it('refuses to capture for a factory session whose organization never resolved', async () => {
+    process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = '1';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const { config, requestContext } = await createMemoryConfig(
+        { projectPath: '/tmp/project', factoryProjectId: 'project-1' },
+        'thread',
+        { vector: true },
+      );
+      expect(requestContext.get('organizationId')).toBeUndefined();
+      expect(requestContext.set).not.toHaveBeenCalledWith('organizationId', expect.anything());
+      expect(config.options.observationalMemory.experimental_subconscious).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0]?.[0]).toContain('Knowledge capture disabled');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('refuses to capture for a projectless factory session marked unresolved', async () => {
+    process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = '1';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const { config, requestContext } = await createMemoryConfig(
+        { projectPath: '/tmp/project', factoryOrgUnresolved: true },
+        'thread',
+        { vector: true },
+      );
+      expect(requestContext.get('organizationId')).toBeUndefined();
+      expect(config.options.observationalMemory.experimental_subconscious).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('logs the refusal once per session, not once per memory resolution', async () => {
+    process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = '1';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      vi.resetModules();
+      getOmScopeMock.mockReturnValue('thread');
+      const { getDynamicMemory } = await import('./memory.js');
+      const resolve = getDynamicMemory({ storage: true } as never, { vector: true } as never);
+      const requestContext = createRequestContext({ projectPath: '/tmp/project', factoryProjectId: 'project-1' });
+
+      resolve({ requestContext: requestContext as never });
+      resolve({ requestContext: requestContext as never });
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    ['refusing first', ['refusing', 'healthy']],
+    ['healthy first', ['healthy', 'refusing']],
+  ])('keeps a refusing and a healthy session apart in the memory cache (%s)', async (_label, order) => {
+    process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = '1';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      vi.resetModules();
+      getOmScopeMock.mockReturnValue('thread');
+      const { getDynamicMemory } = await import('./memory.js');
+      const resolve = getDynamicMemory({ storage: true } as never, { vector: true } as never);
+
+      const contexts: Record<string, RequestContextStub> = {
+        refusing: createRequestContext({ projectPath: '/tmp/project', factoryProjectId: 'project-1' }, 'session-bad'),
+        healthy: createRequestContext(
+          { projectPath: '/tmp/project', factoryProjectId: 'project-1', factoryOrgId: 'org-real' },
+          'session-good',
+        ),
+      };
+
+      const results: Record<string, MemoryConfig> = {};
+      for (const key of order) {
+        results[key] = (
+          resolve({ requestContext: contexts[key] as never }) as unknown as { config: MemoryConfig }
+        ).config;
+      }
+
+      expect(results.healthy.options.observationalMemory.experimental_subconscious).toBeDefined();
+      expect(results.refusing.options.observationalMemory.experimental_subconscious).toBeUndefined();
+      expect(contexts.healthy.get('organizationId')).toBe('org-real');
+      expect(contexts.refusing.get('organizationId')).toBeUndefined();
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('anchors the knowledge scope on the factory project id when present', async () => {
@@ -230,7 +328,7 @@ describe('getDynamicMemory', () => {
     process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS = '1';
     const vector = { vector: true };
     const { config } = await createMemoryConfig(
-      { projectPath: '/tmp/project', factoryProjectId: 'project-1' },
+      { projectPath: '/tmp/project', factoryProjectId: 'project-1', factoryOrgId: 'org-real' },
       'thread',
       vector,
     );

--- a/mastracode/sdk/src/agents/memory.ts
+++ b/mastracode/sdk/src/agents/memory.ts
@@ -76,17 +76,28 @@ Drop caveman for: security warnings, irreversible action confirmations, multi-st
  */
 export const LOCAL_KNOWLEDGE_ORG_ID = 'local';
 
-// One error per session, not per memory resolution. Keyed on the controller so
-// the bookkeeping dies with the session — no unbounded set in a long-running
-// Factory process.
-const reportedOrgUnresolved = new WeakSet<object>();
+// One error per session, not per memory resolution. Keyed on the session id
+// rather than the controller object: the controller is read off the request
+// context on every resolution, so it is a fresh object per request and would
+// dedupe nothing. Bounded so a long-running Factory process cannot grow this
+// without limit — refusing sessions are rare, and losing the oldest ids only
+// costs one extra log line.
+const REPORTED_ORG_UNRESOLVED_LIMIT = 500;
+const reportedOrgUnresolved = new Set<string>();
 
-function reportOrgUnresolved(controller: object | undefined, factoryProjectId: string | undefined) {
-  if (controller) {
-    if (reportedOrgUnresolved.has(controller)) return;
-    reportedOrgUnresolved.add(controller);
+function reportOrgUnresolved(
+  controller: AgentControllerRequestContext<MastraCodeState> | undefined,
+  factoryProjectId: string | undefined,
+) {
+  const sessionId = controller?.session?.id;
+  if (sessionId) {
+    if (reportedOrgUnresolved.has(sessionId)) return;
+    if (reportedOrgUnresolved.size >= REPORTED_ORG_UNRESOLVED_LIMIT) {
+      reportedOrgUnresolved.delete(reportedOrgUnresolved.values().next().value as string);
+    }
+    reportedOrgUnresolved.add(sessionId);
   }
-  const session = (controller as AgentControllerRequestContext<MastraCodeState> | undefined)?.session;
+  const session = controller?.session;
   console.error(
     `[Subconscious] Knowledge capture disabled: no organization resolved for session ${session?.id ?? 'unknown'} (project ${factoryProjectId ?? 'none'}). Knowledge is not written rather than written where it cannot be read.`,
   );

--- a/mastracode/sdk/src/agents/memory.ts
+++ b/mastracode/sdk/src/agents/memory.ts
@@ -70,6 +70,29 @@ Don't say "Agent did x", say "did x". It will be assumed the agent did what was 
 Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question, and anything that requires remembering verbatim content. Resume caveman after clear part done`;
 
 /**
+ * The organization rung local (TUI/studio) knowledge is captured under. A fixed
+ * literal on purpose: deriving it from a hostname or path would fragment local
+ * knowledge per checkout into scopes nothing ever reads.
+ */
+export const LOCAL_KNOWLEDGE_ORG_ID = 'local';
+
+// One error per session, not per memory resolution. Keyed on the controller so
+// the bookkeeping dies with the session — no unbounded set in a long-running
+// Factory process.
+const reportedOrgUnresolved = new WeakSet<object>();
+
+function reportOrgUnresolved(controller: object | undefined, factoryProjectId: string | undefined) {
+  if (controller) {
+    if (reportedOrgUnresolved.has(controller)) return;
+    reportedOrgUnresolved.add(controller);
+  }
+  const session = (controller as AgentControllerRequestContext<MastraCodeState> | undefined)?.session;
+  console.error(
+    `[Subconscious] Knowledge capture disabled: no organization resolved for session ${session?.id ?? 'unknown'} (project ${factoryProjectId ?? 'none'}). Knowledge is not written rather than written where it cannot be read.`,
+  );
+}
+
+/**
  * Dynamic memory factory function.
  * Reads OM thresholds from controller state via requestContext.
  * Model functions also read from requestContext (no mutable bridge needed).
@@ -87,16 +110,24 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
     const factoryProjectId = state?.factoryProjectId;
     const isFactory = typeof factoryProjectId === 'string' && factoryProjectId.trim().length > 0;
 
+    // A Factory-owned session that could not resolve its org refuses to capture:
+    // writing under a substituted identity produces knowledge the fail-closed
+    // read path can never see.
+    let orgUnresolvedRefusal = false;
+
     if (subconsciousEnabled) {
-      // Factory seeds the authoritative org id into session state; prefer it.
-      // The session owner is a USER id — mapping it into organizationId is only
-      // the legacy fallback for clients (TUI/studio) that never set factoryOrgId.
+      // Factory seeds the authoritative org id into session state. There is no
+      // fallback: a session owner is a USER id, never an organization.
       const factoryOrgId = state?.factoryOrgId;
-      const ownerId = controller?.session.ownerId;
+      const factoryOwned = isFactory || state?.factoryOrgUnresolved === true;
       if (typeof factoryOrgId === 'string' && factoryOrgId.trim()) {
         requestContext.set('organizationId', factoryOrgId);
-      } else if (ownerId) {
-        requestContext.set('organizationId', ownerId);
+      } else if (factoryOwned) {
+        orgUnresolvedRefusal = true;
+        reportOrgUnresolved(controller, factoryProjectId);
+      } else {
+        // TUI/studio: an explicit, named scope rather than a cascaded identity.
+        requestContext.set('organizationId', LOCAL_KNOWLEDGE_ORG_ID);
       }
       // Factory runs share one knowledge graph per project: anchor the
       // subconscious knowledge scope's resource rung on the project id.
@@ -104,6 +135,8 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
         requestContext.set('knowledgeResourceId', factoryProjectId);
       }
     }
+
+    const captureEnabled = subconsciousEnabled && !orgUnresolvedRefusal;
 
     const omScope = state?.omScope ?? getOmScope(state?.projectPath);
 
@@ -115,7 +148,7 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
     const observeAttachments = state?.observeAttachments;
     // Factory sessions get a factory-only Subconscious config, so the cache key
     // carries a factory presence bit to keep the two configs from cross-serving.
-    const cacheKey = `${obsThreshold}:${refThreshold}:${omScope}:${observerPreviousObservationTokens}:${caveman ? 1 : 0}:${observeAttachments}:${isFactory ? 1 : 0}:${subconsciousEnabled ? 1 : 0}`;
+    const cacheKey = `${obsThreshold}:${refThreshold}:${omScope}:${observerPreviousObservationTokens}:${caveman ? 1 : 0}:${observeAttachments}:${isFactory ? 1 : 0}:${captureEnabled ? 1 : 0}`;
     if (cachedMemory && cachedMemoryKey === cacheKey) {
       return cachedMemory;
     }
@@ -141,7 +174,7 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
           enabled: true,
           temporalMarkers: true,
           retrieval: vector ? { vector: true } : true,
-          experimental_subconscious: subconsciousEnabled
+          experimental_subconscious: captureEnabled
             ? new Subconscious({
                 defaultScope: 'resource',
                 maxScope: 'resource',

--- a/mastracode/sdk/src/schema.ts
+++ b/mastracode/sdk/src/schema.ts
@@ -22,6 +22,12 @@ export interface MastraCodeState {
   factoryProjectId?: string;
   /** Authoritative organization id seeded by factory at session construction. */
   factoryOrgId?: string;
+  /**
+   * Factory owns this session but could not resolve its organization. Knowledge
+   * capture refuses rather than filing under a substituted identity; without the
+   * marker a projectless factory session is indistinguishable from a local one.
+   */
+  factoryOrgUnresolved?: boolean;
   /** Linked repository used by this session when source-control execution is required. */
   projectRepositoryId?: string;
   /** Persisted sandbox id for reattaching the project's cloud workspace. */
@@ -116,6 +122,7 @@ export const stateSchema = z.object({
   projectName: z.string().optional(),
   factoryProjectId: z.string().optional(),
   factoryOrgId: z.string().optional(),
+  factoryOrgUnresolved: z.boolean().optional(),
   projectRepositoryId: z.string().optional(),
   sandboxId: z.string().optional(),
   sandboxWorkdir: z.string().optional(),


### PR DESCRIPTION
## What's broken

Knowledge captured by the Subconscious was being written under an organization that does not exist, and then being permanently invisible to the thing that reads it.

Two independent defaults met in the middle:

1. `packages/core/src/agent-controller/agent-controller.ts:492` defaults a session's `ownerId` to the agent-controller id — which for the code SDK is the literal `'mastra-code'` (`mastracode/sdk/src/index.ts:1102`).
2. `mastracode/sdk/src/agents/memory.ts` then promoted that `ownerId` into the `organizationId` slot whenever session state carried no `factoryOrgId`.

Scope canonicalization (`packages/core/src/storage/domains/knowledge/base.ts:267`) rejects a *missing* org rung but accepts any non-empty string, so the write succeeded. The Factory read path (`mastracode/factory/src/routes/knowledge.ts:289-302`) is fail-closed on the real org, so those nodes could never be returned.

**The write path failed open with a substituted identity; the read path failed closed on the real one.** In production this produced 18 orphaned knowledge nodes against 582 healthy ones, all on a project owned by a real org.

## The fix, in two halves

Seeding alone gets re-broken by the next producer that forgets. Refusing alone just converts silent corruption into thrown runs. Together, a missed seed becomes a loud, diagnosable failure.

### Half one — every Factory session-creation path seeds the real org

There are five. Two already seeded correctly; three did not:

| Path | Before | After |
|---|---|---|
| Run start coordinator | seeds `factoryOrgId` | unchanged |
| Binding recovery | seeds `factoryOrgId` | unchanged |
| Source-control / chat hydration | read `record.orgId` for settings only | seeds it |
| GitHub webhook re-attach | put org on request context only | seeds it, and heals pre-fix sessions |
| Slack channel session start | never reached the seed | seeds above all four early returns |

No storage lookup was added to session creation. Every seam already held an authoritative `orgId` — it simply was not being written into session state. The Slack hook reads the org off the request context stamped by `gateDispatch` before the session exists, so the existing "no storage read when a mode model is persisted" guarantee is preserved.

### Half two — the SDK stops substituting an identity for an organization

The `ownerId → organizationId` promotion is deleted. Org resolution now has three outcomes:

- **Real org in session state** → scope on it.
- **Factory-owned session with no resolvable org** → refuse. No `organizationId` set, Subconscious disabled for that session, one error logged, no throw. Knowledge is not written rather than written where it can never be read.
- **Anything else (TUI/studio)** → the explicit exported constant `LOCAL_KNOWLEDGE_ORG_ID = 'local'`.

A new `factoryOrgUnresolved` marker on session state carries the refusal signal, because "no project id" does not mean "not a Factory session" — Slack channel sessions and Factory chat sessions both lack one. Without the marker, a real tenant's knowledge would file under `'local'`: the identical bug in a new coat.

## Proof

A replay harness restores a pre-repair production snapshot into a local Postgres, drives a real session-creation seam, and reads the node back **through the knowledge route handler** rather than a storage query — the whole bug is that the route cannot see the node.

| Run | Org rung written | Route read |
|---|---|---|
| Merge-base commit (`2ef2f230a7`, the commit that introduced the fallback) | `mastra-code` | **MISS** |
| This branch | `org_01KPRK…` (the real org) | **HIT** |
| This branch, unresolvable org | none — capture disabled, node count unchanged | n/a |

The red run is the point: the write succeeds and the route still cannot see it.

## Deliberately deferred

- A `user` or `project` rung on `KnowledgeScopeLevel` — five storage backends plus a migration, separately reviewable.
- Factory knowledge-graph UI scope visibility.

## Accepted risk

Local nodes previously written under `org:mastra-code` are orphaned by the switch to `'local'`. Local dev data only, no production impact, no migration in scope.




**Live dogfood check.** Both this branch and #21988 are running merged on our internal dev box. One real chat session there wrote 7 knowledge nodes, all under the real organization rung, zero `org:mastra-code` orphans. That exercises the chat/source-control hydration seam only — the Slack and GitHub webhook seeding are covered by unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Factory sessions now save knowledge under the correct organization. If the organization is unknown, the system does not save knowledge under the wrong organization.

## Changes

- Seed `factoryOrgId` across Factory, Slack, and GitHub session paths.
- Recover organization state from source-control session rows.
- Mark unresolved Factory sessions and refuse Subconscious capture.
- Use `local` for TUI and Studio sessions.
- Remove `ownerId` as an organization fallback.
- Preserve unresolved-state behavior across resumed sessions.
- Add `factoryOrgUnresolved` schema support.
- Add tests for organization seeding, recovery, unresolved sessions, and local scoping.
- Add a replay harness for organization-scoped knowledge routing.
- Add patch changesets for `@mastra/factory` and `@mastra/code-sdk`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
