### PR TITLE
feat(factory-ui): render Factory skills as markdown, with a raw toggle

### DIFF
--- a/.changeset/long-apes-build.md
+++ b/.changeset/long-apes-build.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed code blocks stretching the page. A fenced code block inside markdown reported its longest line as a width requirement, so a long command pushed the whole layout wider than the window instead of scrolling inside the block. Code blocks now stay within the width they are given and scroll horizontally on their own.
+Fixed code blocks stretching the page. A long line inside a fenced markdown block used to widen everything around it, pushing the layout past the window. A code block now keeps to the width it is given, and scrolls horizontally inside itself when set to `overflow="scroll"`.

--- a/.changeset/long-apes-build.md
+++ b/.changeset/long-apes-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed code blocks stretching the page. A fenced code block inside markdown reported its longest line as a width requirement, so a long command pushed the whole layout wider than the window instead of scrolling inside the block. Code blocks now stay within the width they are given and scroll horizontally on their own.

--- a/.changeset/petite-clouds-strive.md
+++ b/.changeset/petite-clouds-strive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Factory skill playbooks in Settings › Agent › Skills now render as formatted markdown instead of a wall of plain text, with a toggle on hover to read the raw SKILL.md source. Long skills scroll inside the card rather than stretching the page.

--- a/mastracode/factory-ui/src/ui/domains/settings/components/FactorySkillsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/FactorySkillsSection.tsx
@@ -1,6 +1,10 @@
+import { Button } from '@mastra/playground-ui/components/Button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Code, FileText } from 'lucide-react';
+import { useState } from 'react';
 
 import { useFactorySkillsQuery } from '../../../../hooks/useFactorySkills';
 import type { FactorySkillInfo } from '../../../../api/types';
@@ -14,6 +18,30 @@ const DISPLAYED_SKILLS: { name: string; title: string }[] = [
   { name: 'factory-review', title: 'Review' },
   { name: 'factory-rereview', title: 'Re-review' },
 ];
