### PR TITLE
fix(playground): align route and sidebar headers

### DIFF
--- a/.changeset/quiet-bears-align.md
+++ b/.changeset/quiet-bears-align.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Aligned the Studio route header with the sidebar in authenticated and public sessions.

--- a/packages/playground/src/components/layout.tsx
+++ b/packages/playground/src/components/layout.tsx
@@ -77,7 +77,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
         <div className="flex h-full min-h-0 flex-col">
           {shouldShowSidebar && <MobileNavbar />}
           {shouldShowSidebar && (
-            <div className="mx-1.5 mt-1 shrink-0 lg:mx-2 lg:mt-0.5">
+            <div className="mx-1.5 mt-1 shrink-0 lg:mx-2 lg:mt-1">
               <RouteHeader />
             </div>
           )}

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -90,7 +90,7 @@ export function AppSidebar() {
 
   return (
     <MainSidebar>
-      <div className="mb-2 pt-2">
+      <div className="mb-1.5 pt-2.5">
         {state === 'collapsed' ? (
           <div className="flex flex-col items-center gap-2">
             <div className="relative grid size-9 place-items-center">
@@ -109,7 +109,7 @@ export function AppSidebar() {
             {isUserAuthenticated && <AuthStatus />}
           </div>
         ) : isUserAuthenticated ? (
-          <span className="flex items-center justify-between pr-2 pl-3">
+          <span className="flex h-7 items-center justify-between pr-2 pl-3">
             <span className="flex min-w-0 flex-1 items-center gap-2">
               <LogoWithoutText className="h-[1.5rem] w-[1.5rem] shrink-0" />
               <span className="font-display truncate text-sm font-semibold tracking-tight whitespace-nowrap">
@@ -120,7 +120,7 @@ export function AppSidebar() {
             <AuthStatus />
           </span>
         ) : (
-          <span className="flex items-center gap-2 pr-2 pl-3">
+          <span className="flex h-7 items-center gap-2 pr-2 pl-3">
             <LogoWithoutText className="h-[1.5rem] w-[1.5rem] shrink-0" />
             <span className="font-display truncate text-sm font-semibold tracking-tight whitespace-nowrap">
               Mastra Studio

--- a/packages/playground/src/lib/route-header/route-header.tsx
+++ b/packages/playground/src/lib/route-header/route-header.tsx
@@ -45,7 +45,7 @@ export function RouteHeader() {
                 className={isCurrent ? 'max-w-[28rem]' : 'max-w-[18rem]'}
               >
                 {IconComponent && (
-                  <Icon>
+                  <Icon className={isCurrent ? 'flex w-6 justify-center' : undefined}>
                     <IconComponent />
                   </Icon>
                 )}


### PR DESCRIPTION
## What

Follow up on #21674 so the Studio route header and sidebar brand row align in both authenticated and public sessions.

- Normalize the expanded sidebar header height across auth states
- Align the route frame with the sidebar search row
- Keep route icons at 16px while centering the current icon in a 24px slot, matching the sidebar logo's optical anchors

## Verification

- `pnpm --filter @internal/playground lint` (0 errors, existing warnings only)
- `pnpm --filter @internal/playground typecheck`
- `pnpm exec oxfmt --check packages/playground/src/components/layout.tsx packages/playground/src/components/ui/app-sidebar.tsx packages/playground/src/lib/route-header/route-header.tsx .changeset/quiet-bears-align.md`
- Production build with dependencies: `pnpm turbo run build --filter=@internal/playground...`
- Playwright geometry checks in authenticated and public states
- Reviewed locally by Justin in dark mode on the Settings screen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Studio header and sidebar now line up correctly. This keeps the layout consistent for both signed-in and public users.

## Changes

- Normalize the expanded sidebar header height across authentication states.
- Align the route header with the sidebar search row.
- Keep route icons at 16px.
- Center the current route icon in a 24px slot.
- Add a changeset for `@internal/playground`.

## Verification

- Linting
- Type checking
- Formatting checks
- Production build
- Playwright geometry checks
- Local dark-mode review on the Settings screen

<!-- end of auto-generated comment: release notes by coderabbit.ai -->