### PR TITLE
fix(playground): tool UI review fixes in Studio chat

### DIFF
--- a/.changeset/grumpy-bears-hug.md
+++ b/.changeset/grumpy-bears-hug.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed chat message action alignment, tightened user message spacing, constrained the chat column width, and compacted the agent header.

--- a/.changeset/major-snakes-beam.md
+++ b/.changeset/major-snakes-beam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed tool UI review regressions: adjacent-only tool rails, pending tool actions, and pending empty file trees

--- a/.changeset/solid-birds-tap.md
+++ b/.changeset/solid-birds-tap.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Improved chat message layout by removing extra text margins, separating multipart content, and hiding empty stored message rows.

--- a/packages/playground/src/domains/agents/components/__tests__/agent-chat-shell.msw.test.tsx
+++ b/packages/playground/src/domains/agents/components/__tests__/agent-chat-shell.msw.test.tsx
@@ -125,6 +125,17 @@ describe('AgentChatShell', () => {
     expect(screen.queryByRole('button', { name: /memory/i })).toBeNull();
   });
 
+  it('uses the compact type scale and row height for the agent title', async () => {
+    renderShell();
+
+    const title = await screen.findByRole('heading', { name: 'Test Agent' });
+    const copyButton = screen.getByTestId('agent-entity-header-copy-id');
+
+    expect(title.classList.contains('text-ui-md')).toBe(true);
+    expect(title.classList.contains('leading-ui-md')).toBe(true);
+    expect(copyButton.parentElement?.classList.contains('py-2')).toBe(true);
+  });
+
   it('never owns or fetches the OM panel data from the shell', async () => {
     const { onOM, onMessages } = renderShell();
 

--- a/packages/playground/src/domains/agents/components/agent-entity-header.tsx
+++ b/packages/playground/src/domains/agents/components/agent-entity-header.tsx
@@ -18,7 +18,7 @@ export const AgentEntityHeader = ({ agentId }: AgentEntityHeaderProps) => {
 
   return (
     <TooltipProvider>
-      <div className="min-w-0 overflow-x-hidden p-3">
+      <div className="min-w-0 overflow-x-hidden px-3 py-2">
         <Tooltip>
           <TooltipTrigger asChild>
             <button
@@ -36,7 +36,7 @@ export const AgentEntityHeader = ({ agentId }: AgentEntityHeaderProps) => {
               {isLoading ? (
                 <Skeleton className="h-3 w-32" />
               ) : (
-                <Txt variant="header-md" as="h2" className="truncate font-medium">
+                <Txt variant="ui-md" as="h2" className="truncate font-medium">
                   {agentName}
                 </Txt>
               )}

--- a/packages/playground/src/domains/agents/components/agent-loading-skeletons.tsx
+++ b/packages/playground/src/domains/agents/components/agent-loading-skeletons.tsx
@@ -20,7 +20,7 @@ function AgentViewHeaderLoadingSkeleton() {
   return (
     <div className="flex items-center justify-between gap-2 pr-3 max-lg:py-2">
       <div className="min-w-0 flex-1 max-lg:hidden">
-        <div className="flex min-w-0 items-center gap-2 p-3">
+        <div className="flex min-w-0 items-center gap-2 px-3 py-2">
           <Skeleton className="size-7 shrink-0 rounded-full" />
           <Skeleton className="h-4 w-36" />
         </div>

--- a/packages/playground/src/lib/ai-ui/__tests__/thread.test.tsx
+++ b/packages/playground/src/lib/ai-ui/__tests__/thread.test.tsx
@@ -170,6 +170,34 @@ const assistantMessage = (text: string, metadata?: MastraDBMessage['content']['m
   content: { format: 2, parts: [{ type: 'text', text }], metadata },
 });
 
+const emptyAssistantMessage = (): MastraDBMessage => ({
+  id: 'a-empty',
+  role: 'assistant',
+  createdAt: new Date(),
+  content: { format: 2, parts: [] },
+});
+
+const askUserMessageWithoutSuspendPayload = (): MastraDBMessage => ({
+  id: 'a-ask-user-without-payload',
+  role: 'assistant',
+  createdAt: new Date(),
+  content: {
+    format: 2,
+    parts: [
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'call-ask-user',
+          toolName: 'ask_user',
+          args: { question: 'What is your favorite color?' },
+          result: { content: 'User answered: Blue', isError: false },
+        },
+      },
+    ],
+  },
+});
+
 const assistantToolMessage = (): MastraDBMessage => ({
   id: 'a-tool-call',
   role: 'assistant',
@@ -224,6 +252,43 @@ describe('Thread', () => {
     expect(screen.queryByText('How can I help you today?')).toBeFalsy();
   });
 
+  describe('when a stored message has no renderable parts', () => {
+    it('does not mount a message scroller item for it', async () => {
+      server.use(...baseHandlers());
+
+      await act(async () => {
+        renderThread([userMessage('question'), emptyAssistantMessage(), assistantMessage('answer')]);
+      });
+
+      expect(document.querySelector('[data-slot="message-scroller-item"][data-message-id="a-empty"]')).toBeNull();
+    });
+  });
+
+  describe('when a stored tool message renders no content', () => {
+    it('does not mount a message scroller item for it', async () => {
+      server.use(...baseHandlers());
+
+      await act(async () => {
+        renderThread([userMessage('question'), askUserMessageWithoutSuspendPayload(), assistantMessage('answer')]);
+      });
+
+      expect(
+        document.querySelector('[data-slot="message-scroller-item"][data-message-id="a-ask-user-without-payload"]'),
+      ).toBeNull();
+    });
+  });
+
+  it('limits the aligned chat surfaces to 740px', async () => {
+    server.use(...baseHandlers());
+
+    await act(async () => {
+      renderThread([userMessage('previous question')]);
+    });
+
+    expect(screen.getByTestId('thread-message-column').className).toContain('max-w-[740px]');
+    expect(document.querySelector<HTMLElement>('.composer-ring')?.className).toContain('max-w-[740px]');
+  });
+
   describe('when a message contains a tool call', () => {
     it('allows the tool hover surface to paint outside the virtualized message item', async () => {
       server.use(...baseHandlers());
@@ -239,15 +304,40 @@ describe('Thread', () => {
       expect(messageItem?.style.contentVisibility).toBe('visible');
     });
 
-    it('keeps off-screen rendering optimization on text-only messages', async () => {
+    it('keeps the latest text-only turn visible so hydration cannot substitute its intrinsic height', async () => {
       server.use(...baseHandlers());
 
       await act(async () => {
-        renderThread([assistantMessage('plain response')]);
+        renderThread([
+          userMessage('previous question'),
+          assistantMessage('previous response'),
+          userMessage('latest question'),
+          assistantMessage('latest response'),
+        ]);
       });
 
       const messageItem = screen
-        .getByText('plain response')
+        .getByText('latest response')
+        .closest<HTMLElement>('[data-slot="message-scroller-item"]');
+
+      expect(messageItem).not.toBeNull();
+      expect(messageItem?.style.contentVisibility).toBe('visible');
+    });
+
+    it('keeps off-screen rendering optimization on historical text-only messages', async () => {
+      server.use(...baseHandlers());
+
+      await act(async () => {
+        renderThread([
+          userMessage('previous question'),
+          assistantMessage('previous response'),
+          userMessage('latest question'),
+          assistantMessage('latest response'),
+        ]);
+      });
+
+      const messageItem = screen
+        .getByText('previous response')
         .closest<HTMLElement>('[data-slot="message-scroller-item"]');
 
       expect(messageItem).not.toBeNull();

--- a/packages/playground/src/lib/ai-ui/attachments/attachment.tsx
+++ b/packages/playground/src/lib/ai-ui/attachments/attachment.tsx
@@ -121,7 +121,7 @@ export const ComposerAttachments = () => {
 
   return (
     <div className="absolute inset-x-0 bottom-full px-2" data-attachments-row>
-      <div className="mx-auto w-full max-w-3xl overflow-x-auto">
+      <div className="mx-auto w-full max-w-[740px] overflow-x-auto">
         <div className="flex flex-row items-center gap-4 px-3 pt-3 pb-1">
           {attachments.map(att => (
             <AttachmentThumbnail key={att.id} attachment={att} />

--- a/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.test.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.test.tsx
@@ -62,6 +62,19 @@ const omPart = (name: string, data: Record<string, unknown>) => ({
   data,
 });
 
+type MessagePart = MastraDBMessage['content']['parts'][number];
+
+const completedToolPart = (toolName: string, toolCallId: string): MessagePart => ({
+  type: 'tool-invocation',
+  toolInvocation: {
+    toolName,
+    toolCallId,
+    state: 'result',
+    args: {},
+    result: { ok: true },
+  },
+});
+
 const baseMessage = (over: Partial<MastraDBMessage>): MastraDBMessage =>
   ({
     id: 'msg-1',
@@ -80,6 +93,50 @@ describe('MessageRow', () => {
       }),
     );
     expect(screen.getByText('world')).toBeTruthy();
+  });
+
+  describe('when one message contains multiple visible parts', () => {
+    it('spaces assistant parts within their shared message container', () => {
+      renderRow(
+        baseMessage({
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              { type: 'text', text: 'first assistant part' },
+              { type: 'text', text: 'second assistant part' },
+            ],
+          },
+        }),
+      );
+
+      const firstPart = screen.getByText('first assistant part').closest('.mastra-markdown');
+      const secondPart = screen.getByText('second assistant part').closest('.mastra-markdown');
+
+      expect(firstPart?.parentElement).toBe(secondPart?.parentElement);
+      expect(firstPart?.parentElement?.classList.contains('space-y-1.5')).toBe(true);
+    });
+
+    it('spaces user parts within their shared message container', () => {
+      renderRow(
+        baseMessage({
+          role: 'user',
+          content: {
+            format: 2,
+            parts: [
+              { type: 'text', text: 'first user part' },
+              { type: 'text', text: 'second user part' },
+            ],
+          },
+        }),
+      );
+
+      const firstPart = screen.getByText('first user part').closest('.mastra-markdown');
+      const secondPart = screen.getByText('second user part').closest('.mastra-markdown');
+
+      expect(firstPart?.parentElement).toBe(secondPart?.parentElement);
+      expect(firstPart?.parentElement?.classList.contains('space-y-1.5')).toBe(true);
+    });
   });
 
   // The reveal only paces if the factory keeps the text part mounted as the
@@ -110,7 +167,11 @@ describe('MessageRow', () => {
         content: { format: 2, parts: [{ type: 'text', text: 'a user line' }] },
       }),
     );
-    expect(screen.getByText('a user line')).toBeTruthy();
+    const bubble = screen.getByText('a user line').closest('.bg-surface3');
+
+    expect(bubble).toBeTruthy();
+    expect(bubble?.classList.contains('px-2')).toBe(true);
+    expect(bubble?.classList.contains('py-1')).toBe(true);
   });
 
   it('drops messages with no displayable role', () => {
@@ -294,6 +355,70 @@ describe('MessageRow', () => {
     expect(document.querySelector('[data-tool-call-rail]')).toBeNull();
   });
 
+  describe('when visible content separates two tool calls', () => {
+    it('does not connect tools across assistant prose', () => {
+      renderRow(
+        baseMessage({
+          role: 'assistant',
+          content: {
+            format: 2,
+            metadata: { mode: 'stream' },
+            parts: [
+              completedToolPart('firstTool', 'call-first'),
+              { type: 'text', text: 'The first result needs explanation.' },
+              completedToolPart('secondTool', 'call-second'),
+            ],
+          },
+        }),
+      );
+
+      expect(screen.getAllByTestId('tool-badge')).toHaveLength(2);
+      expect(document.querySelector('[data-tool-call-rail]')).toBeNull();
+    });
+
+    it('does not connect tools across reasoning', () => {
+      renderRow(
+        baseMessage({
+          role: 'assistant',
+          content: {
+            format: 2,
+            metadata: { mode: 'stream' },
+            parts: [
+              completedToolPart('firstTool', 'call-first'),
+              { type: 'reasoning', reasoning: 'Checking whether another tool is needed.' } as never,
+              completedToolPart('secondTool', 'call-second'),
+            ],
+          },
+        }),
+      );
+
+      expect(screen.getAllByTestId('tool-badge')).toHaveLength(2);
+      expect(document.querySelector('[data-tool-call-rail]')).toBeNull();
+    });
+  });
+
+  describe('when only non-rendered content separates two tool calls', () => {
+    it('connects the visible tools across a hidden tool part', () => {
+      renderRow(
+        baseMessage({
+          role: 'assistant',
+          content: {
+            format: 2,
+            metadata: { mode: 'stream' },
+            parts: [
+              completedToolPart('firstTool', 'call-first'),
+              completedToolPart('updateWorkingMemory', 'call-hidden'),
+              completedToolPart('secondTool', 'call-second'),
+            ],
+          },
+        }),
+      );
+
+      expect(screen.getAllByTestId('tool-badge')).toHaveLength(2);
+      expect(document.querySelectorAll('[data-tool-call-rail]')).toHaveLength(1);
+    });
+  });
+
   it('routes an OM observation tool into the observation marker badge', () => {
     renderRow(
       baseMessage({
@@ -397,7 +522,7 @@ describe('MessageRow', () => {
     expect(container.querySelector('[data-testid="tool-badge"]')).toBeNull();
   });
 
-  it('reveals approval buttons after the collapsed tool is opened', () => {
+  it('reveals approval buttons without requiring the pending tool to be opened', () => {
     renderRow(
       baseMessage({
         role: 'assistant',
@@ -423,10 +548,7 @@ describe('MessageRow', () => {
         },
       }),
     );
-    expect(screen.queryByText('Approve')).toBeNull();
-
-    fireEvent.click(screen.getByRole('button', { name: 'DangerousTool' }));
-
+    expect(screen.getByRole('button', { name: 'DangerousTool' }).getAttribute('aria-expanded')).toBe('true');
     expect(screen.getByText('Approve')).toBeTruthy();
     expect(screen.getByText('Decline')).toBeTruthy();
   });

--- a/packages/playground/src/lib/ai-ui/messages/message-row.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/message-row.tsx
@@ -10,8 +10,8 @@ import type { ReactNode } from 'react';
 import { forwardRef, useCallback, useMemo } from 'react';
 
 import type { DataMessagePart } from '../tools/tool-card';
-import { isInlineToolCallHidden } from '../tools/tool-card-visibility';
 import { DatasetSaveAction } from './dataset-save-action';
+import { getMessageMetadata, getToolPartName, toRenderableMessage } from './message-visibility';
 import { AssistantTextPartRenderer } from './renderers/assistant-text-part-renderer';
 import { DataPartRenderer } from './renderers/data-part-renderer';
 import { DynamicToolPartRenderer } from './renderers/dynamic-tool-part-renderer';
@@ -20,7 +20,6 @@ import { messageStatusRenderers } from './renderers/status-renderers';
 import { ToolInvocationPartRenderer } from './renderers/tool-invocation-part-renderer';
 import { UserFilePartRenderer } from './renderers/user-file-part-renderer';
 import { UserTextPartRenderer } from './renderers/user-text-part-renderer';
-import { getSignalType, isSignalData, isTaskSignalData, isUserSignalType, toReactiveSignalData } from './signal-data';
 import { ProviderLogo } from '@/domains/llm/components/provider-logo';
 
 export interface MessageRowProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
@@ -43,48 +42,6 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const readField = (value: unknown, key: string): unknown => (isRecord(value) ? value[key] : undefined);
 
 /**
- * Normalize the stored message role for display. A `signal`+`type:'user'` row
- * renders as a user message; a non-user (reactive) `signal` row is folded onto
- * an assistant message as a `data-signal` badge (see `toReactiveSignalMessage`);
- * messages without a displayable role are dropped.
- */
-const getMessageDisplayRole = (message: MastraDBMessage): MastraDBMessage['role'] | null => {
-  if (message.role === 'assistant' || message.role === 'user' || message.role === 'system') return message.role;
-  if (message.role === 'signal') return isUserSignalType(getSignalType(message)) ? 'user' : 'assistant';
-  return null;
-};
-
-/**
- * Convert a persisted reactive (non-user) `signal` row into an assistant message
- * carrying a single `data-signal` part, so the existing `SignalBadge` renderer
- * shows it on read-back. Restores 1.41.0 behavior lost in the chat renderer
- * rewrite (PR #17774). Returns `null` when the signal payload is not a shape the
- * `SignalBadge` can render, so the row is dropped instead of leaving an empty
- * assistant bubble.
- */
-const toReactiveSignalMessage = (message: MastraDBMessage): MastraDBMessage | null => {
-  const data = toReactiveSignalData(message);
-  if (!isSignalData(data)) return null;
-  const parts: MastraDBMessage['content']['parts'] = [{ type: 'data-signal', data }];
-  return {
-    ...message,
-    role: 'assistant',
-    content: { ...message.content, parts },
-  };
-};
-
-const toDisplayMessage = (message: MastraDBMessage): MastraDBMessage | null => {
-  const displayRole = getMessageDisplayRole(message);
-  if (displayRole === null) return null;
-  if (message.role === 'signal' && displayRole === 'assistant') return toReactiveSignalMessage(message);
-  if (displayRole === message.role) return message;
-  return { ...message, role: displayRole };
-};
-
-const getMessageMetadata = (message: MastraDBMessage): Record<string, unknown> | undefined =>
-  isRecord(message.content.metadata) ? message.content.metadata : undefined;
-
-/**
  * Collect `data-*` parts from the message so badges (file-tree, sandbox) can read
  * live streaming metadata without reaching into assistant-ui state.
  */
@@ -99,56 +56,6 @@ const getDataParts = (message: MastraDBMessage): DataMessagePart[] =>
       name: 'name' in part && typeof part.name === 'string' ? part.name : undefined,
       data: readField(part, 'data'),
     }));
-
-const getToolPartName = (part: { type: string }): string | undefined => {
-  if (part.type === 'tool-invocation') {
-    const toolName = readField(readField(part, 'toolInvocation'), 'toolName');
-    return typeof toolName === 'string' ? toolName : undefined;
-  }
-
-  if (part.type === 'dynamic-tool' || (part.type.startsWith('tool-') && part.type !== 'tool-invocation')) {
-    const toolName = readField(part, 'toolName');
-    return typeof toolName === 'string' ? toolName : part.type.replace(/^tool-/, '');
-  }
-
-  return undefined;
-};
-
-/** Keep only parts that produce visible UI. This prevents hidden task/state
- * plumbing from leaving empty message rows and action bars behind. */
-const isRenderableMessagePart = (part: MessagePart): boolean => {
-  const toolName = getToolPartName(part);
-  if (toolName !== undefined) return !isInlineToolCallHidden(toolName);
-
-  if (part.type === 'text') {
-    const value = readField(part, 'text');
-    return typeof value === 'string' && value.trim().length > 0;
-  }
-
-  if (part.type === 'reasoning') {
-    const value = readField(part, 'text') ?? readField(part, 'reasoning');
-    return (
-      (typeof value === 'string' && value.trim().length > 0) ||
-      readField(part, 'redacted') === true ||
-      readField(part, 'state') === 'streaming'
-    );
-  }
-
-  if (part.type === 'file') return true;
-
-  if (part.type === 'data-signal') {
-    const data = readField(part, 'data');
-    return isSignalData(data) && !isTaskSignalData(data);
-  }
-
-  return false;
-};
-
-const withRenderableParts = (message: MastraDBMessage): MastraDBMessage => {
-  const parts = message.content.parts.filter(isRenderableMessagePart);
-  if (parts.length === message.content.parts.length) return message;
-  return { ...message, content: { ...message.content, parts } };
-};
 
 const getTextFromParts = (message: MastraDBMessage): string =>
   message.content.parts
@@ -243,27 +150,27 @@ const AssistantActionBar = ({
 
 export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
   ({ message, hasModelList, isSpeaking, onReadAloud, onStopSpeaking, className, ...rootProps }, ref) => {
-    const dbMessage = useMemo(() => toDisplayMessage(message), [message]);
-    const displayMessage = useMemo(() => (dbMessage ? withRenderableParts(dbMessage) : null), [dbMessage]);
+    const displayMessage = useMemo(() => toRenderableMessage(message), [message]);
     const metadata = getMessageMetadata(message);
     const modelMetadata = hasModelList ? getModelMetadata(metadata) : undefined;
     const dataParts = useMemo(() => getDataParts(message), [message]);
-    const visibleToolParts = useMemo(
-      () =>
-        (displayMessage?.content.parts ?? []).filter(part => {
-          const toolName = getToolPartName(part);
-          return toolName !== undefined && !isInlineToolCallHidden(toolName);
-        }),
-      [displayMessage],
-    );
+    const continuedToolParts = useMemo(() => {
+      const parts = displayMessage?.content.parts ?? [];
+      const continued = new Set<object>();
+
+      for (let index = 0; index < parts.length - 1; index += 1) {
+        if (getToolPartName(parts[index]) && getToolPartName(parts[index + 1])) {
+          continued.add(parts[index]);
+        }
+      }
+
+      return continued;
+    }, [displayMessage]);
     const renderToolPart = useCallback(
       (part: object, children: ReactNode) => {
-        const visibleIndex = visibleToolParts.findIndex(candidate => candidate === part);
-        const hasFollowingVisibleTool = visibleIndex >= 0 && visibleIndex < visibleToolParts.length - 1;
-
-        return <ToolCallListItem continued={hasFollowingVisibleTool}>{children}</ToolCallListItem>;
+        return <ToolCallListItem continued={continuedToolParts.has(part)}>{children}</ToolCallListItem>;
       },
-      [visibleToolParts],
+      [continuedToolParts],
     );
 
     const sharedRenderers = useMemo<MessageRenderers>(
@@ -305,7 +212,7 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
       return (
         <div
           ref={ref}
-          className={cn('w-full flex items-end pb-4 pt-2 flex-col', className)}
+          className={cn('flex w-full flex-col items-end', className)}
           {...rootProps}
           data-message-id={message.id}
           data-message-pending={isPending ? 'true' : undefined}
@@ -313,7 +220,7 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
           <DatasetSaveAction messageText={getTextFromParts(message)} />
           <div
             className={cn(
-              'max-w-[max(366px,70%)] break-words px-4 py-2 text-neutral6 text-ui-lg leading-ui-lg rounded-xl bg-surface3',
+              'max-w-[max(366px,70%)] space-y-1.5 break-words px-2 py-1 text-neutral6 text-ui-lg leading-ui-lg rounded-xl bg-surface3',
               isPending && 'opacity-60 animate-pulse',
             )}
           >
@@ -327,11 +234,11 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
 
     return (
       <div ref={ref} className={cn('max-w-full', className)} {...rootProps} data-message-id={message.id}>
-        <div className="text-neutral6 text-ui-lg leading-ui-lg pt-2">
+        <div className="text-neutral6 text-ui-lg leading-ui-lg space-y-1.5 pt-2">
           <MessageFactory message={displayMessage} {...assistantRenderers} status={messageStatusRenderers} />
         </div>
         {showActionBar && (
-          <div className="flex h-6 items-center gap-2 pt-4">
+          <div className="mt-3 flex h-6 items-center gap-2">
             <AssistantActionBar
               text={getTextFromParts(displayMessage)}
               modelMetadata={modelMetadata}

--- a/packages/playground/src/lib/ai-ui/messages/message-visibility.ts
+++ b/packages/playground/src/lib/ai-ui/messages/message-visibility.ts
@@ -1,0 +1,110 @@
+import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+
+import { getAskUserSuspendPayload, isInlineToolCallHidden } from '../tools/tool-card-visibility';
+import { getSignalType, isSignalData, isTaskSignalData, isUserSignalType, toReactiveSignalData } from './signal-data';
+
+type MessagePart = MastraDBMessage['content']['parts'][number];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readField = (value: unknown, key: string): unknown => (isRecord(value) ? value[key] : undefined);
+
+const getMessageDisplayRole = (message: MastraDBMessage): MastraDBMessage['role'] | null => {
+  if (message.role === 'assistant' || message.role === 'user' || message.role === 'system') return message.role;
+  if (message.role === 'signal') return isUserSignalType(getSignalType(message)) ? 'user' : 'assistant';
+  return null;
+};
+
+const toReactiveSignalMessage = (message: MastraDBMessage): MastraDBMessage | null => {
+  const data = toReactiveSignalData(message);
+  if (!isSignalData(data)) return null;
+  const parts: MastraDBMessage['content']['parts'] = [{ type: 'data-signal', data }];
+  return {
+    ...message,
+    role: 'assistant',
+    content: { ...message.content, parts },
+  };
+};
+
+const toDisplayMessage = (message: MastraDBMessage): MastraDBMessage | null => {
+  const displayRole = getMessageDisplayRole(message);
+  if (displayRole === null) return null;
+  if (message.role === 'signal' && displayRole === 'assistant') return toReactiveSignalMessage(message);
+  if (displayRole === message.role) return message;
+  return { ...message, role: displayRole };
+};
+
+export const getMessageMetadata = (message: MastraDBMessage): Record<string, unknown> | undefined =>
+  isRecord(message.content.metadata) ? message.content.metadata : undefined;
+
+export const getToolPartName = (part: { type: string }): string | undefined => {
+  if (part.type === 'tool-invocation') {
+    const toolName = readField(readField(part, 'toolInvocation'), 'toolName');
+    return typeof toolName === 'string' ? toolName : undefined;
+  }
+
+  if (part.type === 'dynamic-tool' || (part.type.startsWith('tool-') && part.type !== 'tool-invocation')) {
+    const toolName = readField(part, 'toolName');
+    return typeof toolName === 'string' ? toolName : part.type.replace(/^tool-/, '');
+  }
+
+  return undefined;
+};
+
+const getToolPartCallId = (part: { type: string }): string | undefined => {
+  const value =
+    part.type === 'tool-invocation'
+      ? readField(readField(part, 'toolInvocation'), 'toolCallId')
+      : readField(part, 'toolCallId');
+  return typeof value === 'string' ? value : undefined;
+};
+
+const isRenderableMessagePart = (part: MessagePart, metadata: Record<string, unknown> | undefined): boolean => {
+  const toolName = getToolPartName(part);
+  if (toolName !== undefined) {
+    if (isInlineToolCallHidden(toolName)) return false;
+    if (toolName !== 'ask_user') return true;
+
+    const toolCallId = getToolPartCallId(part);
+    return toolCallId !== undefined && getAskUserSuspendPayload(metadata, toolName, toolCallId) !== undefined;
+  }
+
+  if (part.type === 'text') {
+    const value = readField(part, 'text');
+    return typeof value === 'string' && value.trim().length > 0;
+  }
+
+  if (part.type === 'reasoning') {
+    const value = readField(part, 'text') ?? readField(part, 'reasoning');
+    return (
+      (typeof value === 'string' && value.trim().length > 0) ||
+      readField(part, 'redacted') === true ||
+      readField(part, 'state') === 'streaming'
+    );
+  }
+
+  if (part.type === 'file') return true;
+
+  if (part.type === 'data-signal') {
+    const data = readField(part, 'data');
+    return isSignalData(data) && !isTaskSignalData(data);
+  }
+
+  return false;
+};
+
+const withRenderableParts = (message: MastraDBMessage): MastraDBMessage => {
+  const metadata = getMessageMetadata(message);
+  const parts = message.content.parts.filter(part => isRenderableMessagePart(part, metadata));
+  if (parts.length === message.content.parts.length) return message;
+  return { ...message, content: { ...message.content, parts } };
+};
+
+export const toRenderableMessage = (message: MastraDBMessage): MastraDBMessage | null => {
+  const displayMessage = toDisplayMessage(message);
+  if (displayMessage === null) return null;
+
+  const renderableMessage = withRenderableParts(displayMessage);
+  return renderableMessage.content.parts.length > 0 ? renderableMessage : null;
+};

--- a/packages/playground/src/lib/ai-ui/messages/renderers/__tests__/assistant-text-part-renderer.test.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/__tests__/assistant-text-part-renderer.test.tsx
@@ -20,12 +20,13 @@ afterEach(() => {
 });
 
 describe('AssistantTextPartRenderer', () => {
-  it('renders markdown text', () => {
+  it('renders markdown text without extra vertical margin', () => {
     const part = { type: 'text', text: 'hello **world**' } as TextPart;
 
-    render(<AssistantTextPartRenderer part={part} />);
+    const { container } = render(<AssistantTextPartRenderer part={part} />);
 
     expect(screen.getByText('world')).not.toBeNull();
+    expect(container.querySelector('.mastra-markdown')?.classList.contains('my-3')).toBe(false);
   });
 
   it('renders the empty string safely when text is missing', () => {

--- a/packages/playground/src/lib/ai-ui/messages/renderers/message-text.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/message-text.tsx
@@ -86,7 +86,7 @@ export const MessageText = ({ text, metadata, externalLinkTarget, streaming }: M
   }
 
   return (
-    <MarkdownRenderer className="my-3" externalLinkTarget={externalLinkTarget} streaming={streaming}>
+    <MarkdownRenderer externalLinkTarget={externalLinkTarget} streaming={streaming}>
       {text}
     </MarkdownRenderer>
   );

--- a/packages/playground/src/lib/ai-ui/task-panel.tsx
+++ b/packages/playground/src/lib/ai-ui/task-panel.tsx
@@ -9,7 +9,7 @@ export const TaskPanel = () => {
 
   return (
     <div className="px-2 pb-1" data-testid="task-panel">
-      <div className="mx-auto w-full max-w-3xl">
+      <div className="mx-auto w-full max-w-[740px]">
         <TaskList tasks={tasks} />
       </div>
     </div>

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -25,7 +25,7 @@ import { cn } from '@mastra/playground-ui/utils/cn';
 import type { MessageFactoryPart } from '@mastra/react';
 import { useSpeechRecognition } from '@mastra/react';
 import { ArrowUp, Mic } from 'lucide-react';
-import { startTransition, useEffect, useMemo, useRef, useState } from 'react';
+import { startTransition, useEffect, useRef, useState } from 'react';
 
 import { AttachFilePopover } from './attachments/attach-file-popover';
 import { ComposerAttachments as ChatComposerAttachments } from './attachments/attachment';
@@ -36,6 +36,7 @@ import { BracketOverlay } from './components/bracket-overlay';
 import './thread.css';
 import { SaveFullConversationAction } from './messages/dataset-save-action';
 import { MessageRow } from './messages/message-row';
+import { toRenderableMessage } from './messages/message-visibility';
 import { SuggestedPromptList } from './suggested-prompt-list';
 import { TaskPanel } from './task-panel';
 import { BrowserThumbnail, useBrowserSession } from '@/domains/agents';
@@ -49,7 +50,7 @@ import { usePlaygroundStore } from '@/store/playground-store';
 
 const SKELETON_DELAY_MS = 300;
 const EMPTY_SUGGESTED_PROMPTS: string[] = [];
-const TOOL_MESSAGE_ITEM_STYLE = { contentVisibility: 'visible' } as const;
+const VISIBLE_MESSAGE_ITEM_STYLE = { contentVisibility: 'visible' } as const;
 
 /**
  * Returns true only after `flag` has stayed true for `delayMs` continuously, so
@@ -140,6 +141,7 @@ export const Thread = ({
   const messagesContainerRef = useRef<HTMLDivElement>(null);
 
   const messages = useChatMessages();
+  const renderableMessages = messages.filter(message => toRenderableMessage(message) !== null);
   const { isRunning } = useChatRunning();
   const { requestContext } = usePlaygroundStore();
   const { isSpeaking, readAloud, stop: stopSpeaking } = useReadAloud(agentId, requestContext);
@@ -147,17 +149,17 @@ export const Thread = ({
   const { hasSession, viewMode } = useBrowserSession();
   const showThumbnailInChat = hasSession && (viewMode === 'collapsed' || viewMode === 'expanded');
 
-  const isEmpty = messages.length === 0;
+  const isEmpty = renderableMessages.length === 0;
   const lastMessage = messages[messages.length - 1];
   const showPending = isRunning && (lastMessage?.role !== 'assistant' || !hasStreamingPart(lastMessage));
   const delayedPending = useDelayedFlag(showPending, SKELETON_DELAY_MS);
-  const threadRailTurns = useMemo(() => buildThreadRailTurns(messages), [messages]);
-  const threadRailAnchorIds = useMemo(() => new Set(threadRailTurns.map(turn => turn.messageId)), [threadRailTurns]);
+  const threadRailTurns = buildThreadRailTurns(renderableMessages);
+  const threadRailAnchorIds = new Set(threadRailTurns.map(turn => turn.messageId));
   // Keyed by the opening message's client key: `data-user-message` reconciliation
   // swaps `message.id` to the server signal id, and a changing key would remount
   // the whole turn.
   const turnGroups: { key: string; messages: MastraDBMessage[]; opensTurn: boolean }[] = [];
-  for (const message of messages) {
+  for (const message of renderableMessages) {
     if (threadRailAnchorIds.has(message.id) || turnGroups.length === 0) {
       turnGroups.push({
         key: getClientMessageKey(message),
@@ -182,7 +184,7 @@ export const Thread = ({
                   <div
                     ref={messagesContainerRef}
                     data-testid="thread-message-column"
-                    className="relative mx-auto w-full max-w-3xl px-4 pb-7 group-has-[[data-attachments-row]]/thread:pb-24"
+                    className="relative mx-auto w-full max-w-[740px] px-4 pb-7 group-has-[[data-attachments-row]]/thread:pb-24"
                   >
                     <BracketOverlay containerRef={messagesContainerRef} />
                     <MessageScrollerContent className="flex flex-col gap-6 py-6">
@@ -202,7 +204,7 @@ export const Thread = ({
                                 key={getClientMessageKey(message)}
                                 messageId={message.id}
                                 scrollAnchor={threadRailAnchorIds.has(message.id)}
-                                style={hasToolCallPart(message) ? TOOL_MESSAGE_ITEM_STYLE : undefined}
+                                style={isLiveTurn || hasToolCallPart(message) ? VISIBLE_MESSAGE_ITEM_STYLE : undefined}
                               >
                                 <MessageRow
                                   message={message}
@@ -224,13 +226,13 @@ export const Thread = ({
                 </div>
               )}
             </MessageScrollerViewport>
-            <div className="pointer-events-none absolute inset-x-0 bottom-4 z-30 mx-auto flex w-full max-w-3xl px-4">
+            <div className="pointer-events-none absolute inset-x-0 bottom-4 z-30 mx-auto flex w-full max-w-[740px] px-4">
               <MessageScrollerButton className="pointer-events-auto static ms-auto translate-x-0 rtl:translate-x-0" />
             </div>
           </MessageScroller>
 
           {showThumbnailInChat && agentId && threadId && (
-            <div className="mx-auto mb-2 w-full max-w-3xl px-4">
+            <div className="mx-auto mb-2 w-full max-w-[740px] px-4">
               <BrowserThumbnail agentName={agentName} />
             </div>
           )}
@@ -320,10 +322,10 @@ const AgentComposer = ({
           void submit();
         }}
       >
-        <ComposerAttachments>
+        <ComposerAttachments className="max-w-[740px]">
           <ChatComposerAttachments />
         </ComposerAttachments>
-        <ComposerRing busy={isRunning}>
+        <ComposerRing busy={isRunning} className="max-w-[740px]">
           <ComposerBox sendingPulseKey={sendPulseKey}>
             <ComposerInput
               ref={textareaRef}

--- a/packages/playground/src/lib/ai-ui/tools/__tests__/tool-card.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/__tests__/tool-card.test.tsx
@@ -228,33 +228,79 @@ describe('ToolCard dispatch', () => {
     expect(badge.querySelector('.text-accent6')).toBeTruthy();
   });
 
-  it('opens list_files when approval metadata arrives', async () => {
-    const toolName = WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES;
-    const props = baseProps({
-      toolName,
-      input: { path: '.' },
-      output: undefined,
-      state: 'input-available',
-    });
-    const view = renderToolCard(props);
-
-    const trigger = screen.getByRole('button', { name: /List Files/ });
-    expect(trigger.getAttribute('aria-expanded')).toBe('false');
-
-    view.rerender(
-      <ToolCard
-        {...props}
-        metadata={{
-          mode: 'stream',
-          requireApprovalMetadata: {
-            [toolName]: { toolCallId: 'call-1', toolName, args: { path: '.' } },
-          },
-        }}
-      />,
+  it('keeps the loading label when a network call has started without a result', () => {
+    renderToolCard(
+      baseProps({
+        toolName: WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES,
+        input: { path: '.' },
+        output: undefined,
+        state: 'input-available',
+        metadata: { mode: 'network', hasMoreMessages: true },
+      }),
     );
 
-    await waitFor(() => expect(trigger.getAttribute('aria-expanded')).toBe('true'));
-    expect(screen.getByRole('button', { name: 'Approve' })).toBeTruthy();
+    const tool = screen.getByRole('group', { name: `Tool: ${WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES}` });
+    expect(tool.getAttribute('aria-busy')).toBe('true');
+    fireEvent.click(screen.getByRole('button', { name: /List Files/ }));
+
+    expect(screen.getByText('Loading...')).toBeTruthy();
+    expect(screen.queryByText('No files found.')).toBeNull();
+  });
+
+  describe('when list_files approval is pending', () => {
+    it('exposes the approval controls without another user action', () => {
+      const toolName = WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES;
+      renderToolCard(
+        baseProps({
+          toolName,
+          input: { path: '.' },
+          output: undefined,
+          state: 'input-available',
+          metadata: {
+            mode: 'stream',
+            requireApprovalMetadata: {
+              [toolName]: { toolCallId: 'call-1', toolName, args: { path: '.' } },
+            },
+          },
+        }),
+      );
+
+      expect(screen.getByRole('button', { name: /List Files/ }).getAttribute('aria-expanded')).toBe('true');
+      expect(screen.getByRole('button', { name: 'Approve' })).toBeTruthy();
+    });
+
+    it('opens when approval arrives and closes after an empty terminal result', () => {
+      const toolName = WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES;
+      const approvalMetadata = {
+        mode: 'stream' as const,
+        requireApprovalMetadata: {
+          [toolName]: { toolCallId: 'call-1', toolName, args: { path: '.' } },
+        },
+      };
+      const props = baseProps({
+        toolName,
+        input: { path: '.' },
+        output: undefined,
+        state: 'input-available',
+        metadata: { mode: 'stream' },
+      });
+      const { rerender } = renderToolCard(props);
+      const trigger = screen.getByRole('button', { name: /List Files/ });
+
+      expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+      rerender(<ToolCard {...props} metadata={approvalMetadata} />);
+
+      expect(trigger.getAttribute('aria-expanded')).toBe('true');
+      expect(screen.getByRole('button', { name: 'Approve' })).toBeTruthy();
+
+      rerender(<ToolCard {...props} output="" state="output-available" metadata={approvalMetadata} />);
+
+      expect(trigger.getAttribute('aria-expanded')).toBe('false');
+      expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull();
+      fireEvent.click(trigger);
+      expect(screen.getByText('No files found.')).toBeTruthy();
+    });
   });
 
   it('routes sandbox execute_command to a disclosure collapsed by default', () => {
@@ -319,6 +365,60 @@ describe('ToolCard dispatch', () => {
     expect(screen.queryByText('$')).toBeNull();
   });
 
+  describe('when sandbox execution approval is pending', () => {
+    it('exposes the approval controls without another user action', () => {
+      const toolName = WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND;
+      renderToolCard(
+        baseProps({
+          toolName,
+          input: { command: 'ls' },
+          output: undefined,
+          state: 'input-available',
+          metadata: {
+            mode: 'stream',
+            requireApprovalMetadata: {
+              [toolName]: { toolCallId: 'call-1', toolName, args: { command: 'ls' } },
+            },
+          },
+        }),
+      );
+
+      expect(screen.getByRole('button', { name: 'Execute Command' }).getAttribute('aria-expanded')).toBe('true');
+      expect(screen.getByRole('button', { name: 'Approve' })).toBeTruthy();
+    });
+
+    it('opens when approval arrives and closes after an empty terminal result', () => {
+      const toolName = WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND;
+      const approvalMetadata = {
+        mode: 'stream' as const,
+        requireApprovalMetadata: {
+          [toolName]: { toolCallId: 'call-1', toolName, args: { command: 'ls' } },
+        },
+      };
+      const props = baseProps({
+        toolName,
+        input: { command: 'ls' },
+        output: undefined,
+        state: 'input-available',
+        metadata: { mode: 'stream' },
+      });
+      const { rerender } = renderToolCard(props);
+      const trigger = screen.getByRole('button', { name: 'Execute Command' });
+
+      expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+      rerender(<ToolCard {...props} metadata={approvalMetadata} />);
+
+      expect(trigger.getAttribute('aria-expanded')).toBe('true');
+      expect(screen.getByRole('button', { name: 'Approve' })).toBeTruthy();
+
+      rerender(<ToolCard {...props} output="" state="output-available" metadata={approvalMetadata} />);
+
+      expect(trigger.getAttribute('aria-expanded')).toBe('false');
+      expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull();
+    });
+  });
+
   it('routes code-mode calls to the code mode badge', () => {
     renderToolCard(
       baseProps({
@@ -347,26 +447,27 @@ describe('ToolCard dispatch', () => {
     expect(screen.getByText('Start job')).toBeTruthy();
   });
 
-  it('surfaces the agent suspend payload when suspendedTools is keyed by toolCallId', () => {
-    renderToolCard(
-      baseProps({
-        toolName: 'agent-billingAgent',
-        toolCallId: 'call-abc',
-        output: { text: 'pending approval' },
-        metadata: {
-          mode: 'stream',
-          // New core format: suspendedTools keyed by toolCallId.
-          suspendedTools: {
-            'call-abc': { suspendPayload: 'approve refund ord_2001?' },
+  describe('when an agent suspend payload is keyed by toolCallId', () => {
+    it('exposes the payload without another user action', () => {
+      renderToolCard(
+        baseProps({
+          toolName: 'agent-billingAgent',
+          toolCallId: 'call-abc',
+          output: { text: 'pending approval' },
+          metadata: {
+            mode: 'stream',
+            // New core format: suspendedTools keyed by toolCallId.
+            suspendedTools: {
+              'call-abc': { suspendPayload: 'approve refund ord_2001?' },
+            },
           },
-        },
-      }),
-    );
+        }),
+      );
 
-    // Agent badge starts collapsed; expand it to reveal the suspend payload.
-    fireEvent.click(screen.getByText('billingAgent'));
-    expect(screen.getByText('Agent suspend payload')).toBeTruthy();
-    expect(screen.getByText('approve refund ord_2001?')).toBeTruthy();
+      expect(screen.getByRole('button', { name: /billingAgent/ }).getAttribute('aria-expanded')).toBe('true');
+      expect(screen.getByText('Agent suspend payload')).toBeTruthy();
+      expect(screen.getByText('approve refund ord_2001?')).toBeTruthy();
+    });
   });
 
   it('surfaces the agent suspend payload when suspendedTools is keyed by toolName (back-compat)', () => {
@@ -385,7 +486,7 @@ describe('ToolCard dispatch', () => {
       }),
     );
 
-    fireEvent.click(screen.getByText('billingAgent'));
+    expect(screen.getByRole('button', { name: /billingAgent/ }).getAttribute('aria-expanded')).toBe('true');
     expect(screen.getByText('Agent suspend payload')).toBeTruthy();
     expect(screen.getByText('approve refund ord_2001?')).toBeTruthy();
   });
@@ -409,7 +510,6 @@ describe('ToolCard dispatch', () => {
         metadata: sharedMetadata,
       }),
     );
-    fireEvent.click(screen.getByText('billingAgent'));
     expect(screen.getByText('approve refund ord_2001?')).toBeTruthy();
     expect(screen.queryByText('approve refund ord_2003?')).toBeNull();
     unmount();
@@ -422,7 +522,6 @@ describe('ToolCard dispatch', () => {
         metadata: sharedMetadata,
       }),
     );
-    fireEvent.click(screen.getByText('billingAgent'));
     expect(screen.getByText('approve refund ord_2003?')).toBeTruthy();
     expect(screen.queryByText('approve refund ord_2001?')).toBeNull();
   });

--- a/packages/playground/src/lib/ai-ui/tools/ask-user-tool.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/ask-user-tool.tsx
@@ -1,7 +1,8 @@
 import { Tool, ToolContent, ToolHeader, ToolIcon } from '@mastra/playground-ui/components/ai/tool-call';
 import { ToolsIcon } from '@mastra/playground-ui/icons/ToolsIcon';
 import { AskUserBadge } from './badges/ask-user-badge';
-import type { AskUserResult, AskUserSuspendPayload } from './badges/types';
+import type { AskUserResult } from './badges/types';
+import { getAskUserSuspendPayload } from './tool-card-visibility';
 import type { MessageMetadata } from '@/lib/ai-ui/messages/message-metadata';
 
 export interface AskUserToolProps {
@@ -9,15 +10,6 @@ export interface AskUserToolProps {
   toolCallId: string;
   output: unknown;
   metadata?: MessageMetadata;
-}
-
-function isAskUserSuspendPayload(payload: unknown): payload is AskUserSuspendPayload {
-  return (
-    typeof payload === 'object' &&
-    payload !== null &&
-    'question' in payload &&
-    typeof (payload as AskUserSuspendPayload).question === 'string'
-  );
 }
 
 function asAskUserResult(output: unknown): AskUserResult | undefined {
@@ -39,10 +31,9 @@ function asAskUserResult(output: unknown): AskUserResult | undefined {
  * (new core), so both keys are tried.
  */
 export const AskUserTool = ({ toolName, toolCallId, output, metadata }: AskUserToolProps) => {
-  const suspendPayload = (metadata?.suspendedTools?.[toolName] ?? metadata?.suspendedTools?.[toolCallId])
-    ?.suspendPayload;
+  const suspendPayload = getAskUserSuspendPayload(metadata, toolName, toolCallId);
 
-  if (!isAskUserSuspendPayload(suspendPayload)) {
+  if (!suspendPayload) {
     return null;
   }
 

--- a/packages/playground/src/lib/ai-ui/tools/badges/__tests__/agent-badge.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/__tests__/agent-badge.test.tsx
@@ -244,4 +244,46 @@ describe('AgentBadge', () => {
       expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull();
     });
   });
+
+  describe('when the sub-agent requires approval', () => {
+    it('exposes the approval controls without another user action', () => {
+      renderWithProviders(
+        <AgentBadge
+          agentId="billing-agent"
+          messages={[]}
+          toolCallId="call-agent-approval"
+          toolName="agent-billing-agent"
+          toolApprovalMetadata={{
+            toolCallId: 'call-agent-approval',
+            toolName: 'agent-billing-agent',
+            args: {},
+          }}
+          isNetwork={false}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /billing-agent/ }).getAttribute('aria-expanded')).toBe('true');
+      expect(screen.getByRole('button', { name: 'Approve' })).toBeTruthy();
+    });
+  });
+
+  describe('when the sub-agent is suspended', () => {
+    it('exposes the suspension payload without another user action', () => {
+      renderWithProviders(
+        <AgentBadge
+          agentId="billing-agent"
+          messages={[]}
+          toolCallId="call-agent-suspended"
+          toolName="agent-billing-agent"
+          toolApprovalMetadata={undefined}
+          isNetwork={false}
+          suspendPayload="Confirm refund order-1"
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /billing-agent/ }).getAttribute('aria-expanded')).toBe('true');
+      expect(screen.getByText('Agent suspend payload')).toBeTruthy();
+      expect(screen.getByText('Confirm refund order-1')).toBeTruthy();
+    });
+  });
 });

--- a/packages/playground/src/lib/ai-ui/tools/badges/__tests__/code-mode-badge.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/__tests__/code-mode-badge.test.tsx
@@ -59,30 +59,28 @@ describe('getCodeModeCall', () => {
 });
 
 describe('CodeModeBadge', () => {
-  it('keeps a pending approval collapsed until requested', () => {
-    renderWithProvider(
-      <CodeModeBadge
-        toolName="execute_typescript"
-        code="return await external_getOrders();"
-        result={undefined}
-        toolCallId="call-approval"
-        toolApprovalMetadata={{
-          toolCallId: 'call-approval',
-          toolName: 'execute_typescript',
-          args: { code: 'return await external_getOrders();' },
-        }}
-        isNetwork={false}
-      />,
-    );
+  describe('when approval is pending', () => {
+    it('exposes the program and approval controls without another user action', () => {
+      renderWithProvider(
+        <CodeModeBadge
+          toolName="execute_typescript"
+          code="return await external_getOrders();"
+          result={undefined}
+          toolCallId="call-approval"
+          toolApprovalMetadata={{
+            toolCallId: 'call-approval',
+            toolName: 'execute_typescript',
+            args: { code: 'return await external_getOrders();' },
+          }}
+          isNetwork={false}
+        />,
+      );
 
-    const trigger = screen.getByRole('button', { name: 'execute_typescript' });
-    expect(trigger.getAttribute('aria-expanded')).toBe('false');
-    expect(screen.queryByRole('group', { name: 'Code mode details' })).toBeNull();
-
-    fireEvent.click(trigger);
-
-    expect(screen.getByRole('group', { name: 'Code mode details' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Approve' })).toBeTruthy();
+      const trigger = screen.getByRole('button', { name: 'execute_typescript' });
+      expect(trigger.getAttribute('aria-expanded')).toBe('true');
+      expect(screen.getByRole('group', { name: 'Code mode details' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Approve' })).toBeTruthy();
+    });
   });
 
   it('renders the program, result, and logs when expanded', () => {

--- a/packages/playground/src/lib/ai-ui/tools/badges/__tests__/tool-action-state.test.ts
+++ b/packages/playground/src/lib/ai-ui/tools/badges/__tests__/tool-action-state.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { isToolApprovalPending } from '../tool-action-state';
+
+describe('isToolApprovalPending', () => {
+  describe('when approval metadata is missing', () => {
+    it('does not require the tool disclosure to open', () => {
+      expect(isToolApprovalPending(undefined, false)).toBe(false);
+    });
+  });
+
+  describe('when an uncalled tool has approval metadata', () => {
+    it('requires the tool disclosure to open', () => {
+      expect(isToolApprovalPending({ toolCallId: 'call-1' }, false)).toBe(true);
+    });
+  });
+
+  describe('when the tool has already been called', () => {
+    it('does not require the tool disclosure to open again', () => {
+      expect(isToolApprovalPending({ toolCallId: 'call-1' }, true)).toBe(false);
+    });
+  });
+});

--- a/packages/playground/src/lib/ai-ui/tools/badges/__tests__/tool-badge.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/__tests__/tool-badge.test.tsx
@@ -121,28 +121,66 @@ describe('ToolBadge', () => {
     expect(screen.getByRole('img', { name: 'Failed' })).toBeTruthy();
   });
 
-  it('keeps pending approvals collapsed until requested', () => {
+  it.each([false, 0, '', null])('treats the falsy result %j as terminal', result => {
     renderWithProviders(
       <ToolBadge
-        toolName="charge_card"
-        args={{ amount: 42 }}
-        result={undefined}
+        toolName="check_value"
+        args={{}}
+        result={result}
         toolOutput={[]}
         toolCallId="call-1"
-        toolApprovalMetadata={{ toolCallId: 'call-1', toolName: 'charge_card', args: { amount: 42 } }}
+        toolApprovalMetadata={{ toolCallId: 'call-1', toolName: 'check_value', args: {} }}
         isNetwork={false}
-        state="input-available"
+        state="output-available"
       />,
     );
 
-    const tool = screen.getByRole('group', { name: 'Tool: charge_card' });
-    const trigger = screen.getByRole('button', { name: /Charge card/ });
-    expect(trigger.getAttribute('aria-expanded')).toBe('false');
-    expect(tool.textContent).not.toContain('Approval is required to continue.');
+    expect(screen.getByRole('button', { name: /Check value/ }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByRole('button', { name: /Approve/ })).toBeNull();
+  });
 
-    fireEvent.click(trigger);
+  describe('when approval is pending', () => {
+    it('exposes the approval controls without another user action', () => {
+      renderWithProviders(
+        <ToolBadge
+          toolName="charge_card"
+          args={{ amount: 42 }}
+          result={undefined}
+          toolOutput={[]}
+          toolCallId="call-1"
+          toolApprovalMetadata={{ toolCallId: 'call-1', toolName: 'charge_card', args: { amount: 42 } }}
+          isNetwork={false}
+          state="input-available"
+        />,
+      );
 
-    expect(tool.textContent).toContain('Approval is required to continue.');
-    expect(screen.getByRole('button', { name: /Approve/ })).toBeTruthy();
+      const tool = screen.getByRole('group', { name: 'Tool: charge_card' });
+      const trigger = screen.getByRole('button', { name: /Charge card/ });
+      expect(trigger.getAttribute('aria-expanded')).toBe('true');
+      expect(tool.textContent).toContain('Approval is required to continue.');
+      expect(screen.getByRole('button', { name: /Approve/ })).toBeTruthy();
+    });
+  });
+
+  describe('when a tool is suspended without approval metadata', () => {
+    it('exposes its suspension payload without another user action', () => {
+      renderWithProviders(
+        <ToolBadge
+          toolName="confirm_order"
+          args={{ orderId: 'order-1' }}
+          result={undefined}
+          toolOutput={[]}
+          toolCallId="call-2"
+          toolApprovalMetadata={undefined}
+          suspendPayload={{ reason: 'Confirm the order total' }}
+          isNetwork={false}
+          state="input-available"
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /Confirm order/ }).getAttribute('aria-expanded')).toBe('true');
+      expect(screen.getByText('Tool suspend payload')).toBeTruthy();
+      expect(screen.getByTestId('tool-suspend-payload').textContent).toContain('Confirm the order total');
+    });
   });
 });

--- a/packages/playground/src/lib/ai-ui/tools/badges/__tests__/workflow-badge.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/__tests__/workflow-badge.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
@@ -82,5 +82,58 @@ describe('WorkflowBadge', () => {
     fireEvent.click(screen.getByRole('button', { name: new RegExp(badgeWorkflow.name) }));
     await waitFor(() => expect(screen.getByTestId('workflow-graph-viewport')).toBeTruthy());
     expect(screen.queryByRole('link', { name: 'See run' })).toBeNull();
+  });
+
+  describe('when workflow approval is pending', () => {
+    it('exposes the approval controls without another user action', async () => {
+      server.use(http.get(`${BASE_URL}/api/workflows/${WORKFLOW_ID}`, () => HttpResponse.json(badgeWorkflow)));
+
+      render(
+        <WorkflowBadge
+          workflowId={WORKFLOW_ID}
+          toolName={`workflow-${WORKFLOW_ID}`}
+          toolCallId="call-approval"
+          toolApprovalMetadata={{
+            toolCallId: 'call-approval',
+            toolName: `workflow-${WORKFLOW_ID}`,
+            args: {},
+          }}
+          isNetwork={false}
+          result={undefined}
+        />,
+        { wrapper: Providers },
+      );
+
+      const badge = await screen.findByTestId('workflow-badge');
+      expect(
+        within(badge)
+          .getByRole('button', { name: new RegExp(badgeWorkflow.name) })
+          .getAttribute('aria-expanded'),
+      ).toBe('true');
+      expect(within(badge).getByRole('button', { name: 'Approve' })).toBeTruthy();
+    });
+  });
+
+  describe('when the workflow is suspended', () => {
+    it('exposes the suspension payload without another user action', async () => {
+      server.use(http.get(`${BASE_URL}/api/workflows/${WORKFLOW_ID}`, () => HttpResponse.json(badgeWorkflow)));
+
+      render(
+        <WorkflowBadge
+          workflowId={WORKFLOW_ID}
+          toolName={`workflow-${WORKFLOW_ID}`}
+          toolCallId="call-suspended"
+          toolApprovalMetadata={undefined}
+          isNetwork={false}
+          result={undefined}
+          suspendPayload="Confirm workflow execution"
+        />,
+        { wrapper: Providers },
+      );
+
+      const badge = await screen.findByTestId('workflow-badge');
+      expect(within(badge).getByText('Workflow suspend payload')).toBeTruthy();
+      expect(within(badge).getByText('Confirm workflow execution')).toBeTruthy();
+    });
   });
 });

--- a/packages/playground/src/lib/ai-ui/tools/badges/agent-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/agent-badge.tsx
@@ -13,6 +13,7 @@ import { ToolCard } from '../tool-card';
 import { isInlineToolCallHidden } from '../tool-card-visibility';
 import { BackgroundTaskMetadataDialogTrigger } from './background-task-metadata-dialog';
 import { NetworkChoiceMetadataDialogTrigger } from './network-choice-metadata-dialog';
+import { isToolApprovalPending } from './tool-action-state';
 import type { ToolApprovalButtonsProps } from './tool-approval-buttons';
 import { ToolApprovalButtons } from './tool-approval-buttons';
 import type { MessageMetadata } from '@/lib/ai-ui/messages/message-metadata';
@@ -99,7 +100,12 @@ export const AgentBadge = ({
     );
 
   return (
-    <Tool data-testid="agent-badge" status={isComplete ? 'success' : 'running'} aria-label={`Tool: ${toolName}`}>
+    <Tool
+      data-testid="agent-badge"
+      status={isComplete ? 'success' : 'running'}
+      defaultOpen={isToolApprovalPending(toolApprovalMetadata, toolCalled) || Boolean(suspendPayload)}
+      aria-label={`Tool: ${toolName}`}
+    >
       <ToolHeader
         actions={
           metadata?.mode === 'network' ? (

--- a/packages/playground/src/lib/ai-ui/tools/badges/code-mode-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/code-mode-badge.tsx
@@ -5,6 +5,7 @@ import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { ToolCoinIcon } from '@mastra/playground-ui/icons/ToolCoinIcon';
 import { formatTypeScript } from '@mastra/playground-ui/utils/formatting';
 import { useEffect, useState } from 'react';
+import { isToolApprovalPending } from './tool-action-state';
 import type { ToolApprovalButtonsProps } from './tool-approval-buttons';
 import { ToolApprovalButtons } from './tool-approval-buttons';
 import type { MessageMetadata } from '@/lib/ai-ui/messages/message-metadata';
@@ -98,7 +99,12 @@ export const CodeModeBadge = ({
   }, [code]);
 
   return (
-    <Tool data-testid="code-mode-badge" status={status} aria-label={`Tool: ${toolName}`}>
+    <Tool
+      data-testid="code-mode-badge"
+      status={status}
+      defaultOpen={isToolApprovalPending(toolApprovalMetadata, toolCalled)}
+      aria-label={`Tool: ${toolName}`}
+    >
       <ToolHeader>
         <ToolIcon tooltip="Code mode">
           <ToolCoinIcon className="text-accent6" />

--- a/packages/playground/src/lib/ai-ui/tools/badges/file-tree-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/file-tree-badge.tsx
@@ -6,6 +6,7 @@ import { cn } from '@mastra/playground-ui/utils/cn';
 import { CopyIcon, CheckIcon, FolderTree, HardDrive } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import type { DataMessagePart } from '../tool-card';
+import { isToolApprovalPending } from './tool-action-state';
 import type { ToolApprovalButtonsProps } from './tool-approval-buttons';
 import { ToolApprovalButtons } from './tool-approval-buttons';
 import type { MessageMetadata } from '@/lib/ai-ui/messages/message-metadata';
@@ -59,7 +60,6 @@ export const FileTreeBadge = ({
   toolCalled: toolCalledProp,
   dataParts,
 }: FileTreeBadgeProps) => {
-  const [isCollapsed, setIsCollapsed] = useState(true);
   const { isCopied, copyToClipboard } = useCopyToClipboard({ copiedDuration: 1500, showToast: false });
   const { Link } = useLinkComponent();
 
@@ -105,7 +105,13 @@ export const FileTreeBadge = ({
   }
 
   const hasResult = !!treeOutput;
-  const toolCalled = toolCalledProp ?? hasResult;
+  const toolCalled = toolCalledProp ?? result !== undefined;
+  const approvalPending = isToolApprovalPending(toolApprovalMetadata, toolCalled);
+  const [isCollapsed, setIsCollapsed] = useState(!approvalPending);
+
+  useEffect(() => {
+    setIsCollapsed(!approvalPending);
+  }, [approvalPending]);
 
   useEffect(() => {
     if (toolApprovalMetadata && !toolCalled) {
@@ -213,7 +219,7 @@ export const FileTreeBadge = ({
         {/* Loading state */}
         {toolCalled && !hasResult && (
           <div className="border-border1 bg-surface2 rounded-md border px-3 py-2">
-            <span className="text-neutral6 text-xs">Loading...</span>
+            <span className="text-neutral6 text-xs">{result === undefined ? 'Loading...' : 'No files found.'}</span>
           </div>
         )}
       </ToolContent>

--- a/packages/playground/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
@@ -5,6 +5,7 @@ import { cn } from '@mastra/playground-ui/utils/cn';
 import { CheckIcon, CopyIcon, TerminalSquare } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { DataMessagePart } from '../tool-card';
+import { isToolApprovalPending } from './tool-action-state';
 import type { ToolApprovalButtonsProps } from './tool-approval-buttons';
 import { ToolApprovalButtons } from './tool-approval-buttons';
 import { WORKSPACE_TOOLS } from '@/domains/workspace/constants';
@@ -157,7 +158,6 @@ export const SandboxExecutionBadge = ({
     return (dataPartsProp ?? []).filter(part => part.type === 'data');
   }, [dataPartsProp]);
 
-  const [isCollapsed, setIsCollapsed] = useState(true);
   const { isCopied, copyToClipboard } = useCopyToClipboard({ copiedDuration: 1500, showToast: false });
   const { Link } = useLinkComponent();
 
@@ -207,6 +207,12 @@ export const SandboxExecutionBadge = ({
   const hasStarted = !!workspaceMetaPart; // metadata is emitted at tool start
   const isRunning = hasStarted && !isStreamingComplete;
   const toolCalled = toolCalledProp ?? isStreamingComplete;
+  const approvalPending = isToolApprovalPending(toolApprovalMetadata, toolCalled);
+  const [isCollapsed, setIsCollapsed] = useState(!approvalPending);
+
+  useEffect(() => {
+    setIsCollapsed(!approvalPending);
+  }, [approvalPending]);
 
   // Get exit info from data chunks
   const exitCode = exitChunk?.data?.exitCode;

--- a/packages/playground/src/lib/ai-ui/tools/badges/tool-action-state.ts
+++ b/packages/playground/src/lib/ai-ui/tools/badges/tool-action-state.ts
@@ -1,0 +1,3 @@
+export function isToolApprovalPending(toolApprovalMetadata: unknown, toolCalled: boolean): boolean {
+  return toolApprovalMetadata !== undefined && !toolCalled;
+}

--- a/packages/playground/src/lib/ai-ui/tools/badges/tool-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/tool-badge.tsx
@@ -3,6 +3,7 @@ import type { ToolCallStatus } from '@mastra/playground-ui/components/ai/tool-ca
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { BackgroundTaskMetadataDialogTrigger } from './background-task-metadata-dialog';
 import { NetworkChoiceMetadataDialogTrigger } from './network-choice-metadata-dialog';
+import { isToolApprovalPending } from './tool-action-state';
 import type { ToolApprovalButtonsProps } from './tool-approval-buttons';
 import { ToolApprovalButtons } from './tool-approval-buttons';
 import type { MessageMetadata } from '@/lib/ai-ui/messages/message-metadata';
@@ -82,7 +83,9 @@ export const ToolBadge = ({
   const selectionReason =
     metadata?.mode === 'network' ? (routingDecision?.selectionReason ?? metadata.selectionReason) : undefined;
   const agentNetworkInput = metadata?.mode === 'network' ? (routingDecision ?? metadata.agentInput) : undefined;
-  const toolCalled = toolCalledProp ?? (result !== undefined || toolOutput.length > 0);
+  const status = toolStatus(state, result);
+  const toolCalled = toolCalledProp ?? (status !== 'running' || toolOutput.length > 0);
+  const actionPending = isToolApprovalPending(toolApprovalMetadata, toolCalled) || Boolean(suspendPayload);
 
   const bgEntry =
     (metadata?.mode === 'stream' || metadata?.mode === 'generate') && metadata.backgroundTasks
@@ -105,7 +108,8 @@ export const ToolBadge = ({
       toolName={toolName}
       input={withoutArgs ? undefined : parseArgs(args)}
       result={result}
-      status={toolStatus(state, result)}
+      status={status}
+      defaultOpen={actionPending}
       headerActions={headerActions}
     >
       {Boolean(suspendPayload) && (

--- a/packages/playground/src/lib/ai-ui/tools/badges/workflow-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/workflow-badge.tsx
@@ -8,6 +8,7 @@ import { useContext, useEffect } from 'react';
 import { BackgroundTaskMetadataDialogTrigger } from './background-task-metadata-dialog';
 import { LoadingBadge } from './loading-badge';
 import { NetworkChoiceMetadataDialogTrigger } from './network-choice-metadata-dialog';
+import { isToolApprovalPending } from './tool-action-state';
 import type { ToolApprovalButtonsProps } from './tool-approval-buttons';
 import { ToolApprovalButtons } from './tool-approval-buttons';
 import {
@@ -86,9 +87,15 @@ export const WorkflowBadge = ({
       <BackgroundTaskMetadataDialogTrigger backgroundTask={bgEntry} />
     ) : null;
   const workflowHref = runId ? `/workflows/${workflowId}/graph/${runId}` : `/workflows/${workflowId}/graph`;
+  const hasToolBeenCalled = toolCalled ?? Boolean(status);
 
   return (
-    <Tool data-testid="workflow-badge" status={toolCallStatus} aria-label={`Tool: ${toolName}`}>
+    <Tool
+      data-testid="workflow-badge"
+      status={toolCallStatus}
+      defaultOpen={isToolApprovalPending(toolApprovalMetadata, hasToolBeenCalled) || Boolean(suspendPayload)}
+      aria-label={`Tool: ${toolName}`}
+    >
       <ToolHeader
         actions={
           <div className="flex items-center gap-1">
@@ -122,7 +129,7 @@ export const WorkflowBadge = ({
         )}
 
         <ToolApprovalButtons
-          toolCalled={toolCalled ?? !!status}
+          toolCalled={hasToolBeenCalled}
           toolCallId={toolCallId}
           toolApprovalMetadata={toolApprovalMetadata}
           toolName={toolName}

--- a/packages/playground/src/lib/ai-ui/tools/tool-card-visibility.ts
+++ b/packages/playground/src/lib/ai-ui/tools/tool-card-visibility.ts
@@ -1,6 +1,27 @@
+import type { AskUserSuspendPayload } from './badges/types';
+
 const TASK_TOOL_NAMES = new Set(['task_write', 'task_update', 'task_complete', 'task_check']);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isAskUserSuspendPayload = (payload: unknown): payload is AskUserSuspendPayload =>
+  isRecord(payload) && typeof payload.question === 'string';
 
 // Inline-hidden tools must not participate in message-level tool grouping or
 // leave separators behind when their ToolCard renders no visible content.
 export const isInlineToolCallHidden = (toolName: string) =>
   toolName === 'updateWorkingMemory' || TASK_TOOL_NAMES.has(toolName);
+
+export const getAskUserSuspendPayload = (
+  metadata: unknown,
+  toolName: string,
+  toolCallId: string,
+): AskUserSuspendPayload | undefined => {
+  if (!isRecord(metadata) || !isRecord(metadata.suspendedTools)) return undefined;
+
+  const suspendedTool = metadata.suspendedTools[toolName] ?? metadata.suspendedTools[toolCallId];
+  if (!isRecord(suspendedTool)) return undefined;
+
+  return isAskUserSuspendPayload(suspendedTool.suspendPayload) ? suspendedTool.suspendPayload : undefined;
+};


### PR DESCRIPTION
## Summary

PR 2 of 3 split from the tool UI review-fix branch, stacked on the playground-ui fixes.

## Scope

- Connect only adjacent tool calls in the sequence rail
- Expose pending tool actions and open pending approvals by default
- Distinguish pending empty file trees
- Chat message layout/visibility refinements (spacing, column width, hidden empty stored rows)
- workflow-stream e2e now expands the collapsed workflow tool card before asserting on nodes

## Intentionally excluded

- Shared playground-ui component changes → previous PR in the stack

## Verification

- Full playground unit suite: 252 files, 1810 passed / 2 skipped
- workflow-stream e2e passes locally against kitchen-sink