+
+function SkillContent({ content }: { content: string }) {
+  const [raw, setRaw] = useState(false);
+
+  return (
+    <div className="group/content relative">
+      <ScrollArea maxHeight="24rem" viewPortClassName="px-4 pb-4" revealScrollbarOnHover={false}>
+        {raw ? (
+          <pre className="text-ui-sm text-icon4 m-0 font-mono whitespace-pre-wrap">{content}</pre>
+        ) : (
+          <MarkdownRenderer className="text-ui-sm text-icon4">{content}</MarkdownRenderer>
+        )}
+      </ScrollArea>
+      <Button
+        size="icon-sm"
+        tooltip={raw ? 'Show formatted' : 'Show raw'}
+        onClick={() => setRaw(shown => !shown)}
+        className="absolute top-1 right-4 opacity-0 transition-opacity group-hover/content:opacity-100 focus-visible:opacity-100"
+      >
+        {raw ? <FileText /> : <Code />}
+      </Button>
+    </div>
+  );
+}
 
 function SkillCard({ title, skill }: { title: string; skill: FactorySkillInfo }) {
   return (
@@ -37,9 +65,7 @@ function SkillCard({ title, skill }: { title: string; skill: FactorySkillInfo })
           />
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <pre className="text-ui-sm text-icon4 max-h-96 overflow-auto px-4 pb-4 font-mono whitespace-pre-wrap">
-            {skill.content}
-          </pre>
+          <SkillContent content={skill.content} />
         </CollapsibleContent>
       </Collapsible>
     </SettingsCard>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/FactorySkillsSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/FactorySkillsSection.msw.test.tsx
@@ -72,6 +72,23 @@ describe('FactorySkillsSection', () => {
     expect(await screen.findByText(/Trace history and diagnose/)).toBeInTheDocument();
   });
 
+  it('toggles the expanded skill between rendered markdown and its raw source', async () => {
+    server.use(http.get(SKILLS_URL, () => HttpResponse.json(catalog)));
+
+    const user = userEvent.setup();
+    renderWithProviders(<FactorySkillsSection />);
+
+    await user.click(await screen.findByRole('button', { name: /Triage/ }));
+    expect(screen.getByRole('heading', { name: 'Triage' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show raw' }));
+    expect(screen.queryByRole('heading', { name: 'Triage' })).not.toBeInTheDocument();
+    expect(screen.getByText(/# Triage/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show formatted' }));
+    expect(screen.getByRole('heading', { name: 'Triage' })).toBeInTheDocument();
+  });
+
   it('surfaces a load failure from the server', async () => {
     server.use(http.get(SKILLS_URL, () => HttpResponse.json({ error: 'boom' }, { status: 500 })));
 

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/FactorySkillsSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/FactorySkillsSection.msw.test.tsx
@@ -89,6 +89,22 @@ describe('FactorySkillsSection', () => {
     expect(screen.getByRole('heading', { name: 'Triage' })).toBeInTheDocument();
   });
 
+  it('reopens a skill on the formatted view after it was left on raw', async () => {
+    server.use(http.get(SKILLS_URL, () => HttpResponse.json(catalog)));
+
+    const user = userEvent.setup();
+    renderWithProviders(<FactorySkillsSection />);
+
+    const trigger = await screen.findByRole('button', { name: /Triage/ });
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', { name: 'Show raw' }));
+    await user.click(trigger);
+    await user.click(trigger);
+
+    expect(await screen.findByRole('heading', { name: 'Triage' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show raw' })).toBeInTheDocument();
+  });
+
   it('surfaces a load failure from the server', async () => {
     server.use(http.get(SKILLS_URL, () => HttpResponse.json({ error: 'boom' }, { status: 500 })));
 

--- a/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
+++ b/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
@@ -56,8 +56,10 @@ export function CodeBlock({
 
   return (
     <figure
+      // A scrolling `pre` still reports its longest line as an intrinsic width, which
+      // grows every ancestor; containment keeps the block inside the width it is given.
       className={cn(
-        'group relative flex w-full flex-col overflow-hidden rounded-2xl border border-border2/40 bg-surface2',
+        'group relative flex w-full flex-col overflow-hidden rounded-2xl border border-border2/40 bg-surface2 [contain:inline-size]',
         className,
       )}
     >


### PR DESCRIPTION
TLDR: the built-in Factory skills read as documents now, not one block of monospace, and a long command inside one no longer stretches the settings page past the window.

---

### What changes

| on Settings › Agent › Skills | before | after |
| --- | --- | --- |
| expand a skill | SKILL.md as raw monospace text | headings, lists and code blocks, rendered |
| want the exact source | nothing to click | a button appears on hover and flips to raw text |
| the skill holds a long command | the page grew wider than the window and scrolled sideways | the code block scrolls, the page stays put |

Row three is a design-system bug, not a settings one. `overflow-x: auto` scrolls what is inside a `pre`, but the box still reports its longest line as a width it needs, and a grid track is floored by that. One `gh pr view …` line in factory-review measures 2062px, which turned the 896px settings column into 2114px and took the page with it. `contain: inline-size` on the CodeBlock figure makes its `w-full` true instead of aspirational, so chat and tool cards are covered by the same change.

### Judgment call

Raw or rendered is per card, and it resets when the card collapses. Making it stick means storing a preference somewhere, and nobody has asked to read four skills in a row as raw text. One hook away if you disagree.

### Not verified

The containment fix has no test. jsdom does not lay out, so nothing in vitest could fail on it, and a test that only restates the class name is worse than none. I measured it in the running app instead: grid track 2114px → 896px, the `pre` at scrollWidth 2062 against clientWidth 844, and document scrollWidth back to matching clientWidth.

```
source        +33  -5
tests         +33   0
changeset     +10   0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory skills now display as formatted Markdown instead of raw text. Users can switch to the raw source when needed, and long code stays inside its card without expanding the page.

## Changes

- Render Factory skill content as Markdown in Settings › Agent › Skills.
- Add a hover control to toggle each skill card between rendered Markdown and raw views.
- Reset the view to formatted Markdown when a skill card is collapsed and reopened.
- Keep long code lines horizontally scrollable within code blocks.
- Apply code block containment to shared chat and tool cards.
- Add test coverage for the skill view toggle and reset behavior.
- Add patch changesets for `@mastra/factory` and `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->