### PR TITLE
fix(core): keep a single fresh copy for transient signals within a turn

### DIFF
--- a/.changeset/transient-signals-single-fresh-copy.md
+++ b/.changeset/transient-signals-single-fresh-copy.md
@@ -1,0 +1,29 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `transient: true` signals so they deliver a single, fresh reminder instead of piling up.
+
+`processInputStep` runs once per model call, not once per turn, so a processor that re-sends a transient reminder each step was adding a new copy each time — by the fifth step of a tool loop the model received five copies of the same `<system-reminder>`. `transient` only ever suppressed persistence, so it never bounded the number of in-prompt copies.
+
+A transient signal now reuses one stable id per emitting processor and tag when the caller doesn't supply one, and re-sending it replaces the previous copy and moves it to the end of the prompt. That gives what the docs describe — one fresh copy near the latest message — with no caller changes.
+
+```ts
+export class SteeringReminderProcessor implements Processor {
+  readonly id = 'steering-reminder';
+
+  async processInputStep({ sendSignal }: ProcessInputStepArgs) {
+    // Before: one copy per step (1, 2, 3, 4, 5 by the fifth step).
+    // After:  one copy, always last.
+    await sendSignal?.({
+      type: 'reactive',
+      contents: 'Stay on the current task and keep answers under three sentences.',
+      transient: true,
+    });
+  }
+}
+```
+
+**If you place your own prompt cache breakpoints:** exclude transient signals when choosing them. A transient signal is in the live prompt but never persisted, so the next turn reloads a history without it — if it sat inside a cached prefix, that prefix is invalidated at the turn boundary and you pay a full rebuild every turn. The outbound projection now marks these rows with `providerOptions.mastra.transient`, and `isTransientSignalMessage()` identifies them on a `MastraDBMessage`.
+
+Passing an explicit `id` still wins, so send distinct ids when one processor needs several concurrent transient reminders under the same tag.

--- a/.changeset/transient-signals-single-fresh-copy.md
+++ b/.changeset/transient-signals-single-fresh-copy.md
@@ -4,7 +4,7 @@
 
 Fixed `transient: true` signals so they deliver a single, fresh reminder instead of piling up.
 
-`processInputStep` runs once per model call, not once per turn, so a processor that re-sends a transient reminder each step was adding a new copy each time — by the fifth step of a tool loop the model received five copies of the same `<system-reminder>`. `transient` only ever suppressed persistence, so it never bounded the number of in-prompt copies.
+`processInputStep` runs once per model call, not once per turn, so a processor that re-sends a transient reminder each step was adding a new copy each time, so the same `<system-reminder>` piled up across the steps of a turn. `transient` only ever suppressed persistence, so it never bounded the number of in-prompt copies.
 
 A transient signal now reuses one stable id per emitting processor and tag when the caller doesn't supply one, and re-sending it replaces the previous copy and moves it to the end of the prompt. That gives what the docs describe — one fresh copy near the latest message — with no caller changes.
 
