### PR TITLE
fix(core): run trailing assistant guard for all Anthropic models

### DIFF
--- a/.changeset/nine-houses-jam.md
+++ b/.changeset/nine-houses-jam.md
@@ -4,6 +4,6 @@
 
 Fixed Anthropic requests failing with a non-retryable 400 error (`This model does not support assistant message prefill`) when a conversation ends with an assistant message and native structured output is used.
 
-The built-in trailing assistant guard, which appends a user message to satisfy this Anthropic constraint, now runs for agents without any configured input processors and for every Anthropic model. Previously it was skipped entirely unless the agent had at least one input processor (or memory/skills), and it only recognized Claude 4.6 model ids — so newer models such as `anthropic/claude-opus-4-7` lost the protection even when it did run. Non-Anthropic models and plain (non structured output) Anthropic calls are unaffected.
+The built-in trailing assistant guard, which appends a user message to satisfy this Anthropic constraint, now runs for agents without any configured input processors and for every Anthropic model. Previously it was skipped entirely unless the agent had at least one input processor (or memory/skills), and it only recognized Claude 4.6 model ids — so newer models such as `anthropic/claude-opus-4-7` lost the protection even when it did run. Non-Anthropic models and plain (non-structured-output) Anthropic calls are unaffected.
 
 Fixes [#21913](https://github.com/mastra-ai/mastra/issues/21913).

--- a/.changeset/nine-houses-jam.md
+++ b/.changeset/nine-houses-jam.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Anthropic requests failing with a non-retryable 400 error (`This model does not support assistant message prefill`) when a conversation ends with an assistant message and native structured output is used.
+
+The built-in trailing assistant guard, which appends a user message to satisfy this Anthropic constraint, now runs for agents without any configured input processors and for every Anthropic model. Previously it was skipped entirely unless the agent had at least one input processor (or memory/skills), and it only recognized Claude 4.6 model ids — so newer models such as `anthropic/claude-opus-4-7` lost the protection even when it did run. Non-Anthropic models and plain (non structured output) Anthropic calls are unaffected.
+
+Fixes [#21913](https://github.com/mastra-ai/mastra/issues/21913).

--- a/packages/core/src/agent/__tests__/structured-output-memory.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output-memory.test.ts
@@ -960,3 +960,79 @@ describe('Structured output stream memory persistence (#14659)', () => {
     }
   });
 });
+
+/**
+ * Regression tests for issue #21913:
+ * The TrailingAssistantGuard was only appended when the agent had configured
+ * input processors (or memory/skills), and only for model ids matching Claude 4.6.
+ * Agents without processors, or on Anthropic models newer than Claude 4.6,
+ * sent trailing-assistant prompts as-is and hit Anthropic's non-retryable
+ * "does not support assistant message prefill" 400.
+ */
+describe('TrailingAssistantGuard without input processors (#21913)', () => {
+  const buildAgent = ({ provider, modelId }: { provider: string; modelId: string }) => {
+    const capturedPrompts: any[] = [];
+    const mockModel = new MockLanguageModelV2({
+      provider,
+      modelId,
+      doGenerate: async options => {
+        capturedPrompts.push(options.prompt);
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text', text: JSON.stringify({ status: 'completed', summary: 'done' }) }],
+          warnings: [],
+        };
+      },
+    });
+    const agent = new Agent({
+      id: `test-agent-21913-${modelId}`,
+      name: 'Test Agent 21913',
+      instructions: 'Report what happened.',
+      model: mockModel,
+    });
+    return { agent, capturedPrompts };
+  };
+
+  const generateWithTrailingAssistant = (agent: Agent) =>
+    agent.generate(
+      [
+        { role: 'user', content: 'Do the task, then report.' },
+        { role: 'assistant', content: 'Task done: the order was placed.' },
+      ],
+      { structuredOutput: { schema: z.object({ status: z.string(), summary: z.string() }) } },
+    );
+
+  const lastNonSystemRole = (capturedPrompts: any[]) => {
+    expect(capturedPrompts.length).toBeGreaterThan(0);
+    const lastPrompt = capturedPrompts[capturedPrompts.length - 1];
+    const nonSystemMessages = lastPrompt.filter((msg: any) => msg.role !== 'system');
+    expect(nonSystemMessages.length).toBeGreaterThan(0);
+    return nonSystemMessages[nonSystemMessages.length - 1].role;
+  };
+
+  it('appends a user message for an Anthropic agent without input processors or memory', async () => {
+    const { agent, capturedPrompts } = buildAgent({ provider: 'anthropic.messages', modelId: 'claude-opus-4-6' });
+
+    await generateWithTrailingAssistant(agent);
+
+    expect(lastNonSystemRole(capturedPrompts)).toBe('user');
+  });
+
+  it('appends a user message for Anthropic models newer than Claude 4.6', async () => {
+    const { agent, capturedPrompts } = buildAgent({ provider: 'anthropic.messages', modelId: 'claude-opus-5' });
+
+    await generateWithTrailingAssistant(agent);
+
+    expect(lastNonSystemRole(capturedPrompts)).toBe('user');
+  });
+
+  it('leaves the trailing assistant message untouched for non-Anthropic models', async () => {
+    const { agent, capturedPrompts } = buildAgent({ provider: 'openai.chat', modelId: 'gpt-5' });
+
+    await generateWithTrailingAssistant(agent);
+
+    expect(lastNonSystemRole(capturedPrompts)).toBe('assistant');
+  });
+});

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -27,6 +27,7 @@ import { getRootExportSpan, getStepAvailableToolNames } from '../../../../observ
 import type { CachedLLMStepResponse } from '../../../../processors';
 import { PrepareStepProcessor } from '../../../../processors/processors/prepare-step';
 import { ProcessorRunner } from '../../../../processors/runner';
