### PR TITLE
fix(channels): clear Slack typing status at run end

### DIFF
--- a/.changeset/true-parrots-crash.md
+++ b/.changeset/true-parrots-crash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Slack channel typing statuses remaining visible after agent runs complete without posting a message. ([#21880](https://github.com/mastra-ai/mastra/issues/21880))

--- a/packages/core/src/channels/__tests__/output-processor.test.ts
+++ b/packages/core/src/channels/__tests__/output-processor.test.ts
@@ -63,6 +63,7 @@ function createRecording() {
 
 function makeChannels(
   opts: {
+    platform?: string;
     streaming?: boolean | { updateIntervalMs?: number };
     textFormat?: 'markdown' | 'plain';
     toolDisplay?: 'cards' | 'text' | 'timeline' | 'grouped' | 'hidden' | ((event: any, ctx: any) => any);
@@ -78,6 +79,8 @@ function makeChannels(
   } = {},
 ) {
   const recording = createRecording();
+  const platform = opts.platform ?? 'test';
+  recording.adapter.name = platform;
   const adapterConfig: Record<string, unknown> = {
     adapter: recording.adapter,
     streaming: opts.streaming ?? false,
@@ -88,10 +91,10 @@ function makeChannels(
   if (opts.cards !== undefined) adapterConfig.cards = opts.cards;
   if (opts.formatToolCall !== undefined) adapterConfig.formatToolCall = opts.formatToolCall;
   const channels = new AgentChannels({
-    adapters: { test: adapterConfig as any },
+    adapters: { [platform]: adapterConfig as any },
   });
   if (opts.logger) (channels as any).__setLogger(opts.logger);
-  return { channels, ...recording };
+  return { channels, platform, ...recording };
 }
 
 async function drive(
@@ -99,8 +102,9 @@ async function drive(
   chunks: any[],
   chatThread: any,
   approvalContext?: { toolCallId: string; messageId: string },
+  platform = 'test',
 ) {
-  const render = (channels as any)._buildRenderContext(chatThread, 'test', approvalContext);
+  const render = (channels as any)._buildRenderContext(chatThread, platform, approvalContext);
   const processor = new ChatChannelOutputProcessor();
   const requestContext = new Map<string, unknown>();
   requestContext.set(CHAT_CHANNEL_RENDER_CONTEXT_KEY, render);
@@ -1098,6 +1102,65 @@ describe('ChatChannelOutputProcessor', () => {
   });
 
   describe('adaptive typing status', () => {
+    it('clears Slack typing status when a hidden-tool run ends without posting', async () => {
+      const { channels, calls, chatThread, platform } = makeChannels({
+        platform: 'slack',
+        streaming: true,
+        toolDisplay: 'hidden',
+      });
+
+      await drive(
+        channels,
+        [
+          { type: 'start', payload: {} },
+          { type: 'tool-call', payload: { toolCallId: 't1', toolName: 'wait', args: {} } },
+          { type: 'tool-result', payload: { toolCallId: 't1', toolName: 'wait', args: {}, result: 'done' } },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+        undefined,
+        platform,
+      );
+
+      expect(calls.filter(c => c.kind === 'post')).toEqual([]);
+      const typingStatuses = calls.filter(c => c.kind === 'startTyping').map(c => (c as any).status);
+      expect(typingStatuses).toEqual(['is working…', 'is calling wait…', '']);
+    });
+
+    it('waits for pending Slack typing updates before clearing the status', async () => {
+      const { channels, calls, chatThread, platform } = makeChannels({ platform: 'slack' });
+      let releaseTypingStatus: (() => void) | undefined;
+      chatThread.startTyping = vi.fn((status: string | undefined) => {
+        calls.push({ kind: 'startTyping', status });
+        if (!status) return Promise.resolve();
+        return new Promise<void>(resolve => {
+          releaseTypingStatus = resolve;
+        });
+      });
+
+      const run = drive(
+        channels,
+        [
+          { type: 'start', payload: {} },
+          { type: 'finish', payload: {} },
+        ],
+        chatThread,
+        undefined,
+        platform,
+      );
+
+      await vi.waitFor(() => expect(releaseTypingStatus).toBeTypeOf('function'));
+      expect(calls.filter(c => c.kind === 'startTyping')).toEqual([{ kind: 'startTyping', status: 'is working…' }]);
+
+      releaseTypingStatus?.();
+      await run;
+
+      expect(calls.filter(c => c.kind === 'startTyping')).toEqual([
+        { kind: 'startTyping', status: 'is working…' },
+        { kind: 'startTyping', status: '' },
+      ]);
+    });
+
     it('emits Thinking → Typing → Calling {tool} → Typing transitions', async () => {
       const { channels, calls, chatThread } = makeChannels({ streaming: false });
       await drive(

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -1474,7 +1474,8 @@ export class AgentChannels {
    * (what `startTyping` maps to) only auto-clears on `chat.postMessage`, not
    * on `chat.stopStream`, so a status set during streaming would stick after
    * the run ends. The static driver leaves the gate `false` so typing works
-   * normally in cards/hidden modes.
+   * normally in cards/hidden modes. Slack statuses are explicitly cleared
+   * when the per-run stream closes because a run may end without posting.
    */
   private async *withTypingStatus(
     stream: AsyncIterable<AgentChunkType<any>>,
@@ -1492,35 +1493,59 @@ export class AgentChannels {
           : defaultTypingStatus;
 
     let currentTypingStatus: string | undefined;
+    let typingStatusStarted = false;
+    let pendingTypingStatus = Promise.resolve();
 
-    for await (const chunk of stream) {
-      if (typingStatusFn && !typingGate.active) {
-        let result: ReturnType<TypingStatusFn>;
-        try {
-          const ctx: TypingStatusContext = {
-            platform,
-            threadId: chatThread.id,
-            currentStatus: currentTypingStatus,
-            channelTools: this.channelToolNames,
-          };
-          result = typingStatusFn(chunk, ctx);
-        } catch (e) {
-          this.logger?.debug('[CHANNEL] typingStatus function threw (continuing)', { error: e });
-          result = undefined;
-        }
-        if (typeof result === 'string' && result.length > 0 && result !== currentTypingStatus) {
-          currentTypingStatus = result;
-          chatThread.startTyping(result).catch(e => {
-            this.logger?.debug('[CHANNEL] Typing indicator failed (best-effort)', { error: e });
-          });
-        }
+    const sendTypingStatus = async (status: string) => {
+      try {
+        await chatThread.startTyping(status);
+      } catch (e) {
+        this.logger?.debug('[CHANNEL] Typing indicator failed (best-effort)', { error: e });
       }
-      // Reset the dedup state on run boundaries so the next run can re-emit
-      // its first status even if it matches the previous run's last status.
-      if (chunk.type === 'finish' || chunk.type === 'error' || chunk.type === 'abort') {
-        currentTypingStatus = undefined;
+    };
+
+    const queueTypingStatus = (status: string) => {
+      if (platform === 'slack') {
+        pendingTypingStatus = pendingTypingStatus.then(() => sendTypingStatus(status));
+      } else {
+        void sendTypingStatus(status);
       }
-      yield chunk;
+    };
+
+    try {
+      for await (const chunk of stream) {
+        if (typingStatusFn && !typingGate.active) {
+          let result: ReturnType<TypingStatusFn>;
+          try {
+            const ctx: TypingStatusContext = {
+              platform,
+              threadId: chatThread.id,
+              currentStatus: currentTypingStatus,
+              channelTools: this.channelToolNames,
+            };
+            result = typingStatusFn(chunk, ctx);
+          } catch (e) {
+            this.logger?.debug('[CHANNEL] typingStatus function threw (continuing)', { error: e });
+            result = undefined;
+          }
+          if (typeof result === 'string' && result.length > 0 && result !== currentTypingStatus) {
+            currentTypingStatus = result;
+            typingStatusStarted = true;
+            queueTypingStatus(result);
+          }
+        }
+        // Reset the dedup state on step/run boundaries so the next step can
+        // re-emit its first status even if it matches the previous one.
+        if (chunk.type === 'finish' || chunk.type === 'error' || chunk.type === 'abort') {
+          currentTypingStatus = undefined;
+        }
+        yield chunk;
+      }
+    } finally {
+      if (platform === 'slack' && typingStatusStarted) {
+        queueTypingStatus('');
+        await pendingTypingStatus;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Clears Slack's agent typing status when a channel run completes without posting a message. This restores terminal cleanup for hidden-tool and other no-message paths.

- Serializes Slack typing-status updates so cleanup cannot race an in-flight update
- Sends an empty Slack status when the per-run output stream closes
- Adds regression coverage for hidden-tool runs and delayed status updates
- Adds a patch changeset for `@mastra/core`

## Related Issue(s)

Fixes #21880

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Slack can show that an agent is typing even when the agent finishes without sending a message. This PR clears that status when each run ends and prevents delayed updates from restoring it.

## Changes

- Serializes Slack typing-status updates to preserve update order.
- Clears the Slack typing status when the output stream closes after a typing update.
- Preserves local status deduplication and reset behavior.
- Adds regression tests for hidden-tool runs and delayed status updates.
- Adds a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->