### PR TITLE
fix(memory): detect long-period multi-line repetition loops in observer output

### DIFF
--- a/.changeset/heavy-lions-listen.md
+++ b/.changeset/heavy-lions-listen.md
@@ -2,4 +2,4 @@
 '@mastra/memory': patch
 ---
 
-Detect long-period multi-line repetition loops in observer/reflector output. The existing degenerate-output check sampled fixed-size windows, which has an aliasing blind spot: a repeating block whose period doesn't align with the sampling stride produces zero duplicate windows even when it dominates the output. Production records showed observer outputs where a 21-line block repeated 62 times (and an 8-line block repeated 140 times) passed the check and inflated observational memory to 2-3x the reflection threshold, causing constant synchronous reflection churn. Observations are line-oriented, so the detector now also flags output where more than half of the substantial lines are exact duplicates.
+Observational memory now detects observer/reflector output where a multi-line block repeats many times (a model repetition loop). Previously such output could slip past the degenerate-output check and balloon stored observations, causing constant synchronous reflection churn; it is now rejected and retried like other degenerate output.

--- a/.changeset/heavy-lions-listen.md
+++ b/.changeset/heavy-lions-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Detect long-period multi-line repetition loops in observer/reflector output. The existing degenerate-output check sampled fixed-size windows, which has an aliasing blind spot: a repeating block whose period doesn't align with the sampling stride produces zero duplicate windows even when it dominates the output. Production records showed observer outputs where a 21-line block repeated 62 times (and an 8-line block repeated 140 times) passed the check and inflated observational memory to 2-3x the reflection threshold, causing constant synchronous reflection churn. Observations are line-oriented, so the detector now also flags output where more than half of the substantial lines are exact duplicates.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -3314,6 +3314,11 @@ User asked about </current-task> parsing and how it works
       ).join('\n');
       const text = `${uniquePrefix}\n${Array(62).fill(block).join('\n')}`;
       expect(detectDegenerateRepetition(text)).toBe(true);
+
+      const description = describeDegenerateOutput(text);
+      expect(description).toContain('duplicateRatio=0.00');
+      expect(description).toContain('duplicateLineRatio=0.96');
+      expect(description).toContain('countedLines=1332');
     });
 
     it('should detect a short-period multi-line repetition loop (8-line block x 140)', () => {
@@ -3323,6 +3328,22 @@ User asked about </current-task> parsing and how it works
           `* 🟡 (14:0${i}) Verified \`verifier-runner.ts\` line ${100 + i}: baseline replay hook number ${i} registered against the lifecycle map.`,
       ).join('\n');
       const text = Array(140).fill(block).join('\n');
+      expect(detectDegenerateRepetition(text)).toBe(true);
+    });
+
+    it('should detect duplicate substantial lines just over the ratio threshold', () => {
+      const repeatedConstraint =
+        '- 🔴 User requires every production change to preserve backwards compatibility and include documented rollback instructions.';
+      const uniqueObservations = Array.from(
+        { length: 8 },
+        (_, i) =>
+          `- 🟡 Distinct reflected project fact ${i}: ${String.fromCharCode(65 + i).repeat(150 + i * 17)} terminal-${i}`,
+      );
+      const lines = uniqueObservations.flatMap(unique => [repeatedConstraint, unique]);
+      lines.push(repeatedConstraint, repeatedConstraint, repeatedConstraint, repeatedConstraint);
+      const text = lines.join('\n');
+
+      expect(text.length).toBeGreaterThan(2000);
       expect(detectDegenerateRepetition(text)).toBe(true);
     });
 