+import { isMaybeAnthropic } from '../../../../processors/trailing-assistant-guard';
 import { execute } from '../../../../stream/aisdk/v5/execute';
 import { MastraModelOutput } from '../../../../stream/base/output';
 import type { ChunkType, TextDeltaPayload, ToolCallPayload } from '../../../../stream/types';
@@ -390,7 +391,9 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             const stepInputProcessors = registryEntry?.prepareStep
               ? [...baseInputProcessors, new PrepareStepProcessor({ prepareStep: registryEntry.prepareStep })]
               : baseInputProcessors;
-            if (stepInputProcessors.length) {
+            // Run even with no configured processors when the model is Anthropic, so
+            // the runner can append its TrailingAssistantGuard (#21913).
+            if (stepInputProcessors.length || isMaybeAnthropic(currentModel)) {
               const inputStepWriter = pubsub
                 ? {
                     custom: async (data: { type: string }) => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -3030,8 +3030,11 @@ describe('PROVIDER_TOOL_CALL observability spans', () => {
     await llmExecutionStep.execute(executeParams);
 
     // Without a step tracker there is no live step to parent under — the span
-    // anchors to the AGENT_RUN fallback recorded at call time.
-    expect(modelStepSpan.createChildSpan).not.toHaveBeenCalled();
+    // anchors to the AGENT_RUN fallback recorded at call time. (The model step
+    // span still gets the TrailingAssistantGuard processor span for Anthropic.)
+    expect(modelStepSpan.createChildSpan).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: SpanType.PROVIDER_TOOL_CALL }),
+    );
     expect(agentRunSpan.createChildSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         type: SpanType.PROVIDER_TOOL_CALL,
@@ -3146,7 +3149,9 @@ describe('PROVIDER_TOOL_CALL observability spans', () => {
         startTime: expect.any(Date),
       }),
     );
-    expect(modelStepSpan.createChildSpan).not.toHaveBeenCalled();
+    expect(modelStepSpan.createChildSpan).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: SpanType.PROVIDER_TOOL_CALL }),
+    );
     expect(providerToolSpan.end).toHaveBeenCalledWith(undefined);
   });
 });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -34,6 +34,7 @@ import { isProcessorWorkflow } from '../../../processors/index';
 import { PrepareStepProcessor } from '../../../processors/processors/prepare-step';
 import { ProcessorRunner } from '../../../processors/runner';
 import type { ProcessorState } from '../../../processors/runner';
+import { isMaybeAnthropic } from '../../../processors/trailing-assistant-guard';
 import { RequestContext } from '../../../request-context';
 import { execute } from '../../../stream/aisdk/v5/execute';
 import { DefaultStepResult } from '../../../stream/aisdk/v5/output-helpers';
@@ -1303,7 +1304,9 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           ...(inputProcessors || []),
           ...(options?.prepareStep ? [new PrepareStepProcessor({ prepareStep: options.prepareStep })] : []),
         ];
