### PR TITLE
Add a secondary project identifier to server telemetry

### DIFF
--- a/.changeset/breezy-tips-walk.md
+++ b/.changeset/breezy-tips-walk.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved project correlation in server telemetry without changing existing project identifiers.

--- a/.changeset/breezy-tips-walk.md
+++ b/.changeset/breezy-tips-walk.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Improved project correlation in server telemetry without changing existing project identifiers.
+Server telemetry events can now carry an optional secondary project identifier, `project_id2`, while all existing project identifiers remain unchanged. It is derived from the `MASTRA_PROJECT_ID` environment variable when set (prefixed `mp_`), falling back to a SHA-256 hash of the project's git `origin` remote URL, and is omitted when neither is available.

--- a/.changeset/breezy-tips-walk.md
+++ b/.changeset/breezy-tips-walk.md
@@ -3,3 +3,8 @@
 ---
 
 Server telemetry events can now carry an optional secondary project identifier, `project_id2`, while all existing project identifiers remain unchanged. It is derived from the `MASTRA_PROJECT_ID` environment variable when set (prefixed `mp_`), falling back to a SHA-256 hash of the project's git `origin` remote URL, and is omitted when neither is available.
+
+```bash
+# Optional: give telemetry a stable project identity across machines and deployments
+MASTRA_PROJECT_ID=<your-platform-project-id> mastra start
+```

--- a/packages/core/src/telemetry/context.test.ts
+++ b/packages/core/src/telemetry/context.test.ts
@@ -1,31 +1,47 @@
 import process from 'node:process';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getServerTelemetryContext } from './context';
