### PR TITLE
feat(factory-ui): redesign the audit log

### DIFF
--- a/.changeset/tall-moments-behave.md
+++ b/.changeset/tall-moments-behave.md
@@ -3,3 +3,10 @@
 ---
 
 Improved the Factory audit log with a density timeline, category filters, responsive rows, and automatic history loading. Intake binding changes now appear in the affected project's audit history.
+
+```ts
+const response = await fetch(
+  `/web/factory/projects/${factoryProjectId}/audit?actions=factory.run.started&limit=50`,
+);
+const page = await response.json();
+```

--- a/.changeset/tall-moments-behave.md
+++ b/.changeset/tall-moments-behave.md
@@ -2,4 +2,4 @@
 '@mastra/factory': minor
 ---
 
-Improved the Factory audit log with a density timeline, category filters, responsive rows, and automatic history loading.
+Improved the Factory audit log with a density timeline, category filters, responsive rows, and automatic history loading. Intake binding changes now appear in the affected project's audit history.

--- a/.changeset/tall-moments-behave.md
+++ b/.changeset/tall-moments-behave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Improved the Factory audit log with a density timeline, category filters, responsive rows, and automatic history loading.

--- a/mastracode/factory-ui/src/hooks/useAuditEvents.ts
+++ b/mastracode/factory-ui/src/hooks/useAuditEvents.ts
@@ -5,6 +5,8 @@ import { queryKeys } from '../api/keys';
 import { fetchAuditEvents, fetchAuditPortalLink } from '../ui/domains/factory/services/audit';
 import type { AuditEventPage } from '../ui/domains/factory/services/audit';
 
