### PR TITLE
fix(observability): recover storage exporter initialization

### DIFF
--- a/.changeset/short-icons-trade.md
+++ b/.changeset/short-icons-trade.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed `MastraStorageExporter` staying disabled when a configured observability store is temporarily unavailable during startup. The exporter now recovers on a later event, so traces resume without restarting the process. (#21943)

--- a/observability/mastra/src/exporters/mastra-storage.test.ts
+++ b/observability/mastra/src/exporters/mastra-storage.test.ts
@@ -230,7 +230,7 @@ describe('MastraStorageExporter', () => {
         );
       });
 
-      it('should log error if storage not available during init()', async () => {
+      it('should log a warning if storage is not available during init()', async () => {
         const mockMastraWithoutStorage = {
           getStorage: vi.fn().mockReturnValue(null),
         } as any;
@@ -242,6 +242,74 @@ describe('MastraStorageExporter', () => {
         expect(mockLogger.warn).toHaveBeenCalledWith(
           'MastraStorageExporter disabled: Storage not available. Traces will not be persisted.',
         );
+      });
+
+      it('should recover when observability storage becomes available after init', async () => {
+        mockObservabilityStore.observabilityStrategy = {
+          preferred: 'realtime',
+          supported: ['realtime', 'batch-with-updates', 'insert-only'],
+        };
+        mockStorage.getStore.mockResolvedValueOnce(undefined).mockResolvedValueOnce(mockObservabilityStore);
+
+        const exporter = new MastraStorageExporter({ logger: mockLogger });
+        await exporter.init({ mastra: mockMastra });
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED));
+
+        expect(mockStorage.getStore).toHaveBeenCalledTimes(2);
+        expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledOnce();
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          'MastraStorageExporter recovered: Observability storage is available. Traces will be persisted.',
+        );
+      });
+
+      it('should recover after observability storage initialization throws', async () => {
+        mockObservabilityStore.observabilityStrategy = {
+          preferred: 'realtime',
+          supported: ['realtime', 'batch-with-updates', 'insert-only'],
+        };
+        mockStorage.getStore
+          .mockRejectedValueOnce(new Error('storage unavailable'))
+          .mockResolvedValueOnce(mockObservabilityStore);
+
+        const exporter = new MastraStorageExporter({ logger: mockLogger });
+        await expect(exporter.init({ mastra: mockMastra })).resolves.not.toThrow();
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED));
+
+        expect(mockStorage.getStore).toHaveBeenCalledTimes(2);
+        expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledOnce();
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'MastraStorageExporter unavailable: Failed to initialize observability storage. Traces will not be persisted until storage becomes available.',
+          { error: 'storage unavailable' },
+        );
+      });
+
+      it('should share a concurrent storage recovery attempt', async () => {
+        mockObservabilityStore.observabilityStrategy = {
+          preferred: 'realtime',
+          supported: ['realtime', 'batch-with-updates', 'insert-only'],
+        };
+        let resolveStorage: (storage: typeof mockObservabilityStore) => void = () => {};
+        const recoveredStorage = new Promise<typeof mockObservabilityStore>(resolve => {
+          resolveStorage = resolve;
+        });
+        mockStorage.getStore.mockResolvedValueOnce(undefined).mockReturnValueOnce(recoveredStorage);
+
+        const exporter = new MastraStorageExporter({ logger: mockLogger });
+        await exporter.init({ mastra: mockMastra });
+
+        const firstExport = exporter.exportTracingEvent(
+          createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'span-1'),
+        );
+        const secondExport = exporter.exportTracingEvent(
+          createMockEvent(TracingEventType.SPAN_STARTED, 'trace-2', 'span-2'),
+        );
+        resolveStorage(mockObservabilityStore);
+        await Promise.all([firstExport, secondExport]);
+
+        expect(mockStorage.getStore).toHaveBeenCalledTimes(2);
+        expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(2);
       });
     });
 

--- a/observability/mastra/src/exporters/mastra-storage.ts
+++ b/observability/mastra/src/exporters/mastra-storage.ts
@@ -63,8 +63,6 @@ function resolveTracingStorageStrategy(
   return observabilityStrategy.preferred;
 }
 
