### PR TITLE
fix(factory): accept MASTRA_PLATFORM_ACCESS_TOKEN as a platform credential

### DIFF
--- a/.changeset/heavy-games-march.md
+++ b/.changeset/heavy-games-march.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Platform GitHub/Linear integrations and the Platform API client ignoring `MASTRA_PLATFORM_ACCESS_TOKEN`, the credential Mastra Platform injects into deployed projects. Integration auto-detection and the API client now accept `MASTRA_PLATFORM_ACCESS_TOKEN` (checked first) or `MASTRA_PLATFORM_SECRET_KEY`, so platform deployments work without manually copying the secret key into the environment.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -218,8 +218,11 @@ export interface MastraFactoryDispatcherConfig {
 
 const CONTROLLER_ID = 'code';
 
-function hasPlatformSecretKey(): boolean {
-  return Boolean(process.env.MASTRA_PLATFORM_SECRET_KEY?.trim());
+function hasPlatformCredentials(): boolean {
+  // MASTRA_PLATFORM_ACCESS_TOKEN is the credential Mastra Platform injects
+  // into deployed projects; MASTRA_PLATFORM_SECRET_KEY is the org secret key
+  // written by project scaffolding. Either enables the platform integrations.
+  return Boolean(process.env.MASTRA_PLATFORM_ACCESS_TOKEN?.trim() || process.env.MASTRA_PLATFORM_SECRET_KEY?.trim());
 }
 
 /**
@@ -352,7 +355,7 @@ export class MastraFactory {
     // Explicit integrations win. Platform credentials fill only missing GitHub
     // and Linear slots so callers can override either provider independently.
     const integrations = [...(this.#config.integrations ?? [])];
-    if (hasPlatformSecretKey()) {
+    if (hasPlatformCredentials()) {
       if (!integrations.some(integration => integration.id === 'github')) {
         integrations.push(new PlatformGithubIntegration({ slug: this.#config.platform?.githubAppSlug }));
       }

--- a/mastracode/factory/src/integrations/platform/api-client.test.ts
+++ b/mastracode/factory/src/integrations/platform/api-client.test.ts
@@ -17,6 +17,7 @@ afterEach(() => {
 describe('PlatformApiClient', () => {
   it('resolves config from MASTRA_SHARED_API_URL and normalizes the /v1 root', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', 'https://platform.example.com/v1/');
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
     vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', accessToken);
 
     expect(platformApiClientConfigFromEnv()).toEqual({
@@ -25,20 +26,26 @@ describe('PlatformApiClient', () => {
     });
   });
 
-  it('defaults shared API config to platform.mastra.ai and requires a secret key', () => {
+  it('defaults shared API config to platform.mastra.ai and requires a credential', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', '');
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
     vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', accessToken);
     expect(platformApiClientConfigFromEnv()).toMatchObject({ baseUrl: 'https://platform.mastra.ai' });
 
     vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
-    expect(() => platformApiClientConfigFromEnv()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
+    expect(() => platformApiClientConfigFromEnv()).toThrow(/MASTRA_PLATFORM_ACCESS_TOKEN/);
   });
 
-  it('requires MASTRA_PLATFORM_SECRET_KEY even when the deprecated access token is set', () => {
+  it('prefers the platform-injected MASTRA_PLATFORM_ACCESS_TOKEN over MASTRA_PLATFORM_SECRET_KEY', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'injected-token');
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'sk_scaffolded');
+    expect(platformApiClientConfigFromEnv()).toMatchObject({ accessToken: 'injected-token' });
+  });
+
+  it('accepts MASTRA_PLATFORM_ACCESS_TOKEN alone', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'injected-token');
     vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'legacy-token');
-    expect(() => platformApiClientConfigFromEnv()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
+    expect(platformApiClientConfigFromEnv()).toMatchObject({ accessToken: 'injected-token' });
   });
 
   it('uses bearer authentication without ambient cookie credentials', async () => {

--- a/mastracode/factory/src/integrations/platform/api-client.ts
+++ b/mastracode/factory/src/integrations/platform/api-client.ts
@@ -6,9 +6,15 @@ export interface PlatformApiClientConfig {
 
 export function platformApiClientConfigFromEnv(): PlatformApiClientConfig {
   const sharedApiUrl = process.env.MASTRA_SHARED_API_URL?.trim() || 'https://platform.mastra.ai/v1';
-  const accessToken = process.env.MASTRA_PLATFORM_SECRET_KEY?.trim();
+  // MASTRA_PLATFORM_ACCESS_TOKEN is the credential Mastra Platform injects
+  // into deployed projects; MASTRA_PLATFORM_SECRET_KEY is the org secret key
+  // written by project scaffolding. The platform API accepts both forms.
+  const accessToken =
+    process.env.MASTRA_PLATFORM_ACCESS_TOKEN?.trim() || process.env.MASTRA_PLATFORM_SECRET_KEY?.trim();
   if (!accessToken) {
-    throw new Error('Platform integration: missing required environment variable MASTRA_PLATFORM_SECRET_KEY.');
+    throw new Error(
+      'Platform integration: missing required environment variable MASTRA_PLATFORM_ACCESS_TOKEN (or MASTRA_PLATFORM_SECRET_KEY).',
+    );
   }
   return { baseUrl: normalizeSharedApiUrl(sharedApiUrl), accessToken };
 }

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -1066,13 +1066,16 @@ describe('PlatformGithubIntegration', () => {
     });
   });
 
-  it('defaults the Platform base URL and requires MASTRA_PLATFORM_SECRET_KEY', () => {
+  it('defaults the Platform base URL and requires a platform credential', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', '');
     expect(new PlatformGithubIntegration().diagnostics()).toMatchObject({ endpointHost: 'platform.mastra.ai' });
 
     vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'legacy-token');
-    expect(() => new PlatformGithubIntegration()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'injected-token');
+    expect(() => new PlatformGithubIntegration()).not.toThrow();
+
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+    expect(() => new PlatformGithubIntegration()).toThrow(/MASTRA_PLATFORM_ACCESS_TOKEN/);
   });
 
   it('exposes an explicitly configured GitHub App slug to webhook rules', () => {

--- a/mastracode/factory/src/integrations/platform/linear/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/linear/integration.test.ts
@@ -558,7 +558,7 @@ describe('PlatformLinearIntegration', () => {
     );
   });
 
-  it('defaults the Platform base URL and requires MASTRA_PLATFORM_SECRET_KEY', () => {
+  it('defaults the Platform base URL and requires a platform credential', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', '');
     expect(new PlatformLinearIntegration().diagnostics()).toEqual({
       mode: 'platform',
@@ -566,8 +566,11 @@ describe('PlatformLinearIntegration', () => {
     });
 
     vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'legacy-token');
-    expect(() => new PlatformLinearIntegration()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'injected-token');
+    expect(() => new PlatformLinearIntegration()).not.toThrow();
+
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+    expect(() => new PlatformLinearIntegration()).toThrow(/MASTRA_PLATFORM_ACCESS_TOKEN/);
   });
 
   const workerContext = {

--- a/mastracode/web/.env.schema
+++ b/mastracode/web/.env.schema
@@ -93,16 +93,18 @@ MASTRA_COOKIE_DOMAIN=
 # ---------------------------------------------------------------------------
 # Mastra Platform integrations and sandbox
 # PlatformGithubIntegration and PlatformLinearIntegration are zero-argument
-# integrations. They use MASTRA_SHARED_API_URL and this Platform secret key.
-# PlatformSandbox is selected automatically only when MASTRA_PLATFORM_SECRET_KEY,
-# MASTRA_PROJECT_ID, and MASTRA_ENVIRONMENT_ID are all set.
+# integrations. They use MASTRA_SHARED_API_URL and a Platform credential:
+# MASTRA_PLATFORM_ACCESS_TOKEN (checked first) or MASTRA_PLATFORM_SECRET_KEY.
+# PlatformSandbox is selected automatically only when one of those credentials
+# plus MASTRA_PROJECT_ID and MASTRA_ENVIRONMENT_ID are all set.
 # ---------------------------------------------------------------------------
 
-# Required when a Platform integration is instantiated or when PlatformSandbox
-# is selected.
-MASTRA_PLATFORM_SECRET_KEY=
-# Deprecated alias for MASTRA_PLATFORM_SECRET_KEY.
+# Credential Mastra Platform injects into deployed projects. Takes precedence
+# over MASTRA_PLATFORM_SECRET_KEY.
 MASTRA_PLATFORM_ACCESS_TOKEN=
+# Org secret key written by project scaffolding. Used when
+# MASTRA_PLATFORM_ACCESS_TOKEN is unset.
+MASTRA_PLATFORM_SECRET_KEY=
 # Required for PlatformSandbox auto-selection.
 # @public
 MASTRA_PROJECT_ID=

--- a/mastracode/web/src/mastra/index.test.ts
+++ b/mastracode/web/src/mastra/index.test.ts
@@ -42,6 +42,7 @@ describe('platform entry (src/mastra/index.ts)', () => {
       'WORKOS_COOKIE_PASSWORD',
       'MASTRA_SHARED_API_URL',
       'MASTRA_PLATFORM_SECRET_KEY',
+      'MASTRA_PLATFORM_ACCESS_TOKEN',
       'MASTRACODE_DISPATCH_MAX_IN_FLIGHT',
     ]) {
       vi.stubEnv(name, '');

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -92,10 +92,11 @@ if (redisUrl) {
 //      `init()` derives the /auth/callback redirect from the deployment's
 //      publicUrl when WORKOS_REDIRECT_URI is unset. `fetchMemberships` lets
 //      token auth resolve the user's organization so the bootstrapped
-//      personal org works without re-auth. Note MASTRA_PLATFORM_SECRET_KEY
-//      does NOT defer to the platform here: it is a compute/integration
-//      credential (sandboxes, GitHub/Linear slots), not an identity signal —
-//      platform compute plus self-managed sign-in is a supported combination.
+//      personal org works without re-auth. Note MASTRA_PLATFORM_ACCESS_TOKEN /
+//      MASTRA_PLATFORM_SECRET_KEY do NOT defer to the platform here: they are
+//      compute/integration credentials (sandboxes, GitHub/Linear slots), not
+//      identity signals — platform compute plus self-managed sign-in is a
+//      supported combination.
 //   4. Nothing configured — leave undefined and MastraFactory installs its
 //      platform-backed default provider.
 const authDisabled = process.env.MASTRACODE_AUTH_DISABLED === '1';
@@ -181,8 +182,15 @@ function localSandboxEnv(): Record<string, string> {
   return env;
 }
 
-const PLATFORM_SANDBOX_ENV_KEYS = ['MASTRA_ENVIRONMENT_ID', 'MASTRA_PROJECT_ID', 'MASTRA_PLATFORM_SECRET_KEY'] as const;
-const hasPlatformSandboxEnv = PLATFORM_SANDBOX_ENV_KEYS.every(key => Boolean(process.env[key]?.trim()));
+const PLATFORM_SANDBOX_ENV_KEYS = ['MASTRA_ENVIRONMENT_ID', 'MASTRA_PROJECT_ID'] as const;
+// MASTRA_PLATFORM_ACCESS_TOKEN is the credential Mastra Platform injects into
+// deployed projects; MASTRA_PLATFORM_SECRET_KEY is the org secret key written
+// by project scaffolding. `PlatformSandbox` only reads the former from env, so
+// whichever is present is passed to it explicitly as `accessToken`.
+const platformSandboxToken =
+  process.env.MASTRA_PLATFORM_ACCESS_TOKEN?.trim() || process.env.MASTRA_PLATFORM_SECRET_KEY?.trim();
+const hasPlatformSandboxEnv =
+  Boolean(platformSandboxToken) && PLATFORM_SANDBOX_ENV_KEYS.every(key => Boolean(process.env[key]?.trim()));
 
 // Private-network exec: the workspace-proxy discovers each sandbox's private
 // IPv6 during `POST /v1/projects/:pid/sandbox` and returns it as an
@@ -197,7 +205,7 @@ const sandboxAddressRegistry = hasPlatformSandboxEnv ? new InProcessSandboxAddre
 // Use PlatformSandbox only when its complete identity is configured. Otherwise
 // fall back to LocalSandbox for single-user development.
 const sandbox = hasPlatformSandboxEnv
-  ? new PlatformSandbox({ addressRegistry: sandboxAddressRegistry })
+  ? new PlatformSandbox({ accessToken: platformSandboxToken, addressRegistry: sandboxAddressRegistry })
   : new LocalSandbox({
       workingDirectory:
         process.env.MASTRACODE_LOCAL_SANDBOX_ROOT?.trim() || join(homedir(), '.mastracode', 'web', 'sandboxes'),


### PR DESCRIPTION
Mastra Platform injects `MASTRA_PLATFORM_ACCESS_TOKEN` into deployed projects, but the platform API client, the factory's integration auto-install check, and the web entry's sandbox selection only looked at `MASTRA_PLATFORM_SECRET_KEY`. #19962 accidentally dropped the access-token path (its own description says either credential should work) and the tests were rewritten around the mistake — so a platform deployment ended up with no GitHub/Linear integrations and a silent `LocalSandbox` fallback.

All three call sites now resolve the credential the same way: `MASTRA_PLATFORM_ACCESS_TOKEN` first, `MASTRA_PLATFORM_SECRET_KEY` as fallback.

```ts
// before: platform deployments threw despite having a credential
// PlatformApiClientError: MASTRA_PLATFORM_SECRET_KEY is required

// after
const config = platformApiClientConfigFromEnv();
// uses MASTRA_PLATFORM_ACCESS_TOKEN, falls back to MASTRA_PLATFORM_SECRET_KEY
```

The web entry also passes the resolved credential to `PlatformSandbox` explicitly, fixing a latent mismatch where the sandbox gate passed on a secret key but the client threw `accessToken is required`.

Tested with the full `@mastra/factory` suite (1732 tests), `mastracode-web` entry tests, typecheck and lint — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The platform can now use either supported credential. This fixes deployments that have an access token but no secret key, so platform integrations and sandbox selection work as expected.

## Changes

- Use `MASTRA_PLATFORM_ACCESS_TOKEN` first.
- Fall back to `MASTRA_PLATFORM_SECRET_KEY`.
- Update platform API client credential validation and error messages.
- Enable automatic Platform GitHub and Linear integration setup with either credential.
- Select `PlatformSandbox` when either credential, project ID, and environment ID are configured.
- Pass the resolved credential explicitly to `PlatformSandbox`.
- Update the environment schema and authentication documentation.
- Add and update tests for credential precedence, fallback, and access-token-only configurations.
- Add a patch changeset for `@mastra/factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->