+const MAX_COMPLETE_AUDIT_PAGES = 25;
+
 export function useAuditEvents(
   factoryProjectId: string | undefined,
   group: string,
@@ -41,12 +43,25 @@ export function useCompleteAuditEvents(
         const events: AuditEventPage['events'] = [];
         const actors: AuditEventPage['actors'] = {};
         let before: string | undefined;
+        const seenCursors = new Set<string>();
+        let pageCount = 0;
 
         do {
+          signal.throwIfAborted();
+          if (pageCount >= MAX_COMPLETE_AUDIT_PAGES) {
+            throw new Error(`Audit history exceeded ${MAX_COMPLETE_AUDIT_PAGES} pages`);
+          }
           const page = await fetchAuditEvents(baseUrl, factoryProjectId, { actorIds, before, limit, signal });
+          pageCount += 1;
           events.push(...page.events);
           for (const [actorId, actor] of Object.entries(page.actors)) actors[actorId] ??= actor;
-          before = page.nextCursor;
+
+          const nextCursor = page.nextCursor;
+          if (nextCursor && (nextCursor === before || seenCursors.has(nextCursor))) {
+            throw new Error('Audit pagination cursor did not advance');
+          }
+          if (nextCursor) seenCursors.add(nextCursor);
+          before = nextCursor;
         } while (before);
 
         return { events, actors };

--- a/mastracode/factory-ui/src/hooks/useAuditEvents.ts
+++ b/mastracode/factory-ui/src/hooks/useAuditEvents.ts
@@ -1,15 +1,10 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { skipToken, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
 import { fetchAuditEvents, fetchAuditPortalLink } from '../ui/domains/factory/services/audit';
 import type { AuditEventPage } from '../ui/domains/factory/services/audit';
 
-/**
- * Cursor-paginated audit trail for the project, newest-first. `group` is the
- * UI's action-group filter key; `actions` the concrete action list it maps to
- * (undefined = all actions).
- */
 export function useAuditEvents(
   factoryProjectId: string | undefined,
   group: string,
@@ -18,19 +13,21 @@ export function useAuditEvents(
   actorIds: string[] = [],
 ) {
   const { baseUrl } = useApiConfig();
-  const actorKey = [...actorIds].sort().join(',');
+  const actorKey = actorIds.toSorted().join(',');
+  const initialPageParam: string | undefined = undefined;
+  const queryFn = factoryProjectId
+    ? ({ pageParam, signal }: { pageParam: string | undefined; signal: AbortSignal }) =>
+        fetchAuditEvents(baseUrl, factoryProjectId, { actions, actorIds, before: pageParam, limit, signal })
+    : skipToken;
   return useInfiniteQuery({
     queryKey: queryKeys.factoryAudit(factoryProjectId, group, actorKey),
-    queryFn: ({ pageParam }) =>
-      fetchAuditEvents(baseUrl, factoryProjectId!, { actions, actorIds, before: pageParam, limit }),
-    initialPageParam: undefined as string | undefined,
+    queryFn,
+    initialPageParam,
     getNextPageParam: (lastPage: AuditEventPage) => lastPage.nextCursor,
-    enabled: Boolean(factoryProjectId),
     staleTime: 15_000,
   });
 }
 
-/** Load the complete project audit history for board-card attribution. */
 export function useCompleteAuditEvents(
   factoryProjectId: string | undefined,
   group: string,
@@ -38,33 +35,31 @@ export function useCompleteAuditEvents(
   actorIds: string[] = [],
 ) {
   const { baseUrl } = useApiConfig();
-  const actorKey = [...actorIds].sort().join(',');
+  const actorKey = actorIds.toSorted().join(',');
+  const queryFn = factoryProjectId
+    ? async ({ signal }: { signal: AbortSignal }): Promise<AuditEventPage> => {
+        const events: AuditEventPage['events'] = [];
+        const actors: AuditEventPage['actors'] = {};
+        let before: string | undefined;
+
+        do {
+          const page = await fetchAuditEvents(baseUrl, factoryProjectId, { actorIds, before, limit, signal });
+          events.push(...page.events);
+          for (const [actorId, actor] of Object.entries(page.actors)) actors[actorId] ??= actor;
+          before = page.nextCursor;
+        } while (before);
+
+        return { events, actors };
+      }
+    : skipToken;
+
   return useQuery({
     queryKey: queryKeys.factoryAudit(factoryProjectId, `${group}:complete`, actorKey),
-    queryFn: async (): Promise<AuditEventPage> => {
-      const events: AuditEventPage['events'] = [];
-      const actors: AuditEventPage['actors'] = {};
-      let before: string | undefined;
-
-      do {
-        const page = await fetchAuditEvents(baseUrl, factoryProjectId!, { actorIds, before, limit });
-        events.push(...page.events);
-        for (const [actorId, actor] of Object.entries(page.actors)) actors[actorId] ??= actor;
-        before = page.nextCursor;
-      } while (before);
-
-      return { events, actors };
-    },
-    enabled: Boolean(factoryProjectId),
+    queryFn,
     staleTime: 15_000,
   });
 }
 
-/**
- * One-time WorkOS Admin Portal URL for the audit-log viewer, or `null` when
- * WorkOS isn't configured (the button is hidden). Links are single-use, so
- * consumers refetch after opening one.
- */
 export function useAuditPortalLink(enabled: boolean) {
   const { baseUrl } = useApiConfig();
   return useQuery({

--- a/mastracode/factory-ui/src/hooks/useAuditEvents.ts
+++ b/mastracode/factory-ui/src/hooks/useAuditEvents.ts
@@ -5,8 +5,6 @@ import { queryKeys } from '../api/keys';
 import { fetchAuditEvents, fetchAuditPortalLink } from '../ui/domains/factory/services/audit';
 import type { AuditEventPage } from '../ui/domains/factory/services/audit';
 
-const MAX_COMPLETE_AUDIT_PAGES = 25;
-
 export function useAuditEvents(
   factoryProjectId: string | undefined,
   group: string,
@@ -44,15 +42,10 @@ export function useCompleteAuditEvents(
         const actors: AuditEventPage['actors'] = {};
         let before: string | undefined;
         const seenCursors = new Set<string>();
-        let pageCount = 0;
 
         do {
           signal.throwIfAborted();
-          if (pageCount >= MAX_COMPLETE_AUDIT_PAGES) {
-            throw new Error(`Audit history exceeded ${MAX_COMPLETE_AUDIT_PAGES} pages`);
-          }
           const page = await fetchAuditEvents(baseUrl, factoryProjectId, { actorIds, before, limit, signal });
-          pageCount += 1;
           events.push(...page.events);
           for (const [actorId, actor] of Object.entries(page.actors)) actors[actorId] ??= actor;
 

--- a/mastracode/factory-ui/src/ui/__tests__/AuditPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/AuditPage.msw.test.tsx
@@ -1,0 +1,184 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../e2e/ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import type { AuditEvent } from '../domains/factory/services/audit';
+import { createAppRoutes } from '../router';
+
+const FACTORY_ID = 'fp-1';
+const HOUR = 3_600_000;
+
+class ImmediateIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin = '0px';
+  readonly scrollMargin = '0px';
+  readonly thresholds = [0];
+
+  constructor(private readonly callback: IntersectionObserverCallback) {}
+
+  disconnect() {}
+
+  observe(target: Element) {
+    const rect = target.getBoundingClientRect();
+    this.callback(
+      [
+        {
+          boundingClientRect: rect,
+          intersectionRatio: 1,
+          intersectionRect: rect,
+          isIntersecting: true,
+          rootBounds: null,
+          target,
+          time: 0,
+        },
+      ],
+      this,
+    );
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  unobserve() {}
+}
+
+function event(id: string, overrides: Partial<AuditEvent>): AuditEvent {
+  return {
+    id,
+    actorId: 'user-1',
+    actorType: 'human',
+    action: 'factory.work_item.stage_moved',
+    targets: [{ type: 'work_item', id: 'wi-1', name: 'Fix reconnect' }],
+    metadata: {},
+    occurredAt: new Date(Date.now() - HOUR).toISOString(),
+    ...overrides,
+  };
+}
+
+function renderAudit() {
+  const router = createMemoryRouter(createAppRoutes(), { initialEntries: [`/factories/${FACTORY_ID}/audit`] });
+  renderWithProviders(<RouterProvider router={router} />);
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('Audit log', () => {
+  it('shows event density, custom rows, expandable details, and automatically fetches the next page', async () => {
+    vi.stubGlobal('IntersectionObserver', ImmediateIntersectionObserver);
+    const requestedCursors: Array<string | null> = [];
+    const recent = event('event-recent', {
+      metadata: { from: 'planning', to: 'execute', decisionId: 'decision-9' },
+    });
+    const older = event('event-older', {
+      actorId: 'agent:thread-9',
+      actorType: 'agent',
+      action: 'factory.run.started',
+      metadata: { agentName: 'Build agent', branch: 'factory/wi-1' },
+      occurredAt: new Date(Date.now() - 3 * 24 * HOUR).toISOString(),
+    });
+
+    server.use(
+      http.get(`${TEST_BASE_URL}/auth/me`, () =>
+        HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+        HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
+      ),
+      http.get(`${TEST_BASE_URL}/api/agent-controller/code/sessions/${FACTORY_ID}/permissions`, () =>
+        HttpResponse.json({ categories: {}, tools: {} }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/audit/portal-link`, () => new HttpResponse(null, { status: 404 })),
+      http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/audit`, ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('before');
+        requestedCursors.push(cursor);
+        const actors = { 'user-1': { id: 'user-1', name: 'Damien Schneider' } };
+        return cursor
+          ? HttpResponse.json({ events: [older], actors })
+          : HttpResponse.json({ events: [recent], actors, nextCursor: 'page-2' });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderAudit();
+
+    expect(await screen.findByRole('slider', { name: 'Audit time range' })).toBeInTheDocument();
+    expect(await screen.findByText('Planning → Building')).toBeInTheDocument();
+    expect(screen.getByText('Damien Schneider')).toBeInTheDocument();
+
+    await waitFor(() => expect(requestedCursors).toEqual([null, 'page-2']));
+    expect(await screen.findByText('Run started')).toBeInTheDocument();
+    expect(screen.getByText('Build agent')).toBeInTheDocument();
+
+    const recentRow = screen.getByRole('button', { expanded: false, name: /Stage moved/ });
+    await user.click(recentRow);
+    expect(recentRow).toHaveAttribute('aria-expanded', 'true');
+    expect(within(recentRow.parentElement ?? recentRow).getByText(/decision-9/)).toBeInTheDocument();
+
+    const olderRow = screen.getByRole('button', { expanded: false, name: /Run started/ });
+    await user.click(olderRow);
+    expect(olderRow).toHaveAttribute('aria-expanded', 'true');
+    expect(recentRow).toHaveAttribute('aria-expanded', 'true');
+
+    const timeline = screen.getByRole('slider', { name: 'Audit time range' });
+    await user.click(timeline);
+    expect(timeline).toHaveFocus();
+    await user.keyboard('{ArrowUp}');
+    const reset = screen.getByRole('button', { name: 'Reset' });
+    await user.click(reset);
+    expect(screen.queryByRole('button', { name: 'Reset' })).not.toBeInTheDocument();
+
+    const startDate = screen.getByRole('button', { name: 'Start date' });
+    expect(startDate).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'End date' })).toBeInTheDocument();
+    await user.click(startDate);
+    expect(await screen.findByTestId('datepicker-calendar')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+
+    await user.click(screen.getByRole('button', { name: 'Runs' }));
+    expect(await screen.findByRole('button', { name: 'Runs' })).toHaveAttribute('aria-pressed', 'true');
+    await user.click(screen.getByRole('button', { name: 'Agent' }));
+    expect(await screen.findByRole('button', { name: 'Runs' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Agent' })).toHaveAttribute('aria-pressed', 'true');
+
+    await user.click(screen.getByRole('button', { name: 'All' }));
+    expect(await screen.findByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Runs' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: 'Agent' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('keeps category toggles available when the log is empty', async () => {
+    server.use(
+      http.get(`${TEST_BASE_URL}/auth/me`, () =>
+        HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+        HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
+      ),
+      http.get(`${TEST_BASE_URL}/api/agent-controller/code/sessions/${FACTORY_ID}/permissions`, () =>
+        HttpResponse.json({ categories: {}, tools: {} }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/audit/portal-link`, () => new HttpResponse(null, { status: 404 })),
+      http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/audit`, () =>
+        HttpResponse.json({ events: [], actors: {} }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderAudit();
+
+    expect(await screen.findByRole('heading', { name: 'No audit events yet' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Audit categories' })).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Audit time range' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Runs' }));
+    expect(await screen.findByRole('heading', { name: 'No matching audit events' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Audit categories' })).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Audit time range' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Runs' })).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ChatHeader.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ChatHeader.tsx
@@ -24,7 +24,10 @@ export function ChatHeader({ mobileContent, children, className, ...props }: Cha
   if (!showHeaderControls && !content && !children) return null;
 
   return (
-    <header className={cn('flex min-w-0 shrink-0 items-center gap-2 px-3 py-2', className)} {...props}>
+    <header
+      className={cn('flex h-(--page-header-height) min-w-0 shrink-0 items-center gap-2 px-3', className)}
+      {...props}
+    >
       <ChatHeaderSidebarTrigger isMobile={isMobile} sidebarCollapsed={sidebarCollapsed} />
       {content}
       {children}

--- a/mastracode/factory-ui/src/ui/domains/factory/auditPresentation.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/auditPresentation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AUDIT_CATEGORIES,
+  auditActionLabel,
+  auditActionsForCategories,
+  auditDayEnd,
+  auditDayStart,
+  auditActorLabel,
+  auditCategory,
+  auditMetadataPreview,
+  auditRangeBetween,
+  auditVisibleMetadata,
+  type AuditNamespace,
+} from './auditPresentation';
+import type { AuditEvent } from './services/audit';
+
+function event(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    id: 'event-1',
+    actorId: 'user-1',
+    actorType: 'human',
+    action: 'factory.work_item.updated',
+    targets: [],
+    metadata: {},
+    occurredAt: '2026-08-21T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('audit presentation', () => {
+  it('labels known actions and categories', () => {
+    expect(auditActionLabel('factory.work_item.stage_moved')).toBe('Stage moved');
+    expect(auditActionLabel('factory.run.started')).toBe('Run started');
+    expect(auditCategory('factory.git.commit')?.label).toBe('Git');
+    expect(auditCategory('factory.unknown.changed')).toBeUndefined();
+  });
+
+  it('hides internal metadata from previews and details', () => {
+    const auditEvent = event({ metadata: { branch: 'feat/audit', attempts: 2, __actorProfile: { name: 'Ada' } } });
+
+    expect(auditVisibleMetadata(auditEvent)).toEqual({ branch: 'feat/audit', attempts: 2 });
+    expect(auditMetadataPreview(auditEvent)).toBe('branch=feat/audit · attempts=2');
+  });
+
+  it('formats stage transitions and actor names', () => {
+    expect(auditMetadataPreview(event({ action: 'factory.work_item.stage_moved', metadata: { to: 'review' } }))).toBe(
+      '→ Review',
+    );
+    expect(auditActorLabel(event(), 'Ada Lovelace')).toBe('Ada Lovelace');
+    expect(auditActorLabel(event({ actorType: 'agent', metadata: { agentName: 'Build agent' } }), undefined)).toBe(
+      'Build agent',
+    );
+  });
+
+  it('treats every selected category as no filter', () => {
+    const all = new Set<AuditNamespace>(AUDIT_CATEGORIES.map(category => category.namespace));
+    expect(auditActionsForCategories(all)).toBeUndefined();
+    expect(auditActionsForCategories(new Set<AuditNamespace>(['run']))).toEqual([
+      'factory.run.started',
+      'factory.run.approved',
+      'factory.run.dismissed',
+    ]);
+    expect(auditActionsForCategories(new Set<AuditNamespace>(['intake']))).toEqual([
+      'factory.intake.config_updated',
+      'factory.intake.binding_updated',
+    ]);
+  });
+
+  it('keeps partial category filters within the server action cap', () => {
+    for (const excluded of AUDIT_CATEGORIES) {
+      const selected = new Set<AuditNamespace>(
+        AUDIT_CATEGORIES.filter(category => category !== excluded).map(category => category.namespace),
+      );
+      expect(auditActionsForCategories(selected)?.length).toBeLessThanOrEqual(16);
+    }
+  });
+
+  it('uses inclusive local-day boundaries for mobile picks', () => {
+    const selected = new Date(2026, 7, 21, 12, 30);
+    const start = new Date(auditDayStart(selected));
+    const end = new Date(auditDayEnd(selected));
+
+    expect([start.getHours(), start.getMinutes(), start.getSeconds(), start.getMilliseconds()]).toEqual([0, 0, 0, 0]);
+    expect([end.getHours(), end.getMinutes(), end.getSeconds(), end.getMilliseconds()]).toEqual([23, 59, 59, 999]);
+  });
+
+  it('orders inverted picks and preserves a minimum range', () => {
+    const minute = 60_000;
+    const bounds = { from: 0, to: 10 * minute };
+
+    expect(auditRangeBetween(8 * minute, 2 * minute, bounds)).toEqual({
+      from: 2 * minute,
+      to: 8 * minute,
+    });
+    expect(auditRangeBetween(4 * minute, 4 * minute, bounds)).toEqual({
+      from: 1.5 * minute,
+      to: 6.5 * minute,
+    });
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/factory/auditPresentation.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/auditPresentation.ts
@@ -2,12 +2,54 @@ import type { AuditEvent } from './services/audit';
 import { stageLabel } from './stages';
 
 export const AUDIT_CATEGORIES = [
-  { namespace: 'work_item', label: 'Work items', dotClass: 'bg-accent3', fillClass: 'fill-accent3' },
-  { namespace: 'run', label: 'Runs', dotClass: 'bg-positive1', fillClass: 'fill-positive1' },
-  { namespace: 'worktree', label: 'Worktrees', dotClass: 'bg-neutral3', fillClass: 'fill-neutral3' },
-  { namespace: 'git', label: 'Git', dotClass: 'bg-(--chart-4)', fillClass: 'fill-(--chart-4)' },
-  { namespace: 'agent', label: 'Agent', dotClass: 'bg-accent6', fillClass: 'fill-accent6' },
-  { namespace: 'intake', label: 'Intake', dotClass: 'bg-neutral2', fillClass: 'fill-neutral2' },
+  {
+    namespace: 'work_item',
+    label: 'Work items',
+    dotClass: 'bg-accent3',
+    fillClass: 'fill-accent3',
+    actions: [
+      'factory.work_item.created',
+      'factory.work_item.updated',
+      'factory.work_item.stage_moved',
+      'factory.work_item.deleted',
+      'factory.work_item.transition_rejected',
+    ],
+  },
+  {
+    namespace: 'run',
+    label: 'Runs',
+    dotClass: 'bg-positive1',
+    fillClass: 'fill-positive1',
+    actions: ['factory.run.started', 'factory.run.approved', 'factory.run.dismissed'],
+  },
+  {
+    namespace: 'worktree',
+    label: 'Worktrees',
+    dotClass: 'bg-neutral3',
+    fillClass: 'fill-neutral3',
+    actions: ['factory.worktree.created', 'factory.worktree.deleted'],
+  },
+  {
+    namespace: 'git',
+    label: 'Git',
+    dotClass: 'bg-(--chart-4)',
+    fillClass: 'fill-(--chart-4)',
+    actions: ['factory.git.commit', 'factory.git.push', 'factory.git.pr_opened'],
+  },
+  {
+    namespace: 'agent',
+    label: 'Agent',
+    dotClass: 'bg-accent6',
+    fillClass: 'fill-accent6',
+    actions: ['factory.agent.commit', 'factory.agent.push', 'factory.agent.pr_opened'],
+  },
+  {
+    namespace: 'intake',
+    label: 'Intake',
+    dotClass: 'bg-neutral2',
+    fillClass: 'fill-neutral2',
+    actions: ['factory.intake.config_updated', 'factory.intake.binding_updated'],
+  },
 ] as const;
 
 export type AuditNamespace = (typeof AUDIT_CATEGORIES)[number]['namespace'];
@@ -15,6 +57,57 @@ export type AuditNamespace = (typeof AUDIT_CATEGORIES)[number]['namespace'];
 export interface AuditTimeRange {
   from: number;
   to: number;
+}
+
+const MINIMUM_AUDIT_RANGE = 5 * 60_000;
+export function auditEventTime(event: AuditEvent): number | undefined {
+  const at = Date.parse(event.occurredAt);
+  return Number.isFinite(at) ? at : undefined;
+}
+
+export function eventInAuditRange(event: AuditEvent, range: AuditTimeRange): boolean {
+  const at = auditEventTime(event);
+  return at !== undefined && at >= range.from && at <= range.to;
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function auditDayStart(date: Date): number {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  return start.getTime();
+}
+
+export function auditDayEnd(date: Date): number {
+  const end = new Date(date);
+  end.setHours(23, 59, 59, 999);
+  return end.getTime();
+}
+export function auditRangeAround(center: number, span: number, bounds: AuditTimeRange): AuditTimeRange {
+  const boundedSpan = Math.min(span, bounds.to - bounds.from);
+  const from = clamp(center - boundedSpan / 2, bounds.from, bounds.to - boundedSpan);
+  return { from, to: from + boundedSpan };
+}
+
+export function auditRangeBetween(anchor: number, current: number, bounds: AuditTimeRange): AuditTimeRange {
+  const from = clamp(Math.min(anchor, current), bounds.from, bounds.to);
+  const to = clamp(Math.max(anchor, current), bounds.from, bounds.to);
+  const minimumSpan = Math.min(
+    Math.max((bounds.to - bounds.from) * 0.03, MINIMUM_AUDIT_RANGE),
+    bounds.to - bounds.from,
+  );
+  return to - from >= minimumSpan ? { from, to } : auditRangeAround((from + to) / 2, minimumSpan, bounds);
+}
+
+export function auditActionsForCategories(selected: ReadonlySet<AuditNamespace>): string[] | undefined {
+  if (selected.size === 0 || selected.size === AUDIT_CATEGORIES.length) return undefined;
+  const actions: string[] = [];
+  for (const category of AUDIT_CATEGORIES) {
+    if (selected.has(category.namespace)) actions.push(...category.actions);
+  }
+  return actions;
 }
 
 export function auditCategory(action: string) {
@@ -37,6 +130,14 @@ function metadataValue(value: unknown): string {
   return typeof value === 'string' ? value : (JSON.stringify(value) ?? String(value));
 }
 
+export function auditVisibleMetadata(event: AuditEvent): Record<string, unknown> {
+  const visible: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(event.metadata)) {
+    if (!key.startsWith('__')) visible[key] = value;
+  }
+  return visible;
+}
+
 export function auditMetadataPreview(event: AuditEvent): string {
   if (event.action === 'factory.work_item.stage_moved') {
     const from = event.metadata.from;
@@ -47,8 +148,8 @@ export function auditMetadataPreview(event: AuditEvent): string {
   }
 
   const details: string[] = [];
-  for (const [key, value] of Object.entries(event.metadata)) {
-    if (!key.startsWith('__')) details.push(`${key}=${metadataValue(value)}`);
+  for (const [key, value] of Object.entries(auditVisibleMetadata(event))) {
+    details.push(`${key}=${metadataValue(value)}`);
   }
   return details.join(' · ');
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/auditPresentation.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/auditPresentation.ts
@@ -1,0 +1,60 @@
+import type { AuditEvent } from './services/audit';
+import { stageLabel } from './stages';
+
+export const AUDIT_CATEGORIES = [
+  { namespace: 'work_item', label: 'Work items', dotClass: 'bg-accent3', fillClass: 'fill-accent3' },
+  { namespace: 'run', label: 'Runs', dotClass: 'bg-positive1', fillClass: 'fill-positive1' },
+  { namespace: 'worktree', label: 'Worktrees', dotClass: 'bg-neutral3', fillClass: 'fill-neutral3' },
+  { namespace: 'git', label: 'Git', dotClass: 'bg-(--chart-4)', fillClass: 'fill-(--chart-4)' },
+  { namespace: 'agent', label: 'Agent', dotClass: 'bg-accent6', fillClass: 'fill-accent6' },
+  { namespace: 'intake', label: 'Intake', dotClass: 'bg-neutral2', fillClass: 'fill-neutral2' },
+] as const;
+
+export type AuditNamespace = (typeof AUDIT_CATEGORIES)[number]['namespace'];
+
+export interface AuditTimeRange {
+  from: number;
+  to: number;
+}
+
+export function auditCategory(action: string) {
+  const namespace = action.split('.')[1];
+  return AUDIT_CATEGORIES.find(category => category.namespace === namespace);
+}
+
+function words(value: string): string {
+  return value.replace(/_/g, ' ');
+}
+
+export function auditActionLabel(action: string): string {
+  const [, namespace, leaf] = action.split('.');
+  const prefix = namespace && namespace !== 'work_item' ? `${words(namespace)} ` : '';
+  const description = leaf ? `${prefix}${words(leaf)}` : words(action);
+  return description.charAt(0).toUpperCase() + description.slice(1);
+}
+
+function metadataValue(value: unknown): string {
+  return typeof value === 'string' ? value : (JSON.stringify(value) ?? String(value));
+}
+
+export function auditMetadataPreview(event: AuditEvent): string {
+  if (event.action === 'factory.work_item.stage_moved') {
+    const from = event.metadata.from;
+    const to = event.metadata.to;
+    if (typeof to === 'string') {
+      return typeof from === 'string' ? `${stageLabel(from)} → ${stageLabel(to)}` : `→ ${stageLabel(to)}`;
+    }
+  }
+
+  const details: string[] = [];
+  for (const [key, value] of Object.entries(event.metadata)) {
+    if (!key.startsWith('__')) details.push(`${key}=${metadataValue(value)}`);
+  }
+  return details.join(' · ');
+}
+
+export function auditActorLabel(event: AuditEvent, actorName: string | undefined): string {
+  if (event.actorType === 'human') return actorName ?? event.actorId;
+  const agentName = event.metadata.agentName;
+  return typeof agentName === 'string' ? agentName : (actorName ?? 'Agent');
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/boardRelevance.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardRelevance.test.ts
@@ -52,14 +52,11 @@ const activityPage: AuditEventPage = {
   events: [
     {
       id: 'event-1',
-      orgId: 'org-1',
       actorId: 'user-ada',
       actorType: 'human',
       action: 'factory.work_item.stage_moved',
       targets: [{ type: 'work_item', id: item.id }],
       metadata: {},
-      githubProjectId: 'factory-1',
-      context: {},
       occurredAt: '2026-08-05T09:00:00.000Z',
     },
   ],

--- a/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditCategoryFilter.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditCategoryFilter.tsx
@@ -20,7 +20,7 @@ function CategoryToggle({
       aria-pressed={pressed}
       onClick={onClick}
       className={cn(
-        'flex cursor-pointer items-center gap-1.5 rounded-full px-2.5 py-1 text-ui-xs font-semibold outline-none transition-colors',
+        'flex cursor-pointer items-center gap-1.5 rounded-full px-2.5 py-1 text-ui-xs font-semibold outline-none transition-colors focus-visible:ring-1 focus-visible:ring-accent1',
         pressed
           ? 'bg-neutral6/10 text-neutral6'
           : 'text-neutral3 hover:bg-neutral6/5 hover:text-neutral5 focus-visible:bg-neutral6/5 focus-visible:text-neutral5',

--- a/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditCategoryFilter.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditCategoryFilter.tsx
@@ -1,0 +1,75 @@
+import { cn } from '@mastra/playground-ui/utils/cn';
+
+import { AUDIT_CATEGORIES } from '../../auditPresentation';
+import type { AuditNamespace } from '../../auditPresentation';
+
+function CategoryToggle({
+  label,
+  dotClass,
+  pressed,
+  onClick,
+}: {
+  label: string;
+  dotClass: string;
+  pressed: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={pressed}
+      onClick={onClick}
+      className={cn(
+        'flex cursor-pointer items-center gap-1.5 rounded-full px-2.5 py-1 text-ui-xs font-semibold outline-none transition-colors',
+        pressed
+          ? 'bg-neutral6/10 text-neutral6'
+          : 'text-neutral3 hover:bg-neutral6/5 hover:text-neutral5 focus-visible:bg-neutral6/5 focus-visible:text-neutral5',
+      )}
+    >
+      <span aria-hidden="true" className={cn('size-1.5 rounded-full', dotClass)} />
+      {label}
+    </button>
+  );
+}
+
+export function AuditCategoryFilter({
+  selectedCategories,
+  countLabel,
+  onToggleCategory,
+  onClearCategories,
+}: {
+  selectedCategories: ReadonlySet<AuditNamespace>;
+  countLabel: string;
+  onToggleCategory: (category: AuditNamespace) => void;
+  onClearCategories: () => void;
+}) {
+  return (
+    <div className="grid min-w-0 grid-cols-1 items-center gap-1 pt-2 sm:grid-cols-[1fr_auto_1fr] sm:gap-2">
+      <span className="hidden sm:block" />
+      <div
+        className="flex max-w-full min-w-0 flex-wrap justify-center gap-1"
+        role="group"
+        aria-label="Audit categories"
+      >
+        <CategoryToggle
+          label="All"
+          dotClass="bg-neutral3"
+          pressed={selectedCategories.size === 0}
+          onClick={onClearCategories}
+        />
+        {AUDIT_CATEGORIES.map(category => (
+          <CategoryToggle
+            key={category.namespace}
+            label={category.label}
+            dotClass={category.dotClass}
+            pressed={selectedCategories.has(category.namespace)}
+            onClick={() => onToggleCategory(category.namespace)}
+          />
+        ))}
+      </div>
+      <span className="text-ui-xs text-neutral2 justify-self-center tabular-nums sm:justify-self-end">
+        {countLabel}
+      </span>
+    </div>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditLogList.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditLogList.tsx
@@ -7,7 +7,13 @@ import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import { relativeTime } from '../../../../../lib/date/relativeTime';
-import { auditActionLabel, auditActorLabel, auditCategory, auditMetadataPreview } from '../../auditPresentation';
+import {
+  auditActionLabel,
+  auditActorLabel,
+  auditCategory,
+  auditMetadataPreview,
+  auditVisibleMetadata,
+} from '../../auditPresentation';
 import type { AuditEvent } from '../../services/audit';
 
 const AUDIT_GRID_CLASS =
@@ -36,7 +42,8 @@ function AuditEventRow({
 }) {
   const category = auditCategory(event.action);
   const target = event.targets[0];
-  const hasMetadata = Object.keys(event.metadata).length > 0;
+  const visibleMetadata = auditVisibleMetadata(event);
+  const hasMetadata = Object.keys(visibleMetadata).length > 0;
   const actor = auditActorLabel(event, actorName);
   const targetLabel = target?.name ?? target?.id;
   const detail = auditMetadataPreview(event);
@@ -106,7 +113,7 @@ function AuditEventRow({
 
       {expanded ? (
         <Code
-          code={JSON.stringify(event.metadata, null, 2)}
+          code={JSON.stringify(visibleMetadata, null, 2)}
           lang="json"
           className="text-ui-xs text-neutral4 m-0 mx-3 mb-3 px-2 py-1 font-sans break-all whitespace-pre-wrap"
         />
@@ -117,10 +124,12 @@ function AuditEventRow({
 
 function InfiniteScrollTrigger({
   hasNextPage,
+  autoLoad,
   isFetchingNextPage,
   onLoadMore,
 }: {
   hasNextPage: boolean;
+  autoLoad: boolean;
   isFetchingNextPage: boolean;
   onLoadMore: () => void;
 }) {
@@ -128,7 +137,7 @@ function InfiniteScrollTrigger({
 
   useEffect(() => {
     const node = trigger.current;
-    if (!node || !hasNextPage || isFetchingNextPage || typeof IntersectionObserver === 'undefined') return;
+    if (!node || !hasNextPage || !autoLoad || isFetchingNextPage || typeof IntersectionObserver === 'undefined') return;
 
     const observer = new IntersectionObserver(
       entries => {
@@ -140,7 +149,7 @@ function InfiniteScrollTrigger({
     );
     observer.observe(node);
     return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
+  }, [autoLoad, hasNextPage, isFetchingNextPage, onLoadMore]);
 
   if (!hasNextPage) return null;
 
@@ -161,12 +170,14 @@ export function AuditLogList({
   events,
   actorNames,
   hasNextPage,
+  autoLoad,
   isFetchingNextPage,
   onLoadMore,
 }: {
   events: AuditEvent[];
   actorNames: ReadonlyMap<string, string>;
   hasNextPage: boolean;
+  autoLoad: boolean;
   isFetchingNextPage: boolean;
   onLoadMore: () => void;
 }) {
@@ -207,6 +218,7 @@ export function AuditLogList({
       </ul>
       <InfiniteScrollTrigger
         hasNextPage={hasNextPage}
+        autoLoad={autoLoad}
         isFetchingNextPage={isFetchingNextPage}
         onLoadMore={onLoadMore}
       />

--- a/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditLogList.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditLogList.tsx
@@ -1,0 +1,215 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Code } from '@mastra/playground-ui/components/Code';
+import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import { ChevronRight } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { relativeTime } from '../../../../../lib/date/relativeTime';
+import { auditActionLabel, auditActorLabel, auditCategory, auditMetadataPreview } from '../../auditPresentation';
+import type { AuditEvent } from '../../services/audit';
+
+const AUDIT_GRID_CLASS =
+  'grid-cols-[4.5rem_minmax(0,1fr)_1rem] lg:grid-cols-[7rem_minmax(8rem,0.8fr)_minmax(10rem,0.9fr)_minmax(11rem,1.1fr)_minmax(13rem,1.4fr)_1rem]';
+
+const CELL_CLASS = 'min-w-0 truncate text-ui-sm';
+
+function AuditCell({ children, className, title }: { children: ReactNode; className?: string; title?: string }) {
+  return (
+    <span className={cn(CELL_CLASS, className)} title={title}>
+      {children || '—'}
+    </span>
+  );
+}
+
+function AuditEventRow({
+  event,
+  actorName,
+  expanded,
+  onToggle,
+}: {
+  event: AuditEvent;
+  actorName: string | undefined;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const category = auditCategory(event.action);
+  const target = event.targets[0];
+  const hasMetadata = Object.keys(event.metadata).length > 0;
+  const actor = auditActorLabel(event, actorName);
+  const targetLabel = target?.name ?? target?.id;
+  const detail = auditMetadataPreview(event);
+  const mobileSummary = [actor, targetLabel, detail].filter(Boolean).join(' · ');
+  const cells = (
+    <>
+      <AuditCell className="text-ui-xs text-neutral2 self-start tabular-nums lg:self-auto" title={event.occurredAt}>
+        {relativeTime(event.occurredAt)}
+      </AuditCell>
+      <AuditCell className={cn('hidden lg:block', event.actorType === 'agent' ? 'text-accent6' : 'text-neutral3')}>
+        {actor}
+      </AuditCell>
+      <AuditCell className="text-neutral5">
+        <span className="flex min-w-0 items-center gap-2">
+          <span
+            aria-hidden="true"
+            className={cn('size-1.5 shrink-0 rounded-full', category?.dotClass ?? 'bg-neutral2')}
+          />
+          <span className="truncate">{auditActionLabel(event.action)}</span>
+        </span>
+      </AuditCell>
+      <AuditCell className="text-neutral4 hidden lg:block">{targetLabel}</AuditCell>
+      <AuditCell className="text-ui-xs text-neutral2 hidden lg:block">{detail}</AuditCell>
+      <span className="text-neutral2 flex justify-end">
+        {hasMetadata ? (
+          <span
+            aria-hidden="true"
+            className={cn(
+              'flex transition-transform duration-150 ease-out motion-reduce:transition-none',
+              expanded && 'rotate-90',
+            )}
+          >
+            <ChevronRight className="size-3.5" />
+          </span>
+        ) : null}
+      </span>
+      <span className="text-ui-xs text-neutral2 col-start-2 col-end-3 row-start-2 min-w-0 truncate lg:hidden">
+        {mobileSummary}
+      </span>
+    </>
+  );
+
+  return (
+    <li
+      className={cn(
+        'rounded-md transition-colors even:bg-neutral6/5 hover:bg-neutral6/10',
+        expanded && 'bg-neutral6/10 even:bg-neutral6/10',
+      )}
+    >
+      {hasMetadata ? (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={onToggle}
+          className={cn(
+            'grid w-full cursor-pointer items-start gap-x-3 gap-y-0.5 rounded-md px-3 py-2 text-left outline-none focus-visible:bg-neutral6/10 lg:items-center lg:gap-4',
+            AUDIT_GRID_CLASS,
+          )}
+        >
+          {cells}
+        </button>
+      ) : (
+        <div className={cn('grid items-start gap-x-3 gap-y-0.5 px-3 py-2 lg:items-center lg:gap-4', AUDIT_GRID_CLASS)}>
+          {cells}
+        </div>
+      )}
+
+      {expanded ? (
+        <Code
+          code={JSON.stringify(event.metadata, null, 2)}
+          lang="json"
+          className="text-ui-xs text-neutral4 m-0 mx-3 mb-3 px-2 py-1 font-sans break-all whitespace-pre-wrap"
+        />
+      ) : null}
+    </li>
+  );
+}
+
+function InfiniteScrollTrigger({
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}: {
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+}) {
+  const trigger = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const node = trigger.current;
+    if (!node || !hasNextPage || isFetchingNextPage || typeof IntersectionObserver === 'undefined') return;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (!entries[0]?.isIntersecting) return;
+        observer.disconnect();
+        onLoadMore();
+      },
+      { rootMargin: '0px 0px 320px' },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
+
+  if (!hasNextPage) return null;
+
+  return (
+    <div ref={trigger} className="flex h-12 items-center justify-center" aria-live="polite">
+      {isFetchingNextPage ? (
+        <Spinner size="sm" aria-label="Loading older events" />
+      ) : (
+        <Button variant="ghost" size="xs" onClick={onLoadMore}>
+          Load older events
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export function AuditLogList({
+  events,
+  actorNames,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}: {
+  events: AuditEvent[];
+  actorNames: ReadonlyMap<string, string>;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+}) {
+  const [openedEventIds, setOpenedEventIds] = useState(() => new Set<string>());
+  const toggleEvent = (eventId: string) => {
+    setOpenedEventIds(current => {
+      const next = new Set(current);
+      if (!next.delete(eventId)) next.add(eventId);
+      return next;
+    });
+  };
+
+  return (
+    <div className="min-w-0 lg:min-w-[57rem] lg:pr-1">
+      <div
+        className={cn(
+          'sticky top-(--page-sticky-top) z-20 hidden items-center gap-4 rounded-lg bg-surface4 px-3 py-2 text-ui-sm font-semibold tracking-tight text-neutral2 lg:grid',
+          AUDIT_GRID_CLASS,
+        )}
+      >
+        <span>When</span>
+        <span>Actor</span>
+        <span>Event</span>
+        <span>Target</span>
+        <span>Details</span>
+        <span />
+      </div>
+      <ul className="m-0 flex list-none flex-col p-0 pt-1" aria-label="Audit events">
+        {events.map(event => (
+          <AuditEventRow
+            key={event.id}
+            event={event}
+            actorName={actorNames.get(event.actorId)}
+            expanded={openedEventIds.has(event.id)}
+            onToggle={() => toggleEvent(event.id)}
+          />
+        ))}
+      </ul>
+      <InfiniteScrollTrigger
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={onLoadMore}
+      />
+    </div>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditMobileDateRange.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditMobileDateRange.tsx
@@ -1,14 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { DateTimePicker } from '@mastra/playground-ui/components/DateTimePicker';
 
-interface TimeRange {
-  from: number;
-  to: number;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
-}
+import { auditDayEnd, auditDayStart, auditRangeBetween, clamp, type AuditTimeRange } from '../../auditPresentation';
 
 function dateLabel(at: number): string {
   return new Date(at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
@@ -19,24 +12,24 @@ export function AuditMobileDateRange({
   range,
   onRangeChange,
 }: {
-  bounds: TimeRange;
-  range: TimeRange | undefined;
-  onRangeChange: (range: TimeRange | undefined) => void;
+  bounds: AuditTimeRange;
+  range: AuditTimeRange | undefined;
+  onRangeChange: (range: AuditTimeRange | undefined) => void;
 }) {
   const value = range ?? bounds;
-  const minValue = new Date(bounds.from);
-  const maxValue = new Date(bounds.to);
+  const minValue = new Date(auditDayStart(new Date(bounds.from)));
+  const maxValue = new Date(auditDayEnd(new Date(bounds.to)));
 
   return (
-    <div className="mb-1 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 lg:hidden">
+    <div className="mb-1 hidden grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 [@media(any-pointer:coarse)]:grid">
       <DateTimePicker
         value={new Date(value.from)}
         minValue={minValue}
         maxValue={maxValue}
         onValueChange={date => {
-          if (!date) return;
-          const from = clamp(date.getTime(), bounds.from, bounds.to);
-          onRangeChange({ from, to: Math.max(from, value.to) });
+          if (!date) return onRangeChange(undefined);
+          const from = clamp(auditDayStart(date), bounds.from, bounds.to);
+          onRangeChange(auditRangeBetween(value.to, from, bounds));
         }}
       >
         <Button
@@ -55,9 +48,9 @@ export function AuditMobileDateRange({
         minValue={minValue}
         maxValue={maxValue}
         onValueChange={date => {
-          if (!date) return;
-          const to = clamp(date.getTime(), bounds.from, bounds.to);
-          onRangeChange({ from: Math.min(value.from, to), to });
+          if (!date) return onRangeChange(undefined);
+          const to = clamp(auditDayEnd(date), bounds.from, bounds.to);
+          onRangeChange(auditRangeBetween(value.from, to, bounds));
         }}
       >
         <Button

--- a/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditMobileDateRange.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditMobileDateRange.tsx
@@ -1,0 +1,75 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { DateTimePicker } from '@mastra/playground-ui/components/DateTimePicker';
+
+interface TimeRange {
+  from: number;
+  to: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function dateLabel(at: number): string {
+  return new Date(at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export function AuditMobileDateRange({
+  bounds,
+  range,
+  onRangeChange,
+}: {
+  bounds: TimeRange;
+  range: TimeRange | undefined;
+  onRangeChange: (range: TimeRange | undefined) => void;
+}) {
+  const value = range ?? bounds;
+  const minValue = new Date(bounds.from);
+  const maxValue = new Date(bounds.to);
+
+  return (
+    <div className="mb-1 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 lg:hidden">
+      <DateTimePicker
+        value={new Date(value.from)}
+        minValue={minValue}
+        maxValue={maxValue}
+        onValueChange={date => {
+          if (!date) return;
+          const from = clamp(date.getTime(), bounds.from, bounds.to);
+          onRangeChange({ from, to: Math.max(from, value.to) });
+        }}
+      >
+        <Button
+          type="button"
+          variant="default"
+          size="xs"
+          aria-label="Start date"
+          className="w-full min-w-0 justify-start"
+        >
+          <span className="truncate">Start · {dateLabel(value.from)}</span>
+        </Button>
+      </DateTimePicker>
+      <span className="text-ui-xs text-neutral2">to</span>
+      <DateTimePicker
+        value={new Date(value.to)}
+        minValue={minValue}
+        maxValue={maxValue}
+        onValueChange={date => {
+          if (!date) return;
+          const to = clamp(date.getTime(), bounds.from, bounds.to);
+          onRangeChange({ from: Math.min(value.from, to), to });
+        }}
+      >
+        <Button
+          type="button"
+          variant="default"
+          size="xs"
+          aria-label="End date"
+          className="w-full min-w-0 justify-start"
+        >
+          <span className="truncate">End · {dateLabel(value.to)}</span>
+        </Button>
+      </DateTimePicker>
+    </div>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditTimeline.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditTimeline.tsx
@@ -2,9 +2,16 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { useId, useRef, useState } from 'react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 
-import { AUDIT_CATEGORIES, auditCategory, type AuditNamespace, type AuditTimeRange } from '../../auditPresentation';
+import {
+  AUDIT_CATEGORIES,
+  auditCategory,
+  auditEventTime,
+  auditRangeAround,
+  auditRangeBetween,
+  clamp,
+  type AuditTimeRange,
+} from '../../auditPresentation';
 import type { AuditEvent } from '../../services/audit';
-import { AuditCategoryFilter } from './AuditCategoryFilter';
 import { AuditMobileDateRange } from './AuditMobileDateRange';
 
 type AuditCategory = (typeof AUDIT_CATEGORIES)[number];
@@ -29,16 +36,7 @@ const BOTTOM = 38;
 const MINUTE = 60_000;
 const DAY = 86_400_000;
 const AUDIT_WINDOW = 7 * DAY;
-
-function auditEventTime(event: AuditEvent): number | undefined {
-  const at = Date.parse(event.occurredAt);
-  return Number.isFinite(at) ? at : undefined;
-}
-
-export function eventInAuditRange(event: AuditEvent, range: AuditTimeRange): boolean {
-  const at = auditEventTime(event);
-  return at !== undefined && at >= range.from && at <= range.to;
-}
+const RANGE_KEYS = new Set(['Escape', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End']);
 
 function eventBounds(events: AuditEvent[]): AuditTimeRange | undefined {
   let from = Number.POSITIVE_INFINITY;
@@ -56,23 +54,6 @@ function eventBounds(events: AuditEvent[]): AuditTimeRange | undefined {
   return { from, to };
 }
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
-}
-
-function rangeAround(center: number, span: number, bounds: AuditTimeRange): AuditTimeRange {
-  const boundedSpan = Math.min(span, bounds.to - bounds.from);
-  const from = clamp(center - boundedSpan / 2, bounds.from, bounds.to - boundedSpan);
-  return { from, to: from + boundedSpan };
-}
-
-function rangeBetween(anchor: number, current: number, bounds: AuditTimeRange): AuditTimeRange {
-  const from = clamp(Math.min(anchor, current), bounds.from, bounds.to);
-  const to = clamp(Math.max(anchor, current), bounds.from, bounds.to);
-  const minimumSpan = Math.min(Math.max((bounds.to - bounds.from) * 0.03, 5 * MINUTE), bounds.to - bounds.from);
-  return to - from >= minimumSpan ? { from, to } : rangeAround((from + to) / 2, minimumSpan, bounds);
-}
-
 function shiftRange(range: AuditTimeRange, delta: number, bounds: AuditTimeRange): AuditTimeRange {
   const span = range.to - range.from;
   const from = clamp(range.from + delta, bounds.from, bounds.to - span);
@@ -83,11 +64,11 @@ function keyboardRange(
   key: string,
   current: AuditTimeRange | undefined,
   bounds: AuditTimeRange,
-): AuditTimeRange | undefined | null {
+): AuditTimeRange | undefined {
   if (key === 'Escape') return undefined;
 
   const total = bounds.to - bounds.from;
-  const range = current ?? rangeAround((bounds.from + bounds.to) / 2, total / 3, bounds);
+  const range = current ?? auditRangeAround((bounds.from + bounds.to) / 2, total / 3, bounds);
   const span = range.to - range.from;
 
   switch (key) {
@@ -96,15 +77,15 @@ function keyboardRange(
     case 'ArrowRight':
       return shiftRange(range, Math.max(span * 0.1, total * 0.02), bounds);
     case 'ArrowUp':
-      return rangeAround((range.from + range.to) / 2, span * 0.8, bounds);
+      return auditRangeAround((range.from + range.to) / 2, span * 0.8, bounds);
     case 'ArrowDown':
-      return rangeAround((range.from + range.to) / 2, span * 1.25, bounds);
+      return auditRangeAround((range.from + range.to) / 2, span * 1.25, bounds);
     case 'Home':
       return { from: bounds.from, to: bounds.from + span };
     case 'End':
       return { from: bounds.to - span, to: bounds.to };
     default:
-      return null;
+      return current;
   }
 }
 
@@ -151,37 +132,31 @@ function boundaryLabel(at: number): string {
 export function AuditTimeline({
   events,
   range,
-  selectedCategories,
   onRangeChange,
-  onToggleCategory,
-  onClearCategories,
 }: {
   events: AuditEvent[];
   range: AuditTimeRange | undefined;
-  selectedCategories: ReadonlySet<AuditNamespace>;
   onRangeChange: (range: AuditTimeRange | undefined) => void;
-  onToggleCategory: (category: AuditNamespace) => void;
-  onClearCategories: () => void;
 }) {
-  const anchor = useRef<number | null>(null);
+  const anchor = useRef<number | undefined>(undefined);
   const [dragRange, setDragRange] = useState<AuditTimeRange>();
   const selectionGradientId = useId().replace(/:/g, '');
   const selectionShadowId = useId().replace(/:/g, '');
+  const instructionsId = useId().replace(/:/g, '');
   const now = Date.now();
   const bounds = eventBounds(events) ?? { from: now - AUDIT_WINDOW, to: now };
 
   const lanes: AuditLane[] = AUDIT_CATEGORIES.map(category => ({ category, marks: [] }));
+  const lanesByNamespace = new Map(lanes.map(lane => [lane.category.namespace, lane]));
   for (const event of events) {
     const at = auditEventTime(event);
     const category = auditCategory(event.action);
     if (at === undefined || !category) continue;
-    lanes
-      .find(lane => lane.category.namespace === category.namespace)
-      ?.marks.push({
-        id: event.id,
-        at,
-        actorType: event.actorType,
-      });
+    lanesByNamespace.get(category.namespace)?.marks.push({
+      id: event.id,
+      at,
+      actorType: event.actorType,
+    });
   }
   const height = TOP + lanes.length * LANE_HEIGHT + BOTTOM;
   const plotWidth = TRACK_END - TRACK_START;
@@ -197,10 +172,6 @@ export function AuditTimeline({
   const labelsAreTight = selectionToX - selectionFromX < 190;
   const resetButtonCenterX = clamp((selectionFromX + selectionToX) / 2, TRACK_START + 32, TRACK_END - 32);
   const selectionLabel = rangeLabel(selection);
-  let selectedCount = 0;
-  for (const event of events) {
-    if (eventInAuditRange(event, selection)) selectedCount += 1;
-  }
 
   const pointerTime = (event: ReactPointerEvent<SVGSVGElement>) => {
     const box = event.currentTarget.getBoundingClientRect();
@@ -211,9 +182,9 @@ export function AuditTimeline({
 
   const settlePointer = (event: ReactPointerEvent<SVGSVGElement>) => {
     const start = anchor.current;
-    if (start === null) return;
-    const next = rangeBetween(start, pointerTime(event), bounds);
-    anchor.current = null;
+    if (start === undefined) return;
+    const next = auditRangeBetween(start, pointerTime(event), bounds);
+    anchor.current = undefined;
     setDragRange(undefined);
     onRangeChange(next);
   };
@@ -227,39 +198,41 @@ export function AuditTimeline({
             viewBox={`0 0 ${WIDTH} ${height}`}
             role="slider"
             aria-label="Audit time range"
+            aria-describedby={instructionsId}
             aria-orientation="horizontal"
             aria-valuemin={bounds.from}
             aria-valuemax={bounds.to}
             aria-valuenow={(selection.from + selection.to) / 2}
             aria-valuetext={selectionLabel}
             tabIndex={0}
-            className="group/timeline block h-auto w-full cursor-default touch-pan-y overflow-visible rounded-md outline-none select-none lg:cursor-crosshair lg:touch-none"
+            className="group/timeline block h-auto w-full cursor-default touch-pan-y overflow-visible rounded-md outline-none select-none lg:cursor-crosshair"
             onKeyDown={event => {
+              if (!RANGE_KEYS.has(event.key)) return;
               const next = keyboardRange(event.key, range, bounds);
-              if (next === null) return;
+              if (next === undefined && event.key !== 'Escape') return;
               event.preventDefault();
               onRangeChange(next);
             }}
             onPointerDown={event => {
-              if (event.pointerType === 'touch') return;
+              if (event.pointerType === 'touch' || event.button !== 0) return;
               event.preventDefault();
               event.currentTarget.focus();
               const at = pointerTime(event);
               anchor.current = at;
-              setDragRange(rangeBetween(at, at, bounds));
+              setDragRange(auditRangeBetween(at, at, bounds));
               event.currentTarget.setPointerCapture(event.pointerId);
             }}
             onPointerMove={event => {
               const start = anchor.current;
-              if (start !== null) setDragRange(rangeBetween(start, pointerTime(event), bounds));
+              if (start !== undefined) setDragRange(auditRangeBetween(start, pointerTime(event), bounds));
             }}
             onPointerUp={settlePointer}
             onPointerCancel={() => {
-              anchor.current = null;
+              anchor.current = undefined;
               setDragRange(undefined);
             }}
           >
-            <title>
+            <title id={instructionsId}>
               Drag to select a time range. Arrow keys move it; up and down change its width; Escape resets it.
             </title>
             <defs>
@@ -386,13 +359,6 @@ export function AuditTimeline({
           ) : null}
         </div>
       </div>
-
-      <AuditCategoryFilter
-        selectedCategories={selectedCategories}
-        countLabel={hasActiveSelection ? `${selectedCount} of ${events.length} loaded` : `${events.length} loaded`}
-        onToggleCategory={onToggleCategory}
-        onClearCategories={onClearCategories}
-      />
     </>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditTimeline.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/audit/AuditTimeline.tsx
@@ -1,0 +1,398 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { useId, useRef, useState } from 'react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+
+import { AUDIT_CATEGORIES, auditCategory, type AuditNamespace, type AuditTimeRange } from '../../auditPresentation';
+import type { AuditEvent } from '../../services/audit';
+import { AuditCategoryFilter } from './AuditCategoryFilter';
+import { AuditMobileDateRange } from './AuditMobileDateRange';
+
+type AuditCategory = (typeof AUDIT_CATEGORIES)[number];
+
+interface AuditMark {
+  id: string;
+  at: number;
+  actorType: AuditEvent['actorType'];
+}
+
+interface AuditLane {
+  category: AuditCategory;
+  marks: AuditMark[];
+}
+
+const WIDTH = 1000;
+const TRACK_START = 48;
+const TRACK_END = 988;
+const TOP = 22;
+const LANE_HEIGHT = 13;
+const BOTTOM = 38;
+const MINUTE = 60_000;
+const DAY = 86_400_000;
+const AUDIT_WINDOW = 7 * DAY;
+
+function auditEventTime(event: AuditEvent): number | undefined {
+  const at = Date.parse(event.occurredAt);
+  return Number.isFinite(at) ? at : undefined;
+}
+
+export function eventInAuditRange(event: AuditEvent, range: AuditTimeRange): boolean {
+  const at = auditEventTime(event);
+  return at !== undefined && at >= range.from && at <= range.to;
+}
+
+function eventBounds(events: AuditEvent[]): AuditTimeRange | undefined {
+  let from = Number.POSITIVE_INFINITY;
+  let to = Number.NEGATIVE_INFINITY;
+
+  for (const event of events) {
+    const at = auditEventTime(event);
+    if (at === undefined) continue;
+    from = Math.min(from, at);
+    to = Math.max(to, at);
+  }
+
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return undefined;
+  if (from === to) return { from: from - 30 * MINUTE, to: to + 30 * MINUTE };
+  return { from, to };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function rangeAround(center: number, span: number, bounds: AuditTimeRange): AuditTimeRange {
+  const boundedSpan = Math.min(span, bounds.to - bounds.from);
+  const from = clamp(center - boundedSpan / 2, bounds.from, bounds.to - boundedSpan);
+  return { from, to: from + boundedSpan };
+}
+
+function rangeBetween(anchor: number, current: number, bounds: AuditTimeRange): AuditTimeRange {
+  const from = clamp(Math.min(anchor, current), bounds.from, bounds.to);
+  const to = clamp(Math.max(anchor, current), bounds.from, bounds.to);
+  const minimumSpan = Math.min(Math.max((bounds.to - bounds.from) * 0.03, 5 * MINUTE), bounds.to - bounds.from);
+  return to - from >= minimumSpan ? { from, to } : rangeAround((from + to) / 2, minimumSpan, bounds);
+}
+
+function shiftRange(range: AuditTimeRange, delta: number, bounds: AuditTimeRange): AuditTimeRange {
+  const span = range.to - range.from;
+  const from = clamp(range.from + delta, bounds.from, bounds.to - span);
+  return { from, to: from + span };
+}
+
+function keyboardRange(
+  key: string,
+  current: AuditTimeRange | undefined,
+  bounds: AuditTimeRange,
+): AuditTimeRange | undefined | null {
+  if (key === 'Escape') return undefined;
+
+  const total = bounds.to - bounds.from;
+  const range = current ?? rangeAround((bounds.from + bounds.to) / 2, total / 3, bounds);
+  const span = range.to - range.from;
+
+  switch (key) {
+    case 'ArrowLeft':
+      return shiftRange(range, -Math.max(span * 0.1, total * 0.02), bounds);
+    case 'ArrowRight':
+      return shiftRange(range, Math.max(span * 0.1, total * 0.02), bounds);
+    case 'ArrowUp':
+      return rangeAround((range.from + range.to) / 2, span * 0.8, bounds);
+    case 'ArrowDown':
+      return rangeAround((range.from + range.to) / 2, span * 1.25, bounds);
+    case 'Home':
+      return { from: bounds.from, to: bounds.from + span };
+    case 'End':
+      return { from: bounds.to - span, to: bounds.to };
+    default:
+      return null;
+  }
+}
+
+function markOffset(id: string): number {
+  let hash = 0;
+  for (const character of id) hash = (hash * 31 + character.charCodeAt(0)) % 7;
+  return hash - 3;
+}
+
+function timelineTick(at: number, span: number): string {
+  const date = new Date(at);
+  if (span > 2 * 86_400_000) return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+function rangeLabel(range: AuditTimeRange): string {
+  const from = new Date(range.from);
+  const to = new Date(range.to);
+  const sameDay = from.toDateString() === to.toDateString();
+  const fromLabel = from.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  const toLabel = to.toLocaleString(undefined, {
+    month: sameDay ? undefined : 'short',
+    day: sameDay ? undefined : 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  return `${fromLabel} – ${toLabel}`;
+}
+
+function boundaryLabel(at: number): string {
+  return new Date(at).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function AuditTimeline({
+  events,
+  range,
+  selectedCategories,
+  onRangeChange,
+  onToggleCategory,
+  onClearCategories,
+}: {
+  events: AuditEvent[];
+  range: AuditTimeRange | undefined;
+  selectedCategories: ReadonlySet<AuditNamespace>;
+  onRangeChange: (range: AuditTimeRange | undefined) => void;
+  onToggleCategory: (category: AuditNamespace) => void;
+  onClearCategories: () => void;
+}) {
+  const anchor = useRef<number | null>(null);
+  const [dragRange, setDragRange] = useState<AuditTimeRange>();
+  const selectionGradientId = useId().replace(/:/g, '');
+  const selectionShadowId = useId().replace(/:/g, '');
+  const now = Date.now();
+  const bounds = eventBounds(events) ?? { from: now - AUDIT_WINDOW, to: now };
+
+  const lanes: AuditLane[] = AUDIT_CATEGORIES.map(category => ({ category, marks: [] }));
+  for (const event of events) {
+    const at = auditEventTime(event);
+    const category = auditCategory(event.action);
+    if (at === undefined || !category) continue;
+    lanes
+      .find(lane => lane.category.namespace === category.namespace)
+      ?.marks.push({
+        id: event.id,
+        at,
+        actorType: event.actorType,
+      });
+  }
+  const height = TOP + lanes.length * LANE_HEIGHT + BOTTOM;
+  const plotWidth = TRACK_END - TRACK_START;
+  const span = bounds.to - bounds.from;
+  const xAt = (at: number) => TRACK_START + ((at - bounds.from) / span) * plotWidth;
+  const selection = dragRange ?? range ?? bounds;
+  const hasActiveSelection = dragRange !== undefined || range !== undefined;
+  const selectionFromX = xAt(selection.from);
+  const selectionToX = xAt(selection.to);
+  const selectionWidth = Math.max(1, selectionToX - selectionFromX);
+  const selectionTop = TOP - 7;
+  const selectionBottom = height - BOTTOM + 8;
+  const labelsAreTight = selectionToX - selectionFromX < 190;
+  const resetButtonCenterX = clamp((selectionFromX + selectionToX) / 2, TRACK_START + 32, TRACK_END - 32);
+  const selectionLabel = rangeLabel(selection);
+  let selectedCount = 0;
+  for (const event of events) {
+    if (eventInAuditRange(event, selection)) selectedCount += 1;
+  }
+
+  const pointerTime = (event: ReactPointerEvent<SVGSVGElement>) => {
+    const box = event.currentTarget.getBoundingClientRect();
+    if (box.width === 0) return bounds.from;
+    const x = ((event.clientX - box.left) / box.width) * WIDTH;
+    return bounds.from + ((clamp(x, TRACK_START, TRACK_END) - TRACK_START) / plotWidth) * span;
+  };
+
+  const settlePointer = (event: ReactPointerEvent<SVGSVGElement>) => {
+    const start = anchor.current;
+    if (start === null) return;
+    const next = rangeBetween(start, pointerTime(event), bounds);
+    anchor.current = null;
+    setDragRange(undefined);
+    onRangeChange(next);
+  };
+
+  return (
+    <>
+      <AuditMobileDateRange bounds={bounds} range={range} onRangeChange={onRangeChange} />
+      <div className="max-w-full overflow-visible lg:overflow-x-auto lg:overscroll-x-contain">
+        <div className="relative min-w-0 lg:min-w-[45rem]">
+          <svg
+            viewBox={`0 0 ${WIDTH} ${height}`}
+            role="slider"
+            aria-label="Audit time range"
+            aria-orientation="horizontal"
+            aria-valuemin={bounds.from}
+            aria-valuemax={bounds.to}
+            aria-valuenow={(selection.from + selection.to) / 2}
+            aria-valuetext={selectionLabel}
+            tabIndex={0}
+            className="group/timeline block h-auto w-full cursor-default touch-pan-y overflow-visible rounded-md outline-none select-none lg:cursor-crosshair lg:touch-none"
+            onKeyDown={event => {
+              const next = keyboardRange(event.key, range, bounds);
+              if (next === null) return;
+              event.preventDefault();
+              onRangeChange(next);
+            }}
+            onPointerDown={event => {
+              if (event.pointerType === 'touch') return;
+              event.preventDefault();
+              event.currentTarget.focus();
+              const at = pointerTime(event);
+              anchor.current = at;
+              setDragRange(rangeBetween(at, at, bounds));
+              event.currentTarget.setPointerCapture(event.pointerId);
+            }}
+            onPointerMove={event => {
+              const start = anchor.current;
+              if (start !== null) setDragRange(rangeBetween(start, pointerTime(event), bounds));
+            }}
+            onPointerUp={settlePointer}
+            onPointerCancel={() => {
+              anchor.current = null;
+              setDragRange(undefined);
+            }}
+          >
+            <title>
+              Drag to select a time range. Arrow keys move it; up and down change its width; Escape resets it.
+            </title>
+            <defs>
+              <linearGradient id={selectionGradientId} x1="0%" y1="0%" x2="0%" y2="100%">
+                <stop offset="0%" stopColor="var(--neutral6)" stopOpacity={0.09} />
+                <stop offset="55%" stopColor="var(--neutral6)" stopOpacity={0.05} />
+                <stop offset="100%" stopColor="var(--neutral6)" stopOpacity={0.025} />
+              </linearGradient>
+              <filter
+                id={selectionShadowId}
+                x="-8%"
+                y="-12%"
+                width="116%"
+                height="124%"
+                colorInterpolationFilters="sRGB"
+              >
+                <feComponentTransfer in="SourceAlpha" result="inverseAlpha">
+                  <feFuncA type="table" tableValues="1 0" />
+                </feComponentTransfer>
+                <feGaussianBlur in="inverseAlpha" stdDeviation={2.5} result="blurredInverse" />
+                <feOffset in="blurredInverse" dy={1.5} result="offsetBlur" />
+                <feFlood floodColor="white" floodOpacity={0.16} result="highlightColor" />
+                <feComposite in="highlightColor" in2="offsetBlur" operator="in" result="innerHighlight" />
+                <feComposite in="innerHighlight" in2="SourceAlpha" operator="in" result="clippedHighlight" />
+                <feComposite in="clippedHighlight" in2="SourceGraphic" operator="over" />
+              </filter>
+            </defs>
+            {[0, 0.25, 0.5, 0.75, 1].map(position => {
+              const at = bounds.from + span * position;
+              const x = TRACK_START + plotWidth * position;
+              return (
+                <g
+                  key={position}
+                  className={position === 0 || position === 0.5 || position === 1 ? undefined : 'hidden lg:block'}
+                >
+                  <line x1={x} y1={TOP - 7} x2={x} y2={height - BOTTOM} className="stroke-border1" />
+                  <text x={x} y={11} textAnchor="middle" className="fill-neutral2 text-[20px] lg:text-[9px]">
+                    {timelineTick(at, span)}
+                  </text>
+                </g>
+              );
+            })}
+
+            {lanes.map((lane, index) => {
+              const y = TOP + index * LANE_HEIGHT + LANE_HEIGHT / 2;
+              return (
+                <g key={lane.category.namespace}>
+                  {lane.marks.map(mark => (
+                    <rect
+                      key={mark.id}
+                      x={xAt(mark.at) - 1}
+                      y={y - 4 + markOffset(mark.id)}
+                      width={2}
+                      height={8}
+                      rx={1}
+                      opacity={mark.actorType === 'agent' ? 1 : 0.65}
+                      className={lane.category.fillClass}
+                    />
+                  ))}
+                </g>
+              );
+            })}
+
+            {hasActiveSelection ? (
+              <>
+                <rect
+                  x={selectionFromX}
+                  y={selectionTop}
+                  width={selectionWidth}
+                  height={selectionBottom - selectionTop}
+                  rx={7}
+                  fill={`url(#${selectionGradientId})`}
+                  filter={`url(#${selectionShadowId})`}
+                />
+                <text
+                  x={selectionFromX + 6}
+                  y={selectionBottom + (labelsAreTight ? 12 : 14)}
+                  textAnchor="start"
+                  className="fill-neutral3 text-[18px] opacity-50 lg:text-[9px]"
+                >
+                  {boundaryLabel(selection.from)}
+                </text>
+                <text
+                  x={selectionToX - 6}
+                  y={selectionBottom + (labelsAreTight ? 24 : 14)}
+                  textAnchor="end"
+                  className="fill-neutral3 text-[18px] opacity-50 lg:text-[9px]"
+                >
+                  {boundaryLabel(selection.to)}
+                </text>
+              </>
+            ) : null}
+            <rect
+              x={hasActiveSelection ? selectionFromX : TRACK_START}
+              y={selectionTop}
+              width={hasActiveSelection ? selectionWidth : plotWidth}
+              height={selectionBottom - selectionTop}
+              rx={7}
+              fill={`url(#${selectionGradientId})`}
+              className="pointer-events-none opacity-0 transition-opacity group-focus-visible/timeline:opacity-45 motion-reduce:transition-none"
+            />
+            <line
+              x1={TRACK_END}
+              y1={TOP - 6}
+              x2={TRACK_END}
+              y2={height - BOTTOM + 6}
+              className="stroke-positive1 opacity-60"
+            />
+          </svg>
+          {range && !dragRange ? (
+            <Button
+              type="button"
+              variant="default"
+              size="xs"
+              onClick={() => onRangeChange(undefined)}
+              className="absolute z-10 -translate-x-1/2 -translate-y-1/2"
+              style={{
+                left: `${(resetButtonCenterX / WIDTH) * 100}%`,
+                top: `${(selectionTop / height) * 100}%`,
+              }}
+            >
+              Reset
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <AuditCategoryFilter
+        selectedCategories={selectedCategories}
+        countLabel={hasActiveSelection ? `${selectedCount} of ${events.length} loaded` : `${events.length} loaded`}
+        onToggleCategory={onToggleCategory}
+        onClearCategories={onClearCategories}
+      />
+    </>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/services/audit.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/audit.ts
@@ -1,11 +1,3 @@
-/**
- * Browser-side helpers for the Factory audit-trail endpoints.
- *
- * Mirrors the server's audit read API (`src/web/audit/routes.ts`): an
- * org+project-scoped event list with keyset pagination, plus an optional
- * one-time WorkOS Admin Portal link for the enterprise audit-log viewer.
- */
-
 export interface AuditTarget {
   type: string;
   id: string;
@@ -20,46 +12,100 @@ export interface AuditActorProfile {
 
 export interface AuditEvent {
   id: string;
-  orgId: string;
-  /** WorkOS user id of whoever performed the action, or `agent:<threadId>`. */
   actorId: string;
-  /** Whether a human or an agent (inside a run) performed the action. */
   actorType: 'human' | 'agent';
-  /** Dot-namespaced action, e.g. 'factory.work_item.stage_moved'. */
   action: string;
   targets: AuditTarget[];
-  /** Bounded event summary — never full payloads. */
   metadata: Record<string, unknown>;
-  githubProjectId: string | null;
-  context: { location?: string; userAgent?: string };
-  /** ISO timestamp. */
   occurredAt: string;
 }
 
 export interface AuditEventPage {
   events: AuditEvent[];
   actors: Record<string, AuditActorProfile>;
-  /** Pass back as `before` to fetch the next (older) page; absent at the end. */
   nextCursor?: string;
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string';
+}
+
+function isAuditTarget(value: unknown): value is AuditTarget {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  return (
+    'type' in value &&
+    typeof value.type === 'string' &&
+    'id' in value &&
+    typeof value.id === 'string' &&
+    (!('name' in value) || isOptionalString(value.name))
+  );
+}
+
+function isAuditActorProfile(value: unknown): value is AuditActorProfile {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  return (
+    'id' in value &&
+    typeof value.id === 'string' &&
+    'name' in value &&
+    typeof value.name === 'string' &&
+    (!('avatarUrl' in value) || isOptionalString(value.avatarUrl))
+  );
+}
+
+function isAuditEvent(value: unknown): value is AuditEvent {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  return (
+    'id' in value &&
+    typeof value.id === 'string' &&
+    'actorId' in value &&
+    typeof value.actorId === 'string' &&
+    'actorType' in value &&
+    (value.actorType === 'human' || value.actorType === 'agent') &&
+    'action' in value &&
+    typeof value.action === 'string' &&
+    'targets' in value &&
+    Array.isArray(value.targets) &&
+    value.targets.every(isAuditTarget) &&
+    'metadata' in value &&
+    typeof value.metadata === 'object' &&
+    value.metadata !== null &&
+    !Array.isArray(value.metadata) &&
+    'occurredAt' in value &&
+    typeof value.occurredAt === 'string'
+  );
+}
+
+function isAuditEventPage(value: unknown): value is AuditEventPage {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  return (
+    'events' in value &&
+    Array.isArray(value.events) &&
+    value.events.every(isAuditEvent) &&
+    'actors' in value &&
+    typeof value.actors === 'object' &&
+    value.actors !== null &&
+    !Array.isArray(value.actors) &&
+    Object.values(value.actors).every(isAuditActorProfile) &&
+    (!('nextCursor' in value) || isOptionalString(value.nextCursor))
+  );
 }
 
 async function throwRequestError(res: Response): Promise<never> {
   let message = `Request failed (${res.status})`;
   try {
-    const body = (await res.json()) as { error?: string; message?: string };
-    if (body.message) message = body.message;
-    else if (body.error) message = body.error;
-  } catch {
-    /* ignore non-JSON */
-  }
+    const body: unknown = await res.json();
+    if (typeof body === 'object' && body !== null) {
+      if ('message' in body && typeof body.message === 'string') message = body.message;
+      else if ('error' in body && typeof body.error === 'string') message = body.error;
+    }
+  } catch {}
   throw new Error(message);
 }
 
-/** Fetch one page of the Factory project's audit trail, newest-first. */
 export async function fetchAuditEvents(
   baseUrl: string,
   factoryProjectId: string,
-  options: { actions?: string[]; actorIds?: string[]; before?: string; limit?: number } = {},
+  options: { actions?: string[]; actorIds?: string[]; before?: string; limit?: number; signal?: AbortSignal } = {},
 ): Promise<AuditEventPage> {
   const query = new URLSearchParams();
   if (options.actions && options.actions.length > 0) query.set('actions', options.actions.join(','));
@@ -70,15 +116,15 @@ export async function fetchAuditEvents(
   const res = await fetch(`${baseUrl}/web/factory/projects/${encodeURIComponent(factoryProjectId)}/audit${qs}`, {
     headers: { Accept: 'application/json' },
     credentials: 'include',
+    signal: options.signal,
   });
   if (!res.ok) return throwRequestError(res);
-  return (await res.json()) as AuditEventPage;
+
+  const data: unknown = await res.json();
+  if (!isAuditEventPage(data)) throw new Error('Invalid audit event response');
+  return data;
 }
 
-/**
- * Fetch a one-time WorkOS Admin Portal URL for the audit-log viewer, or
- * `null` when WorkOS isn't configured (the UI hides the button).
- */
 export async function fetchAuditPortalLink(baseUrl: string): Promise<string | null> {
   const res = await fetch(`${baseUrl}/web/audit/portal-link`, {
     headers: { Accept: 'application/json' },
@@ -86,6 +132,10 @@ export async function fetchAuditPortalLink(baseUrl: string): Promise<string | nu
   });
   if (res.status === 404) return null;
   if (!res.ok) return throwRequestError(res);
-  const data = (await res.json()) as { url: string };
+
+  const data: unknown = await res.json();
+  if (typeof data !== 'object' || data === null || !('url' in data) || typeof data.url !== 'string') {
+    throw new Error('Invalid audit portal response');
+  }
   return data.url;
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/workItemActivity.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/workItemActivity.ts
@@ -88,14 +88,11 @@ function syntheticCreatedEvent(item: WorkItem, hasRealCreateEvent: boolean): Aud
   const creator = externalCreatorProfile(item);
   return {
     id: `synthetic-created:${item.id}`,
-    orgId: item.orgId,
     actorId: isHuman ? item.createdBy : (creator?.id ?? item.createdBy),
     actorType: 'human',
     action: CREATED_ACTION,
     targets: [{ type: 'work_item', id: item.id, name: item.title }],
     metadata: {},
-    githubProjectId: item.githubProjectId,
-    context: {},
     occurredAt: item.createdAt,
   };
 }
@@ -117,14 +114,11 @@ function syntheticAssignedEvent(
   if (auditEvents.some(event => event.action === ASSIGNED_ACTION)) return undefined;
   return {
     id: `synthetic-assigned:${item.id}`,
-    orgId: item.orgId,
     actorId: assignee.id,
     actorType: 'human',
     action: ASSIGNED_ACTION,
     targets: [{ type: 'work_item', id: item.id, name: item.title }],
     metadata: {},
-    githubProjectId: item.githubProjectId,
-    context: {},
     occurredAt: item.updatedAt,
   };
 }

--- a/mastracode/factory-ui/src/ui/layouts/PageLayout.tsx
+++ b/mastracode/factory-ui/src/ui/layouts/PageLayout.tsx
@@ -5,13 +5,16 @@ type PageLayoutProps = {
   header?: ReactNode;
   children: ReactNode;
 };
+const PAGE_HEADER_HEIGHT_CLASS = '[--page-header-height:3.5rem] lg:[--page-header-height:2.75rem]';
 
 /** Standard page chrome that participates in native document scrolling. */
 export function PageLayout({ sidebar, header, children }: PageLayoutProps) {
   return (
     <div className="bg-surface1 relative z-1 flex min-h-dvh">
       <aside className="sticky top-0 h-dvh min-h-0 shrink-0 overflow-hidden py-2">{sidebar}</aside>
-      <div className="border-border1 bg-surface2 relative z-1 flex min-w-0 flex-1 flex-col border-l [--page-sticky-top:0rem] has-[>[data-page-header]:not(:empty)]:[--page-sticky-top:3.5rem] lg:has-[>[data-page-header]:not(:empty)]:[--page-sticky-top:2.75rem]">
+      <div
+        className={`${PAGE_HEADER_HEIGHT_CLASS} border-border1 bg-surface2 relative z-1 flex min-w-0 flex-1 flex-col border-l [--page-sticky-top:0rem] has-[>[data-page-header]:not(:empty)]:[--page-sticky-top:var(--page-header-height)]`}
+      >
         {header ? (
           <div data-page-header className="bg-surface2 sticky top-0 z-2 shrink-0">
             {header}
@@ -29,7 +32,9 @@ export function ViewportLayout({ sidebar, header, children }: PageLayoutProps) {
   return (
     <div className="bg-surface1 relative z-1 flex h-dvh overflow-hidden">
       <aside className="h-full min-h-0 shrink-0 overflow-hidden py-2">{sidebar}</aside>
-      <div className="border-border1 bg-surface2 relative z-1 flex min-w-0 flex-1 flex-col overflow-hidden border-l">
+      <div
+        className={`${PAGE_HEADER_HEIGHT_CLASS} border-border1 bg-surface2 relative z-1 flex min-w-0 flex-1 flex-col overflow-hidden border-l`}
+      >
         {header}
         <main className="isolate flex min-h-0 flex-1 flex-col overflow-hidden">{children}</main>
       </div>

--- a/mastracode/factory-ui/src/ui/layouts/PageLayout.tsx
+++ b/mastracode/factory-ui/src/ui/layouts/PageLayout.tsx
@@ -11,8 +11,12 @@ export function PageLayout({ sidebar, header, children }: PageLayoutProps) {
   return (
     <div className="bg-surface1 relative z-1 flex min-h-dvh">
       <aside className="sticky top-0 h-dvh min-h-0 shrink-0 overflow-hidden py-2">{sidebar}</aside>
-      <div className="border-border1 bg-surface2 relative z-1 flex min-w-0 flex-1 flex-col border-l">
-        {header ? <div className="bg-surface2 sticky top-0 z-2 shrink-0">{header}</div> : null}
+      <div className="border-border1 bg-surface2 relative z-1 flex min-w-0 flex-1 flex-col border-l [--page-sticky-top:0rem] has-[>[data-page-header]:not(:empty)]:[--page-sticky-top:3.5rem] lg:has-[>[data-page-header]:not(:empty)]:[--page-sticky-top:2.75rem]">
+        {header ? (
+          <div data-page-header className="bg-surface2 sticky top-0 z-2 shrink-0">
+            {header}
+          </div>
+        ) : null}
         {/* isolate — DS pill tabs sit at z-10 and would scroll over the sticky header */}
         <main className="isolate flex min-w-0 flex-1 flex-col p-5">{children}</main>
       </div>

--- a/mastracode/factory-ui/src/ui/pages/AuditPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/AuditPage.msw.test.tsx
@@ -1,11 +1,11 @@
-import { screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { server } from '../../../e2e/ui/msw-server';
-import { renderWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import { renderWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../e2e/ui/render';
 import type { AuditEvent } from '../domains/factory/services/audit';
 import { createAppRoutes } from '../router';
 
@@ -60,9 +60,27 @@ function event(id: string, overrides: Partial<AuditEvent>): AuditEvent {
   };
 }
 
+function baseHandlers() {
+  return [
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+      HttpResponse.json({ workItems: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/api/agent-controller/code/sessions/${FACTORY_ID}/permissions`, () =>
+      HttpResponse.json({ categories: {}, tools: {} }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/audit/portal-link`, () => new HttpResponse(null, { status: 404 })),
+  ];
+}
+
 function renderAudit() {
   const router = createMemoryRouter(createAppRoutes(), { initialEntries: [`/factories/${FACTORY_ID}/audit`] });
-  renderWithProviders(<RouterProvider router={router} />);
+  return renderWithProviders(<RouterProvider router={router} />);
 }
 
 afterEach(() => vi.unstubAllGlobals());
@@ -72,7 +90,11 @@ describe('Audit log', () => {
     vi.stubGlobal('IntersectionObserver', ImmediateIntersectionObserver);
     const requestedCursors: Array<string | null> = [];
     const recent = event('event-recent', {
-      metadata: { from: 'planning', to: 'execute', decisionId: 'decision-9' },
+      metadata: {
+        to: 'review',
+        decisionId: 'decision-9',
+        __actorProfile: { name: 'Stored profile' },
+      },
     });
     const older = event('event-older', {
       actorId: 'agent:thread-9',
@@ -83,20 +105,11 @@ describe('Audit log', () => {
     });
 
     server.use(
-      http.get(`${TEST_BASE_URL}/auth/me`, () =>
-        HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
-      ),
-      http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
-        HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
-      ),
-      http.get(`${TEST_BASE_URL}/api/agent-controller/code/sessions/${FACTORY_ID}/permissions`, () =>
-        HttpResponse.json({ categories: {}, tools: {} }),
-      ),
-      http.get(`${TEST_BASE_URL}/web/audit/portal-link`, () => new HttpResponse(null, { status: 404 })),
+      ...baseHandlers(),
       http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/audit`, ({ request }) => {
         const cursor = new URL(request.url).searchParams.get('before');
         requestedCursors.push(cursor);
-        const actors = { 'user-1': { id: 'user-1', name: 'Damien Schneider' } };
+        const actors = { 'user-1': { id: 'canonical-user-1', name: 'Damien Schneider' } };
         return cursor
           ? HttpResponse.json({ events: [older], actors })
           : HttpResponse.json({ events: [recent], actors, nextCursor: 'page-2' });
@@ -104,20 +117,22 @@ describe('Audit log', () => {
     );
 
     const user = userEvent.setup();
-    renderAudit();
+    const { client } = renderAudit();
 
     expect(await screen.findByRole('slider', { name: 'Audit time range' })).toBeInTheDocument();
-    expect(await screen.findByText('Planning → Building')).toBeInTheDocument();
+    expect(await screen.findByText('→ Review')).toBeInTheDocument();
     expect(screen.getByText('Damien Schneider')).toBeInTheDocument();
 
-    await waitFor(() => expect(requestedCursors).toEqual([null, 'page-2']));
-    expect(await screen.findByText('Run started')).toBeInTheDocument();
+    await waitForMutationsIdle(client);
+    expect(requestedCursors).toEqual([null, 'page-2']);
+    expect(screen.getByText('Run started')).toBeInTheDocument();
     expect(screen.getByText('Build agent')).toBeInTheDocument();
 
     const recentRow = screen.getByRole('button', { expanded: false, name: /Stage moved/ });
     await user.click(recentRow);
     expect(recentRow).toHaveAttribute('aria-expanded', 'true');
     expect(within(recentRow.parentElement ?? recentRow).getByText(/decision-9/)).toBeInTheDocument();
+    expect(within(recentRow.parentElement ?? recentRow).queryByText(/__actorProfile/)).not.toBeInTheDocument();
 
     const olderRow = screen.getByRole('button', { expanded: false, name: /Run started/ });
     await user.click(olderRow);
@@ -125,6 +140,10 @@ describe('Audit log', () => {
     expect(recentRow).toHaveAttribute('aria-expanded', 'true');
 
     const timeline = screen.getByRole('slider', { name: 'Audit time range' });
+
+    fireEvent.pointerDown(timeline, { pointerType: 'mouse', button: 2 });
+    fireEvent.pointerUp(timeline, { pointerType: 'mouse', button: 2 });
+    expect(screen.queryByRole('button', { name: 'Reset' })).not.toBeInTheDocument();
     await user.click(timeline);
     expect(timeline).toHaveFocus();
     await user.keyboard('{ArrowUp}');
@@ -153,16 +172,7 @@ describe('Audit log', () => {
 
   it('keeps category toggles available when the log is empty', async () => {
     server.use(
-      http.get(`${TEST_BASE_URL}/auth/me`, () =>
-        HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
-      ),
-      http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
-        HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
-      ),
-      http.get(`${TEST_BASE_URL}/api/agent-controller/code/sessions/${FACTORY_ID}/permissions`, () =>
-        HttpResponse.json({ categories: {}, tools: {} }),
-      ),
-      http.get(`${TEST_BASE_URL}/web/audit/portal-link`, () => new HttpResponse(null, { status: 404 })),
+      ...baseHandlers(),
       http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/audit`, () =>
         HttpResponse.json({ events: [], actors: {} }),
       ),

--- a/mastracode/factory-ui/src/ui/pages/AuditPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/AuditPage.tsx
@@ -1,24 +1,19 @@
 import { Button } from '@mastra/playground-ui/components/Button';
-import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { Notice } from '@mastra/playground-ui/components/Notice';
-import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
-import { Txt } from '@mastra/playground-ui/components/Txt';
 import { ScrollText } from 'lucide-react';
 import { useState } from 'react';
 
 import { useAuditEvents, useAuditPortalLink } from '../../hooks/useAuditEvents';
-import { relativeTime } from '../../lib/date/relativeTime';
+import { AuditLogList } from '../domains/factory/components/audit/AuditLogList';
+import { AuditTimeline, eventInAuditRange } from '../domains/factory/components/audit/AuditTimeline';
+import { DocumentFactoryPageShell } from '../domains/factory/components/FactoryPageShell';
+import type { AuditNamespace, AuditTimeRange } from '../domains/factory/auditPresentation';
 import { SkeletonRows } from '../ui/SkeletonRows';
-import { FactoryPageShell } from '../domains/factory/components/FactoryPageShell';
-import type { AuditEvent } from '../domains/factory/services/audit';
 
-/** Action-group filters mapped to the concrete v1 action taxonomy. */
 const ACTION_GROUPS = [
-  { key: 'all', label: 'All', actions: undefined },
   {
-    key: 'work-items',
-    label: 'Work items',
+    key: 'work_item',
     actions: [
       'factory.work_item.created',
       'factory.work_item.updated',
@@ -27,77 +22,130 @@ const ACTION_GROUPS = [
       'factory.work_item.transition_rejected',
     ],
   },
-  {
-    key: 'runs',
-    label: 'Runs',
-    actions: ['factory.run.started', 'factory.run.approved', 'factory.run.dismissed'],
-  },
-  { key: 'worktrees', label: 'Worktrees', actions: ['factory.worktree.created', 'factory.worktree.deleted'] },
-  { key: 'git', label: 'Git', actions: ['factory.git.commit', 'factory.git.push', 'factory.git.pr_opened'] },
-  {
-    key: 'agent',
-    label: 'Agent',
-    actions: ['factory.agent.commit', 'factory.agent.push', 'factory.agent.pr_opened'],
-  },
-  { key: 'intake', label: 'Intake', actions: ['factory.intake.config_updated'] },
-] as const;
+  { key: 'run', actions: ['factory.run.started', 'factory.run.approved', 'factory.run.dismissed'] },
+  { key: 'worktree', actions: ['factory.worktree.created', 'factory.worktree.deleted'] },
+  { key: 'git', actions: ['factory.git.commit', 'factory.git.push', 'factory.git.pr_opened'] },
+  { key: 'agent', actions: ['factory.agent.commit', 'factory.agent.push', 'factory.agent.pr_opened'] },
+  { key: 'intake', actions: ['factory.intake.config_updated'] },
+] as const satisfies ReadonlyArray<{ key: AuditNamespace; actions: readonly string[] }>;
 
-type GroupKey = (typeof ACTION_GROUPS)[number]['key'];
-
-/** Short human label for a dot-namespaced action, e.g. 'Stage moved'. */
-function actionLabel(action: string): string {
-  const leaf = action.split('.').pop() ?? action;
-  const words = leaf.replace(/_/g, ' ');
-  return words.charAt(0).toUpperCase() + words.slice(1);
+function AuditEmptyTitle({ children }: { children: string }) {
+  return (
+    <span className="flex items-center gap-2">
+      <ScrollText className="text-icon3 size-4" aria-hidden />
+      {children}
+    </span>
+  );
 }
 
-/**
- * The Factory audit log: an append-only, org-scoped record of who did what,
- * when — every work-item mutation, stage move, run start, worktree change, and
- * git action. Backed by the local `audit_events` table; the "Open in WorkOS"
- * button (shown when WorkOS is configured) opens the enterprise viewer.
- */
+function AuditLogEmptyState({
+  hasCategoryFilter,
+  range,
+  onClearCategories,
+  onClearRange,
+}: {
+  hasCategoryFilter: boolean;
+  range: AuditTimeRange | undefined;
+  onClearCategories: () => void;
+  onClearRange: () => void;
+}) {
+  if (range) {
+    return (
+      <EmptyState
+        className="min-h-48"
+        as="h2"
+        iconSlot={null}
+        titleSlot={<AuditEmptyTitle>No events in this range</AuditEmptyTitle>}
+        actionSlot={
+          <Button variant="outline" size="sm" onClick={onClearRange}>
+            Show full range
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (hasCategoryFilter) {
+    return (
+      <EmptyState
+        className="min-h-48"
+        as="h2"
+        iconSlot={null}
+        titleSlot={<AuditEmptyTitle>No matching audit events</AuditEmptyTitle>}
+        actionSlot={
+          <Button variant="outline" size="sm" onClick={onClearCategories}>
+            Show all events
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <EmptyState
+      className="min-h-48"
+      as="h2"
+      iconSlot={null}
+      titleSlot={<AuditEmptyTitle>No audit events yet</AuditEmptyTitle>}
+    />
+  );
+}
+
 export function AuditPage() {
-  return <FactoryPageShell>{project => <AuditContent factoryProjectId={project.id} />}</FactoryPageShell>;
+  return (
+    <DocumentFactoryPageShell>{project => <AuditContent factoryProjectId={project.id} />}</DocumentFactoryPageShell>
+  );
 }
 
 function AuditContent({ factoryProjectId }: { factoryProjectId: string | undefined }) {
-  const [group, setGroup] = useState<GroupKey>('all');
-  const actionFilter = ACTION_GROUPS.find(entry => entry.key === group);
-  const actions = actionFilter?.actions;
-  const eventsQuery = useAuditEvents(factoryProjectId, group, actions ? [...actions] : undefined);
+  const [selectedCategories, setSelectedCategories] = useState(() => new Set<AuditNamespace>());
+  const [selectedRange, setSelectedRange] = useState<AuditTimeRange>();
+  const actions: string[] = [];
+  for (const entry of ACTION_GROUPS) {
+    if (selectedCategories.has(entry.key)) actions.push(...entry.actions);
+  }
+  const filterKey = selectedCategories.size === 0 ? 'all' : [...selectedCategories].toSorted().join(',');
+  const eventsQuery = useAuditEvents(factoryProjectId, filterKey, actions.length > 0 ? actions : undefined);
   const portalQuery = useAuditPortalLink(true);
+
+  const toggleCategory = (category: AuditNamespace) => {
+    setSelectedCategories(current => {
+      const next = new Set(current);
+      if (!next.delete(category)) next.add(category);
+      return next;
+    });
+    setSelectedRange(undefined);
+  };
+  const clearCategories = () => {
+    setSelectedCategories(new Set());
+    setSelectedRange(undefined);
+  };
 
   if (eventsQuery.isError) {
     const message = eventsQuery.error instanceof Error ? eventsQuery.error.message : 'Unable to load audit events.';
     return <Notice variant="destructive">{message}</Notice>;
   }
 
-  const events = eventsQuery.data?.pages.flatMap(page => page.events) ?? [];
-  const hasActionFilter = group !== 'all';
+  const pages = eventsQuery.data?.pages ?? [];
+  const events = pages.flatMap(page => page.events);
+  const actorNames = new Map<string, string>();
+  for (const page of pages) {
+    for (const actor of Object.values(page.actors)) actorNames.set(actor.id, actor.name);
+  }
+  const visibleEvents = selectedRange ? events.filter(event => eventInAuditRange(event, selectedRange)) : events;
+  const portalUrl = portalQuery.data;
+
   return (
-    <section className="flex min-h-0 flex-1 flex-col gap-2" aria-label="Audit history">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <ButtonsGroup spacing="close" role="group" aria-label="Audit filter">
-          {ACTION_GROUPS.map(entry => (
-            <Button
-              key={entry.key}
-              variant={group === entry.key ? 'primary' : 'outline'}
-              size="sm"
-              aria-pressed={group === entry.key}
-              onClick={() => setGroup(entry.key)}
-            >
-              {entry.label}
-            </Button>
-          ))}
-        </ButtonsGroup>
-        {portalQuery.data ? (
+    <section className="flex min-w-0 flex-1 flex-col gap-3" aria-label="Audit history">
+      <h1 className="sr-only">Audit log</h1>
+
+      <div className="min-h-form-xs flex items-center justify-end">
+        {portalUrl ? (
           <Button
             variant="outline"
-            size="sm"
+            size="xs"
             onClick={() => {
-              // Portal links are one-time use: open, then fetch a fresh one.
-              window.open(portalQuery.data!, '_blank', 'noopener,noreferrer');
+              globalThis.open(portalUrl, '_blank', 'noopener,noreferrer');
               void portalQuery.refetch();
             }}
           >
@@ -106,87 +154,37 @@ function AuditContent({ factoryProjectId }: { factoryProjectId: string | undefin
         ) : null}
       </div>
 
-      {eventsQuery.isPending ? (
-        <div className="min-h-0 flex-1">
-          <SkeletonRows label="Loading audit events" rows={4} rowClassName="h-16 w-full" />
-        </div>
-      ) : events.length === 0 ? (
-        <EmptyState
-          className="min-h-0 flex-1"
-          as="h2"
-          iconSlot={<ScrollText className="text-icon3 size-5" aria-hidden />}
-          titleSlot={hasActionFilter ? 'No matching audit events' : 'No audit events yet'}
-          descriptionSlot={
-            hasActionFilter
-              ? `No audit events match the “${actionFilter?.label ?? 'selected'}” filter.`
-              : 'Board changes, runs, and git actions will appear here.'
-          }
-          actionSlot={
-            hasActionFilter ? (
-              <Button variant="outline" size="sm" onClick={() => setGroup('all')}>
-                Show all events
-              </Button>
-            ) : undefined
-          }
+      <div className="flex min-h-0 flex-1 flex-col gap-2">
+        <AuditTimeline
+          events={events}
+          range={selectedRange}
+          selectedCategories={selectedCategories}
+          onRangeChange={setSelectedRange}
+          onToggleCategory={toggleCategory}
+          onClearCategories={clearCategories}
         />
-      ) : (
-        <ScrollArea className="min-h-0 flex-1">
-          <div className="flex flex-col gap-2 pr-1">
-            <ul className="m-0 flex list-none flex-col gap-1 p-0" aria-label="Audit events">
-              {events.map(event => (
-                <AuditEventRow key={event.id} event={event} />
-              ))}
-            </ul>
-            {eventsQuery.hasNextPage ? (
-              <Button
-                variant="outline"
-                size="sm"
-                className="self-center"
-                disabled={eventsQuery.isFetchingNextPage}
-                onClick={() => void eventsQuery.fetchNextPage()}
-              >
-                {eventsQuery.isFetchingNextPage ? 'Loading…' : 'Load more'}
-              </Button>
-            ) : null}
+        {eventsQuery.isPending ? (
+          <div className="min-h-64">
+            <SkeletonRows label="Loading audit events" rows={8} rowClassName="h-10 w-full rounded-md" />
           </div>
-        </ScrollArea>
-      )}
-    </section>
-  );
-}
-
-function AuditEventRow({ event }: { event: AuditEvent }) {
-  const target = event.targets[0];
-  const hasMetadata = Object.keys(event.metadata).length > 0;
-
-  return (
-    <li className="border-border1 bg-surface2 rounded-lg border px-3 py-2">
-      <div className="grid grid-cols-[4rem_10rem_1fr] items-baseline gap-3">
-        <Txt as="span" variant="ui-xs" className="text-icon3" title={event.occurredAt}>
-          {relativeTime(event.occurredAt)}
-        </Txt>
-        <span className="bg-surface4 text-ui-xs text-icon5 inline-flex w-fit rounded-md px-1.5 py-0.5">
-          {actionLabel(event.action)}
-        </span>
-        <div className="flex min-w-0 flex-col gap-0.5">
-          <Txt as="span" variant="ui-sm" className="text-icon6 truncate">
-            {target?.name ?? target?.id ?? '—'}
-          </Txt>
-          <Txt as="span" variant="ui-xs" className="text-icon3">
-            {event.actorType === 'agent'
-              ? `by agent${typeof event.metadata.startedBy === 'string' ? ` · started by ${event.metadata.startedBy}` : ''}`
-              : `by ${event.actorId}`}
-          </Txt>
-        </div>
+        ) : visibleEvents.length === 0 ? (
+          <AuditLogEmptyState
+            hasCategoryFilter={selectedCategories.size > 0}
+            range={selectedRange}
+            onClearCategories={clearCategories}
+            onClearRange={() => setSelectedRange(undefined)}
+          />
+        ) : (
+          <AuditLogList
+            key={filterKey}
+            events={visibleEvents}
+            actorNames={actorNames}
+            hasNextPage={!selectedRange && eventsQuery.hasNextPage}
+            isFetchingNextPage={eventsQuery.isFetchingNextPage}
+            onLoadMore={eventsQuery.fetchNextPage}
+          />
+        )}
       </div>
-      {hasMetadata ? (
-        <details className="mt-1">
-          <summary className="text-ui-xs text-icon3 cursor-pointer">Details</summary>
-          <pre className="bg-surface1 text-ui-xs text-icon4 m-0 mt-1 overflow-x-auto rounded-md p-2">
-            {JSON.stringify(event.metadata, null, 2)}
-          </pre>
-        </details>
-      ) : null}
-    </li>
+    </section>
   );
 }

--- a/mastracode/factory-ui/src/ui/pages/AuditPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/AuditPage.tsx
@@ -6,28 +6,17 @@ import { useState } from 'react';
 
 import { useAuditEvents, useAuditPortalLink } from '../../hooks/useAuditEvents';
 import { AuditLogList } from '../domains/factory/components/audit/AuditLogList';
-import { AuditTimeline, eventInAuditRange } from '../domains/factory/components/audit/AuditTimeline';
+import { AuditCategoryFilter } from '../domains/factory/components/audit/AuditCategoryFilter';
+import { AuditTimeline } from '../domains/factory/components/audit/AuditTimeline';
 import { DocumentFactoryPageShell } from '../domains/factory/components/FactoryPageShell';
-import type { AuditNamespace, AuditTimeRange } from '../domains/factory/auditPresentation';
+import {
+  AUDIT_CATEGORIES,
+  auditActionsForCategories,
+  eventInAuditRange,
+  type AuditNamespace,
+  type AuditTimeRange,
+} from '../domains/factory/auditPresentation';
 import { SkeletonRows } from '../ui/SkeletonRows';
-
-const ACTION_GROUPS = [
-  {
-    key: 'work_item',
-    actions: [
-      'factory.work_item.created',
-      'factory.work_item.updated',
-      'factory.work_item.stage_moved',
-      'factory.work_item.deleted',
-      'factory.work_item.transition_rejected',
-    ],
-  },
-  { key: 'run', actions: ['factory.run.started', 'factory.run.approved', 'factory.run.dismissed'] },
-  { key: 'worktree', actions: ['factory.worktree.created', 'factory.worktree.deleted'] },
-  { key: 'git', actions: ['factory.git.commit', 'factory.git.push', 'factory.git.pr_opened'] },
-  { key: 'agent', actions: ['factory.agent.commit', 'factory.agent.push', 'factory.agent.pr_opened'] },
-  { key: 'intake', actions: ['factory.intake.config_updated'] },
-] as const satisfies ReadonlyArray<{ key: AuditNamespace; actions: readonly string[] }>;
 
 function AuditEmptyTitle({ children }: { children: string }) {
   return (
@@ -100,19 +89,16 @@ export function AuditPage() {
 function AuditContent({ factoryProjectId }: { factoryProjectId: string | undefined }) {
   const [selectedCategories, setSelectedCategories] = useState(() => new Set<AuditNamespace>());
   const [selectedRange, setSelectedRange] = useState<AuditTimeRange>();
-  const actions: string[] = [];
-  for (const entry of ACTION_GROUPS) {
-    if (selectedCategories.has(entry.key)) actions.push(...entry.actions);
-  }
+  const actions = auditActionsForCategories(selectedCategories);
   const filterKey = selectedCategories.size === 0 ? 'all' : [...selectedCategories].toSorted().join(',');
-  const eventsQuery = useAuditEvents(factoryProjectId, filterKey, actions.length > 0 ? actions : undefined);
+  const eventsQuery = useAuditEvents(factoryProjectId, filterKey, actions);
   const portalQuery = useAuditPortalLink(true);
 
   const toggleCategory = (category: AuditNamespace) => {
     setSelectedCategories(current => {
       const next = new Set(current);
       if (!next.delete(category)) next.add(category);
-      return next;
+      return next.size === AUDIT_CATEGORIES.length ? new Set<AuditNamespace>() : next;
     });
     setSelectedRange(undefined);
   };
@@ -130,7 +116,7 @@ function AuditContent({ factoryProjectId }: { factoryProjectId: string | undefin
   const events = pages.flatMap(page => page.events);
   const actorNames = new Map<string, string>();
   for (const page of pages) {
-    for (const actor of Object.values(page.actors)) actorNames.set(actor.id, actor.name);
+    for (const [actorId, actor] of Object.entries(page.actors)) actorNames.set(actorId, actor.name);
   }
   const visibleEvents = selectedRange ? events.filter(event => eventInAuditRange(event, selectedRange)) : events;
   const portalUrl = portalQuery.data;
@@ -145,7 +131,7 @@ function AuditContent({ factoryProjectId }: { factoryProjectId: string | undefin
             variant="outline"
             size="xs"
             onClick={() => {
-              globalThis.open(portalUrl, '_blank', 'noopener,noreferrer');
+              window.open(portalUrl, '_blank', 'noopener,noreferrer');
               void portalQuery.refetch();
             }}
           >
@@ -155,11 +141,10 @@ function AuditContent({ factoryProjectId }: { factoryProjectId: string | undefin
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col gap-2">
-        <AuditTimeline
-          events={events}
-          range={selectedRange}
+        <AuditTimeline events={events} range={selectedRange} onRangeChange={setSelectedRange} />
+        <AuditCategoryFilter
           selectedCategories={selectedCategories}
-          onRangeChange={setSelectedRange}
+          countLabel={selectedRange ? `${visibleEvents.length} of ${events.length} loaded` : `${events.length} loaded`}
           onToggleCategory={toggleCategory}
           onClearCategories={clearCategories}
         />
@@ -179,9 +164,10 @@ function AuditContent({ factoryProjectId }: { factoryProjectId: string | undefin
             key={filterKey}
             events={visibleEvents}
             actorNames={actorNames}
-            hasNextPage={!selectedRange && eventsQuery.hasNextPage}
+            hasNextPage={eventsQuery.hasNextPage}
+            autoLoad={!selectedRange}
             isFetchingNextPage={eventsQuery.isFetchingNextPage}
-            onLoadMore={eventsQuery.fetchNextPage}
+            onLoadMore={() => void eventsQuery.fetchNextPage()}
           />
         )}
       </div>

--- a/mastracode/factory/src/routes/intake.test.ts
+++ b/mastracode/factory/src/routes/intake.test.ts
@@ -11,7 +11,11 @@ import { fakeRouteAuth, mountApiRoutes } from './test-utils.js';
 const auditEvents: Array<Record<string, unknown>> = [];
 const audit: AuditEmitter = {
   async emit({ input }) {
-    auditEvents.push({ action: input.action, metadata: input.metadata });
+    auditEvents.push({
+      action: input.action,
+      metadata: input.metadata,
+      ...(input.factoryProjectId ? { factoryProjectId: input.factoryProjectId } : {}),
+    });
   },
 };
 
@@ -139,18 +143,30 @@ describe('intake configuration', () => {
       expect(await response.json()).toEqual({ bindings });
       expect(await (await buildApp(orgUser).request('/web/intake/bindings')).json()).toEqual({ bindings });
       expect(auditEvents).toEqual([
-        { action: 'factory.intake.binding_updated', metadata: { factoryProjectId: project.id } },
+        {
+          action: 'factory.intake.binding_updated',
+          factoryProjectId: project.id,
+          metadata: { factoryProjectId: project.id },
+        },
       ]);
     });
 
     it('clears a binding when the project is null', async () => {
       const project = await seed.projects.create({ orgId: 'org1', userId: 'u1', input: { name: 'app' } });
       await put({ integrationId: 'linear', sourceId: 'team-1', factoryProjectId: project.id });
+      auditEvents.length = 0;
 
       const response = await put({ integrationId: 'linear', sourceId: 'team-1', factoryProjectId: null });
 
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual({ bindings: [] });
+      expect(auditEvents).toEqual([
+        {
+          action: 'factory.intake.binding_updated',
+          factoryProjectId: project.id,
+          metadata: { factoryProjectId: null },
+        },
+      ]);
     });
 
     it('rejects unknown integrations and malformed bodies', async () => {

--- a/mastracode/factory/src/routes/intake.ts
+++ b/mastracode/factory/src/routes/intake.ts
@@ -220,11 +220,21 @@ export class IntakeRoutes extends Route<IntakeRoutesDeps> {
           }
 
           await intake.ensureReady();
+          const previousBinding =
+            binding.factoryProjectId === null
+              ? await intake.getBinding({
+                  orgId: tenant.orgId,
+                  integrationId: binding.integrationId,
+                  sourceId: binding.sourceId,
+                })
+              : null;
+          const auditFactoryProjectId = binding.factoryProjectId ?? previousBinding?.factoryProjectId;
           await intake.setBinding({ orgId: tenant.orgId, userId: tenant.userId, ...binding });
           await audit.emit({
             context: loose(c),
             input: {
               action: 'factory.intake.binding_updated',
+              ...(auditFactoryProjectId ? { factoryProjectId: auditFactoryProjectId } : {}),
               targets: [{ type: 'intake_source', id: `${binding.integrationId}:${binding.sourceId}` }],
               metadata: { factoryProjectId: binding.factoryProjectId },
             },

--- a/mastracode/factory/src/routes/intake.ts
+++ b/mastracode/factory/src/routes/intake.ts
@@ -220,16 +220,23 @@ export class IntakeRoutes extends Route<IntakeRoutesDeps> {
           }
 
           await intake.ensureReady();
-          const previousBinding =
-            binding.factoryProjectId === null
-              ? await intake.getBinding({
-                  orgId: tenant.orgId,
-                  integrationId: binding.integrationId,
-                  sourceId: binding.sourceId,
-                })
-              : null;
-          const auditFactoryProjectId = binding.factoryProjectId ?? previousBinding?.factoryProjectId;
-          await intake.setBinding({ orgId: tenant.orgId, userId: tenant.userId, ...binding });
+          let auditFactoryProjectId = binding.factoryProjectId;
+          if (binding.factoryProjectId === null) {
+            const previousBinding = await intake.clearBinding({
+              orgId: tenant.orgId,
+              integrationId: binding.integrationId,
+              sourceId: binding.sourceId,
+            });
+            auditFactoryProjectId = previousBinding?.factoryProjectId ?? null;
+          } else {
+            await intake.setBinding({
+              orgId: tenant.orgId,
+              userId: tenant.userId,
+              integrationId: binding.integrationId,
+              sourceId: binding.sourceId,
+              factoryProjectId: binding.factoryProjectId,
+            });
+          }
           await audit.emit({
             context: loose(c),
             input: {

--- a/mastracode/factory/src/storage/domains/intake/base.test.ts
+++ b/mastracode/factory/src/storage/domains/intake/base.test.ts
@@ -95,13 +95,18 @@ describe('IntakeStorage', () => {
       expect(await storage.listBoundSourceIds({ ...binding, factoryProjectId: 'proj-1' })).toEqual([]);
     });
 
-    it('clears a binding when the project is null', async () => {
+    it('clears a binding and returns its project', async () => {
       const storage = await makeStorage();
       const binding = { orgId: 'org1', integrationId: 'linear', sourceId: 'src-a' };
 
       await storage.setBinding({ ...binding, factoryProjectId: 'proj-1' });
-      await storage.setBinding({ ...binding, factoryProjectId: null });
+      expect(await storage.clearBinding(binding)).toEqual({
+        integrationId: 'linear',
+        sourceId: 'src-a',
+        factoryProjectId: 'proj-1',
+      });
 
+      expect(await storage.clearBinding(binding)).toBeNull();
       expect(await storage.listBindings({ orgId: 'org1' })).toEqual([]);
     });
 

--- a/mastracode/factory/src/storage/domains/intake/base.ts
+++ b/mastracode/factory/src/storage/domains/intake/base.ts
@@ -150,23 +150,6 @@ export class IntakeStorage extends FactoryStorageDomain {
     return rows.map(toIntakeSourceBinding);
   }
 
-  async getBinding({
-    orgId,
-    integrationId,
-    sourceId,
-  }: {
-    orgId: string;
-    integrationId: string;
-    sourceId: string;
-  }): Promise<IntakeSourceBinding | null> {
-    const row = await this.#db.findOne<IntakeSourceBindingRow>('intake_source_bindings', {
-      org_id: orgId,
-      integration_id: integrationId,
-      source_id: sourceId,
-    });
-    return row ? toIntakeSourceBinding(row) : null;
-  }
-
   /** Source ids bound to one Factory project. Empty means "nothing bound". */
   async listBoundSourceIds({
     orgId,
@@ -185,10 +168,27 @@ export class IntakeStorage extends FactoryStorageDomain {
     return rows.map(row => row.source_id);
   }
 
-  /**
-   * Points a source at a Factory project, replacing any existing binding.
-   * A `null` project clears the binding.
-   */
+  async clearBinding({
+    orgId,
+    integrationId,
+    sourceId,
+  }: {
+    orgId: string;
+    integrationId: string;
+    sourceId: string;
+  }): Promise<IntakeSourceBinding | null> {
+    const where = { org_id: orgId, integration_id: integrationId, source_id: sourceId };
+    return this.storage.withTransaction(
+      async ops => {
+        const row = await ops.findOne<IntakeSourceBindingRow>('intake_source_bindings', where);
+        if (!row) return null;
+        await ops.deleteMany('intake_source_bindings', where);
+        return toIntakeSourceBinding(row);
+      },
+      { isolationLevel: 'serializable' },
+    );
+  }
+
   async setBinding({
     orgId,
     integrationId,
@@ -199,14 +199,10 @@ export class IntakeStorage extends FactoryStorageDomain {
     orgId: string;
     integrationId: string;
     sourceId: string;
-    factoryProjectId: string | null;
+    factoryProjectId: string;
     userId?: string;
   }): Promise<void> {
     const where = { org_id: orgId, integration_id: integrationId, source_id: sourceId };
-    if (factoryProjectId === null) {
-      await this.#db.deleteMany('intake_source_bindings', where);
-      return;
-    }
     const now = new Date();
     const patch = { factory_project_id: factoryProjectId, updated_at: now };
     const updated = await this.#db.updateMany('intake_source_bindings', where, patch);

--- a/mastracode/factory/src/storage/domains/intake/base.ts
+++ b/mastracode/factory/src/storage/domains/intake/base.ts
@@ -72,6 +72,13 @@ type IntakeSourceBindingRow = {
   source_id: string;
   factory_project_id: string;
 };
+function toIntakeSourceBinding(row: IntakeSourceBindingRow): IntakeSourceBinding {
+  return {
+    integrationId: row.integration_id,
+    sourceId: row.source_id,
+    factoryProjectId: row.factory_project_id,
+  };
+}
 
 export class IntakeStorage extends FactoryStorageDomain {
   constructor() {
@@ -140,11 +147,24 @@ export class IntakeStorage extends FactoryStorageDomain {
       org_id: orgId,
       ...(integrationId ? { integration_id: integrationId } : {}),
     });
-    return rows.map(row => ({
-      integrationId: row.integration_id,
-      sourceId: row.source_id,
-      factoryProjectId: row.factory_project_id,
-    }));
+    return rows.map(toIntakeSourceBinding);
+  }
+
+  async getBinding({
+    orgId,
+    integrationId,
+    sourceId,
+  }: {
+    orgId: string;
+    integrationId: string;
+    sourceId: string;
+  }): Promise<IntakeSourceBinding | null> {
+    const row = await this.#db.findOne<IntakeSourceBindingRow>('intake_source_bindings', {
+      org_id: orgId,
+      integration_id: integrationId,
+      source_id: sourceId,
+    });
+    return row ? toIntakeSourceBinding(row) : null;
   }
 
   /** Source ids bound to one Factory project. Empty means "nothing bound". */


### PR DESCRIPTION
TLDR: the Factory audit log now shows where activity clusters, filters by time and category, loads older events automatically, and attributes intake binding changes to the affected project.

---

```
before   one bordered card per event, manual Load more, no view of density
after    compact alternating rows, density range, category toggles, infinite history
```

The old log made you scan every event to understand what happened around a failure or busy period. The timeline gives that history a shape, while rows stay compact and expand only when their metadata is needed.

Desktop keeps drag and keyboard range selection. Mobile uses the Playground date pickers instead, so a horizontal gesture never has to mean both pan and select.

Category filters share the audit action taxonomy. Selecting every category becomes an unfiltered query instead of exceeding the server action limit. Intake binding and unbinding events now retain project ownership, so they appear in the relevant project history.

### Judgment call

The graph covers every loaded page, not a fixed seven-day window. Empty results fall back to seven days only to keep the layout stable.

### Not verified

The authenticated route would not open in the browser harness, so this has no running screenshot. The route behavior is covered through the real router and network stack with MSW.

### Diff breakdown

```
tests        +320    -7
source      +1211  -240
changeset     +12     0
```