### PR TITLE
fix(factory-ui): draw a re-identified assistant turn once

### DIFF
--- a/.changeset/factory-ui-duplicate-transcript-turn.md
+++ b/.changeset/factory-ui-duplicate-transcript-turn.md
@@ -4,4 +4,4 @@
 
 Fixed assistant turns showing up twice in the chat transcript, with the first copy stripped of the tool cards that belong to it.
 
-A turn can reach the transcript under two identities: the run loop hands the engine a message id that the engine only adopts while its own message is still empty, and a refetched window after a stream gap brings the persisted copy back. The transcript now recognises a message that extends what is already drawn as that same turn and rewrites it in place, instead of drawing a second copy and moving the tool parts over to it.
+The duplicate showed up when a reply came back under a second identity: the server stores a long turn as several messages, and a refetch after a stream gap brings those copies back. The transcript now recognises such a copy as the turn it is already drawing and updates it in place, so the tool cards stay with the text they ran under and nothing lands on screen twice.

--- a/.changeset/factory-ui-duplicate-transcript-turn.md
+++ b/.changeset/factory-ui-duplicate-transcript-turn.md
@@ -4,4 +4,4 @@
 
 Fixed assistant turns showing up twice in the chat transcript, with the first copy stripped of the tool cards that belong to it.
 
-The duplicate showed up when a reply came back under a second identity: the server stores a long turn as several messages, and a refetch after a stream gap brings those copies back. The transcript now recognises such a copy as the turn it is already drawing and updates it in place, so the tool cards stay with the text they ran under and nothing lands on screen twice.
+Tool cards stay attached to the text they ran under. The double came from the same turn arriving under a second identity after a stream gap; the transcript now recognises that copy as the turn it is already drawing and updates it in place.

--- a/.changeset/factory-ui-duplicate-transcript-turn.md
+++ b/.changeset/factory-ui-duplicate-transcript-turn.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed assistant turns showing up twice in the chat transcript, with the first copy stripped of the tool cards that belong to it.
+
+A turn can reach the transcript under two identities: the run loop hands the engine a message id that the engine only adopts while its own message is still empty, and a refetched window after a stream gap brings the persisted copy back. The transcript now recognises a message that extends what is already drawn as that same turn and rewrites it in place, instead of drawing a second copy and moving the tool parts over to it.

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -479,6 +479,33 @@ describe('transcript reducer message entries', () => {
       runtimeTools: { 'tool-1': { argsText: 'the implementation reuses the backing agent' } },
     });
   });
