### PR TITLE
fix(mastracode): keep active prompts below async messages

### DIFF
--- a/.changeset/empty-walls-leave.md
+++ b/.changeset/empty-walls-leave.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed background status messages pushing active Mastra Code prompts out of view.

--- a/mastracode/tui/e2e/tui/update-startup-prompt.ts
+++ b/mastracode/tui/e2e/tui/update-startup-prompt.ts
@@ -1,5 +1,10 @@
+import stripAnsi from 'strip-ansi';
+import { showInfo } from '../../src/tui/display.js';
+import type { TUIState } from '../../src/tui/state.js';
 import { expect } from './expect.js';
 import type { McE2eScenario } from './types.js';
+
+let tuiState: TUIState | undefined;
 
 export const updateStartupPromptScenario: McE2eScenario = {
   name: 'update-startup-prompt',
@@ -11,6 +16,14 @@ export const updateStartupPromptScenario: McE2eScenario = {
       MASTRACODE_UPDATE_CHANGELOG: '  • Startup update prompt e2e fixture entry',
     };
   },
+  async inProcessApp({ startMastraCodeApp }) {
+    tuiState = undefined;
+    return startMastraCodeApp({
+      onTuiCreated(tui) {
+        tuiState = (tui as { state: TUIState }).state;
+      },
+    });
+  },
   async run({ terminal, runtime }) {
     runtime.startLiveOutput(terminal);
 
@@ -18,6 +31,26 @@ export const updateStartupPromptScenario: McE2eScenario = {
     await runtime.waitForScreenText(/A new version of Mastra Code is available: v99\.1\.0/i, terminal, 10_000);
     await runtime.waitForScreenText(/What's new/i, terminal);
     await runtime.waitForScreenText(/Startup update prompt e2e fixture entry/i, terminal);
+    await runtime.waitForScreenText(/Would you like to update now/i, terminal);
+    await runtime.waitForScreenText(/Yes/i, terminal);
+    await runtime.waitForScreenText(/No/i, terminal);
+
+    if (!tuiState) {
+      throw new Error('Expected the in-process TUI state to be available');
+    }
+
+    showInfo(tuiState, 'MCP: delayed background status');
+    await runtime.waitForScreenText(/MCP: delayed background status/i, terminal);
+
+    const view = stripAnsi(terminal.serialize().view);
+    const statusIndex = view.indexOf('MCP: delayed background status');
+    const promptIndex = view.indexOf('Would you like to update now');
+    if (statusIndex < 0 || promptIndex < 0 || statusIndex > promptIndex) {
+      throw new Error(
+        `Expected the active update prompt to remain below the asynchronous MCP status message:\n${view}`,
+      );
+    }
+
     await runtime.waitForScreenText(/Would you like to update now/i, terminal);
     await runtime.waitForScreenText(/Yes/i, terminal);
     await runtime.waitForScreenText(/No/i, terminal);

--- a/mastracode/tui/src/tui/commands/update.ts
+++ b/mastracode/tui/src/tui/commands/update.ts
@@ -6,6 +6,7 @@ import {
   isNewerVersion,
   performUpdate,
 } from '@mastra/code-sdk/utils/update-check';
+import { insertChatComponentWithBoundarySpacing } from '../chat-boundary-reconciliation.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
 import type { SlashCommandContext } from './types.js';
 
@@ -66,7 +67,7 @@ export async function handleUpdateCommand(ctx: SlashCommandContext): Promise<voi
       ctx.state.ui,
     );
 
-    ctx.state.chatContainer.addChild(component);
+    insertChatComponentWithBoundarySpacing(ctx.state.chatContainer, component);
     ctx.state.activeInlineQuestion = component;
     component.focused = true;
     ctx.state.ui.requestRender();

--- a/mastracode/tui/src/tui/display.test.ts
+++ b/mastracode/tui/src/tui/display.test.ts
@@ -2,7 +2,7 @@ import { Container } from '@earendil-works/pi-tui';
 import stripAnsi from 'strip-ansi';
 import { describe, expect, it, vi } from 'vitest';
 
-import { showFormattedError } from './display.js';
+import { showError, showFormattedError, showInfo } from './display.js';
 import type { TUIState } from './state.js';
 
 function createState(): TUIState {
@@ -45,4 +45,25 @@ describe('showFormattedError', () => {
 
     expect(renderedText(state)).toContain('retry 1/10 in 0.5s');
   });
+});
+
+describe('display message ordering', () => {
+  it.each(['activeInlineQuestion', 'activeInlinePlanApproval'] as const)(
+    'keeps %s at the end of the chat while background messages arrive',
+    activePromptKey => {
+      const state = createState();
+      const activePrompt = new Container();
+      state.chatContainer.addChild(activePrompt);
+      (state as unknown as Record<string, unknown>)[activePromptKey] = activePrompt;
+
+      showInfo(state, 'Background info');
+      showError(state, 'Background failure');
+      showFormattedError(state, new Error('Formatted background failure'));
+
+      expect(state.chatContainer.children.at(-1)).toBe(activePrompt);
+      expect(renderedText(state)).toContain('Background info');
+      expect(renderedText(state)).toContain('Background failure');
+      expect(renderedText(state)).toContain('Formatted background failure');
+    },
+  );
 });

--- a/mastracode/tui/src/tui/display.ts
+++ b/mastracode/tui/src/tui/display.ts
@@ -27,15 +27,31 @@ class InfoMessageComponent extends Container {
   }
 }
 
