### PR TITLE
fix(agent-controller): mark a message that lands while the agent is working

### DIFF
--- a/.changeset/fifty-lines-live.md
+++ b/.changeset/fifty-lines-live.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': minor
+---
+
+Messages sent to a busy agent are now marked as interjections by the session itself. Any user message submitted while a run is in flight — including the one `session.steer()` sends after interrupting a run — carries `delivery: 'while-active'`, so the agent reads it as context for the work in progress and a reloaded transcript can still tell a steer apart from a normal message. Clients no longer have to attach the attribute themselves.
+
+```ts
+// before: only callers that passed delivery options got the attribute
+session.sendSignal({ content, ifActive: { attributes: { delivery: 'while-active' } } });
+
+// now: the session stamps it from the run state it already tracks
+session.sendSignal({ content });
+session.steer({ content });
+```
+
+Delivery attributes supplied by the caller still win.

--- a/.changeset/fifty-lines-live.md
+++ b/.changeset/fifty-lines-live.md
@@ -2,15 +2,20 @@
 '@mastra/core': minor
 ---
 
-Messages sent to a busy agent are now marked as interjections by the session itself. Any user message submitted while a run is in flight — including the one `session.steer()` sends after interrupting a run — carries `delivery: 'while-active'`, so the agent reads it as context for the work in progress and a reloaded transcript can still tell a steer apart from a normal message. Clients no longer have to attach the attribute themselves.
+The session now records whether the user was watching the agent work when they hit send, and every client gets it for free. A message typed into a live run — including the one `session.steer()` sends after interrupting — carries `delivery: 'while-active'`; a message that opens a new turn carries `delivery: 'message'`. The agent reads the first as context for the work in progress, and a reloaded transcript can still tell a steer apart from a normal message.
+
+Before, the attribute was resolved from the run state at dispatch time, which reads idle for a steer (a steer aborts its own run before sending), so each client had to describe both delivery routes itself.
 
 ```ts
-// before: only callers that passed delivery options got the attribute
-session.sendSignal({ content, ifActive: { attributes: { delivery: 'while-active' } } });
+// before
+session.sendSignal({
+  content,
+  ifActive: { attributes: { delivery: 'while-active' } },
+  ifIdle: { attributes: { delivery: 'message' } },
+});
 
-// now: the session stamps it from the run state it already tracks
+// now
 session.sendSignal({ content });
-session.steer({ content });
 ```
 
-Delivery attributes supplied by the caller still win.
+A `delivery` the caller sets on the signal still wins.

--- a/.changeset/fifty-lines-live.md
+++ b/.changeset/fifty-lines-live.md
@@ -2,9 +2,9 @@
 '@mastra/core': minor
 ---
 
-The session now records whether the user was watching the agent work when they hit send, and every client gets it for free. A message typed into a live run — including the one `session.steer()` sends after interrupting — carries `delivery: 'while-active'`; a message that opens a new turn carries `delivery: 'message'`. The agent reads the first as context for the work in progress, and a reloaded transcript can still tell a steer apart from a normal message.
+The session now marks a message you send while the agent is working, and every client gets it for free. Any user message submitted with a run in flight — including the one `session.steer()` sends after interrupting a run — carries `delivery: 'while-active'`, so the agent reads it as context for the work in progress and a reloaded transcript can still tell a steer apart from a normal message. A message that opens a new turn is unmarked, as before.
 
