### PR TITLE
feat: add serializable sandbox templates

### DIFF
--- a/.changeset/dry-ghosts-like.md
+++ b/.changeset/dry-ghosts-like.md
@@ -1,0 +1,14 @@
+---
+'@mastra/platform-workspace': minor
+---
+
+Added asynchronous sandbox template builds and reusable template handles for Platform workspaces.
+
+```ts
+const templates = new PlatformTemplateClient();
+const build = await templates.build({ environmentId, definition });
+const ready = await templates.waitUntilReady({ environmentId, templateId: build.templateId });
+const sandbox = new PlatformSandbox({ environmentId, templateId: ready.templateId, templateDefinition: definition });
+```
+
+Template environment values are serialized and must not contain secrets.

--- a/.changeset/kind-boats-repair.md
+++ b/.changeset/kind-boats-repair.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': minor
+---
+
+Added a providerless, immutable `Template()` builder for JSON-serializable sandbox build definitions.
+
+```ts
+const definition = Template().setWorkdir('/workspace').runCmd('pnpm install').toJSON();
+```

--- a/docs/src/content/en/reference/workspace/platform-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/platform-sandbox.mdx
@@ -1,18 +1,18 @@
 ---
-title: "Reference: PlatformSandbox | Workspace"
-description: "Documentation for the PlatformSandbox provider for executing commands in a Mastra Platform environment."
+title: 'Reference: PlatformSandbox | Workspace'
+description: 'Documentation for the PlatformSandbox provider for executing commands in a Mastra Platform environment.'
 packages:
-  - "@mastra/platform-workspace"
+  - '@mastra/platform-workspace'
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # PlatformSandbox
 
 Client for provisioning sandboxes in a Mastra Platform environment. Each `PlatformSandbox` instance owns one remote sandbox: `start()` provisions it, `executeCommand()` runs against it, and `destroy()` tears it down. Construct additional instances to own additional remote sandboxes. Use `clone()` to derive them from a configured template (see [Cloning](#cloning-for-a-fleet-of-sandboxes)).
 
-Sandboxes boot from a pre-built recipe checkpoint with Python 3, Node 22, TypeScript, tsx, and common build tooling already installed. Pass a stable `id` to opt into [checkpoint recovery](#checkpoint-recovery) so a new sandbox boots from the previous one's filesystem.
+Sandboxes boot from a pre-built provider template with Python 3, Node 22, TypeScript, tsx, and common build tooling already installed. You can also build a [reusable template](#reusable-templates) from a providerless serialized definition. Pass a stable `id` to opt into [checkpoint recovery](#checkpoint-recovery) so a new sandbox boots from the previous one's filesystem.
 
 Related providers: [`RailwaySandbox`](/integrations/sandboxes/railway) for self-hosted Railway sandboxes, [`LocalSandbox`](/reference/workspace/local-sandbox) for local sandboxes.
 
@@ -36,6 +36,7 @@ Configure the platform credentials. The access token, project ID, and environmen
     MASTRA_PLATFORM_ACCESS_TOKEN=your-platform-access-token
     MASTRA_PROJECT_ID=your-project-id
     MASTRA_ENVIRONMENT_ID=your-environment-id
+    SANDBOX_PROVIDER=railway
     ```
   </TabItem>
 
@@ -51,6 +52,8 @@ Configure the platform credentials. The access token, project ID, and environmen
 </Tabs>
 
 On a Mastra Platform deployment, `MASTRA_PLATFORM_ACCESS_TOKEN`, `MASTRA_PROJECT_ID`, and `MASTRA_ENVIRONMENT_ID` are injected automatically, so the constructor can be called with no options. For local development, `MASTRA_PLATFORM_ACCESS_TOKEN` can contain an `sk_` API token from your organization's settings page under **API Tokens**.
+
+The sandbox provider resolves from the constructor's `sandboxProvider` option, then `SANDBOX_PROVIDER`, then defaults to `railway`.
 
 ## Usage
 
@@ -112,6 +115,52 @@ const result = await sandbox.executeCommand('cat', ['/workspace/state.json'])
 
 When `sandboxId` is set, `environmentId` isn't required because the sandbox already exists.
 
+### Reusable templates
+
+Build a reusable sandbox template from a providerless definition before creating the sandbox:
+
+```typescript
+import { Template } from '@mastra/core/workspace'
+import { PlatformSandbox, PlatformTemplateClient } from '@mastra/platform-workspace'
+
+const environmentId = 'env_abc'
+const sandboxProvider = 'e2b' as const
+const commitSha = process.env.REPOSITORY_COMMIT_SHA!
+const definition = Template()
+  .setWorkdir('/workspace/repo')
+  .setEnvs({ BUILD_CONFIG_MARKER: 'template-v1' })
+  .aptInstall(['git', 'jq'])
+  .runCmd('git clone https://github.com/mastra-ai/mastra.git /workspace/repo')
+  .runCmd(`git checkout ${commitSha}`)
+  .runCmd('pnpm install --frozen-lockfile')
+  .toJSON()
+
+const templates = new PlatformTemplateClient({ sandboxProvider })
+const build = await templates.build({ environmentId, definition })
+const ready = await templates.waitUntilReady({
+  environmentId,
+  templateId: build.templateId,
+})
+
+const sandbox = new PlatformSandbox({
+  environmentId,
+  sandboxProvider,
+  templateId: ready.templateId,
+  templateDefinition: definition,
+})
+await sandbox.start()
+```
+
+`Template()` supports `runCmd`, `setWorkdir`, `setEnvs`, `aptInstall`, `pipInstall`, and `npmInstall`. Platform replays these operations for E2B or converts them to equivalent Railway template operations.
+
+The opaque `templateId` is bound to the authenticated organization, project, environment, provider, and definition digest. `PlatformSandbox` requires the same `templateDefinition` with the handle. A handle from another tenant, environment, provider, or definition isn't usable.
+
+:::warning
+
+Every template operation is serialized and sent to the provider. Use `setEnvs` only for non-sensitive build configuration. Template definitions don't support credentials, private-repository tokens, or other secrets.
+
+:::
+
 ### Checkpoint recovery
 
 The constructor `id` (explicit or auto-generated) is sent to the platform on `POST /sandbox` as an advisory recovery key:
@@ -149,7 +198,7 @@ const sandbox = new PlatformSandbox({
 
 ### Cloning for a fleet of sandboxes
 
-`clone()` returns an independent sibling `PlatformSandbox` that inherits credentials and defaults (access token, project, environment, network isolation, timeout, instructions, env, idle timeout) with per-instance overrides. The returned sandbox is unstarted and provisions on its own `start()`, so `clone()` performs no I/O:
+`clone()` returns an independent sibling `PlatformSandbox` that inherits credentials and defaults (access token, project, environment, provider, template, network isolation, timeout, instructions, env, idle timeout) with per-instance overrides. The returned sandbox is unstarted and provisions on its own `start()`, so `clone()` performs no I/O:
 
 ```typescript
 const template = new PlatformSandbox({
@@ -201,6 +250,12 @@ The `command` argument is a shell string and is concatenated verbatim into the r
     isOptional: true,
   },
   {
+    name: 'sandboxProvider',
+    type: "'railway' | 'e2b'",
+    description: 'Provider used for sandbox and template routes. Falls back to SANDBOX_PROVIDER, then railway.',
+    isOptional: true,
+  },
+  {
     name: 'environmentId',
     type: 'string',
     description:
@@ -219,6 +274,20 @@ The `command` argument is a shell string and is concatenated verbatim into the r
     type: 'string',
     description:
       'Boot-only fallback checkpoint used when the primary recovery checkpoint for id has no stored state. Later snapshots continue writing to the checkpoint for id.',
+    isOptional: true,
+  },
+  {
+    name: 'templateId',
+    type: 'string',
+    description:
+      'Opaque tenant-bound template handle returned by PlatformTemplateClient. Must be provided with templateDefinition.',
+    isOptional: true,
+  },
+  {
+    name: 'templateDefinition',
+    type: 'SerializedSandboxTemplate',
+    description:
+      'Providerless template definition whose digest is bound to templateId. Must be provided with templateId.',
     isOptional: true,
   },
   {
@@ -337,7 +406,7 @@ The `command` argument is a shell string and is concatenated verbatim into the r
     name: 'clone',
     type: '(options?: SandboxCloneOptions) => PlatformSandbox',
     description:
-      'Construct an unstarted sibling PlatformSandbox that inherits credentials and defaults with per-instance overrides (id, sandboxId, env, idleTimeoutMinutes). Performs no I/O. Use to build a fleet of independent sandboxes from one configured template.',
+      'Construct an unstarted sibling PlatformSandbox that inherits credentials, provider, template, and defaults with per-instance overrides (id, sandboxId, env, idleTimeoutMinutes). Performs no I/O. Use to build a fleet of independent sandboxes from one configured template.',
   },
   {
     name: 'snapshot',

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -1,5 +1,17 @@
 // Workspace
 export * from './workspace';
+export {
+  Template,
+  type AptInstallOptions,
+  type JsonPrimitive,
+  type JsonValue,
+  type NpmInstallOptions,
+  type PipInstallOptions,
+  type SandboxTemplateBuilder,
+  type SandboxTemplateMethod,
+  type SandboxTemplateOperation,
+  type SerializedSandboxTemplate,
+} from './template';
 
 // LSP
 export type { CustomLSPServer, LSPConfig, LSPDiagnostic, DiagnosticSeverity, LSPServerDef } from './lsp/types';

--- a/packages/core/src/workspace/template.test.ts
+++ b/packages/core/src/workspace/template.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { Template, type SandboxTemplateBuilder, type SerializedSandboxTemplate } from './template';
+
+describe('Template', () => {
+  it('serializes the supported E2B-shaped operations in order', () => {
+    const definition = Template()
+      .setWorkdir('/workspace/repo')
+      .setEnvs({ CI: '1', EMPTY: '' })
+      .aptInstall(['git', 'jq'], { noInstallRecommends: true })
+      .pipInstall('ruff', { g: false })
+      .npmInstall(['typescript', 'tsx'], { dev: true })
+      .runCmd(['pnpm install', 'pnpm build'])
+      .toJSON();
+
+    expect(definition).toEqual({
+      schemaVersion: 1,
+      operations: [
+        { method: 'setWorkdir', args: ['/workspace/repo'] },
+        { method: 'setEnvs', args: [{ CI: '1', EMPTY: '' }] },
+        { method: 'aptInstall', args: [['git', 'jq'], { noInstallRecommends: true }] },
+        { method: 'pipInstall', args: ['ruff', { g: false }] },
+        { method: 'npmInstall', args: [['typescript', 'tsx'], { dev: true }] },
+        { method: 'runCmd', args: [['pnpm install', 'pnpm build']] },
+      ],
+    });
+    expect(definition).not.toHaveProperty('provider');
+  });
+
+  it('preserves E2B optional install argument positions', () => {
+    expect(Template().pipInstall().npmInstall(undefined, { g: true }).toJSON().operations).toEqual([
+      { method: 'pipInstall', args: [] },
+      { method: 'npmInstall', args: [null, { g: true }] },
+    ]);
+  });
+
+  it('returns a new immutable builder for every operation', () => {
+    const envs = { MODE: 'build' };
+    const base = Template().setEnvs(envs);
+    const extended = base.runCmd('pnpm build');
+    envs.MODE = 'mutated';
+
+    const first = base.toJSON();
+    const second = extended.toJSON();
+    expect(first.operations).toEqual([{ method: 'setEnvs', args: [{ MODE: 'build' }] }]);
+    expect(second.operations).toHaveLength(2);
+
+    (first.operations[0]!.args[0] as Record<string, string>).MODE = 'changed again';
+    expect(base.toJSON().operations).toEqual([{ method: 'setEnvs', args: [{ MODE: 'build' }] }]);
+  });
+
+  it.each([
+    () => Template().runCmd(''),
+    () => Template().runCmd([]),
+    () => Template().runCmd(['ok', '']),
+    () => Template().setWorkdir(''),
+    () => Template().aptInstall([]),
+    () => Template().setEnvs({ '': 'value' }),
+    () => Template().setEnvs(new Date() as unknown as Record<string, string>),
+    () => Template().aptInstall('git', { noInstallRecommends: 'yes' } as never),
+    () => Template().npmInstall('tsx', { other: true } as never),
+  ])('rejects invalid operation arguments', build => {
+    expect(build).toThrow();
+  });
+
+  it('rejects sparse arrays for every command and package operation', () => {
+    const sparse = new Array<string>(1);
+
+    expect(() => Template().runCmd(sparse)).toThrow(/command\[0\] must be a string/);
+    expect(() => Template().aptInstall(sparse)).toThrow(/packages\[0\] must be a string/);
+    expect(() => Template().pipInstall(sparse)).toThrow(/packages\[0\] must be a string/);
+    expect(() => Template().npmInstall(sparse)).toThrow(/packages\[0\] must be a string/);
+  });
+
+  it('rejects caller-cast non-JSON values before serialization', () => {
+    const cycle: Record<string, unknown> = {};
+    cycle.self = cycle;
+
+    expect(() => Template().setEnvs({ VALUE: Number.NaN as never })).toThrow(/must be a string/);
+    expect(() => Template().setEnvs({ VALUE: cycle as never })).toThrow(/must be a string/);
+  });
+
+  it('enforces exact string and collection boundaries', () => {
+    const maximumString = 'x'.repeat(32 * 1024);
+    expect(Template().runCmd(maximumString).toJSON().operations[0]!.args[0]).toBe(maximumString);
+    expect(() => Template().runCmd(`${maximumString}x`)).toThrow(/32768 characters/);
+
+    const maximumPackages = new Array(512).fill('package');
+    expect(Template().aptInstall(maximumPackages).toJSON().operations[0]!.args[0]).toHaveLength(512);
+    expect(() => Template().aptInstall([...maximumPackages, 'one-too-many'])).toThrow(/512 items/);
+
+    const maximumEnvs = Object.fromEntries(Array.from({ length: 512 }, (_, index) => [`KEY_${index}`, 'value']));
+    expect(Object.keys(Template().setEnvs(maximumEnvs).toJSON().operations[0]!.args[0] as object)).toHaveLength(512);
+    expect(() => Template().setEnvs({ ...maximumEnvs, ONE_TOO_MANY: 'value' })).toThrow(/512 items/);
+  });
+
+  it('enforces operation and serialized-size limits independently', () => {
+    let builder = Template();
+    for (let index = 0; index < 256; index++) builder = builder.runCmd(`echo ${index}`);
+    expect(() => builder.runCmd('one too many')).toThrow(/256 operations/);
+
+    let large = Template();
+    const validMaximumCommand = 'x'.repeat(32 * 1024);
+    expect(() => {
+      for (let index = 0; index < 9; index++) large = large.runCmd(validMaximumCommand);
+    }).toThrow(/262144 bytes/);
+  });
+
+  it('exposes the intended public builder type', () => {
+    expectTypeOf(Template).parameters.toEqualTypeOf<[]>();
+    expectTypeOf(Template()).toEqualTypeOf<SandboxTemplateBuilder>();
+    expectTypeOf(Template().toJSON()).toEqualTypeOf<SerializedSandboxTemplate>();
+
+    type Keys = keyof SandboxTemplateBuilder;
+    expectTypeOf<Keys>().toEqualTypeOf<
+      'runCmd' | 'setWorkdir' | 'setEnvs' | 'aptInstall' | 'pipInstall' | 'npmInstall' | 'toJSON'
+    >();
+  });
+});

--- a/packages/core/src/workspace/template.ts
+++ b/packages/core/src/workspace/template.ts
@@ -1,0 +1,191 @@
+export type JsonPrimitive = null | boolean | number | string;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export type SandboxTemplateMethod = 'runCmd' | 'setWorkdir' | 'setEnvs' | 'aptInstall' | 'pipInstall' | 'npmInstall';
+
+export interface SandboxTemplateOperation {
+  method: SandboxTemplateMethod;
+  args: JsonValue[];
+}
+
+export interface SerializedSandboxTemplate {
+  schemaVersion: 1;
+  operations: SandboxTemplateOperation[];
+}
+
+export interface AptInstallOptions {
+  noInstallRecommends?: boolean;
+  fixMissing?: boolean;
+}
+
+export interface PipInstallOptions {
+  g?: boolean;
+}
+
+export interface NpmInstallOptions {
+  g?: boolean;
+  dev?: boolean;
+}
+
+export interface SandboxTemplateBuilder {
+  runCmd(command: string | string[]): SandboxTemplateBuilder;
+  setWorkdir(path: string): SandboxTemplateBuilder;
+  setEnvs(envs: Record<string, string>): SandboxTemplateBuilder;
+  aptInstall(packages: string | string[], options?: AptInstallOptions): SandboxTemplateBuilder;
+  pipInstall(packages?: string | string[], options?: PipInstallOptions): SandboxTemplateBuilder;
+  npmInstall(packages?: string | string[], options?: NpmInstallOptions): SandboxTemplateBuilder;
+  toJSON(): SerializedSandboxTemplate;
+}
+
+const MAX_OPERATIONS = 256;
+const MAX_SERIALIZED_BYTES = 256 * 1024;
+const MAX_STRING_LENGTH = 32 * 1024;
+const MAX_COLLECTION_ITEMS = 512;
+
+class SerializableSandboxTemplateBuilder implements SandboxTemplateBuilder {
+  readonly #operations: readonly SandboxTemplateOperation[];
+
+  constructor(operations: readonly SandboxTemplateOperation[] = []) {
+    this.#operations = operations;
+  }
+
+  runCmd(command: string | string[]): SandboxTemplateBuilder {
+    return this.#append('runCmd', [validateStringOrStrings(command, 'command')]);
+  }
+
+  setWorkdir(path: string): SandboxTemplateBuilder {
+    return this.#append('setWorkdir', [validateString(path, 'path')]);
+  }
+
+  setEnvs(envs: Record<string, string>): SandboxTemplateBuilder {
+    assertPlainObject(envs, 'envs');
+    const entries = Object.entries(envs);
+    assertCollectionSize(entries.length, 'envs');
+
+    const copy = Object.fromEntries(
+      entries.map(([key, value]) => [
+        validateString(key, 'environment variable name'),
+        validateString(value, `environment variable ${key}`, true),
+      ]),
+    );
+    return this.#append('setEnvs', [copy]);
+  }
+
+  aptInstall(packages: string | string[], options?: AptInstallOptions): SandboxTemplateBuilder {
+    const args: JsonValue[] = [validateStringOrStrings(packages, 'packages')];
+    if (options !== undefined) args.push(validateBooleanOptions(options, ['noInstallRecommends', 'fixMissing']));
+    return this.#append('aptInstall', args);
+  }
+
+  pipInstall(packages?: string | string[], options?: PipInstallOptions): SandboxTemplateBuilder {
+    return this.#appendOptionalInstall('pipInstall', packages, options, ['g']);
+  }
+
+  npmInstall(packages?: string | string[], options?: NpmInstallOptions): SandboxTemplateBuilder {
+    return this.#appendOptionalInstall('npmInstall', packages, options, ['g', 'dev']);
+  }
+
+  toJSON(): SerializedSandboxTemplate {
+    return {
+      schemaVersion: 1,
+      operations: this.#operations.map(operation => ({
+        method: operation.method,
+        args: cloneJson(operation.args),
+      })),
+    };
+  }
+
+  #appendOptionalInstall(
+    method: 'pipInstall' | 'npmInstall',
+    packages: string | string[] | undefined,
+    options: PipInstallOptions | NpmInstallOptions | undefined,
+    optionKeys: readonly string[],
+  ): SandboxTemplateBuilder {
+    const args: JsonValue[] = [];
+    if (packages !== undefined) args.push(validateStringOrStrings(packages, 'packages'));
+    if (options !== undefined) {
+      if (packages === undefined) args.push(null);
+      args.push(validateBooleanOptions(options, optionKeys));
+    }
+    return this.#append(method, args);
+  }
+
+  #append(method: SandboxTemplateMethod, args: JsonValue[]): SandboxTemplateBuilder {
+    if (this.#operations.length >= MAX_OPERATIONS) {
+      throw new RangeError(`Sandbox template cannot contain more than ${MAX_OPERATIONS} operations`);
+    }
+
+    const operation = { method, args: cloneJson(args) } satisfies SandboxTemplateOperation;
+    const operations = [...this.#operations, operation];
+    const serialized = JSON.stringify({ schemaVersion: 1, operations });
+    if (new TextEncoder().encode(serialized).byteLength > MAX_SERIALIZED_BYTES) {
+      throw new RangeError(`Serialized sandbox template cannot exceed ${MAX_SERIALIZED_BYTES} bytes`);
+    }
+
+    return new SerializableSandboxTemplateBuilder(operations);
+  }
+}
+
+export function Template(): SandboxTemplateBuilder {
+  return new SerializableSandboxTemplateBuilder();
+}
+
+function validateString(value: unknown, name: string, allowEmpty = false): string {
+  if (typeof value !== 'string') throw new TypeError(`${name} must be a string`);
+  if (!allowEmpty && value.length === 0) throw new TypeError(`${name} must not be empty`);
+  if (value.length > MAX_STRING_LENGTH) {
+    throw new RangeError(`${name} cannot exceed ${MAX_STRING_LENGTH} characters`);
+  }
+  return value;
+}
+
+function validateStringOrStrings(value: unknown, name: string): string | string[] {
+  if (typeof value === 'string') return validateString(value, name);
+  if (!Array.isArray(value)) throw new TypeError(`${name} must be a string or an array of strings`);
+  assertCollectionSize(value.length, name);
+  if (value.length === 0) throw new TypeError(`${name} must not be empty`);
+  return Array.from(value, (item, index) => validateString(item, `${name}[${index}]`));
+}
+
+function validateBooleanOptions(value: unknown, keys: readonly string[]): Record<string, boolean> {
+  assertPlainObject(value, 'options');
+  const options = value as Record<string, unknown>;
+  const unknownKey = Object.keys(options).find(key => !keys.includes(key));
+  if (unknownKey) throw new TypeError(`Unsupported option: ${unknownKey}`);
+
+  const copy: Record<string, boolean> = {};
+  for (const key of keys) {
+    const option = options[key];
+    if (option === undefined) continue;
+    if (typeof option !== 'boolean') throw new TypeError(`${key} must be a boolean`);
+    copy[key] = option;
+  }
+  return copy;
+}
+
+function assertPlainObject(value: unknown, name: string): asserts value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError(`${name} must be a plain object`);
+  }
+}
+
+function assertCollectionSize(size: number, name: string): void {
+  if (size > MAX_COLLECTION_ITEMS) {
+    throw new RangeError(`${name} cannot contain more than ${MAX_COLLECTION_ITEMS} items`);
+  }
+}
+
+function cloneJson<T extends JsonValue>(value: T): T {
+  if (Array.isArray(value)) return value.map(item => cloneJson(item)) as T;
+  if (typeof value === 'object' && value !== null) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, cloneJson(item)])) as T;
+  }
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new TypeError('Sandbox template values must contain only finite numbers');
+  }
+  return value;
+}