+function insertDisplayMessage(state: TUIState, component: InfoMessageComponent): void {
+  const children = state.chatContainer.children;
+  let insertIndex = children.length;
+
+  for (const activePrompt of [state.activeInlineQuestion, state.activeInlinePlanApproval]) {
+    if (!activePrompt) continue;
+
+    const activePromptIndex = children.indexOf(activePrompt);
+    if (activePromptIndex >= 0) {
+      insertIndex = Math.min(insertIndex, activePromptIndex);
+    }
+  }
+
+  insertChatComponentWithBoundarySpacing(state.chatContainer, component, insertIndex);
+}
+
 export function showError(state: TUIState, message: string): void {
   const component = new InfoMessageComponent([new Text(theme.fg('error', `Error: ${message}`), 1, 0)]);
-  insertChatComponentWithBoundarySpacing(state.chatContainer, component);
+  insertDisplayMessage(state, component);
   state.ui.requestRender();
 }
 
 export function showInfo(state: TUIState, message: string): void {
   const component = new InfoMessageComponent([new Text(theme.fg('muted', message), 1, 0)]);
-  insertChatComponentWithBoundarySpacing(state.chatContainer, component);
+  insertDisplayMessage(state, component);
   state.ui.requestRender();
 }
 
@@ -85,7 +101,7 @@ export function showFormattedError(
   }
 
   const component = new InfoMessageComponent(lines);
-  insertChatComponentWithBoundarySpacing(state.chatContainer, component);
+  insertDisplayMessage(state, component);
   state.ui.requestRender();
 }
 


### PR DESCRIPTION
## Description

- Insert asynchronous info and error messages before any mounted inline question or plan-approval prompt, preserving the active prompt at the chat tail.
- Route the `/update` prompt through the existing chat-boundary reconciler for consistent spacing.
- Add unit coverage for both active prompt types and extend the startup-update terminal scenario with a delayed MCP-like status message.

## Related issue(s)

Fixes #21966

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Validation

- `vitest run src/tui/display.test.ts --reporter=dot --bail 1` (4 tests passed)
- `oxlint` and `eslint` on all changed TypeScript files
- `prettier --check` on all changed TypeScript files
- Repository pre-commit hooks (`lint-staged`)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable for this behavior-only fix)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## AI assistance

This PR was implemented with AI assistance. The regression was reproduced before the fix, and the focused tests and repository checks listed above were run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When startup messages arrive while a question is open, they now appear above the question instead of pushing it away. This keeps the active prompt and its selected option visible.

## Changes

- Insert informational and error messages before active inline question and plan-approval prompts.
- Route `/update` through `insertChatComponentWithBoundarySpacing`.
- Add unit tests for both active prompt types.
- Extend the startup-update E2E test with a delayed MCP-like status message.
- Add a patch changeset for `mastracode`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->