### PR TITLE
fix(core): scope suspended run storage queries

### DIFF
--- a/.changeset/tidy-weeks-find.md
+++ b/.changeset/tidy-weeks-find.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved resource-scoped suspended run discovery by filtering workflow storage before loading snapshots.

--- a/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
+++ b/packages/core/src/agent/__tests__/suspended-run-discovery.test.ts
@@ -291,6 +291,28 @@ describe('suspended-run discovery', () => {
       expect(scoped.total).toBe(1);
     }, 30000);
 
+    it('pushes resourceId into workflow storage queries', async () => {
+      const { agent, storage } = createSuspendedSetup();
+      await suspendRun(agent, 'thread-1', 'resource-1');
+
+      const workflowsStore = (await storage.getStore('workflows'))!;
+      const listWorkflowRuns = vi.spyOn(workflowsStore, 'listWorkflowRuns');
+
+      await agent.listSuspendedRuns({ resourceId: 'resource-1' });
+
+      expect(listWorkflowRuns).toHaveBeenCalledTimes(2);
+      expect(listWorkflowRuns).toHaveBeenCalledWith(
+        expect.objectContaining({ workflowName: 'agentic-loop', status: 'suspended', resourceId: 'resource-1' }),
+      );
+      expect(listWorkflowRuns).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflowName: DurableStepIds.AGENTIC_LOOP,
+          status: 'suspended',
+          resourceId: 'resource-1',
+        }),
+      );
+    }, 30000);
+
     it('paginates with perPage/page while keeping total accurate', async () => {
       // The mock model only tool-calls on its first invocation, so suspend each
       // run from a fresh agent sharing the same storage.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -8016,11 +8016,13 @@ export class Agent<
       });
     }
 
-    // threadId/resourceId live inside the snapshot state rather than in storage
-    // columns, so fetch all matching rows and filter/paginate here to keep
-    // `total` accurate. Durable agents persist their agentic loop under a
-    // separate workflow name, so query both — otherwise suspended durable runs
-    // are never discoverable.
+    // threadId and the owning agent id live inside the snapshot state, so
+    // filter those after loading rows to keep `total` accurate. resourceId is
+    // a first-class workflow-run column and must be pushed into storage so a
+    // resource-scoped lookup does not load suspended snapshots for every
+    // resource. Durable agents persist their agentic loop under a separate
+    // workflow name, so query both — otherwise suspended durable runs are
+    // never discoverable.
     const runs: Awaited<ReturnType<typeof workflowsStore.listWorkflowRuns>>['runs'] = [];
     for (const workflowName of ['agentic-loop', DurableStepIds.AGENTIC_LOOP]) {
       const { runs: workflowRuns } = await workflowsStore.listWorkflowRuns({
@@ -8028,6 +8030,7 @@ export class Agent<
         status: 'suspended',
         fromDate,
         toDate,
+        resourceId,
       });
       runs.push(...workflowRuns);
     }


### PR DESCRIPTION
## Description

Pass `resourceId` to both workflow storage queries used by `Agent.listSuspendedRuns()`. Core still validates suspended status, owning agent, thread, and resource after loading each matching snapshot, so result and authorization semantics stay unchanged while resource-scoped calls avoid loading unrelated snapshots.

## Related issue(s)

Fixes #21844

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable; public API is unchanged)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Validation:

- `pnpm --filter ./packages/core test:unit src/agent/__tests__/suspended-run-discovery.test.ts` (25 tests passed)
- `pnpm --filter ./packages/core check`
- `oxfmt --check` on the changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you search for suspended runs for one resource, the system now asks storage for only that resource’s runs. This avoids loading unrelated data while keeping the existing validation and results unchanged.

## Changes

- Pass `resourceId` to both `agentic-loop` and `durable-agentic-loop` workflow queries.
- Keep in-process validation for suspended status, owning agent, thread, and resource.
- Add a test that verifies both workflow queries receive `resourceId`.
- Add a patch release changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
