### PR TITLE
docs: expand Render Workflows guide with demo and example repo

### DIFF
--- a/docs/src/content/en/integrations/deploy/render.mdx
+++ b/docs/src/content/en/integrations/deploy/render.mdx
@@ -1,55 +1,76 @@
 ---
 title: "Render | Deploy"
-description: "Deploy Mastra with Render"
+description: "Run distributed Mastra agent pipelines with Render Workflows"
 ---
 
-# Render
+# Render Workflows
 
-Deploy Mastra applications on [Render](https://render.com/). Host the Mastra API as a [web service](https://render.com/docs/web-services), or use [Render Workflows](https://render.com/docs/workflows) for long-running tasks with independent retry policies.
+[Render Workflows](https://render.com/docs/workflows?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra) is Render's execution layer for long-running and distributed tasks. It queues work, provisions compute, and records each run.
 
-Choose the deployment path that fits your application:
+This guide is the distributed model: each stage is its own Render task. Reviews can run in parallel, use different compute, and retry without repeating the rest of the pipeline.
 
-- **Mastra API**: Deploy Mastra's [server](/docs/server/overview) as a web service with a public endpoint. The [Web Services guide](https://render.com/docs/web-services) explains how to deploy custom code or a supported [server adapter](/docs/server/server-adapters).
-- **Mastra workflow**: Run an entire Mastra workflow within one task. Render controls the outer run, while Mastra manages its steps and state. See [Defining Workflow Tasks](https://render.com/docs/workflows-defining) for configuration details.
-- **Distributed agent operations**: Give each operation its own compute plan, timeout, and retry policy. Render Workflows handles the execution queue and provides run observability.
+Choose the model that matches the app:
 
-This guide builds an editorial pipeline that reviews a draft from three perspectives in parallel, then passes the feedback to an editor agent. Use the links above if you want to deploy a Mastra API or execute an entire Mastra workflow as one task.
+- **Mastra API:** deploy it as a Render web service.
+- **One Mastra workflow:** run that workflow inside a single Render task.
+- **Distributed pipeline (this guide):** split stages into Render tasks when they need independent compute, retries, parallel execution, or observability.
 
-## How Render Workflows integrates with Mastra
+## How Render Workflows works with Mastra
 
-Mastra supplies the agents and application logic, while Render Workflows defines the execution boundaries. A typical pipeline has three layers:
+Mastra supplies the agents. Render Workflows is the execution boundary around them.
 
-1. A parent task coordinates the run.
-1. Child tasks invoke Mastra agents for focused work.
-1. A final task combines the results.
+A typical pipeline has three layers:
 
-Calling one task from another creates a chained run in a separate instance, with its own compute plan, timeout, and retry policy.
+1. A parent Render task coordinates the run.
+1. Child Render tasks invoke Mastra agents for focused work.
+1. A final Render task combines the results.
+
+Calling one Render task from another creates a chained task run. Each chained run executes in its own instance. You can set compute, timeout, and retries on that task alone.
+
+This guide builds an editorial pipeline that reviews a draft from three perspectives in parallel, then uses a Mastra editor agent to produce a revised version. You can try a running copy in the [live demo](https://render-workflows-mastra.onrender.com).
 
 ## Setup
 
-Create an empty Mastra project named `render-workflows`:
+You need a Render account and the Render CLI. The CLI runs tasks on your own machine during development and creates the Render service that runs them in production.
 
-```bash npm2yarn
-npm create mastra@latest render-workflows -- --empty
+Install the CLI and log in:
+
+```bash
+brew install render
+render login
 ```
 
-Install two additional dependencies:
+:::note
+Requires Render CLI `v2.12.0` or later. For other installation methods, see the [Render CLI docs](https://render.com/docs/cli?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
+:::
+
+Install Mastra and the Render SDK:
 
 ```bash npm2yarn
-npm install @renderinc/sdk tsx
+npm install @mastra/core @renderinc/sdk
 ```
 
-Add your API key to an `.env` file. This example uses OpenAI, but any supported [model provider](/models) works.
+:::note
+Render Workflows requires `@renderinc/sdk@^0.5.0` or later.
+:::
 
-```text title=".env"
+For local TypeScript execution, install `tsx` if your project does not already include it:
+
+```bash npm2yarn
+npm install --save-dev tsx typescript
+```
+
+Set the API key for your model provider. This example uses OpenAI:
+
+```bash title=".env"
 OPENAI_API_KEY=your_openai_api_key
 ```
 
-Install the [Render CLI](https://render.com/docs/cli) to run workflow commands from your terminal.
+Any supported [Mastra model provider](/models) works. The agents in this guide use `openai/gpt-5.6-sol`.
 
-## Distributed agent pipeline
+## Building a distributed agent pipeline
 
-### Create the agents
+### Creating the agents
 
 In `src/mastra`, create an `agents` directory with `reviewer-agent.ts` and `editor-agent.ts`. Define both agents:
 
@@ -59,7 +80,7 @@ import { Agent } from '@mastra/core/agent'
 export const reviewerAgent = new Agent({
   id: 'reviewer-agent',
   name: 'Reviewer Agent',
-  model: '__GATEWAY_OPENAI_MODEL__',
+  model: 'openai/gpt-5.6-sol',
   instructions: `
     Review the supplied draft only from the requested perspective.
     Identify concrete problems and recommend specific changes.
@@ -74,7 +95,7 @@ import { Agent } from '@mastra/core/agent'
 export const editorAgent = new Agent({
   id: 'editor-agent',
   name: 'Editor Agent',
-  model: '__GATEWAY_OPENAI_MODEL__',
+  model: 'openai/gpt-5.6-sol',
   instructions: `
     Revise the supplied draft using the reviewers' feedback.
     Return the complete revised draft and nothing else.
@@ -83,7 +104,7 @@ export const editorAgent = new Agent({
 })
 ```
 
-### Configure the Mastra instance
+### Configuring the Mastra instance
 
 Add both agents to the Mastra instance in `src/mastra/index.ts`:
 
@@ -100,15 +121,13 @@ export const mastra = new Mastra({
 })
 ```
 
-### Create the tasks
+Retrieving agents from the Mastra instance gives them access to shared application services such as logging, storage, and observability.
 
-In `src`, create a `tasks` directory with `review-task.ts`, `revision-task.ts`, and `editorial-task.ts`.
+### Creating the review task
 
-#### Review task
+In `src`, create a `tasks` directory. The reviewer agent handles one area of focus. Its compute plan, five-minute timeout, and retry policy apply only to that analysis. A temporary model-provider failure can trigger another attempt without restarting the other reviewers.
 
-The reviewer agent handles one area of focus. Its compute plan, five-minute timeout, and retry policy apply only to that analysis. A temporary model-provider failure can trigger another attempt without restarting the other reviewers.
-
-```typescript title="src/tasks/review-task.ts"
+```ts title="src/tasks/review-task.ts"
 import { task } from '@renderinc/sdk/workflows'
 import { mastra } from '../mastra/index.js'
 
@@ -145,11 +164,11 @@ export const reviewDraft = task(
 )
 ```
 
-#### Revision task
+### Creating the revision task
 
 This task combines the feedback and produces a revised draft. It uses a larger compute plan and a longer timeout than each reviewer.
 
-```typescript title="src/tasks/revision-task.ts"
+```ts title="src/tasks/revision-task.ts"
 import { task } from '@renderinc/sdk/workflows'
 import { mastra } from '../mastra/index.js'
 
@@ -186,11 +205,11 @@ export const reviseDraft = task(
 )
 ```
 
-#### Editorial task
+### Creating the orchestration task
 
-The parent dispatches three reviews in parallel with `Promise.all()`, then sends their combined feedback to the revision step. Retries are disabled at this level because each child defines its own policy. If you enable orchestration retries, ensure that another attempt can't duplicate external side effects or other non-idempotent work.
+The parent dispatches three reviews in parallel with `Promise.all()`, then sends their combined feedback to the revision step. Retries are disabled at this level because each child defines its own policy. If you enable orchestration retries, ensure that another attempt cannot duplicate external side effects or other non-idempotent work.
 
-```typescript title="src/tasks/editorial-task.ts"
+```ts title="src/tasks/editorial-task.ts"
 import { task } from '@renderinc/sdk/workflows'
 import { reviewDraft } from './review-task.js'
 import { reviseDraft } from './revision-task.js'
@@ -214,7 +233,7 @@ export const editorialPipeline = task(
 )
 ```
 
-### Set up the entry point
+### Registering the tasks
 
 Create `src/index.ts` and import the editorial task:
 
@@ -222,19 +241,9 @@ Create `src/index.ts` and import the editorial task:
 import './tasks/editorial-task.js'
 ```
 
-In `package.json`, add scripts to build the TypeScript project and run the workflow:
+Running the entry point loads the module and registers every task defined with `task()`.
 
-```json title="package.json"
-{
-  "scripts": {
-    "build": "tsc",
-    "dev:workflows": "tsx src/index.ts",
-    "start:workflows": "node dist/index.js"
-  }
-}
-```
-
-Configure `tsconfig.json` for the build:
+Compile the entry point to a directory the production start command can run:
 
 ```json title="tsconfig.json"
 {
@@ -252,56 +261,71 @@ Configure `tsconfig.json` for the build:
 }
 ```
 
-Build the project. The command compiles the JavaScript files into `dist`.
+Add `"type": "module"` and scripts for local development and production:
 
-```bash npm2yarn
-npm run build
+```json title="package.json"
+{
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev:workflows": "tsx src/index.ts",
+    "start:workflows": "node dist/index.js"
+  }
+}
 ```
 
-## Run the pipeline
+Relative imports in the examples above end in `.js` because Node resolves the compiled output as ES modules. Keep those extensions so the built entry point resolves its imports.
 
-### Locally
+Those files are the complete pipeline. The same project is in [render-examples/render-workflows-mastra](https://github.com/render-examples/render-workflows-mastra). Clone it to skip copying the snippets before you run it.
 
-Start the local development server with the Render CLI:
+## Running the pipeline
+
+### Running locally
+
+Start the local Render Workflows development server:
 
 ```bash
-render workflows dev -- npm run dev:workflows
+render workflows dev -- "npm run dev:workflows"
 ```
 
-The server lists the registered tasks:
-
-```bash
-➜ render workflows dev -- npm run dev:workflows
-Workflow server listening on port 8120
-Loaded environment variables from .env
-3 tasks found in npm run dev:workflows
-  • editorial_pipeline
-  • review_draft
-  • revise_draft
-
-To browse and run tasks, open another terminal and run:
-  render workflows tasks list --local
-```
-
-In another terminal, confirm that the tasks are available:
+In another terminal, list the registered tasks:
 
 ```bash
 render workflows tasks list --local
 ```
 
-The command displays each task's name, ID, and creation time. Press `Ctrl+C`, then start the editorial pipeline from the same terminal:
+Start the editorial pipeline:
 
 ```bash
-render workflows tasks runs start editorial_pipeline \
+render workflows tasks start editorial_pipeline \
   --local \
   --input='["Render Workflows runs long-running tasks outside the request lifecycle."]'
 ```
 
-The development server records the parent run, three parallel reviews, and the final revision.
+The local server keeps runs and their logs in memory, so you can inspect them after they finish with `render workflows runs list <task-name> --local`.
 
-### Production
+### Running in production
 
-Create a workflow service from the current repository:
+Running the pipeline on Render requires a *workflow service*. This is the Render service that holds your task definitions: it builds your repository, registers every task it finds, and provisions an instance for each run.
+
+#### 1. Push the project to a Git repository
+
+Render builds workflow services from a repository on GitHub, GitLab, or Bitbucket, so push your project to one of those providers. The first time you use a provider, Render asks for permission to access your repositories.
+
+#### 2. Create the workflow service
+
+In the [Render Dashboard](https://dashboard.render.com), click **New > Workflow** and link the repository from the previous step. Then complete the creation form:
+
+| Field | Value |
+| --- | --- |
+| **Language** | Node |
+| **Region** | The region of any other Render services your tasks connect to |
+| **Build Command** | `npm install && npm run build` |
+| **Start Command** | `npm run start:workflows` |
+
+Click **Deploy Workflow**. Render builds the project and registers `review_draft`, `revise_draft`, and `editorial_pipeline`, which then appear on the workflow's **Tasks** page.
+
+The Render CLI creates the same service without leaving your terminal:
 
 ```bash
 render workflows create \
@@ -312,21 +336,77 @@ render workflows create \
   --run-command "npm run start:workflows"
 ```
 
-Add `OPENAI_API_KEY`, or the key for your chosen model provider, to the service's environment variables.
+`--repo .` reads the `origin` remote of your local repository, so the project must already be pushed.
 
-After deployment, start a production run. If needed, replace `mastra-workflows/editorial_pipeline` with the task slug shown in the Render Dashboard.
+#### 3. Set the workflow's environment variables
+
+Add `OPENAI_API_KEY`, or the key for your chosen model provider, to the workflow service in the Dashboard.
+
+The agents in this guide pin `openai/gpt-5.6-sol`, so set the OpenAI key before the first run.
+
+#### 4. Start a run
 
 ```bash
 render workflows tasks start mastra-workflows/editorial_pipeline \
   --input='["Render Workflows runs long-running tasks outside the request lifecycle."]'
 ```
 
-Open the workflow service in the Render Dashboard to inspect each task run, attempt, result, and log stream.
+The first part of that identifier is your workflow's slug and the second is the task name. Both appear on the task's page in the Render Dashboard, so use the slug shown there if your workflow has a different name.
+
+Open the workflow in the Render Dashboard to inspect each task run, attempt, result, and log stream.
+
+## Triggering from your application
+
+You can trigger the pipeline asynchronously from a Mastra application, web service, or script with the Render SDK.
+
+Triggering runs from code requires a Render API key, which you create in your [Render account settings](https://render.com/docs/api?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra#1-create-an-api-key). Set it in the calling service:
+
+```bash title=".env"
+RENDER_API_KEY=rnd_your_api_key
+```
+
+The SDK reads `RENDER_API_KEY` from the environment automatically.
+
+Start the task and return its run ID immediately:
+
+```ts title="src/start-editorial-pipeline.ts"
+import { Render } from '@renderinc/sdk'
+
+const render = new Render()
+
+export async function startEditorialPipeline(draft: string) {
+  const run = await render.workflows.startTask(
+    'mastra-workflows/editorial_pipeline',
+    [draft],
+  )
+
+  return {
+    taskRunId: run.taskRunId,
+  }
+}
+```
+
+The task continues running after `startTask()` returns. Call `await run.get()` when the caller should wait for the completed result instead.
+
+Returning the task run ID from a request handler lets the application respond without keeping the request open for the full pipeline.
+
+## Constraints
+
+These limits live in Render's docs and can change. Prefer those pages over this list:
+
+- Task arguments and return values must be JSON serializable, up to 4 MB per run. See [Workflows limits](https://render.com/docs/workflows-limits?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
+- A task can run for up to 24 hours. The default timeout is two hours. See [timeouts](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra#timeout).
+- A workflow service can register up to 500 task definitions. See [Workflows limits](https://render.com/docs/workflows-limits?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
+- Render Workflows currently supports TypeScript and Python task definitions. See [defining tasks](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
+
+To run the pipeline on a schedule, trigger it from a [Render cron job](https://render.com/docs/cronjobs?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
 
 ## Related
 
-- [Render Workflows documentation](https://render.com/docs/workflows)
-- [Defining Render workflow tasks](https://render.com/docs/workflows-defining)
-- [Triggering task runs](https://render.com/docs/workflows-running)
-- [Render Workflows TypeScript SDK](https://render.com/docs/workflows-sdk-typescript)
-- [Render Workflows limits and pricing](https://render.com/docs/workflows-limits)
+- [Live demo](https://render-workflows-mastra.onrender.com)
+- [Render Workflows documentation](https://render.com/docs/workflows?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
+- [Defining Render workflow tasks](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
+- [Triggering task runs](https://render.com/docs/workflows-running?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
+- [Render Workflows TypeScript SDK](https://render.com/docs/workflows-sdk-typescript?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
+- [Render Workflows limits and pricing](https://render.com/docs/workflows-limits?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
+

--- a/docs/src/content/en/integrations/deploy/render.mdx
+++ b/docs/src/content/en/integrations/deploy/render.mdx
@@ -9,12 +9,13 @@ description: "Run distributed Mastra agent pipelines with Render Workflows"
 
 This guide is the distributed model: each stage is its own Render task. Reviews can run in parallel, use different compute, and retry without repeating the rest of the pipeline.
 
-Choose the model that matches the app:
+Choose the deployment path that fits your application:
 
-- **Mastra API:** deploy it as a Render web service.
-- **One Mastra workflow:** run that workflow inside a single Render task.
-- **Distributed pipeline (this guide):** split stages into Render tasks when they need independent compute, retries, parallel execution, or observability.
+- **Mastra API**: Deploy Mastra's [server](/docs/server/overview) as a web service with a public endpoint. The [Web Services guide](https://render.com/docs/web-services?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra) explains how to deploy custom code or a supported [server adapter](/docs/server/server-adapters).
+- **Mastra workflow**: Run an entire Mastra workflow within one task. Render controls the outer run, while Mastra manages its steps and state. See [Defining Workflow Tasks](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra) for configuration details.
+- **Distributed agent operations**: Give each operation its own compute plan, timeout, and retry policy. Render Workflows handles the execution queue and provides run observability.
 
+This guide builds an editorial pipeline that reviews a draft from three perspectives in parallel, then passes the feedback to an editor agent. Use the links above if you want to deploy a Mastra API or execute an entire Mastra workflow as one task.
 ## How Render Workflows works with Mastra
 
 Mastra supplies the agents. Render Workflows is the execution boundary around them.


### PR DESCRIPTION
## Summary
- Rewrite the Render deployment page around the distributed agent pipeline (review → revise → editorial parent task).
- Add the live demo, local/production CLI and Dashboard steps, SDK trigger example, and platform constraints.
- Link [render-examples/render-workflows-mastra](https://github.com/render-examples/render-workflows-mastra) after the code section, once the snippets are complete.

Related: #21864 covers the same page from a Mastra-side rewrite. This PR is the Render partner draft of that guide.

## Test plan
- [ ] Preview `docs/src/content/en/integrations/deploy/render.mdx` on the docs site
- [x] Confirm the example repo link sits after **Registering the tasks**, before **Running the pipeline**
- [x] Confirm Render links keep partner UTMs
- [x] Confirm live demo opens: https://render-workflows-mastra.onrender.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR updates the Render guide to explain how to run a distributed AI workflow. It shows how review, revision, and editorial tasks work together in local and production environments.

## Changes

- Rewrites the Render deployment guide around Render Workflows and Mastra agent pipelines.
- Adds instructions for:
  - Model configuration.
  - Agent and task creation.
  - Parallel review orchestration.
  - Task registration.
  - ES modules and build settings.
  - Local and production CLI and Dashboard usage.
  - Environment variables.
  - Application-triggered runs with the SDK.
- Documents platform constraints and scheduling.
- Adds a live demo URL.
- Links to the `render-examples/render-workflows-mastra` repository after the code section.
- Preserves partner UTMs on Render links.
- Updates examples to use current Render CLI commands and `openai/gpt-5.6-sol`.

## Test plan

- Preview the documentation page.
- Verify the example repository link placement.
- Check Render link UTMs.
- Confirm the live demo URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->