### PR TITLE
fix(core): carry the delegated run id across a background task suspend

### DIFF
--- a/.changeset/better-things-lie.md
+++ b/.changeset/better-things-lie.md
@@ -1,0 +1,22 @@
+---
+'@mastra/core': patch
+---
+
+Fixed background tasks failing to resume when the suspended tool was a sub-agent or a nested workflow.
+
+When an agent delegates to a sub-agent as a background task and that nested run suspends — for example to ask for human approval — resuming the task now continues the suspended sub-agent instead of losing track of it.
+
+**What was wrong**
+
+The nested run's id was handed to the background task at suspend time but never persisted, and the task's original arguments are frozen at dispatch. On resume the delegation was therefore re-invoked without it, so it could not find the suspended run. This surfaced either as an `AGENT_RESUME_NO_SNAPSHOT_FOUND` error raised once retries were exhausted, or as the sub-agent silently starting over from the beginning.
+
+```ts
+const { task } = await manager.enqueue(payload, context);
+// the sub-agent suspends, waiting for approval...
+
+await manager.resume(task.id, { approved: true });
+// before: the sub-agent started from scratch, or the task failed after retries
+// after:  the suspended sub-agent run resumes where it left off
+```
+
+Background tools that suspend on their own — anything that is not a delegation — are unaffected, and the run id is kept out of the task's `suspendPayload` so it does not appear on `task.suspended` events.

--- a/packages/core/src/background-tasks/manager.test.ts
+++ b/packages/core/src/background-tasks/manager.test.ts
@@ -884,6 +884,38 @@ describe('BackgroundTaskManager', () => {
       expect(seenArgs[1]).toEqual({ prompt: 'go', suspendedToolRunId: 'inner-run-123' });
     });
 