+const { execFileSync } = vi.hoisted(() => ({ execFileSync: vi.fn() }));
+
+vi.mock('node:child_process', () => ({ execFileSync }));
+
+import { getServerTelemetryContext, resetProjectId2CacheForTests } from './context';
 import { hashTelemetryValue } from './posthog';
 
 describe('getServerTelemetryContext', () => {
   let originalProjectRoot: string | undefined;
+  let originalProjectId: string | undefined;
   let originalDistinctId: string | undefined;
   let originalCommand: string | undefined;
   let originalNodeEnv: string | undefined;
 
   beforeEach(() => {
     originalProjectRoot = process.env.MASTRA_PROJECT_ROOT;
+    originalProjectId = process.env.MASTRA_PROJECT_ID;
     originalDistinctId = process.env.MASTRA_CLI_DISTINCT_ID;
     originalCommand = process.env.MASTRA_TELEMETRY_COMMAND;
     originalNodeEnv = process.env.NODE_ENV;
+
+    delete process.env.MASTRA_PROJECT_ID;
+    execFileSync.mockReset();
+    execFileSync.mockImplementation(() => {
+      throw new Error('git unavailable');
+    });
+    resetProjectId2CacheForTests();
   });
 
   afterEach(() => {
     if (originalProjectRoot !== undefined) process.env.MASTRA_PROJECT_ROOT = originalProjectRoot;
     else delete process.env.MASTRA_PROJECT_ROOT;
+    if (originalProjectId !== undefined) process.env.MASTRA_PROJECT_ID = originalProjectId;
+    else delete process.env.MASTRA_PROJECT_ID;
     if (originalDistinctId !== undefined) process.env.MASTRA_CLI_DISTINCT_ID = originalDistinctId;
     else delete process.env.MASTRA_CLI_DISTINCT_ID;
     if (originalCommand !== undefined) process.env.MASTRA_TELEMETRY_COMMAND = originalCommand;
     else delete process.env.MASTRA_TELEMETRY_COMMAND;
     if (originalNodeEnv !== undefined) process.env.NODE_ENV = originalNodeEnv;
     else delete process.env.NODE_ENV;
+    resetProjectId2CacheForTests();
   });
 
   it('derives context from server telemetry environment variables', () => {
@@ -36,6 +52,7 @@ describe('getServerTelemetryContext', () => {
 
     expect(getServerTelemetryContext()).toEqual({
       projectId: hashTelemetryValue('/tmp/mastra-project').slice(0, 16),
+      projectId2: undefined,
       distinctId: 'cli-distinct-id',
       command: 'dev',
       nodeEnv: 'test',
@@ -50,9 +67,75 @@ describe('getServerTelemetryContext', () => {
 
     expect(getServerTelemetryContext()).toEqual({
       projectId: hashTelemetryValue(process.cwd()).slice(0, 16),
+      projectId2: undefined,
       distinctId: undefined,
       command: 'server',
       nodeEnv: 'development',
+    });
+  });
+
+  describe('projectId2', () => {
+    it('uses the trimmed platform project id with an mp_ prefix and never invokes git', () => {
+      process.env.MASTRA_PROJECT_ROOT = '/tmp/mastra-project';
+      process.env.MASTRA_PROJECT_ID = '  platform-project-id  ';
+
+      const context = getServerTelemetryContext();
+
+      expect(context.projectId2).toBe('mp_platform-project-id');
+      expect(context.projectId).toBe(hashTelemetryValue('/tmp/mastra-project').slice(0, 16));
+      expect(execFileSync).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a hash of the trimmed git origin remote when the platform id is absent', () => {
+      process.env.MASTRA_PROJECT_ROOT = '/tmp/mastra-project';
+      execFileSync.mockReturnValue('  https://github.com/org/repo.git\n');
+
+      const context = getServerTelemetryContext();
+
+      expect(context.projectId2).toBe(hashTelemetryValue('https://github.com/org/repo.git').slice(0, 16));
+      expect(context.projectId).toBe(hashTelemetryValue('/tmp/mastra-project').slice(0, 16));
+      expect(execFileSync).toHaveBeenCalledWith(
+        'git',
+        ['remote', 'get-url', 'origin'],
+        expect.objectContaining({ cwd: '/tmp/mastra-project' }),
+      );
+    });
+
+    it('falls back to git when the platform id is blank', () => {
+      process.env.MASTRA_PROJECT_ID = '   ';
+      execFileSync.mockReturnValue('git@github.com:org/repo.git\n');
+
+      expect(getServerTelemetryContext().projectId2).toBe(
+        hashTelemetryValue('git@github.com:org/repo.git').slice(0, 16),
+      );
+    });
+
+    it('is undefined when git fails', () => {
+      process.env.MASTRA_PROJECT_ROOT = '/tmp/mastra-project';
+      execFileSync.mockImplementation(() => {
+        throw new Error('not a git repository');
+      });
+
+      const context = getServerTelemetryContext();
+
+      expect(context.projectId2).toBeUndefined();
+      expect(context.projectId).toBe(hashTelemetryValue('/tmp/mastra-project').slice(0, 16));
+    });
+
+    it('is undefined when git returns blank output', () => {
+      execFileSync.mockReturnValue('   \n');
+
+      expect(getServerTelemetryContext().projectId2).toBeUndefined();
+    });
+
+    it('caches the git resolution across calls', () => {
+      execFileSync.mockReturnValue('https://github.com/org/repo.git\n');
+
+      const first = getServerTelemetryContext();
+      const second = getServerTelemetryContext();
+
+      expect(first.projectId2).toBe(second.projectId2);
+      expect(execFileSync).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/core/src/telemetry/context.ts
+++ b/packages/core/src/telemetry/context.ts
@@ -1,17 +1,60 @@
+import { execFileSync } from 'node:child_process';
 import { hashTelemetryValue } from './posthog';
 
 export interface ServerTelemetryContext {
   projectId: string;
+  projectId2: string | undefined;
   distinctId: string | undefined;
   command: string;
   nodeEnv: string;
 }
 
+/** `undefined` = not yet computed, `null` = computed and unavailable. */
+let cachedGitProjectId2: string | null | undefined;
+
+function computeGitProjectId2(): string | undefined {
+  try {
+    const remote = execFileSync('git', ['remote', 'get-url', 'origin'], {
+      cwd: process.env.MASTRA_PROJECT_ROOT || process.cwd(),
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    }).trim();
+    return remote ? hashTelemetryValue(remote).slice(0, 16) : undefined;
+  } catch {
+    // Telemetry must never affect server startup: missing git binary, non-repo
+    // directories, or a missing `origin` remote all mean "no secondary id".
+    return undefined;
+  }
+}
+
+/**
+ * Secondary project identity for telemetry correlation. Prefers the Mastra
+ * Platform project id (`mp_`-prefixed, unhashed) and falls back to a hash of
+ * the git `origin` remote, which is stable across machines and checkout paths.
+ * Undefined when neither source is available.
+ */
+function resolveProjectId2(): string | undefined {
+  const platformProjectId = process.env.MASTRA_PROJECT_ID?.trim();
+  if (platformProjectId) {
+    return `mp_${platformProjectId}`;
+  }
+  if (cachedGitProjectId2 === undefined) {
+    cachedGitProjectId2 = computeGitProjectId2() ?? null;
+  }
+  return cachedGitProjectId2 ?? undefined;
+}
+
 export function getServerTelemetryContext(): ServerTelemetryContext {
   return {
     projectId: hashTelemetryValue(process.env.MASTRA_PROJECT_ROOT || process.cwd()).slice(0, 16),
+    projectId2: resolveProjectId2(),
     distinctId: process.env.MASTRA_CLI_DISTINCT_ID || undefined,
     command: process.env.MASTRA_TELEMETRY_COMMAND || 'server',
     nodeEnv: process.env.NODE_ENV || 'development',
   };
+}
+
+export function resetProjectId2CacheForTests(): void {
+  cachedGitProjectId2 = undefined;
 }

--- a/packages/core/src/telemetry/feature-telemetry.test.ts
+++ b/packages/core/src/telemetry/feature-telemetry.test.ts
@@ -13,6 +13,7 @@ vi.mock('posthog-node', () => ({ PostHog }));
 
 import type { Mastra } from '../mastra';
 import { InMemoryStore } from '../storage/mock';
+import { resetProjectId2CacheForTests } from './context';
 import { FEATURE_USAGE_EVENT, syncFeatureUsageTelemetry, trackFeatureUsage } from './feature-telemetry';
 import { hashTelemetryValue, resetEETelemetryForTests } from './posthog';
 
@@ -57,6 +58,7 @@ function makeMastra(overrides: Partial<Record<keyof Mastra, unknown>> = {}): Mas
 describe('feature usage telemetry', () => {
   let originalTelemetryDisabled: string | undefined;
   let originalProjectRoot: string | undefined;
+  let originalProjectId: string | undefined;
   let originalDistinctId: string | undefined;
   let originalCommand: string | undefined;
   let originalNodeEnv: string | undefined;
@@ -64,12 +66,14 @@ describe('feature usage telemetry', () => {
   beforeEach(() => {
     originalTelemetryDisabled = process.env.MASTRA_TELEMETRY_DISABLED;
     originalProjectRoot = process.env.MASTRA_PROJECT_ROOT;
+    originalProjectId = process.env.MASTRA_PROJECT_ID;
     originalDistinctId = process.env.MASTRA_CLI_DISTINCT_ID;
     originalCommand = process.env.MASTRA_TELEMETRY_COMMAND;
     originalNodeEnv = process.env.NODE_ENV;
 
     delete process.env.MASTRA_TELEMETRY_DISABLED;
     process.env.MASTRA_PROJECT_ROOT = '/tmp/feature-telemetry-project';
+    process.env.MASTRA_PROJECT_ID = 'platform-project-id';
     process.env.MASTRA_CLI_DISTINCT_ID = 'cli-distinct-id';
     process.env.MASTRA_TELEMETRY_COMMAND = 'dev';
     process.env.NODE_ENV = 'test';
@@ -78,6 +82,7 @@ describe('feature usage telemetry', () => {
     flush.mockClear();
     PostHog.mockClear();
     resetEETelemetryForTests();
+    resetProjectId2CacheForTests();
   });
 
   afterEach(() => {
@@ -85,6 +90,8 @@ describe('feature usage telemetry', () => {
     else delete process.env.MASTRA_TELEMETRY_DISABLED;
     if (originalProjectRoot !== undefined) process.env.MASTRA_PROJECT_ROOT = originalProjectRoot;
     else delete process.env.MASTRA_PROJECT_ROOT;
+    if (originalProjectId !== undefined) process.env.MASTRA_PROJECT_ID = originalProjectId;
+    else delete process.env.MASTRA_PROJECT_ID;
     if (originalDistinctId !== undefined) process.env.MASTRA_CLI_DISTINCT_ID = originalDistinctId;
     else delete process.env.MASTRA_CLI_DISTINCT_ID;
     if (originalCommand !== undefined) process.env.MASTRA_TELEMETRY_COMMAND = originalCommand;
@@ -92,6 +99,7 @@ describe('feature usage telemetry', () => {
     if (originalNodeEnv !== undefined) process.env.NODE_ENV = originalNodeEnv;
     else delete process.env.NODE_ENV;
     resetEETelemetryForTests();
+    resetProjectId2CacheForTests();
   });
 
   it('tracks a named feature with server telemetry context and metadata', () => {
@@ -104,12 +112,23 @@ describe('feature usage telemetry', () => {
       properties: {
         feature_name: 'agent_builder',
         project_id: hashTelemetryValue('/tmp/feature-telemetry-project').slice(0, 16),
+        project_id2: 'mp_platform-project-id',
         command: 'dev',
         node_env: 'test',
         action: 'open',
         count: 2,
       },
     });
+  });
+
+  it('omits project_id2 when no platform id or git remote is available', () => {
+    // MASTRA_PROJECT_ROOT points at a nonexistent directory, so the git fallback fails.
+    delete process.env.MASTRA_PROJECT_ID;
+
+    trackFeatureUsage('agent_builder');
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0]![0].properties).not.toHaveProperty('project_id2');
   });
 
   it('does not track feature usage when telemetry is disabled', () => {
@@ -168,6 +187,7 @@ describe('feature usage telemetry', () => {
       properties: {
         feature_name: 'mastra_instance_summary',
         project_id: hashTelemetryValue('/tmp/feature-telemetry-project').slice(0, 16),
+        project_id2: 'mp_platform-project-id',
         command: 'dev',
         node_env: 'test',
         agent_count: 2,

--- a/packages/core/src/telemetry/feature-telemetry.test.ts
+++ b/packages/core/src/telemetry/feature-telemetry.test.ts
@@ -139,6 +139,18 @@ describe('feature usage telemetry', () => {
     expect(capture.mock.calls[0]![0].properties).not.toHaveProperty('project_id2');
   });
 
+  it('drops caller-supplied project_id2 metadata when no identifier resolves', () => {
+    // MASTRA_PROJECT_ROOT points at a nonexistent directory, so the git fallback fails.
+    delete process.env.MASTRA_PROJECT_ID;
+
+    trackFeatureUsage('agent_builder', { project_id2: 'spoofed', action: 'open' });
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    const properties = capture.mock.calls[0]![0].properties;
+    expect(properties).not.toHaveProperty('project_id2');
+    expect(properties.action).toBe('open');
+  });
+
   it('does not track feature usage when telemetry is disabled', () => {
     process.env.MASTRA_TELEMETRY_DISABLED = 'true';
 

--- a/packages/core/src/telemetry/feature-telemetry.test.ts
+++ b/packages/core/src/telemetry/feature-telemetry.test.ts
@@ -1,3 +1,6 @@
+import { randomUUID } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { capture, flush, PostHog } = vi.hoisted(() => {
@@ -16,6 +19,11 @@ import { InMemoryStore } from '../storage/mock';
 import { resetProjectId2CacheForTests } from './context';
 import { FEATURE_USAGE_EVENT, syncFeatureUsageTelemetry, trackFeatureUsage } from './feature-telemetry';
 import { hashTelemetryValue, resetEETelemetryForTests } from './posthog';
+
+// Unique and intentionally never created: a nonexistent project root makes the
+// git-remote fallback fail deterministically, no matter what repositories exist
+// on the machine running the tests.
+const projectRoot = path.join(os.tmpdir(), `feature-telemetry-project-${randomUUID()}`);
 
 class UnknownStore {
   stores = {};
@@ -72,7 +80,7 @@ describe('feature usage telemetry', () => {
     originalNodeEnv = process.env.NODE_ENV;
 
     delete process.env.MASTRA_TELEMETRY_DISABLED;
-    process.env.MASTRA_PROJECT_ROOT = '/tmp/feature-telemetry-project';
+    process.env.MASTRA_PROJECT_ROOT = projectRoot;
     process.env.MASTRA_PROJECT_ID = 'platform-project-id';
     process.env.MASTRA_CLI_DISTINCT_ID = 'cli-distinct-id';
     process.env.MASTRA_TELEMETRY_COMMAND = 'dev';
@@ -111,7 +119,7 @@ describe('feature usage telemetry', () => {
       event: FEATURE_USAGE_EVENT,
       properties: {
         feature_name: 'agent_builder',
-        project_id: hashTelemetryValue('/tmp/feature-telemetry-project').slice(0, 16),
+        project_id: hashTelemetryValue(projectRoot).slice(0, 16),
         project_id2: 'mp_platform-project-id',
         command: 'dev',
         node_env: 'test',
@@ -186,7 +194,7 @@ describe('feature usage telemetry', () => {
       event: FEATURE_USAGE_EVENT,
       properties: {
         feature_name: 'mastra_instance_summary',
-        project_id: hashTelemetryValue('/tmp/feature-telemetry-project').slice(0, 16),
+        project_id: hashTelemetryValue(projectRoot).slice(0, 16),
         project_id2: 'mp_platform-project-id',
         command: 'dev',
         node_env: 'test',

--- a/packages/core/src/telemetry/feature-telemetry.ts
+++ b/packages/core/src/telemetry/feature-telemetry.ts
@@ -79,10 +79,11 @@ export function trackFeatureUsage(name: string, metadata?: Record<string, unknow
       return;
     }
 
-    const { projectId, distinctId, command, nodeEnv } = getServerTelemetryContext();
+    const { projectId, projectId2, distinctId, command, nodeEnv } = getServerTelemetryContext();
     captureTelemetryEvent(FEATURE_USAGE_EVENT, distinctId, {
       feature_name: name,
       project_id: projectId,
+      ...(projectId2 ? { project_id2: projectId2 } : {}),
       command,
       node_env: nodeEnv,
       ...metadata,

--- a/packages/core/src/telemetry/feature-telemetry.ts
+++ b/packages/core/src/telemetry/feature-telemetry.ts
@@ -80,13 +80,14 @@ export function trackFeatureUsage(name: string, metadata?: Record<string, unknow
     }
 
     const { projectId, projectId2, distinctId, command, nodeEnv } = getServerTelemetryContext();
+    // Metadata is spread first so it can never override telemetry-controlled fields.
     captureTelemetryEvent(FEATURE_USAGE_EVENT, distinctId, {
+      ...metadata,
       feature_name: name,
       project_id: projectId,
       ...(projectId2 ? { project_id2: projectId2 } : {}),
       command,
       node_env: nodeEnv,
-      ...metadata,
     });
   } catch {
     // Feature telemetry must never affect server startup or runtime behavior.

--- a/packages/core/src/telemetry/feature-telemetry.ts
+++ b/packages/core/src/telemetry/feature-telemetry.ts
@@ -80,9 +80,14 @@ export function trackFeatureUsage(name: string, metadata?: Record<string, unknow
     }
 
     const { projectId, projectId2, distinctId, command, nodeEnv } = getServerTelemetryContext();
-    // Metadata is spread first so it can never override telemetry-controlled fields.
+    // Metadata is spread first so it can never override telemetry-controlled
+    // fields. project_id2 is stripped explicitly: unlike the always-set fields
+    // below, it is only emitted when an identifier actually resolved, so a
+    // caller-supplied value would otherwise leak through in the omitted case.
+    const safeMetadata = { ...metadata };
+    delete safeMetadata.project_id2;
     captureTelemetryEvent(FEATURE_USAGE_EVENT, distinctId, {
-      ...metadata,
+      ...safeMetadata,
       feature_name: name,
       project_id: projectId,
       ...(projectId2 ? { project_id2: projectId2 } : {}),

--- a/packages/core/src/telemetry/usage-telemetry.test.ts
+++ b/packages/core/src/telemetry/usage-telemetry.test.ts
@@ -17,7 +17,8 @@ vi.mock('posthog-node', () => ({ PostHog }));
 import type { Mastra } from '../mastra';
 import type { CreateMetricRecord } from '../storage/domains';
 import { InMemoryStore } from '../storage/mock';
-import { resetEETelemetryForTests } from './posthog';
+import { resetProjectId2CacheForTests } from './context';
+import { hashTelemetryValue, resetEETelemetryForTests } from './posthog';
 import { syncUsageTelemetry, USAGE_TELEMETRY_EVENT } from './usage-telemetry';
 
 const INPUT_METRIC = 'mastra_model_total_input_tokens';
@@ -43,24 +44,36 @@ describe('syncUsageTelemetry', () => {
   let cursorPath: string;
   let store: InMemoryStore;
   let originalTelemetryDisabled: string | undefined;
+  let originalProjectRoot: string | undefined;
+  let originalProjectId: string | undefined;
 
   beforeEach(() => {
     originalTelemetryDisabled = process.env['MASTRA_TELEMETRY_DISABLED'];
+    originalProjectRoot = process.env['MASTRA_PROJECT_ROOT'];
+    originalProjectId = process.env['MASTRA_PROJECT_ID'];
     delete process.env['MASTRA_TELEMETRY_DISABLED'];
     tmpDir = mkdtempSync(path.join(os.tmpdir(), 'mastra-usage-telemetry-'));
     cursorPath = path.join(tmpDir, 'cursors', 'usage-telemetry.json');
+    process.env['MASTRA_PROJECT_ROOT'] = tmpDir;
+    process.env['MASTRA_PROJECT_ID'] = 'platform-project-id';
     store = new InMemoryStore();
     capture.mockClear();
     flush.mockClear();
     PostHog.mockClear();
     resetEETelemetryForTests();
+    resetProjectId2CacheForTests();
   });
 
   afterEach(() => {
     if (originalTelemetryDisabled !== undefined) process.env['MASTRA_TELEMETRY_DISABLED'] = originalTelemetryDisabled;
     else delete process.env['MASTRA_TELEMETRY_DISABLED'];
+    if (originalProjectRoot !== undefined) process.env['MASTRA_PROJECT_ROOT'] = originalProjectRoot;
+    else delete process.env['MASTRA_PROJECT_ROOT'];
+    if (originalProjectId !== undefined) process.env['MASTRA_PROJECT_ID'] = originalProjectId;
+    else delete process.env['MASTRA_PROJECT_ID'];
     rmSync(tmpDir, { recursive: true, force: true });
     resetEETelemetryForTests();
+    resetProjectId2CacheForTests();
   });
 
   async function seedUsage() {
@@ -97,6 +110,8 @@ describe('syncUsageTelemetry', () => {
       output_tokens: 30,
       total_input_tokens: 150,
       total_output_tokens: 30,
+      project_id: hashTelemetryValue(tmpDir).slice(0, 16),
+      project_id2: 'mp_platform-project-id',
       is_first_sync: true,
       window_start: null,
       window_end: '2026-06-03T00:00:00.000Z',
@@ -110,9 +125,25 @@ describe('syncUsageTelemetry', () => {
       is_first_sync: true,
     });
 
-    // Cursor file written with the sync timestamp.
+    // Cursor file written with the sync timestamp, keyed solely by the
+    // path-derived project_id — never by project_id2.
     const cursors = JSON.parse(readFileSync(cursorPath, 'utf-8'));
-    expect(Object.values(cursors.projects)).toEqual(['2026-06-03T00:00:00.000Z']);
+    expect(cursors.projects).toEqual({
+      [hashTelemetryValue(tmpDir).slice(0, 16)]: '2026-06-03T00:00:00.000Z',
+    });
+  });
+
+  it('omits project_id2 when no platform id or git remote is available', async () => {
+    // The temp project root is not a git repository and no platform id is set.
+    delete process.env['MASTRA_PROJECT_ID'];
+    await seedUsage();
+
+    await syncUsageTelemetry(makeMastra(store), { cursorPath, now: new Date('2026-06-03T00:00:00Z') });
+
+    expect(capture).toHaveBeenCalledTimes(2);
+    for (const [event] of capture.mock.calls) {
+      expect(event.properties).not.toHaveProperty('project_id2');
+    }
   });
 
   it('only sends usage recorded after the last sync, with cumulative totals', async () => {

--- a/packages/core/src/telemetry/usage-telemetry.ts
+++ b/packages/core/src/telemetry/usage-telemetry.ts
@@ -102,7 +102,7 @@ export async function syncUsageTelemetry(mastra: Mastra, options: SyncUsageTelem
       return;
     }
 
-    const { projectId, distinctId, command, nodeEnv } = getServerTelemetryContext();
+    const { projectId, projectId2, distinctId, command, nodeEnv } = getServerTelemetryContext();
     const cursorPath = options.cursorPath ?? getDefaultCursorPath();
     const lastSyncedAt = readCursor(cursorPath, projectId);
     const now = options.now ?? new Date();
@@ -149,6 +149,7 @@ export async function syncUsageTelemetry(mastra: Mastra, options: SyncUsageTelem
         command,
         node_env: nodeEnv,
         project_id: projectId,
+        ...(projectId2 ? { project_id2: projectId2 } : {}),
         is_first_sync: isFirstSync,
         window_start: lastSyncedAt?.toISOString() ?? null,
         window_end: now.toISOString(),


### PR DESCRIPTION
## Summary

Mastra's server telemetry events (`mastra_feature_usage` and `mastra_model_token_usage`) identify projects by hashing the project's absolute filesystem path. That identity fragments when the same project runs from different paths (each checkout looks like a new project) and collides when unrelated projects run from standardized container paths like `/app` (they all look like one project).

This PR adds an optional secondary identifier, `project_id2`, to both events so the same project can be correlated across machines, checkouts, and deployments:

1. When `MASTRA_PROJECT_ID` is set (e.g. projects linked to Mastra Platform), `project_id2` is the literal id prefixed with `mp_`.
2. Otherwise it falls back to the first 16 hex characters of a SHA-256 hash of the project's git `origin` remote URL — stable across machines and checkout paths, and never sent raw.
3. When neither source is available, the property is omitted entirely.

The existing `project_id`, event names, and usage-sync cursor behavior are unchanged, so all current analytics remain intact. The git lookup uses a fixed-argument subprocess (no shell), has a 2-second timeout, runs at most once per process, and any failure simply omits the field — telemetry can never affect server startup.

## Test plan

- [x] `pnpm --filter ./packages/core exec vitest run src/telemetry/context.test.ts src/telemetry/feature-telemetry.test.ts src/telemetry/usage-telemetry.test.ts` — 23/23 pass (8 new tests covering platform-id precedence and trimming, git fallback argv/cwd, failure and blank-output omission, per-process caching, unchanged `project_id`, event property presence/absence, and unchanged cursor keying)
- [x] `pnpm --filter ./packages/core check` — clean
- [x] `pnpm build:core` — 14/14 tasks pass

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This adds a second project identifier to telemetry events. It helps connect usage data to a project while keeping existing identifiers and behavior unchanged.

## Changes

- Add optional `project_id2` to `mastra_feature_usage` and `mastra_model_token_usage`.
- Use `mp_` plus `MASTRA_PROJECT_ID` when available.
- Otherwise, use the first 16 hexadecimal characters of the SHA-256 hash of the Git `origin` URL.
- Omit `project_id2` when no identifier is available.
- Resolve the Git remote without a shell.
- Limit Git lookup to 2 seconds and once per process.
- Keep Git failures from affecting server startup.
- Remove caller-supplied `project_id2` when no valid identifier resolves.
- Preserve `project_id`, event names, usage-sync cursor behavior, and project surface snapshot telemetry.
- Add test coverage for identifier sources, fallback behavior, caching, failures, and metadata precedence.
- Add a patch changeset for `@mastra/core` with usage documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->