### PR TITLE
feat(factory): show Slack messages and session owners as people, not ids

### DIFF
--- a/.changeset/slack-clean-titles-and-owners.md
+++ b/.changeset/slack-clean-titles-and-owners.md
@@ -1,0 +1,22 @@
+---
+'@mastra/factory': patch
+---
+
+Slack-born work items are now titled with what was said. A message that starts by mentioning the bot used to become a card named `@U0BMHEJ7RLY your turn to work on the…`; it now reads `your turn to work on the tasks`, on a single line.
+
+Slack messages in the chat transcript read as messages too. The thread history the agent was given used to be dumped into the bubble as `[Thread context — messages…]` followed by `[Ada Lovelace (<@U0B9NEZ90KH>)] (msg:1787155628.734549): …` lines; it now collapses into a `2 earlier messages` row that expands into named, timestamped messages, and the bubble keeps only what was said — with the bot addressed by name instead of `@U0BMHEJ7RLY`.
+
+Sessions listed for a project also carry their owner's display profile, so a workspace sidebar can attribute a session to a person instead of to a `user_01KN527V…` id. Resolution goes through the auth provider (`IUserProvider`); providers that cannot resolve users by id simply leave the owner unnamed.
+
+```jsonc
+// GET /web/github/projects/:id/sessions
+{
+  "sessions": [
+    {
+      "sessionId": "…",
+      "userId": "user_01KN527V…",
+      "owner": { "id": "user_01KN527V…", "name": "Ada Lovelace", "avatarUrl": "https://…" },
+    },
+  ],
+}
+```

