### PR TITLE
fix(core): ignore stale background task dispatches

### DIFF
--- a/.changeset/calm-tasks-stay.md
+++ b/.changeset/calm-tasks-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed background tasks to ignore stale dispatches after completion, failure, timeout, or suspension.

--- a/packages/core/src/background-tasks/manager-lifecycle.test.ts
+++ b/packages/core/src/background-tasks/manager-lifecycle.test.ts
@@ -281,6 +281,139 @@ describe('BackgroundTaskManager lifecycle', () => {
     await pubsub.close();
   });
 
+  it.each(
+    (['completed', 'failed', 'timed_out', 'suspended'] as const).flatMap(status =>
+      ([undefined, 1, 2] as const).map(deliveryAttempt => ({ status, deliveryAttempt })),
+    ),
+  )(
+    'ignores a stale dispatch for a $status task at delivery attempt $deliveryAttempt',
+    async ({ status, deliveryAttempt }) => {
+      const pubsub = new CapturingPubSub();
+      const manager = new BackgroundTaskManager({ enabled: true });
+      await manager.init(pubsub);
+
+      const task = makeRunningTask({ status });
+      const updateTask = vi.fn(async () => {});
+      const createRun = vi.fn();
+      const getInternalWorkflow = vi.fn(() => ({ createRun }));
+      const executionHook = vi.spyOn(manager, 'runLocalExecutionHook');
+      manager.registerTaskContext(task.id, { executor: { execute: vi.fn() } });
+      manager.__registerMastra({
+        getStorage: () => ({
+          getStore: async () => ({
+            getTask: async () => task,
+            updateTask,
+            listTasks: async () => ({ tasks: [] }),
+          }),
+        }),
+        __getInternalWorkflow: getInternalWorkflow,
+      } as unknown as Mastra);
+      const publish = vi.spyOn(pubsub, 'publish');
+      const ack = vi.fn(async () => {});
+      const event: Event = {
+        type: 'task.dispatch',
+        id: 'event-1',
+        data: { taskId: task.id },
+        runId: task.id,
+        createdAt: new Date(),
+        ...(deliveryAttempt === undefined ? {} : { deliveryAttempt }),
+      };
+
+      await pubsub.dispatchCallback!(event, ack);
+
+      expect(ack).toHaveBeenCalledOnce();
+      expect(updateTask).not.toHaveBeenCalled();
+      expect(publish).not.toHaveBeenCalled();
+      expect(executionHook).not.toHaveBeenCalled();
+      expect(getInternalWorkflow).not.toHaveBeenCalled();
+      expect(createRun).not.toHaveBeenCalled();
+      expect(manager.taskContexts.has(task.id)).toBe(true);
+      await manager.shutdown();
+      await pubsub.close();
+    },
+  );
+
+  it.each([undefined, 1])('ignores a duplicate first delivery for a running task (%s)', async deliveryAttempt => {
+    const pubsub = new CapturingPubSub();
+    const manager = new BackgroundTaskManager({ enabled: true });
+    await manager.init(pubsub);
+
+    const task = makeRunningTask();
+    const updateTask = vi.fn(async () => {});
+    const getInternalWorkflow = vi.fn();
+    manager.__registerMastra({
+      getStorage: () => ({
+        getStore: async () => ({
+          getTask: async () => task,
+          updateTask,
+          listTasks: async () => ({ tasks: [] }),
+        }),
+      }),
+      __getInternalWorkflow: getInternalWorkflow,
+    } as unknown as Mastra);
+    const ack = vi.fn(async () => {});
+    const event: Event = {
+      type: 'task.dispatch',
+      id: 'event-1',
+      data: { taskId: task.id },
+      runId: task.id,
+      createdAt: new Date(),
+      ...(deliveryAttempt === undefined ? {} : { deliveryAttempt }),
+    };
+
+    await pubsub.dispatchCallback!(event, ack);
+
+    expect(ack).toHaveBeenCalledOnce();
+    expect(updateTask).not.toHaveBeenCalled();
+    expect(getInternalWorkflow).not.toHaveBeenCalled();
+    await manager.shutdown();
+    await pubsub.close();
+  });
+
+  it('still restarts an explicitly restarted running task', async () => {
+    const pubsub = new CapturingPubSub();
+    const manager = new BackgroundTaskManager({ enabled: true });
+    await manager.init(pubsub);
+
+    const task = makeRunningTask();
+    const updateTask = vi.fn(async () => {});
+    const start = vi.fn(async () => ({ status: 'success' }));
+    const restart = vi.fn(async () => ({ status: 'success' }));
+    const deleteWorkflowRunById = vi.fn(async () => {});
+    manager.__registerMastra({
+      getStorage: () => ({
+        getStore: async () => ({
+          getTask: async () => task,
+          updateTask,
+          listTasks: async () => ({ tasks: [] }),
+        }),
+      }),
+      __getInternalWorkflow: () => ({
+        getWorkflowRunById: async () => ({ status: 'running' }),
+        createRun: async () => ({ start, restart }),
+        deleteWorkflowRunById,
+      }),
+    } as unknown as Mastra);
+    const ack = vi.fn(async () => {});
+    const event: Event = {
+      type: 'task.dispatch',
+      id: 'event-1',
+      data: { taskId: task.id, isRestart: true },
+      runId: task.id,
+      createdAt: new Date(),
+    };
+
+    await pubsub.dispatchCallback!(event, ack);
+
+    expect(updateTask).toHaveBeenCalledWith(task.id, expect.objectContaining({ status: 'running' }));
+    expect(restart).toHaveBeenCalledOnce();
+    expect(start).not.toHaveBeenCalled();
+    expect(ack).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(deleteWorkflowRunById).toHaveBeenCalledWith(task.id));
+    await manager.shutdown();
+    await pubsub.close();
+  });
+
   it('does not consume a retry when a redelivered dispatch was declined before starting', async () => {
     const pubsub = new CapturingPubSub();
     const manager = new BackgroundTaskManager({ enabled: true });

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -1007,10 +1007,13 @@ export class BackgroundTaskManager {
       return true;
     }
 
-    if (isRestart && task.status !== 'running') {
-      // Either gone or already done/cancelled by another worker. Drop the
-      // event silently — the worker group ensures exactly-once delivery, but
-      // the task may have moved on between publish and pickup.
+    const isRunningRedelivery = task.status === 'running' && deliveryAttempt > 1;
+    const canDispatch = isRestart ? task.status === 'running' : task.status === 'pending' || isRunningRedelivery;
+
+    if (!canDispatch) {
+      // The task moved to a state this delivery cannot start. Acknowledge the
+      // stale event without clearing its context: suspended tasks still need
+      // that context to resume, and terminal result hooks may still be running.
       return true;
     }
 


### PR DESCRIPTION
## Description

Prevents stale or duplicate `task.dispatch` events from restarting background tasks whose persisted state is already completed, failed, timed out, or suspended.

Previously, `handleDispatch()` rejected only missing and cancelled tasks. A delayed or duplicate dispatch could therefore change a finished or suspended task back to `running` and start its workflow again, potentially repeating tool calls or other external side effects.

This change validates the persisted task state before modifying storage or starting execution.

Closes #21969 

## Changes

- Accept normal dispatches only for `pending` tasks.
- Accept broker redelivery for `running` tasks only when `deliveryAttempt > 1`.
- Preserve explicit restart behavior for `running` tasks.
- Acknowledge and ignore dispatches for:
  - `completed`
  - `failed`
  - `timed_out`
  - `suspended`
- Ignore duplicate first-delivery events for tasks already marked `running`.
- Preserve task context when rejecting terminal or suspended dispatches.
- Keep the existing cleanup behavior for missing and cancelled tasks.
- Preserve existing retry-count behavior for accepted redeliveries.
- Add an `@mastra/core` patch changeset.

## Test plan

Added lifecycle regression coverage verifying that:

1. Completed, failed, timed-out, and suspended tasks ignore both initial and redelivered stale dispatches.
2. Rejected dispatches are acknowledged.
3. Rejected dispatches do not:
   - update the task back to `running`;
   - publish a `task.running` event;
   - invoke execution hooks;
   - create or start a workflow run.
4. Suspended-task context remains registered for later resume handling.
5. A duplicate first delivery for an already-running task is ignored.
6. An explicit restart for a running task continues through the restart path.
7. Existing pending-task and running-task redelivery behavior remains covered.

Validation completed locally:

- [x] ESLint
- [x] Oxlint
- [x] Formatting check
- [x] Git whitespace check
- [ ] Focused unit suite — local test collection was blocked by unrelated incomplete workspace dependency imports; clean CI will provide final execution validation

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue in the description
- [x] I have added regression tests covering the fix
- [x] I have added the required changeset
- [x] I have run the available static checks
- [x] The change does not modify public APIs or types
- [x] No documentation changes are required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR prevents old or repeated task messages from restarting tasks that already finished or stopped. It still allows valid retries, resumes, and explicit restarts.

## Changes

- Accepts dispatches for pending tasks and valid redeliveries of running tasks.
- Ignores stale or duplicate dispatches for completed, failed, timed-out, or suspended tasks.
- Acknowledges rejected dispatches without changing task state or restarting workflows.
- Preserves suspended-task context and existing cleanup and retry behavior.
- Keeps explicit restart behavior.
- Adds lifecycle regression tests.
- Adds an `@mastra/core` patch changeset.

## Validation

- Static validation passed locally.
- Focused unit tests were blocked by unrelated incomplete workspace dependency imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->