### PR TITLE
fix(core): pin agent version across resume

### DIFF
--- a/.changeset/bright-dots-resume.md
+++ b/.changeset/bright-dots-resume.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Pinned resolved agent versions in suspended workflow snapshots so resumed runs continue with the exact version that started them.
+Resolved root agent versions before model validation and pinned them in suspended workflow snapshots so resumed runs continue with the exact version that started them.

--- a/.changeset/bright-dots-resume.md
+++ b/.changeset/bright-dots-resume.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Pinned resolved agent versions in suspended workflow snapshots so resumed runs continue with the exact version that started them.

--- a/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
+++ b/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
@@ -110,7 +110,6 @@ describe('agentic-loop snapshot lifecycle', () => {
 
     const mastra = new Mastra({
       agents: { agent },
-      versions: { agents: { 'versioned-agent': { status: 'published' } } },
       editor: { agent: { applyStoredOverrides } } as any,
       logger: false,
       storage: new InMemoryStore(),
@@ -121,6 +120,7 @@ describe('agentic-loop snapshot lifecycle', () => {
     const stream = await agent.stream('Find the user with name - Dero Israel', {
       requireToolApproval: true,
       requestContext,
+      versions: { agents: { 'versioned-agent': { status: 'published' } } },
     });
 
     let toolCallId = '';

--- a/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
+++ b/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
@@ -120,11 +120,12 @@ describe('agentic-loop snapshot lifecycle', () => {
     });
     const workflowsStore = (await mastra.getStorage()!.getStore('workflows'))!;
 
-    const requestContext = new RequestContext();
+    const requestContext = new RequestContext([
+      [MASTRA_VERSIONS_KEY, { agents: { 'versioned-agent': { status: 'published' } } }],
+    ]);
     const stream = await agent.stream('Find the user with name - Dero Israel', {
       requireToolApproval: true,
       requestContext,
-      versions: { agents: { 'versioned-agent': { status: 'published' } } },
     });
 
     let toolCallId = '';
@@ -153,8 +154,20 @@ describe('agentic-loop snapshot lifecycle', () => {
       // consume
     }
 
+    // Resuming with the exact v1 snapshot must not replace the caller-owned
+    // published selector that a later new run will reuse.
+    expect(requestContext.get(MASTRA_VERSIONS_KEY)).toEqual({
+      agents: { 'versioned-agent': { status: 'published' } },
+    });
+
+    const nextRun = await agent.stream('Start a new run', { requestContext });
+    for await (const _chunk of nextRun.fullStream) {
+      // consume
+    }
+
     expect(applyStoredOverrides).toHaveBeenNthCalledWith(1, agent, { status: 'published' });
     expect(applyStoredOverrides).toHaveBeenNthCalledWith(2, agent, { versionId: 'v1' });
+    expect(applyStoredOverrides).toHaveBeenNthCalledWith(3, agent, { status: 'published' });
   }, 30000);
 
   it('keeps snapshot rows while suspended and deletes all rows after resume completes', async () => {

--- a/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
+++ b/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { Mastra } from '../../mastra';
+import { MASTRA_VERSIONS_KEY, RequestContext } from '../../request-context';
 import { InMemoryStore } from '../../storage';
 import { createTool } from '../../tools';
 import type { WorkflowRunState } from '../../workflows';
@@ -90,6 +91,68 @@ function summarizeRuns(runs: { workflowName: string; runId: string; snapshot: st
 }
 
 describe('agentic-loop snapshot lifecycle', () => {
+  it('pins a resolved root agent version in the snapshot and restores it on resume', async () => {
+    const agent = new Agent({
+      id: 'versioned-agent',
+      name: 'Versioned Agent',
+      instructions: 'You find users.',
+      model: createMockModel(),
+      tools: { findUserTool: createFindUserTool() },
+    });
+
+    let publishedVersionId = 'v1';
+    const applyStoredOverrides = vi.fn(async (source: Agent, selector: { versionId: string } | { status: string }) => {
+      const versionId = 'versionId' in selector ? selector.versionId : publishedVersionId;
+      const fork = source.__fork();
+      fork.__setRawConfig({ ...(source.toRawConfig() ?? {}), resolvedVersionId: versionId });
+      return fork;
+    });
+
+    const mastra = new Mastra({
+      agents: { agent },
+      versions: { agents: { 'versioned-agent': { status: 'published' } } },
+      editor: { agent: { applyStoredOverrides } } as any,
+      logger: false,
+      storage: new InMemoryStore(),
+    });
+    const workflowsStore = (await mastra.getStorage()!.getStore('workflows'))!;
+
+    const requestContext = new RequestContext();
+    const stream = await agent.stream('Find the user with name - Dero Israel', {
+      requireToolApproval: true,
+      requestContext,
+    });
+
+    let toolCallId = '';
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'tool-call-approval') {
+        toolCallId = chunk.payload.toolCallId;
+      }
+    }
+    expect(toolCallId).toBeTruthy();
+
+    const loopRow = (await workflowsStore.listWorkflowRuns({})).runs.find(row => row.workflowName === 'agentic-loop');
+    const snapshot =
+      typeof loopRow?.snapshot === 'string' ? JSON.parse(loopRow.snapshot) : (loopRow?.snapshot as WorkflowRunState);
+    expect(snapshot.requestContext?.[MASTRA_VERSIONS_KEY]).toEqual({
+      agents: { 'versioned-agent': { versionId: 'v1' } },
+    });
+    expect(requestContext.get(MASTRA_VERSIONS_KEY)).toEqual({
+      agents: { 'versioned-agent': { status: 'published' } },
+    });
+
+    // Publishing v2 after the run suspended must not change the version used
+    // to resume the already-started v1 run.
+    publishedVersionId = 'v2';
+    const resumed = await agent.approveToolCall({ runId: stream.runId, toolCallId });
+    for await (const _chunk of resumed.fullStream) {
+      // consume
+    }
+
+    expect(applyStoredOverrides).toHaveBeenNthCalledWith(1, agent, { status: 'published' });
+    expect(applyStoredOverrides).toHaveBeenNthCalledWith(2, agent, { versionId: 'v1' });
+  }, 30000);
+
   it('keeps snapshot rows while suspended and deletes all rows after resume completes', async () => {
     const agent = new Agent({
       id: 'user-agent',

--- a/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
+++ b/packages/core/src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts
@@ -15,7 +15,7 @@ import { InMemoryStore } from '../../storage';
 import { createTool } from '../../tools';
 import type { WorkflowRunState } from '../../workflows';
 import { Agent } from '../agent';
-import { convertArrayToReadableStream, MockLanguageModelV2 } from './mock-model';
+import { convertArrayToReadableStream, getSingleDummyResponseModel, MockLanguageModelV2 } from './mock-model';
 
 const mockFindUser = vi.fn().mockImplementation(async (data: { name: string }) => {
   return { name: data.name, email: 'dero@mail.com' };
@@ -92,11 +92,14 @@ function summarizeRuns(runs: { workflowName: string; runId: string; snapshot: st
 
 describe('agentic-loop snapshot lifecycle', () => {
   it('pins a resolved root agent version in the snapshot and restores it on resume', async () => {
+    const storedVersionModel = createMockModel();
     const agent = new Agent({
       id: 'versioned-agent',
       name: 'Versioned Agent',
       instructions: 'You find users.',
-      model: createMockModel(),
+      // The code-defined model is intentionally legacy/unsupported. Public
+      // validation must run against the resolved stored version's model.
+      model: getSingleDummyResponseModel('v1'),
       tools: { findUserTool: createFindUserTool() },
     });
 
@@ -104,6 +107,7 @@ describe('agentic-loop snapshot lifecycle', () => {
     const applyStoredOverrides = vi.fn(async (source: Agent, selector: { versionId: string } | { status: string }) => {
       const versionId = 'versionId' in selector ? selector.versionId : publishedVersionId;
       const fork = source.__fork();
+      fork.__updateModel({ model: storedVersionModel });
       fork.__setRawConfig({ ...(source.toRawConfig() ?? {}), resolvedVersionId: versionId });
       return fork;
     });

--- a/packages/core/src/agent/__tests__/subagent-versioning.test.ts
+++ b/packages/core/src/agent/__tests__/subagent-versioning.test.ts
@@ -414,7 +414,9 @@ describe('Sub-agent version resolution', () => {
       versions,
     });
 
-    const resolveSpy = vi.spyOn(mastra, 'resolveVersionedAgent').mockResolvedValue(sub);
+    const resolveSpy = vi
+      .spyOn(mastra, 'resolveVersionedAgent')
+      .mockImplementation(async target => (target === supervisor ? supervisor : sub));
 
     await supervisor.generate('Do something', { maxSteps: 3 });
 
@@ -447,7 +449,9 @@ describe('Sub-agent version resolution', () => {
       versions,
     });
 
-    const resolveSpy = vi.spyOn(mastra, 'resolveVersionedAgent').mockResolvedValue(sub);
+    const resolveSpy = vi
+      .spyOn(mastra, 'resolveVersionedAgent')
+      .mockImplementation(async target => (target === supervisor ? supervisor : sub));
 
     await supervisor.generate('Do something', { maxSteps: 3 });
 
@@ -478,7 +482,9 @@ describe('Sub-agent version resolution', () => {
       agents: { supervisor, sub },
     });
 
-    const resolveSpy = vi.spyOn(mastra, 'resolveVersionedAgent').mockResolvedValue(sub);
+    const resolveSpy = vi
+      .spyOn(mastra, 'resolveVersionedAgent')
+      .mockImplementation(async target => (target === supervisor ? supervisor : sub));
 
     await supervisor.generate('Do something', { maxSteps: 3, requestContext: ctx });
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6727,32 +6727,36 @@ export class Agent<
       });
     }
 
+    // Version selectors are execution metadata. Keep them on an execution-local
+    // context so an exact version restored from a snapshot cannot pin a later
+    // run that reuses the caller-owned context.
+    const executionRequestContext = mergedVersions ? new RequestContext(requestContext.entries()) : requestContext;
     if (mergedVersions) {
-      requestContext.set(MASTRA_VERSIONS_KEY, mergedVersions);
+      executionRequestContext.set(MASTRA_VERSIONS_KEY, mergedVersions);
     }
 
     if (!mergedVersions || this.#storedVersionApplied || !this.#mastra) {
-      return { agent: this, requestContext, versions: mergedVersions };
+      return { agent: this, requestContext: executionRequestContext, versions: mergedVersions };
     }
 
     const selfVersionSelector =
       mergedVersions.agents?.[this.id] ??
       (mergedVersions.defaultStatus ? { status: mergedVersions.defaultStatus } : undefined);
     if (!selfVersionSelector) {
-      return { agent: this, requestContext, versions: mergedVersions };
+      return { agent: this, requestContext: executionRequestContext, versions: mergedVersions };
     }
 
     try {
       const resolved = await this.#mastra.resolveVersionedAgent(this as unknown as Agent, selfVersionSelector);
       if (resolved === (this as unknown as Agent)) {
-        return { agent: this, requestContext, versions: mergedVersions };
+        return { agent: this, requestContext: executionRequestContext, versions: mergedVersions };
       }
 
       const resolvedVersionId = resolved.toRawConfig()?.resolvedVersionId;
       if (typeof resolvedVersionId !== 'string' || resolvedVersionId.length === 0) {
         return {
           agent: resolved as unknown as Agent<TAgentId, TTools, TOutput, TRequestContext>,
-          requestContext,
+          requestContext: executionRequestContext,
           versions: mergedVersions,
         };
       }
@@ -6760,14 +6764,11 @@ export class Agent<
       const pinnedVersions = mergeVersionOverrides(mergedVersions, {
         agents: { [this.id]: { versionId: resolvedVersionId } },
       });
-      // Keep the caller-owned selector unchanged for future new runs. Only
-      // this execution and the workflow snapshot receive the exact version.
-      const resolvedRequestContext = new RequestContext(requestContext.entries());
-      resolvedRequestContext.set(MASTRA_VERSIONS_KEY, pinnedVersions);
+      executionRequestContext.set(MASTRA_VERSIONS_KEY, pinnedVersions);
 
       return {
         agent: resolved as unknown as Agent<TAgentId, TTools, TOutput, TRequestContext>,
-        requestContext: resolvedRequestContext,
+        requestContext: executionRequestContext,
         versions: pinnedVersions,
       };
     } catch (versionError) {
@@ -6777,7 +6778,7 @@ export class Agent<
         versionSelector: selfVersionSelector,
         error: versionError,
       });
-      return { agent: this, requestContext, versions: mergedVersions };
+      return { agent: this, requestContext: executionRequestContext, versions: mergedVersions };
     }
   }
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6699,6 +6699,88 @@ export class Agent<
     return snapshotVersions as VersionOverrides;
   }
 
+  async #resolveVersionedExecution({
+    requestContext = new RequestContext(),
+    versions,
+    snapshot,
+  }: {
+    requestContext?: RequestContext;
+    versions?: VersionOverrides;
+    snapshot?: WorkflowRunState | null;
+  }): Promise<{
+    agent: Agent<TAgentId, TTools, TOutput, TRequestContext>;
+    requestContext: RequestContext;
+    versions?: VersionOverrides;
+  }> {
+    const snapshotVersions = this.#getSnapshotVersionOverrides(snapshot);
+    const requestVersions = requestContext.get(MASTRA_VERSIONS_KEY) as VersionOverrides | undefined;
+    let mergedVersions = mergeVersionOverrides(this.#mastra?.getVersionOverrides(), snapshotVersions);
+    mergedVersions = mergeVersionOverrides(mergedVersions, requestVersions);
+    mergedVersions = mergeVersionOverrides(mergedVersions, versions);
+
+    // An exact root version persisted by the suspended run is authoritative
+    // over current defaults and call-site selectors for that continuation.
+    const snapshotSelfVersion = snapshotVersions?.agents?.[this.id];
+    if (snapshotSelfVersion && typeof snapshotSelfVersion === 'object' && 'versionId' in snapshotSelfVersion) {
+      mergedVersions = mergeVersionOverrides(mergedVersions, {
+        agents: { [this.id]: snapshotSelfVersion },
+      });
+    }
+
+    if (mergedVersions) {
+      requestContext.set(MASTRA_VERSIONS_KEY, mergedVersions);
+    }
+
+    if (!mergedVersions || this.#storedVersionApplied || !this.#mastra) {
+      return { agent: this, requestContext, versions: mergedVersions };
+    }
+
+    const selfVersionSelector =
+      mergedVersions.agents?.[this.id] ??
+      (mergedVersions.defaultStatus ? { status: mergedVersions.defaultStatus } : undefined);
+    if (!selfVersionSelector) {
+      return { agent: this, requestContext, versions: mergedVersions };
+    }
+
+    try {
+      const resolved = await this.#mastra.resolveVersionedAgent(this as unknown as Agent, selfVersionSelector);
+      if (resolved === (this as unknown as Agent)) {
+        return { agent: this, requestContext, versions: mergedVersions };
+      }
+
+      const resolvedVersionId = resolved.toRawConfig()?.resolvedVersionId;
+      if (typeof resolvedVersionId !== 'string' || resolvedVersionId.length === 0) {
+        return {
+          agent: resolved as unknown as Agent<TAgentId, TTools, TOutput, TRequestContext>,
+          requestContext,
+          versions: mergedVersions,
+        };
+      }
+
+      const pinnedVersions = mergeVersionOverrides(mergedVersions, {
+        agents: { [this.id]: { versionId: resolvedVersionId } },
+      });
+      // Keep the caller-owned selector unchanged for future new runs. Only
+      // this execution and the workflow snapshot receive the exact version.
+      const resolvedRequestContext = new RequestContext(requestContext.entries());
+      resolvedRequestContext.set(MASTRA_VERSIONS_KEY, pinnedVersions);
+
+      return {
+        agent: resolved as unknown as Agent<TAgentId, TTools, TOutput, TRequestContext>,
+        requestContext: resolvedRequestContext,
+        versions: pinnedVersions,
+      };
+    } catch (versionError) {
+      this.logger.warn('Failed to resolve versioned agent for execution, using code-defined default', {
+        agent: this.name,
+        agentId: this.id,
+        versionSelector: selfVersionSelector,
+        error: versionError,
+      });
+      return { agent: this, requestContext, versions: mergedVersions };
+    }
+  }
+
   #getSuspendedToolCalls(existingSnapshot: WorkflowRunState | null | undefined): AgentRunToolCall[] {
     const toolCalls: AgentRunToolCall[] = [];
 
@@ -6989,87 +7071,7 @@ export class Agent<
     const threadStreamPubSub = _threadStreamPubSub ?? this.getPubSub();
     const existingSnapshot = resumeContext?.snapshot;
     const snapshotMemoryInfo = this.#getSnapshotMemoryInfo(existingSnapshot);
-    const snapshotVersions = this.#getSnapshotVersionOverrides(existingSnapshot);
     const requestContext = options.requestContext || new RequestContext();
-
-    // Build version overrides by merging: Mastra defaults < snapshot < requestContext < call-site.
-    // A resumed run carries the versions that were active when it suspended.
-    const requestVersions = requestContext.get(MASTRA_VERSIONS_KEY) as VersionOverrides | undefined;
-    let mergedVersions = mergeVersionOverrides(this.#mastra?.getVersionOverrides(), snapshotVersions);
-    mergedVersions = mergeVersionOverrides(mergedVersions, requestVersions);
-
-    // Merge call-site version overrides on top for new runs.
-    if (options.versions) {
-      mergedVersions = mergeVersionOverrides(mergedVersions, options.versions);
-    }
-
-    // The root agent version is part of the suspended run's identity. Once a
-    // status selector has been resolved and persisted as an exact versionId,
-    // a resume must not move that run to a newer published/draft version.
-    const snapshotSelfVersion = snapshotVersions?.agents?.[this.id];
-    if (snapshotSelfVersion && typeof snapshotSelfVersion === 'object' && 'versionId' in snapshotSelfVersion) {
-      mergedVersions = mergeVersionOverrides(mergedVersions, {
-        agents: { [this.id]: snapshotSelfVersion },
-      });
-    }
-
-    if (mergedVersions) {
-      requestContext.set(MASTRA_VERSIONS_KEY, mergedVersions);
-    }
-
-    // Resolve a versioned variant of *this* agent when a version override
-    // selects it (by id or defaultStatus) and delegate execution to it. This
-    // keeps direct programmatic calls consistent with HTTP routes and
-    // sub-agent delegation, which already honor version overrides.
-    if (mergedVersions && !this.#storedVersionApplied && this.#mastra) {
-      const selfVersionSelector =
-        mergedVersions.agents?.[this.id] ??
-        (mergedVersions.defaultStatus ? { status: mergedVersions.defaultStatus } : undefined);
-      if (selfVersionSelector) {
-        try {
-          const resolved = await this.#mastra.resolveVersionedAgent(this as unknown as Agent, selfVersionSelector);
-          if (resolved !== (this as unknown as Agent)) {
-            const resolvedVersionId = resolved.toRawConfig()?.resolvedVersionId;
-            let resolvedRequestContext = requestContext;
-            let resolvedVersions: VersionOverrides | undefined = options.versions;
-            if (typeof resolvedVersionId === 'string' && resolvedVersionId.length > 0) {
-              const pinnedVersions = mergeVersionOverrides(mergedVersions, {
-                agents: { [this.id]: { versionId: resolvedVersionId } },
-              });
-              // Keep the caller-owned RequestContext selector unchanged so it
-              // can resolve the latest published/draft version on a later run.
-              // Only this execution and its persisted snapshot are pinned.
-              resolvedRequestContext = new RequestContext(requestContext.entries());
-              resolvedRequestContext.set(MASTRA_VERSIONS_KEY, pinnedVersions);
-              // The delegated fork merges call-site versions again. Pass the
-              // pinned aggregate so an original status selector cannot replace
-              // the exact root version before the workflow snapshot is saved.
-              resolvedVersions = pinnedVersions;
-            }
-
-            // Cast: reassembled options are exactly this method's input. The
-            // `unknown` annotation breaks the circular return-type inference
-            // of the self-recursion (TS7023).
-            const delegated: unknown = (resolved as unknown as this).#execute<OUTPUT>({
-              methodType,
-              resumeContext,
-              _threadStreamPubSub,
-              ...options,
-              requestContext: resolvedRequestContext,
-              versions: resolvedVersions,
-            } as unknown as InnerAgentExecutionOptions<OUTPUT> & { _threadStreamPubSub?: PubSub });
-            return delegated as never;
-          }
-        } catch (versionError) {
-          this.logger.warn('Failed to resolve versioned agent for direct call, using code-defined default', {
-            agent: this.name,
-            agentId: this.id,
-            versionSelector: selfVersionSelector,
-            error: versionError,
-          });
-        }
-      }
-    }
 
     // Resolve workspace early so we can get browser from it if needed
     const earlyWorkspace = await this.getWorkspace({ requestContext });
@@ -7889,8 +7891,13 @@ export class Agent<
       actor,
     });
 
-    const llm = await this.getLLM({
+    const versionedExecution = await this.#resolveVersionedExecution({
       requestContext: mergedOptions.requestContext,
+      versions: mergedOptions.versions,
+    });
+
+    const llm = await versionedExecution.agent.getLLM({
+      requestContext: versionedExecution.requestContext,
       model: mergedOptions.model as DynamicArgument<MastraModelConfig, TRequestContext> | undefined,
     });
 
@@ -7921,6 +7928,8 @@ export class Agent<
     const executeOptions = {
       ...loopOptions,
       actor,
+      requestContext: versionedExecution.requestContext,
+      versions: versionedExecution.versions,
       structuredOutput: mergedOptions.structuredOutput
         ? {
             ...mergedOptions.structuredOutput,
@@ -7935,7 +7944,7 @@ export class Agent<
       maxProcessorRetries: mergedOptions.maxProcessorRetries ?? this.#maxProcessorRetries,
     } as unknown as InnerAgentExecutionOptions<any> & { _threadStreamPubSub?: PubSub };
 
-    const result = await this.#execute(executeOptions);
+    const result = await versionedExecution.agent.#execute(executeOptions);
 
     if (result.status !== 'success') {
       if (result.status === 'failed') {
@@ -8530,8 +8539,18 @@ export class Agent<
       actor,
     });
 
-    const llm = await this.getLLM({
+    const versionedExecution = await this.#resolveVersionedExecution({
       requestContext: mergedOptions.requestContext,
+      versions: mergedOptions.versions,
+    });
+    const executionLoopOptions = {
+      ...loopOptions,
+      requestContext: versionedExecution.requestContext,
+      versions: versionedExecution.versions,
+    };
+
+    const llm = await versionedExecution.agent.getLLM({
+      requestContext: versionedExecution.requestContext,
       model: mergedOptions.model as DynamicArgument<MastraModelConfig, TRequestContext> | undefined,
     });
 
@@ -8562,7 +8581,7 @@ export class Agent<
     const threadStreamPubSub = this.getPubSub();
     await agentThreadStreamRuntime.waitForCrossAgentThreadRun(
       this as Agent<any, any, any, any>,
-      loopOptions as AgentExecutionOptions<OUTPUT>,
+      executionLoopOptions as AgentExecutionOptions<OUTPUT>,
       threadStreamPubSub,
     );
 
@@ -8573,7 +8592,7 @@ export class Agent<
         entityId: this.id,
       }) ?? randomUUID();
     const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(
-      { ...loopOptions, runId: mergedOptions.runId, actor } as AgentExecutionOptions<OUTPUT>,
+      { ...executionLoopOptions, runId: mergedOptions.runId, actor } as AgentExecutionOptions<OUTPUT>,
       threadStreamPubSub,
     );
 
@@ -8595,7 +8614,7 @@ export class Agent<
       _threadStreamPubSub: threadStreamPubSub,
     } as unknown as InnerAgentExecutionOptions<OUTPUT> & { _threadStreamPubSub?: PubSub };
 
-    const result = await this.#execute(executeOptions);
+    const result = await versionedExecution.agent.#execute(executeOptions);
 
     if (result.status !== 'success') {
       if (result.status === 'failed') {
@@ -8890,8 +8909,19 @@ export class Agent<
       method: 'resumeStream',
     });
 
-    const llm = await this.getLLM({
+    const versionedExecution = await this.#resolveVersionedExecution({
       requestContext: mergedStreamOptions.requestContext,
+      versions: mergedStreamOptions.versions,
+      snapshot: resumeSnapshot,
+    });
+    const executionLoopStreamOptions = {
+      ...loopStreamOptions,
+      requestContext: versionedExecution.requestContext,
+      versions: versionedExecution.versions,
+    };
+
+    const llm = await versionedExecution.agent.getLLM({
+      requestContext: versionedExecution.requestContext,
       model: mergedStreamOptions.model as DynamicArgument<MastraModelConfig, TRequestContext> | undefined,
     });
 
@@ -8917,15 +8947,15 @@ export class Agent<
     const threadStreamPubSub = this.getPubSub();
     await agentThreadStreamRuntime.waitForCrossAgentThreadRun(
       this as Agent<any, any, any, any>,
-      loopStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
+      executionLoopStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
       threadStreamPubSub,
     );
     const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(
-      { ...loopStreamOptions, actor } as unknown as AgentExecutionOptions<OUTPUT>,
+      { ...executionLoopStreamOptions, actor } as unknown as AgentExecutionOptions<OUTPUT>,
       threadStreamPubSub,
     );
 
-    const result = await this.#execute({
+    const result = await versionedExecution.agent.#execute({
       ...preparedOptions,
       actor,
       structuredOutput: mergedStreamOptions.structuredOutput
@@ -9055,8 +9085,14 @@ export class Agent<
       method: 'resumeGenerate',
     });
 
-    const llm = await this.getLLM({
+    const versionedExecution = await this.#resolveVersionedExecution({
       requestContext: mergedOptions.requestContext,
+      versions: mergedOptions.versions,
+      snapshot: resumeSnapshot,
+    });
+
+    const llm = await versionedExecution.agent.getLLM({
+      requestContext: versionedExecution.requestContext,
       model: mergedOptions.model as DynamicArgument<MastraModelConfig, TRequestContext> | undefined,
     });
 
@@ -9083,9 +9119,11 @@ export class Agent<
       });
     }
 
-    const result = await this.#execute({
+    const result = await versionedExecution.agent.#execute({
       ...loopOptions,
       actor,
+      requestContext: versionedExecution.requestContext,
+      versions: versionedExecution.versions,
       structuredOutput: mergedOptions.structuredOutput
         ? {
             ...mergedOptions.structuredOutput,

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -7031,6 +7031,7 @@ export class Agent<
           if (resolved !== (this as unknown as Agent)) {
             const resolvedVersionId = resolved.toRawConfig()?.resolvedVersionId;
             let resolvedRequestContext = requestContext;
+            let resolvedVersions: VersionOverrides | undefined = options.versions;
             if (typeof resolvedVersionId === 'string' && resolvedVersionId.length > 0) {
               const pinnedVersions = mergeVersionOverrides(mergedVersions, {
                 agents: { [this.id]: { versionId: resolvedVersionId } },
@@ -7040,6 +7041,10 @@ export class Agent<
               // Only this execution and its persisted snapshot are pinned.
               resolvedRequestContext = new RequestContext(requestContext.entries());
               resolvedRequestContext.set(MASTRA_VERSIONS_KEY, pinnedVersions);
+              // The delegated fork merges call-site versions again. Pass the
+              // pinned aggregate so an original status selector cannot replace
+              // the exact root version before the workflow snapshot is saved.
+              resolvedVersions = pinnedVersions;
             }
 
             // Cast: reassembled options are exactly this method's input. The
@@ -7051,6 +7056,7 @@ export class Agent<
               _threadStreamPubSub,
               ...options,
               requestContext: resolvedRequestContext,
+              versions: resolvedVersions,
             } as unknown as InnerAgentExecutionOptions<OUTPUT> & { _threadStreamPubSub?: PubSub });
             return delegated as never;
           }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6690,6 +6690,15 @@ export class Agent<
     return undefined;
   }
 
+  #getSnapshotVersionOverrides(existingSnapshot: WorkflowRunState | null | undefined): VersionOverrides | undefined {
+    const snapshotVersions = existingSnapshot?.requestContext?.[MASTRA_VERSIONS_KEY];
+    if (!snapshotVersions || typeof snapshotVersions !== 'object' || Array.isArray(snapshotVersions)) {
+      return undefined;
+    }
+
+    return snapshotVersions as VersionOverrides;
+  }
+
   #getSuspendedToolCalls(existingSnapshot: WorkflowRunState | null | undefined): AgentRunToolCall[] {
     const toolCalls: AgentRunToolCall[] = [];
 
@@ -6980,15 +6989,28 @@ export class Agent<
     const threadStreamPubSub = _threadStreamPubSub ?? this.getPubSub();
     const existingSnapshot = resumeContext?.snapshot;
     const snapshotMemoryInfo = this.#getSnapshotMemoryInfo(existingSnapshot);
+    const snapshotVersions = this.#getSnapshotVersionOverrides(existingSnapshot);
     const requestContext = options.requestContext || new RequestContext();
 
-    // Build version overrides by merging: Mastra defaults < requestContext < call-site
+    // Build version overrides by merging: Mastra defaults < snapshot < requestContext < call-site.
+    // A resumed run carries the versions that were active when it suspended.
     const requestVersions = requestContext.get(MASTRA_VERSIONS_KEY) as VersionOverrides | undefined;
-    let mergedVersions = mergeVersionOverrides(this.#mastra?.getVersionOverrides(), requestVersions);
+    let mergedVersions = mergeVersionOverrides(this.#mastra?.getVersionOverrides(), snapshotVersions);
+    mergedVersions = mergeVersionOverrides(mergedVersions, requestVersions);
 
-    // Merge call-site version overrides on top (call-site wins over request + Mastra defaults)
+    // Merge call-site version overrides on top for new runs.
     if (options.versions) {
       mergedVersions = mergeVersionOverrides(mergedVersions, options.versions);
+    }
+
+    // The root agent version is part of the suspended run's identity. Once a
+    // status selector has been resolved and persisted as an exact versionId,
+    // a resume must not move that run to a newer published/draft version.
+    const snapshotSelfVersion = snapshotVersions?.agents?.[this.id];
+    if (snapshotSelfVersion && typeof snapshotSelfVersion === 'object' && 'versionId' in snapshotSelfVersion) {
+      mergedVersions = mergeVersionOverrides(mergedVersions, {
+        agents: { [this.id]: snapshotSelfVersion },
+      });
     }
 
     if (mergedVersions) {
@@ -7007,6 +7029,19 @@ export class Agent<
         try {
           const resolved = await this.#mastra.resolveVersionedAgent(this as unknown as Agent, selfVersionSelector);
           if (resolved !== (this as unknown as Agent)) {
+            const resolvedVersionId = resolved.toRawConfig()?.resolvedVersionId;
+            let resolvedRequestContext = requestContext;
+            if (typeof resolvedVersionId === 'string' && resolvedVersionId.length > 0) {
+              const pinnedVersions = mergeVersionOverrides(mergedVersions, {
+                agents: { [this.id]: { versionId: resolvedVersionId } },
+              });
+              // Keep the caller-owned RequestContext selector unchanged so it
+              // can resolve the latest published/draft version on a later run.
+              // Only this execution and its persisted snapshot are pinned.
+              resolvedRequestContext = new RequestContext(requestContext.entries());
+              resolvedRequestContext.set(MASTRA_VERSIONS_KEY, pinnedVersions);
+            }
+
             // Cast: reassembled options are exactly this method's input. The
             // `unknown` annotation breaks the circular return-type inference
             // of the self-recursion (TS7023).
@@ -7015,7 +7050,7 @@ export class Agent<
               resumeContext,
               _threadStreamPubSub,
               ...options,
-              requestContext,
+              requestContext: resolvedRequestContext,
             } as unknown as InnerAgentExecutionOptions<OUTPUT> & { _threadStreamPubSub?: PubSub });
             return delegated as never;
           }


### PR DESCRIPTION
## Description

Resolve the effective stored root Agent before public model compatibility validation, then execute with that resolved Agent. This keeps stored instructions, model, tools, processors, and workspace on one official execution path instead of validating the code-defined Agent and switching later inside the workflow.

After a `draft` / `published` selector resolves, pin its exact `resolvedVersionId` in an execution-local RequestContext. The existing workflow snapshot contract persists that value, and resume restores it before resolving the root Agent. The snapshot's exact root `versionId` is authoritative only for that continuation.

New runs still resolve status selectors at execution time. The caller-owned RequestContext keeps its status selector so later new runs hot-switch to newly published versions. This reuses `resolvedVersionId`, `VersionOverrides`, workflow `requestContext`, and `resolveVersionedAgent()`; it adds no Channel-specific resolver or application-side version authority.

## Related issue(s)

Fixes #21846

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable; public API is unchanged)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Validation:

- `vitest run src/agent/__tests__/agentic-loop-snapshot-lifecycle.test.ts src/agent/__tests__/subagent-versioning.test.ts --exclude '**/tool-builder/**'` (30 tests passed; no type errors)
- `tsc --noEmit` in `packages/core`
- `oxfmt --write` on the changed TypeScript files, followed by `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a workflow pauses and resumes later, it now uses the same root Agent version that started the workflow. New workflows still use the latest selected version.

## Changes

- Pin the resolved root Agent `resolvedVersionId` in the execution-local `RequestContext`.
- Persist and restore the pinned version through workflow snapshots.
- Resolve the stored Agent before model compatibility validation and execution.
- Preserve caller-owned `RequestContext` selectors for later runs.
- Keep existing behavior for exact version selectors and code-defined Agents.
- Add regression tests for publication changes, snapshot pinning, call-site selectors, and request-context behavior.
- Add a `@mastra/core` patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
