### PR TITLE
feat(mastracode): add Parallel web search provider

### DIFF
--- a/.changeset/parallel-web-search-provider.md
+++ b/.changeset/parallel-web-search-provider.md
@@ -1,0 +1,12 @@
+---
+'@mastra/code-sdk': minor
+---
+
+Added Parallel as an opt-in web search and extraction provider for Mastra Code.
+
+When `PARALLEL_API_KEY` is configured in your environment, Mastra Code enables Parallel-backed implementations of the built-in `web_search` and `web_extract` tools. This provides a model-independent search solution for models that lack native web search capabilities without needing manual MCP server configuration.
+
+**Precedence:**
+1. Tavily (`TAVILY_API_KEY`)
+2. Parallel (`PARALLEL_API_KEY`)
+3. Anthropic / OpenAI native model search (when supported by the active model)

--- a/.changeset/parallel-web-search-provider.md
+++ b/.changeset/parallel-web-search-provider.md
@@ -10,3 +10,13 @@ When `PARALLEL_API_KEY` is configured in your environment, Mastra Code enables P
 1. Tavily (`TAVILY_API_KEY`)
 2. Parallel (`PARALLEL_API_KEY`)
 3. Anthropic / OpenAI native model search (when supported by the active model)
+
+**Example tool call input:**
+
+```json
+{
+  "search_queries": ["mastra agents documentation", "mastra dynamic workflows"],
+  "objective": "Find documentation and examples for configuring agents and workflows in Mastra"
+}
+```
+

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -633,6 +633,7 @@ Running `/theme` with no arguments shows the current theme. The choice is persis
 | `MASTRACODE_SHELL_MODE` | Direct TUI `!` shell mode (`default`, `path`, or `login`) |
 | `MASTRACODE_DISPATCH_MAX_IN_FLIGHT` | Maximum concurrent Factory background dispatches per replica; invalid or unset values use the default |
 | `TAVILY_API_KEY` | Enable Tavily-powered web search and extract tools |
+| `PARALLEL_API_KEY` | Enable Parallel-powered web search and extract tools (used when `TAVILY_API_KEY` is not set) |
 
 ## Resource ID override
 

--- a/docs/src/mastra-code/tools.mdx
+++ b/docs/src/mastra-code/tools.mdx
@@ -151,11 +151,16 @@ Request access to directories outside the project root. The user is prompted to 
 
 Search the web for documentation, error messages, package APIs, and other information.
 
-This tool is available through three providers:
+This tool is available through four providers, selected by the following precedence:
 
-- **Tavily**: When the `TAVILY_API_KEY` environment variable is set (takes priority).
-- **Anthropic web search**: Built into Anthropic models, used when no Tavily key is configured.
-- **OpenAI web search**: Built into OpenAI models, used when no Tavily key is configured.
+1. **Tavily**: When `TAVILY_API_KEY` is set (highest priority).
+2. **Parallel**: When `PARALLEL_API_KEY` is set and no Tavily key is configured.
+3. **Anthropic web search**: Built into Anthropic models, used when no Tavily or Parallel key is configured.
+4. **OpenAI web search**: Built into OpenAI models, used when no Tavily or Parallel key is configured.
+
+The input schema depends on the active provider:
+
+**Tavily / Anthropic / OpenAI:**
 
 | Parameter | Type | Required | Description |
 | - | - | - | - |
@@ -164,15 +169,32 @@ This tool is available through three providers:
 | `maxResults` | `number` | No | Maximum number of results (default: 10) |
 | `includeImages` | `boolean` | No | Include related images (default: false) |
 
+**Parallel:**
+
+| Parameter | Type | Required | Description |
+| - | - | - | - |
+| `search_queries` | `string[]` | Yes | Concise keyword search queries (3-6 words each). Provide 2-3 for best results. |
+| `objective` | `string` | No | Natural-language description of the goal driving the search |
+
 ### `web_extract`
 
-Extract the full content of one or more web pages. Requires a Tavily API key (`TAVILY_API_KEY`).
+Extract the full content of one or more web pages. Requires a Tavily API key (`TAVILY_API_KEY`) or Parallel API key (`PARALLEL_API_KEY`).
+
+**Tavily:**
 
 | Parameter | Type | Required | Description |
 | - | - | - | - |
 | `urls` | `string[]` | Yes | URLs to extract content from (max 20) |
 | `extractDepth` | `"basic" \| "advanced"` | No | Extraction depth (default: `"basic"`) |
 | `includeImages` | `boolean` | No | Include extracted image URLs (default: false) |
