### PR TITLE
feat(playground): conversation review suite for traces and threads (flagged)

### DIFF
--- a/.changeset/thin-bags-pick.md
+++ b/.changeset/thin-bags-pick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added an experimental conversation review suite to Studio, gated behind a feature flag. Traces gain a readable Review mode alongside the technical Advanced timeline: the case input, the agent response, and a plain-language step summary, with raw message data collapsed behind a disclosure. Reviewers can rate a response, add notes, and highlight text to leave attributed inline annotations, all stored through the existing feedback API. A new Threads surface groups an agent's turns into reviewable conversations with review status, shareable links, and JSON export. Enable it with the traceReview=on URL parameter or the VITE_TRACE_REVIEW build flag.

--- a/packages/playground-ui/src/domains/traces/components/__tests__/fixtures/trace-review-view.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/fixtures/trace-review-view.ts
@@ -1,0 +1,47 @@
+import type { MastraClient } from '@mastra/client-js';
+import { SpanType } from '@mastra/core/observability';
+import { TraceStatus } from '@mastra/core/storage';
+
+type GetSpanResponse = Awaited<ReturnType<MastraClient['getSpan']>>;
+type GetTraceLightResponse = Awaited<ReturnType<MastraClient['getTraceLight']>>;
+
+export const clinicalRootSpan: GetSpanResponse['span'] = {
+  traceId: 'trace-clinical',
+  spanId: 'root',
+  parentSpanId: null,
+  name: 'Clinical diagnosis agent',
+  spanType: SpanType.AGENT_RUN,
+  isEvent: false,
+  startedAt: new Date('2026-08-21T15:00:00.000Z'),
+  endedAt: new Date('2026-08-21T15:00:02.000Z'),
+  createdAt: new Date('2026-08-21T15:00:00.000Z'),
+  updatedAt: new Date('2026-08-21T15:00:02.000Z'),
+  status: TraceStatus.SUCCESS,
+  input: [
+    {
+      role: 'user',
+      content: 'A 58-year-old patient has abrupt tearing chest pain radiating to the back.',
+    },
+  ],
+  output: {
+    text: '## Leading diagnosis\n\nAcute aortic dissection requires immediate evaluation.',
+  },
+};
+
+export const clinicalLightSpans: GetTraceLightResponse['spans'] = [
+  clinicalRootSpan,
+  {
+    ...clinicalRootSpan,
+    spanId: 'model',
+    parentSpanId: 'root',
+    name: 'Generate clinical differential',
+    spanType: SpanType.MODEL_GENERATION,
+  },
+  {
+    ...clinicalRootSpan,
+    spanId: 'tool',
+    parentSpanId: 'root',
+    name: 'Check urgent red flags',
+    spanType: SpanType.TOOL_CALL,
+  },
+];

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -22,6 +22,56 @@ afterEach(() => {
   scrollIntoView.mockClear();
 });
 