--- a/workspaces/platform-workspace/README.md
+++ b/workspaces/platform-workspace/README.md
@@ -12,15 +12,16 @@ npm install @mastra/platform-workspace
 
 All options can be passed to the constructor or read from environment variables:
 
-| Option          | Env var                        | Required         |
-| --------------- | ------------------------------ | ---------------- |
-| `accessToken`   | `MASTRA_PLATFORM_ACCESS_TOKEN` | Yes              |
-| `projectId`     | `MASTRA_PROJECT_ID`            | Yes              |
-| `environmentId` | `MASTRA_ENVIRONMENT_ID`        | Yes (sandbox)    |
-| `actingUserId`  | —                              | No (sandbox)     |
-| `bucketName`    | `MASTRA_PLATFORM_BUCKET_NAME`  | Yes (filesystem) |
+| Option            | Env var                        | Required         |
+| ----------------- | ------------------------------ | ---------------- |
+| `accessToken`     | `MASTRA_PLATFORM_ACCESS_TOKEN` | Yes              |
+| `projectId`       | `MASTRA_PROJECT_ID`            | Yes              |
+| `environmentId`   | `MASTRA_ENVIRONMENT_ID`        | Yes (sandbox)    |
+| `actingUserId`    | —                              | No (sandbox)     |
+| `sandboxProvider` | `SANDBOX_PROVIDER`             | No (sandbox)     |
+| `bucketName`      | `MASTRA_PLATFORM_BUCKET_NAME`  | Yes (filesystem) |
 
