### PR TITLE
feat(factory): integrate slash command menu

### DIFF
--- a/.changeset/early-walls-wash.md
+++ b/.changeset/early-walls-wash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved slash commands with a composer-integrated menu and consistent workspace panel elevation.

--- a/.changeset/empty-bees-rhyme.md
+++ b/.changeset/empty-bees-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved floating surfaces with softer, consistent elevation.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
@@ -287,11 +287,11 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
   }
 
   return (
-    <ComposerRoot onSubmit={onSubmit} onDrop={onDrop} onDragOver={e => e.preventDefault()} className="relative">
-      <ComposerSuggestions suggestions={suggestions} activeIndex={activeSuggestion} onSelect={applyCommand} />
+    <ComposerRoot onSubmit={onSubmit} onDrop={onDrop} onDragOver={e => e.preventDefault()}>
       <ComposerRing busy={busy || chatPreparing} className={modeColorClass}>
         <ComposerBox ref={spotlightRef} className={cn('composer-spotlight', modeColorClass)}>
           <div aria-hidden="true" className="composer-spotlight-surface" />
+          <ComposerSuggestions suggestions={suggestions} activeIndex={activeSuggestion} onSelect={applyCommand} />
           <ComposerImageAttachments images={images} onRemove={removeImage} />
           <ComposerInput
             ref={inputRef}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ComposerParts.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ComposerParts.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ComposerAttachments } from '@mastra/playground-ui/components/Composer';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { X } from 'lucide-react';
+import { useEffect, useRef } from 'react';
 
 import type { SlashCommand } from '../services/commands';
 import type { PendingImage } from './useComposerImages';
