### PR TITLE
fix(playground-ui): align section variant layouts

### DIFF
--- a/.changeset/metal-ways-flash.md
+++ b/.changeset/metal-ways-flash.md
@@ -1,16 +1,16 @@
 ---
-'@mastra/playground-ui': minor
+'@mastra/playground-ui': patch
 ---
 
-Added `flat` and `factory` variants to `Section`, including standard, view-only, and destructive row compositions.
+Added aligned `flat` and `factory` layouts to `Section`, including standard, view-only, and destructive row compositions.
 
 ```tsx
 <Section variant="factory">
   <Section.Header>
-    <div>
+    <Section.HeaderText>
       <Section.Heading>Security</Section.Heading>
       <Section.Description>Manage sign-in requirements.</Section.Description>
-    </div>
+    </Section.HeaderText>
   </Section.Header>
   <Section.Content>
     <Section.Row label="Two-factor authentication">

--- a/.changeset/metal-ways-flash.md
+++ b/.changeset/metal-ways-flash.md
@@ -1,16 +1,16 @@
 ---
-'@mastra/playground-ui': patch
+'@mastra/playground-ui': minor
 ---
 
-Added aligned `flat` and `factory` layouts to `Section`, including standard, view-only, and destructive row compositions.
+Added `flat` and `factory` variants to `Section`, including standard, view-only, and destructive row compositions.
 
 ```tsx
 <Section variant="factory">
   <Section.Header>
-    <Section.HeaderText>
+    <div>
       <Section.Heading>Security</Section.Heading>
       <Section.Description>Manage sign-in requirements.</Section.Description>
-    </Section.HeaderText>
+    </div>
   </Section.Header>
   <Section.Content>
     <Section.Row label="Two-factor authentication">

--- a/.changeset/quiet-sections-align.md
+++ b/.changeset/quiet-sections-align.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Aligned the `flat` and `factory` Section layouts so their headings, row content, and actions share consistent horizontal edges.