-Before, the attribute was resolved from the run state at dispatch time, which reads idle for a steer (a steer aborts its own run before sending), so each client had to describe both delivery routes itself.
+The attribute used to be resolved from the run state at dispatch time, which reads idle for a steer (a steer aborts its own run before sending), so each client had to describe both delivery routes itself.
 
 ```ts
 // before

--- a/.changeset/pink-paths-remain.md
+++ b/.changeset/pink-paths-remain.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a steer losing its identity once the run it interrupted was gone. `session.steer()` now tags the message it sends with `delivery: 'while-active'`, the same attribute a message sent to a busy agent carries, so the model still reads it as an interjection and a reloaded transcript can still tell it apart from a normal message.

--- a/.changeset/pink-paths-remain.md
+++ b/.changeset/pink-paths-remain.md
@@ -1,5 +1,0 @@
----
-'@mastra/core': patch
----
-
-Fixed a steer losing its identity once the run it interrupted was gone. `session.steer()` now tags the message it sends with `delivery: 'while-active'`, the same attribute a message sent to a busy agent carries, so the model still reads it as an interjection and a reloaded transcript can still tell it apart from a normal message.

--- a/.changeset/slash-command-steer-label.md
+++ b/.changeset/slash-command-steer-label.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+A slash command sent while the agent is working now shows the `steer` label right away, like a typed message does. It used to render unlabeled during the run and then come back labeled after a reload.

--- a/mastracode/tui/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/tui/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -30,11 +30,6 @@ import type { EventHandlerContext } from '../handlers/types.js';
 import { MastraTUI, consumePendingImages, syncInitialThreadState } from '../mastra-tui.js';
 import type { TUIState } from '../state.js';
 
-const EXPECTED_USER_SIGNAL_DELIVERY_OPTIONS = {
-  ifActive: { attributes: { delivery: 'while-active' } },
-  ifIdle: { attributes: { delivery: 'message' } },
-};
-
 function createQueueState(overrides: Partial<TUIState> = {}): TUIState {
   // Mirror production wiring: state.session is the same object as
   // controller.session. Tests pass per-session behavior under `session`
@@ -297,7 +292,6 @@ describe('MastraTUI queueing', () => {
 
     expect(sendSignal).toHaveBeenCalledWith({
       content: 'stay pending',
-      ...EXPECTED_USER_SIGNAL_DELIVERY_OPTIONS,
     });
     expect(state.pendingSignalMessageComponentsById.has('signal-1')).toBe(true);
     expect(state.chatContainer.children).toHaveLength(1);
@@ -336,7 +330,6 @@ describe('MastraTUI queueing', () => {
 
     expect(sendSignal).toHaveBeenCalledWith({
       content: 'starts new thread',
-      ...EXPECTED_USER_SIGNAL_DELIVERY_OPTIONS,
     });
     expect(state.pendingNewThread).toBe(false);
   });
@@ -403,7 +396,6 @@ describe('MastraTUI queueing', () => {
 
     expect(sendSignal).toHaveBeenCalledWith({
       content: 'new thread follow-up',
-      ...EXPECTED_USER_SIGNAL_DELIVERY_OPTIONS,
     });
     expect(mocks.addUserMessage).toHaveBeenCalledWith(state, {
       id: 'signal-after-new',
@@ -438,7 +430,6 @@ describe('MastraTUI queueing', () => {
 
     expect(sendSignal).toHaveBeenCalledWith({
       content: 'render directly',
-      ...EXPECTED_USER_SIGNAL_DELIVERY_OPTIONS,
     });
     expect(state.pendingSignalMessageComponentsById.has('signal-idle-1')).toBe(false);
     expect(state.chatContainer.children).toHaveLength(0);
@@ -477,7 +468,6 @@ describe('MastraTUI queueing', () => {
         { type: 'text', text: "what's in this image?" },
         { type: 'file', data: 'data:image/png;base64,abc', mediaType: 'image/png' },
       ],
-      ...EXPECTED_USER_SIGNAL_DELIVERY_OPTIONS,
     });
     expect(mocks.addUserMessage).toHaveBeenCalledWith(state, {
       id: 'signal-image-1',

--- a/mastracode/tui/src/tui/commands/send-slash-command-message.ts
+++ b/mastracode/tui/src/tui/commands/send-slash-command-message.ts
@@ -18,7 +18,7 @@ export async function sendSlashCommandMessage(
 
   if (isCurrentThreadActive(ctx)) {
     const signal = ctx.state.session.sendSignal({ content });
-    addPendingUserMessage(ctx.state, signal.id, displayText);
+    addPendingUserMessage(ctx.state, signal.id, displayText, undefined, { isInterjection: true });
     try {
       await signal.accepted;
     } catch (error) {

--- a/mastracode/tui/src/tui/mastra-tui.ts
+++ b/mastracode/tui/src/tui/mastra-tui.ts
@@ -29,7 +29,6 @@ import {
   isNewerVersion,
   performUpdate,
 } from '@mastra/code-sdk/utils/update-check';
-import type { AgentSignalAttributes } from '@mastra/core/agent';
 import type { AgentControllerEvent, MastraDBMessage } from '@mastra/core/agent-controller';
 import type { Workspace } from '@mastra/core/workspace';
 import { insertChatComponentWithBoundarySpacing } from './chat-boundary-reconciliation.js';
@@ -92,21 +91,8 @@ export type { MastraTUIOptions } from './state.js';
 // MastraTUI Class
 // =============================================================================
 
-/**
- * Delivery option attributes applied to user-message signals. When the signal is delivered to an
- * active run it is tagged as while-active; when it starts a new run it is a message.
- * The LLM sees these as XML attributes on the `<user-message>` element.
- */
 type GithubPollingChangedHandler = (event: { threadId: string; resourceId: string; running: boolean }) => void;
 type GithubSignalsWithPollingEvents = { onPollingChanged?: (handler: GithubPollingChangedHandler) => void };
-
-const USER_SIGNAL_DELIVERY_OPTIONS: {
-  ifActive: { attributes: AgentSignalAttributes };
-  ifIdle: { attributes: AgentSignalAttributes };
-} = {
-  ifActive: { attributes: { delivery: 'while-active' } },
-  ifIdle: { attributes: { delivery: 'message' } },
-};
 
 const USER_MESSAGE_APPROVAL_INTERRUPT = {
   reason: 'interrupted_by_user_message',
@@ -461,7 +447,6 @@ export class MastraTUI {
 
       const signal = this.state.session.sendSignal({
         content: this.createUserSignalContent(content, images),
-        ...USER_SIGNAL_DELIVERY_OPTIONS,
       });
       this.remapOptimisticUserMessage(optimisticMessageId, signal.id);
       signal.accepted.catch((error: unknown) => {
@@ -493,7 +478,6 @@ export class MastraTUI {
 
       const signal = this.state.session.sendSignal({
         content: this.createUserSignalContent(content, images),
-        ...USER_SIGNAL_DELIVERY_OPTIONS,
       });
 
       if (hasActiveRun) {

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -1884,10 +1884,10 @@ class SessionPermissions {
   }
 }
 
-/** Mark a user signal as reaching the agent mid-work. A delivery the caller chose wins. */
-function asInterjection(signal: CreatedAgentSignal): CreatedAgentSignal {
+/** Stamp at submit time: a steer aborts its own run, so the route resolved downstream reads idle. */
+function withDelivery(signal: CreatedAgentSignal, delivery: 'while-active' | 'message'): CreatedAgentSignal {
   if (signal.type !== 'user' || signal.attributes?.delivery !== undefined) return signal;
-  return resolveDeliveryAttributes(signal, { delivery: 'while-active' });
+  return resolveDeliveryAttributes(signal, { delivery });
 }
 
 /** The session-state / thread-settings key holding a subagent model id. */
@@ -3348,16 +3348,16 @@ export class Session<TState = unknown> {
     // the post-interrupt window where a fresh signal must wait for the dying
     // run to fully idle before starting a new run.
     const submittedAbortRequested = this.run.isAbortRequested();
-    const signalInput: AgentSignalInput =
-      'content' in input
-        ? { type: 'user', tagName: 'user', contents: input.content, providerOptions: input.providerOptions }
-        : input;
-    // A steer lands in the second window: its abort already cleared the controller,
-    // so the delivery route resolved downstream reads idle and cannot tag it.
     const submittedWhileWorking =
-      submittedIsRunning || (submittedAbortRequested && Boolean(submittedRunId ?? submittedActiveRunId));
-    const submittedSignal = createSignal(signalInput);
-    const signal = submittedWhileWorking ? asInterjection(submittedSignal) : submittedSignal;
+      submittedIsRunning || (submittedAbortRequested && Boolean(submittedRunId || submittedActiveRunId));
+    const signal = withDelivery(
+      createSignal(
+        'content' in input
+          ? { type: 'user', tagName: 'user', contents: input.content, providerOptions: input.providerOptions }
+          : input,
+      ),
+      submittedWhileWorking ? 'while-active' : 'message',
+    );
     const accepted = Promise.resolve().then(async () => {
       if (!this.thread.getId()) {
         const thread = await this.thread.create();

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -1885,9 +1885,9 @@ class SessionPermissions {
 }
 
 /** Stamp at submit time: a steer aborts its own run, so the route resolved downstream reads idle. */
-function withDelivery(signal: CreatedAgentSignal, delivery: 'while-active' | 'message'): CreatedAgentSignal {
+function asInterjection(signal: CreatedAgentSignal): CreatedAgentSignal {
   if (signal.type !== 'user' || signal.attributes?.delivery !== undefined) return signal;
-  return resolveDeliveryAttributes(signal, { delivery });
+  return resolveDeliveryAttributes(signal, { delivery: 'while-active' });
 }
 
 /** The session-state / thread-settings key holding a subagent model id. */
@@ -3350,14 +3350,12 @@ export class Session<TState = unknown> {
     const submittedAbortRequested = this.run.isAbortRequested();
     const submittedWhileWorking =
       submittedIsRunning || (submittedAbortRequested && Boolean(submittedRunId || submittedActiveRunId));
-    const signal = withDelivery(
-      createSignal(
-        'content' in input
-          ? { type: 'user', tagName: 'user', contents: input.content, providerOptions: input.providerOptions }
-          : input,
-      ),
-      submittedWhileWorking ? 'while-active' : 'message',
+    const submitted = createSignal(
+      'content' in input
+        ? { type: 'user', tagName: 'user', contents: input.content, providerOptions: input.providerOptions }
+        : input,
     );
+    const signal = submittedWhileWorking ? asInterjection(submitted) : submitted;
     const accepted = Promise.resolve().then(async () => {
       if (!this.thread.getId()) {
         const thread = await this.thread.create();

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3277,8 +3277,6 @@ export class Session<TState = unknown> {
       | AgentSignalInput
       | {
           content: AgentSignalContents;
-          /** Attributes carried whichever delivery path the signal takes. */
-          attributes?: AgentSignalAttributes;
           ifActive?: { attributes?: AgentSignalAttributes };
           ifIdle?: { attributes?: AgentSignalAttributes };
           tracingContext?: TracingContext;
@@ -3341,13 +3339,7 @@ export class Session<TState = unknown> {
     const submittedAbortRequested = this.run.isAbortRequested();
     const signal = createSignal(
       'content' in input
-        ? {
-            type: 'user',
-            tagName: 'user',
-            contents: input.content,
-            attributes: input.attributes,
-            providerOptions: input.providerOptions,
-          }
+        ? { type: 'user', tagName: 'user', contents: input.content, providerOptions: input.providerOptions }
         : input,
     );
     const accepted = Promise.resolve().then(async () => {
@@ -3511,13 +3503,10 @@ export class Session<TState = unknown> {
             resolveAgentEnd?.();
           }
         });
-    const signal = this.sendSignal({
-      content: messageInput,
-      attributes,
-      tracingContext,
-      tracingOptions,
-      requestContext: requestContextInput,
-    });
+    const signal = this.sendSignal(
+      { type: 'user', tagName: 'user', contents: messageInput, attributes },
+      { tracingContext, tracingOptions, requestContext: requestContextInput },
+    );
     if (wasActive) {
       await signal.accepted;
     } else {

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3277,6 +3277,8 @@ export class Session<TState = unknown> {
       | AgentSignalInput
       | {
           content: AgentSignalContents;
+          /** Attributes carried whichever delivery path the signal takes. */
+          attributes?: AgentSignalAttributes;
           ifActive?: { attributes?: AgentSignalAttributes };
           ifIdle?: { attributes?: AgentSignalAttributes };
           tracingContext?: TracingContext;
@@ -3339,7 +3341,13 @@ export class Session<TState = unknown> {
     const submittedAbortRequested = this.run.isAbortRequested();
     const signal = createSignal(
       'content' in input
-        ? { type: 'user', tagName: 'user', contents: input.content, providerOptions: input.providerOptions }
+        ? {
+            type: 'user',
+            tagName: 'user',
+            contents: input.content,
+            attributes: input.attributes,
+            providerOptions: input.providerOptions,
+          }
         : input,
     );
     const accepted = Promise.resolve().then(async () => {
@@ -3477,12 +3485,14 @@ export class Session<TState = unknown> {
   async sendMessage({
     content,
     files,
+    attributes,
     tracingContext,
     tracingOptions,
     requestContext: requestContextInput,
   }: {
     content: string;
     files?: Array<{ data: string; mediaType: string; filename?: string }>;
+    attributes?: AgentSignalAttributes;
     tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
     requestContext?: RequestContext;
@@ -3503,6 +3513,7 @@ export class Session<TState = unknown> {
         });
     const signal = this.sendSignal({
       content: messageInput,
+      attributes,
       tracingContext,
       tracingOptions,
       requestContext: requestContextInput,
@@ -3530,7 +3541,9 @@ export class Session<TState = unknown> {
     this.abort();
     this.followUps.clear();
     this.emit({ type: 'follow_up_queued', count: 0 });
-    await this.sendMessage({ content, requestContext });
+    // Tagged here because the interjection outlives the run it interrupts: the
+    // delivery branches see an idle session once the abort lands.
+    await this.sendMessage({ content, requestContext, attributes: { delivery: 'while-active' } });
   }
 
   /**

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -1,7 +1,12 @@
 import type { Agent } from '../agent';
 import type { MastraDBMessage, MastraProviderMetadata } from '../agent/message-list/state/types';
 import { createSignal, resolveDeliveryAttributes } from '../agent/signals';
-import type { AgentSignalAttributes, AgentSignalContents, AgentSignalInput } from '../agent/signals';
+import type {
+  AgentSignalAttributes,
+  AgentSignalContents,
+  AgentSignalInput,
+  CreatedAgentSignal,
+} from '../agent/signals';
 import type {
   AgentThreadSubscription,
   MastraBrowser,
@@ -1879,6 +1884,12 @@ class SessionPermissions {
   }
 }
 
+/** Mark a user signal as reaching the agent mid-work. A delivery the caller chose wins. */
+function asInterjection(signal: CreatedAgentSignal): CreatedAgentSignal {
+  if (signal.type !== 'user' || signal.attributes?.delivery !== undefined) return signal;
+  return resolveDeliveryAttributes(signal, { delivery: 'while-active' });
+}
+
 /** The session-state / thread-settings key holding a subagent model id. */
 function subagentModelKey(agentType?: string): string {
   return agentType ? `subagentModelId_${agentType}` : 'subagentModelId';
@@ -3341,15 +3352,12 @@ export class Session<TState = unknown> {
       'content' in input
         ? { type: 'user', tagName: 'user', contents: input.content, providerOptions: input.providerOptions }
         : input;
-    // A steer's abort leaves the delivery route reading idle, so the interjection is
-    // stamped from this snapshot instead. An explicit delivery from the caller wins.
-    const interjected =
+    // A steer lands in the second window: its abort already cleared the controller,
+    // so the delivery route resolved downstream reads idle and cannot tag it.
+    const submittedWhileWorking =
       submittedIsRunning || (submittedAbortRequested && Boolean(submittedRunId ?? submittedActiveRunId));
-    const created = createSignal(signalInput);
-    const signal =
-      interjected && created.type === 'user' && created.attributes?.delivery === undefined
-        ? resolveDeliveryAttributes(created, { delivery: 'while-active' })
-        : created;
+    const submittedSignal = createSignal(signalInput);
+    const signal = submittedWhileWorking ? asInterjection(submittedSignal) : submittedSignal;
     const accepted = Promise.resolve().then(async () => {
       if (!this.thread.getId()) {
         const thread = await this.thread.create();

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3337,10 +3337,18 @@ export class Session<TState = unknown> {
     // the post-interrupt window where a fresh signal must wait for the dying
     // run to fully idle before starting a new run.
     const submittedAbortRequested = this.run.isAbortRequested();
-    const signal = createSignal(
+    const signalInput: AgentSignalInput =
       'content' in input
         ? { type: 'user', tagName: 'user', contents: input.content, providerOptions: input.providerOptions }
-        : input,
+        : input;
+    // A steer's abort leaves the delivery route reading idle, so the interjection is
+    // stamped from this snapshot instead. Caller-supplied delivery attributes win.
+    const interjected =
+      submittedIsRunning || (submittedAbortRequested && Boolean(submittedRunId ?? submittedActiveRunId));
+    const signal = createSignal(
+      signalInput.type === 'user' && interjected
+        ? { ...signalInput, attributes: { delivery: 'while-active', ...signalInput.attributes } }
+        : signalInput,
     );
     const accepted = Promise.resolve().then(async () => {
       if (!this.thread.getId()) {
@@ -3477,14 +3485,12 @@ export class Session<TState = unknown> {
   async sendMessage({
     content,
     files,
-    attributes,
     tracingContext,
     tracingOptions,
     requestContext: requestContextInput,
   }: {
     content: string;
     files?: Array<{ data: string; mediaType: string; filename?: string }>;
-    attributes?: AgentSignalAttributes;
     tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
     requestContext?: RequestContext;
@@ -3503,10 +3509,12 @@ export class Session<TState = unknown> {
             resolveAgentEnd?.();
           }
         });
-    const signal = this.sendSignal(
-      { type: 'user', tagName: 'user', contents: messageInput, attributes },
-      { tracingContext, tracingOptions, requestContext: requestContextInput },
-    );
+    const signal = this.sendSignal({
+      content: messageInput,
+      tracingContext,
+      tracingOptions,
+      requestContext: requestContextInput,
+    });
     if (wasActive) {
       await signal.accepted;
     } else {
@@ -3530,9 +3538,7 @@ export class Session<TState = unknown> {
     this.abort();
     this.followUps.clear();
     this.emit({ type: 'follow_up_queued', count: 0 });
-    // Tagged here because the interjection outlives the run it interrupts: the
-    // delivery branches see an idle session once the abort lands.
-    await this.sendMessage({ content, requestContext, attributes: { delivery: 'while-active' } });
+    await this.sendMessage({ content, requestContext });
   }
 
   /**

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -1,6 +1,6 @@
 import type { Agent } from '../agent';
 import type { MastraDBMessage, MastraProviderMetadata } from '../agent/message-list/state/types';
-import { createSignal } from '../agent/signals';
+import { createSignal, resolveDeliveryAttributes } from '../agent/signals';
 import type { AgentSignalAttributes, AgentSignalContents, AgentSignalInput } from '../agent/signals';
 import type {
   AgentThreadSubscription,
@@ -3342,14 +3342,14 @@ export class Session<TState = unknown> {
         ? { type: 'user', tagName: 'user', contents: input.content, providerOptions: input.providerOptions }
         : input;
     // A steer's abort leaves the delivery route reading idle, so the interjection is
-    // stamped from this snapshot instead. Caller-supplied delivery attributes win.
+    // stamped from this snapshot instead. An explicit delivery from the caller wins.
     const interjected =
       submittedIsRunning || (submittedAbortRequested && Boolean(submittedRunId ?? submittedActiveRunId));
-    const signal = createSignal(
-      signalInput.type === 'user' && interjected
-        ? { ...signalInput, attributes: { delivery: 'while-active', ...signalInput.attributes } }
-        : signalInput,
-    );
+    const created = createSignal(signalInput);
+    const signal =
+      interjected && created.type === 'user' && created.attributes?.delivery === undefined
+        ? resolveDeliveryAttributes(created, { delivery: 'while-active' })
+        : created;
     const accepted = Promise.resolve().then(async () => {
       if (!this.thread.getId()) {
         const thread = await this.thread.create();

--- a/packages/core/src/agent-controller/signal-messages.test.ts
+++ b/packages/core/src/agent-controller/signal-messages.test.ts
@@ -1018,6 +1018,24 @@ describe('AgentController signal messages', () => {
     expect(JSON.stringify(prompts)).toContain('<user delivery=\\"while-active\\">also do this</user>');
   });
 
+  it('tags a message sent to an idle session as a plain message', async () => {
+    const releases: Array<() => void> = [];
+    const prompts: unknown[] = [];
+    const { session } = await createController(new InMemoryStore(), createGatedAgent(prompts, releases));
+    await session.thread.create();
+
+    const first = session.sendSignal({ content: 'start the run' });
+    await first.accepted;
+    await waitFor(() => session.getCurrentRunId() !== null && releases.length === 1);
+    releases.shift()?.();
+    await waitFor(() => session.getCurrentRunId() === null);
+    const followUp = session.sendSignal({ content: 'a new turn' });
+    await followUp.accepted;
+    await waitFor(() => prompts.length === 2);
+
+    expect(JSON.stringify(prompts)).toContain('<user delivery=\\"message\\">a new turn</user>');
+  });
+
   it('leaves a delivery chosen by the caller alone', async () => {
     const releases: Array<() => void> = [];
     const prompts: unknown[] = [];

--- a/packages/core/src/agent-controller/signal-messages.test.ts
+++ b/packages/core/src/agent-controller/signal-messages.test.ts
@@ -1018,7 +1018,7 @@ describe('AgentController signal messages', () => {
     expect(JSON.stringify(prompts)).toContain('<user delivery=\\"while-active\\">also do this</user>');
   });
 
-  it('tags a message sent to an idle session as a plain message', async () => {
+  it('leaves a message that opens a new turn unmarked', async () => {
     const releases: Array<() => void> = [];
     const prompts: unknown[] = [];
     const { session } = await createController(new InMemoryStore(), createGatedAgent(prompts, releases));
@@ -1033,7 +1033,9 @@ describe('AgentController signal messages', () => {
     await followUp.accepted;
     await waitFor(() => prompts.length === 2);
 
-    expect(JSON.stringify(prompts)).toContain('<user delivery=\\"message\\">a new turn</user>');
+    const idleTurn = JSON.stringify(prompts[1]);
+    expect(idleTurn).toContain('a new turn');
+    expect(idleTurn).not.toContain('delivery');
   });
 
   it('leaves a delivery chosen by the caller alone', async () => {

--- a/packages/core/src/agent-controller/signal-messages.test.ts
+++ b/packages/core/src/agent-controller/signal-messages.test.ts
@@ -8,24 +8,27 @@ import { AgentController } from './agent-controller';
 import { createMockWorkspace } from './test-utils';
 import type { AgentControllerEvent } from './types';
 
-function createTextStreamModel(responseText: string) {
+function createTextStreamModel(responseText: string, onPrompt?: (prompt: unknown) => void) {
   return new MockLanguageModelV2({
-    doStream: async () => ({
-      rawCall: { rawPrompt: null, rawSettings: {} },
-      warnings: [],
-      stream: convertArrayToReadableStream([
-        { type: 'stream-start', warnings: [] },
-        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
-        { type: 'text-start', id: 'text-1' },
-        { type: 'text-delta', id: 'text-1', delta: responseText },
-        { type: 'text-end', id: 'text-1' },
-        {
-          type: 'finish',
-          finishReason: 'stop',
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        },
-      ]),
-    }),
+    doStream: async ({ prompt }) => {
+      onPrompt?.(prompt);
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: responseText },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          },
+        ]),
+      };
+    },
   });
 }
 
@@ -1279,6 +1282,21 @@ describe('AgentController signal messages', () => {
         }),
       }),
     });
+  });
+
+  it('tags a steer as a while-active user message so it survives a reload as an interjection', async () => {
+    const prompts: unknown[] = [];
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a test agent.',
+      model: createTextStreamModel('Hello', prompt => prompts.push(prompt)),
+    });
+    const { session } = await createController(new InMemoryStore(), agent);
+
+    await session.steer({ content: 'do this instead' });
+
+    expect(JSON.stringify(prompts)).toContain('<user delivery=\\"while-active\\">do this instead</user>');
   });
 
   it('emits state signal data parts as renderable message updates', async () => {

--- a/packages/core/src/agent-controller/signal-messages.test.ts
+++ b/packages/core/src/agent-controller/signal-messages.test.ts
@@ -1018,6 +1018,29 @@ describe('AgentController signal messages', () => {
     expect(JSON.stringify(prompts)).toContain('<user delivery=\\"while-active\\">also do this</user>');
   });
 
+  it('leaves a delivery chosen by the caller alone', async () => {
+    const releases: Array<() => void> = [];
+    const prompts: unknown[] = [];
+    const { session } = await createController(new InMemoryStore(), createGatedAgent(prompts, releases));
+    await session.thread.create();
+
+    const first = session.sendSignal({ content: 'start the run' });
+    await first.accepted;
+    await waitFor(() => session.getCurrentRunId() !== null && releases.length === 1);
+    const interjection = session.sendSignal({
+      type: 'user',
+      tagName: 'user',
+      contents: 'queued for later',
+      attributes: { delivery: 'message' },
+    });
+    await interjection.accepted;
+    releases.shift()?.();
+    await waitFor(() => session.getCurrentRunId() === null);
+
+    expect(JSON.stringify(prompts)).toContain('<user delivery=\\"message\\">queued for later</user>');
+    expect(JSON.stringify(prompts)).not.toContain('while-active');
+  });
+
   // A steer aborts before it sends, so by the time the runtime resolves a delivery
   // route it sees an idle session — the interjection has to be stamped at submit time.
   it('tags a steer as a while-active interjection even though its abort left the session idle', async () => {

--- a/packages/core/src/agent-controller/signal-messages.test.ts
+++ b/packages/core/src/agent-controller/signal-messages.test.ts
@@ -8,27 +8,67 @@ import { AgentController } from './agent-controller';
 import { createMockWorkspace } from './test-utils';
 import type { AgentControllerEvent } from './types';
 
-function createTextStreamModel(responseText: string, onPrompt?: (prompt: unknown) => void) {
+function createTextStreamModel(responseText: string) {
   return new MockLanguageModelV2({
-    doStream: async ({ prompt }) => {
-      onPrompt?.(prompt);
-      return {
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        warnings: [],
-        stream: convertArrayToReadableStream([
-          { type: 'stream-start', warnings: [] },
-          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
-          { type: 'text-start', id: 'text-1' },
-          { type: 'text-delta', id: 'text-1', delta: responseText },
-          { type: 'text-end', id: 'text-1' },
-          {
-            type: 'finish',
-            finishReason: 'stop',
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-          },
-        ]),
-      };
-    },
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: responseText },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ]),
+    }),
+  });
+}
+
+function createGatedAgent(prompts: unknown[], releases: Array<() => void>) {
+  let callCount = 0;
+  return new Agent({
+    id: 'gated-agent',
+    name: 'gated-agent',
+    instructions: 'You are a test agent.',
+    model: new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        callCount += 1;
+        const callIndex = callCount;
+        prompts.push(prompt);
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: new ReadableStream({
+            async start(controller) {
+              controller.enqueue({ type: 'stream-start', warnings: [] });
+              controller.enqueue({
+                type: 'response-metadata',
+                id: `id-${callIndex}`,
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              });
+              controller.enqueue({ type: 'text-start', id: 'text-1' });
+              controller.enqueue({ type: 'text-delta', id: 'text-1', delta: `response ${callIndex}` });
+              controller.enqueue({ type: 'text-end', id: 'text-1' });
+              if (callIndex === 1) {
+                await new Promise<void>(resolve => releases.push(resolve));
+              }
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+              controller.close();
+            },
+          }),
+        };
+      },
+    }),
   });
 }
 
@@ -961,6 +1001,42 @@ describe('AgentController signal messages', () => {
     expect(JSON.stringify(prompts[3])).toContain('second active interjection');
   });
 
+  it('tags a message sent into a live run as a while-active interjection', async () => {
+    const releases: Array<() => void> = [];
+    const prompts: unknown[] = [];
+    const { session } = await createController(new InMemoryStore(), createGatedAgent(prompts, releases));
+    await session.thread.create();
+
+    const first = session.sendSignal({ content: 'start the run' });
+    await first.accepted;
+    await waitFor(() => session.getCurrentRunId() !== null && releases.length === 1);
+    const interjection = session.sendSignal({ content: 'also do this' });
+    await interjection.accepted;
+    releases.shift()?.();
+    await waitFor(() => session.getCurrentRunId() === null);
+
+    expect(JSON.stringify(prompts)).toContain('<user delivery=\\"while-active\\">also do this</user>');
+  });
+
+  // A steer aborts before it sends, so by the time the runtime resolves a delivery
+  // route it sees an idle session — the interjection has to be stamped at submit time.
+  it('tags a steer as a while-active interjection even though its abort left the session idle', async () => {
+    const releases: Array<() => void> = [];
+    const prompts: unknown[] = [];
+    const { session } = await createController(new InMemoryStore(), createGatedAgent(prompts, releases));
+    await session.thread.create();
+
+    const first = session.sendSignal({ content: 'start the run' });
+    await first.accepted;
+    await waitFor(() => session.getCurrentRunId() !== null && releases.length === 1);
+    const steered = session.steer({ content: 'do this instead' });
+    releases.shift()?.();
+    await steered;
+    await waitFor(() => prompts.length === 2);
+
+    expect(JSON.stringify(prompts)).toContain('<user delivery=\\"while-active\\">do this instead</user>');
+  });
+
   it('emits echoed file user-message signals as user message events', async () => {
     const storage = new InMemoryStore();
     const { session } = await createController(storage);
@@ -1282,21 +1358,6 @@ describe('AgentController signal messages', () => {
         }),
       }),
     });
-  });
-
-  it('tags a steer as a while-active user message so it survives a reload as an interjection', async () => {
-    const prompts: unknown[] = [];
-    const agent = new Agent({
-      id: 'test-agent',
-      name: 'test-agent',
-      instructions: 'You are a test agent.',
-      model: createTextStreamModel('Hello', prompt => prompts.push(prompt)),
-    });
-    const { session } = await createController(new InMemoryStore(), agent);
-
-    await session.steer({ content: 'do this instead' });
-
-    expect(JSON.stringify(prompts)).toContain('<user delivery=\\"while-active\\">do this instead</user>');
   });
 
   it('emits state signal data parts as renderable message updates', async () => {


### PR DESCRIPTION
You interrupt the agent and redirect it. The model reads your redirect as a brand new turn, and once the thread reloads the transcript can no longer tell it from a normal message — that is the duplicate-looking steer in the factory report.

A user message submitted while a run is alive now carries `delivery: 'while-active'`, and the session stamps it.

Steer in particular could never be tagged downstream, because it aborts before it sends. By the time the runtime resolves a delivery route the session already reads idle, so the route answers "new run" while the human's intent was "into the work in progress". Those are two different facts and only the first is knowable downstream. The session is the one place that knows both, and it already takes the run snapshot it needs a few lines above.

### What changes

| situation | before | after |
| --- | --- | --- |
| you interrupt the agent and redirect it | model reads a bare new turn | model reads `while-active`, context for the work in flight |
| you reload a factory thread you steered | steer comes back a normal bubble | comes back a steer |
| you send a slash command mid-run in the TUI | unlabeled until the next reload | labeled `steer` right away |
| you type in the TUI while the agent is idle | wrapped in `<user delivery="message">` | plain text, no wrapper |
| a factory rule supersedes a review pass already running | kickoff arrives as a bare message | arrives wrapped `while-active` |

### Judgment call

The first three rows are the bug. The last two are mine.

Dropping the idle marking: the system prompt already reads an absent attribute as a normal turn, so `delivery="message"` was never load-bearing. Marking both routes wrapped every idle message in XML the model did not need, enough to break a recorded prompt in the Mastra Code e2e. Only the interjection is worth a wrapper.

Marking rule kickoffs: no human is watching when a rule fires, so I checked where it actually lands. `cancelInFlight` is set by one default rule — a card re-entering Review supersedes the pass already running, aborts it, and dispatches the next one into the same session. The kickoff is bound to the same work item and role by construction, so `while-active` asserts something true: it arrived while work was in flight, and `factory-rereview` should read it against the pass it just lost. The attribute never claimed a human was present. A rule that wants the opposite passes `attributes: { delivery: 'message' }` and wins the merge, no core change.

Queued follow-ups stay unmarked. The run engine calls `run.reset()` before `drainFollowUpQueue()` at all three drain sites, so the snapshot reads idle and a drained follow-up opens its turn like any other message.

### Cost

None. One object spread per user signal submitted with a run in flight, no extra call, query or round trip. The TUI drops a constant and a type import.

### Side effects to check

`mastracode/factory/src/rules/dispatcher.ts` and the two skill entry points (`routes/skills.ts`, `skills/service.ts`) reach the new stamp whenever they fire on a live session. I traced all three in the code but ran none of them.

### On deploy

Nothing migrates. Steers already persisted keep their empty attributes, so old threads still render them as normal messages after a reload; only new ones are labeled.

### Tested

Four tests in `signal-messages.test.ts`, each red when I remove the piece it guards: a message into a live run, a message opening a new turn, a caller-set delivery winning, and a steer whose own abort left the session idle. The TUI queueing suite passes with the constant gone.

I reran the Mastra Code e2e scenarios that assert on delivery against a rebuilt core: the while-active follow-up and the report-issue handoff pass, and the steer-drain recovery scenario fails identically on `main` — it wants network. I did not exercise the factory dispatcher or the skill routes.

```
tests        +122  -10    ← 74% of the additions
changeset     +26    0
source        +18  -20    ← net -2
```