+
+  it('rewrites the entry when the same turn comes back under a new message id', () => {
+    // The engine adopts the run loop's message id only while its own message is
+    // still empty, so a turn can start streaming under one identity and keep
+    // going under another. Drawing both leaves the first copy stripped of the
+    // tool parts the second one claims, next to a full copy of its own text.
+    const started = dbMessage('streamed-turn', 'assistant', [
+      { type: 'text', text: 'gh is missing here.' },
+      {
+        type: 'tool-invocation',
+        toolInvocation: { state: 'result', toolCallId: 'tool-1', toolName: 'execute_command', args: {}, result: 'ok' },
+      },
+    ]);
+    const reidentified = dbMessage('adopted-turn', 'assistant', [
+      ...started.content.parts,
+      { type: 'text', text: 'Installing it now.' },
+    ]);
+
+    let state = transcriptReducer(initialTranscript, {
+      type: 'event',
+      event: { type: 'message_start', message: started },
+    });
+    state = transcriptReducer(state, { type: 'event', event: { type: 'message_update', message: reidentified } });
+
+    expect(state.entries).toHaveLength(1);
+    expect(messageParts(state.entries[0])).toEqual(reidentified.content.parts);
+  });
 });
 
 describe('transcript reducer mergeWindow', () => {
@@ -900,6 +927,61 @@ describe('transcript reducer mergeWindow', () => {
     expect(next.entries).toHaveLength(2);
   });
 
+  it('inserts a window copy whose parts prove it is a different turn', () => {
+    let state = createInitialTranscript({ messages: [] });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('streamed-turn', 'assistant', [
+          { type: 'text', text: 'Checking.' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'result', toolCallId: 'tool-1', toolName: 'view', args: {}, result: 'ok' },
+          },
+        ]),
+      },
+    });
+
+    const next = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [
+        dbMessage('other-turn', 'assistant', [
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'result', toolCallId: 'tool-9', toolName: 'view', args: {}, result: 'ok' },
+          },
+          { type: 'text', text: 'Checking.' },
+        ]),
+      ],
+    });
+
+    expect(next.entries).toHaveLength(2);
+  });
+
+  it('inserts a window copy that adds a text part the gap swallowed', () => {
+    let state = createInitialTranscript({ messages: [] });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('streamed-turn', 'assistant', [{ type: 'text', text: 'Almost' }]),
+      },
+    });
+
+    const next = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [
+        dbMessage('step-2', 'assistant', [
+          { type: 'text', text: 'Almost' },
+          { type: 'text', text: 'but not approvable yet.' },
+        ]),
+      ],
+    });
+
+    expect(next.entries).toHaveLength(2);
+  });
+
   it('lets the persisted copy claim the local echo of a steer', () => {
     // A steer sent while the tab is hidden loses its live signal event to the
     // SSE gap: the reconnect refetch is the first time the timeline sees it, and
@@ -914,6 +996,39 @@ describe('transcript reducer mergeWindow', () => {
 
     expect(next.entries).toHaveLength(1);
     expect(next.entries[0]).toMatchObject({ steer: true });
+  });
+
+  it('does not redraw a turn whose persisted copy carries tool calls the stream never delivered', () => {
+    let state = createInitialTranscript({ messages: [] });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('streamed-turn', 'assistant', [{ type: 'text', text: 'gh is missing here.' }]),
+      },
+    });
+
+    const next = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [
+        dbMessage('persisted-turn', 'assistant', [
+          { type: 'text', text: 'gh is missing here.' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'execute_command',
+              args: {},
+              result: 'ok',
+            },
+          },
+        ]),
+      ],
+    });
+
+    expect(next.entries).toHaveLength(1);
+    expect(messageParts(next.entries[0])).toHaveLength(2);
   });
 
   it('draws both when the same text is sent twice', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -506,6 +506,33 @@ describe('transcript reducer message entries', () => {
     expect(state.entries).toHaveLength(1);
     expect(messageParts(state.entries[0])).toEqual(reidentified.content.parts);
   });
+
+  it('draws a rotated turn as its own entry even when its text repeats the last one', () => {
+    // The run loop seals one response and opens the next at a step boundary, and
+    // the engine announces the new id on its first empty text part. That
+    // announcement is what tells a fresh turn apart from a re-identified one
+    // when the model happens to open with the same words.
+    const first = dbMessage('turn-1', 'assistant', [{ type: 'text', text: 'Let me check' }]);
+    let state = transcriptReducer(initialTranscript, {
+      type: 'event',
+      event: { type: 'message_start', message: first },
+    });
+    state = transcriptReducer(state, { type: 'event', event: { type: 'message_end', message: first } });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: { type: 'message_start', message: dbMessage('turn-2', 'assistant', [{ type: 'text', text: '' }]) },
+    });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('turn-2', 'assistant', [{ type: 'text', text: 'Let me check the tests too' }]),
+      },
+    });
+
+    expect(state.entries).toHaveLength(2);
+    expect(messageParts(state.entries[0])).toEqual(first.content.parts);
+  });
 });
 
 describe('transcript reducer mergeWindow', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -532,6 +532,7 @@ describe('transcript reducer message entries', () => {
 
     expect(state.entries).toHaveLength(2);
     expect(messageParts(state.entries[0])).toEqual(first.content.parts);
+    expect(messageParts(state.entries[1])).toEqual([{ type: 'text', text: 'Let me check the tests too' }]);
   });
 });
 