+
+**Parallel:**
+
+| Parameter | Type | Required | Description |
+| - | - | - | - |
+| `urls` | `string[]` | Yes | URLs to extract content from |
+| `objective` | `string` | No | Natural-language description of what content to focus on |
+
 
 ## Task management
 

--- a/mastracode/sdk/package.json
+++ b/mastracode/sdk/package.json
@@ -67,6 +67,7 @@
     "@mastra/schema-compat": "workspace:*",
     "@mastra/stagehand": "workspace:*",
     "@mastra/tavily": "workspace:*",
+    "@parallel-web/ai-sdk-tools": "^1.0.0",
     "ai": "^6.0.236",
     "execa": "^9.6.1",
     "libsql": "^0.5.29",

--- a/mastracode/sdk/src/agents/prompts/index.ts
+++ b/mastracode/sdk/src/agents/prompts/index.ts
@@ -8,7 +8,7 @@ export { fastModePrompt } from './fast.js';
 
 import { buildBasePrompt } from '@mastra/core/coding-agent';
 import type { PromptContext as BasePromptContext } from '@mastra/core/coding-agent';
-import { hasTavilyKey } from '../../tools/index.js';
+import { hasTavilyKey, hasParallelKey } from '../../tools/index.js';
 import { getLocalPlansRelativeDir } from '../../utils/plans.js';
 import { loadAgentInstructions, formatAgentInstructions, createGitRefInstructionReader } from './agent-instructions.js';
 import { buildModePromptFn } from './build.js';
