### PR TITLE
feat(langfuse): support additional request headers

### DIFF
--- a/.changeset/silly-crews-knock.md
+++ b/.changeset/silly-crews-knock.md
@@ -1,0 +1,5 @@
+---
+'@mastra/langfuse': minor
+---
+
+Added support for custom headers in Langfuse requests.

--- a/docs/src/content/en/reference/observability/tracing/exporters/langfuse.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/langfuse.mdx
@@ -25,6 +25,7 @@ interface LangfuseExporterConfig extends BaseExporterConfig {
   publicKey?: string
   secretKey?: string
   baseUrl?: string
+  additionalHeaders?: Record<string, string>
   realtime?: boolean
   flushAt?: number
   flushInterval?: number
@@ -56,6 +57,12 @@ Extends `BaseExporterConfig`, which includes:
     name: 'baseUrl',
     type: 'string',
     description: 'Langfuse host URL. Falls back to LANGFUSE_BASE_URL env var. Default: https://cloud.langfuse.com',
+    required: false,
+  },
+  {
+    name: 'additionalHeaders',
+    type: 'Record<string, string>',
+    description: 'Additional headers sent with requests to Langfuse.',
     required: false,
   },
   {
@@ -146,6 +153,7 @@ const exporter = new LangfuseExporter({
   publicKey: process.env.LANGFUSE_PUBLIC_KEY,
   secretKey: process.env.LANGFUSE_SECRET_KEY,
   baseUrl: 'https://cloud.langfuse.com',
+  additionalHeaders: { 'x-custom-header': 'custom-value' },
   realtime: true,
 })
 ```

--- a/observability/langfuse/README.md
+++ b/observability/langfuse/README.md
@@ -57,6 +57,7 @@ const mastra = new Mastra({
             publicKey: 'pk-lf-...',
             secretKey: 'sk-lf-...',
             baseUrl: 'https://cloud.langfuse.com', // Optional
+            additionalHeaders: { 'x-custom-header': 'custom-value' }, // Optional
             realtime: true, // Optional - flush after each event
             flushAt: 200, // Optional - spans per OTEL batch
             flushInterval: 15, // Optional - seconds between OTEL batch flushes
@@ -70,16 +71,17 @@ const mastra = new Mastra({
 
 ### Configuration Options
 
-| Option          | Type      | Description                                                                  |
-| --------------- | --------- | ---------------------------------------------------------------------------- |
-| `publicKey`     | `string`  | Langfuse public key. Defaults to `LANGFUSE_PUBLIC_KEY` env var               |
-| `secretKey`     | `string`  | Langfuse secret key. Defaults to `LANGFUSE_SECRET_KEY` env var               |
-| `baseUrl`       | `string`  | Langfuse host URL. Defaults to `LANGFUSE_BASE_URL` env var or Langfuse cloud |
-| `realtime`      | `boolean` | Flush after each event for immediate visibility. Defaults to `false`         |
-| `flushAt`       | `number`  | Maximum number of spans per OTEL export batch                                |
-| `flushInterval` | `number`  | Maximum time in seconds before pending spans are exported                    |
-| `environment`   | `string`  | Langfuse tracing environment tag                                             |
-| `release`       | `string`  | Langfuse release tag                                                         |
+| Option              | Type                     | Description                                                                  |
+| ------------------- | ------------------------ | ---------------------------------------------------------------------------- |
+| `publicKey`         | `string`                 | Langfuse public key. Defaults to `LANGFUSE_PUBLIC_KEY` env var               |
+| `secretKey`         | `string`                 | Langfuse secret key. Defaults to `LANGFUSE_SECRET_KEY` env var               |
+| `baseUrl`           | `string`                 | Langfuse host URL. Defaults to `LANGFUSE_BASE_URL` env var or Langfuse cloud |
+| `additionalHeaders` | `Record<string, string>` | Additional headers sent with requests to Langfuse                            |
+| `realtime`          | `boolean`                | Flush after each event for immediate visibility. Defaults to `false`         |
+| `flushAt`           | `number`                 | Maximum number of spans per OTEL export batch                                |
+| `flushInterval`     | `number`                 | Maximum time in seconds before pending spans are exported                    |
+| `environment`       | `string`                 | Langfuse tracing environment tag                                             |
+| `release`           | `string`                 | Langfuse release tag                                                         |
 
 ### High-Volume Streaming
 

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -182,6 +182,9 @@ describe('LangfuseExporter', () => {
         publicKey: 'pk-test',
         secretKey: 'sk-test',
         baseUrl: 'https://custom.langfuse.com',
+        additionalHeaders: {
+          'x-custom-header': 'custom-value',
+        },
         environment: 'production',
         release: '1.0.0',
       });
@@ -191,6 +194,9 @@ describe('LangfuseExporter', () => {
           publicKey: 'pk-test',
           secretKey: 'sk-test',
           baseUrl: 'https://custom.langfuse.com',
+          additionalHeaders: {
+            'x-custom-header': 'custom-value',
+          },
           environment: 'production',
           release: '1.0.0',
           exportMode: 'batched',
@@ -233,6 +239,9 @@ describe('LangfuseExporter', () => {
         publicKey: 'pk-test',
         secretKey: 'sk-test',
         baseUrl: 'https://custom.langfuse.com',
+        additionalHeaders: {
+          'x-custom-header': 'custom-value',
+        },
       });
 
       expect(clientConstructorArgs[0]).toEqual(
@@ -240,6 +249,9 @@ describe('LangfuseExporter', () => {
           publicKey: 'pk-test',
           secretKey: 'sk-test',
           baseUrl: 'https://custom.langfuse.com',
+          additionalHeaders: {
+            'x-custom-header': 'custom-value',
+          },
         }),
       );
     });

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -26,6 +26,8 @@ export interface LangfuseExporterConfig extends BaseExporterConfig {
   secretKey?: string;
   /** Langfuse host URL (defaults to https://cloud.langfuse.com) */
   baseUrl?: string;
+  /** Additional headers sent with requests to Langfuse */
+  additionalHeaders?: Record<string, string>;
   /** Enable realtime mode - flushes after each event for immediate visibility */
   realtime?: boolean;
   /** Maximum number of spans per OTEL export batch */
@@ -77,6 +79,7 @@ export class LangfuseExporter extends BaseExporter {
       publicKey,
       secretKey,
       baseUrl,
+      additionalHeaders: config.additionalHeaders,
       environment: config.environment,
       release: config.release,
       exportMode: this.#realtime ? 'immediate' : 'batched',
@@ -91,6 +94,7 @@ export class LangfuseExporter extends BaseExporter {
       publicKey,
       secretKey,
       baseUrl,
+      additionalHeaders: config.additionalHeaders,
     });
 
     this.#environment = config.environment ?? process.env.LANGFUSE_TRACING_ENVIRONMENT;


### PR DESCRIPTION
Fixes #21950

Adds the `additionalHeaders` option to `LangfuseExporter` and forwards it to both the Langfuse span processor and client. This lets applications send custom headers to Langfuse, including self-hosted deployments behind an authenticated proxy.

The change includes constructor coverage, reference and package documentation, and a minor changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This change lets users add custom headers to Langfuse requests. This supports self-hosted Langfuse deployments and authenticated proxies.

## Changes

- Added optional `additionalHeaders?: Record<string, string>` to `LangfuseExporterConfig`.
- Forwarded `additionalHeaders` to `LangfuseSpanProcessor` and `LangfuseClient`.
- Added constructor tests for both integrations.
- Updated public reference documentation and package documentation.
- Added a changeset for `@mastra/langfuse`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->