### PR TITLE
fix(memory): use async buffering in the observation threshold→blockAfter band

### DIFF
--- a/.changeset/gold-lions-wave.md
+++ b/.changeset/gold-lions-wave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Observational memory: use async buffering in the threshold→blockAfter band instead of blocking sync observation. Previously, reaching the observation threshold without an activatable buffered chunk fell straight through to a blocking synchronous observer call — even when async buffering was enabled and pending tokens were far below `blockAfter`. Now, pending tokens between the threshold and `blockAfter` trigger background buffering (the resulting chunk is activated on a later step), and blocking sync observation is reserved for pending tokens at or above `blockAfter`. This matches the documented reflection `blockAfter` semantics and eliminates repeated blocking observer calls in long agent sessions.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -11222,11 +11222,16 @@ describe('Full Async Buffering Flow', () => {
     expect(observerCalls.length).toBeGreaterThan(0);
   });
 
-  it('should trigger sync observation at step > 0 even when bufferTokens is set without blockAfter', async () => {
+  it('should keep observing at step > 0 when bufferTokens is set without blockAfter', async () => {
     // Regression test: when async buffering is enabled (bufferTokens set) but blockAfter
-    // is NOT configured, sync observation at step > 0 must still fire once pending tokens
+    // is NOT configured, observation at step > 0 must still fire once pending tokens
     // exceed the threshold. Previously, the blockAfter gate had `if (!blockAfter) return false`
     // which silently disabled ALL sync observation when blockAfter was unset.
+    //
+    // With threshold→blockAfter band semantics, pending tokens between the threshold
+    // (2000) and the default blockAfter (1.2x = 2400) are handled by background band
+    // buffering + activation instead of a blocking sync observation — so the observer
+    // still runs, just asynchronously across steps.
     const { step, waitForAsyncOps, observerCalls, storage, threadId, resourceId } = await setupAsyncBufferingScenario({
       messageTokens: 2000, // Threshold that will be exceeded
       bufferTokens: 500, // Async buffering enabled
@@ -11262,16 +11267,79 @@ describe('Full Async Buffering Flow', () => {
       );
     }
 
-    // Step 1: the blockAfter gate must not have silently disabled sync
-    // observation — the regression this test guards is `if (!blockAfter) return
-    // false` disabling ALL sync observation at step > 0.
+    // Steps 1-2: the blockAfter gate must not have silently disabled observation —
+    // the regression this test guards is `if (!blockAfter) return false` disabling
+    // ALL sync observation at step > 0. Step 1 activates the step-0 buffered chunk
+    // (a swap, no observer call) leaving the fresh messages in the threshold→blockAfter
+    // band; step 2 triggers band buffering, which runs the observer on them.
     await step(1);
+    await waitForAsyncOps();
+    await step(2);
     await waitForAsyncOps();
     expect(observerCalls.length).toBeGreaterThan(callsAfterStep0);
 
     // Verify observations were actually persisted to the record
     const record = await storage.getObservationalMemory(threadId, resourceId);
     expect(record?.activeObservations).toBeTruthy();
+  });
+
+  it('should buffer in the threshold→blockAfter band instead of running a blocking sync observation', async () => {
+    // ~2200 pending tokens sit between the threshold (2000) and blockAfter (2x = 4000).
+    // Reaching the threshold without a buffered chunk must trigger background band
+    // buffering — NOT a blocking sync observation (the sync-at-threshold race that
+    // caused blocking observer calls on every turn even with async buffering enabled).
+    const { om, step, waitForAsyncOps, observerCalls, storage, threadId, resourceId } =
+      await setupAsyncBufferingScenario({
+        messageTokens: 2000,
+        bufferTokens: 500,
+        bufferActivation: 1.0,
+        blockAfter: 2, // 2x threshold = 4000
+        reflectionObservationTokens: 50000,
+        messageCount: 20, // ~2200 tokens: in the band
+      });
+
+    const status = await om.getStatus({ threadId, resourceId });
+    expect(status.observationBlockAfter).toBe(4000);
+    expect(status.inAsyncObservationBand).toBe(true);
+    expect(status.shouldBuffer).toBe(true);
+
+    await step(0);
+    await waitForAsyncOps();
+
+    // Band buffering ran the observer in the background and produced a chunk...
+    expect(observerCalls.length).toBeGreaterThan(0);
+    const record = await storage.getObservationalMemory(threadId, resourceId);
+    expect(getBufferedChunks(record).length).toBeGreaterThan(0);
+    // ...but no sync observation committed observations directly.
+    expect(record?.activeObservations ?? '').toBe('');
+
+    // The next step activates the buffered chunk (a swap, no extra observer call).
+    const callsBeforeActivation = observerCalls.length;
+    await step(1);
+    const postActivation = await storage.getObservationalMemory(threadId, resourceId);
+    expect(postActivation?.activeObservations).toContain('Observed');
+    expect(observerCalls.length).toBe(callsBeforeActivation);
+  });
+
+  it('should run a blocking sync observation once pending tokens reach blockAfter with no buffered chunk', async () => {
+    // ~2200 pending tokens exceed blockAfter (2x threshold 1000 = 2000). With no
+    // activatable chunk, the band no longer applies — a sync observation must fire
+    // so context is bounded.
+    const { step, observerCalls, storage, threadId, resourceId } = await setupAsyncBufferingScenario({
+      messageTokens: 1000,
+      bufferTokens: 250,
+      bufferActivation: 1.0,
+      blockAfter: 2, // 2x threshold = 2000
+      reflectionObservationTokens: 50000,
+      messageCount: 20, // ~2200 tokens: past blockAfter
+    });
+
+    await step(0);
+
+    // Sync observation committed directly during the step — no async wait needed.
+    expect(observerCalls.length).toBeGreaterThan(0);
+    const record = await storage.getObservationalMemory(threadId, resourceId);
+    expect(record?.activeObservations).toContain('Observed');
   });
 
   it('should defer async buffering when messages contain pending tool calls (state: call)', async () => {

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -219,7 +219,26 @@ export class ObservationStep {
     // pendingTokens < threshold) nor this one — the #16523 dead zone. Now the block also
     // runs at step 0, but ONLY when observation is imminent, so buckets aren't drained on
     // turns where nothing will fire.
-    const willObserveNow = statusSnapshot.shouldObserve && !hasIncompleteToolCalls;
+    // In the threshold→blockAfter band, sync observation must not fire: buffering
+    // was (or will be) triggered above, and the resulting chunk gets activated on a
+    // later step/turn. Only run the threshold pipeline in-band when a buffered
+    // chunk is already available to activate (a cheap swap, no blocking model call).
+    const observeGate = (status: typeof statusSnapshot) =>
+      status.shouldObserve && !hasIncompleteToolCalls && (!status.inAsyncObservationBand || status.canActivate);
+    let willObserveNow = observeGate(statusSnapshot);
+    if (!willObserveNow && statusSnapshot.shouldObserve && !hasIncompleteToolCalls) {
+      // In-band without an activatable chunk per the cached record — a background
+      // buffer op may have completed since the cache was taken. Refresh once and
+      // re-check so a ready chunk gets activated instead of lingering.
+      await this.turn.refreshRecord();
+      statusSnapshot = await om.getStatus({
+        threadId,
+        resourceId,
+        record: this.turn.record,
+        messages: getObservableMessages(messageList),
+      });
+      willObserveNow = observeGate(statusSnapshot);
+    }
     /** In-flight message ids the step-0 cleanup must never remove from live context. */
     let step0PreserveIds: string[] | undefined;
     if (this.stepNumber > 0 || willObserveNow) {
@@ -276,7 +295,7 @@ export class ObservationStep {
       // Threshold observation (skip if tool calls pending)
       if (willObserveNow) {
         const preObsGeneration = this.turn.record.generationCount;
-        const obsResult = await this.runThresholdObservation();
+        const obsResult = await this.runThresholdObservation(statusSnapshot.inAsyncObservationBand);
         observerExchange = obsResult.observerExchange;
         if (obsResult.succeeded) {
           observed = true;
@@ -384,7 +403,7 @@ export class ObservationStep {
    * waitForBuffering → re-check → activate → reflect → observe (sync fallback when
    * buffered activation did not happen)
    */
-  private async runThresholdObservation(): Promise<{
+  private async runThresholdObservation(inAsyncObservationBand?: boolean): Promise<{
     succeeded: boolean;
     record: any;
     activatedMessageIds?: string[];
@@ -394,7 +413,13 @@ export class ObservationStep {
     const om = this.turn.om;
 
     // Wait for any in-flight buffering to settle, then refresh the turn cache once.
-    await om.waitForBuffering(threadId, resourceId);
+    // In the threshold→blockAfter band this path is only entered when a buffered
+    // chunk is already activatable — skip the wait so an in-flight buffer op (possibly
+    // fired earlier this same step) doesn't turn the cheap activation swap into a
+    // blocking wait on the observer model.
+    if (!inAsyncObservationBand) {
+      await om.waitForBuffering(threadId, resourceId);
+    }
     await this.turn.refreshRecord();
 
     // A step-0 seeded response message exists ONLY as a marker anchor in the live list.
@@ -455,6 +480,17 @@ export class ObservationStep {
           activatedMessageIds: activation.activatedMessageIds,
         };
       }
+    }
+
+    // In the threshold→blockAfter band, never fall through to a blocking sync
+    // observation — background buffering is responsible for producing a chunk,
+    // and activation will pick it up on a later step/turn. Sync observation is
+    // reserved for pending tokens at/above blockAfter (or async disabled).
+    if (freshStatus.inAsyncObservationBand) {
+      omDebug(
+        `[OM:observe] in async band (pending=${freshStatus.pendingTokens}, threshold=${freshStatus.threshold}, blockAfter=${freshStatus.observationBlockAfter}) — deferring to async buffering instead of sync observation`,
+      );
+      return { succeeded: false, record: freshStatus.record };
     }
 
     // Sync observation — we've waited for buffering and tried activation,

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -2849,6 +2849,14 @@ ${formattedMessages}
     canActivate: boolean;
     asyncObservationEnabled: boolean;
     asyncReflectionEnabled: boolean;
+    /** Resolved absolute observation blockAfter (only set when async observation is enabled). */
+    observationBlockAfter?: number;
+    /**
+     * Pending tokens are in the threshold→blockAfter band: past the observation
+     * threshold but below blockAfter, so async buffering/activation should be
+     * used instead of a blocking synchronous observation.
+     */
+    inAsyncObservationBand: boolean;
     scope: 'resource' | 'thread';
   }> {
     const { threadId, resourceId, record: providedRecord, messages } = opts;
@@ -2885,10 +2893,17 @@ ${formattedMessages}
     const bufferedChunkCount = bufferedChunks.length;
     const bufferedChunkTokens = bufferedChunks.reduce((sum, chunk) => sum + (chunk.messageTokens ?? 0), 0);
 
-    // Should buffer? Check interval boundary using DB-backed state
+    // Should buffer? Check interval boundary using DB-backed state.
+    // Buffering is also allowed in the threshold→blockAfter band: reaching the
+    // observation threshold without a buffered chunk must kick off background
+    // buffering (so a chunk becomes activatable) rather than leaving sync
+    // observation as the only way out of the band.
     const asyncObservationEnabled = this.buffering.isAsyncObservationEnabled();
+    const observationBlockAfter = asyncObservationEnabled ? this.observationConfig.blockAfter : undefined;
+    const inAsyncObservationBand =
+      observationBlockAfter !== undefined && pendingTokens >= threshold && pendingTokens < observationBlockAfter;
     let shouldBuffer = false;
-    if (asyncObservationEnabled && pendingTokens < threshold) {
+    if (asyncObservationEnabled && (pendingTokens < threshold || inAsyncObservationBand)) {
       const lockKey = this.buffering.getLockKey(threadId, resourceId);
       shouldBuffer = this.buffering.shouldTriggerAsyncObservation(
         pendingTokens,
@@ -2933,6 +2948,8 @@ ${formattedMessages}
       canActivate,
       asyncObservationEnabled,
       asyncReflectionEnabled: this.buffering.isAsyncReflectionEnabled(),
+      observationBlockAfter,
+      inAsyncObservationBand,
       scope: this.scope,
     };
   }

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -190,10 +190,13 @@ export interface ObservationConfig {
   activateOnProviderChange?: boolean;
 
   /**
-   * Token threshold above which buffered activation is allowed to overshoot the
-   * retention target. Crossing `blockAfter` does not trigger a blocking observation;
-   * a synchronous observation runs when `messageTokens` is reached and buffered
-   * activation did not happen.
+   * Token threshold above which a blocking synchronous observation is allowed.
+   * Between `messageTokens` and `blockAfter`, only async buffering/activation is
+   * used: reaching the observation threshold without an activatable buffered chunk
+   * triggers background buffering instead of a blocking observation. Above
+   * `blockAfter`, a synchronous observation runs when buffered activation did not
+   * happen. Buffered activation is also allowed to overshoot the retention target
+   * past this threshold.
    *
    * Accepts either:
    * - A multiplier (1 ≤ value < 100): multiplied by `messageTokens`.


### PR DESCRIPTION
## Summary

With async buffering enabled, reaching the observation threshold without an activatable buffered chunk fell straight through to a **blocking synchronous observer call** — even when pending tokens were barely past the threshold and far below `blockAfter`. Worse, `getStatus`'s `shouldBuffer` required `pendingTokens < threshold`, so once past the threshold no background buffering could even start, guaranteeing the blocking path on every subsequent turn. Production sessions showed agents stalling on blocking observations turn after turn despite async buffering being configured.

## Fix

The observation threshold→`blockAfter` band now behaves like the already-documented reflection `blockAfter` semantics:

- **In the band** (`threshold ≤ pending < blockAfter`): background buffering is triggered (reusing the coordinator's existing interval/dedupe/ramp logic), and the resulting chunk is activated on a later step via a cheap swap — no blocking model call
- **At/above `blockAfter`** (or async disabled): blocking sync observation fires as before, bounding context growth
- In-band pipeline entry skips the buffering wait (it's only reachable with a chunk ready to activate) so an in-flight buffer op doesn't turn the activation swap into a blocking wait on the observer model
- The cached turn record is refreshed once when in-band without a visible chunk, so a chunk that landed mid-turn gets activated instead of lingering
- `getStatus` now exposes `observationBlockAfter` and `inAsyncObservationBand`; the observation `blockAfter` doc is updated to the new semantics

## Test plan

- 2 new tests: in-band turns buffer in the background and activate on the next step (no sync commit); pending at/above `blockAfter` with no chunk still sync-observes
- 1 existing regression test updated to the band semantics (`bufferTokens` without explicit `blockAfter` still observes across steps — the `if (!blockAfter) return false` regression it guards remains covered)
- Full OM suite: 51 files, 1187 tests pass
- `tsc --noEmit` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The memory system can now prepare observations in the background before it must pause to calculate them. This reduces blocking model calls while preserving immediate processing when the limit is reached.

## Changes

- Buffer observations asynchronously between `threshold` and `blockAfter`.
- Use blocking synchronous observation only at or above `blockAfter`, or when async buffering is disabled.
- Activate completed buffered chunks without waiting for another buffering operation.
- Refresh the cached turn record when required.
- Expose `observationBlockAfter` and `inAsyncObservationBand` through `getStatus()`.
- Update `blockAfter` documentation.
- Add two tests and update one regression test.
- Add a patch changeset for `@mastra/memory`.

## Validation

- OM suite: 51 files and 1,187 tests passed.
- `tsc --noEmit` passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->