### PR TITLE
fix(isolated-vm): update isolated-vm to 6.2.0 to patch critical sandbox escape

### DIFF
--- a/.changeset/fair-rocks-boil.md
+++ b/.changeset/fair-rocks-boil.md
@@ -1,0 +1,5 @@
+---
+'@mastra/isolated-vm': patch
+---
+
+Updated isolated-vm to version 6.2.0 to fix a critical sandbox escape vulnerability (type confusion in ExternalCopy) that could allow untrusted code to corrupt host memory and escape the sandbox.

--- a/code-mode/isolated-vm/package.json
+++ b/code-mode/isolated-vm/package.json
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "esbuild": "^0.28.0",
-    "isolated-vm": "^6.1.2"
+    "isolated-vm": "^6.2.0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1364,8 +1364,8 @@ importers:
         specifier: ^0.28.0
         version: 0.28.1
       isolated-vm:
-        specifier: ^6.1.2
-        version: 6.1.2
+        specifier: ^6.2.0
+        version: 6.2.0
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -26497,8 +26497,8 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
-  isolated-vm@6.1.2:
-    resolution: {integrity: sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==}
+  isolated-vm@6.2.0:
+    resolution: {integrity: sha512-UuSlxSHWt2QuJ5WvBhzlIJx2VVZN/a44SqBbEZFKNdvuSyhOvhmyDo8SQ+njVbhnh/njoL/aW0bUTiFYlpweGQ==}
     engines: {node: '>=22.0.0'}
 
   isomorphic-ws@5.0.0:
@@ -27995,9 +27995,11 @@ packages:
 
   node-gyp-build@3.9.0:
     resolution: {integrity: sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==}
+    hasBin: true
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-gyp@8.4.1:
     resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
@@ -52221,7 +52223,7 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isolated-vm@6.1.2:
+  isolated-vm@6.2.0:
     dependencies:
       node-gyp-build: 4.8.4
 


### PR DESCRIPTION
## Summary

Updates the `isolated-vm` dependency in `@mastra/isolated-vm` from 6.1.2 to 6.2.0.

isolated-vm 6.1.2 is affected by a critical sandbox escape vulnerability: a type confusion in `ExternalCopy` allows untrusted code running inside an isolate to corrupt host memory, potentially leading to remote code execution outside the sandbox. This is especially relevant for Mastra's Code Mode, which executes model-generated code inside isolated-vm. The fix is released in isolated-vm 6.2.0 (and 7.0.1 on the 7.x line).

## Changes
- Bump `isolated-vm` to `^6.2.0` in `code-mode/isolated-vm`
- Update `pnpm-lock.yaml` (previously pinned to vulnerable 6.1.2)
- Add patch changeset for `@mastra/isolated-vm`

## Test plan
- `pnpm turbo build --filter ./code-mode/isolated-vm` — builds successfully
- `pnpm --filter ./code-mode/isolated-vm test` — all 24 transport tests pass against isolated-vm 6.2.0, including sandbox timeout behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates the sandbox security package to a fixed version. It prevents a critical vulnerability that could allow code to escape the sandbox through `ExternalCopy`.

## Changes

- Updated `isolated-vm` from `^6.1.2` to `^6.2.0`.
- Added a patch changeset for `@mastra/isolated-vm`.
- Build succeeds.
- All 24 transport tests pass, including sandbox timeout tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->