### PR TITLE
chore(examples): drop requireApproval from confirmTomatoPrep demo tool

### DIFF
--- a/examples/agent/src/mastra/agents/model-v2-agent.ts
+++ b/examples/agent/src/mastra/agents/model-v2-agent.ts
@@ -88,7 +88,6 @@ const chefUiDemoApprovalTool = createTool({
   id: 'confirm-tomato-prep',
   description: 'Confirm a mise en place checklist before the sous-chef continues.',
   inputSchema: z.object({ ingredient: z.string() }),
-  requireApproval: true,
   execute: async ({ ingredient }) => ({ approvedIngredient: ingredient }),
 });
 


### PR DESCRIPTION
## Summary

PR 3 of 3 split from the tool UI review-fix branch.

## Scope

- Drop `requireApproval` from the `confirmTomatoPrep` demo tool in `examples/agent` (approval flow was blocking the sub-agent demo)

## Verification

- Trivial one-line diff; exercised via the Studio chef-model-v2 audit