-type Resolve = (value: void | PromiseLike<void>) => void;
-
 type FlushResult = {
   failed: boolean;
   retryAttempt?: number;
@@ -80,8 +78,8 @@ export class MastraStorageExporter extends BaseExporter {
   name = 'mastra-storage-exporter';
 
   #config: MastraStorageExporterConfig;
-  #isInitializing = false;
-  #initPromises: Set<Resolve> = new Set();
+  #initializationPromise?: Promise<void>;
+  #wasUnavailable = false;
   #eventBuffer: EventBuffer;
 
   #storage?: MastraCompositeStore;
@@ -114,56 +112,77 @@ export class MastraStorageExporter extends BaseExporter {
    * Initialize the exporter (called after all dependencies are ready)
    */
   async init(options: InitExporterOptions): Promise<void> {
-    try {
-      this.#isInitializing = true;
-      this.#emitDropEvent = options.emitDropEvent;
-
-      this.#storage = options.mastra?.getStorage();
-      if (!this.#storage) {
-        this.logger.warn('MastraStorageExporter disabled: Storage not available. Traces will not be persisted.');
-        return;
-      }
-
-      this.#observabilityStorage = await this.#storage.getStore('observability');
-      if (!this.#observabilityStorage) {
-        this.logger.warn(
-          'MastraStorageExporter disabled: Observability storage not available. Traces will not be persisted.',
-        );
-        return;
-      }
-
-      // Initialize the resolved strategy once observability store is available
-      if (!this.#resolvedStrategy) {
-        this.#resolvedStrategy = resolveTracingStorageStrategy(
-          this.#config,
-          this.#observabilityStorage,
-          this.#storage.constructor.name,
-          this.logger,
-        );
-
-        this.logger.debug('tracing storage exporter initialized', {
-          strategy: this.#resolvedStrategy,
-          source: this.#config.strategy !== 'auto' ? 'user' : 'auto',
-          storageAdapter: this.#storage.constructor.name,
-          maxBatchSize: this.#config.maxBatchSize,
-          maxBatchWaitMs: this.#config.maxBatchWaitMs,
-        });
-      }
-
-      if (this.#resolvedStrategy) {
-        this.#eventBuffer.init({ strategy: this.#resolvedStrategy });
-      }
-    } finally {
-      this.#isInitializing = false;
-      /**
-       * Assumes caller waits until export of a parent span is completed before calling
-       * export for child spans , order is not relevant for resolve
-       */
-      this.#initPromises.forEach(resolve => {
-        resolve();
-      });
-      this.#initPromises.clear();
+    this.#emitDropEvent = options.emitDropEvent;
+    this.#storage = options.mastra?.getStorage();
+    if (!this.#storage) {
+      this.logger.warn('MastraStorageExporter disabled: Storage not available. Traces will not be persisted.');
+      return;
     }
+    await this.ensureInitialized();
+  }
+
+  private warnUnavailable(message: string, error?: unknown): void {
+    if (this.#wasUnavailable) return;
+    this.#wasUnavailable = true;
+    if (error === undefined) {
+      this.logger.warn(message);
+      return;
+    }
+    this.logger.warn(message, { error: error instanceof Error ? error.message : String(error) });
+  }
+
+  private async initializeStorage(): Promise<void> {
+    const storage = this.#storage;
+    if (!storage) return;
+
+    try {
+      this.#observabilityStorage = await storage.getStore('observability');
+    } catch (error) {
+      this.warnUnavailable(
+        'MastraStorageExporter unavailable: Failed to initialize observability storage. Traces will not be persisted until storage becomes available.',
+        error,
+      );
+      return;
+    }
+
+    if (!this.#observabilityStorage) {
+      this.warnUnavailable(
+        'MastraStorageExporter unavailable: Observability storage not available. Traces will not be persisted until storage becomes available.',
+      );
+      return;
+    }
+
+    this.#resolvedStrategy = resolveTracingStorageStrategy(
+      this.#config,
+      this.#observabilityStorage,
+      storage.constructor.name,
+      this.logger,
+    );
+
+    this.#eventBuffer.init({ strategy: this.#resolvedStrategy });
+    this.logger.debug('tracing storage exporter initialized', {
+      strategy: this.#resolvedStrategy,
+      source: this.#config.strategy !== 'auto' ? 'user' : 'auto',
+      storageAdapter: storage.constructor.name,
+      maxBatchSize: this.#config.maxBatchSize,
+      maxBatchWaitMs: this.#config.maxBatchWaitMs,
+    });
+
+    if (this.#wasUnavailable) {
+      this.#wasUnavailable = false;
+      this.logger.info(
+        'MastraStorageExporter recovered: Observability storage is available. Traces will be persisted.',
+      );
+    }
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.#observabilityStorage || !this.#storage) return;
+
+    this.#initializationPromise ??= this.initializeStorage().finally(() => {
+      this.#initializationPromise = undefined;
+    });
+    await this.#initializationPromise;
   }
 
   /**
@@ -532,7 +551,7 @@ export class MastraStorageExporter extends BaseExporter {
   }
 
   async _exportTracingEvent(event: TracingEvent): Promise<void> {
-    await this.waitForInit();
+    await this.ensureInitialized();
     if (!this.#observabilityStorage) {
       this.logger.debug('Cannot store traces. Observability storage is not initialized');
       return;
@@ -543,22 +562,10 @@ export class MastraStorageExporter extends BaseExporter {
   }
 
   /**
-   * Resolves when an ongoing init call is finished
-   * Doesn't wait for the caller to call init
-   * @returns
-   */
-  private async waitForInit(): Promise<void> {
-    if (!this.#isInitializing) return;
-    return new Promise(resolve => {
-      this.#initPromises.add(resolve);
-    });
-  }
-
-  /**
    * Handle metric events — buffer for batch flush.
    */
   async onMetricEvent(event: MetricEvent): Promise<void> {
-    await this.waitForInit();
+    await this.ensureInitialized();
     if (!this.#observabilityStorage) return;
 
     this.#eventBuffer.addEvent(event);
@@ -569,7 +576,7 @@ export class MastraStorageExporter extends BaseExporter {
    * Handle log events — buffer for batch flush.
    */
   async onLogEvent(event: LogEvent): Promise<void> {
-    await this.waitForInit();
+    await this.ensureInitialized();
     if (!this.#observabilityStorage) return;
 
     this.#eventBuffer.addEvent(event);
@@ -580,7 +587,7 @@ export class MastraStorageExporter extends BaseExporter {
    * Handle score events — buffer for batch flush.
    */
   async onScoreEvent(event: ScoreEvent): Promise<void> {
-    await this.waitForInit();
+    await this.ensureInitialized();
     if (!this.#observabilityStorage) return;
 
     this.#eventBuffer.addEvent(event);
@@ -591,7 +598,7 @@ export class MastraStorageExporter extends BaseExporter {
    * Handle feedback events — buffer for batch flush.
    */
   async onFeedbackEvent(event: FeedbackEvent): Promise<void> {
-    await this.waitForInit();
+    await this.ensureInitialized();
     if (!this.#observabilityStorage) return;
 
     this.#eventBuffer.addEvent(event);


### PR DESCRIPTION
`MastraStorageExporter` currently stays inactive for the lifetime of the process when its configured observability store is temporarily unavailable during startup. Later events are dropped even after storage recovers.

This retries store acquisition when a later event arrives, shares concurrent recovery attempts, and logs the unavailable and recovered state transitions. A genuinely unconfigured storage exporter remains disabled as before, and the deprecated `DefaultExporter` is unchanged.

Before: storage fails during startup → traces remain disabled until restart.

After: storage fails during startup → a later event retries initialization → trace persistence resumes automatically.

Verified with the observability package test suite (1,052 passing, 2 skipped), package lint/build, and an unavailable-to-healthy recovery against a real ClickHouse container with the persisted span read back.

## Related 
Fixes #21943.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

If the observability store is briefly unavailable, `MastraStorageExporter` now waits and tries again when a later event arrives. It shares recovery attempts and logs when storage becomes unavailable or recovers.

## Changes

- Added retry support for configured observability storage.
- Deduplicated concurrent storage recovery attempts.
- Added initialization checks before event export.
- Updated warning behavior for unavailable storage.
- Added tests for recovery, concurrent retries, and event persistence.
- Added a patch changeset.
- Kept unconfigured exporters disabled.
- Kept the deprecated `DefaultExporter` unchanged.

## Validation

- Ran the observability test suite.
- Ran package lint and build checks.
- Tested recovery with a real ClickHouse container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->