@@ -3622,6 +3643,26 @@ _range: \`ignored-by-reconciler\`_
       const result = parseReflectorOutput(output);
       expect(result.observations).toContain('Project Context');
       expect(result.observations).toContain('Completed auth implementation');
+    });
+
+    it('should preserve substantial repeated lines at the duplicate ratio boundary', () => {
+      const repeatedConstraint =
+        '- 🔴 User requires every production change to preserve backwards compatibility and include documented rollback instructions.';
+      const uniqueObservations = Array.from(
+        { length: 9 },
+        (_, i) =>
+          `- 🟡 Distinct reflected project fact ${i}: ${String.fromCharCode(65 + i).repeat(150 + i * 17)} terminal-${i}`,
+      );
+      const lines = uniqueObservations.flatMap(unique => [repeatedConstraint, unique]);
+      lines.push(repeatedConstraint, repeatedConstraint);
+      const output = lines.join('\n');
+
+      expect(output.length).toBeGreaterThan(2000);
+      const result = parseReflectorOutput(output);
+
+      expect(result.degenerate).not.toBe(true);
+      expect(result.observations).toContain(repeatedConstraint);
+      expect(result.observations).toContain('Distinct reflected project fact 8');
     });
 
     it('should strip ephemeral anchor IDs from reflector output', () => {

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -3295,6 +3295,57 @@ User asked about </current-task> parsing and how it works
       expect(result.degenerate).toBe(true);
       expect(result.observations).toBe('');
     });
+
+    // Long-period multi-line loops defeat the window-sampling strategy: with a
+    // repeating block of period P chars, sampled windows only collide when two
+    // sample positions are congruent mod P, so ~50 samples land on ~50 distinct
+    // phases and find zero duplicates. Both cases below reproduce real observer
+    // output found in production records (2026-08-21).
+    it('should detect a long-period multi-line repetition loop (21-line block x 62)', () => {
+      const block = Array.from(
+        { length: 21 },
+        (_, i) =>
+          `* 🟡 (08:44) Found \`API.md\` lines ${200 + i * 10}-${210 + i * 10}: \`/api/learning/entities/:entityId/route-${i}\` accepts \`signalName\` — no catalog enrichment currently present.`,
+      ).join('\n');
+      const uniquePrefix = Array.from(
+        { length: 30 },
+        (_, i) =>
+          `* 🔴 (0${(i % 9) + 1}:1${i % 6}) User asked about distinct topic number ${i} with unique detail ${i * 37}`,
+      ).join('\n');
+      const text = `${uniquePrefix}\n${Array(62).fill(block).join('\n')}`;
+      expect(detectDegenerateRepetition(text)).toBe(true);
+    });
+
+    it('should detect a short-period multi-line repetition loop (8-line block x 140)', () => {
+      const block = Array.from(
+        { length: 8 },
+        (_, i) =>
+          `* 🟡 (14:0${i}) Verified \`verifier-runner.ts\` line ${100 + i}: baseline replay hook number ${i} registered against the lifecycle map.`,
+      ).join('\n');
+      const text = Array(140).fill(block).join('\n');
+      expect(detectDegenerateRepetition(text)).toBe(true);
+    });
+
+    it('should not flag long legitimate output with unique lines', () => {
+      const text = Array.from(
+        { length: 300 },
+        (_, i) =>
+          `* 🟡 (1${i % 10}:${String(i % 60).padStart(2, '0')}) Observation number ${i}: examined file-${i}.ts and found unique detail ${i * 13} relating to subsystem ${i % 7}`,
+      ).join('\n');
+      expect(text.length).toBeGreaterThan(2000);
+      expect(detectDegenerateRepetition(text)).toBe(false);
+    });
+
+    it('should not flag output where only short lines repeat', () => {
+      const unique = Array.from(
+        { length: 40 },
+        (_, i) =>
+          `* 🟡 (12:${String(i % 60).padStart(2, '0')}) Unique observation ${i} with distinct content token ${i * 31}`,
+      );
+      // Interleave legitimately repetitive short separators/bullets
+      const text = unique.flatMap(line => [line, '---', '## Current Task']).join('\n');
+      expect(detectDegenerateRepetition(text)).toBe(false);
+    });
   });
 
   describe('describeDegenerateOutput', () => {
@@ -3305,6 +3356,7 @@ User asked about </current-task> parsing and how it works
       const description = describeDegenerateOutput(text);
       expect(description).toContain(`length=${text.length}`);
       expect(description).toMatch(/duplicateRatio=0\.\d+/);
+      expect(description).toMatch(/duplicateLineRatio=(?:\d+\.\d+|n\/a)/);
       expect(description).toMatch(/topWindowCount=\d+/);
       expect(description).toContain('topWindow="');
       expect(description).toContain('head="');

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -3357,6 +3357,7 @@ User asked about </current-task> parsing and how it works
       expect(description).toContain(`length=${text.length}`);
       expect(description).toMatch(/duplicateRatio=0\.\d+/);
       expect(description).toMatch(/duplicateLineRatio=(?:\d+\.\d+|n\/a)/);
+      expect(description).toMatch(/countedLines=\d+/);
       expect(description).toMatch(/topWindowCount=\d+/);
       expect(description).toContain('topWindow="');
       expect(description).toContain('head="');

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -1620,6 +1620,13 @@ function extractListItemsOnly(content: string): string {
 const MAX_OBSERVATION_LINE_CHARS = 10_000;
 
 /**
+ * Minimum trimmed line length considered by the duplicate-line degenerate
+ * check. Short lines (blank lines, separators, terse bullets) legitimately
+ * repeat; long identical lines almost never do.
+ */
+const MIN_DUPLICATE_LINE_CHARS = 24;
+
+/**
  * Truncate individual observation lines that exceed the maximum length.
  */
 export function sanitizeObservationLines(observations: string): string {
@@ -1674,6 +1681,29 @@ export function detectDegenerateRepetition(text: string): boolean {
     if (line.length > 50_000) return true;
   }
 
+  // Strategy 3: Exact-duplicate line ratio. The window sampling above has an
+  // aliasing blind spot: for a repeating block with period P chars, sampled
+  // windows only collide when two sample positions are congruent mod P, so a
+  // long-period multi-line loop (e.g. a 21-line block repeated 62 times,
+  // observed in production) can dominate the output while producing zero
+  // duplicate windows. Observations are line-oriented, so count exact
+  // duplicates among substantial lines instead — legitimate output almost
+  // never repeats long identical lines.
+  const seenLines = new Map<string, number>();
+  let duplicateLines = 0;
+  let totalCountedLines = 0;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length < MIN_DUPLICATE_LINE_CHARS) continue;
+    totalCountedLines++;
+    const count = (seenLines.get(trimmed) ?? 0) + 1;
+    seenLines.set(trimmed, count);
+    if (count > 1) duplicateLines++;
+  }
+  if (totalCountedLines >= 20 && duplicateLines / totalCountedLines > 0.5) {
+    return true;
+  }
+
   return false;
 }
 
@@ -1713,15 +1743,27 @@ export function describeDegenerateOutput(text: string, snippetChars = 400): stri
   }
 
   let longestLine = 0;