--- a/packages/playground-ui/src/ds/components/Section/section-header.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section-header.tsx
@@ -9,8 +9,8 @@ export function SectionHeader({ children, className, ...props }: SectionHeaderPr
       data-slot="section-header"
       className={cn(
         'group-data-[variant=default]/section:grid group-data-[variant=default]/section:grid-cols-[1fr_auto] group-data-[variant=default]/section:items-center',
-        'group-data-[variant=flat]/section:flex group-data-[variant=flat]/section:min-w-0 group-data-[variant=flat]/section:flex-col group-data-[variant=flat]/section:gap-4 group-data-[variant=flat]/section:px-1 group-data-[variant=flat]/section:pb-4 sm:group-data-[variant=flat]/section:flex-row sm:group-data-[variant=flat]/section:items-start sm:group-data-[variant=flat]/section:justify-between sm:group-data-[variant=flat]/section:gap-6',
-        'group-data-[variant=factory]/section:flex group-data-[variant=factory]/section:min-w-0 group-data-[variant=factory]/section:flex-col group-data-[variant=factory]/section:gap-2 sm:group-data-[variant=factory]/section:flex-row sm:group-data-[variant=factory]/section:items-start sm:group-data-[variant=factory]/section:justify-between sm:group-data-[variant=factory]/section:gap-4',
+        'group-data-[variant=flat]/section:flex group-data-[variant=flat]/section:min-w-0 group-data-[variant=flat]/section:flex-col group-data-[variant=flat]/section:gap-4 group-data-[variant=flat]/section:px-4 group-data-[variant=flat]/section:pb-4 sm:group-data-[variant=flat]/section:flex-row sm:group-data-[variant=flat]/section:items-start sm:group-data-[variant=flat]/section:justify-between sm:group-data-[variant=flat]/section:gap-6',
+        'group-data-[variant=factory]/section:flex group-data-[variant=factory]/section:min-w-0 group-data-[variant=factory]/section:flex-col group-data-[variant=factory]/section:gap-2 group-data-[variant=factory]/section:px-4 sm:group-data-[variant=factory]/section:flex-row sm:group-data-[variant=factory]/section:items-start sm:group-data-[variant=factory]/section:justify-between sm:group-data-[variant=factory]/section:gap-4',
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/Section/section-heading.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section-heading.tsx
@@ -13,7 +13,7 @@ export function SectionHeading({ headingLevel = 'h2', children, className, ...pr
       data-slot="section-heading"
       className={cn(
         'group-data-[variant=default]/section:flex group-data-[variant=default]/section:items-center group-data-[variant=default]/section:gap-2 group-data-[variant=default]/section:text-ui-lg group-data-[variant=default]/section:font-bold group-data-[variant=default]/section:text-neutral4 group-data-[variant=default]/section:[&>svg]:size-[1.2em] group-data-[variant=default]/section:[&>svg]:opacity-50',
-        'group-data-[variant=flat]/section:text-ui-lg group-data-[variant=flat]/section:leading-ui-lg group-data-[variant=flat]/section:font-medium group-data-[variant=flat]/section:text-balance group-data-[variant=flat]/section:text-neutral5',
+        'group-data-[variant=flat]/section:text-ui-lg group-data-[variant=flat]/section:leading-ui-lg group-data-[variant=flat]/section:font-semibold group-data-[variant=flat]/section:text-balance group-data-[variant=flat]/section:text-neutral5',
         'group-data-[variant=factory]/section:text-ui-lg group-data-[variant=factory]/section:leading-ui-lg group-data-[variant=factory]/section:font-semibold group-data-[variant=factory]/section:text-balance group-data-[variant=factory]/section:text-neutral5',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/Section/section-root.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section-root.tsx
@@ -15,8 +15,8 @@ export function SectionRoot({ variant = 'default', children, className, ...props
       className={cn(
         'group/section',
         variant === 'default' && 'grid gap-4',
-        variant === 'flat' && 'min-w-0',
-        variant === 'factory' && 'flex min-w-0 flex-col gap-2',
+        variant === 'flat' && 'w-full min-w-0',
+        variant === 'factory' && 'flex w-full min-w-0 flex-col gap-2',
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/Section/section-row.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section-row.tsx
@@ -46,7 +46,7 @@ function SectionRowLayout({
       className={cn(
         'grid min-w-0 gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center',
         'sm:group-data-[variant=default]/section:gap-4',
-        'group-data-[variant=flat]/section:px-1 group-data-[variant=flat]/section:py-4 sm:group-data-[variant=flat]/section:gap-8',
+        'group-data-[variant=flat]/section:p-4 sm:group-data-[variant=flat]/section:gap-8',
         'group-data-[variant=factory]/section:px-4 group-data-[variant=factory]/section:py-3 sm:group-data-[variant=factory]/section:gap-4',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/Section/section.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section.stories.tsx
@@ -179,22 +179,76 @@ export const PermissionAndDestructiveRows: Story = {
 
 export const MultipleSections: Story = {
   render: () => (
-    <div className="w-125 space-y-8">
-      <Section>
+    <div className="w-[calc(100vw-2rem)] max-w-150 space-y-8">
+      <Section variant="factory">
         <Section.Header>
-          <Section.Heading>General</Section.Heading>
+          <Section.HeaderText>
+            <Section.Heading>Behavior</Section.Heading>
+            <Section.Description>Choose how agents handle tools and completion alerts.</Section.Description>
+          </Section.HeaderText>
         </Section.Header>
-        <div className="border-border1 bg-surface2 rounded-md border p-4">
-          <p className="text-neutral5 text-sm">General settings content</p>
-        </div>
+        <Section.Content>
+          <Section.Row label="Auto-approve tools" description="Run tool calls without asking.">
+            <Switch aria-label="Auto-approve tools" />
+          </Section.Row>
+          <Section.Divider />
+          <Section.Row label="Smart editing" description="Use AST-aware edits when available.">
+            <Switch aria-label="Smart editing" defaultChecked />
+          </Section.Row>
+          <Section.Divider />
+          <Section.Row
+            label="Notifications"
+            description="Choose how completion alerts are delivered."
+            htmlFor="multiple-notifications"
+          >
+            <Select defaultValue="off">
+              <SelectTrigger id="multiple-notifications" className="w-full sm:w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="off">Off</SelectItem>
+                <SelectItem value="bell">Bell</SelectItem>
+                <SelectItem value="system">System</SelectItem>
+              </SelectContent>
+            </Select>
+          </Section.Row>
+        </Section.Content>
       </Section>
-      <Section>
+
+      <Section variant="flat">
         <Section.Header>
-          <Section.Heading>Advanced</Section.Heading>
+          <Section.HeaderText>
+            <Section.Heading>Security</Section.Heading>
+            <Section.Description>Manage sign-in requirements for your account.</Section.Description>
+          </Section.HeaderText>
         </Section.Header>
-        <div className="border-border1 bg-surface2 rounded-md border p-4">
-          <p className="text-neutral5 text-sm">Advanced settings content</p>
-        </div>
+        <Section.Content>
+          <Section.Row label="Two-factor authentication" description="Require a verification code when signing in.">
+            <Switch aria-label="Two-factor authentication" />
+          </Section.Row>
+          <Section.Row
+            label="Session timeout"
+            description="Sign out after a period of inactivity."
+            htmlFor="multiple-timeout"
+          >
+            <Select defaultValue="30">
+              <SelectTrigger id="multiple-timeout" className="w-full sm:w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="15">15 minutes</SelectItem>
+                <SelectItem value="30">30 minutes</SelectItem>
+                <SelectItem value="60">1 hour</SelectItem>
+              </SelectContent>
+            </Select>
+          </Section.Row>
+          <Section.Divider />
+          <Section.Row label="Active sessions" description="Review devices currently signed in to your account.">
+            <Button size="sm" variant="ghost">
+              Review
+            </Button>
+          </Section.Row>
+        </Section.Content>
       </Section>
     </div>
   ),

--- a/packages/playground-ui/src/ds/components/Section/section.test.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section.test.tsx
@@ -94,7 +94,7 @@ describe('Section', () => {
       'group-data-[variant=factory]/section:px-4',
     );
     expect(screen.getByText('Flat row').closest('[data-slot="section-row"]')?.className).toContain(
-      'group-data-[variant=flat]/section:px-4',
+      'group-data-[variant=flat]/section:p-4',
     );
   });
 

--- a/packages/playground-ui/src/ds/components/Section/section.test.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section.test.tsx
@@ -57,6 +57,47 @@ describe('Section', () => {
     expect(screen.getByText('Leave organization').className).toContain('text-accent2');
   });
 
+  it('aligns flat and factory content to the same horizontal inset', () => {
+    render(
+      <div>
+        <Section variant="factory">
+          <Section.Header>
+            <Section.Heading>Factory</Section.Heading>
+          </Section.Header>
+          <Section.Content>
+            <Section.Row label="Factory row" />
+          </Section.Content>
+        </Section>
+        <Section variant="flat">
+          <Section.Header>
+            <Section.Heading>Flat</Section.Heading>
+          </Section.Header>
+          <Section.Content>
+            <Section.Row label="Flat row" />
+          </Section.Content>
+        </Section>
+      </div>,
+    );
+
+    const factory = screen.getByRole('heading', { name: 'Factory' }).closest('[data-slot="section"]');
+    const flat = screen.getByRole('heading', { name: 'Flat' }).closest('[data-slot="section"]');
+
+    expect(factory?.className).toContain('w-full');
+    expect(flat?.className).toContain('w-full');
+    expect(factory?.querySelector('[data-slot="section-header"]')?.className).toContain(
+      'group-data-[variant=factory]/section:px-4',
+    );
+    expect(flat?.querySelector('[data-slot="section-header"]')?.className).toContain(
+      'group-data-[variant=flat]/section:px-4',
+    );
+    expect(screen.getByText('Factory row').closest('[data-slot="section-row"]')?.className).toContain(
+      'group-data-[variant=factory]/section:px-4',
+    );
+    expect(screen.getByText('Flat row').closest('[data-slot="section-row"]')?.className).toContain(
+      'group-data-[variant=flat]/section:px-4',
+    );
+  });
+
   it('renders factory rows with explicit dividers', () => {
     render(
       <Section variant="factory">


### PR DESCRIPTION
## Description

Aligns the `flat` and `factory` Section variants when they appear in the same settings view.

- Gives both variants the same full-width behavior and 16px horizontal inset
- Aligns section headings, row text, and action edges
- Uses the same heading size and weight across both variants
- Adds a paired Storybook example and an alignment regression test
- Adds a separate patch changeset for the alignment fix

## Related issue(s)

No issue. Follow-up to #21939.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Verification

- `pnpm --filter ./packages/playground-ui typecheck`
- `pnpm --filter ./packages/playground-ui test --run src/ds/components/Section/section.test.tsx`
- `pnpm --filter ./packages/playground-ui build`
- `pnpm exec eslint src/ds/components/Section --quiet`
- `pnpm exec oxfmt --check packages/playground-ui/src/ds/components/Section .changeset/metal-ways-flash.md`
- WCAG 2 A/AA scan passed at mobile width
- Reviewed locally in the `Layout/Section/Multiple Sections` story

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (Storybook)
- [x] I have added tests that prove my fix is effective
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes `flat` and `factory` settings sections look and line up the same when shown together. It also adds an example and a test to prevent the layouts from becoming inconsistent.

## Changes

- Added consistent full-width layouts for `flat` and `factory` sections.
- Standardized 16px horizontal insets for headers, rows, and actions.
- Updated the flat heading to use `font-semibold`.
- Added a paired Storybook example with realistic controls.
- Added a regression test for widths, insets, and alignment.
- Changed the Playground UI changeset from minor to patch.
- Verified with typechecking, tests, build, linting, formatting, and WCAG scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->