+describe('TraceDataPanelView — review mode', () => {
+  describe('when readable review content is provided', () => {
+    it('shows the review content instead of the technical timeline', () => {
+      render(
+        <TraceDataPanelView
+          {...baseProps}
+          viewMode="review"
+          onViewModeChange={vi.fn()}
+          reviewSlot={<div>Readable clinical review</div>}
+        />,
+      );
+
+      expect(screen.getByText('Readable clinical review')).not.toBeNull();
+      expect(screen.queryByText('agent run')).toBeNull();
+    });
+
+    it('lets the user switch to the advanced trace', () => {
+      const onViewModeChange = vi.fn();
+      render(
+        <TraceDataPanelView
+          {...baseProps}
+          viewMode="review"
+          onViewModeChange={onViewModeChange}
+          reviewSlot={<div>Readable clinical review</div>}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+
+      expect(onViewModeChange).toHaveBeenCalledWith('advanced');
+    });
+  });
+
+  describe('when advanced mode is selected', () => {
+    it('shows the technical timeline', () => {
+      render(
+        <TraceDataPanelView
+          {...baseProps}
+          viewMode="advanced"
+          onViewModeChange={vi.fn()}
+          reviewSlot={<div>Readable clinical review</div>}
+        />,
+      );
+
+      expect(screen.getByText('agent run')).not.toBeNull();
+      expect(screen.queryByText('Readable clinical review')).toBeNull();
+    });
+  });
+});
+
 describe('TraceDataPanelView — Add tool mocks to item', () => {
   it('fires onAddTraceMocksToItem with the traceId when the button is clicked', () => {
     const onAddTraceMocksToItem = vi.fn();

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-review-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-review-view.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TraceReviewView } from '../trace-review-view';
+import { clinicalLightSpans, clinicalRootSpan } from './fixtures/trace-review-view';
+
+afterEach(cleanup);
+
+describe('TraceReviewView', () => {
+  describe('when a completed agent trace is available', () => {
+    it('renders the case and response as readable text', () => {
+      render(<TraceReviewView rootSpan={clinicalRootSpan} spans={clinicalLightSpans} />);
+
+      expect(screen.getByRole('heading', { name: 'Case' })).not.toBeNull();
+      expect(screen.getAllByText(/58-year-old patient/).length).toBeGreaterThan(0);
+      expect(screen.getByRole('heading', { name: 'Agent response' })).not.toBeNull();
+      expect(screen.getByRole('heading', { name: 'Leading diagnosis' })).not.toBeNull();
+      expect(screen.getAllByText(/Acute aortic dissection/).length).toBeGreaterThan(0);
+    });
+
+    it('collapses raw message data behind a disclosure', () => {
+      render(<TraceReviewView rootSpan={clinicalRootSpan} spans={clinicalLightSpans} />);
+
+      const disclosures = screen.getAllByText('Raw message data');
+      expect(disclosures).toHaveLength(2);
+      expect(disclosures[0]?.closest('details')?.open).toBe(false);
+    });
+
+    it('summarizes technical spans as plain-language steps', () => {
+      render(<TraceReviewView rootSpan={clinicalRootSpan} spans={clinicalLightSpans} />);
+
+      expect(screen.getByText('Generated the response')).not.toBeNull();
+      expect(screen.getByText('Used Check urgent red flags')).not.toBeNull();
+      expect(screen.queryByText('MODEL_GENERATION')).toBeNull();
+    });
+
+    it('shows step durations and success indicators', () => {
+      render(<TraceReviewView rootSpan={clinicalRootSpan} spans={clinicalLightSpans} />);
+
+      expect(screen.getAllByText('2.0s').length).toBeGreaterThan(0);
+    });
+
+    it('renders the feedback slot below the review sections', () => {
+      render(
+        <TraceReviewView
+          rootSpan={clinicalRootSpan}
+          spans={clinicalLightSpans}
+          feedbackSlot={<div>Feedback form</div>}
+        />,
+      );
+
+      expect(screen.getByText('Feedback form')).not.toBeNull();
+    });
+
+    it('starts a note for the section the reviewer is reading', () => {
+      const onReviewTargetChange = vi.fn();
+      render(
+        <TraceReviewView
+          rootSpan={clinicalRootSpan}
+          spans={clinicalLightSpans}
+          onReviewTargetChange={onReviewTargetChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Add note about agent response' }));
+
+      expect(onReviewTargetChange).toHaveBeenCalledWith('response');
+    });
+
+    it('starts a note for the case and the reasoning sections', () => {
+      const onReviewTargetChange = vi.fn();
+      render(
+        <TraceReviewView
+          rootSpan={clinicalRootSpan}
+          spans={clinicalLightSpans}
+          onReviewTargetChange={onReviewTargetChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Add note about case' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Add note about reasoning' }));
+
+      expect(onReviewTargetChange).toHaveBeenNthCalledWith(1, 'case');
+      expect(onReviewTargetChange).toHaveBeenNthCalledWith(2, 'reasoning');
+    });
+
+    it('hides the note actions when no handler is provided', () => {
+      render(<TraceReviewView rootSpan={clinicalRootSpan} spans={clinicalLightSpans} />);
+
+      expect(screen.queryByRole('button', { name: /add note/i })).toBeNull();
+    });
+  });
+
+  describe('when the reviewer selects response text', () => {
+    const selectText = (container: HTMLElement, needle: string) => {
+      const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+      let node: Node | null = walker.nextNode();
+      while (node && !node.textContent?.includes(needle)) node = walker.nextNode();
+      if (!node?.textContent) throw new Error(`Text not found: ${needle}`);
+      const range = document.createRange();
+      const start = node.textContent.indexOf(needle);
+      range.setStart(node, start);
+      range.setEnd(node, start + needle.length);
+      const selection = window.getSelection();
+      if (!selection) throw new Error('Selection unavailable');
+      selection.removeAllRanges();
+      selection.addRange(range);
+    };
+
+    it('offers to annotate the selection and reports the quote', () => {
+      const onAnnotate = vi.fn();
+      const { container } = render(
+        <TraceReviewView rootSpan={clinicalRootSpan} spans={clinicalLightSpans} onAnnotate={onAnnotate} />,
+      );
+
+      selectText(container, 'Acute aortic dissection');
+      const [responseText] = screen.getAllByText(/Acute aortic dissection/);
+      if (!responseText) throw new Error('Response text not rendered');
+      fireEvent.mouseUp(responseText);
+      fireEvent.click(screen.getByRole('button', { name: 'Annotate selection in agent response' }));
+
+      expect(onAnnotate).toHaveBeenCalledWith({ target: 'response', quote: 'Acute aortic dissection' });
+    });
+
+    it('shows no annotate action without a selection', () => {
+      render(<TraceReviewView rootSpan={clinicalRootSpan} spans={clinicalLightSpans} onAnnotate={vi.fn()} />);
+
+      expect(screen.queryByRole('button', { name: /annotate selection/i })).toBeNull();
+    });
+  });
+
+  describe('when saved annotations exist for a section', () => {
+    it('renders the annotations slot inside that section', () => {
+      render(
+        <TraceReviewView
+          rootSpan={clinicalRootSpan}
+          spans={clinicalLightSpans}
+          annotationsSlot={target => (target === 'response' ? <div>Saved annotation</div> : null)}
+        />,
+      );
+
+      expect(screen.getByText('Saved annotation')).not.toBeNull();
+    });
+  });
+
+  describe('when the trace has no intermediate steps', () => {
+    it('says no steps were recorded', () => {
+      render(<TraceReviewView rootSpan={clinicalRootSpan} spans={[clinicalRootSpan]} />);
+
+      expect(screen.getByText('No intermediate steps were recorded.')).not.toBeNull();
+    });
+  });
+
+  describe('when the root span has no readable content', () => {
+    it('says the section was not recorded', () => {
+      render(<TraceReviewView rootSpan={{ ...clinicalRootSpan, input: undefined, output: undefined }} spans={[]} />);
+
+      expect(screen.getByText('No readable case was recorded.')).not.toBeNull();
+      expect(screen.getByText('No readable agent response was recorded.')).not.toBeNull();
+    });
+  });
+
+  describe('when the trace is still loading', () => {
+    it('shows a loading message', () => {
+      render(<TraceReviewView spans={[]} isLoading />);
+
+      expect(screen.getByText('Loading review…')).not.toBeNull();
+    });
+  });
+
+  describe('when the root span is unavailable', () => {
+    it('says review content is unavailable', () => {
+      render(<TraceReviewView spans={[]} />);
+
+      expect(screen.getByText('Review content is unavailable for this trace.')).not.toBeNull();
+    });
+  });
+});

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -10,9 +10,11 @@ import {
   WrenchIcon,
 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { getAllSpanIds } from '../hooks/get-all-span-ids';
 import { useDownloadTraceJson } from '../hooks/use-download-trace-json';
 import type { TraceUsageSummary } from '../trace-list-columns';
+import type { TraceViewMode } from '../types';
 import { formatHierarchicalSpans } from './format-hierarchical-spans';
 import { TraceKeysAndValues } from './trace-keys-and-values';
 import { TraceTimeline } from './trace-timeline';
@@ -20,6 +22,7 @@ import { Button } from '@/ds/components/Button';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 import { DataPanel } from '@/ds/components/DataPanel';
 import { Notice } from '@/ds/components/Notice';
+import { Tab, TabList, Tabs } from '@/ds/components/Tabs';
 import { Icon } from '@/ds/icons/Icon';
 import type { LinkComponent } from '@/ds/types/link-component';
 import { truncateString } from '@/lib/truncate-string';
@@ -68,6 +71,9 @@ export interface TraceDataPanelViewProps {
    * handlers (e.g. inline below an experiment result).
    */
   showUnavailableFeaturesMsg?: boolean;
+  viewMode?: TraceViewMode;
+  onViewModeChange?: (mode: TraceViewMode) => void;
+  reviewSlot?: ReactNode;
 }
 
 export function TraceDataPanelView({
@@ -91,6 +97,9 @@ export function TraceDataPanelView({
   traceHref,
   anchorSpanId,
   showUnavailableFeaturesMsg = true,
+  viewMode,
+  onViewModeChange,
+  reviewSlot,
 }: TraceDataPanelViewProps) {
   const isOnTracePage = placement === 'trace-page';
   const [internalCollapsed, setInternalCollapsed] = useState(false);
@@ -148,6 +157,16 @@ export function TraceDataPanelView({
   };
 
   const showOpenTracePageLink = !isOnTracePage && LinkComponent && traceHref;
+  const showViewModeTabs = reviewSlot !== undefined && viewMode !== undefined && onViewModeChange !== undefined;
+  const isReviewMode = showViewModeTabs && viewMode === 'review';
+  const viewModeTabs = showViewModeTabs ? (
+    <Tabs defaultTab="review" value={viewMode} onValueChange={onViewModeChange}>
+      <TabList variant="pill" className="min-w-0">
+        <Tab value="review">Review</Tab>
+        <Tab value="advanced">Advanced</Tab>
+      </TabList>
+    </Tabs>
+  ) : null;
 
   // Shared across both header layouts (list side panel and full trace page) so a trace can be
   // downloaded from wherever it's being inspected.
@@ -168,7 +187,8 @@ export function TraceDataPanelView({
       <DataPanel.Header>
         {isOnTracePage ? (
           <>
-            <DataPanel.Heading>Trace Timeline</DataPanel.Heading>
+            <DataPanel.Heading>{isReviewMode ? 'Trace Review' : 'Trace Timeline'}</DataPanel.Heading>
+            {viewModeTabs}
             <ButtonsGroup className="ml-auto shrink-0">{downloadTraceButton}</ButtonsGroup>
           </>
         ) : (
@@ -176,6 +196,7 @@ export function TraceDataPanelView({
             <DataPanel.Heading>
               Trace <b># {truncateString(traceId, 12)}</b>
             </DataPanel.Heading>
+            {viewModeTabs}
             <ButtonsGroup className="ml-auto shrink-0">
               {onCollapsedChange && (
                 <Button
@@ -219,60 +240,66 @@ export function TraceDataPanelView({
           <DataPanel.NoData>No spans found for this trace.</DataPanel.NoData>
         ) : (
           <DataPanel.Content>
-            {!isOnTracePage && rootSpan && (
-              <TraceKeysAndValues rootSpan={rootSpan} usage={isSubtrace ? undefined : usage} className="mb-6" />
+            {isReviewMode ? (
+              reviewSlot
+            ) : (
+              <>
+                {!isOnTracePage && rootSpan && (
+                  <TraceKeysAndValues rootSpan={rootSpan} usage={isSubtrace ? undefined : usage} className="mb-6" />
+                )}
+
+                {!isOnTracePage && (onEvaluateTrace || onSaveAsDatasetItem || onAddTraceMocksToItem) && (
+                  <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+                    {onEvaluateTrace && (
+                      <Button size="sm" onClick={onEvaluateTrace}>
+                        <Icon>
+                          <CircleGaugeIcon />
+                        </Icon>
+                        Evaluate Trace
+                      </Button>
+                    )}
+                    {onSaveAsDatasetItem && (
+                      <Button size="sm" onClick={() => onSaveAsDatasetItem({ traceId, rootSpanId: rootSpan?.spanId })}>
+                        <Icon>
+                          <SaveIcon />
+                        </Icon>
+                        Save as Dataset Item
+                      </Button>
+                    )}
+                    {onAddTraceMocksToItem && (
+                      <Button size="sm" onClick={() => onAddTraceMocksToItem({ traceId })}>
+                        <Icon>
+                          <WrenchIcon />
+                        </Icon>
+                        Add tool mocks to item
+                      </Button>
+                    )}
+                  </div>
+                )}
+
+                {!isOnTracePage &&
+                  !onEvaluateTrace &&
+                  !onSaveAsDatasetItem &&
+                  !onAddTraceMocksToItem &&
+                  showUnavailableFeaturesMsg && (
+                    <Notice variant="info" className="mb-6">
+                      <Notice.Message>
+                        Evaluating traces and saving them as dataset items is available in Mastra Studio (local or
+                        deployed).
+                      </Notice.Message>
+                    </Notice>
+                  )}
+
+                <TraceTimeline
+                  hierarchicalSpans={hierarchicalSpans}
+                  onSpanClick={handleSpanClick}
+                  selectedSpanId={selectedSpanId}
+                  expandedSpanIds={expandedSpanIds}
+                  setExpandedSpanIds={setExpandedSpanIds}
+                  chartWidth={timelineChartWidth}
+                />
+              </>
             )}
-
-            {!isOnTracePage && (onEvaluateTrace || onSaveAsDatasetItem || onAddTraceMocksToItem) && (
-              <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
-                {onEvaluateTrace && (
-                  <Button size="sm" onClick={onEvaluateTrace}>
-                    <Icon>
-                      <CircleGaugeIcon />
-                    </Icon>
-                    Evaluate Trace
-                  </Button>
-                )}
-                {onSaveAsDatasetItem && (
-                  <Button size="sm" onClick={() => onSaveAsDatasetItem({ traceId, rootSpanId: rootSpan?.spanId })}>
-                    <Icon>
-                      <SaveIcon />
-                    </Icon>
-                    Save as Dataset Item
-                  </Button>
-                )}
-                {onAddTraceMocksToItem && (
-                  <Button size="sm" onClick={() => onAddTraceMocksToItem({ traceId })}>
-                    <Icon>
-                      <WrenchIcon />
-                    </Icon>
-                    Add tool mocks to item
-                  </Button>
-                )}
-              </div>
-            )}
-
-            {!isOnTracePage &&
-              !onEvaluateTrace &&
-              !onSaveAsDatasetItem &&
-              !onAddTraceMocksToItem &&
-              showUnavailableFeaturesMsg && (
-                <Notice variant="info" className="mb-6">
-                  <Notice.Message>
-                    Evaluating traces and saving them as dataset items is available in Mastra Studio (local or
-                    deployed).
-                  </Notice.Message>
-                </Notice>
-              )}
-
-            <TraceTimeline
-              hierarchicalSpans={hierarchicalSpans}
-              onSpanClick={handleSpanClick}
-              selectedSpanId={selectedSpanId}
-              expandedSpanIds={expandedSpanIds}
-              setExpandedSpanIds={setExpandedSpanIds}
-              chartWidth={timelineChartWidth}
-            />
           </DataPanel.Content>
         ))}
     </DataPanel>

--- a/packages/playground-ui/src/domains/traces/components/trace-review-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-review-view.tsx
@@ -1,0 +1,253 @@
+import type { LightSpanRecord } from '@mastra/core/storage';
+import {
+  AlertCircleIcon,
+  CheckCircle2Icon,
+  ChevronRightIcon,
+  HighlighterIcon,
+  MessageSquarePlusIcon,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useRef, useState } from 'react';
+import { formatSpanDuration } from '../utils/span-utils';
+import { getReadableTraceInput, getReadableTraceOutput } from '../utils/trace-review-utils';
+import { Button } from '@/ds/components/Button';
+import { MarkdownRenderer } from '@/ds/components/MarkdownRenderer';
+import { cn } from '@/lib/utils';
+
+export type TraceReviewTarget = 'case' | 'response' | 'reasoning';
+
+export interface TraceReviewSelection {
+  target: TraceReviewTarget;
+  quote: string;
+}
+
+type DetailedSpan = LightSpanRecord & {
+  input?: unknown;
+  output?: unknown;
+  result?: unknown;
+};
+
+export interface TraceReviewViewProps {
+  rootSpan?: DetailedSpan;
+  spans: LightSpanRecord[];
+  isLoading?: boolean;
+  onReviewTargetChange?: (target: TraceReviewTarget) => void;
+  /** Called when the reviewer selects text in a section and asks to annotate it. */
+  onAnnotate?: (selection: TraceReviewSelection) => void;
+  /** Rendered under a section heading; receives the section so consumers can show saved annotations inline. */
+  annotationsSlot?: (target: TraceReviewTarget) => ReactNode;
+  feedbackSlot?: ReactNode;
+}
+
+function getStepLabel(span: LightSpanRecord): string {
+  const type = span.spanType.toLowerCase().split('_')[0];
+  if (type === 'model') return 'Generated the response';
+  if (type === 'tool' || type === 'provider') return `Used ${span.name}`;
+  if (type === 'memory') return 'Checked conversation context';
+  if (type === 'workflow') return `Ran ${span.name}`;
+  if (type === 'scorer') return 'Evaluated the response';
+  return span.name;
+}
+
+export function RawDataDisclosure({ label, value }: { label: string; value: unknown }) {
+  if (value == null) return null;
+
+  return (
+    <details className="group mt-3">
+      <summary
+        className={cn(
+          'flex w-fit cursor-pointer list-none items-center gap-1.5 rounded-md px-2 py-1 text-ui-sm text-neutral3',
+          'transition-colors select-none hover:bg-surface4 hover:text-neutral5',
+          '[&::-webkit-details-marker]:hidden',
+        )}
+      >
+        <ChevronRightIcon className="size-3.5 transition-transform group-open:rotate-90" />
+        {label}
+      </summary>
+      <pre className="bg-surface1 text-ui-sm text-neutral4 mt-2 max-h-64 overflow-auto rounded-lg p-3 whitespace-pre-wrap">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </details>
+  );
+}
+
+function getSectionSelection(container: HTMLElement | null): string {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || !container) return '';
+  if (!selection.anchorNode || !container.contains(selection.anchorNode)) return '';
+  return selection.toString().trim();
+}
+
+function ReviewSection({
+  title,
+  content,
+  rawValue,
+  target,
+  onReviewTargetChange,
+  onAnnotate,
+  annotationsSlot,
+}: {
+  title: string;
+  content: string;
+  rawValue?: unknown;
+  target: TraceReviewTarget;
+  onReviewTargetChange?: (target: TraceReviewTarget) => void;
+  onAnnotate?: (selection: TraceReviewSelection) => void;
+  annotationsSlot?: (target: TraceReviewTarget) => ReactNode;
+}) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [selectedQuote, setSelectedQuote] = useState('');
+
+  const refreshSelection = () => {
+    if (onAnnotate) setSelectedQuote(getSectionSelection(contentRef.current));
+  };
+
+  return (
+    <section className="border-border1 bg-surface2 rounded-xl border p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h3 className="text-ui-lg text-neutral6 font-medium">{title}</h3>
+        <div className="flex items-center gap-1">
+          {onAnnotate && selectedQuote && (
+            <Button
+              type="button"
+              size="sm"
+              variant="primary"
+              aria-label={`Annotate selection in ${title.toLowerCase()}`}
+              onClick={() => {
+                onAnnotate({ target, quote: selectedQuote });
+                setSelectedQuote('');
+              }}
+            >
+              <HighlighterIcon />
+              Annotate selection
+            </Button>
+          )}
+          {onReviewTargetChange && (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              aria-label={`Add note about ${title.toLowerCase()}`}
+              onClick={() => onReviewTargetChange(target)}
+            >
+              <MessageSquarePlusIcon />
+              Add note
+            </Button>
+          )}
+        </div>
+      </div>
+      {content ? (
+        <div ref={contentRef} onMouseUp={refreshSelection} onKeyUp={refreshSelection}>
+          <MarkdownRenderer className="text-ui-md text-neutral5 max-w-[65ch]">{content}</MarkdownRenderer>
+        </div>
+      ) : (
+        <p className="text-ui-md text-neutral3">No readable {title.toLowerCase()} was recorded.</p>
+      )}
+      <RawDataDisclosure label="Raw message data" value={rawValue} />
+      {annotationsSlot?.(target)}
+    </section>
+  );
+}
+
+export function TraceReviewView({
+  rootSpan,
+  spans,
+  isLoading,
+  onReviewTargetChange,
+  onAnnotate,
+  annotationsSlot,
+  feedbackSlot,
+}: TraceReviewViewProps) {
+  if (isLoading) {
+    return <p className="text-ui-md text-neutral3 py-8 text-center">Loading review…</p>;
+  }
+
+  if (!rootSpan) {
+    return <p className="text-ui-md text-neutral3 py-8 text-center">Review content is unavailable for this trace.</p>;
+  }
+
+  const input = getReadableTraceInput(rootSpan.input);
+  const output = getReadableTraceOutput(rootSpan.output ?? rootSpan.result);
+  const steps = spans.filter(span => span.spanId !== rootSpan.spanId);
+
+  return (
+    <div className="grid gap-4">
+      <ReviewSection
+        title="Case"
+        content={input}
+        rawValue={rootSpan.input}
+        target="case"
+        onReviewTargetChange={onReviewTargetChange}
+        onAnnotate={onAnnotate}
+        annotationsSlot={annotationsSlot}
+      />
+      <ReviewSection
+        title="Agent response"
+        content={output}
+        rawValue={rootSpan.output ?? rootSpan.result}
+        target="response"
+        onReviewTargetChange={onReviewTargetChange}
+        onAnnotate={onAnnotate}
+        annotationsSlot={annotationsSlot}
+      />
+
+      <section className="border-border1 bg-surface2 rounded-xl border p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-ui-lg text-neutral6 font-medium">How the response was produced</h3>
+            <p className="text-ui-sm text-neutral3 mt-1">A plain-language summary of the recorded steps.</p>
+          </div>
+          {onReviewTargetChange && (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              aria-label="Add note about reasoning"
+              onClick={() => onReviewTargetChange('reasoning')}
+            >
+              <MessageSquarePlusIcon />
+              Add note
+            </Button>
+          )}
+        </div>
+
+        {steps.length === 0 ? (
+          <p className="text-ui-md text-neutral3">No intermediate steps were recorded.</p>
+        ) : (
+          <ol className="grid gap-2">
+            {steps.map((step, index) => {
+              const failed = step.status === 'error';
+              const duration = formatSpanDuration(step.startedAt, step.endedAt);
+              return (
+                <li
+                  key={step.spanId}
+                  className="bg-surface3 grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-lg px-3 py-2"
+                >
+                  <span
+                    className={cn(
+                      'flex size-6 items-center justify-center rounded-full text-ui-xs font-medium',
+                      failed ? 'bg-accent2/10 text-accent2' : 'bg-surface5 text-neutral5',
+                    )}
+                  >
+                    {index + 1}
+                  </span>
+                  <span className="text-ui-md text-neutral5 flex min-w-0 items-center gap-2">
+                    {failed ? (
+                      <AlertCircleIcon className="text-accent2 size-4 shrink-0" />
+                    ) : (
+                      <CheckCircle2Icon className="text-neutral3 size-4 shrink-0" />
+                    )}
+                    <span className="truncate">{getStepLabel(step)}</span>
+                  </span>
+                  {duration && <span className="text-ui-sm text-neutral3 tabular-nums">{duration}</span>}
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </section>
+
+      {feedbackSlot}
+    </div>
+  );
+}

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-view-mode.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-view-mode.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useTraceViewMode } from '../use-trace-view-mode';
+
+beforeEach(() => window.localStorage.clear());
+
+describe('useTraceViewMode', () => {
+  describe('when no preference has been saved', () => {
+    it('starts in review mode', () => {
+      const { result } = renderHook(() => useTraceViewMode());
+
+      expect(result.current.viewMode).toBe('review');
+    });
+  });
+
+  describe('when the user changes modes', () => {
+    it('updates the current mode immediately', () => {
+      const { result } = renderHook(() => useTraceViewMode());
+
+      act(() => result.current.setViewMode('advanced'));
+
+      expect(result.current.viewMode).toBe('advanced');
+    });
+
+    it('remembers the selected mode under the trace view-mode key', () => {
+      const first = renderHook(() => useTraceViewMode());
+
+      act(() => first.result.current.setViewMode('advanced'));
+      first.unmount();
+
+      expect(window.localStorage.getItem('mastra:traces:view-mode')).toBe('advanced');
+
+      const second = renderHook(() => useTraceViewMode());
+      expect(second.result.current.viewMode).toBe('advanced');
+    });
+
+    it('keeps a stored review preference', () => {
+      window.localStorage.setItem('mastra:traces:view-mode', 'review');
+
+      const { result } = renderHook(() => useTraceViewMode());
+      expect(result.current.viewMode).toBe('review');
+    });
+  });
+
+  describe('when storage contains an invalid value', () => {
+    it('falls back to review mode', () => {
+      window.localStorage.setItem('mastra:traces:view-mode', 'timeline');
+
+      const { result } = renderHook(() => useTraceViewMode());
+      expect(result.current.viewMode).toBe('review');
+    });
+  });
+});

--- a/packages/playground-ui/src/domains/traces/hooks/index.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/index.ts
@@ -15,6 +15,7 @@ export { useEntityNames } from './use-entity-names';
 export { useEnvironments } from './use-environments';
 export { useServiceNames } from './use-service-names';
 export { useTraceSpanNavigation } from './use-trace-span-navigation';
+export { useTraceViewMode } from './use-trace-view-mode';
 export { useTraceListNavigation } from './use-trace-list-navigation';
 export {
   useTraceUrlState,

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-view-mode.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-view-mode.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import type { TraceViewMode } from '../types';
+
+const TRACE_VIEW_MODE_STORAGE_KEY = 'mastra:traces:view-mode';
+
+function readStoredViewMode(): TraceViewMode {
+  if (typeof window === 'undefined') return 'review';
+
+  try {
+    const stored = window.localStorage.getItem(TRACE_VIEW_MODE_STORAGE_KEY);
+    return stored === 'advanced' || stored === 'review' ? stored : 'review';
+  } catch {
+    return 'review';
+  }
+}
+
+export function useTraceViewMode() {
+  const [viewMode, setViewModeState] = useState<TraceViewMode>(readStoredViewMode);
+
+  const setViewMode = (mode: TraceViewMode) => {
+    setViewModeState(mode);
+    try {
+      window.localStorage.setItem(TRACE_VIEW_MODE_STORAGE_KEY, mode);
+    } catch {}
+  };
+
+  return { viewMode, setViewMode };
+}

--- a/packages/playground-ui/src/domains/traces/types.ts
+++ b/packages/playground-ui/src/domains/traces/types.ts
@@ -30,6 +30,7 @@ export type TraceDatePreset = 'all' | 'last-24h' | 'last-3d' | 'last-7d' | 'last
 
 /** Tab identifier for SpanDataPanelView. */
 export type SpanTab = 'details' | 'scoring' | 'feedback';
+export type TraceViewMode = 'review' | 'advanced';
 
 /** Canonical list of context field IDs used for trace filtering and value extraction */
 export const CONTEXT_FIELD_IDS = [

--- a/packages/playground-ui/src/domains/traces/utils/trace-review-utils.test.ts
+++ b/packages/playground-ui/src/domains/traces/utils/trace-review-utils.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { getReadableTraceInput, getReadableTraceOutput } from './trace-review-utils';
+
+describe('getReadableTraceInput', () => {
+  describe('when the input is an agent message array', () => {
+    it('returns only the user message text', () => {
+      const input = [
+        { role: 'system', content: 'You are a clinician.' },
+        { role: 'user', content: 'A patient reports chest pain.' },
+      ];
+
+      expect(getReadableTraceInput(input)).toBe('A patient reports chest pain.');
+    });
+
+    it('joins multiple user messages with blank lines', () => {
+      const input = [
+        { role: 'user', content: 'First message.' },
+        { role: 'assistant', content: 'Reply.' },
+        { role: 'user', content: 'Second message.' },
+      ];
+
+      expect(getReadableTraceInput(input)).toBe('First message.\n\nSecond message.');
+    });
+
+    it('extracts text parts from structured message content', () => {
+      const input = [{ role: 'user', content: [{ type: 'text', text: 'Structured part.' }] }];
+
+      expect(getReadableTraceInput(input)).toBe('Structured part.');
+    });
+  });
+
+  describe('when the input is a Mastra message object', () => {
+    it('reads contents from a single user message object', () => {
+      const input = {
+        contents: 'A 35-year-old woman has fever and headache.',
+        metadata: { clientMessageId: 'client-1' },
+        type: 'user',
+        tagName: 'user',
+        id: 'msg-1',
+        toDBMessage: '[Function]',
+      };
+
+      expect(getReadableTraceInput(input)).toBe('A 35-year-old woman has fever and headache.');
+    });
+
+    it('reads contents from an array of typed messages without leaking framework fields', () => {
+      const input = [
+        { contents: 'First question.', type: 'user', id: 'msg-1', acceptedAt: '2026-08-21T00:00:00Z' },
+        { contents: 'Assistant reply.', type: 'assistant', id: 'msg-2' },
+        { contents: 'Second question.', type: 'user', id: 'msg-3' },
+      ];
+
+      expect(getReadableTraceInput(input)).toBe('First question.\n\nSecond question.');
+    });
+  });
+
+  describe('when the input uses the legacy messages wrapper', () => {
+    it('unwraps the messages array', () => {
+      const input = { messages: [{ role: 'user', content: 'Wrapped case.' }] };
+
+      expect(getReadableTraceInput(input)).toBe('Wrapped case.');
+    });
+  });
+
+  describe('when the input is a plain string', () => {
+    it('returns the string unchanged', () => {
+      expect(getReadableTraceInput('Plain case text.')).toBe('Plain case text.');
+    });
+
+    it('drops whitespace-only text', () => {
+      expect(getReadableTraceInput([{ role: 'user', content: '   ' }])).toBe('');
+    });
+  });
+
+  describe('when message content mixes field shapes', () => {
+    it('falls back from a non-string text field to the content field', () => {
+      const input = [{ role: 'user', content: [{ text: 42, content: 'Fallback content.' }] }];
+
+      expect(getReadableTraceInput(input)).toBe('Fallback content.');
+    });
+
+    it('reads a string value field', () => {
+      const input = [{ role: 'user', content: [{ value: 'Value text.' }] }];
+
+      expect(getReadableTraceInput(input)).toBe('Value text.');
+    });
+  });
+
+  describe('when the input is a structured object without messages', () => {
+    it('formats keys as readable labels', () => {
+      const formatted = getReadableTraceInput({ labResults: 'WBC 14,000', patientAge: 58 });
+
+      expect(formatted).toBe('Lab results: WBC 14,000\nPatient age: 58');
+    });
+
+    it('converts underscore keys to single spaces', () => {
+      expect(getReadableTraceInput({ medical__history: 'asthma' })).toBe('Medical history: asthma');
+    });
+
+    it('formats nested arrays as indented lists', () => {
+      const formatted = getReadableTraceInput({ medications: ['lisinopril', 'metformin'] });
+
+      expect(formatted).toBe('Medications:\n  - lisinopril\n  - metformin');
+    });
+
+    it('omits empty values', () => {
+      const formatted = getReadableTraceInput({ history: '', symptoms: 'nausea' });
+
+      expect(formatted).toBe('Symptoms: nausea');
+    });
+  });
+
+  describe('when the input is missing', () => {
+    it('returns an empty string', () => {
+      expect(getReadableTraceInput(null)).toBe('');
+      expect(getReadableTraceInput(undefined)).toBe('');
+    });
+  });
+});
+
+describe('getReadableTraceOutput', () => {
+  describe('when the output is an assistant message array', () => {
+    it('returns the assistant message text', () => {
+      const output = [
+        { role: 'user', content: 'Question.' },
+        { role: 'assistant', content: 'The likely diagnosis is appendicitis.' },
+      ];
+
+      expect(getReadableTraceOutput(output)).toBe('The likely diagnosis is appendicitis.');
+    });
+  });
+
+  describe('when the output is an object with a text field', () => {
+    it('returns the text field', () => {
+      expect(getReadableTraceOutput({ text: 'Diagnosis summary.' })).toBe('Diagnosis summary.');
+    });
+  });
+
+  describe('when the output nests text under a result field', () => {
+    it('returns the nested text', () => {
+      expect(getReadableTraceOutput({ result: { text: 'Nested result.' } })).toBe('Nested result.');
+    });
+  });
+
+  describe('when the output is a plain string', () => {
+    it('returns the string unchanged', () => {
+      expect(getReadableTraceOutput('Direct answer.')).toBe('Direct answer.');
+    });
+  });
+
+  describe('when the output is a structured object without text', () => {
+    it('formats keys as readable labels', () => {
+      expect(getReadableTraceOutput({ confidenceLevel: 'moderate' })).toBe('Confidence level: moderate');
+    });
+  });
+
+  describe('when the output is missing', () => {
+    it('returns an empty string', () => {
+      expect(getReadableTraceOutput(null)).toBe('');
+    });
+  });
+});

--- a/packages/playground-ui/src/domains/traces/utils/trace-review-utils.ts
+++ b/packages/playground-ui/src/domains/traces/utils/trace-review-utils.ts
@@ -1,0 +1,97 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function extractContentText(value: unknown): string[] {
+  if (typeof value === 'string') return value.trim() ? [value.trim()] : [];
+  if (Array.isArray(value)) return value.flatMap(extractContentText);
+  if (!isRecord(value)) return [];
+
+  if (typeof value.text === 'string') return extractContentText(value.text);
+  if (value.content !== undefined) return extractContentText(value.content);
+  if (typeof value.value === 'string') return extractContentText(value.value);
+  return [];
+}
+
+function getMessageRole(message: unknown): string | undefined {
+  if (!isRecord(message)) return undefined;
+  if (typeof message.role === 'string') return message.role;
+  if (typeof message.type === 'string') return message.type;
+  return undefined;
+}
+
+function getMessageBody(message: unknown): unknown {
+  if (!isRecord(message)) return undefined;
+  return message.contents ?? message.content;
+}
+
+function isMessage(value: unknown): boolean {
+  return getMessageRole(value) !== undefined && getMessageBody(value) !== undefined;
+}
+
+function getMessageList(value: unknown): unknown[] | undefined {
+  if (Array.isArray(value)) return value;
+  if (isRecord(value) && Array.isArray(value.messages)) return value.messages;
+  if (isMessage(value)) return [value];
+  return undefined;
+}
+
+function getMessageText(messages: unknown[], role: 'user' | 'assistant'): string {
+  return messages
+    .filter(message => getMessageRole(message) === role)
+    .flatMap(message => extractContentText(getMessageBody(message)))
+    .join('\n\n');
+}
+
+function humanizeKey(key: string): string {
+  const spaced = key.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]+/g, ' ');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+function formatStructuredValue(value: unknown, depth = 0): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    return value
+      .map(item => formatStructuredValue(item, depth + 1))
+      .filter(Boolean)
+      .map(item => `${'  '.repeat(depth)}- ${item}`)
+      .join('\n');
+  }
+  if (!isRecord(value)) return String(value);
+
+  return Object.entries(value)
+    .map(([key, item]) => {
+      const formatted = formatStructuredValue(item, depth + 1);
+      if (!formatted) return '';
+      return formatted.includes('\n')
+        ? `${'  '.repeat(depth)}${humanizeKey(key)}:\n${formatted}`
+        : `${'  '.repeat(depth)}${humanizeKey(key)}: ${formatted}`;
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function getReadableTraceInput(input: unknown): string {
+  const messages = getMessageList(input);
+  if (messages) return getMessageText(messages, 'user');
+
+  const directText = extractContentText(input).join('\n\n');
+  return directText || formatStructuredValue(input);
+}
+
+export function getReadableTraceOutput(output: unknown): string {
+  const messages = getMessageList(output);
+  if (messages) return getMessageText(messages, 'assistant');
+
+  if (isRecord(output)) {
+    for (const key of ['text', 'content', 'output', 'result', 'message']) {
+      const text = extractContentText(output[key]).join('\n\n');
+      if (text) return text;
+    }
+  }
+
+  const directText = extractContentText(output).join('\n\n');
+  return directText || formatStructuredValue(output);
+}

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -13,6 +13,7 @@ import { WorkflowLayout } from './domains/workflows/workflow-layout';
 import SignalsOverviewPage from './ee/signals';
 import { SignalsEntityCrumb } from './ee/signals/signals-entity-crumb';
 import { PostHogProvider } from './lib/analytics';
+import { isTraceReviewEnabled } from './lib/feature-flags';
 import { Link } from './lib/link';
 import { StudioIndexRedirect } from './lib/studio-index-redirect';
 import { AgentBuilderRoot } from './pages/agent-builder';
@@ -76,6 +77,8 @@ import { StudioSettingsPage } from './pages/settings';
 import { SignUp } from './pages/signup';
 import Templates from './pages/templates';
 import Template from './pages/templates/template';
+import ThreadsPage from './pages/threads';
+import ThreadPage from './pages/threads/thread';
 import AgentTool from './pages/tools/agent-tool';
 import Tool from './pages/tools/tool';
 import Traces from './pages/traces';
@@ -218,6 +221,7 @@ const MinimalRootLayout = () => {
 // Determine platform status at module level for route configuration
 const isMastraPlatform = Boolean(window.MASTRA_CLOUD_API_ENDPOINT);
 const isExperimentalFeatures = coreFeatures.has('datasets');
+const isTraceReview = isTraceReviewEnabled();
 
 const agentCmsChildRoutes = [
   { index: true, element: <CmsAgentInformationPage /> },
@@ -387,6 +391,12 @@ export const routes: RouteObject[] = [
           { id: 'signals-agent', Component: SignalsEntityCrumb, heading: 'Agent' },
         ]),
       },
+      ...(isTraceReview
+        ? [
+            { path: '/threads', element: <ThreadsPage />, handle: navHandle('/threads') },
+            { path: '/threads/:threadKey', element: <ThreadPage />, handle: navHandle('/threads') },
+          ]
+        : []),
       { path: '/traces', element: <Traces />, handle: navHandle('/traces') },
       {
         path: '/traces/:traceId',

--- a/packages/playground/src/domains/threads-view/components/thread-trace-inspector.tsx
+++ b/packages/playground/src/domains/threads-view/components/thread-trace-inspector.tsx
@@ -1,0 +1,37 @@
+import { SideDialog } from '@mastra/playground-ui/components/SideDialog';
+import { SpanDetailsView } from '@mastra/playground-ui/domains/traces/components/span-details-view';
+import { TraceDetailsView } from '@mastra/playground-ui/domains/traces/components/trace-details-view';
+import { useSpanDetail } from '@mastra/playground-ui/domains/traces/hooks/use-span-detail';
+import { useTraceLightSpans } from '@mastra/playground-ui/domains/traces/hooks/use-trace-light-spans';
+import { useState } from 'react';
+
+export function ThreadTraceInspector({ traceId, onClose }: { traceId: string; onClose: () => void }) {
+  const [selectedSpanId, setSelectedSpanId] = useState<string | undefined>();
+  const { data: traceLight, isLoading } = useTraceLightSpans(traceId);
+  const { data: spanDetailData, isLoading: isLoadingSpan } = useSpanDetail(traceId, selectedSpanId ?? '');
+
+  return (
+    <SideDialog dialogTitle="Trace details" dialogDescription="Technical trace for this turn" isOpen onClose={onClose}>
+      <SideDialog.Content>
+        <div className="grid content-start gap-4">
+          <TraceDetailsView
+            traceId={traceId}
+            spans={traceLight?.spans}
+            isLoading={isLoading}
+            onClose={onClose}
+            onSpanSelect={setSelectedSpanId}
+            selectedSpanId={selectedSpanId}
+          />
+          {selectedSpanId && (
+            <SpanDetailsView
+              spanId={selectedSpanId}
+              span={spanDetailData?.span}
+              isLoading={isLoadingSpan}
+              onClose={() => setSelectedSpanId(undefined)}
+            />
+          )}
+        </div>
+      </SideDialog.Content>
+    </SideDialog>
+  );
+}

--- a/packages/playground/src/domains/threads-view/components/thread-turn-card.tsx
+++ b/packages/playground/src/domains/threads-view/components/thread-turn-card.tsx
@@ -1,0 +1,210 @@
+import type { FeedbackRecord } from '@mastra/core/storage';
+import { Button } from '@mastra/playground-ui/components/Button';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@mastra/playground-ui/components/HoverCard';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
+import type { TraceReviewSelection } from '@mastra/playground-ui/domains/traces/components/trace-review-view';
+import { RawDataDisclosure } from '@mastra/playground-ui/domains/traces/components/trace-review-view';
+import { formatSpanDuration } from '@mastra/playground-ui/domains/traces/utils/span-utils';
+import {
+  getReadableTraceInput,
+  getReadableTraceOutput,
+} from '@mastra/playground-ui/domains/traces/utils/trace-review-utils';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import { format } from 'date-fns';
+import { AlertCircleIcon, AlertTriangleIcon, CheckCircle2Icon, HighlighterIcon, PencilLineIcon } from 'lucide-react';
+import { useRef, useState } from 'react';
+import type { ConversationThread } from '../hooks/use-conversation-threads';
+import { AnnotatedMarkdown } from '@/domains/traces/components/annotated-markdown';
+import { TraceAnnotationComposer, TraceAnnotationList } from '@/domains/traces/components/trace-annotations';
+import { TraceReviewFeedback } from '@/domains/traces/components/trace-review-feedback';
+import { useTraceFeedback } from '@/domains/traces/hooks/use-trace-feedback';
+
+type ThreadTurn = ConversationThread['turns'][number];
+
+const assessmentLabels = {
+  accurate: { label: 'Accurate', Icon: CheckCircle2Icon, className: 'text-neutral5' },
+  'needs-correction': { label: 'Needs correction', Icon: PencilLineIcon, className: 'text-neutral4' },
+  unsafe: { label: 'Potentially unsafe', Icon: AlertTriangleIcon, className: 'text-accent2' },
+} as const;
+
+type AssessmentKey = keyof typeof assessmentLabels;
+
+function getAssessmentKey(feedback: FeedbackRecord): AssessmentKey {
+  if (feedback.value === 1) return 'accurate';
+  if (feedback.value === -1) return 'unsafe';
+  return 'needs-correction';
+}
+
+function getConsensus(reviews: FeedbackRecord[]): { key: AssessmentKey; count: number } | undefined {
+  if (reviews.length === 0) return undefined;
+  const counts = new Map<AssessmentKey, number>();
+  for (const review of reviews) {
+    const key = getAssessmentKey(review);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  // Safety concerns win ties; otherwise the most common assessment.
+  const ranked = [...counts.entries()].sort(
+    (a, b) => b[1] - a[1] || (a[0] === 'unsafe' ? -1 : b[0] === 'unsafe' ? 1 : 0),
+  );
+  const top = ranked[0]!;
+  return { key: top[0], count: top[1] };
+}
+
+function ReviewedBadge({ reviews }: { reviews: FeedbackRecord[] }) {
+  const consensus = getConsensus(reviews);
+  if (!consensus) return null;
+  const consensusUi = assessmentLabels[consensus.key];
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger
+        render={<button type="button" aria-label={`Reviewed: ${consensusUi.label}. Show review details`} />}
+        className="text-neutral5 hover:bg-surface4 flex cursor-default items-center gap-1 rounded-md px-1 py-0.5"
+      >
+        <CheckCircle2Icon className="size-3.5" /> Reviewed
+      </HoverCardTrigger>
+      <HoverCardContent side="bottom" align="start" className="w-80 p-3">
+        <p className={cn('flex items-center gap-1.5 text-ui-md font-medium', consensusUi.className)}>
+          <consensusUi.Icon className="size-4" />
+          {consensusUi.label}
+          {reviews.length > 1 && (
+            <span className="text-neutral3 font-normal">
+              {consensus.count} of {reviews.length} reviews
+            </span>
+          )}
+        </p>
+        <ul className="mt-2 grid gap-2">
+          {reviews.map((review, index) => {
+            const ui = assessmentLabels[getAssessmentKey(review)];
+            return (
+              <li key={review.feedbackId ?? index} className="bg-surface3 rounded-lg p-2">
+                <div className="text-ui-sm text-neutral3 flex items-center gap-2">
+                  <ui.Icon className={cn('size-3.5', ui.className)} />
+                  <span className="text-neutral5 font-medium">{review.feedbackUserId || 'Unattributed'}</span>
+                  <span>{format(new Date(review.timestamp), 'MMM d, h:mm aaa')}</span>
+                </div>
+                {review.comment && <p className="text-ui-sm text-neutral5 mt-1">{review.comment}</p>}
+              </li>
+            );
+          })}
+        </ul>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+function getSelectionInside(container: HTMLElement | null): string {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || !container) return '';
+  if (!selection.anchorNode || !container.contains(selection.anchorNode)) return '';
+  return selection.toString().trim();
+}
+
+export function ThreadTurnCard({
+  turn,
+  index,
+  onInspectTrace,
+}: {
+  turn: ThreadTurn;
+  index: number;
+  onInspectTrace: (traceId: string) => void;
+}) {
+  const responseRef = useRef<HTMLDivElement>(null);
+  const [selectedQuote, setSelectedQuote] = useState('');
+  const [pendingAnnotation, setPendingAnnotation] = useState<TraceReviewSelection | undefined>();
+  const [showReviewForm, setShowReviewForm] = useState(false);
+
+  const { data: feedbackData } = useTraceFeedback({ traceId: turn.traceId });
+  const reviews = (feedbackData?.feedback ?? []).filter(feedback => feedback.feedbackType === 'review');
+  const annotations = (feedbackData?.feedback ?? []).filter(feedback => feedback.feedbackType === 'annotation');
+  const isReviewed = reviews.length > 0;
+
+  const caseText = getReadableTraceInput(turn.input);
+  const responseText = getReadableTraceOutput(turn.output);
+  const duration = formatSpanDuration(turn.startedAt, turn.endedAt);
+  const failed = turn.status === 'error';
+
+  const refreshSelection = () => setSelectedQuote(getSelectionInside(responseRef.current));
+
+  return (
+    <article className="border-border1 bg-surface2 rounded-xl border p-4">
+      <header className="text-ui-sm text-neutral3 mb-3 flex flex-wrap items-center gap-2">
+        <span className="text-neutral5 font-medium">Turn {index + 1}</span>
+        {turn.entityName && <span className="bg-surface5 rounded-full px-2 py-0.5">{turn.entityName}</span>}
+        {duration && <span className="tabular-nums">{duration}</span>}
+        {failed && (
+          <span className="text-accent2 flex items-center gap-1">
+            <AlertCircleIcon className="size-3.5" /> This turn failed
+          </span>
+        )}
+        <ReviewedBadge reviews={reviews} />
+        <span className="ml-auto flex items-center gap-1">
+          {selectedQuote && (
+            <Button
+              type="button"
+              size="sm"
+              variant="primary"
+              aria-label={`Annotate selection in turn ${index + 1}`}
+              onClick={() => {
+                setPendingAnnotation({ target: 'response', quote: selectedQuote });
+                setSelectedQuote('');
+              }}
+            >
+              <HighlighterIcon />
+              Annotate selection
+            </Button>
+          )}
+          <Button type="button" size="sm" variant="ghost" onClick={() => setShowReviewForm(open => !open)}>
+            {showReviewForm ? 'Hide review' : isReviewed ? 'Review again' : 'Review turn'}
+          </Button>
+          <Button type="button" size="sm" variant="ghost" onClick={() => onInspectTrace(turn.traceId)}>
+            Full trace
+          </Button>
+        </span>
+      </header>
+
+      <div className="grid gap-3">
+        <div className="bg-surface5 max-w-[65ch] justify-self-end rounded-lg px-4 py-3">
+          {caseText ? (
+            <MarkdownRenderer className="text-ui-md text-neutral6">{caseText}</MarkdownRenderer>
+          ) : (
+            <p className="text-ui-md text-neutral3">No readable message was recorded.</p>
+          )}
+        </div>
+        <div
+          ref={responseRef}
+          onMouseUp={refreshSelection}
+          onKeyUp={refreshSelection}
+          className={cn('max-w-[65ch] rounded-lg bg-surface3 px-4 py-3', failed && 'border border-accent2/40')}
+        >
+          {responseText ? (
+            <AnnotatedMarkdown annotations={annotations} className="text-ui-md text-neutral5">
+              {responseText}
+            </AnnotatedMarkdown>
+          ) : (
+            <p className="text-ui-md text-neutral3">No readable response was recorded.</p>
+          )}
+        </div>
+      </div>
+
+      <RawDataDisclosure label="Raw turn data" value={{ input: turn.input, output: turn.output }} />
+
+      <TraceAnnotationList feedbackData={feedbackData} />
+
+      {pendingAnnotation && (
+        <TraceAnnotationComposer
+          traceId={turn.traceId}
+          spanId={turn.spanId}
+          selection={pendingAnnotation}
+          onDone={() => setPendingAnnotation(undefined)}
+        />
+      )}
+
+      {showReviewForm && (
+        <div className="mt-3">
+          <TraceReviewFeedback traceId={turn.traceId} spanId={turn.spanId} />
+        </div>
+      )}
+    </article>
+  );
+}

--- a/packages/playground/src/domains/threads-view/hooks/__tests__/use-conversation-threads.test.ts
+++ b/packages/playground/src/domains/threads-view/hooks/__tests__/use-conversation-threads.test.ts
@@ -1,0 +1,84 @@
+import type { MastraClient } from '@mastra/client-js';
+import { SpanType } from '@mastra/core/observability';
+import { TraceStatus } from '@mastra/core/storage';
+import { describe, expect, it } from 'vitest';
+import { groupTracesIntoThreads } from '../use-conversation-threads';
+
+type TraceRootSpan = Awaited<ReturnType<MastraClient['listTraces']>>['spans'][number];
+
+const baseSpan: TraceRootSpan = {
+  traceId: 'trace-1',
+  spanId: 'span-1',
+  name: 'agent run',
+  spanType: SpanType.AGENT_RUN,
+  isEvent: false,
+  startedAt: new Date('2026-08-21T10:00:00.000Z'),
+  endedAt: new Date('2026-08-21T10:00:05.000Z'),
+  createdAt: new Date('2026-08-21T10:00:00.000Z'),
+  updatedAt: null,
+  status: TraceStatus.SUCCESS,
+};
+
+describe('groupTracesIntoThreads', () => {
+  describe('when turns share a threadId', () => {
+    it('groups them into one conversation ordered by start time', () => {
+      const threads = groupTracesIntoThreads([
+        { ...baseSpan, traceId: 'trace-2', threadId: 'thread-a', startedAt: new Date('2026-08-21T11:00:00.000Z') },
+        { ...baseSpan, traceId: 'trace-1', threadId: 'thread-a' },
+      ]);
+
+      expect(threads).toHaveLength(1);
+      expect(threads[0]?.isConversation).toBe(true);
+      expect(threads[0]?.turns.map(turn => turn.traceId)).toEqual(['trace-1', 'trace-2']);
+    });
+  });
+
+  describe('when a turn has no conversation identifier', () => {
+    it('keeps it as a single-turn conversation', () => {
+      const threads = groupTracesIntoThreads([baseSpan]);
+
+      expect(threads).toHaveLength(1);
+      expect(threads[0]?.isConversation).toBe(false);
+      expect(threads[0]?.turns).toHaveLength(1);
+    });
+  });
+
+  describe('when a turn failed', () => {
+    it('marks the conversation as having errors', () => {
+      const threads = groupTracesIntoThreads([
+        { ...baseSpan, threadId: 'thread-a' },
+        { ...baseSpan, traceId: 'trace-2', threadId: 'thread-a', status: TraceStatus.ERROR },
+      ]);
+
+      expect(threads[0]?.hasErrors).toBe(true);
+    });
+  });
+
+  describe('when multiple actors participate', () => {
+    it('lists each actor once', () => {
+      const threads = groupTracesIntoThreads([
+        { ...baseSpan, threadId: 'thread-a', entityName: 'patient-agent' },
+        { ...baseSpan, traceId: 'trace-2', threadId: 'thread-a', entityName: 'physician-agent' },
+        { ...baseSpan, traceId: 'trace-3', threadId: 'thread-a', entityName: 'patient-agent' },
+      ]);
+
+      expect(threads[0]?.actors).toEqual(['patient-agent', 'physician-agent']);
+    });
+  });
+
+  describe('when conversations are sorted', () => {
+    it('puts the most recently active conversation first', () => {
+      const threads = groupTracesIntoThreads([
+        { ...baseSpan, threadId: 'old', endedAt: new Date('2026-08-21T09:00:00.000Z') },
+        {
+          ...baseSpan,
+          traceId: 'trace-2',
+          threadId: 'new',
+          endedAt: new Date('2026-08-21T12:00:00.000Z'),
+        },
+      ]);
+
+      expect(threads.map(thread => thread.threadKey)).toEqual(['thread:new', 'thread:old']);
+    });
+  });
+});

--- a/packages/playground/src/domains/threads-view/hooks/use-conversation-threads.ts
+++ b/packages/playground/src/domains/threads-view/hooks/use-conversation-threads.ts
@@ -1,0 +1,76 @@
+import type { MastraClient } from '@mastra/client-js';
+import { useMastraClient } from '@mastra/react';
+import { useQuery } from '@tanstack/react-query';
+
+type ListTracesResponse = Awaited<ReturnType<MastraClient['listTraces']>>;
+type TraceRootSpan = ListTracesResponse['spans'][number];
+
+export interface ConversationThread {
+  /** Stable grouping key: threadId, else sessionId, else the trace itself. */
+  threadKey: string;
+  /** True when the key came from a real conversation identifier. */
+  isConversation: boolean;
+  turns: TraceRootSpan[];
+  actors: string[];
+  startedAt: Date | string;
+  lastActivityAt: Date | string;
+  hasErrors: boolean;
+}
+
+function getThreadKey(span: TraceRootSpan): { key: string; isConversation: boolean } {
+  if (span.threadId) return { key: `thread:${span.threadId}`, isConversation: true };
+  if (span.sessionId) return { key: `session:${span.sessionId}`, isConversation: true };
+  return { key: `trace:${span.traceId}`, isConversation: false };
+}
+
+export function groupTracesIntoThreads(spans: TraceRootSpan[]): ConversationThread[] {
+  const byKey = new Map<string, ConversationThread & { actorSet: Set<string> }>();
+
+  for (const span of spans) {
+    const { key, isConversation } = getThreadKey(span);
+    const existing = byKey.get(key);
+    const actor = span.entityName ?? span.name;
+    const failed = span.status === 'error';
+
+    if (!existing) {
+      byKey.set(key, {
+        threadKey: key,
+        isConversation,
+        turns: [span],
+        actorSet: new Set(actor ? [actor] : []),
+        actors: [],
+        startedAt: span.startedAt,
+        lastActivityAt: span.endedAt ?? span.startedAt,
+        hasErrors: failed,
+      });
+      continue;
+    }
+
+    existing.turns.push(span);
+    if (actor) existing.actorSet.add(actor);
+    if (new Date(span.startedAt) < new Date(existing.startedAt)) existing.startedAt = span.startedAt;
+    const activity = span.endedAt ?? span.startedAt;
+    if (new Date(activity) > new Date(existing.lastActivityAt)) existing.lastActivityAt = activity;
+    existing.hasErrors = existing.hasErrors || failed;
+  }
+
+  const threads: ConversationThread[] = [...byKey.values()].map(({ actorSet, ...thread }) => ({
+    ...thread,
+    actors: [...actorSet],
+    turns: [...thread.turns].sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime()),
+  }));
+
+  return threads.sort((a, b) => new Date(b.lastActivityAt).getTime() - new Date(a.lastActivityAt).getTime());
+}
+
+export function useConversationThreads() {
+  const client = useMastraClient();
+
+  return useQuery({
+    queryKey: ['conversation-threads'],
+    queryFn: async () => {
+      const response = await client.listTraces({ pagination: { page: 0, perPage: 100 } });
+      return groupTracesIntoThreads(response.spans);
+    },
+  });
+}

--- a/packages/playground/src/domains/threads-view/hooks/use-thread-review-status.ts
+++ b/packages/playground/src/domains/threads-view/hooks/use-thread-review-status.ts
@@ -1,0 +1,20 @@
+import { useMastraClient } from '@mastra/react';
+import { useQuery } from '@tanstack/react-query';
+
+/** Trace IDs that carry at least one human review, from the most recent feedback page. */
+export function useReviewedTraceIds() {
+  const client = useMastraClient();
+
+  return useQuery({
+    queryKey: ['reviewed-trace-ids'],
+    queryFn: async () => {
+      const response = await client.listFeedback({ pagination: { page: 0, perPage: 100 } });
+      const reviewed = new Set<string>();
+      for (const feedback of response.feedback) {
+        if (feedback.feedbackType === 'review' && feedback.traceId) reviewed.add(feedback.traceId);
+      }
+      return reviewed;
+    },
+    refetchInterval: 5000,
+  });
+}

--- a/packages/playground/src/domains/threads-view/utils/__tests__/export-conversation.test.ts
+++ b/packages/playground/src/domains/threads-view/utils/__tests__/export-conversation.test.ts
@@ -1,0 +1,98 @@
+import type { MastraClient } from '@mastra/client-js';
+import { SpanType } from '@mastra/core/observability';
+import type { FeedbackRecord } from '@mastra/core/storage';
+import { TraceStatus } from '@mastra/core/storage';
+import { describe, expect, it } from 'vitest';
+import type { ConversationThread } from '../../hooks/use-conversation-threads';
+import { buildConversationExport } from '../export-conversation';
+
+type TraceRootSpan = Awaited<ReturnType<MastraClient['listTraces']>>['spans'][number];
+
+const turn: TraceRootSpan = {
+  traceId: 'trace-1',
+  spanId: 'span-1',
+  name: "agent run: 'clinical-diagnosis-agent'",
+  spanType: SpanType.AGENT_RUN,
+  isEvent: false,
+  startedAt: new Date('2026-08-21T10:00:00.000Z'),
+  endedAt: new Date('2026-08-21T10:00:05.000Z'),
+  createdAt: new Date('2026-08-21T10:00:00.000Z'),
+  updatedAt: null,
+  status: TraceStatus.SUCCESS,
+  entityName: 'Clinical Diagnosis Agent',
+  input: [{ role: 'user', content: 'Chest pain case.' }],
+  output: { text: 'Evaluate urgently.' },
+};
+
+const thread: ConversationThread = {
+  threadKey: 'thread:demo',
+  isConversation: true,
+  turns: [turn],
+  actors: ['Clinical Diagnosis Agent'],
+  startedAt: turn.startedAt,
+  lastActivityAt: turn.endedAt!,
+  hasErrors: false,
+};
+
+const feedback: FeedbackRecord[] = [
+  {
+    feedbackId: 'fb-1',
+    timestamp: new Date('2026-08-21T11:00:00.000Z'),
+    traceId: 'trace-1',
+    feedbackType: 'review',
+    value: 1,
+    comment: 'Sound reasoning.',
+    feedbackUserId: 'Dr. Reyes',
+  },
+  {
+    feedbackId: 'fb-2',
+    timestamp: new Date('2026-08-21T11:05:00.000Z'),
+    traceId: 'trace-1',
+    feedbackType: 'annotation',
+    value: 'Evaluate urgently',
+    comment: 'Needs a timeframe.',
+    feedbackUserId: 'Dr. Chen',
+    metadata: { reviewTarget: 'response', quote: 'Evaluate urgently' },
+  },
+];
+
+describe('buildConversationExport', () => {
+  describe('when a thread has reviews and annotations', () => {
+    it('exports readable turns with attributed reviews and annotations', () => {
+      const payload = buildConversationExport(thread, new Map([['trace-1', feedback]]));
+
+      expect(payload.threadKey).toBe('thread:demo');
+      expect(payload.turns).toHaveLength(1);
+      const exported = payload.turns[0]!;
+      expect(exported.actor).toBe('Clinical Diagnosis Agent');
+      expect(exported.message).toBe('Chest pain case.');
+      expect(exported.response).toBe('Evaluate urgently.');
+      expect(exported.reviews).toEqual([
+        {
+          assessment: 'accurate',
+          note: 'Sound reasoning.',
+          reviewer: 'Dr. Reyes',
+          timestamp: feedback[0]!.timestamp,
+        },
+      ]);
+      expect(exported.annotations).toEqual([
+        {
+          quote: 'Evaluate urgently',
+          note: 'Needs a timeframe.',
+          reviewer: 'Dr. Chen',
+          timestamp: feedback[1]!.timestamp,
+        },
+      ]);
+      expect(exported.raw.input).toEqual(turn.input);
+    });
+  });
+
+  describe('when a turn has no feedback', () => {
+    it('exports empty review and annotation lists', () => {
+      const payload = buildConversationExport(thread, new Map());
+
+      expect(payload.turns[0]!.reviews).toEqual([]);
+      expect(payload.turns[0]!.annotations).toEqual([]);
+    });
+  });
+});

--- a/packages/playground/src/domains/threads-view/utils/export-conversation.ts
+++ b/packages/playground/src/domains/threads-view/utils/export-conversation.ts
@@ -1,0 +1,56 @@
+import type { FeedbackRecord } from '@mastra/core/storage';
+import {
+  getReadableTraceInput,
+  getReadableTraceOutput,
+} from '@mastra/playground-ui/domains/traces/utils/trace-review-utils';
+import type { ConversationThread } from '../hooks/use-conversation-threads';
+
+export function buildConversationExport(thread: ConversationThread, feedbackByTraceId: Map<string, FeedbackRecord[]>) {
+  return {
+    threadKey: thread.threadKey,
+    exportedAt: new Date().toISOString(),
+    actors: thread.actors,
+    startedAt: thread.startedAt,
+    lastActivityAt: thread.lastActivityAt,
+    turns: thread.turns.map((turn, index) => {
+      const feedback = feedbackByTraceId.get(turn.traceId) ?? [];
+      return {
+        turn: index + 1,
+        traceId: turn.traceId,
+        actor: turn.entityName ?? turn.name,
+        status: turn.status,
+        startedAt: turn.startedAt,
+        endedAt: turn.endedAt,
+        message: getReadableTraceInput(turn.input),
+        response: getReadableTraceOutput(turn.output),
+        reviews: feedback
+          .filter(entry => entry.feedbackType === 'review')
+          .map(entry => ({
+            assessment: entry.value === 1 ? 'accurate' : entry.value === -1 ? 'potentially-unsafe' : 'needs-correction',
+            note: entry.comment ?? null,
+            reviewer: entry.feedbackUserId ?? null,
+            timestamp: entry.timestamp,
+          })),
+        annotations: feedback
+          .filter(entry => entry.feedbackType === 'annotation')
+          .map(entry => ({
+            quote: typeof entry.metadata?.quote === 'string' ? entry.metadata.quote : null,
+            note: entry.comment ?? null,
+            reviewer: entry.feedbackUserId ?? null,
+            timestamp: entry.timestamp,
+          })),
+        raw: { input: turn.input ?? null, output: turn.output ?? null },
+      };
+    }),
+  };
+}
+
+export function downloadConversationJson(threadKey: string, payload: unknown) {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `conversation-${threadKey.replace(/[^a-zA-Z0-9-_]/g, '_')}.json`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/packages/playground/src/domains/traces/components/__tests__/annotated-markdown.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/annotated-markdown.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import type { FeedbackRecord } from '@mastra/core/storage';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AnnotatedMarkdown } from '../annotated-markdown';
+
+afterEach(cleanup);
+
+const annotation: FeedbackRecord = {
+  feedbackId: 'fb-1',
+  timestamp: new Date('2026-08-21T11:00:00.000Z'),
+  traceId: 'trace-1',
+  feedbackType: 'annotation',
+  value: 'surgical evaluation',
+  comment: 'Specify the timeframe for surgery consult.',
+  feedbackUserId: 'Dr. Reyes',
+  metadata: { reviewTarget: 'response', quote: 'surgical evaluation' },
+};
+
+describe('AnnotatedMarkdown', () => {
+  describe('when an annotation quote matches the text', () => {
+    it('highlights the quote inline', async () => {
+      const { container } = render(
+        <AnnotatedMarkdown annotations={[annotation]}>Same-day surgical evaluation is warranted.</AnnotatedMarkdown>,
+      );
+
+      await waitFor(() => {
+        const mark = container.querySelector('mark[data-annotation-key="fb-1"]');
+        expect(mark?.textContent).toBe('surgical evaluation');
+      });
+    });
+
+    it('opens the comment with author when the highlight is clicked', async () => {
+      const { container } = render(
+        <AnnotatedMarkdown annotations={[annotation]}>Same-day surgical evaluation is warranted.</AnnotatedMarkdown>,
+      );
+
+      await waitFor(() => expect(container.querySelector('mark[data-annotation-key]')).not.toBeNull());
+      fireEvent.click(container.querySelector('mark[data-annotation-key]')!);
+
+      expect(screen.getByRole('dialog', { name: 'Annotation' })).not.toBeNull();
+      expect(screen.getByText('Specify the timeframe for surgery consult.')).not.toBeNull();
+      expect(screen.getByText('Dr. Reyes')).not.toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Close annotation' }));
+      expect(screen.queryByRole('dialog', { name: 'Annotation' })).toBeNull();
+    });
+  });
+
+  describe('when no annotation matches', () => {
+    it('renders the markdown without highlights', () => {
+      const { container } = render(<AnnotatedMarkdown annotations={[]}>Plain response text.</AnnotatedMarkdown>);
+
+      expect(container.querySelector('mark')).toBeNull();
+      expect(screen.getByText('Plain response text.')).not.toBeNull();
+    });
+  });
+});

--- a/packages/playground/src/domains/traces/components/__tests__/trace-annotations.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/trace-annotations.msw.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import type { ListFeedbackResponse } from '@mastra/core/storage';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TraceAnnotationComposer, TraceAnnotationList } from '../trace-annotations';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+const withProviders = (children: React.ReactNode) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>,
+  );
+};
+
+beforeEach(() => window.localStorage.clear());
+afterEach(() => cleanup());
+
+describe('TraceAnnotationComposer', () => {
+  describe('when the reviewer saves a note on a highlighted quote', () => {
+    it('posts an attributed annotation with the quote', async () => {
+      const onFeedback = vi.fn<(body: unknown) => void>();
+      const onDone = vi.fn();
+      server.use(
+        http.post(`${BASE_URL}/api/observability/feedback`, async ({ request }) => {
+          onFeedback(await request.json());
+          return HttpResponse.json({ success: true });
+        }),
+      );
+
+      withProviders(
+        <TraceAnnotationComposer
+          traceId="trace-a"
+          spanId="span-a"
+          selection={{ target: 'response', quote: 'Acute aortic dissection' }}
+          onDone={onDone}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText('Annotation'), {
+        target: { value: 'Should mention blood pressure control first.' },
+      });
+      fireEvent.change(screen.getByLabelText('Your name'), { target: { value: 'Dr. Reyes' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save annotation' }));
+
+      await waitFor(() => expect(onFeedback).toHaveBeenCalledTimes(1));
+      expect(onFeedback).toHaveBeenCalledWith({
+        feedback: {
+          traceId: 'trace-a',
+          spanId: 'span-a',
+          feedbackSource: 'studio',
+          feedbackType: 'annotation',
+          value: 'Acute aortic dissection',
+          comment: 'Should mention blood pressure control first.',
+          feedbackUserId: 'Dr. Reyes',
+          metadata: { reviewTarget: 'response', quote: 'Acute aortic dissection' },
+        },
+      });
+      expect(onDone).toHaveBeenCalled();
+      expect(window.localStorage.getItem('mastra:studio:reviewer-name')).toBe('Dr. Reyes');
+    });
+  });
+
+  describe('when the note is empty', () => {
+    it('keeps the save button disabled', () => {
+      withProviders(
+        <TraceAnnotationComposer traceId="trace-a" selection={{ target: 'case', quote: 'fever' }} onDone={vi.fn()} />,
+      );
+
+      expect(screen.getByRole('button', { name: 'Save annotation' }).hasAttribute('disabled')).toBe(true);
+    });
+  });
+});
+
+describe('TraceAnnotationList', () => {
+  const feedbackData: ListFeedbackResponse = {
+    feedback: [
+      {
+        feedbackId: 'fb-1',
+        timestamp: new Date('2026-08-21T16:00:00.000Z'),
+        traceId: 'trace-a',
+        feedbackType: 'annotation',
+        value: 'Acute aortic dissection',
+        comment: 'Confidence is overstated.',
+        feedbackUserId: 'Dr. Reyes',
+        metadata: { reviewTarget: 'response', quote: 'Acute aortic dissection' },
+      },
+      {
+        feedbackId: 'fb-2',
+        timestamp: new Date('2026-08-21T16:05:00.000Z'),
+        traceId: 'trace-a',
+        feedbackType: 'review',
+        value: 1,
+      },
+    ],
+    pagination: { total: 2, page: 0, perPage: 10, hasMore: false },
+  };
+
+  describe('when annotations exist for the section', () => {
+    it('shows the quote, note, and author', () => {
+      withProviders(<TraceAnnotationList feedbackData={feedbackData} target="response" />);
+
+      expect(screen.getByText('“Acute aortic dissection”')).not.toBeNull();
+      expect(screen.getByText('Confidence is overstated.')).not.toBeNull();
+      expect(screen.getByText('Dr. Reyes')).not.toBeNull();
+    });
+  });
+
+  describe('when no annotations match the section', () => {
+    it('renders nothing', () => {
+      const { container } = withProviders(<TraceAnnotationList feedbackData={feedbackData} target="case" />);
+
+      expect(container.textContent).toBe('');
+    });
+  });
+});

--- a/packages/playground/src/domains/traces/components/__tests__/trace-review-feedback.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/trace-review-feedback.msw.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TraceReviewFeedback } from '../trace-review-feedback';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+const renderForm = (props?: Partial<Parameters<typeof TraceReviewFeedback>[0]>) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <TraceReviewFeedback traceId="trace-a" spanId="span-a" {...props} />
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+};
+
+afterEach(() => cleanup());
+
+describe('TraceReviewFeedback', () => {
+  describe('when the reviewer submits an assessment with a note', () => {
+    it('posts the review as trace feedback', async () => {
+      const onFeedback = vi.fn<(body: unknown) => void>();
+      server.use(
+        http.post(`${BASE_URL}/api/observability/feedback`, async ({ request }) => {
+          onFeedback(await request.json());
+          return HttpResponse.json({ success: true });
+        }),
+      );
+
+      renderForm({ target: 'response' });
+
+      fireEvent.click(screen.getByRole('radio', { name: 'Needs correction' }));
+      fireEvent.change(screen.getByLabelText(/note/i), { target: { value: 'Missing red flags.' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save review' }));
+
+      await waitFor(() => expect(onFeedback).toHaveBeenCalledTimes(1));
+      expect(onFeedback).toHaveBeenCalledWith({
+        feedback: {
+          traceId: 'trace-a',
+          spanId: 'span-a',
+          feedbackSource: 'studio',
+          feedbackType: 'review',
+          value: 0,
+          comment: 'Missing red flags.',
+          metadata: { reviewTarget: 'response' },
+        },
+      });
+    });
+  });
+
+  describe('when no assessment is selected', () => {
+    it('keeps the save button disabled', () => {
+      renderForm();
+
+      const saveButton = screen.getByRole('button', { name: 'Save review' });
+      expect(saveButton.hasAttribute('disabled')).toBe(true);
+    });
+  });
+});

--- a/packages/playground/src/domains/traces/components/annotated-markdown.tsx
+++ b/packages/playground/src/domains/traces/components/annotated-markdown.tsx
@@ -1,0 +1,118 @@
+import type { FeedbackRecord } from '@mastra/core/storage';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
+import { format } from 'date-fns';
+import { HighlighterIcon } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+const MARK_ATTRIBUTE = 'data-annotation-key';
+
+function annotationKey(annotation: FeedbackRecord, index: number): string {
+  return annotation.feedbackId ?? `annotation-${index}`;
+}
+
+function getQuote(annotation: FeedbackRecord): string | undefined {
+  const quote = annotation.metadata?.quote;
+  return typeof quote === 'string' && quote.trim() ? quote : undefined;
+}
+
+function clearMarks(container: HTMLElement) {
+  for (const mark of [...container.querySelectorAll(`mark[${MARK_ATTRIBUTE}]`)]) {
+    const parent = mark.parentNode;
+    while (mark.firstChild) parent?.insertBefore(mark.firstChild, mark);
+    mark.remove();
+    parent?.normalize();
+  }
+}
+
+function findQuoteRange(container: HTMLElement, quote: string): Range | undefined {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let node: Node | null = walker.nextNode();
+  while (node) {
+    const text = node.textContent ?? '';
+    const start = text.indexOf(quote);
+    if (start >= 0) {
+      const range = document.createRange();
+      range.setStart(node, start);
+      range.setEnd(node, start + quote.length);
+      return range;
+    }
+    node = walker.nextNode();
+  }
+  return undefined;
+}
+
+function applyMarks(container: HTMLElement, annotations: FeedbackRecord[]) {
+  clearMarks(container);
+  annotations.forEach((annotation, index) => {
+    const quote = getQuote(annotation);
+    if (!quote) return;
+    const range = findQuoteRange(container, quote);
+    if (!range) return;
+
+    const mark = document.createElement('mark');
+    mark.setAttribute(MARK_ATTRIBUTE, annotationKey(annotation, index));
+    mark.style.backgroundColor = 'color-mix(in oklch, var(--accent1) 25%, transparent)';
+    mark.style.color = 'inherit';
+    mark.style.cursor = 'pointer';
+    mark.style.borderRadius = '2px';
+    try {
+      range.surroundContents(mark);
+    } catch {
+      // The quote crosses element boundaries; it stays reachable in the annotation list.
+    }
+  });
+}
+
+export interface AnnotatedMarkdownProps {
+  children: string;
+  annotations: FeedbackRecord[];
+  className?: string;
+}
+
+/** Renders markdown with saved annotation quotes highlighted inline; clicking a highlight opens the comment. */
+export function AnnotatedMarkdown({ children, annotations, className }: AnnotatedMarkdownProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [activeKey, setActiveKey] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (containerRef.current) applyMarks(containerRef.current, annotations);
+  });
+
+  const activeAnnotation = annotations.find((annotation, index) => annotationKey(annotation, index) === activeKey);
+
+  const handleClick = (event: React.MouseEvent) => {
+    const mark = (event.target as HTMLElement).closest?.(`mark[${MARK_ATTRIBUTE}]`);
+    setActiveKey(mark?.getAttribute(MARK_ATTRIBUTE) ?? undefined);
+  };
+
+  return (
+    <div className="relative">
+      <div ref={containerRef} onClick={handleClick}>
+        <MarkdownRenderer className={className}>{children}</MarkdownRenderer>
+      </div>
+
+      {activeAnnotation && (
+        <div
+          role="dialog"
+          aria-label="Annotation"
+          className="border-border1 bg-surface4 absolute right-0 bottom-full z-10 mb-2 w-80 rounded-lg border p-3 shadow-lg"
+        >
+          <div className="text-ui-sm text-neutral3 flex items-center gap-2">
+            <HighlighterIcon className="size-3.5" />
+            <span className="text-neutral5 font-medium">{activeAnnotation.feedbackUserId || 'Unattributed'}</span>
+            <span>{format(new Date(activeAnnotation.timestamp), 'MMM d, h:mm aaa')}</span>
+            <button
+              type="button"
+              aria-label="Close annotation"
+              className="text-neutral3 hover:text-neutral6 ml-auto cursor-pointer rounded px-1"
+              onClick={() => setActiveKey(undefined)}
+            >
+              ✕
+            </button>
+          </div>
+          {activeAnnotation.comment && <p className="text-ui-md text-neutral5 mt-2">{activeAnnotation.comment}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/playground/src/domains/traces/components/trace-annotations.tsx
+++ b/packages/playground/src/domains/traces/components/trace-annotations.tsx
@@ -1,0 +1,146 @@
+import type { FeedbackRecord, ListFeedbackResponse } from '@mastra/core/storage';
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Input } from '@mastra/playground-ui/components/Input';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
+import type {
+  TraceReviewSelection,
+  TraceReviewTarget,
+} from '@mastra/playground-ui/domains/traces/components/trace-review-view';
+import { toast } from '@mastra/playground-ui/utils/toast';
+import { useMastraClient } from '@mastra/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { format } from 'date-fns';
+import { HighlighterIcon } from 'lucide-react';
+import { useState } from 'react';
+import { readReviewerName, saveReviewerName } from '../reviewer-name';
+
+function getAnnotationTarget(feedback: FeedbackRecord): TraceReviewTarget | undefined {
+  const target = feedback.metadata?.reviewTarget;
+  return target === 'case' || target === 'response' || target === 'reasoning' ? target : undefined;
+}
+
+export interface TraceAnnotationComposerProps {
+  traceId: string;
+  spanId?: string;
+  selection: TraceReviewSelection;
+  onDone: () => void;
+}
+
+export function TraceAnnotationComposer({ traceId, spanId, selection, onDone }: TraceAnnotationComposerProps) {
+  const client = useMastraClient();
+  const queryClient = useQueryClient();
+  const [note, setNote] = useState('');
+  const [reviewerName, setReviewerName] = useState(readReviewerName);
+
+  const saveAnnotation = useMutation({
+    mutationFn: () =>
+      client.createFeedback({
+        feedback: {
+          traceId,
+          spanId,
+          feedbackSource: 'studio',
+          feedbackType: 'annotation',
+          value: selection.quote,
+          comment: note.trim(),
+          feedbackUserId: reviewerName.trim() || undefined,
+          metadata: { reviewTarget: selection.target, quote: selection.quote },
+        },
+      }),
+    onSuccess: () => {
+      toast.success('Annotation saved');
+      saveReviewerName(reviewerName.trim());
+      onDone();
+      void queryClient.invalidateQueries({ queryKey: ['trace-feedback'] });
+    },
+    onError: () => toast.error('The annotation could not be saved. Try again.'),
+  });
+
+  const canSubmit = note.trim().length > 0 && !saveAnnotation.isPending;
+
+  return (
+    <form
+      aria-label="Annotate selection"
+      className="border-border1 bg-surface3 mt-3 rounded-lg border p-3"
+      onSubmit={event => {
+        event.preventDefault();
+        if (canSubmit) saveAnnotation.mutate();
+      }}
+    >
+      <blockquote className="border-neutral4 text-ui-sm text-neutral4 border-l-2 pl-3 italic">
+        “{selection.quote}”
+      </blockquote>
+
+      <label className="mt-3 block">
+        <span className="text-ui-sm text-neutral4 mb-1.5 block">Annotation</span>
+        <Textarea
+          autoFocus={!('ontouchstart' in window)}
+          value={note}
+          onChange={event => setNote(event.target.value)}
+          placeholder="What's wrong or noteworthy about this part?"
+          spellCheck
+          rows={2}
+        />
+      </label>
+
+      <label className="mt-2 block">
+        <span className="text-ui-sm text-neutral4 mb-1.5 block">Your name</span>
+        <Input
+          value={reviewerName}
+          onChange={event => setReviewerName(event.target.value)}
+          placeholder="So your team knows who wrote this"
+          autoComplete="name"
+        />
+      </label>
+
+      <div className="mt-3 flex items-center gap-2">
+        <Button type="submit" variant="primary" size="sm" disabled={!canSubmit}>
+          {saveAnnotation.isPending ? 'Saving…' : 'Save annotation'}
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onDone}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export interface TraceAnnotationListProps {
+  feedbackData?: ListFeedbackResponse | null;
+  /** Restrict to one review section. When omitted, every annotation on the trace is shown. */
+  target?: TraceReviewTarget;
+}
+
+export function TraceAnnotationList({ feedbackData, target }: TraceAnnotationListProps) {
+  const annotations = (feedbackData?.feedback ?? []).filter(
+    feedback =>
+      feedback.feedbackType === 'annotation' && (target === undefined || getAnnotationTarget(feedback) === target),
+  );
+
+  if (annotations.length === 0) return null;
+
+  return (
+    <ul className="mt-3 grid gap-2" aria-label={target ? `Annotations on ${target}` : 'Annotations'}>
+      {annotations.map((annotation, index) => {
+        const quote = typeof annotation.metadata?.quote === 'string' ? annotation.metadata.quote : undefined;
+        return (
+          <li
+            key={annotation.feedbackId ?? `${annotation.traceId}-${index}`}
+            className="border-border1 bg-surface3 rounded-lg border p-3"
+          >
+            <div className="text-ui-sm text-neutral3 flex items-center gap-2">
+              <HighlighterIcon className="size-3.5" />
+              <span className="text-neutral5 font-medium">{annotation.feedbackUserId || 'Unattributed'}</span>
+              <span>{format(new Date(annotation.timestamp), 'MMM d, h:mm aaa')}</span>
+            </div>
+            {quote && (
+              <blockquote className="border-neutral4 text-ui-sm text-neutral4 mt-2 border-l-2 pl-3 italic">
+                “{quote}”
+              </blockquote>
+            )}
+            {annotation.comment && <p className="text-ui-md text-neutral5 mt-2">{annotation.comment}</p>}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/playground/src/domains/traces/components/trace-review-feedback.tsx
+++ b/packages/playground/src/domains/traces/components/trace-review-feedback.tsx
@@ -1,0 +1,135 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Textarea } from '@mastra/playground-ui/components/Textarea';
+import type { TraceReviewTarget } from '@mastra/playground-ui/domains/traces/components/trace-review-view';
+import { toast } from '@mastra/playground-ui/utils/toast';
+import { useMastraClient } from '@mastra/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AlertTriangleIcon, CheckCircle2Icon, PencilLineIcon } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { readReviewerName } from '../reviewer-name';
+import { cn } from '@/lib/utils';
+
+const assessments = [
+  { value: 1, label: 'Accurate', Icon: CheckCircle2Icon },
+  { value: 0, label: 'Needs correction', Icon: PencilLineIcon },
+  { value: -1, label: 'Potentially unsafe', Icon: AlertTriangleIcon },
+] as const;
+
+type AssessmentValue = (typeof assessments)[number]['value'];
+
+const targetLabels: Record<TraceReviewTarget, string> = {
+  case: 'the case',
+  response: 'the agent response',
+  reasoning: 'how the response was produced',
+};
+
+export interface TraceReviewFeedbackProps {
+  traceId: string;
+  spanId?: string;
+  target?: TraceReviewTarget;
+  onClearTarget?: () => void;
+}
+
+export function TraceReviewFeedback({ traceId, spanId, target, onClearTarget }: TraceReviewFeedbackProps) {
+  const client = useMastraClient();
+  const queryClient = useQueryClient();
+  const [assessment, setAssessment] = useState<AssessmentValue | undefined>();
+  const [comment, setComment] = useState('');
+  const commentRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (target) commentRef.current?.focus();
+  }, [target]);
+
+  const submitReview = useMutation({
+    mutationFn: () =>
+      client.createFeedback({
+        feedback: {
+          traceId,
+          spanId,
+          feedbackSource: 'studio',
+          feedbackType: 'review',
+          value: assessment ?? 0,
+          comment: comment.trim() || undefined,
+          feedbackUserId: readReviewerName().trim() || undefined,
+          metadata: target ? { reviewTarget: target } : undefined,
+        },
+      }),
+    onSuccess: () => {
+      toast.success('Review saved');
+      setAssessment(undefined);
+      setComment('');
+      onClearTarget?.();
+      void queryClient.invalidateQueries({ queryKey: ['trace-feedback'] });
+    },
+    onError: () => toast.error('The review could not be saved. Try again.'),
+  });
+
+  const canSubmit = assessment !== undefined && !submitReview.isPending;
+
+  return (
+    <form
+      aria-label="Clinical review"
+      className="border-border1 bg-surface2 rounded-xl border p-4"
+      onSubmit={event => {
+        event.preventDefault();
+        if (canSubmit) submitReview.mutate();
+      }}
+    >
+      <h3 className="text-ui-lg text-neutral6 font-medium">Your review</h3>
+      <p className="text-ui-sm text-neutral3 mt-1">
+        {target ? `Note about ${targetLabels[target]}.` : 'Rate the response and add an optional note.'}
+      </p>
+
+      <div role="radiogroup" aria-label="Overall assessment" className="mt-3 flex flex-wrap gap-2">
+        {assessments.map(({ value, label, Icon }) => {
+          const selected = assessment === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              onClick={() => setAssessment(selected ? undefined : value)}
+              className={cn(
+                'flex items-center gap-2 rounded-full border px-3 py-1.5 text-ui-md transition-colors',
+                'focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
+                selected
+                  ? value === -1
+                    ? 'border-accent2 bg-accent2/10 text-accent2'
+                    : 'border-neutral6 bg-neutral6 text-surface1'
+                  : 'border-border1 bg-transparent text-neutral4 hover:bg-surface4 hover:text-neutral6',
+              )}
+            >
+              <Icon className="size-4" />
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      <label className="mt-3 block">
+        <span className="text-ui-sm text-neutral4 mb-1.5 block">Note (optional)</span>
+        <Textarea
+          ref={commentRef}
+          value={comment}
+          onChange={event => setComment(event.target.value)}
+          placeholder="What should change about this response?"
+          spellCheck
+          rows={3}
+        />
+      </label>
+
+      <div className="mt-3 flex items-center gap-3">
+        <Button type="submit" variant="primary" size="md" disabled={!canSubmit}>
+          {submitReview.isPending ? 'Saving…' : 'Save review'}
+        </Button>
+        {target && onClearTarget && (
+          <Button type="button" variant="ghost" size="md" onClick={onClearTarget}>
+            Clear section
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/packages/playground/src/domains/traces/reviewer-name.ts
+++ b/packages/playground/src/domains/traces/reviewer-name.ts
@@ -1,0 +1,15 @@
+const REVIEWER_NAME_STORAGE_KEY = 'mastra:studio:reviewer-name';
+
+export function readReviewerName(): string {
+  try {
+    return window.localStorage.getItem(REVIEWER_NAME_STORAGE_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export function saveReviewerName(name: string) {
+  try {
+    window.localStorage.setItem(REVIEWER_NAME_STORAGE_KEY, name);
+  } catch {}
+}

--- a/packages/playground/src/lib/feature-flags.ts
+++ b/packages/playground/src/lib/feature-flags.ts
@@ -1,0 +1,22 @@
+const TRACE_REVIEW_STORAGE_KEY = 'mastra:flags:trace-review';
+
+/**
+ * Gates the conversation-review suite: Review mode on traces, the review form,
+ * annotations, and the Threads surface.
+ *
+ * Resolution order: `?traceReview=on|off` URL override (persisted), then the
+ * persisted localStorage value, then the `VITE_TRACE_REVIEW` build-time env.
+ */
+export function isTraceReviewEnabled(): boolean {
+  try {
+    const urlValue = new URLSearchParams(window.location.search).get('traceReview');
+    if (urlValue === 'on' || urlValue === 'off') {
+      window.localStorage.setItem(TRACE_REVIEW_STORAGE_KEY, urlValue);
+    }
+    const stored = window.localStorage.getItem(TRACE_REVIEW_STORAGE_KEY);
+    if (stored === 'on') return true;
+    if (stored === 'off') return false;
+  } catch {}
+
+  return import.meta.env.VITE_TRACE_REVIEW === 'true';
+}

--- a/packages/playground/src/lib/nav/nav-items.tsx
+++ b/packages/playground/src/lib/nav/nav-items.tsx
@@ -14,8 +14,9 @@ import { ToolsIcon } from '@mastra/playground-ui/icons/ToolsIcon';
 import { TraceIcon } from '@mastra/playground-ui/icons/TraceIcon';
 import { WorkflowIcon } from '@mastra/playground-ui/icons/WorkflowIcon';
 import { WorkspacesIcon } from '@mastra/playground-ui/icons/WorkspacesIcon';
-import { BookIcon, LayoutGrid } from 'lucide-react';
+import { BookIcon, LayoutGrid, MessagesSquareIcon } from 'lucide-react';
 import type { ComponentType, SVGProps } from 'react';
+import { isTraceReviewEnabled } from '@/lib/feature-flags';
 
 export type NavIcon = ComponentType<SVGProps<SVGSVGElement>>;
 
@@ -170,6 +171,20 @@ export const mainNav: NavSection[] = [
         docs: { href: 'https://mastra.ai/en/docs/observability/overview', label: 'Metrics documentation' },
         isOnMastraPlatform: true,
       },
+      ...(isTraceReviewEnabled()
+        ? [
+            {
+              name: 'Threads',
+              url: '/threads',
+              Icon: MessagesSquareIcon as NavIcon,
+              docs: {
+                href: 'https://mastra.ai/en/docs/observability/tracing/overview',
+                label: 'Traces documentation',
+              },
+              isOnMastraPlatform: true,
+            },
+          ]
+        : []),
       {
         name: 'Traces',
         url: '/traces',

--- a/packages/playground/src/pages/threads/index.tsx
+++ b/packages/playground/src/pages/threads/index.tsx
@@ -1,0 +1,114 @@
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
+import { getReadableTraceInput } from '@mastra/playground-ui/domains/traces/utils/trace-review-utils';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import { format } from 'date-fns';
+import { AlertCircleIcon, CheckCircle2Icon, CircleDashedIcon, MessagesSquareIcon } from 'lucide-react';
+import { useNavigate } from 'react-router';
+import type { ConversationThread } from '@/domains/threads-view/hooks/use-conversation-threads';
+import { useConversationThreads } from '@/domains/threads-view/hooks/use-conversation-threads';
+import { useReviewedTraceIds } from '@/domains/threads-view/hooks/use-thread-review-status';
+
+function ThreadCard({
+  thread,
+  reviewedTraceIds,
+  onOpen,
+}: {
+  thread: ConversationThread;
+  reviewedTraceIds?: Set<string>;
+  onOpen: () => void;
+}) {
+  const firstTurn = thread.turns[0];
+  const readable = firstTurn ? getReadableTraceInput(firstTurn.input) : '';
+  const previewSource = readable || firstTurn?.name || thread.threadKey;
+  const preview = previewSource.length > 120 ? `${previewSource.slice(0, 120)}…` : previewSource;
+  const reviewedTurns = thread.turns.filter(turn => reviewedTraceIds?.has(turn.traceId)).length;
+  const fullyReviewed = reviewedTurns === thread.turns.length && thread.turns.length > 0;
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className={cn(
+        'w-full rounded-xl border border-border1 bg-surface2 px-4 py-3 text-left transition-colors hover:bg-surface3',
+        'focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-ui-md text-neutral6 line-clamp-2">{preview}</p>
+        <span
+          className={cn(
+            'flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-ui-sm',
+            fullyReviewed ? 'bg-surface5 text-neutral5' : 'bg-surface4 text-neutral3',
+          )}
+        >
+          {fullyReviewed ? <CheckCircle2Icon className="size-3.5" /> : <CircleDashedIcon className="size-3.5" />}
+          {fullyReviewed ? 'Reviewed' : `${reviewedTurns}/${thread.turns.length} reviewed`}
+        </span>
+      </div>
+      <div className="text-ui-sm text-neutral3 mt-2 flex flex-wrap items-center gap-2">
+        <span>
+          {thread.turns.length} {thread.turns.length === 1 ? 'turn' : 'turns'}
+        </span>
+        {thread.actors.map(actor => (
+          <span key={actor} className="bg-surface5 text-neutral4 rounded-full px-2 py-0.5">
+            {actor}
+          </span>
+        ))}
+        {thread.hasErrors && (
+          <span className="text-accent2 flex items-center gap-1">
+            <AlertCircleIcon className="size-3.5" /> Error
+          </span>
+        )}
+        <span className="ml-auto tabular-nums">{format(new Date(thread.lastActivityAt), 'MMM d, h:mm aaa')}</span>
+      </div>
+    </button>
+  );
+}
+
+export default function ThreadsPage() {
+  const { data: threads, isLoading, error } = useConversationThreads();
+  const { data: reviewedTraceIds } = useReviewedTraceIds();
+  const navigate = useNavigate();
+
+  if (isLoading) {
+    return (
+      <PageLayout width="default" height="full">
+        <PageLayout.MainArea isCentered>
+          <p className="text-ui-md text-neutral3">Loading conversations…</p>
+        </PageLayout.MainArea>
+      </PageLayout>
+    );
+  }
+
+  if (error || !threads || threads.length === 0) {
+    return (
+      <PageLayout width="default" height="full">
+        <PageLayout.MainArea isCentered>
+          <div className="grid justify-items-center gap-2 text-center">
+            <MessagesSquareIcon className="text-neutral3 size-8" />
+            <p className="text-ui-lg text-neutral5">No conversations yet</p>
+            <p className="text-ui-md text-neutral3 max-w-[45ch]">
+              Threads group an agent's turns into one reviewable conversation. Run an agent to see its conversations
+              here.
+            </p>
+          </div>
+        </PageLayout.MainArea>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout width="default" height="full">
+      <div className="mx-auto grid w-full max-w-3xl content-start gap-2 overflow-y-auto">
+        {threads.map(thread => (
+          <ThreadCard
+            key={thread.threadKey}
+            thread={thread}
+            reviewedTraceIds={reviewedTraceIds}
+            onOpen={() => void navigate(`/threads/${encodeURIComponent(thread.threadKey)}`)}
+          />
+        ))}
+      </div>
+    </PageLayout>
+  );
+}

--- a/packages/playground/src/pages/threads/thread/index.tsx
+++ b/packages/playground/src/pages/threads/thread/index.tsx
@@ -1,0 +1,132 @@
+import type { FeedbackRecord } from '@mastra/core/storage';
+import { Button } from '@mastra/playground-ui/components/Button';
+import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
+import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
+import { toast } from '@mastra/playground-ui/utils/toast';
+import { useMastraClient } from '@mastra/react';
+import { AlertCircleIcon, ArrowLeftIcon, DownloadIcon, Link2Icon } from 'lucide-react';
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { ThreadTraceInspector } from '@/domains/threads-view/components/thread-trace-inspector';
+import { ThreadTurnCard } from '@/domains/threads-view/components/thread-turn-card';
+import { useConversationThreads } from '@/domains/threads-view/hooks/use-conversation-threads';
+import { useReviewedTraceIds } from '@/domains/threads-view/hooks/use-thread-review-status';
+import { buildConversationExport, downloadConversationJson } from '@/domains/threads-view/utils/export-conversation';
+
+export default function ThreadPage() {
+  const { threadKey } = useParams() as { threadKey: string };
+  const navigate = useNavigate();
+  const { data: threads, isLoading } = useConversationThreads();
+  const { data: reviewedTraceIds } = useReviewedTraceIds();
+  const thread = threads?.find(candidate => candidate.threadKey === threadKey);
+  const [inspectedTraceId, setInspectedTraceId] = useState<string | undefined>();
+  const [isExporting, setIsExporting] = useState(false);
+  const client = useMastraClient();
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      toast.success('Link copied');
+    } catch {
+      toast.error('The link could not be copied.');
+    }
+  };
+
+  const handleDownload = async () => {
+    if (!thread) return;
+    setIsExporting(true);
+    try {
+      const feedbackByTraceId = new Map<string, FeedbackRecord[]>();
+      for (const turn of thread.turns) {
+        const response = await client.listFeedback({
+          filters: { traceId: turn.traceId },
+          pagination: { page: 0, perPage: 100 },
+        });
+        feedbackByTraceId.set(turn.traceId, response.feedback);
+      }
+      downloadConversationJson(thread.threadKey, buildConversationExport(thread, feedbackByTraceId));
+    } catch {
+      toast.error('The conversation could not be exported.');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const reviewedTurns = thread?.turns.filter(turn => reviewedTraceIds?.has(turn.traceId)).length ?? 0;
+
+  return (
+    <PageLayout width="default" height="full">
+      <PageLayout.TopArea>
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            size="icon-md"
+            variant="ghost"
+            tooltip="All conversations"
+            aria-label="All conversations"
+            onClick={() => void navigate('/threads')}
+          >
+            <ArrowLeftIcon />
+          </Button>
+          <div className="min-w-0">
+            <h1 className="text-ui-lg text-neutral6 truncate font-medium">Conversation review</h1>
+            {thread && (
+              <p className="text-ui-sm text-neutral3">
+                {thread.turns.length} {thread.turns.length === 1 ? 'turn' : 'turns'}
+                {thread.actors.length > 0 && <> · {thread.actors.join(', ')}</>}
+                {' · '}
+                {reviewedTurns}/{thread.turns.length} reviewed
+              </p>
+            )}
+          </div>
+          {thread?.hasErrors && (
+            <span className="text-ui-sm text-accent2 flex items-center gap-1">
+              <AlertCircleIcon className="size-4" /> Contains a failed turn
+            </span>
+          )}
+          {thread && (
+            <ButtonsGroup className="ml-auto">
+              <Button type="button" size="md" tooltip="Copy conversation link" onClick={() => void handleCopyLink()}>
+                <Link2Icon />
+              </Button>
+              <Button
+                type="button"
+                size="md"
+                tooltip="Download conversation JSON"
+                disabled={isExporting}
+                onClick={() => void handleDownload()}
+              >
+                <DownloadIcon />
+              </Button>
+            </ButtonsGroup>
+          )}
+        </div>
+      </PageLayout.TopArea>
+
+      <div className="mx-auto grid w-full max-w-4xl content-start gap-4 overflow-y-auto pt-4">
+        {isLoading ? (
+          <p className="text-ui-md text-neutral3 py-16 text-center">Loading conversation…</p>
+        ) : !thread ? (
+          <div className="grid justify-items-center gap-3 py-16 text-center">
+            <p className="text-ui-lg text-neutral5">This conversation is no longer available.</p>
+            <Button type="button" variant="outline" onClick={() => void navigate('/threads')}>
+              Back to all conversations
+            </Button>
+          </div>
+        ) : (
+          thread.turns.map((turn, index) => (
+            <ThreadTurnCard key={turn.traceId} turn={turn} index={index} onInspectTrace={setInspectedTraceId} />
+          ))
+        )}
+      </div>
+
+      {inspectedTraceId && (
+        <ThreadTraceInspector
+          key={inspectedTraceId}
+          traceId={inspectedTraceId}
+          onClose={() => setInspectedTraceId(undefined)}
+        />
+      )}
+    </PageLayout>
+  );
+}

--- a/packages/playground/src/pages/traces/__tests__/fixtures/traces.ts
+++ b/packages/playground/src/pages/traces/__tests__/fixtures/traces.ts
@@ -6,6 +6,7 @@ type ListTracesResponse = Awaited<ReturnType<MastraClient['listTraces']>>;
 type ListBranchesResponse = Awaited<ReturnType<MastraClient['listBranches']>>;
 type MetricBreakdownResponse = Awaited<ReturnType<MastraClient['getMetricBreakdown']>>;
 type GetTraceLightResponse = Awaited<ReturnType<MastraClient['getTraceLight']>>;
+type GetSpanResponse = Awaited<ReturnType<MastraClient['getSpan']>>;
 type GetBranchResponse = Awaited<ReturnType<MastraClient['getBranch']>>;
 type ListFeedbackResponse = Awaited<ReturnType<MastraClient['listFeedback']>>;
 
@@ -75,6 +76,15 @@ export const traceUsageBreakdown: MetricBreakdownResponse = {
 export const traceLightSpans: GetTraceLightResponse = {
   traceId: 'trace-a',
   spans: [{ ...trace, parentSpanId: null }],
+};
+
+export const traceRootSpan: GetSpanResponse = {
+  span: {
+    ...trace,
+    parentSpanId: null,
+    input: [{ role: 'user', content: 'A patient reports sudden chest pain.' }],
+    output: { text: 'The presentation requires urgent evaluation.' },
+  },
 };
 
 export const rootBranchSpans: GetBranchResponse = {

--- a/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
+++ b/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
@@ -20,6 +20,7 @@ import {
   traceLightSpans,
   traceList,
   traceListWithTwoTraces,
+  traceRootSpan,
   traceUsageBreakdown,
 } from './fixtures/traces';
 import { TestLinkProvider } from '@/test/link-provider';
@@ -55,6 +56,9 @@ const setTracePageHandlers = (systemPackages: GetSystemPackagesResponse) => {
     http.get(`${TEST_BASE_URL}/api/observability/discovery/entity-names`, () => HttpResponse.json(emptyEntityNames)),
     http.get(`${TEST_BASE_URL}/api/observability/discovery/service-names`, () => HttpResponse.json(emptyServiceNames)),
     http.get(`${TEST_BASE_URL}/api/observability/discovery/environments`, () => HttpResponse.json(emptyEnvironments)),
+    http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId/spans/:spanId`, () =>
+      HttpResponse.json(traceRootSpan),
+    ),
     http.post(`${TEST_BASE_URL}/api/observability/metrics/breakdown`, () => {
       onBreakdownRequest();
       return HttpResponse.json(traceUsageBreakdown);
@@ -79,7 +83,63 @@ beforeEach(() => {
     TRACE_COLUMN_STORAGE_KEY,
     serializeTraceColumnPreferences({ visibleColumns: ['inputTokens'], metadataKeys: [] }),
   );
+  // Usage assertions below inspect the technical panel, which only renders in advanced mode.
+  window.localStorage.setItem('mastra:traces:view-mode', 'advanced');
   onBreakdownRequest.mockClear();
+});
+
+describe('Traces page review mode', () => {
+  describe('when a trace is opened without a saved preference', () => {
+    it('shows the readable case and response', async () => {
+      window.localStorage.setItem('mastra:flags:trace-review', 'on');
+      window.localStorage.removeItem('mastra:traces:view-mode');
+      setTracePageHandlers(metricsCapableSystemPackages);
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a/light`, () => HttpResponse.json(traceLightSpans)),
+        http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
+      );
+
+      renderPage('/traces?traceId=trace-a');
+
+      expect(await screen.findByText('A patient reports sudden chest pain.')).not.toBeNull();
+      expect(screen.getByText('The presentation requires urgent evaluation.')).not.toBeNull();
+      expect(screen.queryByText('Studio preview agent')).toBeNull();
+    });
+  });
+
+  describe('when advanced mode was saved', () => {
+    it('shows the technical timeline', async () => {
+      window.localStorage.setItem('mastra:flags:trace-review', 'on');
+      window.localStorage.setItem('mastra:traces:view-mode', 'advanced');
+      setTracePageHandlers(metricsCapableSystemPackages);
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a/light`, () => HttpResponse.json(traceLightSpans)),
+        http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
+      );
+
+      renderPage('/traces?traceId=trace-a');
+
+      expect(await screen.findByText('Studio preview agent')).not.toBeNull();
+      expect(screen.queryByText('A patient reports sudden chest pain.')).toBeNull();
+    });
+  });
+});
+
+describe('Traces page review flag', () => {
+  describe('when the trace-review flag is off', () => {
+    it('opens the technical timeline without review tabs', async () => {
+      setTracePageHandlers(metricsCapableSystemPackages);
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a/light`, () => HttpResponse.json(traceLightSpans)),
+        http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
+      );
+
+      renderPage('/traces?traceId=trace-a');
+
+      expect(await screen.findByText('Studio preview agent')).not.toBeNull();
+      expect(screen.queryByRole('tab', { name: 'Review' })).toBeNull();
+    });
+  });
 });
 
 describe('Traces page usage columns', () => {

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -10,6 +10,11 @@ import { NoTracesInfo } from '@mastra/playground-ui/domains/traces/components/no
 import { SpanDataPanelView } from '@mastra/playground-ui/domains/traces/components/span-data-panel-view';
 import { TraceColumnsMenu } from '@mastra/playground-ui/domains/traces/components/trace-columns-menu';
 import { TraceDataPanelView } from '@mastra/playground-ui/domains/traces/components/trace-data-panel-view';
+import { TraceReviewView } from '@mastra/playground-ui/domains/traces/components/trace-review-view';
+import type {
+  TraceReviewSelection,
+  TraceReviewTarget,
+} from '@mastra/playground-ui/domains/traces/components/trace-review-view';
 import { TracesErrorContent } from '@mastra/playground-ui/domains/traces/components/traces-error-content';
 import { TracesLayout } from '@mastra/playground-ui/domains/traces/components/traces-layout';
 import { TracesListView } from '@mastra/playground-ui/domains/traces/components/traces-list-view';
@@ -26,6 +31,7 @@ import { useTraceOrBranchSpans } from '@mastra/playground-ui/domains/traces/hook
 import { useTraceSpanNavigation } from '@mastra/playground-ui/domains/traces/hooks/use-trace-span-navigation';
 import { useTraceUrlState } from '@mastra/playground-ui/domains/traces/hooks/use-trace-url-state';
 import { useTraceUsage } from '@mastra/playground-ui/domains/traces/hooks/use-trace-usage';
+import { useTraceViewMode } from '@mastra/playground-ui/domains/traces/hooks/use-trace-view-mode';
 import { useTraces } from '@mastra/playground-ui/domains/traces/hooks/use-traces';
 import {
   buildTraceListFilters,
@@ -47,7 +53,10 @@ import { ScoreDataPanel } from '@/domains/traces/components/score-data-panel';
 import { SpanFeedbackList } from '@/domains/traces/components/span-feedback-list';
 import { SpanScoresList } from '@/domains/traces/components/span-scores-list';
 import { SpanScoring } from '@/domains/traces/components/span-scoring';
+import { TraceAnnotationComposer, TraceAnnotationList } from '@/domains/traces/components/trace-annotations';
+import { TraceReviewFeedback } from '@/domains/traces/components/trace-review-feedback';
 import { useTraceFeedback } from '@/domains/traces/hooks/use-trace-feedback';
+import { isTraceReviewEnabled } from '@/lib/feature-flags';
 import { Link } from '@/lib/link';
 
 type TracesPageProps = {
@@ -59,6 +68,15 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
   const isScoped = !!scopedEntityId;
   const [searchParams, setSearchParams] = useSearchParams();
   const url = useTraceUrlState(searchParams, setSearchParams);
+  const traceReviewEnabled = isTraceReviewEnabled();
+  const { viewMode: storedViewMode, setViewMode } = useTraceViewMode();
+  const viewMode = traceReviewEnabled ? storedViewMode : 'advanced';
+  const [reviewTarget, setReviewTarget] = useState<TraceReviewTarget | undefined>();
+  const [pendingAnnotation, setPendingAnnotation] = useState<TraceReviewSelection | undefined>();
+  useEffect(() => {
+    setReviewTarget(undefined);
+    setPendingAnnotation(undefined);
+  }, [url.traceIdParam]);
 
   useEffect(() => {
     if (!scopedEntityId) return;
@@ -132,6 +150,13 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
     anchorSpanId: url.listMode === 'branches' ? (url.anchorSpanIdParam ?? null) : null,
     listMode: url.listMode,
   });
+  const reviewRootSpan = anchorSpanId
+    ? lightSpans?.find(span => span.spanId === anchorSpanId)
+    : lightSpans?.find(span => span.parentSpanId == null);
+  const { data: reviewRootSpanData, isLoading: isLoadingReviewRootSpan } = useSpanDetail(
+    viewMode === 'review' ? url.traceIdParam : undefined,
+    viewMode === 'review' ? reviewRootSpan?.spanId : undefined,
+  );
   const { data: spanDetailData, isLoading: isLoadingSpanDetail } = useSpanDetail(
     url.traceIdParam ?? '',
     url.spanIdParam ?? '',
@@ -518,6 +543,40 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
               placement="traces-list"
               LinkComponent={Link}
               traceHref={`/traces/${url.traceIdParam}`}
+              viewMode={traceReviewEnabled ? viewMode : undefined}
+              onViewModeChange={traceReviewEnabled ? setViewMode : undefined}
+              reviewSlot={
+                !traceReviewEnabled ? undefined : (
+                  <TraceReviewView
+                    rootSpan={reviewRootSpanData?.span}
+                    spans={lightSpans ?? []}
+                    isLoading={isLoadingReviewRootSpan}
+                    onReviewTargetChange={setReviewTarget}
+                    onAnnotate={setPendingAnnotation}
+                    annotationsSlot={target => (
+                      <>
+                        <TraceAnnotationList feedbackData={feedbackData} target={target} />
+                        {pendingAnnotation?.target === target && url.traceIdParam && (
+                          <TraceAnnotationComposer
+                            traceId={url.traceIdParam}
+                            spanId={reviewRootSpan?.spanId}
+                            selection={pendingAnnotation}
+                            onDone={() => setPendingAnnotation(undefined)}
+                          />
+                        )}
+                      </>
+                    )}
+                    feedbackSlot={
+                      <TraceReviewFeedback
+                        traceId={url.traceIdParam}
+                        spanId={reviewRootSpan?.spanId}
+                        target={reviewTarget}
+                        onClearTarget={() => setReviewTarget(undefined)}
+                      />
+                    }
+                  />
+                )
+              }
             />
           ) : null
         }

--- a/packages/playground/src/pages/traces/trace/index.tsx
+++ b/packages/playground/src/pages/traces/trace/index.tsx
@@ -6,11 +6,17 @@ import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { SpanDataPanelView } from '@mastra/playground-ui/domains/traces/components/span-data-panel-view';
 import { TraceDataPanelView } from '@mastra/playground-ui/domains/traces/components/trace-data-panel-view';
 import { TraceKeysAndValues } from '@mastra/playground-ui/domains/traces/components/trace-keys-and-values';
+import { TraceReviewView } from '@mastra/playground-ui/domains/traces/components/trace-review-view';
+import type {
+  TraceReviewSelection,
+  TraceReviewTarget,
+} from '@mastra/playground-ui/domains/traces/components/trace-review-view';
 import { TracesErrorContent } from '@mastra/playground-ui/domains/traces/components/traces-error-content';
 import { useSpanDetail } from '@mastra/playground-ui/domains/traces/hooks/use-span-detail';
 import { useTraceLightSpans } from '@mastra/playground-ui/domains/traces/hooks/use-trace-light-spans';
 import { useTraceSpanNavigation } from '@mastra/playground-ui/domains/traces/hooks/use-trace-span-navigation';
 import { useTraceUsage } from '@mastra/playground-ui/domains/traces/hooks/use-trace-usage';
+import { useTraceViewMode } from '@mastra/playground-ui/domains/traces/hooks/use-trace-view-mode';
 import type { SpanTab } from '@mastra/playground-ui/domains/traces/types';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { CircleGaugeIcon, SaveIcon } from 'lucide-react';
@@ -24,7 +30,10 @@ import { ScoreDataPanel } from '@/domains/traces/components/score-data-panel';
 import { SpanFeedbackList } from '@/domains/traces/components/span-feedback-list';
 import { SpanScoresList } from '@/domains/traces/components/span-scores-list';
 import { SpanScoring } from '@/domains/traces/components/span-scoring';
+import { TraceAnnotationComposer, TraceAnnotationList } from '@/domains/traces/components/trace-annotations';
+import { TraceReviewFeedback } from '@/domains/traces/components/trace-review-feedback';
 import { useTraceFeedback } from '@/domains/traces/hooks/use-trace-feedback';
+import { isTraceReviewEnabled } from '@/lib/feature-flags';
 import { RouteHeaderActions } from '@/lib/route-header';
 
 export default function TracePage() {
@@ -43,9 +52,18 @@ export default function TracePage() {
   const [spanScoresPage, setSpanScoresPage] = useState(0);
   const [datasetDialogOpen, setDatasetDialogOpen] = useState(false);
 
+  const traceReviewEnabled = isTraceReviewEnabled();
+  const { viewMode: storedViewMode, setViewMode } = useTraceViewMode();
+  const viewMode = traceReviewEnabled ? storedViewMode : 'advanced';
+  const [reviewTarget, setReviewTarget] = useState<TraceReviewTarget | undefined>();
+  const [pendingAnnotation, setPendingAnnotation] = useState<TraceReviewSelection | undefined>();
   const { data: traceLight, isLoading: isTraceLoading, error: traceError } = useTraceLightSpans(traceId);
   const lightSpans = useMemo(() => traceLight?.spans ?? [], [traceLight?.spans]);
   const rootSpan = useMemo(() => lightSpans.find(s => s.parentSpanId == null), [lightSpans]);
+  const { data: reviewRootSpanData, isLoading: isLoadingReviewRootSpan } = useSpanDetail(
+    viewMode === 'review' ? traceId : undefined,
+    viewMode === 'review' ? rootSpan?.spanId : undefined,
+  );
 
   const observabilityCapabilities = useObservabilityStorageCapabilities();
   const traceUsage = useTraceUsage({
@@ -231,6 +249,40 @@ export default function TracePage() {
           initialSpanId={featuredSpanId}
           placement="trace-page"
           timelineChartWidth={featuredSpanId ? 'default' : 'wide'}
+          viewMode={traceReviewEnabled ? viewMode : undefined}
+          onViewModeChange={traceReviewEnabled ? setViewMode : undefined}
+          reviewSlot={
+            !traceReviewEnabled ? undefined : (
+              <TraceReviewView
+                rootSpan={reviewRootSpanData?.span}
+                spans={lightSpans}
+                isLoading={isLoadingReviewRootSpan}
+                onReviewTargetChange={setReviewTarget}
+                onAnnotate={setPendingAnnotation}
+                annotationsSlot={target => (
+                  <>
+                    <TraceAnnotationList feedbackData={feedbackData} target={target} />
+                    {pendingAnnotation?.target === target && (
+                      <TraceAnnotationComposer
+                        traceId={traceId}
+                        spanId={rootSpan?.spanId}
+                        selection={pendingAnnotation}
+                        onDone={() => setPendingAnnotation(undefined)}
+                      />
+                    )}
+                  </>
+                )}
+                feedbackSlot={
+                  <TraceReviewFeedback
+                    traceId={traceId}
+                    spanId={rootSpan?.spanId}
+                    target={reviewTarget}
+                    onClearTarget={() => setReviewTarget(undefined)}
+                  />
+                }
+              />
+            )
+          }
         />
         {featuredSpanId && !isTraceLoading && (
           <div


### PR DESCRIPTION
## Description

Adds an experimental conversation review suite to Studio, off by default behind a feature flag. This came out of hands-on sessions with a design partner whose non-technical domain experts need to review agent output. They couldn't parse the span timeline, didn't know where to leave feedback, and had no way to follow a multi-turn conversation. This PR is the first pass at closing that gap, and it's intentionally a handoff state: the core flows work end to end, and the remaining work is listed below.

### What's in here

**Review mode on traces** (`packages/playground-ui` + `packages/playground`)
- Trace panels get a Review/Advanced pill toggle. Review shows the readable case input, the agent response as markdown, and a plain-language step summary ("Used check urgent red flags", "Generated the response"). Advanced is the existing timeline, untouched. The chosen mode persists in localStorage.
- `trace-review-utils.ts` extracts readable text from agent message shapes ({role, content} arrays, Mastra message objects with `contents`/`type`, `{messages}` wrappers, structured objects). Framework fields land under a collapsed "Raw message data" disclosure instead of rendering inline.

**Review + annotation** (`packages/playground`)
- A review form (Accurate / Needs correction / Potentially unsafe + note) posts through the existing feedback API as `feedbackType: 'review'`.
- Highlight text in a response to leave an inline annotation: `feedbackType: 'annotation'`, quote in metadata, author in `feedbackUserId`. The reviewer name is remembered in localStorage. Saved annotations render as inline highlights; clicking one opens the comment.

**Threads** (`packages/playground`)
- `/threads` groups traces into conversations by `threadId` (falling back to `sessionId`), no instrumentation changes required. Cards show turn count, actors, errors, and review progress.
- `/threads/:threadKey` renders the conversation as chat turns with inline review, annotation, a "Reviewed" hover card showing notes and consensus, a technical trace slide-over per turn, a copy-link button, and a conversation JSON export (readable turns + attributed reviews/annotations + raw payloads).

### Feature flag

Everything is gated by one flag, default off. Studio is unchanged when it's off (a regression test covers this).

- URL: `?traceReview=on` / `?traceReview=off` (persists to localStorage)
- Build-time: `VITE_TRACE_REVIEW=true`

### How to demo

1. Run any agent project with a storage provider that supports feedback (DuckDB or PG v-next; see remaining work for libsql).
2. `pnpm dev:playground`, open the playground with `?traceReview=on`.
3. Threads appears in the Observability nav. Traces open in Review mode.

### Testing

- MSW + typed client-js fixtures throughout; annotation/review payloads asserted against the real wire contract.
- 162 playground-ui tests, all playground trace/thread suites green, typecheck green in both packages.
- Mutation testing run on every new production file; remaining survivors are JSX wiring and equivalent mutants.

### Remaining work for whoever picks this up

1. `@mastra/libsql` doesn't implement `createFeedback`/`listFeedback`, so review saves fail on the default local store. Implementing it (the DuckDB implementation in `stores/duckdb/.../feedback.ts` is a direct template) unblocks the default `mastra dev` experience.
2. Thread grouping is client-side over `listTraces` (first 100). A server-side `GET /observability/threads` aggregation with feedback/scores joined is the scalable version.
3. Span-noise reduction: one agent turn emits ~10 spans including duplicated framework content. Worth fixing at emission in core rather than only collapsing in UI.
4. Configurable review scores/labels per project (instead of the hardcoded three-option scale), and reviewer identity from auth instead of a typed name.
5. Docs under `docs/` once the flag graduates.

## Related issue(s)

Internal design-partner feedback; no public issue.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] Tests added/updated
- [x] Changeset added (`@mastra/playground-ui`, minor)
- [ ] Docs (deferred until the flag graduates)
