### PR TITLE
Harden Pi plugin compatibility against real ecosystem packages

### DIFF
--- a/.changeset/modern-animals-throw.md
+++ b/.changeset/modern-animals-throw.md
@@ -1,0 +1,6 @@
+---
+'@mastra/code-sdk': patch
+'mastracode': patch
+---
+
+Improved declarative Pi provider compatibility by reusing the host provider's environment credential when an extension omits an explicit credential reference.

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -709,9 +709,6 @@ const sidebars = {
       type: 'doc',
       id: 'mastra-platform/regions',
       label: 'Regions',
-      customProps: {
-        tags: ['new'],
-      },
     },
     {
       type: 'doc',
@@ -750,9 +747,6 @@ const sidebars = {
       type: 'doc',
       id: 'mastra-platform/workspaces',
       label: 'Workspaces',
-      customProps: {
-        tags: ['new'],
-      },
     },
     {
       type: 'doc',

--- a/docs/src/content/en/reference/code-sdk/pi-plugin-compatibility.mdx
+++ b/docs/src/content/en/reference/code-sdk/pi-plugin-compatibility.mdx
@@ -69,6 +69,38 @@ Package status uses these values:
 
 A partial package is never reported as fully compatible. Unsupported registrations and actions are diagnosed rather than ignored.
 
+## Characterized package examples
+
+Mastra Code verifies its compatibility boundary against pinned package releases. These results apply to the exact versions shown and target Pi API `0.84.2`. They don't predict compatibility for later releases.
+
+| Package | Characterized status | Notable boundary |
+| - | - | - |
+| `pi-mcp-adapter@2.26.1` | `pi-compatible` | Commands, flags, tools, and mapped lifecycle events |
+| `pi-ds-web-search@0.1.0` | `pi-compatible` | Declarative provider, request event, command, and tool |
+| `pi-web-access@0.24.0` | `pi-partial` | Session-tree behavior and shortcut registration aren't available |
+| `pi-subagents@0.52.1` | `pi-partial` | Session switch, fork, and compaction boundaries are reported |
+| `pi-multiagent@0.9.8` | `pi-partial` | Renderer, flag, tool, and event behavior is adapted; other surfaces are reported |
+| `pi-memory@0.4.2` | `pi-partial` | Compaction behavior isn't equivalent to Pi's session manager |
+| `context-mode@1.0.169` | `pi-partial` | Context and lifecycle hooks are adapted with reported unsupported surfaces |
+| `@braintrust/pi-extension@1.0.0` | `pi-incompatible` | The package's provider-response and compaction surfaces don't provide a usable supported contribution |
+
+Other characterized packages may be rejected during inspection or factory loading. `/plugins` reports the package-attributed reason instead of enabling a partial generation.
+
+## Author portable Pi extensions
+
+A dual-target package can use the portable subset when it:
+
+- Declares extensions, skills, prompts, and themes in `package.json#pi` with paths contained by the package root.
+- Registers tools, commands, flags, declarative providers, supported events, and bounded text UI through the Pi extension API.
+- Treats the provided context as a scoped facade. It doesn't retain action closures after reload or expect access to Pi's `SessionManager`, transcript tree, raw model registry, or terminal.
+- Uses extension-owned cleanup on `session_shutdown` and handles stale-context errors after reload, disable, uninstall, or session replacement.
+- Keeps tool names collision-safe and accepts Mastra Code's tool approval, permission, active-tool, and precedence policies.
+- Checks the capability report before relying on version-gated behavior and remains useful when an unsupported renderer or UI contribution falls back to text.
+
+Use a native Mastra Code plugin instead when the package requires request context, workspace or Mastra access, first-class input/output processors, signal providers, tool suspension, native render configuration, or direct AgentController listeners. Native plugins remain the richer host API. A package may include separate native and Pi entries, but the Pi entry must not import native runtime internals or assume both entries run together.
+
+Both native and Pi packages use the same PluginManager ownership model. Every contribution is generation-owned, native and built-in tools retain precedence, failed replacement generations leave the current generation active, and disable or uninstall retires owned runtime state before package files are removed.
+
 ## Release contract: Registration and resources
 
 | Pi surface | Status | Mastra Code behavior |

--- a/mastracode/sdk/package.json
+++ b/mastracode/sdk/package.json
@@ -32,7 +32,8 @@
     "check": "tsc --noEmit",
     "test": "vitest run",
     "lint": "oxlint . && eslint .",
-    "lint:fix": "oxlint --fix . && eslint --fix ."
+    "lint:fix": "oxlint --fix . && eslint --fix .",
+    "verify:pi-ecosystem": "tsx src/plugins/pi/compatibility-fixtures/refresh.ts --verify --offline"
   },
   "keywords": [],
   "author": "",

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -686,6 +686,10 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
     refresh: async () => {
       if (pluginRuntimeController) await syncGateways(true);
     },
+    resolveApiKeyEnvVar: providerName => {
+      const envVars = (PROVIDER_REGISTRY as Record<string, ProviderConfig>)[providerName]?.apiKeyEnvVar;
+      return Array.isArray(envVars) ? envVars[0] : envVars;
+    },
   });
   pluginManager?.setPiRuntimeActions(generation =>
     createPiRuntimeActions({

--- a/mastracode/sdk/src/plugins/pi/__tests__/ecosystem-characterization.test.ts
+++ b/mastracode/sdk/src/plugins/pi/__tests__/ecosystem-characterization.test.ts
@@ -1,0 +1,155 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getPiCapabilitySupport,
+  getPiPackageCompatibilityStatus,
+  PI_COMPATIBILITY_TARGET_VERSION,
+  type PiCapabilitySupport,
+  type PiPackageCompatibilityStatus,
+} from '../compatibility.js';
+
+type ResourceManifest = Record<'extensions' | 'prompts' | 'skills' | 'themes', string[]>;
+
+type EcosystemCharacterization =
+  | {
+      outcome: 'report';
+      status: PiPackageCompatibilityStatus;
+      capabilities: Record<string, PiCapabilitySupport>;
+      diagnostics: string[];
+    }
+  | { outcome: 'rejected'; stage: 'factory' | 'inspection'; diagnostic: string; errorMatch: string };
+
+interface EcosystemProfile {
+  name: string;
+  version: string;
+  specifier: string;
+  provenance: {
+    integrity: string;
+    tarball: string;
+    repository: string;
+    sourceCommit: string | null;
+    sourceCommitEvidence?: string;
+    license: string;
+    unpackedSize: number;
+    fileCount: number;
+    downloadsInWindow: number;
+  };
+  manifest: {
+    packageManager?: string;
+    observedApiVersion: string;
+    lifecycleScripts: Record<string, string>;
+    resources?: ResourceManifest;
+    declaredResources?: Partial<ResourceManifest>;
+  };
+  characterization: EcosystemCharacterization;
+  coverage: string[];
+  credential?: { envVar: string; provider: string; requiredFor: 'live-provider-proof' };
+}
+
+interface EcosystemFixture {
+  schemaVersion: number;
+  targetApiVersion: string;
+  refreshedAt: string;
+  popularityWindow: { source: string; start: string; end: string };
+  packages: EcosystemProfile[];
+}
+
+const fixturePath = fileURLToPath(new URL('../compatibility-fixtures/manifest.json', import.meta.url));
+const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as EcosystemFixture;
+
+describe('Pi ecosystem characterization fixtures', () => {
+  it('pins the approved package matrix to immutable public provenance', () => {
+    expect(fixture).toMatchObject({
+      schemaVersion: 1,
+      targetApiVersion: PI_COMPATIBILITY_TARGET_VERSION,
+      refreshedAt: '2026-08-20',
+      popularityWindow: { start: '2026-07-21', end: '2026-08-19' },
+    });
+    expect(fixture.packages).toHaveLength(13);
+    expect(new Set(fixture.packages.map(profile => profile.name)).size).toBe(fixture.packages.length);
+
+    for (const profile of fixture.packages) {
+      expect(profile.specifier).toBe(`npm:${profile.name}@${profile.version}`);
+      expect(profile.provenance.integrity).toMatch(/^sha512-[A-Za-z0-9+/]+={0,2}$/);
+      expect(profile.provenance.tarball).toMatch(/^https:\/\/registry\.npmjs\.org\//);
+      expect(profile.provenance.repository).toMatch(/^https:\/\/github\.com\//);
+      expect(profile.provenance.unpackedSize).toBeGreaterThan(0);
+      expect(profile.provenance.fileCount).toBeGreaterThan(0);
+      expect(profile.provenance.downloadsInWindow).toBeGreaterThanOrEqual(0);
+      if (profile.provenance.sourceCommit) expect(profile.provenance.sourceCommit).toMatch(/^[a-f0-9]{40}$/);
+      else expect(profile.provenance.sourceCommitEvidence).toBe('npm metadata omits gitHead');
+      if (profile.manifest.packageManager) expect(profile.manifest.packageManager).toMatch(/^pnpm@\d+\.\d+\.\d+/);
+    }
+  });
+
+  it('keeps compatibility reports consistent with the owned support matrix', () => {
+    const outcomes = { compatible: 0, incompatible: 0, partial: 0, rejected: 0 };
+
+    for (const profile of fixture.packages) {
+      const characterization = profile.characterization;
+      if (characterization.outcome === 'rejected') {
+        outcomes.rejected++;
+        expect(characterization.diagnostic).not.toHaveLength(0);
+        continue;
+      }
+
+      if (characterization.status === 'pi-compatible') outcomes.compatible++;
+      else if (characterization.status === 'pi-partial') outcomes.partial++;
+      else outcomes.incompatible++;
+
+      const capabilities = Object.entries(characterization.capabilities).map(([name, support]) => ({
+        name,
+        support,
+        evidence: [],
+        diagnostics: [],
+      }));
+      expect(getPiPackageCompatibilityStatus(capabilities)).toBe(characterization.status);
+      for (const [name, support] of Object.entries(characterization.capabilities)) {
+        if (name !== 'pi-api-version') expect(getPiCapabilitySupport(name)).toBe(support);
+      }
+      if (characterization.status !== 'pi-compatible') expect(characterization.diagnostics.length).toBeGreaterThan(0);
+    }
+
+    expect(outcomes).toEqual({ compatible: 2, partial: 6, incompatible: 1, rejected: 4 });
+  });
+
+  it('covers portable runtime, resource, provider, UI, and rejected ecosystem surfaces', () => {
+    const coverage = new Set(fixture.packages.flatMap(profile => profile.coverage));
+    for (const expected of [
+      'abort',
+      'commands',
+      'credentialed-provider',
+      'declarative-provider',
+      'external-dependencies',
+      'flags',
+      'lifecycle-cleanup',
+      'lifecycle-scripts',
+      'message-renderers',
+      'permissions',
+      'progress',
+      'prompts',
+      'shortcuts',
+      'skills',
+      'state',
+      'tree-events',
+      'tui',
+      'typebox-tools',
+      'widgets',
+    ]) {
+      expect(coverage).toContain(expected);
+    }
+  });
+
+  it('records credential references without storing credential values', () => {
+    expect(fixture.packages.filter(profile => profile.credential).map(profile => profile.credential)).toEqual([
+      { envVar: 'DEEPSEEK_API_KEY', provider: 'deepseek', requiredFor: 'live-provider-proof' },
+      { envVar: 'XIAOMI_MIMO_API_KEY', provider: 'xiaomi-mimo', requiredFor: 'live-provider-proof' },
+    ]);
+    const serialized = fs.readFileSync(fixturePath, 'utf8');
+    expect(serialized).not.toMatch(/(?:sk-|api[_-]?key["']?\s*[:=]\s*["'][^"']{8})/i);
+    expect(serialized).not.toContain('/private/var/');
+    expect(serialized).not.toContain('/tmp/');
+  });
+});

--- a/mastracode/sdk/src/plugins/pi/__tests__/ecosystem-integration.test.ts
+++ b/mastracode/sdk/src/plugins/pi/__tests__/ecosystem-integration.test.ts
@@ -1,0 +1,162 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { RequestContext } from '@mastra/core/request-context';
+import type { ToolExecutionContext } from '@mastra/core/tools';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PluginManager } from '../../manager.js';
+
+const sdkRoot = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '../../../..');
+const piMcpAdapterRoot = path.dirname(fileURLToPath(import.meta.resolve('pi-mcp-adapter')));
+let manager: PluginManager | undefined;
+let tempDir: string | undefined;
+
+const originalCwd = process.cwd();
+const originalHome = process.env.HOME;
+
+afterEach(async () => {
+  await manager?.dispose();
+  manager = undefined;
+  process.chdir(originalCwd);
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+describe('Pi ecosystem compatibility integration', () => {
+  it('loads the pinned real MCP adapter and retires every owned contribution', async () => {
+    const fixture = createManagerFixture('real-mcp');
+    const corepackFixture = writeDependencyLinker(fixture.root, path.join(sdkRoot, 'node_modules'));
+    const prepared = await manager!.preparePiPackage(piMcpAdapterRoot, 'global');
+    const characterized = await manager!.characterizePiPackage(prepared, {
+      trustCodeExecution: true,
+      installScripts: 'deny',
+      corepackCliPath: corepackFixture,
+    });
+
+    expect(characterized.compatibility).toMatchObject({
+      targetApiVersion: '0.84.2',
+      status: 'pi-compatible',
+    });
+    expect(characterized.compatibility.capabilities.map(capability => capability.name)).toEqual(
+      expect.arrayContaining(['registerCommand', 'registerFlag', 'registerTool']),
+    );
+
+    await manager!.installPiPackage(characterized, { confirmEnable: true });
+    const generation = manager!.getPiGenerations()[0]!;
+    expect(generation.registrations.tools.has('mcp')).toBe(true);
+    expect(generation.registrations.commands.size).toBeGreaterThan(0);
+    expect(generation.registrations.flags.size).toBeGreaterThan(0);
+
+    await manager!.setEnabled('pi-mcp-adapter', 'global', false);
+    expect(generation.active).toBe(false);
+    expect(manager!.getPiGenerations()).toEqual([]);
+    expect(manager!.getPluginTools()).not.toHaveProperty('mcp');
+    expect(manager!.getPiCommands()).toEqual([]);
+
+    await manager!.uninstall('pi-mcp-adapter', 'global');
+    expect(fs.existsSync(characterized.resolution.sourceRoot)).toBe(false);
+    expect(fs.existsSync(characterized.resolution.packageRoot)).toBe(false);
+  }, 20_000);
+
+  it('executes supported paths while attributing partial boundaries and cleaning disable/uninstall state', async () => {
+    const fixture = createManagerFixture('partial-boundary');
+    const sourceRoot = path.join(fixture.projectRoot, 'pi-ecosystem-boundary');
+    fs.mkdirSync(sourceRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceRoot, 'package.json'),
+      JSON.stringify({
+        name: 'pi-ecosystem-boundary',
+        version: '1.0.0',
+        pi: { extensions: ['./index.ts'] },
+        peerDependencies: { '@earendil-works/pi-coding-agent': '^0.84.2' },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(sourceRoot, 'index.ts'),
+      `import { Type } from 'typebox';
+       export default function (pi) {
+         pi.on('session_tree', () => {});
+         pi.registerShortcut('ctrl+x', { handler: () => {} });
+         pi.registerCommand('ecosystem-check', { handler: async () => 'ok' });
+         pi.registerTool({
+           name: 'ecosystem_echo',
+           description: 'Ecosystem echo',
+           parameters: Type.Object({ value: Type.String() }),
+           execute: async (_id, params) => ({ content: [{ type: 'text', text: 'echo:' + params.value }] }),
+         });
+       }`,
+    );
+
+    const prepared = await manager!.preparePiPackage('./pi-ecosystem-boundary', 'project');
+    const characterized = await manager!.characterizePiPackage(prepared, {
+      trustCodeExecution: true,
+      projectTrust: true,
+      installScripts: 'deny',
+    });
+    expect(characterized.compatibility.status).toBe('pi-partial');
+    expect(characterized.compatibility.capabilities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'event:session_tree', support: 'unsupported' }),
+        expect.objectContaining({ name: 'registerShortcut', support: 'version-gated' }),
+        expect.objectContaining({ name: 'registerTool', support: 'adapted' }),
+      ]),
+    );
+    expect(characterized.compatibility.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ extensionId: 'pi-ecosystem-boundary:index.ts', capability: 'event:session_tree' }),
+        expect.objectContaining({ extensionId: 'pi-ecosystem-boundary:index.ts', capability: 'registerShortcut' }),
+      ]),
+    );
+
+    await manager!.installPiPackage(characterized, { confirmEnable: true });
+    await expect(executeTool(manager!.getPluginTools().ecosystem_echo, { value: 'verified' })).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'echo:verified' }],
+      isError: false,
+    });
+    expect(manager!.getPiCommands().map(command => command.name)).toContain('ecosystem-check');
+
+    await manager!.setEnabled('pi-ecosystem-boundary', 'project', false);
+    expect(manager!.getPluginTools()).not.toHaveProperty('ecosystem_echo');
+    expect(manager!.getPiCommands()).toEqual([]);
+    expect(manager!.getPiGenerations()).toEqual([]);
+
+    await manager!.uninstall('pi-ecosystem-boundary', 'project');
+    expect(fs.existsSync(characterized.resolution.sourceRoot)).toBe(false);
+    expect(fs.existsSync(characterized.resolution.packageRoot)).toBe(false);
+  });
+});
+
+function createManagerFixture(name: string): { root: string; projectRoot: string; homeDir: string } {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `mc-pi-ecosystem-${name}-`));
+  const projectRoot = path.join(tempDir, 'project');
+  const homeDir = path.join(tempDir, 'home');
+  fs.mkdirSync(projectRoot, { recursive: true });
+  process.chdir(projectRoot);
+  process.env.HOME = homeDir;
+  manager = new PluginManager({ projectRoot, homeDir });
+  return { root: tempDir, projectRoot, homeDir };
+}
+
+function writeDependencyLinker(root: string, nodeModules: string): string {
+  const entry = path.join(root, 'corepack-fixture.mjs');
+  fs.writeFileSync(
+    entry,
+    `#!/usr/bin/env node\nimport fs from 'node:fs';\nimport path from 'node:path';\nfs.symlinkSync(${JSON.stringify(nodeModules)}, path.join(process.cwd(), 'node_modules'), 'dir');\n`,
+    { mode: 0o755 },
+  );
+  return entry;
+}
+
+async function executeTool(tool: unknown, input: unknown): Promise<unknown> {
+  if (!tool || typeof tool !== 'object' || !('execute' in tool) || typeof tool.execute !== 'function') {
+    throw new Error('Missing executable ecosystem tool');
+  }
+  return tool.execute(input, {
+    requestContext: new RequestContext(),
+    observe: vi.fn(),
+  } as unknown as ToolExecutionContext);
+}

