### PR TITLE
fix(agent-controller): split the streamed reply where the run loop splits the stored one

### DIFF
--- a/.changeset/upset-suns-study.md
+++ b/.changeset/upset-suns-study.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the streamed reply splitting differently from the stored one. When the agent's turn was interrupted mid-run — a message sent while it was working, a resumed tool approval, a state signal — the live stream kept everything in one assistant message while storage had already sealed it and opened a new one. Coming back to the thread (tab switch, reload) replayed the second half as an extra copy. The stream now closes its message at the same boundary the run loop does.

--- a/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
@@ -71,6 +71,10 @@ function lastMessageEvent(events: AgentControllerEvent[]): MastraDBMessage {
   throw new Error('no message event emitted');
 }
 
+function textOf(message: MastraDBMessage): string {
+  return message.content.parts.flatMap(part => (part.type === 'text' ? [part.text] : [])).join('');
+}
+
 function requestContext(): RequestContext {
   return new RequestContext();
 }
@@ -338,6 +342,60 @@ describe('SessionRunEngine — MastraDBMessage contract', () => {
     const assistantEnds = events.filter(event => event.type === 'message_end' && event.message.role === 'assistant');
     expect(assistantEnds[0]?.message.id).toBe('response-1');
     expect(lastMessageEvent(events).id).toBe('response-2');
+  });
+
+  it('Given a rotated response id mid-turn, When the next step starts, Then the stream splits where the loop did', async () => {
+    const { engine, events } = createHarness();
+    const state = engine.createStreamState();
+    const ctx = requestContext();
+
+    await engine.processStreamChunk(state, chunk({ type: 'step-start', payload: { messageId: 'response-1' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-start', payload: { id: 't1' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-delta', payload: { id: 't1', text: 'first' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'step-start', payload: { messageId: 'response-2' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-start', payload: { id: 't2' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-delta', payload: { id: 't2', text: 'second' } }), ctx);
+
+    const assistantEnds = events.filter(event => event.type === 'message_end' && event.message.role === 'assistant');
+    expect(assistantEnds.map(event => event.message.id)).toEqual(['response-1']);
+    expect(textOf(assistantEnds[0]!.message)).toBe('first');
+    expect(lastMessageEvent(events).id).toBe('response-2');
+    expect(textOf(lastMessageEvent(events))).toBe('second');
+  });
+
+  it('Given repeated step-starts for one response id, When the turn streams, Then it stays a single message', async () => {
+    const { engine, events } = createHarness();
+    const state = engine.createStreamState();
+    const ctx = requestContext();
+
+    await engine.processStreamChunk(state, chunk({ type: 'step-start', payload: { messageId: 'response-1' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-start', payload: { id: 't1' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-delta', payload: { id: 't1', text: 'first' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'step-start', payload: { messageId: 'response-1' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-start', payload: { id: 't2' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-delta', payload: { id: 't2', text: ' second' } }), ctx);
+
+    expect(events.filter(event => event.type === 'message_end')).toHaveLength(0);
+    expect(lastMessageEvent(events).id).toBe('response-1');
+    expect(textOf(lastMessageEvent(events))).toBe('first second');
+  });
+
+  it('Given a stream joined mid-message, When a later step-start rotates the id, Then the split still follows the loop', async () => {
+    const { engine, events } = createHarness();
+    const state = engine.createStreamState();
+    const ctx = requestContext();
+
+    await engine.processStreamChunk(state, chunk({ type: 'text-start', payload: { id: 't1' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-delta', payload: { id: 't1', text: 'joined' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'step-start', payload: { messageId: 'response-1' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'step-start', payload: { messageId: 'response-2' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-start', payload: { id: 't2' } }), ctx);
+    await engine.processStreamChunk(state, chunk({ type: 'text-delta', payload: { id: 't2', text: 'next' } }), ctx);
+
+    const assistantEnds = events.filter(event => event.type === 'message_end' && event.message.role === 'assistant');
+    expect(assistantEnds.map(event => textOf(event.message))).toEqual(['joined']);
+    expect(lastMessageEvent(events).id).toBe('response-2');
+    expect(textOf(lastMessageEvent(events))).toBe('next');
   });
 
   it('Given an id already emitted or content already streamed, When step-start arrives, Then the engine keeps its own id', async () => {

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -501,12 +501,14 @@ export class SessionRunEngine {
     switch (chunk.type) {
       case 'step-start': {
         // Adopt the loop's response message id so the streamed turn and its
-        // persisted copy share one identity (clients dedupe by id). An id is
-        // consumed on first offer and binds only while the message is still
-        // empty — an emitted id must never change, and a re-offered id must
-        // never attach to a later message.
+        // persisted copy share one identity (clients dedupe by id). The loop
+        // mints a new id only when it seals one persisted response and opens
+        // the next, so every id after the first marks that boundary — rotate
+        // with it, or the persisted tail comes back as a duplicate on reload.
+        // An emitted id never changes, and an id binds to one message only.
         const messageId = getString(getPayload(chunk).messageId);
         if (!messageId || state.offeredResponseIds.has(messageId)) break;
+        if (state.offeredResponseIds.size > 0) this.finishCurrentMessageAndRotate(state);
         state.offeredResponseIds.add(messageId);
         if (!this.hasCurrentMessageContent(state)) {
           state.currentMessage.id = messageId;


### PR DESCRIPTION
Stops a reply from coming back duplicated when you leave a thread and return to it.

Until now the run engine kept one assistant message for a whole run, while the run loop seals a response and opens a new one every time the turn is interrupted mid-flight — a message you send while it works, a resumed tool approval, a state signal. Storage followed the loop, the live stream did not, so the thread you were reading and the thread on disk disagreed about where one message ends. Switch tab, come back, and the refetched window handed the client a second half it had already drawn under the first half's id: the same text twice, and a tool card cut in two around a steer.

The engine already adopts the id `step-start` offers, it just refused to move once its message had content. Since the loop mints a new id only when it opens a new persisted response, every id after the first is that boundary, and the fix is to rotate on it — one line, no new state, the set of offered ids already knew whether the loop had spoken. A stream that joins mid-message keeps its own id for what it already drew and still splits at the next boundary.

Worth knowing for review: this leans on the loop pairing `rotateResponseMessageId()` with `markResponseMessageBoundary()`. I checked all six call sites (agentic loop drain and resume, processor state signals, durable equivalents) and the pairing holds everywhere; if a future site rotates without a boundary the stream would drift again silently.

The client-side heal shipped in #21651 stays: the composer's optimistic echo still lives under a `local-…` id the server never confirms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Assistant messages now split in the same places as saved responses. This prevents duplicate text and incorrectly split tool cards when a thread reloads or resumes.

## Changes

- Rotate the response message ID at each new `step-start` boundary.
- Finalize the current assistant message before assigning the new ID.
- Preserve the current ID during mid-message streams.
- Cover interrupted turns, resumed tool approvals, drained signals, and state signals.
- Keep optimistic `local-…` composer message handling unchanged.
- Add tests for rotated IDs, repeated IDs, and joined streams.
- Add a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->