### PR TITLE
perf(factory): load bundled skills inline instead of through workspace discovery

### DIFF
--- a/.changeset/shy-maps-deny.md
+++ b/.changeset/shy-maps-deny.md
@@ -1,0 +1,21 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Added a `skills` option to `MastraCodeConfig`. Agent-level skills passed here are forwarded to the coding agent and are available in every session, independent of the request-scoped workspace.
+
+```ts
+import { createSkill } from '@mastra/core/skills';
+import { mountAgentControllerOnMastra } from '@mastra/code-sdk';
+
+const { controller } = await mountAgentControllerOnMastra({
+  cwd: process.cwd(),
+  skills: [
+    createSkill({
+      name: 'triage',
+      description: 'Triage an incoming issue',
+      instructions: '...',
+    }),
+  ],
+});
+```

--- a/.changeset/wild-cloths-sink.md
+++ b/.changeset/wild-cloths-sink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved Factory startup and run kickoff by loading the bundled Factory skills once at startup as agent-owned inline skills. Invoking a bundled skill no longer waits for workspace skill discovery or sandbox materialization, so runs start immediately even before a session sandbox exists. Repository-provided skills (`.mastracode/skills`, `.claude/skills`, `.agents/skills`) are still discovered from the session workspace, now in the background after the sandbox materializes.

--- a/docs/src/content/en/reference/code-sdk/mount-agent-controller.mdx
+++ b/docs/src/content/en/reference/code-sdk/mount-agent-controller.mdx
@@ -80,6 +80,13 @@ const { controller } = await mountAgentControllerOnMastra({ mastra })
     defaultValue: 'explore/plan/execute',
   },
   {
+    name: 'skills',
+    type: 'AgentConfig["skills"]',
+    description:
+      'Agent-owned skills available independently of the request-scoped workspace. Accepts static or resolver-based skill inputs.',
+    isOptional: true,
+  },
+  {
     name: 'extraTools',
     type: 'Record<string, ToolAction> | (ctx) => Record<string, ToolAction>',
     description: 'Extra tools merged into the dynamic tool set.',

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -72,6 +72,7 @@ import { observeSessionFirstExec } from './session/first-exec-capture.js';
 import { observeSessionFirstMessage } from './session/first-message-capture.js';
 import { hydrateSessionMemorySettings } from './session/memory-settings-hydration.js';
 import { hydrateSessionModelPack } from './session/model-pack-hydration.js';
+import { loadFactorySkillCatalog } from './skills/catalog.js';
 import { createSpaStaticMiddleware, resolveUiDistDir } from './spa-static.js';
 import { createStateSigner } from './state-signing.js';
 import { observeAgentGitAction } from './storage/domains/audit/agent-audit.js';
@@ -372,6 +373,7 @@ export class MastraFactory {
     }
     const rules = this.#config.rules ?? builtInFactoryRules();
     assertFactoryRules(rules);
+    const factorySkills = await loadFactorySkillCatalog();
 
     // FactoryStorage owns every app-table domain and initializes them through
     // the same lifecycle as the backend connection.
@@ -672,6 +674,7 @@ export class MastraFactory {
           fleet,
           workspaceRegistry,
         }),
+        skills: factorySkills.skills,
         disableGithubSignals: true,
         // Memory settings live in the factory's `memory-settings` app table (per
         // org/user), so the host machine's TUI settings.json must not seed them.
