### PR TITLE
fix(factory): smooth thread history loading

### DIFF
--- a/.changeset/factory-thread-history-reveal.md
+++ b/.changeset/factory-thread-history-reveal.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved loaded Factory conversations with a smooth staggered reveal.

--- a/mastracode/factory-ui/src/hooks/__tests__/useRouteThreadSync.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useRouteThreadSync.msw.test.tsx
@@ -21,6 +21,7 @@ const API = `${TEST_BASE_URL}/api/agent-controller/code`;
 const transcript: ChatTranscriptApi = {
   transcript: initialTranscript,
   busy: false,
+  initialHistoryReady: true,
   localUser: vi.fn(),
   reset: vi.fn(),
   resolvePrompt: vi.fn(),

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ConnectionActivity.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ConnectionActivity.msw.test.tsx
@@ -28,6 +28,7 @@ function renderActivity(status: ChatConnectionApi['status'], busy: boolean) {
   const transcript: ChatTranscriptApi = {
     transcript: initialTranscript,
     busy,
+    initialHistoryReady: true,
     localUser: vi.fn(),
     reset: vi.fn(),
     resolvePrompt: vi.fn(),

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -14,7 +14,7 @@ import { MessageFactory } from '@mastra/react/ui';
 import type { FilePart, MessageRoleRenderers, ReasoningPart, TextPart, ToolInvocationPart } from '@mastra/react/ui';
 import { Bell, CircleDot, ExternalLink, Info, Layers, Slack } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 import { useChatSessionContext } from '../context/useChatSessionContext';
@@ -501,27 +501,22 @@ function SignalRow({ kind, label, message }: { kind: string; label: string; mess
 const HISTORY_ENTRY_STAGGER_MS = 55;
 const HISTORY_ENTRY_STAGGER_LIMIT = 10;
 
+interface PreparedTranscriptEntry {
+  entry: TimelineEntry;
+  content: ReactNode;
+}
+
+function createHistoryRevealDelays(entries: PreparedTranscriptEntry[]): Record<string, number> {
+  const visibleEntries = entries.filter(({ content }) => content !== null);
+  const staggerStart = Math.max(visibleEntries.length - HISTORY_ENTRY_STAGGER_LIMIT, 0);
+  return Object.fromEntries(
+    visibleEntries.map(({ entry }, index) => [entry.id, Math.max(index - staggerStart, 0) * HISTORY_ENTRY_STAGGER_MS]),
+  );
+}
+
 export function Transcript({ tail }: { tail?: ReactNode }) {
   const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
   const { transcript, resolvePrompt, busy } = useChatTranscript();
-  const historyRef = useRef<HTMLDivElement>(null);
-  useLayoutEffect(() => {
-    const entries = historyRef.current?.querySelectorAll<HTMLElement>('[data-transcript-history-entry]');
-    if (!entries?.length) return;
-
-    const staggerStart = Math.max(entries.length - HISTORY_ENTRY_STAGGER_LIMIT, 0);
-    entries.forEach((entry, index) => {
-      entry.style.animationDelay = `${Math.max(index - staggerStart, 0) * HISTORY_ENTRY_STAGGER_MS}ms`;
-      entry.classList.add('transcript-history-enter');
-    });
-
-    return () => {
-      entries.forEach(entry => {
-        entry.style.removeProperty('animation-delay');
-        entry.classList.remove('transcript-history-enter');
-      });
-    };
-  }, []);
   const hookArgs = {
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
@@ -542,21 +537,21 @@ export function Transcript({ tail }: { tail?: ReactNode }) {
   };
 
   return (
-    <div ref={historyRef} className="contents">
-      <TranscriptEntries
-        entries={transcript.entries}
-        isSubmitting={approveMutation.isPending || respondMutation.isPending}
-        onApprove={onApprove}
-        onRespond={onRespond}
-        running={busy}
-        tail={tail}
-      />
-    </div>
+    <TranscriptEntries
+      entries={transcript.entries}
+      revealInitialEntries
+      isSubmitting={approveMutation.isPending || respondMutation.isPending}
+      onApprove={onApprove}
+      onRespond={onRespond}
+      running={busy}
+      tail={tail}
+    />
   );
 }
 
 export function TranscriptEntries({
   entries,
+  revealInitialEntries = false,
   isSubmitting = false,
   onApprove,
   onRespond,
@@ -564,6 +559,7 @@ export function TranscriptEntries({
   tail,
 }: {
   entries: TimelineEntry[];
+  revealInitialEntries?: boolean;
   isSubmitting?: boolean;
   onApprove: (toolCallId: string, approved: boolean, promptId: string) => void;
   onRespond: (toolCallId: string, resumeData: string | string[] | PlanResume, promptId: string) => void;
@@ -588,9 +584,7 @@ export function TranscriptEntries({
   const renderEntry = (entry: TimelineEntry): ReactNode => {
     switch (entry.kind) {
       case 'message':
-        return (
-          <MessageBubble entry={entry} suspensions={suspensions} isSubmitting={isSubmitting} onRespond={onRespond} />
-        );
+        return renderMessageBubble({ entry, suspensions, isSubmitting, onRespond });
       case 'notice':
         return <NoticeCard entry={entry} />;
       case 'approval':
@@ -610,6 +604,11 @@ export function TranscriptEntries({
     }
   };
 
+  const preparedEntries = entries.map(entry => ({ entry, content: renderEntry(entry) }));
+  const [historyRevealDelays] = useState(() =>
+    revealInitialEntries ? createHistoryRevealDelays(preparedEntries) : {},
+  );
+
   // A turn is what you can see: the run echoes the message you sent back as a signal
   // that draws nothing, and letting that open a turn would take the room off your bubble.
   const drawsContent = (entry: MessageEntry): boolean =>
@@ -617,18 +616,22 @@ export function TranscriptEntries({
   const opensTurn = (entry: TimelineEntry): boolean =>
     entry.kind === 'message' && startsUserTurn(entry.message) && drawsContent(entry);
 
-  const turnGroups: { key: string; entries: TimelineEntry[]; opensTurn: boolean }[] = [];
-  for (const entry of entries) {
-    const opens = opensTurn(entry);
+  const turnGroups: { key: string; entries: PreparedTranscriptEntry[]; opensTurn: boolean }[] = [];
+  for (const preparedEntry of preparedEntries) {
+    const opens = opensTurn(preparedEntry.entry);
     if (!opens && turnGroups.length > 0) {
-      turnGroups.at(-1)?.entries.push(entry);
+      turnGroups.at(-1)?.entries.push(preparedEntry);
       continue;
     }
     // A gap sorts above the turn it introduces but arrives after it: inside that turn the
     // room absorbs its height, outside it shifts the transcript a beat later.
     const previous = turnGroups.at(-1);
-    const introduction = previous && isTimeGap(previous.entries.at(-1)) ? previous.entries.splice(-1) : [];
-    turnGroups.push({ key: entry.id, entries: [...introduction, entry], opensTurn: opens });
+    const introduction = previous && isTimeGap(previous.entries.at(-1)?.entry) ? previous.entries.splice(-1) : [];
+    turnGroups.push({
+      key: preparedEntry.entry.id,
+      entries: [...introduction, preparedEntry],
+      opensTurn: opens,
+    });
   }
 
   return (
@@ -642,21 +645,23 @@ export function TranscriptEntries({
             key={group.key}
             className={cn('flex flex-col', group.opensTurn && 'turn-room', holdsRoom && 'turn-room-open')}
           >
-            {group.entries.map(entry => {
-              const rendered = renderEntry(entry);
-              if (!rendered) return null;
+            {group.entries.map(({ entry, content }) => {
+              const historyRevealDelay = historyRevealDelays[entry.id];
 
               return (
                 <MessageScrollerItem
-                  data-transcript-history-entry=""
                   key={entry.id}
                   messageId={entry.id}
                   scrollAnchor={opensTurn(entry)}
                   // Estimated off-screen heights would make the prepend anchor restore
                   // the wrong offset — measure the real thing.
-                  className="[content-visibility:visible]"
+                  className={cn(
+                    '[content-visibility:visible]',
+                    historyRevealDelay !== undefined && 'transcript-history-enter',
+                  )}
+                  style={historyRevealDelay === undefined ? undefined : { animationDelay: `${historyRevealDelay}ms` }}
                 >
-                  {rendered}
+                  {content}
                 </MessageScrollerItem>
               );
             })}
@@ -709,7 +714,7 @@ export function ChannelOriginBadge({ origin }: { origin: { platform: string; aut
   );
 }
 
-function MessageBubble({
+function renderMessageBubble({
   entry,
   suspensions,
   isSubmitting,

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -507,11 +507,8 @@ interface PreparedTranscriptEntry {
 }
 
 function createHistoryRevealDelays(entries: PreparedTranscriptEntry[]): Record<string, number> {
-  const visibleEntries = entries.filter(({ content }) => content !== null);
-  const staggerStart = Math.max(visibleEntries.length - HISTORY_ENTRY_STAGGER_LIMIT, 0);
-  return Object.fromEntries(
-    visibleEntries.map(({ entry }, index) => [entry.id, Math.max(index - staggerStart, 0) * HISTORY_ENTRY_STAGGER_MS]),
-  );
+  const visibleEntries = entries.filter(({ content }) => content !== null).slice(-HISTORY_ENTRY_STAGGER_LIMIT);
+  return Object.fromEntries(visibleEntries.map(({ entry }, index) => [entry.id, index * HISTORY_ENTRY_STAGGER_MS]));
 }
 
 export function Transcript({ tail }: { tail?: ReactNode }) {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -14,7 +14,7 @@ import { MessageFactory } from '@mastra/react/ui';
 import type { FilePart, MessageRoleRenderers, ReasoningPart, TextPart, ToolInvocationPart } from '@mastra/react/ui';
 import { Bell, CircleDot, ExternalLink, Info, Layers, Slack } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 import { useChatSessionContext } from '../context/useChatSessionContext';
@@ -498,10 +498,30 @@ function SignalRow({ kind, label, message }: { kind: string; label: string; mess
 // ---------------------------------------------------------------------------
 // Transcript
 // ---------------------------------------------------------------------------
+const HISTORY_ENTRY_STAGGER_MS = 55;
+const HISTORY_ENTRY_STAGGER_LIMIT = 10;
 
 export function Transcript({ tail }: { tail?: ReactNode }) {
   const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
   const { transcript, resolvePrompt, busy } = useChatTranscript();
+  const historyRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const entries = historyRef.current?.querySelectorAll<HTMLElement>('[data-transcript-history-entry]');
+    if (!entries?.length) return;
+
+    const staggerStart = Math.max(entries.length - HISTORY_ENTRY_STAGGER_LIMIT, 0);
+    entries.forEach((entry, index) => {
+      entry.style.animationDelay = `${Math.max(index - staggerStart, 0) * HISTORY_ENTRY_STAGGER_MS}ms`;
+      entry.classList.add('transcript-history-enter');
+    });
+
+    return () => {
+      entries.forEach(entry => {
+        entry.style.removeProperty('animation-delay');
+        entry.classList.remove('transcript-history-enter');
+      });
+    };
+  }, []);
   const hookArgs = {
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
@@ -522,14 +542,16 @@ export function Transcript({ tail }: { tail?: ReactNode }) {
   };
 
   return (
-    <TranscriptEntries
-      entries={transcript.entries}
-      isSubmitting={approveMutation.isPending || respondMutation.isPending}
-      onApprove={onApprove}
-      onRespond={onRespond}
-      running={busy}
-      tail={tail}
-    />
+    <div ref={historyRef} className="contents">
+      <TranscriptEntries
+        entries={transcript.entries}
+        isSubmitting={approveMutation.isPending || respondMutation.isPending}
+        onApprove={onApprove}
+        onRespond={onRespond}
+        running={busy}
+        tail={tail}
+      />
+    </div>
   );
 }
 
@@ -626,6 +648,7 @@ export function TranscriptEntries({
 
               return (
                 <MessageScrollerItem
+                  data-transcript-history-entry=""
                   key={entry.id}
                   messageId={entry.id}
                   scrollAnchor={opensTurn(entry)}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
@@ -147,6 +147,23 @@ describe('TranscriptEntries turn groups', () => {
     expect(document.querySelectorAll(ROOM_SELECTOR)).toHaveLength(1);
   });
 
+  it('limits the history reveal to the latest ten visible entries', () => {
+    const history = Array.from({ length: 12 }, (_, index) =>
+      textEntry(`history-${index + 1}`, index % 2 === 0 ? 'user' : 'assistant', `history message ${index + 1}`),
+    );
+    renderWithProviders(
+      <TranscriptEntries entries={history} revealInitialEntries onApprove={() => {}} onRespond={() => {}} />,
+    );
+
+    const animatedEntries = Array.from(document.querySelectorAll<HTMLElement>('.transcript-history-enter'));
+    expect(animatedEntries).toHaveLength(10);
+    expect(animatedEntries.map(entry => entry.style.animationDelay)).toEqual(
+      Array.from({ length: 10 }, (_, index) => `${index * 55}ms`),
+    );
+    expect(document.querySelector('[data-message-id="history-1"]')).not.toHaveClass('transcript-history-enter');
+    expect(document.querySelector('[data-message-id="history-2"]')).not.toHaveClass('transcript-history-enter');
+  });
+
   it('takes the gap that introduces a turn into that turn, where the room absorbs it', () => {
     renderWithProviders(
       <TranscriptEntries

--- a/mastracode/factory-ui/src/ui/domains/chat/components/chat-enter.css
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/chat-enter.css
@@ -15,6 +15,24 @@
   }
 }
 
+@keyframes transcript-history-in {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 10px, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .transcript-history-enter {
+    animation: transcript-history-in 480ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
+  }
+}
+
 /* Rise and fade run on their own clocks: the opacity settles early while the
  * travel keeps a long decelerating tail, which is what reads as smooth.
  *

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptContext.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptContext.ts
@@ -16,6 +16,7 @@ export interface LoadMoreHistory {
 export interface ChatTranscriptApi {
   transcript: TranscriptState;
   busy: boolean;
+  initialHistoryReady: boolean;
   localUser: (text: string, steer?: boolean, files?: OutgoingFile[]) => void;
   reset: (threadId?: string, state?: SessionStateSnapshot) => void;
   resolvePrompt: (id: string) => void;

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
@@ -43,9 +43,8 @@ export function ChatTranscriptProvider({
   // post-navigation revalidation all fold in through the same path.
   const mergeWindow = useEffectEvent((messages: MastraDBMessage[]) => transcriptApi.mergeWindow(messages));
   useEffect(() => {
-    if (initialMessages && initialMessages.length > 0) {
-      mergeWindow(initialMessages);
-    }
+    if (initialMessages === undefined) return;
+    mergeWindow(initialMessages);
   }, [initialMessages]);
 
   const loadMore: LoadMoreHistory = {
@@ -121,7 +120,7 @@ function ChatTranscriptValueProvider({
   const { sessionError, sandboxPreparing } = useChatSessionContext();
   const messagesInitializing = useChatMessagesInitializing();
   const messagesError = useChatMessagesError();
-  const { transcript, reset, localUser, resolvePrompt, clearPending, pushNotice } = transcriptApi;
+  const { transcript, initialHistoryReady, reset, localUser, resolvePrompt, clearPending, pushNotice } = transcriptApi;
   const effectiveThreadId = transcript.threadId ?? threadId ?? connection.createdThreadId;
 
   const effectiveTranscript: TranscriptState = {
@@ -135,6 +134,7 @@ function ChatTranscriptValueProvider({
   const transcriptValue: ChatTranscriptApi = {
     transcript: effectiveTranscript,
     busy,
+    initialHistoryReady,
     localUser,
     reset,
     resolvePrompt,

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerTranscript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerTranscript.ts
@@ -1,8 +1,8 @@
 import type { AgentControllerEvent, AgentControllerSessionState, MastraDBMessage } from '@mastra/client-js';
-import { useReducer, useRef } from 'react';
+import { useReducer } from 'react';
 
 import { createInitialTranscript, transcriptReducer } from '../services/transcript';
-import type { OutgoingFile, TranscriptState } from '../services/transcript';
+import type { OutgoingFile } from '../services/transcript';
 
 /** What the session-state route hydrates the status line with before the first event lands. */
 export type SessionStateSnapshot = Pick<AgentControllerSessionState, 'omProgress' | 'tokenUsage'>;
@@ -24,8 +24,10 @@ export function useAgentControllerTranscript({
       usage: initialState?.tokenUsage,
     }),
   );
-  const transcriptRef = useRef<TranscriptState>(transcript);
-  transcriptRef.current = transcript;
+  const [initialHistoryReady, markInitialHistoryReady] = useReducer(
+    () => true,
+    !initialThreadId || initialMessages !== undefined,
+  );
 
   const reset = (threadId?: string, state?: SessionStateSnapshot) => {
     dispatch({
@@ -58,11 +60,12 @@ export function useAgentControllerTranscript({
 
   const mergeWindow = (messages: MastraDBMessage[]) => {
     dispatch({ type: 'mergeWindow', messages });
+    markInitialHistoryReady();
   };
 
   return {
     transcript,
-    transcriptRef,
+    initialHistoryReady,
     reset,
     onEvent,
     localUser,

--- a/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
@@ -21,6 +21,7 @@ import { GoalPanel } from '../domains/chat/components/GoalPanel';
 import { TaskPanel } from '../domains/chat/components/TaskPanel';
 import { PageTitle } from '../domains/chat/components/PageTitle';
 import { SessionFavicon } from '../domains/chat/components/SessionFavicon';
+import { SessionPrepareSteps } from '../domains/chat/components/SessionPrepareSteps';
 import { Transcript } from '../domains/chat/components/Transcript';
 import { TranscriptHistoryLoader } from '../domains/chat/components/TranscriptHistoryLoader';
 import { ThreadRailLayer } from '../domains/chat/components/ThreadRailLayer';
@@ -162,7 +163,9 @@ function ThreadShell({
 }
 
 function ThreadTranscript() {
-  const { transcript } = useChatTranscript();
+  const { transcript, initialHistoryReady } = useChatTranscript();
+
+  if (!initialHistoryReady) return <SessionPrepareSteps />;
 
   return (
     <>

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageLoading.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageLoading.msw.test.tsx
@@ -4,7 +4,7 @@
  * mounted with a centered spinner in the main slot only — clicking around the
  * sidebar must never blank the whole shell (the old early-return behavior).
  */
-import type { AgentControllerThreadInfo } from '@mastra/client-js';
+import type { AgentControllerThreadInfo, MastraDBMessage } from '@mastra/client-js';
 import { screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
@@ -13,6 +13,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { server } from '../../../../e2e/ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '../../../../e2e/ui/render';
 import { createAppRoutes } from '../../router';
+import { assistantOnlyThreadMessages, threadRailMessages } from './fixtures/thread-rail';
 
 const FACTORY_ID = 'fp-1';
 const REPO_ID = 'ghp-1';
@@ -51,9 +52,11 @@ function deferred() {
 function stubThreadRoute({
   initialThreadId = SESSION_ID,
   threads = [],
+  messages = [],
 }: {
   initialThreadId?: string;
   threads?: AgentControllerThreadInfo[];
+  messages?: MastraDBMessage[];
 } = {}) {
   const sessionGate = deferred();
   const messagesGate = deferred();
@@ -63,6 +66,9 @@ function stubThreadRoute({
   server.use(
     http.get(`${TEST_BASE_URL}/auth/me`, () =>
       HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/config/model-packs`, () =>
+      HttpResponse.json({ packs: [], activePackId: null, sessionPackId: null }),
     ),
     http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
       HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
@@ -132,7 +138,7 @@ function stubThreadRoute({
     http.get(`${AC}/sessions/:resourceId/threads`, () => HttpResponse.json({ threads })),
     http.get(`${AC}/sessions/:resourceId/threads/:threadId/messages`, async () => {
       await messagesGate.promise;
-      return HttpResponse.json({ messages: [] });
+      return HttpResponse.json({ messages });
     }),
     http.get(`${AC}/modes`, () => HttpResponse.json({ modes: [] })),
     // Right workspace-files panel, which appears once workspacePath resolves.
@@ -189,6 +195,41 @@ describe('ThreadPage loading shell', () => {
     messagesGate.resolve();
     await waitFor(() => expect(screen.queryByRole('status', { name: 'Preparing session' })).not.toBeInTheDocument());
     expect(screen.getByRole('region', { name: 'Factory session' })).toBeInTheDocument();
+  });
+
+  it('reveals loaded history without briefly rendering the empty thread state', async () => {
+    const { sessionGate, messagesGate } = stubThreadRoute({ messages: assistantOnlyThreadMessages });
+    renderThreadRoute();
+    sessionGate.resolve();
+    await screen.findByRole('status', { name: 'Preparing session' });
+
+    let renderedEmptyState = false;
+    const observer = new MutationObserver(records => {
+      renderedEmptyState ||= records.some(record =>
+        Array.from(record.addedNodes).some(node => node.textContent?.includes('What can I help you build?')),
+      );
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    messagesGate.resolve();
+    await screen.findByText('There are no user turns in this thread.');
+    observer.disconnect();
+
+    expect(renderedEmptyState).toBe(false);
+  });
+
+  it('stagger-reveals loaded transcript entries in order', async () => {
+    const { sessionGate, messagesGate } = stubThreadRoute({ messages: threadRailMessages });
+    renderThreadRoute();
+    sessionGate.resolve();
+    await screen.findByRole('status', { name: 'Preparing session' });
+
+    messagesGate.resolve();
+    await screen.findByText('Run the focused checks');
+
+    const entries = Array.from(document.querySelectorAll<HTMLElement>('[data-transcript-history-entry]'));
+    expect(entries.map(entry => entry.style.animationDelay)).toEqual(['0ms', '55ms', '110ms']);
+    expect(entries.every(entry => entry.classList.contains('transcript-history-enter'))).toBe(true);
   });
 
   it('waits for sandbox readiness before synchronizing an existing route thread', async () => {

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageLoading.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageLoading.msw.test.tsx
@@ -13,7 +13,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { server } from '../../../../e2e/ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '../../../../e2e/ui/render';
 import { createAppRoutes } from '../../router';
-import { assistantOnlyThreadMessages, threadRailMessages } from './fixtures/thread-rail';
+import { assistantOnlyThreadMessages, threadRailMessagesWithEcho } from './fixtures/thread-rail';
 
 const FACTORY_ID = 'fp-1';
 const REPO_ID = 'ghp-1';
@@ -219,7 +219,7 @@ describe('ThreadPage loading shell', () => {
   });
 
   it('stagger-reveals loaded transcript entries in order', async () => {
-    const { sessionGate, messagesGate } = stubThreadRoute({ messages: threadRailMessages });
+    const { sessionGate, messagesGate } = stubThreadRoute({ messages: threadRailMessagesWithEcho });
     renderThreadRoute();
     sessionGate.resolve();
     await screen.findByRole('status', { name: 'Preparing session' });
@@ -227,9 +227,9 @@ describe('ThreadPage loading shell', () => {
     messagesGate.resolve();
     await screen.findByText('Run the focused checks');
 
-    const entries = Array.from(document.querySelectorAll<HTMLElement>('[data-transcript-history-entry]'));
+    const entries = Array.from(document.querySelectorAll<HTMLElement>('.transcript-history-enter'));
+    expect(entries).toHaveLength(3);
     expect(entries.map(entry => entry.style.animationDelay)).toEqual(['0ms', '55ms', '110ms']);
-    expect(entries.every(entry => entry.classList.contains('transcript-history-enter'))).toBe(true);
   });
 
   it('waits for sandbox readiness before synchronizing an existing route thread', async () => {

--- a/mastracode/factory-ui/src/ui/pages/__tests__/fixtures/thread-rail.ts
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/fixtures/thread-rail.ts
@@ -50,3 +50,19 @@ export const threadRailMessages: MastraDBMessage[] = [
     },
   },
 ];
+
+const echoedUserMessage: MastraDBMessage = {
+  id: 'user-plan-echo',
+  role: 'user',
+  createdAt,
+  content: {
+    format: 2,
+    parts: [{ type: 'data-user-message', data: { contents: 'Review the implementation plan' } }],
+  },
+};
+
+export const threadRailMessagesWithEcho: MastraDBMessage[] = [
+  ...threadRailMessages.slice(0, 1),
+  echoedUserMessage,
+  ...threadRailMessages.slice(1),
+];


### PR DESCRIPTION
TLDR: loaded Factory conversations keep the preparing state until their history is ready, then reveal the transcript line by line instead of snapping in.

---

An existing thread could stop showing its preparation steps one render before its saved messages reached the transcript. The empty-thread screen flashed in that gap, then the whole conversation appeared at once.

The loader now stays up until the messages are in the transcript. Once they are, the latest visible rows fade and rise in order.

### What changes

| situation | before | after |
| --- | --- | --- |
| an existing thread finishes loading | empty-thread screen can flash | preparation stays until history is merged |
| saved transcript appears | every row snaps in together | the latest 10 visible rows fade and rise with a 55ms stagger |

### Judgment call

The reveal is deliberately slow for now: 480ms per row with 55ms between rows, capped at the latest 10 so long conversations do not take seconds. Reduced-motion users still get the transcript immediately.

### Not verified

I did not record the animation in a browser. The loading boundary and stagger order are covered, but the final feel still needs eyes in the running Factory UI.

```
tests        +78   -2
source       +75  -25   ← net +50
changeset     +5    0
```