### PR TITLE
fix(e2e): unblock CI by signaling the server directly in the SIGTERM drain test

### DIFF
--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -437,25 +437,66 @@ describe.sequential.for([['pnpm'] as const])(`%s monorepo`, ([pkgManager]) => {
     it(
       'drains an in-flight response before the generated server exits on SIGTERM',
       async () => {
-        const response = await fetch(`http://localhost:${port}/shutdown-drain`);
-        const reader = response.body!.getReader();
-        const decoder = new TextDecoder();
-        const firstChunk = await reader.read();
-        expect(decoder.decode(firstChunk.value)).toBe('started\n');
+        // Run the built server directly and signal it directly. Going through
+        // `npm run start` (npm -> sh -> mastra CLI -> node) is not a reliable
+        // signal chain on CI runners: the SIGTERM sent to npm never reached
+        // the server, the stream never ended, and the test hung until its
+        // timeout. CLI signal forwarding is covered by unit tests in
+        // packages/cli/src/commands/start/start.test.ts; the behavior under
+        // test here is the generated server's graceful drain.
+        const drainPort = await getPort();
+        const outputDir = join(fixturePath, 'apps', 'custom', '.mastra', 'output');
+        const drainController = new AbortController();
+        const server = execaNode('index.mjs', {
+          cwd: outputDir,
+          cancelSignal: drainController.signal,
+          env: {
+            OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+            MASTRA_PORT: drainPort.toString(),
+          },
+        });
+        activeProcesses.push({ controller: drainController, proc: server });
 
-        proc!.kill('SIGTERM');
+        try {
+          // Poll the server until it's ready
+          const maxAttempts = 60;
+          for (let i = 0; i < maxAttempts; i++) {
+            try {
+              const res = await fetch(`http://localhost:${drainPort}/api/tools`);
+              if (res.ok) break;
+            } catch {
+              // Server not ready yet
+            }
+            if (i === maxAttempts - 1) {
+              throw new Error('Drain test server failed to start within timeout');
+            }
+            await new Promise(resolve => setTimeout(resolve, 1000));
+          }
 
-        let remaining = '';
-        while (true) {
-          const chunk = await reader.read();
-          if (chunk.done) break;
-          remaining += decoder.decode(chunk.value, { stream: true });
+          const response = await fetch(`http://localhost:${drainPort}/shutdown-drain`);
+          const reader = response.body!.getReader();
+          const decoder = new TextDecoder();
+          const firstChunk = await reader.read();
+          expect(decoder.decode(firstChunk.value)).toBe('started\n');
+
+          server.kill('SIGTERM');
+
+          let remaining = '';
+          while (true) {
+            const chunk = await reader.read();
+            if (chunk.done) break;
+            remaining += decoder.decode(chunk.value, { stream: true });
+          }
+
+          expect(remaining).toBe('finished\n');
+          await expect(server).resolves.toMatchObject({ exitCode: 0 });
+          // Full shutdown includes the drain window plus core teardown; the vitest
+          // default 5s timeout is tighter than the server's own worst-case bounds.
+        } finally {
+          // Never leave the drain server running if an assertion failed.
+          server.kill('SIGKILL');
+          await Promise.race([server.catch(() => {}), new Promise(resolve => setTimeout(resolve, 5_000))]);
         }
-
-        expect(remaining).toBe('finished\n');
-        await expect(proc).resolves.toMatchObject({ exitCode: 0 });
-        // Full shutdown includes the drain window plus core teardown; the vitest
-        // default 5s timeout is tighter than the server's own worst-case bounds.
       },
       timeout,
     );


### PR DESCRIPTION
## Summary

The `E2E Tests / E2E monorepo` check has failed on **every PR** since #21990 merged (it was red on #21990's own head commit too). The failing test is `drains an in-flight response before the generated server exits on SIGTERM`, timing out at exactly 300s.

**Root cause:** the test killed the `npm` process from `execa('npm', ['run', 'start'])` and relied on the `npm → sh → mastra CLI → node server` chain to forward SIGTERM. On the CI runners the signal never reached the server (its shutdown log never appears during the test window — the orphaned server only shuts down later during suite cleanup), so the in-flight stream never finished and `reader.read()` pended until the vitest timeout.

**Fix:** run the built output (`index.mjs`) directly with `execaNode` on a dedicated port and SIGTERM that process directly. The behavior under test is the *generated server's* graceful drain from #21990 — CLI signal forwarding is already covered by unit tests in `packages/cli/src/commands/start/start.test.ts`. A `finally` block SIGKILLs the drain server so a failed assertion can never leak a process or hang the suite.

Test-only change; no changeset needed.

## Test plan
- Ran the full monorepo E2E suite locally: **29/29 passed**, drain test completes in **1.5s** (previously 300s timeout on CI)
- CI on this PR is the real-environment verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The test now starts the server directly so it can stop the correct process. This prevents CI timeouts and confirms that in-flight requests finish during shutdown.

## Changes

- Updated the SIGTERM drain E2E test to launch the built server with `execaNode` on a dedicated port.
- Sends SIGTERM directly to the server process.
- Verifies streamed `started` and `finished` responses during shutdown.
- Confirms that the server exits cleanly.
- Sends SIGKILL in a `finally` block to prevent leaked processes.
- Keeps CLI signal forwarding covered by existing unit tests.
- Test-only change. No changeset required.

## Validation

- All 29 E2E tests passed locally.
- The drain test completed in 1.5 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->