### PR TITLE
docs: refine sandbox guidance

### DIFF
--- a/docs/src/content/en/docs/sandbox/filesystem.mdx
+++ b/docs/src/content/en/docs/sandbox/filesystem.mdx
@@ -14,7 +14,7 @@ A filesystem gives an agent tools for reading, writing, listing, and [searching]
 Configure files in two ways:
 
 - [Direct filesystem access](#direct-filesystem-access) uses `filesystem` with one filesystem provider or a [`CompositeFilesystem`](#manual-composition) that you create yourself.
-- [Mounts](#mounts) uses `mounts` to create a `CompositeFilesystem` from path-prefixed providers. When the workspace also has a static sandbox, Mastra attempts to mount each provider at its configured path inside the sandbox so commands can access the same files. Remote sandbox mounts typically use Filesystem in Userspace (FUSE).
+- [Mounts](#mounts) uses `mounts` to create a `CompositeFilesystem` from path-prefixed providers. When a static sandbox and filesystem provider support mounting, Mastra automatically mounts the provider at its configured path. Remote sandbox mounts typically use Filesystem in Userspace (FUSE).
 
 Configure either `filesystem` or `mounts`, not both. Configuring both throws a `WorkspaceError` with the code `INVALID_CONFIG`.
 
@@ -80,7 +80,7 @@ See [Search](/docs/sandbox/search) to index the files for keyword or semantic re
 
 ## Mounts
 
-Use `mounts` when programs inside a sandbox need to access persistent files by path. The agent still receives file tools, while command tools can run commands such as `ls`, `cat`, or `python` against the same files.
+Use `mounts` when programs inside a sandbox need to access persistent files by path. Mastra creates the mount automatically when the sandbox and filesystem provider support it. The agent still receives file tools, while command tools can run commands such as `ls`, `cat`, or `python` against the same files.
 
 For example, mount an S3 bucket at `/workspace` inside a Daytona sandbox:
 
@@ -193,7 +193,7 @@ Use manual composition when another part of your application needs the composite
 
 ## Mount availability
 
-File tools and composite routing work without FUSE. Remote sandboxes can use FUSE to make cloud storage visible to commands. `LocalSandbox` uses symlinks instead.
+File tools and composite routing work without a sandbox mount. When a remote sandbox and filesystem provider support mounting, `mounts` automatically uses FUSE to make the files visible to commands. `LocalSandbox` uses symlinks instead.
 
 Built-in sandbox mounting currently includes:
 
@@ -208,27 +208,27 @@ Remote mounts may require `s3fs`, `gcsfuse`, or `blobfuse2` inside the sandbox. 
 
 If a sandbox mount is unavailable or fails, the workspace remains usable. File tools continue to access the provider through its SDK, but commands can't see that path. Mastra describes these providers to the agent as available through file tools only.
 
-## Multi-tenant filesystems
+## Filesystems per user or thread
 
 The `filesystem` option accepts a resolver when storage should vary by request, user, role, or tenant:
 
 ```typescript
 const workspace = new Workspace({
   filesystem: ({ requestContext }) => {
-    const tenantId = requestContext.get('tenant-id') as string
+    const userId = requestContext.get('user-id') as string
 
     return new S3Filesystem({
       bucket: process.env.S3_BUCKET!,
       region: process.env.S3_REGION!,
-      prefix: `tenants/${tenantId}`,
+      prefix: `users/${userId}`,
     })
   },
 })
 ```
 
-Each tenant gets its own filesystem view, and file tools resolve the provider from the request context automatically.
+Each user gets a separate filesystem view, and file tools resolve the provider from the request context automatically.
 
-`mounts` doesn't accept a resolver and can't be combined with a sandbox resolver. When each user or thread needs separate storage inside a separate sandbox, create and mount the provider inside the sandbox resolver. See [Multi-tenant sandboxes](/docs/sandbox/overview#multi-tenant-sandboxes).
+`mounts` doesn't accept a resolver and can't be combined with a sandbox resolver. When each user or thread needs separate storage inside a separate sandbox, create and mount the provider inside the sandbox resolver. See [Sandboxes per user or thread](/docs/sandbox/overview#sandboxes-per-user-or-thread).
 
 ## Policies and containment
 

--- a/docs/src/content/en/docs/sandbox/overview.mdx
+++ b/docs/src/content/en/docs/sandbox/overview.mdx
@@ -11,29 +11,29 @@ import { IntegrationGrid } from '@site/src/components/integrations/grid';
 
 {/* vale ai-tells.VerbTricolon = NO */}
 
-A sandbox gives your agent an environment where it can run commands, execute code, install dependencies, and manage processes. Sandboxes can isolate potentially risky agent-run code from your host, and they can also provide a place to run longer-lived or more resource-intensive work outside your application process.
+A sandbox gives your agent an isolated environment where it can run commands, execute code, install dependencies, and manage processes. This lets agents perform work that would be risky, resource-intensive, or impractical to run directly inside your application.
+
+Sandboxes are often temporary, so files created inside them may disappear when the environment stops. A [filesystem](/docs/sandbox/filesystem) gives the agent a place to read, write, and [search](/docs/sandbox/search) files that can outlive the sandbox. You can use one to keep outputs between runs, seed a new sandbox with existing files, or give the agent documents it can search while working. Filesystems also work without a sandbox, for example when an agent only needs a knowledge base or access to files in a service such as Google Drive.
 
 {/* vale ai-tells.VerbTricolon = YES */}
 
-[Filesystems](/docs/sandbox/filesystem) give the agent files it can read, write, and [search](/docs/sandbox/search). They can provide a knowledge base for your agent, or be shared with a sandbox so commands can work with the same files and keep data beyond the sandbox's lifetime.
-
 ## When to use sandboxes
 
-Sandboxes work well for:
+Use a sandbox when an agent needs to:
 
-- **Coding agents and software factories**: Clone repositories and run shell, Git, build, or test workflows without giving autonomous agents access to the host system.
-- **Deep research and analysis**: Use specialized libraries to process downloaded PDFs or presentations and produce new artifacts.
-- **Long-running and parallel tasks**: Run work in separate environments without tying it to one request or sharing files and processes.
+- Clone repositories and run shell, Git, build, or test workflows in a separate environment.
+- Process PDFs, presentations, or other files with specialized libraries and produce new artifacts.
+- Run long-lived or parallel work in separate environments with isolated files and processes.
 
 If an agent only needs to read, write, or search files, configure [direct filesystem access](/docs/sandbox/filesystem#direct-filesystem-access).
 
 ## Quickstart
 
-Give an agent a local sandbox and filesystem:
+Give an agent a local sandbox:
 
 ```typescript title="src/mastra/agents/coding-agent.ts"
 import { Agent } from '@mastra/core/agent'
-import { LocalFilesystem, LocalSandbox, Workspace } from '@mastra/core/workspace'
+import { LocalSandbox, Workspace } from '@mastra/core/workspace'
 
 export const codingAgent = new Agent({
   id: 'coding-agent',
@@ -44,9 +44,6 @@ export const codingAgent = new Agent({
     sandbox: new LocalSandbox({
       workingDirectory: './workspace',
     }),
-    filesystem: new LocalFilesystem({
-      basePath: './workspace',
-    }),
   }),
 })
 
@@ -55,13 +52,11 @@ await codingAgent.generate('List the files in the sandbox directory')
 
 :::warning
 
-`LocalSandbox` is the quickest sandbox to set up, but commands run on the host by default. Enable [native isolation](#localsandbox) whenever possible. For applications exposed to untrusted users, use a remote or container backend with a stronger isolation boundary instead.
+`LocalSandbox` runs commands on the application host by default and isn't isolated or secure. Enable [native isolation](#localsandbox), or use a remote or container sandbox when running untrusted code.
 
 :::
 
-To use a different sandbox for each user, tenant, or thread, configure a [sandbox resolver](#multi-tenant-sandboxes) instead.
-
-The `LocalSandbox` above is one static instance. Every request and memory thread that uses `codingAgent` shares its files, processes, and lifecycle state. A memory thread doesn't create an isolated sandbox by itself.
+A static sandbox is shared across every request and memory thread that uses the agent. Use a [resolver](#sandboxes-per-user-or-thread) when each user or thread needs a separate environment. See [Lifecycle and persistence](#lifecycle-and-persistence) for sharing and cleanup details.
 
 ## Using the sandbox
 
@@ -89,7 +84,7 @@ const workspace = new Workspace({
 })
 ```
 
-Omitting a tool entry keeps its capability-driven default. Set `{ enabled: false }` on one tool to remove it, or set the top-level `enabled: false` to disable generated tools by default. A per-tool `{ enabled: true }` overrides that global setting. The top-level `requireApproval` policy applies to every generated tool unless a per-tool entry overrides it.
+Set `{ enabled: false }` on one tool to remove it, or set the top-level `enabled: false` to disable generated tools by default. A per-tool `{ enabled: true }` overrides that global setting. The top-level `requireApproval` policy applies to every generated tool unless a per-tool entry overrides it.
 
 See the [sandbox tools reference](/reference/workspace/workspace-class#sandbox-tools) for all generated tools and the [tool configuration reference](/reference/workspace/workspace-class#tool-configuration) for approvals, output limits, and hooks.
 
@@ -128,16 +123,11 @@ export const startServerTool = createTool({
 })
 ```
 
-## Supported backends
+## Sandboxes
 
 ### `LocalSandbox`
 
 [`LocalSandbox`](/reference/workspace/local-sandbox) executes commands on the same machine as your Mastra application. By default, commands run directly on the host with the permissions of the application process.
-
-Enable native isolation to restrict filesystem and network access at the operating-system level:
-
-- **macOS**: Seatbelt (`sandbox-exec`)
-- **Linux**: Bubblewrap (`bwrap`)
 
 ```typescript
 const sandbox = new LocalSandbox({
@@ -150,55 +140,50 @@ const sandbox = new LocalSandbox({
 })
 ```
 
-Use `LocalSandbox.detectIsolation()` to check whether Seatbelt or Bubblewrap is available on the current operating system. The [`nativeSandbox` options](/reference/workspace/local-sandbox#nativesandboxconfig) control network access, read-only or writable paths, write access to the working directory, and system binaries. You can also provide a custom Seatbelt profile or Bubblewrap arguments. See [`LocalSandbox`](/reference/workspace/local-sandbox) for the full configuration.
+Enable native isolation to restrict filesystem and network access at the operating-system level. On macOS, native isolation uses Seatbelt (`sandbox-exec`). On Linux, it uses Bubblewrap (`bwrap`). Use `LocalSandbox.detectIsolation()` to check whether Seatbelt or Bubblewrap is available on the current operating system.
 
-### Other backends
+The [`nativeSandbox` options](/reference/workspace/local-sandbox#nativesandboxconfig) control network access, read-only or writable paths, write access to the working directory, and system binaries. You can also provide a custom Seatbelt profile or Bubblewrap arguments. See [`LocalSandbox`](/reference/workspace/local-sandbox) for the full configuration.
 
-Use a remote or container backend when commands need a stronger boundary from the host application or when workloads need to scale beyond the resources of your application server. Each backend has its own isolation, persistence, networking, and mount behavior:
+### Remote sandboxes
+
+Use a remote or container sandbox when commands need a stronger boundary from the host application or when workloads need to scale beyond the resources of your application server. Each sandbox has its own isolation, persistence, networking, and mount behavior:
 
 <IntegrationGrid section="Sandboxes" />
 
-If Mastra doesn't support your execution backend, implement the [sandbox provider interface](/reference/workspace/sandbox) to add it.
+If Mastra doesn't support your sandbox provider, implement the [sandbox provider interface](/reference/workspace/sandbox) to add it.
 
 ## Filesystem
 
-Each sandbox has a native filesystem that commands can use. Treat it as ephemeral because its contents follow the sandbox's lifecycle.
+Every sandbox has a filesystem for commands. `LocalSandbox` uses the host filesystem, while remote sandboxes have isolated filesystems that are often temporary. For files that need to outlive a sandbox, use external storage.
 
-To seed a sandbox with files or keep files between runs, give the agent a [filesystem](/docs/sandbox/filesystem). Use mounts when sandbox commands need access to the same files.
+Mastra filesystems connect agents and sandboxes to provider-backed storage such as Amazon S3, Google Cloud Storage, or Google Drive. Configuring one gives the agent tools to read, write, and search files. When a remote sandbox and provider support mounting, Mastra automatically mounts the storage through Filesystem in Userspace (FUSE). Commands use normal file paths while the provider stores changes outside the sandbox.
 
-## Multi-tenant sandboxes
+See [Filesystem](/docs/sandbox/filesystem) for providers, file tools, and mounts.
+
+## Sandboxes per user or thread
 
 Use a **resolver** when each user, tenant, or thread needs a separate sandbox. Set `sandboxCacheKey` to the identity that owns the sandbox so later requests reuse the same live environment.
 
 This example creates and caches one Daytona sandbox per user:
 
 ```typescript title="src/mastra/workspaces.ts"
-import type { RequestContext } from '@mastra/core/request-context'
 import { Workspace } from '@mastra/core/workspace'
 import { DaytonaSandbox } from '@mastra/daytona'
 
-const getUserId = (requestContext: RequestContext) => {
-  const userId = requestContext.get('user-id')
-  if (typeof userId !== 'string' || !userId) {
-    throw new Error('A user ID is required to resolve this sandbox')
-  }
-
-  return userId
-}
-
 const workspace = new Workspace({
   sandbox: async ({ requestContext }) => {
-    const sandbox = new DaytonaSandbox({ id: `user-${getUserId(requestContext)}` })
+    const userId = requestContext.get('user-id') as string
+    const sandbox = new DaytonaSandbox({ id: `user-${userId}` })
     await sandbox.start()
     return sandbox
   },
-  sandboxCacheKey: ({ requestContext }) => getUserId(requestContext),
+  sandboxCacheKey: ({ requestContext }) => requestContext.get('user-id') as string,
 })
 ```
 
 The first request from a user creates the sandbox. Later requests with the same user ID reuse it.
 
-For a sandbox with persistent storage, create the filesystem and mount it inside the resolver. This example creates one Daytona sandbox and one S3 storage prefix per memory thread, then mounts the storage at `/workspace`:
+For a sandbox with persistent storage, create a [filesystem](/docs/sandbox/filesystem) and mount it inside the resolver. This example creates one Daytona sandbox and one S3 storage prefix per memory thread, then mounts the storage at `/workspace`:
 
 ```typescript title="src/mastra/workspaces.ts"
 import { MASTRA_THREAD_ID_KEY, type RequestContext } from '@mastra/core/request-context'
@@ -206,14 +191,8 @@ import { Workspace } from '@mastra/core/workspace'
 import { DaytonaSandbox } from '@mastra/daytona'
 import { S3Filesystem } from '@mastra/s3'
 
-const getThreadId = (requestContext: RequestContext) => {
-  const threadId = requestContext.get(MASTRA_THREAD_ID_KEY)
-  if (typeof threadId !== 'string' || !threadId) {
-    throw new Error('A memory thread is required to resolve this sandbox')
-  }
-
-  return threadId
-}
+const getThreadId = (requestContext: RequestContext) =>
+  requestContext.get(MASTRA_THREAD_ID_KEY) as string
 
 const createThreadFilesystem = (threadId: string) =>
   new S3Filesystem({
@@ -243,25 +222,17 @@ The first request in a thread runs the resolver and starts the sandbox. Later re
 
 The example mounts the filesystem inside the resolver because static `mounts` can't be combined with a sandbox resolver. Generated tools resolve the filesystem and sandbox from the request context automatically.
 
-### Resolver ownership
+:::warning
 
-You are responsible for every sandbox returned by a resolver. It must be ready to use when returned. Keep track of it and destroy it through your application lifecycle code when it's no longer needed. `workspace.destroy()` doesn't destroy resolver-returned sandboxes.
+Your application owns sandboxes returned by a resolver. Destroy them and call `workspace.clearSandboxCache(cacheKey)` when the user, thread, or session ends. `workspace.destroy()` doesn't destroy resolver-returned sandboxes.
 
-Resolvers are incompatible with `mounts` and [`lsp: true`](/docs/sandbox/lsp), because both require a static sandbox during configuration. Using a resolver with `mounts` throws an `INVALID_CONFIG` error. With `lsp: true`, Mastra disables LSP and logs a warning.
+:::
 
 ### Tool availability
 
-With a static sandbox, Mastra knows which capabilities the backend supports and only gives the agent the corresponding tools. Application code should also check that an optional capability is available before using it:
+With a static sandbox, Mastra knows which capabilities the backend supports and only gives the agent the corresponding tools. Application code should also check that an optional capability is available before using it.
 
-```typescript
-const processManager = workspace.sandbox?.processes
-
-if (processManager) {
-  await processManager.spawn('pnpm dev')
-}
-```
-
-With a [resolver-backed sandbox](#multi-tenant-sandboxes), the backend isn't known until a request runs, so Mastra initially makes all sandbox tools available. If the resolved backend doesn't support the tool the agent calls, the call fails with `SandboxFeatureNotSupportedError`.
+With a [resolver-backed sandbox](#sandboxes-per-user-or-thread), the backend isn't known until a request runs, so Mastra initially makes all sandbox tools available. If the resolved backend doesn't support the tool the agent calls, the call fails with `SandboxFeatureNotSupportedError`.
 
 ## Background processes
 
@@ -301,7 +272,7 @@ Who shares a sandbox depends on where you configure it and whether you use a res
 | Resource-scoped resolver | The resolver caches one sandbox for each resource ID. |
 | Thread-scoped resolver | A memory thread keeps its sandbox across requests in that thread. |
 
-A static sandbox isn't automatically scoped to the current resource or memory thread. For resource or thread scope, use a resolver and set `sandboxCacheKey` to the corresponding ID. See [Multi-tenant sandboxes](#multi-tenant-sandboxes).
+A static sandbox isn't automatically scoped to the current resource or memory thread. For resource or thread scope, use a resolver and set `sandboxCacheKey` to the corresponding ID. See [Sandboxes per user or thread](#sandboxes-per-user-or-thread).
 
 ### Start
 

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -52,14 +52,14 @@ const workspace = new Workspace({
     name: 'filesystem',
     type: 'WorkspaceFilesystem | WorkspaceFilesystemResolver',
     description:
-      'Filesystem provider instance, or a resolver function that receives `requestContext` and returns a filesystem per request. See [multi-tenant filesystems](/docs/sandbox/filesystem#multi-tenant-filesystems).',
+      'Filesystem provider instance, or a resolver function that receives `requestContext` and returns a filesystem per request. See [filesystems per user or thread](/docs/sandbox/filesystem#filesystems-per-user-or-thread).',
     isOptional: true,
   },
   {
     name: 'sandbox',
     type: 'WorkspaceSandbox | WorkspaceSandboxResolver',
     description:
-      'Sandbox provider instance, or a resolver function that receives `requestContext` and returns a sandbox per request. See [multi-tenant sandboxes](/docs/sandbox/overview#multi-tenant-sandboxes).',
+      'Sandbox provider instance, or a resolver function that receives `requestContext` and returns a sandbox per request. See [sandboxes per user or thread](/docs/sandbox/overview#sandboxes-per-user-or-thread).',
     isOptional: true,
   },
   {
@@ -725,7 +725,7 @@ Added when a filesystem is configured:
 | `mastra_workspace_mkdir` | Create a directory. Creates parent directories automatically if they don't exist. |
 | `mastra_workspace_grep` | Search file contents using regex patterns. Supports glob filtering, context lines, and case-insensitive search. |
 
-With a static filesystem, write tools (`write_file`, `edit_file`, `delete`, `mkdir`) are excluded when the filesystem is in read-only mode. With a [runtime-defined filesystem](/docs/sandbox/filesystem#multi-tenant-filesystems), write tools are always included and read-only is enforced at runtime.
+With a static filesystem, write tools (`write_file`, `edit_file`, `delete`, `mkdir`) are excluded when the filesystem is in read-only mode. With a [runtime-defined filesystem](/docs/sandbox/filesystem#filesystems-per-user-or-thread), write tools are always included and read-only is enforced at runtime.
 
 The `read_file` tool accepts `mediaTypes` and `maxMediaBytes` options to control which mime types are surfaced to the model as native media parts and how large those files can be:
 
@@ -774,7 +774,7 @@ Added when a sandbox is configured:
 | `mastra_workspace_get_process_output` | Get stdout, stderr, and status of a background process by PID. Accepts `tail` to limit output lines and `wait: true` to block until exit. Only available when the sandbox has a process manager. |
 | `mastra_workspace_kill_process` | Kill a background process by PID. Returns the last 50 lines of output. Only available when the sandbox has a process manager. |
 
-With a static sandbox, capability checks (`executeCommand`, `processes`) decide which tool variants are exposed. With a [runtime-defined sandbox](/docs/sandbox/overview#multi-tenant-sandboxes), all sandbox tools are registered and the runtime throws a clear error if the resolved sandbox doesn't implement a requested capability.
+With a static sandbox, capability checks (`executeCommand`, `processes`) decide which tool variants are exposed. With a [runtime-defined sandbox](/docs/sandbox/overview#sandboxes-per-user-or-thread), all sandbox tools are registered and the runtime throws a clear error if the resolved sandbox doesn't implement a requested capability.
 
 The `execute_command` tool accepts a `backgroundProcesses` option for lifecycle callbacks on background processes:
 


### PR DESCRIPTION
## Summary

- focus the overview on sandbox use cases, isolation, and lifecycle
- clarify filesystem persistence and automatic mounts for supported providers
- replace multi-tenant terminology with per-user or per-thread guidance

## Validation

- `pnpm exec oxfmt-mdx --check src/content/en/docs/sandbox/overview.mdx src/content/en/docs/sandbox/filesystem.mdx src/content/en/reference/workspace/workspace-class.mdx`
- `pnpm exec remark --no-stdout --frail --quiet src/content/en/docs/sandbox/overview.mdx src/content/en/docs/sandbox/filesystem.mdx src/content/en/reference/workspace/workspace-class.mdx`
- `pnpm vale --minAlertLevel=error --output=line src/content/en/docs/sandbox/overview.mdx src/content/en/docs/sandbox/filesystem.mdx src/content/en/reference/workspace/workspace-class.mdx`
- production docs build

Full `pnpm validate` remains blocked by unrelated expired `new` tags for the Regions and Workspaces sidebar entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This update makes the sandbox documentation easier to understand. It explains what sandboxes do, how files persist, and how to use them safely for each user or thread.

## Changes

- Refocused the sandbox overview on use cases, isolation, and lifecycle.
- Clarified temporary sandboxes versus persistent filesystems.
- Documented provider-dependent mounts, remote FUSE mounts, and `LocalSandbox` symlinks.
- Added guidance for native isolation, remote sandboxes, filesystem persistence, resolver ownership, and cleanup.
- Replaced multi-tenant terminology with per-user or per-thread guidance.
- Updated Workspace links and examples to use request-context IDs.
- Removed `LocalFilesystem` from the quickstart.
- Documented resolver-time errors for unsupported capabilities.

## Validation

- Formatting, Markdown linting, Vale checks, and the production docs build pass.
- Full `pnpm validate` remains blocked by unrelated expired `new` tags for the Regions and Workspaces sidebar entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->