### PR TITLE
fix(cli): ignore .env.schema when discovering deploy env files

### DIFF
--- a/.changeset/lint-ignore-env-schema.md
+++ b/.changeset/lint-ignore-env-schema.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Ignore `.env.schema` (varlock) when discovering deploy env files. `mastra lint` no longer lints against `.env.schema`, and `mastra deploy` no longer offers it in the env file selector.

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -489,11 +489,12 @@ describe('getDeployEnvFiles', () => {
     await expect(getDeployEnvFiles('/project')).resolves.toEqual([]);
   });
 
-  it('returns sorted deploy env files, excluding .example files', async () => {
+  it('returns sorted deploy env files, excluding .example and .env.schema files', async () => {
     const { readdir } = await import('node:fs/promises');
     vi.mocked(readdir).mockResolvedValue([
       { name: '.env.production', isFile: () => true, isSymbolicLink: () => false },
       { name: '.env.example', isFile: () => true, isSymbolicLink: () => false },
+      { name: '.env.schema', isFile: () => true, isSymbolicLink: () => false },
       { name: '.env', isFile: () => true, isSymbolicLink: () => false },
       { name: 'package.json', isFile: () => true, isSymbolicLink: () => false },
     ] as unknown as Awaited<ReturnType<typeof readdir>>);

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -125,7 +125,8 @@ export async function getDeployEnvFiles(projectDir: string): Promise<string[]> {
       entry =>
         (entry.isFile() || entry.isSymbolicLink()) &&
         (entry.name === '.env' || entry.name.startsWith('.env.')) &&
-        !entry.name.endsWith('.example'),
+        !entry.name.endsWith('.example') &&
+        entry.name !== '.env.schema',
     )
     .map(entry => entry.name)
     .sort((a, b) => a.localeCompare(b));


### PR DESCRIPTION
## Summary

varlock's `.env.schema` file was being picked up by `getDeployEnvFiles`, which caused:

- `mastra lint` to lint against `.env.schema` (treating schema declarations as real env values)
- `mastra deploy` to include `.env.schema` in the interactive env file selector

Excludes `.env.schema` from discovery, alongside the existing `.example` exclusion. Both `mastra lint` and `mastra deploy` use the same helper, so this fixes both paths.

## Test plan

- Updated `getDeployEnvFiles` test fixture to include `.env.schema` and asserts it is filtered out
- `pnpm vitest run src/commands/studio/deploy.test.ts -t getDeployEnvFiles` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The deploy command now ignores `.env.schema` files. This prevents schema definitions from being treated as real environment values.

## Changes

- Updated `getDeployEnvFiles` to exclude `.env.schema`, alongside `.env.example`.
- Updated the deploy test fixture and assertions to verify the exclusion.
- Added a changeset for the `mastra` patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->