### PR TITLE
fix(datasets): use snapshot semantics for item versions

### DIFF
--- a/.changeset/cold-snakes-like.md
+++ b/.changeset/cold-snakes-like.md
@@ -1,0 +1,5 @@
+---
+'@mastra/spanner': patch
+---
+
+Fixed versioned dataset item lookups to return the item visible in the requested dataset snapshot.

--- a/.changeset/cool-snails-camp.md
+++ b/.changeset/cool-snails-camp.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed versioned dataset item lookups to return the item visible in the requested dataset snapshot.

--- a/.changeset/giant-colts-change.md
+++ b/.changeset/giant-colts-change.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Fixed versioned dataset item lookups to return the item visible in the requested dataset snapshot.

--- a/.changeset/tangy-stamps-crash.md
+++ b/.changeset/tangy-stamps-crash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed versioned dataset item lookups to return the item visible in the requested dataset snapshot.

--- a/.changeset/tangy-states-clap.md
+++ b/.changeset/tangy-states-clap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mysql': patch
+---
+
+Fixed versioned dataset item lookups to return the item visible in the requested dataset snapshot.

--- a/packages/core/src/datasets/__tests__/dataset.test.ts
+++ b/packages/core/src/datasets/__tests__/dataset.test.ts
@@ -188,11 +188,13 @@ describe('Dataset', () => {
   });
 
   // 12. getItem — with version
