### PR TITLE
fix(factory): support plan approvals in AgentController chat

### DIFF
--- a/.changeset/calm-steaks-eat.md
+++ b/.changeset/calm-steaks-eat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Added optional plan content fields to PlanResume so hosts can preserve submitted plans in approval history.

--- a/.changeset/calm-steaks-eat.md
+++ b/.changeset/calm-steaks-eat.md
@@ -2,4 +2,14 @@
 '@mastra/client-js': patch
 ---
 
-Added optional plan content fields to PlanResume so hosts can preserve submitted plans in approval history.
+Added optional plan content fields to `PlanResume` so hosts can preserve submitted plans in approval history.
+
+```typescript
+const response: PlanResume = {
+  action: 'rejected',
+  title: 'Add authentication',
+  path: '.artifacts/plans/authentication.md',
+  plan: '# Add authentication\n\n1. Configure the provider.',
+  feedback: 'Use the existing session middleware.',
+};
+```

--- a/.changeset/lemon-colts-bet.md
+++ b/.changeset/lemon-colts-bet.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Preserved plan revision feedback in submit_plan results so hosts can replay resolved approvals.

--- a/.changeset/modern-nights-knock.md
+++ b/.changeset/modern-nights-knock.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved plan cards to show expansion controls only when content is clipped and keep approval actions readable.

--- a/.changeset/purple-taxis-cross.md
+++ b/.changeset/purple-taxis-cross.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed Factory plan approvals to load submitted plans, preserve resolved history, and accept revision feedback in the composer.

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -204,10 +204,20 @@ function hydrateEventTimestamps(event: ParsedEvent): AgentControllerEvent {
   return isKnownParsedEvent(event) ? hydrateKnownEvent(event) : event;
 }
 
