### PR TITLE
fix(factory): keep steering in active runs

### DIFF
--- a/.changeset/tall-feet-join.md
+++ b/.changeset/tall-feet-join.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory steering messages so they no longer interrupt active work. Pending steering messages now show their delivery state and use the same neutral style as other user messages.

--- a/mastracode/factory-ui/src/hooks/__tests__/useRouteThreadSync.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useRouteThreadSync.msw.test.tsx
@@ -23,6 +23,7 @@ const transcript: ChatTranscriptApi = {
   busy: false,
   initialHistoryReady: true,
   localUser: vi.fn(),
+  failLocalUser: vi.fn(),
   reset: vi.fn(),
   resolvePrompt: vi.fn(),
   clearPending: vi.fn(),

--- a/mastracode/factory-ui/src/hooks/useAgentControllerRunMutations.ts
+++ b/mastracode/factory-ui/src/hooks/useAgentControllerRunMutations.ts
@@ -45,15 +45,6 @@ export function useSendAgentControllerMessageMutation(args: AgentControllerRunMu
   });
 }
 
-export function useSteerAgentControllerMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(args);
-  const invalidateSession = useSessionInvalidation(args);
-  return useMutation({
-    mutationFn: (text: string) => requireAgentControllerSession(session).steer(text),
-    onSuccess: invalidateSession,
-  });
-}
-
 export function useFollowUpAgentControllerMutation(args: AgentControllerRunMutationArgs) {
   const { session } = createAgentControllerClient(args);
   const invalidateSession = useSessionInvalidation(args);

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
@@ -26,7 +26,6 @@ import { useChatTranscript } from '../context/useChatTranscript';
 import {
   useAbortAgentControllerMutation,
   useSendAgentControllerMessageMutation,
-  useSteerAgentControllerMutation,
 } from '../../../../hooks/useAgentControllerRunMutations';
 import { useCreateAgentControllerThreadMutation } from '../../../../hooks/useAgentControllerThreadMutations';
 import { usePreparingThreadId } from '../hooks/usePreparingThreadId';
@@ -84,7 +83,6 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
   };
   const createThreadMutation = useCreateAgentControllerThreadMutation(hookArgs);
   const sendMutation = useSendAgentControllerMessageMutation(hookArgs);
-  const steerMutation = useSteerAgentControllerMutation(hookArgs);
   const abortMutation = useAbortAgentControllerMutation(hookArgs);
   const planFeedback = usePendingPlanFeedback();
 
