### PR TITLE
fix(core): seal the response when its message id rotates

### DIFF
--- a/.changeset/rare-gifts-decide.md
+++ b/.changeset/rare-gifts-decide.md
@@ -4,7 +4,7 @@
 
 Fixed a reply coming back duplicated after an interrupted turn. When an error-retry processor or the durable loop moved the response message id without sealing the stored response, the streamed message split where the stored one did not, so the second half reappeared under its own id on reload. Rotating a response message id now seals the response it leaves behind, so the two can no longer drift apart.
 
-Durable runs now honour the same error-retry hooks as regular runs: `processAPIError` receives `messageId` and a working `rotateResponseMessageId`, so a processor can close the failed response and answer the retry in a message of its own instead of appending to it.
+Durable runs now honour the same error-retry hooks as regular runs: `processAPIError` receives `messageId` and a working `rotateResponseMessageId`, so a processor can close the failed response and answer the retry in a message of its own instead of appending to it. The same handler was also working on a throwaway copy of the conversation, so anything it added there was dropped: a signal sent from `processAPIError` never reached the retried request. It does now.
 
 ```ts
 const agent = new Agent({

--- a/.changeset/rare-gifts-decide.md
+++ b/.changeset/rare-gifts-decide.md
@@ -2,4 +2,6 @@
 '@mastra/core': patch
 ---
 
-Fixed a reply coming back duplicated after an interrupted turn. When an error-retry processor or the durable loop moved the response message id without sealing the stored response, the streamed message split where the stored one did not, so the second half reappeared under its own id on reload. Rotating a response message id now seals the response it leaves behind.
+Fixed a reply coming back duplicated after an interrupted turn. When an error-retry processor or the durable loop moved the response message id without sealing the stored response, the streamed message split where the stored one did not, so the second half reappeared under its own id on reload. Rotating a response message id now seals the response it leaves behind, so the two can no longer drift apart.
+
+Durable runs gained the same error-retry hooks the regular agent already had: a `processAPIError` processor now receives `messageId` and `rotateResponseMessageId`, works on the run's live message list instead of a throwaway copy, and a rotation survives the retry that follows it. Message ids minted during a durable run also honour a custom `generateId` configured on `Mastra`, which some paths silently ignored.

--- a/.changeset/rare-gifts-decide.md
+++ b/.changeset/rare-gifts-decide.md
@@ -4,4 +4,23 @@
 
 Fixed a reply coming back duplicated after an interrupted turn. When an error-retry processor or the durable loop moved the response message id without sealing the stored response, the streamed message split where the stored one did not, so the second half reappeared under its own id on reload. Rotating a response message id now seals the response it leaves behind, so the two can no longer drift apart.
 
-Durable runs gained the same error-retry hooks the regular agent already had: a `processAPIError` processor now receives `messageId` and `rotateResponseMessageId`, works on the run's live message list instead of a throwaway copy, and a rotation survives the retry that follows it. Message ids minted during a durable run also honour a custom `generateId` configured on `Mastra`, which some paths silently ignored.
+Durable runs now honour the same error-retry hooks as regular runs: `processAPIError` receives `messageId` and a working `rotateResponseMessageId`, so a processor can close the failed response and answer the retry in a message of its own instead of appending to it.
+
+```ts
+const agent = new Agent({
+  name: 'support',
+  model: 'openai/gpt-5-nano',
+  maxProcessorRetries: 1,
+  errorProcessors: [
+    {
+      id: 'retry-in-a-new-message',
+      processAPIError: async ({ rotateResponseMessageId }) => {
+        rotateResponseMessageId?.();
+        return { retry: true };
+      },
+    },
+  ],
+});
+```
+
+Message ids minted during a durable run also honour a custom `generateId` configured on `Mastra`, which some paths silently ignored.

--- a/.changeset/rare-gifts-decide.md
+++ b/.changeset/rare-gifts-decide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a reply coming back duplicated after an interrupted turn. When an error-retry processor or the durable loop moved the response message id without sealing the stored response, the streamed message split where the stored one did not, so the second half reappeared under its own id on reload. Rotating a response message id now seals the response it leaves behind.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-error-processor-rotation.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-error-processor-rotation.test.ts
@@ -6,12 +6,12 @@ import { EventEmitterPubSub } from '../../../events/event-emitter';
 import { Agent } from '../../agent';
 import { createDurableAgent } from '../create-durable-agent';
 
-function makeFailThenAnswerModel() {
+function makeFailThenAnswerModel(failures = 1) {
   let calls = 0;
   return new MockLanguageModelV2({
     doStream: async () => {
       calls++;
-      if (calls === 1) {
+      if (calls <= failures) {
         throw new APICallError({
           message: 'upstream failed',
           url: 'https://model.example.com/v1/messages',
@@ -75,5 +75,33 @@ describe('durable agent API-error retry', () => {
     expect(rotations[0]!.before).toBeTruthy();
     expect(rotations[0]!.after).toBeTruthy();
     expect(rotations[0]!.after).not.toBe(rotations[0]!.before);
+  });
+  it('carries a rotated id into the next retry instead of falling back', async () => {
+    const rotations: Array<{ before: string | undefined; after: string | undefined }> = [];
+    const agent = new Agent({
+      id: 'durable-api-error-rotation-chain',
+      name: 'durable-api-error-rotation-chain',
+      instructions: 'You are helpful.',
+      model: [{ model: makeFailThenAnswerModel(2) as LanguageModelV2, maxRetries: 0 }],
+      maxProcessorRetries: 2,
+      errorProcessors: [
+        {
+          id: 'rotate-on-api-error',
+          processAPIError: async ({ messageId, rotateResponseMessageId }) => {
+            rotations.push({ before: messageId, after: rotateResponseMessageId?.() });
+            return { retry: true };
+          },
+        },
+      ],
+    });
+
+    const durableAgent = createDurableAgent({ agent, pubsub: new EventEmitterPubSub() });
+    const { fullStream, cleanup } = await durableAgent.stream('hello');
+    for await (const _chunk of fullStream) {
+    }
+    await cleanup?.();
+
+    expect(rotations).toHaveLength(2);
+    expect(rotations[1]!.before).toBe(rotations[0]!.after);
   });
 });

--- a/packages/core/src/agent/durable/__tests__/durable-agent-error-processor-rotation.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-error-processor-rotation.test.ts
@@ -1,0 +1,79 @@
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { APICallError } from '@internal/ai-sdk-v5';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../create-durable-agent';
+
+function makeFailThenAnswerModel() {
+  let calls = 0;
+  return new MockLanguageModelV2({
+    doStream: async () => {
+      calls++;
+      if (calls === 1) {
+        throw new APICallError({
+          message: 'upstream failed',
+          url: 'https://model.example.com/v1/messages',
+          requestBodyValues: {},
+          statusCode: 500,
+          isRetryable: false,
+        });
+      }
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'resp-2', modelId: 'mock-model', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'the retried answer' },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      };
+    },
+  });
+}
+
+describe('durable agent API-error retry', () => {
+  it('lets an error processor rotate the response id before the retry', async () => {
+    const rotations: Array<{ before: string | undefined; after: string | undefined }> = [];
+    const agent = new Agent({
+      id: 'durable-api-error-rotation',
+      name: 'durable-api-error-rotation',
+      instructions: 'You are helpful.',
+      model: [{ model: makeFailThenAnswerModel() as LanguageModelV2, maxRetries: 0 }],
+      maxProcessorRetries: 1,
+      errorProcessors: [
+        {
+          id: 'rotate-on-api-error',
+          processAPIError: async ({ messageId, rotateResponseMessageId }) => {
+            rotations.push({ before: messageId, after: rotateResponseMessageId?.() });
+            return { retry: true };
+          },
+        },
+      ],
+    });
+
+    const durableAgent = createDurableAgent({ agent, pubsub: new EventEmitterPubSub() });
+    const { fullStream, cleanup } = await durableAgent.stream('hello');
+
+    const chunks: any[] = [];
+    for await (const chunk of fullStream) {
+      chunks.push(chunk);
+    }
+    await cleanup?.();
+
+    const text = chunks
+      .filter(chunk => chunk.type === 'text-delta')
+      .map(chunk => chunk.payload?.text ?? '')
+      .join('');
+    expect(text).toBe('the retried answer');
+
+    expect(rotations).toHaveLength(1);
+    expect(rotations[0]!.before).toBeTruthy();
+    expect(rotations[0]!.after).toBeTruthy();
+    expect(rotations[0]!.after).not.toBe(rotations[0]!.before);
+  });
+});

--- a/packages/core/src/agent/durable/__tests__/durable-agent-error-processor-rotation.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-error-processor-rotation.test.ts
@@ -6,11 +6,12 @@ import { EventEmitterPubSub } from '../../../events/event-emitter';
 import { Agent } from '../../agent';
 import { createDurableAgent } from '../create-durable-agent';
 
-function makeFailThenAnswerModel(failures = 1) {
+function makeFailThenAnswerModel(failures = 1, recordPrompt?: (prompt: unknown) => void) {
   let calls = 0;
   return new MockLanguageModelV2({
-    doStream: async () => {
+    doStream: async ({ prompt }) => {
       calls++;
+      recordPrompt?.(prompt);
       if (calls <= failures) {
         throw new APICallError({
           message: 'upstream failed',
@@ -102,6 +103,36 @@ describe('durable agent API-error retry', () => {
     await cleanup?.();
 
     expect(rotations).toHaveLength(2);
+    expect(rotations[0]!.after).toBeTruthy();
     expect(rotations[1]!.before).toBe(rotations[0]!.after);
+  });
+  it('lets an error processor put a signal in front of the retried request', async () => {
+    const prompts: unknown[] = [];
+    const agent = new Agent({
+      id: 'durable-api-error-signal',
+      name: 'durable-api-error-signal',
+      instructions: 'You are helpful.',
+      model: [{ model: makeFailThenAnswerModel(1, prompt => prompts.push(prompt)) as LanguageModelV2, maxRetries: 0 }],
+      maxProcessorRetries: 1,
+      errorProcessors: [
+        {
+          id: 'signal-on-api-error',
+          processAPIError: async ({ sendSignal }) => {
+            await sendSignal?.({ type: 'user', contents: 'keep the answer short this time' });
+            return { retry: true };
+          },
+        },
+      ],
+    });
+
+    const durableAgent = createDurableAgent({ agent, pubsub: new EventEmitterPubSub() });
+    const { fullStream, cleanup } = await durableAgent.stream('hello');
+    for await (const _chunk of fullStream) {
+    }
+    await cleanup?.();
+
+    expect(prompts).toHaveLength(2);
+    expect(JSON.stringify(prompts[0])).not.toContain('keep the answer short this time');
+    expect(JSON.stringify(prompts[1])).toContain('keep the answer short this time');
   });
 });

--- a/packages/core/src/agent/durable/utils/index.ts
+++ b/packages/core/src/agent/durable/utils/index.ts
@@ -12,6 +12,8 @@ export {
 
 export { applyToolPayloadTransformToChunk } from './apply-tool-payload-transform';
 
+export { createRunMessageList } from './run-message-list';
+
 export {
   resolveRuntimeDependencies,
   rebuildRunToolsFromMastra,

--- a/packages/core/src/agent/durable/utils/resolve-runtime.ts
+++ b/packages/core/src/agent/durable/utils/resolve-runtime.ts
@@ -14,7 +14,7 @@ import { RequestContext } from '../../../request-context';
 import { getNeedsApprovalFn } from '../../../tools/toolchecks';
 import type { CoreTool, RequireToolApproval, ToolApprovalContext } from '../../../tools/types';
 import type { Workspace } from '../../../workspace';
-import { MessageList } from '../../message-list';
+import type { MessageList } from '../../message-list';
 import { SaveQueueManager } from '../../save-queue';
 import { globalRunRegistry } from '../run-registry';
 import type {
@@ -27,6 +27,7 @@ import type {
   DurableAgenticWorkflowInput,
   RegistryModelListEntry,
 } from '../types';
+import { createRunMessageList } from './run-message-list';
 
 /**
  * Runtime dependencies that need to be resolved at step execution time.
@@ -150,7 +151,8 @@ export async function resolveRuntimeDependencies(options: ResolveRuntimeOptions)
   const existingEntry = globalRunRegistry.get(runId);
   const messageList = existingEntry?.messageList
     ? existingEntry.messageList.deserialize(input.messageListState)
-    : new MessageList({
+    : createRunMessageList({
+        mastra,
         threadId: input.state.threadId,
         resourceId: input.state.resourceId,
       }).deserialize(input.messageListState);

--- a/packages/core/src/agent/durable/utils/run-message-list.ts
+++ b/packages/core/src/agent/durable/utils/run-message-list.ts
@@ -1,0 +1,15 @@
+import type { Mastra } from '../../../mastra';
+import { MessageList } from '../../message-list';
+
+/** The id generator does not survive the serialize/deserialize round-trip a durable run makes on every step. */
+export function createRunMessageList({
+  mastra,
+  threadId,
+  resourceId,
+}: {
+  mastra?: Mastra;
+  threadId?: string;
+  resourceId?: string;
+}): MessageList {
+  return new MessageList({ threadId, resourceId, generateMessageId: mastra?.generateId?.bind(mastra) });
+}

--- a/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
+++ b/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
@@ -7,7 +7,6 @@ import type { AIModelGenerationSpan, ExportedSpan, SpanType } from '../../../obs
 import { RequestContext } from '../../../request-context';
 import { PUBSUB_SYMBOL } from '../../../workflows/constants';
 import { createWorkflow } from '../../../workflows/create';
-import { MessageList } from '../../message-list';
 import { DurableStepIds, DurableAgentDefaults } from '../constants';
 import { globalRunRegistry } from '../run-registry';
 import { emitChunkEvent, emitFinishEvent, emitIterationCompleteEvent } from '../stream-adapter';
@@ -18,6 +17,7 @@ import type {
   DurableLLMStepOutput,
   DurableToolCallOutput,
 } from '../types';
+import { createRunMessageList } from '../utils/run-message-list';
 import { runDurableFinishSideEffects } from './finalize-run';
 import {
   modelConfigSchema,
@@ -416,14 +416,10 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
           try {
             const pendingSignals = registryEntry.drainPendingSignals('pending');
             if (pendingSignals.length > 0) {
-              const drainList = new MessageList();
-              drainList.deserialize(state.messageListState);
-              const nextMessageId = drainList.rotateResponseMessageId(
-                () =>
-                  (mastra as Mastra | undefined)?.generateId?.() ??
-                  globalThis.crypto?.randomUUID?.() ??
-                  `msg_${Date.now()}`,
+              const drainList = createRunMessageList({ mastra: mastra as Mastra | undefined }).deserialize(
+                state.messageListState,
               );
+              const nextMessageId = drainList.rotateResponseMessageId();
               state.messageId = nextMessageId;
 
               for (const pendingSignal of pendingSignals) {
@@ -460,7 +456,7 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
 
           try {
             // Deserialize messageList for the callback's messages snapshot
-            const callbackMessageList = new MessageList();
+            const callbackMessageList = createRunMessageList({ mastra: mastra as Mastra | undefined });
             try {
               callbackMessageList.deserialize(state.messageListState);
             } catch {
@@ -566,14 +562,10 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
         // the next singleIterationWorkflow input via map-to-llm-input.
         if (!isFinal) {
           try {
-            const boundaryList = new MessageList();
-            boundaryList.deserialize(state.messageListState);
-            state.messageId = boundaryList.rotateResponseMessageId(
-              () =>
-                (mastra as Mastra | undefined)?.generateId?.() ??
-                globalThis.crypto?.randomUUID?.() ??
-                `msg_${Date.now()}`,
+            const boundaryList = createRunMessageList({ mastra: mastra as Mastra | undefined }).deserialize(
+              state.messageListState,
             );
+            state.messageId = boundaryList.rotateResponseMessageId();
             state.messageListState = boundaryList.serialize();
           } catch {
             // Keep the id when the state can't be sealed: an un-sealed merge is

--- a/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
+++ b/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
@@ -418,12 +418,12 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
             if (pendingSignals.length > 0) {
               const drainList = new MessageList();
               drainList.deserialize(state.messageListState);
-              drainList.markResponseMessageBoundary();
-
-              const nextMessageId =
-                (mastra as Mastra | undefined)?.generateId?.() ??
-                globalThis.crypto?.randomUUID?.() ??
-                `msg_${Date.now()}`;
+              const nextMessageId = drainList.rotateResponseMessageId(
+                () =>
+                  (mastra as Mastra | undefined)?.generateId?.() ??
+                  globalThis.crypto?.randomUUID?.() ??
+                  `msg_${Date.now()}`,
+              );
               state.messageId = nextMessageId;
 
               for (const pendingSignal of pendingSignals) {
@@ -561,30 +561,23 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
           }
         }
 
-        // Rotate messageId for the next iteration. Each iteration's assistant
-        // response is a distinct message, mirroring the non-durable agentic
-        // loop which calls rotateResponseMessageId() between iterations. The
-        // mutated state.messageId flows into the next singleIterationWorkflow
-        // input via map-to-llm-input.
-        //
-        // We also mark the current MessageList's last assistant message as a
-        // response boundary so MessageMerger won't collapse the next
-        // iteration's assistant content into it. Without this, persisted
-        // memory keeps a single assistant message and the rotated id is never
-        // observable to consumers.
+        // Each iteration's assistant response is a distinct message, mirroring
+        // the non-durable agentic loop. The mutated state.messageId flows into
+        // the next singleIterationWorkflow input via map-to-llm-input.
         if (!isFinal) {
-          const nextMessageId =
-            (mastra as Mastra | undefined)?.generateId?.() ?? globalThis.crypto?.randomUUID?.() ?? `msg_${Date.now()}`;
-          state.messageId = nextMessageId;
-
           try {
             const boundaryList = new MessageList();
             boundaryList.deserialize(state.messageListState);
-            boundaryList.markResponseMessageBoundary();
+            state.messageId = boundaryList.rotateResponseMessageId(
+              () =>
+                (mastra as Mastra | undefined)?.generateId?.() ??
+                globalThis.crypto?.randomUUID?.() ??
+                `msg_${Date.now()}`,
+            );
             state.messageListState = boundaryList.serialize();
           } catch {
-            // Boundary marking is best-effort; if deserialization fails the
-            // next iteration will still run with the un-marked state.
+            // Keep the id when the state can't be sealed: an un-sealed merge is
+            // recoverable, a rotated id without its boundary duplicates on reload.
           }
         }
 

--- a/packages/core/src/agent/durable/workflows/steps/goal.ts
+++ b/packages/core/src/agent/durable/workflows/steps/goal.ts
@@ -487,7 +487,10 @@ export function createDurableGoalStep() {
             }
           : undefined,
         rotateResponseMessageId: () => {
-          currentMessageId = mastra?.generateId?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+          currentMessageId = messageList.rotateResponseMessageId(
+            () => mastra?.generateId?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+            currentMessageId,
+          );
           nextState.messageId = currentMessageId;
           return currentMessageId;
         },

--- a/packages/core/src/agent/durable/workflows/steps/goal.ts
+++ b/packages/core/src/agent/durable/workflows/steps/goal.ts
@@ -22,10 +22,10 @@ import {
   resolveGoalStore,
   writeObjective,
 } from '../../../goal';
-import { MessageList } from '../../../message-list';
 import type { ToolsInput } from '../../../types';
 import { globalRunRegistry } from '../../run-registry';
 import { emitChunkEvent } from '../../stream-adapter';
+import { createRunMessageList } from '../../utils/run-message-list';
 
 function isWorkingMemoryTool(name: string): boolean {
   return name === 'updateWorkingMemory' || name === 'setWorkingMemory' || name === 'update-working-memory';
@@ -341,8 +341,7 @@ export function createDurableGoalStep() {
         }
 
         // Build scorer context.
-        const messageList = new MessageList();
-        messageList.deserialize(state.messageListState);
+        const messageList = createRunMessageList({ mastra }).deserialize(state.messageListState);
 
         const toolCalls = (lastStep?.toolCalls ?? []) as Array<{ toolName?: string; args?: unknown }>;
         const toolResults = (lastStep?.toolResults ?? []) as Array<{ toolName?: string; result?: unknown }>;
@@ -473,8 +472,7 @@ export function createDurableGoalStep() {
       };
 
       // Inject feedback into messageList via signal so the next LLM call sees it.
-      const messageList = new MessageList();
-      messageList.deserialize(nextState.messageListState);
+      const messageList = createRunMessageList({ mastra }).deserialize(nextState.messageListState);
 
       let currentMessageId = nextState.messageId;
       const sendSignal = createProcessorSendSignal({
@@ -487,10 +485,7 @@ export function createDurableGoalStep() {
             }
           : undefined,
         rotateResponseMessageId: () => {
-          currentMessageId = messageList.rotateResponseMessageId(
-            () => mastra?.generateId?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
-            currentMessageId,
-          );
+          currentMessageId = messageList.rotateResponseMessageId(currentMessageId);
           nextState.messageId = currentMessageId;
           return currentMessageId;
         },

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -415,7 +415,10 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                   model: currentModel,
                   messageId: currentMessageId,
                   rotateResponseMessageId: () => {
-                    currentMessageId = messageList.rotateResponseMessageId(() => crypto.randomUUID(), currentMessageId);
+                    currentMessageId = messageList.rotateResponseMessageId(
+                      () => mastra?.generateId?.() ?? crypto.randomUUID(),
+                      currentMessageId,
+                    );
                     return currentMessageId;
                   },
                   tools: currentTools,

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -415,7 +415,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                   model: currentModel,
                   messageId: currentMessageId,
                   rotateResponseMessageId: () => {
-                    currentMessageId = crypto.randomUUID();
+                    currentMessageId = messageList.rotateResponseMessageId(() => crypto.randomUUID(), currentMessageId);
                     return currentMessageId;
                   },
                   tools: currentTools,

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -38,7 +38,6 @@ import type { CoreTool } from '../../../../tools/types';
 import { createMastraProxy, makeCoreTool } from '../../../../utils';
 import { PUBSUB_SYMBOL } from '../../../../workflows/constants';
 import { createStep } from '../../../../workflows/workflow';
-import { MessageList } from '../../../message-list';
 import { TripWire } from '../../../trip-wire';
 import { isSupportedLanguageModel } from '../../../utils';
 import { ensureRemoteAbortListener } from '../../abort-transport';
@@ -308,6 +307,14 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
         typedInput.options?.maxProcessorRetries ??
         (globalRunRegistry.get(runId)?.errorProcessors?.length ? 10 : undefined);
 
+      // A retry must keep the id the error processor rotated to, so this lives
+      // outside both loops.
+      let currentMessageId = messageId;
+      const rotateResponseMessageId = () => {
+        currentMessageId = messageList.rotateResponseMessageId(currentMessageId);
+        return currentMessageId;
+      };
+
       for (let modelIndex = 0; modelIndex < modelList.length; modelIndex++) {
         const modelEntry = modelList[modelIndex]!;
         const maxRetries = modelEntry.maxRetries || 0;
@@ -330,8 +337,6 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 `Unsupported model version: ${(model as any).specificationVersion}. Model must implement doStream.${hint}`,
               );
             }
-
-            let currentMessageId = messageId;
 
             // 5. Prepare tools - cast through unknown as CoreTool and ToolSet are structurally compatible at runtime
             let currentModel = model;
@@ -414,13 +419,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                   threadId: typedInput.state?.threadId,
                   model: currentModel,
                   messageId: currentMessageId,
-                  rotateResponseMessageId: () => {
-                    currentMessageId = messageList.rotateResponseMessageId(
-                      () => mastra?.generateId?.() ?? crypto.randomUUID(),
-                      currentMessageId,
-                    );
-                    return currentMessageId;
-                  },
+                  rotateResponseMessageId,
                   tools: currentTools,
                   toolChoice: currentToolChoice,
                   providerOptions: currentProviderOptions,
@@ -577,7 +576,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               if (isFirstModelRequest && registryEntry?.drainPendingSignals) {
                 const preRunSignals = registryEntry.drainPendingSignals('pre-run');
                 if (preRunSignals.length > 0) {
-                  currentMessageId = mastra?.generateId?.() ?? crypto.randomUUID();
+                  rotateResponseMessageId();
                 }
                 for (const preRunSignal of preRunSignals) {
                   const signalForTranscript = messageList.addSignal(preRunSignal);
@@ -1403,12 +1402,12 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                     agentName: typedInput.agentName ?? typedInput.agentId,
                     processorStates: registryEntryInner.processorStates,
                   });
-                  const currentMessageList = new MessageList();
-                  currentMessageList.deserialize(typedInput.messageListState);
                   const { retry } = await runner.runProcessAPIError({
                     error: lastError,
-                    messages: currentMessageList.get.all.db(),
-                    messageList: currentMessageList,
+                    messages: messageList.get.all.db(),
+                    messageList,
+                    messageId: currentMessageId,
+                    rotateResponseMessageId,
                     stepNumber: (inputData as any).stepIndex ?? 0,
                     steps: (inputData as any).accumulatedSteps ?? [],
                     retryCount: processorRetryCount,
@@ -1812,12 +1811,12 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                   agentName: typedInput.agentName ?? typedInput.agentId,
                   processorStates: registryEntry.processorStates,
                 });
-                const currentMessageList = new MessageList();
-                currentMessageList.deserialize(typedInput.messageListState);
                 const { retry } = await runner.runProcessAPIError({
                   error: lastError,
-                  messages: currentMessageList.get.all.db(),
-                  messageList: currentMessageList,
+                  messages: messageList.get.all.db(),
+                  messageList,
+                  messageId: currentMessageId,
+                  rotateResponseMessageId,
                   stepNumber: (inputData as any).stepIndex ?? 0,
                   steps: (inputData as any).accumulatedSteps ?? [],
                   retryCount: processorRetryCount,

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -307,8 +307,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
         typedInput.options?.maxProcessorRetries ??
         (globalRunRegistry.get(runId)?.errorProcessors?.length ? 10 : undefined);
 
-      // A retry must keep the id the error processor rotated to, so this lives
-      // outside both loops.
+      // Hoisted: a retry must keep the id an error processor rotated to.
       let currentMessageId = messageId;
       const rotateResponseMessageId = () => {
         currentMessageId = messageList.rotateResponseMessageId(currentMessageId);

--- a/packages/core/src/agent/durable/workflows/steps/signal-drain.ts
+++ b/packages/core/src/agent/durable/workflows/steps/signal-drain.ts
@@ -3,10 +3,10 @@ import type { PubSub } from '../../../../events/pubsub';
 import type { Mastra } from '../../../../mastra';
 import { PUBSUB_SYMBOL } from '../../../../workflows/constants';
 import { createStep } from '../../../../workflows/workflow';
-import { MessageList } from '../../../message-list';
 import { DurableStepIds } from '../../constants';
 import { globalRunRegistry } from '../../run-registry';
 import { emitChunkEvent } from '../../stream-adapter';
+import { createRunMessageList } from '../../utils/run-message-list';
 
 const SIGNAL_DRAIN_STEP_ID = `${DurableStepIds.AGENTIC_EXECUTION}-signal-drain`;
 
@@ -40,15 +40,10 @@ export function createDurableSignalDrainStep() {
         const pendingSignals = drainFn('pending');
         if (pendingSignals.length === 0) return execOutput;
 
-        const drainList = new MessageList();
-        drainList.deserialize(execOutput.messageListState);
-        const nextMessageId = drainList.rotateResponseMessageId(
-          () =>
-            (params.mastra as Mastra | undefined)?.generateId?.() ??
-            globalThis.crypto?.randomUUID?.() ??
-            `msg_${Date.now()}`,
-          execOutput.messageId,
+        const drainList = createRunMessageList({ mastra: params.mastra as Mastra | undefined }).deserialize(
+          execOutput.messageListState,
         );
+        const nextMessageId = drainList.rotateResponseMessageId(execOutput.messageId);
 
         const pubsub = (params as any)[PUBSUB_SYMBOL] as PubSub | undefined;
         for (const pendingSignal of pendingSignals) {

--- a/packages/core/src/agent/durable/workflows/steps/signal-drain.ts
+++ b/packages/core/src/agent/durable/workflows/steps/signal-drain.ts
@@ -42,12 +42,13 @@ export function createDurableSignalDrainStep() {
 
         const drainList = new MessageList();
         drainList.deserialize(execOutput.messageListState);
-        drainList.markResponseMessageBoundary(execOutput.messageId);
-
-        const nextMessageId =
-          (params.mastra as Mastra | undefined)?.generateId?.() ??
-          globalThis.crypto?.randomUUID?.() ??
-          `msg_${Date.now()}`;
+        const nextMessageId = drainList.rotateResponseMessageId(
+          () =>
+            (params.mastra as Mastra | undefined)?.generateId?.() ??
+            globalThis.crypto?.randomUUID?.() ??
+            `msg_${Date.now()}`,
+          execOutput.messageId,
+        );
 
         const pubsub = (params as any)[PUBSUB_SYMBOL] as PubSub | undefined;
         for (const pendingSignal of pendingSignals) {

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1393,6 +1393,16 @@ export class MessageList {
     return true;
   }
 
+  /**
+   * Mint the id of the next response message, sealing the current one first.
+   * Merging looks at roles, not ids, and only ever targets the tail: a moved id
+   * whose boundary is missing folds the next response into the previous row.
+   */
+  public rotateResponseMessageId(generateId: () => string, sealMessageId?: string): string {
+    if (!this.markResponseMessageBoundary(sealMessageId)) this.markResponseMessageBoundary();
+    return generateId();
+  }
+
   public markResponseMessageBoundary(messageId?: string): boolean {
     const message = messageId
       ? this.messages.find(message => message.id === messageId)

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1393,11 +1393,7 @@ export class MessageList {
     return true;
   }
 
-  /**
-   * Mint the id of the next response message, sealing the current one first.
-   * Merging looks at roles, not ids, and only ever targets the tail: a moved id
-   * whose boundary is missing folds the next response into the previous row.
-   */
+  /** Sealing is not optional: a moved id whose boundary is missing folds the next response into the previous row. */
   public rotateResponseMessageId(generateId: () => string, sealMessageId?: string): string {
     if (!this.markResponseMessageBoundary(sealMessageId)) this.markResponseMessageBoundary();
     return generateId();

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1394,9 +1394,9 @@ export class MessageList {
   }
 
   /** Sealing is not optional: a moved id whose boundary is missing folds the next response into the previous row. */
-  public rotateResponseMessageId(generateId: () => string, sealMessageId?: string): string {
+  public rotateResponseMessageId(sealMessageId?: string): string {
     if (!this.markResponseMessageBoundary(sealMessageId)) this.markResponseMessageBoundary();
-    return generateId();
+    return this.newMessageId('assistant');
   }
 
   public markResponseMessageBoundary(messageId?: string): boolean {

--- a/packages/core/src/agent/message-list/tests/response-message-rotation.test.ts
+++ b/packages/core/src/agent/message-list/tests/response-message-rotation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { MessageList } from '../message-list';
+import type { MastraDBMessage } from '../state/types';
+
+function assistantMessage(id: string, text: string): MastraDBMessage {
+  return {
+    id,
+    role: 'assistant',
+    createdAt: new Date(),
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text }],
+    },
+  };
+}
+
+describe('MessageList response message rotation', () => {
+  it('Given a rotated response id, When the next response arrives, Then it lands in its own message', () => {
+    const messageList = new MessageList({ threadId: 'thread-1' });
+    messageList.add({ role: 'user', content: 'hi' }, 'input');
+    messageList.add(assistantMessage('response-1', 'first'), 'response');
+
+    const nextMessageId = messageList.rotateResponseMessageId(() => 'response-2', 'response-1');
+    messageList.add(assistantMessage(nextMessageId, 'second'), 'response');
+
+    const assistantMessages = messageList.get.all.db().filter(message => message.role === 'assistant');
+    expect(assistantMessages.map(message => message.id)).toEqual(['response-1', 'response-2']);
+  });
+
+  it('Given a seal target that is not in the list, When the id rotates, Then the tail is sealed anyway', () => {
+    const messageList = new MessageList({ threadId: 'thread-1' });
+    messageList.add({ role: 'user', content: 'hi' }, 'input');
+    messageList.add(assistantMessage('response-1', 'first'), 'response');
+
+    const nextMessageId = messageList.rotateResponseMessageId(() => 'response-2', 'never-persisted');
+    messageList.add(assistantMessage(nextMessageId, 'second'), 'response');
+
+    const assistantMessages = messageList.get.all.db().filter(message => message.role === 'assistant');
+    expect(assistantMessages.map(message => message.id)).toEqual(['response-1', 'response-2']);
+  });
+});

--- a/packages/core/src/agent/message-list/tests/response-message-rotation.test.ts
+++ b/packages/core/src/agent/message-list/tests/response-message-rotation.test.ts
@@ -17,11 +17,14 @@ function assistantMessage(id: string, text: string): MastraDBMessage {
 
 describe('MessageList response message rotation', () => {
   it('Given a rotated response id, When the next response arrives, Then it lands in its own message', () => {
-    const messageList = new MessageList({ threadId: 'thread-1' });
+    const messageList = new MessageList({
+      threadId: 'thread-1',
+      generateMessageId: context => (context?.role === 'assistant' ? 'response-2' : 'user-1'),
+    });
     messageList.add({ role: 'user', content: 'hi' }, 'input');
     messageList.add(assistantMessage('response-1', 'first'), 'response');
 
-    const nextMessageId = messageList.rotateResponseMessageId(() => 'response-2', 'response-1');
+    const nextMessageId = messageList.rotateResponseMessageId('response-1');
     messageList.add(assistantMessage(nextMessageId, 'second'), 'response');
 
     const assistantMessages = messageList.get.all.db().filter(message => message.role === 'assistant');
@@ -29,11 +32,14 @@ describe('MessageList response message rotation', () => {
   });
 
   it('Given a seal target that is not in the list, When the id rotates, Then the tail is sealed anyway', () => {
-    const messageList = new MessageList({ threadId: 'thread-1' });
+    const messageList = new MessageList({
+      threadId: 'thread-1',
+      generateMessageId: context => (context?.role === 'assistant' ? 'response-2' : 'user-1'),
+    });
     messageList.add({ role: 'user', content: 'hi' }, 'input');
     messageList.add(assistantMessage('response-1', 'first'), 'response');
 
-    const nextMessageId = messageList.rotateResponseMessageId(() => 'response-2', 'never-persisted');
+    const nextMessageId = messageList.rotateResponseMessageId('never-persisted');
     messageList.add(assistantMessage(nextMessageId, 'second'), 'response');
 
     const assistantMessages = messageList.get.all.db().filter(message => message.role === 'assistant');

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -85,9 +85,12 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
   let startTimestamp = internalToUse.now?.();
 
   let currentResponseMessageId = rest.experimental_generateMessageId?.() || internalToUse.generateId?.();
-  const rotateResponseMessageId = () => {
-    currentResponseMessageId = internalToUse.generateId?.();
-    return currentResponseMessageId!;
+  const rotateResponseMessageId = (sealMessageId?: string) => {
+    currentResponseMessageId = messageList.rotateResponseMessageId(
+      () => internalToUse.generateId?.() ?? generateId(),
+      sealMessageId ?? currentResponseMessageId,
+    );
+    return currentResponseMessageId;
   };
 
   let modelOutput: MastraModelOutput<OUTPUT> | undefined;

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -86,10 +86,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
 
   let currentResponseMessageId = rest.experimental_generateMessageId?.() || internalToUse.generateId?.();
   const rotateResponseMessageId = (sealMessageId?: string) => {
-    currentResponseMessageId = messageList.rotateResponseMessageId(
-      () => internalToUse.generateId?.() ?? generateId(),
-      sealMessageId ?? currentResponseMessageId,
-    );
+    currentResponseMessageId = messageList.rotateResponseMessageId(sealMessageId ?? currentResponseMessageId);
     return currentResponseMessageId;
   };
 

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -287,7 +287,7 @@ export type LoopRun<Tools extends ToolSet = ToolSet, OUTPUT = undefined> = LoopO
   runId: string;
   startTimestamp: number;
   _internal: StreamInternal;
-  rotateResponseMessageId: () => string;
+  rotateResponseMessageId: (sealMessageId?: string) => string;
   streamState: {
     serialize: () => any;
     deserialize: (state: any) => void;

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
@@ -103,6 +103,10 @@ async function runGoalStep(
       return signal;
     },
     markResponseMessageBoundary: vi.fn(),
+    rotateResponseMessageId: (generateId: () => string, sealMessageId?: string) => {
+      messageList.markResponseMessageBoundary(sealMessageId);
+      return generateId();
+    },
     get: { all: { db: () => opts?.dbMessages ?? [] } },
   };
 

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
@@ -103,10 +103,6 @@ async function runGoalStep(
       return signal;
     },
     markResponseMessageBoundary: vi.fn(),
-    rotateResponseMessageId: (generateId: () => string, sealMessageId?: string) => {
-      messageList.markResponseMessageBoundary(sealMessageId);
-      return generateId();
-    },
     get: { all: { db: () => opts?.dbMessages ?? [] } },
   };
 
@@ -156,6 +152,10 @@ async function runGoalStep(
           : {}),
     },
     messageList,
+    rotateResponseMessageId: (sealMessageId?: string) => {
+      messageList.markResponseMessageBoundary(sealMessageId);
+      return 'response-2';
+    },
     requestContext,
     mastra,
     controller: { enqueue: (c: any) => chunks.push(c) },

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
@@ -1,4 +1,3 @@
-import { generateId } from '@internal/ai-sdk-v5';
 import type { ToolSet } from '@internal/ai-sdk-v5';
 import {
   createGoalScorer,
@@ -101,8 +100,19 @@ function formatJudgeActivityMessage(name: string | undefined, args: unknown): st
 export function createGoalStep<Tools extends ToolSet = ToolSet, OUTPUT = undefined>(
   params: OuterLLMRun<Tools, OUTPUT>,
 ) {
-  const { goal, messageList, requestContext, mastra, controller, runId, _internal, agentId, agentName, outputWriter } =
-    params;
+  const {
+    goal,
+    messageList,
+    requestContext,
+    mastra,
+    controller,
+    runId,
+    _internal,
+    agentId,
+    agentName,
+    outputWriter,
+    rotateResponseMessageId: rotateLoopResponseMessageId,
+  } = params;
 
   return createStep({
     id: 'goalStep',
@@ -482,10 +492,7 @@ export function createGoalStep<Tools extends ToolSet = ToolSet, OUTPUT = undefin
             }
           : undefined,
         rotateResponseMessageId: () => {
-          currentMessageId = messageList.rotateResponseMessageId(
-            () => _internal?.generateId?.() ?? generateId(),
-            currentMessageId,
-          );
+          currentMessageId = rotateLoopResponseMessageId(currentMessageId);
           inputData.messageId = currentMessageId;
           return currentMessageId;
         },

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
@@ -482,7 +482,10 @@ export function createGoalStep<Tools extends ToolSet = ToolSet, OUTPUT = undefin
             }
           : undefined,
         rotateResponseMessageId: () => {
-          currentMessageId = _internal?.generateId?.() ?? generateId();
+          currentMessageId = messageList.rotateResponseMessageId(
+            () => _internal?.generateId?.() ?? generateId(),
+            currentMessageId,
+          );
           inputData.messageId = currentMessageId;
           return currentMessageId;
         },

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -2237,8 +2237,10 @@ describe('createLLMExecutionStep gateway provider tools', () => {
         serialize: vi.fn(),
         deserialize: vi.fn(),
       },
-      rotateResponseMessageId: (sealMessageId?: string) =>
-        messageList.rotateResponseMessageId(() => 'rotated-response-id', sealMessageId),
+      rotateResponseMessageId: (sealMessageId?: string) => {
+        messageList.markResponseMessageBoundary(sealMessageId);
+        return 'rotated-response-id';
+      },
       _internal: {
         generateId: () => 'rotated-response-id',
         threadId: 'thread-123',
@@ -2330,8 +2332,10 @@ describe('createLLMExecutionStep gateway provider tools', () => {
         serialize: vi.fn(),
         deserialize: vi.fn(),
       },
-      rotateResponseMessageId: (sealMessageId?: string) =>
-        messageList.rotateResponseMessageId(() => 'rotated-response-id', sealMessageId),
+      rotateResponseMessageId: (sealMessageId?: string) => {
+        messageList.markResponseMessageBoundary(sealMessageId);
+        return 'rotated-response-id';
+      },
       _internal: {
         generateId: () => 'rotated-response-id',
         threadId: 'thread-123',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -2237,6 +2237,8 @@ describe('createLLMExecutionStep gateway provider tools', () => {
         serialize: vi.fn(),
         deserialize: vi.fn(),
       },
+      rotateResponseMessageId: (sealMessageId?: string) =>
+        messageList.rotateResponseMessageId(() => 'rotated-response-id', sealMessageId),
       _internal: {
         generateId: () => 'rotated-response-id',
         threadId: 'thread-123',
@@ -2328,6 +2330,8 @@ describe('createLLMExecutionStep gateway provider tools', () => {
         serialize: vi.fn(),
         deserialize: vi.fn(),
       },
+      rotateResponseMessageId: (sealMessageId?: string) =>
+        messageList.rotateResponseMessageId(() => 'rotated-response-id', sealMessageId),
       _internal: {
         generateId: () => 'rotated-response-id',
         threadId: 'thread-123',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -2178,7 +2178,17 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     });
   });
 
-  it('syncs outputStream.messageId with the rotated id on the API-error retry path', async () => {
+  it('rotates and seals the failed response on the API-error retry path', async () => {
+    messageList.add(
+      {
+        id: 'msg-0',
+        role: 'assistant',
+        createdAt: new Date(),
+        content: { format: 2, parts: [{ type: 'text', text: 'half a sentence' }] },
+      },
+      'response',
+    );
+
     const doStream = vi.fn(async () => {
       throw new APICallError({
         message: 'upstream failed',
@@ -2246,6 +2256,23 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     // subsequent chunks written through the stream would split across two ids.
     expect(result.stepResult.reason).toBe('retry');
     expect(result.messageId).toBe('rotated-response-id');
+
+    // The rotated id only splits the transcript if the failed response was
+    // sealed; without the boundary the retry merges back under `msg-0`.
+    messageList.add(
+      {
+        id: result.messageId,
+        role: 'assistant',
+        createdAt: new Date(),
+        content: { format: 2, parts: [{ type: 'text', text: 'the retried answer' }] },
+      },
+      'response',
+    );
+    const assistantIds = messageList.get.all
+      .db()
+      .filter(message => message.role === 'assistant')
+      .map(message => message.id);
+    expect(assistantIds).toEqual(['msg-0', 'rotated-response-id']);
   });
 
   it('passes the rotated response message id to processor custom data writers', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1294,7 +1294,10 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           workspace,
         };
         const rotateResponseMessageId = () => {
-          currentMessageId = readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? generateId();
+          currentMessageId = messageList.rotateResponseMessageId(
+            () => readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? generateId(),
+            currentMessageId,
+          );
           currentStep.messageId = currentMessageId;
           return currentMessageId;
         };
@@ -1951,7 +1954,10 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               abortSignal: options?.abortSignal,
               messageId: currentMessageId,
               rotateResponseMessageId: () => {
-                currentMessageId = readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? generateId();
+                currentMessageId = messageList.rotateResponseMessageId(
+                  () => readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? generateId(),
+                  currentMessageId,
+                );
                 // Keep the active output stream in sync so bail/retry paths
                 // below report the rotated id instead of the stale one, and so
                 // any subsequent chunks the stream writes itself use the new id.
@@ -2097,7 +2103,10 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           abortSignal: options?.abortSignal,
           messageId: currentMessageId,
           rotateResponseMessageId: () => {
-            currentMessageId = readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? generateId();
+            currentMessageId = messageList.rotateResponseMessageId(
+              () => readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? generateId(),
+              currentMessageId,
+            );
             // Keep the active output stream in sync so the retry payload and
             // any downstream chunks use the rotated id.
             outputStream.messageId = currentMessageId;

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1,7 +1,7 @@
 import { ReadableStream } from 'node:stream/web';
 import { isAbortError } from '@ai-sdk/provider-utils-v5';
 import type { LanguageModelV2Usage } from '@ai-sdk/provider-v5';
-import { APICallError, generateId } from '@internal/ai-sdk-v5';
+import { APICallError } from '@internal/ai-sdk-v5';
 import type { CallSettings, StepResult, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
 import type { StructuredOutputOptions } from '../../../agent';
 import type { MessageList } from '../../../agent/message-list';
@@ -1294,10 +1294,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           workspace,
         };
         const rotateResponseMessageId = () => {
-          currentMessageId = messageList.rotateResponseMessageId(
-            () => readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? generateId(),
-            currentMessageId,
-          );
+          currentMessageId = rotateLoopResponseMessageId(currentMessageId);
           currentStep.messageId = currentMessageId;
           return currentMessageId;
         };
@@ -1954,10 +1951,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               abortSignal: options?.abortSignal,
               messageId: currentMessageId,
               rotateResponseMessageId: () => {
-                currentMessageId = messageList.rotateResponseMessageId(
-                  () => readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? generateId(),
-                  currentMessageId,
-                );
+                currentMessageId = rotateLoopResponseMessageId(currentMessageId);
                 // Keep the active output stream in sync so bail/retry paths
                 // below report the rotated id instead of the stale one, and so
                 // any subsequent chunks the stream writes itself use the new id.
@@ -2103,10 +2097,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           abortSignal: options?.abortSignal,
           messageId: currentMessageId,
           rotateResponseMessageId: () => {
-            currentMessageId = messageList.rotateResponseMessageId(
-              () => readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? generateId(),
-              currentMessageId,
-            );
+            currentMessageId = rotateLoopResponseMessageId(currentMessageId);
             // Keep the active output stream in sync so the retry payload and
             // any downstream chunks use the rotated id.
             outputStream.messageId = currentMessageId;

--- a/packages/core/src/loop/workflows/agentic-execution/signal-drain-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/signal-drain-step.ts
@@ -28,8 +28,7 @@ export function createSignalDrainStep<Tools extends ToolSet = ToolSet, OUTPUT = 
         return typedInput;
       }
 
-      messageList.markResponseMessageBoundary(typedInput.stepResult?.messageId ?? typedInput.messageId);
-      const nextMessageId = rotateResponseMessageId();
+      const nextMessageId = rotateResponseMessageId(typedInput.stepResult?.messageId ?? typedInput.messageId);
       for (const pendingSignal of pendingSignals) {
         const signalForTranscript = messageList.addSignal(pendingSignal);
         controller.enqueue(signalForTranscript.toDataPart() as unknown as ChunkType<OUTPUT>);

--- a/packages/core/src/loop/workflows/agentic-loop/index.ts
+++ b/packages/core/src/loop/workflows/agentic-loop/index.ts
@@ -109,9 +109,9 @@ export function createAgenticLoopWorkflow<Tools extends ToolSet = ToolSet, OUTPU
       // fresh response message for the continuation. See issue #19445.
       if (isResumeContinuationPending) {
         isResumeContinuationPending = false;
-        messageList.markResponseMessageBoundary(typedInputData.stepResult?.messageId ?? typedInputData.messageId);
-
-        const nextMessageId = rest.rotateResponseMessageId();
+        const nextMessageId = rest.rotateResponseMessageId(
+          typedInputData.stepResult?.messageId ?? typedInputData.messageId,
+        );
         typedInputData.messageId = nextMessageId;
         if (typedInputData.stepResult) {
           typedInputData.stepResult.messageId = nextMessageId;
@@ -121,9 +121,9 @@ export function createAgenticLoopWorkflow<Tools extends ToolSet = ToolSet, OUTPU
 
       const pendingSignals = readScoped(scopeCtx, DRAIN_PENDING_SIGNALS_KEY, 'drainPendingSignals')?.(runId) ?? [];
       if (pendingSignals.length > 0) {
-        messageList.markResponseMessageBoundary(typedInputData.stepResult?.messageId ?? typedInputData.messageId);
-
-        const nextMessageId = rest.rotateResponseMessageId();
+        const nextMessageId = rest.rotateResponseMessageId(
+          typedInputData.stepResult?.messageId ?? typedInputData.messageId,
+        );
         typedInputData.messageId = nextMessageId;
         for (const pendingSignal of pendingSignals) {
           const signalForTranscript = messageList.addSignal(pendingSignal);

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -407,12 +407,7 @@ export class ProcessorRunner {
     };
 
     const stateId = processor.stateId ?? processor.id;
-    const beforeAddStateSignal = rotateResponseMessageId
-      ? () => {
-          messageList.markResponseMessageBoundary();
-          rotateResponseMessageId();
-        }
-      : undefined;
+    const beforeAddStateSignal = rotateResponseMessageId;
     const trackingById = getStateSignalsMetadata(thread.metadata);
     const tracking = trackingById[stateId];
     const { activeStateSignals, contextWindow, lastSnapshot, deltasSinceSnapshot } = await resolveStateSignalHistory({
@@ -1576,12 +1571,7 @@ export class ProcessorRunner {
               memoryConfig: memoryContext?.memoryConfig,
               messageList,
               defaultId: processor.stateId ?? processor.id,
-              beforeAddSignal: rotateResponseMessageId
-                ? () => {
-                    messageList.markResponseMessageBoundary();
-                    rotateResponseMessageId();
-                  }
-                : undefined,
+              beforeAddSignal: rotateResponseMessageId,
               writeSignal: signal => writer?.custom(signal.toDataPart()),
             });
             return result.skipped ? result : result.signal;

--- a/packages/core/src/processors/send-signal.ts
+++ b/packages/core/src/processors/send-signal.ts
@@ -10,8 +10,8 @@ export function createProcessorSendSignal(args: {
 }): (signalInput: AgentSignalInput) => Promise<CreatedAgentSignal> {
   return async signalInput => {
     const signal = createSignal(signalInput);
-    args.messageList.markResponseMessageBoundary();
-    args.rotateResponseMessageId?.();
+    if (args.rotateResponseMessageId) args.rotateResponseMessageId();
+    else args.messageList.markResponseMessageBoundary();
     const signalForTranscript = args.messageList.addSignal(signal);
     await args.writer?.custom(signalForTranscript.toDataPart());
     return signalForTranscript;

--- a/packages/core/src/processors/send-signal.ts
+++ b/packages/core/src/processors/send-signal.ts
@@ -10,8 +10,8 @@ export function createProcessorSendSignal(args: {
 }): (signalInput: AgentSignalInput) => Promise<CreatedAgentSignal> {
   return async signalInput => {
     const signal = createSignal(signalInput);
-    if (args.rotateResponseMessageId) args.rotateResponseMessageId();
-    else args.messageList.markResponseMessageBoundary();
+    args.messageList.markResponseMessageBoundary();
+    args.rotateResponseMessageId?.();
     const signalForTranscript = args.messageList.addSignal(signal);
     await args.writer?.custom(signalForTranscript.toDataPart());
     return signalForTranscript;

--- a/packages/core/src/workflows/processor-step.test.ts
+++ b/packages/core/src/workflows/processor-step.test.ts
@@ -304,7 +304,6 @@ describe('createStep with Processor', () => {
       await step.execute({ inputData, outputWriter: writer } as any);
 
       expect(processInputStepMock).toHaveBeenCalledWith(expect.objectContaining({ sendSignal: expect.any(Function) }));
-      expect(messageList.markResponseMessageBoundary).toHaveBeenCalledTimes(1);
       expect(messageList.addSignal).toHaveBeenCalledWith(expect.objectContaining({ tagName: 'system-reminder' }));
       expect(rotateResponseMessageId).toHaveBeenCalledTimes(1);
       expect(writer).toHaveBeenCalledWith(expect.objectContaining({ type: 'data-signal', transient: true }), {

--- a/packages/core/src/workflows/processor-step.test.ts
+++ b/packages/core/src/workflows/processor-step.test.ts
@@ -304,6 +304,7 @@ describe('createStep with Processor', () => {
       await step.execute({ inputData, outputWriter: writer } as any);
 
       expect(processInputStepMock).toHaveBeenCalledWith(expect.objectContaining({ sendSignal: expect.any(Function) }));
+      expect(messageList.markResponseMessageBoundary).toHaveBeenCalledTimes(1);
       expect(messageList.addSignal).toHaveBeenCalledWith(expect.objectContaining({ tagName: 'system-reminder' }));
       expect(rotateResponseMessageId).toHaveBeenCalledTimes(1);
       expect(writer).toHaveBeenCalledWith(expect.objectContaining({ type: 'data-signal', transient: true }), {


### PR DESCRIPTION
TLDR: an answer that gets retried after a provider error comes back as its own message, instead of being folded into the failed one when the thread reloads.

---

You ask something, the provider errors mid-answer, an error processor retries. On screen you see the failed attempt, then a fresh answer under it. Reload the thread and the two are one message, because the id moved but the stored response was never closed. Merging goes by role, not by id, so storage kept appending while the live stream had already split.

Rotating a response message id now closes the response it leaves behind. `MessageList.rotateResponseMessageId()` does both, and every rotator goes through it, including the one handed to error processors.

### What changes

| a run moves to a new response message id | before | after |
| --- | --- | --- |
| an error processor retries after an API error | the retry lands inside the failed answer on reload | its own message, stream and storage agree |
| the same, on a durable agent | the processor gets no `messageId` and `rotateResponseMessageId` is `undefined` | both arrive, and the rotation lands on the run's own message list |
| a second retry follows that rotation | falls back to the id from before the rotation | keeps the rotated id |
| that processor calls `sendSignal` | the signal goes to a throwaway copy, the retried request never sees it | the retried prompt carries it |
| a durable run under `new Mastra({ generateId })` | ids come from `crypto.randomUUID()` | ids come from the configured generator |
| the durable state cannot be deserialized | rotates anyway, boundary lost | keeps the id, next answer merges |

### Judgment call

Rows one to five are the bug. Row six is mine: on a state we cannot read, I stopped rotating. A merge nobody asked for is annoying and recoverable, a rotated id with no boundary duplicates the answer on every reload, so I take the merge.

The other choice is where the pairing lives. I could have fixed the three unpaired call sites. Instead the mint does both, so the next person who reaches for a new response id cannot forget the seal.

I left `createProcessorSendSignal` sealing on its own even though its rotator now seals too. The factory is public and takes a caller-supplied rotator, so dropping its seal would quietly change what an out-of-tree rotator has to do. Redundant, not contradictory.

### Gain

Two `MessageList` deserializations disappear per durable API error: the handler now reads the run's live list instead of rebuilding a throwaway copy from the serialized state. That copy is also what made the fourth row possible.

### Side effects to check

An error processor on a durable run now works on the run's real conversation. Adding a signal is the point, but the same handle lets it drop or edit messages for real where those edits used to die with the copy. This is what the streaming path has always done, so the two now behave the same way.

Sealing by id falls back to the last assistant message when the id no longer resolves. That fallback is what the resume and signal-drain paths hit when a step result carries a stale id.

### Tested

Two `MessageList` tests, three durable tests (an error processor rotates and the retry answers under the new id, a second failure whose `messageId` is the id the first rotation returned, and a signal sent from the handler showing up in the retried prompt), and the existing loop retry test now asserts the retried answer does not merge back.

The three durable tests all fail against main's own copy of the durable step and pass against this branch, so they pin the fix rather than the wiring. The `MessageList` tests fail if the seal is dropped from the rotate method.

Locally: 295 files across `src/processors`, `src/loop`, message-list, durable and `processor-step`. 3605 tests pass, none fail, tsc clean.

Not covered: the branch where the durable state cannot be deserialized. Reaching it means corrupting the serialized state mid-run, which no honest test can stage, so it stays read-only in the diff.

```
tests          +226   -1    ← 69% of the additions
source          +99  -95    ← net +4
  durable       +62  -63
  loop          +29  -20
  runner          +2  -12
  message-list    +6    0    ← the shared rotate and seal method
changeset       +26    0    ← carries the API example
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a request fails and tries again, the system now keeps each answer separate instead of mixing them together. It also keeps messages and signals during durable retries so the next attempt has the correct context.

## Summary

- Added `MessageList.rotateResponseMessageId()` to seal the replaced response and create a new response ID.
- Updated loop, processor, and durable workflow paths to use centralized response rotation.
- Preserved response IDs and configured ID generators across durable retries and serialization.
- Preserved the current ID when durable state cannot be deserialized.
- Added fallback sealing for stale message IDs by sealing the latest assistant message.
- Ensured signals from durable error processors reach retried prompts.
- Added tests for response separation, retry chains, stale seal targets, ID preservation, and signal propagation.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->