-/** Resume payload for the built-in `submit_plan` suspension. */
+/**
+ * Resume payload for the built-in `submit_plan` suspension.
+ *
+ * The tool suspends with only the plan file `path`; hosts read that file to render
+ * the approval. `path`/`title`/`plan` let the host back-fill what it rendered so the
+ * persisted tool result (`submittedPlan`) replays the plan durably in history even
+ * after the plan file changes or disappears.
+ */
 export interface PlanResume {
   action: 'approved' | 'rejected';
   feedback?: string;
+  path?: string;
+  title?: string;
+  plan?: string;
 }
 
 /**

--- a/mastracode/factory-ui/src/api/keys.ts
+++ b/mastracode/factory-ui/src/api/keys.ts
@@ -78,6 +78,10 @@ export const queryKeys = {
     ['workspace-files', workspacePath ?? null, threadId ?? null] as const,
   workspaceFile: (workspacePath: string | undefined, filePath: string | undefined, threadId?: string) =>
     ['workspace-file', workspacePath ?? null, filePath ?? null, threadId ?? null] as const,
+  // Keyed by toolCallId so each plan (re)submission fetches the file fresh
+  // instead of reusing the previous submission's cached content.
+  planFile: (workspacePath: string | undefined, filePath: string | undefined, toolCallId: string | undefined) =>
+    ['plan-file', workspacePath ?? null, filePath ?? null, toolCallId ?? null] as const,
   workspaceChanges: (workspacePath: string | undefined) => ['workspace-changes', workspacePath ?? null] as const,
   workspaceDiff: (
     workspacePath: string | undefined,

--- a/mastracode/factory-ui/src/hooks/use-fs.ts
+++ b/mastracode/factory-ui/src/hooks/use-fs.ts
@@ -33,6 +33,14 @@ function workspaceFileUrl(workspacePath: string | undefined, path: string | unde
   return `/web/workspace/file?${new URLSearchParams({ workspacePath, path, threadId })}`;
 }
 
+function planFileUrl(workspacePath: string | undefined, path: string | undefined) {
+  if (!workspacePath || !path) return undefined;
+  // The session file route only approves `.artifacts/*` reads without a thread
+  // file listing; Factory plans always live under `.artifacts/plans/`.
+  if (!path.startsWith('.artifacts/')) return undefined;
+  return `/web/workspace/file?${new URLSearchParams({ workspacePath, path })}`;
+}
+
 function workspaceChangesUrl(workspacePath: string | undefined) {
   if (!workspacePath) return undefined;
   return `/web/workspace/changes?${new URLSearchParams({ workspacePath })}`;
@@ -114,6 +122,26 @@ export function useWorkspaceFile(
   const url = workspaceFileUrl(workspacePath, filePath, threadId);
   return useQuery<WorkspaceFile>({
     queryKey: queryKeys.workspaceFile(workspacePath, filePath, threadId),
+    enabled,
+    queryFn: url ? () => client.get<WorkspaceFile>(url) : skipToken,
+  });
+}
+
+/**
+ * Read a submitted plan's markdown from the session workspace. Keyed by
+ * `toolCallId` so a plan resubmission (same path, new tool call) fetches the
+ * revised file instead of replaying the previous submission from cache.
+ */
+export function usePlanFile(
+  workspacePath: string | undefined,
+  path: string | undefined,
+  toolCallId: string | undefined,
+  { enabled = true }: { enabled?: boolean } = {},
+) {
+  const { client } = useApiConfig();
+  const url = planFileUrl(workspacePath, path);
+  return useQuery<WorkspaceFile>({
+    queryKey: queryKeys.planFile(workspacePath, path, toolCallId),
     enabled,
     queryFn: url ? () => client.get<WorkspaceFile>(url) : skipToken,
   });

--- a/mastracode/factory-ui/src/hooks/use-fs.ts
+++ b/mastracode/factory-ui/src/hooks/use-fs.ts
@@ -33,11 +33,14 @@ function workspaceFileUrl(workspacePath: string | undefined, path: string | unde
   return `/web/workspace/file?${new URLSearchParams({ workspacePath, path, threadId })}`;
 }
 
+export function isPlanReadablePath(path: string | undefined): path is string {
+  return Boolean(path?.startsWith('.artifacts/'));
+}
+
 function planFileUrl(workspacePath: string | undefined, path: string | undefined) {
-  if (!workspacePath || !path) return undefined;
+  if (!workspacePath || !isPlanReadablePath(path)) return undefined;
   // The session file route only approves `.artifacts/*` reads without a thread
   // file listing; Factory plans always live under `.artifacts/plans/`.
-  if (!path.startsWith('.artifacts/')) return undefined;
   return `/web/workspace/file?${new URLSearchParams({ workspacePath, path })}`;
 }
 

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
@@ -31,6 +31,7 @@ import {
 import { useCreateAgentControllerThreadMutation } from '../../../../hooks/useAgentControllerThreadMutations';
 import { usePreparingThreadId } from '../hooks/usePreparingThreadId';
 import { useCreateUserSessionFromDraft } from '../hooks/useCreateUserSessionFromDraft';
+import { usePendingPlanFeedback } from '../hooks/usePendingPlanFeedback';
 import { commandRequiresReadySession, matchCommands } from '../services/commands';
 import { AGENT_CONTROLLER_ID } from '../services/constants';
 import { getModeColorClass } from './mode-colors';
@@ -85,27 +86,32 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
   const sendMutation = useSendAgentControllerMessageMutation(hookArgs);
   const steerMutation = useSteerAgentControllerMutation(hookArgs);
   const abortMutation = useAbortAgentControllerMutation(hookArgs);
+  const planFeedback = usePendingPlanFeedback();
 
   const preparingThreadId = usePreparingThreadId();
   const createDraftSessionMutation = useCreateUserSessionFromDraft();
   const blocked = onUserDraft ? !factorySessionState : status !== 'ready' && !preparingThreadId;
   const draftConfigNotReady =
     onUserDraft && (modesLoading || modesError !== undefined || modelLoading || modelError !== undefined);
-  const attachDisabled = onUserDraft || blocked || chatPreparing;
+  const attachDisabled = onUserDraft || blocked || chatPreparing || planFeedback.pending;
   const { images, setImages, fileInputRef, removeImage, onPaste, onDrop, onFileInputChange } = useComposerImages({
     onUserDraft,
-    disabled: chatPreparing,
+    disabled: chatPreparing || planFeedback.pending,
   });
   const spotlightRef = useComposerSpotlight();
   const modeSwitchPendingRef = useRef(false);
-  const suggestions = matchCommands(draft);
+  const suggestions = planFeedback.pending ? [] : matchCommands(draft);
   const showSuggestions = suggestions.length > 0;
   const [activeSuggestion, setActiveSuggestion] = useState(0);
-  const composerDisabled = createDraftSessionMutation.isPending || blocked;
-  const sendDisabled = composerDisabled || draftConfigNotReady || chatPreparing;
+  const composerDisabled = createDraftSessionMutation.isPending || blocked || planFeedback.isSubmitting;
+  const sendDisabled = composerDisabled || draftConfigNotReady || chatPreparing || planFeedback.loading;
   const textareaDisabled = composerDisabled && !chatPreparing;
   const initializingPlaceholder = useInitializingPlaceholder(chatPreparing, draft.length === 0);
-  const normalPlaceholder = busy && !preparingThreadId ? 'Steer the agent…' : 'Ask Mastra Code…';
+  const normalPlaceholder = planFeedback.pending
+    ? 'Give feedback on this plan…'
+    : busy && !preparingThreadId
+      ? 'Steer the agent…'
+      : 'Ask Mastra Code…';
   const placeholder = initializingPlaceholder ?? normalPlaceholder;
   const sendTitle = chatPreparing ? 'Initializing session…' : undefined;
 
@@ -169,9 +175,10 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
     e.preventDefault();
     if (sendDisabled) return;
     const text = draft.trim();
-    if (!text && images.length === 0) return;
+    if ((!text && images.length === 0) || (planFeedback.pending && !text)) return;
     updateDraft('');
     void handleInput(text).catch(error => {
+      if (planFeedback.pending) updateDraft(text);
       clearPending();
       pushNotice(error instanceof Error ? error.message : 'The message could not be sent.', 'error');
     });
@@ -236,6 +243,11 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
   };
 
   async function handleInput(text: string) {
+    if (planFeedback.pending) {
+      await planFeedback.submitFeedback(text);
+      setImages([]);
+      return;
+    }
     if (onUserDraft && text.startsWith('/')) {
       if (commandRequiresReadySession(text)) {
         updateDraft(text);
@@ -331,7 +343,9 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
                 type="submit"
                 variant="outline"
                 size="icon-sm"
-                disabled={sendDisabled || (!draft.trim() && images.length === 0)}
+                disabled={
+                  sendDisabled || (!draft.trim() && images.length === 0) || (planFeedback.pending && !draft.trim())
+                }
                 aria-label="Send message"
                 title={sendTitle}
               >

--- a/mastracode/factory-ui/src/ui/domains/chat/components/SubmitPlanCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/SubmitPlanCard.tsx
@@ -17,7 +17,7 @@ import {
   PlanTitle,
 } from '@mastra/playground-ui/components/ai/plan';
 
-import { usePlanFile } from '../../../../hooks/use-fs';
+import { isPlanReadablePath, usePlanFile } from '../../../../hooks/use-fs';
 import { useThreadWorkspacePath } from '../../workspace-viewer/hooks/useThreadWorkspacePath';
 import { parsePlanMarkdown, resolveInlinePlan } from './submit-plan-source';
 
@@ -44,8 +44,7 @@ export function SubmitPlanCard({ toolCallId, input, output, isSubmitting = false
   const path = inline.path;
 
   const workspace = useThreadWorkspacePath();
-  // The session file route only approves `.artifacts/*` reads; Factory plans always live there.
-  const fetchable = inline.plan === undefined && Boolean(path?.startsWith('.artifacts/'));
+  const fetchable = inline.plan === undefined && isPlanReadablePath(path);
   const file = usePlanFile(workspace.workspacePath, path, toolCallId, { enabled: fetchable });
   const fetched = fetchable && file.data?.content !== undefined ? parsePlanMarkdown(file.data.content) : undefined;
 

--- a/mastracode/factory-ui/src/ui/domains/chat/components/SubmitPlanCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/SubmitPlanCard.tsx
@@ -1,0 +1,144 @@
+import type { PlanResume } from '@mastra/client-js';
+import { Button } from '@mastra/playground-ui/components/Button';
+import {
+  Plan,
+  PlanActionGroup,
+  PlanBody,
+  PlanContent,
+  PlanControls,
+  PlanCopyButton,
+  PlanExpandButton,
+  PlanHeader,
+  PlanHeaderActions,
+  PlanIntro,
+  PlanLabel,
+  PlanMain,
+  PlanPath,
+  PlanTitle,
+} from '@mastra/playground-ui/components/ai/plan';
+
+import { usePlanFile } from '../../../../hooks/use-fs';
+import { useThreadWorkspacePath } from '../../workspace-viewer/hooks/useThreadWorkspacePath';
+import { parsePlanMarkdown, resolveInlinePlan } from './submit-plan-source';
+
+/**
+ * The `submit_plan` approval and history card.
+ *
+ * Content resolution lives in `submit-plan-source.ts`; this card fetches the
+ * plan file from the session workspace when the call carries no inline plan,
+ * and on approve/reject back-fills `path`/`title`/`plan` into the resume data
+ * so the persisted tool result replays the plan durably even after the plan
+ * file changes or disappears.
+ */
+
+export interface SubmitPlanCardProps {
+  toolCallId: string;
+  input?: unknown;
+  output?: unknown;
+  isSubmitting?: boolean;
+  onRespond?: (response: PlanResume) => void;
+}
+
+export function SubmitPlanCard({ toolCallId, input, output, isSubmitting = false, onRespond }: SubmitPlanCardProps) {
+  const inline = resolveInlinePlan(input, output);
+  const path = inline.path;
+
+  const workspace = useThreadWorkspacePath();
+  // The session file route only approves `.artifacts/*` reads; Factory plans always live there.
+  const fetchable = inline.plan === undefined && Boolean(path?.startsWith('.artifacts/'));
+  const file = usePlanFile(workspace.workspacePath, path, toolCallId, { enabled: fetchable });
+  const fetched = fetchable && file.data?.content !== undefined ? parsePlanMarkdown(file.data.content) : undefined;
+
+  const title = inline.title ?? fetched?.title ?? 'Plan';
+  const plan = inline.plan ?? fetched?.plan ?? '';
+  const loading =
+    fetchable &&
+    !fetched &&
+    !file.isError &&
+    (workspace.isPending || (Boolean(workspace.workspacePath) && file.isPending));
+  const unavailable = inline.plan === undefined && !fetched && !loading;
+  // Responding while the plan is still loading would back-fill an empty plan
+  // into the durable result — hold responses until the fetch settles.
+  const respondDisabled = isSubmitting || loading;
+
+  const respond = (response: PlanResume) =>
+    onRespond?.({
+      ...response,
+      ...(path ? { path } : {}),
+      ...(plan ? { plan } : {}),
+      ...(title !== 'Plan' || plan ? { title } : {}),
+    });
+
+  return (
+    <Plan role="group" aria-label="Plan approval">
+      <PlanHeader>
+        <PlanLabel />
+        <PlanHeaderActions>
+          <PlanCopyButton content={plan} disabled={plan.length === 0} />
+        </PlanHeaderActions>
+      </PlanHeader>
+      <PlanBody>
+        <PlanIntro>
+          <PlanTitle>{title}</PlanTitle>
+          {path ? <PlanPath>{path}</PlanPath> : null}
+        </PlanIntro>
+        <PlanMain>
+          {loading ? (
+            <p aria-label="Loading plan" className="text-ui-sm text-neutral3 my-2">
+              Loading plan…
+            </p>
+          ) : unavailable ? (
+            <p role="note" className="text-ui-sm text-neutral3 my-2">
+              The plan could not be loaded from {path ?? 'its file'}. You can still respond below.
+            </p>
+          ) : (
+            <PlanContent>{plan}</PlanContent>
+          )}
+          {inline.feedback ? (
+            <div role="note" aria-label="Plan feedback" className="border-accent1 mt-4 border-l-2 pl-3">
+              <p className="text-ui-xs text-neutral3 mb-1">Feedback</p>
+              <p className="text-ui-sm text-neutral5 whitespace-pre-wrap">{inline.feedback}</p>
+            </div>
+          ) : null}
+          {onRespond ? (
+            <PlanControls>
+              <>
+                <PlanActionGroup>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="primary"
+                    className="whitespace-nowrap"
+                    aria-label="Approve the plan and switch to build"
+                    disabled={respondDisabled}
+                    onClick={() => respond({ action: 'approved' })}
+                  >
+                    Approve & build
+                  </Button>
+                </PlanActionGroup>
+                <span className="flex justify-center">
+                  <PlanExpandButton />
+                </span>
+                <PlanActionGroup>
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="whitespace-nowrap"
+                    aria-label="Reject the plan"
+                    disabled={respondDisabled}
+                    onClick={() => respond({ action: 'rejected' })}
+                  >
+                    Reject
+                  </Button>
+                </PlanActionGroup>
+              </>
+            </PlanControls>
+          ) : (
+            // Resolved cards keep the expand control; it hides itself when the collapsed body is not clipped.
+            <PlanControls />
+          )}
+        </PlanMain>
+      </PlanBody>
+    </Plan>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ToolFactory.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ToolFactory.tsx
@@ -1,27 +1,11 @@
 import type { PlanResume } from '@mastra/client-js';
 import { AskUser } from '@mastra/playground-ui/components/ai/ask-user';
 import type { AskUserAnswer, AskUserOption, AskUserPayload } from '@mastra/playground-ui/components/ai/ask-user';
-import { Button } from '@mastra/playground-ui/components/Button';
-import {
-  Plan,
-  PlanActionGroup,
-  PlanBody,
-  PlanContent,
-  PlanControls,
-  PlanCopyButton,
-  PlanExpandButton,
-  PlanHeader,
-  PlanHeaderActions,
-  PlanIntro,
-  PlanLabel,
-  PlanMain,
-  PlanPath,
-  PlanTitle,
-} from '@mastra/playground-ui/components/ai/plan';
 import { memo } from 'react';
 import type { ReactNode } from 'react';
 
 import { SkillMessage } from './SkillMessage';
+import { SubmitPlanCard } from './SubmitPlanCard';
 
 type ToolStatus = 'running' | 'done' | 'error';
 
@@ -86,25 +70,9 @@ function askUserPayload(input: unknown): AskUserPayload | undefined {
   return { question, ...(options ? { options, selectionMode } : {}) };
 }
 
-interface PlanData {
-  title: string;
-  path?: string;
-  content: string;
-}
-
-function planData(input: unknown): PlanData {
-  const payload = record(input);
-  const plan = record(payload?.plan) ?? payload;
-  const path = stringValue(plan?.path) ?? stringValue(payload?.path);
-  return {
-    title: stringValue(plan?.title) ?? 'Plan',
-    ...(path ? { path } : {}),
-    content: stringValue(plan?.content) ?? stringValue(plan?.summary) ?? '',
-  };
-}
-
 function ToolFactoryComponent({
   toolName,
+  toolCallId,
   input,
   output,
   status,
@@ -140,55 +108,14 @@ function ToolFactoryComponent({
   }
 
   if (toolName === 'submit_plan') {
-    const plan = planData(input);
     return (
-      <Plan role="group" aria-label="Plan approval">
-        <PlanHeader>
-          <PlanLabel />
-          <PlanHeaderActions>
-            <PlanCopyButton content={plan.content} />
-          </PlanHeaderActions>
-        </PlanHeader>
-        <PlanBody>
-          <PlanIntro>
-            <PlanTitle>{plan.title}</PlanTitle>
-            {plan.path ? <PlanPath>{plan.path}</PlanPath> : null}
-          </PlanIntro>
-          <PlanMain>
-            <PlanContent>{plan.content}</PlanContent>
-            <PlanControls>
-              {onRespond ? (
-                <>
-                  <PlanActionGroup>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="primary"
-                      aria-label="Approve the plan and switch to build"
-                      disabled={isSubmitting}
-                      onClick={() => onRespond({ action: 'approved' })}
-                    >
-                      Approve & build
-                    </Button>
-                  </PlanActionGroup>
-                  <PlanExpandButton />
-                  <PlanActionGroup>
-                    <Button
-                      type="button"
-                      size="sm"
-                      aria-label="Reject the plan"
-                      disabled={isSubmitting}
-                      onClick={() => onRespond({ action: 'rejected' })}
-                    >
-                      Reject
-                    </Button>
-                  </PlanActionGroup>
-                </>
-              ) : null}
-            </PlanControls>
-          </PlanMain>
-        </PlanBody>
-      </Plan>
+      <SubmitPlanCard
+        toolCallId={toolCallId}
+        input={input}
+        output={output}
+        isSubmitting={isSubmitting}
+        onRespond={onRespond}
+      />
     );
   }
 

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -28,6 +28,7 @@ import { isTerminalInvocationState } from '../services/transcript';
 import { MESSAGE_HOVER, MessageMeta } from './MessageMeta';
 import { ToolCard } from './tool/ToolCard';
 import { ToolGroup, TOOL_GROUP_MIN } from './tool/ToolGroup';
+import { SubmitPlanCard } from './SubmitPlanCard';
 import { isTranscriptToolVisible, ToolFactory } from './ToolFactory';
 import { ROW_RAIL, ROW_TRIGGER, TranscriptRow } from './TranscriptRow';
 
@@ -193,34 +194,12 @@ function SuspensionCard({
 
   if (prompt.toolName === 'submit_plan') {
     return (
-      <div className={promptCardSuspension} role="group" aria-label="Plan approval">
-        <div className={promptTitle}>Plan: {payload.plan?.title ?? payload.title ?? 'Proposed plan'}</div>
-        {payload.plan?.summary && (
-          <div className="text-ui-smd text-icon5 font-mono leading-relaxed break-words whitespace-pre-wrap">
-            {payload.plan.summary}
-          </div>
-        )}
-        <div className={promptActions}>
-          <Button
-            variant="primary"
-            size="sm"
-            aria-label="Approve the plan and switch to build"
-            autoFocus
-            disabled={isSubmitting}
-            onClick={() => onRespond(prompt.toolCallId, { action: 'approved' }, prompt.id)}
-          >
-            Approve &amp; build
-          </Button>
-          <Button
-            size="sm"
-            aria-label="Reject the plan"
-            disabled={isSubmitting}
-            onClick={() => onRespond(prompt.toolCallId, { action: 'rejected' }, prompt.id)}
-          >
-            Reject
-          </Button>
-        </div>
-      </div>
+      <SubmitPlanCard
+        toolCallId={prompt.toolCallId}
+        input={prompt.suspendPayload}
+        isSubmitting={isSubmitting}
+        onRespond={response => onRespond(prompt.toolCallId, response, prompt.id)}
+      />
     );
   }
 

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerPlanFeedback.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerPlanFeedback.msw.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../../../../e2e/ui/msw-server';
+import { TEST_BASE_URL, waitForMutationsIdle } from '../../../../../../e2e/ui/render';
+import { releaseSession, renderThread, stubPreparingSession } from './composer-session-test-fixture';
+
+const API = `${TEST_BASE_URL}/api/agent-controller/code`;
+
+describe('Composer plan feedback', () => {
+  describe('when a submit_plan approval is pending', () => {
+    it('resumes the plan suspension with the composer message as revision feedback', async () => {
+      const onResume = vi.fn();
+      server.use(
+        http.post(`${API}/sessions/:resourceId/tool-suspension`, async ({ request }) => {
+          onResume(await request.json());
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+      const session = stubPreparingSession({ materialized: true, autoAgentEnd: false });
+      const user = userEvent.setup();
+      const { client } = renderThread();
+      await releaseSession(session.finishWorkspace, client);
+
+      await session.emit({
+        type: 'tool_suspended',
+        toolCallId: 'plan-call-1',
+        toolName: 'submit_plan',
+        args: { path: '.artifacts/plans/ship.md' },
+        suspendPayload: {
+          toolId: 'submit_plan',
+          path: '.artifacts/plans/ship.md',
+          title: 'Ship it',
+          plan: 'Add the feature.',
+        },
+      });
+
+      const composer = await screen.findByRole('textbox', { name: 'Message' });
+      await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Give feedback on this plan…'));
+      await user.type(composer, 'Cover the rollback path too.{enter}');
+      await waitForMutationsIdle(client);
+
+      expect(onResume).toHaveBeenCalledWith({
+        toolCallId: 'plan-call-1',
+        resumeData: {
+          action: 'rejected',
+          feedback: 'Cover the rollback path too.',
+          path: '.artifacts/plans/ship.md',
+          title: 'Ship it',
+          plan: 'Add the feature.',
+        },
+      });
+      expect(session.posted).toEqual([]);
+      expect(session.steerAttempts).toBe(0);
+    });
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/SubmitPlanCard.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/SubmitPlanCard.msw.test.tsx
@@ -1,0 +1,275 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../../../../e2e/ui/msw-server';
+import { TEST_BASE_URL, renderWithProviders } from '../../../../../../e2e/ui/render';
+import type { WorkspaceFile } from '../../../../../api/types';
+import type { FactoryUserSession } from '../../../workspaces/services/github';
+import { SubmitPlanCard } from '../SubmitPlanCard';
+
+const PLAN_PATH = '.artifacts/plans/add-dark-mode.md';
+const WORKSPACE = 'sc-session-1';
+const PLAN_MARKDOWN = '# Ship dark mode\n\n## Steps\n\n1. Add the toggle';
+
+const stubContentHeight = (height: number) => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => height,
+  });
+};
+
+afterEach(() => {
+  Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
+});
+
+const userSession = {
+  id: 'thread-1',
+  sessionId: WORKSPACE,
+  projectRepositoryId: 'repo-1',
+  orgId: 'org-1',
+  userId: 'user-1',
+  visibility: 'private',
+  title: 'Dark mode',
+  branch: 'mastra/user/dark-mode',
+  baseBranch: 'main',
+  sandboxId: 'sb-1',
+  sandboxWorkdir: '/workspaces/dark-mode',
+  materializedAt: '2026-08-19T10:00:00.000Z',
+  createdAt: '2026-08-19T10:00:00.000Z',
+  updatedAt: '2026-08-19T10:00:00.000Z',
+} satisfies FactoryUserSession;
+
+function workspaceFile(params: URLSearchParams): WorkspaceFile {
+  return {
+    workspacePath: params.get('workspacePath') ?? '',
+    path: params.get('path') ?? '',
+    name: 'add-dark-mode.md',
+    size: PLAN_MARKDOWN.length,
+    updatedAt: '2026-08-19T10:05:00.000Z',
+    contentType: 'text',
+    content: PLAN_MARKDOWN,
+  };
+}
+
+function stubUserSession() {
+  server.use(
+    http.get(`${TEST_BASE_URL}/web/user-sessions/:threadId`, () => HttpResponse.json({ session: userSession })),
+  );
+}
+
+/** Records plan-file reads; responds with the plan markdown unless `fail` is set. */
+function stubPlanFile({ fail = false }: { fail?: boolean } = {}) {
+  const requests: URLSearchParams[] = [];
+  server.use(
+    http.get(`${TEST_BASE_URL}/web/workspace/file`, ({ request }) => {
+      const params = new URL(request.url).searchParams;
+      requests.push(params);
+      if (fail) return HttpResponse.json({ error: 'Session workspace is not available' }, { status: 403 });
+      return HttpResponse.json(workspaceFile(params));
+    }),
+  );
+  return requests;
+}
+
+function renderCard(props: Partial<Parameters<typeof SubmitPlanCard>[0]> = {}) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/factories/f-1/user/threads/thread-1']}>
+      <Routes>
+        <Route
+          path="/factories/:factoryId/user/threads/:threadId"
+          element={<SubmitPlanCard toolCallId="call-1" input={{ toolId: 'submit_plan', path: PLAN_PATH }} {...props} />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('SubmitPlanCard', () => {
+  describe('when a plan is pending approval', () => {
+    it('reads the plan file from the session workspace and renders its title and body', async () => {
+      stubUserSession();
+      const requests = stubPlanFile();
+      renderCard({ onRespond: () => {} });
+
+      // The `# heading` becomes the card title, the rest the rendered body.
+      expect(await screen.findByText('Ship dark mode')).toBeInTheDocument();
+      expect(await screen.findByText('Add the toggle')).toBeInTheDocument();
+      expect(screen.getByText('add-dark-mode.md')).toBeInTheDocument();
+
+      // The read is scoped to this session's workspace, not a raw disk path.
+      expect(requests).toHaveLength(1);
+      expect(requests[0].get('workspacePath')).toBe(WORKSPACE);
+      expect(requests[0].get('path')).toBe(PLAN_PATH);
+    });
+
+    it('back-fills the rendered plan into the approval resume data for durable history', async () => {
+      stubUserSession();
+      stubPlanFile();
+      const onRespond = vi.fn();
+      const user = userEvent.setup();
+      renderCard({ onRespond });
+
+      await screen.findByText('Ship dark mode');
+      await user.click(screen.getByRole('button', { name: 'Approve the plan and switch to build' }));
+
+      expect(onRespond).toHaveBeenCalledWith({
+        action: 'approved',
+        path: PLAN_PATH,
+        title: 'Ship dark mode',
+        plan: '## Steps\n\n1. Add the toggle',
+      });
+    });
+
+    it('blocks copy and responses while the plan file is loading', async () => {
+      stubUserSession();
+      let releasePlan: (() => void) | undefined;
+      server.use(
+        http.get(`${TEST_BASE_URL}/web/workspace/file`, async ({ request }) => {
+          await new Promise<void>(resolve => {
+            releasePlan = resolve;
+          });
+          const params = new URL(request.url).searchParams;
+          return HttpResponse.json(workspaceFile(params));
+        }),
+      );
+      const onRespond = vi.fn();
+      renderCard({ onRespond });
+
+      expect(await screen.findByLabelText('Loading plan')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Copy plan' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Approve the plan and switch to build' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Reject the plan' })).toBeDisabled();
+      expect(onRespond).not.toHaveBeenCalled();
+
+      await waitFor(() => expect(releasePlan).toBeTypeOf('function'));
+      releasePlan?.();
+      await screen.findByText('Ship dark mode');
+      expect(screen.getByRole('button', { name: 'Copy plan' })).toBeEnabled();
+      expect(screen.getByRole('button', { name: 'Approve the plan and switch to build' })).toBeEnabled();
+      expect(screen.getByRole('button', { name: 'Reject the plan' })).toBeEnabled();
+    });
+
+    it('keeps approve and reject usable when the plan file cannot be read', async () => {
+      stubUserSession();
+      stubPlanFile({ fail: true });
+      const onRespond = vi.fn();
+      const user = userEvent.setup();
+      renderCard({ onRespond });
+
+      expect(await screen.findByRole('note')).toHaveTextContent('The plan could not be loaded');
+
+      const reject = screen.getByRole('button', { name: 'Reject the plan' });
+      expect(reject).toBeEnabled();
+      await user.click(reject);
+
+      // No content to back-fill — only the action and path travel.
+      expect(onRespond).toHaveBeenCalledWith({ action: 'rejected', path: PLAN_PATH });
+    });
+
+    it('does not fetch paths outside the workspace artifacts root', async () => {
+      stubUserSession();
+      const requests = stubPlanFile();
+      renderCard({ input: { toolId: 'submit_plan', path: '.mastracode/plans/local.md' }, onRespond: () => {} });
+
+      expect(await screen.findByRole('note')).toHaveTextContent('The plan could not be loaded');
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  describe('expand affordance', () => {
+    it('hides the expand control for a plan that fits the collapsed card', async () => {
+      stubUserSession();
+      stubPlanFile();
+      renderCard({ onRespond: () => {} });
+
+      await screen.findByText('Ship dark mode');
+      expect(screen.queryByRole('button', { name: 'Expand plan' })).not.toBeInTheDocument();
+    });
+
+    it('offers expansion when the rendered plan overflows the collapsed card', async () => {
+      stubContentHeight(1000);
+      stubUserSession();
+      stubPlanFile();
+      renderCard({
+        onRespond: () => {},
+        // Inline plan: no fetch needed; the layout stub reports actual overflow.
+        input: { path: PLAN_PATH, title: 'Long plan', plan: `detailed step\n`.repeat(60) },
+      });
+
+      expect(await screen.findByText('Long plan')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Expand plan' })).toBeInTheDocument();
+    });
+
+    it('hides the expand control on a resolved short plan (after approve or reject)', async () => {
+      stubUserSession();
+      renderCard({
+        input: { path: PLAN_PATH },
+        output: {
+          toolId: 'submit_plan',
+          content: 'Plan rejected.',
+          submittedPlan: { title: 'Ship dark mode', path: PLAN_PATH, plan: 'Persisted body' },
+        },
+      });
+
+      expect(await screen.findByText('Ship dark mode')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Expand plan' })).not.toBeInTheDocument();
+    });
+
+    it('keeps the expand control on a resolved overflowing plan', async () => {
+      stubContentHeight(1000);
+      stubUserSession();
+      renderCard({
+        input: { path: PLAN_PATH },
+        output: {
+          toolId: 'submit_plan',
+          content: 'Plan approved.',
+          submittedPlan: { title: 'Long plan', path: PLAN_PATH, plan: `detailed step\n`.repeat(60) },
+        },
+      });
+
+      expect(await screen.findByText('Long plan')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Expand plan' })).toBeInTheDocument();
+    });
+  });
+
+  describe('when a resolved call carries the persisted plan', () => {
+    it('renders revision feedback with the rejected plan', async () => {
+      stubUserSession();
+      renderCard({
+        input: { path: PLAN_PATH },
+        output: {
+          toolId: 'submit_plan',
+          content: 'Plan rejected.',
+          submittedPlan: {
+            title: 'Ship dark mode',
+            path: PLAN_PATH,
+            plan: 'Persisted body',
+            feedback: 'Add a rollback step.',
+          },
+        },
+      });
+
+      expect(await screen.findByRole('note', { name: 'Plan feedback' })).toHaveTextContent('Add a rollback step.');
+    });
+
+    it('renders result.submittedPlan without refetching the plan file', async () => {
+      stubUserSession();
+      const requests = stubPlanFile();
+      renderCard({
+        input: { path: PLAN_PATH },
+        output: {
+          toolId: 'submit_plan',
+          content: 'Plan approved.',
+          submittedPlan: { title: 'Ship dark mode', path: PLAN_PATH, plan: 'Persisted body' },
+        },
+      });
+
+      expect(await screen.findByText('Ship dark mode')).toBeInTheDocument();
+      expect(screen.getByText('Persisted body')).toBeInTheDocument();
+      await waitFor(() => expect(requests).toHaveLength(0));
+    });
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx
@@ -1,9 +1,11 @@
 import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent-controller';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { renderWithProviders } from '../../../../../../e2e/ui/render';
+import { initialTranscript, transcriptReducer } from '../../services/transcript';
 import type { TimelineEntry, ToolCall } from '../../services/transcript';
 import { TranscriptEntries } from '../Transcript';
 
@@ -49,7 +51,12 @@ function runningTool(toolCallId: string, toolName: string, args: unknown): Mastr
 }
 
 function renderEntries(entries: TimelineEntry[]) {
-  return renderWithProviders(<TranscriptEntries entries={entries} onApprove={() => {}} onRespond={() => {}} />);
+  // The plan card resolves its workspace from the route, so entries render under a router like in the app.
+  return renderWithProviders(
+    <MemoryRouter>
+      <TranscriptEntries entries={entries} onApprove={() => {}} onRespond={() => {}} />
+    </MemoryRouter>,
+  );
 }
 
 describe('TranscriptEntries tool rows', () => {
@@ -174,6 +181,47 @@ describe('TranscriptEntries tool rows', () => {
 
     expect(screen.queryByRole('group', { name: /Tool group/ })).not.toBeInTheDocument();
     expect(screen.getByRole('group', { name: promptLabel })).toBeInTheDocument();
+  });
+
+  it('reconstructs a resolved submit_plan card from persisted message history after reload', () => {
+    const persistedMessage: MastraDBMessage = {
+      id: 'msg-plan-resolved',
+      role: 'assistant',
+      createdAt: CREATED_AT,
+      content: {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'plan-call-1',
+              toolName: 'submit_plan',
+              args: { path: '.artifacts/plans/reloaded.md' },
+              result: {
+                toolId: 'submit_plan',
+                content: 'Plan rejected with feedback.',
+                submittedPlan: {
+                  title: 'Reloaded plan',
+                  path: '.artifacts/plans/reloaded.md',
+                  plan: '## Durable step\n\nUse the persisted result.',
+                  feedback: 'Add a rollback step.',
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+    const restored = transcriptReducer(initialTranscript, { type: 'mergeWindow', messages: [persistedMessage] });
+
+    renderEntries(restored.entries);
+
+    const card = screen.getByRole('group', { name: 'Plan approval' });
+    expect(within(card).getByText('Reloaded plan')).toBeInTheDocument();
+    expect(within(card).getByText('Use the persisted result.')).toBeInTheDocument();
+    expect(within(card).getByRole('note', { name: 'Plan feedback' })).toHaveTextContent('Add a rollback step.');
+    expect(within(card).queryByRole('button', { name: /approve|reject/i })).not.toBeInTheDocument();
   });
 
   it('breaks a run on a suspended call so the agent question stays answerable', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/submit-plan-source.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/submit-plan-source.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { parsePlanMarkdown, resolveInlinePlan } from '../submit-plan-source';
+
+describe('submit plan source', () => {
+  it('prefers the durable submitted plan over stale invocation input', () => {
+    expect(
+      resolveInlinePlan(
+        { path: '.artifacts/plans/current.md', title: 'Stale title', plan: 'Stale body' },
+        {
+          submittedPlan: {
+            path: '.artifacts/plans/approved.md',
+            title: 'Approved title',
+            plan: 'Approved body',
+            feedback: 'Add rollback steps',
+          },
+        },
+      ),
+    ).toEqual({
+      path: '.artifacts/plans/approved.md',
+      title: 'Approved title',
+      plan: 'Approved body',
+      feedback: 'Add rollback steps',
+    });
+  });
+
+  it('supports legacy nested plan payloads', () => {
+    expect(
+      resolveInlinePlan(
+        {
+          path: '.artifacts/plans/legacy.md',
+          plan: { title: 'Legacy title', content: 'Legacy body' },
+        },
+        undefined,
+      ),
+    ).toEqual({
+      path: '.artifacts/plans/legacy.md',
+      title: 'Legacy title',
+      plan: 'Legacy body',
+    });
+  });
+
+  it('keeps a path-only call fetchable by leaving the plan undefined', () => {
+    expect(resolveInlinePlan({ path: '.artifacts/plans/fetch.md' }, undefined)).toEqual({
+      path: '.artifacts/plans/fetch.md',
+      title: undefined,
+      plan: undefined,
+    });
+  });
+
+  it('parses the first Markdown heading as the title', () => {
+    expect(parsePlanMarkdown('\n# Ship it\n\n## Steps\n\n1. Verify')).toEqual({
+      title: 'Ship it',
+      plan: '## Steps\n\n1. Verify',
+    });
+  });
+
+  it('keeps heading-free Markdown as the plan body', () => {
+    expect(parsePlanMarkdown('## Steps\n\n1. Verify\n')).toEqual({
+      plan: '## Steps\n\n1. Verify',
+    });
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/components/submit-plan-source.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/submit-plan-source.ts
@@ -1,0 +1,87 @@
+/**
+ * Plan-source resolution for the `submit_plan` card.
+ *
+ * The tool call only ever carries the plan file `path` — the plan body lives in
+ * a Markdown file inside the session workspace. A card can therefore source its
+ * content from three places, in precedence order:
+ *
+ * 1. The persisted `result.submittedPlan` of a resolved call (offline replay).
+ * 2. An enriched payload (`title`/`plan` present on the args/suspend payload).
+ * 3. The plan file fetched from the session workspace, parsed like the TUI's
+ *    `readPlanFile`.
+ */
+
+export interface InlinePlanSource {
+  title?: string;
+  path?: string;
+  plan?: string;
+  feedback?: string;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/** The persisted `submittedPlan` from a resolved tool result, when the resume was enriched. */
+function persistedPlan(output: unknown): InlinePlanSource | undefined {
+  const submitted = record(record(output)?.submittedPlan);
+  if (!submitted) return undefined;
+  const source: InlinePlanSource = {
+    title: stringValue(submitted.title),
+    path: stringValue(submitted.path),
+    plan: stringValue(submitted.plan),
+    feedback: stringValue(submitted.feedback),
+  };
+  return source.title || source.path || source.plan || source.feedback ? source : undefined;
+}
+
+/** Suspend payload / tool args: flat `{ path, title?, plan? }`, or the legacy nested `{ plan: { title, content } }`. */
+function payloadPlan(input: unknown): InlinePlanSource {
+  const payload = record(input);
+  const nested = record(payload?.plan);
+  return {
+    title: stringValue(payload?.title) ?? stringValue(nested?.title),
+    path: stringValue(payload?.path) ?? stringValue(nested?.path),
+    plan: stringValue(payload?.plan) ?? stringValue(nested?.content) ?? stringValue(nested?.summary),
+  };
+}
+
+/**
+ * Resolve the inline plan content carried by the tool call itself.
+ * Persisted results take precedence over live payload data; a missing `plan`
+ * means the card must fetch the plan file from the workspace.
+ */
+export function resolveInlinePlan(input: unknown, output: unknown): InlinePlanSource {
+  const persisted = persistedPlan(output);
+  const payload = payloadPlan(input);
+  return {
+    title: persisted?.title ?? payload.title,
+    path: persisted?.path ?? payload.path,
+    plan: persisted?.plan ?? payload.plan,
+    ...(persisted?.feedback ? { feedback: persisted.feedback } : {}),
+  };
+}
+
+/** Split a plan file into title and body — the leading `# Title` heading is the title (mirrors the TUI's `readPlanFile`). */
+export function parsePlanMarkdown(raw: string): { title?: string; plan: string } {
+  const lines = raw.split(/\r?\n/);
+  const headingIndex = lines.findIndex(line => line.trim().length > 0);
+  const heading = headingIndex >= 0 ? lines[headingIndex] : undefined;
+  if (heading?.startsWith('# ')) {
+    return {
+      title: heading.slice(2).trim(),
+      plan: lines
+        .slice(headingIndex + 1)
+        .join('\n')
+        .replace(/^\n+/, '')
+        .trimEnd(),
+    };
+  }
+  return { plan: raw.trimEnd() };
+}

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/usePendingPlanFeedback.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/usePendingPlanFeedback.ts
@@ -1,6 +1,6 @@
 import type { PlanResume } from '@mastra/client-js';
 
-import { usePlanFile } from '../../../../hooks/use-fs';
+import { isPlanReadablePath, usePlanFile } from '../../../../hooks/use-fs';
 import { useRespondAgentControllerSuspensionMutation } from '../../../../hooks/useAgentControllerRunMutations';
 import { useThreadWorkspacePath } from '../../workspace-viewer/hooks/useThreadWorkspacePath';
 import { parsePlanMarkdown, resolveInlinePlan } from '../components/submit-plan-source';
@@ -23,7 +23,7 @@ export function usePendingPlanFeedback() {
   const prompt = pendingSubmitPlan(transcript.entries);
   const inline = resolveInlinePlan(prompt?.suspendPayload, undefined);
   const workspace = useThreadWorkspacePath();
-  const fetchable = inline.plan === undefined && Boolean(inline.path?.startsWith('.artifacts/'));
+  const fetchable = inline.plan === undefined && isPlanReadablePath(inline.path);
   const file = usePlanFile(workspace.workspacePath, inline.path, prompt?.toolCallId, {
     enabled: Boolean(prompt) && fetchable,
   });

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/usePendingPlanFeedback.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/usePendingPlanFeedback.ts
@@ -1,0 +1,66 @@
+import type { PlanResume } from '@mastra/client-js';
+
+import { usePlanFile } from '../../../../hooks/use-fs';
+import { useRespondAgentControllerSuspensionMutation } from '../../../../hooks/useAgentControllerRunMutations';
+import { useThreadWorkspacePath } from '../../workspace-viewer/hooks/useThreadWorkspacePath';
+import { parsePlanMarkdown, resolveInlinePlan } from '../components/submit-plan-source';
+import { useChatSessionContext } from '../context/useChatSessionContext';
+import { useChatTranscript } from '../context/useChatTranscript';
+import { AGENT_CONTROLLER_ID } from '../services/constants';
+import type { TimelineEntry } from '../services/transcript';
+
+function pendingSubmitPlan(entries: TimelineEntry[]) {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry?.kind === 'suspension' && entry.toolName === 'submit_plan') return entry;
+  }
+  return undefined;
+}
+
+export function usePendingPlanFeedback() {
+  const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
+  const { transcript, resolvePrompt } = useChatTranscript();
+  const prompt = pendingSubmitPlan(transcript.entries);
+  const inline = resolveInlinePlan(prompt?.suspendPayload, undefined);
+  const workspace = useThreadWorkspacePath();
+  const fetchable = inline.plan === undefined && Boolean(inline.path?.startsWith('.artifacts/'));
+  const file = usePlanFile(workspace.workspacePath, inline.path, prompt?.toolCallId, {
+    enabled: Boolean(prompt) && fetchable,
+  });
+  const fetched = fetchable && file.data?.content !== undefined ? parsePlanMarkdown(file.data.content) : undefined;
+  const loading =
+    Boolean(prompt) &&
+    fetchable &&
+    !fetched &&
+    !file.isError &&
+    (workspace.isPending || (Boolean(workspace.workspacePath) && file.isPending));
+  const respondMutation = useRespondAgentControllerSuspensionMutation({
+    agentControllerId: AGENT_CONTROLLER_ID,
+    resourceId,
+    scope: projectPath,
+    baseUrl,
+    enabled: sessionEnabled,
+  });
+
+  const submitFeedback = async (feedback: string) => {
+    if (!prompt || !feedback.trim()) return;
+    const title = inline.title ?? fetched?.title;
+    const plan = inline.plan ?? fetched?.plan;
+    const resumeData: PlanResume = {
+      action: 'rejected',
+      feedback: feedback.trim(),
+      ...(inline.path ? { path: inline.path } : {}),
+      ...(title ? { title } : {}),
+      ...(plan ? { plan } : {}),
+    };
+    await respondMutation.mutateAsync({ toolCallId: prompt.toolCallId, resumeData });
+    resolvePrompt(prompt.id);
+  };
+
+  return {
+    pending: Boolean(prompt),
+    loading,
+    isSubmitting: respondMutation.isPending,
+    submitFeedback,
+  };
+}

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -24,6 +24,7 @@ import type { TracingContext, TracingOptions } from '../observability';
 import type { RequestContext } from '../request-context';
 import { toStandardSchema } from '../schema';
 import type { PublicSchema, StandardSchemaWithJSON } from '../schema';
+import type { SubmitPlanResumeData } from '../tools/builtin/submit-plan';
 import { safeStringify } from '../utils';
 import { Workspace } from '../workspace';
 
@@ -3661,7 +3662,7 @@ export class Session<TState = unknown> {
       if (suspension?.toolName === 'submit_plan') {
         await this.handlePlanApprovalResume({
           toolCallId: resolvedToolCallId,
-          response: resumeData as { action: 'approved' | 'rejected'; feedback?: string },
+          response: resumeData as SubmitPlanResumeData,
           requestContext,
         });
         return;
@@ -3691,7 +3692,7 @@ export class Session<TState = unknown> {
     requestContext,
   }: {
     toolCallId: string;
-    response: { action: 'approved' | 'rejected'; feedback?: string };
+    response: SubmitPlanResumeData;
     requestContext?: RequestContext;
   }): Promise<void> {
     if (response.action === 'rejected') {

--- a/packages/core/src/tools/builtin/submit-plan.test.ts
+++ b/packages/core/src/tools/builtin/submit-plan.test.ts
@@ -45,14 +45,28 @@ describe('submitPlanTool (native suspend)', () => {
     });
   });
 
-  it('reports rejection with feedback back to the model from resumeData', async () => {
-    const ctx = makeAgentContext({ resumeData: { action: 'rejected', feedback: 'Add tests' } });
+  it('reports rejection with feedback back to the model and persists it for history', async () => {
+    const ctx = makeAgentContext({
+      resumeData: {
+        action: 'rejected',
+        feedback: 'Add tests',
+        path: '.mastracode/plans/ship-it.md',
+        title: 'Ship it',
+        plan: 'Do it',
+      },
+    });
 
     const result = await (submitPlanTool as any).execute({ path: '.mastracode/plans/ship-it.md' }, ctx);
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain('The user wants revisions.');
     expect(result.content).toContain('User feedback: Add tests');
+    expect(result.submittedPlan).toEqual({
+      title: 'Ship it',
+      path: '.mastracode/plans/ship-it.md',
+      plan: 'Do it',
+      feedback: 'Add tests',
+    });
   });
 
   it('tells the model to stop and wait when rejected without feedback', async () => {

--- a/packages/core/src/tools/builtin/submit-plan.ts
+++ b/packages/core/src/tools/builtin/submit-plan.ts
@@ -104,6 +104,7 @@ export const submitPlanTool = createTool({
               title: resumeData.title,
               path: resumeData.path,
               plan: resumeData.plan,
+              feedback: resumeData.feedback,
             },
           };
         }

--- a/packages/playground-ui/src/ds/components/ai/plan/plan.test.tsx
+++ b/packages/playground-ui/src/ds/components/ai/plan/plan.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -33,10 +33,22 @@ const mockClipboard = (writeText: ReturnType<typeof vi.fn>) => {
   });
 };
 
+// jsdom has no layout engine, so rendered content always measures zero height.
+// Stubbing `scrollHeight` simulates content that overflows (or fits) the
+// collapsed card so clipping detection can be exercised.
+const stubContentHeight = (height: number | (() => number)) => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => (typeof height === 'function' ? height() : height),
+  });
+};
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   Reflect.deleteProperty(navigator, 'clipboard');
+  Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
 });
 
 describe('Plan', () => {
@@ -158,7 +170,154 @@ describe('Plan', () => {
     expect(screen.getByRole('button', { name: /approve plan/i })).toBeTruthy();
   });
 
+  it('hints that an overflowing plan is clipped and clears the hint when expanded', () => {
+    stubContentHeight(1000);
+
+    renderPlan(
+      <Plan>
+        <PlanBody>
+          <PlanMain>
+            <PlanContent>{`## Steps\n\n${'step '.repeat(150)}`}</PlanContent>
+            <PlanControls />
+          </PlanMain>
+        </PlanBody>
+      </Plan>,
+    );
+
+    const clipped = document.querySelector<HTMLElement>('[data-slot="plan-content"][data-clipped]');
+    expect(clipped).toBeTruthy();
+    expect(clipped?.classList.contains('mask-b-from-60%')).toBe(true);
+    expect(clipped?.classList.contains('mask-b-to-100%')).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: /expand plan/i }));
+
+    const expanded = document.querySelector<HTMLElement>('[data-slot="plan-content"]');
+    expect(expanded?.getAttribute('data-clipped')).toBeNull();
+    expect(expanded?.classList.contains('mask-b-from-60%')).toBe(false);
+    expect(expanded?.classList.contains('mask-b-to-100%')).toBe(false);
+  });
+
+  it('shows no clip hint or expand control when the plan fits the collapsed card', () => {
+    stubContentHeight(120);
+
+    renderPlan(
+      <Plan>
+        <PlanBody>
+          <PlanMain>
+            <PlanContent>{'## Steps\n\n- Move data'}</PlanContent>
+            <PlanControls />
+          </PlanMain>
+        </PlanBody>
+      </Plan>,
+    );
+
+    expect(document.querySelector('[data-slot="plan-content"][data-clipped]')).toBeNull();
+    expect(screen.queryByRole('button', { name: /expand plan/i })).toBeNull();
+    expect(document.querySelector('[data-slot="plan-controls"]')?.classList.contains('empty:hidden')).toBe(true);
+  });
+
+  it('treats content at exactly the collapsed height as fitting', () => {
+    stubContentHeight(220);
+
+    renderPlan(
+      <Plan>
+        <PlanBody>
+          <PlanMain>
+            <PlanContent>{'## Steps\n\n- Move data'}</PlanContent>
+            <PlanControls />
+          </PlanMain>
+        </PlanBody>
+      </Plan>,
+    );
+
+    expect(document.querySelector('[data-slot="plan-content"][data-clipped]')).toBeNull();
+    expect(screen.queryByRole('button', { name: /expand plan/i })).toBeNull();
+  });
+
+  it('measures against a custom collapsed height', () => {
+    stubContentHeight(150);
+
+    renderPlan(
+      <Plan collapsedHeight={100}>
+        <PlanBody>
+          <PlanMain>
+            <PlanContent>{'## Steps\n\n- Move data'}</PlanContent>
+            <PlanControls />
+          </PlanMain>
+        </PlanBody>
+      </Plan>,
+    );
+
+    expect(document.querySelector('[data-slot="plan-content"][data-clipped]')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /expand plan/i })).toBeTruthy();
+  });
+
+  it('remeasures when the collapsed height changes', () => {
+    stubContentHeight(150);
+
+    const { rerender } = renderPlan(
+      <Plan collapsedHeight={220}>
+        <PlanContent>{'## Steps\n\n- Move data'}</PlanContent>
+        <PlanControls />
+      </Plan>,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Expand plan' })).toBeNull();
+
+    rerender(
+      <TooltipProvider>
+        <Plan collapsedHeight={100}>
+          <PlanContent>{'## Steps\n\n- Move data'}</PlanContent>
+          <PlanControls />
+        </Plan>
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Expand plan' })).toBeTruthy();
+  });
+
+  it('observes content resizing and disconnects the observer on unmount', () => {
+    let height = 120;
+    let notifyResize: (() => void) | undefined;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    stubContentHeight(() => height);
+
+    class ResizeObserverStub implements ResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        notifyResize = () => callback([], this);
+      }
+
+      observe = observe;
+      unobserve = vi.fn();
+      disconnect = disconnect;
+    }
+
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+
+    const { unmount } = renderPlan(
+      <Plan>
+        <PlanContent>{'## Steps\n\n- Move data'}</PlanContent>
+        <PlanControls />
+      </Plan>,
+    );
+
+    const measuredContent = document.querySelector('[data-slot="plan-content"] > div');
+    expect(observe).toHaveBeenCalledWith(measuredContent);
+    expect(screen.queryByRole('button', { name: 'Expand plan' })).toBeNull();
+
+    height = 500;
+    act(() => notifyResize?.());
+
+    expect(screen.getByRole('button', { name: 'Expand plan' })).toBeTruthy();
+
+    unmount();
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
   it('expands from the composed expand button', () => {
+    stubContentHeight(1000);
+
     renderPlan(
       <Plan>
         <PlanBody>
@@ -174,14 +333,23 @@ describe('Plan', () => {
     if (!content) throw new Error('Expected plan content to render.');
 
     expect(content.style.maxHeight).toBe('220px');
+    expect(content.classList.contains('overflow-hidden')).toBe(true);
 
-    fireEvent.click(screen.getByRole('button', { name: /expand plan/i }));
+    const expandButton = screen.getByRole('button', { name: 'Expand plan' });
+    expect(expandButton.getAttribute('aria-label')).toBe('Expand plan');
+    expect(expandButton.textContent).toContain('Expand plan');
+    fireEvent.click(expandButton);
 
-    expect(screen.getByRole('button', { name: /collapse plan/i })).toBeTruthy();
+    const collapseButton = screen.getByRole('button', { name: 'Collapse plan' });
+    expect(collapseButton.getAttribute('aria-label')).toBe('Collapse plan');
+    expect(collapseButton.textContent).toContain('Collapse plan');
     expect(content.style.maxHeight).toBe('');
+    expect(content.classList.contains('overflow-hidden')).toBe(false);
   });
 
   it('keeps the expand and collapse action on one line without shrinking', () => {
+    stubContentHeight(1000);
+
     renderPlan(
       <Plan>
         <PlanContent>{'## Steps\n\n- Move data'}</PlanContent>
@@ -202,6 +370,7 @@ describe('Plan', () => {
 
   it('preserves fixed expand behavior when unsupported button props are provided at runtime', () => {
     const overrideClick = vi.fn();
+    stubContentHeight(1000);
 
     renderPlan(
       <Plan>

--- a/packages/playground-ui/src/ds/components/ai/plan/plan.tsx
+++ b/packages/playground-ui/src/ds/components/ai/plan/plan.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, ClipboardList, CopyIcon, Maximize2, Minimize2 } from 'lucide-react';
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useLayoutEffect, useRef, useState } from 'react';
 import type { ComponentProps, ReactNode } from 'react';
 
 import { Badge } from '@/ds/components/Badge';
@@ -15,6 +15,9 @@ const DEFAULT_COLLAPSED_HEIGHT = 220;
 interface PlanContextValue {
   collapsedHeight: number;
   isExpanded: boolean;
+  /** Whether the rendered content overflows the collapsed height (measured, not estimated). */
+  isClipped: boolean;
+  setClipped: (clipped: boolean) => void;
   toggleExpanded: () => void;
 }
 
@@ -36,6 +39,7 @@ export interface PlanProps extends ComponentProps<'div'> {
 
 export function Plan({ children, collapsedHeight = DEFAULT_COLLAPSED_HEIGHT, className, ...props }: PlanProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isClipped, setClipped] = useState(false);
 
   const toggleExpanded = () => {
     setIsExpanded(current => !current);
@@ -44,6 +48,8 @@ export function Plan({ children, collapsedHeight = DEFAULT_COLLAPSED_HEIGHT, cla
   const contextValue = {
     collapsedHeight,
     isExpanded,
+    isClipped,
+    setClipped,
     toggleExpanded,
   };
 
@@ -208,16 +214,44 @@ export interface PlanContentProps extends Omit<ComponentProps<'div'>, 'children'
 }
 
 export function PlanContent({ children, className, style, ...props }: PlanContentProps) {
-  const { collapsedHeight, isExpanded } = usePlanContext();
+  const { collapsedHeight, isExpanded, isClipped, setClipped } = usePlanContext();
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // Measure the rendered content against the collapsed height so the clip hint
+  // and expand control track actual overflow — not an estimate of it.
+  useLayoutEffect(() => {
+    const element = contentRef.current;
+    if (!element) return;
+
+    const measure = () => setClipped(element.scrollHeight > collapsedHeight);
+    measure();
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [children, collapsedHeight, setClipped]);
+
+  const showClipHint = !isExpanded && isClipped;
 
   return (
     <div
       data-slot="plan-content"
-      className={cn('relative', !isExpanded && 'overflow-hidden', className)}
+      // The clip hint masks the content itself, so it reads correctly on any card background.
+      {...(showClipHint ? { 'data-clipped': '' } : {})}
+      className={cn(
+        'relative',
+        !isExpanded && 'overflow-hidden',
+        showClipHint && 'mask-b-from-60% mask-b-to-100%',
+        className,
+      )}
       style={!isExpanded ? { ...style, maxHeight: collapsedHeight } : style}
       {...props}
     >
-      <div className="[&_code]:bg-surface4 [&_h1]:text-header-md [&_h1]:leading-header-md [&_h2]:text-header-sm [&_h2]:leading-header-sm [&_h3]:text-ui-lg [&_h3]:leading-ui-lg [&_p]:text-ui-md [&_p]:leading-6">
+      <div
+        ref={contentRef}
+        className="[&_code]:bg-surface4 [&_h1]:text-header-md [&_h1]:leading-header-md [&_h2]:text-header-sm [&_h2]:leading-header-sm [&_h3]:text-ui-lg [&_h3]:leading-ui-lg [&_p]:text-ui-md [&_p]:leading-6"
+      >
         <MarkdownRenderer className="text-neutral6">{children}</MarkdownRenderer>
       </div>
     </div>
@@ -247,7 +281,11 @@ export function PlanControls({ children, className, ...props }: PlanControlsProp
   const hasActions = Boolean(children);
 
   return (
-    <div data-slot="plan-controls" className={cn('relative z-10 mt-4 flex justify-center', className)} {...props}>
+    <div
+      data-slot="plan-controls"
+      className={cn('relative z-10 mt-4 flex justify-center empty:hidden', className)}
+      {...props}
+    >
       {hasActions ? (
         <div className="grid w-full max-w-sm grid-cols-[1fr_auto_1fr] items-center gap-2 px-10">{children}</div>
       ) : (
@@ -273,7 +311,10 @@ export type PlanExpandButtonProps = Omit<
 >;
 
 export function PlanExpandButton({ className, ...props }: PlanExpandButtonProps) {
-  const { isExpanded, toggleExpanded } = usePlanContext();
+  const { isExpanded, isClipped, toggleExpanded } = usePlanContext();
+
+  // Nothing to expand: the collapsed card already shows the whole plan.
+  if (!isClipped && !isExpanded) return null;
 
   return (
     <Button

--- a/packages/playground/src/lib/ai-ui/tools/__tests__/submit-plan-tool.msw.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/__tests__/submit-plan-tool.msw.test.tsx
@@ -13,6 +13,13 @@ import { server } from '@/test/msw-server';
 const BASE_URL = 'http://localhost:4111';
 const toolCallId = 'submit-plan-call';
 
+const stubContentHeight = (height: number) => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => height,
+  });
+};
+
 const pendingProps: SubmitPlanToolProps = {
   agentId: 'plan-agent',
   toolName: 'submit_plan',
@@ -66,7 +73,10 @@ function usePlanFileHandler() {
   );
 }
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
+});
 
 describe('SubmitPlanTool', () => {
   describe('when submit_plan is suspended with a plan path', () => {
@@ -127,20 +137,20 @@ describe('SubmitPlanTool', () => {
       expect(approveButton.classList.contains('whitespace-nowrap')).toBe(true);
     });
 
-    it('hides the expand action when the plan body is 500 characters or shorter', async () => {
+    it('offers expansion when a short plan overflows the collapsed height', async () => {
+      stubContentHeight(221);
       server.use(
         http.get(`${BASE_URL}/api/agents/:agentId/plans/file`, () =>
           HttpResponse.json({
             path: submittedPlanPath,
-            content: `# Short plan\n\n${'x'.repeat(500)}`,
+            content: '# Short plan\n\nA tall rendered block.',
           }),
         ),
       );
 
       renderSubmitPlan(pendingProps);
 
-      expect(await screen.findByRole('heading', { name: 'Short plan' })).not.toBeNull();
-      expect(screen.queryByRole('button', { name: 'Expand plan' })).toBeNull();
+      expect(await screen.findByRole('button', { name: 'Expand plan' })).not.toBeNull();
     });
 
     it('keeps three control cells when a long plan does not overflow', async () => {
@@ -221,6 +231,27 @@ describe('SubmitPlanTool', () => {
       expect(await screen.findByRole('heading', { name: 'Persisted plan' })).not.toBeNull();
       expect(screen.getByText('This content came from the transcript.')).not.toBeNull();
       expect(onPlanRequest).not.toHaveBeenCalled();
+    });
+
+    it('offers expansion when short persisted content overflows the collapsed height', async () => {
+      stubContentHeight(221);
+
+      renderSubmitPlan({
+        agentId: 'plan-agent',
+        toolName: 'submit_plan',
+        toolCallId,
+        output: {
+          content: 'Plan approved.',
+          isError: false,
+          submittedPlan: {
+            title: 'Short persisted plan',
+            path: submittedPlanPath,
+            plan: 'A tall rendered block.',
+          },
+        },
+      });
+
+      expect(await screen.findByRole('button', { name: 'Expand plan' })).not.toBeNull();
     });
   });
 

--- a/packages/playground/src/lib/ai-ui/tools/__tests__/submit-plan-tool.msw.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/__tests__/submit-plan-tool.msw.test.tsx
@@ -61,14 +61,14 @@ function renderSubmitPlan(props: SubmitPlanToolProps) {
   return { approveToolcall };
 }
 
-function usePlanFileHandler() {
+function usePlanFileHandler(planFile = submittedPlanFile) {
   server.use(
     http.get(`${BASE_URL}/api/agents/:agentId/plans/file`, ({ params, request }) => {
       const path = new URL(request.url).searchParams.get('path');
       if (params.agentId !== 'plan-agent' || path !== submittedPlanPath) {
         return HttpResponse.json({ message: 'Plan not found' }, { status: 404 });
       }
-      return HttpResponse.json(submittedPlanFile);
+      return HttpResponse.json(planFile);
     }),
   );
 }
@@ -143,7 +143,7 @@ describe('SubmitPlanTool', () => {
         ...submittedPlanFile,
         content: '# Short plan\n\nA tall rendered block.',
       };
-      server.use(http.get(`${BASE_URL}/api/agents/:agentId/plans/file`, () => HttpResponse.json(overflowingPlanFile)));
+      usePlanFileHandler(overflowingPlanFile);
 
       renderSubmitPlan(pendingProps);
 

--- a/packages/playground/src/lib/ai-ui/tools/__tests__/submit-plan-tool.msw.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/__tests__/submit-plan-tool.msw.test.tsx
@@ -139,14 +139,11 @@ describe('SubmitPlanTool', () => {
 
     it('offers expansion when a short plan overflows the collapsed height', async () => {
       stubContentHeight(221);
-      server.use(
-        http.get(`${BASE_URL}/api/agents/:agentId/plans/file`, () =>
-          HttpResponse.json({
-            path: submittedPlanPath,
-            content: '# Short plan\n\nA tall rendered block.',
-          }),
-        ),
-      );
+      const overflowingPlanFile = {
+        ...submittedPlanFile,
+        content: '# Short plan\n\nA tall rendered block.',
+      };
+      server.use(http.get(`${BASE_URL}/api/agents/:agentId/plans/file`, () => HttpResponse.json(overflowingPlanFile)));
 
       renderSubmitPlan(pendingProps);
 

--- a/packages/playground/src/lib/ai-ui/tools/__tests__/submit-plan-tool.msw.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/__tests__/submit-plan-tool.msw.test.tsx
@@ -143,7 +143,7 @@ describe('SubmitPlanTool', () => {
       expect(screen.queryByRole('button', { name: 'Expand plan' })).toBeNull();
     });
 
-    it('shows a secondary expand action when the plan body exceeds 500 characters', async () => {
+    it('keeps three control cells when a long plan does not overflow', async () => {
       server.use(
         http.get(`${BASE_URL}/api/agents/:agentId/plans/file`, () =>
           HttpResponse.json({
@@ -155,12 +155,11 @@ describe('SubmitPlanTool', () => {
 
       renderSubmitPlan(pendingProps);
 
-      const expandButton = await screen.findByRole('button', { name: 'Expand plan' });
-      expect(expandButton.getAttribute('data-variant')).toBe('default');
+      await screen.findByRole('heading', { name: 'Long plan' });
+      expect(screen.queryByRole('button', { name: 'Expand plan' })).toBeNull();
 
-      const primaryButtons = document.querySelectorAll('button[data-variant="primary"]');
-      expect(primaryButtons).toHaveLength(1);
-      expect(primaryButtons[0]?.getAttribute('aria-label')).toBe('Approve the plan and switch to build');
+      const controls = document.querySelector('[data-slot="plan-controls"] > div');
+      expect(controls?.children).toHaveLength(3);
     });
 
     it('resumes the tool with the displayed plan when approved', async () => {

--- a/packages/playground/src/lib/ai-ui/tools/submit-plan-tool.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/submit-plan-tool.tsx
@@ -21,8 +21,6 @@ import { useAgentPlan } from '@/domains/agents/hooks/use-agent-plan';
 import type { MessageMetadata } from '@/lib/ai-ui/messages/message-metadata';
 import { useToolCall } from '@/services/tool-call-provider';
 
-const PLAN_EXPAND_CHARACTER_THRESHOLD = 500;
-
 export interface SubmitPlanToolProps {
   agentId: string;
   agentVersionId?: string;
@@ -94,7 +92,6 @@ function getSuspendedPlanPath(
 
 function SubmittedPlanCard({ plan }: { plan: SubmittedPlan }) {
   const document = getPlanDocument(plan.content);
-  const canExpand = document.body.length > PLAN_EXPAND_CHARACTER_THRESHOLD;
 
   return (
     <Plan role="group" aria-label="Submitted plan">
@@ -111,7 +108,7 @@ function SubmittedPlanCard({ plan }: { plan: SubmittedPlan }) {
         </PlanIntro>
         <PlanMain>
           <PlanContent>{document.body}</PlanContent>
-          {canExpand ? <PlanControls /> : null}
+          <PlanControls />
         </PlanMain>
       </PlanBody>
     </Plan>
@@ -131,7 +128,6 @@ function PendingPlanCard({ agentId, agentVersionId, requestContext, toolCallId, 
   const { approveToolcall, isRunning, toolCallApprovals } = useToolCall();
   const content = data?.content;
   const document = content ? getPlanDocument(content) : undefined;
-  const canExpand = Boolean(document && document.body.length > PLAN_EXPAND_CHARACTER_THRESHOLD);
   const isAnswered = toolCallApprovals[toolCallId] !== undefined;
   const controlsDisabled = isLoading || isRunning || isAnswered;
 
@@ -182,7 +178,9 @@ function PendingPlanCard({ agentId, agentVersionId, requestContext, toolCallId, 
                 Approve &amp; build
               </Button>
             </PlanActionGroup>
-            <span>{canExpand ? <PlanExpandButton /> : null}</span>
+            <span className="flex justify-center">
+              <PlanExpandButton />
+            </span>
             <PlanActionGroup>
               <Button
                 type="button"

--- a/packages/playground/src/lib/ai-ui/tools/submit-plan-tool.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/submit-plan-tool.tsx
@@ -182,7 +182,7 @@ function PendingPlanCard({ agentId, agentVersionId, requestContext, toolCallId, 
                 Approve &amp; build
               </Button>
             </PlanActionGroup>
-            {canExpand ? <PlanExpandButton /> : <span aria-hidden="true" />}
+            <span>{canExpand ? <PlanExpandButton /> : null}</span>
             <PlanActionGroup>
               <Button
                 type="button"


### PR DESCRIPTION
PR #21658 added `submit_plan` support for generic Agent clients and Studio/Playground. This PR builds on that work for Factory's AgentController chat path, where plans are written under `.artifacts/plans` and read through Factory's authorized workspace route.

Previously, Factory approval cards usually received only a file path, so the plan body could be empty and resolved approvals could lose their content after refresh. Revision feedback typed into the composer also could not reach the pending plan.

Factory now loads the submitted plan, carries its title, path, content, and feedback through approval or rejection, and replays resolved cards from the durable tool result. While a plan is pending, composer messages become revision feedback. The shared plan card also uses measured rendered overflow instead of a character-count estimate, keeping expansion controls and approval actions consistent in Factory and Playground.

Verified with focused and full Factory UI, core, Playground, and playground-ui tests; package typechecks and builds; lint and formatting; and mutation coverage for the plan overflow behavior.