### PR TITLE
fix(memory): end Observational Memory tracing spans

### DIFF
--- a/.changeset/om-tracing-span-end.md
+++ b/.changeset/om-tracing-span-end.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+End Observational Memory tracing spans. `withOmTracingSpan` created the `om.observer` / `om.observer.multi-thread` / `om.reflector` span but never called `span.end()` (or `span.error()` on failure), so the spans stayed open forever. Exporters and bridges that retain a trace until all of its spans finish (for example the Datadog bridge, where dd-trace holds the trace's full span list with all LLM Observability payloads) leaked memory on every observer or reflector run, and the `om.*` spans never flushed to any exporter. The spans now end on success and record the error and rethrow on failure.

--- a/packages/memory/src/processors/observational-memory/__tests__/tracing.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/tracing.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const getOrCreateSpanMock = vi.fn();
+
+vi.mock('@mastra/core/observability', () => ({
+  getOrCreateSpan: (...args: unknown[]) => getOrCreateSpanMock(...args),
+  createObservabilityContext: ({ currentSpan }: { currentSpan?: unknown }) => ({
+    tracingContext: { currentSpan },
+  }),
+  EntityType: { OUTPUT_STEP_PROCESSOR: 'output_step_processor' },
+  SpanType: { GENERIC: 'generic' },
+}));
+
+import { withOmTracingSpan } from '../tracing';
+
+function createMockSpan() {
+  return {
+    executeInContext: vi.fn((fn: () => unknown) => fn()),
+    end: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe('withOmTracingSpan', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ends the span when the callback resolves', async () => {
+    const span = createMockSpan();
+    getOrCreateSpanMock.mockReturnValue(span);
+
+    const result = await withOmTracingSpan({
+      phase: 'observer',
+      model: 'test/model',
+      inputTokens: 123,
+      callback: async () => 'ok',
+    });
+
+    expect(result).toBe('ok');
+    expect(span.end).toHaveBeenCalledTimes(1);
+    expect(span.error).not.toHaveBeenCalled();
+  });
+
+  it('records the error and rethrows when the callback fails', async () => {
+    const span = createMockSpan();
+    getOrCreateSpanMock.mockReturnValue(span);
+    const failure = new Error('observer failed');
+
+    await expect(
+      withOmTracingSpan({
+        phase: 'reflector',
+        model: 'test/model',
+        inputTokens: 456,
+        callback: async () => {
+          throw failure;
+        },
+      }),
+    ).rejects.toThrow('observer failed');
+
+    expect(span.error).toHaveBeenCalledWith({ error: failure });
+    expect(span.end).not.toHaveBeenCalled();
+  });
+
+  it('runs the callback directly when no span is created', async () => {
+    getOrCreateSpanMock.mockReturnValue(undefined);
+    const callback = vi.fn(async () => 'no-span');
+
+    await expect(
+      withOmTracingSpan({
+        phase: 'observer',
+        model: 'test/model',
+        inputTokens: 0,
+        callback,
+      }),
+    ).resolves.toBe('no-span');
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/tracing.test.ts
+++ b/packages/memory/src/processors/observational-memory/tracing.test.ts
@@ -11,7 +11,7 @@ vi.mock('@mastra/core/observability', () => ({
   SpanType: { GENERIC: 'generic' },
 }));
 
-import { withOmTracingSpan } from '../tracing';
+import { withOmTracingSpan } from './tracing';
 
 function createMockSpan() {
   return {
@@ -56,7 +56,7 @@ describe('withOmTracingSpan', () => {
           throw failure;
         },
       }),
-    ).rejects.toThrow('observer failed');
+    ).rejects.toBe(failure);
 
     expect(span.error).toHaveBeenCalledWith({ error: failure });
     expect(span.end).not.toHaveBeenCalled();

--- a/packages/memory/src/processors/observational-memory/tracing.ts
+++ b/packages/memory/src/processors/observational-memory/tracing.ts
@@ -71,5 +71,14 @@ export async function withOmTracingSpan<T>({
     return callback(childObservabilityContext);
   }
 
-  return span.executeInContext(() => callback(childObservabilityContext));
+  return span.executeInContext(async () => {
+    try {
+      const result = await callback(childObservabilityContext);
+      span.end();
+      return result;
+    } catch (error) {
+      span.error({ error });
+      throw error;
+    }
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #22062.

`withOmTracingSpan` created the `om.observer` / `om.observer.multi-thread` / `om.reflector` span, ran the callback in its context, and returned without ever calling `span.end()` (or `span.error()` on failure), so every Observational Memory observer/reflector run left a span open forever.

Consequences:

- Bridges/exporters that retain a trace until all of its spans finish leak memory on every run. With the `DatadogBridge`, dd-trace holds the trace's entire span list — including all LLM Observability payloads — so a production app leaked several MB per observed chat turn (heap snapshots showed `om.observer` as the only span family with undefined duration, 80/80 unfinished on one pod).
- The `om.*` spans never flush, so the telemetry they exist for never reaches any exporter.

## Change

End the span around the callback, mirroring the other tracing helpers: `span.end()` on success, `span.error({ error })` + rethrow on failure. No behavior change for Observational Memory itself.

## Tests

New `tracing.test.ts` unit test (fails against the previous implementation):
- span ends when the callback resolves;
- error is recorded and rethrown when the callback fails (span not double-ended);
- callback still runs when no span is created.

Verified against a production build of a real app: with this change all `om.observer` spans finish and heap growth from retained traces stops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Observational Memory spans now close when their work finishes. This prevents memory leaks and allows telemetry to reach exporters.

## Changes

- End `om.observer`, `om.observer.multi-thread`, and `om.reflector` spans after successful callbacks.
- Record callback errors on spans, then rethrow the original errors.
- Execute callbacks normally when no span exists.
- Add tests for success, failure, error rethrowing, and missing spans.
- Add a patch changeset for `@mastra/memory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->