### PR TITLE
fix(code-sdk): stop telling every host to run /login

### DIFF
--- a/.changeset/factory-login-command.md
+++ b/.changeset/factory-login-command.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Added a `/login` command to the web chat composer. Credential errors used to name a command the web UI did not have, leaving no way to act on them from the browser. Typing `/login` now opens Settings → Models, where providers are connected.

--- a/.changeset/provider-auth-required-error.md
+++ b/.changeset/provider-auth-required-error.md
@@ -1,0 +1,19 @@
+---
+'@mastra/code-sdk': minor
+---
+
+Fixed credential failures that told every interface to run `/login`, a command only the terminal UI has. A provider fetch without a usable credential now throws `ProviderAuthRequiredError`, which states the fact and leaves the remedy to the host running the agent.
+
+```ts
+import { ProviderAuthRequiredError } from '@mastra/code-sdk/auth/provider-auth-error';
+
+try {
+  await run();
+} catch (error) {
+  // Before: the message hardcoded "Run /login first."
+  // Now: match the error and point the user at whatever sign-in path your host offers.
+  if (error instanceof ProviderAuthRequiredError) showSignIn();
+}
+```
+
+The error name is stable across serialization, so a client that only receives `{ name, message }` over the wire can match it too.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerLoginCommand.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerLoginCommand.msw.test.tsx
@@ -21,6 +21,8 @@ describe('the /login command', () => {
     await waitFor(() => expect(input).toBeEnabled());
     await user.type(input, '/login{Enter}');
 
-    expect(await screen.findByTestId('navigated-path')).toHaveTextContent(/\/settings\/models$/);
+    const navigated = await screen.findByTestId('navigated-path');
+    expect(navigated).toHaveTextContent(/\/settings\/models$/);
+    expect(navigated).toHaveAttribute('data-return-to', expect.stringContaining('/threads/thread-test'));
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerLoginCommand.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerLoginCommand.msw.test.tsx
@@ -1,0 +1,26 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { renderWithProviders } from '../../../../../../e2e/ui/render';
+import { Composer } from '../Composer';
+import { OverlayTestProviders, useOverlayControllerHandlers } from './overlay-test-utils';
+
+beforeEach(useOverlayControllerHandlers);
+
+describe('the /login command', () => {
+  it('takes the user to the settings section where providers are connected', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <OverlayTestProviders>
+        <Composer />
+      </OverlayTestProviders>,
+    );
+
+    const input = await screen.findByRole('textbox', { name: 'Message' });
+    await waitFor(() => expect(input).toBeEnabled());
+    await user.type(input, '/login{Enter}');
+
+    expect(await screen.findByTestId('navigated-path')).toHaveTextContent(/\/settings\/models$/);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/overlay-test-utils.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/overlay-test-utils.tsx
@@ -1,7 +1,7 @@
 import { MainSidebarProvider } from '@mastra/playground-ui/components/MainSidebar';
 import { http, HttpResponse } from 'msw';
 import type { ReactNode } from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 
 import { ChatSessionTestProvider as ChatSessionProvider } from '../../context/ChatSessionTestProvider';
 import { server } from '../../../../../../e2e/ui/msw-server';
@@ -136,6 +136,11 @@ export function useOverlayControllerHandlers() {
   );
 }
 
+/** Renders wherever a command navigates the app, so tests can assert the destination. */
+function NavigatedPath() {
+  return <span data-testid="navigated-path">{useLocation().pathname}</span>;
+}
+
 export function OverlayTestProviders({ children }: { children: ReactNode }) {
   return (
     <MemoryRouter
@@ -152,6 +157,7 @@ export function OverlayTestProviders({ children }: { children: ReactNode }) {
             </MainSidebarProvider>
           }
         />
+        <Route path="*" element={<NavigatedPath />} />
       </Routes>
     </MemoryRouter>
   );

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/overlay-test-utils.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/overlay-test-utils.tsx
@@ -136,9 +136,14 @@ export function useOverlayControllerHandlers() {
   );
 }
 
-/** Renders wherever a command navigates the app, so tests can assert the destination. */
+/** Renders where a command navigated and the location it carries back, so tests can assert both. */
 function NavigatedPath() {
-  return <span data-testid="navigated-path">{useLocation().pathname}</span>;
+  const { pathname, state } = useLocation();
+  return (
+    <span data-testid="navigated-path" data-return-to={JSON.stringify(state)}>
+      {pathname}
+    </span>
+  );
 }
 
 export function OverlayTestProviders({ children }: { children: ReactNode }) {

--- a/mastracode/factory-ui/src/ui/domains/chat/context/useRunPaletteCommand.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/useRunPaletteCommand.ts
@@ -1,6 +1,6 @@
 import type { ToolCategory } from '@mastra/client-js';
 
-import { useParams } from 'react-router';
+import { useLocation, useNavigate, useParams } from 'react-router';
 import {
   useClearAgentControllerGoalMutation,
   usePauseAgentControllerGoalMutation,
@@ -12,6 +12,7 @@ import {
   useFollowUpAgentControllerMutation,
 } from '../../../../hooks/useAgentControllerRunMutations';
 import { useFactoryQuery } from '../../../../hooks/useFactories';
+import { settingsSectionPath } from '../../settings/settingsSections';
 import type { SlashCommand } from '../services/commands';
 import { SLASH_COMMANDS } from '../services/commands';
 import { AGENT_CONTROLLER_ID } from '../services/constants';
@@ -26,6 +27,8 @@ const TOOL_CATEGORIES: ToolCategory[] = ['read', 'edit', 'execute', 'mcp', 'othe
 export function useRunPaletteCommand(prefillComposer: (draft: string) => void) {
   const { factoryId } = useParams<{ factoryId: string }>();
   const factoryQuery = useFactoryQuery(factoryId);
+  const navigate = useNavigate();
+  const location = useLocation();
   const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
   const { transcript, busy, localUser, pushNotice } = useChatTranscript();
   const { activeModeId } = useChatModes();
@@ -104,6 +107,9 @@ export function useRunPaletteCommand(prefillComposer: (draft: string) => void) {
             `Running: ${busy}`,
           ].join('\n'),
         );
+        return;
+      case 'login':
+        if (factoryId) void navigate(settingsSectionPath(factoryId, 'models'), { state: { from: location } });
         return;
       case 'abort':
         await abortMutation.mutateAsync();

--- a/mastracode/factory-ui/src/ui/domains/chat/services/commands.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/commands.ts
@@ -24,6 +24,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: 'think', description: 'Hint on extended thinking', requiresSession: false },
   { name: 'om', description: 'Show observational-memory phase', requiresSession: false },
   { name: 'settings', description: 'Show session state', requiresSession: false },
+  { name: 'login', description: 'Connect a model provider', requiresSession: false },
   { name: 'follow-up', args: '<message>', description: 'Queue a follow-up message', requiresSession: true },
   { name: 'abort', description: 'Abort the current run', requiresSession: true },
   { name: 'help', description: 'Show the command list', requiresSession: false },

--- a/mastracode/sdk/src/auth/index.ts
+++ b/mastracode/sdk/src/auth/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './types.js';
+export * from './provider-auth-error.js';
 export * from './storage.js';
 export { anthropicOAuthProvider } from './providers/anthropic.js';
 export { githubCopilotOAuthProvider } from './providers/github-copilot.js';

--- a/mastracode/sdk/src/auth/provider-auth-error.ts
+++ b/mastracode/sdk/src/auth/provider-auth-error.ts
@@ -1,0 +1,12 @@
+/** Wire-stable `Error.name`: the server flattens errors to `{ name, message }`, so hosts match on this. */
+export const PROVIDER_AUTH_REQUIRED_ERROR = 'ProviderAuthRequiredError';
+
+/**
+ * A provider credential is missing or no longer usable. The message states the
+ * fact only — how the user re-authenticates is the host's call (`/login` in the
+ * TUI, Settings → Models in the factory web UI), so no host advertises a
+ * command another host doesn't have.
+ */
+export class ProviderAuthRequiredError extends Error {
+  readonly name = PROVIDER_AUTH_REQUIRED_ERROR;
+}

--- a/mastracode/sdk/src/providers/claude-max.ts
+++ b/mastracode/sdk/src/providers/claude-max.ts
@@ -9,6 +9,7 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import type { MastraModelConfig } from '@mastra/core/llm';
 import { wrapLanguageModel } from 'ai';
 import type { LanguageModelMiddleware } from 'ai';
+import { ProviderAuthRequiredError } from '../auth/provider-auth-error.js';
 import { AuthStorage } from '../auth/storage.js';
 import type { CredentialStore } from '../auth/types.js';
 import type { ThinkingLevel } from './openai-codex.js';
@@ -254,7 +255,7 @@ export function buildAnthropicOAuthFetch(opts: { authStorage?: CredentialStore }
 
     const accessToken = await storage.getApiKey('anthropic');
     if (!accessToken) {
-      throw new Error('Not logged in to Anthropic. Run /login first.');
+      throw new ProviderAuthRequiredError('Not logged in to Anthropic.');
     }
 
     // Preserve existing headers, strip auth-related ones

--- a/mastracode/sdk/src/providers/github-copilot.ts
+++ b/mastracode/sdk/src/providers/github-copilot.ts
@@ -17,6 +17,7 @@ import type { JSONSchema7 } from '@mastra/schema-compat';
 import { applyCompatLayer, GoogleSchemaCompatLayer } from '@mastra/schema-compat';
 import { wrapLanguageModel } from 'ai';
 import type { LanguageModelMiddleware } from 'ai';
+import { ProviderAuthRequiredError } from '../auth/provider-auth-error.js';
 import { COPILOT_HEADERS, fetchCopilotModels, getGitHubCopilotBaseUrl } from '../auth/providers/github-copilot.js';
 import type { CopilotModelEntry, GitHubCopilotCredentials } from '../auth/providers/github-copilot.js';
 import { AuthStorage } from '../auth/storage.js';
@@ -123,13 +124,13 @@ export function buildGitHubCopilotOAuthFetch(
 
     const cred = storage.get(COPILOT_PROVIDER_ID);
     if (!cred || cred.type !== 'oauth') {
-      throw new Error('Not logged in to GitHub Copilot. Run /login first.');
+      throw new ProviderAuthRequiredError('Not logged in to GitHub Copilot.');
     }
 
     // getApiKey() refreshes the Copilot bearer if it has expired.
     const accessToken = await storage.getApiKey(COPILOT_PROVIDER_ID);
     if (!accessToken) {
-      throw new Error('Failed to refresh GitHub Copilot token. Please /login again.');
+      throw new ProviderAuthRequiredError('Failed to refresh the GitHub Copilot token.');
     }
     storage.reload();
 

--- a/mastracode/sdk/src/providers/openai-codex.ts
+++ b/mastracode/sdk/src/providers/openai-codex.ts
@@ -12,6 +12,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import type { MastraModelConfig } from '@mastra/core/llm';
 import { wrapLanguageModel } from 'ai';
 import type { LanguageModelMiddleware } from 'ai';
+import { ProviderAuthRequiredError } from '../auth/provider-auth-error.js';
 import { AuthStorage } from '../auth/storage.js';
 import type { CredentialStore } from '../auth/types.js';
 
@@ -139,14 +140,14 @@ async function getCodexBearer(
 
   const cred = storage.get('openai-codex');
   if (!cred || cred.type !== 'oauth') {
-    throw new Error('Not logged in to OpenAI Codex. Run /login first.');
+    throw new ProviderAuthRequiredError('Not logged in to OpenAI Codex.');
   }
 
   let accessToken = cred.access;
   if (Date.now() >= cred.expires) {
     const refreshedToken = await storage.getApiKey('openai-codex');
     if (!refreshedToken) {
-      throw new Error('Failed to refresh OpenAI Codex token. Please /login again.');
+      throw new ProviderAuthRequiredError('Failed to refresh the OpenAI Codex token.');
     }
     accessToken = refreshedToken;
     storage.reload();

--- a/mastracode/sdk/src/providers/xai.ts
+++ b/mastracode/sdk/src/providers/xai.ts
@@ -10,6 +10,7 @@
 
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { MastraModelConfig } from '@mastra/core/llm';
+import { ProviderAuthRequiredError } from '../auth/provider-auth-error.js';
 import { AuthStorage } from '../auth/storage.js';
 import type { CredentialStore } from '../auth/types.js';
 
@@ -44,13 +45,13 @@ export function buildXAIOAuthFetch(opts: { authStorage?: CredentialStore } = {})
 
     const cred = storage.get(XAI_PROVIDER_ID);
     if (!cred || cred.type !== 'oauth') {
-      throw new Error('Not logged in to xAI. Run /login first.');
+      throw new ProviderAuthRequiredError('Not logged in to xAI.');
     }
 
     // getApiKey() refreshes the access token if it has expired.
     const accessToken = await storage.getApiKey(XAI_PROVIDER_ID);
     if (!accessToken) {
-      throw new Error('Failed to refresh xAI token. Please /login again.');
+      throw new ProviderAuthRequiredError('Failed to refresh the xAI token.');
     }
 
     // Preserve existing headers, strip auth-related ones. Explicit init

--- a/mastracode/sdk/src/utils/__tests__/errors.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/errors.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
+import { ProviderAuthRequiredError } from '../../auth/provider-auth-error.js';
 import { parseError } from '../errors.js';
 
 describe('parseError', () => {
+  it('classifies a provider credential failure as auth without rewriting its message', () => {
+    const parsed = parseError(new ProviderAuthRequiredError('Not logged in to Anthropic.'));
+
+    expect(parsed.type).toBe('auth');
+    expect(parsed.message).toBe('Not logged in to Anthropic.');
+  });
+
   it('preserves useful detail for network-style errors', () => {
     const error = new Error('fetch failed: socket hang up');
 

--- a/mastracode/sdk/src/utils/__tests__/errors.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/errors.test.ts
@@ -11,6 +11,14 @@ describe('parseError', () => {
     expect(parsed.message).toBe('Not logged in to Anthropic.');
   });
 
+  it('classifies a credential failure that reached the host as a flattened wire payload', () => {
+    const parsed = parseError({ name: 'ProviderAuthRequiredError', message: 'Not logged in to Anthropic.' });
+
+    expect(parsed.type).toBe('auth');
+    expect(parsed.message).toBe('Not logged in to Anthropic.');
+    expect(parsed.retryable).toBe(false);
+  });
+
   it('preserves useful detail for network-style errors', () => {
     const error = new Error('fetch failed: socket hang up');
 

--- a/mastracode/sdk/src/utils/errors.ts
+++ b/mastracode/sdk/src/utils/errors.ts
@@ -93,8 +93,28 @@ function extractRequestUrl(error: unknown): string | undefined {
   return undefined;
 }
 
+/** A flattened error crossing the wire: the server sends `{ name, message }`, not an `Error`. */
+function isSerializedError(value: unknown): value is { name: string; message: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'name' in value &&
+    typeof value.name === 'string' &&
+    'message' in value &&
+    typeof value.message === 'string'
+  );
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  if (!isSerializedError(error)) return new Error(String(error));
+  const rebuilt = new Error(error.message);
+  rebuilt.name = error.name;
+  return rebuilt;
+}
+
 export function parseError(error: unknown): ParsedError {
-  const err = error instanceof Error ? error : new Error(String(error));
+  const err = toError(error);
   const message = err.message.toLowerCase();
   const errorObj = error as Record<string, unknown>;
   const detail = summarizeErrorDetail(error);

--- a/mastracode/sdk/src/utils/errors.ts
+++ b/mastracode/sdk/src/utils/errors.ts
@@ -3,6 +3,8 @@
  * Parses API errors and provides user-friendly messages.
  */
 
+import { PROVIDER_AUTH_REQUIRED_ERROR } from '../auth/provider-auth-error.js';
+
 export interface ParsedError {
   /** User-friendly error message */
   message: string;
@@ -98,6 +100,11 @@ export function parseError(error: unknown): ParsedError {
   const detail = summarizeErrorDetail(error);
   const requestUrl = extractRequestUrl(error);
 
+  // Matched by name, not instance: the error may have crossed a serialization boundary.
+  if (err.name === PROVIDER_AUTH_REQUIRED_ERROR) {
+    return { message: err.message, detail, requestUrl, type: 'auth', retryable: false, originalError: err };
+  }
+
   // Check for rate limiting
   if (
     message.includes('rate limit') ||
@@ -127,7 +134,7 @@ export function parseError(error: unknown): ParsedError {
     errorObj.status === 401
   ) {
     return {
-      message: 'Authentication failed. Please check your API key or login with /login.',
+      message: 'Authentication failed. Check the credential configured for this provider.',
       detail,
       requestUrl,
       type: 'auth',


### PR DESCRIPTION

<img width="1139" height="903" alt="image" src="https://github.com/user-attachments/assets/8647da1c-42de-4f18-ac5e-780aa48d139b" />


A credential error in the factory web UI told the user to run `/login`, a command the web composer didn't have.

The message came from the SDK, which hardcoded the terminal's remedy into the error text every host ends up rendering. So the web, Slack and headless all inherited an instruction only the TUI could satisfy. I moved that: providers now throw `ProviderAuthRequiredError` with the fact alone ("Not logged in to Anthropic."), and each host decides what to do about it. The error name survives serialization, so a client that only receives `{ name, message }` over the wire can still match it.

Side effect I like: the TUI actually gained a hint. The old raw string matched none of `parseError`'s auth patterns, so it was typed `unknown` and no hint line was printed — the remedy lived in the message only. Now it classifies as `auth` and the existing `Hint: Use /login to authenticate with a provider` shows up under the error.

And since the web now needed a real answer, `/login` exists in the factory composer: it opens Settings → Models, where providers are connected, and closing returns you to the chat. The test asserts the destination, and I checked it goes red without the handler. I didn't add a hint line to the web transcript — that would have meant pulling the SDK into the browser bundle or duplicating the error name, and a discoverable `/login` in the command menu covers it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Provider errors now explain that a provider login is required instead of instructing every app to run `/login`. Each host can choose the correct reconnection flow, while the TUI and web composer provide their own login guidance.

## Changes

- Added `ProviderAuthRequiredError` with a stable serialized name.
- Updated Anthropic, GitHub Copilot, OpenAI Codex, and xAI authentication failures to use this error.
- Updated `parseError` to restore serialized `{ name, message }` errors and classify provider authentication failures as non-retryable.
- Added the `/login` command to the factory web composer.
- Made `/login` open Settings → Models and return to the chat when closed.
- Added tests for serialized error parsing and `/login` navigation.
- Added changesets for `@mastra/code-sdk` and `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->