-The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` env var (useful for staging).
+The sandbox provider resolves from the explicit `sandboxProvider` option, then `SANDBOX_PROVIDER`, then defaults to `railway`. The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` env var (useful for staging).
 
 Requests to the proxy are authenticated with `Authorization: Bearer <accessToken>`. For sandbox requests authenticated with a project access token, set `actingUserId` to the stable opaque user subject from your authentication system. It is sent as `x-acting-user-id` for token partitioning and attribution; it is not an authorization claim.
 
@@ -66,7 +67,7 @@ Pass `readOnly: true` to mount the bucket read-only. Mutating calls will throw `
 
 ## Sandbox
 
-`PlatformSandbox` executes commands inside a Railway-backed sandbox tied to a Platform environment. Sessions boot from a pre-built recipe checkpoint (Python 3, Node 22, TypeScript/tsx, common build tooling).
+`PlatformSandbox` executes commands inside a provider-backed sandbox tied to a Platform environment. Sessions boot from the configured provider template or checkpoint.
 
 ```typescript
 const sandbox = new PlatformSandbox({ environmentId: 'env_abc' });
@@ -80,6 +81,46 @@ console.log(result.stdout);
 ```
 
 Pass an existing `sandboxId` to reattach to a live sandbox instead of creating a new one.
+
+### Reusable templates
+
+Use the providerless `Template()` builder to prebuild a public repository at an immutable commit. Platform starts the provider build asynchronously and returns an opaque template handle:
+
+```typescript
+import { Template } from '@mastra/core/workspace';
+import { PlatformSandbox, PlatformTemplateClient } from '@mastra/platform-workspace';
+
+const environmentId = 'env_abc';
+const sandboxProvider = 'e2b' as const;
+const commitSha = process.env.REPOSITORY_COMMIT_SHA!;
+const definition = Template()
+  .setWorkdir('/workspace/repo')
+  .setEnvs({ BUILD_CONFIG_MARKER: 'template-v1' })
+  .aptInstall(['git', 'jq'])
+  .runCmd('git clone https://github.com/mastra-ai/mastra.git /workspace/repo')
+  .runCmd(`git checkout ${commitSha}`)
+  .runCmd('pnpm install --frozen-lockfile')
+  .toJSON();
+
+const templates = new PlatformTemplateClient({ sandboxProvider });
+const build = await templates.build({ environmentId, definition });
+const ready = await templates.waitUntilReady({
+  environmentId,
+  templateId: build.templateId,
+});
+
+const sandbox = new PlatformSandbox({
+  environmentId,
+  sandboxProvider,
+  templateId: ready.templateId,
+  templateDefinition: definition,
+});
+await sandbox.start();
+```
+
+The handle is bound to the authenticated organization, project, environment, provider, and definition digest. Sandbox creation requires the same serialized definition so Platform can verify the digest and reconstruct provider-specific template input when needed.
+
+All operation arguments are serialized and sent to the provider. Values passed to `setEnvs` must contain only non-sensitive build configuration. Credentials, private-repository tokens, and other secrets aren't supported in template definitions.
 
 ## Errors
 

--- a/workspaces/platform-workspace/package.json
+++ b/workspaces/platform-workspace/package.json
@@ -23,6 +23,7 @@
     "build:lib": "pnpm build",
     "build:watch": "pnpm build --watch",
     "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
+    "test:types": "vitest run --typecheck src/template-compatibility.test.ts",
     "test:cloud": "vitest run --passWithNoTests ./src/**/*.integration.test.ts",
     "test:watch": "vitest watch",
     "test": "pnpm test:unit",
@@ -43,7 +44,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.4.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.62.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/workspaces/platform-workspace/src/client.test.ts
+++ b/workspaces/platform-workspace/src/client.test.ts
@@ -65,6 +65,38 @@ describe('PlatformClient', () => {
     expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/e2b/projects/proj_123/fs/bucket/path');
   });
 
+  it('prefers an explicit sandboxProvider over SANDBOX_PROVIDER', async () => {
+    vi.stubEnv('SANDBOX_PROVIDER', 'railway');
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi.fn().mockResolvedValue(response('{}', { status: 200 }));
+    const client = new PlatformClient({
+      accessToken: 'sk_test',
+      projectId: 'proj_123',
+      sandboxProvider: 'e2b',
+      fetch: fetchMock,
+    });
+
+    await client.request('/sandbox');
+
+    expect(client.sandboxProvider).toBe('e2b');
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/e2b/projects/proj_123/sandbox');
+  });
+
+  it('can force provider-prefixed routes while preserving legacy sandbox routing', async () => {
+    vi.stubEnv('SANDBOX_PROVIDER', undefined);
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi.fn().mockResolvedValue(response('{}', { status: 200 }));
+    const client = new PlatformClient({ accessToken: 'sk_test', projectId: 'proj_123', fetch: fetchMock });
+
+    await client.request('/sandbox');
+    await client.requestProvider('/templates/builds');
+
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox');
+    expect(String(fetchMock.mock.calls[1]![0])).toBe(
+      'https://proxy.test/v1/railway/projects/proj_123/templates/builds',
+    );
+  });
+
   it('rejects unsupported SANDBOX_PROVIDER values', () => {
     vi.stubEnv('SANDBOX_PROVIDER', 'unknown');
 

--- a/workspaces/platform-workspace/src/client.ts
+++ b/workspaces/platform-workspace/src/client.ts
@@ -2,6 +2,7 @@ export interface PlatformClientOptions {
   accessToken?: string;
   projectId?: string;
   actingUserId?: string;
+  sandboxProvider?: SandboxProvider;
   /**
    * Advisory correlation id for the factory session driving this client.
    * Sent as `x-mastra-session-id` on every proxy request so proxy-side logs
@@ -47,7 +48,8 @@ function resolveSandboxProvider(value: string | undefined): SandboxProvider {
 }
 
 export function resolvePlatformOptions(options: PlatformClientOptions) {
-  const configuredSandboxProvider = process.env.SANDBOX_PROVIDER?.trim();
+  const environmentSandboxProvider = process.env.SANDBOX_PROVIDER?.trim();
+  const configuredSandboxProvider = options.sandboxProvider ?? environmentSandboxProvider;
 
   return {
     accessToken: requireOption(options.accessToken ?? process.env.MASTRA_PLATFORM_ACCESS_TOKEN, 'accessToken'),
@@ -55,7 +57,7 @@ export function resolvePlatformOptions(options: PlatformClientOptions) {
     actingUserId: options.actingUserId?.trim() || undefined,
     proxyUrl: (process.env.MASTRA_WORKSPACE_PROXY_URL ?? DEFAULT_PROXY_URL).replace(/\/$/, ''),
     sandboxProvider: resolveSandboxProvider(configuredSandboxProvider),
-    useLegacyRoutes: !configuredSandboxProvider,
+    useLegacyRoutes: !options.sandboxProvider && !environmentSandboxProvider,
     sessionId: options.sessionId,
     threadId: options.threadId,
     fetch: options.fetch ?? fetch,
@@ -138,6 +140,14 @@ export class PlatformClient {
 
   async request(path: string, options: PlatformRequestOptions = {}): Promise<Response> {
     const providerPath = this.useLegacyRoutes ? '' : `/${this.sandboxProvider}`;
+    return this.requestAtPath(providerPath, path, options);
+  }
+
+  async requestProvider(path: string, options: PlatformRequestOptions = {}): Promise<Response> {
+    return this.requestAtPath(`/${this.sandboxProvider}`, path, options);
+  }
+
+  private async requestAtPath(providerPath: string, path: string, options: PlatformRequestOptions): Promise<Response> {
     const url = new URL(`${this.proxyUrl}/v1${providerPath}/projects/${encodeURIComponent(this.projectId)}${path}`);
     for (const [key, value] of Object.entries(options.query ?? {})) {
       if (value !== undefined) url.searchParams.set(key, String(value));

--- a/workspaces/platform-workspace/src/index.ts
+++ b/workspaces/platform-workspace/src/index.ts
@@ -1,5 +1,21 @@
-export { PlatformClient, PlatformApiError, type PlatformClientOptions, type PlatformProxyError } from './client.js';
+export {
+  PlatformClient,
+  PlatformApiError,
+  type PlatformClientOptions,
+  type PlatformProxyError,
+  type SandboxProvider,
+} from './client.js';
 export { PlatformFilesystem, type PlatformFilesystemOptions } from './filesystem.js';
+export {
+  PlatformTemplateClient,
+  PlatformTemplateBuildError,
+  PlatformTemplateBuildTimeoutError,
+  type BuildPlatformTemplateInput,
+  type GetPlatformTemplateInput,
+  type PlatformTemplateBuild,
+  type PlatformTemplateStatus,
+  type WaitForPlatformTemplateInput,
+} from './templates.js';
 export {
   PlatformSandbox,
   SandboxExecTransportError,

--- a/workspaces/platform-workspace/src/provider.test.ts
+++ b/workspaces/platform-workspace/src/provider.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { platformSandboxProvider } from './provider.js';
+
+type OperationSchema = {
+  properties: {
+    method: { const: string };
+    args: Record<string, unknown>;
+  };
+};
+
+describe('platformSandboxProvider', () => {
+  it('requires template handles and definitions together', () => {
+    const schema = platformSandboxProvider.configSchema!;
+
+    expect(schema.dependentRequired).toEqual({
+      templateId: ['templateDefinition'],
+      templateDefinition: ['templateId'],
+    });
+  });
+
+  it('describes each protocol-v1 operation with method-specific arguments', () => {
+    const schema = platformSandboxProvider.configSchema!;
+    const properties = schema.properties as Record<string, Record<string, unknown>>;
+    const templateDefinition = properties.templateDefinition;
+    const templateProperties = templateDefinition.properties as Record<string, Record<string, unknown>>;
+    const operations = templateProperties.operations;
+    const operationSchemas = (operations.items as { oneOf: OperationSchema[] }).oneOf;
+
+    expect(properties.sandboxProvider).toMatchObject({ enum: ['railway', 'e2b'] });
+    expect(templateDefinition).toMatchObject({
+      type: 'object',
+      required: ['schemaVersion', 'operations'],
+      additionalProperties: false,
+    });
+    expect(templateProperties.schemaVersion).toEqual({ const: 1 });
+    expect(operations.maxItems).toBe(256);
+    expect(operationSchemas.map(operation => operation.properties.method.const)).toEqual([
+      'runCmd',
+      'setWorkdir',
+      'setEnvs',
+      'aptInstall',
+      'pipInstall',
+      'npmInstall',
+    ]);
+
+    const runCmd = operationSchemas[0]!;
+    const setEnvs = operationSchemas[2]!;
+    const aptInstall = operationSchemas[3]!;
+    expect(runCmd.properties.args).toMatchObject({ minItems: 1, maxItems: 1 });
+    expect(setEnvs.properties.args).toMatchObject({ minItems: 1, maxItems: 1 });
+    expect(aptInstall.properties.args).toMatchObject({ minItems: 1, maxItems: 2 });
+  });
+});

--- a/workspaces/platform-workspace/src/provider.ts
+++ b/workspaces/platform-workspace/src/provider.ts
@@ -4,6 +4,113 @@ import { PlatformFilesystem } from './filesystem.js';
 import type { PlatformSandboxOptions } from './sandbox.js';
 import { PlatformSandbox } from './sandbox.js';
 
+const nonEmptyStringSchema = { type: 'string', minLength: 1, maxLength: 32 * 1024 } as const;
+const stringOrStringsSchema = {
+  oneOf: [nonEmptyStringSchema, { type: 'array', items: nonEmptyStringSchema, minItems: 1, maxItems: 512 }],
+} as const;
+const envsSchema = {
+  type: 'object',
+  propertyNames: nonEmptyStringSchema,
+  additionalProperties: { type: 'string', maxLength: 32 * 1024 },
+  maxProperties: 512,
+} as const;
+const booleanOptionsSchema = (properties: Record<string, { type: 'boolean' }>) => ({
+  type: 'object',
+  properties,
+  additionalProperties: false,
+});
+const aptInstallOptionsSchema = booleanOptionsSchema({
+  noInstallRecommends: { type: 'boolean' },
+  fixMissing: { type: 'boolean' },
+});
+const pipInstallOptionsSchema = booleanOptionsSchema({ g: { type: 'boolean' } });
+const npmInstallOptionsSchema = booleanOptionsSchema({ g: { type: 'boolean' }, dev: { type: 'boolean' } });
+const operationSchema = {
+  oneOf: [
+    {
+      type: 'object',
+      properties: {
+        method: { const: 'runCmd' },
+        args: { type: 'array', prefixItems: [stringOrStringsSchema], minItems: 1, maxItems: 1 },
+      },
+      required: ['method', 'args'],
+      additionalProperties: false,
+    },
+    {
+      type: 'object',
+      properties: {
+        method: { const: 'setWorkdir' },
+        args: { type: 'array', prefixItems: [nonEmptyStringSchema], minItems: 1, maxItems: 1 },
+      },
+      required: ['method', 'args'],
+      additionalProperties: false,
+    },
+    {
+      type: 'object',
+      properties: {
+        method: { const: 'setEnvs' },
+        args: { type: 'array', prefixItems: [envsSchema], minItems: 1, maxItems: 1 },
+      },
+      required: ['method', 'args'],
+      additionalProperties: false,
+    },
+    {
+      type: 'object',
+      properties: {
+        method: { const: 'aptInstall' },
+        args: {
+          type: 'array',
+          prefixItems: [stringOrStringsSchema, aptInstallOptionsSchema],
+          minItems: 1,
+          maxItems: 2,
+        },
+      },
+      required: ['method', 'args'],
+      additionalProperties: false,
+    },
+    {
+      type: 'object',
+      properties: {
+        method: { const: 'pipInstall' },
+        args: {
+          oneOf: [
+            { type: 'array', maxItems: 0 },
+            { type: 'array', prefixItems: [stringOrStringsSchema], minItems: 1, maxItems: 1 },
+            {
+              type: 'array',
+              prefixItems: [{ oneOf: [stringOrStringsSchema, { type: 'null' }] }, pipInstallOptionsSchema],
+              minItems: 2,
+              maxItems: 2,
+            },
+          ],
+        },
+      },
+      required: ['method', 'args'],
+      additionalProperties: false,
+    },
+    {
+      type: 'object',
+      properties: {
+        method: { const: 'npmInstall' },
+        args: {
+          oneOf: [
+            { type: 'array', maxItems: 0 },
+            { type: 'array', prefixItems: [stringOrStringsSchema], minItems: 1, maxItems: 1 },
+            {
+              type: 'array',
+              prefixItems: [{ oneOf: [stringOrStringsSchema, { type: 'null' }] }, npmInstallOptionsSchema],
+              minItems: 2,
+              maxItems: 2,
+            },
+          ],
+        },
+      },
+      required: ['method', 'args'],
+      additionalProperties: false,
+    },
+  ],
+} as const;
+
 export const platformSandboxProvider: SandboxProvider<PlatformSandboxOptions> = {
   id: 'platform',
   name: 'Mastra Platform Sandbox',
@@ -17,8 +124,32 @@ export const platformSandboxProvider: SandboxProvider<PlatformSandboxOptions> = 
       },
       projectId: { type: 'string', description: 'Platform project ID (falls back to MASTRA_PROJECT_ID)' },
       actingUserId: { type: 'string', description: 'Opaque user subject attributed to sandbox requests' },
+      sandboxProvider: {
+        type: 'string',
+        description: 'Sandbox provider (falls back to SANDBOX_PROVIDER, then railway)',
+        enum: ['railway', 'e2b'],
+      },
       environmentId: { type: 'string', description: 'Platform environment ID (falls back to MASTRA_ENVIRONMENT_ID)' },
       sandboxId: { type: 'string', description: 'Reattach to an existing Platform sandbox by ID' },
+      templateId: {
+        type: 'string',
+        minLength: 1,
+        description: 'Opaque tenant-bound Platform template handle',
+      },
+      templateDefinition: {
+        type: 'object',
+        description: 'Serialized non-secret template definition bound to templateId',
+        properties: {
+          schemaVersion: { const: 1 },
+          operations: {
+            type: 'array',
+            items: operationSchema,
+            maxItems: 256,
+          },
+        },
+        required: ['schemaVersion', 'operations'],
+        additionalProperties: false,
+      },
       idleTimeoutMinutes: { type: 'number', description: 'Minutes before the sandbox can be destroyed while idle' },
       networkIsolation: {
         type: 'string',
@@ -28,6 +159,10 @@ export const platformSandboxProvider: SandboxProvider<PlatformSandboxOptions> = 
       },
       env: { type: 'object', description: 'Environment variables', additionalProperties: { type: 'string' } },
       timeout: { type: 'number', description: 'Default command timeout in ms' },
+    },
+    dependentRequired: {
+      templateId: ['templateDefinition'],
+      templateDefinition: ['templateId'],
     },
   },
   createSandbox: config => new PlatformSandbox(config),

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -1,3 +1,4 @@
+import { Template } from '@mastra/core/workspace';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DirectExecWebSocket, DirectExecWebSocketFactory } from './direct-exec.js';
 import { PlatformSandbox, type SandboxAddressRegistry } from './sandbox.js';
@@ -137,6 +138,65 @@ describe('PlatformSandbox', () => {
     // init_exec frame carries command + cwd + env.
     const init = JSON.parse(sockets[0]!.sent[0]!) as { data: Record<string, unknown> };
     expect(init.data).toEqual({ command: 'echo ok', cwd: '/workspace', env: { A: '1' } });
+  });
+
+  it.each(['railway', 'e2b'] as const)(
+    'forwards and clones tenant-bound template inputs for %s',
+    async sandboxProvider => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const definition = Template().setWorkdir('/workspace/repo').runCmd('pnpm build').toJSON();
+      const fetchMock = vi.fn().mockResolvedValue(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const parent = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        sandboxProvider,
+        environmentId: 'env_123',
+        templateId: 'opaque-template-handle',
+        templateDefinition: definition,
+        fetch: fetchMock,
+      });
+      definition.operations[0]!.args[0] = '/mutated';
+
+      const clone = parent.clone();
+      await clone._start();
+
+      expect(String(fetchMock.mock.calls[0]![0])).toBe(
+        `https://proxy.test/v1/${sandboxProvider}/projects/proj_123/sandbox`,
+      );
+      expect(JSON.parse(fetchMock.mock.calls[0]![1].body as string)).toMatchObject({
+        environmentId: 'env_123',
+        templateId: 'opaque-template-handle',
+        templateDefinition: Template().setWorkdir('/workspace/repo').runCmd('pnpm build').toJSON(),
+      });
+    },
+  );
+
+  it('uses the provider-prefixed Railway route for templates when SANDBOX_PROVIDER is unset', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi.fn().mockResolvedValue(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
+    const sandbox = new PlatformSandbox({
+      accessToken: 'sk_test',
+      projectId: 'proj_123',
+      environmentId: 'env_123',
+      templateId: 'opaque-template-handle',
+      templateDefinition: Template().runCmd('true').toJSON(),
+      fetch: fetchMock,
+    });
+
+    await sandbox._start();
+
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/railway/projects/proj_123/sandbox');
+  });
+
+  it('requires templateId and templateDefinition together', () => {
+    const options = { accessToken: 'sk_test', projectId: 'proj_123', environmentId: 'env_123' };
+    expect(() => new PlatformSandbox({ ...options, templateId: 'opaque-template-handle' })).toThrow(
+      'templateId and templateDefinition must be provided together',
+    );
+    expect(() => new PlatformSandbox({ ...options, templateDefinition: Template().runCmd('true').toJSON() })).toThrow(
+      'templateId and templateDefinition must be provided together',
+    );
   });
 
   it('uses E2B direct exec for E2B leases instead of the Railway WebSocket protocol', async () => {

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -8,6 +8,7 @@ import type {
   ProviderStatus,
   SandboxCloneOptions,
   SandboxInfo,
+  SerializedSandboxTemplate,
   SpawnProcessOptions,
 } from '@mastra/core/workspace';
 import {
@@ -58,6 +59,10 @@ export interface PlatformSandboxOptions extends Omit<MastraSandboxOptions, 'proc
   sandboxId?: string;
   /** Boot-only fallback checkpoint for a fresh sandbox whose primary recovery key has no state. */
   seedCheckpointName?: string;
+  /** Opaque tenant-bound template handle returned by PlatformTemplateClient. */
+  templateId?: string;
+  /** Serialized non-secret template definition bound to templateId. */
+  templateDefinition?: SerializedSandboxTemplate;
   idleTimeoutMinutes?: number;
   networkIsolation?: PlatformSandboxNetworkIsolation;
   env?: Record<string, string>;
@@ -356,6 +361,8 @@ export class PlatformSandbox extends MastraSandbox {
   private readonly _environmentId: string;
   private _sandboxId?: string;
   private readonly _seedCheckpointName?: string;
+  private readonly _templateId?: string;
+  private readonly _templateDefinition?: SerializedSandboxTemplate;
   private readonly _idleTimeoutMinutes?: number;
   private readonly _networkIsolation?: PlatformSandboxNetworkIsolation;
   private readonly _env: Record<string, string>;
@@ -452,6 +459,11 @@ export class PlatformSandbox extends MastraSandbox {
     if (!this._environmentId && !options.sandboxId) throw new Error('environmentId is required');
     this._sandboxId = options.sandboxId;
     this._seedCheckpointName = options.seedCheckpointName;
+    if ((options.templateId === undefined) !== (options.templateDefinition === undefined)) {
+      throw new Error('templateId and templateDefinition must be provided together');
+    }
+    this._templateId = options.templateId;
+    this._templateDefinition = options.templateDefinition ? structuredClone(options.templateDefinition) : undefined;
     this._idleTimeoutMinutes = options.idleTimeoutMinutes;
     this._networkIsolation = options.networkIsolation;
     this._env = options.env ?? {};
@@ -495,6 +507,9 @@ export class PlatformSandbox extends MastraSandbox {
       ...(id !== undefined && { id }),
       accessToken: this._client.accessToken,
       projectId: this._client.projectId,
+      ...(this._templateId !== undefined || this._client.sandboxProvider !== 'railway'
+        ? { sandboxProvider: this._client.sandboxProvider }
+        : {}),
       actingUserId: options.actingUserId ?? this._client.actingUserId,
       ...(this._client.sessionId !== undefined && { sessionId: this._client.sessionId }),
       ...(this._client.threadId !== undefined && { threadId: this._client.threadId }),
@@ -502,6 +517,8 @@ export class PlatformSandbox extends MastraSandbox {
       environmentId: this._environmentId,
       ...(options.sandboxId !== undefined && { sandboxId: options.sandboxId }),
       ...(seedCheckpointName !== undefined && { seedCheckpointName }),
+      ...(this._templateId !== undefined && { templateId: this._templateId }),
+      ...(this._templateDefinition !== undefined && { templateDefinition: structuredClone(this._templateDefinition) }),
       idleTimeoutMinutes: options.idleTimeoutMinutes ?? this._idleTimeoutMinutes,
       ...(this._networkIsolation !== undefined && { networkIsolation: this._networkIsolation }),
       env: options.env ?? this._env,
@@ -575,6 +592,8 @@ export class PlatformSandbox extends MastraSandbox {
       // to a fresh sandbox, matching pre-existing behavior.
       id: this.id,
       seedCheckpointName: this._seedCheckpointName,
+      templateId: this._templateId,
+      templateDefinition: this._templateDefinition,
       environmentId: this._environmentId,
       idleTimeoutMinutes: this._idleTimeoutMinutes,
       networkIsolation: this._networkIsolation,
@@ -589,7 +608,11 @@ export class PlatformSandbox extends MastraSandbox {
     const requestStartedAt = Date.now();
     for (let attempt = 1; ; attempt++) {
       try {
-        response = await this._client.request('/sandbox', {
+        const request =
+          this._templateId === undefined
+            ? this._client.request.bind(this._client)
+            : this._client.requestProvider.bind(this._client);
+        response = await request('/sandbox', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body,

--- a/workspaces/platform-workspace/src/template-compatibility.test.ts
+++ b/workspaces/platform-workspace/src/template-compatibility.test.ts
@@ -1,0 +1,61 @@
+import { Template, type SandboxTemplateBuilder } from '@mastra/core/workspace';
+import type { TemplateBuilder as E2BTemplateBuilder } from 'e2b';
+import { describe, expect, it } from 'vitest';
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? (<Value>() => Value extends Right ? 1 : 2) extends <Value>() => Value extends Left ? 1 : 2
+      ? true
+      : false
+    : false;
+type Expect<Value extends true> = Value;
+
+type RunCmdCommandMatchesE2B = Expect<
+  Equal<Parameters<SandboxTemplateBuilder['runCmd']>[0], Parameters<E2BTemplateBuilder['runCmd']>[0]>
+>;
+type RunCmdDeliberatelyExcludesUserOption = Expect<
+  Equal<Parameters<SandboxTemplateBuilder['runCmd']>, [command: string | string[]]>
+>;
+type SetWorkdirAcceptsE2BStringPath = Expect<
+  Parameters<SandboxTemplateBuilder['setWorkdir']>[0] extends Parameters<E2BTemplateBuilder['setWorkdir']>[0]
+    ? true
+    : false
+>;
+type SetEnvsMatchesE2B = Expect<
+  Equal<Parameters<SandboxTemplateBuilder['setEnvs']>, Parameters<E2BTemplateBuilder['setEnvs']>>
+>;
+type AptInstallMatchesE2B = Expect<
+  Equal<Parameters<SandboxTemplateBuilder['aptInstall']>, Parameters<E2BTemplateBuilder['aptInstall']>>
+>;
+type PipInstallMatchesE2B = Expect<
+  Equal<Parameters<SandboxTemplateBuilder['pipInstall']>, Parameters<E2BTemplateBuilder['pipInstall']>>
+>;
+type NpmInstallMatchesE2B = Expect<
+  Equal<Parameters<SandboxTemplateBuilder['npmInstall']>, Parameters<E2BTemplateBuilder['npmInstall']>>
+>;
+
+type E2BTemplateCompatibilityAssertions =
+  | RunCmdCommandMatchesE2B
+  | RunCmdDeliberatelyExcludesUserOption
+  | SetWorkdirAcceptsE2BStringPath
+  | SetEnvsMatchesE2B
+  | AptInstallMatchesE2B
+  | PipInstallMatchesE2B
+  | NpmInstallMatchesE2B;
+
+describe('E2B template signature compatibility', () => {
+  it('keeps the supported serializable subset structurally compatible', () => {
+    expect(true satisfies E2BTemplateCompatibilityAssertions).toBe(true);
+  });
+
+  it('deliberately excludes non-portable E2B options and methods', () => {
+    const assertExcludedOperations = () => {
+      // @ts-expect-error The E2B user option isn't portable to Railway in protocol v1.
+      Template().runCmd('whoami', { user: 'root' });
+      // @ts-expect-error Local filesystem copies aren't JSON-portable build operations.
+      Template().copy('package.json', '/workspace/package.json');
+    };
+
+    expect(assertExcludedOperations).toBeTypeOf('function');
+  });
+});

--- a/workspaces/platform-workspace/src/templates.test.ts
+++ b/workspaces/platform-workspace/src/templates.test.ts
@@ -1,0 +1,186 @@
+import { Template } from '@mastra/core/workspace';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlatformTemplateBuildError, PlatformTemplateBuildTimeoutError, PlatformTemplateClient } from './templates.js';
+
+function jsonResponse(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function rejectWhenAborted(_input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const signal = init?.signal;
+  if (!signal) return Promise.reject(new Error('Expected an AbortSignal'));
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise((_resolve, reject) => {
+    signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+  });
+}
+
+function client(fetchMock: typeof fetch, sandboxProvider?: 'railway' | 'e2b') {
+  return new PlatformTemplateClient({
+    accessToken: 'sk_test',
+    projectId: 'project id',
+    fetch: fetchMock,
+    ...(sandboxProvider && { sandboxProvider }),
+  });
+}
+
+describe('PlatformTemplateClient', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('starts a build on the explicit provider route with the exact providerless definition', async () => {
+    vi.stubEnv('SANDBOX_PROVIDER', 'railway');
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const definition = Template().setEnvs({ BUILD_MODE: 'production' }).runCmd('pnpm build').toJSON();
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ templateId: 'tpl_handle', status: 'building' }, 202));
+
+    await expect(
+      client(fetchMock as typeof fetch, 'e2b').build({ environmentId: 'env_123', definition }),
+    ).resolves.toEqual({ templateId: 'tpl_handle', status: 'building' });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://proxy.test/v1/e2b/projects/project%20id/templates');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(String(init.body))).toEqual({ environmentId: 'env_123', definition });
+    expect(JSON.parse(String(init.body))).not.toHaveProperty('buildSecrets');
+  });
+
+  it('uses SANDBOX_PROVIDER and defaults to provider-prefixed Railway routes when it is unset', async () => {
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const definition = Template().runCmd('true').toJSON();
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(jsonResponse({ templateId: 'tpl', status: 'queued' }, 202)));
+
+    vi.stubEnv('SANDBOX_PROVIDER', 'e2b');
+    await client(fetchMock as typeof fetch).build({ environmentId: 'env', definition });
+    vi.stubEnv('SANDBOX_PROVIDER', undefined);
+    await client(fetchMock as typeof fetch).build({ environmentId: 'env', definition });
+
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('/v1/e2b/projects/');
+    expect(String(fetchMock.mock.calls[1]![0])).toContain('/v1/railway/projects/');
+  });
+
+  it('rejects an invalid provider environment value', () => {
+    vi.stubEnv('SANDBOX_PROVIDER', 'other');
+    expect(() => client(vi.fn() as unknown as typeof fetch)).toThrow(
+      'SANDBOX_PROVIDER must be either "railway" or "e2b"',
+    );
+  });
+
+  it('gets status with an encoded opaque handle and environment scope', async () => {
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ templateId: 'opaque/value', status: 'ready' }));
+
+    await expect(
+      client(fetchMock as typeof fetch, 'railway').get({ environmentId: 'env a', templateId: 'opaque/value' }),
+    ).resolves.toEqual({ templateId: 'opaque/value', status: 'ready' });
+
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(
+      'https://proxy.test/v1/railway/projects/project%20id/templates/opaque%2Fvalue?environmentId=env+a',
+    );
+  });
+
+  it('polls provider-owned status until ready', async () => {
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ templateId: 'tpl', status: 'queued' }))
+      .mockResolvedValueOnce(jsonResponse({ templateId: 'tpl', status: 'building' }))
+      .mockResolvedValueOnce(jsonResponse({ templateId: 'tpl', status: 'ready' }));
+
+    await expect(
+      client(fetchMock as typeof fetch).waitUntilReady({
+        environmentId: 'env',
+        templateId: 'tpl',
+        intervalMs: 100,
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toEqual({ templateId: 'tpl', status: 'ready' });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws a typed error when the provider build fails', async () => {
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ templateId: 'tpl', status: 'failed', error: 'Package installation failed' }));
+
+    await expect(
+      client(fetchMock as typeof fetch).waitUntilReady({ environmentId: 'env', templateId: 'tpl' }),
+    ).rejects.toMatchObject({
+      name: 'PlatformTemplateBuildError',
+      template: { templateId: 'tpl', status: 'failed', error: 'Package installation failed' },
+    } satisfies Partial<PlatformTemplateBuildError>);
+  });
+
+  it('supports aborting before and during an in-flight status request', async () => {
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi.fn(rejectWhenAborted);
+    const alreadyAborted = new AbortController();
+    alreadyAborted.abort(new Error('stop before polling'));
+
+    await expect(
+      client(fetchMock as typeof fetch).waitUntilReady({
+        environmentId: 'env',
+        templateId: 'tpl',
+        signal: alreadyAborted.signal,
+      }),
+    ).rejects.toThrow('stop before polling');
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const inFlight = new AbortController();
+    const wait = client(fetchMock as typeof fetch).waitUntilReady({
+      environmentId: 'env',
+      templateId: 'tpl',
+      signal: inFlight.signal,
+    });
+    inFlight.abort(new Error('stop in flight'));
+
+    await expect(wait).rejects.toThrow('stop in flight');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the overall timeout to an in-flight status request', async () => {
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi.fn(rejectWhenAborted);
+
+    await expect(
+      client(fetchMock as typeof fetch).waitUntilReady({
+        environmentId: 'env',
+        templateId: 'tpl',
+        intervalMs: 100,
+        timeoutMs: 5,
+      }),
+    ).rejects.toBeInstanceOf(PlatformTemplateBuildTimeoutError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { intervalMs: 0, timeoutMs: 1 },
+    { intervalMs: 99, timeoutMs: 1 },
+    { intervalMs: 100, timeoutMs: 0 },
+    { intervalMs: 100.5, timeoutMs: 10 },
+    { intervalMs: 100, timeoutMs: 2_147_483_648 },
+    { intervalMs: 2_147_483_648, timeoutMs: 10 },
+  ])('rejects invalid polling durations: %o', async ({ intervalMs, timeoutMs }) => {
+    await expect(
+      client(vi.fn() as unknown as typeof fetch).waitUntilReady({
+        environmentId: 'env',
+        templateId: 'tpl',
+        intervalMs,
+        timeoutMs,
+      }),
+    ).rejects.toBeInstanceOf(RangeError);
+  });
+
+  it('rejects malformed template responses', async () => {
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ id: 'provider-id', status: 'READY' }));
+
+    await expect(client(fetchMock as typeof fetch).get({ environmentId: 'env', templateId: 'tpl' })).rejects.toThrow(
+      'Invalid sandbox template response',
+    );
+  });
+});

--- a/workspaces/platform-workspace/src/templates.ts
+++ b/workspaces/platform-workspace/src/templates.ts
@@ -1,0 +1,164 @@
+import type { SerializedSandboxTemplate } from '@mastra/core/workspace';
+import type { PlatformClientOptions } from './client.js';
+import { PlatformClient } from './client.js';
+
+export type PlatformTemplateStatus = 'queued' | 'building' | 'ready' | 'failed';
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_WAIT_TIMEOUT_MS = 15 * 60_000;
+const MIN_POLL_INTERVAL_MS = 100;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export interface PlatformTemplateBuild {
+  templateId: string;
+  status: PlatformTemplateStatus;
+  error?: string | null;
+}
+
+export interface BuildPlatformTemplateInput {
+  environmentId: string;
+  definition: SerializedSandboxTemplate;
+}
+
+export interface GetPlatformTemplateInput {
+  environmentId: string;
+  templateId: string;
+  signal?: AbortSignal;
+}
+
+export interface WaitForPlatformTemplateInput extends GetPlatformTemplateInput {
+  intervalMs?: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export class PlatformTemplateBuildError extends Error {
+  readonly template: PlatformTemplateBuild;
+
+  constructor(template: PlatformTemplateBuild) {
+    super(template.error ? `Sandbox template build failed: ${template.error}` : 'Sandbox template build failed');
+    this.name = 'PlatformTemplateBuildError';
+    this.template = template;
+  }
+}
+
+export class PlatformTemplateBuildTimeoutError extends Error {
+  readonly templateId: string;
+  readonly timeoutMs: number;
+
+  constructor(templateId: string, timeoutMs: number) {
+    super(`Sandbox template ${templateId} was not ready within ${timeoutMs}ms`);
+    this.name = 'PlatformTemplateBuildTimeoutError';
+    this.templateId = templateId;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export class PlatformTemplateClient {
+  private readonly client: PlatformClient;
+
+  constructor(options: PlatformClientOptions = {}) {
+    this.client = new PlatformClient(options);
+  }
+
+  async build(input: BuildPlatformTemplateInput): Promise<PlatformTemplateBuild> {
+    const response = await this.client.requestProvider('/templates', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        environmentId: input.environmentId,
+        definition: input.definition,
+      }),
+    });
+    return readTemplateBuild(response);
+  }
+
+  async get(input: GetPlatformTemplateInput): Promise<PlatformTemplateBuild> {
+    const response = await this.client.requestProvider(`/templates/${encodeURIComponent(input.templateId)}`, {
+      query: { environmentId: input.environmentId },
+      signal: input.signal,
+    });
+    return readTemplateBuild(response);
+  }
+
+  async waitUntilReady(input: WaitForPlatformTemplateInput): Promise<PlatformTemplateBuild> {
+    const intervalMs = validateDuration(
+      input.intervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+      'intervalMs',
+      MIN_POLL_INTERVAL_MS,
+    );
+    const timeoutMs = validateDuration(input.timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS, 'timeoutMs', 1);
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    const signal = input.signal ? AbortSignal.any([input.signal, timeoutSignal]) : timeoutSignal;
+
+    try {
+      while (true) {
+        throwIfAborted(signal);
+        const template = await this.get({
+          environmentId: input.environmentId,
+          templateId: input.templateId,
+          signal,
+        });
+        throwIfAborted(signal);
+        if (template.status === 'ready') return template;
+        if (template.status === 'failed') throw new PlatformTemplateBuildError(template);
+
+        await sleep(intervalMs, signal);
+      }
+    } catch (error) {
+      if (input.signal?.aborted) throw abortReason(input.signal);
+      if (timeoutSignal.aborted) throw new PlatformTemplateBuildTimeoutError(input.templateId, timeoutMs);
+      throw error;
+    }
+  }
+}
+
+async function readTemplateBuild(response: Response): Promise<PlatformTemplateBuild> {
+  const value = (await response.json()) as unknown;
+  if (typeof value !== 'object' || value === null) throw new TypeError('Invalid sandbox template response');
+
+  const { templateId, status, error } = value as Record<string, unknown>;
+  if (typeof templateId !== 'string' || !isTemplateStatus(status)) {
+    throw new TypeError('Invalid sandbox template response');
+  }
+  if (error !== undefined && error !== null && typeof error !== 'string') {
+    throw new TypeError('Invalid sandbox template response');
+  }
+  return { templateId, status, ...(error !== undefined && { error: error as string | null }) };
+}
+
+function isTemplateStatus(value: unknown): value is PlatformTemplateStatus {
+  return value === 'queued' || value === 'building' || value === 'ready' || value === 'failed';
+}
+
+function validateDuration(value: number, name: string, minimum: number): number {
+  if (!Number.isSafeInteger(value) || value < minimum || value > MAX_TIMER_DELAY_MS) {
+    throw new RangeError(`${name} must be an integer between ${minimum} and ${MAX_TIMER_DELAY_MS}`);
+  }
+  return value;
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new DOMException('The operation was aborted', 'AbortError');
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw abortReason(signal);
+}
+
+function sleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  if (signal?.aborted) return Promise.reject(abortReason(signal));
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(
+        signal?.reason instanceof Error ? signal.reason : new DOMException('The operation was aborted', 'AbortError'),
+      );
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the OSS contract for providerless, JSON-serializable sandbox templates. Callers can build a portable E2B-shaped definition, submit it through provider-prefixed Platform routes, and create a sandbox with the returned tenant-bound template handle.

Template environment values are serialized and must contain only non-sensitive build configuration.

## Changes

- add immutable `Template()` builder to `@mastra/core/workspace`
- support `runCmd`, `setWorkdir`, `setEnvs`, `aptInstall`, `pipInstall`, and `npmInstall`
- validate operation shapes, JSON safety, collection bounds, and serialized size
- add `PlatformTemplateClient` build/status polling APIs with explicit → `SANDBOX_PROVIDER` → Railway provider resolution
- forward matching `templateId` and `templateDefinition` through `PlatformSandbox`, including clones
- require provider-prefixed sandbox routes when a template handle is used
- add editor schema coverage, E2B signature compatibility assertions, changesets, README guidance, and reference docs

## Test plan

- `pnpm exec vitest --project unit:packages/core run packages/core/src/workspace/template.test.ts packages/core/src/workspace/sandbox/local-sandbox.test.ts --reporter=dot --bail=1`
- `pnpm --filter ./packages/core check`
- `pnpm build:core`
- `pnpm --filter @mastra/platform-workspace test:unit`
- `pnpm --filter @mastra/platform-workspace build`
- `pnpm --filter @mastra/platform-workspace lint`
- `pnpm lint:format`
- packed ESM/CJS/TypeScript consumer smoke: `PROOF: GREEN`