@@ -15,27 +17,57 @@ export function ComposerSuggestions({
   activeIndex: number;
   onSelect: (name: string) => void;
 }) {
-  if (suggestions.length === 0) return null;
+  const open = suggestions.length > 0;
+  const retainedSuggestionsRef = useRef(suggestions);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const displayedSuggestions = open ? suggestions : retainedSuggestionsRef.current;
+  const activeCommandName = displayedSuggestions[activeIndex]?.name;
+
+  useEffect(() => {
+    if (open) retainedSuggestionsRef.current = suggestions;
+  }, [open, suggestions]);
+
+  useEffect(() => {
+    if (open) optionRefs.current[activeIndex]?.scrollIntoView({ block: 'nearest' });
+  }, [activeCommandName, activeIndex, open]);
 
   return (
-    <div className="border-border1 bg-surface3 absolute right-0 bottom-full left-0 z-20 mx-auto mb-2 w-full max-w-3xl rounded-md border p-1 shadow-lg">
-      {suggestions.map((command, index) => (
-        <button
-          key={command.name}
-          type="button"
-          className={cn(
-            'flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-ui-sm',
-            index === activeIndex ? 'bg-surface4 text-icon6' : 'text-icon3',
-          )}
-          onMouseDown={event => {
-            event.preventDefault();
-            onSelect(command.name);
-          }}
-        >
-          <span>/{command.name}</span>
-          <span>{command.description}</span>
-        </button>
-      ))}
+    <div
+      inert={!open}
+      role="region"
+      aria-label="Slash commands"
+      aria-hidden={!open}
+      className={cn(
+        "after:bg-border1/60 relative grid overflow-hidden transition-[grid-template-rows,opacity] after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:content-[''] ease-out-custom motion-reduce:transition-none",
+        open ? 'grid-rows-[1fr] opacity-100 duration-slow' : 'grid-rows-[0fr] opacity-0 duration-normal',
+      )}
+    >
+      <div className="min-h-0 overflow-hidden">
+        <ScrollArea maxHeight="min(22rem, 50dvh)" viewPortClassName="overscroll-contain">
+          <div className="flex flex-col gap-px p-1.5">
+            {displayedSuggestions.map((command, index) => (
+              <button
+                ref={element => {
+                  optionRefs.current[index] = element;
+                }}
+                key={command.name}
+                type="button"
+                className={cn(
+                  'flex w-full cursor-pointer items-center justify-between gap-4 rounded-2xl px-2 py-1.5 text-left text-ui-sm transition-colors duration-150 ease-out motion-reduce:transition-none',
+                  index === activeIndex ? 'bg-surface4 text-icon6' : 'text-icon3 hover:bg-surface4 hover:text-icon6',
+                )}
+                onMouseDown={event => {
+                  event.preventDefault();
+                  onSelect(command.name);
+                }}
+              >
+                <span className="shrink-0">/{command.name}</span>
+                <span className="min-w-0 truncate text-right">{command.description}</span>
+              </button>
+            ))}
+          </div>
+        </ScrollArea>
+      </div>
     </div>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerSlashSuggestions.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerSlashSuggestions.msw.test.tsx
@@ -17,7 +17,7 @@ function renderComposer() {
 
 /** The input stays disabled until the controller connection is ready. */
 async function findReadyInput(): Promise<HTMLTextAreaElement> {
-  const input = (await screen.findByRole('textbox', { name: 'Message' })) as HTMLTextAreaElement;
+  const input = await screen.findByRole<HTMLTextAreaElement>('textbox', { name: 'Message' });
   await waitFor(() => expect(input).toBeEnabled());
   return input;
 }
@@ -36,20 +36,6 @@ describe('Composer slash-command suggestions', () => {
       for (const command of SLASH_COMMANDS) {
         expect(await screen.findByRole('button', { name: new RegExp(`^/${command.name}\\s`) })).toBeInTheDocument();
       }
-    });
-
-    it('renders the suggestions outside the clipping composer box', async () => {
-      const user = userEvent.setup();
-      renderComposer();
-
-      const input = await findReadyInput();
-      await user.type(input, '/');
-
-      // ComposerBox uses overflow-hidden; a popover nested inside it would be
-      // invisibly clipped even though it exists in the DOM.
-      const suggestion = await screen.findByRole('button', { name: /^\/help\s/ });
-      expect(suggestion.closest('[data-slot="composer-box"]')).toBeNull();
-      expect(suggestion.closest('[data-slot="composer"]')).not.toBeNull();
     });
   });
 

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFilesSurface.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/components/WorkspaceFilesSurface.tsx
@@ -16,7 +16,7 @@ export function WorkspaceFilesSurface() {
       data-testid="workspace-files-card"
       className={cn(
         'border-border1 bg-surface3 absolute top-3 right-3 z-20 flex flex-col overflow-hidden rounded-xl border',
-        'shadow-[0_1px_2px_-1px_oklch(0%_0_0deg/12%),0_16px_40px_-20px_oklch(0%_0_0deg/22%)]',
+        'shadow-dialog',
         '[interpolate-size:allow-keywords] duration-360 ease-out-custom transition-[translate,scale,opacity,width,height]',
         'will-change-[translate,opacity] motion-reduce:transition-none',
         'w-(--workspace-files-card)',

--- a/packages/playground-ui/theme.css
+++ b/packages/playground-ui/theme.css
@@ -389,8 +389,7 @@ html.light {
   --shadow-card: 0 2px 8px oklch(0 0 0 / 0.4);
   --shadow-elevated: 0 8px 24px oklch(0 0 0 / 0.5);
 
-  /* Drop-shadow only — no white inset: @theme inlines values, so it can't theme per-mode and reads dirty on dark. */
-  --shadow-dialog: 0 8px 24px -8px oklch(0% 0 0deg / 28%), 0 24px 56px -16px oklch(0% 0 0deg / 36%);
+  --shadow-dialog: 0 1px 2px -1px oklch(0% 0 0deg / 12%), 0 16px 40px -20px oklch(0% 0 0deg / 22%);
   --shadow-glow-accent1: 0 0 20px oklch(0.723 0.219 149.579 / 0.25);
   --shadow-glow-accent2: 0 0 20px oklch(0.637 0.237 25.331 / 0.25);
   --shadow-focus-ring: 0 0 0 3px oklch(0.723 0.219 149.579 / 0.12);

--- a/packages/playground-ui/theme.css
+++ b/packages/playground-ui/theme.css
@@ -388,7 +388,6 @@ html.light {
   --shadow-inner: inset 0 2px 4px oklch(0 0 0 / 0.3);
   --shadow-card: 0 2px 8px oklch(0 0 0 / 0.4);
   --shadow-elevated: 0 8px 24px oklch(0 0 0 / 0.5);
-
   --shadow-dialog: 0 1px 2px -1px oklch(0% 0 0deg / 12%), 0 16px 40px -20px oklch(0% 0 0deg / 22%);
   --shadow-glow-accent1: 0 0 20px oklch(0.723 0.219 149.579 / 0.25);
   --shadow-glow-accent2: 0 0 20px oklch(0.637 0.237 25.331 / 0.25);


### PR DESCRIPTION
TLDR: typing `/` now expands the composer into a rounded, scrollable command menu instead of opening a detached popover.

---

| in a Factory thread | before | after |
| --- | --- | --- |
| type `/` | a detached popover floated above the composer | the composer expands into a smooth, rounded command menu with keyboard-aware scrolling |
| open the workspace or notification panel | the workspace panel carried a local shadow while notifications used the design-system elevation | both use the same softer `shadow-dialog` elevation |

The menu stays mounted only long enough to animate closed, respects reduced motion, keeps the active keyboard option visible, and uses the shared ScrollArea. Command rows have concentric 16px corners, pointer affordance and a 1px gap.

### Not verified

`shadow-dialog` is also used by dialogs, tooltips, selects, dropdowns, drawers and hover cards. The new value builds for all of them, but I only checked the Factory composer in the running app.

```
tests          +1  -15
source        +55  -24    ← net +31
changeset     +10    0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Typing `/` in a Factory thread opens a command menu that is easier to use with a mouse, keyboard, and screen reader. Workspace and notification panels now use a consistent, softer shadow.

## Changes

- Integrated the slash command menu into the Factory composer.
- Added animated open and close behavior with delayed unmounting.
- Added scrollable command results with keyboard-aware scrolling.
- Added reduced-motion support and accessibility attributes.
- Updated command-row styling and text truncation.
- Reused the shared `ScrollArea` component.
- Applied the `shadow-dialog` utility to the workspace files surface.
- Updated the `--shadow-dialog` theme token with a softer shadow.
- Updated slash command tests.
- Added patch changesets for `@mastra/factory` and `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->