### PR TITLE
fix(deployer): bundling fails when imports come from a virtual entry module

### DIFF
--- a/.changeset/tidy-moons-cheer.md
+++ b/.changeset/tidy-moons-cheer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix `ERR_INVALID_ARG_VALUE` during bundling when a bare import is resolved from a Rollup virtual module. `nodeModulesExtensionResolver` now skips NUL-prefixed importers (e.g. `\0virtual:#entry`) instead of treating them as filesystem paths.

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
@@ -59,6 +59,12 @@ describe('nodeModulesExtensionResolver', () => {
       expect(result).toBeNull();
     });
 
+    it('virtual importers', async () => {
+      const result = await resolveId('lodash/get', '\0virtual:#entry');
+      expect(result).toBeNull();
+      expect(getPackageInfo).not.toHaveBeenCalled();
+    });
+
     it('builtin modules', async () => {
       const result = await resolveId('fs', '/project/src/index.ts');
       expect(result).toBeNull();

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
@@ -35,7 +35,15 @@ export function nodeModulesExtensionResolver(): Plugin {
     name: 'node-modules-extension-resolver',
     async resolveId(id, importer, options) {
       // Only bare package imports are relevant here.
-      if (!importer || !isBareModuleSpecifier(id) || isExternalProtocolImport(id) || isAbsolute(id)) {
+      // Virtual modules (e.g. `\0virtual:#entry`) are not real filesystem paths, so they can't be
+      // used as a resolution base for package lookups.
+      if (
+        !importer ||
+        importer.startsWith('\0') ||
+        !isBareModuleSpecifier(id) ||
+        isExternalProtocolImport(id) ||
+        isAbsolute(id)
+      ) {
         return null;
       }
 


### PR DESCRIPTION
## Summary

Bundling a Mastra project could fail with `ERR_INVALID_ARG_VALUE: The argument 'path' must be a string, Uint8Array, or URL without null bytes` and never produce output.

Rollup gives virtual modules ids that start with a NUL byte (for example `\0virtual:#entry`). The deployer's module resolver assumed every importer was a real file on disk, so when an import arrived from a virtual entry it tried to look up a `package.json` next to a path that cannot exist, and the build crashed.

The resolver now ignores virtual importers, since there is no directory to resolve packages relative to, and lets the rest of the pipeline handle those imports normally.

Reported and diagnosed in #21948. Closes #21948.

## Test plan

- Added a regression test covering a bare import arriving from a virtual importer, asserting resolution is skipped and no package lookup happens.
- `pnpm --filter ./packages/deployer vitest run src/build/plugins/node-modules-extension-resolver.test.ts` — 19/19 passing.