### PR TITLE
fix(mastracode): truncate oversized MCP tool results for the model

### DIFF
--- a/.changeset/olive-hands-brake.md
+++ b/.changeset/olive-hands-brake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Truncate oversized MCP tool results for the model. Unlike mastracode's workspace tools (capped at ~2k tokens), MCP servers return unbounded results — a chrome-devtools accessibility snapshot or web page extraction can be 30-100k tokens, dominating the agent's context window and observational memory's pending-token accounting. MCP tools are now wrapped with a `toModelOutput` that caps model-facing text at 10k tokens using head+tail truncation with a notice; results under the cap, and results containing media parts, are untouched, and the full result is always preserved for display and storage.

--- a/mastracode/sdk/src/mcp/manager.ts
+++ b/mastracode/sdk/src/mcp/manager.ts
@@ -19,6 +19,7 @@ import {
 } from './config.js';
 import type { ExternalMcpDiscoveryOptions } from './config.js';
 import { loadDisabledServers, loadGlobalDisableState, saveDisabledServers, saveGlobalDisableState } from './state.js';
+import { withMcpResultTruncation } from './truncate.js';
 import type {
   McpConfig,
   McpHttpOAuthConfig,
@@ -391,7 +392,7 @@ export function createMcpManager(
       // Flatten toolsets into the namespaced tools map (serverName_toolName)
       for (const [serverName, serverTools] of Object.entries(typedToolsets)) {
         for (const [toolName, toolConfig] of Object.entries(serverTools)) {
-          tools[`${serverName}_${toolName}`] = toolConfig;
+          tools[`${serverName}_${toolName}`] = withMcpResultTruncation(toolConfig);
         }
       }
 
@@ -513,7 +514,7 @@ export function createMcpManager(
       } else if (serverTools && Object.keys(serverTools).length > 0) {
         const toolNames = Object.keys(serverTools).map(t => `${name}_${t}`);
         for (const [toolName, toolConfig] of Object.entries(serverTools)) {
-          tools[`${name}_${toolName}`] = toolConfig;
+          tools[`${name}_${toolName}`] = withMcpResultTruncation(toolConfig);
         }
         const status: McpServerStatus = {
           name,

--- a/mastracode/sdk/src/mcp/truncate.test.ts
+++ b/mastracode/sdk/src/mcp/truncate.test.ts
@@ -1,0 +1,104 @@
+import { estimateTokenCount } from 'tokenx';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_MCP_RESULT_MAX_TOKENS, truncateSandwich, withMcpResultTruncation } from './truncate.js';
+
+/** ~N tokens of distinct text (tokenx estimates ~1 token per short word). */
+function bigText(tokens: number): string {
+  return Array.from({ length: tokens }, (_, i) => `word${i}`).join(' ');
+}
+
+function callToolResult(text: string) {
+  return { content: [{ type: 'text', text }] };
+}
+
+describe('withMcpResultTruncation', () => {
+  it('leaves small results untouched (toModelOutput returns undefined)', () => {
+    const wrapped = withMcpResultTruncation({ id: 'tool', execute: vi.fn() } as any);
+    expect(wrapped.toModelOutput!(callToolResult('small result'))).toBeUndefined();
+  });
+
+  it('preserves the rest of the tool config', () => {
+    const execute = vi.fn();
+    const wrapped = withMcpResultTruncation({ id: 'tool', description: 'desc', execute } as any);
+    expect(wrapped.id).toBe('tool');
+    expect(wrapped.description).toBe('desc');
+    expect(wrapped.execute).toBe(execute);
+  });
+
+  it('truncates an oversized text-only CallToolResult for the model', () => {
+    const wrapped = withMcpResultTruncation({ id: 'tool' } as any);
+    const text = bigText(DEFAULT_MCP_RESULT_MAX_TOKENS * 3);
+
+    const modelOutput = wrapped.toModelOutput!(callToolResult(text)) as { type: string; value: string };
+
+    expect(modelOutput.type).toBe('text');
+    expect(modelOutput.value).toContain('truncated for the model');
+    // Bounded near the cap (notice adds a little).
+    expect(estimateTokenCount(modelOutput.value)).toBeLessThan(DEFAULT_MCP_RESULT_MAX_TOKENS * 1.1);
+    // Keeps both ends.
+    expect(modelOutput.value).toContain('word0 ');
+    expect(modelOutput.value.trimEnd().endsWith(`word${DEFAULT_MCP_RESULT_MAX_TOKENS * 3 - 1}`)).toBe(true);
+  });
+
+  it('truncates oversized string results', () => {
+    const wrapped = withMcpResultTruncation({ id: 'tool' } as any);
+    const modelOutput = wrapped.toModelOutput!(bigText(DEFAULT_MCP_RESULT_MAX_TOKENS * 2)) as {
+      type: string;
+      value: string;
+    };
+    expect(modelOutput.type).toBe('text');
+    expect(estimateTokenCount(modelOutput.value)).toBeLessThan(DEFAULT_MCP_RESULT_MAX_TOKENS * 1.1);
+  });
+
+  it('truncates oversized structured results via the base toModelOutput', () => {
+    const text = bigText(DEFAULT_MCP_RESULT_MAX_TOKENS * 2);
+    const base = vi.fn(() => ({ type: 'text', value: text }));
+    const wrapped = withMcpResultTruncation({ id: 'tool', toModelOutput: base } as any);
+
+    const modelOutput = wrapped.toModelOutput!({ structured: true }) as { type: string; value: string };
+
+    expect(base).toHaveBeenCalled();
+    expect(modelOutput.value).toContain('truncated for the model');
+    expect(estimateTokenCount(modelOutput.value)).toBeLessThan(DEFAULT_MCP_RESULT_MAX_TOKENS * 1.1);
+  });
+
+  it('returns the base output unchanged when it is under the cap', () => {
+    const base = { type: 'json', value: { ok: true } };
+    const wrapped = withMcpResultTruncation({ id: 'tool', toModelOutput: () => base } as any);
+    expect(wrapped.toModelOutput!({ structured: true })).toBe(base);
+  });
+
+  it('never truncates results containing non-text content parts', () => {
+    const wrapped = withMcpResultTruncation({ id: 'tool' } as any);
+    const result = {
+      content: [
+        { type: 'text', text: bigText(DEFAULT_MCP_RESULT_MAX_TOKENS * 2) },
+        { type: 'image', data: 'base64...', mimeType: 'image/png' },
+      ],
+    };
+    // Media would be dropped by a text-only truncation — leave untouched.
+    expect(wrapped.toModelOutput!(result)).toBeUndefined();
+  });
+
+  it('respects a custom token cap', () => {
+    const wrapped = withMcpResultTruncation({ id: 'tool' } as any, 100);
+    const modelOutput = wrapped.toModelOutput!(callToolResult(bigText(1000))) as { type: string; value: string };
+    expect(estimateTokenCount(modelOutput.value)).toBeLessThan(200);
+  });
+});
+
+describe('truncateSandwich', () => {
+  it('returns short text unchanged', () => {
+    expect(truncateSandwich('short', 100)).toBe('short');
+  });
+
+  it('keeps head and tail with a notice between', () => {
+    const text = bigText(1000);
+    const out = truncateSandwich(text, 100);
+    expect(out).toContain('word0 ');
+    expect(out.trimEnd().endsWith('word999')).toBe(true);
+    expect(out).toContain('truncated for the model');
+    expect(estimateTokenCount(out)).toBeLessThan(200);
+  });
+});

--- a/mastracode/sdk/src/mcp/truncate.ts
+++ b/mastracode/sdk/src/mcp/truncate.ts
@@ -1,0 +1,125 @@
+/**
+ * Model-facing truncation for MCP tool results.
+ *
+ * Unlike mastracode's workspace tools (which cap their own results at ~2k
+ * tokens), MCP servers return whatever they like — a chrome-devtools
+ * accessibility snapshot or a web page extraction can easily be 30-100k
+ * tokens. Untruncated, a single such result dominates the agent's context
+ * window and observational memory's pending-token accounting.
+ *
+ * The wrap composes a `toModelOutput` that only takes effect when the
+ * model-facing payload exceeds the cap: under the cap it defers entirely to
+ * the tool's own `toModelOutput` (or returns `undefined`, which leaves the
+ * raw result untouched). The full result is always preserved for
+ * display/storage — only what the model reads is bounded.
+ */
+
+import { estimateTokenCount, sliceByTokens } from 'tokenx';
+
+/**
+ * Cap for model-facing MCP tool result content. Generous compared to the 2k
+ * workspace-tool cap because MCP results (a11y snapshots, page extractions)
+ * are often consumed structurally by the model, but far below the pathological
+ * sizes observed in practice.
+ */
+export const DEFAULT_MCP_RESULT_MAX_TOKENS = 10_000;
+
+/** MCP CallToolResult-style content part. */
+interface ContentPart {
+  type?: unknown;
+  text?: unknown;
+}
+
+/**
+ * Join the text of an MCP `content` array. Returns undefined when the array
+ * contains any non-text part (images, resources) — truncating those results
+ * to a text-only payload would drop the media the model may need.
+ */
+function joinTextOnlyContent(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return undefined;
+  const texts: string[] = [];
+  for (const part of content as ContentPart[]) {
+    if (!part || typeof part !== 'object' || part.type !== 'text' || typeof part.text !== 'string') {
+      return undefined;
+    }
+    texts.push(part.text);
+  }
+  return texts.join('\n');
+}
+
+function safeStringify(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Head+tail truncation with a notice in the middle. Keeps both ends because
+ * structured results (snapshots, listings) carry useful anchors at the start
+ * and recency at the end.
+ */
+export function truncateSandwich(text: string, limit: number): string {
+  const totalTokens = estimateTokenCount(text);
+  if (totalTokens <= limit) return text;
+  const headBudget = Math.floor(limit / 2);
+  const tailBudget = limit - headBudget;
+  const head = sliceByTokens(text, 0, headBudget);
+  const tail = sliceByTokens(text, -tailBudget);
+  const notice = `\n[...MCP tool result truncated for the model — showing first ~${headBudget} + last ~${tailBudget} of ~${totalTokens} tokens. The full result was too large to include...]\n`;
+  return `${head}${notice}${tail}`;
+}
+
+/**
+ * Derive the model-facing text of a tool result when the tool has no
+ * `toModelOutput` of its own. Plain MCP tools return the raw CallToolResult
+ * (`{ content: [...] }`); structured tools return `structuredContent`.
+ * Returns undefined when the payload is not safely representable as text
+ * (e.g. contains media parts).
+ */
+function deriveModelText(output: unknown): string | undefined {
+  if (typeof output === 'string') return output;
+  if (output && typeof output === 'object' && 'content' in (output as Record<string, unknown>)) {
+    return joinTextOnlyContent((output as Record<string, unknown>).content);
+  }
+  return safeStringify(output);
+}
+
+type ToModelOutput = (output: unknown) => unknown;
+
+/**
+ * Wrap an MCP tool config so oversized results are truncated for the model.
+ * Under the cap the tool behaves exactly as before; over it, the model sees a
+ * head+tail slice with a truncation notice while the raw result stays intact.
+ */
+export function withMcpResultTruncation<T extends { toModelOutput?: ToModelOutput }>(
+  toolConfig: T,
+  maxTokens: number = DEFAULT_MCP_RESULT_MAX_TOKENS,
+): T {
+  const baseToModelOutput = toolConfig.toModelOutput;
+
+  const toModelOutput: ToModelOutput = (output: unknown) => {
+    const base = baseToModelOutput ? baseToModelOutput(output) : undefined;
+
+    if (base && typeof base === 'object') {
+      // Structured tools produce { type: 'text' | 'json', value }.
+      const { type, value } = base as { type?: unknown; value?: unknown };
+      const text = type === 'text' && typeof value === 'string' ? value : safeStringify(value);
+      if (text !== undefined && estimateTokenCount(text) > maxTokens) {
+        return { type: 'text', value: truncateSandwich(text, maxTokens) };
+      }
+      return base;
+    }
+
+    const text = deriveModelText(output);
+    if (text !== undefined && estimateTokenCount(text) > maxTokens) {
+      return { type: 'text', value: truncateSandwich(text, maxTokens) };
+    }
+    // Under the cap (or not safely truncatable): leave the result untouched.
+    return base;
+  };
+
+  return { ...toolConfig, toModelOutput };
+}


### PR DESCRIPTION
## Summary

mastracode's workspace tools cap their own results (200-line tail + ~2k-token safety net), but **MCP tool results flow into the agent's context unbounded**. A chrome-devtools accessibility snapshot or `web_extract` page dump can be 30–100k tokens. Production sessions doing browser testing showed context windows past 150k tokens driven by these results — which also inflates observational memory's pending-token accounting and forces constant observation cycles.

## Fix

Every MCP tool registered by the MCP manager is wrapped with a `toModelOutput` that bounds what the model reads:

- Model-facing text is capped at **10k tokens** (generous vs. the 2k workspace cap, since snapshots are consumed structurally) using head+tail slices around a truncation notice — start anchors and recent output both survive
- Results **under the cap** defer to the tool's own `toModelOutput` (structured MCP tools) or return `undefined`, leaving behavior byte-identical to today
- Results containing **media parts** (screenshots) are never truncated — text-only truncation would drop the media
- The **raw result is always preserved** for display/storage; only the model-facing view is bounded

This uses the same `providerMetadata.mastra.modelOutput` mechanism as workspace sandbox tools and structured MCP tools, so observational memory's token counting also sees the truncated size.

## Test plan

- New `truncate.test.ts` (10 tests): small results untouched, oversized CallToolResult/string/structured results truncated under cap with both ends preserved, media-bearing results never truncated, custom cap respected, tool config passthrough
- Existing `src/mcp/` suites pass (142 tests)
- `tsc --noEmit`: only a pre-existing error from a stale core build remains (verified present without this change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Large MCP tool results can overload the agent’s context. This change keeps the beginning and end of large text results, while preserving the full result for display and storage.

## Changes

- Wraps every MCP tool with `withMcpResultTruncation`.
- Limits model-facing text results to 10,000 tokens by default.
- Preserves smaller results and existing `toModelOutput` handlers.
- Leaves media-containing results unchanged.
- Keeps raw results available for display and storage.
- Supports custom token limits.
- Adds tests for text, structured, media, custom-limit, and configuration passthrough cases.
- Adds a patch changeset for `@mastra/code-sdk`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->