### PR TITLE
fix(platform-workspace): wait for Railway sandbox readiness

### DIFF
--- a/.changeset/wide-eels-marry.md
+++ b/.changeset/wide-eels-marry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/platform-workspace': patch
+---
+
+Fixed Platform sandboxes retrying commands while the provider is still starting and recovering when the provider reports a destroyed sandbox.

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -83,6 +83,7 @@ class FakeSocket implements DirectExecWebSocket {
 
 describe('PlatformSandbox', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
   });
 
@@ -655,6 +656,118 @@ describe('PlatformSandbox', () => {
       expect(sockets).toHaveLength(2);
       expect(sockets[0]!.subprotocols[1]).toBe('jwt.first');
       expect(sockets[1]!.subprotocols[1]).toBe('jwt.second');
+    });
+
+    it('waits for a CREATING sandbox and retries until direct exec succeeds', async () => {
+      vi.useFakeTimers();
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.first' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.second' }))
+        .mockResolvedValueOnce(leaseResponse({ jwt: 'jwt.third' }));
+      const sockets: FakeSocket[] = [];
+      const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+        const socket = new FakeSocket(endpoint, subprotocols);
+        sockets.push(socket);
+        queueMicrotask(() => {
+          socket.onopen?.({});
+          if (sockets.length < 3) {
+            socket.onclose?.({ code: 1008, reason: 'Sandbox is not running (status: CREATING).' });
+          } else {
+            socket.fireBinary(1, 'ready');
+            socket.onmessage?.({ data: JSON.stringify({ type: 'exit', data: { exit_code: 0 } }) });
+          }
+        });
+        return socket;
+      };
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      const promise = sandbox.executeCommand('echo ready');
+      await vi.advanceTimersByTimeAsync(3_000);
+      await expect(promise).resolves.toMatchObject({ success: true, exitCode: 0, stdout: 'ready' });
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(sockets).toHaveLength(3);
+    });
+
+    it('bounds retries when a sandbox remains CREATING', async () => {
+      vi.useFakeTimers();
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockImplementation(() => Promise.resolve(leaseResponse()));
+      const sockets: FakeSocket[] = [];
+      const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+        const socket = new FakeSocket(endpoint, subprotocols);
+        sockets.push(socket);
+        queueMicrotask(() => {
+          socket.onopen?.({});
+          socket.onclose?.({ code: 1008, reason: 'Sandbox is not running (status: CREATING).' });
+        });
+        return socket;
+      };
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      const { SandboxExecTransportError } = await import('./sandbox.js');
+      const errorPromise = sandbox.executeCommand('echo ready').catch(cause => cause);
+      await vi.advanceTimersByTimeAsync(120_000);
+      const error = (await errorPromise) as InstanceType<typeof SandboxExecTransportError>;
+      expect(error).toBeInstanceOf(SandboxExecTransportError);
+      expect(error).toMatchObject({
+        sandboxId: 'sbx_1',
+        closeCode: 1008,
+        closeReason: 'Sandbox is not running (status: CREATING).',
+      });
+      expect(error.attempts).toBeGreaterThan(2);
+      expect(sockets.length).toBe(error.attempts);
+    });
+
+    it('maps a DESTROYED provider close to SandboxDestroyedError', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+        .mockResolvedValueOnce(leaseResponse());
+      const factory: DirectExecWebSocketFactory = (endpoint, subprotocols) => {
+        const socket = new FakeSocket(endpoint, subprotocols);
+        queueMicrotask(() => {
+          socket.onopen?.({});
+          socket.onclose?.({ code: 1008, reason: 'Sandbox is not running (status: DESTROYED).' });
+        });
+        return socket;
+      };
+
+      const sandbox = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+        webSocketFactory: factory,
+      });
+
+      await sandbox._start();
+      const { SandboxDestroyedError } = await import('./sandbox.js');
+      await expect(sandbox.executeCommand('echo ready')).rejects.toBeInstanceOf(SandboxDestroyedError);
+      expect((sandbox as unknown as { _sandboxId: unknown })._sandboxId).toBeUndefined();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
     it('throws SandboxDestroyedError when a transport failure is followed by 410 on the retry mint', async () => {

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -150,6 +150,17 @@ const SIDECAR_PROBE_INTERVAL_MS = 250;
  * later execs will use private-net once it succeeds.
  */
 const TRANSPORT_READY_WAIT_MS = 5_000;
+/** Maximum time to wait when Railway accepts exec connections but reports the sandbox is still creating. */
+const SANDBOX_CREATING_RETRY_TIMEOUT_MS = 120_000;
+/** Initial delay between direct-exec retries while the provider reports `CREATING`. */
+const SANDBOX_CREATING_RETRY_BASE_DELAY_MS = 1_000;
+/** Cap the readiness retry delay so a newly ready sandbox is picked up promptly. */
+const SANDBOX_CREATING_RETRY_MAX_DELAY_MS = 5_000;
+
+function getUnavailableSandboxStatus(result: Awaited<ReturnType<typeof execViaLease>>): string | undefined {
+  if (result.closeCode !== 1008 || !result.closeReason) return undefined;
+  return /Sandbox is not running \(status:\s*([A-Z_]+)\)/i.exec(result.closeReason)?.[1]?.toUpperCase();
+}
 
 /**
  * Diagnostic error thrown when the direct-exec WebSocket transport fails
@@ -1098,10 +1109,10 @@ export class PlatformSandbox extends MastraSandbox {
   }
 
   /**
-   * Run a single exec against the direct-exec transport, with one in-flight
-   * retry on WebSocket transport failure (socket closed without an `exit`
-   * frame and the exec did not time out). The retry mints a fresh lease
-   * — the failure could be a stale JWT — and reopens a new WebSocket.
+   * Run a single exec against the direct-exec transport. Generic WebSocket
+   * transport failures get one retry with a fresh lease. A provider close
+   * that explicitly reports `CREATING` gets bounded readiness retries because
+   * the control plane can return before Railway accepts commands.
    *
    * Error taxonomy:
    * - **410 on `/exec-lease`** (either attempt) → the sandbox is gone.
@@ -1135,14 +1146,11 @@ export class PlatformSandbox extends MastraSandbox {
     let lastResult: Awaited<ReturnType<typeof execViaLease>> | undefined;
     let lastLease: (ExecLease & { expiresAtMs: number | null }) | undefined;
     let attemptsMade = 0;
-    // Two attempts: initial + one retry. On the second attempt we drop the
-    // cached lease so we don't reuse a JWT that may itself be the cause of
-    // the transport failure — but only if the cache still holds the same
-    // lease we just failed against. A concurrent exec sharing this instance
-    // may have already cached a fresh, unrelated lease in between, and we
-    // must not discard that.
-    for (let attempt = 0; attempt < 2; attempt++) {
-      if (attempt > 0 && lastLease && this._lease === lastLease) this._lease = null;
+    let transportFailures = 0;
+    const creatingDeadline = Date.now() + SANDBOX_CREATING_RETRY_TIMEOUT_MS;
+
+    while (transportFailures < 2) {
+      if (lastLease && this._lease === lastLease) this._lease = null;
       let lease: ExecLease & { expiresAtMs: number | null };
       try {
         lease = await this._ensureLease();
@@ -1161,14 +1169,14 @@ export class PlatformSandbox extends MastraSandbox {
             {
               ...(priorSandboxId && { sandboxId: priorSandboxId }),
               command: fullCommand,
-              attempts: attempt + 1,
+              attempts: attemptsMade + 1,
             },
           );
         }
         throw error;
       }
       lastLease = lease;
-      attemptsMade = attempt + 1;
+      attemptsMade++;
       const result = await execViaLease(lease, {
         command: fullCommand,
         ...(options?.cwd !== undefined && { cwd: options.cwd }),
@@ -1182,12 +1190,41 @@ export class PlatformSandbox extends MastraSandbox {
       // mid-stream drop, expired token). Any other outcome (real exit code
       // or timed-out) is a valid result and we return it.
       if (result.exitCode !== null || result.timedOut) return result;
+
+      const unavailableStatus = getUnavailableSandboxStatus(result);
+      if (unavailableStatus === 'DESTROYED') {
+        this._lease = null;
+        const priorSandboxId = this._sandboxId;
+        this._sandboxId = undefined;
+        throw new SandboxDestroyedError(
+          `Sandbox ${priorSandboxId ?? '(unknown)'} was destroyed while opening direct exec`,
+          {
+            ...(priorSandboxId && { sandboxId: priorSandboxId }),
+            command: fullCommand,
+            attempts: attemptsMade,
+          },
+        );
+      }
+
+      if (unavailableStatus === 'CREATING') {
+        const remainingMs = creatingDeadline - Date.now();
+        if (remainingMs <= 0) break;
+        const delayMs = Math.min(
+          SANDBOX_CREATING_RETRY_BASE_DELAY_MS * 2 ** Math.min(attemptsMade - 1, 3),
+          SANDBOX_CREATING_RETRY_MAX_DELAY_MS,
+          remainingMs,
+        );
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+        continue;
+      }
+
+      transportFailures++;
     }
 
-    // Both attempts failed at the transport layer against a live sandbox.
-    // Surface a loud, typed error with close diagnostics so callers can
-    // distinguish "your command failed" from "the sandbox transport is
-    // broken."
+    // The bounded CREATING wait expired, or both generic transport attempts
+    // failed against a live sandbox. Surface a loud, typed error with close
+    // diagnostics so callers can distinguish command failure from a broken
+    // sandbox transport.
     const result = lastResult!;
     const lease = lastLease!;
     // The lease from the failed second attempt is still cached; drop it so


### PR DESCRIPTION
Railway can accept sandbox creation before direct exec is ready. The first command then receives a WebSocket close with `Sandbox is not running (status: CREATING)` and currently fails after two immediate attempts.

This change retries that specific readiness response with bounded backoff for up to 120 seconds. If Railway reports `DESTROYED`, it now raises `SandboxDestroyedError` so the existing Factory recovery path can provision a replacement. Other transport failures keep their existing two-attempt behavior.

Before:
```text
CREATING -> immediate retry -> SandboxExecTransportError
```

After:
```text
CREATING -> bounded readiness retries -> command runs
DESTROYED -> SandboxDestroyedError -> caller recovery
```

Verified with 141 platform-workspace unit tests, TypeScript, build, lint, and formatting checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Railway can create a sandbox before it is ready to run commands. This change waits and retries while the sandbox starts, and it reports destroyed sandboxes so the system can replace them.

## Changes

- Retry direct execution when Railway reports `CREATING`.
- Use exponential backoff for up to 120 seconds.
- Throw `SandboxDestroyedError` when Railway reports `DESTROYED`.
- Clear local sandbox state before recovery.
- Preserve two-attempt retries for other transport failures.
- Add tests for retries, timeout handling, destroyed sandboxes, and timer cleanup.
- Add a patch changeset for `@mastra/platform-workspace`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->