### PR TITLE
fix(core): forward unmapped AI SDK content parts in generate-to-stream

### DIFF
--- a/.changeset/great-schools-marry.md
+++ b/.changeset/great-schools-marry.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Stop `doGenerate()` from silently dropping AI SDK content parts it does not expand explicitly.
+
+`createStreamFromGenerateResult()` converted a `doGenerate()` result with an if/else chain that ended at `source` and had no fallback, so any other content part was discarded without an error. The stream still carried `stream-start`, `response-metadata` and `finish`, which made the loss easy to miss.
+
+The affected parts are `tool-approval-request` (provider v3 and v4) and `custom` plus `reasoning-file` (provider v4). They need no start/delta/end expansion because the spec's stream-part unions reuse the same content types verbatim, and `doStream()` already forwards them untouched. They are now forwarded unchanged, so the generate path is no longer lossier than the stream path and provider-specific content, generated reasoning files and required tool approvals reach stream consumers, output processors and message persistence.

--- a/packages/core/src/llm/model/aisdk/generate-to-stream.test.ts
+++ b/packages/core/src/llm/model/aisdk/generate-to-stream.test.ts
@@ -141,4 +141,104 @@ describe('createStreamFromGenerateResult', () => {
     expect(textEnd.providerMetadata).toBeUndefined();
     expect(file.providerMetadata).toBeUndefined();
   });
+
+  // The AI SDK content union is wider than the parts this converter expands
+  // explicitly. 'reasoning-file' and 'custom' are provider-v4 content types and
+  // 'tool-approval-request' exists in provider-v3 and v4. All three are also
+  // valid stream parts with an identical shape, so doStream() forwards them
+  // untouched; the generate path must not be lossier than the stream path.
+  describe('content parts that map straight to a stream part', () => {
+    it('should forward a reasoning-file part instead of dropping it', async () => {
+      const result = {
+        warnings: [],
+        content: [{ type: 'reasoning-file', mediaType: 'image/png', data: 'aGVsbG8=' }],
+        finishReason: 'stop',
+        usage: { promptTokens: 1, completionTokens: 1 },
+      };
+
+      const chunks = await collectStream(createStreamFromGenerateResult(result));
+
+      expect(chunks).toContainEqual({
+        type: 'reasoning-file',
+        mediaType: 'image/png',
+        data: 'aGVsbG8=',
+      });
+    });
+
+    it('should forward a custom part with its provider kind and metadata', async () => {
+      const providerMetadata = { openai: { itemId: 'item_1' } };
+      const result = {
+        warnings: [],
+        content: [{ type: 'custom', kind: 'openai.reasoning-summary', providerMetadata }],
+        finishReason: 'stop',
+        usage: { promptTokens: 1, completionTokens: 1 },
+      };
+
+      const chunks = await collectStream(createStreamFromGenerateResult(result));
+
+      expect(chunks).toContainEqual({
+        type: 'custom',
+        kind: 'openai.reasoning-summary',
+        providerMetadata,
+      });
+    });
+
+    it('should forward a tool-approval-request so approvals reach consumers', async () => {
+      const result = {
+        warnings: [],
+        content: [
+          { type: 'tool-call', toolCallId: 'call_1', toolName: 'deleteFile', input: '{}' },
+          { type: 'tool-approval-request', approvalId: 'approval_1', toolCallId: 'call_1' },
+        ],
+        finishReason: 'tool-calls',
+        usage: { promptTokens: 1, completionTokens: 1 },
+      };
+
+      const chunks = await collectStream(createStreamFromGenerateResult(result));
+
+      expect(chunks).toContainEqual({
+        type: 'tool-approval-request',
+        approvalId: 'approval_1',
+        toolCallId: 'call_1',
+      });
+    });
+
+    it('should preserve content order when forwarded parts sit between expanded ones', async () => {
+      const result = {
+        warnings: [],
+        content: [
+          { type: 'text', text: 'before' },
+          { type: 'custom', kind: 'acme.marker' },
+          { type: 'text', text: 'after' },
+        ],
+        finishReason: 'stop',
+        usage: { promptTokens: 1, completionTokens: 1 },
+      };
+
+      const chunks = (await collectStream(createStreamFromGenerateResult(result))) as Array<{
+        type: string;
+        delta?: string;
+      }>;
+
+      const order = chunks
+        .filter(c => c.type === 'text-delta' || c.type === 'custom')
+        .map(c => (c.type === 'custom' ? 'custom' : c.delta));
+
+      expect(order).toEqual(['before', 'custom', 'after']);
+    });
+
+    it('should still map handled parts rather than forwarding them verbatim', async () => {
+      const result = {
+        warnings: [],
+        content: [{ type: 'source', sourceType: 'url', id: 'src_1', url: 'https://example.com', title: 'Example' }],
+        finishReason: 'stop',
+        usage: { promptTokens: 1, completionTokens: 1 },
+      };
+
+      const chunks = (await collectStream(createStreamFromGenerateResult(result))) as Array<{ type: string }>;
+
+      // A single mapped 'source' event, not the raw content part echoed alongside it.
+      expect(chunks.filter(c => c.type === 'source')).toHaveLength(1);
+    });
+  });
 });

