### PR TITLE
fix(datasets): use point lookups for experiment items

### DIFF
--- a/packages/core/src/datasets/dataset.ts
+++ b/packages/core/src/datasets/dataset.ts
@@ -841,13 +841,10 @@ export class Dataset {
 
     const datasetsStore = await this.#getDatasetsStore();
     const dataset = await datasetsStore.getDatasetById({ id: this.id, filters: this.#scope });
-    // SCD-2 range lookup at the experiment's pinned dataset version.
-    const item =
-      experiment.datasetVersion !== null
-        ? (await datasetsStore.getItemsByVersion({ datasetId: this.id, version: experiment.datasetVersion })).find(
-            candidate => candidate.id === args.itemId,
-          )
-        : await datasetsStore.getItemById({ id: args.itemId });
+    const item = await datasetsStore.getItemById({
+      id: args.itemId,
+      datasetVersion: experiment.datasetVersion ?? undefined,
+    });
     if (!item || item.datasetId !== this.id) {
       throw new MastraError({
         id: 'DATASET_ITEM_NOT_FOUND',
@@ -934,15 +931,10 @@ export class Dataset {
     }
 
     const datasetsStore = await this.#getDatasetsStore();
-    // SCD-2 range lookup: the item must be visible at the experiment's pinned
-    // dataset version (an exact-version match would miss items created at an
-    // earlier version that are still current).
-    const item =
-      experiment.datasetVersion !== null
-        ? (await datasetsStore.getItemsByVersion({ datasetId: this.id, version: experiment.datasetVersion })).find(
-            candidate => candidate.id === args.itemId,
-          )
-        : await datasetsStore.getItemById({ id: args.itemId });
+    const item = await datasetsStore.getItemById({
+      id: args.itemId,
+      datasetVersion: experiment.datasetVersion ?? undefined,
+    });
     if (!item || item.datasetId !== this.id) {
       throw new MastraError({
         id: 'DATASET_ITEM_NOT_FOUND',


### PR DESCRIPTION
PR #21888 added snapshot-correct item loading for caller-driven experiments by fetching the full pinned dataset snapshot and finding the requested item in memory. That workaround was necessary while versioned `getItemById` used exact revision matching.

Now that #21979 has merged and `getItemById({ datasetVersion })` uses SCD-2 snapshot semantics, this switches `runExperimentItem` and `submitExperimentResult` to the indexed point lookup. Behavior stays the same, but each item operation no longer loads and scans the complete snapshot.

This is a stacked follow-up targeting `durable-experiments`. Tested with the 30 caller-driven experiment tests, the core typecheck and build, core lint, and formatting checks.
