### PR TITLE
feat: SCD-2 point lookup for dataset items

### DIFF
--- a/.changeset/point-lookup-items.md
+++ b/.changeset/point-lookup-items.md
@@ -1,0 +1,10 @@
+---
+'@mastra/core': minor
+'@mastra/pg': minor
+'@mastra/libsql': minor
+'@mastra/mysql': minor
+'@mastra/mongodb': minor
+'@mastra/spanner': minor
+---
+
+Add `getItemAtVersion` point lookup to the datasets storage domain. It returns the single dataset item visible at a pinned dataset version using SCD-2 range semantics, with an indexed query in every storage adapter. `Dataset.runExperimentItem` and `Dataset.submitExperimentResult` now use it to resolve items, so per-item caller-driven experiment calls no longer materialize the full dataset at the pinned version on each request.

--- a/packages/core/src/datasets/dataset.ts
+++ b/packages/core/src/datasets/dataset.ts
@@ -843,9 +843,11 @@ export class Dataset {
     // SCD-2 range lookup at the experiment's pinned dataset version.
     const item =
       experiment.datasetVersion !== null
-        ? (await datasetsStore.getItemsByVersion({ datasetId: this.id, version: experiment.datasetVersion })).find(
-            candidate => candidate.id === args.itemId,
-          )
+        ? await datasetsStore.getItemAtVersion({
+            datasetId: this.id,
+            itemId: args.itemId,
+            version: experiment.datasetVersion,
+          })
         : await datasetsStore.getItemById({ id: args.itemId });
     if (!item || item.datasetId !== this.id) {
       throw new MastraError({
@@ -938,9 +940,11 @@ export class Dataset {
     // earlier version that are still current).
     const item =
       experiment.datasetVersion !== null
-        ? (await datasetsStore.getItemsByVersion({ datasetId: this.id, version: experiment.datasetVersion })).find(
-            candidate => candidate.id === args.itemId,
-          )
+        ? await datasetsStore.getItemAtVersion({
+            datasetId: this.id,
+            itemId: args.itemId,
+            version: experiment.datasetVersion,
+          })
         : await datasetsStore.getItemById({ id: args.itemId });
     if (!item || item.datasetId !== this.id) {
       throw new MastraError({

--- a/packages/core/src/storage/domains/datasets/__tests__/datasets.test.ts
+++ b/packages/core/src/storage/domains/datasets/__tests__/datasets.test.ts
@@ -646,6 +646,38 @@ describe('DatasetsInMemory', () => {
       expect(items).toHaveLength(0);
     });
 
+    it('getItemAtVersion returns the row visible at the pinned version (SCD-2 range)', async () => {
+      const dataset = await storage.createDataset({ name: 'test' });
+      const item = await storage.addItem({ datasetId: dataset.id, input: { n: 1 } });
+      await storage.updateItem({ id: item.id, datasetId: dataset.id, input: { n: 2 } });
+
+      const v1 = await storage.getItemAtVersion({ datasetId: dataset.id, itemId: item.id, version: 1 });
+      expect(v1?.input).toEqual({ n: 1 });
+
+      const v2 = await storage.getItemAtVersion({ datasetId: dataset.id, itemId: item.id, version: 2 });
+      expect(v2?.input).toEqual({ n: 2 });
+
+      // Range semantics: still visible at a later pinned version
+      const v9 = await storage.getItemAtVersion({ datasetId: dataset.id, itemId: item.id, version: 9 });
+      expect(v9?.input).toEqual({ n: 2 });
+
+      const v0 = await storage.getItemAtVersion({ datasetId: dataset.id, itemId: item.id, version: 0 });
+      expect(v0).toBeNull();
+    });
+
+    it('getItemAtVersion scopes by dataset and hides deleted items', async () => {
+      const dataset = await storage.createDataset({ name: 'test' });
+      const other = await storage.createDataset({ name: 'other' });
+      const item = await storage.addItem({ datasetId: dataset.id, input: { n: 1 } });
+
+      const wrongDs = await storage.getItemAtVersion({ datasetId: other.id, itemId: item.id, version: 1 });
+      expect(wrongDs).toBeNull();
+
+      await storage.deleteItem({ id: item.id, datasetId: dataset.id });
+      const afterDelete = await storage.getItemAtVersion({ datasetId: dataset.id, itemId: item.id, version: 2 });
+      expect(afterDelete).toBeNull();
+    });
+
     it('getItemHistory returns all rows including tombstones (T3.15)', async () => {
       const dataset = await storage.createDataset({ name: 'test' });
       const item = await storage.addItem({ datasetId: dataset.id, input: { n: 1 } });

--- a/packages/core/src/storage/domains/datasets/base.ts
+++ b/packages/core/src/storage/domains/datasets/base.ts
@@ -220,6 +220,21 @@ export abstract class DatasetsStorage extends StorageDomain {
 
   // SCD-2 queries
   abstract getItemsByVersion(args: { datasetId: string; version: number }): Promise<DatasetItem[]>;
+
+  /**
+   * Point lookup for a single item visible at a pinned dataset version (SCD-2 range
+   * semantics: `datasetVersion <= version AND (validTo IS NULL OR validTo > version)`
+   * excluding deleted rows). Returns `null` when the item is not visible at that version
+   * or belongs to a different dataset.
+   *
+   * The default implementation filters `getItemsByVersion`; adapters should override
+   * with an indexed point query so per-item callers avoid materializing the whole version.
+   */
+  async getItemAtVersion(args: { datasetId: string; itemId: string; version: number }): Promise<DatasetItem | null> {
+    const items = await this.getItemsByVersion({ datasetId: args.datasetId, version: args.version });
+    return items.find(item => item.id === args.itemId) ?? null;
+  }
+
   abstract getItemHistory(itemId: string): Promise<DatasetItemRow[]>;
 
   // Dataset version methods

--- a/packages/core/src/storage/domains/datasets/inmemory.ts
+++ b/packages/core/src/storage/domains/datasets/inmemory.ts
@@ -432,6 +432,16 @@ export class DatasetsInMemory extends DatasetsStorage {
     return items;
   }
 
+  async getItemAtVersion(args: { datasetId: string; itemId: string; version: number }): Promise<DatasetItem | null> {
+    const rows = this.db.datasetItems.get(args.itemId);
+    if (!rows || rows.length === 0 || rows[0]!.datasetId !== args.datasetId) return null;
+
+    const visible = rows.find(
+      r => r.datasetVersion <= args.version && (r.validTo === null || r.validTo > args.version) && !r.isDeleted,
+    );
+    return visible ? toDatasetItem(visible) : null;
+  }
+
   async getItemHistory(itemId: string): Promise<DatasetItemRow[]> {
     // ALL rows including tombstones, ordered by datasetVersion DESC (newest first)
     const rows = this.db.datasetItems.get(itemId);

--- a/stores/_test-utils/src/domains/datasets/index.ts
+++ b/stores/_test-utils/src/domains/datasets/index.ts
@@ -953,6 +953,54 @@ export function createDatasetsTests({
         expect(v3Items).toHaveLength(2);
       });
 
+      it('getItemAtVersion returns the row visible at the pinned version (SCD-2 range)', async () => {
+        // At version 1: original row is visible even though a later version exists
+        const v1 = await datasetsStorage.getItemAtVersion({ datasetId: ds.id, itemId: item1.id, version: 1 });
+        expect(v1!.input).toEqual({ q: 'original' });
+
+        // At version 2: the updated row is visible
+        const v2 = await datasetsStorage.getItemAtVersion({ datasetId: ds.id, itemId: item1.id, version: 2 });
+        expect(v2!.input).toEqual({ q: 'updated' });
+
+        // A row created at version 1 remains visible at a later pinned version (range, not exact match)
+        const v9 = await datasetsStorage.getItemAtVersion({ datasetId: ds.id, itemId: item1.id, version: 9 });
+        expect(v9!.input).toEqual({ q: 'updated' });
+
+        // Before the item existed: not visible
+        const v0 = await datasetsStorage.getItemAtVersion({ datasetId: ds.id, itemId: item1.id, version: 0 });
+        expect(v0).toBeNull();
+      });
+
+      it('getItemAtVersion scopes to the dataset and excludes items added after the pinned version', async () => {
+        // Wrong dataset: null
+        const other = await datasetsStorage.createDataset({ name: 'scd2-queries-other' });
+        const wrongDs = await datasetsStorage.getItemAtVersion({ datasetId: other.id, itemId: item1.id, version: 2 });
+        expect(wrongDs).toBeNull();
+
+        // Item added at version 3 is not visible at version 2
+        const late = await datasetsStorage.addItem({ datasetId: ds.id, input: { q: 'late' } });
+        const notYet = await datasetsStorage.getItemAtVersion({ datasetId: ds.id, itemId: late.id, version: 2 });
+        expect(notYet).toBeNull();
+        const visible = await datasetsStorage.getItemAtVersion({ datasetId: ds.id, itemId: late.id, version: 3 });
+        expect(visible!.input).toEqual({ q: 'late' });
+      });
+
+      it('getItemAtVersion returns null for deleted items at versions after the delete', async () => {
+        const doomed = await datasetsStorage.addItem({ datasetId: ds.id, input: { q: 'doomed' } });
+        // version is now 3
+        await datasetsStorage.deleteItem({ id: doomed.id, datasetId: ds.id });
+        // version is now 4
+        const afterDelete = await datasetsStorage.getItemAtVersion({ datasetId: ds.id, itemId: doomed.id, version: 4 });
+        expect(afterDelete).toBeNull();
+        // Still visible at the pre-delete version
+        const beforeDelete = await datasetsStorage.getItemAtVersion({
+          datasetId: ds.id,
+          itemId: doomed.id,
+          version: 3,
+        });
+        expect(beforeDelete!.input).toEqual({ q: 'doomed' });
+      });
+
       it('getItemHistory returns all rows ordered by datasetVersion DESC', async () => {
         const history = await datasetsStorage.getItemHistory(item1.id);
         expect(history.length).toBeGreaterThanOrEqual(2);

--- a/stores/libsql/src/storage/domains/datasets/index.ts
+++ b/stores/libsql/src/storage/domains/datasets/index.ts
@@ -879,6 +879,27 @@ export class DatasetsLibSQL extends DatasetsStorage {
     }
   }
 
+  async getItemAtVersion(args: { datasetId: string; itemId: string; version: number }): Promise<DatasetItem | null> {
+    try {
+      const result = await this.#client.execute({
+        sql: `SELECT ${buildSelectColumns(TABLE_DATASET_ITEMS)} FROM ${TABLE_DATASET_ITEMS} WHERE id = ? AND datasetId = ? AND datasetVersion <= ? AND (validTo IS NULL OR validTo > ?) AND isDeleted = 0 LIMIT 1`,
+        args: [args.itemId, args.datasetId, args.version, args.version],
+      });
+
+      const row = result.rows?.[0];
+      return row ? this.transformItemRow(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'GET_ITEM_AT_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
   async getItemHistory(itemId: string): Promise<DatasetItemRow[]> {
     try {
       // ALL rows including tombstones, ordered by datasetVersion DESC (newest first)

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -1095,6 +1095,29 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
     }
   }
 
+  async getItemAtVersion(args: { datasetId: string; itemId: string; version: number }): Promise<DatasetItem | null> {
+    try {
+      const collection = await this.getCollection(TABLE_DATASET_ITEMS);
+      const row = await collection.findOne({
+        id: args.itemId,
+        datasetId: args.datasetId,
+        datasetVersion: { $lte: args.version },
+        $or: [{ validTo: null }, { validTo: { $gt: args.version } }],
+        isDeleted: false,
+      });
+      return row ? this.transformItemRow(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'GET_ITEM_AT_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
   async getItemHistory(itemId: string): Promise<DatasetItemRow[]> {
     try {
       const collection = await this.getCollection(TABLE_DATASET_ITEMS);

--- a/stores/mysql/src/storage/domains/datasets/index.ts
+++ b/stores/mysql/src/storage/domains/datasets/index.ts
@@ -986,6 +986,28 @@ export class DatasetsMySQL extends DatasetsStorage {
     }
   }
 
+  async getItemAtVersion(args: { datasetId: string; itemId: string; version: number }): Promise<DatasetItem | null> {
+    try {
+      const tableItemsName = formatTableName(TABLE_DATASET_ITEMS);
+      const [rows] = await this.pool.execute<RowDataPacket[]>(
+        `SELECT * FROM ${tableItemsName} WHERE \`id\` = ? AND \`datasetId\` = ? AND \`datasetVersion\` <= ? AND (\`validTo\` IS NULL OR \`validTo\` > ?) AND \`isDeleted\` = 0 LIMIT 1`,
+        [args.itemId, args.datasetId, args.version, args.version],
+      );
+
+      const row = (rows as any[])[0];
+      return row ? this.mapItem(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: 'MYSQL_GET_ITEM_AT_VERSION_FAILED',
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
   async getItemHistory(itemId: string): Promise<DatasetItemRow[]> {
     try {
       const tableItemsName = formatTableName(TABLE_DATASET_ITEMS);

--- a/stores/pg/src/storage/domains/datasets/index.ts
+++ b/stores/pg/src/storage/domains/datasets/index.ts
@@ -1179,6 +1179,26 @@ export class DatasetsPG extends DatasetsStorage {
     }
   }
 
+  async getItemAtVersion(args: { datasetId: string; itemId: string; version: number }): Promise<DatasetItem | null> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_DATASET_ITEMS, schemaName: getSchemaName(this.#schema) });
+      const row = await this.#db.client.oneOrNone(
+        `SELECT * FROM ${tableName} WHERE "id" = $1 AND "datasetId" = $2 AND "datasetVersion" <= $3 AND ("validTo" IS NULL OR "validTo" > $3) AND "isDeleted" = false LIMIT 1`,
+        [args.itemId, args.datasetId, args.version],
+      );
+      return row ? this.transformItemRow(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_ITEM_AT_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
   async getItemHistory(itemId: string): Promise<DatasetItemRow[]> {
     try {
       const tableName = getTableName({ indexName: TABLE_DATASET_ITEMS, schemaName: getSchemaName(this.#schema) });

--- a/stores/spanner/src/storage/domains/datasets/index.ts
+++ b/stores/spanner/src/storage/domains/datasets/index.ts
@@ -1032,6 +1032,35 @@ export class DatasetsSpanner extends DatasetsStorage {
     }
   }
 
+  async getItemAtVersion(args: { datasetId: string; itemId: string; version: number }): Promise<DatasetItem | null> {
+    try {
+      const tableName = quoteIdent(TABLE_DATASET_ITEMS, 'table name');
+      const [rows] = await this.database.run({
+        sql: `SELECT * FROM ${tableName}
+              WHERE ${quoteIdent('id', 'column name')} = @itemId
+                AND ${quoteIdent('datasetId', 'column name')} = @datasetId
+                AND ${quoteIdent('datasetVersion', 'column name')} <= @version
+                AND (${quoteIdent('validTo', 'column name')} IS NULL OR ${quoteIdent('validTo', 'column name')} > @version)
+                AND ${quoteIdent('isDeleted', 'column name')} = FALSE
+              LIMIT 1`,
+        params: { itemId: args.itemId, datasetId: args.datasetId, version: args.version },
+        json: true,
+      });
+      const row = (rows as Array<Record<string, any>>)[0];
+      return row ? rowToItem(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('SPANNER', 'GET_ITEM_AT_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { datasetId: args.datasetId, itemId: args.itemId, version: args.version },
+        },
+        error,
+      );
+    }
+  }
+
   async getItemHistory(itemId: string): Promise<DatasetItemRow[]> {
     try {
       const tableName = quoteIdent(TABLE_DATASET_ITEMS, 'table name');


### PR DESCRIPTION
## Summary

Adds `getItemAtVersion({ datasetId, itemId, version })` to the datasets storage domain — a point lookup for the single item row visible at a pinned dataset version, using SCD-2 range semantics (`datasetVersion <= v AND (validTo IS NULL OR validTo > v)`, excluding deleted rows).

Previously, `Dataset.runExperimentItem` and `Dataset.submitExperimentResult` resolved items by materializing **every** item visible at the experiment's pinned version and searching the array. For a durable orchestrator (e.g. Temporal) fanning out N per-item calls, that's O(N) storage reads per call — O(N²) total. Each call is now a single indexed point lookup.

Stacked on #21888 (caller-driven experiments); addresses the deferred item-lookup follow-up from its review.

## Changes

- `@mastra/core`: `DatasetsStorage.getItemAtVersion` with a default implementation that filters `getItemsByVersion` (external adapters keep working without changes); indexed override in the in-memory store; `dataset.ts` call sites in `runExperimentItem` and `submitExperimentResult` switched to the point lookup
- `@mastra/pg`, `@mastra/libsql`, `@mastra/mysql`, `@mastra/mongodb`, `@mastra/spanner`: indexed point-query overrides (same predicate as `getItemsByVersion` plus the item id, `LIMIT 1`)
- Shared adapter test suite: 3 new tests — range visibility across versions, dataset scoping + post-pin item exclusion, deleted-item invisibility
- Core in-memory tests for the same semantics

No behavior change: the lookup returns exactly the row the previous filter-based approach found.

## Test plan

- Core datasets + caller-driven experiments suites: 117 tests passing (type-checked run)
- Shared storage suite on libsql: new `getItemAtVersion` tests passing
- `tsc --noEmit` clean on core and all five store adapters

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>