### PR TITLE
docs: expand Render Workflows deployment guide

### DIFF
--- a/docs/src/content/en/integrations/deploy/render.mdx
+++ b/docs/src/content/en/integrations/deploy/render.mdx
@@ -17,9 +17,7 @@ This guide builds an editorial pipeline that reviews a draft from three perspect
 
 ## How Render Workflows works with Mastra
 
-Mastra supplies the agents. Render Workflows is the execution boundary around them.
-
-A typical pipeline has three layers:
+Mastra supplies the agents and application logic, while Render Workflows defines the execution boundaries. A typical pipeline has three layers:
 
 1. A parent Render task coordinates the run.
 2. Child Render tasks invoke Mastra agents for focused work.

--- a/docs/src/content/en/integrations/deploy/render.mdx
+++ b/docs/src/content/en/integrations/deploy/render.mdx
@@ -5,12 +5,12 @@ description: "Run distributed Mastra agent pipelines with Render Workflows"
 
 # Render
 
-Deploy Mastra applications on [Render](https://render.com/?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra). Host the Mastra API as a [web service](https://render.com/docs/web-services?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra), or use [Render Workflows](https://render.com/docs/workflows?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra) for long-running tasks with independent retry policies.
+Deploy Mastra applications on [Render](https://render.com/). Host the Mastra API as a [web service](https://render.com/docs/web-services), or use [Render Workflows](https://render.com/docs/workflows) for long-running tasks with independent retry policies.
 
 Choose the deployment path that fits your application:
 
-- **Mastra API**: Deploy Mastra's [server](/docs/server/overview) as a web service with a public endpoint. The [Web Services guide](https://render.com/docs/web-services?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra) explains how to deploy custom code or a supported [server adapter](/docs/server/server-adapters).
-- **Mastra workflow**: Run an entire Mastra workflow within one task. Render controls the outer run, while Mastra manages its steps and state. See [Defining Workflow Tasks](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra) for configuration details.
+- **Mastra API**: Deploy Mastra's [server](/docs/server/overview) as a web service with a public endpoint. The [Web Services guide](https://render.com/docs/web-services) explains how to deploy custom code or a supported [server adapter](/docs/server/server-adapters).
+- **Mastra workflow**: Run an entire Mastra workflow within one task. Render controls the outer run, while Mastra manages its steps and state. See [Defining Workflow Tasks](https://render.com/docs/workflows-defining) for configuration details.
 - **Distributed agent operations**: Give each operation its own compute plan, timeout, and retry policy. Render Workflows handles the execution queue and provides run observability.
 
 This guide builds an editorial pipeline that reviews a draft from three perspectives in parallel, then passes the feedback to an editor agent. Use the links above if you want to deploy a Mastra API or execute an entire Mastra workflow as one task.
@@ -20,8 +20,8 @@ This guide builds an editorial pipeline that reviews a draft from three perspect
 Mastra supplies the agents and application logic, while Render Workflows defines the execution boundaries. A typical pipeline has three layers:
 
 1. A parent Render task coordinates the run.
-2. Child Render tasks invoke Mastra agents for focused work.
-3. A final Render task combines the results.
+1. Child Render tasks invoke Mastra agents for focused work.
+1. A final Render task combines the results.
 
 Calling one Render task from another creates a chained task run. Each chained run executes in its own instance. You can set compute, timeout, and retries on that task alone.
 
@@ -39,7 +39,7 @@ render login
 ```
 
 :::note
-Requires Render CLI `v2.12.0` or later. For other installation methods, see the [Render CLI docs](https://render.com/docs/cli?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
+Requires Render CLI `v2.12.0` or later. For other installation methods, see the [Render CLI docs](https://render.com/docs/cli).
 :::
 
 Create an empty Mastra project named `render-workflows`:
@@ -273,7 +273,7 @@ Add these scripts next to the ones `create mastra` already added. `create mastra
 
 Relative imports in the examples above end in `.js` because Node resolves the compiled output as ES modules. Keep those extensions so the built entry point resolves its imports.
 
-Those files are the complete pipeline. [render-examples/render-workflows-mastra](https://github.com/render-examples/render-workflows-mastra) mirrors this `src/` layout and adds a web UI that starts the parent task. Its agents use `openai/gpt-5.6-sol` instead of `__GATEWAY_OPENAI_MODEL__`, which only works in Mastra's docs site. Clone it to skip copying the snippets before you run it.
+Those files are the complete pipeline. [render-examples/render-workflows-mastra](https://github.com/render-examples/render-workflows-mastra) mirrors this `src/` layout and adds a web UI that starts the parent task. Its agents use the provider-specific model ID `__GATEWAY_OPENAI_MODEL__`. In this page's source, that value is represented by a documentation token that is replaced during the docs build. Clone it to skip copying the snippets before you run it.
 
 ## Running the pipeline
 
@@ -303,7 +303,7 @@ The local server keeps runs and their logs in memory, so you can inspect them af
 
 ### Running in production
 
-Running the pipeline on Render requires a *workflow service*. This is the Render service that holds your task definitions: it builds your repository, registers every task it finds, and provisions an instance for each run.
+Running the pipeline on Render requires a _workflow service_. This is the Render service that holds your task definitions: it builds your repository, registers every task it finds, and provisions an instance for each run.
 
 #### 1. Push the project to a Git repository
 
@@ -311,10 +311,10 @@ Render builds workflow services from a repository on GitHub, GitLab, or Bitbucke
 
 #### 2. Create the workflow service
 
-In the [Render Dashboard](https://dashboard.render.com?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra), click **New > Workflow** and link the repository from the previous step. Then complete the creation form:
+In the [Render Dashboard](https://dashboard.render.com), click **New > Workflow** and link the repository from the previous step. Then complete the creation form:
 
 | Field | Value |
-| --- | --- |
+| - | - |
 | **Language** | Node |
 | **Region** | The region of any other Render services your tasks connect to |
 | **Build Command** | `npm install && npm run build` |
@@ -354,7 +354,7 @@ Open the workflow in the Render Dashboard to inspect each task run, attempt, res
 
 You can trigger the pipeline asynchronously from a Mastra application, web service, or script with the Render SDK.
 
-Triggering runs from code requires a Render API key, which you create in your [Render account settings](https://render.com/docs/api?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra#1-create-an-api-key). Set it in the calling service:
+Triggering runs from code requires a Render API key, which you create in your [Render account settings](https://render.com/docs/api#1-create-an-api-key). Set it in the calling service:
 
 ```text title=".env"
 RENDER_API_KEY=rnd_your_api_key
@@ -370,10 +370,7 @@ import { Render } from '@renderinc/sdk'
 const render = new Render()
 
 export async function startEditorialPipeline(draft: string) {
-  const run = await render.workflows.startTask(
-    'mastra-workflows/editorial_pipeline',
-    [draft],
-  )
+  const run = await render.workflows.startTask('mastra-workflows/editorial_pipeline', [draft])
 
   return {
     taskRunId: run.taskRunId,
@@ -389,19 +386,18 @@ Returning the task run ID from a request handler lets the application respond wi
 
 These limits live in Render's docs and can change. Prefer those pages over this list:
 
-- Task arguments and return values must be JSON serializable. Arguments to a single run cannot exceed 4 MB. See [defining tasks](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra#task-arguments) and [Workflows limits](https://render.com/docs/workflows-limits?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
-- A task can run for up to 24 hours. The default timeout is two hours. See [timeouts](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra#timeout).
-- A workflow service can register up to 500 task definitions. See [Workflows limits](https://render.com/docs/workflows-limits?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
-- Render Workflows currently supports TypeScript and Python task definitions. See [defining tasks](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
+- Task arguments and return values must be JSON serializable. Arguments to a single run cannot exceed 4 MB. See [defining tasks](https://render.com/docs/workflows-defining#task-arguments) and [Workflows limits](https://render.com/docs/workflows-limits).
+- A task can run for up to 24 hours. The default timeout is two hours. See [timeouts](https://render.com/docs/workflows-defining#timeout).
+- A workflow service can register up to 500 task definitions. See [Workflows limits](https://render.com/docs/workflows-limits).
+- Render Workflows currently supports TypeScript and Python task definitions. See [defining tasks](https://render.com/docs/workflows-defining).
 
-To run the pipeline on a schedule, create a [Render cron job](https://render.com/docs/cronjobs?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra) whose command calls `render workflows tasks start` or `startTask()`.
+To run the pipeline on a schedule, create a [Render cron job](https://render.com/docs/cronjobs) whose command calls `render workflows tasks start` or `startTask()`.
 
 ## Related
 
 - [Live demo](https://render-workflows-mastra.onrender.com)
-- [Render Workflows documentation](https://render.com/docs/workflows?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
-- [Defining Render workflow tasks](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
-- [Triggering task runs](https://render.com/docs/workflows-running?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
-- [Render Workflows TypeScript SDK](https://render.com/docs/workflows-sdk-typescript?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
-- [Render Workflows limits and pricing](https://render.com/docs/workflows-limits?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
-
+- [Render Workflows documentation](https://render.com/docs/workflows)
+- [Defining Render workflow tasks](https://render.com/docs/workflows-defining)
+- [Triggering task runs](https://render.com/docs/workflows-running)
+- [Render Workflows TypeScript SDK](https://render.com/docs/workflows-sdk-typescript)
+- [Render Workflows limits and pricing](https://render.com/docs/workflows-limits)

--- a/docs/src/content/en/integrations/deploy/render.mdx
+++ b/docs/src/content/en/integrations/deploy/render.mdx
@@ -1,31 +1,48 @@
 ---
 title: "Render | Deploy"
-description: "Deploy Mastra with Render"
+description: "Run distributed Mastra agent pipelines with Render Workflows"
 ---
 
 # Render
 
-Deploy Mastra applications on [Render](https://render.com/). Host the Mastra API as a [web service](https://render.com/docs/web-services), or use [Render Workflows](https://render.com/docs/workflows) for long-running tasks with independent retry policies.
+Deploy Mastra applications on [Render](https://render.com/?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra). Host the Mastra API as a [web service](https://render.com/docs/web-services?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra), or use [Render Workflows](https://render.com/docs/workflows?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra) for long-running tasks with independent retry policies.
 
 Choose the deployment path that fits your application:
 
-- **Mastra API**: Deploy Mastra's [server](/docs/server/overview) as a web service with a public endpoint. The [Web Services guide](https://render.com/docs/web-services) explains how to deploy custom code or a supported [server adapter](/docs/server/server-adapters).
-- **Mastra workflow**: Run an entire Mastra workflow within one task. Render controls the outer run, while Mastra manages its steps and state. See [Defining Workflow Tasks](https://render.com/docs/workflows-defining) for configuration details.
+- **Mastra API**: Deploy Mastra's [server](/docs/server/overview) as a web service with a public endpoint. The [Web Services guide](https://render.com/docs/web-services?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra) explains how to deploy custom code or a supported [server adapter](/docs/server/server-adapters).
+- **Mastra workflow**: Run an entire Mastra workflow within one task. Render controls the outer run, while Mastra manages its steps and state. See [Defining Workflow Tasks](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra) for configuration details.
 - **Distributed agent operations**: Give each operation its own compute plan, timeout, and retry policy. Render Workflows handles the execution queue and provides run observability.
 
 This guide builds an editorial pipeline that reviews a draft from three perspectives in parallel, then passes the feedback to an editor agent. Use the links above if you want to deploy a Mastra API or execute an entire Mastra workflow as one task.
 
-## How Render Workflows integrates with Mastra
+## How Render Workflows works with Mastra
 
-Mastra supplies the agents and application logic, while Render Workflows defines the execution boundaries. A typical pipeline has three layers:
+Mastra supplies the agents. Render Workflows is the execution boundary around them.
 
-1. A parent task coordinates the run.
-1. Child tasks invoke Mastra agents for focused work.
-1. A final task combines the results.
+A typical pipeline has three layers:
 
-Calling one task from another creates a chained run in a separate instance, with its own compute plan, timeout, and retry policy.
+1. A parent Render task coordinates the run.
+2. Child Render tasks invoke Mastra agents for focused work.
+3. A final Render task combines the results.
+
+Calling one Render task from another creates a chained task run. Each chained run executes in its own instance. You can set compute, timeout, and retries on that task alone.
+
+This guide builds an editorial pipeline that reviews a draft from three perspectives in parallel, then uses a Mastra editor agent to produce a revised version. You can try a running copy in the [live demo](https://render-workflows-mastra.onrender.com).
 
 ## Setup
+
+You need a Render account and the Render CLI. The CLI runs a local task server during development. You can also use it to create a workflow service on Render.
+
+Install the CLI and log in:
+
+```bash
+brew install render
+render login
+```
+
+:::note
+Requires Render CLI `v2.12.0` or later. For other installation methods, see the [Render CLI docs](https://render.com/docs/cli?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
+:::
 
 Create an empty Mastra project named `render-workflows`:
 
@@ -33,23 +50,31 @@ Create an empty Mastra project named `render-workflows`:
 npm create mastra@latest render-workflows -- --empty
 ```
 
-Install two additional dependencies:
+```bash
+cd render-workflows
+```
+
+Install the Render SDK:
 
 ```bash npm2yarn
 npm install @renderinc/sdk tsx
 ```
 
-Add your API key to an `.env` file. This example uses OpenAI, but any supported [model provider](/models) works.
+:::note
+Render Workflows requires `@renderinc/sdk@^0.5.0` or later.
+:::
+
+Set the API key for your model provider. This example uses OpenAI:
 
 ```text title=".env"
 OPENAI_API_KEY=your_openai_api_key
 ```
 
-Install the [Render CLI](https://render.com/docs/cli) to run workflow commands from your terminal.
+Any supported [Mastra model provider](/models) works.
 
-## Distributed agent pipeline
+## Building a distributed agent pipeline
 
-### Create the agents
+### Creating the agents
 
 In `src/mastra`, create an `agents` directory with `reviewer-agent.ts` and `editor-agent.ts`. Define both agents:
 
@@ -83,7 +108,7 @@ export const editorAgent = new Agent({
 })
 ```
 
-### Configure the Mastra instance
+### Configuring the Mastra instance
 
 Add both agents to the Mastra instance in `src/mastra/index.ts`:
 
@@ -100,15 +125,13 @@ export const mastra = new Mastra({
 })
 ```
 
-### Create the tasks
+Retrieving agents from the Mastra instance gives them access to shared application services such as logging, storage, and observability.
 
-In `src`, create a `tasks` directory with `review-task.ts`, `revision-task.ts`, and `editorial-task.ts`.
+### Creating the review task
 
-#### Review task
+In `src`, create a `tasks` directory. The reviewer agent handles one area of focus. Its compute plan, five-minute timeout, and retry policy apply only to that analysis. A temporary model-provider failure can trigger another attempt without restarting the other reviewers.
 
-The reviewer agent handles one area of focus. Its compute plan, five-minute timeout, and retry policy apply only to that analysis. A temporary model-provider failure can trigger another attempt without restarting the other reviewers.
-
-```typescript title="src/tasks/review-task.ts"
+```ts title="src/tasks/review-task.ts"
 import { task } from '@renderinc/sdk/workflows'
 import { mastra } from '../mastra/index.js'
 
@@ -145,11 +168,11 @@ export const reviewDraft = task(
 )
 ```
 
-#### Revision task
+### Creating the revision task
 
 This task combines the feedback and produces a revised draft. It uses a larger compute plan and a longer timeout than each reviewer.
 
-```typescript title="src/tasks/revision-task.ts"
+```ts title="src/tasks/revision-task.ts"
 import { task } from '@renderinc/sdk/workflows'
 import { mastra } from '../mastra/index.js'
 
@@ -186,11 +209,11 @@ export const reviseDraft = task(
 )
 ```
 
-#### Editorial task
+### Creating the orchestration task
 
-The parent dispatches three reviews in parallel with `Promise.all()`, then sends their combined feedback to the revision step. Retries are disabled at this level because each child defines its own policy. If you enable orchestration retries, ensure that another attempt can't duplicate external side effects or other non-idempotent work.
+The parent dispatches three reviews in parallel with `Promise.all()`, then sends their combined feedback to the revision step. Retries are disabled at this level because each child defines its own policy. If you enable orchestration retries, ensure that another attempt cannot duplicate external side effects or other non-idempotent work.
 
-```typescript title="src/tasks/editorial-task.ts"
+```ts title="src/tasks/editorial-task.ts"
 import { task } from '@renderinc/sdk/workflows'
 import { reviewDraft } from './review-task.js'
 import { reviseDraft } from './revision-task.js'
@@ -214,7 +237,7 @@ export const editorialPipeline = task(
 )
 ```
 
-### Set up the entry point
+### Registering the tasks
 
 Create `src/index.ts` and import the editorial task:
 
@@ -222,7 +245,23 @@ Create `src/index.ts` and import the editorial task:
 import './tasks/editorial-task.js'
 ```
 
-In `package.json`, add scripts to build the TypeScript project and run the workflow:
+Running the entry point loads the module and registers every task defined with `task()`.
+
+`create mastra` already wrote `tsconfig.json` and `package.json`. Keep those files. For the workflow start command, `tsc` must emit JavaScript into `dist`, so set these compiler options (do not leave `noEmit: true`):
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false
+  }
+}
+```
+
+Add these scripts next to the ones `create mastra` already added. `create mastra` already sets `"type": "module"`:
 
 ```json title="package.json"
 {
@@ -234,74 +273,58 @@ In `package.json`, add scripts to build the TypeScript project and run the workf
 }
 ```
 
-Configure `tsconfig.json` for the build:
+Relative imports in the examples above end in `.js` because Node resolves the compiled output as ES modules. Keep those extensions so the built entry point resolves its imports.
 
-```json title="tsconfig.json"
-{
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "rootDir": "src",
-    "outDir": "dist",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true
-  },
-  "include": ["src/**/*"]
-}
-```
+Those files are the complete pipeline. [render-examples/render-workflows-mastra](https://github.com/render-examples/render-workflows-mastra) mirrors this `src/` layout and adds a web UI that starts the parent task. Its agents use `openai/gpt-5.6-sol` instead of `__GATEWAY_OPENAI_MODEL__`, which only works in Mastra's docs site. Clone it to skip copying the snippets before you run it.
 
-Build the project. The command compiles the JavaScript files into `dist`.
+## Running the pipeline
 
-```bash npm2yarn
-npm run build
-```
+### Running locally
 
-## Run the pipeline
-
-### Locally
-
-Start the local development server with the Render CLI:
+Start the local Render Workflows development server:
 
 ```bash
-render workflows dev -- npm run dev:workflows
+render workflows dev -- "npm run dev:workflows"
 ```
 
-The server lists the registered tasks:
-
-```bash
-➜ render workflows dev -- npm run dev:workflows
-Workflow server listening on port 8120
-Loaded environment variables from .env
-3 tasks found in npm run dev:workflows
-  • editorial_pipeline
-  • review_draft
-  • revise_draft
-
-To browse and run tasks, open another terminal and run:
-  render workflows tasks list --local
-```
-
-In another terminal, confirm that the tasks are available:
+In another terminal, list the registered tasks:
 
 ```bash
 render workflows tasks list --local
 ```
 
-The command displays each task's name, ID, and creation time. Press `Ctrl+C`, then start the editorial pipeline from the same terminal:
+Start the editorial pipeline:
 
 ```bash
-render workflows tasks runs start editorial_pipeline \
+render workflows tasks start editorial_pipeline \
   --local \
   --input='["Render Workflows runs long-running tasks outside the request lifecycle."]'
 ```
 
-The development server records the parent run, three parallel reviews, and the final revision.
+The local server keeps runs and their logs in memory, so you can inspect them after they finish with `render workflows runs list <task-name> --local`.
 
-### Production
+### Running in production
 
-Create a workflow service from the current repository:
+Running the pipeline on Render requires a *workflow service*. This is the Render service that holds your task definitions: it builds your repository, registers every task it finds, and provisions an instance for each run.
+
+#### 1. Push the project to a Git repository
+
+Render builds workflow services from a repository on GitHub, GitLab, or Bitbucket, so push your project to one of those providers. The first time you use a provider, Render asks for permission to access your repositories.
+
+#### 2. Create the workflow service
+
+In the [Render Dashboard](https://dashboard.render.com?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra), click **New > Workflow** and link the repository from the previous step. Then complete the creation form:
+
+| Field | Value |
+| --- | --- |
+| **Language** | Node |
+| **Region** | The region of any other Render services your tasks connect to |
+| **Build Command** | `npm install && npm run build` |
+| **Start Command** | `npm run start:workflows` |
+
+Click **Deploy Workflow**. Render builds the project and registers `review_draft`, `revise_draft`, and `editorial_pipeline`, which then appear on the workflow's **Tasks** page.
+
+The Render CLI creates the same service without leaving your terminal:
 
 ```bash
 render workflows create \
@@ -312,21 +335,75 @@ render workflows create \
   --run-command "npm run start:workflows"
 ```
 
-Add `OPENAI_API_KEY`, or the key for your chosen model provider, to the service's environment variables.
+`--repo .` reads the `origin` remote of your local repository, so the project must already be pushed.
 
-After deployment, start a production run. If needed, replace `mastra-workflows/editorial_pipeline` with the task slug shown in the Render Dashboard.
+#### 3. Set the workflow's environment variables
+
+Add `OPENAI_API_KEY`, or the key for your chosen model provider, to the workflow service in the Dashboard before the first run.
+
+#### 4. Start a run
 
 ```bash
 render workflows tasks start mastra-workflows/editorial_pipeline \
   --input='["Render Workflows runs long-running tasks outside the request lifecycle."]'
 ```
 
-Open the workflow service in the Render Dashboard to inspect each task run, attempt, result, and log stream.
+The first part of that identifier is your workflow's slug and the second is the task name. Both appear on the task's page in the Render Dashboard, so use the slug shown there if your workflow has a different name.
+
+Open the workflow in the Render Dashboard to inspect each task run, attempt, result, and log stream.
+
+## Triggering from your application
+
+You can trigger the pipeline asynchronously from a Mastra application, web service, or script with the Render SDK.
+
+Triggering runs from code requires a Render API key, which you create in your [Render account settings](https://render.com/docs/api?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra#1-create-an-api-key). Set it in the calling service:
+
+```text title=".env"
+RENDER_API_KEY=rnd_your_api_key
+```
+
+The SDK reads `RENDER_API_KEY` from the environment automatically.
+
+Start the task and return its run ID immediately:
+
+```ts title="src/start-editorial-pipeline.ts"
+import { Render } from '@renderinc/sdk'
+
+const render = new Render()
+
+export async function startEditorialPipeline(draft: string) {
+  const run = await render.workflows.startTask(
+    'mastra-workflows/editorial_pipeline',
+    [draft],
+  )
+
+  return {
+    taskRunId: run.taskRunId,
+  }
+}
+```
+
+The task continues running after `startTask()` returns. Call `await run.get()` when the caller should wait for the completed result instead.
+
+Returning the task run ID from a request handler lets the application respond without keeping the request open for the full pipeline.
+
+## Constraints
+
+These limits live in Render's docs and can change. Prefer those pages over this list:
+
+- Task arguments and return values must be JSON serializable. Arguments to a single run cannot exceed 4 MB. See [defining tasks](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra#task-arguments) and [Workflows limits](https://render.com/docs/workflows-limits?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
+- A task can run for up to 24 hours. The default timeout is two hours. See [timeouts](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra#timeout).
+- A workflow service can register up to 500 task definitions. See [Workflows limits](https://render.com/docs/workflows-limits?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
+- Render Workflows currently supports TypeScript and Python task definitions. See [defining tasks](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra).
+
+To run the pipeline on a schedule, create a [Render cron job](https://render.com/docs/cronjobs?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra) whose command calls `render workflows tasks start` or `startTask()`.
 
 ## Related
 
-- [Render Workflows documentation](https://render.com/docs/workflows)
-- [Defining Render workflow tasks](https://render.com/docs/workflows-defining)
-- [Triggering task runs](https://render.com/docs/workflows-running)
-- [Render Workflows TypeScript SDK](https://render.com/docs/workflows-sdk-typescript)
-- [Render Workflows limits and pricing](https://render.com/docs/workflows-limits)
+- [Live demo](https://render-workflows-mastra.onrender.com)
+- [Render Workflows documentation](https://render.com/docs/workflows?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
+- [Defining Render workflow tasks](https://render.com/docs/workflows-defining?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
+- [Triggering task runs](https://render.com/docs/workflows-running?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
+- [Render Workflows TypeScript SDK](https://render.com/docs/workflows-sdk-typescript?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
+- [Render Workflows limits and pricing](https://render.com/docs/workflows-limits?utm_source=partner\&utm_medium=partnerships\&utm_campaign=2026_partnership_mastra)
+


### PR DESCRIPTION
Expands the Render deployment guide with a complete distributed agent workflow, local and production setup, application-triggered runs, and platform constraints. It also uses the shared docs model token and removes tracking parameters from Render links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates the Render deployment guide to show how to run distributed agent workflows. It explains local and production setup, application-triggered runs, and Render-specific limits.

## Changes

- Added a complete distributed agent workflow example.
- Added CLI, SDK, task registration, and TypeScript build instructions.
- Added local and production execution steps.
- Added environment variable and application-triggered workflow instructions.
- Documented Render platform constraints.
- Restored the Mastra and Render workflow introduction.
- Updated the guide to use the shared documentation model token.
- Cleaned Render links and removed tracking parameters.
- Normalized ordered list markers for prose linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->