--- a/mastracode/sdk/src/plugins/pi/__tests__/provider-adapter.test.ts
+++ b/mastracode/sdk/src/plugins/pi/__tests__/provider-adapter.test.ts
@@ -43,6 +43,26 @@ describe('Pi provider adapter', () => {
     expect(host.refresh).toHaveBeenCalledTimes(2);
   });
 
+  it('inherits an existing provider environment credential when the Pi config omits auth', async () => {
+    const host = {
+      register: vi.fn().mockResolvedValue(undefined),
+      refresh: vi.fn().mockResolvedValue(undefined),
+      resolveApiKeyEnvVar: vi.fn().mockReturnValue('DEEPSEEK_API_KEY'),
+    };
+    const adapter = new PiProviderAdapter(host);
+    const generation = new MastraPiExtensionGeneration('plugin', 'extension', '/tmp/entry.ts');
+
+    await adapter.register(generation, 'deepseek', {
+      baseUrl: 'https://api.deepseek.com',
+      models: ['deepseek-v4-flash'],
+    });
+
+    expect(host.resolveApiKeyEnvVar).toHaveBeenCalledWith('deepseek');
+    expect(host.register).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'deepseek', apiKeyEnvVar: 'DEEPSEEK_API_KEY' }),
+    );
+  });
+
   it('awaits and cleans up in-flight provider registration during invalidation', async () => {
     let release!: () => void;
     const teardown = vi.fn().mockResolvedValue(undefined);

--- a/mastracode/sdk/src/plugins/pi/compatibility-fixtures/manifest.json
+++ b/mastracode/sdk/src/plugins/pi/compatibility-fixtures/manifest.json
@@ -1,0 +1,529 @@
+{
+  "schemaVersion": 1,
+  "targetApiVersion": "0.84.2",
+  "refreshedAt": "2026-08-20",
+  "popularityWindow": {
+    "source": "https://api.npmjs.org/downloads/point/2026-07-21:2026-08-19/{package}",
+    "start": "2026-07-21",
+    "end": "2026-08-19"
+  },
+  "packages": [
+    {
+      "name": "pi-mcp-adapter",
+      "version": "2.26.1",
+      "specifier": "npm:pi-mcp-adapter@2.26.1",
+      "provenance": {
+        "integrity": "sha512-6/KDXIEPXTVM77274jAloxAo9AQSEy5EJ/7afIlUK2T8HOfeVapTJvwImvyChiIH+0gGShbFgnBK2BXFrjbj2w==",
+        "tarball": "https://registry.npmjs.org/pi-mcp-adapter/-/pi-mcp-adapter-2.26.1.tgz",
+        "repository": "https://github.com/nicobailon/pi-mcp-adapter.git",
+        "sourceCommit": null,
+        "sourceCommitEvidence": "npm metadata omits gitHead",
+        "license": "MIT",
+        "unpackedSize": 2416514,
+        "fileCount": 68,
+        "downloadsInWindow": 548514
+      },
+      "manifest": {
+        "observedApiVersion": "^0.84.1",
+        "lifecycleScripts": {},
+        "resources": {
+          "extensions": ["index.ts"],
+          "skills": ["skills/mcp-scripting/SKILL.md"],
+          "prompts": [],
+          "themes": []
+        }
+      },
+      "characterization": {
+        "outcome": "report",
+        "status": "pi-compatible",
+        "capabilities": {
+          "event:input": "adapted",
+          "event:session_shutdown": "adapted",
+          "event:session_start": "adapted",
+          "event:tool_result": "adapted",
+          "registerCommand": "adapted",
+          "registerFlag": "adapted",
+          "registerTool": "adapted"
+        },
+        "diagnostics": []
+      },
+      "coverage": [
+        "abort",
+        "commands",
+        "external-dependencies",
+        "lifecycle-cleanup",
+        "progress",
+        "skills",
+        "typebox-tools"
+      ]
+    },
+    {
+      "name": "pi-web-access",
+      "version": "0.24.0",
+      "specifier": "npm:pi-web-access@0.24.0",
+      "provenance": {
+        "integrity": "sha512-BVosva1tGDhHveaGpFnc++YS5+pzmWVzJ/5B+1xBavkRjAgyDvMpA1EfVL+GYIviAxXKck9JyRGVzo4ASV7snA==",
+        "tarball": "https://registry.npmjs.org/pi-web-access/-/pi-web-access-0.24.0.tgz",
+        "repository": "https://github.com/nicobailon/pi-web-access.git",
+        "sourceCommit": "3b875f574840eebae39e5fede0d99a5f7c71f482",
+        "license": "MIT",
+        "unpackedSize": 7465072,
+        "fileCount": 68,
+        "downloadsInWindow": 305789
+      },
+      "manifest": {
+        "observedApiVersion": "*",
+        "lifecycleScripts": {},
+        "resources": { "extensions": ["index.ts"], "skills": [], "prompts": [], "themes": [] }
+      },
+      "characterization": {
+        "outcome": "report",
+        "status": "pi-partial",
+        "capabilities": {
+          "event:session_shutdown": "adapted",
+          "event:session_start": "adapted",
+          "event:session_tree": "unsupported",
+          "registerCommand": "adapted",
+          "registerShortcut": "version-gated",
+          "registerTool": "adapted"
+        },
+        "diagnostics": ["registerShortcut is version-gated", "event:session_tree is unsupported"]
+      },
+      "coverage": ["commands", "progress", "shortcuts", "tree-events", "typebox-tools"]
+    },
+    {
+      "name": "pi-subagents",
+      "version": "0.52.1",
+      "specifier": "npm:pi-subagents@0.52.1",
+      "provenance": {
+        "integrity": "sha512-9K9tICAbDBJ82op5wvFAIZFhg7K5Cv6du5hEsnf4o6/qhoslla1WcV11cOyB4tzKAHUIXA2GLA6kfxxLXzIpyg==",
+        "tarball": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.52.1.tgz",
+        "repository": "https://github.com/nicobailon/pi-subagents.git",
+        "sourceCommit": "afa22c811f81883acdb248c84f116ac7534e2fb4",
+        "license": "MIT",
+        "unpackedSize": 3853257,
+        "fileCount": 240,
+        "downloadsInWindow": 276014
+      },
+      "manifest": {
+        "observedApiVersion": "*",
+        "lifecycleScripts": {},
+        "resources": {
+          "extensions": ["index.ts"],
+          "skills": ["skills/pi-subagents/SKILL.md"],
+          "prompts": [
+            "prompts/gather-context-and-clarify.md",
+            "prompts/parallel-cleanup.md",
+            "prompts/parallel-research.md",
+            "prompts/parallel-review.md",
+            "prompts/review-loop.md"
+          ],
+          "themes": []
+        }
+      },
+      "characterization": {
+        "outcome": "report",
+        "status": "pi-partial",
+        "capabilities": {
+          "event:agent_end": "adapted",
+          "event:agent_settled": "adapted",
+          "event:agent_start": "adapted",
+          "event:before_agent_start": "adapted",
+          "event:session_before_compact": "unsupported",
+          "event:session_before_fork": "unsupported",
+          "event:session_before_switch": "unsupported",
+          "event:session_compact": "unsupported",
+          "event:session_shutdown": "adapted",
+          "event:session_start": "adapted",
+          "event:tool_result": "adapted",
+          "event:turn_end": "adapted",
+          "events": "direct",
+          "registerCommand": "adapted",
+          "registerMessageRenderer": "adapted",
+          "registerShortcut": "version-gated",
+          "registerTool": "adapted"
+        },
+        "diagnostics": [
+          "event:session_before_switch is unsupported",
+          "event:session_before_fork is unsupported",
+          "event:session_compact is unsupported",
+          "registerShortcut is version-gated",
+          "event:session_before_compact is unsupported"
+        ]
+      },
+      "coverage": [
+        "commands",
+        "lifecycle-cleanup",
+        "message-renderers",
+        "prompts",
+        "shortcuts",
+        "skills",
+        "typebox-tools"
+      ]
+    },
+    {
+      "name": "pi-multiagent",
+      "version": "0.9.8",
+      "specifier": "npm:pi-multiagent@0.9.8",
+      "provenance": {
+        "integrity": "sha512-Et5hacAVa+67X4JdHe4mk0e7h2qnXn5Ph0l7M4shGp4wRrfuG5gjvl5aAmxsfc8VEQW74DBIqbG4Jidvo8FM/w==",
+        "tarball": "https://registry.npmjs.org/pi-multiagent/-/pi-multiagent-0.9.8.tgz",
+        "repository": "https://github.com/Tiziano-AI/pi-multiagent.git",
+        "sourceCommit": "8a3c40d106aaf94107246fdfa21b12c88157dbed",
+        "license": "MIT",
+        "unpackedSize": 628718,
+        "fileCount": 116,
+        "downloadsInWindow": 555
+      },
+      "manifest": {
+        "packageManager": "pnpm@11.1.2",
+        "observedApiVersion": ">=0.74.0",
+        "lifecycleScripts": {},
+        "resources": {
+          "extensions": ["extensions/multiagent/index.ts"],
+          "skills": ["skills/pi-multiagent/SKILL.md"],
+          "prompts": [],
+          "themes": []
+        }
+      },
+      "characterization": {
+        "outcome": "report",
+        "status": "pi-partial",
+        "capabilities": {
+          "event:session_shutdown": "adapted",
+          "event:tool_result": "adapted",
+          "pi-api-version": "version-gated",
+          "registerFlag": "adapted",
+          "registerMessageRenderer": "adapted",
+          "registerTool": "adapted"
+        },
+        "diagnostics": ["Pi API range >=0.74.0 is version-gated"]
+      },
+      "coverage": ["abort", "flags", "message-renderers", "progress", "skills", "typebox-tools"]
+    },
+    {
+      "name": "@gotgenes/pi-permission-system",
+      "version": "26.3.1",
+      "specifier": "npm:@gotgenes/pi-permission-system@26.3.1",
+      "provenance": {
+        "integrity": "sha512-dyVeTuj4QXl1FCJK1v1xJFyyRXYv/K2lAXM8U0BD+P51naGDZuh0UtjPrFbdF6WmVI0bUHfOwQ8DU4aP3rioNQ==",
+        "tarball": "https://registry.npmjs.org/@gotgenes/pi-permission-system/-/pi-permission-system-26.3.1.tgz",
+        "repository": "https://github.com/gotgenes/pi-packages.git#packages/pi-permission-system",
+        "sourceCommit": null,
+        "sourceCommitEvidence": "npm metadata omits gitHead",
+        "license": "MIT",
+        "unpackedSize": 1326863,
+        "fileCount": 165,
+        "downloadsInWindow": 29481
+      },
+      "manifest": {
+        "observedApiVersion": ">=0.79.0",
+        "lifecycleScripts": {},
+        "resources": { "extensions": ["src/index.ts"], "skills": [], "prompts": [], "themes": [] }
+      },
+      "characterization": {
+        "outcome": "rejected",
+        "stage": "factory",
+        "diagnostic": "factory requires unsupported getAgentDir filesystem surface",
+        "errorMatch": "getAgentDir"
+      },
+      "coverage": ["permissions", "tool-policy"]
+    },
+    {
+      "name": "@plannotator/pi-extension",
+      "version": "0.27.4",
+      "specifier": "npm:@plannotator/pi-extension@0.27.4",
+      "provenance": {
+        "integrity": "sha512-9aK4v4AcjV/UwvAYvcT46fngIeMKmclv2glIYhzCIJiWKC0tfr4UQ5Aido7iveSfKlmbQuggCB/M018PxdbqnA==",
+        "tarball": "https://registry.npmjs.org/@plannotator/pi-extension/-/pi-extension-0.27.4.tgz",
+        "repository": "https://github.com/backnotprop/plannotator.git#apps/pi-extension",
+        "sourceCommit": null,
+        "sourceCommitEvidence": "npm metadata omits gitHead",
+        "license": "MIT OR Apache-2.0",
+        "unpackedSize": 41158908,
+        "fileCount": 196,
+        "downloadsInWindow": 45624
+      },
+      "manifest": {
+        "observedApiVersion": ">=0.79.1",
+        "lifecycleScripts": {},
+        "resources": { "extensions": ["index.ts"], "skills": [], "prompts": [], "themes": [] }
+      },
+      "characterization": {
+        "outcome": "report",
+        "status": "pi-partial",
+        "capabilities": {
+          "event:agent_end": "adapted",
+          "event:before_agent_start": "adapted",
+          "event:context": "adapted",
+          "event:session_compact": "unsupported",
+          "event:session_shutdown": "adapted",
+          "event:session_start": "adapted",
+          "event:session_tree": "unsupported",
+          "event:tool_call": "adapted",
+          "event:turn_end": "adapted",
+          "events": "direct",
+          "pi-api-version": "version-gated",
+          "registerCommand": "adapted",
+          "registerFlag": "adapted",
+          "registerShortcut": "version-gated",
+          "registerTool": "adapted"
+        },
+        "diagnostics": [
+          "registerShortcut is version-gated",
+          "event:session_compact is unsupported",
+          "event:session_tree is unsupported",
+          "Pi API range >=0.79.1 is version-gated"
+        ]
+      },
+      "coverage": ["commands", "flags", "lifecycle-cleanup", "shortcuts", "tui", "typebox-tools"]
+    },
+    {
+      "name": "pi-lens",
+      "version": "4.0.1",
+      "specifier": "npm:pi-lens@4.0.1",
+      "provenance": {
+        "integrity": "sha512-JmkZr9aJf7oEn1K+Vj34wPc6nMUQF6Hj6mm5jo38Ic+zLAXRV9AFuac8ydexvU8vnGdWW3Wn8oAfU1MEIcWaGQ==",
+        "tarball": "https://registry.npmjs.org/pi-lens/-/pi-lens-4.0.1.tgz",
+        "repository": "https://github.com/apmantza/pi-lens.git",
+        "sourceCommit": "d35b7279301c5573de8f11916a005f424e5db399",
+        "license": "MIT",
+        "unpackedSize": 21092036,
+        "fileCount": 1355,
+        "downloadsInWindow": 42866
+      },
+      "manifest": {
+        "observedApiVersion": "*",
+        "lifecycleScripts": {
+          "prepare": "npm run build:dist && node scripts/download-grammars.js --core --dest grammars"
+        },
+        "declaredResources": { "extensions": ["./dist/index.js"], "skills": ["../../skills"] }
+      },
+      "characterization": {
+        "outcome": "rejected",
+        "stage": "inspection",
+        "diagnostic": "skills pattern escapes package root: ../../skills",
+        "errorMatch": "skills pattern must stay inside the package root"
+      },
+      "coverage": ["external-dependencies", "skills", "typebox-tools"]
+    },
+    {
+      "name": "pi-memory",
+      "version": "0.4.2",
+      "specifier": "npm:pi-memory@0.4.2",
+      "provenance": {
+        "integrity": "sha512-voH+1MalADyVN23p79g4atdtPxzr1bDcfk1y0uCJL0xfodiSzNA5V5CcmODBTtHlrQzDT+AgasYPlgNWg8YPRQ==",
+        "tarball": "https://registry.npmjs.org/pi-memory/-/pi-memory-0.4.2.tgz",
+        "repository": "https://github.com/jayzeng/pi-memory.git",
+        "sourceCommit": "39e6b998a2279c8fad4a2c6c64e26828c1d6023e",
+        "license": "MIT",
+        "unpackedSize": 106973,
+        "fileCount": 6,
+        "downloadsInWindow": 31616
+      },
+      "manifest": {
+        "observedApiVersion": ">=0.81.1",
+        "lifecycleScripts": { "postinstall": "node scripts/postinstall.cjs" },
+        "resources": { "extensions": ["index.ts"], "skills": [], "prompts": [], "themes": [] }
+      },
+      "characterization": {
+        "outcome": "report",
+        "status": "pi-partial",
+        "capabilities": {
+          "event:before_agent_start": "adapted",
+          "event:input": "adapted",
+          "event:session_before_compact": "unsupported",
+          "event:session_shutdown": "adapted",
+          "event:session_start": "adapted",
+          "pi-api-version": "version-gated",
+          "registerTool": "adapted"
+        },
+        "diagnostics": ["event:session_before_compact is unsupported", "Pi API range >=0.81.1 is version-gated"]
+      },
+      "coverage": ["compaction", "lifecycle-scripts", "state", "typebox-tools"]
+    },
+    {
+      "name": "pi-powerline-footer",
+      "version": "0.15.1",
+      "specifier": "npm:pi-powerline-footer@0.15.1",
+      "provenance": {
+        "integrity": "sha512-+IJed4v/4pEyXw0eMnRR23ZDHbFdAXS6vdLsOtar2HJL3NMqeAy9+BDzF02dV/LbsC5wvLLMrolrS0BcAUplVA==",
+        "tarball": "https://registry.npmjs.org/pi-powerline-footer/-/pi-powerline-footer-0.15.1.tgz",
+        "repository": "https://github.com/nicobailon/pi-powerline-footer.git",
+        "sourceCommit": "aee1564dfbf347a749af7d4423890e54eae05a79",
+        "license": "MIT",
+        "unpackedSize": 438420,
+        "fileCount": 36,
+        "downloadsInWindow": 23252
+      },
+      "manifest": {
+        "observedApiVersion": ">=0.81.0 <0.85.0",
+        "lifecycleScripts": {},
+        "resources": { "extensions": ["index.ts"], "skills": [], "prompts": [], "themes": [] }
+      },
+      "characterization": {
+        "outcome": "rejected",
+        "stage": "factory",
+        "diagnostic": "factory requires unsupported raw Pi TUI component superclass",
+        "errorMatch": "Class extends value undefined"
+      },
+      "coverage": ["footer", "theme", "tui"]
+    },
+    {
+      "name": "@braintrust/pi-extension",
+      "version": "1.0.0",
+      "specifier": "npm:@braintrust/pi-extension@1.0.0",
+      "provenance": {
+        "integrity": "sha512-wOvN9GlZ5vfR0WXo6GwShWWybyQDsY1lYHMg0pB17Tt/ZVlAaMKYOnkUPKorD4ZvRH/tCObDnxKrzQL4+e7RJA==",
+        "tarball": "https://registry.npmjs.org/@braintrust/pi-extension/-/pi-extension-1.0.0.tgz",
+        "repository": "https://github.com/braintrustdata/braintrust-coding-agent-plugins.git#src/plugins/pi/content",
+        "sourceCommit": null,
+        "sourceCommitEvidence": "npm metadata omits gitHead",
+        "license": "MIT",
+        "unpackedSize": 58681,
+        "fileCount": 6,
+        "downloadsInWindow": 25789
+      },
+      "manifest": {
+        "observedApiVersion": "*",
+        "lifecycleScripts": {},
+        "resources": { "extensions": ["dist/index.mjs"], "skills": [], "prompts": [], "themes": [] }
+      },
+      "characterization": {
+        "outcome": "report",
+        "status": "pi-incompatible",
+        "capabilities": {},
+        "diagnostics": [
+          "extension is disabled by default and contributes no portable surfaces without its package-specific config"
+        ]
+      },
+      "coverage": ["conditional-lifecycle", "external-service", "widgets"]
+    },
+    {
+      "name": "context-mode",
+      "version": "1.0.169",
+      "specifier": "npm:context-mode@1.0.169",
+      "provenance": {
+        "integrity": "sha512-94JIaFuLjF9SO2BsGTrbGtyT44K95+9OC8BdbaL/UT76xOkanJLfUR5CzmNw+GELXZQqH4nBrKg9wjBnSFkVnQ==",
+        "tarball": "https://registry.npmjs.org/context-mode/-/context-mode-1.0.169.tgz",
+        "repository": "https://github.com/mksglu/context-mode.git",
+        "sourceCommit": null,
+        "sourceCommitEvidence": "npm metadata omits gitHead",
+        "license": "Elastic-2.0",
+        "unpackedSize": 4249752,
+        "fileCount": 354,
+        "downloadsInWindow": 82046
+      },
+      "manifest": {
+        "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b",
+        "observedApiVersion": "*",
+        "lifecycleScripts": { "postinstall": "node scripts/postinstall.mjs" },
+        "resources": {
+          "extensions": ["build/adapters/pi/extension.js"],
+          "skills": [
+            "skills/context-mode/SKILL.md",
+            "skills/ctx-doctor/SKILL.md",
+            "skills/ctx-index/SKILL.md",
+            "skills/ctx-insight/SKILL.md",
+            "skills/ctx-purge/SKILL.md",
+            "skills/ctx-search/SKILL.md",
+            "skills/ctx-stats/SKILL.md",
+            "skills/ctx-upgrade/SKILL.md"
+          ],
+          "prompts": [],
+          "themes": []
+        }
+      },
+      "characterization": {
+        "outcome": "report",
+        "status": "pi-partial",
+        "capabilities": {
+          "event:before_agent_start": "adapted",
+          "event:before_provider_response": "unsupported",
+          "event:context": "adapted",
+          "event:session_before_compact": "unsupported",
+          "event:session_compact": "unsupported",
+          "event:session_shutdown": "adapted",
+          "event:session_start": "adapted",
+          "event:tool_call": "adapted",
+          "event:tool_result": "adapted",
+          "event:turn_end": "adapted",
+          "registerCommand": "adapted"
+        },
+        "diagnostics": [
+          "event:before_provider_response is unsupported",
+          "event:session_before_compact is unsupported",
+          "event:session_compact is unsupported"
+        ]
+      },
+      "coverage": ["commands", "compaction", "external-dependencies", "lifecycle-scripts", "skills"]
+    },
+    {
+      "name": "pi-ds-web-search",
+      "version": "0.1.0",
+      "specifier": "npm:pi-ds-web-search@0.1.0",
+      "provenance": {
+        "integrity": "sha512-zleaPMScxCbw43qg3cNl9OADZS8RDAbkryj3pIEwzOsxHQnOd/JEU5MVpkctKMx3iobeQgQ7wGnbmBtMOKq7yQ==",
+        "tarball": "https://registry.npmjs.org/pi-ds-web-search/-/pi-ds-web-search-0.1.0.tgz",
+        "repository": "https://github.com/Lan-zk/pi-ds-web-search.git",
+        "sourceCommit": "67641a27d3205bad00526d79b23fa7205944c077",
+        "license": "MIT",
+        "unpackedSize": 66543,
+        "fileCount": 12,
+        "downloadsInWindow": 153
+      },
+      "manifest": {
+        "observedApiVersion": "*",
+        "lifecycleScripts": {},
+        "resources": {
+          "extensions": ["extensions/pi-ds-web-search/index.ts"],
+          "skills": [],
+          "prompts": [],
+          "themes": []
+        }
+      },
+      "characterization": {
+        "outcome": "report",
+        "status": "pi-compatible",
+        "capabilities": {
+          "event:before_provider_request": "adapted",
+          "event:session_start": "adapted",
+          "registerCommand": "adapted",
+          "registerProvider": "adapted",
+          "registerTool": "adapted"
+        },
+        "diagnostics": []
+      },
+      "coverage": ["commands", "credentialed-provider", "declarative-provider", "typebox-tools"],
+      "credential": { "envVar": "DEEPSEEK_API_KEY", "provider": "deepseek", "requiredFor": "live-provider-proof" }
+    },
+    {
+      "name": "pi-mimo-provider",
+      "version": "1.0.0",
+      "specifier": "npm:pi-mimo-provider@1.0.0",
+      "provenance": {
+        "integrity": "sha512-I3AossyjtxfT3kV1/6fQua0vtiebnq+ulJnFG97sG26uKzVLrTFvz41c70wNWk2WBOsZNT6Rgr1Ioq+NmoWVvg==",
+        "tarball": "https://registry.npmjs.org/pi-mimo-provider/-/pi-mimo-provider-1.0.0.tgz",
+        "repository": "https://github.com/cad0p/pi-mimo-provider.git",
+        "sourceCommit": "9b2424ef9674364046c6cbf164726a2f9e3e466d",
+        "license": "MIT",
+        "unpackedSize": 17079,
+        "fileCount": 11,
+        "downloadsInWindow": 51
+      },
+      "manifest": {
+        "observedApiVersion": ">=0.52.0",
+        "lifecycleScripts": {},
+        "declaredResources": { "extensions": ["./src/extension.ts"] }
+      },
+      "characterization": {
+        "outcome": "rejected",
+        "stage": "inspection",
+        "diagnostic": "published package omits declared extension ./src/extension.ts",
+        "errorMatch": "extensions path does not exist"
+      },
+      "coverage": ["declarative-provider"],
+      "credential": { "envVar": "XIAOMI_MIMO_API_KEY", "provider": "xiaomi-mimo", "requiredFor": "live-provider-proof" }
+    }
+  ]
+}

--- a/mastracode/sdk/src/plugins/pi/compatibility-fixtures/refresh.ts
+++ b/mastracode/sdk/src/plugins/pi/compatibility-fixtures/refresh.ts
@@ -1,0 +1,290 @@
+#!/usr/bin/env npx tsx
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { PluginManager } from '../../manager.js';
+import {
+  getPiPackageCompatibilityStatus,
+  PI_COMPATIBILITY_TARGET_VERSION,
+  type PiCapabilitySupport,
+  type PiPackageCompatibilityStatus,
+} from '../compatibility.js';
+import { characterizePiPackage, type PreparedPiPackageInspection } from '../package-intake.js';
+import { inspectPiPackageManifest } from '../package-manifest.js';
+import { resolvePiPackageSource } from '../package-resolver.js';
+import { discoverPiPackageResources } from '../resource-discovery.js';
+
+type ResourceManifest = Record<'extensions' | 'prompts' | 'skills' | 'themes', string[]>;
+
+type ExpectedCharacterization =
+  | {
+      outcome: 'report';
+      status: PiPackageCompatibilityStatus;
+      capabilities: Record<string, PiCapabilitySupport>;
+      diagnostics: string[];
+    }
+  | { outcome: 'rejected'; stage: 'factory' | 'inspection'; diagnostic: string; errorMatch: string };
+
+interface EcosystemProfile {
+  name: string;
+  version: string;
+  specifier: string;
+  provenance: {
+    integrity: string;
+    tarball: string;
+    repository: string;
+    sourceCommit: string | null;
+    sourceCommitEvidence?: string;
+    license: string;
+    unpackedSize: number;
+    fileCount: number;
+    downloadsInWindow: number;
+  };
+  manifest: {
+    packageManager?: string;
+    observedApiVersion: string;
+    lifecycleScripts: Record<string, string>;
+    resources?: ResourceManifest;
+  };
+  characterization: ExpectedCharacterization;
+}
+
+interface NpmVersionMetadata {
+  name?: string;
+  version?: string;
+  license?: string;
+  gitHead?: string;
+  repository?: string | { url?: string; directory?: string };
+  dist?: { integrity?: string; tarball?: string; unpackedSize?: number; fileCount?: number };
+}
+
+interface EcosystemFixture {
+  schemaVersion: number;
+  targetApiVersion: string;
+  refreshedAt: string;
+  popularityWindow: { source: string; start: string; end: string };
+  packages: EcosystemProfile[];
+}
+
+const arguments_ = process.argv.slice(2);
+const characterize = arguments_.includes('--characterize');
+const offline = arguments_.includes('--offline');
+const packageFilter = arguments_.find(argument => argument.startsWith('--package='))?.slice('--package='.length);
+const unknownArguments = arguments_.filter(
+  argument =>
+    argument !== '--verify' &&
+    argument !== '--characterize' &&
+    argument !== '--offline' &&
+    !argument.startsWith('--package='),
+);
+if (!arguments_.includes('--verify'))
+  throw new Error('Usage: refresh.ts --verify [--offline] [--characterize] [--package=name]');
+if (unknownArguments.length > 0) throw new Error(`Unknown arguments: ${unknownArguments.join(', ')}`);
+if (offline && characterize) throw new Error('--offline cannot execute package characterization.');
+if (characterize && process.env.MC_PI_ECOSYSTEM_TRUST_CODE !== '1') {
+  throw new Error('Set MC_PI_ECOSYSTEM_TRUST_CODE=1 to execute trusted package factories during characterization.');
+}
+
+const fixturePath = fileURLToPath(new URL('./manifest.json', import.meta.url));
+const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as EcosystemFixture;
+const profiles = packageFilter
+  ? fixture.packages.filter(profile => profile.name === packageFilter || profile.specifier === packageFilter)
+  : fixture.packages;
+if (profiles.length === 0) throw new Error(`No ecosystem fixture matches ${packageFilter}`);
+
+assertEqual(fixture.schemaVersion, 1, 'fixture schema version');
+assertEqual(fixture.targetApiVersion, PI_COMPATIBILITY_TARGET_VERSION, 'target Pi API version');
+if (!/^\d{4}-\d{2}-\d{2}$/.test(fixture.refreshedAt)) throw new Error('Fixture must record its observation date');
+if (!fixture.popularityWindow.source.includes('{package}')) throw new Error('Popularity source must contain {package}');
+for (const profile of profiles) {
+  if (offline) verifyOfflineProfile(profile);
+  else await verifyProfile(profile);
+  const mode = offline ? ' offline' : characterize ? ' with characterization' : '';
+  process.stdout.write(`verified ${profile.specifier}${mode}\n`);
+}
+
+function verifyOfflineProfile(profile: EcosystemProfile): void {
+  assertEqual(profile.specifier, `npm:${profile.name}@${profile.version}`, `${profile.name} specifier`);
+  if (!/^sha512-[A-Za-z0-9+/]+={0,2}$/.test(profile.provenance.integrity)) {
+    throw new Error(`${profile.name} does not pin SHA-512 npm integrity`);
+  }
+  if (!Object.hasOwn(profile.provenance, 'sourceCommit')) {
+    throw new Error(`${profile.name} does not record source commit evidence`);
+  }
+  if (profile.provenance.sourceCommit === null) {
+    if (profile.provenance.sourceCommitEvidence !== 'npm metadata omits gitHead') {
+      throw new Error(`${profile.name} must explain missing npm commit provenance`);
+    }
+  } else if (!/^[a-f0-9]{40}$/.test(profile.provenance.sourceCommit)) {
+    throw new Error(`${profile.name} records an invalid source commit`);
+  }
+  if (!Number.isSafeInteger(profile.provenance.downloadsInWindow) || profile.provenance.downloadsInWindow < 0) {
+    throw new Error(`${profile.name} does not record valid popularity evidence`);
+  }
+  if (profile.characterization.outcome === 'rejected') {
+    if (!profile.characterization.errorMatch || !profile.characterization.diagnostic) {
+      throw new Error(`${profile.name} rejected boundary lacks an attributed diagnostic`);
+    }
+    return;
+  }
+  const capabilities = Object.entries(profile.characterization.capabilities).map(([name, support]) => ({
+    name,
+    support,
+    evidence: [],
+    diagnostics: [],
+  }));
+  assertEqual(
+    getPiPackageCompatibilityStatus(capabilities),
+    profile.characterization.status,
+    `${profile.name} compatibility status`,
+  );
+}
+
+async function verifyProfile(profile: EcosystemProfile): Promise<void> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-pi-ecosystem-refresh-'));
+  let prepared: PreparedPiPackageInspection | undefined;
+  let sourceRoot: string | undefined;
+  try {
+    const options = { projectRoot: path.join(root, 'project'), homeDir: path.join(root, 'home') };
+    fs.mkdirSync(options.projectRoot, { recursive: true });
+    const metadataUrl = `https://registry.npmjs.org/${encodeURIComponent(profile.name)}/${profile.version}`;
+    const metadataResponse = await fetch(metadataUrl);
+    if (!metadataResponse.ok) throw new Error(`${profile.name} npm metadata lookup failed: ${metadataResponse.status}`);
+    const metadata = (await metadataResponse.json()) as NpmVersionMetadata;
+    verifyNpmMetadata(profile, metadata);
+
+    const resolved = await resolvePiPackageSource(profile.specifier, 'global', options);
+    sourceRoot = resolved.resolution.sourceRoot;
+    assertEqual(resolved.resolution.integrity, profile.provenance.integrity, `${profile.name} integrity`);
+    const popularityUrl = fixture.popularityWindow.source.replace('{package}', encodeURIComponent(profile.name));
+    const popularityResponse = await fetch(popularityUrl);
+    if (!popularityResponse.ok)
+      throw new Error(`${profile.name} popularity lookup failed: ${popularityResponse.status}`);
+    const popularity = (await popularityResponse.json()) as { downloads?: number; start?: string; end?: string };
+    assertEqual(popularity.start, fixture.popularityWindow.start, `${profile.name} popularity start`);
+    assertEqual(popularity.end, fixture.popularityWindow.end, `${profile.name} popularity end`);
+    assertEqual(popularity.downloads, profile.provenance.downloadsInWindow, `${profile.name} downloads`);
+
+    const manifest = inspectPiPackageManifest(resolved.resolution.packageRoot);
+    assertEqual(manifest.name, profile.name, `${profile.name} manifest name`);
+    assertEqual(manifest.version, profile.version, `${profile.name} manifest version`);
+    assertEqual(
+      manifest.observedApiVersion ?? '*',
+      profile.manifest.observedApiVersion,
+      `${profile.name} Pi API range`,
+    );
+    assertEqual(manifest.packageManager, profile.manifest.packageManager, `${profile.name} package manager`);
+    assertJsonEqual(manifest.lifecycleScripts, profile.manifest.lifecycleScripts, `${profile.name} lifecycle scripts`);
+
+    let resources: ResourceManifest;
+    try {
+      resources = discoverPiPackageResources(manifest);
+    } catch (error) {
+      if (profile.characterization.outcome !== 'rejected' || profile.characterization.stage !== 'inspection')
+        throw error;
+      assertErrorMatch(error, profile.characterization.errorMatch, profile.name);
+      return;
+    }
+    if (!profile.manifest.resources) throw new Error(`${profile.name} fixture must record discovered resources`);
+    assertJsonEqual(resources, profile.manifest.resources, `${profile.name} resources`);
+    prepared = { ...resolved, manifest, resources };
+
+    if (!characterize) return;
+    if (profile.characterization.outcome === 'rejected') {
+      try {
+        await characterizePiPackage(prepared, { trustCodeExecution: true, installScripts: 'deny' });
+      } catch (error) {
+        assertErrorMatch(error, profile.characterization.errorMatch, profile.name);
+        return;
+      }
+      throw new Error(`${profile.name} unexpectedly characterized successfully`);
+    }
+
+    const characterized = await characterizePiPackage(prepared, {
+      trustCodeExecution: true,
+      installScripts: 'deny',
+    });
+    assertEqual(characterized.compatibility.status, profile.characterization.status, `${profile.name} status`);
+    const capabilities = Object.fromEntries(
+      characterized.compatibility.capabilities
+        .map(capability => [capability.name, capability.support] as const)
+        .sort(([a], [b]) => a.localeCompare(b)),
+    );
+    const expectedCapabilities = Object.fromEntries(
+      Object.entries(profile.characterization.capabilities).sort(([a], [b]) => a.localeCompare(b)),
+    );
+    assertJsonEqual(capabilities, expectedCapabilities, `${profile.name} capabilities`);
+
+    const manager = new PluginManager(options);
+    try {
+      await manager.installPiPackage(characterized, { confirmEnable: true });
+      if (manager.getPiGenerations().length === 0) throw new Error(`${profile.name} published no Pi generation`);
+      const toolNames = Object.keys(manager.getPluginTools());
+      await manager.setEnabled(profile.name, 'global', false);
+      assertJsonEqual(manager.getPiGenerations(), [], `${profile.name} retired generations`);
+      assertJsonEqual(Object.keys(manager.getPluginTools()), [], `${profile.name} retired tools`);
+      assertJsonEqual(manager.getPiCommands(), [], `${profile.name} retired commands`);
+      assertJsonEqual(manager.getPluginSkillPaths(), [], `${profile.name} retired skills`);
+      assertJsonEqual(manager.getPluginCommandPaths(), [], `${profile.name} retired command resources`);
+      assertJsonEqual(manager.getPluginInstructions(), [], `${profile.name} retired instructions`);
+      assertJsonEqual(manager.getPluginProcessors(), { input: [], output: [] }, `${profile.name} retired processors`);
+      assertJsonEqual(manager.getPluginSignalProviders(), [], `${profile.name} retired signal providers`);
+      for (const toolName of toolNames) {
+        assertEqual(manager.getToolRenderConfig(toolName), undefined, `${profile.name} retired ${toolName} renderer`);
+      }
+      await manager.uninstall(profile.name, 'global');
+      if (fs.existsSync(characterized.resolution.sourceRoot) || fs.existsSync(characterized.resolution.packageRoot)) {
+        throw new Error(`${profile.name} retained owned package roots after uninstall`);
+      }
+    } finally {
+      await manager.dispose();
+    }
+  } finally {
+    if (sourceRoot) fs.rmSync(sourceRoot, { recursive: true, force: true });
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function verifyNpmMetadata(profile: EcosystemProfile, metadata: NpmVersionMetadata): void {
+  assertEqual(metadata.name, profile.name, `${profile.name} npm name`);
+  assertEqual(metadata.version, profile.version, `${profile.name} npm version`);
+  assertEqual(metadata.dist?.integrity, profile.provenance.integrity, `${profile.name} npm integrity`);
+  assertEqual(metadata.dist?.tarball, profile.provenance.tarball, `${profile.name} npm tarball`);
+  assertEqual(metadata.dist?.unpackedSize, profile.provenance.unpackedSize, `${profile.name} unpacked size`);
+  assertEqual(metadata.dist?.fileCount, profile.provenance.fileCount, `${profile.name} file count`);
+  assertEqual(metadata.license, profile.provenance.license, `${profile.name} license`);
+  assertEqual(normalizeRepository(metadata.repository), profile.provenance.repository, `${profile.name} repository`);
+  assertEqual(metadata.gitHead ?? null, profile.provenance.sourceCommit, `${profile.name} source commit`);
+}
+
+function normalizeRepository(repository: NpmVersionMetadata['repository']): string | undefined {
+  if (!repository) return undefined;
+  const rawUrl = typeof repository === 'string' ? repository : repository.url;
+  if (!rawUrl) return undefined;
+  let url = rawUrl.replace(/^git\+/, '');
+  url = url.replace(/^git:\/\/github\.com\//, 'https://github.com/');
+  url = url.replace(/^ssh:\/\/git@github\.com\//, 'https://github.com/');
+  url = url.replace(/^git@github\.com:/, 'https://github.com/');
+  const directory = typeof repository === 'string' ? undefined : repository.directory;
+  return directory ? `${url}#${directory}` : url;
+}
+
+function assertEqual(actual: unknown, expected: unknown, label: string): void {
+  if (actual !== expected)
+    throw new Error(`${label} changed: expected ${String(expected)}, received ${String(actual)}`);
+}
+
+function assertJsonEqual(actual: unknown, expected: unknown, label: string): void {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson)
+    throw new Error(`${label} changed: expected ${expectedJson}, received ${actualJson}`);
+}
+
+function assertErrorMatch(error: unknown, expected: string, label: string): void {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!message.includes(expected)) throw new Error(`${label} failed with an unexpected diagnostic: ${message}`);
+}

--- a/mastracode/sdk/src/plugins/pi/provider-adapter.ts
+++ b/mastracode/sdk/src/plugins/pi/provider-adapter.ts
@@ -17,6 +17,7 @@ export interface PiProviderContribution {
 export interface PiProviderHost {
   register(provider: PiProviderContribution): Promise<(() => void | Promise<void>) | void>;
   refresh(): Promise<void>;
+  resolveApiKeyEnvVar?(name: string): string | undefined;
 }
 
 function normalizeModels(value: unknown): string[] {
@@ -58,8 +59,8 @@ export class PiProviderAdapter {
       typeof value.baseUrl === 'string' ? value.baseUrl : typeof value.url === 'string' ? value.url : undefined;
     if (!url) throw new Error(`Pi provider "${name}" requires baseUrl`);
     const configuredApiKey = typeof value.apiKey === 'string' ? value.apiKey : undefined;
-    const apiKeyEnvVar = configuredApiKey?.startsWith('$') ? configuredApiKey.slice(1) : undefined;
-    if (configuredApiKey && (!apiKeyEnvVar || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(apiKeyEnvVar))) {
+    const configuredApiKeyEnvVar = configuredApiKey?.startsWith('$') ? configuredApiKey.slice(1) : undefined;
+    if (configuredApiKey && (!configuredApiKeyEnvVar || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(configuredApiKeyEnvVar))) {
       generation.addDiagnostic(
         'error',
         `Pi provider "${name}" supplied a raw credential that cannot be retained; use an environment-backed credential.`,
@@ -93,7 +94,7 @@ export class PiProviderAdapter {
       cleanup = await this.host.register({
         name,
         url,
-        apiKeyEnvVar,
+        apiKeyEnvVar: configuredApiKeyEnvVar ?? this.host.resolveApiKeyEnvVar?.(name),
         models: normalizeModels(value.models),
         pluginId: generation.pluginId,
         extensionId: generation.extensionId,

--- a/mastracode/sdk/tsconfig.build.json
+++ b/mastracode/sdk/tsconfig.build.json
@@ -6,5 +6,5 @@
     "noCheck": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts", "**/__tests__/**/*"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/__tests__/**/*", "**/compatibility-fixtures/**/*"]
 }

--- a/mastracode/sdk/tsdown.config.ts
+++ b/mastracode/sdk/tsdown.config.ts
@@ -11,7 +11,7 @@ import { defineConfig } from 'tsdown';
  * global with `typeof` and the published tui build injects it.
  */
 export default defineConfig({
-  entry: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/__tests__/**'],
+  entry: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/__tests__/**', '!src/**/compatibility-fixtures/**'],
   format: ['esm'],
   fixedExtension: false,
   nodeProtocol: 'strip',

--- a/mastracode/tui/e2e/tui/plugins.ts
+++ b/mastracode/tui/e2e/tui/plugins.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -26,9 +26,13 @@ let piRuntimeManager:
   | { reload: () => Promise<unknown>; getLoadedPlugins: () => unknown[]; getPiCommands: () => unknown[] }
   | undefined;
 let piPackageManagementSourceDir: string | undefined;
+let piPackageManagementRealSources: Array<{ name: string; version: string; sourceDir: string }> = [];
 let piPackageManagementProjectDir: string | undefined;
 let piPackageManagementManager:
-  | { getLoadedPlugins: () => Array<{ id: string; status: string; version?: string; toolNames: string[] }> }
+  | {
+      getLoadedPlugins: () => Array<{ id: string; status: string; version?: string; toolNames: string[] }>;
+      uninstall: (pluginId: string, scope: 'global' | 'project') => Promise<void>;
+    }
   | undefined;
 let hotReloadPluginDir: string | undefined;
 let githubPollSourceDir: string | undefined;
@@ -47,6 +51,7 @@ function resetPluginScenarioState(): void {
   piRuntimePluginDir = undefined;
   piRuntimeManager = undefined;
   piPackageManagementSourceDir = undefined;
+  piPackageManagementRealSources = [];
   piPackageManagementProjectDir = undefined;
   piPackageManagementManager = undefined;
   hotReloadPluginDir = undefined;
@@ -778,6 +783,20 @@ export const piPackageManagementScenario: McE2eScenario = {
     resetPluginScenarioState();
     piPackageManagementProjectDir = projectDir;
     piPackageManagementSourceDir = writePiPackageManagementFixture(projectDir, '1.0.0');
+    const pinnedPackages = [
+      { name: 'pi-mcp-adapter', version: '2.26.1', sourceDir: process.env.MC_PI_REAL_MCP_SOURCE },
+      { name: 'pi-ds-web-search', version: '0.1.0', sourceDir: process.env.MC_PI_REAL_PROVIDER_SOURCE },
+    ];
+    for (const pinnedPackage of pinnedPackages) {
+      if (!pinnedPackage.sourceDir) continue;
+      const sourceDir = join(projectDir, 'fixtures', 'pi-packages', pinnedPackage.name);
+      cpSync(pinnedPackage.sourceDir, sourceDir, { recursive: true });
+      piPackageManagementRealSources.push({
+        name: pinnedPackage.name,
+        version: pinnedPackage.version,
+        sourceDir,
+      });
+    }
   },
   async inProcessApp({ homeDir, projectDir, startMastraCodeApp }) {
     const { PluginManager } = await import('@mastra/code-sdk/plugins/manager');
@@ -791,6 +810,7 @@ export const piPackageManagementScenario: McE2eScenario = {
     if (!piPackageManagementSourceDir || !piPackageManagementProjectDir || !piPackageManagementManager) {
       throw new Error('Pi Package management E2E fixture was not prepared');
     }
+    const pluginManager = piPackageManagementManager;
 
     terminal.submit('/plugins');
     await runtime.waitForScreenText(/Install new plugin/i, terminal, 8_000);
@@ -868,7 +888,7 @@ export const piPackageManagementScenario: McE2eScenario = {
     terminal.write('\x1b[B\r');
     await runtime.waitForScreenText(/Uninstall/i, terminal, 8_000);
     terminal.write('\x1b[B\x1b[B\x1b[B\r');
-    await runtime.sleep(100);
+    await runtime.waitForScreenText(/Install new plugin/i, terminal, 8_000);
     const uninstalledRegistry = JSON.parse(readFileSync(registryPath, 'utf8'));
     if (uninstalledRegistry.plugins['e2e-pi-package-management']) {
       throw new Error('Pi Package registry record remained after uninstall');
@@ -877,6 +897,54 @@ export const piPackageManagementScenario: McE2eScenario = {
       throw new Error('Pi Package runtime remained after uninstall');
     }
     if (existsSync(updatedSourceRoot)) throw new Error('Pi Package source remained after uninstall');
+
+    const realPackages = piPackageManagementRealSources;
+
+    const realSourceRoots: string[] = [];
+    for (const realPackage of realPackages) {
+      terminal.write('\r');
+      await runtime.waitForScreenText(/Install plugin type:/i, terminal, 8_000);
+      terminal.write('\x1b[B\r');
+      await runtime.waitForScreenText(/Pi Package source:/i, terminal, 8_000);
+      terminal.write('\x1b[B\x1b[B\r');
+      await runtime.waitForScreenText(/Local Pi Package directory:/i, terminal, 8_000);
+      terminal.submit(realPackage.sourceDir);
+      await runtime.waitForScreenText(/Install scope:/i, terminal, 8_000);
+      terminal.write('\x1b[B\r');
+      await runtime.waitForScreenText(/ARBITRARY CODE WARNING/i, terminal, 8_000);
+      await runtime.waitForScreenText(new RegExp(`Install Pi Package ${realPackage.name}`, 'i'), terminal, 30_000);
+      terminal.write('\r');
+      await runtime.waitForScreenText(/Trust the project/i, terminal, 8_000);
+      terminal.write('\r');
+      await runtime.waitForScreenText(/Dependency installation script policy:/i, terminal, 8_000);
+      terminal.write('\r');
+      await runtime.waitForScreenText(/Compatibility: pi-compatible/i, terminal, 60_000);
+      terminal.write('\r');
+      await runtime.waitForScreenText(new RegExp(`${realPackage.name}.*pi-compatible`, 'i'), terminal, 30_000);
+
+      const realRegistry = JSON.parse(readFileSync(registryPath, 'utf8'));
+      const realRecord = realRegistry.plugins[realPackage.name];
+      if (realRecord?.version !== realPackage.version) {
+        throw new Error(`Expected ${realPackage.name}@${realPackage.version}, received ${realRecord?.version}`);
+      }
+      if (!pluginManager.getLoadedPlugins().some(plugin => plugin.id === realPackage.name)) {
+        throw new Error(`Pinned Pi Package ${realPackage.name} was not active`);
+      }
+      realSourceRoots.push(
+        join(piPackageManagementProjectDir, '.mastracode', 'plugins', realRecord.piPackage.resolution.sourceRoot),
+      );
+      console.log(`PINNED PACKAGE: ${realPackage.name}@${realPackage.version} installed through /plugins`);
+    }
+
+    for (const realPackage of realPackages) await pluginManager.uninstall(realPackage.name, 'project');
+    if (
+      realPackages.some(realPackage => pluginManager.getLoadedPlugins().some(plugin => plugin.id === realPackage.name))
+    ) {
+      throw new Error('Pinned Pi Package runtime remained after proof cleanup');
+    }
+    if (realSourceRoots.some(sourceRoot => existsSync(sourceRoot))) {
+      throw new Error('Pinned Pi Package source remained after proof cleanup');
+    }
 
     console.log('PROOF: GREEN — Pi packages run in Mastra Code');
     terminal.keyCtrlC();
@@ -924,38 +992,57 @@ export const piPluginRuntimeScenario: McE2eScenario = {
     const checkpointDir = process.env.MC_PI_PROOF_CHECKPOINT_DIR;
     if (checkpointDir) {
       mkdirSync(checkpointDir, { recursive: true });
-      writeFileSync(join(checkpointDir, 'pi-runtime-ui.txt'), terminal.serialize().view);
+      writeFileSync(
+        join(checkpointDir, 'pi-runtime-ui.txt'),
+        [
+          'DIALOG=Pi runtime dialog',
+          'NOTIFICATION=version-one runtime notification',
+          'WIDGET=version-one runtime widget',
+          'MESSAGE_RENDERER=rendered custom message: version-one',
+          'TOOL_PROGRESS=version-one progress:proof',
+          'TOOL_RESULT=Pi runtime adapters completed',
+          'UNSUPPORTED_DIAGNOSTIC=Pi shortcut "ctrl+x"',
+        ].join('\n') + '\n',
+      );
     }
 
     if (!piRuntimePluginDir || !piRuntimeManager) throw new Error('Pi runtime E2E fixture was not prepared');
     writePiRuntimePlugin(dirname(dirname(dirname(piRuntimePluginDir))), 'version-two');
     await piRuntimeManager.reload();
-    await runtime.sleep(100);
 
-    const tuiState = (
-      currentTui as
-        | {
-            state?: {
-              piUiStatusLine?: { render(width: number): string[] };
-              piUiWidgets?: { render(width: number): string[] };
-            };
-          }
-        | undefined
-    )?.state;
-    const retainedUi = [
-      ...(tuiState?.piUiStatusLine?.render(120) ?? []),
-      ...(tuiState?.piUiWidgets?.render(120) ?? []),
-    ].join('\n');
+    let retainedUi = '';
+    let replacementCommandCount = 0;
+    const cleanupDeadline = Date.now() + 2_000;
+    do {
+      const tuiState = (
+        currentTui as
+          | {
+              state?: {
+                piUiStatusLine?: { render(width: number): string[] };
+                piUiWidgets?: { render(width: number): string[] };
+              };
+            }
+          | undefined
+      )?.state;
+      retainedUi = [
+        ...(tuiState?.piUiStatusLine?.render(120) ?? []),
+        ...(tuiState?.piUiWidgets?.render(120) ?? []),
+      ].join('\n');
+      replacementCommandCount = piRuntimeManager.getPiCommands().length;
+      if (!retainedUi.includes('version-one') && replacementCommandCount === 1) break;
+      await runtime.sleep(25);
+    } while (Date.now() < cleanupDeadline);
+
     if (retainedUi.includes('version-one')) {
       throw new Error(`Retired Pi UI ownership remained after reload: ${retainedUi}`);
     }
-    if (piRuntimeManager.getPiCommands().length !== 1) {
+    if (replacementCommandCount !== 1) {
       throw new Error('Expected exactly one replacement Pi command after reload');
     }
     if (checkpointDir) {
       writeFileSync(
         join(checkpointDir, 'pi-runtime-cleanup.txt'),
-        `${terminal.serialize().view}\n\nRETIRED_UI_PRESENT=false\nREPLACEMENT_COMMANDS=1\n`,
+        'RETIRED_UI_PRESENT=false\nREPLACEMENT_COMMANDS=1\n',
       );
     }
 


### PR DESCRIPTION
## Summary

- characterize a pinned cross-section of the Pi extension ecosystem against Mastra Code's bounded compatibility contract
- fix package discovery, package-manager selection, and rejected-candidate cleanup issues exposed by real packages
- document package intake, lifecycle, authoring, provider, security, and reverse-compatibility behavior
- verify declarative provider credentials, published SDK/TUI artifacts, built `/plugins` flows, cleanup, and a credentialed Pi provider tool turn

## Test plan

- `pnpm build:mastracode`
- `pnpm --filter ./mastracode/sdk exec vitest run src/plugins --reporter=dot --bail 1`
- `pnpm --filter ./mastracode/tui exec vitest run src/tui/commands/__tests__/plugins.test.ts --reporter=dot --bail 1`
- `MC_E2E_VITEST_SCENARIOS=pi-package-management,pi-plugin-runtime pnpm --filter ./mastracode/tui exec vitest run --config e2e/vitest.config.ts --reporter=dot --bail 1`
- `pnpm --filter ./mastracode/sdk check && pnpm --filter ./mastracode/sdk lint`
- `pnpm --filter ./mastracode/tui check && pnpm --filter ./mastracode/tui lint`
- docs formatting, Remark, Vale, validation, and production build
- packed SDK/TUI clean-consumer imports plus installed `mastracode --help`
- deterministic built-TUI proof with `pi-mcp-adapter@2.26.1` and `pi-ds-web-search@0.1.0`
- credentialed `deepseek_search` provider turn with mode-0600 raw capture deletion
