### PR TITLE
perf(pg): refresh observability tags incrementally

### DIFF
--- a/.changeset/cozy-times-allow.md
+++ b/.changeset/cozy-times-allow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Improved PostgreSQL observability tag discovery to refresh incrementally instead of rescanning retained event history.

--- a/stores/pg/src/storage/domains/observability/v-next/discovery.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/discovery.test.ts
@@ -1,3 +1,4 @@
+import type { IMastraLogger } from '@mastra/core/logger';
 import { EntityType } from '@mastra/core/observability';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -10,10 +11,14 @@ interface FakeTagClientOptions {
   lockedCache?: { values: string[]; refreshedAt: Date } | null;
   cursors?: Record<string, string>;
   tagsByTable?: Record<string, { values: string[]; xactId: string | null; cursorId: string | null }>;
+  advisoryLockError?: Error;
 }
 
 function createFakeTagClient(options: FakeTagClientOptions = {}) {
-  const query = vi.fn(async () => ({ rows: [], rowCount: 0 }));
+  const query = vi.fn(async (sql: string) => {
+    if (sql.includes('pg_advisory_xact_lock') && options.advisoryLockError) throw options.advisoryLockError;
+    return { rows: [], rowCount: 0 };
+  });
   const one = vi.fn(async (sql: string) => {
     if (sql.includes('pg_snapshot_xmin')) return { xactId: '100' };
 
@@ -85,8 +90,31 @@ describe('Postgres observability tag discovery', () => {
       await vi.waitFor(() => {
         expect(tx.query).toHaveBeenCalledWith(expect.stringContaining('pg_advisory_xact_lock'), ['test_schema:tags']);
       });
+      expect(tx.query.mock.calls.slice(0, 2)).toEqual([
+        [`SET LOCAL lock_timeout = '5s'`],
+        [expect.stringContaining('pg_advisory_xact_lock'), ['test_schema:tags']],
+      ]);
       expect(tx.one).not.toHaveBeenCalled();
       expect(tx.manyOrNone).not.toHaveBeenCalled();
+    });
+
+    it('falls back to cached values when the advisory lock times out', async () => {
+      const staleCache = { values: ['stale-tag'], refreshedAt: new Date(0) };
+      const lockError = new Error('canceling statement due to lock timeout');
+      const warn = vi.fn();
+      const logger = { warn } as unknown as IMastraLogger;
+      const { client } = createFakeTagClient({
+        outerCache: staleCache,
+        advisoryLockError: lockError,
+      });
+
+      await expect(getTags(client, 'test_schema', {}, { ttlSeconds: 0, logger })).resolves.toEqual({
+        tags: ['stale-tag'],
+      });
+      expect(warn).toHaveBeenCalledWith(
+        '[observability/v-next] background refresh failed for discovery cache key "tags"',
+        { error: lockError },
+      );
     });
   });
 

--- a/stores/pg/src/storage/domains/observability/v-next/discovery.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/discovery.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DbClient, TxClient } from '../../../client';
+import { TABLE_LOG_EVENTS, TABLE_METRIC_EVENTS, TABLE_SPAN_EVENTS } from './ddl';
+import { getTags, invalidateTagDiscoveryCache } from './discovery';
+
+interface FakeTagClientOptions {
+  outerCache?: { values: string[]; refreshedAt: Date } | null;
+  lockedCache?: { values: string[]; refreshedAt: Date } | null;
+  cursors?: Record<string, string>;
+  tagsByTable?: Record<string, { values: string[]; xactId: string | null; cursorId: string | null }>;
+}
+
+function createFakeTagClient(options: FakeTagClientOptions = {}) {
+  const query = vi.fn(async () => ({ rows: [], rowCount: 0 }));
+  const one = vi.fn(async (sql: string) => {
+    if (sql.includes('pg_snapshot_xmin')) return { xactId: '100' };
+
+    for (const table of [TABLE_SPAN_EVENTS, TABLE_METRIC_EVENTS, TABLE_LOG_EVENTS]) {
+      if (sql.includes(`"${table}"`)) {
+        return options.tagsByTable?.[table] ?? { values: [], xactId: null, cursorId: null };
+      }
+    }
+
+    throw new Error(`Unexpected one() query: ${sql}`);
+  });
+  const oneOrNone = vi.fn(async () => options.lockedCache ?? null);
+  const manyOrNone = vi.fn(async () =>
+    Object.entries(options.cursors ?? {}).map(([cacheKey, cursor]) => ({ cacheKey, values: [cursor] })),
+  );
+  const tx = { query, one, oneOrNone, manyOrNone } as unknown as TxClient;
+  const client = {
+    oneOrNone: vi.fn(async () => options.outerCache ?? null),
+    tx: vi.fn(async callback => callback(tx)),
+    none: vi.fn(async () => null),
+  } as unknown as DbClient;
+
+  return { client, tx: { query, one, oneOrNone, manyOrNone } };
+}
+
+describe('Postgres observability tag discovery', () => {
+  describe('when the cache has no cursor state', () => {
+    it('reads each signal through the safe cursor range and stores values with three cursors', async () => {
+      const { client, tx } = createFakeTagClient({
+        tagsByTable: {
+          [TABLE_SPAN_EVENTS]: { values: ['shared', 'z-tag'], xactId: '10', cursorId: '3' },
+          [TABLE_METRIC_EVENTS]: { values: ['a-tag', 'shared'], xactId: '11', cursorId: '4' },
+          [TABLE_LOG_EVENTS]: { values: [], xactId: null, cursorId: null },
+        },
+      });
+
+      await expect(getTags(client, 'test_schema', {}, { ttlSeconds: 0 })).resolves.toEqual({
+        tags: ['a-tag', 'shared', 'z-tag'],
+      });
+
+      const signalQueries = tx.one.mock.calls.filter(([sql]) => sql.includes('WITH new_rows AS MATERIALIZED'));
+      expect(signalQueries).toHaveLength(3);
+      for (const [sql, params] of signalQueries) {
+        expect(sql).toContain('("xactId", "cursorId") > ($1::xid8, $2::bigint)');
+        expect(sql).toContain('"xactId" < $3::xid8');
+        expect(params).toEqual(['0', '0', '100']);
+      }
+
+      const upserts = tx.query.mock.calls.filter(([sql]) => sql.startsWith('INSERT INTO'));
+      expect(upserts).toHaveLength(4);
+      expect(upserts.map(([, values]) => values?.[0])).toEqual([
+        'tags',
+        `tags:cursor:${TABLE_SPAN_EVENTS}`,
+        `tags:cursor:${TABLE_METRIC_EVENTS}`,
+        `tags:cursor:${TABLE_LOG_EVENTS}`,
+      ]);
+    });
+  });
+
+  describe('when another process refreshes while this caller waits for the advisory lock', () => {
+    it('keeps the stale-while-revalidate response and skips redundant signal reads', async () => {
+      const { client, tx } = createFakeTagClient({
+        outerCache: { values: ['stale-tag'], refreshedAt: new Date(0) },
+        lockedCache: { values: ['fresh-tag'], refreshedAt: new Date() },
+      });
+
+      await expect(getTags(client, 'test_schema', {}, { ttlSeconds: 300 })).resolves.toEqual({ tags: ['stale-tag'] });
+
+      await vi.waitFor(() => {
+        expect(tx.query).toHaveBeenCalledWith(expect.stringContaining('pg_advisory_xact_lock'), ['test_schema:tags']);
+      });
+      expect(tx.one).not.toHaveBeenCalled();
+      expect(tx.manyOrNone).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when all signal cursors are present', () => {
+    it('starts after each cursor and merges newly discovered tags with cached values', async () => {
+      const cursorValues = {
+        [`tags:cursor:${TABLE_SPAN_EVENTS}`]: '10:3',
+        [`tags:cursor:${TABLE_METRIC_EVENTS}`]: '11:4',
+        [`tags:cursor:${TABLE_LOG_EVENTS}`]: '12:5',
+      };
+      const staleCache = { values: ['cached-tag'], refreshedAt: new Date(0) };
+      const { client, tx } = createFakeTagClient({
+        outerCache: staleCache,
+        lockedCache: staleCache,
+        cursors: cursorValues,
+        tagsByTable: {
+          [TABLE_LOG_EVENTS]: { values: ['new-tag'], xactId: '13', cursorId: '6' },
+        },
+      });
+
+      await expect(getTags(client, 'test_schema', {}, { ttlSeconds: 0 })).resolves.toEqual({
+        tags: ['cached-tag', 'new-tag'],
+      });
+
+      const signalQueries = tx.one.mock.calls.filter(([sql]) => sql.includes('WITH new_rows AS MATERIALIZED'));
+      expect(signalQueries.map(([, params]) => params?.slice(0, 2))).toEqual([
+        ['10', '3'],
+        ['11', '4'],
+        ['12', '5'],
+      ]);
+    });
+  });
+
+  describe('when signal rows are deleted', () => {
+    it('invalidates unscoped, scoped, and cursor tag cache keys', async () => {
+      const { client } = createFakeTagClient();
+
+      await invalidateTagDiscoveryCache(client, 'test_schema');
+
+      expect(client.none).toHaveBeenCalledWith(expect.stringContaining(`"cacheKey" LIKE 'tags:%'`));
+    });
+  });
+});

--- a/stores/pg/src/storage/domains/observability/v-next/discovery.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/discovery.test.ts
@@ -1,8 +1,9 @@
+import { EntityType } from '@mastra/core/observability';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { DbClient, TxClient } from '../../../client';
 import { TABLE_LOG_EVENTS, TABLE_METRIC_EVENTS, TABLE_SPAN_EVENTS } from './ddl';
-import { getTags, invalidateTagDiscoveryCache } from './discovery';
+import { getTags, invalidateTagDiscoveryCache, reconcileTagDiscoveryCacheAfterTraceDelete } from './discovery';
 
 interface FakeTagClientOptions {
   outerCache?: { values: string[]; refreshedAt: Date } | null;
@@ -120,6 +121,43 @@ describe('Postgres observability tag discovery', () => {
   });
 
   describe('when signal rows are deleted', () => {
+    it('removes only unreferenced tags while preserving discovery cursors', async () => {
+      const query = vi.fn(async () => ({ rows: [], rowCount: 0 }));
+      const manyOrNone = vi.fn(async (sql: string, _params?: unknown[]) => {
+        if (sql.includes('SELECT "cacheKey", "values"')) {
+          return [
+            { cacheKey: 'tags', values: ['gone-tag', 'shared-tag', 'unaffected-tag'] },
+            { cacheKey: `tags:${EntityType.AGENT}`, values: ['gone-tag', 'shared-tag', 'unaffected-tag'] },
+          ];
+        }
+        if (sql.includes('FROM UNNEST')) return [{ value: 'shared-tag' }];
+        throw new Error(`Unexpected manyOrNone() query: ${sql}`);
+      });
+      const tx = { query, manyOrNone } as unknown as TxClient;
+
+      await reconcileTagDiscoveryCacheAfterTraceDelete(tx, 'test_schema', [
+        { tags: ['gone-tag', 'shared-tag'], entityType: EntityType.AGENT },
+      ]);
+
+      const locks = query.mock.calls.filter(([sql]) => sql.includes('pg_advisory_xact_lock'));
+      expect(locks.map(([, params]) => params?.[0])).toEqual([
+        'test_schema:tags',
+        `test_schema:tags:${EntityType.AGENT}`,
+      ]);
+      const survivalReads = manyOrNone.mock.calls.filter(([sql]) => sql.includes('FROM UNNEST'));
+      expect(survivalReads.map(([, params]) => params)).toEqual([
+        [['gone-tag', 'shared-tag']],
+        [['gone-tag', 'shared-tag'], EntityType.AGENT],
+      ]);
+      const updates = query.mock.calls.filter(([sql]) => sql.startsWith('UPDATE'));
+      expect(updates.map(([, params]) => params)).toEqual([
+        ['tags', JSON.stringify(['shared-tag', 'unaffected-tag'])],
+        [`tags:${EntityType.AGENT}`, JSON.stringify(['shared-tag', 'unaffected-tag'])],
+      ]);
+      expect(updates.every(([sql]) => !sql.includes('"refreshedAt"'))).toBe(true);
+      expect(query.mock.calls.some(([sql]) => sql.startsWith('DELETE'))).toBe(false);
+    });
+
     it('invalidates unscoped, scoped, and cursor tag cache keys', async () => {
       const { client } = createFakeTagClient();
 

--- a/stores/pg/src/storage/domains/observability/v-next/discovery.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/discovery.ts
@@ -49,6 +49,7 @@ import {
   TABLE_SPAN_EVENTS,
 } from './ddl';
 import { decodeDeltaCursor, encodeDeltaCursor, readSafeXactHorizon } from './polling';
+import type { DeletedTraceTagRow } from './tracing';
 
 const DEFAULT_TTL_SECONDS = 5 * 60; // 5 minutes
 
@@ -347,6 +348,93 @@ async function refreshTagsIncrementally(
     }
     return values;
   });
+}
+
+/** Return candidate tags that are still referenced by any discovery signal. */
+async function readSurvivingTags(
+  client: Pick<TxClient, 'manyOrNone'>,
+  schema: string,
+  candidates: string[],
+  entityType?: EntityType,
+): Promise<Set<string>> {
+  const entityFilter = entityType ? `AND "entityType" = $2` : '';
+  const params: unknown[] = [candidates];
+  if (entityType) params.push(entityType);
+  const references = ENTITY_DISCOVERY_TABLES.map(
+    table =>
+      `SELECT 1
+       FROM ${qualifiedTable(schema, table)}
+       WHERE "tags" @> ARRAY[candidate.tag]::text[] ${entityFilter}`,
+  ).join(' UNION ALL ');
+  const rows = await client.manyOrNone<{ value: string }>(
+    `SELECT candidate.tag AS value
+     FROM UNNEST($1::text[]) AS candidate(tag)
+     WHERE EXISTS (${references})
+     ORDER BY candidate.tag`,
+    params,
+  );
+  return new Set(rows.map(row => row.value));
+}
+
+/**
+ * Remove tags made obsolete by trace deletion without discarding incremental
+ * cursors. Candidate lookups use the existing GIN tag indexes, so deletion
+ * cost scales with tags on the deleted spans instead of retained history.
+ */
+export async function reconcileTagDiscoveryCacheAfterTraceDelete(
+  client: TxClient,
+  schema: string,
+  deletedRows: DeletedTraceTagRow[],
+): Promise<void> {
+  const candidatesByCacheKey = new Map<string, Set<string>>();
+  const addCandidates = (cacheKey: string, tags: string[]) => {
+    const candidates = candidatesByCacheKey.get(cacheKey) ?? new Set<string>();
+    for (const tag of tags) {
+      if (tag) candidates.add(tag);
+    }
+    if (candidates.size > 0) candidatesByCacheKey.set(cacheKey, candidates);
+  };
+
+  for (const row of deletedRows) {
+    addCandidates('tags', row.tags);
+    if (row.entityType) addCandidates(`tags:${row.entityType}`, row.tags);
+  }
+
+  const cacheKeys = [...candidatesByCacheKey.keys()].sort();
+  if (cacheKeys.length === 0) return;
+
+  // Coordinate with incremental refreshes for every affected cache key. The
+  // sorted order also makes concurrent multi-key repairs deadlock-safe.
+  for (const cacheKey of cacheKeys) {
+    await client.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [`${schema}:${cacheKey}`]);
+  }
+
+  const discoveryTable = qualifiedTable(schema, TABLE_DISCOVERY);
+  const cacheRows = await client.manyOrNone<{ cacheKey: string; values: string[] }>(
+    `SELECT "cacheKey", "values"
+     FROM ${discoveryTable}
+     WHERE "cacheKey" = ANY($1::text[])`,
+    [cacheKeys],
+  );
+  const valuesByCacheKey = new Map(cacheRows.map(row => [row.cacheKey, row.values]));
+
+  for (const cacheKey of cacheKeys) {
+    const currentValues = valuesByCacheKey.get(cacheKey);
+    if (!currentValues) continue;
+    const candidateSet = candidatesByCacheKey.get(cacheKey) ?? new Set<string>();
+    const candidates = [...candidateSet].sort();
+    const entityType = cacheKey === 'tags' ? undefined : (cacheKey.slice('tags:'.length) as EntityType);
+    const surviving = await readSurvivingTags(client, schema, candidates, entityType);
+    const nextValues = currentValues.filter(value => !candidateSet.has(value) || surviving.has(value));
+    if (nextValues.length === currentValues.length) continue;
+
+    // Keep refreshedAt and all cursor rows unchanged. The repair only removes
+    // values proven absent; subsequent refreshes continue from their cursors.
+    await client.query(`UPDATE ${discoveryTable} SET "values" = $2::jsonb WHERE "cacheKey" = $1`, [
+      cacheKey,
+      JSON.stringify(nextValues),
+    ]);
+  }
 }
 
 /** Remove tag values and cursor state after signal rows are deleted. */

--- a/stores/pg/src/storage/domains/observability/v-next/discovery.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/discovery.ts
@@ -7,8 +7,9 @@
  *   - if no cache row exists, compute synchronously and serve.
  *   - if cache row exists and is fresher than `discoveryTtlSeconds`, serve as-is.
  *   - if cache row is stale, kick off an async refresh and serve the cached
- *     value. The refresh upserts on a single row keyed by cacheKey, so
- *     concurrent readers race harmlessly with last-write-wins semantics.
+ *     value. Generic discovery values use last-write-wins upserts; tag
+ *     discovery additionally serializes its value/cursor refresh across
+ *     processes with a PostgreSQL advisory lock.
  *
  * No in-memory caching: the table-backed cache works across multiple
  * frontends pointing at the same database and survives serverless restarts.
@@ -37,7 +38,7 @@ import type {
 
 import { parseSqlIdentifier } from '@mastra/core/utils';
 
-import type { DbClient } from '../../../client';
+import type { DbClient, TxClient } from '../../../client';
 import {
   qualifiedTable,
   TABLE_DISCOVERY,
@@ -47,6 +48,7 @@ import {
   TABLE_FEEDBACK_EVENTS,
   TABLE_SPAN_EVENTS,
 } from './ddl';
+import { decodeDeltaCursor, encodeDeltaCursor, readSafeXactHorizon } from './polling';
 
 const DEFAULT_TTL_SECONDS = 5 * 60; // 5 minutes
 
@@ -81,7 +83,7 @@ export interface DiscoveryConfig {
  *
  * Covers two stampede shapes:
  *  - cold start: N concurrent first-callers all want the values, but only
- *    one of them needs to actually run `refresh()` + `upsertCache()`. The
+ *    one of them needs to actually run the refresh-and-store operation. The
  *    others await the same promise.
  *  - stale refresh: N concurrent stale-readers serve the cached values
  *    immediately and share one background refresh.
@@ -95,8 +97,7 @@ const inFlightRefreshes = new Map<string, Promise<string[]>>();
 function startOrJoinRefresh(
   dedupeKey: string,
   cacheKey: string,
-  refresh: () => Promise<string[]>,
-  upsert: (values: string[]) => Promise<void>,
+  refreshAndStore: () => Promise<string[]>,
   logger: IMastraLogger | undefined,
 ): Promise<string[]> {
   const existing = inFlightRefreshes.get(dedupeKey);
@@ -104,9 +105,7 @@ function startOrJoinRefresh(
 
   const promise = (async () => {
     try {
-      const values = await refresh();
-      await upsert(values);
-      return values;
+      return await refreshAndStore();
     } catch (error) {
       // Surface refresh failures — silently swallowing them would mask real
       // DB/connectivity issues behind permanently stale data. Prefer the
@@ -148,6 +147,7 @@ async function readWithRefresh(
   refresh: () => Promise<string[]>,
   ttlSeconds: number,
   logger: IMastraLogger | undefined,
+  options?: { refreshStoresValues?: boolean },
 ): Promise<string[]> {
   const table = qualifiedTable(schema, TABLE_DISCOVERY);
   // pg returns `timestamptz` as a JS Date — type the field accordingly.
@@ -162,13 +162,15 @@ async function readWithRefresh(
   if (!stale) return row!.values;
 
   const dedupeKey = `${schema}:${cacheKey}`;
-  const refreshing = startOrJoinRefresh(
-    dedupeKey,
-    cacheKey,
-    refresh,
-    values => upsertCache(client, schema, cacheKey, values),
-    logger,
-  );
+  const refreshAndStore =
+    options?.refreshStoresValues === true
+      ? refresh
+      : async () => {
+          const values = await refresh();
+          await upsertCache(client, schema, cacheKey, values);
+          return values;
+        };
+  const refreshing = startOrJoinRefresh(dedupeKey, cacheKey, refreshAndStore, logger);
 
   // Force-refresh path: `ttlSeconds <= 0` is the contract used by
   // `refreshAllDiscoveryCaches()` (and the future `mastra observability
@@ -203,7 +205,12 @@ async function readWithRefresh(
   return row.values;
 }
 
-async function upsertCache(client: DbClient, schema: string, cacheKey: string, values: string[]): Promise<void> {
+async function upsertCache(
+  client: Pick<DbClient, 'query'>,
+  schema: string,
+  cacheKey: string,
+  values: string[],
+): Promise<void> {
   const table = qualifiedTable(schema, TABLE_DISCOVERY);
   await client.query(
     `INSERT INTO ${table} ("cacheKey", "refreshedAt", "values")
@@ -212,6 +219,141 @@ async function upsertCache(client: DbClient, schema: string, cacheKey: string, v
        "refreshedAt" = EXCLUDED."refreshedAt",
        "values" = EXCLUDED."values"`,
     [cacheKey, JSON.stringify(values)],
+  );
+}
+
+const ZERO_CURSOR = '0:0';
+
+function tagCursorCacheKey(cacheKey: string, table: string): string {
+  return `${cacheKey}:cursor:${table}`;
+}
+
+function readCachedCursor(values: unknown): string | null {
+  if (!Array.isArray(values) || typeof values[0] !== 'string') return null;
+  try {
+    const cursor = decodeDeltaCursor(values[0]);
+    return encodeDeltaCursor(cursor.xactId, cursor.cursorId);
+  } catch {
+    // Discovery state is disposable. A malformed cursor should cause a safe
+    // full rebuild rather than make tag discovery permanently fail.
+    return null;
+  }
+}
+
+interface IncrementalTagsResult {
+  values: string[];
+  xactId: string | null;
+  cursorId: string | null;
+}
+
+async function readIncrementalTags(
+  client: Pick<TxClient, 'one'>,
+  schema: string,
+  table: string,
+  cursor: string,
+  safeXactHorizon: string,
+  entityType?: EntityType,
+): Promise<IncrementalTagsResult> {
+  const { xactId, cursorId } = decodeDeltaCursor(cursor);
+  const entityFilter = entityType ? `AND "entityType" = $4` : '';
+  const params: unknown[] = [xactId, cursorId, safeXactHorizon];
+  if (entityType) params.push(entityType);
+
+  return client.one<IncrementalTagsResult>(
+    `WITH new_rows AS MATERIALIZED (
+       SELECT "xactId", "cursorId", "entityType", "tags"
+       FROM ${qualifiedTable(schema, table)}
+       WHERE ("xactId", "cursorId") > ($1::xid8, $2::bigint)
+         AND "xactId" < $3::xid8
+     ),
+     new_tags AS (
+       SELECT DISTINCT tag AS v
+       FROM new_rows
+       CROSS JOIN LATERAL UNNEST("tags") AS expanded(tag)
+       WHERE tag IS NOT NULL AND tag <> '' ${entityFilter}
+     ),
+     last_cursor AS (
+       SELECT "xactId", "cursorId"
+       FROM new_rows
+       ORDER BY "xactId" DESC, "cursorId" DESC
+       LIMIT 1
+     )
+     SELECT
+       COALESCE((SELECT ARRAY_AGG(v ORDER BY v) FROM new_tags), '{}'::text[]) AS "values",
+       (SELECT "xactId"::text FROM last_cursor) AS "xactId",
+       (SELECT "cursorId"::text FROM last_cursor) AS "cursorId"`,
+    params,
+  );
+}
+
+async function refreshTagsIncrementally(
+  client: DbClient,
+  schema: string,
+  cacheKey: string,
+  args: GetTagsArgs,
+  ttlSeconds: number,
+): Promise<string[]> {
+  const discoveryTable = qualifiedTable(schema, TABLE_DISCOVERY);
+  const cursorKeys = ENTITY_DISCOVERY_TABLES.map(table => tagCursorCacheKey(cacheKey, table));
+
+  return client.tx(async tx => {
+    // The in-memory map only dedupes callers in this process. A transaction
+    // advisory lock serializes refreshes across server instances that share
+    // the same schema and cache key.
+    await tx.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [`${schema}:${cacheKey}`]);
+
+    const current = await tx.oneOrNone<{ values: string[]; refreshedAt: Date }>(
+      `SELECT "values", "refreshedAt" FROM ${discoveryTable} WHERE "cacheKey" = $1`,
+      [cacheKey],
+    );
+
+    // Another process may have refreshed while this caller waited for the
+    // lock. Recheck freshness before touching the signal tables.
+    if (ttlSeconds > 0 && current) {
+      const ageMs = Date.now() - new Date(current.refreshedAt).getTime();
+      if (ageMs <= ttlSeconds * 1000) return current.values;
+    }
+
+    const cursorRows = current
+      ? await tx.manyOrNone<{ cacheKey: string; values: unknown }>(
+          `SELECT "cacheKey", "values"
+           FROM ${discoveryTable}
+           WHERE "cacheKey" = ANY($1::text[])`,
+          [cursorKeys],
+        )
+      : [];
+    const cursorByKey = new Map(cursorRows.map(row => [row.cacheKey, readCachedCursor(row.values)]));
+    const canRefreshIncrementally =
+      current !== null && cursorKeys.every(key => typeof cursorByKey.get(key) === 'string');
+    const safeXactHorizon = await readSafeXactHorizon(tx);
+    const discovered = new Set(canRefreshIncrementally ? (current?.values ?? []) : []);
+    const nextCursors = new Map<string, string>();
+
+    for (const table of ENTITY_DISCOVERY_TABLES) {
+      const cursorKey = tagCursorCacheKey(cacheKey, table);
+      const cursor = canRefreshIncrementally ? (cursorByKey.get(cursorKey) ?? ZERO_CURSOR) : ZERO_CURSOR;
+      const result = await readIncrementalTags(tx, schema, table, cursor, safeXactHorizon, args.entityType);
+      for (const value of result.values) discovered.add(value);
+      nextCursors.set(
+        cursorKey,
+        result.xactId !== null && result.cursorId !== null ? encodeDeltaCursor(result.xactId, result.cursorId) : cursor,
+      );
+    }
+
+    const values = [...discovered].sort();
+    await upsertCache(tx, schema, cacheKey, values);
+    for (const [cursorKey, cursor] of nextCursors) {
+      await upsertCache(tx, schema, cursorKey, [cursor]);
+    }
+    return values;
+  });
+}
+
+/** Remove tag values and cursor state after signal rows are deleted. */
+export async function invalidateTagDiscoveryCache(client: DbClient, schema: string): Promise<void> {
+  await client.none(
+    `DELETE FROM ${qualifiedTable(schema, TABLE_DISCOVERY)}
+     WHERE "cacheKey" = 'tags' OR "cacheKey" LIKE 'tags:%'`,
   );
 }
 
@@ -330,22 +472,10 @@ export async function getTags(
 ): Promise<GetTagsResponse> {
   const ttl = config.ttlSeconds ?? DEFAULT_TTL_SECONDS;
   const cacheKey = args.entityType ? `tags:${args.entityType}` : 'tags';
-
-  const refresh = async (): Promise<string[]> => {
-    const filter = args.entityType ? `AND "entityType" = $1` : '';
-    const params = args.entityType ? [args.entityType] : [];
-    const unions = ENTITY_DISCOVERY_TABLES.map(
-      t =>
-        `SELECT DISTINCT UNNEST("tags") AS v FROM ${qualifiedTable(schema, t)} WHERE array_length("tags", 1) > 0 ${filter}`,
-    ).join(' UNION ');
-    const rows = await client.manyOrNone<{ v: string }>(
-      `SELECT v FROM (${unions}) sub WHERE v IS NOT NULL AND v <> '' ORDER BY v`,
-      params,
-    );
-    return rows.map(r => r.v);
-  };
-
-  const values = await readWithRefresh(client, schema, cacheKey, refresh, ttl, config.logger);
+  const refreshAndStore = () => refreshTagsIncrementally(client, schema, cacheKey, args, ttl);
+  const values = await readWithRefresh(client, schema, cacheKey, refreshAndStore, ttl, config.logger, {
+    refreshStoresValues: true,
+  });
   return { tags: values };
 }
 

--- a/stores/pg/src/storage/domains/observability/v-next/discovery.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/discovery.ts
@@ -301,6 +301,7 @@ async function refreshTagsIncrementally(
     // The in-memory map only dedupes callers in this process. A transaction
     // advisory lock serializes refreshes across server instances that share
     // the same schema and cache key.
+    await tx.query(`SET LOCAL lock_timeout = '5s'`);
     await tx.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [`${schema}:${cacheKey}`]);
 
     const current = await tx.oneOrNone<{ values: string[]; refreshedAt: Date }>(

--- a/stores/pg/src/storage/domains/observability/v-next/index.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/index.ts
@@ -290,6 +290,7 @@ export class ObservabilityStoragePostgresVNext extends ObservabilityStorage {
       const results: PruneResult[] = [];
       const now = Date.now();
       let invalidatesTagDiscovery = false;
+      let pruneFailed = false;
 
       try {
         for (const [key, entry] of Object.entries(ObservabilityStoragePostgresVNext.retentionTables)) {
@@ -316,12 +317,20 @@ export class ObservabilityStoragePostgresVNext extends ObservabilityStorage {
 
           results.push({ domain: 'observability', table: entry.table, deleted: outcome.deleted, done: outcome.done });
         }
+      } catch (error) {
+        pruneFailed = true;
+        throw error;
       } finally {
         // Pruning is not atomic across signal tables. If a later table fails
         // after an earlier one deleted rows, the monotonic tag cache still
         // has to be rebuilt on its next read.
         if (invalidatesTagDiscovery) {
-          await discoveryOps.invalidateTagDiscoveryCache(this.#client, this.#schema);
+          try {
+            await discoveryOps.invalidateTagDiscoveryCache(this.#client, this.#schema);
+          } catch (error) {
+            if (!pruneFailed) throw error;
+            this.logger?.warn?.('[observability/v-next] tag discovery invalidation failed after prune', { error });
+          }
         }
       }
 

--- a/stores/pg/src/storage/domains/observability/v-next/index.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/index.ts
@@ -289,21 +289,40 @@ export class ObservabilityStoragePostgresVNext extends ObservabilityStorage {
 
       const results: PruneResult[] = [];
       const now = Date.now();
+      let invalidatesTagDiscovery = false;
 
-      for (const [key, entry] of Object.entries(ObservabilityStoragePostgresVNext.retentionTables)) {
-        const policy = policies[key];
-        if (!policy) continue;
+      try {
+        for (const [key, entry] of Object.entries(ObservabilityStoragePostgresVNext.retentionTables)) {
+          const policy = policies[key];
+          if (!policy) continue;
 
-        if (options?.signal?.aborted) {
-          results.push({ domain: 'observability', table: entry.table, deleted: 0, done: false });
-          continue;
+          if (options?.signal?.aborted) {
+            results.push({ domain: 'observability', table: entry.table, deleted: 0, done: false });
+            continue;
+          }
+
+          const cutoff = retentionCutoff(policy, now);
+          const args = { client: this.#client, schema: this.#schema, table: entry.table, cutoff, options };
+          const outcome = mode === 'timescale' ? await pruneTimescaleTable(args) : await prunePartitionedTable(args);
+
+          if (
+            outcome.deleted > 0 &&
+            (entry.table === TABLE_SPAN_EVENTS ||
+              entry.table === TABLE_METRIC_EVENTS ||
+              entry.table === TABLE_LOG_EVENTS)
+          ) {
+            invalidatesTagDiscovery = true;
+          }
+
+          results.push({ domain: 'observability', table: entry.table, deleted: outcome.deleted, done: outcome.done });
         }
-
-        const cutoff = retentionCutoff(policy, now);
-        const args = { client: this.#client, schema: this.#schema, table: entry.table, cutoff, options };
-        const outcome = mode === 'timescale' ? await pruneTimescaleTable(args) : await prunePartitionedTable(args);
-
-        results.push({ domain: 'observability', table: entry.table, deleted: outcome.deleted, done: outcome.done });
+      } finally {
+        // Pruning is not atomic across signal tables. If a later table fails
+        // after an earlier one deleted rows, the monotonic tag cache still
+        // has to be rebuilt on its next read.
+        if (invalidatesTagDiscovery) {
+          await discoveryOps.invalidateTagDiscoveryCache(this.#client, this.#schema);
+        }
       }
 
       return results;
@@ -576,9 +595,16 @@ export class ObservabilityStoragePostgresVNext extends ObservabilityStorage {
   // -------------------------------------------------------------------------
 
   override async batchDeleteTraces(args: BatchDeleteTracesArgs): Promise<void> {
-    await this.#run('BATCH_DELETE_TRACES', () => tracingOps.batchDeleteTraces(this.#client, this.#schema, args), {
-      count: args.traceIds.length,
-    });
+    await this.#run(
+      'BATCH_DELETE_TRACES',
+      async () => {
+        await tracingOps.batchDeleteTraces(this.#client, this.#schema, args);
+        if (args.traceIds.length > 0) {
+          await discoveryOps.invalidateTagDiscoveryCache(this.#client, this.#schema);
+        }
+      },
+      { count: args.traceIds.length },
+    );
   }
 
   override async dangerouslyClearAll(): Promise<void> {

--- a/stores/pg/src/storage/domains/observability/v-next/index.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/index.ts
@@ -291,6 +291,7 @@ export class ObservabilityStoragePostgresVNext extends ObservabilityStorage {
       const now = Date.now();
       let invalidatesTagDiscovery = false;
       let pruneFailed = false;
+      let pruneError: unknown;
 
       try {
         for (const [key, entry] of Object.entries(ObservabilityStoragePostgresVNext.retentionTables)) {
@@ -319,20 +320,21 @@ export class ObservabilityStoragePostgresVNext extends ObservabilityStorage {
         }
       } catch (error) {
         pruneFailed = true;
-        throw error;
-      } finally {
-        // Pruning is not atomic across signal tables. If a later table fails
-        // after an earlier one deleted rows, the monotonic tag cache still
-        // has to be rebuilt on its next read.
-        if (invalidatesTagDiscovery) {
-          try {
-            await discoveryOps.invalidateTagDiscoveryCache(this.#client, this.#schema);
-          } catch (error) {
-            if (!pruneFailed) throw error;
-            this.logger?.warn?.('[observability/v-next] tag discovery invalidation failed after prune', { error });
-          }
+        pruneError = error;
+      }
+
+      // Pruning is not atomic across signal tables. If a later table fails
+      // after an earlier one deleted rows, the monotonic tag cache still
+      // has to be rebuilt on its next read.
+      if (invalidatesTagDiscovery) {
+        try {
+          await discoveryOps.invalidateTagDiscoveryCache(this.#client, this.#schema);
+        } catch (error) {
+          if (!pruneFailed) throw error;
+          this.logger?.warn?.('[observability/v-next] tag discovery invalidation failed after prune', { error });
         }
       }
+      if (pruneFailed) throw pruneError;
 
       return results;
     });

--- a/stores/pg/src/storage/domains/observability/v-next/index.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/index.ts
@@ -607,10 +607,11 @@ export class ObservabilityStoragePostgresVNext extends ObservabilityStorage {
     await this.#run(
       'BATCH_DELETE_TRACES',
       async () => {
-        await tracingOps.batchDeleteTraces(this.#client, this.#schema, args);
-        if (args.traceIds.length > 0) {
-          await discoveryOps.invalidateTagDiscoveryCache(this.#client, this.#schema);
-        }
+        if (args.traceIds.length === 0) return;
+        await this.#client.tx(async tx => {
+          const deletedRows = await tracingOps.batchDeleteTraces(tx, this.#schema, args);
+          await discoveryOps.reconcileTagDiscoveryCacheAfterTraceDelete(tx, this.#schema, deletedRows);
+        });
       },
       { count: args.traceIds.length },
     );

--- a/stores/pg/src/storage/domains/observability/v-next/integration.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/integration.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { coreFeatures } from '@mastra/core/features';
-import { SpanType } from '@mastra/core/observability';
+import { EntityType, SpanType } from '@mastra/core/observability';
 import { Pool } from 'pg';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -948,7 +948,7 @@ describe('ObservabilityStoragePostgresVNext — integration', () => {
       }
     });
 
-    it('invalidates tag values and cursors when traces are deleted', async () => {
+    it('reconciles tag values without discarding cursors when traces are deleted', async () => {
       const harness = await createHarness({
         schemaPrefix: 'obs_vnext_discovery_tags_delete',
         discovery: { ttlSeconds: 0 },
@@ -959,20 +959,48 @@ describe('ObservabilityStoragePostgresVNext — integration', () => {
           span: makeSpan({
             traceId: 'deleted-tag-trace',
             spanId: 'deleted-tag-span',
-            tags: ['deleted-tag'],
+            entityType: EntityType.AGENT,
+            tags: ['deleted-tag', 'shared-tag'],
           }),
         });
-        expect(await harness.domain.getTags({})).toEqual({ tags: ['deleted-tag'] });
+        await harness.domain.batchCreateLogs({
+          logs: [makeLog({ logId: 'remaining-tag-log', entityType: EntityType.AGENT, tags: ['shared-tag'] })],
+        });
+        expect(await harness.domain.getTags({})).toEqual({ tags: ['deleted-tag', 'shared-tag'] });
+        expect(await harness.domain.getTags({ entityType: EntityType.AGENT })).toEqual({
+          tags: ['deleted-tag', 'shared-tag'],
+        });
+
+        const cursorsBefore = await harness.baseClient.manyOrNone<{ cacheKey: string; values: string[] }>(
+          `SELECT "cacheKey", "values"
+           FROM ${qualifiedTable(harness.schema, TABLE_DISCOVERY)}
+           WHERE "cacheKey" LIKE 'tags%:cursor:%'
+           ORDER BY "cacheKey"`,
+        );
+        expect(cursorsBefore).toHaveLength(6);
 
         await harness.domain.batchDeleteTraces({ traceIds: ['deleted-tag-trace'] });
 
-        const cacheRows = await harness.baseClient.one<{ count: string }>(
-          `SELECT COUNT(*)::text AS "count"
+        const valueRows = await harness.baseClient.manyOrNone<{ cacheKey: string; values: string[] }>(
+          `SELECT "cacheKey", "values"
            FROM ${qualifiedTable(harness.schema, TABLE_DISCOVERY)}
-           WHERE "cacheKey" = 'tags' OR "cacheKey" LIKE 'tags:%'`,
+           WHERE "cacheKey" = ANY($1::text[])
+           ORDER BY "cacheKey"`,
+          [['tags', `tags:${EntityType.AGENT}`]],
         );
-        expect(Number(cacheRows.count)).toBe(0);
-        expect(await harness.domain.getTags({})).toEqual({ tags: [] });
+        expect(valueRows).toEqual([
+          { cacheKey: 'tags', values: ['shared-tag'] },
+          { cacheKey: `tags:${EntityType.AGENT}`, values: ['shared-tag'] },
+        ]);
+        const cursorsAfter = await harness.baseClient.manyOrNone<{ cacheKey: string; values: string[] }>(
+          `SELECT "cacheKey", "values"
+           FROM ${qualifiedTable(harness.schema, TABLE_DISCOVERY)}
+           WHERE "cacheKey" LIKE 'tags%:cursor:%'
+           ORDER BY "cacheKey"`,
+        );
+        expect(cursorsAfter).toEqual(cursorsBefore);
+        expect(await harness.domain.getTags({})).toEqual({ tags: ['shared-tag'] });
+        expect(await harness.domain.getTags({ entityType: EntityType.AGENT })).toEqual({ tags: ['shared-tag'] });
       } finally {
         await harness.close();
       }

--- a/stores/pg/src/storage/domains/observability/v-next/integration.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/integration.test.ts
@@ -848,6 +848,133 @@ describe('ObservabilityStoragePostgresVNext — integration', () => {
     });
   });
 
+  describe('discovery — incremental tags', () => {
+    it('refreshes tags from rows after the persisted signal cursors', async () => {
+      const harness = await createHarness({
+        schemaPrefix: 'obs_vnext_discovery_tags_incremental',
+        discovery: { ttlSeconds: 0 },
+      });
+
+      try {
+        await harness.domain.createSpan({
+          span: makeSpan({
+            traceId: 'tag-cursor-trace',
+            spanId: 'tag-cursor-span',
+            tags: ['initial-tag'],
+          }),
+        });
+
+        expect(await harness.domain.getTags({})).toEqual({ tags: ['initial-tag'] });
+
+        const cursorRows = await harness.baseClient.manyOrNone<{ cacheKey: string; values: string[] }>(
+          `SELECT "cacheKey", "values"
+           FROM ${qualifiedTable(harness.schema, TABLE_DISCOVERY)}
+           WHERE "cacheKey" LIKE 'tags:cursor:%'
+           ORDER BY "cacheKey"`,
+        );
+        expect(cursorRows).toHaveLength(3);
+        expect(cursorRows.every(row => /^\d+:\d+$/.test(row.values[0] ?? ''))).toBe(true);
+
+        // Signal tables are insert-only. Mutating an old row here makes a
+        // repeated full-history scan observable without relying on timing or
+        // EXPLAIN output: an incremental refresh must not revisit this row.
+        await harness.baseClient.none(
+          `UPDATE ${qualifiedTable(harness.schema, TABLE_SPAN_EVENTS)}
+           SET "tags" = ARRAY['mutated-old-tag']::text[]
+           WHERE "traceId" = 'tag-cursor-trace'`,
+        );
+        await harness.domain.batchCreateLogs({
+          logs: [makeLog({ logId: 'tag-cursor-log', tags: ['new-tag'] })],
+        });
+
+        expect(await harness.domain.getTags({})).toEqual({ tags: ['initial-tag', 'new-tag'] });
+      } finally {
+        await harness.close();
+      }
+    });
+
+    it('does not skip tags from a lower cursor that commits after a higher cursor', async () => {
+      const harness = await createHarness({
+        schemaPrefix: 'obs_vnext_discovery_tags_xact',
+        discovery: { ttlSeconds: 0 },
+      });
+      const txA = await harness.baseClient.connect();
+      const txB = await harness.baseClient.connect();
+      let txAReleased = false;
+      let txBReleased = false;
+
+      try {
+        expect(await harness.domain.getTags({})).toEqual({ tags: [] });
+        const table = qualifiedTable(harness.schema, TABLE_LOG_EVENTS);
+
+        await txA.query('BEGIN');
+        await txA.query(
+          `INSERT INTO ${table} ("logId", "timestamp", "level", "message", "tags")
+           VALUES ($1, $2, $3, $4, $5::text[])`,
+          ['tag-xact-a', dayAt(0, 8).toISOString(), 'info', 'lower cursor commits last', ['lower-tag']],
+        );
+
+        await txB.query('BEGIN');
+        await txB.query(
+          `INSERT INTO ${table} ("logId", "timestamp", "level", "message", "tags")
+           VALUES ($1, $2, $3, $4, $5::text[])`,
+          ['tag-xact-b', dayAt(0, 8, 0, 1).toISOString(), 'info', 'higher cursor commits first', ['higher-tag']],
+        );
+        await txB.query('COMMIT');
+        txB.release();
+        txBReleased = true;
+
+        expect(await harness.domain.getTags({})).toEqual({ tags: [] });
+
+        await txA.query('COMMIT');
+        txA.release();
+        txAReleased = true;
+
+        expect(await harness.domain.getTags({})).toEqual({ tags: ['higher-tag', 'lower-tag'] });
+      } finally {
+        if (!txAReleased) {
+          await txA.query('ROLLBACK').catch(() => undefined);
+          txA.release();
+        }
+        if (!txBReleased) {
+          await txB.query('ROLLBACK').catch(() => undefined);
+          txB.release();
+        }
+        await harness.close();
+      }
+    });
+
+    it('invalidates tag values and cursors when traces are deleted', async () => {
+      const harness = await createHarness({
+        schemaPrefix: 'obs_vnext_discovery_tags_delete',
+        discovery: { ttlSeconds: 0 },
+      });
+
+      try {
+        await harness.domain.createSpan({
+          span: makeSpan({
+            traceId: 'deleted-tag-trace',
+            spanId: 'deleted-tag-span',
+            tags: ['deleted-tag'],
+          }),
+        });
+        expect(await harness.domain.getTags({})).toEqual({ tags: ['deleted-tag'] });
+
+        await harness.domain.batchDeleteTraces({ traceIds: ['deleted-tag-trace'] });
+
+        const cacheRows = await harness.baseClient.one<{ count: string }>(
+          `SELECT COUNT(*)::text AS "count"
+           FROM ${qualifiedTable(harness.schema, TABLE_DISCOVERY)}
+           WHERE "cacheKey" = 'tags' OR "cacheKey" LIKE 'tags:%'`,
+        );
+        expect(Number(cacheRows.count)).toBe(0);
+        expect(await harness.domain.getTags({})).toEqual({ tags: [] });
+      } finally {
+        await harness.close();
+      }
+    });
+  });
+
   describe('discovery — stale SWR', () => {
     it('returns stale cached values immediately and refreshes them in the background', async () => {
       const harness = await createHarness({

--- a/stores/pg/src/storage/domains/observability/v-next/integration.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/integration.test.ts
@@ -898,8 +898,11 @@ describe('ObservabilityStoragePostgresVNext — integration', () => {
         schemaPrefix: 'obs_vnext_discovery_tags_xact',
         discovery: { ttlSeconds: 0 },
       });
-      const txA = await harness.baseClient.connect();
-      const txB = await harness.baseClient.connect();
+      // Keep the harness pool available for getTags() while both writer
+      // transactions remain open.
+      const writerPool = new Pool({ connectionString: defaultConnection.connectionString, max: 2 });
+      const txA = await writerPool.connect();
+      const txB = await writerPool.connect();
       let txAReleased = false;
       let txBReleased = false;
 
@@ -940,6 +943,7 @@ describe('ObservabilityStoragePostgresVNext — integration', () => {
           await txB.query('ROLLBACK').catch(() => undefined);
           txB.release();
         }
+        await writerPool.end();
         await harness.close();
       }
     });

--- a/stores/pg/src/storage/domains/observability/v-next/polling.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/polling.ts
@@ -87,7 +87,7 @@ export function decodeDeltaCursor(cursor: string): DeltaCursorParts {
   };
 }
 
-export async function readSafeXactHorizon(client: DbClient): Promise<string> {
+export async function readSafeXactHorizon(client: Pick<DbClient, 'one'>): Promise<string> {
   const row = await client.one<{ xactId: string }>(`SELECT pg_snapshot_xmin(pg_current_snapshot())::text AS "xactId"`);
   return validatePgInteger(row.xactId);
 }

--- a/stores/pg/src/storage/domains/observability/v-next/tracing.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/tracing.ts
@@ -10,6 +10,7 @@ import type {
   BatchCreateSpansArgs,
   BatchDeleteTracesArgs,
   CreateSpanArgs,
+  EntityType,
   GetSpansArgs,
   GetSpansResponse,
   GetSpanArgs,
@@ -19,7 +20,7 @@ import type {
   GetTraceLightResponse,
 } from '@mastra/core/storage';
 
-import type { DbClient } from '../../../client';
+import type { DbClient, TxClient } from '../../../client';
 import { qualifiedTable, TABLE_SPAN_EVENTS } from './ddl';
 import { rowToLightSpanRecord, rowToSpanRecord, spanRecordToRow } from './helpers';
 import { buildInsert, SPAN_LIGHT_SELECT_COLUMNS, SPAN_SELECT_COLUMNS } from './sql';
@@ -114,11 +115,36 @@ export async function getTraceLight(
 // Deletes
 // ---------------------------------------------------------------------------
 
-export async function batchDeleteTraces(client: DbClient, schema: string, args: BatchDeleteTracesArgs): Promise<void> {
-  if (args.traceIds.length === 0) return;
+export interface DeletedTraceTagRow {
+  tags: string[];
+  entityType: EntityType | null;
+}
+
+/** Delete trace spans and return the tag context needed for cache repair. */
+export async function batchDeleteTraces(
+  client: Pick<TxClient, 'manyOrNone'>,
+  schema: string,
+  args: BatchDeleteTracesArgs,
+): Promise<DeletedTraceTagRow[]> {
+  if (args.traceIds.length === 0) return [];
   const span = qualifiedTable(schema, TABLE_SPAN_EVENTS);
-  const placeholders = args.traceIds.map((_, i) => `$${i + 1}`).join(', ');
-  await client.query(`DELETE FROM ${span} WHERE "traceId" IN (${placeholders})`, args.traceIds);
+  return client.manyOrNone<DeletedTraceTagRow>(
+    `WITH deleted AS (
+       DELETE FROM ${span}
+       WHERE "traceId" = ANY($1::text[])
+       RETURNING "tags", "entityType"
+     )
+     SELECT
+       deleted."entityType",
+       COALESCE(
+         ARRAY_AGG(DISTINCT expanded.tag) FILTER (WHERE expanded.tag IS NOT NULL AND expanded.tag <> ''),
+         '{}'::text[]
+       ) AS "tags"
+     FROM deleted
+     LEFT JOIN LATERAL UNNEST(deleted."tags") AS expanded(tag) ON TRUE
+     GROUP BY deleted."entityType"`,
+    [args.traceIds],
+  );
 }
 
 /** Truncate the span_events table. */


### PR DESCRIPTION
## Description

Replace repeated full-history observability tag discovery scans in PostgreSQL with transaction-safe incremental refreshes.

- Persist a safe cursor for each span, metric, and log event table after the initial cache build.
- Read and unnest only rows committed after those cursors on subsequent refreshes.
- Serialize refreshes across processes with a transaction-scoped advisory lock.
- Invalidate accumulated tag values and cursor state after trace deletion or retention pruning.
- Preserve the existing stale-while-revalidate API behavior.

## Related issue(s)

Fixes #21835

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Testing

- Targeted unit tests: 4 passed.
- ESLint, Oxlint, and formatting checks passed for all changed files.
- The package JavaScript bundle completed successfully.
- Package type checking reports no errors in the changed production files; the full command is currently blocked by one unrelated existing error in `packages/memory/src/processors/observational-memory/token-counter.ts`.
- PostgreSQL integration coverage was added for incremental refreshes, overlapping transactions, and delete invalidation. It was not run locally because Docker is unavailable in the current environment.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

PostgreSQL now remembers which observability events it has already checked. It checks only new events, which reduces database work while keeping tag results accurate.

## Summary

- Added incremental tag discovery for span, metric, and log events.
- Persisted safe cursors for each event table.
- Limited reads to events between each cursor and the safe transaction horizon.
- Added a transaction-scoped advisory lock with a five-second `lock_timeout`.
- Updated tag and cursor state atomically.
- Preserved stale-while-revalidate behavior and fallback handling after lock timeouts.
- Reconciled or invalidated tag state after trace deletion and retention pruning.
- Rebuilt discovery state when cursor data is invalid.
- Added unit and PostgreSQL integration coverage for incremental refreshes, overlapping transactions, cursor handling, lock timeout fallback, and deletion invalidation.
- Added a patch changeset for `@mastra/pg`.

Targeted tests and static checks passed. PostgreSQL integration tests were not run because Docker was unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->