### PR TITLE
fix(core): stop instead of destroy registered workspaces on Mastra.shutdown()

### DIFF
--- a/.changeset/workspace-shutdown-stop.md
+++ b/.changeset/workspace-shutdown-stop.md
@@ -2,8 +2,8 @@
 '@mastra/core': minor
 ---
 
-`Mastra.shutdown()` no longer destroys registered workspaces' sandboxes by default. Remote sandboxes (E2B, Platform, and other providers) were being killed on every process restart; they are now stopped instead, so providers that support suspension pause the sandbox and resume it later with filesystem and memory intact.
+`Mastra.shutdown()` no longer destroys registered workspaces' sandboxes. Remote sandboxes (E2B, Platform, and other providers) were being killed on every process restart; they are now stopped instead, so providers that support suspension pause the sandbox and resume it later with filesystem and memory intact.
 
 - New `Workspace.stop()`: shuts down language servers, closes the browser, and stops the sandbox without destroying anything. The workspace stays usable and the sandbox can start again later.
-- `LocalSandbox.stop()` now kills background processes (previously only `destroy()` did), so the stop-by-default shutdown cannot leak child processes on local sandboxes. Files in the working directory are untouched.
-- `mastra.addWorkspace(workspace, key, { shutdownBehavior })` accepts `'stop'` (default), `'destroy'`, or `'none'` to control what `shutdown()` does per workspace.
+- `LocalSandbox.stop()` now kills background processes (previously only `destroy()` did), so the stop-on-shutdown behavior cannot leak child processes on local sandboxes. Files in the working directory are untouched.
+- Full teardown remains explicit: `workspace.destroy()` or `mastra.removeWorkspace(id, { destroy: true })`.

--- a/.changeset/workspace-shutdown-stop.md
+++ b/.changeset/workspace-shutdown-stop.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': minor
+---
+
+`Mastra.shutdown()` no longer destroys registered workspaces' sandboxes by default. Remote sandboxes (E2B, Platform, and other providers) were being killed on every process restart; they are now stopped instead, so providers that support suspension pause the sandbox and resume it later with filesystem and memory intact.
+
+- New `Workspace.stop()`: shuts down language servers, closes the browser, and stops the sandbox without destroying anything. The workspace stays usable and the sandbox can start again later.
+- `LocalSandbox.stop()` now kills background processes (previously only `destroy()` did), so the stop-by-default shutdown cannot leak child processes on local sandboxes. Files in the working directory are untouched.
+- `mastra.addWorkspace(workspace, key, { shutdownBehavior })` accepts `'stop'` (default), `'destroy'`, or `'none'` to control what `shutdown()` does per workspace.

--- a/.changeset/workspace-shutdown-stop.md
+++ b/.changeset/workspace-shutdown-stop.md
@@ -7,3 +7,11 @@
 - New `Workspace.stop()`: shuts down language servers, closes the browser, and stops the sandbox without destroying anything. The workspace stays usable and the sandbox can start again later.
 - `LocalSandbox.stop()` now kills background processes (previously only `destroy()` did), so the stop-on-shutdown behavior cannot leak child processes on local sandboxes. Files in the working directory are untouched.
 - Full teardown remains explicit: `workspace.destroy()` or `mastra.removeWorkspace(id, { destroy: true })`.