@@ -168,7 +166,7 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
   const steer = async (text: string) => {
     if (!text.trim()) return;
     localUser(text, true);
-    await steerMutation.mutateAsync(text);
+    await sendMutation.mutateAsync({ text });
   };
 
   const onSubmit = (e: { preventDefault: () => void }) => {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
@@ -68,7 +68,7 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { status } = useChatConnection();
-  const { busy, localUser, reset, clearPending, pushNotice } = useChatTranscript();
+  const { busy, localUser, failLocalUser, reset, clearPending, pushNotice } = useChatTranscript();
   const { modes, activeModeId, isLoading: modesLoading, error: modesError, setMode } = useChatModes();
   const { activeModelId, isLoading: modelLoading, error: modelError } = useChatModels();
   const { composerDraft: draft, composerInputRef: inputRef, setComposerDraft, runComposerCommand } = useChatCommands();
@@ -165,8 +165,13 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
 
   const steer = async (text: string) => {
     if (!text.trim()) return;
-    localUser(text, true);
-    await sendMutation.mutateAsync({ text });
+    const localId = localUser(text, true);
+    try {
+      await sendMutation.mutateAsync({ text });
+    } catch (error) {
+      failLocalUser(localId);
+      throw error;
+    }
   };
 
   const onSubmit = (e: { preventDefault: () => void }) => {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ConnectionActivity.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/StatusLine/__tests__/ConnectionActivity.msw.test.tsx
@@ -30,6 +30,7 @@ function renderActivity(status: ChatConnectionApi['status'], busy: boolean) {
     busy,
     initialHistoryReady: true,
     localUser: vi.fn(),
+    failLocalUser: vi.fn(),
     reset: vi.fn(),
     resolvePrompt: vi.fn(),
     clearPending: vi.fn(),

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -712,17 +712,23 @@ function renderMessageBubble({
   const toolGroups = collectToolGroups(parts, suspensions, entry.runtimeTools);
   const origin = channelOrigin(entry);
   const prose = messageText(parts);
+  const steeringPending = entry.steer === true && entry.deliveryStatus === 'pending';
   const roles: MessageRoleRenderers = {
     User: ({ children }) => (
       <div className={cn(MESSAGE_HOVER, 'my-3 ml-auto flex w-fit max-w-[70%] flex-col items-end')}>
         <div
           className={cn(
-            'text-text1 rounded-xl px-4 py-2 break-words',
-            entry.steer ? 'bg-warning1/10' : 'bg-neutral6/5',
+            'text-text1 bg-neutral6/5 rounded-xl border border-transparent px-4 py-2 break-words',
+            steeringPending && 'border-border1 border-dashed',
           )}
         >
           {children}
         </div>
+        {entry.steer && (
+          <span className="text-ui-xs text-icon3 mt-1" aria-live="polite">
+            {steeringPending ? 'Steering…' : 'Steered message'}
+          </span>
+        )}
         {origin && <ChannelOriginBadge origin={origin} />}
         {prose ? <MessageMeta text={prose} createdAt={entry.message.createdAt} align="end" /> : null}
       </div>

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -690,6 +690,12 @@ export function ChannelOriginBadge({ origin }: { origin: { platform: string; aut
   );
 }
 
+function steeringLabel(entry: MessageEntry): string | undefined {
+  if (!entry.steer) return undefined;
+  if (entry.deliveryStatus === 'pending') return 'Steering…';
+  if (entry.deliveryStatus === 'failed') return 'Not sent';
+  return 'Steered message';
+}
 function renderMessageBubble({
   entry,
   suspensions,
@@ -702,6 +708,7 @@ function renderMessageBubble({
   onRespond: (toolCallId: string, resumeData: string | string[] | PlanResume, promptId: string) => void;
 }) {
   const messageParts = entry.message.content.parts ?? [];
+
   const parts = messageParts.filter(part => isRenderablePart(part, suspensions, entry.runtimeTools));
   const message =
     parts.length === messageParts.length
@@ -712,7 +719,9 @@ function renderMessageBubble({
   const toolGroups = collectToolGroups(parts, suspensions, entry.runtimeTools);
   const origin = channelOrigin(entry);
   const prose = messageText(parts);
-  const steeringPending = entry.steer === true && entry.deliveryStatus === 'pending';
+  const steeringStatus = steeringLabel(entry);
+  const steeringPending = entry.deliveryStatus === 'pending';
+  const steeringFailed = entry.deliveryStatus === 'failed';
   const roles: MessageRoleRenderers = {
     User: ({ children }) => (
       <div className={cn(MESSAGE_HOVER, 'my-3 ml-auto flex w-fit max-w-[70%] flex-col items-end')}>
@@ -724,9 +733,12 @@ function renderMessageBubble({
         >
           {children}
         </div>
-        {entry.steer && (
-          <span className="text-ui-xs text-icon3 mt-1" aria-live="polite">
-            {steeringPending ? 'Steering…' : 'Steered message'}
+        {steeringStatus && (
+          <span
+            className={cn('text-ui-xs text-icon3 mt-1', steeringFailed && 'text-notice-destructive-fg')}
+            aria-live="polite"
+          >
+            {steeringStatus}
           </span>
         )}
         {origin && <ChannelOriginBadge origin={origin} />}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerSteering.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerSteering.msw.test.tsx
@@ -54,4 +54,25 @@ describe('Composer steering', () => {
     expect(screen.queryByText('Steering…')).not.toBeInTheDocument();
     expect(screen.getAllByText(MESSAGE)).toHaveLength(1);
   });
+
+  it('marks a rejected steering message as not sent', async () => {
+    const session = stubPreparingSession({ autoAgentEnd: false, failDispatch: true });
+    const user = userEvent.setup();
+    const { client } = renderThread();
+    await releaseSession(session.finishWorkspace, client);
+    await session.emit({ type: 'agent_start' });
+
+    const composer = await screen.findByRole('textbox', { name: 'Message' });
+    await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Steer the agent…'));
+    await user.type(composer, MESSAGE);
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByText('Not sent')).toBeInTheDocument();
+    await waitForMutationsIdle(client);
+    expect(screen.queryByText('Steering…')).not.toBeInTheDocument();
+    expect(screen.getAllByText(MESSAGE)).toHaveLength(1);
+    expect(screen.getByText(/Sandbox is gone/)).toBeInTheDocument();
+    expect(session.delivered).toEqual([]);
+    expect(session.steerAttempts).toBe(0);
+  });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerSteering.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerSteering.msw.test.tsx
@@ -1,0 +1,57 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { waitForMutationsIdle } from '../../../../../../e2e/ui/render';
+import { releaseSession, renderThread, stubPreparingSession } from './composer-session-test-fixture';
+
+const MESSAGE = 'Use the platform token, then continue';
+
+describe('Composer steering', () => {
+  it('queues the message without interrupting the active run and confirms its delivery', async () => {
+    const session = stubPreparingSession({ autoAgentEnd: false });
+    const user = userEvent.setup();
+    const { client } = renderThread();
+    await releaseSession(session.finishWorkspace, client);
+    await session.emit({ type: 'agent_start' });
+
+    const composer = await screen.findByRole('textbox', { name: 'Message' });
+    await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Steer the agent…'));
+    await user.type(composer, MESSAGE);
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => expect(session.delivered).toEqual([MESSAGE]));
+    await waitForMutationsIdle(client);
+    expect(session.steerAttempts).toBe(0);
+    expect(screen.getByText('Steering…')).toBeInTheDocument();
+    expect(screen.getAllByText(MESSAGE)).toHaveLength(1);
+
+    const createdAt = new Date('2026-08-20T10:00:00.000Z');
+    await session.emit({
+      type: 'message_start',
+      message: {
+        id: 'signal-steer',
+        role: 'signal',
+        createdAt,
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: MESSAGE }],
+          metadata: {
+            signal: {
+              id: 'signal-steer',
+              type: 'user',
+              tagName: 'user',
+              contents: MESSAGE,
+              createdAt: createdAt.toISOString(),
+              attributes: { delivery: 'while-active' },
+            },
+          },
+        },
+      },
+    });
+
+    expect(await screen.findByText('Steered message')).toBeInTheDocument();
+    expect(screen.queryByText('Steering…')).not.toBeInTheDocument();
+    expect(screen.getAllByText(MESSAGE)).toHaveLength(1);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
@@ -178,18 +178,32 @@ describe('TranscriptEntries turn groups', () => {
       steer: true,
     });
     const { rerender } = renderWithProviders(
-      <TranscriptEntries entries={state.entries} onApprove={() => {}} onRespond={() => {}} running />,
+      <TranscriptEntries
+        entries={state.entries}
+        onApprove={() => {}}
+        onRespond={() => {}}
+        running
+        tail={<div data-testid="steering-tail" />}
+      />,
     );
-    const room = screen.getByText('change direction').closest(ROOM_SELECTOR);
+    const room = screen.getByTestId('steering-tail').parentElement;
     expect(room).toBeInstanceOf(HTMLElement);
 
     state = transcriptReducer(state, {
       type: 'event',
       event: { type: 'message_start', message: steerSignal('signal-steer', 'change direction') },
     });
-    rerender(<TranscriptEntries entries={state.entries} onApprove={() => {}} onRespond={() => {}} running />);
+    rerender(
+      <TranscriptEntries
+        entries={state.entries}
+        onApprove={() => {}}
+        onRespond={() => {}}
+        running
+        tail={<div data-testid="steering-tail" />}
+      />,
+    );
 
-    expect(screen.getByText('change direction').closest(ROOM_SELECTOR)).toBe(room);
+    expect(screen.getByTestId('steering-tail').parentElement).toBe(room);
     expect(state.entries[0]).toMatchObject({ message: { id: 'signal-steer' } });
   });
 

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
@@ -3,6 +3,7 @@ import { screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { renderWithProviders } from '../../../../../../e2e/ui/render';
+import { createInitialTranscript, transcriptReducer } from '../../services/transcript';
 import type { TimelineEntry } from '../../services/transcript';
 import { TranscriptEntries } from '../Transcript';
 
@@ -51,6 +52,28 @@ function echoEntry(id: string, text: string): TimelineEntry {
     content: { format: 2, parts: [{ type: 'data-user-message', data: { contents: text } }] },
   };
   return { kind: 'message', id, message };
+}
+
+function steerSignal(id: string, text: string): MastraDBMessage {
+  return {
+    id,
+    role: 'signal',
+    createdAt: CREATED_AT,
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text }],
+      metadata: {
+        signal: {
+          id,
+          type: 'user',
+          tagName: 'user',
+          contents: text,
+          createdAt: CREATED_AT.toISOString(),
+          attributes: { delivery: 'while-active' },
+        },
+      },
+    },
+  };
 }
 
 const entries = [
@@ -145,6 +168,29 @@ describe('TranscriptEntries turn groups', () => {
     expect(screen.getByText('first question').closest(ROOM_SELECTOR)).toBe(room);
     expect(screen.getByText('first answer').closest(ROOM_SELECTOR)).toBe(room);
     expect(document.querySelectorAll(ROOM_SELECTOR)).toHaveLength(1);
+  });
+
+  it('keeps the same room node when a pending steer is confirmed', () => {
+    let state = createInitialTranscript({ messages: [], threadId: 'thread-1' });
+    state = transcriptReducer(state, {
+      type: 'localUser',
+      text: 'change direction',
+      steer: true,
+    });
+    const { rerender } = renderWithProviders(
+      <TranscriptEntries entries={state.entries} onApprove={() => {}} onRespond={() => {}} running />,
+    );
+    const room = screen.getByText('change direction').closest(ROOM_SELECTOR);
+    expect(room).toBeInstanceOf(HTMLElement);
+
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: { type: 'message_start', message: steerSignal('signal-steer', 'change direction') },
+    });
+    rerender(<TranscriptEntries entries={state.entries} onApprove={() => {}} onRespond={() => {}} running />);
+
+    expect(screen.getByText('change direction').closest(ROOM_SELECTOR)).toBe(room);
+    expect(state.entries[0]).toMatchObject({ message: { id: 'signal-steer' } });
   });
 
   it('limits the history reveal to the latest ten visible entries', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptContext.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptContext.ts
@@ -17,7 +17,8 @@ export interface ChatTranscriptApi {
   transcript: TranscriptState;
   busy: boolean;
   initialHistoryReady: boolean;
-  localUser: (text: string, steer?: boolean, files?: OutgoingFile[]) => void;
+  localUser: (text: string, steer?: boolean, files?: OutgoingFile[]) => string;
+  failLocalUser: (id: string) => void;
   reset: (threadId?: string, state?: SessionStateSnapshot) => void;
   resolvePrompt: (id: string) => void;
   clearPending: () => void;

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
@@ -120,7 +120,8 @@ function ChatTranscriptValueProvider({
   const { sessionError, sandboxPreparing } = useChatSessionContext();
   const messagesInitializing = useChatMessagesInitializing();
   const messagesError = useChatMessagesError();
-  const { transcript, initialHistoryReady, reset, localUser, resolvePrompt, clearPending, pushNotice } = transcriptApi;
+  const { transcript, initialHistoryReady, reset, localUser, failLocalUser, resolvePrompt, clearPending, pushNotice } =
+    transcriptApi;
   const effectiveThreadId = transcript.threadId ?? threadId ?? connection.createdThreadId;
 
   const effectiveTranscript: TranscriptState = {
@@ -136,6 +137,7 @@ function ChatTranscriptValueProvider({
     busy,
     initialHistoryReady,
     localUser,
+    failLocalUser,
     reset,
     resolvePrompt,
     clearPending,

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerTranscript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerTranscript.ts
@@ -1,7 +1,7 @@
 import type { AgentControllerEvent, AgentControllerSessionState, MastraDBMessage } from '@mastra/client-js';
 import { useReducer } from 'react';
 
-import { createInitialTranscript, transcriptReducer } from '../services/transcript';
+import { createInitialTranscript, createLocalMessageId, transcriptReducer } from '../services/transcript';
 import type { OutgoingFile } from '../services/transcript';
 
 /** What the session-state route hydrates the status line with before the first event lands. */
@@ -43,7 +43,13 @@ export function useAgentControllerTranscript({
   };
 
   const localUser = (text: string, steer?: boolean, files?: OutgoingFile[]) => {
-    dispatch({ type: 'localUser', text, steer, files });
+    const id = createLocalMessageId();
+    dispatch({ type: 'localUser', id, text, steer, files });
+    return id;
+  };
+
+  const failLocalUser = (id: string) => {
+    dispatch({ type: 'failLocalUser', id });
   };
 
   const resolvePrompt = (id: string) => {
@@ -69,6 +75,7 @@ export function useAgentControllerTranscript({
     reset,
     onEvent,
     localUser,
+    failLocalUser,
     resolvePrompt,
     clearPending,
     pushNotice,

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -1288,6 +1288,28 @@ describe('live user-signal events render the same as their persisted copy', () =
     });
   });
 
+  it('preserves optimistic content when a data-only signal confirms through a server window', () => {
+    let state = createInitialTranscript({ messages: [], threadId: 't1' });
+    state = transcriptReducer(state, {
+      type: 'localUser',
+      text: 'hello from the composer',
+      steer: true,
+    });
+
+    state = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [liveComposerSignal({ delivery: 'while-active' })],
+    });
+
+    expect(state.entries).toHaveLength(1);
+    expect(state.entries[0]).toMatchObject({
+      id: 'sig-web',
+      steer: true,
+      deliveryStatus: 'delivered',
+      message: { role: 'user', content: { parts: [{ type: 'text', text: 'hello from the composer' }] } },
+    });
+  });
+
   it('keeps non-user signals alone', () => {
     const reminder = signalMessage({ id: 'sig-2', type: 'system-reminder', tagName: 'reminder', text: 'stay on task' });
     let state = createInitialTranscript({ messages: [], threadId: 't1' });

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -1016,6 +1016,7 @@ describe('transcript reducer mergeWindow', () => {
     // the echo it belongs to carries a client-minted `local-…` id.
     let state = createInitialTranscript({ messages: [], threadId: 't1' });
     state = transcriptReducer(state, { type: 'localUser', text: 'stop and read the file', steer: true });
+    const localId = state.entries[0]?.id;
 
     const next = transcriptReducer(state, {
       type: 'mergeWindow',
@@ -1031,7 +1032,12 @@ describe('transcript reducer mergeWindow', () => {
     });
 
     expect(next.entries).toHaveLength(1);
-    expect(next.entries[0]).toMatchObject({ id: 'sig-1', steer: true, deliveryStatus: 'delivered' });
+    expect(next.entries[0]).toMatchObject({
+      id: localId,
+      steer: true,
+      deliveryStatus: 'delivered',
+      message: { id: 'sig-1' },
+    });
   });
 
   it('does not redraw a turn whose persisted copy carries tool calls the stream never delivered', () => {
@@ -1253,6 +1259,7 @@ describe('live user-signal events render the same as their persisted copy', () =
       steer: true,
     });
     expect(state.entries[0]).toMatchObject({ steer: true, deliveryStatus: 'pending' });
+    const localId = state.entries[0]?.id;
 
     const delivered = liveComposerSignal({ delivery: 'while-active' });
     state = transcriptReducer(state, { type: 'event', event: { type: 'message_start', message: delivered } });
@@ -1260,10 +1267,14 @@ describe('live user-signal events render the same as their persisted copy', () =
 
     expect(state.entries).toHaveLength(1);
     expect(state.entries[0]).toMatchObject({
-      id: 'sig-web',
+      id: localId,
       steer: true,
       deliveryStatus: 'delivered',
-      message: { role: 'user', content: { parts: [{ type: 'text', text: 'hello from the composer' }] } },
+      message: {
+        id: 'sig-web',
+        role: 'user',
+        content: { parts: [{ type: 'text', text: 'hello from the composer' }] },
+      },
     });
   });
 
@@ -1274,6 +1285,7 @@ describe('live user-signal events render the same as their persisted copy', () =
       text: 'hello from the composer',
       steer: true,
     });
+    const localId = state.entries[0]?.id;
 
     state = transcriptReducer(state, {
       type: 'event',
@@ -1282,9 +1294,10 @@ describe('live user-signal events render the same as their persisted copy', () =
 
     expect(state.entries).toHaveLength(1);
     expect(state.entries[0]).toMatchObject({
-      id: 'sig-web',
+      id: localId,
       steer: false,
       deliveryStatus: undefined,
+      message: { id: 'sig-web' },
     });
   });
 
@@ -1295,6 +1308,7 @@ describe('live user-signal events render the same as their persisted copy', () =
       text: 'hello from the composer',
       steer: true,
     });
+    const localId = state.entries[0]?.id;
 
     state = transcriptReducer(state, {
       type: 'mergeWindow',
@@ -1303,10 +1317,67 @@ describe('live user-signal events render the same as their persisted copy', () =
 
     expect(state.entries).toHaveLength(1);
     expect(state.entries[0]).toMatchObject({
-      id: 'sig-web',
+      id: localId,
       steer: true,
       deliveryStatus: 'delivered',
-      message: { role: 'user', content: { parts: [{ type: 'text', text: 'hello from the composer' }] } },
+      message: {
+        id: 'sig-web',
+        role: 'user',
+        content: { parts: [{ type: 'text', text: 'hello from the composer' }] },
+      },
+    });
+  });
+
+  it('confirms a failed steer when its streamed signal arrives later', () => {
+    let state = createInitialTranscript({ messages: [], threadId: 't1' });
+    state = transcriptReducer(state, {
+      type: 'localUser',
+      text: 'hello from the composer',
+      steer: true,
+    });
+    const localId = state.entries[0]?.id;
+    if (!localId) throw new Error('Expected an optimistic message');
+    state = transcriptReducer(state, { type: 'failLocalUser', id: localId });
+
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: {
+        type: 'message_start',
+        message: liveComposerSignal({ delivery: 'while-active' }),
+      },
+    });
+
+    expect(state.entries).toHaveLength(1);
+    expect(state.entries[0]).toMatchObject({
+      id: localId,
+      steer: true,
+      deliveryStatus: 'delivered',
+      message: { id: 'sig-web' },
+    });
+  });
+
+  it('confirms a failed steer when its server-window copy arrives later', () => {
+    let state = createInitialTranscript({ messages: [], threadId: 't1' });
+    state = transcriptReducer(state, {
+      type: 'localUser',
+      text: 'hello from the composer',
+      steer: true,
+    });
+    const localId = state.entries[0]?.id;
+    if (!localId) throw new Error('Expected an optimistic message');
+    state = transcriptReducer(state, { type: 'failLocalUser', id: localId });
+
+    state = transcriptReducer(state, {
+      type: 'mergeWindow',
+      messages: [liveComposerSignal({ delivery: 'while-active' })],
+    });
+
+    expect(state.entries).toHaveLength(1);
+    expect(state.entries[0]).toMatchObject({
+      id: localId,
+      steer: true,
+      deliveryStatus: 'delivered',
+      message: { id: 'sig-web' },
     });
   });
 

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -1019,11 +1019,19 @@ describe('transcript reducer mergeWindow', () => {
 
     const next = transcriptReducer(state, {
       type: 'mergeWindow',
-      messages: [signalMessage({ id: 'sig-1', type: 'user', tagName: 'user', text: 'stop and read the file' })],
+      messages: [
+        signalMessage({
+          id: 'sig-1',
+          type: 'user',
+          tagName: 'user',
+          text: 'stop and read the file',
+          attributes: { delivery: 'while-active' },
+        }),
+      ],
     });
 
     expect(next.entries).toHaveLength(1);
-    expect(next.entries[0]).toMatchObject({ steer: true });
+    expect(next.entries[0]).toMatchObject({ id: 'sig-1', steer: true, deliveryStatus: 'delivered' });
   });
 
   it('does not redraw a turn whose persisted copy carries tool calls the stream never delivered', () => {
@@ -1164,14 +1172,14 @@ describe('live user-signal events render the same as their persisted copy', () =
     };
   }
 
-  /** The same live shape for a message typed into the web composer: no channel provenance. */
-  function liveComposerSignal(): MastraDBMessage {
+  function liveComposerSignal(attributes?: Record<string, unknown>): MastraDBMessage {
     const composerPayload = {
       id: 'sig-web',
       type: 'user',
       tagName: 'user',
       contents: 'hello from the composer',
       createdAt: '2026-07-27T16:00:00.000Z',
+      attributes,
     };
     return {
       id: 'sig-web',
@@ -1216,31 +1224,68 @@ describe('live user-signal events render the same as their persisted copy', () =
 
     expect(firstEntryParts(state)).toEqual([{ type: 'text', text: 'hello from slack' }]);
   });
-
-  /**
-   * Regression: the composer already renders an optimistic local echo under a
-   * `local-…` id. The streamed signal event carries the signal's own id, so the
-   * two cannot dedupe — drawing both showed the message twice. Only channel
-   * messages get the drawable-text projection.
-   */
-  it('leaves a composer-origin live event undrawable so the local echo stays the only bubble', () => {
+  it('keeps a normal composer signal hidden behind its optimistic message', () => {
     let state = createInitialTranscript({ messages: [], threadId: 't1' });
     state = transcriptReducer(state, { type: 'localUser', text: 'hello from the composer' });
     state = transcriptReducer(state, {
       type: 'event',
       event: { type: 'message_start', message: liveComposerSignal() },
     });
-    state = transcriptReducer(state, { type: 'event', event: { type: 'message_end', message: liveComposerSignal() } });
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: { type: 'message_end', message: liveComposerSignal() },
+    });
 
     const drawable = state.entries.filter(
       entry =>
         entry.kind === 'message' &&
-        (entry.message.content.parts ?? []).some(
-          part => part.type === 'text' && part.text.includes('hello from the composer'),
-        ),
+        entry.message.content.parts.some(part => part.type === 'text' && part.text.includes('hello from the composer')),
     );
     expect(drawable).toHaveLength(1);
-    expect(drawable[0] && 'id' in drawable[0] ? drawable[0].id : '').toMatch(/^local-/);
+    expect(drawable[0]?.id).toMatch(/^local-/);
+  });
+
+  it('confirms the optimistic composer message with the streamed signal', () => {
+    let state = createInitialTranscript({ messages: [], threadId: 't1' });
+    state = transcriptReducer(state, {
+      type: 'localUser',
+      text: 'hello from the composer',
+      steer: true,
+    });
+    expect(state.entries[0]).toMatchObject({ steer: true, deliveryStatus: 'pending' });
+
+    const delivered = liveComposerSignal({ delivery: 'while-active' });
+    state = transcriptReducer(state, { type: 'event', event: { type: 'message_start', message: delivered } });
+    state = transcriptReducer(state, { type: 'event', event: { type: 'message_end', message: delivered } });
+
+    expect(state.entries).toHaveLength(1);
+    expect(state.entries[0]).toMatchObject({
+      id: 'sig-web',
+      steer: true,
+      deliveryStatus: 'delivered',
+      message: { role: 'user', content: { parts: [{ type: 'text', text: 'hello from the composer' }] } },
+    });
+  });
+
+  it('turns an optimistic steer into a normal message when the run ended before delivery', () => {
+    let state = createInitialTranscript({ messages: [], threadId: 't1' });
+    state = transcriptReducer(state, {
+      type: 'localUser',
+      text: 'hello from the composer',
+      steer: true,
+    });
+
+    state = transcriptReducer(state, {
+      type: 'event',
+      event: { type: 'message_start', message: liveComposerSignal() },
+    });
+
+    expect(state.entries).toHaveLength(1);
+    expect(state.entries[0]).toMatchObject({
+      id: 'sig-web',
+      steer: false,
+      deliveryStatus: undefined,
+    });
   });
 
   it('keeps non-user signals alone', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -673,7 +673,9 @@ function claimOnScreenEntries(
     for (const [index, candidate] of onScreen.entries()) {
       if (!candidate || (eligible && !eligible(candidate.entry))) continue;
       const sameMessage =
-        candidate.entry.id === message.id || toolCallIds.some(toolCallId => candidate.toolCallIds.has(toolCallId));
+        candidate.entry.id === message.id ||
+        candidate.entry.message.id === message.id ||
+        toolCallIds.some(toolCallId => candidate.toolCallIds.has(toolCallId));
       const alreadyDrawn = redrawsEntry(candidate, displayed, texts, toolCallIds);
 
       const claimsIdentity = sameMessage && !claimedEntries.has(index);
@@ -690,16 +692,20 @@ function claimOnScreenEntries(
   return anchors;
 }
 
+function isUnconfirmedSteer(entry: MessageEntry): boolean {
+  return entry.deliveryStatus === 'pending' || entry.deliveryStatus === 'failed';
+}
+
 function confirmPendingUserMessages(state: TranscriptState, anchors: Map<MastraDBMessage, number>): TranscriptState {
   const confirmed = new Map<number, MessageEntry>();
   for (const [message, index] of anchors) {
     const current = state.entries[index];
-    if (current?.kind !== 'message' || current.deliveryStatus !== 'pending') continue;
+    if (current?.kind !== 'message' || !isUnconfirmedSteer(current)) continue;
     const canonical = toMessageEntry(preserveOptimisticUserContent(message, current.message), {
       streaming: current.streaming,
       runtimeTools: current.runtimeTools,
     });
-    if (canonical.message.role === 'user') confirmed.set(index, canonical);
+    if (canonical.message.role === 'user') confirmed.set(index, { ...canonical, id: current.id });
   }
   if (confirmed.size === 0) return state;
 
@@ -987,10 +993,12 @@ function indexOfSameTurn(entries: TimelineEntry[], message: MastraDBMessage): nu
 function upsertMessage(state: TranscriptState, message: MastraDBMessage, streaming: boolean): TranscriptState {
   if (message.role !== 'assistant' && message.role !== 'signal') return state;
   const entries = [...state.entries];
-  let idx = entries.findIndex(e => e.kind === 'message' && e.id === message.id);
+  let idx = entries.findIndex(
+    entry => entry.kind === 'message' && (entry.id === message.id || entry.message.id === message.id),
+  );
   if (message.role === 'assistant' && idx === -1) idx = indexOfSameTurn(entries, message);
   if (message.role === 'signal' && idx === -1 && !isChannelOriginSignal(message)) {
-    idx = claimOnScreenEntries(entries, [message], entry => entry.deliveryStatus === 'pending').get(message) ?? -1;
+    idx = claimOnScreenEntries(entries, [message], isUnconfirmedSteer).get(message) ?? -1;
   }
   const prev = idx !== -1 ? entries[idx] : undefined;
   const prevEntry = prev?.kind === 'message' ? prev : undefined;
@@ -998,7 +1006,11 @@ function upsertMessage(state: TranscriptState, message: MastraDBMessage, streami
     message.role === 'assistant'
       ? preserveRuntimeToolParts(message, prevEntry?.message)
       : preserveOptimisticUserContent(message, prevEntry?.message);
-  const entry = toMessageEntry(nextMessage, { streaming, runtimeTools: prevEntry?.runtimeTools });
+  const canonicalEntry = toMessageEntry(nextMessage, { streaming, runtimeTools: prevEntry?.runtimeTools });
+  const entry =
+    message.role === 'signal' && prevEntry?.message.role === 'user'
+      ? { ...canonicalEntry, id: prevEntry.id }
+      : canonicalEntry;
 
   if (message.role === 'assistant') {
     const ownedToolCallIds = new Set(

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -46,6 +46,7 @@ export interface MessageEntry {
   streaming?: boolean;
   /** A steer (interjection) vs a normal message. */
   steer?: boolean;
+  deliveryStatus?: 'pending' | 'delivered';
 }
 
 export interface NoticeEntry {
@@ -239,7 +240,7 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
                 parts: [{ type: 'text', text: action.text }, ...(action.files ?? []).map(toOutgoingFilePart)],
               },
             },
-            { steer: action.steer },
+            { steer: action.steer, deliveryStatus: action.steer ? 'pending' : undefined },
           ),
         ],
       };
@@ -601,7 +602,8 @@ function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]):
   if (messages.length === 0) return state;
 
   const onScreenIndex = claimOnScreenEntries(state.entries, messages);
-  const reconciled = reconcileToolResults(adoptCoveringWindowCopies(state, onScreenIndex), messages);
+  const confirmed = confirmPendingUserMessages(state, onScreenIndex);
+  const reconciled = reconcileToolResults(adoptCoveringWindowCopies(confirmed, onScreenIndex), messages);
 
   if (messages.every(message => onScreenIndex.has(message))) return reconciled;
 
@@ -639,7 +641,11 @@ function mergeServerWindow(state: TranscriptState, messages: MastraDBMessage[]):
  * is consumed once per entry, so sending the same words twice still draws two
  * bubbles.
  */
-function claimOnScreenEntries(entries: TimelineEntry[], messages: MastraDBMessage[]): Map<MastraDBMessage, number> {
+function claimOnScreenEntries(
+  entries: TimelineEntry[],
+  messages: MastraDBMessage[],
+  eligible?: (entry: MessageEntry) => boolean,
+): Map<MastraDBMessage, number> {
   const onScreen = entries.map(indexMessageEntry);
   const anchors = new Map<MastraDBMessage, number>();
   const claimedEntries = new Set<number>();
@@ -648,11 +654,11 @@ function claimOnScreenEntries(entries: TimelineEntry[], messages: MastraDBMessag
   for (const message of messages) {
     const displayed = toMessageEntry(message).message;
     const toolCallIds = toolCallIdsOf(displayed.content.parts);
-    const texts = drawableTexts(displayed);
+    const texts = drawableTexts(message);
     const textClaim = (index: number) => `${index} ${texts.join('\n')}`;
 
     for (const [index, candidate] of onScreen.entries()) {
-      if (!candidate) continue;
+      if (!candidate || (eligible && !eligible(candidate.entry))) continue;
       const sameMessage =
         candidate.entry.id === message.id || toolCallIds.some(toolCallId => candidate.toolCallIds.has(toolCallId));
       const alreadyDrawn = redrawsEntry(candidate, displayed, texts, toolCallIds);
@@ -669,6 +675,25 @@ function claimOnScreenEntries(entries: TimelineEntry[], messages: MastraDBMessag
   }
 
   return anchors;
+}
+
+function confirmPendingUserMessages(state: TranscriptState, anchors: Map<MastraDBMessage, number>): TranscriptState {
+  const confirmed = new Map<number, MessageEntry>();
+  for (const [message, index] of anchors) {
+    const current = state.entries[index];
+    if (current?.kind !== 'message' || current.deliveryStatus !== 'pending') continue;
+    const canonical = toMessageEntry(message, {
+      streaming: current.streaming,
+      runtimeTools: current.runtimeTools,
+    });
+    if (canonical.message.role === 'user') confirmed.set(index, canonical);
+  }
+  if (confirmed.size === 0) return state;
+
+  return {
+    ...state,
+    entries: state.entries.map((entry, index) => confirmed.get(index) ?? entry),
+  };
 }
 
 /**
@@ -705,9 +730,16 @@ function indexMessageEntry(entry: TimelineEntry): OnScreenMessage | undefined {
 }
 
 function drawableTexts(message: MastraDBMessage): string[] {
-  return message.content.parts.flatMap(part =>
+  const textParts = message.content.parts.flatMap(part =>
     part.type === 'text' && part.text.trim().length > 0 ? [part.text.trim()] : [],
   );
+  if (textParts.length > 0 || message.role !== 'signal') return textParts;
+
+  return message.content.parts.flatMap(part => {
+    if (part.type !== 'data-user-message' || !('data' in part)) return [];
+    const text = signalContentsToText(part.data).trim();
+    return text ? [text] : [];
+  });
 }
 
 function toolCallIdsOf(parts: MastraMessagePart[]): string[] {
@@ -893,7 +925,12 @@ function signalContentsToText(data: unknown): string {
 
 function toMessageEntry(
   message: MastraDBMessage,
-  options: { streaming?: boolean; steer?: boolean; runtimeTools?: Record<string, ToolCall> } = {},
+  options: {
+    streaming?: boolean;
+    steer?: boolean;
+    deliveryStatus?: MessageEntry['deliveryStatus'];
+    runtimeTools?: Record<string, ToolCall>;
+  } = {},
 ): MessageEntry {
   const signalMetadata = message.role === 'signal' ? message.content.metadata?.signal : undefined;
   const signal =
@@ -907,6 +944,7 @@ function toMessageEntry(
       : undefined;
   const normalized = isUserSignal && isChannelOriginSignal(message) ? withRenderableSignalText(message) : message;
   const displayMessage = isUserSignal ? { ...normalized, role: 'user' as const } : normalized;
+  const steer = options.steer ?? (isUserSignal ? attributes?.delivery === 'while-active' : undefined);
 
   return {
     kind: 'message',
@@ -914,7 +952,8 @@ function toMessageEntry(
     message: displayMessage,
     runtimeTools: options.runtimeTools,
     streaming: options.streaming,
-    steer: options.steer ?? (isUserSignal ? attributes?.delivery === 'while-active' : undefined),
+    steer,
+    deliveryStatus: options.deliveryStatus ?? (steer ? 'delivered' : undefined),
   };
 }
 
@@ -937,9 +976,15 @@ function upsertMessage(state: TranscriptState, message: MastraDBMessage, streami
   const entries = [...state.entries];
   let idx = entries.findIndex(e => e.kind === 'message' && e.id === message.id);
   if (message.role === 'assistant' && idx === -1) idx = indexOfSameTurn(entries, message);
+  if (message.role === 'signal' && idx === -1 && !isChannelOriginSignal(message)) {
+    idx = claimOnScreenEntries(entries, [message], entry => entry.deliveryStatus === 'pending').get(message) ?? -1;
+  }
   const prev = idx !== -1 ? entries[idx] : undefined;
   const prevEntry = prev?.kind === 'message' ? prev : undefined;
-  const nextMessage = message.role === 'assistant' ? preserveRuntimeToolParts(message, prevEntry?.message) : message;
+  const nextMessage =
+    message.role === 'assistant'
+      ? preserveRuntimeToolParts(message, prevEntry?.message)
+      : preserveOptimisticUserContent(message, prevEntry?.message);
   const entry = toMessageEntry(nextMessage, { streaming, runtimeTools: prevEntry?.runtimeTools });
 
   if (message.role === 'assistant') {
@@ -968,6 +1013,20 @@ function upsertMessage(state: TranscriptState, message: MastraDBMessage, streami
   if (idx === -1) entries.push(entry);
   else entries[idx] = entry;
   return { ...state, entries };
+}
+
+function preserveOptimisticUserContent(message: MastraDBMessage, previous?: MastraDBMessage): MastraDBMessage {
+  if (!previous || previous.role !== 'user' || message.role !== 'signal' || isChannelOriginSignal(message)) {
+    return message;
+  }
+  const hasDrawablePart = message.content.parts.some(part => part.type === 'text' || part.type === 'file');
+  const hasUserDataPart = message.content.parts.some(part => part.type === 'data-user-message');
+  if (hasDrawablePart || !hasUserDataPart) return message;
+
+  return {
+    ...message,
+    content: { ...message.content, parts: previous.content.parts },
+  };
 }
 
 function preserveRuntimeToolParts(message: MastraDBMessage, previous?: MastraDBMessage): MastraDBMessage {

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -46,7 +46,7 @@ export interface MessageEntry {
   streaming?: boolean;
   /** A steer (interjection) vs a normal message. */
   steer?: boolean;
-  deliveryStatus?: 'pending' | 'delivered';
+  deliveryStatus?: 'pending' | 'delivered' | 'failed';
 }
 
 export interface NoticeEntry {
@@ -176,6 +176,9 @@ export const initialTranscript: TranscriptState = {
 };
 
 let noticeSeq = 0;
+export function createLocalMessageId(): string {
+  return `local-${Date.now()}-${noticeSeq++}`;
+}
 
 /** A file attached to an outgoing message (base64-encoded, mirrors the client-js `sendMessage` files option). */
 export interface OutgoingFile {
@@ -186,7 +189,8 @@ export interface OutgoingFile {
 
 type Action =
   | { type: 'event'; event: AgentControllerEvent }
-  | { type: 'localUser'; text: string; steer?: boolean; files?: OutgoingFile[] }
+  | { type: 'localUser'; id?: string; text: string; steer?: boolean; files?: OutgoingFile[] }
+  | { type: 'failLocalUser'; id: string }
   | { type: 'clearPending' }
   | { type: 'localNotice'; text: string; level: 'info' | 'error' }
   | { type: 'resolvePrompt'; id: string }
@@ -232,7 +236,7 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
           ...state.entries,
           toMessageEntry(
             {
-              id: `local-${Date.now()}-${noticeSeq++}`,
+              id: action.id ?? createLocalMessageId(),
               role: 'user',
               createdAt: new Date(),
               content: {
@@ -248,6 +252,15 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
       return mergeServerWindow(state, action.messages);
     case 'clearPending':
       return { ...state, pending: false };
+    case 'failLocalUser':
+      return {
+        ...state,
+        entries: state.entries.map(entry =>
+          entry.kind === 'message' && entry.id === action.id && entry.deliveryStatus === 'pending'
+            ? { ...entry, deliveryStatus: 'failed' }
+            : entry,
+        ),
+      };
     case 'localNotice':
       return pushNotice(state, action.level, action.text);
     case 'resolvePrompt':
@@ -682,7 +695,7 @@ function confirmPendingUserMessages(state: TranscriptState, anchors: Map<MastraD
   for (const [message, index] of anchors) {
     const current = state.entries[index];
     if (current?.kind !== 'message' || current.deliveryStatus !== 'pending') continue;
-    const canonical = toMessageEntry(message, {
+    const canonical = toMessageEntry(preserveOptimisticUserContent(message, current.message), {
       streaming: current.streaming,
       runtimeTools: current.runtimeTools,
     });


### PR DESCRIPTION
TLDR: steering a running Factory session now joins the active run instead of aborting it, and the message shows when the agent has picked it up.

---

```
before   steer → abort the run, restart from the message
after    queue the message, keep work running, confirm it at the next turn
```

Factory used the explicit `steer` endpoint, whose core semantics abort the active run. The TUI already sends an ordinary message into the live session, where it waits for the next agent iteration without interrupting current output; Factory now uses that path too.

The optimistic bubble starts with a dashed border and `Steering…`. The stream's canonical `delivery="while-active"` echo changes it to the neutral user bubble with `Steered message`. If the run ended before delivery, the same echo turns it into a normal message instead.

```
tests        +119  -17
source        +77  -23
changeset      +5    0
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a run is active, new messages wait for the agent instead of stopping its current work. The UI shows when a message is waiting, confirms it after delivery, and reports when sending fails.

## Changes

- Queue steering messages through the standard message mutation.
- Remove the dedicated steering mutation hook.
- Track local message delivery with `deliveryStatus: 'pending' | 'delivered' | 'failed'`.
- Return local message IDs and add `failLocalUser` for failed sends.
- Preserve optimistic user message content during live transcript updates.
- Confirm pending messages through `delivery="while-active"` events and server-window reconciliation.
- Hide duplicate normal composer signals.
- Convert undelivered steering messages into normal messages when the run ends.
- Update message bubbles:
  - Show a dashed border and “Steering…” while delivery is pending.
  - Show “Not sent” and destructive styling when delivery fails.
  - Show a neutral bubble with “Steered message” after delivery.
- Add React Query and SSE coverage with MSW.
- Add transcript reducer tests for confirmation, duplicate signals, server-window merging, and fallback content.
- Add a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->