### PR TITLE
chore(factory): improve knowledge graph presentation

### DIFF
--- a/.changeset/quiet-graphs-show.md
+++ b/.changeset/quiet-graphs-show.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improve knowledge graph presentation.

--- a/.changeset/quiet-graphs-show.md
+++ b/.changeset/quiet-graphs-show.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Improve knowledge graph presentation.
+Project the bounded knowledge-node description into graph snapshots (hover synopsis); long-form content stays on the node detail view.

--- a/mastracode/factory-ui/src/ui/domains/factory/components/knowledge/KnowledgeFlyout.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/knowledge/KnowledgeFlyout.tsx
@@ -265,6 +265,17 @@ export function KnowledgeFlyout({
           </header>
 
           <div className="min-h-0 flex-1 overflow-y-auto pb-4">
+            {nodeQuery.data.node.content ? (
+              <Collapsible defaultOpen>
+                <SectionHeader title="Content" />
+                <CollapsibleContent>
+                  <p className="text-icon5 px-4 pb-3 text-xs leading-relaxed break-words whitespace-pre-wrap">
+                    <RecordText text={nodeQuery.data.node.content} onNodeRef={onNodeRef} />
+                  </p>
+                </CollapsibleContent>
+              </Collapsible>
+            ) : null}
+
             <Collapsible defaultOpen>
               <SectionHeader title="Knowledge node" />
               <CollapsibleContent>
@@ -282,17 +293,6 @@ export function KnowledgeFlyout({
                 </dl>
               </CollapsibleContent>
             </Collapsible>
-
-            {nodeQuery.data.node.content ? (
-              <Collapsible defaultOpen>
-                <SectionHeader title="Content" />
-                <CollapsibleContent>
-                  <p className="text-icon5 px-4 pb-3 text-xs leading-relaxed whitespace-pre-wrap">
-                    <RecordText text={nodeQuery.data.node.content} onNodeRef={onNodeRef} />
-                  </p>
-                </CollapsibleContent>
-              </Collapsible>
-            ) : null}
 
             <Collapsible defaultOpen>
               <SectionHeader title="Knowledge records" count={nodeQuery.data.records.length} />

--- a/mastracode/factory-ui/src/ui/domains/factory/components/knowledge/KnowledgeFlyout.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/knowledge/KnowledgeFlyout.tsx
@@ -265,7 +265,7 @@ export function KnowledgeFlyout({
           </header>
 
           <div className="min-h-0 flex-1 overflow-y-auto pb-4">
-            {nodeQuery.data.node.content ? (
+            {nodeQuery.data.node.content.trim() ? (
               <Collapsible defaultOpen>
                 <SectionHeader title="Content" />
                 <CollapsibleContent>

--- a/mastracode/factory-ui/src/ui/domains/factory/components/knowledge/KnowledgeGraph.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/knowledge/KnowledgeGraph.tsx
@@ -617,6 +617,14 @@ function GraphHoverCard({ hover, nodesById }: { hover: HoverCard; nodesById: Map
         <div className="mb-1 flex items-center gap-1.5">
           <span className="text-icon6 font-semibold">{node.name}</span>
         </div>
+        {node.content?.trim() ? (
+          <p
+            data-testid="knowledge-hover-description"
+            className="text-icon5 mb-2 line-clamp-3 max-w-72 leading-relaxed break-words"
+          >
+            {node.content}
+          </p>
+        ) : null}
         <dl className="text-icon4 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">
           <dt>Kind</dt>
           <dd>{node.kind}</dd>

--- a/mastracode/factory-ui/src/ui/domains/factory/components/knowledge/KnowledgeGraph.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/knowledge/KnowledgeGraph.tsx
@@ -617,12 +617,12 @@ function GraphHoverCard({ hover, nodesById }: { hover: HoverCard; nodesById: Map
         <div className="mb-1 flex items-center gap-1.5">
           <span className="text-icon6 font-semibold">{node.name}</span>
         </div>
-        {node.content?.trim() ? (
+        {node.description?.trim() ? (
           <p
             data-testid="knowledge-hover-description"
             className="text-icon5 mb-2 line-clamp-3 max-w-72 leading-relaxed break-words"
           >
-            {node.content}
+            {node.description}
           </p>
         ) : null}
         <dl className="text-icon4 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">

--- a/mastracode/factory-ui/src/ui/domains/factory/services/knowledge.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/knowledge.ts
@@ -15,6 +15,7 @@ export interface KnowledgeGraphNode {
   id: string;
   name: string;
   kind: string;
+  content?: string;
   scope: string[];
   rung: KnowledgeRung;
   /** A pinned record's wikilinks reference this node (the pin accent). */

--- a/mastracode/factory-ui/src/ui/domains/factory/services/knowledge.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/knowledge.ts
@@ -15,7 +15,7 @@ export interface KnowledgeGraphNode {
   id: string;
   name: string;
   kind: string;
-  content?: string;
+  description?: string;
   scope: string[];
   rung: KnowledgeRung;
   /** A pinned record's wikilinks reference this node (the pin accent). */

--- a/mastracode/factory-ui/src/ui/pages/__tests__/KnowledgePage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/KnowledgePage.msw.test.tsx
@@ -56,6 +56,8 @@ const graphFixture: KnowledgeGraphPayload = {
       id: 'ent-1',
       name: 'Payments Service',
       kind: 'service',
+      content:
+        'Handles charging flows through [[Deploy Runbook]]. Operational reference: https://github.com/mastra-ai/mastra/tree/main/mastracode/factory',
       scope: ['org:org-1', `resource:${FACTORY_ID}`],
       rung: 'resource',
       pinned: true,
@@ -240,6 +242,45 @@ describe('KnowledgePage', () => {
     ).toBeInTheDocument();
   }, 15000);
 
+  it('shows snapshot content in the hover card without fetching node details', async () => {
+    let nodeDetailRequests = 0;
+    stubKnowledgeRoute();
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/knowledge/nodes/:nodeId`, () => {
+        nodeDetailRequests += 1;
+        return HttpResponse.json(nodeFixture);
+      }),
+    );
+    renderRoute();
+
+    const paymentsLabel = await screen.findByText('Payments Service');
+    const paymentsNode = paymentsLabel.closest('[data-testid="knowledge-node"]');
+    expect(paymentsNode).not.toBeNull();
+    fireEvent.mouseEnter(paymentsNode!, { clientX: 120, clientY: 80 });
+
+    const description = await screen.findByTestId('knowledge-hover-description');
+    expect(description).toHaveTextContent('Handles charging flows through');
+    expect(description).toHaveClass('line-clamp-3');
+    expect(nodeDetailRequests).toBe(0);
+  });
+
+  it('omits hover description chrome for absent and whitespace-only content', async () => {
+    stubKnowledgeRoute({
+      ...graphFixture,
+      nodes: graphFixture.nodes.map(node =>
+        node.id === 'ent-1' ? { ...node, content: '   \n  ' } : { ...node, content: undefined },
+      ),
+    });
+    renderRoute();
+
+    const nodes = await screen.findAllByTestId('knowledge-node');
+    fireEvent.mouseEnter(nodes[0]!, { clientX: 120, clientY: 80 });
+    expect(screen.queryByTestId('knowledge-hover-description')).not.toBeInTheDocument();
+    fireEvent.mouseLeave(nodes[0]!);
+    fireEvent.mouseEnter(nodes[1]!, { clientX: 140, clientY: 100 });
+    expect(screen.queryByTestId('knowledge-hover-description')).not.toBeInTheDocument();
+  });
+
   it('opens the flyout on node click with knowledge records and reasoning drill-in', async () => {
     stubKnowledgeRoute();
     renderRoute();
@@ -256,6 +297,9 @@ describe('KnowledgePage', () => {
     expect(await screen.findByText(/for charging flows/)).toBeInTheDocument();
     expect(flyout).toHaveTextContent('Payments Service');
     expect(flyout).toHaveTextContent('Handles charging flows through');
+    const contentHeading = within(flyout).getByText('Content');
+    const metadataHeading = within(flyout).getByText('Knowledge node');
+    expect(contentHeading.compareDocumentPosition(metadataHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     // A10: the pinned knowledge record card carries the amber standout marker.
     const knowledgeRecords = screen.getAllByTestId('knowledge-record');
     expect(within(knowledgeRecords[0]!).getByRole('button', { name: 'Deploy Runbook' })).toBeInTheDocument();

--- a/mastracode/factory-ui/src/ui/pages/__tests__/KnowledgePage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/KnowledgePage.msw.test.tsx
@@ -97,7 +97,10 @@ const graphFixture: KnowledgeGraphPayload = {
   version: '01TESTVERSION',
 };
 
-function stubKnowledgeRoute(graph: KnowledgeGraphPayload | { status: number; message: string } = graphFixture) {
+function stubKnowledgeRoute(
+  graph: KnowledgeGraphPayload | { status: number; message: string } = graphFixture,
+  nodePayload = nodeFixture,
+) {
   server.use(
     http.get(`${TEST_BASE_URL}/auth/me`, () =>
       HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
@@ -153,7 +156,7 @@ function stubKnowledgeRoute(graph: KnowledgeGraphPayload | { status: number; mes
       return HttpResponse.json(graph);
     }),
     http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/knowledge/nodes/:nodeId`, () =>
-      HttpResponse.json(nodeFixture),
+      HttpResponse.json(nodePayload),
     ),
   );
 }
@@ -275,10 +278,27 @@ describe('KnowledgePage', () => {
 
     const nodes = await screen.findAllByTestId('knowledge-node');
     fireEvent.mouseEnter(nodes[0]!, { clientX: 120, clientY: 80 });
+    expect(screen.getByTestId('knowledge-hover-card')).toBeInTheDocument();
     expect(screen.queryByTestId('knowledge-hover-description')).not.toBeInTheDocument();
     fireEvent.mouseLeave(nodes[0]!);
     fireEvent.mouseEnter(nodes[1]!, { clientX: 140, clientY: 100 });
+    expect(screen.getByTestId('knowledge-hover-card')).toBeInTheDocument();
     expect(screen.queryByTestId('knowledge-hover-description')).not.toBeInTheDocument();
+  });
+
+  it('omits flyout content chrome for whitespace-only content', async () => {
+    stubKnowledgeRoute(undefined, {
+      ...nodeFixture,
+      node: { ...nodeFixture.node, content: '   \n  ' },
+    });
+    renderRoute();
+
+    const nodes = await screen.findAllByTestId('knowledge-node');
+    fireEvent.click(nodes[0]);
+
+    const flyout = await screen.findByTestId('knowledge-flyout');
+    expect(await within(flyout).findByText('Knowledge node')).toBeInTheDocument();
+    expect(within(flyout).queryByText('Content')).not.toBeInTheDocument();
   });
 
   it('opens the flyout on node click with knowledge records and reasoning drill-in', async () => {

--- a/mastracode/factory-ui/src/ui/pages/__tests__/KnowledgePage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/KnowledgePage.msw.test.tsx
@@ -276,12 +276,17 @@ describe('KnowledgePage', () => {
     });
     renderRoute();
 
-    const nodes = await screen.findAllByTestId('knowledge-node');
-    fireEvent.mouseEnter(nodes[0]!, { clientX: 120, clientY: 80 });
+    // Select by label so the whitespace-only node (ent-1) is definitely exercised,
+    // regardless of render order.
+    const whitespaceNode = (await screen.findByText('Payments Service')).closest('[data-testid="knowledge-node"]');
+    const absentNode = (await screen.findByText('Deploy Runbook')).closest('[data-testid="knowledge-node"]');
+    expect(whitespaceNode).not.toBeNull();
+    expect(absentNode).not.toBeNull();
+    fireEvent.mouseEnter(whitespaceNode!, { clientX: 120, clientY: 80 });
     expect(screen.getByTestId('knowledge-hover-card')).toBeInTheDocument();
     expect(screen.queryByTestId('knowledge-hover-description')).not.toBeInTheDocument();
-    fireEvent.mouseLeave(nodes[0]!);
-    fireEvent.mouseEnter(nodes[1]!, { clientX: 140, clientY: 100 });
+    fireEvent.mouseLeave(whitespaceNode!);
+    fireEvent.mouseEnter(absentNode!, { clientX: 140, clientY: 100 });
     expect(screen.getByTestId('knowledge-hover-card')).toBeInTheDocument();
     expect(screen.queryByTestId('knowledge-hover-description')).not.toBeInTheDocument();
   });

--- a/mastracode/factory-ui/src/ui/pages/__tests__/KnowledgePage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/KnowledgePage.msw.test.tsx
@@ -56,7 +56,7 @@ const graphFixture: KnowledgeGraphPayload = {
       id: 'ent-1',
       name: 'Payments Service',
       kind: 'service',
-      content:
+      description:
         'Handles charging flows through [[Deploy Runbook]]. Operational reference: https://github.com/mastra-ai/mastra/tree/main/mastracode/factory',
       scope: ['org:org-1', `resource:${FACTORY_ID}`],
       rung: 'resource',
@@ -245,7 +245,7 @@ describe('KnowledgePage', () => {
     ).toBeInTheDocument();
   }, 15000);
 
-  it('shows snapshot content in the hover card without fetching node details', async () => {
+  it('shows the snapshot description in the hover card without fetching node details', async () => {
     let nodeDetailRequests = 0;
     stubKnowledgeRoute();
     server.use(
@@ -267,11 +267,11 @@ describe('KnowledgePage', () => {
     expect(nodeDetailRequests).toBe(0);
   });
 
-  it('omits hover description chrome for absent and whitespace-only content', async () => {
+  it('omits hover description chrome for absent and whitespace-only descriptions', async () => {
     stubKnowledgeRoute({
       ...graphFixture,
       nodes: graphFixture.nodes.map(node =>
-        node.id === 'ent-1' ? { ...node, content: '   \n  ' } : { ...node, content: undefined },
+        node.id === 'ent-1' ? { ...node, description: '   \n  ' } : { ...node, description: undefined },
       ),
     });
     renderRoute();

--- a/mastracode/factory/src/routes/knowledge.test.ts
+++ b/mastracode/factory/src/routes/knowledge.test.ts
@@ -61,8 +61,9 @@ async function node(
   name: string,
   scope: KnowledgeScope,
   kind = 'concept',
+  content?: string,
 ): Promise<KnowledgeNode> {
-  return store.createNode({ name, kind, scope });
+  return store.createNode({ name, kind, scope, ...(content !== undefined ? { content } : {}) });
 }
 
 async function record(
@@ -123,6 +124,39 @@ describe('KnowledgeRoutes', () => {
     expect(body.edges[0]).toMatchObject({ source: service.id, target: runbook.id, type: 'wikilink' });
     expect(body.nodes.find(node => node.id === service.id)?.recordCount).toBe(1);
     expect(body.truncated).toBe(false);
+  });
+
+  it('projects node content into graph snapshots without normalizing contract values', async () => {
+    const h = await createHarness();
+    const longContent =
+      'Payments coordinates settlement and reconciliation. '.repeat(20) +
+      'Repository: https://github.com/mastra-ai/mastra/tree/main/mastracode/factory';
+    const described = await node(h.knowledge, 'Described', h.projectScope, 'service', longContent);
+    const absent = await node(h.knowledge, 'Absent', h.projectScope);
+    const empty = await node(h.knowledge, 'Empty', h.projectScope, 'concept', '');
+    const whitespace = await node(h.knowledge, 'Whitespace', h.projectScope, 'concept', '   \n  ');
+
+    const { status, body } = await graph(h);
+    expect(status).toBe(200);
+    expect(body.nodes.find(node => node.id === described.id)?.content).toBe(longContent);
+    expect(body.nodes.find(node => node.id === absent.id)).not.toHaveProperty('content');
+    expect(body.nodes.find(node => node.id === empty.id)?.content).toBe('');
+    expect(body.nodes.find(node => node.id === whitespace.id)?.content).toBe('   \n  ');
+    expect(body.nodes).toHaveLength(4);
+    expect(body.records).toHaveLength(0);
+    expect(body.truncated).toBe(false);
+
+    const withContent = JSON.stringify(body);
+    const withoutContent = JSON.stringify({
+      ...body,
+      nodes: body.nodes.map(({ content: _content, ...node }) => node),
+    });
+    const delta = Buffer.byteLength(withContent) - Buffer.byteLength(withoutContent);
+    console.log(
+      `PAYLOAD_BYTES withoutContent=${Buffer.byteLength(withoutContent)} withContent=${Buffer.byteLength(withContent)} delta=${delta}`,
+    );
+    expect(delta).toBeGreaterThan(0);
+    expect(delta).toBe(Buffer.byteLength(withContent) - Buffer.byteLength(withoutContent));
   });
 
   // 2

--- a/mastracode/factory/src/routes/knowledge.test.ts
+++ b/mastracode/factory/src/routes/knowledge.test.ts
@@ -156,7 +156,6 @@ describe('KnowledgeRoutes', () => {
       `PAYLOAD_BYTES withoutContent=${Buffer.byteLength(withoutContent)} withContent=${Buffer.byteLength(withContent)} delta=${delta}`,
     );
     expect(delta).toBeGreaterThan(0);
-    expect(delta).toBe(Buffer.byteLength(withContent) - Buffer.byteLength(withoutContent));
   });
 
   // 2

--- a/mastracode/factory/src/routes/knowledge.test.ts
+++ b/mastracode/factory/src/routes/knowledge.test.ts
@@ -61,9 +61,9 @@ async function node(
   name: string,
   scope: KnowledgeScope,
   kind = 'concept',
-  content?: string,
+  description?: string,
 ): Promise<KnowledgeNode> {
-  return store.createNode({ name, kind, scope, ...(content !== undefined ? { content } : {}) });
+  return store.createNode({ name, kind, scope, ...(description !== undefined ? { description } : {}) });
 }
 
 async function record(
@@ -126,36 +126,33 @@ describe('KnowledgeRoutes', () => {
     expect(body.truncated).toBe(false);
   });
 
-  it('projects node content into graph snapshots without normalizing contract values', async () => {
+  it('projects the bounded description into graph snapshots and never leaks content', async () => {
     const h = await createHarness();
-    const longContent =
-      'Payments coordinates settlement and reconciliation. '.repeat(20) +
-      'Repository: https://github.com/mastra-ai/mastra/tree/main/mastracode/factory';
-    const described = await node(h.knowledge, 'Described', h.projectScope, 'service', longContent);
+    const synopsis =
+      'Payments coordinates settlement and reconciliation. Repository: https://github.com/mastra-ai/mastra/tree/main/mastracode/factory';
+    const described = await node(h.knowledge, 'Described', h.projectScope, 'service', synopsis);
     const absent = await node(h.knowledge, 'Absent', h.projectScope);
     const empty = await node(h.knowledge, 'Empty', h.projectScope, 'concept', '');
-    const whitespace = await node(h.knowledge, 'Whitespace', h.projectScope, 'concept', '   \n  ');
+    // A node with long-form content but no description must not fall back to content.
+    const contentful = await h.knowledge.createNode({
+      name: 'Contentful',
+      kind: 'doc',
+      scope: h.projectScope,
+      content: 'Long-form body that must never appear in the graph payload. '.repeat(20),
+    });
 
     const { status, body } = await graph(h);
     expect(status).toBe(200);
-    expect(body.nodes.find(node => node.id === described.id)?.content).toBe(longContent);
-    expect(body.nodes.find(node => node.id === absent.id)).not.toHaveProperty('content');
-    expect(body.nodes.find(node => node.id === empty.id)?.content).toBe('');
-    expect(body.nodes.find(node => node.id === whitespace.id)?.content).toBe('   \n  ');
+    expect(body.nodes.find(node => node.id === described.id)?.description).toBe(synopsis);
+    expect(body.nodes.find(node => node.id === absent.id)).not.toHaveProperty('description');
+    expect(body.nodes.find(node => node.id === empty.id)?.description).toBe('');
+    expect(body.nodes.find(node => node.id === contentful.id)).not.toHaveProperty('description');
+    for (const graphNode of body.nodes) {
+      expect(graphNode).not.toHaveProperty('content');
+    }
     expect(body.nodes).toHaveLength(4);
     expect(body.records).toHaveLength(0);
     expect(body.truncated).toBe(false);
-
-    const withContent = JSON.stringify(body);
-    const withoutContent = JSON.stringify({
-      ...body,
-      nodes: body.nodes.map(({ content: _content, ...node }) => node),
-    });
-    const delta = Buffer.byteLength(withContent) - Buffer.byteLength(withoutContent);
-    console.log(
-      `PAYLOAD_BYTES withoutContent=${Buffer.byteLength(withoutContent)} withContent=${Buffer.byteLength(withContent)} delta=${delta}`,
-    );
-    expect(delta).toBeGreaterThan(0);
   });
 
   // 2

--- a/mastracode/factory/src/routes/knowledge.test.ts
+++ b/mastracode/factory/src/routes/knowledge.test.ts
@@ -145,7 +145,8 @@ describe('KnowledgeRoutes', () => {
     expect(status).toBe(200);
     expect(body.nodes.find(node => node.id === described.id)?.description).toBe(synopsis);
     expect(body.nodes.find(node => node.id === absent.id)).not.toHaveProperty('description');
-    expect(body.nodes.find(node => node.id === empty.id)?.description).toBe('');
+    // '' is a curator clear — projected as omitted, same as absent.
+    expect(body.nodes.find(node => node.id === empty.id)).not.toHaveProperty('description');
     expect(body.nodes.find(node => node.id === contentful.id)).not.toHaveProperty('description');
     for (const graphNode of body.nodes) {
       expect(graphNode).not.toHaveProperty('content');

--- a/mastracode/factory/src/routes/knowledge.ts
+++ b/mastracode/factory/src/routes/knowledge.ts
@@ -68,6 +68,7 @@ export interface KnowledgeGraphNode {
   id: string;
   name: string;
   kind: string;
+  content?: string;
   scope: KnowledgeScope;
   /** Deepest rung of the record's scope: org | resource | thread. */
   rung: 'org' | 'resource' | 'thread';
@@ -513,6 +514,7 @@ export class KnowledgeRoutes extends Route<KnowledgeRoutesDeps> {
               id: node.id,
               name: node.name,
               kind: node.kind,
+              ...(node.content !== undefined ? { content: node.content } : {}),
               scope: node.scope,
               rung: deepestRung(node.scope),
               pinned: accented.has(node.id),

--- a/mastracode/factory/src/routes/knowledge.ts
+++ b/mastracode/factory/src/routes/knowledge.ts
@@ -68,7 +68,7 @@ export interface KnowledgeGraphNode {
   id: string;
   name: string;
   kind: string;
-  content?: string;
+  description?: string;
   scope: KnowledgeScope;
   /** Deepest rung of the record's scope: org | resource | thread. */
   rung: 'org' | 'resource' | 'thread';
@@ -514,7 +514,7 @@ export class KnowledgeRoutes extends Route<KnowledgeRoutesDeps> {
               id: node.id,
               name: node.name,
               kind: node.kind,
-              ...(node.content !== undefined ? { content: node.content } : {}),
+              ...(node.description !== undefined ? { description: node.description } : {}),
               scope: node.scope,
               rung: deepestRung(node.scope),
               pinned: accented.has(node.id),

--- a/mastracode/factory/src/routes/knowledge.ts
+++ b/mastracode/factory/src/routes/knowledge.ts
@@ -514,7 +514,8 @@ export class KnowledgeRoutes extends Route<KnowledgeRoutesDeps> {
               id: node.id,
               name: node.name,
               kind: node.kind,
-              ...(node.description !== undefined ? { description: node.description } : {}),
+              // Empty string is a curator clear — omit it so the payload carries no dead keys.
+              ...(node.description ? { description: node.description } : {}),
               scope: node.scope,
               rung: deepestRung(node.scope),
               pinned: accented.has(node.id),


### PR DESCRIPTION
## Summary

- include entity content in knowledge graph snapshots
- show entity content on graph hover and at the top of the detail flyout
- omit content presentation for blank values while preserving existing wikilink behavior

This is stacked on #21830.

## Test plan

- `pnpm --dir mastracode/factory exec vitest run --project unit:mastra-factory src/routes/knowledge.test.ts --reporter=dot`
- `pnpm --dir mastracode/factory check`
- `pnpm --dir mastracode/factory lint`
- `pnpm --dir mastracode/factory-ui exec vitest run --project msw:factory-ui src/ui/pages/__tests__/KnowledgePage.msw.test.tsx --reporter=dot --bail 1`
- `pnpm --dir mastracode/factory-ui typecheck`
