### PR TITLE
fix(playground): workspace image preview crash

### DIFF
--- a/packages/playground/src/domains/workspace/components/file-browser.tsx
+++ b/packages/playground/src/domains/workspace/components/file-browser.tsx
@@ -558,8 +558,12 @@ export function FileViewer({ path, content, isLoading, mimeType, onClose }: File
           </div>
         ) : isImage ? (
           <div className="flex items-center justify-center p-4">
+            {/* content is already base64 here (the caller requests encoding: 'base64'
+                for image files) — re-encoding it through btoa() would both be wrong
+                (btoa expects raw Latin1 bytes, not an already-base64 string) and
+                throw outright once the caller stops mis-reading images as text. */}
             <img
-              src={`data:${mimeType || 'image/png'};base64,${btoa(content)}`}
+              src={`data:${mimeType || 'image/png'};base64,${content}`}
               alt={fileName}
               className="max-h-[400px] max-w-full object-contain"
             />

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -127,10 +127,15 @@ export default function Workspace() {
   const deleteFile = useDeleteWorkspaceFile();
   const createDirectory = useCreateWorkspaceDirectory();
 
-  // Selected file content - pass workspaceId
+  // Selected file content - pass workspaceId. Request base64 for images: reading
+  // binary content as text (the default) corrupts it, and previewing that text as
+  // if it were base64 throws "btoa: characters outside Latin1 range" downstream.
+  const selectedFileExt = selectedFile?.split('.').pop()?.toLowerCase();
+  const selectedFileIsImage = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'].includes(selectedFileExt ?? '');
   const { data: fileContent, isLoading: isLoadingFileContent } = useWorkspaceFile(selectedFile ?? '', {
     enabled: !!selectedFile,
     workspaceId: effectiveWorkspaceId,
+    encoding: selectedFileIsImage ? 'base64' : undefined,
   });
 
   // Skills - pass workspaceId to get skills from the selected workspace


### PR DESCRIPTION
## Summary

Fixes #22090.

Clicking an image file in the workspace file browser (Studio) throws:

```
InvalidCharacterError: Failed to execute 'btoa' on 'Window': The string
to be encoded contains characters outside of the Latin1 range.
```

This reproduces reliably for essentially any real image — found while previewing agent-generated PNGs in a project's workspace.

## Root cause

Two compounding issues:

1. `useWorkspaceFile()` in `packages/playground/src/pages/workspace/index.tsx` never passed an `encoding` option, so the server read image files as utf-8 text (its default), silently corrupting the binary content on read.
2. `packages/playground/src/domains/workspace/components/file-browser.tsx` then called `btoa(content)` on that already-corrupted text to build the `<img>` `data:` URI. `btoa()` requires a Latin1-only string, so this throws for any real image, since compressed binary data almost always contains byte sequences outside that range once mangled through a UTF-8 decode.

## Fix

Request `encoding: 'base64'` when the selected file is an image, matching the pattern the upload path (`useWriteWorkspaceFileFromFile` in `use-workspace.ts`) already uses correctly. Verified the server's `fs/read` handler and `LocalFilesystem.readFile()` already support `'base64'` end-to-end — it's passed straight through to Node's `fs.readFile(path, { encoding: 'base64' })`, which returns a proper base64 string — so no server-side changes were needed.

With `content` already base64, the `<img>` `src` no longer needs (or should) re-encode it through `btoa()` at all.

## Testing

- `tsc --noEmit -p tsconfig.build.json` in `packages/playground`: no new errors introduced by this change (pre-existing "Cannot find module" errors from unbuilt sibling workspace packages are unrelated to these two files).
- Manually reproduced the crash, applied the fix, confirmed image previews render correctly in the workspace file browser afterward.
