### PR TITLE
fix(playground-ui): remove hidden search label spacing

### DIFF
--- a/.changeset/sour-waves-prove.md
+++ b/.changeset/sour-waves-prove.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed hidden search field labels taking up layout space.

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.test.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { SearchFieldBlock } from './search-field-block';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SearchFieldBlock', () => {
+  it.each(['vertical', 'horizontal'] as const)('removes a hidden label from the %s layout flow', layout => {
+    render(<SearchFieldBlock name="search" label="Search" labelIsHidden layout={layout} />);
+
+    const label = screen.getByText('Search');
+
+    expect(label.tagName).toBe('LABEL');
+    expect(label.classList.contains('sr-only')).toBe(true);
+    expect(label.children).toHaveLength(0);
+    expect((screen.getByLabelText('Search') as HTMLInputElement).id).toBe('input-search');
+  });
+
+  it('keeps a visible label in the layout flow', () => {
+    render(<SearchFieldBlock name="search" label="Search" />);
+
+    expect(screen.getByText('Search').classList.contains('sr-only')).toBe(false);
+  });
+});

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.test.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.test.tsx
@@ -9,20 +9,32 @@ afterEach(() => {
 });
 
 describe('SearchFieldBlock', () => {
-  it.each(['vertical', 'horizontal'] as const)('removes a hidden label from the %s layout flow', layout => {
-    render(<SearchFieldBlock name="search" label="Search" labelIsHidden layout={layout} />);
+  it('removes a vertically hidden label from the layout flow', () => {
+    render(<SearchFieldBlock name="search" label="Search" labelIsHidden />);
 
     const label = screen.getByText('Search');
 
     expect(label.tagName).toBe('LABEL');
     expect(label.classList.contains('sr-only')).toBe(true);
-    expect(label.children).toHaveLength(0);
-    expect((screen.getByLabelText('Search') as HTMLInputElement).id).toBe('input-search');
+    expect(screen.getByRole<HTMLInputElement>('textbox', { name: 'Search' }).id).toBe('input-search');
   });
 
-  it('keeps a visible label in the layout flow', () => {
-    render(<SearchFieldBlock name="search" label="Search" />);
+  it('hides the horizontal label column while preserving the accessible name', () => {
+    const { container } = render(<SearchFieldBlock name="search" label="Search" labelIsHidden layout="horizontal" />);
 
-    expect(screen.getByText('Search').classList.contains('sr-only')).toBe(false);
+    const [labelColumn, inputColumn] = container.firstElementChild?.children ?? [];
+
+    expect(labelColumn?.classList.contains('sr-only')).toBe(true);
+    expect(inputColumn?.classList.contains('col-span-full')).toBe(true);
+    expect(screen.getByRole<HTMLInputElement>('textbox', { name: 'Search' }).id).toBe('input-search');
+  });
+
+  it('keeps a visible horizontal label in a separate column', () => {
+    const { container } = render(<SearchFieldBlock name="search" label="Search" layout="horizontal" />);
+
+    const [labelColumn, inputColumn] = container.firstElementChild?.children ?? [];
+
+    expect(labelColumn?.classList.contains('sr-only')).toBe(false);
+    expect(inputColumn?.classList.contains('col-span-full')).toBe(false);
   });
 });

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
@@ -5,7 +5,6 @@ import { Input } from '../../Input';
 import type { InputProps } from '../../Input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../Tooltip';
 import { FieldBlock } from '../block/field-block';
-import { VisuallyHidden } from '@/ds/primitives/visually-hidden';
 import { cn } from '@/lib/utils';
 
 export type SearchFieldBlockProps = {
@@ -80,15 +79,15 @@ export function SearchFieldBlock({
     <FieldBlock.Layout layout={layout} className={className}>
       {layout === 'horizontal' ? (
         <FieldBlock.Column>
-          <FieldBlock.Label name={name} required={required}>
-            {labelIsHidden ? <VisuallyHidden>{label}</VisuallyHidden> : label}
+          <FieldBlock.Label name={name} required={required} className={labelIsHidden ? 'sr-only' : undefined}>
+            {label}
           </FieldBlock.Label>
         </FieldBlock.Column>
       ) : null}
       <FieldBlock.Column>
         {layout === 'vertical' && label ? (
-          <FieldBlock.Label name={name} required={required}>
-            {labelIsHidden ? <VisuallyHidden>{label}</VisuallyHidden> : label}
+          <FieldBlock.Label name={name} required={required} className={labelIsHidden ? 'sr-only' : undefined}>
+            {label}
           </FieldBlock.Label>
         ) : null}
         <div className="group relative">

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
@@ -78,13 +78,13 @@ export function SearchFieldBlock({
   return (
     <FieldBlock.Layout layout={layout} className={className}>
       {layout === 'horizontal' ? (
-        <FieldBlock.Column>
-          <FieldBlock.Label name={name} required={required} className={labelIsHidden ? 'sr-only' : undefined}>
+        <FieldBlock.Column className={labelIsHidden ? 'sr-only' : undefined}>
+          <FieldBlock.Label name={name} required={required}>
             {label}
           </FieldBlock.Label>
         </FieldBlock.Column>
       ) : null}
-      <FieldBlock.Column>
+      <FieldBlock.Column className={layout === 'horizontal' && labelIsHidden ? 'col-span-full' : undefined}>
         {layout === 'vertical' && label ? (
           <FieldBlock.Label name={name} required={required} className={labelIsHidden ? 'sr-only' : undefined}>
             {label}


### PR DESCRIPTION
This fixes hidden SearchFieldBlock labels still reserving space in grid and flex layouts. Instead of wrapping the label text in VisuallyHidden, the label element now receives the sr-only utility, keeping it associated with the input while removing it from layout flow.

Before: labelIsHidden rendered <VisuallyHidden>{label}</VisuallyHidden> inside the visible label element.

After: labelIsHidden applies className="sr-only" directly to FieldBlock.Label.

Verified with the focused SearchFieldBlock Vitest coverage, the playground-ui typecheck, mutation testing for the changed component, and git diff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This change keeps hidden search labels available to screen readers without taking up layout space. It also adds tests for vertical and horizontal search fields.

## Changes

- Applied `sr-only` to hidden labels and horizontal label columns.
- Made hidden horizontal inputs span the full width.
- Removed the unused `VisuallyHidden` import.
- Preserved accessible input names and generated IDs.
- Added Vitest coverage for hidden and visible labels.
- Added a patch changeset for `@mastra/playground-ui`.

## Verification

- Focused Vitest tests
- `playground-ui` typechecking
- Mutation testing
- Git diff checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->