@@ -1249,5 +1250,27 @@ describe('live user-signal events render the same as their persisted copy', () =
 
     const entry = state.entries.find(e => 'id' in e && e.id === 'sig-2');
     expect(messageParts(entry)).toEqual([{ type: 'text', text: 'stay on task' }]);
+  });
+
+  it('leaves a sealed turn alone when a later turn opens with the same words', () => {
+    // A turn only gets re-identified while it is still streaming. Once sealed it
+    // is history, and a fresh turn that happens to open on the same words — an
+    // SSE gap having swallowed its empty opening event — must not overwrite it.
+    const sealed = dbMessage('turn-1', 'assistant', [{ type: 'text', text: 'Done.' }]);
+    let state = transcriptReducer(initialTranscript, {
+      type: 'event',
+      event: { type: 'message_start', message: sealed },
+    });
+    state = transcriptReducer(state, { type: 'event', event: { type: 'message_end', message: sealed } });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('turn-2', 'assistant', [{ type: 'text', text: 'Done. Now the next thing' }]),
+      },
+    });
+
+    expect(state.entries).toHaveLength(2);
+    expect(messageParts(state.entries[0])).toEqual(sealed.content.parts);
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -920,23 +920,16 @@ function toMessageEntry(
 
 /**
  * Where an assistant message the timeline has never seen under this id belongs.
- * A message that extends an entry part for part is that entry re-identified —
- * rewrite it, or the tool parts migrate to the new copy and leave the old text
- * stranded beside a full copy of itself. A resumed turn carries the suspended
- * turn's tool call but not its text, fails the prefix, and stays its own entry.
+ * A live turn the message extends part for part is that turn re-identified —
+ * rewrite it, or its tool parts migrate to the copy and strand the old text
+ * beside it. Only the live turn is a candidate; sealed entries are history.
  */
 function indexOfSameTurn(entries: TimelineEntry[], message: MastraDBMessage): number {
-  for (let index = entries.length - 1; index >= 0; index--) {
-    const entry = entries[index];
-    if (entry.kind !== 'message' || entry.message.role !== 'assistant') continue;
-    if (windowCopyCovers(entry.message.content.parts, message.content.parts)) return index;
-  }
-
-  const latestIdx = latestAssistantIndex(entries);
-  const latest = latestIdx === -1 ? undefined : entries[latestIdx];
-  const isPlaceholder =
-    latest?.kind === 'message' && latest.message.role === 'assistant' && latest.id.startsWith('assistant-tools-');
-  return isPlaceholder ? latestIdx : -1;
+  const index = latestAssistantIndex(entries);
+  const entry = entries[index];
+  if (entry?.kind !== 'message') return -1;
+  if (entry.id.startsWith('assistant-tools-')) return index;
+  return entry.streaming && windowCopyCovers(entry.message.content.parts, message.content.parts) ? index : -1;
 }
 
 function upsertMessage(state: TranscriptState, message: MastraDBMessage, streaming: boolean): TranscriptState {

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -600,8 +600,8 @@ function persistedSuspensionPrompts(message: MastraDBMessage): SuspensionPrompt[
 function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]): TranscriptState {
   if (messages.length === 0) return state;
 
-  const reconciled = reconcileToolResults(adoptCoveringWindowCopies(state, messages), messages);
-  const onScreenIndex = claimOnScreenEntries(reconciled.entries, messages);
+  const onScreenIndex = claimOnScreenEntries(state.entries, messages);
+  const reconciled = reconcileToolResults(adoptCoveringWindowCopies(state, onScreenIndex), messages);
 
   if (messages.every(message => onScreenIndex.has(message))) return reconciled;
 
@@ -655,13 +655,7 @@ function claimOnScreenEntries(entries: TimelineEntry[], messages: MastraDBMessag
       if (!candidate) continue;
       const sameMessage =
         candidate.entry.id === message.id || toolCallIds.some(toolCallId => candidate.toolCallIds.has(toolCallId));
-      // Whole text parts have to match: a window copy that extends what an SSE
-      // gap left on screen still needs inserting for its tail to appear at all.
-      const alreadyDrawn =
-        toolCallIds.length === 0 &&
-        texts.length > 0 &&
-        candidate.entry.message.role === displayed.role &&
-        texts.every(text => candidate.texts.has(text));
+      const alreadyDrawn = redrawsEntry(candidate, displayed, texts, toolCallIds);
 
       const claimsIdentity = sameMessage && !claimedEntries.has(index);
       const claimsText = alreadyDrawn && !claimedTexts.has(textClaim(index));
@@ -675,6 +669,24 @@ function claimOnScreenEntries(entries: TimelineEntry[], messages: MastraDBMessag
   }
 
   return anchors;
+}
+
+/**
+ * True when the window copy is the entry already drawn, seen from another
+ * identity. A copy carrying tool calls must also extend the entry positionally
+ * — that prefix tells a re-identified turn apart from a different one repeating
+ * the same words, and its tools then land through adoption instead of a second,
+ * text-duplicating entry.
+ */
+function redrawsEntry(
+  candidate: OnScreenMessage,
+  displayed: MastraDBMessage,
+  texts: string[],
+  toolCallIds: string[],
+): boolean {
+  if (texts.length === 0 || candidate.entry.message.role !== displayed.role) return false;
+  if (!texts.every(text => candidate.texts.has(text))) return false;
+  return toolCallIds.length === 0 || windowCopyCovers(candidate.entry.message.content.parts, displayed.content.parts);
 }
 
 interface OnScreenMessage {
@@ -719,19 +731,17 @@ export function isTerminalInvocationState(state: ToolInvocationMessagePart['tool
  * only fires when nothing on screen would be lost; a live turn ahead of the
  * snapshot fails the prefix check and keeps its streamed parts.
  */
-function adoptCoveringWindowCopies(state: TranscriptState, messages: MastraDBMessage[]): TranscriptState {
+function adoptCoveringWindowCopies(state: TranscriptState, anchors: Map<MastraDBMessage, number>): TranscriptState {
+  const copyByEntry = new Map<number, MastraDBMessage>();
+  for (const [message, index] of anchors) {
+    if (message.role === 'assistant') copyByEntry.set(index, message);
+  }
+
   let changed = false;
-  const entries = state.entries.map(entry => {
-    if (entry.kind !== 'message' || entry.message.role !== 'assistant') return entry;
+  const entries = state.entries.map((entry, index) => {
+    const copy = copyByEntry.get(index);
+    if (!copy || entry.kind !== 'message' || entry.message.role !== 'assistant') return entry;
     const onScreenParts = entry.message.content.parts;
-    const toolCallIds = new Set(toolCallIdsOf(onScreenParts));
-    const copy = messages.find(
-      message =>
-        message.role === 'assistant' &&
-        (message.id === entry.id ||
-          (toolCallIds.size > 0 && toolCallIdsOf(message.content.parts).some(id => toolCallIds.has(id)))),
-    );
-    if (!copy) return entry;
     const covers = windowCopyCovers(onScreenParts, copy.content.parts);
     const identical = covers && windowCopyCovers(copy.content.parts, onScreenParts);
     if (!covers || identical) return entry;
@@ -908,17 +918,32 @@ function toMessageEntry(
   };
 }
 
+/**
+ * Where an assistant message the timeline has never seen under this id belongs.
+ * A message that extends an entry part for part is that entry re-identified —
+ * rewrite it, or the tool parts migrate to the new copy and leave the old text
+ * stranded beside a full copy of itself. A resumed turn carries the suspended
+ * turn's tool call but not its text, fails the prefix, and stays its own entry.
+ */
+function indexOfSameTurn(entries: TimelineEntry[], message: MastraDBMessage): number {
+  for (let index = entries.length - 1; index >= 0; index--) {
+    const entry = entries[index];
+    if (entry.kind !== 'message' || entry.message.role !== 'assistant') continue;
+    if (windowCopyCovers(entry.message.content.parts, message.content.parts)) return index;
+  }
+
+  const latestIdx = latestAssistantIndex(entries);
+  const latest = latestIdx === -1 ? undefined : entries[latestIdx];
+  const isPlaceholder =
+    latest?.kind === 'message' && latest.message.role === 'assistant' && latest.id.startsWith('assistant-tools-');
+  return isPlaceholder ? latestIdx : -1;
+}
+
 function upsertMessage(state: TranscriptState, message: MastraDBMessage, streaming: boolean): TranscriptState {
   if (message.role !== 'assistant' && message.role !== 'signal') return state;
   const entries = [...state.entries];
   let idx = entries.findIndex(e => e.kind === 'message' && e.id === message.id);
-  if (message.role === 'assistant' && idx === -1) {
-    const latestIdx = latestAssistantIndex(entries);
-    const latest = latestIdx === -1 ? undefined : entries[latestIdx];
-    if (latest?.kind === 'message' && latest.message.role === 'assistant' && latest.id.startsWith('assistant-tools-')) {
-      idx = latestIdx;
-    }
-  }
+  if (message.role === 'assistant' && idx === -1) idx = indexOfSameTurn(entries, message);
   const prev = idx !== -1 ? entries[idx] : undefined;
   const prevEntry = prev?.kind === 'message' ? prev : undefined;
   const nextMessage = message.role === 'assistant' ? preserveRuntimeToolParts(message, prevEntry?.message) : message;


### PR DESCRIPTION
An assistant turn could be drawn twice in the chat transcript, the first copy stripped of the tool cards that belong to it — the text on its own, then the same text again with its steps underneath.

A turn can reach the transcript under two identities. The engine adopts the run loop's message id only while its own message is still empty, so a turn that already holds a part keeps streaming under the id the client first saw while the persisted copy carries another. On top of that, the window refetched after a stream gap brings that persisted copy back. Before, both landed as a new entry, and the tool parts migrated to it because a tool call belongs to whichever message last claimed it — leaving the earlier entry as bare text. Now the transcript pairs a message that extends an entry part for part with that entry and rewrites it in place, in the stream path and in the window merge alike; a resumed turn, which carries the suspended turn's tool call but not its text, fails that prefix and stays its own entry as before.

I found this from a real session rather than a hunch: the persisted window for the thread in question holds each of the duplicated sentences exactly once, and a fresh reload draws them once — so the second copy was born in the client. Both new tests fail on main and pass here. I also ran mutation testing over the reconciliation code (Stryker, scoped to the changed functions): the two rules this PR introduces are killed by the new tests; what survives is short-circuit guards and one pre-existing untested path (the `assistant-tools-` placeholder), which I left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The chat no longer shows the same assistant response twice when streaming updates or refreshed data changes its ID. It updates the existing response and keeps tool cards in the correct place.

## Changes

- Reconcile re-identified assistant messages with existing transcript entries.
- Replace matching entries in place when new parts extend the existing turn exactly.
- Keep resumed turns separate when they share a tool call but not the original text.
- Add regression tests for streaming and refetched-window reconciliation.
- Add mutation testing coverage for the changed functions.
- Add a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->