### PR TITLE
fix(mcp): declare @modelcontextprotocol/sdk v1 as a direct dependency

### DIFF
--- a/.changeset/violet-keys-think.md
+++ b/.changeset/violet-keys-think.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed `Cannot find package '@modelcontextprotocol/sdk'` when importing `@mastra/mcp` in projects that skip automatic peer installation (e.g. npm with `--legacy-peer-deps`), by declaring the MCP SDK v1 peer required by `@modelcontextprotocol/ext-apps` as a direct dependency.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -37,14 +37,15 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.7.1",
-    "exit-hook": "^5.1.0",
-    "fast-deep-equal": "^3.1.3",
-    "@modelcontextprotocol/server": "2.0.0",
     "@modelcontextprotocol/client": "2.0.0",
+    "@modelcontextprotocol/core": "2.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.1",
     "@modelcontextprotocol/node": "2.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "@modelcontextprotocol/server-legacy": "2.0.0",
-    "@modelcontextprotocol/core": "2.0.0"
+    "exit-hook": "^5.1.0",
+    "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {
     "@mastra/core": ">=1.0.0-0 <2.0.0-0"
@@ -61,6 +62,7 @@
     "@mastra/schema-compat": "workspace:*",
     "@mendable/firecrawl-js": "^1.29.3",
     "@types/node": "22.20.1",
+    "@types/semver": "^7.7.1",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
     "ai": "^5.0.221",
@@ -68,6 +70,7 @@
     "get-port": "^7.1.0",
     "hono": "^4.12.8",
     "hono-mcp-server-sse-transport": "0.0.7",
+    "semver": "^7.8.5",
     "tsdown": "0.22.9",
     "tsx": "catalog:",
     "typescript": "catalog:",

--- a/packages/mcp/src/server/package-dependencies.test.ts
+++ b/packages/mcp/src/server/package-dependencies.test.ts
@@ -1,0 +1,54 @@
+import { readFile } from 'node:fs/promises';
+import { intersects } from 'semver';
+import { expect, it } from 'vitest';
+
+const packageRoot = new URL('../../', import.meta.url);
+
+/**
+ * Required peers of our runtime dependencies that are intentionally NOT declared by
+ * @mastra/mcp. Every entry needs a justification: an undeclared required peer crashes
+ * consumers whose package manager skips automatic peer installation (e.g. npm with
+ * --legacy-peer-deps), see https://github.com/mastra-ai/mastra/issues/21974.
+ */
+const UNDECLARED_PEER_ALLOWLIST: Record<string, string> = {
+  zod: 'always resolvable: @modelcontextprotocol/sdk and @mastra/core (our required peer) ship zod as a regular dependency',
+};
+
+async function readPackageJson(url: URL): Promise<Record<string, any>> {
+  return JSON.parse(await readFile(url, 'utf8'));
+}
+
+it('declares every required peer of its runtime dependencies (#21974)', async () => {
+  const pkg = await readPackageJson(new URL('package.json', packageRoot));
+  const problems: string[] = [];
+
+  for (const depName of Object.keys(pkg.dependencies)) {
+    const depPkg = await readPackageJson(new URL(`node_modules/${depName}/package.json`, packageRoot));
+
+    for (const [peerName, peerRange] of Object.entries<string>(depPkg.peerDependencies ?? {})) {
+      if (depPkg.peerDependenciesMeta?.[peerName]?.optional) continue;
+      // A peer the dependency also ships as a regular dependency is always resolvable.
+      if (depPkg.dependencies?.[peerName]) continue;
+
+      const declaredRange = pkg.dependencies[peerName] ?? pkg.peerDependencies?.[peerName];
+      if (declaredRange) {
+        if (!intersects(declaredRange, peerRange, { includePrerelease: true })) {
+          problems.push(
+            `${depName} requires peer ${peerName}@${peerRange}, but @mastra/mcp declares ${peerName}@${declaredRange}, which never satisfies it`,
+          );
+        }
+        continue;
+      }
+
+      if (peerName in UNDECLARED_PEER_ALLOWLIST) continue;
+
+      problems.push(
+        `${depName} requires peer ${peerName}@${peerRange}, but @mastra/mcp neither declares it nor allowlists it. ` +
+          `Consumers installing with npm --legacy-peer-deps will crash at import time if the peer is loaded eagerly. ` +
+          `Declare it in dependencies, or add it to UNDECLARED_PEER_ALLOWLIST with a justification.`,
+      );
+    }
+  }
+
+  expect(problems, problems.join('\n')).toEqual([]);
+});

