### PR TITLE
fix(e2b): retry failed mounts after sandbox recovery

### DIFF
--- a/.changeset/nine-seals-learn.md
+++ b/.changeset/nine-seals-learn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/e2b': patch
+---
+
+Fixed E2B sandbox recovery so configured mounts that previously errored are retried after the physical sandbox is replaced.

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -2254,25 +2254,35 @@ describe('E2BSandbox Internal Methods', () => {
       expect(sandbox.status).toBe('stopped');
     });
 
-    it('resets failed mounts to pending when replacing a dead sandbox', () => {
-      const sandbox = new E2BSandbox();
+    it.each([
+      { state: 'mounted', expectedState: 'pending', error: undefined },
+      { state: 'mounting', expectedState: 'pending', error: undefined },
+      { state: 'error', expectedState: 'pending', error: 'transient mount failure' },
+      { state: 'unsupported', expectedState: 'unsupported', error: 'unsupported filesystem' },
+      { state: 'unavailable', expectedState: 'unavailable', error: 'filesystem unavailable' },
+    ] as const)('handles $state mounts correctly and preserves their metadata', ({ state, expectedState, error }) => {
+      const config = { type: 's3', bucket: 'test-bucket', region: 'us-east-1' } as const;
       const filesystem = {
         id: 'test-s3',
         name: 'S3Filesystem',
         provider: 's3',
         status: 'ready',
-        getMountConfig: () => ({ type: 's3', bucket: 'test-bucket', region: 'us-east-1' }),
+        getMountConfig: () => config,
       } as any;
+      const sandbox = new E2BSandbox();
       sandbox.mounts.add({ '/data': filesystem });
-      sandbox.mounts.set('/data', { state: 'error', error: 'transient mount failure' });
+      sandbox.mounts.set('/data', { state, config, error });
+      const configHash = sandbox.mounts.get('/data')?.configHash;
+      expect(configHash).toBeDefined();
 
       (sandbox as any).handleSandboxTimeout();
 
-      expect(sandbox.mounts.get('/data')).toMatchObject({
-        filesystem,
-        state: 'pending',
-      });
-      expect(sandbox.mounts.get('/data')?.error).toBeUndefined();
+      const entry = sandbox.mounts.get('/data');
+      expect(entry?.filesystem).toBe(filesystem);
+      expect(entry?.config).toBe(config);
+      expect(entry?.configHash).toBe(configHash);
+      expect(entry?.state).toBe(expectedState);
+      expect(entry?.error).toBe(expectedState === 'pending' ? undefined : error);
     });
   });
 
@@ -2281,6 +2291,22 @@ describe('E2BSandbox Internal Methods', () => {
       const { Sandbox } = await import('e2b');
       const sandbox = new E2BSandbox();
       await sandbox._start();
+
+      const filesystem = {
+        id: 'test-s3',
+        name: 'S3Filesystem',
+        provider: 's3',
+        status: 'ready',
+        getMountConfig: () => ({
+          type: 's3',
+          bucket: 'test-bucket',
+          region: 'us-east-1',
+          accessKeyId: 'test-key',
+          secretAccessKey: 'test-secret',
+        }),
+      } as any;
+      sandbox.mounts.add({ '/data': filesystem });
+      sandbox.mounts.set('/data', { state: 'error', error: 'transient mount failure' });
 
       let callCount = 0;
       mockSandbox.commands.run.mockImplementation((_cmd: string, opts?: any) => {
@@ -2301,6 +2327,11 @@ describe('E2BSandbox Internal Methods', () => {
       expect(result.success).toBe(true);
       // create called once in initial start(), once in retry start()
       expect(Sandbox.create).toHaveBeenCalledTimes(2);
+      expect(sandbox.mounts.get('/data')).toMatchObject({
+        filesystem,
+        state: 'mounted',
+      });
+      expect(sandbox.mounts.get('/data')?.error).toBeUndefined();
     });
 
     it('does not retry infinitely (only once)', async () => {

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -2253,6 +2253,27 @@ describe('E2BSandbox Internal Methods', () => {
       expect((sandbox as any)._sandbox).toBeNull();
       expect(sandbox.status).toBe('stopped');
     });
+
+    it('resets failed mounts to pending when replacing a dead sandbox', () => {
+      const sandbox = new E2BSandbox();
+      const filesystem = {
+        id: 'test-s3',
+        name: 'S3Filesystem',
+        provider: 's3',
+        status: 'ready',
+        getMountConfig: () => ({ type: 's3', bucket: 'test-bucket', region: 'us-east-1' }),
+      } as any;
+      sandbox.mounts.add({ '/data': filesystem });
+      sandbox.mounts.set('/data', { state: 'error', error: 'transient mount failure' });
+
+      (sandbox as any).handleSandboxTimeout();
+
+      expect(sandbox.mounts.get('/data')).toMatchObject({
+        filesystem,
+        state: 'pending',
+      });
+      expect(sandbox.mounts.get('/data')?.error).toBeUndefined();
+    });
   });
 
   describe('executeCommand retry on dead sandbox', () => {

--- a/workspaces/e2b/src/sandbox/index.ts
+++ b/workspaces/e2b/src/sandbox/index.ts
@@ -1030,10 +1030,12 @@ export class E2BSandbox extends MastraSandbox {
   private handleSandboxTimeout(): void {
     this._sandbox = null;
 
-    // Reset mounted entries to pending so they get re-mounted on restart
+    // Reset retryable entries to pending so they get re-mounted on restart.
+    // A mount error belongs to the dead physical sandbox and must not prevent
+    // the configured filesystem from being attempted in its replacement.
     for (const [path, entry] of this.mounts.entries) {
-      if (entry.state === 'mounted' || entry.state === 'mounting') {
-        this.mounts.set(path, { state: 'pending' });
+      if (entry.state === 'mounted' || entry.state === 'mounting' || entry.state === 'error') {
+        this.mounts.set(path, { state: 'pending', error: undefined });
       }
     }
 


### PR DESCRIPTION
## Description

Reset retryable E2B mount entries in `error` state to `pending` when a dead physical sandbox is replaced. This lets the existing `processPending()` recovery path attempt the configured filesystem in the replacement sandbox instead of carrying the old sandbox's mount error forward indefinitely.

The change intentionally leaves non-retryable states such as `unsupported` and `unavailable` unchanged. It also clears stale error metadata and adds a focused regression test plus a patch changeset.

Verification:

- `pnpm --filter @mastra/e2b exec vitest run src/sandbox/index.test.ts`
- `pnpm --filter @mastra/e2b test:unit`
- `pnpm --filter @mastra/e2b lint`
- `pnpm --filter @mastra/e2b build`
- `pnpm build:core`

## Related issue(s)

Fixes #21866.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an E2B sandbox is replaced, the system now retries failed file mounts. This keeps configured filesystems available after recovery.

## Changes

- Reset retryable mounts in `error` state to `pending` during E2B sandbox replacement.
- Clear stale mount errors before retry.
- Preserve non-retryable states such as `unsupported` and `unavailable`.
- Add regression tests for mount recovery and mount state handling.
- Add a patch changeset for `@mastra/e2b`.

## Verification

- Focused tests
- Unit tests
- Linting
- Package build
- Core build
<!-- end of auto-generated comment: release notes by coderabbit.ai -->