+
+```typescript
+// Suspend live resources; the workspace stays usable
+await workspace.stop();
+
+// Full teardown is explicit
+await workspace.destroy();
+```

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -433,7 +433,7 @@ Stop the workspace's live resources without destroying them.
 await workspace.stop()
 ```
 
-`stop()` shuts down language servers, closes the browser, and stops the sandbox provider. Remote sandbox providers suspend or pause the sandbox so it can resume later; `LocalSandbox` kills its background processes and unmounts filesystems. The workspace itself stays usable: the filesystem, search index, and skills are untouched, and a later sandbox operation can start the sandbox again.
+`stop()` shuts down language servers and closes the browser, then stops the sandbox provider. Remote sandbox providers suspend or pause the sandbox so it can resume later. `LocalSandbox` kills its background processes and unmounts filesystems. Stopping isn't a teardown. The filesystem, search index, and skills keep working, and the next sandbox operation starts the sandbox again.
 
 `mastra.shutdown()` calls `stop()` for registered workspaces, so a process restart suspends remote sandboxes instead of deleting them. To fully tear a workspace down, call `destroy()` or `mastra.removeWorkspace(id, { destroy: true })` explicitly.
 

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -425,6 +425,18 @@ Initialization performs:
 - Starts the sandbox provider (creates working directory, sets up isolation if configured)
 - Indexes files from `autoIndexPaths` for search
 
+#### `stop()`
+
+Stop the workspace's live resources without destroying them.
+
+```typescript
+await workspace.stop()
+```
+
+`stop()` shuts down language servers, closes the browser, and stops the sandbox provider. Remote sandbox providers suspend or pause the sandbox so it can resume later; `LocalSandbox` kills its background processes and unmounts filesystems. The workspace itself stays usable: the filesystem, search index, and skills are untouched, and a later sandbox operation can start the sandbox again.
+
+`mastra.shutdown()` calls `stop()` for registered workspaces by default, so a process restart suspends remote sandboxes instead of deleting them. Register a workspace with `mastra.addWorkspace(workspace, undefined, { shutdownBehavior: 'destroy' })` to destroy it on shutdown instead, or `{ shutdownBehavior: 'none' }` to leave it untouched.
+
 #### `destroy()`
 
 Destroy the workspace and clean up resources.
@@ -435,7 +447,7 @@ await workspace.destroy()
 
 `destroy()` closes workspace-owned resources in order: language servers, browsers, sandbox providers, and filesystem providers. It also clears cached sandbox references.
 
-Call `destroy()` when your application is done with a workspace. `mastra.shutdown()` calls it for registered workspaces during shutdown. To remove a workspace from the Mastra registry, use [`mastra.removeWorkspace()`](/reference/core/removeWorkspace).
+Call `destroy()` when your application is done with a workspace and its sandbox. To remove a workspace from the Mastra registry, use [`mastra.removeWorkspace()`](/reference/core/removeWorkspace).
 
 `LocalFilesystem.destroy()` doesn't delete files on disk. Resolver-backed filesystem and sandbox providers are owned by your application and must be cleaned up by your application.
 

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -435,7 +435,7 @@ await workspace.stop()
 
 `stop()` shuts down language servers, closes the browser, and stops the sandbox provider. Remote sandbox providers suspend or pause the sandbox so it can resume later; `LocalSandbox` kills its background processes and unmounts filesystems. The workspace itself stays usable: the filesystem, search index, and skills are untouched, and a later sandbox operation can start the sandbox again.
 
-`mastra.shutdown()` calls `stop()` for registered workspaces by default, so a process restart suspends remote sandboxes instead of deleting them. Register a workspace with `mastra.addWorkspace(workspace, undefined, { shutdownBehavior: 'destroy' })` to destroy it on shutdown instead, or `{ shutdownBehavior: 'none' }` to leave it untouched.
+`mastra.shutdown()` calls `stop()` for registered workspaces, so a process restart suspends remote sandboxes instead of deleting them. To fully tear a workspace down, call `destroy()` or `mastra.removeWorkspace(id, { destroy: true })` explicitly.
 
 #### `destroy()`
 

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -87,7 +87,7 @@ import {
 import { WorkflowEventProcessor } from '../workflows/evented/workflow-event-processor';
 import { computeNextFireAt } from '../workflows/scheduler';
 import type { WorkflowScheduleConfig, SchedulerConfig, Scheduler } from '../workflows/scheduler';
-import type { AnyWorkspace, RegisteredWorkspace, Workspace } from '../workspace';
+import type { AnyWorkspace, RegisteredWorkspace, Workspace, WorkspaceShutdownBehavior } from '../workspace';
 import {
   declaredSchedulesOf,
   findFsAgentScheduleHandler,
@@ -3254,7 +3254,13 @@ export class Mastra<
   public addWorkspace(
     workspace: AnyWorkspace,
     key?: string,
-    metadata?: { source?: 'mastra' | 'agent'; agentId?: string; agentName?: string },
+    metadata?: {
+      source?: 'mastra' | 'agent';
+      agentId?: string;
+      agentName?: string;
+      /** What `shutdown()` does with this workspace. Defaults to `'stop'`. */
+      shutdownBehavior?: WorkspaceShutdownBehavior;
+    },
   ): void {
     if (!workspace) {
       throw createUndefinedPrimitiveError('workspace', workspace, key);
@@ -3279,6 +3285,7 @@ export class Mastra<
       source,
       ...(metadata?.agentId ? { agentId: metadata.agentId } : {}),
       ...(metadata?.agentName ? { agentName: metadata.agentName } : {}),
+      ...(metadata?.shutdownBehavior ? { shutdownBehavior: metadata.shutdownBehavior } : {}),
     };
   }
 
@@ -6557,13 +6564,31 @@ export class Mastra<
       }
     });
 
+    // Tear down registered workspaces per their shutdown behavior. The default
+    // is 'stop', not 'destroy': remote sandboxes suspend/pause and stay
+    // resumable across process restarts, and LocalSandbox.stop() kills its
+    // background processes, so nothing leaks. 'destroy' remains available as
+    // an explicit registration override, and 'none' leaves the workspace
+    // untouched (e.g. when the provider's idle lifecycle owns suspension).
     const workspaceIds = Object.keys(this.#workspaces);
     const teardownResults = await Promise.allSettled(
-      workspaceIds.map(id => this.removeWorkspace(id, { destroy: true })),
+      workspaceIds.map(async id => {
+        const entry = this.#workspaces[id];
+        if (!entry) return;
+        const behavior = entry.shutdownBehavior ?? 'stop';
+        if (behavior === 'destroy') {
+          await this.removeWorkspace(id, { destroy: true });
+          return;
+        }
+        if (behavior === 'stop') {
+          await entry.workspace.stop();
+        }
+        await this.removeWorkspace(id);
+      }),
     );
     teardownResults.forEach((result, index) => {
       if (result.status === 'rejected') {
-        this.#logger?.error('Failed to destroy workspace during shutdown', {
+        this.#logger?.error('Failed to tear down workspace during shutdown', {
           workspaceId: workspaceIds[index],
           error: result.reason,
         });

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -87,7 +87,7 @@ import {
 import { WorkflowEventProcessor } from '../workflows/evented/workflow-event-processor';
 import { computeNextFireAt } from '../workflows/scheduler';
 import type { WorkflowScheduleConfig, SchedulerConfig, Scheduler } from '../workflows/scheduler';
-import type { AnyWorkspace, RegisteredWorkspace, Workspace, WorkspaceShutdownBehavior } from '../workspace';
+import type { AnyWorkspace, RegisteredWorkspace, Workspace } from '../workspace';
 import {
   declaredSchedulesOf,
   findFsAgentScheduleHandler,
@@ -3254,13 +3254,7 @@ export class Mastra<
   public addWorkspace(
     workspace: AnyWorkspace,
     key?: string,
-    metadata?: {
-      source?: 'mastra' | 'agent';
-      agentId?: string;
-      agentName?: string;
-      /** What `shutdown()` does with this workspace. Defaults to `'stop'`. */
-      shutdownBehavior?: WorkspaceShutdownBehavior;
-    },
+    metadata?: { source?: 'mastra' | 'agent'; agentId?: string; agentName?: string },
   ): void {
     if (!workspace) {
       throw createUndefinedPrimitiveError('workspace', workspace, key);
@@ -3285,7 +3279,6 @@ export class Mastra<
       source,
       ...(metadata?.agentId ? { agentId: metadata.agentId } : {}),
       ...(metadata?.agentName ? { agentName: metadata.agentName } : {}),
-      ...(metadata?.shutdownBehavior ? { shutdownBehavior: metadata.shutdownBehavior } : {}),
     };
   }
 
@@ -6564,25 +6557,17 @@ export class Mastra<
       }
     });
 
-    // Tear down registered workspaces per their shutdown behavior. The default
-    // is 'stop', not 'destroy': remote sandboxes suspend/pause and stay
-    // resumable across process restarts, and LocalSandbox.stop() kills its
-    // background processes, so nothing leaks. 'destroy' remains available as
-    // an explicit registration override, and 'none' leaves the workspace
-    // untouched (e.g. when the provider's idle lifecycle owns suspension).
+    // Stop — don't destroy — registered workspaces. Remote sandboxes
+    // suspend/pause and stay resumable across process restarts, and
+    // LocalSandbox.stop() kills its background processes, so nothing leaks.
+    // Callers that want a full teardown destroy workspaces explicitly via
+    // removeWorkspace(id, { destroy: true }) or workspace.destroy().
     const workspaceIds = Object.keys(this.#workspaces);
     const teardownResults = await Promise.allSettled(
       workspaceIds.map(async id => {
         const entry = this.#workspaces[id];
         if (!entry) return;
-        const behavior = entry.shutdownBehavior ?? 'stop';
-        if (behavior === 'destroy') {
-          await this.removeWorkspace(id, { destroy: true });
-          return;
-        }
-        if (behavior === 'stop') {
-          await entry.workspace.stop();
-        }
+        await entry.workspace.stop();
         await this.removeWorkspace(id);
       }),
     );

--- a/packages/core/src/mastra/workspace-cleanup.test.ts
+++ b/packages/core/src/mastra/workspace-cleanup.test.ts
@@ -71,10 +71,12 @@ describe('Workspace cleanup', () => {
   });
 
   describe('shutdown', () => {
-    it('destroys and unregisters registered workspaces', async () => {
+    it('stops and unregisters registered workspaces by default without destroying them', async () => {
       const mastra = new Mastra({ logger: false });
       const workspaceA = createWorkspace('workspace-a');
       const workspaceB = createWorkspace('workspace-b');
+      const stopA = vi.spyOn(workspaceA, 'stop').mockResolvedValue(undefined);
+      const stopB = vi.spyOn(workspaceB, 'stop').mockResolvedValue(undefined);
       const destroyA = vi.spyOn(workspaceA, 'destroy').mockResolvedValue(undefined);
       const destroyB = vi.spyOn(workspaceB, 'destroy').mockResolvedValue(undefined);
       mastra.addWorkspace(workspaceA);
@@ -82,30 +84,60 @@ describe('Workspace cleanup', () => {
 
       await mastra.shutdown();
 
-      expect(destroyA).toHaveBeenCalledTimes(1);
-      expect(destroyB).toHaveBeenCalledTimes(1);
+      expect(stopA).toHaveBeenCalledTimes(1);
+      expect(stopB).toHaveBeenCalledTimes(1);
+      expect(destroyA).not.toHaveBeenCalled();
+      expect(destroyB).not.toHaveBeenCalled();
       expect(mastra.listWorkspaces()).toEqual({});
     });
 
-    it('continues shutdown after a workspace destroy failure and keeps failed workspaces registered', async () => {
+    it('destroys a workspace registered with shutdownBehavior "destroy"', async () => {
+      const mastra = new Mastra({ logger: false });
+      const workspace = createWorkspace('destroy-on-shutdown');
+      const destroy = vi.spyOn(workspace, 'destroy').mockResolvedValue(undefined);
+      const stop = vi.spyOn(workspace, 'stop').mockResolvedValue(undefined);
+      mastra.addWorkspace(workspace, undefined, { shutdownBehavior: 'destroy' });
+
+      await mastra.shutdown();
+
+      expect(destroy).toHaveBeenCalledTimes(1);
+      expect(stop).not.toHaveBeenCalled();
+      expect(mastra.listWorkspaces()).toEqual({});
+    });
+
+    it('leaves a workspace registered with shutdownBehavior "none" untouched', async () => {
+      const mastra = new Mastra({ logger: false });
+      const workspace = createWorkspace('leave-alone');
+      const destroy = vi.spyOn(workspace, 'destroy').mockResolvedValue(undefined);
+      const stop = vi.spyOn(workspace, 'stop').mockResolvedValue(undefined);
+      mastra.addWorkspace(workspace, undefined, { shutdownBehavior: 'none' });
+
+      await mastra.shutdown();
+
+      expect(destroy).not.toHaveBeenCalled();
+      expect(stop).not.toHaveBeenCalled();
+      expect(mastra.listWorkspaces()).toEqual({});
+    });
+
+    it('continues shutdown after a workspace stop failure and keeps failed workspaces registered', async () => {
       const mastra = new Mastra({ logger: false });
       const failingWorkspace = createWorkspace('failing-workspace');
       const successfulWorkspace = createWorkspace('successful-workspace');
-      const error = new Error('destroy failed');
-      const failingDestroy = vi.spyOn(failingWorkspace, 'destroy').mockRejectedValue(error);
-      const successfulDestroy = vi.spyOn(successfulWorkspace, 'destroy').mockResolvedValue(undefined);
+      const error = new Error('stop failed');
+      const failingStop = vi.spyOn(failingWorkspace, 'stop').mockRejectedValue(error);
+      const successfulStop = vi.spyOn(successfulWorkspace, 'stop').mockResolvedValue(undefined);
       mastra.addWorkspace(failingWorkspace);
       mastra.addWorkspace(successfulWorkspace);
 
       await expect(mastra.shutdown()).resolves.toBeUndefined();
 
-      expect(failingDestroy).toHaveBeenCalledTimes(1);
-      expect(successfulDestroy).toHaveBeenCalledTimes(1);
+      expect(failingStop).toHaveBeenCalledTimes(1);
+      expect(successfulStop).toHaveBeenCalledTimes(1);
       expect(mastra.listWorkspaces()['failing-workspace']?.workspace).toBe(failingWorkspace);
       expect(mastra.listWorkspaces()).not.toHaveProperty('successful-workspace');
     });
 
-    it('destroys registered workspaces before closing storage', async () => {
+    it('stops registered workspaces before closing storage', async () => {
       const callOrder: string[] = [];
       const storage = {
         name: 'order-test-storage',
@@ -118,18 +150,18 @@ describe('Workspace cleanup', () => {
 
       const mastra = new Mastra({ logger: false, storage });
       const workspace = createWorkspace('order-workspace');
-      vi.spyOn(workspace, 'destroy').mockImplementation(async () => {
-        callOrder.push('workspace.destroy');
+      vi.spyOn(workspace, 'stop').mockImplementation(async () => {
+        callOrder.push('workspace.stop');
       });
       mastra.addWorkspace(workspace);
 
       await mastra.shutdown();
 
-      expect(callOrder).toEqual(['workspace.destroy', 'storage.close']);
+      expect(callOrder).toEqual(['workspace.stop', 'storage.close']);
       expect(storage.close).toHaveBeenCalledTimes(1);
     });
 
-    it('destroys multiple workspaces concurrently (parallel teardown)', async () => {
+    it('stops multiple workspaces concurrently (parallel teardown)', async () => {
       const mastra = new Mastra({ logger: false });
       const workspaceA = createWorkspace('parallel-a');
       const workspaceB = createWorkspace('parallel-b');
@@ -137,21 +169,21 @@ describe('Workspace cleanup', () => {
       let started = 0;
       let active = 0;
       let maxActive = 0;
-      let releaseDestroys!: () => void;
+      let releaseStops!: () => void;
       const release = new Promise<void>(resolve => {
-        releaseDestroys = resolve;
+        releaseStops = resolve;
       });
 
-      const slowDestroy = async () => {
+      const slowStop = async () => {
         started += 1;
         active += 1;
         maxActive = Math.max(maxActive, active);
         await release;
         active -= 1;
       };
-      vi.spyOn(workspaceA, 'destroy').mockImplementation(slowDestroy);
-      vi.spyOn(workspaceB, 'destroy').mockImplementation(slowDestroy);
-      vi.spyOn(workspaceC, 'destroy').mockImplementation(slowDestroy);
+      vi.spyOn(workspaceA, 'stop').mockImplementation(slowStop);
+      vi.spyOn(workspaceB, 'stop').mockImplementation(slowStop);
+      vi.spyOn(workspaceC, 'stop').mockImplementation(slowStop);
 
       mastra.addWorkspace(workspaceA);
       mastra.addWorkspace(workspaceB);
@@ -163,7 +195,7 @@ describe('Workspace cleanup', () => {
         await vi.waitFor(() => expect(started).toBe(3), { timeout: 500, interval: 5 });
         expect(maxActive).toBe(3);
       } finally {
-        releaseDestroys();
+        releaseStops();
       }
       await shutdownPromise;
 

--- a/packages/core/src/mastra/workspace-cleanup.test.ts
+++ b/packages/core/src/mastra/workspace-cleanup.test.ts
@@ -91,34 +91,6 @@ describe('Workspace cleanup', () => {
       expect(mastra.listWorkspaces()).toEqual({});
     });
 
-    it('destroys a workspace registered with shutdownBehavior "destroy"', async () => {
-      const mastra = new Mastra({ logger: false });
-      const workspace = createWorkspace('destroy-on-shutdown');
-      const destroy = vi.spyOn(workspace, 'destroy').mockResolvedValue(undefined);
-      const stop = vi.spyOn(workspace, 'stop').mockResolvedValue(undefined);
-      mastra.addWorkspace(workspace, undefined, { shutdownBehavior: 'destroy' });
-
-      await mastra.shutdown();
-
-      expect(destroy).toHaveBeenCalledTimes(1);
-      expect(stop).not.toHaveBeenCalled();
-      expect(mastra.listWorkspaces()).toEqual({});
-    });
-
-    it('leaves a workspace registered with shutdownBehavior "none" untouched', async () => {
-      const mastra = new Mastra({ logger: false });
-      const workspace = createWorkspace('leave-alone');
-      const destroy = vi.spyOn(workspace, 'destroy').mockResolvedValue(undefined);
-      const stop = vi.spyOn(workspace, 'stop').mockResolvedValue(undefined);
-      mastra.addWorkspace(workspace, undefined, { shutdownBehavior: 'none' });
-
-      await mastra.shutdown();
-
-      expect(destroy).not.toHaveBeenCalled();
-      expect(stop).not.toHaveBeenCalled();
-      expect(mastra.listWorkspaces()).toEqual({});
-    });
-
     it('continues shutdown after a workspace stop failure and keeps failed workspaces registered', async () => {
       const mastra = new Mastra({ logger: false });
       const failingWorkspace = createWorkspace('failing-workspace');

--- a/packages/core/src/workspace/lsp/manager.test.ts
+++ b/packages/core/src/workspace/lsp/manager.test.ts
@@ -243,13 +243,17 @@ describe('LSPManager', () => {
   });
 
   describe('shutdownAll', () => {
-    it('cleans up all clients and rejects later acquisitions', async () => {
+    it('cleans up all clients and accepts new acquisitions once complete', async () => {
       await manager['getClientInternal']('/project/src/app.ts');
 
       await manager.shutdownAll();
+      expect(mockShutdown).toHaveBeenCalledTimes(1);
 
+      // A completed shutdown resets the manager: the next acquisition spawns
+      // a fresh client instead of being rejected forever. Workspace.stop()
+      // relies on this to keep a stopped workspace's diagnostics working.
       const client = await manager['getClientInternal']('/project/src/app.ts');
-      expect(client).toBeNull();
+      expect(client).not.toBeNull();
     });
 
     it('waits for queued initialization before shutting clients down', async () => {

--- a/packages/core/src/workspace/lsp/manager.ts
+++ b/packages/core/src/workspace/lsp/manager.ts
@@ -605,6 +605,12 @@ export class LSPManager {
       this.initPromises.clear();
       this.activeClientLeases.clear();
       this.fileLocks.clear();
+      // Everything is drained and cleared — return the manager to its
+      // fresh-constructed state so it can spawn clients again. This makes
+      // shutdownAll() a "stop" rather than a one-way door: Workspace.stop()
+      // relies on the same manager accepting clients after a restart.
+      this.shuttingDown = false;
+      this.shutdownPromise = undefined;
     })();
 
     return this.shutdownPromise;

--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -185,6 +185,25 @@ describe('LocalSandbox', () => {
       expect(sandbox.status).toBe('stopped');
     });
 
+    it('should kill background processes on stop()', async () => {
+      if (os.platform() === 'win32') return; // Uses POSIX commands
+
+      await sandbox._start();
+      const handle = await sandbox.processes.spawn('sleep 30');
+      await expect(sandbox.processes.list()).resolves.toHaveLength(1);
+
+      await sandbox._stop();
+
+      expect(sandbox.status).toBe('stopped');
+      await expect(sandbox.processes.list()).resolves.toEqual([]);
+      // The OS process itself is gone, not just untracked. `pid` is the OS
+      // pid stringified for local sandboxes; signal 0 probes existence.
+      await vi.waitFor(() => expect(() => process.kill(Number(handle.pid), 0)).toThrow(), {
+        timeout: 2000,
+        interval: 25,
+      });
+    });
+
     it('should destroy successfully', async () => {
       await sandbox._start();
       await sandbox._destroy();

--- a/packages/core/src/workspace/sandbox/local-sandbox.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.ts
@@ -483,11 +483,19 @@ export class LocalSandbox extends MastraSandbox {
 
   /**
    * Stop the local sandbox.
-   * Unmounts all active mounts before stopping.
+   * Kills background processes and unmounts all active mounts. Unlike remote
+   * providers, a local sandbox has no suspend/resume — its background
+   * processes ARE the runtime state, so a stopped sandbox must not leave them
+   * running. Files in the working directory are untouched and `start()` works
+   * again afterwards.
    * Status management is handled by the base class.
    */
   async stop(): Promise<void> {
     this.logger.debug('Stopping sandbox', { workingDirectory: this.workingDirectory });
+
+    // Kill all background processes — "stopped" means not running.
+    const procs = await this.processes.list();
+    await Promise.all(procs.map(p => this.processes.kill(p.pid)));
 
     // Unmount all active mounts (best-effort)
     for (const mountPath of [...this._activeMountPaths]) {

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -2860,6 +2860,20 @@ Line 3 conclusion`;
       expect(workspace.lsp).toBeInstanceOf(LSPManager);
     });
 