@@ -786,10 +789,12 @@ export class MastraFactory {
             factoryReady,
             knowledgeEnabled,
             rules,
+            factorySkills,
             factoryTransitionService: transitionService,
             onFactoryRuntime: ({ transitionService: runtimeTransitionService, prepareBinding }) => {
               this.#dispatcher ??= new FactoryDecisionDispatcher({
                 controller,
+                factorySkills,
                 transitionService: runtimeTransitionService,
                 storage: storage.getDomain<WorkItemsStorage>('work-items'),
                 maxInFlight: this.#config.dispatcher?.maxInFlight,

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -3,12 +3,15 @@ import { builtInFactoryRules, defaultFactoryRules } from '../../rules/defaults.j
 import { FactoryDecisionDispatcher } from '../../rules/dispatcher.js';
 import { FactoryStartCoordinator } from '../../rules/start-coordinator.js';
 import { FactoryTransitionService } from '../../rules/transition-service.js';
+import { createFactorySkillCatalog } from '../../skills/catalog.js';
 import { createFactoryStorageForTests } from '../../storage/test-utils.js';
 import { GithubAppIdentity } from './app-identity.js';
 import type { GithubIntegration } from './integration.js';
 import { createGithubPullRequestReconciler, GithubRules } from './rules.js';
 import type { ReconcileIssueState, ReconcilePullRequestState } from './rules.js';
 import { changeRequestTargetKey } from './subscriptions.js';
+
+const factorySkills = createFactorySkillCatalog([]);
 
 async function setup(permission: string | undefined) {
   const seeded = await createFactoryStorageForTests();
@@ -548,9 +551,10 @@ describe('GithubRules', () => {
       branch: 'factory/issue-42',
       baseBranch: 'main',
     });
-    const coordinator = new FactoryStartCoordinator(controller as never, workItems, transitionService, sourceControl);
+    const coordinator = new FactoryStartCoordinator(controller as never, workItems, factorySkills, transitionService, sourceControl);
     const primeCredentials = vi.fn(async () => {});
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       transitionService,
       storage: workItems,
@@ -902,6 +906,7 @@ describe('GithubRules', () => {
       rules,
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: { getSessionByResource: vi.fn(async () => undefined) } as never,
       transitionService: new FactoryTransitionService({ storage: workItems, rules }),
       storage: workItems,
@@ -984,6 +989,7 @@ describe('GithubRules', () => {
       rules,
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: { getSessionByResource: vi.fn(async () => undefined) } as never,
       transitionService: new FactoryTransitionService({ storage: workItems, rules }),
       storage: workItems,
@@ -1375,7 +1381,7 @@ describe('GithubRules', () => {
       branch: 'factory/issue-42',
       baseBranch: 'main',
     });
-    const coordinator = new FactoryStartCoordinator(controller as never, workItems, transitionService, sourceControl);
+    const coordinator = new FactoryStartCoordinator(controller as never, workItems, factorySkills, transitionService, sourceControl);
     const prepared = await coordinator.prepare({
       orgId: 'org-1',
       userId: 'user-1',
@@ -1408,6 +1414,7 @@ describe('GithubRules', () => {
       data: { kind: 'factory-pr-provenance', workItemId: prepared.workItemId },
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       transitionService,
       storage: workItems,

--- a/mastracode/factory/src/routes/skills.test.ts
+++ b/mastracode/factory/src/routes/skills.test.ts
@@ -2,10 +2,14 @@ import type { Skill } from '@mastra/core/workspace';
 import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createFactorySkillCatalog, loadFactorySkillCatalog } from '../skills/catalog.js';
 import { SourceControlStorageInMemory } from '../storage/domains/source-control/inmemory.js';
 import { SkillRoutes } from './skills.js';
 import { fakeRouteAuth, mountApiRoutes } from './test-utils.js';
 import type { TestAuthUser } from './test-utils.js';
+
+const factorySkills = createFactorySkillCatalog([]);
+const bundledFactorySkills = await loadFactorySkillCatalog();
 
 const skill: Skill = {
   name: 'understand-pr',
@@ -70,6 +74,7 @@ function createHarness(
       auth: fakeRouteAuth(),
       controllerId: 'code',
       controller: { getSessionByResource } as never,
+      factorySkills,
       authorizeSessionAddress,
     }).routes(),
   );
@@ -304,6 +309,7 @@ describe('workspace skill invocation route', () => {
         auth: fakeRouteAuth(),
         controllerId: 'code',
         controller: { getSessionByResource } as never,
+        factorySkills,
         sourceControlStorage,
       }).routes(),
     );
@@ -440,6 +446,7 @@ describe('factory skills catalog route', () => {
         auth: fakeRouteAuth({ enabled: options.authEnabled ?? true }),
         controllerId: 'code',
         controller: { getSessionByResource: vi.fn(async () => undefined) } as never,
+        factorySkills: bundledFactorySkills,
       }).routes(),
     );
     return app;

--- a/mastracode/factory/src/routes/skills.ts
+++ b/mastracode/factory/src/routes/skills.ts
@@ -4,7 +4,7 @@ import type { ApiRoute } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
 
-import { listFactorySkills } from '../skills/catalog.js';
+import type { FactorySkillCatalog } from '../skills/catalog.js';
 import { resolveSkillInvocation, SkillInvocationError } from '../skills/service.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 import type { RouteDependencies } from './route.js';
@@ -34,6 +34,7 @@ interface SessionAuthorizationResult {
 export interface SkillRoutesDeps extends RouteDependencies {
   controllerId: string;
   controller: Pick<AgentController<MastraCodeState>, 'getSessionByResource'>;
+  factorySkills: FactorySkillCatalog;
   sourceControlStorage?: SourceControlStorageHandle;
   ensureSourceControlReady?: () => Promise<void>;
   authorizeSessionAddress?: (
@@ -135,7 +136,7 @@ export class SkillRoutes extends Route<SkillRoutesDeps> {
   }
 
   routes(): ApiRoute[] {
-    const { controllerId, controller, authorizeSessionAddress: customAuthorize } = this.deps;
+    const { controllerId, controller, factorySkills, authorizeSessionAddress: customAuthorize } = this.deps;
     const authorize =
       customAuthorize ??
       ((context: Context, address: { resourceId: string; projectRepositoryId?: string; scope?: string }) =>
@@ -167,7 +168,7 @@ export class SkillRoutes extends Route<SkillRoutesDeps> {
       }
 
       try {
-        const resolved = await resolveSkillInvocation(controller, body);
+        const resolved = await resolveSkillInvocation(controller, factorySkills, body);
         if (dispatch) {
           void resolved.session.sendMessage({ content: resolved.message }).catch((error: unknown) => {
             console.error('Workspace skill dispatch failed after acceptance', error);
@@ -191,7 +192,7 @@ export class SkillRoutes extends Route<SkillRoutesDeps> {
           return c.json({ error: 'unauthorized', message: 'Authentication required.' }, 401);
         }
       }
-      return c.json({ skills: await listFactorySkills() });
+      return c.json({ skills: factorySkills.list });
     };
 
     return [

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -17,6 +17,7 @@ import type { BaseCheckpointTriggers } from '../sandbox/base-checkpoint-triggers
 import type { SandboxFleet } from '../sandbox/fleet.js';
 import { ensureFactorySourceSession, resolveFactoryDefaultModelId } from '../session/factory-session.js';
 import { LiveSessions } from '../session/live-sessions.js';
+import type { FactorySkillCatalog } from '../skills/catalog.js';
 import type { StateSigner } from '../state-signing.js';
 import type { AuditEmitter } from '../storage/domains/audit/domain.js';
 import type { ChannelIdentityStorage } from '../storage/domains/channel-identity/base.js';
@@ -85,6 +86,8 @@ export interface FactoryApiRoutesDeps {
   knowledgeEnabled: boolean;
   /** Resolved Factory rule set, threaded from the host (no service locator). */
   rules: FactoryRules;
+  /** Bundled Factory skills loaded once during startup. */
+  factorySkills: FactorySkillCatalog;
   factoryTransitionService?: FactoryTransitionService;
   sessionRetirement?: import('../sandbox/session-retirement.js').SessionRetirementCoordinator;
   onFactoryRuntime?: (runtime: {
@@ -389,6 +392,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
     ? new FactoryStartCoordinator(
         deps.controller,
         deps.domains.workItems,
+        deps.factorySkills,
         transitionService,
         githubIntegration?.sourceControlStorage,
         deps.domains.memorySettings,
@@ -439,6 +443,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
       auth: deps.auth,
       controllerId: deps.controllerId,
       controller: deps.controller,
+      factorySkills: deps.factorySkills,
       sourceControlStorage: githubStorage,
       ensureSourceControlReady: githubRegistration?.ensureReady,
     }).routes(),

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { createFactorySkillCatalog } from '../skills/catalog.js';
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import { builtInFactoryRules, defaultFactoryRules } from './defaults.js';
@@ -9,6 +10,7 @@ import { FactoryTransitionService } from './transition-service.js';
 import type { FactoryCommitDecision } from './types.js';
 
 const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
+const factorySkills = createFactorySkillCatalog([]);
 
 async function createItem(storage: WorkItemsStorage, sourceKey = 'github-issue:1') {
   return (
@@ -188,6 +190,7 @@ describe('FactoryDecisionDispatcher', () => {
       storage,
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -212,6 +215,7 @@ describe('FactoryDecisionDispatcher', () => {
     );
     const { controller } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService: new FactoryTransitionService({ rules: defaultFactoryRules({ version: 'rules-v1' }), storage }),
@@ -247,6 +251,7 @@ describe('FactoryDecisionDispatcher', () => {
     const sweep = vi.spyOn(storage, 'revokeStaleRunBindings');
     const { controller } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService: new FactoryTransitionService({ rules: defaultFactoryRules({ version: 'rules-v1' }), storage }),
@@ -283,6 +288,7 @@ describe('FactoryDecisionDispatcher', () => {
     const reconcileToolResults = vi.fn(async () => {});
     const { controller } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService: new FactoryTransitionService({ rules: defaultFactoryRules({ version: 'rules-v1' }), storage }),
@@ -430,6 +436,7 @@ describe('FactoryDecisionDispatcher', () => {
       kickoffMessage: null,
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -473,6 +480,7 @@ describe('FactoryDecisionDispatcher', () => {
       agentEndReason: 'complete',
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -527,6 +535,7 @@ describe('FactoryDecisionDispatcher', () => {
       });
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -595,6 +604,7 @@ describe('FactoryDecisionDispatcher', () => {
       });
       const renew = vi.spyOn(storage, 'renewDeferredDecisionLease');
       const dispatcher = new FactoryDecisionDispatcher({
+        factorySkills,
         controller: controller as never,
         isAutoRunEnabled: async () => true,
         transitionService,
@@ -655,6 +665,7 @@ describe('FactoryDecisionDispatcher', () => {
         kickoffMessage: null,
       });
       const dispatcher = new FactoryDecisionDispatcher({
+        factorySkills,
         controller: controller as never,
         isAutoRunEnabled: async () => true,
         transitionService,
@@ -737,6 +748,7 @@ describe('FactoryDecisionDispatcher', () => {
         kickoffMessage: null,
       });
       const dispatcher = new FactoryDecisionDispatcher({
+        factorySkills,
         controller: controller as never,
         isAutoRunEnabled: async () => true,
         transitionService,
@@ -813,6 +825,7 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const primeCredentials = vi.fn(async () => {});
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -890,6 +903,7 @@ describe('FactoryDecisionDispatcher', () => {
       kickoffMessage: null,
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -936,6 +950,7 @@ describe('FactoryDecisionDispatcher', () => {
       kickoffMessage: null,
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -985,6 +1000,7 @@ describe('FactoryDecisionDispatcher', () => {
       signalAccepted: Promise.resolve({ accepted: true, action: 'wake' }),
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1061,6 +1077,7 @@ describe('FactoryDecisionDispatcher', () => {
         signalAccepted: Promise.resolve({ accepted: true, action: 'wake' }),
       });
       const dispatcher = new FactoryDecisionDispatcher({
+        factorySkills,
         controller: controller as never,
         isAutoRunEnabled: async () => true,
         transitionService,
@@ -1120,6 +1137,7 @@ describe('FactoryDecisionDispatcher', () => {
       emitAgentEndDuringSignal: true,
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1174,6 +1192,7 @@ describe('FactoryDecisionDispatcher', () => {
       agentEndReason: reason,
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1230,6 +1249,7 @@ describe('FactoryDecisionDispatcher', () => {
       endRunAfterDroppedSignal: true,
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1285,6 +1305,7 @@ describe('FactoryDecisionDispatcher', () => {
       acceptRedeliveredSignal: true,
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1338,6 +1359,7 @@ describe('FactoryDecisionDispatcher', () => {
       accepted: Promise.reject(new Error('Platform proxy request failed with 500: internal_error')),
     }));
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1370,6 +1392,7 @@ describe('FactoryDecisionDispatcher', () => {
     await bindWorkRun(storage, item.id);
     const { controller, session } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       transitionService,
       storage,
@@ -1410,6 +1433,7 @@ describe('FactoryDecisionDispatcher', () => {
     await storage.armAutonomy({ orgId: 'org-1', id: item.id, now: new Date('2030-01-01T00:00:00Z') });
     const { controller, session } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       transitionService,
       storage,
@@ -1448,6 +1472,7 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const { controller, session } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       transitionService,
       storage,
@@ -1506,6 +1531,7 @@ describe('FactoryDecisionDispatcher', () => {
       }),
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       transitionService,
       storage,
@@ -1555,6 +1581,7 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const { controller } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       transitionService,
       storage,
@@ -1579,6 +1606,7 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const { controller, sendNotificationSignal } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1626,6 +1654,7 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const primeCredentials = vi.fn(async () => {});
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1688,6 +1717,7 @@ describe('FactoryDecisionDispatcher', () => {
       accepted: Promise.resolve({ accepted: true as const, action: 'blocked' }),
     }));
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1737,6 +1767,7 @@ describe('FactoryDecisionDispatcher', () => {
       accepted: Promise.resolve({ accepted: true as const, action: undefined }),
     }));
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1783,6 +1814,7 @@ describe('FactoryDecisionDispatcher', () => {
       });
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1855,6 +1887,7 @@ describe('FactoryDecisionDispatcher', () => {
       });
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1907,6 +1940,7 @@ describe('FactoryDecisionDispatcher', () => {
     const { controller, session } = createSession();
     vi.spyOn(storage, 'completeDeferredDecision').mockRejectedValueOnce(new Error('database unavailable'));
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -1957,6 +1991,7 @@ describe('FactoryDecisionDispatcher', () => {
     });
     vi.spyOn(storage, 'completeDeferredDecision').mockRejectedValueOnce(new Error('database unavailable'));
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -2023,6 +2058,7 @@ describe('FactoryDecisionDispatcher', () => {
     };
     const { controller } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService: recoveringTransition,
@@ -2085,6 +2121,7 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const { controller } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -2146,6 +2183,7 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const { controller } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -2197,6 +2235,7 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const { controller, sendNotificationSignal } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -2223,6 +2262,7 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const { controller } = createSession();
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -2264,6 +2304,7 @@ describe('FactoryDecisionDispatcher', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       transitionService,
       sourceControl as never,
     );
@@ -2289,6 +2330,7 @@ describe('FactoryDecisionDispatcher', () => {
     });
     const primeCredentials = vi.fn(async () => {});
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -2299,6 +2341,7 @@ describe('FactoryDecisionDispatcher', () => {
 
     await dispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
     const restarted = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -2350,6 +2393,7 @@ describe('FactoryDecisionDispatcher', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       transitionService,
       sourceControl as never,
     );
@@ -2374,6 +2418,7 @@ describe('FactoryDecisionDispatcher', () => {
       },
     });
     const dispatcher = new FactoryDecisionDispatcher({
+      factorySkills,
       controller: controller as never,
       isAutoRunEnabled: async () => true,
       transitionService,
@@ -2399,6 +2444,7 @@ describe('FactoryDecisionDispatcher', () => {
         rules: defaultFactoryRules({ version: 'rules-v1' }),
       });
       const dispatcher = new FactoryDecisionDispatcher({
+        factorySkills,
         controller: controller as never,
         isAutoRunEnabled: async () => true,
         transitionService,

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -4,6 +4,7 @@ import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentController, AgentControllerEventListener } from '@mastra/core/agent-controller';
 import { RequestContext } from '@mastra/core/request-context';
 
+import type { FactorySkillCatalog } from '../skills/catalog.js';
 import { resolvePromptInvocation, resolveSkillInvocation } from '../skills/service.js';
 import type { SkillSession } from '../skills/service.js';
 import type {
@@ -74,6 +75,7 @@ export interface FactoryBindingPreparationInput {
 
 export interface FactoryDecisionDispatcherOptions {
   controller: FactoryController;
+  factorySkills: FactorySkillCatalog;
   transitionService: Pick<FactoryTransitionService, 'transition'>;
   storage: WorkItemsStorage;
   ownerId?: string;
@@ -165,6 +167,7 @@ async function awaitNotification(
 
 export class FactoryDecisionDispatcher {
   readonly #controller: FactoryController;
+  readonly #factorySkills: FactorySkillCatalog;
   readonly #transitionService: Pick<FactoryTransitionService, 'transition'>;
   readonly #storage: WorkItemsStorage;
   readonly #ownerId: string;
@@ -185,6 +188,7 @@ export class FactoryDecisionDispatcher {
 
   constructor(options: FactoryDecisionDispatcherOptions) {
     this.#controller = options.controller;
+    this.#factorySkills = options.factorySkills;
     this.#transitionService = options.transitionService;
     this.#storage = options.storage;
     this.#ownerId = options.ownerId ?? `factory-dispatcher:${randomUUID()}`;
@@ -469,7 +473,7 @@ export class FactoryDecisionDispatcher {
                 resourceId: binding.resourceId,
                 prompt: decision.prompt,
               })
-            : await resolveSkillInvocation(this.#controller, {
+            : await resolveSkillInvocation(this.#controller, this.#factorySkills, {
                 resourceId: binding.resourceId,
                 name: decision.skillName,
                 arguments: decision.arguments,

--- a/mastracode/factory/src/rules/start-coordinator.test.ts
+++ b/mastracode/factory/src/rules/start-coordinator.test.ts
@@ -1,12 +1,15 @@
 import { RequestContext } from '@mastra/core/request-context';
+import { createSkill } from '@mastra/core/skills';
 import { describe, expect, it, vi } from 'vitest';
 
+import { createFactorySkillCatalog } from '../skills/catalog.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import { defaultFactoryRules } from './defaults.js';
 import { FactoryStartCoordinator } from './start-coordinator.js';
 import { FactoryTransitionService } from './transition-service.js';
 
 const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
+const factorySkills = createFactorySkillCatalog([]);
 
 function makeController(sendMessage = vi.fn(async () => {})) {
   let threadId: string | undefined;
@@ -135,6 +138,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -167,6 +171,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -183,6 +188,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -200,6 +206,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -226,6 +233,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage.workItems,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
       storage.memorySettings,
@@ -250,6 +258,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -288,6 +297,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       transitionService,
       makeSourceControl() as never,
     );
@@ -307,6 +317,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -341,6 +352,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -363,27 +375,30 @@ describe('FactoryStartCoordinator', () => {
   });
 
   it.each(['factory-review', 'factory-rereview'] as const)(
-    'tags %s skill kickoffs with untrustedCheckout',
+    'resolves bundled %s kickoffs without workspace discovery',
     async skillName => {
       const storage = (await createFactoryStorageForTests()).workItems;
+      const prepareRunStart = vi.spyOn(storage, 'prepareRunStart');
       const { controller, session } = makeController();
-      session.getWorkspace.mockReturnValue({
-        skills: {
-          maybeRefresh: vi.fn(async () => {}),
-          get: vi.fn(async () => ({ name: skillName, description: 'Review a PR', instructions: 'Review.' })),
-        },
-      } as never);
+      session.getWorkspace.mockImplementation(() => {
+        throw new Error('workspace discovery must not run');
+      });
+      const bundledSkills = createFactorySkillCatalog([
+        createSkill({ name: skillName, description: 'Review a PR', instructions: 'Review carefully.' }),
+      ]);
       const coordinator = new FactoryStartCoordinator(
         controller as never,
         storage,
+        bundledSkills,
         undefined,
         makeSourceControl() as never,
       );
 
       const request = startRequest({ kickoffMessage: null });
       request.invocation = { type: 'skill', skillName, arguments: 'PR #1' } as never;
-      await coordinator.prepare(request);
+      const prepared = await coordinator.prepare(request);
 
+      expect(session.getWorkspace).not.toHaveBeenCalled();
       expect(session.state.set).toHaveBeenCalledWith({
         factoryProjectId: PROJECT_ID,
         projectRepositoryId: 'project-repository-1',
@@ -391,8 +406,66 @@ describe('FactoryStartCoordinator', () => {
         untrustedCheckout: true,
         baseRef: 'main',
       });
+      expect(prepared.bindingId).toEqual(expect.any(String));
+      expect(prepareRunStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kickoffMessage: `<skill name="${skillName}">\nReview carefully.\n\nARGUMENTS: PR #1\n</skill>`,
+        }),
+      );
     },
   );
+
+  it('rejects a bundled non-user-invocable skill without workspace discovery', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { controller, session } = makeController();
+    session.getWorkspace.mockImplementation(() => {
+      throw new Error('workspace discovery must not run');
+    });
+    const bundledSkills = createFactorySkillCatalog([
+      createSkill({
+        name: 'factory-hidden',
+        description: 'Hidden Factory skill',
+        instructions: 'Hidden.',
+        'user-invocable': false,
+      }),
+    ]);
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      bundledSkills,
+      undefined,
+      makeSourceControl() as never,
+    );
+    const request = startRequest({ kickoffMessage: null });
+    request.invocation = { type: 'skill', skillName: 'factory-hidden', arguments: '' } as never;
+
+    await expect(coordinator.prepare(request)).rejects.toThrow('Skill not found: factory-hidden.');
+    expect(session.getWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('keeps repository skill kickoff discovery as a fallback', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { controller, session } = makeController();
+    const maybeRefresh = vi.fn(async () => {});
+    const get = vi.fn(async () =>
+      createSkill({ name: 'repository-review', description: 'Repository review', instructions: 'Review repository.' }),
+    );
+    session.getWorkspace.mockReturnValue({ skills: { maybeRefresh, get } } as never);
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      factorySkills,
+      undefined,
+      makeSourceControl() as never,
+    );
+    const request = startRequest({ kickoffMessage: null });
+    request.invocation = { type: 'skill', skillName: 'repository-review', arguments: '' } as never;
+
+    await coordinator.prepare(request);
+
+    expect(maybeRefresh).toHaveBeenCalledOnce();
+    expect(get).toHaveBeenCalledWith('repository-review');
+  });
 
   it('falls back to intake metadata for baseRef when the session record has no base branch', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
@@ -400,7 +473,13 @@ describe('FactoryStartCoordinator', () => {
     const sourceControl = makeSourceControl();
     const record = await sourceControl.sessions.getBySessionId('session-1');
     record!.baseBranch = '';
-    const coordinator = new FactoryStartCoordinator(controller as never, storage, undefined, sourceControl as never);
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      factorySkills,
+      undefined,
+      sourceControl as never,
+    );
 
     const request = startRequest({ role: 'review', kickoffMessage: null });
     request.workItem.input.externalSource.type = 'pull-request' as never;
@@ -422,6 +501,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -441,6 +521,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -477,6 +558,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       transitionService,
       makeSourceControl() as never,
     );
@@ -497,6 +579,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -511,6 +594,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -531,6 +615,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );
@@ -550,6 +635,7 @@ describe('FactoryStartCoordinator', () => {
     const coordinator = new FactoryStartCoordinator(
       controller as never,
       storage,
+      factorySkills,
       undefined,
       makeSourceControl() as never,
     );

--- a/mastracode/factory/src/rules/start-coordinator.ts
+++ b/mastracode/factory/src/rules/start-coordinator.ts
@@ -1,9 +1,11 @@
 import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentController } from '@mastra/core/agent-controller';
 import { RequestContext } from '@mastra/core/request-context';
-import { formatSkillActivation } from '@mastra/core/workspace';
+import type { Skill } from '@mastra/core/skills';
 
 import { hydrateFactorySession } from '../session/factory-session.js';
+import type { FactorySkillCatalog } from '../skills/catalog.js';
+import { formatSkillInvocationMessage } from '../skills/service.js';
 import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
 import type { SourceControlSession, SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 import type { CreateWorkItemInput, WorkItemsStorage } from '../storage/domains/work-items/base.js';
@@ -56,26 +58,24 @@ export interface FactoryStartPreparedResult {
 type FactoryController = AgentController<MastraCodeState>;
 type FactorySession = Awaited<ReturnType<FactoryController['createSession']>>;
 
-function escapeSkillBoundary(value: string): string {
-  return value.replaceAll('</skill>', '&lt;/skill&gt;');
-}
-
 async function resolveKickoffMessage(
   session: FactorySession,
+  factorySkills: FactorySkillCatalog,
   invocation: FactoryStartRequest['invocation'],
 ): Promise<string | null> {
   if (!invocation) return null;
   if (invocation.type === 'prompt') return invocation.prompt;
 
-  const skills = session.getWorkspace()?.skills;
-  await skills?.maybeRefresh();
-  const skill = await skills?.get(invocation.skillName);
+  let skill: Skill | null | undefined = factorySkills.get(invocation.skillName);
+  if (!skill) {
+    const skills = session.getWorkspace()?.skills;
+    await skills?.maybeRefresh();
+    skill = await skills?.get(invocation.skillName);
+  }
   if (!skill || skill['user-invocable'] === false) {
     throw new Error(`Skill not found: ${invocation.skillName}.`);
   }
-  const args = invocation.arguments.trim();
-  const content = `${formatSkillActivation(skill)}${args ? `\n\nARGUMENTS: ${args}` : ''}`.trim();
-  return `<skill name="${skill.name}">\n${escapeSkillBoundary(content)}\n</skill>`;
+  return formatSkillInvocationMessage(skill, invocation.arguments);
 }
 
 async function resolveSourceSession(
@@ -109,6 +109,7 @@ async function configureThread(session: FactorySession, request: FactoryStartReq
 export class FactoryStartCoordinator {
   readonly #controller: FactoryController;
   readonly #storage: WorkItemsStorage;
+  readonly #factorySkills: FactorySkillCatalog;
   readonly #transitionService?: Pick<FactoryTransitionService, 'transition'>;
   readonly #sourceControl?: SourceControlStorageHandle;
   readonly #memorySettings?: MemorySettingsStorage;
@@ -116,12 +117,14 @@ export class FactoryStartCoordinator {
   constructor(
     controller: FactoryController,
     storage: WorkItemsStorage,
+    factorySkills: FactorySkillCatalog,
     transitionService?: Pick<FactoryTransitionService, 'transition'>,
     sourceControl?: SourceControlStorageHandle,
     memorySettings?: MemorySettingsStorage,
   ) {
     this.#controller = controller;
     this.#storage = storage;
+    this.#factorySkills = factorySkills;
     this.#transitionService = transitionService;
     this.#sourceControl = sourceControl;
     this.#memorySettings = memorySettings;
@@ -184,7 +187,7 @@ export class FactoryStartCoordinator {
       memorySettings: this.#memorySettings,
     });
     const threadId = await configureThread(session, request);
-    const kickoffMessage = await resolveKickoffMessage(session, request.invocation);
+    const kickoffMessage = await resolveKickoffMessage(session, this.#factorySkills, request.invocation);
     const prepared = await storage.prepareRunStart({
       orgId: request.orgId,
       userId: request.userId,

--- a/mastracode/factory/src/skills/agent-integration.test.ts
+++ b/mastracode/factory/src/skills/agent-integration.test.ts
@@ -1,0 +1,67 @@
+import { createCodingAgent } from '@mastra/core/coding-agent';
+import { describe, expect, it } from 'vitest';
+
+import { createFactorySkillCatalog } from './catalog.js';
+
+function systemText(prompt: unknown): string {
+  if (!Array.isArray(prompt)) return '';
+  return prompt
+    .filter(message => message?.role === 'system')
+    .map(message => (typeof message.content === 'string' ? message.content : JSON.stringify(message.content)))
+    .join('\n');
+}
+
+describe('Factory skill agent integration', () => {
+  it('registers bundled inline skills on the real coding agent without a workspace', async () => {
+    let capturedPrompt: unknown;
+    let capturedTools: unknown;
+    const model = {
+      specificationVersion: 'v2',
+      provider: 'factory-test',
+      modelId: 'factory-test-model',
+      supportedUrls: {},
+      doGenerate: async ({ prompt, tools }: { prompt: unknown; tools: unknown }) => {
+        capturedPrompt = prompt;
+        capturedTools = tools;
+        return {
+          content: [{ type: 'text', text: 'ok' }],
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          rawCall: { rawPrompt: prompt, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    } as never;
+    const catalog = createFactorySkillCatalog([
+      {
+        __inline: true,
+        __referenceContents: {},
+        name: 'factory-test',
+        description: 'Factory integration skill',
+        instructions: 'Use the Factory integration instructions.',
+        path: 'inline/factory-test',
+        source: { type: 'local', projectPath: 'inline/factory-test' },
+        references: [],
+        scripts: [],
+        assets: [],
+      },
+    ]);
+    const agent = createCodingAgent({
+      id: 'factory-agent-integration',
+      name: 'Factory Agent Integration',
+      instructions: 'You are a Factory coding agent.',
+      model,
+      tools: {},
+      workspace: undefined,
+      skills: catalog.skills,
+    });
+
+    await agent.generate('Start');
+
+    expect(
+      Array.isArray(capturedTools) ? capturedTools.map(tool => tool.name) : Object.keys(capturedTools ?? {}),
+    ).toContain('skill');
+    expect(systemText(capturedPrompt)).toContain('factory-test');
+    expect(systemText(capturedPrompt)).toContain('available_skills');
+  });
+});

--- a/mastracode/factory/src/skills/agent-integration.test.ts
+++ b/mastracode/factory/src/skills/agent-integration.test.ts
@@ -1,4 +1,7 @@
 import { createCodingAgent } from '@mastra/core/coding-agent';
+import { createSkill } from '@mastra/core/skills';
+import type { SkillSource } from '@mastra/core/workspace';
+import { Workspace } from '@mastra/core/workspace';
 import { describe, expect, it } from 'vitest';
 
 import { createFactorySkillCatalog } from './catalog.js';
@@ -11,46 +14,41 @@ function systemText(prompt: unknown): string {
     .join('\n');
 }
 
+function makeCaptureModel(captured: { prompt?: unknown; tools?: unknown }) {
+  return {
+    specificationVersion: 'v2',
+    provider: 'factory-test',
+    modelId: 'factory-test-model',
+    supportedUrls: {},
+    doGenerate: async ({ prompt, tools }: { prompt: unknown; tools: unknown }) => {
+      captured.prompt = prompt;
+      captured.tools = tools;
+      return {
+        content: [{ type: 'text', text: 'ok' }],
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        rawCall: { rawPrompt: prompt, rawSettings: {} },
+        warnings: [],
+      };
+    },
+  } as never;
+}
+
+const bundledTestSkill = createSkill({
+  name: 'factory-test',
+  description: 'Factory integration skill',
+  instructions: 'Use the Factory integration instructions.',
+});
+
 describe('Factory skill agent integration', () => {
   it('registers bundled inline skills on the real coding agent without a workspace', async () => {
-    let capturedPrompt: unknown;
-    let capturedTools: unknown;
-    const model = {
-      specificationVersion: 'v2',
-      provider: 'factory-test',
-      modelId: 'factory-test-model',
-      supportedUrls: {},
-      doGenerate: async ({ prompt, tools }: { prompt: unknown; tools: unknown }) => {
-        capturedPrompt = prompt;
-        capturedTools = tools;
-        return {
-          content: [{ type: 'text', text: 'ok' }],
-          finishReason: 'stop',
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-          rawCall: { rawPrompt: prompt, rawSettings: {} },
-          warnings: [],
-        };
-      },
-    } as never;
-    const catalog = createFactorySkillCatalog([
-      {
-        __inline: true,
-        __referenceContents: {},
-        name: 'factory-test',
-        description: 'Factory integration skill',
-        instructions: 'Use the Factory integration instructions.',
-        path: 'inline/factory-test',
-        source: { type: 'local', projectPath: 'inline/factory-test' },
-        references: [],
-        scripts: [],
-        assets: [],
-      },
-    ]);
+    const captured: { prompt?: unknown; tools?: unknown } = {};
+    const catalog = createFactorySkillCatalog([bundledTestSkill]);
     const agent = createCodingAgent({
       id: 'factory-agent-integration',
       name: 'Factory Agent Integration',
       instructions: 'You are a Factory coding agent.',
-      model,
+      model: makeCaptureModel(captured),
       tools: {},
       workspace: undefined,
       skills: catalog.skills,
@@ -59,9 +57,50 @@ describe('Factory skill agent integration', () => {
     await agent.generate('Start');
 
     expect(
-      Array.isArray(capturedTools) ? capturedTools.map(tool => tool.name) : Object.keys(capturedTools ?? {}),
+      Array.isArray(captured.tools) ? captured.tools.map(tool => tool.name) : Object.keys(captured.tools ?? {}),
     ).toContain('skill');
-    expect(systemText(capturedPrompt)).toContain('factory-test');
-    expect(systemText(capturedPrompt)).toContain('available_skills');
+    expect(systemText(captured.prompt)).toContain('factory-test');
+    expect(systemText(captured.prompt)).toContain('available_skills');
+  });
+
+  it('keeps repository skills out of the prompt before materialization and never reads the repository source', async () => {
+    const captured: { prompt?: unknown; tools?: unknown } = {};
+    const sourceCalls: string[] = [];
+    const track = (method: string) => {
+      sourceCalls.push(method);
+      throw new Error(`repository skill source must not be touched before materialization (${method})`);
+    };
+    const repositorySource: SkillSource = {
+      exists: async () => track('exists'),
+      stat: async () => track('stat'),
+      readFile: async () => track('readFile'),
+      readdir: async () => track('readdir'),
+    };
+    // Mirrors the Factory session workspace pre-materialization state: the
+    // dynamic resolver reports no repository roots yet, so discovery resolves
+    // immediately without touching the repository source.
+    const workspace = new Workspace({
+      id: 'factory-agent-integration-pre-materialization',
+      name: 'Factory pre-materialization workspace',
+      skills: () => [],
+      skillSource: repositorySource,
+    });
+    const catalog = createFactorySkillCatalog([bundledTestSkill]);
+    const agent = createCodingAgent({
+      id: 'factory-agent-integration-workspace',
+      name: 'Factory Agent Integration Workspace',
+      instructions: 'You are a Factory coding agent.',
+      model: makeCaptureModel(captured),
+      tools: {},
+      workspace,
+      skills: catalog.skills,
+    });
+
+    await agent.generate('Start');
+
+    const system = systemText(captured.prompt);
+    expect(system).toContain('factory-test');
+    expect(system).not.toContain('repo-shadow-skill');
+    expect(sourceCalls).toEqual([]);
   });
 });

--- a/mastracode/factory/src/skills/catalog.test.ts
+++ b/mastracode/factory/src/skills/catalog.test.ts
@@ -1,0 +1,108 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { isInlineSkill } from '@mastra/core/skills';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  FACTORY_SKILL_NAMES,
+  createFactorySkillCatalog,
+  loadFactorySkillCatalog,
+  type FactorySkillCatalog,
+} from './catalog.js';
+
+const temporaryDirectories: string[] = [];
+
+async function temporarySkillRoot(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'factory-skills-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function writeSkill(
+  root: string,
+  name: string,
+  options: { frontmatter?: string; instructions?: string; references?: Record<string, string> } = {},
+): Promise<void> {
+  const directory = join(root, name);
+  await mkdir(directory, { recursive: true });
+  const frontmatter =
+    options.frontmatter ??
+    `name: ${name}\ndescription: ${name} description\nlicense: MIT\ncompatibility: Mastra Factory\nuser-invocable: true\nmetadata:\n  owner: factory`;
+  await writeFile(join(directory, 'SKILL.md'), `---\n${frontmatter}\n---\n\n${options.instructions ?? `# ${name}`}\n`);
+  for (const [referencePath, content] of Object.entries(options.references ?? {})) {
+    const absolutePath = join(directory, 'references', referencePath);
+    await mkdir(join(absolutePath, '..'), { recursive: true });
+    await writeFile(absolutePath, content);
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { recursive: true, force: true })));
+});
+
+describe('Factory skill catalog', () => {
+  it('loads all bundled Factory skills as one immutable inline catalog', async () => {
+    const catalog = await loadFactorySkillCatalog();
+
+    expect(catalog.skills).toHaveLength(FACTORY_SKILL_NAMES.size);
+    expect(catalog.list).toHaveLength(FACTORY_SKILL_NAMES.size);
+    expect(catalog.skills.every(isInlineSkill)).toBe(true);
+    expect(catalog.skills.map(skill => skill.name).sort()).toEqual([...FACTORY_SKILL_NAMES].sort());
+    expect(catalog.get('factory-triage')).toBe(catalog.skills.find(skill => skill.name === 'factory-triage'));
+    expect(catalog.get('factory-triage')?.instructions).toContain('# Factory Triage');
+    expect(Object.isFrozen(catalog)).toBe(true);
+    expect(Object.isFrozen(catalog.skills)).toBe(true);
+    expect(Object.isFrozen(catalog.list)).toBe(true);
+  });
+
+  it('preserves supported frontmatter and reference contents', async () => {
+    const root = await temporarySkillRoot();
+    await writeSkill(root, 'factory-test', {
+      instructions: '# Test instructions',
+      references: { 'nested/checklist.md': '# Checklist' },
+    });
+
+    const catalog = await loadFactorySkillCatalog({ sourcePath: root, names: ['factory-test'] });
+    const skill = catalog.get('factory-test')!;
+
+    expect(skill).toMatchObject({
+      name: 'factory-test',
+      description: 'factory-test description',
+      instructions: '# Test instructions',
+      license: 'MIT',
+      compatibility: 'Mastra Factory',
+      'user-invocable': true,
+      metadata: { owner: 'factory' },
+      references: ['nested/checklist.md'],
+    });
+    expect(skill.__referenceContents).toEqual({ 'nested/checklist.md': '# Checklist' });
+  });
+
+  it('names the missing or malformed bundled asset in startup errors', async () => {
+    const root = await temporarySkillRoot();
+
+    await expect(loadFactorySkillCatalog({ sourcePath: root, names: ['factory-missing'] })).rejects.toThrow(
+      'Invalid bundled Factory skill "factory-missing"',
+    );
+
+    await writeSkill(root, 'factory-malformed', { frontmatter: 'description: missing name' });
+    await expect(loadFactorySkillCatalog({ sourcePath: root, names: ['factory-malformed'] })).rejects.toThrow(
+      'Invalid bundled Factory skill "factory-malformed"',
+    );
+  });
+
+  it('rejects duplicate names and keeps lookup stable after mutation attempts', async () => {
+    const root = await temporarySkillRoot();
+    await writeSkill(root, 'factory-one');
+    const skill = (await loadFactorySkillCatalog({ sourcePath: root, names: ['factory-one'] })).skills[0]!;
+
+    expect(() => createFactorySkillCatalog([skill, skill])).toThrow('Duplicate bundled Factory skill "factory-one".');
+
+    const catalog: FactorySkillCatalog = createFactorySkillCatalog([skill]);
+    expect(() => catalog.skills.push(skill)).toThrow();
+    expect(() => catalog.list.push({ name: 'other', description: 'other', content: 'other' })).toThrow();
+    expect(catalog.get('factory-one')).toBe(skill);
+  });
+});

--- a/mastracode/factory/src/skills/catalog.ts
+++ b/mastracode/factory/src/skills/catalog.ts
@@ -1,15 +1,30 @@
-/**
- * Read-only catalog of the Factory skills bundled with the server.
- *
- * These are the built-in skills the Factory pipeline invokes at each stage
- * (triage, plan, review, …). The catalog reads the bundled `SKILL.md` files
- * so the settings UI can show users exactly what each skill instructs the
- * agent to do.
- */
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { readFile, readdir } from 'node:fs/promises';
+import { dirname, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-import { FACTORY_SKILL_NAMES, FACTORY_SKILLS_SOURCE_PATH } from '../workspace.js';
+import { createSkill } from '@mastra/core/skills';
+import type { InlineSkill, InlineSkillInput } from '@mastra/core/skills';
+
+const bundleDirectory = dirname(fileURLToPath(import.meta.url));
+const bundledFactorySkillsPath = join(bundleDirectory, 'factory-skills');
+
+export const FACTORY_SKILLS_SOURCE_PATH =
+  [
+    bundledFactorySkillsPath,
+    join(bundleDirectory, '..', 'factory-skills'),
+    join(bundleDirectory, '..', '..', 'factory-skills'),
+    join(process.cwd(), 'src', 'mastra', 'public', 'factory-skills'),
+  ].find(existsSync) ?? bundledFactorySkillsPath;
+
+export const FACTORY_SKILL_NAMES = new Set([
+  'configure-factory-rules',
+  'factory-complete-issue',
+  'factory-plan',
+  'factory-rereview',
+  'factory-review',
+  'factory-triage',
+]);
 
 export interface FactorySkillInfo {
   name: string;
@@ -18,29 +33,170 @@ export interface FactorySkillInfo {
   content: string;
 }
 
-function parseSkillMarkdown(name: string, raw: string): FactorySkillInfo {
-  const frontmatterMatch = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
-  let description = '';
-  let content = raw;
-  if (frontmatterMatch?.[1] !== undefined) {
-    content = raw.slice(frontmatterMatch[0].length);
-    const descriptionLine = frontmatterMatch[1].match(/^description:\s*(.+)$/m);
-    if (descriptionLine?.[1]) description = descriptionLine[1].trim();
-  }
-  return { name, description, content: content.trim() };
+export interface FactorySkillCatalog {
+  skills: InlineSkill[];
+  get(name: string): InlineSkill | undefined;
+  list: FactorySkillInfo[];
 }
 
-/** List the bundled Factory skills, skipping any missing from the bundle. */
-export async function listFactorySkills(): Promise<FactorySkillInfo[]> {
-  const skills: FactorySkillInfo[] = [];
-  for (const name of [...FACTORY_SKILL_NAMES].sort()) {
-    let raw: string;
+interface ParsedFrontmatter {
+  name?: unknown;
+  description?: unknown;
+  license?: unknown;
+  compatibility?: unknown;
+  'user-invocable'?: unknown;
+  metadata?: unknown;
+}
+
+function parseScalar(value: string): unknown {
+  const trimmed = value.trim();
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (trimmed === 'null') return null;
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
     try {
-      raw = await readFile(join(FACTORY_SKILLS_SOURCE_PATH, name, 'SKILL.md'), 'utf8');
+      return JSON.parse(trimmed);
     } catch {
+      throw new Error(`invalid inline JSON value: ${trimmed}`);
+    }
+  }
+  return trimmed;
+}
+
+function parseFrontmatter(raw: string): { data: ParsedFrontmatter; instructions: string } {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match?.[1]) throw new Error('missing or malformed YAML frontmatter');
+
+  const data: Record<string, unknown> = {};
+  const lines = match[1].split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+    const field = line.match(/^([a-zA-Z][a-zA-Z0-9-]*):(?:\s*(.*))?$/);
+    if (!field?.[1]) throw new Error(`invalid frontmatter line ${index + 1}`);
+    const key = field[1];
+    const rawValue = field[2] ?? '';
+    if (rawValue.trim()) {
+      data[key] = parseScalar(rawValue);
       continue;
     }
-    skills.push(parseSkillMarkdown(name, raw));
+
+    const nested: Record<string, unknown> = {};
+    while (index + 1 < lines.length) {
+      const next = lines[index + 1]!;
+      if (!/^\s+/.test(next)) break;
+      index += 1;
+      if (!next.trim() || next.trimStart().startsWith('#')) continue;
+      const nestedField = next.match(/^\s+([a-zA-Z][a-zA-Z0-9_-]*):\s*(.*)$/);
+      if (!nestedField?.[1]) throw new Error(`invalid nested frontmatter line ${index + 1}`);
+      nested[nestedField[1]] = parseScalar(nestedField[2] ?? '');
+    }
+    data[key] = nested;
   }
-  return skills;
+
+  return { data: data as ParsedFrontmatter, instructions: raw.slice(match[0].length).trim() };
+}
+
+async function readReferences(skillDirectory: string): Promise<Record<string, string> | undefined> {
+  const referencesDirectory = join(skillDirectory, 'references');
+  let entries;
+  try {
+    entries = await readdir(referencesDirectory, { recursive: true, withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+
+  const references: Record<string, string> = {};
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const absolutePath = join(entry.parentPath, entry.name);
+    const referencePath = relative(referencesDirectory, absolutePath).split(sep).join('/');
+    references[referencePath] = await readFile(absolutePath, 'utf8');
+  }
+  return Object.keys(references).length > 0 ? references : undefined;
+}
+
+function validateOptionalFields(name: string, data: ParsedFrontmatter): void {
+  if (data.license !== undefined && typeof data.license !== 'string') {
+    throw new Error(`license must be a string`);
+  }
+  if (data.compatibility !== undefined && typeof data.compatibility !== 'string') {
+    throw new Error(`compatibility must be a string`);
+  }
+  if (data['user-invocable'] !== undefined && typeof data['user-invocable'] !== 'boolean') {
+    throw new Error(`user-invocable must be a boolean`);
+  }
+  if (
+    data.metadata !== undefined &&
+    (typeof data.metadata !== 'object' || data.metadata === null || Array.isArray(data.metadata))
+  ) {
+    throw new Error(`metadata must be an object`);
+  }
+  if (data.name !== name) {
+    throw new Error(`frontmatter name must be "${name}"`);
+  }
+}
+
+async function loadBundledSkill(sourcePath: string, expectedName: string): Promise<InlineSkill> {
+  const skillDirectory = join(sourcePath, expectedName);
+  try {
+    const raw = await readFile(join(skillDirectory, 'SKILL.md'), 'utf8');
+    const { data, instructions } = parseFrontmatter(raw);
+    validateOptionalFields(expectedName, data);
+    if (typeof data.description !== 'string' || !data.description.trim()) {
+      throw new Error('description must be a non-empty string');
+    }
+    if (!instructions) throw new Error('instructions must be non-empty');
+    const references = await readReferences(skillDirectory);
+    const input: InlineSkillInput = {
+      name: expectedName,
+      description: data.description.trim(),
+      instructions,
+      ...(data.license !== undefined ? { license: data.license as string } : {}),
+      ...(data.compatibility !== undefined ? { compatibility: data.compatibility } : {}),
+      ...(data['user-invocable'] !== undefined ? { 'user-invocable': data['user-invocable'] as boolean } : {}),
+      ...(data.metadata !== undefined ? { metadata: data.metadata as Record<string, unknown> } : {}),
+      ...(references ? { references } : {}),
+    };
+    return createSkill(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid bundled Factory skill "${expectedName}": ${message}`, { cause: error });
+  }
+}
+
+export function createFactorySkillCatalog(skills: InlineSkill[]): FactorySkillCatalog {
+  const byName = new Map<string, InlineSkill>();
+  for (const skill of skills) {
+    if (byName.has(skill.name)) throw new Error(`Duplicate bundled Factory skill "${skill.name}".`);
+    byName.set(skill.name, skill);
+  }
+
+  const frozenSkills = [...skills];
+  Object.freeze(frozenSkills);
+  const list = frozenSkills.map(skill =>
+    Object.freeze({ name: skill.name, description: skill.description, content: skill.instructions }),
+  );
+  Object.freeze(list);
+
+  return Object.freeze({
+    skills: frozenSkills,
+    get: (name: string) => byName.get(name),
+    list,
+  });
+}
+
+export async function loadFactorySkillCatalog(options?: {
+  sourcePath?: string;
+  names?: Iterable<string>;
+}): Promise<FactorySkillCatalog> {
+  const sourcePath = options?.sourcePath ?? FACTORY_SKILLS_SOURCE_PATH;
+  const names = [...(options?.names ?? FACTORY_SKILL_NAMES)].sort();
+  if (new Set(names).size !== names.length) throw new Error('Duplicate bundled Factory skill names are configured.');
+  const skills = await Promise.all(names.map(name => loadBundledSkill(sourcePath, name)));
+  return createFactorySkillCatalog(skills);
 }

--- a/mastracode/factory/src/skills/catalog.ts
+++ b/mastracode/factory/src/skills/catalog.ts
@@ -9,11 +9,15 @@ import type { InlineSkill, InlineSkillInput } from '@mastra/core/skills';
 const bundleDirectory = dirname(fileURLToPath(import.meta.url));
 const bundledFactorySkillsPath = join(bundleDirectory, 'factory-skills');
 
-export const FACTORY_SKILLS_SOURCE_PATH =
+const FACTORY_SKILLS_SOURCE_PATH =
   [
+    // Assets copied next to the built module (bundled dist layout).
     bundledFactorySkillsPath,
+    // Assets one level up from `dist/skills/` in the packed npm tarball.
     join(bundleDirectory, '..', 'factory-skills'),
+    // Assets at the package root when running from `src/skills/`.
     join(bundleDirectory, '..', '..', 'factory-skills'),
+    // Local dev server layout (`mastra factory dev` public assets).
     join(process.cwd(), 'src', 'mastra', 'public', 'factory-skills'),
   ].find(existsSync) ?? bundledFactorySkillsPath;
 

--- a/mastracode/factory/src/skills/service.test.ts
+++ b/mastracode/factory/src/skills/service.test.ts
@@ -1,0 +1,78 @@
+import { createSkill } from '@mastra/core/skills';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createFactorySkillCatalog } from './catalog.js';
+import { dispatchSkillInvocation, resolveSkillInvocation } from './service.js';
+
+function createSession(options?: { repositorySkill?: ReturnType<typeof createSkill> }) {
+  const maybeRefresh = vi.fn(async () => {});
+  const get = vi.fn(async (name: string) => (name === options?.repositorySkill?.name ? options.repositorySkill : null));
+  const sendMessage = vi.fn(async () => {});
+  const getWorkspace = vi.fn(() => ({ skills: { maybeRefresh, get } }));
+  return { session: { getWorkspace, sendMessage }, maybeRefresh, get, getWorkspace, sendMessage };
+}
+
+describe('Factory skill invocation service', () => {
+  it('resolves bundled skills without workspace discovery', async () => {
+    const bundled = createSkill({
+      name: 'factory-test',
+      description: 'Bundled test skill',
+      instructions: 'Follow bundled instructions.',
+    });
+    const factorySkills = createFactorySkillCatalog([bundled]);
+    const { session, getWorkspace } = createSession();
+    const controller = { getSessionByResource: vi.fn(async () => session) };
+
+    const resolved = await resolveSkillInvocation(controller as never, factorySkills, {
+      resourceId: 'resource-1',
+      name: 'factory-test',
+      arguments: 'review </skill> carefully',
+    });
+
+    expect(getWorkspace).not.toHaveBeenCalled();
+    expect(resolved.skillName).toBe('factory-test');
+    expect(resolved.message).toContain('ARGUMENTS: review &lt;/skill&gt; carefully');
+    expect(resolved.message).toContain('Follow bundled instructions.');
+  });
+
+  it('falls back to repository discovery for non-bundled skills', async () => {
+    const repositorySkill = createSkill({
+      name: 'repository-test',
+      description: 'Repository test skill',
+      instructions: 'Follow repository instructions.',
+    });
+    const factorySkills = createFactorySkillCatalog([]);
+    const { session, maybeRefresh, get, getWorkspace } = createSession({ repositorySkill });
+    const controller = { getSessionByResource: vi.fn(async () => session) };
+
+    const resolved = await resolveSkillInvocation(controller as never, factorySkills, {
+      resourceId: 'resource-1',
+      name: 'repository-test',
+    });
+
+    expect(getWorkspace).toHaveBeenCalledOnce();
+    expect(maybeRefresh).toHaveBeenCalledOnce();
+    expect(get).toHaveBeenCalledWith('repository-test');
+    expect(resolved.message).toContain('Follow repository instructions.');
+  });
+
+  it('dispatches the formatted bundled skill message once', async () => {
+    const bundled = createSkill({
+      name: 'factory-test',
+      description: 'Bundled test skill',
+      instructions: 'Follow bundled instructions.',
+    });
+    const factorySkills = createFactorySkillCatalog([bundled]);
+    const { session, sendMessage } = createSession();
+    const controller = { getSessionByResource: vi.fn(async () => session) };
+
+    const result = await dispatchSkillInvocation(controller as never, factorySkills, {
+      resourceId: 'resource-1',
+      name: 'factory-test',
+      arguments: 'do it',
+    });
+
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenCalledWith({ content: result.message });
+  });
+});

--- a/mastracode/factory/src/skills/service.ts
+++ b/mastracode/factory/src/skills/service.ts
@@ -2,8 +2,11 @@ import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { SendAgentSignalResult } from '@mastra/core/agent';
 import type { AgentController } from '@mastra/core/agent-controller';
 import type { RequestContext } from '@mastra/core/request-context';
+import type { Skill } from '@mastra/core/skills';
 import { formatSkillActivation } from '@mastra/core/workspace';
 import type { Workspace } from '@mastra/core/workspace';
+
+import type { FactorySkillCatalog } from './catalog.js';
 
 export interface SkillInvocationInput {
   resourceId: string;
@@ -47,6 +50,12 @@ function escapeSkillBoundary(value: string): string {
   return value.replaceAll('</skill>', '&lt;/skill&gt;');
 }
 
+export function formatSkillInvocationMessage(skill: Skill, argumentsValue?: string): string {
+  const args = argumentsValue?.trim();
+  const content = `${formatSkillActivation(skill)}${args ? `\n\nARGUMENTS: ${args}` : ''}`.trim();
+  return `<skill name="${skill.name}">\n${escapeSkillBoundary(content)}\n</skill>`;
+}
+
 /** Kicks a run off from a plain prompt, for runs that activate no skill. */
 export async function resolvePromptInvocation(
   controller: Pick<AgentController<MastraCodeState>, 'getSessionByResource'>,
@@ -59,32 +68,35 @@ export async function resolvePromptInvocation(
 
 export async function resolveSkillInvocation(
   controller: Pick<AgentController<MastraCodeState>, 'getSessionByResource'>,
+  factorySkills: FactorySkillCatalog,
   input: SkillInvocationInput,
 ): Promise<{ session: SkillSession; skillName: string; message: string }> {
   const session = (await controller.getSessionByResource(input.resourceId, input.scope)) as SkillSession | undefined;
   if (!session) throw new SkillInvocationError('session_not_found', 'Agent controller session not found.');
 
-  const skills = session.getWorkspace().skills;
-  await skills?.maybeRefresh();
-  const skill = await skills?.get(input.name);
+  let skill: Skill | null | undefined = factorySkills.get(input.name);
+  if (!skill) {
+    const skills = session.getWorkspace().skills;
+    await skills?.maybeRefresh();
+    skill = await skills?.get(input.name);
+  }
   if (!skill || skill['user-invocable'] === false) {
     throw new SkillInvocationError('skill_not_found', `Skill not found: ${input.name}.`);
   }
 
-  const args = input.arguments?.trim();
-  const content = `${formatSkillActivation(skill)}${args ? `\n\nARGUMENTS: ${args}` : ''}`.trim();
   return {
     session,
     skillName: skill.name,
-    message: `<skill name="${skill.name}">\n${escapeSkillBoundary(content)}\n</skill>`,
+    message: formatSkillInvocationMessage(skill, input.arguments),
   };
 }
 
 export async function dispatchSkillInvocation(
   controller: Pick<AgentController<MastraCodeState>, 'getSessionByResource'>,
+  factorySkills: FactorySkillCatalog,
   input: SkillInvocationInput,
 ): Promise<{ skillName: string; message: string }> {
-  const resolved = await resolveSkillInvocation(controller, input);
+  const resolved = await resolveSkillInvocation(controller, factorySkills, input);
   await resolved.session.sendMessage({ content: resolved.message });
   return { skillName: resolved.skillName, message: resolved.message };
 }

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -4,8 +4,8 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getDynamicWorkspace } from '@mastra/code-sdk/agents/workspace';
 import { RequestContext } from '@mastra/core/request-context';
+import { mergeWorkspaceSkills, resolveAgentSkills } from '@mastra/core/skills';
 import { LocalSandbox } from '@mastra/core/workspace';
-import type { LocalFilesystem } from '@mastra/core/workspace';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -66,6 +66,7 @@ vi.mock('./integrations/github/sandbox', async importOriginal => ({
 import { MaterializeError } from './integrations/github/sandbox.js';
 import { injectGithubToken } from './integrations/github/token-refresh.js';
 import { SandboxFleet } from './sandbox/fleet.js';
+import { loadFactorySkillCatalog } from './skills/catalog.js';
 import {
   checkpointNameForSession,
   createWorkspaceFactory,
@@ -264,7 +265,7 @@ describe('getFactoryWorkspace', () => {
     expect(checkpointNameForSession('session-a')).not.toBe(checkpointNameForSession('session-b'));
   });
 
-  it('keeps Factory and default workspace cache identities separate', async () => {
+  it('falls through to the plain dynamic workspace for non-session resolution', async () => {
     const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'mastracode-web-factory-cache-'));
     tempDirs.push(projectPath);
     const requestContext = createRequestContext(projectPath);
@@ -272,9 +273,11 @@ describe('getFactoryWorkspace', () => {
     const defaultWorkspace = await getDynamicWorkspace({ requestContext });
     const factoryWorkspace = await getFactoryWorkspace({ requestContext });
 
+    // Bundled Factory skills are agent-owned inline skills now, so the
+    // non-session Factory path no longer needs a synthetic skill identity —
+    // it resolves the same dynamic workspace as the default resolver.
     expect(defaultWorkspace.id).toBe(`mastra-code-workspace-${projectPath}`);
-    expect(factoryWorkspace.id).toBe(`mastra-code-workspace-${projectPath}-web-factory`);
-    expect(factoryWorkspace.id).not.toBe(defaultWorkspace.id);
+    expect(factoryWorkspace.id).toBe(defaultWorkspace.id);
   });
 
   it('keeps the reserved skill list aligned with packaged Factory assets', async () => {
@@ -530,7 +533,7 @@ describe('getFactoryWorkspace', () => {
     expect(phase3).toContain('env -u GH_TOKEN -u GITHUB_TOKEN pnpm --filter <pkg> test');
   });
 
-  it('adds read-only Web Factory skills and keeps them authoritative over project shadows', async () => {
+  it('keeps agent-owned Factory skills authoritative over project shadows through the real merge path', async () => {
     const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'mastracode-web-factory-skills-'));
     tempDirs.push(projectPath);
     const shadowDir = path.join(projectPath, '.mastracode', 'skills', 'factory-triage');
@@ -540,22 +543,25 @@ describe('getFactoryWorkspace', () => {
       '---\nname: factory-triage\ndescription: Project shadow\n---\n\n# Shadowed Project Skill',
     );
 
+    // Bundled skills are agent-owned inline skills; project checkouts can
+    // still ship a skill with a Factory name, but the agent/workspace merge
+    // (agent-level wins name collisions) keeps the bundled definition
+    // authoritative — no workspace-level source filtering involved.
+    const catalog = await loadFactorySkillCatalog();
+    const agentSkills = resolveAgentSkills([...catalog.skills]);
     const workspace = await getFactoryWorkspace({ requestContext: createRequestContext(projectPath) });
-    const configureRules = await workspace.skills?.get('configure-factory-rules');
-    const factoryTriage = await workspace.skills?.get('factory-triage');
-    const factoryReview = await workspace.skills?.get('factory-review');
-    const filesystem = workspace.filesystem as LocalFilesystem;
+    await workspace.skills?.maybeRefresh();
 
-    expect(workspace.id).toContain('-web-factory');
-    expect(configureRules?.instructions).toContain('# Configure Factory Rules');
-    expect(factoryTriage?.instructions).toContain('# Factory Triage');
-    expect(factoryTriage?.instructions).not.toContain('# Shadowed Project Skill');
-    expect(factoryReview?.instructions).toContain('# Factory Review');
-    expect(filesystem.allowedPaths).not.toContain('/__mastracode_factory_skills__');
-    await expect(filesystem.writeFile(path.join(factoryTriage!.path, 'SKILL.md'), 'mutated')).rejects.toMatchObject({
-      name: 'PermissionError',
-      code: 'EACCES',
-    });
+    // The project shadow is a real repository skill on the workspace side.
+    const workspaceTriage = await workspace.skills?.get('factory-triage');
+    expect(workspaceTriage?.instructions).toContain('# Shadowed Project Skill');
+
+    const { merged } = await mergeWorkspaceSkills(agentSkills, workspace.skills!);
+    const mergedTriage = await merged.get('factory-triage');
+    expect(mergedTriage?.instructions).toContain('# Factory Triage');
+    expect(mergedTriage?.instructions).not.toContain('# Shadowed Project Skill');
+    const mergedReview = await merged.get('factory-review');
+    expect(mergedReview?.instructions).toContain('# Factory Review');
   });
 });
 
@@ -655,42 +661,114 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.sessions.find(session => session.id === 'session-b')?.sandboxWorkdir).toBe(workdirB);
   });
 
-  it('resolves bundled Factory skills without waiting on sandbox materialization (kickoff path stays lazy)', async () => {
+  it('resolves an empty workspace skill catalog without waiting on sandbox materialization (kickoff stays lazy)', async () => {
     const { resolver } = await createLocalFactory();
     addProject();
     addSession({ id: 'session-a' });
     // Session start fires a background warm-up, so materialization *starts*;
-    // the guarantee under test is that kickoff skill resolution never awaits
-    // it. Make provisioning hang forever: skill resolution must still finish.
+    // the guarantee under test is that workspace skill discovery never awaits
+    // it. Make provisioning hang forever: discovery must still finish.
     mocks.ensureSandbox.mockImplementationOnce(() => new Promise(() => {}) as any);
 
     const workspace = (await resolver({ requestContext: createGithubRequestContext('project-1', 'session-a') }))!;
     await workspace.skills?.maybeRefresh();
-    const review = await workspace.skills?.get('factory-review');
+    const listed = await workspace.skills?.list();
 
-    expect(review?.instructions).toContain('# Factory Review');
-    // The repo checkout never happened, so project skill roots were guarded
-    // (reported empty) instead of forcing the sandbox to exist.
+    // Repository skill roots do not exist before the checkout does, so the
+    // dynamic path resolver reports none and discovery completes immediately
+    // with an empty catalog. Bundled Factory skills are agent-owned inline
+    // skills and are deliberately NOT part of the workspace catalog.
+    expect(listed).toEqual([]);
+    expect(await workspace.skills?.get('factory-review')).toBeFalsy();
     expect(mocks.materializeRepo).not.toHaveBeenCalled();
   });
 
-  it('delegates project skill roots to the sandbox once it is materialized', async () => {
-    const { resolver } = await createLocalFactory();
+  /**
+   * Resolve a session workspace with the session workdir already pinned into
+   * controller state, so resolution does NOT fire the background sandbox
+   * warm-up. This gives the tests below deterministic control over when
+   * materialization happens (only their own sandbox operation triggers it).
+   */
+  async function resolveWithoutWarmup(resolver: (args: any) => Promise<any>, root: string, sessionId: string) {
+    const requestContext = createGithubRequestContext('project-1', sessionId);
+    await (requestContext.get('controller') as any).setState({
+      projectPath: path.join(root, 'github-sessions', 'octocat', 'hello', sessionId),
+    });
+    return (await resolver({ requestContext }))!;
+  }
+
+  it('exposes repository skill roots and rescans in the background after materialization', async () => {
+    const { root, resolver } = await createLocalFactory();
     addProject();
     addSession({ id: 'session-a' });
 
-    const workspace = (await resolver({ requestContext: createGithubRequestContext('project-1', 'session-a') }))!;
-    // Kickoff-order discovery: initialize skills first (project roots guarded),
+    const workspace = await resolveWithoutWarmup(resolver, root, 'session-a');
+    // Kickoff-order discovery: initialize skills first (no repository roots),
     // then materialize the sandbox the way a first real operation would.
     await workspace.skills?.maybeRefresh();
+    const maybeRefreshSpy = vi.spyOn(workspace.skills!, 'maybeRefresh');
     await (workspace as any).sandbox.getInfo();
     const sandbox = await mocks.ensureSandbox.mock.results[0]!.value;
-    sandbox.executeCommand.mockClear();
 
-    // With the sandbox live, the guarded fallback must pass skill discovery
-    // through to the checkout instead of reporting empty roots.
-    await workspace.skills?.refresh();
-    expect(sandbox.executeCommand).toHaveBeenCalled();
+    // Materialization triggers exactly one background maybeRefresh (never a
+    // blocking one); it re-resolves the dynamic paths, sees the transition to
+    // the repository roots, and scans them through the live sandbox.
+    await vi.waitFor(() => expect(maybeRefreshSpy).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(sandbox.executeCommand).toHaveBeenCalled());
+  });
+
+  it('logs a failed post-materialization rescan and lets a later refresh succeed', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { root, resolver } = await createLocalFactory();
+      addProject();
+      addSession({ id: 'session-a' });
+
+      const workspace = await resolveWithoutWarmup(resolver, root, 'session-a');
+      const maybeRefreshSpy = vi
+        .spyOn(workspace.skills!, 'maybeRefresh')
+        .mockRejectedValueOnce(new Error('scan failed'));
+      await (workspace as any).sandbox.getInfo();
+
+      await vi.waitFor(() =>
+        expect(warn).toHaveBeenCalledWith(
+          '[Mastra Factory] Post-materialization skill refresh failed',
+          expect.objectContaining({ sessionId: 'session-a', error: expect.stringContaining('scan failed') }),
+        ),
+      );
+      // The failure is logged, never thrown, and the guaranteed retry path
+      // (the next maybeRefresh, e.g. SkillsProcessor step 0) still works.
+      expect(maybeRefreshSpy).toHaveBeenCalledTimes(1);
+      await expect(workspace.skills!.maybeRefresh()).resolves.toBeUndefined();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('keeps a discovery started before materialization on the pre-materialization path set', async () => {
+    const { root, resolver } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+
+    const workspace = await resolveWithoutWarmup(resolver, root, 'session-a');
+    // Start discovery while unmaterialized and kick off materialization
+    // concurrently. The discovery resolves its dynamic paths (empty) within a
+    // few microtasks, long before the materialization pipeline's many awaited
+    // steps complete, so the scan is pinned to the pre-materialization set.
+    const inFlight = workspace.skills!.maybeRefresh();
+    const materializing = (workspace as any).sandbox.getInfo();
+    await inFlight;
+
+    // The pinned scan completed against the empty set without waiting on (or
+    // being switched by) the concurrent materialization.
+    expect(await workspace.skills!.list()).toEqual([]);
+
+    await materializing;
+    // A fresh maybeRefresh re-resolves the dynamic paths and scans the
+    // repository roots through the now-live sandbox.
+    const sandbox = await mocks.ensureSandbox.mock.results[0]!.value;
+    await workspace.skills!.maybeRefresh();
+    await vi.waitFor(() => expect(sandbox.executeCommand).toHaveBeenCalled());
   });
 
   it('opens the session for a session-shaped auth user, whose org lives on the session half', async () => {
@@ -1353,7 +1431,7 @@ describe('GitHub session workspace preparation', () => {
       }),
     ).rejects.toThrow('runtime injection failed');
 
-    expect(removeWorkspace).toHaveBeenCalledWith('mfw-project-1-session-a-web-factory');
+    expect(removeWorkspace).toHaveBeenCalledWith('mfw-project-1-session-a');
     expect(destroy).toHaveBeenCalled();
     expect(() => injectGithubToken(reviewerContext, 'stale-reviewer-token')).toThrow(/no longer matches/);
   });
@@ -1693,7 +1771,7 @@ describe('GitHub session workspace preparation', () => {
 
     const result = await workspace({ requestContext: createRequestContext(projectPath) });
 
-    expect(result.id).toBe(`mastra-code-workspace-${projectPath}-web-factory`);
+    expect(result.id).toBe(`mastra-code-workspace-${projectPath}`);
     expect(mocks.ensureSandbox).not.toHaveBeenCalled();
   });
 
@@ -1705,7 +1783,7 @@ describe('GitHub session workspace preparation', () => {
 
     const result = await workspace({ requestContext: createUnscopedGithubRequestContext('project-1', projectPath) });
 
-    expect(result.id).toBe(`mastra-code-workspace-${projectPath}-web-factory`);
+    expect(result.id).toBe(`mastra-code-workspace-${projectPath}`);
     expect(mocks.ensureSandbox).not.toHaveBeenCalled();
     expect(mocks.materializeRepo).not.toHaveBeenCalled();
   });
@@ -1745,11 +1823,11 @@ describe('GitHub session workspace preparation', () => {
         mastra: mastra as any,
       });
 
-      expect(built.id).toBe('mfw-project-1-session-a-web-factory');
+      expect(built.id).toBe('mfw-project-1-session-a');
       expect(mastra.addWorkspace).toHaveBeenCalledTimes(1);
       expect(mastra.addWorkspace).toHaveBeenCalledWith(
         built,
-        'mfw-project-1-session-a-web-factory',
+        'mfw-project-1-session-a',
         expect.objectContaining({ source: 'mastra' }),
       );
     });
@@ -1765,7 +1843,7 @@ describe('GitHub session workspace preparation', () => {
         mastra: mastra as any,
       });
 
-      expect(mastra.getWorkspaceById('mfw-project-1-session-a-web-factory')).toBe(built);
+      expect(mastra.getWorkspaceById('mfw-project-1-session-a')).toBe(built);
     });
 
     it('short-circuits on the second call for the same session without re-registering', async () => {
@@ -1807,7 +1885,7 @@ describe('GitHub session workspace preparation', () => {
         mastra: mastra as any,
       });
 
-      expect(mastra.removeWorkspace).toHaveBeenCalledWith('mfw-project-1-session-a-web-factory');
+      expect(mastra.removeWorkspace).toHaveBeenCalledWith('mfw-project-1-session-a');
       expect(mocks.ensureSandbox).toHaveBeenCalledTimes(2);
       expect(mocks.runWorktreeSetup).toHaveBeenCalledTimes(2);
     });
@@ -1858,7 +1936,7 @@ describe('GitHub session workspace preparation', () => {
       finishMaterialization();
 
       await expect(opening).rejects.toThrow('retired during workspace materialization');
-      expect(mastra.removeWorkspace).toHaveBeenCalledWith('mfw-project-1-session-a-web-factory');
+      expect(mastra.removeWorkspace).toHaveBeenCalledWith('mfw-project-1-session-a');
       expect(mastra.workspaces.size).toBe(0);
       // Retirement mid-materialization must not leave a live sandbox binding
       // behind: the just-built sandbox is torn down (releasing the binding

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -3,11 +3,10 @@ import path from 'node:path';
 import { SandboxFilesystem } from '@mastra/code-sdk/agents/sandbox-filesystem';
 import { MASTRACODE_WORKSPACE_TOOLS } from '@mastra/code-sdk/agents/tool-availability';
 import { getDynamicWorkspace } from '@mastra/code-sdk/agents/workspace';
-import type { WorkspaceSkillExtension } from '@mastra/code-sdk/agents/workspace';
 import { DEFAULT_CONFIG_DIR } from '@mastra/code-sdk/constants';
 import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
-import { LocalSandbox, LocalSkillSource, Workspace } from '@mastra/core/workspace';
+import { LocalSandbox, Workspace } from '@mastra/core/workspace';
 import type { SkillSource, SkillSourceEntry, SkillSourceStat } from '@mastra/core/workspace';
 import { getFactoryAuthUserFromContext, getFactoryAuthUserId } from './auth.js';
 import type { MastraFactorySandboxConfig } from './factory.js';
@@ -28,7 +27,6 @@ import { registerGithubPatKind, registerGithubTokenInjector } from './integratio
 import { getFactorySessionAddress } from './rules/binding-context.js';
 import { baseCheckpointIsStale } from './sandbox/base-checkpoint-triggers.js';
 import type { SandboxBindingStore, SandboxFleet } from './sandbox/fleet.js';
-import { FACTORY_SKILL_NAMES, FACTORY_SKILLS_SOURCE_PATH } from './skills/catalog.js';
 import type { WorkItemsStorage } from './storage/domains/work-items/base.js';
 
 const WORKSPACE_ID_PREFIX = 'mfw';
@@ -79,63 +77,6 @@ export function isMissingWorkdirError(error: unknown, workdir: string | undefine
   return !existsSync(workdir);
 }
 
-const FACTORY_SKILLS_MOUNT = path.resolve(path.parse(process.cwd()).root, '__mastracode_factory_skills__');
-
-class FactorySkillSource implements SkillSource {
-  readonly #factorySource = new LocalSkillSource({ basePath: FACTORY_SKILLS_SOURCE_PATH });
-  readonly #fallbackSkillRoots: Set<string>;
-
-  constructor(
-    readonly fallback: SkillSource,
-    fallbackSkillRoots: string[],
-  ) {
-    this.#fallbackSkillRoots = new Set(fallbackSkillRoots.map(skillPath => path.normalize(skillPath)));
-  }
-
-  #isFactoryPath(skillPath: string): boolean {
-    const normalized = path.normalize(skillPath);
-    return normalized === FACTORY_SKILLS_MOUNT || normalized.startsWith(`${FACTORY_SKILLS_MOUNT}${path.sep}`);
-  }
-
-  #factoryPath(skillPath: string): string {
-    return path.relative(FACTORY_SKILLS_MOUNT, path.normalize(skillPath));
-  }
-
-  exists(skillPath: string): Promise<boolean> {
-    return this.#isFactoryPath(skillPath)
-      ? this.#factorySource.exists(this.#factoryPath(skillPath))
-      : this.fallback.exists(skillPath);
-  }
-
-  stat(skillPath: string): Promise<SkillSourceStat> {
-    return this.#isFactoryPath(skillPath)
-      ? this.#factorySource.stat(this.#factoryPath(skillPath))
-      : this.fallback.stat(skillPath);
-  }
-
-  readFile(skillPath: string): Promise<string | Buffer> {
-    return this.#isFactoryPath(skillPath)
-      ? this.#factorySource.readFile(this.#factoryPath(skillPath))
-      : this.fallback.readFile(skillPath);
-  }
-
-  async readdir(skillPath: string): Promise<SkillSourceEntry[]> {
-    if (this.#isFactoryPath(skillPath)) {
-      return this.#factorySource.readdir(this.#factoryPath(skillPath));
-    }
-    const entries = await this.fallback.readdir(skillPath);
-    if (this.#fallbackSkillRoots.has(path.normalize(skillPath))) {
-      return entries.filter(entry => !FACTORY_SKILL_NAMES.has(entry.name));
-    }
-    return entries;
-  }
-
-  realpath(skillPath: string): Promise<string> {
-    if (this.#isFactoryPath(skillPath)) return Promise.resolve(path.normalize(skillPath));
-    return this.fallback.realpath ? this.fallback.realpath(skillPath) : Promise.resolve(skillPath);
-  }
-}
-
 function skillSourceEnoent(skillPath: string): Error {
   const error = new Error(`ENOENT: no such file or directory, '${skillPath}'`) as Error & { code: string };
   error.code = 'ENOENT';
@@ -149,8 +90,8 @@ function skillSourceEnoent(skillPath: string): Error {
  * responds); without this guard the first project-root read would hit the lazy
  * sandbox handle and force full provisioning + repo materialization. While the
  * sandbox is unmaterialized, project skill roots simply appear empty — bundled
- * Factory skills resolve from local disk via `FactorySkillSource`. Once the
- * sandbox exists, every call delegates straight through.
+ * Factory skills are agent-owned inline skills and never touch this source.
+ * Once the sandbox exists, every call delegates straight through.
  */
 class UnmaterializedAwareSkillSource implements SkillSource {
   constructor(
@@ -181,12 +122,6 @@ class UnmaterializedAwareSkillSource implements SkillSource {
     return this.fallback.realpath ? this.fallback.realpath(skillPath) : Promise.resolve(skillPath);
   }
 }
-
-const factorySkillExtension: WorkspaceSkillExtension = {
-  id: 'web-factory',
-  paths: [FACTORY_SKILLS_MOUNT],
-  createSource: (fallback, fallbackSkillRoots) => new FactorySkillSource(fallback, fallbackSkillRoots),
-};
 
 type DynamicWorkspaceContext = Parameters<typeof getDynamicWorkspace>[0];
 
@@ -271,7 +206,6 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
   const constructedWorkspaces = new Map<string, Workspace>();
 
   return async ({ requestContext, mastra, skillExtension }: DynamicWorkspaceContext) => {
-    const effectiveSkillExtension = skillExtension ?? factorySkillExtension;
     const ctx = requestContext.get('controller') as AgentControllerRequestContext<MastraCodeState> | undefined;
     const session =
       ctx?.resourceId && github ? await github.sourceControlStorage.sessions.getBySessionId(ctx.resourceId) : null;
@@ -285,7 +219,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         // every message.
         return undefined;
       }
-      return getDynamicWorkspace({ requestContext, mastra, skillExtension: effectiveSkillExtension });
+      return getDynamicWorkspace({ requestContext, mastra, skillExtension });
     }
 
     const user = getFactoryAuthUserFromContext(requestContext);
@@ -361,8 +295,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       },
     };
 
-    const extensionId = effectiveSkillExtension ? `-${effectiveSkillExtension.id}` : '';
-    const workspaceId = `${WORKSPACE_ID_PREFIX}-${projectRepository.id}-${session.id}${extensionId}`;
+    const workspaceId = `${WORKSPACE_ID_PREFIX}-${projectRepository.id}-${session.id}`;
     const workspaceGeneration = workspaceRegistry.generation(session.sessionId);
     const configDir = sandboxConfig.workdir ?? DEFAULT_CONFIG_DIR;
 
@@ -679,11 +612,20 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         inflight.then(
           sb => {
             materializedSandboxes.set(workspaceId, sb);
-            // Project skill roots (.claude/skills etc.) were reported empty by
-            // the unmaterialized-source guard during discovery; rescan now that
-            // the checkout exists so repo-local skills become visible without
-            // waiting for the maybeRefresh cooldown. Fire-and-forget.
-            void workspace.skills?.refresh().catch(() => {});
+            // The dynamic path resolver returned no repository roots while the
+            // sandbox was unmaterialized; `maybeRefresh()` re-resolves the
+            // dynamic paths, sees the transition to the repository roots, and
+            // rescans in the background. `refresh()` alone would reuse the old
+            // (empty) resolved path set. Failures are logged — the guaranteed
+            // retry is the SkillsProcessor step-0 `maybeRefresh()` on the next
+            // agent turn.
+            void workspace.skills?.maybeRefresh().catch(error => {
+              console.warn('[Mastra Factory] Post-materialization skill refresh failed', {
+                workspaceId,
+                sessionId: session.sessionId,
+                error: error instanceof Error ? error.message.slice(-2000) : String(error),
+              });
+            });
           },
           () => {},
         );
@@ -780,19 +722,21 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     const guardedSkillFallback = new UnmaterializedAwareSkillSource(filesystem, () =>
       materializedSandboxes.has(workspaceId),
     );
-    const skillPaths = [...(effectiveSkillExtension?.paths ?? []), ...projectSkillPaths];
     const workspace = new Workspace({
       id: workspaceId,
       name: 'Mastra Code Factory Session Workspace',
       filesystem,
       sandbox: lazySandbox as unknown as ConstructorParameters<typeof Workspace>[0]['sandbox'],
       tools: MASTRACODE_WORKSPACE_TOOLS,
-      skills: skillPaths,
-      // Project skill roots live in the sandbox checkout; guard them so skill
-      // discovery before materialization (e.g. kickoff skill resolution in the
-      // start coordinator) never forces sandbox provisioning.
-      skillSource:
-        effectiveSkillExtension?.createSource(guardedSkillFallback, projectSkillPaths) ?? guardedSkillFallback,
+      // Repository skill roots live in the sandbox checkout; before the
+      // sandbox materializes they do not exist, so the dynamic resolver
+      // reports no paths at all. Discovery on an unmaterialized workspace
+      // therefore completes immediately with an empty catalog — bundled
+      // Factory skills are agent-owned inline skills and never depend on
+      // this workspace. After materialization the resolver exposes the
+      // repository roots and `maybeRefresh()` picks up the transition.
+      skills: () => (materializedSandboxes.has(workspaceId) ? projectSkillPaths : []),
+      skillSource: guardedSkillFallback,
     });
     // Register with the Mastra instance so sync HTTP handlers that resolve
     // the workspace via `mastra.getWorkspaceById(id)` (file tree, permissions

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -1,6 +1,5 @@
 import { existsSync } from 'node:fs';
-import path, { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { SandboxFilesystem } from '@mastra/code-sdk/agents/sandbox-filesystem';
 import { MASTRACODE_WORKSPACE_TOOLS } from '@mastra/code-sdk/agents/tool-availability';
 import { getDynamicWorkspace } from '@mastra/code-sdk/agents/workspace';
@@ -29,6 +28,7 @@ import { registerGithubPatKind, registerGithubTokenInjector } from './integratio
 import { getFactorySessionAddress } from './rules/binding-context.js';
 import { baseCheckpointIsStale } from './sandbox/base-checkpoint-triggers.js';
 import type { SandboxBindingStore, SandboxFleet } from './sandbox/fleet.js';
+import { FACTORY_SKILL_NAMES, FACTORY_SKILLS_SOURCE_PATH } from './skills/catalog.js';
 import type { WorkItemsStorage } from './storage/domains/work-items/base.js';
 
 const WORKSPACE_ID_PREFIX = 'mfw';
@@ -79,28 +79,7 @@ export function isMissingWorkdirError(error: unknown, workdir: string | undefine
   return !existsSync(workdir);
 }
 
-const bundleDirectory = dirname(fileURLToPath(import.meta.url));
-const bundledFactorySkillsPath = join(bundleDirectory, 'factory-skills');
-export const FACTORY_SKILLS_SOURCE_PATH =
-  [
-    // Deploy bundle: the consumer copies `factory-skills/` next to the built
-    // server module (e.g. via its public/ dir).
-    bundledFactorySkillsPath,
-    // Package layout: `dist/../factory-skills` (also `src/../factory-skills`
-    // when running tests against sources).
-    join(bundleDirectory, '..', 'factory-skills'),
-    // Consumer repo running from its package root before a build.
-    join(process.cwd(), 'src', 'mastra', 'public', 'factory-skills'),
-  ].find(existsSync) ?? bundledFactorySkillsPath;
 const FACTORY_SKILLS_MOUNT = path.resolve(path.parse(process.cwd()).root, '__mastracode_factory_skills__');
-export const FACTORY_SKILL_NAMES = new Set([
-  'configure-factory-rules',
-  'factory-complete-issue',
-  'factory-plan',
-  'factory-rereview',
-  'factory-review',
-  'factory-triage',
-]);
 
 class FactorySkillSource implements SkillSource {
   readonly #factorySource = new LocalSkillSource({ basePath: FACTORY_SKILLS_SOURCE_PATH });

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -470,6 +470,41 @@ describe('createMastraCode', () => {
     expect(agentControllerConfig?.subagents).toEqual([subagent]);
   }, 10_000);
 
+  it('forwards static agent skills without replacing request-scoped workspace wiring', async () => {
+    const { createMastraCode } = await import('../index.js');
+    const skills = ['./skills/review'];
+
+    await createMastraCode({ skills });
+
+    const codeAgentConfig = agentConstructorMock.mock.calls[0]?.[0] as
+      | { skills?: unknown; workspace?: unknown }
+      | undefined;
+    expect(codeAgentConfig?.skills).toBe(skills);
+    expect(codeAgentConfig?.workspace).toBeUndefined();
+  });
+
+  it('forwards a resolver-based agent skills input unchanged', async () => {
+    const { createMastraCode } = await import('../index.js');
+    const skills = vi.fn(() => ['./skills/review']);
+
+    await createMastraCode({ skills });
+
+    const codeAgentConfig = agentConstructorMock.mock.calls[0]?.[0] as { skills?: unknown } | undefined;
+    expect(codeAgentConfig?.skills).toBe(skills);
+  });
+
+  it('leaves agent skills undefined when omitted', async () => {
+    const { createMastraCode } = await import('../index.js');
+
+    await createMastraCode();
+
+    const codeAgentConfig = agentConstructorMock.mock.calls[0]?.[0] as
+      | { skills?: unknown; workspace?: unknown }
+      | undefined;
+    expect(codeAgentConfig?.skills).toBeUndefined();
+    expect(codeAgentConfig?.workspace).toBeUndefined();
+  });
+
   it('uses configured mastra gateway settings when creating the MastraCode gateway', async () => {
     const settings = createMockSettings();
     settings.memoryGateway = { baseUrl: 'https://gateway.example.com/v1' };

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { hostname } from 'node:os';
 import path from 'node:path';
 
-import type { Agent } from '@mastra/core/agent';
+import type { Agent, AgentConfig } from '@mastra/core/agent';
 import { AgentController } from '@mastra/core/agent-controller';
 import type {
   IntervalHandler,
@@ -243,6 +243,8 @@ export interface MastraCodeConfig {
   modes?: AgentControllerMode[];
   /** Override or extend subagent definitions. Default: explore/plan/execute */
   subagents?: AgentControllerSubagent[];
+  /** Agent-owned skills available independently of the request-scoped workspace. */
+  skills?: AgentConfig['skills'];
   /** Extra tools merged into the dynamic tool set. Can be a static record or a (sync or async) function that receives requestContext. */
   extraTools?:
     | Record<string, ToolLike | undefined>
@@ -832,6 +834,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
     // workspace. An explicit `undefined` is required: the factory only builds a
     // default when the `workspace` key is absent.
     workspace: undefined,
+    skills: config?.skills,
     instructions: getDynamicInstructions,
     // `settingsPath` matches the source `createMastraCode()` reads from so the
     // per-mode thinking defaults resolve against the same config file.
@@ -858,7 +861,13 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
         },
       },
     },
-    tools: createDynamicTools(mcpManager, config?.extraTools, config?.disabledTools, storage, pluginTools),
+    tools: createDynamicTools(
+      mcpManager,
+      config?.extraTools,
+      config?.disabledTools,
+      storage,
+      pluginTools,
+    ) as AgentConfig['tools'],
     hooks: createToolHooks(hookManager, config?.postToolObserver),
     scorers: {
       outcome: {


### PR DESCRIPTION
Factory's six bundled skills (`factory-review`, `factory-triage`, `factory-plan`, etc.) used to be presented as workspace filesystem content through a synthetic skill mount, so invoking one waited on workspace skill discovery — which on a cold session could block behind sandbox materialization and the sandbox transport race. This PR moves those bundled skills to where they belong: they're read once at Factory startup, turned into inline `createSkill()` definitions, and registered as agent-owned skills, so kickoff, HTTP dispatch, and the durable dispatcher resolve them from an in-memory catalog with zero sandbox or filesystem I/O.

To support that, `MastraCodeConfig` gains a `skills` field that forwards agent-level skills to the coding agent:

```ts
import { createSkill } from '@mastra/core/skills';
import { mountAgentControllerOnMastra } from '@mastra/code-sdk';

const { controller } = await mountAgentControllerOnMastra({
  cwd: process.cwd(),
  skills: [createSkill({ name: 'triage', description: '...', instructions: '...' })],
});
```

Repository-provided skills (`.mastracode/skills`, `.claude/skills`, `.agents/skills`) stay workspace-owned: they resolve to no paths before the session sandbox materializes and are discovered by a background refresh afterward. The synthetic mount (`FACTORY_SKILLS_MOUNT`, `FactorySkillSource`, `factorySkillExtension`, reserved-name filtering) is deleted — agent-level merge precedence keeps the bundled definitions authoritative over same-named repo skills. No Core changes, no new dependencies.

Verified with an HTTP-level red/green proof against a real local Factory server and real PlatformSandbox: on base, a bundled-skill kickoff hangs while workspace discovery is held; on this branch the same request returns 202 in ~40ms with zero workspace refresh calls and zero pre-materialization sandbox commands.