@@ -13,7 +13,7 @@ export class SteeringReminderProcessor implements Processor {
   readonly id = 'steering-reminder';
 
   async processInputStep({ sendSignal }: ProcessInputStepArgs) {
-    // Before: one copy per step (1, 2, 3, 4, 5 by the fifth step).
+    // Before: a new copy added on every step, piling up across the turn.
     // After:  one copy, always last.
     await sendSignal?.({
       type: 'reactive',

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -679,7 +679,7 @@ export class SteeringReminderProcessor implements Processor {
 A transient signal is still in the prompt for the current call, so the model sees it near the latest message. It's not retained, so re-sending it on each call keeps a single fresh copy in context instead of an accumulating history, and stored thread history never includes it.
 
 :::warning
-**Keep transient signals out of your prompt cache breakpoints.** A transient signal is in the live prompt but never persisted, so the next turn reloads a history that doesn't contain it. If the signal sits inside a cached prefix, the reloaded history diverges at exactly that position and the whole span after it is invalidated — you pay a full prefix rebuild on the first call of every turn (measured at roughly 1.6x the token cost of the same conversation without the signal).
+**Keep transient signals out of your prompt cache breakpoints.** A transient signal is in the live prompt but never persisted, so the next turn reloads a history that doesn't contain it. If the signal sits inside a cached prefix, the reloaded history diverges at exactly that position and the whole span after it is invalidated — you pay a full prefix rebuild on the first call of every turn.
 
 The rule: a transient signal must come **after** the last `cache_control` breakpoint, so it lands in the uncached remainder. If you place breakpoints yourself, skip signal messages when choosing them. The outbound projection marks them with `providerOptions.mastra.transient`, and `isTransientSignalMessage()` identifies them on a `MastraDBMessage`.
 :::

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -676,7 +676,13 @@ export class SteeringReminderProcessor implements Processor {
 }
 ```
 
-A transient signal is still in the prompt for the current call, so the model sees it near the latest turn. It's not retained, so re-sending it each turn keeps a single fresh copy in context instead of an accumulating history, and stored thread history never includes it. Because nothing is written, it also keeps a stable prompt cache prefix across turns.
+A transient signal is still in the prompt for the current call, so the model sees it near the latest message. It's not retained, so re-sending it on each call keeps a single fresh copy in context instead of an accumulating history, and stored thread history never includes it.
+
+:::warning
+**Keep transient signals out of your prompt cache breakpoints.** A transient signal is in the live prompt but never persisted, so the next turn reloads a history that doesn't contain it. If the signal sits inside a cached prefix, the reloaded history diverges at exactly that position and the whole span after it is invalidated — you pay a full prefix rebuild on the first call of every turn (measured at roughly 1.6x the token cost of the same conversation without the signal).
+
+The rule: a transient signal must come **after** the last `cache_control` breakpoint, so it lands in the uncached remainder. If you place breakpoints yourself, skip signal messages when choosing them. The outbound projection marks them with `providerOptions.mastra.transient`, and `isTransientSignalMessage()` identifies them on a `MastraDBMessage`.
+:::
 
 ### Emit custom stream events
 

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -7,7 +7,7 @@ import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import type { IMastraLogger } from '../../logger';
 import { getTransformedToolPayload, hasTransformedToolPayload } from '../../tools/payload-transform';
 import type { IdGeneratorContext } from '../../types';
-import { createSignal, isCreatedAgentSignal, mastraDBMessageToSignal } from '../signals';
+import { createSignal, isCreatedAgentSignal, isTransientSignalMessage, mastraDBMessageToSignal } from '../signals';
 import type { CreatedAgentSignal } from '../signals';
 import { AIV4Adapter, AIV5Adapter, AIV6Adapter } from './adapters';
 import { CacheKeyGenerator } from './cache/CacheKeyGenerator';
@@ -259,6 +259,26 @@ export class MessageList {
         ? createSignal({ ...signalInput, type: signal.type })
         : createSignal({ ...signalInput, type: signal.type, transient: signal.transient });
 
+    // A transient signal is delivery-only and exists to be re-injected, so the transcript should
+    // hold exactly one copy and that copy should be the last thing the model reads. Dropping any
+    // previous row with the same id first makes addOne take its append path with the fresh
+    // monotonic `createdAt` stamped above, so the sort at the end of addOne places it after the
+    // newest message. Without this the id-keyed upsert either appends a duplicate (rotating id) or,
+    // when the contents are byte-identical, classifies the message as unchanged and writes nothing
+    // at all — leaving the copy anchored at its original index while the turn grows behind it.
+    //
+    // This is what makes `transient` deliver what the docs promise on its own — "a single fresh copy
+    // near the latest message" — without the caller having to know that ids drive deduplication.
+    // Repositioning a row does move it out of any prompt-cache span that already covered it, so a
+    // consumer that places cache breakpoints should exclude transient signal rows when choosing
+    // them; see the note on `isTransientSignalMessage` in agent/signals.ts.
+    //
+    // No `type` gate is needed: createSignal rejects `transient` on `state` signals, which are the
+    // ones whose cross-turn tracking depends on keeping a stable row.
+    if (signalForTranscript.transient) {
+      this.removeByIds([signalForTranscript.id]);
+    }
+
     this.addOne(signalForTranscript.toDBMessage(this.memoryInfo ?? undefined), source);
     return signalForTranscript;
   }
@@ -407,18 +427,39 @@ export class MessageList {
       metadata: { createdAt },
     };
 
-    return [
-      convertInputToMastraDBMessage(promptMessage as MessageInput, 'input', {
-        memoryInfo: this.memoryInfo,
-        newMessageId: () => message.id,
-        generateCreatedAt: (_messageSource, start) => {
-          if (start instanceof Date) return start;
-          if (typeof start === 'string' || typeof start === 'number') return new Date(start);
-          return createdAt;
-        },
-        dbMessages: this.messages,
-      }),
-    ];
+    const projected = convertInputToMastraDBMessage(promptMessage as MessageInput, 'input', {
+      memoryInfo: this.memoryInfo,
+      newMessageId: () => message.id,
+      generateCreatedAt: (_messageSource, start) => {
+        if (start instanceof Date) return start;
+        if (typeof start === 'string' || typeof start === 'number') return new Date(start);
+        return createdAt;
+      },
+      dbMessages: this.messages,
+    });
+
+    // Mark a delivery-only reminder in the outbound projection. Once the signal is rewritten to
+    // `role: 'user'` here, nothing downstream can tell it apart from a normal turn — but a consumer
+    // placing prompt-cache breakpoints has to, because a transient row is absent from the next
+    // turn's reloaded history: any cached span containing it dies at the turn boundary and costs a
+    // full prefix rebuild per turn. Surfacing the flag lets such a consumer keep its breakpoints
+    // behind the reminder without having to pattern-match on the rendered XML tag, which would also
+    // catch persisted reminders.
+    if (isTransientSignalMessage(message)) {
+      projected.content.parts = projected.content.parts.map(part =>
+        part.type === 'text'
+          ? {
+              ...part,
+              providerMetadata: {
+                ...part.providerMetadata,
+                mastra: { ...(part.providerMetadata?.mastra as Record<string, unknown> | undefined), transient: true },
+              },
+            }
+          : part,
+      );
+    }
+
+    return [projected];
   }
 
   public makeMessageSourceChecker(): {

--- a/packages/core/src/agent/message-list/tests/message-list-transient-signal.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-transient-signal.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { createSignal } from '../../signals';
+import { MessageList } from '../index';
+
+/**
+ * State signals are out of scope here: `createSignal` rejects `transient` on them, which is why
+ * `addSignal` needs no `type` gate (see agent/signals.test.ts for that invariant).
+ *
+ * A transient signal is delivery-only: it is re-injected on every step and never persisted.
+ * `addSignal` therefore drops the previous row before appending the new one, so the transcript
+ * holds a single copy and that copy is the last thing the model reads.
+ *
+ * The outbound projection also marks the row with `providerOptions.mastra.transient`, which is how
+ * a consumer that places prompt-cache breakpoints can keep them behind the reminder — a transient
+ * row is absent from the next turn's reloaded history, so a cached span containing it is
+ * invalidated at the turn boundary.
+ */
+describe('transient signals in MessageList', () => {
+  const MARKER = 'stay on the current task';
+
+  function newList() {
+    const list = new MessageList({ threadId: 'transient-thread' });
+    list.add([{ role: 'user', content: 'hello' }], 'input');
+    return list;
+  }
+
+  function promptTexts(list: MessageList): string[] {
+    return list.get.all.aiV5.prompt().map(message => {
+      if (typeof message.content === 'string') return message.content;
+      if (!Array.isArray(message.content)) return '';
+      return message.content
+        .filter((part: any) => part.type === 'text')
+        .map((part: any) => part.text)
+        .join('\n');
+    });
+  }
+
+  function sendTransient(list: MessageList, id = 'reminder-1') {
+    list.addSignal(createSignal({ id, type: 'reactive', contents: MARKER, transient: true }));
+  }
+
+  it('keeps a single copy when the same transient signal is re-sent', () => {
+    const list = newList();
+
+    sendTransient(list);
+    sendTransient(list);
+    sendTransient(list);
+
+    expect(list.get.all.db().filter(message => message.role === 'signal')).toHaveLength(1);
+    expect(promptTexts(list).filter(text => text.includes(MARKER))).toHaveLength(1);
+  });
+
+  it('moves the surviving copy to the end as the transcript grows', () => {
+    const list = newList();
+
+    sendTransient(list);
+    list.add([{ role: 'assistant', content: 'first answer' }], 'response');
+    sendTransient(list);
+    list.add([{ role: 'assistant', content: 'second answer' }], 'response');
+    sendTransient(list);
+
+    const texts = promptTexts(list);
+    expect(texts.filter(text => text.includes(MARKER))).toHaveLength(1);
+    // Re-sending appends a fresh row, so the reminder is always the final prompt entry.
+    expect(texts[texts.length - 1]).toContain(MARKER);
+  });
+
+  it('exposes the transient flag on the outbound projection', () => {
+    const list = newList();
+    sendTransient(list);
+
+    const reminder = list.get.all.aiV5.prompt().find(message => {
+      const content = message.content;
+      return Array.isArray(content) && content.some((part: any) => part.type === 'text' && part.text.includes(MARKER));
+    });
+
+    expect(reminder).toBeDefined();
+    const textPart = (reminder!.content as any[]).find(part => part.type === 'text');
+    expect(textPart.providerOptions?.mastra?.transient).toBe(true);
+  });
+
+  it('does not mark a non-transient signal as transient in the projection', () => {
+    const list = newList();
+    list.addSignal(createSignal({ id: 'kept-1', type: 'reactive', contents: MARKER }));
+
+    const reminder = list.get.all.aiV5.prompt().find(message => {
+      const content = message.content;
+      return Array.isArray(content) && content.some((part: any) => part.type === 'text' && part.text.includes(MARKER));
+    });
+
+    expect(reminder).toBeDefined();
+    const textPart = (reminder!.content as any[]).find(part => part.type === 'text');
+    expect(textPart.providerOptions?.mastra?.transient).toBeUndefined();
+  });
+
+  it('leaves a non-transient signal in place when it is re-sent', () => {
+    const list = newList();
+
+    list.addSignal(createSignal({ id: 'kept-1', type: 'reactive', contents: MARKER }));
+    list.add([{ role: 'assistant', content: 'answer' }], 'response');
+    list.addSignal(createSignal({ id: 'kept-1', type: 'reactive', contents: MARKER }));
+
+    const texts = promptTexts(list);
+    // One row, because the id matches — but it is not repositioned, so it is not last.
+    expect(texts.filter(text => text.includes(MARKER))).toHaveLength(1);
+    expect(texts[texts.length - 1]).not.toContain(MARKER);
+  });
+});

--- a/packages/core/src/agent/signals.ts
+++ b/packages/core/src/agent/signals.ts
@@ -189,6 +189,18 @@ function normalizeSignalType(input: Pick<AgentSignalInput, 'type' | 'tagName'>):
   );
 }
 
+/**
+ * The tag name a signal will carry once created, resolvable before `createSignal` runs.
+ *
+ * Callers that need to derive something from the tag name — such as a stable transcript id for a
+ * re-injected transient signal — must not have to duplicate the type-to-tag defaulting rules.
+ *
+ * @experimental Agent signals are experimental and may change in a future release.
+ */
+export function resolveSignalTagName(input: Pick<AgentSignalInput, 'type' | 'tagName'>): AgentSignalTagName {
+  return input.tagName ?? normalizeSignalType(input).tagName;
+}
+
 function normalizeSignal(signal: AgentSignalInput | CreatedAgentSignal) {
   const { type, tagName } = normalizeSignalType(signal);
   return {

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -704,7 +704,7 @@ export class ProcessorRunner {
           requestContext,
           retryCount,
           writer,
-          sendSignal: createProcessorSendSignal({ messageList, writer }),
+          sendSignal: createProcessorSendSignal({ messageList, writer, processorId: processor.id }),
         });
 
         // Stop recording and get mutations for this processor
@@ -1205,7 +1205,7 @@ export class ProcessorRunner {
           messageList,
           requestContext,
           retryCount,
-          sendSignal: createProcessorSendSignal({ messageList }),
+          sendSignal: createProcessorSendSignal({ messageList, processorId: processor.id }),
         });
 
         // Handle MessageList, MastraDBMessage[], or { messages, systemMessages } return types
@@ -1536,7 +1536,12 @@ export class ProcessorRunner {
           writer,
           abortSignal: args.abortSignal,
           agent: this.agent,
-          sendSignal: createProcessorSendSignal({ messageList, writer, rotateResponseMessageId }),
+          sendSignal: createProcessorSendSignal({
+            messageList,
+            writer,
+            rotateResponseMessageId,
+            processorId: processor.id,
+          }),
           sendStateSignal: async (
             stateSignal: AgentStateSignalInput | (Omit<AgentStateSignalInput, 'id'> & { id?: string }),
           ) => {
@@ -1969,7 +1974,7 @@ export class ProcessorRunner {
           agent: this.agent,
           retryCount,
           writer,
-          sendSignal: createProcessorSendSignal({ messageList, writer }),
+          sendSignal: createProcessorSendSignal({ messageList, writer, processorId: processor.id }),
         });
 
         // Stop recording and get mutations for this processor
@@ -2353,7 +2358,12 @@ export class ProcessorRunner {
           abortSignal,
           messageId: args.messageId,
           ...(rotateResponseMessageId ? { rotateResponseMessageId } : {}),
-          sendSignal: createProcessorSendSignal({ messageList, writer, rotateResponseMessageId }),
+          sendSignal: createProcessorSendSignal({
+            messageList,
+            writer,
+            rotateResponseMessageId,
+            processorId: processor.id,
+          }),
         });
 
         // Stop recording and get mutations for this processor

--- a/packages/core/src/processors/send-signal.ts
+++ b/packages/core/src/processors/send-signal.ts
@@ -8,8 +8,8 @@ import type { ProcessorStreamWriter } from './index';
  *
  * A transient signal is meant to be re-injected — typically from `processInputStep`, which runs
  * once per model call — and the message-list upsert is keyed on `id`. Without a stable id every
- * re-injection mints a fresh UUID and lands as an additional copy in the same turn, so by the fifth
- * step of a tool loop the model sees five copies of one reminder. Keying on the emitting processor
+ * re-injection mints a fresh UUID and lands as an additional copy in the same turn, so every step
+ * of a tool loop adds another copy of the same reminder. Keying on the emitting processor
  * plus the tag name gives each emitter one slot per tag without the caller having to know that ids
  * are what drive deduplication.
  *
@@ -26,7 +26,7 @@ import type { ProcessorStreamWriter } from './index';
  * from the same processor and tag distinguishes them itself.
  */
 function defaultTransientSignalId(processorId: string, tagName: string): string {
-  return `transient:${processorId}:${tagName}`;
+  return `transient:${encodeURIComponent(processorId)}:${encodeURIComponent(tagName)}`;
 }
 
 export function createProcessorSendSignal(args: {

--- a/packages/core/src/processors/send-signal.ts
+++ b/packages/core/src/processors/send-signal.ts
@@ -1,15 +1,47 @@
 import type { MessageList } from '../agent/message-list';
-import { createSignal } from '../agent/signals';
+import { createSignal, resolveSignalTagName } from '../agent/signals';
 import type { AgentSignalInput, CreatedAgentSignal } from '../agent/signals';
 import type { ProcessorStreamWriter } from './index';
+
+/**
+ * Stable transcript id for a transient signal whose sender did not supply one.
+ *
+ * A transient signal is meant to be re-injected — typically from `processInputStep`, which runs
+ * once per model call — and the message-list upsert is keyed on `id`. Without a stable id every
+ * re-injection mints a fresh UUID and lands as an additional copy in the same turn, so by the fifth
+ * step of a tool loop the model sees five copies of one reminder. Keying on the emitting processor
+ * plus the tag name gives each emitter one slot per tag without the caller having to know that ids
+ * are what drive deduplication.
+ *
+ * With a stable id every re-injection targets the same transcript row — one slot per emitting
+ * processor and tag — instead of minting a new UUID and stacking copies. The message list then
+ * drops that row and re-appends it (see the transient branch in `addSignal`), so a single copy is
+ * kept and repositioned after the newest message on each step: recency is per step, not per turn.
+ * A transient signal is never persisted, so the next turn reloads a history without it and appends
+ * it fresh. Keeping the cached prompt prefix stable across the moving copy is the consumer's job —
+ * place prompt-cache breakpoints behind transient rows; see the note on `isTransientSignalMessage`
+ * in agent/signals.ts.
+ *
+ * An explicitly supplied `id` always wins: a caller that wants several concurrent transient signals
+ * from the same processor and tag distinguishes them itself.
+ */
+function defaultTransientSignalId(processorId: string, tagName: string): string {
+  return `transient:${processorId}:${tagName}`;
+}
 
 export function createProcessorSendSignal(args: {
   messageList: MessageList;
   writer?: ProcessorStreamWriter;
   rotateResponseMessageId?: () => string;
+  /** Id of the processor this `sendSignal` is handed to; used to key re-injected transient signals. */
+  processorId?: string;
 }): (signalInput: AgentSignalInput) => Promise<CreatedAgentSignal> {
   return async signalInput => {
-    const signal = createSignal(signalInput);
+    const input =
+      signalInput.transient && !signalInput.id && args.processorId
+        ? { ...signalInput, id: defaultTransientSignalId(args.processorId, resolveSignalTagName(signalInput)) }
+        : signalInput;
+    const signal = createSignal(input);
     args.messageList.markResponseMessageBoundary();
     args.rotateResponseMessageId?.();
     const signalForTranscript = args.messageList.addSignal(signal);

--- a/packages/core/src/processors/sendSignal-integration.test.ts
+++ b/packages/core/src/processors/sendSignal-integration.test.ts
@@ -449,4 +449,121 @@ describe('sendSignal integration through ProcessorRunner', () => {
     expect((signals[0]!.content.metadata?.signal as Record<string, unknown>).transient).toBe(true);
     expect(isTransientSignalMessage(signals[0]!)).toBe(true);
   });
+
+  describe('transient signals are deduplicated and kept last', () => {
+    const MARKER = 'stay on the current task';
+
+    /**
+     * Drive N steps of one turn through the same runner and MessageList, measuring the
+     * prompt as the model would receive it: right after the step's processors run, and
+     * before the loop appends the assistant turn that follows.
+     */
+    async function runSteps(runner: ProcessorRunner, steps: number) {
+      const seen: { copies: number; lastIndex: number; total: number }[] = [];
+      for (let step = 0; step < steps; step++) {
+        // Each step but the first is preceded by the previous step's assistant turn.
+        if (step > 0) {
+          messageList.add([{ role: 'assistant', content: `step ${step - 1}` }], 'response');
+        }
+
+        await runner.runProcessInputStep({
+          messageList,
+          stepNumber: step,
+          steps: [],
+          model: {} as any,
+          tools: {},
+          retryCount: 0,
+          messageId: `response-${step}`,
+          writer: { custom: async () => {} },
+        });
+
+        const prompt = messageList.get.all.aiV5.prompt();
+        const texts = prompt.map(extractPromptText);
+        seen.push({
+          copies: texts.filter(t => t.includes(MARKER)).length,
+          lastIndex: texts.reduce((acc, t, i) => (t.includes(MARKER) ? i : acc), -1),
+          total: prompt.length,
+        });
+      }
+      return seen;
+    }
+
+    function makeRunner(returnMode: 'nothing' | 'messageList' | 'ctxMessages') {
+      return new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'steering-reminder',
+            processInputStep: async (args: any) => {
+              await args.sendSignal?.({ type: 'reactive', contents: MARKER, transient: true });
+              if (returnMode === 'messageList') return args.messageList;
+              if (returnMode === 'ctxMessages') return args.messages;
+              return undefined;
+            },
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+    }
+
+    it('keeps exactly one copy across the steps of a turn', async () => {
+      const seen = await runSteps(makeRunner('nothing'), 4);
+
+      expect(seen.map(s => s.copies)).toEqual([1, 1, 1, 1]);
+      expect(messageList.get.all.db().filter(m => m.role === 'signal')).toHaveLength(1);
+    });
+
+    it('re-emits the reminder as the last prompt message on every step', async () => {
+      const seen = await runSteps(makeRunner('nothing'), 4);
+
+      // The reminder is always the final entry, so the model reads it last.
+      expect(seen.every(s => s.lastIndex === s.total - 1)).toBe(true);
+    });
+
+    it('reuses the same stable id instead of minting a new one per step', async () => {
+      await runSteps(makeRunner('nothing'), 3);
+
+      const signals = messageList.get.all.db().filter(m => m.role === 'signal');
+      expect(signals).toHaveLength(1);
+      expect(signals[0]!.id).toBe('transient:steering-reminder:system-reminder');
+    });
+
+    it('behaves the same when the processor returns the messageList it mutated', async () => {
+      const seen = await runSteps(makeRunner('messageList'), 4);
+
+      expect(seen.map(s => s.copies)).toEqual([1, 1, 1, 1]);
+      expect(seen.every(s => s.lastIndex === s.total - 1)).toBe(true);
+    });
+
+    it('does not duplicate the reminder when the processor returns the ctx.messages snapshot', async () => {
+      // Returning the pre-call snapshot makes the runner re-apply it, which reverts the
+      // reposition — but the stable id means the row is replaced, never duplicated.
+      const seen = await runSteps(makeRunner('ctxMessages'), 4);
+
+      expect(seen.map(s => s.copies)).toEqual([1, 1, 1, 1]);
+      expect(messageList.get.all.db().filter(m => m.role === 'signal')).toHaveLength(1);
+    });
+
+    it('leaves a non-transient signal untouched', async () => {
+      const runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'persisted-reminder',
+            processInputStep: async ({ sendSignal }: any) => {
+              await sendSignal?.({ type: 'reactive', contents: MARKER });
+            },
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const seen = await runSteps(runner, 3);
+
+      // No stable id and no removal: the pre-existing accumulate-per-step behaviour stands.
+      expect(seen.map(s => s.copies)).toEqual([1, 2, 3]);
+    });
+  });
 });

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1099,6 +1099,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                 messageList: processorMessageList,
                 writer: processorWriter,
                 rotateResponseMessageId: rotateCurrentResponseMessageId,
+                processorId: processor.id,
               }),
             }
           : {}),

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1005,6 +1005,7 @@ function createStepFromProcessor<TProcessorId extends string>(
                 messageList: processorMessageList,
                 writer: processorWriter,
                 rotateResponseMessageId: rotateCurrentResponseMessageId,
+                processorId: processor.id,
               }),
             }
           : {}),


### PR DESCRIPTION
## Description

`processInputStep` runs once per model call, not once per turn, so a processor that re-sends a `transient` steering reminder was adding a new copy each step — five copies of the same `<system-reminder>` by the fifth step of a tool loop. `transient: true` correctly prevents accumulation **across turns** (nothing persisted), but **within a turn** nothing is reloaded from storage, so the flag had nothing to act on and the documented *"single fresh copy"* promise was not met.

Two small changes, using only machinery that already exists:

- **`MessageList.addSignal`** — when `signal.transient === true`, `removeByIds([id])` before the add. `addSignal` already stamps a fresh `createdAt`, so the re-add takes the append path and the sort places the row last: one copy, repositioned after the newest message (dedup **and** recency from one mechanism). No `type` gate needed — `createSignal` already forbids `transient` on `state` signals, which are the ones that must stay put.
- **`createProcessorSendSignal`** — give a transient signal with no caller-supplied `id` a stable default keyed on the emitting `processorId` + tag, so re-injection targets one row. An explicitly supplied `id` always wins.

Docs (`processors.mdx`) updated: `transient` governs *persistence*, not in-prompt copies; `processInputStep` runs once per call; plus a prompt-cache caveat (below).

**Validation:** type-check clean and unit tests green on current `main` (branch rebased onto it); also validated end-to-end in a real consumer app (single copy, per-step recency, nothing persisted).

**Note for reviewers — prompt-cache trade-off.** The reminder is repositioned to the tail each step, so a cache breakpoint whose span contains it would break. This is a *consumer-side* concern, not the library's: a transient row is absent from the next turn's reloaded history, so any cached span containing it already dies at the turn boundary regardless. The fix keeps the reminder deduplicated and last, and marks it with `providerOptions.mastra.transient` / `isTransientSignalMessage()` so a consumer can keep its cache breakpoints behind it — documented in the added `processors.mdx` warning.

## Related issue(s)

Closes #22060

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Transient reminders no longer repeat during one turn. Each processor keeps one fresh copy near the latest message, while reminders still disappear after the turn.

## Summary

- Deduplicate transient signals by processor and signal tag.
- Reuse stable generated IDs unless an explicit ID is provided.
- Move replaced transient signals to the end of the transcript.
- Mark transient signal content with `providerMetadata.mastra.transient`.
- Preserve accumulating behavior for non-transient signals.
- Pass processor IDs through processor and workflow signal creation.
- Add unit and integration tests for deduplication, ordering, IDs, and prompt metadata.
- Update documentation for transient persistence, processor execution, and prompt-cache placement.
- Add a changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->