--- a/packages/core/src/llm/model/aisdk/generate-to-stream.ts
+++ b/packages/core/src/llm/model/aisdk/generate-to-stream.ts
@@ -2,7 +2,15 @@ import { randomUUID } from 'node:crypto';
 
 /**
  * Converts a doGenerate result to a ReadableStream format.
- * This is shared between V2 and V3 model wrappers since the content/result structure is compatible.
+ *
+ * Shared by the V2, V3 and V4 model wrappers (AISDKV5/V6/V7LanguageModel) since
+ * the content/result structure is compatible across those spec versions.
+ *
+ * Text and reasoning parts are expanded into their start/delta/end triples and
+ * tool calls into their tool-input triple, because doStream() emits them that
+ * way. Every other content part is already shaped like its stream-part
+ * counterpart and is forwarded unchanged, so the generate path stays in sync
+ * with the stream path as the AI SDK content union grows.
  */
 export function createStreamFromGenerateResult(result: {
   warnings: unknown[];

--- a/packages/core/src/llm/model/aisdk/generate-to-stream.ts
+++ b/packages/core/src/llm/model/aisdk/generate-to-stream.ts
@@ -160,6 +160,14 @@ export function createStreamFromGenerateResult(result: {
               providerMetadata: source.providerMetadata,
             });
           }
+        } else {
+          // Content parts that need no expansion ('reasoning-file', 'custom' and
+          // 'tool-approval-request') are themselves valid stream parts: the spec's
+          // stream-part union reuses the same content types verbatim. doStream()
+          // hands them to consumers untouched, so forward them unchanged here to
+          // keep doGenerate() lossless. Without this branch they are silently
+          // dropped and never reach stream consumers, processors or persistence.
+          controller.enqueue(message);
         }
       }
 

--- a/packages/core/src/llm/model/aisdk/v7/model.test.ts
+++ b/packages/core/src/llm/model/aisdk/v7/model.test.ts
@@ -324,6 +324,15 @@ describe('AISDKV7LanguageModel', () => {
         mediaType: 'image/png',
         data: 'aGVsbG8=',
       });