+  const seenLines = new Map<string, number>();
+  let duplicateLines = 0;
+  let totalCountedLines = 0;
   for (const line of text.split('\n')) {
     if (line.length > longestLine) longestLine = line.length;
+    const trimmed = line.trim();
+    if (trimmed.length < MIN_DUPLICATE_LINE_CHARS) continue;
+    totalCountedLines++;
+    const count = (seenLines.get(trimmed) ?? 0) + 1;
+    seenLines.set(trimmed, count);
+    if (count > 1) duplicateLines++;
   }
 
   const duplicateRatio = totalWindows > 0 ? (duplicateWindows / totalWindows).toFixed(2) : 'n/a';
+  const duplicateLineRatio = totalCountedLines > 0 ? (duplicateLines / totalCountedLines).toFixed(2) : 'n/a';
   const parts = [
     `length=${text.length}`,
     `sampledWindows=${totalWindows}`,
     `duplicateRatio=${duplicateRatio}`,
+    `duplicateLineRatio=${duplicateLineRatio}`,
+    `countedLines=${totalCountedLines}`,
     `longestLine=${longestLine}`,
     `topWindowCount=${topCount}`,
   ];


### PR DESCRIPTION
## Summary

Observational memory's degenerate-output detector (`detectDegenerateRepetition`) misses long-period multi-line repetition loops, letting garbage observer output get appended to observational memory.

The existing check samples ~50 fixed-size 200-char windows at stride `len/50` and looks for duplicate windows. That has an aliasing blind spot: for a repeating block with period P chars, two sampled windows only collide when their positions are congruent mod P — so a long multi-line block repeated dozens of times lands every sample on a *different phase* of the loop and produces **zero** duplicate windows.

This happened in production (mastracode sessions, 2026-08-21): one observer output contained a 21-line block repeated 62 times (68% of all lines), another an 8-line block repeated 140 times. Both measured `duplicateRatio=0.00` under the window check. The appended garbage inflated observation tokens from ~43k to ~107k in a single cycle — 2-3x past the reflection threshold — causing synchronous reflection on every subsequent activation, reflector no-progress churn, and eventually aggressive compression when a high-ladder reflection finally landed.

## Fix

Add a third strategy: exact-duplicate-line ratio. Observations are line-oriented, and legitimate output almost never repeats long identical lines. If >50% of substantial lines (≥24 trimmed chars, with ≥20 such lines total) are exact duplicates, the output is degenerate — triggering the existing retry-once-then-discard flow instead of appending the loop.

`describeDegenerateOutput` now also reports `duplicateLineRatio`/`countedLines` so strategy-3 triggers are diagnosable in logs.

Measured against real records:

| Record | window `duplicateRatio` | new `duplicateLineRatio` | flagged |
|---|---|---|---|
| corrupted (21-line × 62) | 0.00 | 0.70 | ✅ |
| corrupted (8-line × 140) | 0.00 | 0.66 | ✅ |
| clean record A | 0.00 | 0.01 | — |
| clean record B | 0.00 | 0.02 | — |

## Test plan

- New unit tests reproducing both production repetition patterns (long-period blocks the window sampler cannot see) and false-positive guards (long unique output; output where only short separator lines repeat)
- Full `observational-memory.test.ts` suite: 478 passed
- `tsc --noEmit` clean in `packages/memory`
- Verified the new detector against the actual corrupted + clean `activeObservations` blobs from the affected local DB (table above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The detector now finds repeated text blocks that the old check could miss. This prevents repeated observer and reflector output from causing unnecessary retries and memory growth.

## Changes

- Added exact duplicate-line detection to `detectDegenerateRepetition`.
- Counts lines with at least 24 trimmed characters.
- Flags output when at least 20 lines qualify and more than 50% are duplicates.
- Added `duplicateLineRatio` and `countedLines` diagnostic metrics.
- Added regression tests for 21-line and 8-line repetition blocks.
- Added false-positive tests for unique output and repeated short separators.
- Added a patch changeset for `@mastra/memory`.

## Validation

- Observational-memory tests pass.
- TypeScript compilation, lint, and build pass for `packages/memory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->