### PR TITLE
fix(playground): workspace image and video preview crash/garbled render

### DIFF
--- a/packages/playground/src/domains/workspace/components/file-browser.tsx
+++ b/packages/playground/src/domains/workspace/components/file-browser.tsx
@@ -558,8 +558,12 @@ export function FileViewer({ path, content, isLoading, mimeType, onClose }: File
           </div>
         ) : isImage ? (
           <div className="flex items-center justify-center p-4">
+            {/* content is already base64 here (the caller requests encoding: 'base64'
+                for image files) — re-encoding it through btoa() would both be wrong
+                (btoa expects raw Latin1 bytes, not an already-base64 string) and
+                throw outright once the caller stops mis-reading images as text. */}
             <img
-              src={`data:${mimeType || 'image/png'};base64,${btoa(content)}`}
+              src={`data:${mimeType || 'image/png'};base64,${content}`}
               alt={fileName}
               className="max-h-[400px] max-w-full object-contain"
             />

--- a/packages/playground/src/domains/workspace/components/file-browser.tsx
+++ b/packages/playground/src/domains/workspace/components/file-browser.tsx
@@ -28,6 +28,7 @@ import {
 import { useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { coldarkCold, coldarkDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import { isImageFile, isVideoFile, videoMimeType } from '../file-type-utils';
 import type { FileEntry } from '../types';
 
 // =============================================================================
@@ -529,7 +530,8 @@ export interface FileViewerProps {
 export function FileViewer({ path, content, isLoading, mimeType, onClose }: FileViewerProps) {
   const fileName = path.split('/').pop() || path;
   const ext = fileName.split('.').pop()?.toLowerCase();
-  const isImage = mimeType?.startsWith('image/') || ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'].includes(ext || '');
+  const isImage = isImageFile(path, mimeType);
+  const isVideo = isVideoFile(path, mimeType);
   const language = getLanguageFromExtension(ext);
 
   return (
@@ -567,6 +569,17 @@ export function FileViewer({ path, content, isLoading, mimeType, onClose }: File
               alt={fileName}
               className="max-h-[400px] max-w-full object-contain"
             />
+          </div>
+        ) : isVideo ? (
+          <div className="flex items-center justify-center p-4">
+            {/* Same base64-content contract as the image branch above — the
+                caller requests encoding: 'base64' for video files too. */}
+            <video controls className="max-h-[400px] max-w-full">
+              <source
+                src={`data:${videoMimeType(path, mimeType)};base64,${content}`}
+                type={videoMimeType(path, mimeType)}
+              />
+            </video>
           </div>
         ) : language ? (
           <HighlightedCode content={content} language={language} />

--- a/packages/playground/src/domains/workspace/file-type-utils.ts
+++ b/packages/playground/src/domains/workspace/file-type-utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared file-type predicates for the workspace file browser/viewer. Kept out
+ * of file-browser.tsx (which also exports React components) so Vite's Fast
+ * Refresh boundary stays clean — mixing component and non-component exports
+ * in one file breaks Fast Refresh for that file.
+ *
+ * Used both to decide the request encoding (pages/workspace/index.tsx) and to
+ * decide the preview mode (FileViewer). Keeping these in sync matters:
+ * requesting text encoding for a file FileViewer renders as media (or vice
+ * versa) reproduces the btoa() InvalidCharacterError crash these predicates
+ * exist to prevent — images crash outright, video just renders as garbled
+ * binary text instead of a player.
+ */
+
+const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'avif', 'tiff', 'tif'];
+const VIDEO_MIME_TYPES: Record<string, string> = {
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  m4v: 'video/mp4',
+  ogv: 'video/ogg',
+};
+
+export function isImageFile(path: string, mimeType?: string): boolean {
+  if (mimeType?.startsWith('image/')) return true;
+  const ext = path.split('/').pop()?.split('.').pop()?.toLowerCase();
+  return IMAGE_EXTENSIONS.includes(ext ?? '');
+}
+
+export function isVideoFile(path: string, mimeType?: string): boolean {
+  if (mimeType?.startsWith('video/')) return true;
+  const ext = path.split('/').pop()?.split('.').pop()?.toLowerCase();
+  return ext !== undefined && ext in VIDEO_MIME_TYPES;
+}
+
+export function videoMimeType(path: string, mimeType?: string): string {
+  if (mimeType?.startsWith('video/')) return mimeType;
+  const ext = path.split('/').pop()?.split('.').pop()?.toLowerCase();
+  return VIDEO_MIME_TYPES[ext ?? ''] ?? 'video/mp4';
+}

--- a/packages/playground/src/domains/workspace/hooks/use-workspace.ts
+++ b/packages/playground/src/domains/workspace/hooks/use-workspace.ts
@@ -97,7 +97,12 @@ export const useWorkspaceFile = (
   const client = useMastraClient();
 
   return useQuery({
-    queryKey: ['workspace', 'file', path, options?.workspaceId],
+    // encoding is part of the cache key: without it, a text fetch and a base64
+    // fetch of the same path/workspace collide on the same cache entry, so
+    // whichever ran first gets served back for the other — a stale response
+    // in the wrong encoding for both the file browser (garbled text) and the
+    // image preview (the InvalidCharacterError this whole fix exists for).
+    queryKey: ['workspace', 'file', path, options?.workspaceId, options?.encoding],
     queryFn: async (): Promise<FileReadResponse> => {
       if (!isWorkspaceV1Supported(client)) {
         throw new Error('Workspace v1 not supported by core or client');

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -16,6 +16,7 @@ import { NoWorkspacesInfo } from '@/domains/workspace/components/no-workspaces-i
 import { SearchWorkspacePanel, SearchSkillsPanel } from '@/domains/workspace/components/search-panel';
 import { WorkspaceNotConfigured } from '@/domains/workspace/components/workspace-not-configured';
 import { WorkspaceNotSupported } from '@/domains/workspace/components/workspace-not-supported';
+import { isImageFile, isVideoFile } from '@/domains/workspace/file-type-utils';
 import { useInstallSkill, useUpdateSkills, useRemoveSkill } from '@/domains/workspace/hooks';
 import {
   useWorkspaceInfo,
@@ -127,15 +128,18 @@ export default function Workspace() {
   const deleteFile = useDeleteWorkspaceFile();
   const createDirectory = useCreateWorkspaceDirectory();
 
-  // Selected file content - pass workspaceId. Request base64 for images: reading
-  // binary content as text (the default) corrupts it, and previewing that text as
-  // if it were base64 throws "btoa: characters outside Latin1 range" downstream.
-  const selectedFileExt = selectedFile?.split('.').pop()?.toLowerCase();
-  const selectedFileIsImage = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'].includes(selectedFileExt ?? '');
+  // Selected file content - pass workspaceId. Request base64 for images and
+  // videos: reading binary content as text (the default) corrupts it, and
+  // previewing that text as if it were base64 throws "btoa: characters
+  // outside Latin1 range" downstream (images) or renders raw garbled bytes
+  // (videos, no crash but useless). isImageFile/isVideoFile are the same
+  // predicates FileViewer uses to decide how to render — they must stay in
+  // sync, or a file requested as text gets rendered as media (or vice versa).
+  const selectedFileIsMedia = isImageFile(selectedFile ?? '') || isVideoFile(selectedFile ?? '');
   const { data: fileContent, isLoading: isLoadingFileContent } = useWorkspaceFile(selectedFile ?? '', {
     enabled: !!selectedFile,
     workspaceId: effectiveWorkspaceId,
-    encoding: selectedFileIsImage ? 'base64' : undefined,
+    encoding: selectedFileIsMedia ? 'base64' : undefined,
   });
 
   // Skills - pass workspaceId to get skills from the selected workspace

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -127,10 +127,15 @@ export default function Workspace() {
   const deleteFile = useDeleteWorkspaceFile();
   const createDirectory = useCreateWorkspaceDirectory();
 
-  // Selected file content - pass workspaceId
+  // Selected file content - pass workspaceId. Request base64 for images: reading
+  // binary content as text (the default) corrupts it, and previewing that text as
+  // if it were base64 throws "btoa: characters outside Latin1 range" downstream.
+  const selectedFileExt = selectedFile?.split('.').pop()?.toLowerCase();
+  const selectedFileIsImage = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'].includes(selectedFileExt ?? '');
   const { data: fileContent, isLoading: isLoadingFileContent } = useWorkspaceFile(selectedFile ?? '', {
     enabled: !!selectedFile,
     workspaceId: effectiveWorkspaceId,
+    encoding: selectedFileIsImage ? 'base64' : undefined,
   });
 
   // Skills - pass workspaceId to get skills from the selected workspace


### PR DESCRIPTION
Fixes #22090.

(Reopened as a fresh PR — #22089 was auto-closed by the triage bot for having no linked issue before I linked #22090 to it, and GitHub is refusing to let me reopen it directly. Same branch, same commits, nothing else changed.)

## Summary

Clicking an image file in the workspace file browser (Studio) throws:

```
InvalidCharacterError: Failed to execute 'btoa' on 'Window': The string
to be encoded contains characters outside of the Latin1 range.
```

This reproduces reliably for essentially any real image — found while previewing agent-generated PNGs in a project's workspace. Video files (.mp4/.webm/.mov/.m4v/.ogv) had the same underlying issue without the crash: rendered as garbled binary text instead of a playable preview.

## Root cause

Two compounding issues:

1. `useWorkspaceFile()` in `packages/playground/src/pages/workspace/index.tsx` never passed an `encoding` option, so the server read image/video files as utf-8 text (its default), silently corrupting the binary content on read.
2. `packages/playground/src/domains/workspace/components/file-browser.tsx` then called `btoa(content)` on that already-corrupted text to build the `<img>` `data:` URI. `btoa()` requires a Latin1-only string, so this throws for any real image, since compressed binary data almost always contains byte sequences outside that range once mangled through a UTF-8 decode. Video files hit the same corrupted-read problem but never reached a `btoa()` call, so they silently rendered as garbled text instead of crashing.

## Fix

Request `encoding: 'base64'` when the selected file is an image or video (`isImageFile`/`isVideoFile`, in a new `file-type-utils.ts`), matching the pattern the upload path (`useWriteWorkspaceFileFromFile` in `use-workspace.ts`) already uses correctly. Verified the server's `fs/read` handler and `LocalFilesystem.readFile()` already support `'base64'` end-to-end — it's passed straight through to Node's `fs.readFile(path, { encoding: 'base64' })`, which returns a proper base64 string — so no server-side changes were needed.

With `content` already base64, the `<img>`/`<video>` `src` no longer needs (or should) re-encode it through `btoa()` at all.

`isImageFile`/`isVideoFile` live in their own file rather than `file-browser.tsx` — oxlint's `react(only-export-components)` correctly flagged mixing component and non-component exports in one file as breaking Vite Fast Refresh for it.

## Testing

- `tsc --noEmit -p tsconfig.build.json` in `packages/playground`: no new errors introduced (pre-existing "Cannot find module" errors from unbuilt sibling workspace packages are unrelated to these files).
- Manually reproduced both crashes, applied the fix, confirmed image and video previews render correctly in the workspace file browser afterward — verified live against a real per-client workspace with generated `.mp4` hero videos and `.png` stills, no console errors, no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Studio now reads image and video files in a safe format. Images display correctly, and videos play instead of showing corrupted text.

## Changes

- Added shared utilities to detect image and video files by MIME type or file extension.
- Updated workspace reads to request `base64` encoding for image and video files.
- Updated image previews to use the existing base64 content without calling `btoa()`.
- Added video previews with MIME-aware data URLs and playback controls.
- Included the requested encoding in the workspace file query cache key.
- Kept text files on the default encoding.
- Confirmed correct PNG and video previews through manual testing.
- TypeScript checking introduced no new errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->