+    it('replaces the LSP manager with a fresh one after stop()', async () => {
+      const sandbox = new LocalSandbox({ workingDirectory: tempDir });
+      const workspace = new Workspace({ sandbox, lsp: true });
+      const before = workspace.lsp;
+      expect(before).toBeInstanceOf(LSPManager);
+
+      await workspace.stop();
+
+      // A shut-down LSPManager permanently refuses new clients, so stop()
+      // must install a fresh manager for the workspace to stay usable.
+      expect(workspace.lsp).toBeInstanceOf(LSPManager);
+      expect(workspace.lsp).not.toBe(before);
+    });
+
     it('does not create LSPManager when lsp is not configured', async () => {
       const sandbox = new LocalSandbox({ workingDirectory: tempDir });
       const workspace = new Workspace({ sandbox });

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -566,6 +566,44 @@ Line 3 conclusion`;
       expect(stops).toBe(1);
     });
 
+    it('destroy() waits for an in-flight stop() and wins', async () => {
+      let stopStarted!: () => void;
+      const stopStartedGate = new Promise<void>(resolve => {
+        stopStarted = resolve;
+      });
+      let releaseStop!: () => void;
+      const stopGate = new Promise<void>(resolve => {
+        releaseStop = resolve;
+      });
+      const order: string[] = [];
+      const sandbox = {
+        provider: 'fake',
+        stop: async () => {
+          order.push('stop:start');
+          stopStarted();
+          await stopGate;
+          order.push('stop:end');
+        },
+        destroy: async () => {
+          order.push('destroy');
+        },
+      } as any;
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        sandbox,
+      });
+
+      const stopping = workspace.stop();
+      await stopStartedGate;
+      const destroying = workspace.destroy();
+      releaseStop();
+      await Promise.all([stopping, destroying]);
+
+      // The destroy must not interleave with the stop's teardown.
+      expect(order).toEqual(['stop:start', 'stop:end', 'destroy']);
+      expect(workspace.status).toBe('destroyed');
+    });
+
     it('should release the search index even when a resource fails to destroy', async () => {
       const filesystem = new LocalFilesystem({ basePath: tempDir });
       const workspace = new Workspace({

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -524,6 +524,22 @@ Line 3 conclusion`;
       expect(await workspace.search('lazy')).toEqual([]);
     });
 