-  it('getItem with version returns DatasetItem at that version', async () => {
-    const added = await ds.addItem({ input: { x: 1 } });
-    const fetched = await ds.getItem({ itemId: added.id, version: added.datasetVersion });
+  it('getItem with version returns the item visible in that dataset snapshot', async () => {
+    const itemA = await ds.addItem({ input: { x: 1 } });
+    const itemB = await ds.addItem({ input: { x: 2 } });
+
+    const fetched = await ds.getItem({ itemId: itemA.id, version: itemB.datasetVersion });
     expect(fetched).not.toBeNull();
-    expect(fetched!.datasetVersion).toBe(added.datasetVersion);
+    expect(fetched!.datasetVersion).toBe(itemA.datasetVersion);
   });
 
   // 13. getItem — nonexistent returns null

--- a/packages/core/src/storage/domains/datasets/__tests__/datasets.test.ts
+++ b/packages/core/src/storage/domains/datasets/__tests__/datasets.test.ts
@@ -373,6 +373,47 @@ describe('DatasetsInMemory', () => {
       expect(notFound).toBeNull();
     });
 
+    it('getItemById returns the item row visible in the requested dataset snapshot', async () => {
+      const dataset = await storage.createDataset({ name: 'test' });
+      const itemA = await storage.addItem({ datasetId: dataset.id, input: { value: 'original' } });
+
+      await expect(storage.getItemById({ id: itemA.id, datasetVersion: 0 })).resolves.toBeNull();
+
+      const itemB = await storage.addItem({ datasetId: dataset.id, input: { value: 'second item' } });
+      await expect(storage.getItemById({ id: itemA.id, datasetVersion: itemB.datasetVersion })).resolves.toMatchObject({
+        id: itemA.id,
+        datasetVersion: itemA.datasetVersion,
+        input: { value: 'original' },
+      });
+
+      const updated = await storage.updateItem({
+        id: itemA.id,
+        datasetId: dataset.id,
+        input: { value: 'updated' },
+      });
+      await expect(storage.getItemById({ id: itemA.id, datasetVersion: itemB.datasetVersion })).resolves.toMatchObject({
+        datasetVersion: itemA.datasetVersion,
+        input: { value: 'original' },
+      });
+      await expect(
+        storage.getItemById({ id: itemA.id, datasetVersion: updated.datasetVersion }),
+      ).resolves.toMatchObject({
+        datasetVersion: updated.datasetVersion,
+        input: { value: 'updated' },
+      });
+
+      await storage.deleteItem({ id: itemA.id, datasetId: dataset.id });
+      await expect(
+        storage.getItemById({ id: itemA.id, datasetVersion: updated.datasetVersion }),
+      ).resolves.toMatchObject({
+        datasetVersion: updated.datasetVersion,
+        input: { value: 'updated' },
+      });
+      await expect(
+        storage.getItemById({ id: itemA.id, datasetVersion: updated.datasetVersion + 1 }),
+      ).resolves.toBeNull();
+    });
+
     it('updateItem modifies item fields', async () => {
       const dataset = await storage.createDataset({ name: 'test' });
       const item = await storage.addItem({ datasetId: dataset.id, input: { a: 1 } });
@@ -554,7 +595,7 @@ describe('DatasetsInMemory', () => {
       expect(fetched).toBeNull();
     });
 
-    it('getItemById with datasetVersion returns exact row (T3.13)', async () => {
+    it('getItemById with datasetVersion returns the row visible in the snapshot (T3.13)', async () => {
       const dataset = await storage.createDataset({ name: 'test' });
       const item = await storage.addItem({ datasetId: dataset.id, input: { n: 1 }, scorerIds: ['quality'] });
 
@@ -577,9 +618,9 @@ describe('DatasetsInMemory', () => {
       expect(atV2?.input).toEqual({ n: 2 });
       expect(atV2?.scorerIds).toEqual(['safety']);
 
-      // Version 99 — doesn't exist
+      // The current row remains visible in later snapshots
       const atV99 = await storage.getItemById({ id: item.id, datasetVersion: 99 });
-      expect(atV99).toBeNull();
+      expect(atV99?.input).toEqual({ n: 2 });
     });
 
     it('every mutation inserts a dataset_version row (T3.11)', async () => {

--- a/packages/core/src/storage/domains/datasets/inmemory.ts
+++ b/packages/core/src/storage/domains/datasets/inmemory.ts
@@ -401,8 +401,12 @@ export class DatasetsInMemory extends DatasetsStorage {
     if (!rows || rows.length === 0) return null;
 
     if (args.datasetVersion !== undefined) {
-      // T3.13 — exact version match, exclude deleted
-      const row = rows.find(r => r.datasetVersion === args.datasetVersion && !r.isDeleted);
+      const datasetVersion = args.datasetVersion;
+      const row = rows
+        .filter(
+          r => r.datasetVersion <= datasetVersion && (r.validTo === null || r.validTo > datasetVersion) && !r.isDeleted,
+        )
+        .sort((a, b) => b.datasetVersion - a.datasetVersion)[0];
       return row ? toDatasetItem(row) : null;
     }
 

--- a/packages/server/src/server/handlers/datasets.test.ts
+++ b/packages/server/src/server/handlers/datasets.test.ts
@@ -700,6 +700,27 @@ describe('Datasets Handlers', () => {
     });
   });
 
+  describe('GET_ITEM_VERSION_ROUTE', () => {
+    it('returns an unchanged item visible in a later dataset snapshot', async () => {
+      const dataset = await mastra.datasets.create({ name: 'Versioned Item DS' });
+      const itemA = await dataset.addItem({ input: { value: 'first' } });
+      const itemB = await dataset.addItem({ input: { value: 'second' } });
+
+      const fetched = (await GET_ITEM_VERSION_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        datasetId: dataset.id,
+        itemId: itemA.id,
+        datasetVersion: itemB.datasetVersion,
+      } as any)) as any;
+
+      expect(fetched).toMatchObject({
+        id: itemA.id,
+        datasetVersion: itemA.datasetVersion,
+        input: { value: 'first' },
+      });
+    });
+  });
+
   describe('item tool mocks', () => {
     it('round-trips toolMocks and unmockedToolPolicy through add, get, and update', async () => {
       const dataset = await mastra.datasets.create({ name: 'Mocks DS' });

--- a/stores/_test-utils/src/domains/datasets/index.ts
+++ b/stores/_test-utils/src/domains/datasets/index.ts
@@ -531,6 +531,42 @@ export function createDatasetsTests({
         expect(notFound).toBeNull();
       });
 
+      it('getItemById returns the item row visible in the requested dataset snapshot', async () => {
+        const ds = await datasetsStorage.createDataset({ name: 'item-get-at-version' });
+        const itemA = await datasetsStorage.addItem({ datasetId: ds.id, input: { q: 'original' } });
+
+        await expect(datasetsStorage.getItemById({ id: itemA.id, datasetVersion: 0 })).resolves.toBeNull();
+
+        const itemB = await datasetsStorage.addItem({ datasetId: ds.id, input: { q: 'second item' } });
+        await expect(
+          datasetsStorage.getItemById({ id: itemA.id, datasetVersion: itemB.datasetVersion }),
+        ).resolves.toMatchObject({
+          id: itemA.id,
+          datasetVersion: itemA.datasetVersion,
+          input: { q: 'original' },
+        });
+
+        const updated = await datasetsStorage.updateItem({
+          id: itemA.id,
+          datasetId: ds.id,
+          input: { q: 'updated' },
+        });
+        await expect(
+          datasetsStorage.getItemById({ id: itemA.id, datasetVersion: itemB.datasetVersion }),
+        ).resolves.toMatchObject({ datasetVersion: itemA.datasetVersion, input: { q: 'original' } });
+        await expect(
+          datasetsStorage.getItemById({ id: itemA.id, datasetVersion: updated.datasetVersion }),
+        ).resolves.toMatchObject({ datasetVersion: updated.datasetVersion, input: { q: 'updated' } });
+
+        await datasetsStorage.deleteItem({ id: itemA.id, datasetId: ds.id });
+        await expect(
+          datasetsStorage.getItemById({ id: itemA.id, datasetVersion: updated.datasetVersion }),
+        ).resolves.toMatchObject({ datasetVersion: updated.datasetVersion, input: { q: 'updated' } });
+        await expect(
+          datasetsStorage.getItemById({ id: itemA.id, datasetVersion: updated.datasetVersion + 1 }),
+        ).resolves.toBeNull();
+      });
+
       const toolMocksFixture = [
         { toolName: 'getWeather', args: { city: 'Seattle' }, output: { temp: 52 } },
         { toolName: 'getWeather', args: { city: 'Seattle' }, output: { temp: 48 } },
@@ -930,7 +966,7 @@ export function createDatasetsTests({
         expect(current!.input).toEqual({ q: 'updated' });
       });
 
-      it('getItemById with version returns that exact version', async () => {
+      it('getItemById with version returns the row visible in that snapshot', async () => {
         const v1 = await datasetsStorage.getItemById({ id: item1.id, datasetVersion: 1 });
         expect(v1!.input).toEqual({ q: 'original' });
 

--- a/stores/libsql/src/storage/domains/datasets/index.ts
+++ b/stores/libsql/src/storage/domains/datasets/index.ts
@@ -833,10 +833,9 @@ export class DatasetsLibSQL extends DatasetsStorage {
     try {
       let result;
       if (args.datasetVersion !== undefined) {
-        // T3.13 — exact version match, exclude deleted
         result = await this.#client.execute({
-          sql: `SELECT ${buildSelectColumns(TABLE_DATASET_ITEMS)} FROM ${TABLE_DATASET_ITEMS} WHERE id = ? AND datasetVersion = ? AND isDeleted = 0`,
-          args: [args.id, args.datasetVersion],
+          sql: `SELECT ${buildSelectColumns(TABLE_DATASET_ITEMS)} FROM ${TABLE_DATASET_ITEMS} WHERE id = ? AND datasetVersion <= ? AND (validTo IS NULL OR validTo > ?) AND isDeleted = 0 ORDER BY datasetVersion DESC LIMIT 1`,
+          args: [args.id, args.datasetVersion, args.datasetVersion],
         });
       } else {
         // T3.12 — current row (validTo IS NULL AND isDeleted = false)

--- a/stores/mysql/src/storage/domains/datasets/index.ts
+++ b/stores/mysql/src/storage/domains/datasets/index.ts
@@ -942,8 +942,8 @@ export class DatasetsMySQL extends DatasetsStorage {
 
       if (args.datasetVersion !== undefined) {
         [rows] = await this.pool.execute<RowDataPacket[]>(
-          `SELECT * FROM ${tableItemsName} WHERE \`id\` = ? AND \`datasetVersion\` = ? AND \`isDeleted\` = 0`,
-          [args.id, args.datasetVersion],
+          `SELECT * FROM ${tableItemsName} WHERE \`id\` = ? AND \`datasetVersion\` <= ? AND (\`validTo\` IS NULL OR \`validTo\` > ?) AND \`isDeleted\` = 0 ORDER BY \`datasetVersion\` DESC LIMIT 1`,
+          [args.id, args.datasetVersion, args.datasetVersion],
         );
       } else {
         [rows] = await this.pool.execute<RowDataPacket[]>(

--- a/stores/pg/src/storage/domains/datasets/index.ts
+++ b/stores/pg/src/storage/domains/datasets/index.ts
@@ -1136,7 +1136,7 @@ export class DatasetsPG extends DatasetsStorage {
 
       if (args.datasetVersion !== undefined) {
         result = await this.#db.client.oneOrNone(
-          `SELECT * FROM ${tableName} WHERE "id" = $1 AND "datasetVersion" = $2 AND "isDeleted" = false`,
+          `SELECT * FROM ${tableName} WHERE "id" = $1 AND "datasetVersion" <= $2 AND ("validTo" IS NULL OR "validTo" > $2) AND "isDeleted" = false ORDER BY "datasetVersion" DESC LIMIT 1`,
           [args.id, args.datasetVersion],
         );
       } else {

--- a/stores/spanner/src/storage/domains/datasets/index.ts
+++ b/stores/spanner/src/storage/domains/datasets/index.ts
@@ -980,8 +980,11 @@ export class DatasetsSpanner extends DatasetsStorage {
       if (args.datasetVersion !== undefined) {
         sql = `SELECT * FROM ${tableName}
                WHERE ${quoteIdent('id', 'column name')} = @id
-                 AND ${quoteIdent('datasetVersion', 'column name')} = @datasetVersion
-                 AND ${quoteIdent('isDeleted', 'column name')} = FALSE LIMIT 1`;
+                 AND ${quoteIdent('datasetVersion', 'column name')} <= @datasetVersion
+                 AND (${quoteIdent('validTo', 'column name')} IS NULL OR ${quoteIdent('validTo', 'column name')} > @datasetVersion)
+                 AND ${quoteIdent('isDeleted', 'column name')} = FALSE
+               ORDER BY ${quoteIdent('datasetVersion', 'column name')} DESC
+               LIMIT 1`;
         params.datasetVersion = args.datasetVersion;
       } else {
         sql = `SELECT * FROM ${tableName}


### PR DESCRIPTION
Versioned dataset item lookups currently require an item row created at the exact requested dataset version. That means an unchanged item can incorrectly return `null` even though it is part of that dataset snapshot.

For example, if item A is created at version 1 and item B is added at version 2, `dataset.getItem({ itemId: itemA.id, version: 2 })` now returns item A's version 1 row instead of `null`.

This updates the in-memory, LibSQL, PostgreSQL, MySQL, and Spanner point lookups to use the SCD-2 validity range, while preserving the existing current-item behavior. MongoDB already used these semantics. It also adds regression coverage for the storage adapters, the public Dataset API, update and delete boundaries, and the HTTP item-version route.

Tested with the focused core and server suites; the complete dataset suites for LibSQL, PostgreSQL, MySQL, Spanner, and MongoDB; affected package builds, core typechecking, linting, and formatting checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

An item can remain valid across several dataset versions. This change makes versioned lookups return the item that existed in the requested snapshot, even when it was not created in that exact version.

## Changes

- Updated SCD-2 snapshot lookups for in-memory, LibSQL, PostgreSQL, MySQL, and Spanner stores.
- Preserved current-item lookup behavior.
- Excluded deleted item revisions from historical results.
- Added regression tests for item creation, updates, deletions, storage adapters, the Dataset API, and the HTTP item-version route.
- Added patch changesets for the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->