--- a/packages/mcp/src/server/package-dependencies.test.ts
+++ b/packages/mcp/src/server/package-dependencies.test.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { intersects } from 'semver';
+import { subset } from 'semver';
 import { expect, it } from 'vitest';
 
 const packageRoot = new URL('../../', import.meta.url);
@@ -32,9 +32,11 @@ it('declares every required peer of its runtime dependencies (#21974)', async ()
 
       const declaredRange = pkg.dependencies[peerName] ?? pkg.peerDependencies?.[peerName];
       if (declaredRange) {
-        if (!intersects(declaredRange, peerRange, { includePrerelease: true })) {
+        // Containment (not just overlap): every version our range can resolve to
+        // must satisfy the peer range.
+        if (!subset(declaredRange, peerRange, { includePrerelease: true })) {
           problems.push(
-            `${depName} requires peer ${peerName}@${peerRange}, but @mastra/mcp declares ${peerName}@${declaredRange}, which never satisfies it`,
+            `${depName} requires peer ${peerName}@${peerRange}, but @mastra/mcp declares ${peerName}@${declaredRange}, which can resolve to versions outside that range`,
           );
         }
         continue;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5183,6 +5183,9 @@ importers:
       '@modelcontextprotocol/node':
         specifier: 2.0.0
         version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.30)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3)
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0
@@ -5229,6 +5232,9 @@ importers:
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -5250,6 +5256,9 @@ importers:
       hono-mcp-server-sse-transport:
         specifier: 0.0.7
         version: 0.0.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(hono@4.12.30)
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
       tsdown:
         specifier: 0.22.9
         version: 0.22.9(@volar/typescript@2.4.23(typescript@6.0.3))(oxc-resolver@11.20.0)(tsx@4.23.1)(typescript@6.0.3)
@@ -30386,18 +30395,22 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
+    hasBin: true
 
   semver@7.8.2:
     resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
     engines: {node: '>=10'}
+    hasBin: true
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
+    hasBin: true
 
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
@@ -44958,7 +44971,7 @@ snapshots:
       '@stryker-mutator/util': 10.0.0
       semver: 7.8.5
       tslib: 2.8.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0)(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@26.1.0(bufferutil@4.1.0)(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
 
   '@supabase/auth-js@2.111.0':
     dependencies:


### PR DESCRIPTION
Fixes #21974

Importing `@mastra/mcp` >= 1.16 crashes in projects that skip automatic peer installation (npm with `--legacy-peer-deps`):

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@modelcontextprotocol/sdk'
```

The MCP 2.0 migration removed the v1 SDK from `@mastra/mcp`'s dependencies, but `@modelcontextprotocol/ext-apps` — eagerly imported by the server entrypoint — still requires it as a peer. When npm doesn't auto-install peers, the import fails at module load time.

This declares `@modelcontextprotocol/sdk@^1.29.0` (matching the `ext-apps` peer range) as a direct dependency so it's always installed, and adds a regression test asserting that every required peer of every runtime dependency is either declared by `@mastra/mcp`, satisfied by the dependency itself, or explicitly allowlisted with a justification — so this class of bug can't silently return for any future dependency.

Test plan: reproduced the original crash with `npm install --legacy-peer-deps @mastra/mcp@1.17.0 @mastra/core@1.60.0`, then packed the patched package, installed it the same way into a clean project, and confirmed `import("@mastra/mcp")` succeeds. Server tests (152), lint, and typecheck all pass. The new regression test fails when the SDK dependency is removed and passes with it in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

`@mastra/mcp` now includes a package that it needs when it runs. This prevents import failures with `npm --legacy-peer-deps` and adds a test to catch similar dependency issues.

## Changes

- Added `@modelcontextprotocol/sdk@^1.29.0` as a direct runtime dependency.
- Added a regression test that verifies runtime peer dependencies are declared, satisfied, or explicitly allowlisted with justification.
- Used `semver.subset` to verify that declared dependency ranges fully satisfy peer ranges.
- Added `semver` and `@types/semver` as development dependencies.
- Added a changeset for a patch release.
- Validated package imports, server tests, lint, and typecheck.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->