--- a/.changeset/slack-message-bot-identity.md
+++ b/.changeset/slack-message-bot-identity.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': patch
+---
+
+Inbound channel messages now carry the bot's own identity next to the author's, so a client can name the id the message text addresses instead of printing `<@U0BMHEJ7RLY>`.
+
+```ts
+message.content.providerMetadata.mastra.channels.slack;
+// {
+//   messageId: '1787155628.734549',
+//   author: { userId: 'U0B9NEZ90KH', userName: 'ada', fullName: 'Ada Lovelace' },
+//   bot: { userId: 'U0BMHEJ7RLY', userName: 'Mastra Code' },   // new
+// }
+```

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ChannelMessage.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ChannelMessage.tsx
@@ -1,0 +1,146 @@
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { Slack } from 'lucide-react';
+import { useState } from 'react';
+
+import type { MessageEntry } from '../services/transcript';
+import { messageClock } from './MessageMeta';
+import { ROW_RAIL, ROW_TRIGGER, TranscriptRow } from './TranscriptRow';
+
+import { parseChannelMessage } from './channel-message';
+import type { ChannelContextMessage, MentionNames } from './channel-message';
+
+export type { ChannelContextMessage } from './channel-message';
+
+const CHANNEL_PLATFORM_LABEL: Record<string, string> = {
+  slack: 'Slack',
+};
+
+/** Author and bot facts `agent-channels` stamps on `providerMetadata.mastra.channels.<platform>`. */
+export interface ChannelOrigin {
+  platform: string;
+  authorName?: string;
+  bot?: { userId: string; userName?: string };
+}
+
+export function channelOrigin(entry: MessageEntry): ChannelOrigin | undefined {
+  const mastra = entry.message.content.providerMetadata?.mastra;
+  const channels = isRecord(mastra) ? mastra.channels : undefined;
+  if (!isRecord(channels)) return undefined;
+  const platform = Object.keys(channels)[0];
+  if (!platform) return undefined;
+  const info = channels[platform];
+  const author = isRecord(info) && isRecord(info.author) ? info.author : undefined;
+  const bot = isRecord(info) && isRecord(info.bot) ? info.bot : undefined;
+  const authorName =
+    typeof author?.fullName === 'string'
+      ? author.fullName
+      : typeof author?.userName === 'string'
+        ? author.userName
+        : undefined;
+  return {
+    platform,
+    authorName,
+    ...(typeof bot?.userId === 'string'
+      ? { bot: { userId: bot.userId, ...(typeof bot.userName === 'string' ? { userName: bot.userName } : {}) } }
+      : {}),
+  };
+}
+
+type MessageParts = MessageEntry['message']['content']['parts'];
+
+/** The thread history lifted out of the text part that carried it, leaving only what was said. */
+export function channelMessageView(
+  parts: MessageParts,
+  origin: ChannelOrigin,
+): { platform: string; context: ChannelContextMessage[]; parts: MessageParts } | undefined {
+  const index = parts.findIndex(part => part.type === 'text');
+  const source = parts[index];
+  if (!source || source.type !== 'text') return undefined;
+
+  const { context, body } = parseChannelMessage(source.text, mentionNames(origin));
+  const rewritten = parts.map((part, at) => (at === index ? { ...part, text: body } : part));
+  return {
+    platform: origin.platform,
+    context,
+    parts: rewritten.filter(part => part.type !== 'text' || part.text.trim().length > 0),
+  };
+}
+
+/** Names the transcript can put to the platform ids a message mentions. */
+function mentionNames(origin: ChannelOrigin): MentionNames {
+  const names = new Map<string, string>();
+  if (origin.bot?.userName) names.set(origin.bot.userId, origin.bot.userName);
+  return names;
+}
+
+export function ChannelOriginBadge({ origin }: { origin: ChannelOrigin }) {
+  const label = platformLabel(origin.platform);
+  return (
+    <div className="text-ui-xs text-icon3 mt-1 flex items-center gap-1" aria-label={`Sent from ${label}`}>
+      <PlatformIcon platform={origin.platform} />
+      <span>
+        via {label}
+        {origin.authorName ? ` · ${origin.authorName}` : ''}
+      </span>
+    </div>
+  );
+}
+
+/** The thread the agent was pulled into, as messages rather than as the block the model reads. */
+export function ChannelThreadContext({ platform, messages }: { platform: string; messages: ChannelContextMessage[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const label = `${messages.length} earlier message${messages.length === 1 ? '' : 's'}`;
+
+  return (
+    <Collapsible
+      open={expanded}
+      onOpenChange={setExpanded}
+      className="max-w-full min-w-0"
+      role="group"
+      aria-label={`${platformLabel(platform)} thread context`}
+    >
+      <CollapsibleTrigger className={ROW_TRIGGER}>
+        <TranscriptRow icon={<PlatformIcon platform={platform} />} label={label} expanded={expanded} />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="max-w-full min-w-0">
+        <div className={ROW_RAIL}>
+          {messages.map(message => (
+            <div key={message.id} className="mb-2 last:mb-0">
+              <div className="flex items-baseline gap-1.5">
+                <Txt as="span" variant="ui-sm" className="text-icon5">
+                  {message.author}
+                </Txt>
+                {message.isBot && (
+                  <Txt as="span" variant="ui-xs" className="text-icon3">
+                    bot
+                  </Txt>
+                )}
+                {message.at && (
+                  <time className="text-ui-xs text-icon3" dateTime={message.at.toISOString()}>
+                    {messageClock.format(message.at)}
+                  </time>
+                )}
+              </div>
+              <Txt as="p" variant="ui-sm" className="text-icon4 m-0 whitespace-pre-wrap">
+                {message.text}
+              </Txt>
+            </div>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function platformLabel(platform: string): string {
+  return CHANNEL_PLATFORM_LABEL[platform] ?? platform;
+}
+
+function PlatformIcon({ platform }: { platform: string }) {
+  return platform === 'slack' ? <Slack className="size-3" aria-hidden="true" /> : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/MessageMeta.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/MessageMeta.tsx
@@ -3,7 +3,8 @@ import { cn } from '@mastra/playground-ui/utils/cn';
 
 export const MESSAGE_HOVER = 'group/message';
 
-const clock = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' });
+/** One clock across the transcript: message times and quoted channel history read the same. */
+export const messageClock = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' });
 const calendar = new Intl.DateTimeFormat(undefined, { dateStyle: 'full', timeStyle: 'short' });
 
 export function MessageMeta({ text, createdAt, align }: { text: string; createdAt: Date; align: 'start' | 'end' }) {
@@ -19,7 +20,7 @@ export function MessageMeta({ text, createdAt, align }: { text: string; createdA
     >
       <CopyButton content={text} size="icon-xs" variant="ghost" tooltip="Copy message" showToast={false} />
       <time className="text-ui-xs text-icon3" dateTime={time.toISOString()} title={calendar.format(time)}>
-        {clock.format(time)}
+        {messageClock.format(time)}
       </time>
     </div>
   );

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -12,7 +12,7 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { MessageFactory } from '@mastra/react/ui';
 import type { FilePart, MessageRoleRenderers, ReasoningPart, TextPart, ToolInvocationPart } from '@mastra/react/ui';
-import { Bell, CircleDot, ExternalLink, Info, Layers, Slack } from 'lucide-react';
+import { Bell, CircleDot, ExternalLink, Info, Layers } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
@@ -25,6 +25,7 @@ import {
 } from '../../../../hooks/useAgentControllerRunMutations';
 import { AGENT_CONTROLLER_ID } from '../services/constants';
 import { isTerminalInvocationState } from '../services/transcript';
+import { ChannelOriginBadge, ChannelThreadContext, channelMessageView, channelOrigin } from './ChannelMessage';
 import { MESSAGE_HOVER, MessageMeta } from './MessageMeta';
 import { ToolCard } from './tool/ToolCard';
 import { ToolGroup, TOOL_GROUP_MIN } from './tool/ToolGroup';
@@ -646,46 +647,6 @@ export function TranscriptEntries({
   );
 }
 
-const CHANNEL_PLATFORM_LABEL: Record<string, string> = {
-  slack: 'Slack',
-};
-
-/**
- * Channel provenance for a message that arrived via a channel adapter.
- * `agent-channels` stamps `content.providerMetadata.mastra.channels.<platform>`
- * with author facts on inbound messages exactly so UIs can show origin
- * without unpacking the signal envelope.
- */
-export function channelOrigin(entry: MessageEntry): { platform: string; authorName?: string } | undefined {
-  const mastra = entry.message.content.providerMetadata?.mastra;
-  const channels = isRecord(mastra) ? mastra.channels : undefined;
-  if (!isRecord(channels)) return undefined;
-  const platform = Object.keys(channels)[0];
-  if (!platform) return undefined;
-  const info = channels[platform];
-  const author = isRecord(info) && isRecord(info.author) ? info.author : undefined;
-  const authorName =
-    typeof author?.fullName === 'string'
-      ? author.fullName
-      : typeof author?.userName === 'string'
-        ? author.userName
-        : undefined;
-  return { platform, authorName };
-}
-
-export function ChannelOriginBadge({ origin }: { origin: { platform: string; authorName?: string } }) {
-  const label = CHANNEL_PLATFORM_LABEL[origin.platform] ?? origin.platform;
-  return (
-    <div className="text-ui-xs text-icon3 mt-1 flex items-center gap-1" aria-label={`Sent from ${label}`}>
-      {origin.platform === 'slack' && <Slack className="size-3" aria-hidden="true" />}
-      <span>
-        via {label}
-        {origin.authorName ? ` · ${origin.authorName}` : ''}
-      </span>
-    </div>
-  );
-}
-
 function MessageBubble({
   entry,
   suspensions,
@@ -698,19 +659,25 @@ function MessageBubble({
   onRespond: (toolCallId: string, resumeData: string | string[] | PlanResume, promptId: string) => void;
 }) {
   const messageParts = entry.message.content.parts ?? [];
-  const parts = messageParts.filter(part => isRenderablePart(part, suspensions, entry.runtimeTools));
+  const renderableParts = messageParts.filter(part => isRenderablePart(part, suspensions, entry.runtimeTools));
+  const origin = channelOrigin(entry);
+  // The thread history rides inside the message text; read it out so the bubble keeps only what was said.
+  const channel = origin ? channelMessageView(renderableParts, origin) : undefined;
+  const parts = channel?.parts ?? renderableParts;
   const message =
-    parts.length === messageParts.length
+    !channel && parts.length === messageParts.length
       ? entry.message
       : { ...entry.message, content: { ...entry.message.content, parts } };
   const hasRenderablePart = parts.length > 0;
 
   const toolGroups = collectToolGroups(parts, suspensions, entry.runtimeTools);
-  const origin = channelOrigin(entry);
   const prose = messageText(parts);
   const roles: MessageRoleRenderers = {
     User: ({ children }) => (
       <div className={cn(MESSAGE_HOVER, 'my-3 ml-auto flex w-fit max-w-[70%] flex-col items-end')}>
+        {channel && channel.context.length > 0 && (
+          <ChannelThreadContext platform={channel.platform} messages={channel.context} />
+        )}
         <div
           className={cn(
             'text-text1 rounded-xl px-4 py-2 break-words',

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ChannelOriginBadge.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ChannelOriginBadge.msw.test.tsx
@@ -9,7 +9,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import type { MessageEntry } from '../../services/transcript';
-import { channelOrigin, ChannelOriginBadge } from '../Transcript';
+import { channelOrigin, ChannelOriginBadge } from '../ChannelMessage';
 
 function userEntry(providerMetadata?: Record<string, unknown>): MessageEntry {
   return {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ChannelThreadContext.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ChannelThreadContext.msw.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import type { MessageEntry } from '../../services/transcript';
+import { ChannelThreadContext, channelMessageView } from '../ChannelMessage';
+
+const ORIGIN = {
+  platform: 'slack',
+  authorName: 'Ada Lovelace',
+  bot: { userId: 'U0BMHEJ7RLY', userName: 'Mastra Code' },
+};
+
+const SLACK_TEXT = [
+  '[Thread context — messages in this thread before you joined]',
+  '[Ada Lovelace (<@U0B9NEZ90KH>)] (msg:1787155628.734549): once the merges land, remove this',
+  '',
+  '@U0BMHEJ7RLY your turn, buddy',
+].join('\n');
+
+function textParts(text: string): MessageEntry['message']['content']['parts'] {
+  return [{ type: 'text', text }];
+}
+
+describe('channelMessageView', () => {
+  it('given a Slack message carrying thread history, when viewed, then the bubble keeps only what was said', () => {
+    const view = channelMessageView(textParts(SLACK_TEXT), ORIGIN);
+
+    expect(view?.parts).toEqual([{ type: 'text', text: '@Mastra Code your turn, buddy' }]);
+    expect(view?.context).toHaveLength(1);
+  });
+
+  it('drops the text part entirely when the message was nothing but thread history', () => {
+    const view = channelMessageView(textParts(SLACK_TEXT.split('\n').slice(0, 2).join('\n')), ORIGIN);
+
+    expect(view?.parts).toEqual([]);
+  });
+});
+
+describe('ChannelThreadContext', () => {
+  it('given thread history, when collapsed, then it is summarized and no platform ids show', async () => {
+    const view = channelMessageView(textParts(SLACK_TEXT), ORIGIN);
+    render(<ChannelThreadContext platform="slack" messages={view!.context} />);
+
+    expect(screen.getByText('1 earlier message')).toBeInTheDocument();
+    expect(screen.queryByText(/U0B9NEZ90KH|msg:/)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    expect(screen.getByText('once the merges land, remove this')).toBeInTheDocument();
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/components/channel-message.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/channel-message.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseChannelMessage } from './channel-message';
+
+const BOT = new Map([['U0BMHEJ7RLY', 'Mastra Code']]);
+
+const withContext = [
+  '[Thread context — messages in this thread before you joined]',
+  '[Ada Lovelace (<@U0B9NEZ90KH>)] (msg:1787155628.734549): once the merges land, remove this',
+  '[Grace Hopper (<@U0BNLQLFJAY>)] (msg:1787155677.460559): waiting on <@U0B9NEZ90KH>',
+  '',
+  '@U0BMHEJ7RLY your turn, buddy',
+].join('\n');
+
+describe('parseChannelMessage', () => {
+  it('given a message carrying thread history, when parsed, then the body is what was actually said', () => {
+    const view = parseChannelMessage(withContext, BOT);
+
+    expect(view.body).toBe('@Mastra Code your turn, buddy');
+    expect(view.context).toHaveLength(2);
+  });
+
+  it('names the people the history addresses by id', () => {
+    const [first, second] = parseChannelMessage(withContext, BOT).context;
+
+    expect(first).toMatchObject({ author: 'Ada Lovelace', text: 'once the merges land, remove this' });
+    expect(second).toMatchObject({ author: 'Grace Hopper', text: 'waiting on @Ada Lovelace' });
+  });
+
+  it('reads the platform message id as the time it was sent', () => {
+    const [first] = parseChannelMessage(withContext, BOT).context;
+
+    expect(first?.at?.toISOString()).toBe(new Date(1787155628 * 1000).toISOString());
+  });
+
+  it('keeps history messages that span several lines whole', () => {
+    const text = [
+      '[Thread context — messages in this thread before you joined]',
+      '[Ada Lovelace (<@U0B9NEZ90KH>)] (msg:1787155628.734549): first line',
+      '',
+      'still Ada',
+      '[Grace Hopper (<@U0BNLQLFJAY>)] (msg:1787155677.460559): last word',
+      '',
+      'so, what now?',
+    ].join('\n');
+
+    const view = parseChannelMessage(text, BOT);
+
+    expect(view.context.map(message => message.text)).toEqual(['first line\n\nstill Ada', 'last word']);
+    expect(view.body).toBe('so, what now?');
+  });
+
+  it('marks bot history and falls back to the raw id for unknown authors', () => {
+    const text = [
+      '[Thread context — messages in this thread before you joined]',
+      '[<@U0BQQQ1ZZZ>] (msg:1787155628.734549): who am I',
+      '[Deploybot (<@U0BDEPLOY1>) (bot)] (msg:1787155629.734549): shipped',
+      '',
+      'ok',
+    ].join('\n');
+
+    const [unknown, bot] = parseChannelMessage(text, BOT).context;
+
+    expect(unknown).toMatchObject({ author: '@U0BQQQ1ZZZ', isBot: false });
+    expect(bot).toMatchObject({ author: 'Deploybot', isBot: true });
+  });
+
+  it('given a plain channel message, when parsed, then only its mentions are named', () => {
+    const view = parseChannelMessage('hey <@U0BMHEJ7RLY>, can you look?', BOT);
+
+    expect(view).toEqual({ context: [], body: 'hey @Mastra Code, can you look?' });
+  });
+
+  it('leaves ordinary text alone', () => {
+    const view = parseChannelMessage('ping @ada about the U0BMHEJ7RLY rollout', BOT);
+
+    expect(view.body).toBe('ping @ada about the U0BMHEJ7RLY rollout');
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/components/channel-message.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/channel-message.ts
@@ -1,0 +1,125 @@
+/**
+ * A channel message reaches the agent written for the model: the thread history
+ * it missed, inlined as a text block, and people addressed by platform id.
+ *
+ * ```
+ * [Thread context — messages in this thread before you joined]
+ * [Ada Lovelace (<@U0B9NEZ90KH>)] (msg:1787155628.734549): shipping this today
+ *
+ * <@U0BMHEJ7RLY> can you review it?
+ * ```
+ */
+export interface ChannelContextMessage {
+  id: string;
+  author: string;
+  text: string;
+  /** Platform message ids that are epoch timestamps (Slack) — the time it was sent. */
+  at?: Date;
+  isBot: boolean;
+}
+
+export interface ChannelMessageView {
+  context: ChannelContextMessage[];
+  body: string;
+}
+
+const CONTEXT_HEADER = '[Thread context';
+const ENTRY = /^\[(.+?)\] \(msg:([^)]+)\): ([\s\S]*)$/;
+const AUTHOR_MENTION = /\s*\(<@([^>]+)>\)$/;
+/** A history line for someone whose profile the platform did not resolve: `[<@U01>]`. */
+const ANONYMOUS_AUTHOR = /^<@([^>]+)>$/;
+const BOT_SUFFIX = ' (bot)';
+/** `<@U123>` as platforms write it, and `@U123` as adapters leave it when the profile is unknown. */
+const MENTION = /<@([UWB][A-Z0-9]{5,})>|(?<![\w@])@([UWB][A-Z0-9]{5,})\b/g;
+const EPOCH_MESSAGE_ID = /^(\d{9,})\.\d+$/;
+
+/** Platform user id → display name, for every mention we can put a name to. */
+export type MentionNames = ReadonlyMap<string, string>;
+
+export function parseChannelMessage(text: string, names: MentionNames): ChannelMessageView {
+  const lines = text.split('\n');
+  if (!lines[0]?.startsWith(CONTEXT_HEADER)) return { context: [], body: resolveMentions(text, names) };
+
+  const bodyStart = contextEnd(lines);
+  const entries = groupEntries(lines.slice(1, bodyStart));
+  const known = new Map(names);
+  for (const entry of entries) {
+    if (entry.userId && entry.name) known.set(entry.userId, entry.name);
+  }
+
+  return {
+    context: entries.map(entry => ({
+      id: entry.id,
+      author: entry.name || authorFromId(entry.userId, known),
+      text: resolveMentions(entry.text, known),
+      at: sentAt(entry.id),
+      isBot: entry.isBot,
+    })),
+    body: resolveMentions(lines.slice(bodyStart).join('\n').trim(), known),
+  };
+}
+
+/**
+ * Index of the blank line separating the context block from the body. History
+ * entries can themselves span blank lines, so the split is the first blank
+ * line with no further entry after it.
+ */
+function contextEnd(lines: string[]): number {
+  let end = lines.length;
+  for (let index = lines.length - 1; index > 0; index--) {
+    if (lines[index]!.trim()) continue;
+    if (lines.slice(index + 1).some(line => ENTRY.test(line))) break;
+    end = index;
+  }
+  return end;
+}
+
+interface ContextEntry {
+  id: string;
+  name: string;
+  userId?: string;
+  text: string;
+  isBot: boolean;
+}
+
+function groupEntries(lines: string[]): ContextEntry[] {
+  const entries: ContextEntry[] = [];
+  for (const line of lines) {
+    const match = ENTRY.exec(line);
+    if (!match) {
+      const previous = entries.at(-1);
+      if (previous) previous.text += `\n${line}`;
+      continue;
+    }
+    const [, rawPrefix = '', id = '', text = ''] = match;
+    const isBot = rawPrefix.endsWith(BOT_SUFFIX);
+    const prefix = isBot ? rawPrefix.slice(0, -BOT_SUFFIX.length) : rawPrefix;
+    const named = AUTHOR_MENTION.exec(prefix);
+    const anonymous = ANONYMOUS_AUTHOR.exec(prefix);
+    entries.push({
+      id,
+      name: anonymous ? '' : (named ? prefix.slice(0, named.index) : prefix).trim(),
+      userId: named?.[1] ?? anonymous?.[1],
+      text,
+      isBot,
+    });
+  }
+  return entries;
+}
+
+function authorFromId(userId: string | undefined, names: MentionNames): string {
+  if (!userId) return 'Unknown';
+  return names.get(userId) ?? `@${userId}`;
+}
+
+function sentAt(messageId: string): Date | undefined {
+  const seconds = EPOCH_MESSAGE_ID.exec(messageId)?.[1];
+  return seconds ? new Date(Number(seconds) * 1000) : undefined;
+}
+
+function resolveMentions(text: string, names: MentionNames): string {
+  return text.replace(MENTION, (raw, bracketed?: string, bare?: string) => {
+    const name = names.get(bracketed ?? bare ?? '');
+    return name ? `@${name}` : raw;
+  });
+}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -38,11 +38,6 @@ function userSessionStatus({
   return undefined;
 }
 
-/** WorkOS user ids are long and opaque; keep enough to tell owners apart. */
-function truncateOwnerId(userId: string): string {
-  return userId.length > 13 ? `${userId.slice(0, 13)}…` : userId;
-}
-
 export function UserSessionsSection() {
   const { baseUrl } = useApiConfig();
   const { factoryId } = useParams<{ factoryId: string }>();
@@ -137,9 +132,7 @@ export function UserSessionsSection() {
                 key={session.sessionId}
                 name={name}
                 title={getUserSessionTooltip(session)}
-                // No org-member display-name lookup exists in factory-ui yet, so
-                // non-owned sessions show a truncated owner id.
-                owner={viewerUserId && !isOwn(session) ? truncateOwnerId(session.userId) : undefined}
+                owner={viewerUserId && !isOwn(session) ? session.owner?.name : undefined}
                 url={url}
                 active={active}
                 disabled={pending}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsAttribution.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsAttribution.msw.test.tsx
@@ -78,7 +78,13 @@ describe('user session attribution', () => {
     // viewer's own; the sidebar must re-order and attribute it.
     stubSessions(
       [
-        userSession({ id: 'row-other', sessionId: 'sess-other', userId: 'user-owner-1', branch: 'user/alpha' }),
+        userSession({
+          id: 'row-other',
+          sessionId: 'sess-other',
+          userId: 'user-owner-1',
+          owner: { id: 'user-owner-1', name: 'Ada Lovelace' },
+          branch: 'user/alpha',
+        }),
         userSession({ id: 'row-mine', sessionId: 'sess-mine', userId: 'user-viewer-9', branch: 'user/mine' }),
       ],
       'user-viewer-9',
@@ -90,19 +96,32 @@ describe('user session attribution', () => {
     // The non-owned session carries its owner in the accessible name; the
     // viewer's own does not.
     const mine = await screen.findByRole('button', { name: 'mine' });
-    const other = screen.getByRole('button', { name: 'alpha, started by user-owner-1' });
+    const other = screen.getByRole('button', { name: 'alpha, started by Ada Lovelace' });
     expect(mine).toBeInTheDocument();
     expect(other).toBeInTheDocument();
 
     const labels = screen
       .getAllByRole('button')
       .map(button => button.getAttribute('aria-label'))
-      .filter(label => label === 'mine' || label === 'alpha, started by user-owner-1');
-    expect(labels).toEqual(['mine', 'alpha, started by user-owner-1']);
+      .filter(label => label === 'mine' || label === 'alpha, started by Ada Lovelace');
+    expect(labels).toEqual(['mine', 'alpha, started by Ada Lovelace']);
 
-    // The owner is still shown as visible text on the non-owned row only.
-    expect(screen.getByText('user-owner-1')).toBeInTheDocument();
-    expect(screen.queryByText('user-viewer-9')).not.toBeInTheDocument();
+    // The owner reads as a person, never as the raw user id.
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    expect(screen.queryByText(/user-owner-1|user-viewer-9/)).not.toBeInTheDocument();
+  });
+
+  it('leaves a session unattributed when the auth provider cannot name its owner', async () => {
+    stubSessions(
+      [userSession({ id: 'row-other', sessionId: 'sess-other', userId: 'user-owner-1', branch: 'user/alpha' })],
+      'user-viewer-9',
+    );
+
+    const { client } = renderSection();
+    await waitForMutationsIdle(client);
+
+    expect(await screen.findByRole('button', { name: 'alpha' })).toBeInTheDocument();
+    expect(screen.queryByText('user-owner-1')).not.toBeInTheDocument();
   });
 
   it('offers delete only on the viewer-owned session', async () => {

--- a/mastracode/factory-ui/src/ui/domains/workspaces/services/github.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/services/github.ts
@@ -629,12 +629,21 @@ async function postRepositoryGitOp<T>(
   return (await res.json()) as T;
 }
 
+/** The person who started a session, as the auth provider names them. */
+export interface SessionOwner {
+  id: string;
+  name: string;
+  avatarUrl?: string;
+}
+
 export interface FactoryUserSession {
   id: string;
   sessionId: string;
   projectRepositoryId: string;
   orgId: string;
   userId: string;
+  /** Absent when the auth provider cannot resolve users by id. */
+  owner?: SessionOwner;
   visibility: 'org' | 'private';
   title?: string;
   branch: string;

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -348,6 +348,7 @@ export class MastraFactory {
     // One RouteAuth seam per boot, closed over the resolved provider. Every
     // factory route module receives this handle — no service locator.
     const routeAuth = createFactoryRouteAuth(auth);
+    const users = auth && isUserProvider(auth) ? auth : undefined;
 
     // Explicit integrations win. Platform credentials fill only missing GitHub
     // and Linear slots so callers can override either provider independently.
@@ -413,7 +414,7 @@ export class MastraFactory {
       auth: routeAuth,
       audit: auditStorage,
       projects: factoryProjectsStorage,
-      users: auth && isUserProvider(auth) ? auth : undefined,
+      users,
       sinks: integrations,
       agentTenant: requestContext => {
         const user = getFactoryAuthUserFromContext(requestContext);
@@ -770,6 +771,7 @@ export class MastraFactory {
             controllerId: CONTROLLER_ID,
             controller,
             auth: routeAuth,
+            users,
             authStorage,
             audit: auditDomain,
             publicOrigin,

--- a/mastracode/factory/src/integrations/base.ts
+++ b/mastracode/factory/src/integrations/base.ts
@@ -41,6 +41,7 @@ import type { MemorySettingsStorage } from '../storage/domains/memory-settings/b
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import type { UserDirectory } from '../users.js';
 
 /** Factory-owned hooks integrations may invoke. */
 export interface IntegrationHooks {
@@ -69,6 +70,8 @@ export interface IntegrationPostToolContext {
 export interface IntegrationContext {
   /** Host auth seam — integration routes resolve callers through this. */
   auth: RouteAuth;
+  /** Names user ids, when the auth provider can resolve arbitrary users. */
+  users?: UserDirectory;
   /**
    * Sandbox fleet for per-project sandboxes. Always constructed at boot; a
    * fleet built without a machine config reports `enabled: false` and

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -1134,6 +1134,7 @@ export class GithubIntegration implements FactoryIntegration {
       projects: ctx.storage.projects,
       ingestFactoryEvent,
       sessionRetirement: ctx.sessionRetirement,
+      ...(ctx.users ? { users: ctx.users } : {}),
     });
   }
 

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -609,6 +609,7 @@ function buildApp(
     controller?: NonNullable<Parameters<typeof buildGithubRoutes>[0]>['controller'];
     stateSigner?: typeof stateSigner | null;
     sessionRetirement?: SessionRetirementCoordinator;
+    users?: NonNullable<Parameters<typeof buildGithubRoutes>[0]>['users'];
   } = {},
 ) {
   const app = new Hono();
@@ -1478,6 +1479,26 @@ describe('ensure (materialize)', () => {
 });
 
 // ── Phase 4: worktree / commit / push / pr git routes ─────────────────────
+function orgSessionRow() {
+  const now = new Date().toISOString();
+  return {
+    id: 'r1',
+    projectRepositoryId: 'p1',
+    orgId: 'org1',
+    sessionId: 's-org-other',
+    userId: 'u1',
+    visibility: 'org',
+    branch: 'user/session-s-org-other',
+    title: null,
+    baseBranch: 'main',
+    sandboxId: null,
+    sandboxWorkdir: null,
+    materializedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
 function seedMaterializedProject(
   opts: { orgId?: string; userId?: string; setupCommand?: string | null; teardownCommand?: string | null } = {},
 ) {
@@ -1911,6 +1932,34 @@ describe('Factory session routes', () => {
     expect(res.status).toBe(200);
     const listed = (await res.json()).sessions.map((s: { sessionId: string }) => s.sessionId).sort();
     expect(listed).toEqual(['s-legacy-null', 's-org-other', 's-private-mine']);
+  });
+
+  it('names the org member who owns each listed session', async () => {
+    seedMaterializedProject();
+    tables.sessions.push(orgSessionRow());
+
+    const users = {
+      getUser: async (userId: string) =>
+        userId === 'u1' ? { id: 'u1', name: 'Ada Lovelace', avatarUrl: 'https://img/ada.png' } : null,
+    };
+    const res = await buildApp({ workosId: 'u2' }, { users }).request('/web/github/projects/p1/sessions');
+
+    expect((await res.json()).sessions[0].owner).toEqual({
+      id: 'u1',
+      name: 'Ada Lovelace',
+      avatarUrl: 'https://img/ada.png',
+    });
+  });
+
+  it('lists sessions unnamed when the auth provider cannot resolve users', async () => {
+    seedMaterializedProject();
+    tables.sessions.push(orgSessionRow());
+
+    const res = await buildApp({ workosId: 'u2' }).request('/web/github/projects/p1/sessions');
+    const [session] = (await res.json()).sessions;
+
+    expect(session.sessionId).toBe('s-org-other');
+    expect(session.owner).toBeUndefined();
   });
 
   it('derives a branch from a server-generated UUID when no session ID is supplied', async () => {

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -33,6 +33,8 @@ import type {
   SourceControlInstallation,
   SourceControlRepository,
 } from '../../storage/domains/source-control/base.js';
+import { resolveUserProfiles } from '../../users.js';
+import type { UserDirectory, UserProfile } from '../../users.js';
 import { getGithubFeatureDiagnostics, isGithubFeatureEnabled } from './config.js';
 import type { GithubIntegration } from './integration.js';
 import { clearGithubPat, getGithubPat, getGithubPatStatus, setGithubPat } from './pat.js';
@@ -130,6 +132,8 @@ export interface MountGithubRoutesOptions {
   emitAudit?: AuditEmitter['emit'];
   /** Factory projects domain — resolves a project's default triage model. */
   projects?: FactoryProjectsStorage;
+  /** Names the org members who own the sessions a project lists. */
+  users?: UserDirectory;
   sessionRetirement?: import('../../sandbox/session-retirement.js').SessionRetirementCoordinator;
   /** Authoritative Factory rule ingress for normalized, signature-verified GitHub deliveries. */
   ingestFactoryEvent?: (event: ParsedGithubWebhook) => Promise<unknown>;
@@ -359,7 +363,7 @@ async function ingestPolledEvents(
  */
 export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[] {
   const routes: ApiRoute[] = [];
-  const { auth, fleet, storage, github, stateSigner, controller, emitAudit, sessionRetirement } = options;
+  const { auth, fleet, storage, github, stateSigner, controller, emitAudit, sessionRetirement, users } = options;
   const diagnostics = () =>
     getGithubFeatureDiagnostics({ github, auth, appDbConfigured: storage !== undefined, stateSigner, fleet });
 
@@ -961,7 +965,7 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
   );
 
   // ── Sessions / commit / push / PR ────────────────────────────────────────
-  routes.push(...buildProjectGitRoutes({ github, auth, fleet, controller, emitAudit, sessionRetirement }));
+  routes.push(...buildProjectGitRoutes({ github, auth, fleet, controller, emitAudit, sessionRetirement, users }));
 
   return routes;
 }
@@ -1191,6 +1195,18 @@ async function loadOwnedProject(options: {
   return { orgId, userId, project, sandboxRow };
 }
 
+/** Sessions carrying the person who started them, so a list can name its owners. */
+async function withOwners<TSession extends { userId: string }>(
+  sessions: TSession[],
+  users: UserDirectory | undefined,
+): Promise<Array<TSession & { owner?: UserProfile }>> {
+  const profiles = await resolveUserProfiles(users, [...new Set(sessions.map(session => session.userId))]);
+  return sessions.map(session => {
+    const owner = profiles.get(session.userId);
+    return owner ? { ...session, owner } : session;
+  });
+}
+
 function buildProjectGitRoutes({
   github,
   auth,
@@ -1198,6 +1214,7 @@ function buildProjectGitRoutes({
   controller,
   emitAudit,
   sessionRetirement,
+  users,
 }: {
   github: GithubIntegration;
   auth: RouteAuth;
@@ -1205,6 +1222,7 @@ function buildProjectGitRoutes({
   controller?: MountedMastraCode['controller'];
   emitAudit?: AuditEmitter['emit'];
   sessionRetirement?: MountGithubRoutesOptions['sessionRetirement'];
+  users?: UserDirectory;
 }): ApiRoute[] {
   return [
     // ── Create / list Factory sessions ──────────────────────────────────────
@@ -1224,7 +1242,7 @@ function buildProjectGitRoutes({
           projectRepositoryId: project.id,
           viewerUserId: userId,
         });
-        return c.json({ sessions });
+        return c.json({ sessions: await withOwners(sessions, users) });
       },
     }),
     registerApiRoute('/web/github/projects/:id/sessions', {

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -578,6 +578,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         projects: ctx.storage.projects,
         emitAudit: ctx.hooks?.emitAudit,
         ingestFactoryEvent,
+        ...(ctx.users ? { users: ctx.users } : {}),
       }).filter(
         route =>
           route.path !== '/web/github/status' &&

--- a/mastracode/factory/src/integrations/slack/slack.test.ts
+++ b/mastracode/factory/src/integrations/slack/slack.test.ts
@@ -8,6 +8,7 @@ import {
   createHandlers,
   resolveLinkedSender,
   resolveFactoryForLink,
+  workItemTitle,
 } from './slack.js';
 
 /**
@@ -783,6 +784,26 @@ describe('Slack thread work-item creation', () => {
 
     expect(thread.post).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalled();
+  });
+
+  it('the card is titled with what was said, not with the ids the message addressed', async () => {
+    const deps = makeWorkItemDeps();
+    const handlers = createHandlers(deps as any);
+    const message = { ...makeMessage('T-1'), text: '<@U0BMHEJ7RLY> your turn to work\non the tasks' };
+
+    await handlers.onDirectMessage!(makeWorkItemThread(), message, vi.fn(), handlerCtx(deps.mastra));
+
+    expect(deps.upsert.mock.calls[0][0].input.title).toBe('your turn to work on the tasks');
+  });
+});
+
+describe('workItemTitle', () => {
+  it('keeps people the platform named and drops the ones it did not', () => {
+    expect(workItemTitle('ping @Ada about <@U0BQQQ1ZZZ>')).toBe('ping @Ada about');
+  });
+
+  it('caps a long message so the card stays one line', () => {
+    expect(workItemTitle('x'.repeat(120))).toBe(`${'x'.repeat(79)}\u2026`);
   });
 });
 

--- a/mastracode/factory/src/integrations/slack/slack.ts
+++ b/mastracode/factory/src/integrations/slack/slack.ts
@@ -482,6 +482,16 @@ async function gateDispatch(
   return {};
 }
 
+const TITLE_MAX = 80;
+/** Slack ids the adapter could not put a name to (`<@U0B…>`, `@U0B…`) — noise in a human-facing card. */
+const UNNAMED_MENTION = /<@[UWB][A-Z0-9]{5,}>|(?<![\w@])@[UWB][A-Z0-9]{5,}\b/g;
+
+/** The first line of what was said, as a Work-board card reads it. */
+export function workItemTitle(text: string): string {
+  const said = text.replace(UNNAMED_MENTION, ' ').replace(/\s+/g, ' ').trim();
+  return said.length > TITLE_MAX ? `${said.slice(0, TITLE_MAX - 1)}…` : said;
+}
+
 /**
  * Upsert the Work-board card for a dispatched Slack-thread run. Keyed on the
  * thread via `externalSource` — the work-items domain's unique
@@ -519,7 +529,7 @@ export async function upsertThreadWorkItem({
   url?: string;
 }): Promise<void> {
   try {
-    const title = message.text.length > 80 ? `${message.text.slice(0, 79)}…` : message.text;
+    const title = workItemTitle(message.text);
 
     await workItems.upsert({
       orgId: link.orgId ?? '',

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -31,6 +31,7 @@ import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js
 import type { QueueHealthStorage } from '../storage/domains/queue-health/base.js';
 import type { SourceControlStorage } from '../storage/domains/source-control/base.js';
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import type { UserDirectory } from '../users.js';
 import { ConfigRoutes } from './config.js';
 import { invalidateCustomProvidersSnapshots } from './custom-provider-source.js';
 import { buildFsRoutes } from './fs.js';
@@ -53,6 +54,8 @@ export interface FactoryApiRoutesDeps {
   controller: AgentController<MastraCodeState>;
   /** Request-auth seam threaded from the host (no service locator). */
   auth: RouteAuth;
+  /** Names user ids for the surfaces that show who owns a session or acted on a work item. */
+  users?: UserDirectory;
   authStorage: AuthStorage;
   audit: AuditEmitter;
   fsRoot?: string;
@@ -224,7 +227,14 @@ export async function prepareFactoryRuleBinding(
 export function buildIntegrationContext(
   deps: Pick<
     FactoryApiRoutesDeps,
-    'controller' | 'publicOrigin' | 'auth' | 'fleet' | 'factoryStorage' | 'integrationStorage' | 'sourceControlStorage'
+    | 'controller'
+    | 'publicOrigin'
+    | 'auth'
+    | 'users'
+    | 'fleet'
+    | 'factoryStorage'
+    | 'integrationStorage'
+    | 'sourceControlStorage'
   > & {
     stateSigner: StateSigner;
     emitAudit?: AuditEmitter['emit'];
@@ -247,6 +257,7 @@ export function buildIntegrationContext(
 ): IntegrationContext {
   return {
     auth: deps.auth,
+    ...(deps.users ? { users: deps.users } : {}),
     fleet: deps.fleet,
     ...(deps.baseCheckpoints ? { baseCheckpoints: deps.baseCheckpoints } : {}),
     factoryStorage: deps.factoryStorage,

--- a/mastracode/factory/src/storage/domains/audit/domain.ts
+++ b/mastracode/factory/src/storage/domains/audit/domain.ts
@@ -1,10 +1,12 @@
 import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
 import type { RequestContext } from '@mastra/core/request-context';
-import type { ApiRoute, IUserProvider } from '@mastra/core/server';
+import type { ApiRoute } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
 
 import type { RouteAuth } from '../../../routes/route.js';
+import { resolveUserProfiles } from '../../../users.js';
+import type { UserDirectory, UserProfile } from '../../../users.js';
 import type { FactoryProjectsStorage } from '../projects/base.js';
 import type {
   AuditContext,
@@ -49,11 +51,7 @@ interface FactorySessionState {
   projectRepositoryId?: string;
 }
 
-export interface AuditActorProfile {
-  id: string;
-  name: string;
-  avatarUrl?: string;
-}
+export type AuditActorProfile = UserProfile;
 
 /**
  * Reserved metadata key on `AuditEventRow.metadata` that carries the acting
@@ -108,7 +106,7 @@ export interface AuditDomainOptions {
   /** Projects domain handle, used to scope the audit trail route. */
   projects: FactoryProjectsStorage;
   /** Resolve persisted human actor ids to display names and profile images. */
-  users?: Pick<IUserProvider, 'getUser' | 'getUsers'>;
+  users?: UserDirectory;
   /** Best-effort fan-out destinations notified after each recorded event. */
   sinks?: AuditSink[];
   /** Resolve the acting tenant for agent-emitted events from the request context. */
@@ -334,24 +332,8 @@ export class AuditDomain implements AuditEmitter, AuditAgentEmitter {
     const unresolved = humanActorIds.filter(actorId => !profiles[actorId]);
     if (unresolved.length === 0 || !this.#users) return profiles;
 
-    try {
-      const users = this.#users.getUsers
-        ? await this.#users.getUsers(unresolved)
-        : await Promise.all(unresolved.map(actorId => this.#users?.getUser(actorId) ?? null));
-      for (const [index, user] of users.entries()) {
-        if (!user) continue;
-        const name = user.name?.trim() || user.email?.trim() || user.id;
-        const actorId = unresolved[index] ?? user.id;
-        profiles[actorId] = {
-          id: user.id,
-          name,
-          ...(user.avatarUrl ? { avatarUrl: user.avatarUrl } : {}),
-        };
-      }
-    } catch (err) {
-      console.warn('[Audit] Failed to resolve audit actor profiles', {
-        error: err instanceof Error ? err.message : String(err),
-      });
+    for (const [actorId, profile] of await resolveUserProfiles(this.#users, unresolved)) {
+      profiles[actorId] = profile;
     }
     return profiles;
   }

--- a/mastracode/factory/src/users.ts
+++ b/mastracode/factory/src/users.ts
@@ -1,0 +1,42 @@
+import type { IUserProvider } from '@mastra/core/server';
+
+/** Naming a user by id. Optional everywhere: providers that proxy the shared API cannot resolve arbitrary users. */
+export type UserDirectory = Pick<IUserProvider, 'getUser' | 'getUsers'>;
+
+export interface UserProfile {
+  id: string;
+  name: string;
+  avatarUrl?: string;
+}
+
+/** Display profiles keyed by user id; unnamable ids are absent, and an outage degrades to ids. */
+export async function resolveUserProfiles(
+  directory: UserDirectory | undefined,
+  userIds: string[],
+): Promise<Map<string, UserProfile>> {
+  const profiles = new Map<string, UserProfile>();
+  if (!directory || userIds.length === 0) return profiles;
+
+  const users = await lookup(directory, userIds);
+  for (const [index, user] of users.entries()) {
+    if (!user) continue;
+    const id = userIds[index] ?? user.id;
+    profiles.set(id, {
+      id: user.id,
+      name: user.name?.trim() || user.email?.trim() || user.id,
+      ...(user.avatarUrl ? { avatarUrl: user.avatarUrl } : {}),
+    });
+  }
+  return profiles;
+}
+
+async function lookup(directory: UserDirectory, userIds: string[]) {
+  try {
+    return directory.getUsers
+      ? await directory.getUsers(userIds)
+      : await Promise.all(userIds.map(userId => directory.getUser(userId)));
+  } catch (error) {
+    console.warn('[factory] user directory lookup failed', error);
+    return [];
+  }
+}

--- a/packages/core/src/channels/__tests__/agent-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-channels.test.ts
@@ -425,6 +425,42 @@ describe('AgentChannels', () => {
       );
     });
 
+    it('stamps the bot identity so a reader can name the id the message mentions', async () => {
+      const db = new InMemoryDB();
+      const memoryStore = new InMemoryMemory({ db });
+      const mockMastra = {
+        getStorage: () => ({ getStore: () => memoryStore }),
+        getServer: () => null,
+      } as any;
+      await agentChannels.initialize(mockMastra);
+      (agentChannels.adapters.discord as any).botUserId = 'U0BMHEJ7RLY';
+
+      const chatThread = {
+        id: 'channel-1:thread-1',
+        channelId: 'channel-1',
+        isDM: false,
+        adapter: agentChannels.adapters.discord,
+        isSubscribed: vi.fn().mockResolvedValue(true),
+        subscribe: vi.fn().mockResolvedValue(undefined),
+        mentionUser: vi.fn((userId: string) => `<@${userId}>`),
+        messages: (async function* () {})(),
+      } as any;
+      const message = {
+        id: 'message-1',
+        text: '<@U0BMHEJ7RLY> your turn',
+        author: { userId: 'user-1', userName: 'tyler', fullName: 'Tyler Barnes' },
+        attachments: [],
+      } as any;
+
+      await (agentChannels as any).processChatMessage(chatThread, message, mockMastra, new RequestContext());
+
+      const [signal] = mockAgent.sendMessage.mock.calls[0];
+      expect(signal.providerOptions.mastra.channels.discord.bot).toEqual({
+        userId: 'U0BMHEJ7RLY',
+        userName: 'TestBot',
+      });
+    });
+
     it('skips messages with no text and no attachments', async () => {
       const db = new InMemoryDB();
       const memoryStore = new InMemoryMemory({ db });

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -1003,6 +1003,12 @@ export class AgentChannels {
               ...(actorMention !== undefined ? { mention: actorMention } : {}),
               ...(actor.isBot !== undefined ? { isBot: actor.isBot } : {}),
             },
+            // Message text addresses the bot by id (`<@U123>`); a reader needs this to name it.
+            ...(botUserId !== undefined
+              ? {
+                  bot: { userId: botUserId, ...(adapter.userName !== undefined ? { userName: adapter.userName } : {}) },
+                }
+              : {}),
           },
         },
       },


### PR DESCRIPTION
TLDR: Slack messages in the chat read as messages, and a session in the sidebar is attributed to a person instead of to a user id.

---

A Slack thread reaches the agent written for the model: the history it missed inlined as `[Thread context — …]`, people addressed as `<@U0B9NEZ90KH>`, the bot as `@U0BMHEJ7RLY`. The chat printed that verbatim, and the Work-board card took the first 80 characters of it as its title. The sidebar had the same problem one layer down — a session someone else started showed `user_01KN527V…`, because no display name was ever fetched.

The block still reaches the model unchanged; the agent needs that history. What changed is that the UI reads it instead of printing it, and the server names the people it already had ids for.

### What changes

| situation | before | after |
| --- | --- | --- |
| a Slack thread with earlier messages opens in the chat | `[Thread context — …]` then `[Ada Lovelace (<@U0B9NEZ90KH>)] (msg:1787155628.734549): …` inside the bubble | a `1 earlier message` row above the bubble, expanding into named, timestamped messages |
| someone mentions the bot | `@U0BMHEJ7RLY your turn` | `@Mastra Code your turn` |
| that thread opens a Work-board card | `@U0BMHEJ7RLY your turn to wor…`, newlines and all | `your turn to work on the tasks`, one line |
| another member's session in the sidebar | `user_01KN527V…` | `Ada Lovelace` |
| the auth provider cannot resolve users by id | a truncated id | no attribution at all |

### Judgment call

The first three rows are the fix: ugly output, cleaned where each piece is born. The block is model-facing, so the chat fixes it in the UI; the card title is human-facing, so it is fixed at creation, where every future reader gets it.

The last two rows are mine. Owner names resolve through the auth provider at read time — the `IUserProvider` seam `AuditDomain` already uses — instead of being snapshotted into the sessions table. No migration, sessions created before this name their owners too, and a rename shows up on the next load. When the provider cannot name someone I show nothing rather than an id, since an id told the reader nothing they could act on.

`avatarUrl` reaches the client and is not drawn: the smallest DS `Avatar` is 24px, too heavy for that row. Drop it from the payload if you would rather not ship unused data.

### Cost

Listing sessions costs one `getUser` per distinct owner. WorkOS caches org memberships but not users and implements no `getUsers`, so eight sessions from eight owners is eight parallel calls per load. The list has no polling and a 30s `staleTime`, so a load means a mount or an invalidation. If it ever shows up, the cache belongs in `resolveUserProfiles`, not at the call sites.

### On deploy

Nothing migrates. Work items upsert with `reuseMode: 'preserve'`, so cards that already exist keep the title they were born with — only threads dispatched after this get clean ones. I did not backfill.

### Side effects to check

- `channels.<platform>.bot` is new on inbound message metadata in core: additive, but it is wire data clients and storage now see.
- `resolveUserProfiles` swallows a provider failure with a warn and returns no names. The audit trail's actor resolution goes through it now, so its old `[Audit] Failed to resolve…` line is gone.
- A channel message whose text is *only* the history block renders nothing — the bubble drops the empty text part and returns `null`. I could not build one through Slack, since a mention always carries text.

### Not verified

- No after screenshot. I did not run the app; the collapsed row sitting above the right-aligned bubble is covered by tests, not by eye.
- The parser fixtures are written from the block core produces, not captured from a live Slack thread.
- Mention resolution is Slack-id shaped (`U…`, `W…`, `B…`). Discord snowflakes are numeric and stay raw — the transcript only labels Slack today anyway.

```
factory-ui     +295  -54   ← 146 of it the new ChannelMessage.tsx; Transcript −44
tests          +265   -8   ← 38% of the additions
factory        +101  -31   ← users.ts +42, audit domain −18 net
changeset       +36    0
core             +6    0
```