@@ -38,7 +38,10 @@ const modePrompts: Record<string, string | ((ctx: PromptContext) => string)> = {
 export function buildFullPrompt(ctx: PromptContext): string {
   // Determine whether web search tools are available
   const modelId = ctx.modelId;
-  const hasWebSearch = hasTavilyKey() || (!!modelId && modelId.startsWith('anthropic/'));
+  const hasWebSearch =
+    hasTavilyKey() ||
+    hasParallelKey() ||
+    (!!modelId && (modelId.startsWith('anthropic/') || modelId.startsWith('openai/')));
 
   // Collect per-tool deny rules so guidance omits denied tools
   const deniedTools = new Set<string>();

--- a/mastracode/sdk/src/agents/tools.test.ts
+++ b/mastracode/sdk/src/agents/tools.test.ts
@@ -4,12 +4,16 @@ vi.mock('../tools/index.js', () => ({
   createWebSearchTool: () => ({ description: 'web search' }),
   createWebExtractTool: () => ({ description: 'web extract' }),
   hasTavilyKey: () => false,
+  createParallelWebSearchTool: () => ({ description: 'parallel web search' }),
+  createParallelWebExtractTool: () => ({ description: 'parallel web extract' }),
+  hasParallelKey: () => false,
   requestSandboxAccessTool: { description: 'request sandbox access' },
 }));
 
 import { createDynamicTools, createToolHooks } from './tools.js';
+import * as toolsIndex from '../tools/index.js';
 
-function createRequestContext(state: Record<string, unknown>, modeId: string = 'build') {
+function createRequestContext(state: Record<string, unknown>, modeId: string = 'build', modelId?: string) {
   const getState = () => state;
   return {
     get(key: string) {
@@ -17,7 +21,7 @@ function createRequestContext(state: Record<string, unknown>, modeId: string = '
       return {
         modeId,
         getState,
-        session: { state: { get: getState } },
+        session: { state: { get: getState }, modelId },
       };
     },
   } as any;
@@ -53,7 +57,36 @@ describe('createDynamicTools', () => {
     expect(allowedTools.request_access).not.toBe(requestAccessReplacement);
     expect(allowedTools.request_access.description).toBe('request sandbox access');
   });
+
+  it('selects Parallel web tools when PARALLEL_API_KEY is set but TAVILY_API_KEY is not', () => {
+    vi.spyOn(toolsIndex, 'hasParallelKey').mockReturnValue(true);
+    vi.spyOn(toolsIndex, 'hasTavilyKey').mockReturnValue(false);
+
+    const getDynamicTools = createDynamicTools();
+    const allowedTools = getDynamicTools({ requestContext: createRequestContext({}) });
+
+    expect(allowedTools.web_search).toBeDefined();
+    expect(allowedTools.web_search.description).toBe('parallel web search');
+    expect(allowedTools.web_extract).toBeDefined();
+    expect(allowedTools.web_extract.description).toBe('parallel web extract');
+
+    vi.restoreAllMocks();
+  });
+
+  it('prefers Tavily over Parallel when both keys are set', () => {
+    vi.spyOn(toolsIndex, 'hasTavilyKey').mockReturnValue(true);
+    vi.spyOn(toolsIndex, 'hasParallelKey').mockReturnValue(true);
+
+    const getDynamicTools = createDynamicTools();
+    const allowedTools = getDynamicTools({ requestContext: createRequestContext({}) });
+
+    expect(allowedTools.web_search.description).toBe('web search');
+    expect(allowedTools.web_extract.description).toBe('web extract');
+
+    vi.restoreAllMocks();
+  });
 });
+
 
 describe('createToolHooks', () => {
   it('maps PreToolUse and PostToolUse hook manager calls to agent tool hooks', async () => {

--- a/mastracode/sdk/src/agents/tools.ts
+++ b/mastracode/sdk/src/agents/tools.ts
@@ -15,7 +15,15 @@ import type { HookManager } from '../hooks/index.js';
 import type { McpManager } from '../mcp/index.js';
 import type { MastraCodeComposedState } from '../schema.js';
 import { MC_TOOLS } from '../tool-names.js';
-import { createWebSearchTool, createWebExtractTool, hasTavilyKey, requestSandboxAccessTool } from '../tools/index.js';
+import {
+  createWebSearchTool,
+  createWebExtractTool,
+  hasTavilyKey,
+  createParallelWebSearchTool,
+  createParallelWebExtractTool,
+  hasParallelKey,
+  requestSandboxAccessTool,
+} from '../tools/index.js';
 import { createWorkflowTool } from '../tools/workflows/create-workflow.js';
 import { deleteWorkflowTool } from '../tools/workflows/delete-workflow.js';
 import { getWorkflowTool } from '../tools/workflows/get-workflow.js';
@@ -118,11 +126,12 @@ export function createDynamicTools(
   disabledTools?: string[],
   storage?: MastraCompositeStore,
   pluginTools?: Record<string, ToolLike>,
-) {
+): any {
   return function getDynamicTools({
     requestContext,
   }: {
     requestContext: RequestContext;
+    mastra?: any;
   }): Record<string, ToolLike> | Promise<Record<string, ToolLike>> {
     const ctx = requestContext.get('controller') as AgentControllerRequestContext<MastraCodeComposedState> | undefined;
     const state = ctx?.getState();
@@ -155,6 +164,9 @@ export function createDynamicTools(
     if (hasTavilyKey()) {
       tools.web_search = createWebSearchTool();
       tools.web_extract = createWebExtractTool();
+    } else if (hasParallelKey()) {
+      tools.web_search = createParallelWebSearchTool();
+      tools.web_extract = createParallelWebExtractTool();
     } else if (isAnthropicModel) {
       const anthropic = createAnthropic({});
       tools.web_search = anthropic.tools.webSearch_20250305();

--- a/mastracode/sdk/src/tools/__tests__/web-search.test.ts
+++ b/mastracode/sdk/src/tools/__tests__/web-search.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+const mockSearchExecute = vi.fn();
+const mockExtractExecute = vi.fn();
+
+vi.mock('@parallel-web/ai-sdk-tools', () => ({
+  createSearchTool: vi.fn(() => ({
+    description: 'Search the web using Parallel',
+    inputSchema: { type: 'object' },
+    execute: mockSearchExecute,
+  })),
+  createExtractTool: vi.fn(() => ({
+    description: 'Extract content using Parallel',
+    inputSchema: { type: 'object' },
+    execute: mockExtractExecute,
+  })),
+}));
+
+import {
+  hasTavilyKey,
+  hasParallelKey,
+  createParallelWebSearchTool,
+  createParallelWebExtractTool,
+} from '../web-search.js';
+
+describe('web-search tools', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('hasTavilyKey', () => {
+    it('returns true when TAVILY_API_KEY is present', () => {
+      process.env.TAVILY_API_KEY = 'test-key';
+      expect(hasTavilyKey()).toBe(true);
+    });
+
+    it('returns false when TAVILY_API_KEY is missing', () => {
+      delete process.env.TAVILY_API_KEY;
+      expect(hasTavilyKey()).toBe(false);
+    });
+  });
+
+  describe('hasParallelKey', () => {
+    it('returns true when PARALLEL_API_KEY is present', () => {
+      process.env.PARALLEL_API_KEY = 'parallel-key';
+      expect(hasParallelKey()).toBe(true);
+    });
+
+    it('returns false when PARALLEL_API_KEY is missing', () => {
+      delete process.env.PARALLEL_API_KEY;
+      expect(hasParallelKey()).toBe(false);
+    });
+  });
+
+  describe('createParallelWebSearchTool', () => {
+    it('creates a tool with the SDK description and inputSchema', () => {
+      const tool = createParallelWebSearchTool();
+      expect(tool.id).toBe('web-search');
+      expect(tool.description).toBe('Search the web using Parallel');
+      expect(tool.inputSchema).toBeDefined();
+    });
+
+    it('formats results to markdown string with truncation', async () => {
+      mockSearchExecute.mockResolvedValueOnce({
+        results: [
+          {
+            title: 'Mastra Documentation',
+            url: 'https://mastra.ai/docs',
+            excerpts: ['Mastra is an agent framework.'],
+          },
+          {
+            url: 'https://example.com',
+            excerpts: ['First excerpt', 'Second excerpt'],
+          },
+        ],
+      });
+
+      const tool = createParallelWebSearchTool();
+      const result = await tool.execute(
+        { search_queries: ['mastra documentation'] },
+        {} as any,
+      );
+
+      expect(mockSearchExecute).toHaveBeenCalledWith(
+        { search_queries: ['mastra documentation'] },
+        expect.anything(),
+      );
+      expect(result).toContain('## Mastra Documentation\nhttps://mastra.ai/docs\nMastra is an agent framework.');
+      expect(result).toContain('## https://example.com\nFirst excerpt\n\nSecond excerpt');
+    });
+  });
+
+  describe('createParallelWebExtractTool', () => {
+    it('creates a tool with the SDK description and inputSchema', () => {
+      const tool = createParallelWebExtractTool();
+      expect(tool.id).toBe('web-extract');
+      expect(tool.description).toBe('Extract content using Parallel');
+      expect(tool.inputSchema).toBeDefined();
+    });
+
+    it('formats extracted results and errors to markdown string', async () => {
+      mockExtractExecute.mockResolvedValueOnce({
+        results: [
+          {
+            title: 'Page Title',
+            url: 'https://mastra.ai',
+            excerpts: ['Extracted markdown content.'],
+          },
+        ],
+        errors: [
+          {
+            url: 'https://bad.url',
+            error_type: 'http_404',
+          },
+        ],
+      });
+
+      const tool = createParallelWebExtractTool();
+      const result = await tool.execute(
+        { urls: ['https://mastra.ai', 'https://bad.url'] },
+        {} as any,
+      );
+
+      expect(mockExtractExecute).toHaveBeenCalledWith(
+        { urls: ['https://mastra.ai', 'https://bad.url'] },
+        expect.anything(),
+      );
+      expect(result).toContain('## Page Title\nhttps://mastra.ai\nExtracted markdown content.');
+      expect(result).toContain('## https://bad.url\nError: http_404');
+    });
+  });
+});

--- a/mastracode/sdk/src/tools/index.ts
+++ b/mastracode/sdk/src/tools/index.ts
@@ -3,4 +3,5 @@
  */
 
 export { createWebSearchTool, createWebExtractTool, hasTavilyKey } from './web-search.js';
+export { createParallelWebSearchTool, createParallelWebExtractTool, hasParallelKey } from './web-search.js';
 export { requestSandboxAccessTool } from './request-sandbox-access.js';

--- a/mastracode/sdk/src/tools/web-search.test.ts
+++ b/mastracode/sdk/src/tools/web-search.test.ts
@@ -21,7 +21,7 @@ import {
   hasParallelKey,
   createParallelWebSearchTool,
   createParallelWebExtractTool,
-} from '../web-search.js';
+} from './web-search.js';
 
 describe('web-search tools', () => {
   const originalEnv = process.env;

--- a/mastracode/sdk/src/tools/web-search.ts
+++ b/mastracode/sdk/src/tools/web-search.ts
@@ -1,5 +1,6 @@
 import { createTool } from '@mastra/core/tools';
 import { createTavilySearchTool, createTavilyExtractTool } from '@mastra/tavily';
+import { createSearchTool as createParallelSearchToolSdk, createExtractTool as createParallelExtractToolSdk } from '@parallel-web/ai-sdk-tools';
 
 import { truncateStringForTokenEstimate } from '../utils/token-estimator.js';
 
@@ -15,6 +16,15 @@ const MIN_RELEVANCE_SCORE = 0.25;
  */
 export function hasTavilyKey(): boolean {
   return !!process.env.TAVILY_API_KEY;
+}
+
+/**
+ * Check whether a Parallel API key is available in the environment.
+ * Used to decide whether to include Parallel-backed web tools when
+ * Tavily is not configured.
+ */
+export function hasParallelKey(): boolean {
+  return !!process.env.PARALLEL_API_KEY;
 }
 
 /**
@@ -76,6 +86,70 @@ export function createWebExtractTool() {
 
       for (const r of output.failedResults) {
         parts.push(`## ${r.url}\nError: ${r.error}`);
+      }
+
+      const text = parts.join('\n\n');
+      return truncateStringForTokenEstimate(text, MAX_WEB_EXTRACT_TOKENS);
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Parallel-backed web tools
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps @parallel-web/ai-sdk-tools search with mastracode-specific behavior:
+ * markdown string formatting and token truncation.
+ */
+export function createParallelWebSearchTool() {
+  const parallelSearchTool = createParallelSearchToolSdk();
+
+  return createTool({
+    id: 'web-search',
+    description: parallelSearchTool.description!,
+    inputSchema: parallelSearchTool.inputSchema as any,
+    execute: async (input, context) => {
+      const output: any = await (parallelSearchTool as any).execute!(input as any, context as any);
+
+      const parts: string[] = [];
+
+      for (const r of output.results ?? []) {
+        const header = r.title ? `## ${r.title}\n${r.url}` : `## ${r.url}`;
+        const body = (r.excerpts ?? []).join('\n\n');
+        parts.push(`${header}\n${body}`);
+      }
+
+      const text = parts.join('\n\n');
+      return truncateStringForTokenEstimate(text, MAX_WEB_SEARCH_TOKENS);
+    },
+  });
+}
+
+/**
+ * Wraps @parallel-web/ai-sdk-tools extract with mastracode-specific behavior:
+ * markdown string formatting and token truncation.
+ */
+export function createParallelWebExtractTool() {
+  const parallelExtractTool = createParallelExtractToolSdk();
+
+  return createTool({
+    id: 'web-extract',
+    description: parallelExtractTool.description!,
+    inputSchema: parallelExtractTool.inputSchema as any,
+    execute: async (input, context) => {
+      const output: any = await (parallelExtractTool as any).execute!(input as any, context as any);
+
+      const parts: string[] = [];
+
+      for (const r of output.results ?? []) {
+        const header = r.title ? `## ${r.title}\n${r.url}` : `## ${r.url}`;
+        const body = (r.excerpts ?? []).join('\n\n');
+        parts.push(`${header}\n${body}`);
+      }
+
+      for (const r of output.errors ?? []) {
+        parts.push(`## ${r.url}\nError: ${r.error_type}`);
       }
 
       const text = parts.join('\n\n');

--- a/mastracode/sdk/src/workflows/register-primitives.ts
+++ b/mastracode/sdk/src/workflows/register-primitives.ts
@@ -33,7 +33,14 @@ import { LazyNotificationsStorage } from '../agents/tools.js';
 import { workflowBuilderAgent } from '../agents/workflow-builder-agent.js';
 import type { McpManager } from '../mcp';
 import { MC_TOOLS } from '../tool-names.js';
-import { createWebExtractTool, createWebSearchTool, hasTavilyKey } from '../tools/web-search.js';
+import {
+  createWebExtractTool,
+  createWebSearchTool,
+  hasTavilyKey,
+  createParallelWebSearchTool,
+  createParallelWebExtractTool,
+  hasParallelKey,
+} from '../tools/web-search.js';
 
 export interface RegisterWorkflowBuilderPrimitivesOptions {
   projectPath: string;
@@ -83,11 +90,14 @@ export async function registerWorkflowBuilderPrimitives(
     mastra.addTool(tool, toolId);
   }
 
-  // 3. Web tools — Tavily only. Provider-native web tools (Anthropic/OpenAI)
+  // 3. Web tools — Tavily or Parallel. Provider-native web tools (Anthropic/OpenAI)
   //    are model-locked and would freeze workflows to one provider.
   if (hasTavilyKey()) {
     mastra.addTool(createWebSearchTool(), 'web-search');
     mastra.addTool(createWebExtractTool(), 'web-extract');
+  } else if (hasParallelKey()) {
+    mastra.addTool(createParallelWebSearchTool(), 'web-search');
+    mastra.addTool(createParallelWebExtractTool(), 'web-extract');
   }
 
   // 4. notification_inbox — LazyNotificationsStorage resolves the notifications

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2570,6 +2570,9 @@ importers:
       '@mastra/tavily':
         specifier: workspace:*
         version: link:../../integrations/tavily
+      '@parallel-web/ai-sdk-tools':
+        specifier: ^1.0.0
+        version: 1.0.0(ai@6.0.241(zod@4.4.3))
       ai:
         specifier: ^6.0.236
         version: 6.0.241(zod@4.4.3)
@@ -18086,6 +18089,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@parallel-web/ai-sdk-tools@1.0.0':
+    resolution: {integrity: sha512-OmPMRXlYDsnXXe5wjqJDv1YYoUReYwR6f4Ut5CTDh6TmtAHW2jvFSJ0jZJaM/eNJA2w1Q2Ic3axBTqnwY9QVwg==}
+    peerDependencies:
+      ai: ^6.0.0
+
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
@@ -28522,6 +28530,9 @@ packages:
 
   papaparse@5.5.4:
     resolution: {integrity: sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==}
+
+  parallel-web@0.5.0:
+    resolution: {integrity: sha512-p3JR9ENwbXtQJFTn4rWrraYKzHISkG2lwoRmVQceEqepgMtpuE6v/BEMi4yAmGum6ejK2F4DDKLkcqeFxnqztg==}
 
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
@@ -42951,6 +42962,12 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.75.0':
     optional: true
 
+  '@parallel-web/ai-sdk-tools@1.0.0(ai@6.0.241(zod@4.4.3))':
+    dependencies:
+      ai: 6.0.241(zod@4.4.3)
+      parallel-web: 0.5.0
+      zod: 4.4.3
+
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -54923,6 +54940,8 @@ snapshots:
   pako@2.1.0: {}
 
   papaparse@5.5.4: {}
+
+  parallel-web@0.5.0: {}
 
   param-case@3.0.4:
     dependencies:


### PR DESCRIPTION
## Description

Adds [Parallel](https://parallel.ai) as an opt-in web search and extraction provider for Mastra Code's built-in web tools (`web_search` and `web_extract`).

When `PARALLEL_API_KEY` is configured in the environment, Mastra Code exposes Parallel-backed implementations using `@parallel-web/ai-sdk-tools`. The output is formatted as LLM-friendly markdown strings with token truncation to match Mastra Code's existing tool contract.

**Provider Precedence:**
1. **Tavily**: When `TAVILY_API_KEY` is set (takes priority)
2. **Parallel**: When `PARALLEL_API_KEY` is set (and no Tavily key is present)
3. **Anthropic / OpenAI**: Native web search built into active model provider (fallback)

**Changes included:**
- Added `@parallel-web/ai-sdk-tools` dependency to `@mastra/code-sdk`.
- Implemented `hasParallelKey()`, `createParallelWebSearchTool()`, and `createParallelWebExtractTool()` in `mastracode/sdk/src/tools/web-search.ts`.
- Integrated Parallel into the tool selection cascade (`tools.ts`), workflow primitive registration (`register-primitives.ts`), and prompt guidance (`prompts/index.ts`).
- Updated configuration reference and web tools documentation.
- Added comprehensive unit tests for `web_search` / `web_extract` tools and cascade selection.
- Added changeset.

## Related issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/21201

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets Mastra Code use Parallel for web searches and page extraction when `PARALLEL_API_KEY` is configured. It keeps Tavily first, then uses Parallel, and finally uses the model’s native search.

## Changes

- Added Parallel-backed `web_search` and `web_extract` tools.
- Preserved the existing Mastra Code tool interface and workflow tool IDs.
- Formatted Parallel results as LLM-friendly Markdown.
- Added token-based output truncation and error formatting.
- Added provider precedence:
  1. Tavily
  2. Parallel
  3. Native Anthropic or OpenAI search
- Added `PARALLEL_API_KEY` configuration documentation.
- Added prompt guidance for Parallel credentials and supported model prefixes.
- Added the `@parallel-web/ai-sdk-tools` dependency.
- Added unit tests for provider selection, precedence, formatting, truncation, and errors.
- Added a changeset for `@mastra/code-sdk`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->