+    it('stop() stops the sandbox but keeps the workspace usable', async () => {
+      const filesystem = new LocalFilesystem({ basePath: tempDir });
+      const sandbox = new LocalSandbox({ workingDirectory: tempDir });
+      const workspace = new Workspace({ filesystem, sandbox, bm25: true });
+
+      await workspace.index('/doc1.txt', 'The quick brown fox jumps over the lazy dog');
+      await sandbox._start();
+      expect(sandbox.status).toBe('running');
+
+      await workspace.stop();
+
+      expect(sandbox.status).toBe('stopped');
+      // Not a teardown: the search index survives and the workspace stays usable.
+      expect((await workspace.search('quick')).length).toBeGreaterThan(0);
+    });
+
     it('should release the search index even when a resource fails to destroy', async () => {
       const filesystem = new LocalFilesystem({ basePath: tempDir });
       const workspace = new Workspace({

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -2898,7 +2898,7 @@ Line 3 conclusion`;
       expect(workspace.lsp).toBeInstanceOf(LSPManager);
     });
 
-    it('replaces the LSP manager with a fresh one after stop()', async () => {
+    it('keeps the LSP manager usable after stop()', async () => {
       const sandbox = new LocalSandbox({ workingDirectory: tempDir });
       const workspace = new Workspace({ sandbox, lsp: true });
       const before = workspace.lsp;
@@ -2906,10 +2906,9 @@ Line 3 conclusion`;
 
       await workspace.stop();
 
-      // A shut-down LSPManager permanently refuses new clients, so stop()
-      // must install a fresh manager for the workspace to stay usable.
-      expect(workspace.lsp).toBeInstanceOf(LSPManager);
-      expect(workspace.lsp).not.toBe(before);
+      // shutdownAll() drains and resets the manager, so the same instance
+      // spawns clients again on the next diagnostics request.
+      expect(workspace.lsp).toBe(before);
     });
 
     it('does not create LSPManager when lsp is not configured', async () => {

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -540,6 +540,32 @@ Line 3 conclusion`;
       expect((await workspace.search('quick')).length).toBeGreaterThan(0);
     });
 
+    it('coalesces concurrent stop() calls onto one in-flight teardown', async () => {
+      let stops = 0;
+      let release!: () => void;
+      const gate = new Promise<void>(resolve => {
+        release = resolve;
+      });
+      const sandbox = {
+        provider: 'fake',
+        stop: async () => {
+          stops += 1;
+          await gate;
+        },
+      } as any;
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        sandbox,
+      });
+
+      const first = workspace.stop();
+      const second = workspace.stop();
+      release();
+      await Promise.all([first, second]);
+
+      expect(stops).toBe(1);
+    });
+
     it('should release the search index even when a resource fails to destroy', async () => {
       const filesystem = new LocalFilesystem({ basePath: tempDir });
       const workspace = new Workspace({

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -604,6 +604,42 @@ Line 3 conclusion`;
       expect(workspace.status).toBe('destroyed');
     });
 
+    it('concurrent destroy() calls during an in-flight stop() destroy once', async () => {
+      let stopStarted!: () => void;
+      const stopStartedGate = new Promise<void>(resolve => {
+        stopStarted = resolve;
+      });
+      let releaseStop!: () => void;
+      const stopGate = new Promise<void>(resolve => {
+        releaseStop = resolve;
+      });
+      let destroys = 0;
+      const sandbox = {
+        provider: 'fake',
+        stop: async () => {
+          stopStarted();
+          await stopGate;
+        },
+        destroy: async () => {
+          destroys += 1;
+        },
+      } as any;
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        sandbox,
+      });
+
+      const stopping = workspace.stop();
+      await stopStartedGate;
+      const firstDestroy = workspace.destroy();
+      const secondDestroy = workspace.destroy();
+      releaseStop();
+      await Promise.all([stopping, firstDestroy, secondDestroy]);
+
+      expect(destroys).toBe(1);
+      expect(workspace.status).toBe('destroyed');
+    });
+
     it('should release the search index even when a resource fails to destroy', async () => {
       const filesystem = new LocalFilesystem({ basePath: tempDir });
       const workspace = new Workspace({

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -458,27 +458,12 @@ export type { WorkspaceStatus } from './types';
  */
 export type AnyWorkspace = Workspace<WorkspaceFilesystem | undefined, WorkspaceSandbox | undefined, any>;
 
-/**
- * What `Mastra.shutdown()` does with a registered workspace:
- * - `'stop'` (default) — stop live resources ({@link Workspace.stop}): remote
- *   sandboxes suspend/pause and stay resumable, local sandboxes kill their
- *   background processes. Nothing is deleted.
- * - `'destroy'` — full teardown ({@link Workspace.destroy}), including
- *   destroying the sandbox.
- * - `'none'` — leave the workspace entirely alone (e.g. sandboxes whose
- *   lifecycle is owned elsewhere, or where the provider's idle timeout
- *   already handles suspension).
- */
-export type WorkspaceShutdownBehavior = 'destroy' | 'stop' | 'none';
-
 /** A workspace entry in the Mastra registry, enriched with source metadata. */
 export interface RegisteredWorkspace {
   workspace: Workspace;
   source: 'mastra' | 'agent';
   agentId?: string;
   agentName?: string;
-  /** Override for what `Mastra.shutdown()` does with this workspace. Defaults to `'stop'`. */
-  shutdownBehavior?: WorkspaceShutdownBehavior;
 }
 
 // =============================================================================
@@ -1326,9 +1311,8 @@ export class Workspace<
    * and skills are untouched, and a later sandbox operation may start the
    * sandbox again.
    *
-   * This is what `Mastra.shutdown()` calls for registered workspaces by
-   * default, so a process restart suspends remote sandboxes instead of
-   * deleting them.
+   * This is what `Mastra.shutdown()` calls for registered workspaces, so a
+   * process restart suspends remote sandboxes instead of deleting them.
    */
   async stop(): Promise<void> {
     if (this._teardownStarted || this._status === 'destroyed') {

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -569,6 +569,7 @@ export class Workspace<
 
   private _status: WorkspaceStatus = 'pending';
   private _destroyPromise?: Promise<void>;
+  private _stopPromise?: Promise<void>;
   private readonly _fs?: WorkspaceFilesystem;
   private readonly _filesystemResolver?: WorkspaceFilesystemResolver;
   private readonly _sandbox?: WorkspaceSandbox;
@@ -1318,7 +1319,21 @@ export class Workspace<
     if (this._teardownStarted || this._status === 'destroyed') {
       return;
     }
+    // Coalesce concurrent stop() calls onto one in-flight teardown, same as
+    // destroy() does with _destroyPromise.
+    if (this._stopPromise) {
+      return await this._stopPromise;
+    }
 
+    this._stopPromise = this._performStop();
+    try {
+      await this._stopPromise;
+    } finally {
+      this._stopPromise = undefined;
+    }
+  }
+
+  private async _performStop(): Promise<void> {
     // Shutdown LSP before the sandbox — LSP clients need running processes
     // to send shutdown/exit. Cleared so a later access lazily recreates it.
     if (this._lsp) {

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -588,7 +588,6 @@ export class Workspace<
   /** Set as soon as `destroy()` begins, and never cleared. */
   private _teardownStarted = false;
   private _lsp?: LSPManager;
-  private _lspFactory?: () => LSPManager;
   private _logger?: IMastraLogger;
 
   constructor(config: WorkspaceConfig<TFilesystem, TSandbox, TMounts>) {
@@ -736,11 +735,7 @@ export class Workspace<
       } else {
         const lspConfig = config.lsp === true ? {} : config.lsp;
         const defaultRoot = lspConfig.root ?? findProjectRoot(process.cwd()) ?? process.cwd();
-        // Kept as a factory so stop() can replace a shut-down manager with a
-        // fresh one — LSPManager is one-way: shutdownAll() permanently
-        // refuses new clients.
-        this._lspFactory = () => new LSPManager(processes, defaultRoot, lspConfig, this._fs);
-        this._lsp = this._lspFactory();
+        this._lsp = new LSPManager(processes, defaultRoot, lspConfig, this._fs);
       }
     }
 
@@ -1340,18 +1335,15 @@ export class Workspace<
 
   private async _performStop(): Promise<void> {
     // Shutdown LSP before the sandbox — LSP clients need running processes
-    // to send shutdown/exit. A shut-down LSPManager permanently refuses new
-    // clients, so replace it with a fresh one; clients spawn lazily, so this
-    // costs nothing until diagnostics are next requested.
+    // to send shutdown/exit. The manager is kept: shutdownAll() drains its
+    // clients and resets it, so it spawns clients again on the next
+    // diagnostics request.
     if (this._lsp) {
       try {
         await this._lsp.shutdownAll();
       } catch {
         // LSP shutdown errors are non-blocking
       }
-      // Skip the recreate when a destroy began while we were stopping — a
-      // destroyed workspace must not resurrect an LSP manager.
-      this._lsp = this._teardownStarted ? undefined : this._lspFactory?.();
     }
 
     // Close browser before the sandbox
@@ -1407,7 +1399,6 @@ export class Workspace<
           // LSP shutdown errors are non-blocking
         }
         this._lsp = undefined;
-        this._lspFactory = undefined;
       }
 
       // Close browser before sandbox

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -1349,7 +1349,9 @@ export class Workspace<
       } catch {
         // LSP shutdown errors are non-blocking
       }
-      this._lsp = this._lspFactory?.();
+      // Skip the recreate when a destroy began while we were stopping — a
+      // destroyed workspace must not resurrect an LSP manager.
+      this._lsp = this._teardownStarted ? undefined : this._lspFactory?.();
     }
 
     // Close browser before the sandbox
@@ -1379,6 +1381,13 @@ export class Workspace<
 
     this._teardownStarted = true;
     this._status = 'destroying';
+    // Let an in-flight stop() settle before destructive cleanup so the two
+    // teardowns never interleave on the same LSP manager, browser, and
+    // sandbox. _teardownStarted is already set, so the stop cannot recreate
+    // the LSP manager under us.
+    if (this._stopPromise) {
+      await this._stopPromise.catch(() => {});
+    }
     this._destroyPromise = this._performDestroy();
 
     try {

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -1373,14 +1373,18 @@ export class Workspace<
 
     this._teardownStarted = true;
     this._status = 'destroying';
-    // Let an in-flight stop() settle before destructive cleanup so the two
-    // teardowns never interleave on the same LSP manager, browser, and
-    // sandbox. _teardownStarted is already set, so the stop cannot recreate
-    // the LSP manager under us.
-    if (this._stopPromise) {
-      await this._stopPromise.catch(() => {});
-    }
-    this._destroyPromise = this._performDestroy();
+    // Assigned before any await so a concurrent destroy() during the
+    // stop-drain below joins this promise instead of starting a second
+    // destroy path.
+    this._destroyPromise = (async () => {
+      // Let an in-flight stop() settle before destructive cleanup so the two
+      // teardowns never interleave on the same LSP manager, browser, and
+      // sandbox.
+      if (this._stopPromise) {
+        await this._stopPromise.catch(() => {});
+      }
+      await this._performDestroy();
+    })();
 
     try {
       await this._destroyPromise;

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -458,12 +458,27 @@ export type { WorkspaceStatus } from './types';
  */
 export type AnyWorkspace = Workspace<WorkspaceFilesystem | undefined, WorkspaceSandbox | undefined, any>;
 
+/**
+ * What `Mastra.shutdown()` does with a registered workspace:
+ * - `'stop'` (default) — stop live resources ({@link Workspace.stop}): remote
+ *   sandboxes suspend/pause and stay resumable, local sandboxes kill their
+ *   background processes. Nothing is deleted.
+ * - `'destroy'` — full teardown ({@link Workspace.destroy}), including
+ *   destroying the sandbox.
+ * - `'none'` — leave the workspace entirely alone (e.g. sandboxes whose
+ *   lifecycle is owned elsewhere, or where the provider's idle timeout
+ *   already handles suspension).
+ */
+export type WorkspaceShutdownBehavior = 'destroy' | 'stop' | 'none';
+
 /** A workspace entry in the Mastra registry, enriched with source metadata. */
 export interface RegisteredWorkspace {
   workspace: Workspace;
   source: 'mastra' | 'agent';
   agentId?: string;
   agentName?: string;
+  /** Override for what `Mastra.shutdown()` does with this workspace. Defaults to `'stop'`. */
+  shutdownBehavior?: WorkspaceShutdownBehavior;
 }
 
 // =============================================================================
@@ -1298,6 +1313,50 @@ export class Workspace<
   private assertSearchWritable(): void {
     if (this._teardownStarted) {
       throw new WorkspaceNotReadyError(this.id, this._status);
+    }
+  }
+
+  /**
+   * Stop the workspace's live resources without destroying them.
+   *
+   * Shuts down LSP clients, closes the browser, and stops the sandbox
+   * (`stop`, not `destroy` — remote providers pause/suspend so the sandbox
+   * can be resumed later; {@link LocalSandbox} kills its background
+   * processes). The workspace itself stays usable: filesystem, search index,
+   * and skills are untouched, and a later sandbox operation may start the
+   * sandbox again.
+   *
+   * This is what `Mastra.shutdown()` calls for registered workspaces by
+   * default, so a process restart suspends remote sandboxes instead of
+   * deleting them.
+   */
+  async stop(): Promise<void> {
+    if (this._teardownStarted || this._status === 'destroyed') {
+      return;
+    }
+
+    // Shutdown LSP before the sandbox — LSP clients need running processes
+    // to send shutdown/exit. Cleared so a later access lazily recreates it.
+    if (this._lsp) {
+      try {
+        await this._lsp.shutdownAll();
+      } catch {
+        // LSP shutdown errors are non-blocking
+      }
+      this._lsp = undefined;
+    }
+
+    // Close browser before the sandbox
+    if (this._browser) {
+      try {
+        await this._browser.close();
+      } catch {
+        // Browser close errors are non-blocking
+      }
+    }
+
+    if (this._sandbox) {
+      await callLifecycle(this._sandbox, 'stop');
     }
   }
 

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -588,6 +588,7 @@ export class Workspace<
   /** Set as soon as `destroy()` begins, and never cleared. */
   private _teardownStarted = false;
   private _lsp?: LSPManager;
+  private _lspFactory?: () => LSPManager;
   private _logger?: IMastraLogger;
 
   constructor(config: WorkspaceConfig<TFilesystem, TSandbox, TMounts>) {
@@ -735,7 +736,11 @@ export class Workspace<
       } else {
         const lspConfig = config.lsp === true ? {} : config.lsp;
         const defaultRoot = lspConfig.root ?? findProjectRoot(process.cwd()) ?? process.cwd();
-        this._lsp = new LSPManager(processes, defaultRoot, lspConfig, this._fs);
+        // Kept as a factory so stop() can replace a shut-down manager with a
+        // fresh one — LSPManager is one-way: shutdownAll() permanently
+        // refuses new clients.
+        this._lspFactory = () => new LSPManager(processes, defaultRoot, lspConfig, this._fs);
+        this._lsp = this._lspFactory();
       }
     }
 
@@ -1335,14 +1340,16 @@ export class Workspace<
 
   private async _performStop(): Promise<void> {
     // Shutdown LSP before the sandbox — LSP clients need running processes
-    // to send shutdown/exit. Cleared so a later access lazily recreates it.
+    // to send shutdown/exit. A shut-down LSPManager permanently refuses new
+    // clients, so replace it with a fresh one; clients spawn lazily, so this
+    // costs nothing until diagnostics are next requested.
     if (this._lsp) {
       try {
         await this._lsp.shutdownAll();
       } catch {
         // LSP shutdown errors are non-blocking
       }
-      this._lsp = undefined;
+      this._lsp = this._lspFactory?.();
     }
 
     // Close browser before the sandbox
@@ -1391,6 +1398,7 @@ export class Workspace<
           // LSP shutdown errors are non-blocking
         }
         this._lsp = undefined;
+        this._lspFactory = undefined;
       }
 
       // Close browser before sandbox


### PR DESCRIPTION
## Summary

`Mastra.shutdown()` destroys every registered workspace (`removeWorkspace(id, { destroy: true })`), which **kills remote sandboxes on every process restart** — an E2B or Platform VM is deleted, filesystem and all, when a dev server restarts or a replica redeploys, even though those providers support suspend/resume.

The destroy-on-shutdown cascade came from #17661, whose real motivation was local: `LocalSandbox.stop()` didn't kill background processes, so anything short of `destroy()` leaked child processes across dev restarts. This PR fixes that root cause and makes shutdown non-destructive:

- **`LocalSandbox.stop()` now kills background processes.** "Stopped" means not running — a local sandbox has no suspend/resume, its background processes *are* the runtime state. Files in the working directory are untouched and `start()` works again afterwards.
- **New `Workspace.stop()`**: shuts down language servers, closes the browser, and stops the sandbox (`stop`, not `destroy`). The workspace stays usable — filesystem, search index, and skills untouched. Concurrent `stop()` calls coalesce onto one in-flight teardown, mirroring `destroy()`'s `_destroyPromise` pattern.
- **`Mastra.shutdown()` stops registered workspaces instead of destroying them.** Remote sandboxes suspend/pause and resume later with state intact; local sandboxes stop cleanly with no process leak.
- **Full teardown stays explicit**: `workspace.destroy()` and `removeWorkspace(id, { destroy: true })` are unchanged.

## Why now

Hit this live: a dev-server watcher restart destroyed a running E2B session VM mid-test (`Mastra.shutdown()` → `Workspace.destroy()` → `E2BSandbox.kill()`), deleting the sandbox and its filesystem. With this change the same restart leaves the VM to the provider's pause lifecycle and a later session resumes it.

## Provider survey

Every remote provider's `stop()` deliberately preserves a resume path that `destroy()` deletes — the old destroy-on-shutdown was throwing that state away:

| Provider | `stop()` | `destroy()` | shutdown-stop effect |
|---|---|---|---|
| e2b | pause (resume w/ memory) | kill VM | the motivating win |
| daytona | provider stop (resumable) | delete | win |
| railway | flush checkpoint + teardown | delete checkpoint + teardown | win — old shutdown was deleting Railway checkpoints |
| modal | kill procs + fs snapshot + terminate | terminate, no snapshot | win — snapshot survives for resume |
| docker | `container.stop` (restartable) | remove container + volumes | win |
| platform | flush in-flight capture, checkpoint preserved server-side | full teardown | win |
| cloudflare | no-op detach (remote sandbox preserved) | delete | win |
| blaxel / apple-container / agentcore | kill procs / stop container / gated session stop | harder teardown | neutral-to-win |
| local | (this PR) kill procs, keep files | + seatbelt/folder cleanup | fixed |

Never-started sandboxes are safe at shutdown: the base `_stop()` early-returns on `'stopped'`, and provider bodies guard the unattached case (best-effort identity lookups or null-resolve returns). E2B's `stop()` propagates pause failures by design — at shutdown that surfaces as a logged error, not a hang.

## Behavior notes

- Failure semantics preserved: a workspace whose stop fails stays registered and shutdown continues for the rest (same as the old destroy-failure path).
- Workspace status is unchanged by `stop()` — the sandbox's own status (`'stopped'`) is the accurate signal, and the workspace remains fully usable (the next sandbox operation restarts it implicitly).
- Docs updated (`Workspace` reference: new `stop()` section, `destroy()` no longer described as the shutdown default).

## Test plan

- `packages/core` focused vitest: `workspace-cleanup.test.ts` (shutdown stops by default and never calls destroy, failure keeps workspace registered, stop ordered before storage.close, parallel teardown), `local-sandbox.test.ts` (new: `stop()` kills background processes — OS pid probed dead), `workspace.test.ts` (new: `stop()` leaves the workspace usable; concurrent `stop()` calls coalesce) — 345 passed
- `mastra-sandbox.test.ts` 26 passed, `shutdown.test.ts` + `shutdown-storage.test.ts` 6 passed
- `pnpm --filter ./packages/core check` (tsc) clean, oxfmt clean, Vale clean on the docs page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets workspaces stop their running resources without deleting their files. Workspaces can restart later, while full cleanup remains available through explicit destroy methods.

## Changes

- Added `Workspace.stop()` to stop language servers, close the browser, and stop the sandbox.
- Preserved workspace files, search data, and skills after `stop()`.
- Coalesced concurrent `stop()` calls.
- Made `destroy()` wait for an in-flight `stop()` before destructive cleanup.
- Reset `LSPManager` after shutdown so the workspace can use it again.
- Updated `LocalSandbox.stop()` to terminate background processes without deleting files.
- Updated `Mastra.shutdown()` to stop registered workspaces instead of destroying them.
- Kept failed workspaces registered and continued shutting down other workspaces.
- Preserved explicit destruction through `workspace.destroy()` and `removeWorkspace(id, { destroy: true })`.
- Updated documentation and tests for lifecycle behavior, process cleanup, concurrent stops, shutdown ordering, restart support, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
