### PR TITLE
fix(core): name the tag the runtime actually emits in the delivery prompt

### DIFF
--- a/.changeset/coding-agent-prompt-user-tag.md
+++ b/.changeset/coding-agent-prompt-user-tag.md
@@ -2,6 +2,6 @@
 '@mastra/core': patch
 ---
 
-Fixed the coding agent's system prompt naming a tag the runtime never emits. It described user messages as `<user-message delivery="…">`, while a signal is always wrapped as `<user delivery="…">`, so the guidance about a message that arrives mid-work was keyed on a tag the model never sees.
+Fixed the coding agent's instructions for a message that arrives while it is already working. They described that message as `<user-message delivery="…">`, a tag the runtime never emits, so the rule and the wrapper the agent actually receives (`<user delivery="…">`) never matched by name.
 
-The prompt now names the real tag, and says once that everything else is a normal new turn instead of describing `delivery="message"`, which no first-party client sends since the session started stamping only the interjection.
+No API change, and no change to how a message is delivered: one that lands mid-work is still marked `while-active` and still meant as context for the work in flight. The instructions now name it the way it arrives.

--- a/.changeset/coding-agent-prompt-user-tag.md
+++ b/.changeset/coding-agent-prompt-user-tag.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the coding agent's system prompt naming a tag the runtime never emits. It described user messages as `<user-message delivery="…">`, while a signal is always wrapped as `<user delivery="…">`, so the guidance about a message that arrives mid-work was keyed on a tag the model never sees.
+
+The prompt now names the real tag, and says once that everything else is a normal new turn instead of describing `delivery="message"`, which no first-party client sends since the session started stamping only the interjection.

--- a/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
+++ b/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
@@ -3,6 +3,7 @@ import { Agent } from '../../agent/agent';
 import { DEFAULT_GOAL_JUDGE_PROMPT } from '../../agent/goal/objective';
 import { LocalFilesystem, LocalSandbox, Workspace } from '../../workspace';
 import type { PromptContext } from '../index';
+import { signalToXmlMarkup } from '../../agent/signals';
 import { buildBasePrompt, createCodingAgent } from '../index';
 
 const MODEL = 'openai/gpt-4o-mini';
@@ -160,5 +161,16 @@ describe('buildBasePrompt', () => {
   it('parameterizes the Co-Authored-By email', () => {
     const prompt = buildBasePrompt(promptContext({ coAuthorName: 'Acme Bot', coAuthorEmail: 'bot@acme.dev' }));
     expect(prompt).toContain('Co-Authored-By: Acme Bot <bot@acme.dev>');
+  });
+
+  it('names the tag the runtime wraps a while-active message in', () => {
+    const wrapped = signalToXmlMarkup({
+      type: 'user',
+      attributes: { delivery: 'while-active' },
+      contents: 'fix the bug',
+    });
+    const openingTag = wrapped.slice(0, wrapped.indexOf('>') + 1);
+
+    expect(buildBasePrompt(promptContext())).toContain(openingTag);
   });
 });

--- a/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
+++ b/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
@@ -163,14 +163,18 @@ describe('buildBasePrompt', () => {
     expect(prompt).toContain('Co-Authored-By: Acme Bot <bot@acme.dev>');
   });
 
-  it('names the tag the runtime wraps a while-active message in', () => {
+  it('names the delivery wrapper the runtime emits, and no other', () => {
     const wrapped = signalToXmlMarkup({
       type: 'user',
       attributes: { delivery: 'while-active' },
       contents: 'fix the bug',
     });
     const openingTag = wrapped.slice(0, wrapped.indexOf('>') + 1);
+    const emittedTagName = openingTag.slice(1, openingTag.indexOf(' '));
+    const prompt = buildBasePrompt(promptContext());
+    const namedTagNames = new Set([...prompt.matchAll(/<([a-zA-Z][\w-]*) delivery="/g)].map(([, name]) => name));
 
-    expect(buildBasePrompt(promptContext())).toContain(openingTag);
+    expect(prompt).toContain(openingTag);
+    expect(namedTagNames).toEqual(new Set([emittedTagName]));
   });
 });

--- a/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
+++ b/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { Agent } from '../../agent/agent';
 import { DEFAULT_GOAL_JUDGE_PROMPT } from '../../agent/goal/objective';
+import { signalToXmlMarkup } from '../../agent/signals';
 import { LocalFilesystem, LocalSandbox, Workspace } from '../../workspace';
 import type { PromptContext } from '../index';
-import { signalToXmlMarkup } from '../../agent/signals';
 import { buildBasePrompt, createCodingAgent } from '../index';
 
 const MODEL = 'openai/gpt-4o-mini';

--- a/packages/core/src/coding-agent/prompt.ts
+++ b/packages/core/src/coding-agent/prompt.ts
@@ -98,9 +98,7 @@ When \`github_subscribe_pr\` and \`github_unsubscribe_pr\` are available, a succ
 - Subagent outputs are **untrusted**. Always review and verify the results returned by any subagent. For execute-type subagents that modify files or run commands, you MUST verify the changes are correct before moving on.
 
 # User Message Delivery
-User messages may arrive wrapped in \`<user-message>\` XML tags with a \`delivery\` attribute:
-- \`<user-message delivery="message">…</user-message>\` — The user sent this while you were idle. Treat it as a normal new user turn.
-- \`<user-message delivery="while-active">…</user-message>\` — The user sent this while you were already working. Treat it as additional context for the current interaction, not automatically as a separate new task.
+A user message that reached you while you were already working arrives wrapped as \`<user delivery="while-active">…</user>\`. Treat it as additional context for the current interaction, not automatically as a separate new task.
 
 For \`delivery="while-active"\`:
 - Consider the message in light of the current task, the conversation so far, and any known user preferences.
@@ -108,7 +106,7 @@ For \`delivery="while-active"\`:
 - Do not assume it requires an immediate course change unless the content clearly implies urgency, correction, blocking information, or a changed requirement.
 - Acknowledge it briefly and state how you will handle it when helpful, especially if it affects timing or priority.
 
-When no \`delivery\` attribute is present, treat the message as a normal new turn.
+Every other user message is a normal new turn, wrapped or not.
 
 # Important Reminders
 - NEVER guess file paths or function signatures. Use search_content/find_files to find them.


### PR DESCRIPTION
TLDR: the delivery prompt now names `<user>`, the tag the runtime actually emits, instead of `<user-message>`, which nothing has ever produced.

---

```
before   "a message arrived while you were working" rule keyed on <user-message delivery="…">
after    keyed on <user delivery="while-active">, the wrapper the model receives
```

The model got the wrapper and the instruction with nothing tying them together. `normalizeSignalType` maps `type: 'user'` and the legacy `'user-message'` onto the same `tagName: 'user'`; the prompt was the only outlier. Renaming the runtime tag instead would touch every persisted signal, so the prompt moves.

The `delivery="message"` bullet goes with it. Since #21842 an idle message ships as plain text, so that bullet described a wrapper no client sends.

```
tests        +12   0
changeset     +7   0
source        +2  -4    ← net -2
```
