### PR TITLE
fix(deployer): stop logging ERR_INVALID_ARG_VALUE during mastra build

### DIFF
--- a/.changeset/wide-things-search.md
+++ b/.changeset/wide-things-search.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed a confusing `ERR_INVALID_ARG_VALUE` error being logged during `mastra build` while bundling the application. The build succeeded, but the logged stack trace suggested a failure.

--- a/packages/deployer/src/build/package-info.test.ts
+++ b/packages/deployer/src/build/package-info.test.ts
@@ -84,6 +84,17 @@ describe('getPackageRootPath', () => {
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
+
+  it('ignores rollup virtual module ids passed as parentPath', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Rollup virtual module ids contain a null byte; Node rejects such paths, and mlly
+    // would otherwise log a raw ERR_INVALID_ARG_VALUE error to the console.
+    await expect(getPackageRootPath('rollup', '\0virtual:#entry')).resolves.not.toBeNull();
+    await expect(getPackageRootPath('mastra-nonexistent-package', '\0virtual:#entry')).resolves.toBeNull();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('getPackageMetadata', () => {

--- a/packages/deployer/src/build/package-info.ts
+++ b/packages/deployer/src/build/package-info.ts
@@ -44,6 +44,11 @@ export async function getPackageRootPath(packageName: string, parentPath?: strin
 
   try {
     let options: { paths?: string[] } | undefined = undefined;
+    // Rollup virtual module ids (e.g. `\0virtual:#entry`) contain a null byte and are not
+    // filesystem paths. Node rejects paths with null bytes, so resolve without a parent instead.
+    if (parentPath?.includes('\0')) {
+      parentPath = undefined;
+    }
     if (parentPath) {
       options = {
         paths: [toParentDirectoryUrl(parentPath)],


### PR DESCRIPTION
During `mastra build`, a scary-looking error was logged even though the build succeeded:

```
TypeError [ERR_INVALID_ARG_VALUE]: The argument 'path' must be a string, Uint8Array, or URL without null bytes. Received '.../\x00virtual:#entry/package.json'
    at Object.readFileSync (node:fs:439:14)
    at read (.../mlly/dist/index.mjs:572:17)
    ...
```

The bundler registers the server entry as a rollup virtual module (`\0virtual:#entry`), and that virtual module id was being passed as the parent path for package resolution. Node rejects paths containing null bytes, so mlly threw and local-pkg logged the raw error to the console.

`getPackageRootPath` now drops parent paths containing a null byte and resolves from the default base instead, which covers every call site. Added a regression test that fails without the fix (it asserts nothing is logged to `console.error` when a virtual module id is used as the parent path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some build steps use special module names that are not valid file paths. The update detects these names and uses a safe default instead, so successful builds no longer log misleading errors.

## Changes

- Updated `getPackageRootPath` to ignore `parentPath` values containing null bytes.
- Added regression tests for Rollup virtual module IDs.
- Added a patch changeset for `@mastra/deployer`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->