+
+      // Untagging the content is only half the job: consumers read the
+      // synthesized stream, so assert the part survives the conversion too.
+      const generateChunks = await collectStream(generateResult.stream);
+      expect(generateChunks).toContainEqual({
+        type: 'reasoning-file',
+        mediaType: 'image/png',
+        data: 'aGVsbG8=',
+      });
     });
 
     it('produces flat data the shared chunk transform maps to a valid FileChunk payload', async () => {


### PR DESCRIPTION
Fixes #21778

## What was broken

`createStreamFromGenerateResult()` converts a `doGenerate()` result into the stream shape the rest of Mastra consumes. It walked `result.content` with an `if / else if` chain that ended at `source` and had **no fallback branch**, so any content part outside the handled six was dropped on the floor. No error, no warning: the stream still carried `stream-start`, `response-metadata` and `finish`, so the loss was invisible to callers.

`packages/core/src/llm/model/aisdk/generate-to-stream.ts` (before):

```ts
for (const message of result.content) {
  if (message.type === 'tool-call') { ... }
  else if (message.type === 'tool-result') { ... }
  else if (message.type === 'text') { ... }
  else if (message.type === 'reasoning') { ... }
  else if (message.type === 'file') { ... }
  else if (message.type === 'source') { ... }
  // anything else: silently discarded
}
```

### The asymmetry that makes it a bug

`doStream()` is a pass-through, `doGenerate()` is an allowlist. That is the whole defect:

| wrapper | `doStream()` | `doGenerate()` |
| --- | --- | --- |
| `v5/model.ts:111` | `return await this.#model.doStream(...)` — provider stream verbatim | synthesized by the converter |
| `v6/model.ts:97` | `return await this.#model.doStream(...)` — provider stream verbatim | synthesized by the converter |
| `v7/model.ts:229` | provider stream, file data untagged only | synthesized by the converter |

So the same model returning the same content part delivers it to consumers when streamed and drops it when generated.

### Which parts, and in which spec versions

The issue lists three types but does not say which specs they belong to. Checked against the exact provider packages this repo pins (`packages/core/package.json`):

| content union | pinned version | members | dropped before this PR |
| --- | --- | --- | --- |
| `LanguageModelV2Content` (v5 wrapper) | `@ai-sdk/provider@2.0.3` | text, reasoning, file, source, tool-call, tool-result | **none** |
| `LanguageModelV3Content` (v6 wrapper) | `@ai-sdk/provider@3.0.14` | + `tool-approval-request` | 1 |
| `LanguageModelV4Content` (v7 wrapper) | `@ai-sdk/provider@4.0.4` | + `tool-approval-request`, `custom`, `reasoning-file` | 3 |

So V2 has no gap at all, and the report's implied "always three missing" only holds for V4.

## The fix

One `else` branch that forwards the part unchanged. This is not an invented mapping: the spec's stream-part unions **reuse the same content types verbatim**, e.g. from `@ai-sdk/provider@4.0.4`:

```ts
type LanguageModelV4StreamPart =
  | { type: 'text-start'; ... }
  | ...
  | LanguageModelV4ToolApprovalRequest
  | LanguageModelV4CustomContent
  | LanguageModelV4ReasoningFile
  | LanguageModelV4Source
  | ...
```

`LanguageModelV3StreamPart` likewise includes `LanguageModelV3ToolApprovalRequest`. A `reasoning-file` content part *is* a `reasoning-file` stream part. `text`, `reasoning` and `tool-call` still get their start/delta/end expansion because that is what `doStream()` emits for them; everything else needs no transformation.

This also keeps the converter correct as the content union grows, instead of needing a new branch each time the AI SDK adds a type.

## Before / after

`vitest run src/llm/model/aisdk/generate-to-stream.test.ts src/llm/model/aisdk/v7/model.test.ts`

| content part | spec versions | before | after |
| --- | --- | --- | --- |
| `reasoning-file` | v4 | dropped, absent from stream | forwarded as a `reasoning-file` stream part |
| `custom` | v4 | dropped, absent from stream | forwarded with `kind` + `providerMetadata` intact |
| `tool-approval-request` | v3, v4 | dropped, absent from stream | forwarded with `approvalId` + `toolCallId` intact |
| `text` / `reasoning` / `tool-call` | v2, v3, v4 | expanded to start/delta/end | unchanged |
| `file` / `source` / `tool-result` | v2, v3, v4 | mapped | unchanged |

Suite totals for `vitest run src/llm src/stream` (project `unit:packages/core`), same command on both refs:

| ref | tests | passed | failed | failed files |
| --- | --- | --- | --- | --- |
| `origin/main` | 559 | 555 | 4 | 7 |
| this branch | 564 | 560 | 4 | 7 |

Net `+5` tests, `+5` passing, and the failure set is **byte-identical** on both refs, so nothing here regressed.

## How I tested

Node 22.21.1, pnpm 11.21.0, Windows.

1. `vitest run src/llm/model/aisdk/` (project `unit:packages/core`) — **42 passed / 5 files**, covering the converter plus all three wrappers.
2. `tsc --noEmit -p tsconfig.build.json` in `packages/core` — exit 0.
3. `oxlint src/llm/model/aisdk/` — exit 0.
4. `oxfmt --check` — run against the **committed blobs**, not the working tree: this checkout has `core.autocrlf=true`, so every CRLF file (including ones this PR never touches, e.g. `v5/model.ts`) reports as unformatted locally. All four changed files pass.
5. Baseline comparison: `vitest run src/llm src/stream` on `origin/main` and on this branch. The 4 failing tests and 7 failing files are identical on both and are pre-existing Windows `EPERM` rename races in `src/llm/model/provider-registry.test.ts` and suite-level import failures under `src/llm/model` and `src/llm/gateways`. None involve `generate-to-stream`.

### Mutation testing

The fallback branch was replaced with `/* MUTATED: fallback removed */`, confirmed applied via `git diff` (not just an on-disk edit), and the suite re-run:

| test | mutated | restored |
| --- | --- | --- |
| forwards `reasoning-file` | FAIL | pass |
| forwards `custom` | FAIL | pass |
| forwards `tool-approval-request` | FAIL | pass |
| preserves content ordering | FAIL | pass |
| v7 `untags reasoning-file ...` (new stream assertion) | FAIL | pass |
| still maps `source` to one event | pass | pass |
| 4 pre-existing converter tests | pass | pass |

`5 failed | 17 passed (22)` mutated, `22 passed (22)` restored.

The `source` guard passing under mutation is intentional: it exists to catch the *opposite* defect (the fallback double-emitting an already-handled part), so the fix alone must not be what satisfies it.

I also verified the specific claim that the pre-existing v7 test was vacuous. With the code mutated **and** that test reverted to its `origin/main` form, it reports `13 passed (13)` — green against the live bug. Re-adding the `generateResult.stream` assertion turns it red.

## A test that was not testing the code

`v7/model.test.ts` already had `untags reasoning-file data in both doStream parts and doGenerate content`. It asserted the **doStream** case against `streamResult.stream`, but the **doGenerate** case against `generateResult.content` only.

Untagging happens in `untagResponseFileContent()` *before* `createStreamFromGenerateResult()` is called, so `content` was correct while the synthesized stream had already lost the part. The test passed for the entire life of the bug. It now also asserts on `generateResult.stream`, which is what consumers actually read.

Two of the new converter tests are deliberately not satisfied by the fix alone: one pins content **ordering** so forwarded parts stay interleaved with expanded ones, and one asserts `source` still produces a single mapped event rather than being echoed verbatim by the new fallback.

## What I deliberately did not do

- **No downstream chunk mapping.** `convertFullStreamChunkToMastra` in `stream/aisdk/v5/transform.ts:116` has no `case` for these three types and returns `undefined` for them. That is unchanged and applies **equally to the stream path**, so this PR restores generate/stream parity without altering what either path does downstream. Giving `tool-approval-request` a first-class Mastra chunk is a real and separate gap; happy to open an issue for it rather than widen this diff.
- **No changes to the wrappers.** The defect is in the shared converter, so all three wrappers are fixed by the one branch.
- **No new content-type branches.** `custom` and `reasoning-file` carry no fields needing expansion, so a bespoke branch would only restate the pass-through.

## Note on the report

The reproduction snippet in the issue uses `{ type: 'custom', kind: 'provider-specific-content' }`, which does not satisfy the spec: `LanguageModelV4CustomContent.kind` is typed `` `${string}.${string}` `` (`{provider}.{provider-type}`). The tests here use `openai.reasoning-summary` and `acme.marker` instead. The rest of the report reproduced exactly as described.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a model returns extra information, Mastra now keeps it instead of silently removing it. This preserves tool approvals, custom content, and reasoning files for downstream users.

## Changes

- Updated `createStreamFromGenerateResult()` to forward unhandled AI SDK content parts unchanged.
- Preserved existing mappings and expansions for handled content parts.
- Added coverage for:
  - `reasoning-file`
  - `custom`
  - `tool-approval-request`
  - Content ordering
  - Source mapping without duplication
  - V7 reasoning-file stream output
- Updated compatibility documentation for AI SDK V5–V7 wrappers.
- Added a `@mastra/core` patch changeset.

## Validation

- Targeted tests
- TypeScript compilation
- Linting
- Formatting checks
- Mutation testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->