### PR TITLE
fix(factory-ui): restore typecheck broken by optional buffering display-state flags

### DIFF
--- a/mastracode/factory-ui/src/ui/domains/chat/services/runtime.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/runtime.ts
@@ -105,8 +105,8 @@ export function runtimeReducer(state: ChatRuntimeState, event: AgentControllerEv
         ...state,
         omProgress: event.displayState.omProgress,
         usage: event.displayState.tokenUsage,
-        bufferingMessages: event.displayState.bufferingMessages,
-        bufferingObservations: event.displayState.bufferingObservations,
+        bufferingMessages: event.displayState.bufferingMessages ?? false,
+        bufferingObservations: event.displayState.bufferingObservations ?? false,
       };
     case 'goal_evaluation':
       return {


### PR DESCRIPTION
## Summary

`pnpm --filter ./mastracode/factory-ui typecheck` fails on main with 2 errors in `src/ui/domains/chat/services/runtime.ts`: the SDK's display-state event now types `bufferingMessages`/`bufferingObservations` as optional (`boolean | undefined`), while `ChatRuntimeState` requires booleans. This defaults absent flags to `false`, the runtime's idle state.

No behavior change when the flags are present. `@internal/factory-ui` is private, so no changeset.

## Test plan

- factory-ui typecheck: clean (was 2 errors on main)
- chat domain tests: 221/221 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some status updates did not include buffering information. The runtime now treats missing buffering values as `false`, so the chat interface can typecheck correctly without changing behavior when values are present.

## Changes

- Updated the `display_state_changed` reducer in `runtime.ts`.
- Defaulted missing `bufferingMessages` and `bufferingObservations` values to `false`.
- Restored `factory-ui` typechecking after the SDK type change.
- Passed all 221 chat domain tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->