+    // `resumeData` is optional on `manager.resume()`. A resume without it must
+    // still reach the nested run — otherwise the delegation silently starts a
+    // second run and the first one is stranded.
+    it('carries the delegated run id even when resumed without resumeData', async () => {
+      const seenArgs: Array<Record<string, unknown>> = [];
+      let attempts = 0;
+      const executeFn = vi.fn(async (args: any, _opts: any) => {
+        seenArgs.push(args);
+        attempts += 1;
+        if (attempts === 1) {
+          await _opts.suspend({ awaiting: 'approval' }, { runId: 'inner-run-789' });
+          return undefined;
+        }
+        return { resumedWith: args.suspendedToolRunId };
+      });
+
+      const { task } = await manager.enqueue(
+        { toolName: 't', toolCallId: 'cdeleg4', args: { prompt: 'go' }, agentId: 'a1', runId: 'outer-run-4' },
+        ctx(executeFn),
+      );
+      await tick(200);
+      expect((await manager.getTask(task.id))?.status).toBe('suspended');
+
+      await manager.resume(task.id);
+      await tick(200);
+
+      const completed = await manager.getTask(task.id);
+      expect(completed?.status).toBe('completed');
+      expect(completed?.result).toEqual({ resumedWith: 'inner-run-789' });
+      expect(seenArgs[1]).toEqual({ prompt: 'go', suspendedToolRunId: 'inner-run-789' });
+    });
+
     // The task row's suspendPayload is published on `task.suspended` lifecycle
     // events and is user-facing, so the internal run id must not leak into it.
     it('keeps the delegated run id out of the persisted suspendPayload', async () => {

--- a/packages/core/src/background-tasks/manager.test.ts
+++ b/packages/core/src/background-tasks/manager.test.ts
@@ -848,6 +848,89 @@ describe('BackgroundTaskManager', () => {
       expect(cancelled?.status).toBe('cancelled');
     });
 
+    // Delegating tools (agent-as-tool, workflow-as-tool) suspend an inner run
+    // and hand its id back via `suspendOptions.runId`. `task.args` is frozen at
+    // dispatch time and the workflow runtime drops every `suspendOptions` field
+    // except `resumeLabel`, so without an explicit carry the inner run id is
+    // lost and the resumed delegation cannot find its snapshot.
+    it('carries the delegated run id from suspend back into args on resume', async () => {
+      const seenArgs: Array<Record<string, unknown>> = [];
+      const executeFn = vi.fn(async (args: any, opts: any) => {
+        seenArgs.push(args);
+        if (!opts.resumeData) {
+          await opts.suspend({ awaiting: 'approval' }, { runId: 'inner-run-123' });
+          return undefined;
+        }
+        return { resumedWith: args.suspendedToolRunId };
+      });
+
+      const { task } = await manager.enqueue(
+        { toolName: 't', toolCallId: 'cdeleg1', args: { prompt: 'go' }, agentId: 'a1', runId: 'outer-run' },
+        ctx(executeFn),
+      );
+      await tick(200);
+      expect((await manager.getTask(task.id))?.status).toBe('suspended');
+
+      await manager.resume(task.id, { approved: true });
+      await tick(200);
+
+      const completed = await manager.getTask(task.id);
+      expect(completed?.status).toBe('completed');
+      expect(completed?.result).toEqual({ resumedWith: 'inner-run-123' });
+
+      // First attempt sees the original args; the resumed attempt gets the
+      // inner run id merged in alongside them.
+      expect(seenArgs[0]).toEqual({ prompt: 'go' });
+      expect(seenArgs[1]).toEqual({ prompt: 'go', suspendedToolRunId: 'inner-run-123' });
+    });
+
+    // The task row's suspendPayload is published on `task.suspended` lifecycle
+    // events and is user-facing, so the internal run id must not leak into it.
+    it('keeps the delegated run id out of the persisted suspendPayload', async () => {
+      const executeFn = vi.fn(async (_args: any, opts: any) => {
+        if (!opts.resumeData) {
+          await opts.suspend({ awaiting: 'approval' }, { runId: 'inner-run-456' });
+          return undefined;
+        }
+        return 'ok';
+      });
+
+      const { task } = await manager.enqueue(
+        { toolName: 't', toolCallId: 'cdeleg2', args: {}, agentId: 'a1', runId: 'outer-run-2' },
+        ctx(executeFn),
+      );
+      await tick(200);
+
+      const suspended = await manager.getTask(task.id);
+      expect(suspended?.suspendPayload).toEqual({ awaiting: 'approval' });
+    });
+
+    // Plain (non-delegating) tools never pass a runId. They must keep working
+    // untouched — their state lives entirely in args + resumeData.
+    it('leaves args untouched when the tool suspends without a runId', async () => {
+      const seenArgs: Array<Record<string, unknown>> = [];
+      const executeFn = vi.fn(async (args: any, opts: any) => {
+        seenArgs.push(args);
+        if (!opts.resumeData) {
+          await opts.suspend({ ask: 'domain' });
+          return undefined;
+        }
+        return 'ok';
+      });
+
+      const { task } = await manager.enqueue(
+        { toolName: 't', toolCallId: 'cdeleg3', args: { name: 'dero' }, agentId: 'a1', runId: 'outer-run-3' },
+        ctx(executeFn),
+      );
+      await tick(200);
+      await manager.resume(task.id, { domain: 'example.com' });
+      await tick(200);
+
+      expect((await manager.getTask(task.id))?.status).toBe('completed');
+      expect(seenArgs[1]).toEqual({ name: 'dero' });
+      expect(seenArgs[1]).not.toHaveProperty('suspendedToolRunId');
+    });
+
     it('throws when resuming a task that is not suspended', async () => {
       const executeFn = vi.fn().mockResolvedValue('done');
       const { task } = await manager.enqueue(

--- a/packages/core/src/background-tasks/workflow.ts
+++ b/packages/core/src/background-tasks/workflow.ts
@@ -34,6 +34,51 @@ const bodyOutputSchema = z.object({
 const WORKFLOW_STATUS_TO_PERSIST = ['suspended', 'pending', 'paused', 'waiting'];
 
 /**
+ * Key under which the inner (delegated) run id rides the `run-attempt` step's
+ * own suspend payload.
+ *
+ * Delegating tools — agent-as-tool, workflow-as-tool — do not suspend
+ * themselves: they relay a suspension that happened inside a nested run, and
+ * pass that nested run's id back through `suspendOptions.runId`. Resuming
+ * needs it, because the nested run can only be reached by id.
+ *
+ * The workflow runtime drops every `suspendOptions` field except
+ * `resumeLabel`, and `task.args` is frozen at dispatch time, so neither
+ * carries the id across a suspend. The step's suspend *payload*, however, is
+ * persisted in the run snapshot and handed back to the step body as
+ * `suspendData` on resume — so that is where we stash it.
+ *
+ * Deliberately kept out of the payload persisted on the task row: the task
+ * row's `suspendPayload` is published on `task.suspended` lifecycle events and
+ * is user-facing. Only the runtime's copy carries this key.
+ */
+const DELEGATED_RUN_ID_KEY = '__mastraDelegatedRunId';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Attach the delegated run id to the payload handed to the workflow runtime's
+ * `suspend`. Non-object payloads are left untouched — delegating tools always
+ * suspend with an object or nothing, and rewrapping a primitive would change a
+ * shape callers may rely on.
+ */
+function withDelegatedRunId(data: unknown, delegatedRunId?: unknown): unknown {
+  if (typeof delegatedRunId !== 'string' || !delegatedRunId) return data;
+  if (data === undefined || data === null) return { [DELEGATED_RUN_ID_KEY]: delegatedRunId };
+  if (!isPlainObject(data)) return data;
+  return { ...data, [DELEGATED_RUN_ID_KEY]: delegatedRunId };
+}
+
+/** Recover the delegated run id from the step's persisted suspend payload. */
+function readDelegatedRunId(suspendData: unknown): string | undefined {
+  if (!isPlainObject(suspendData)) return undefined;
+  const value = suspendData[DELEGATED_RUN_ID_KEY];
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+/**
  * Builds the per-task workflow that owns executor + retries.
  *
  * Uses the standard (default) execution engine so the workflow runs entirely
@@ -57,7 +102,7 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
     id: 'run-attempt',
     inputSchema: bodyIOSchema,
     outputSchema: attemptOutputSchema,
-    execute: async ({ inputData, abortSignal: workflowAbortSignal, suspend, resumeData }) => {
+    execute: async ({ inputData, abortSignal: workflowAbortSignal, suspend, resumeData, suspendData }) => {
       const { taskId } = inputData;
       const storage = await manager.getStorage();
       const task = await storage.getTask(taskId);
@@ -157,8 +202,20 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
         pendingSuspend = { data, suspendOptions };
       };
 
+      // Delegating tools (agent-as-tool, workflow-as-tool) suspend an *inner*
+      // run and hand its id back via `suspendOptions.runId`. That id is the
+      // only way to reach the inner snapshot on resume, and it is not part of
+      // `task.args` (which is frozen at dispatch time). It rides the step's
+      // own suspend payload — see `DELEGATED_RUN_ID_KEY` — so the runtime
+      // persists it in the workflow snapshot and hands it back here as
+      // `suspendData`. Re-inject it under the `suspendedToolRunId` key the
+      // delegating tools read.
+      const delegatedRunId = readDelegatedRunId(suspendData);
+      const execArgs =
+        resumeData !== undefined && delegatedRunId ? { ...task.args, suspendedToolRunId: delegatedRunId } : task.args;
+
       try {
-        const result = await executor.execute(task.args, {
+        const result = await executor.execute(execArgs, {
           abortSignal: abortController.signal,
           onProgress,
           suspend: wrappedSuspend,
@@ -168,7 +225,10 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
         });
 
         if (pendingSuspend) {
-          return suspend(pendingSuspend.data, pendingSuspend.suspendOptions as SuspendOptions);
+          return suspend(
+            withDelegatedRunId(pendingSuspend.data, pendingSuspend.suspendOptions?.runId),
+            pendingSuspend.suspendOptions as SuspendOptions,
+          );
         }
 
         return { taskId, outcome: 'success' as const, result };

--- a/packages/core/src/background-tasks/workflow.ts
+++ b/packages/core/src/background-tasks/workflow.ts
@@ -210,9 +210,13 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
       // persists it in the workflow snapshot and hands it back here as
       // `suspendData`. Re-inject it under the `suspendedToolRunId` key the
       // delegating tools read.
+      //
+      // Not gated on `resumeData`: it is optional on `manager.resume()`, and a
+      // resume without it must still reach the nested run rather than silently
+      // starting a second one. On the initial attempt there is no prior
+      // suspension, so `suspendData` is undefined and nothing is injected.
       const delegatedRunId = readDelegatedRunId(suspendData);
-      const execArgs =
-        resumeData !== undefined && delegatedRunId ? { ...task.args, suspendedToolRunId: delegatedRunId } : task.args;
+      const execArgs = delegatedRunId ? { ...task.args, suspendedToolRunId: delegatedRunId } : task.args;
 
       try {
         const result = await executor.execute(execArgs, {


### PR DESCRIPTION
## Description

Delegating tools (agent-as-tool, workflow-as-tool) don't suspend themselves — they relay
a suspension from a nested run and hand that run's id back via `suspendOptions.runId`.
The background-task workflow dropped it: the runtime keeps only `resumeLabel` out of
`suspendOptions`, and `task.args` is frozen at dispatch time, so on resume the delegation
was re-invoked with no `suspendedToolRunId` and couldn't reach the suspended run. It
surfaced either as `AGENT_RESUME_NO_SNAPSHOT_FOUND` once retries were exhausted, or
(since #21729) as the sub-agent silently starting over.

Before:

```ts
await manager.resume(taskId, { approved: true });
// executor.execute(task.args, { resumeData })
// -> no suspendedToolRunId in args -> the suspended sub-agent run is never found
```

After — the id rides the `run-attempt` step's own suspend payload, which the runtime
already persists in the run snapshot and hands back as `suspendData` on resume:

```ts
await manager.resume(taskId, { approved: true });
// executor.execute({ ...task.args, suspendedToolRunId }, { resumeData })
// -> resumeStream picks up the suspended sub-agent run
```

No storage schema change, so none of the store adapters are touched, and it survives a
process restart. The payload written to the task row is deliberately left alone so the
internal id doesn't leak onto `task.suspended` lifecycle events. Background tools that
suspend on their own pass no runId and behave exactly as before.

Three tests in `manager.test.ts` cover it: the resume path, the no-leak check, and a
guard that plain tools' args stay untouched.

## Related issue(s)

Fixes #21900

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a background task pauses while using a nested agent or workflow, it now remembers where it paused. When the task resumes, it continues that run instead of starting over. Plain background tools remain unchanged.

## What changed

- Persist the delegated run ID in the `run-attempt` suspend payload.
- Restore the run ID as `suspendedToolRunId` when resuming a task, including when `manager.resume()` receives no `resumeData`.
- Forward the user’s resume input to the nested run.
- Keep the internal run ID out of task lifecycle events and user-facing `suspendPayload`.
- Preserve existing behavior for background tools that do not delegate to nested runs.
- Add a patch changeset for `@mastra/core`.

## Tests

- Verify delegated runs resume with the stored run ID.
- Verify resumes without data reuse the suspended delegated run.
- Verify the internal run ID does not leak into suspend payloads.
- Verify ordinary suspended tools retain their original arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->