-        if (inputStepProcessors && inputStepProcessors.length > 0) {
+        // Run even with no configured processors when the model is Anthropic, so
+        // the runner can append its TrailingAssistantGuard (#21913).
+        if (inputStepProcessors.length > 0 || isMaybeAnthropic(model)) {
           const processorRunner = new ProcessorRunner({
             inputProcessors: inputStepProcessors,
             outputProcessors: [],

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -31,7 +31,7 @@ import {
 } from './span-payload';
 import type { ProcessorStepOutput } from './step-schema';
 import { REPROCESS_PART_KEY } from './stream-reprocess';
-import { isMaybeClaude46, TrailingAssistantGuard } from './trailing-assistant-guard';
+import { isMaybeAnthropic, TrailingAssistantGuard } from './trailing-assistant-guard';
 import type {
   CachedLLMStepChunk,
   CachedLLMStepResponse,
@@ -1382,9 +1382,9 @@ export class ProcessorRunner {
       retryCount: args.retryCount ?? 0,
     };
 
-    // Append the trailing assistant guard when the resolved model is Claude 4.6
+    // Append the trailing assistant guard when the resolved model is Anthropic
     const processors =
-      stepInput.model && isMaybeClaude46(stepInput.model)
+      stepInput.model && isMaybeAnthropic(stepInput.model)
         ? [...this.inputProcessors, new TrailingAssistantGuard()]
         : this.inputProcessors;
 

--- a/packages/core/src/processors/trailing-assistant-guard.test.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 
 import type { MastraDBMessage } from '../agent/message-list';
-import { isMaybeClaude46, TrailingAssistantGuard } from './trailing-assistant-guard';
+import { isMaybeAnthropic, TrailingAssistantGuard } from './trailing-assistant-guard';
 import type { ProcessInputStepArgs } from './index';
 
 const createMessage = (role: 'user' | 'assistant', text: string): MastraDBMessage => ({
@@ -25,42 +25,44 @@ const makeArgs = (
       'structuredOutput' in overrides ? overrides.structuredOutput : { schema: z.object({ answer: z.string() }) },
   }) as ProcessInputStepArgs;
 
-describe('isMaybeClaude46', () => {
-  it('detects Claude 4.6 string model configs from Anthropic providers', () => {
-    expect(isMaybeClaude46('anthropic/claude-opus-4-6')).toBe(true);
-    expect(isMaybeClaude46('anthropic/claude-sonnet-4.6')).toBe(true);
+describe('isMaybeAnthropic', () => {
+  it('detects Anthropic string model configs regardless of model version', () => {
+    expect(isMaybeAnthropic('anthropic/claude-opus-4-6')).toBe(true);
+    expect(isMaybeAnthropic('anthropic/claude-sonnet-4.6')).toBe(true);
+    expect(isMaybeAnthropic('anthropic/claude-opus-5')).toBe(true);
+    expect(isMaybeAnthropic('anthropic/claude-sonnet-4-5')).toBe(true);
   });
 
-  it('rejects non-Claude 4.6 string model configs', () => {
-    expect(isMaybeClaude46('anthropic/claude-sonnet-4-5')).toBe(false);
-    expect(isMaybeClaude46('openai/claude-opus-4-6')).toBe(false);
+  it('rejects non-Anthropic string model configs', () => {
+    expect(isMaybeAnthropic('openai/claude-opus-4-6')).toBe(false);
+    expect(isMaybeAnthropic('openai/gpt-5')).toBe(false);
   });
 
-  it('detects Claude 4.6 language model objects', () => {
-    expect(isMaybeClaude46({ provider: 'anthropic', modelId: 'claude-opus-4-6' })).toBe(true);
-    expect(isMaybeClaude46({ provider: 'anthropic.messages', modelId: 'claude-sonnet-4.6' })).toBe(true);
+  it('detects Anthropic language model objects regardless of model version', () => {
+    expect(isMaybeAnthropic({ provider: 'anthropic', modelId: 'claude-opus-4-6' })).toBe(true);
+    expect(isMaybeAnthropic({ provider: 'anthropic.messages', modelId: 'claude-opus-5' })).toBe(true);
   });
 
-  it('rejects non-Claude 4.6 language model objects', () => {
-    expect(isMaybeClaude46({ provider: 'anthropic', modelId: 'claude-sonnet-4-5' })).toBe(false);
-    expect(isMaybeClaude46({ provider: 'openai', modelId: 'claude-opus-4-6' })).toBe(false);
+  it('rejects non-Anthropic language model objects', () => {
+    expect(isMaybeAnthropic({ provider: 'openai', modelId: 'claude-opus-4-6' })).toBe(false);
+    expect(isMaybeAnthropic({ provider: 'openai.chat', modelId: 'gpt-5' })).toBe(false);
   });
 
-  it('treats dynamic model functions and unknown shapes as possibly Claude 4.6', () => {
-    expect(isMaybeClaude46(() => 'anthropic/claude-opus-4-6')).toBe(true);
-    expect(isMaybeClaude46({})).toBe(true);
-    expect(isMaybeClaude46(undefined)).toBe(true);
+  it('treats dynamic model functions and unknown shapes as possibly Anthropic', () => {
+    expect(isMaybeAnthropic(() => 'anthropic/claude-opus-4-6')).toBe(true);
+    expect(isMaybeAnthropic({})).toBe(true);
+    expect(isMaybeAnthropic(undefined)).toBe(true);
   });
 
-  it('detects Claude 4.6 inside fallback arrays', () => {
+  it('detects Anthropic inside fallback arrays', () => {
     expect(
-      isMaybeClaude46([{ model: 'openai/gpt-5' }, { model: { provider: 'anthropic', modelId: 'claude-sonnet-4.6' } }]),
+      isMaybeAnthropic([{ model: 'openai/gpt-5' }, { model: { provider: 'anthropic', modelId: 'claude-opus-5' } }]),
     ).toBe(true);
   });
 
-  it('rejects fallback arrays without a Claude 4.6 candidate', () => {
+  it('rejects fallback arrays without an Anthropic candidate', () => {
     expect(
-      isMaybeClaude46([{ model: 'openai/gpt-5' }, { model: { provider: 'anthropic', modelId: 'claude-sonnet-4-5' } }]),
+      isMaybeAnthropic([{ model: 'openai/gpt-5' }, { model: { provider: 'openai.chat', modelId: 'gpt-5-mini' } }]),
     ).toBe(false);
   });
 });

--- a/packages/core/src/processors/trailing-assistant-guard.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.ts
@@ -64,6 +64,11 @@ export class TrailingAssistantGuard implements Processor<'trailing-assistant-gua
     const lastMessage = messages[messages.length - 1];
     if (!lastMessage || lastMessage.role !== 'assistant') return;
 
+    // MessageList orders by createdAt and assigns fast-arriving messages synthetic
+    // future timestamps, so a plain `new Date()` can tie with (or precede) the
+    // trailing assistant message and get sorted before it. Stamp strictly later.
+    const createdAt = new Date(Math.max(Date.now(), new Date(lastMessage.createdAt).getTime() + 1));
+
     return {
       messages: [
         ...messages,
@@ -74,7 +79,7 @@ export class TrailingAssistantGuard implements Processor<'trailing-assistant-gua
             format: 2 as const,
             parts: [{ type: 'text' as const, text: 'Generate the structured response.' }],
           },
-          createdAt: new Date(),
+          createdAt,
         },
       ],
     };

--- a/packages/core/src/processors/trailing-assistant-guard.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.ts
@@ -2,16 +2,14 @@ import { randomUUID } from 'node:crypto';
 
 import type { Processor, ProcessInputStepArgs, ProcessInputStepResult } from './index';
 
-const CLAUDE_46_PATTERN = /[^0-9]4[.-]6/;
-
 /**
- * Checks whether a model config could be Claude 4.6.
+ * Checks whether a model config could be an Anthropic model.
  *
  * Handles raw model configs (strings like `'anthropic/claude-opus-4-6'`),
  * language model objects (with `provider` and `modelId`), dynamic functions
  * (returns `true` as a safe default), and model fallback arrays.
  */
-export function isMaybeClaude46(
+export function isMaybeAnthropic(
   model:
     | string
     | { provider?: string; modelId?: string }
@@ -22,16 +20,16 @@ export function isMaybeClaude46(
   if (typeof model === 'function') return true;
 
   if (Array.isArray(model)) {
-    return model.some(m => isMaybeClaude46(m.model ?? m));
+    return model.some(m => isMaybeAnthropic(m.model ?? m));
   }
 
   if (typeof model === 'string') {
-    return model.startsWith('anthropic') && CLAUDE_46_PATTERN.test(model);
+    return model.startsWith('anthropic');
   }
 
   if (model && typeof model === 'object' && 'provider' in model && 'modelId' in model) {
-    const { provider, modelId } = model as { provider: string; modelId: string };
-    return provider.startsWith('anthropic') && CLAUDE_46_PATTERN.test(modelId);
+    const { provider } = model as { provider: string };
+    return provider.startsWith('anthropic');
   }
 
   return true;
@@ -39,16 +37,19 @@ export function isMaybeClaude46(
 
 /**
  * Guards against trailing assistant messages when using native structured output
- * with Anthropic Claude 4.6.
+ * with Anthropic models.
  *
- * Claude 4.6 rejects requests where the last message is an assistant message when
+ * Anthropic rejects requests where the last message is an assistant message when
  * using output format (structured output), interpreting it as pre-filling the response.
- * This processor appends a user message to prevent that error.
+ * This applies to every Claude model; Claude 4.6 and later additionally reject
+ * trailing assistant messages without structured output. This processor appends
+ * a user message to prevent that error on the structured output path.
  *
- * This processor should only be added when the agent uses a Claude 4.6 model.
- * Use {@link isMaybeClaude46} to check before adding.
+ * This processor should only be added when the agent uses an Anthropic model.
+ * Use {@link isMaybeAnthropic} to check before adding.
  *
  * @see https://github.com/mastra-ai/mastra/issues/12800
+ * @see https://github.com/mastra-ai/mastra/issues/21913
  */
 export class TrailingAssistantGuard implements Processor<'trailing-assistant-guard'> {
   readonly id = 'trailing-assistant-guard' as const;


### PR DESCRIPTION
## Description

`TrailingAssistantGuard` exists to stop Anthropic's non-retryable 400 — `This model does not support assistant message prefill` — when a conversation ends with an assistant message and native structured output is used. Two independent gates kept it from running in the common cases: the step-level processor runner only executed when the agent had at least one configured input processor (or memory/skills), and the guard was keyed to Claude 4.6 model ids only, so newer Anthropic models lost the protection even when the runner did execute.

```ts
// Before: non-retryable 400 prefill error — the guard never ran
// (agent has no input processors, and/or the model id is not Claude 4.6)
const agent = new Agent({ model: anthropic('claude-opus-4-7'), ... });
await agent.generate(conversationEndingWithAssistantMessage, {
  structuredOutput: { schema },
});

// After: the guard appends its user message and the request succeeds
```

- Widens `isMaybeClaude46` to `isMaybeAnthropic` (provider check, internal symbol). Verified against the live Anthropic API that every Claude model — including pre-4.6 ones like `anthropic/claude-haiku-4-5` — rejects trailing-assistant messages under native structured output (older models use a different error text), so provider-wide gating cannot regress a previously working request
- Runs the input-step processor runner when the resolved step model is maybe-Anthropic even with no configured processors, in both the agentic loop and the durable agent execution step; the runner appends the guard as before
- Plain (non structured output) calls stay untouched: intentional assistant prefill on models that accept it keeps working, and non-Anthropic models keep the exact previous behavior
- Also fixes a latent ordering race in the guard itself: the appended user message was stamped with `new Date()`, which can tie with the trailing assistant message's synthetic ordering timestamp and get sorted before it, silently re-triggering the 400. The guard now stamps its message strictly after the last message
- Verified end-to-end with real credentials: the issue's reproduction (all four previously failing configurations now pass), the original #12800 memory scenario, a prefill regression check on `anthropic/claude-sonnet-4-6`-era models, and an OpenAI control

## Related Issue(s)

Fixes #21913

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an Anthropic conversation ends with the assistant, this change adds a user message so structured-output requests do not fail. It applies to all Anthropic models, even when no input processors are configured.

## Changes

- Detects Anthropic models with `isMaybeAnthropic` instead of Claude 4.6-specific matching.
- Runs the input-step processor pipeline for Anthropic models without configured input processors.
- Applies the fix to agentic-loop and durable agent execution paths.
- Ensures the guard message is stamped after the final assistant message.
- Preserves behavior for non-Anthropic models, non-structured-output calls, and intentional prefill.
- Adds regression tests for model detection, memory scenarios, prefill behavior, newer Claude models, and an OpenAI control.
- Adds a `@mastra/core` patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
