### PR TITLE
fix(core): don't strip thinking blocks from the latest assistant message on Anthropic tool continuations

### DIFF
--- a/.changeset/yummy-worlds-shout.md
+++ b/.changeset/yummy-worlds-shout.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Anthropic 400 errors ("thinking or redacted_thinking blocks in the latest assistant message cannot be modified") during tool-use turns with extended thinking. ProviderHistoryCompat no longer strips reasoning parts from the trailing assistant message of an active tool-use continuation, which Anthropic requires to be replayed exactly as it was generated. Historical assistant messages are still sanitized.

--- a/packages/core/src/agent/message-list/tests/anthropic-thinking-roundtrip.test.ts
+++ b/packages/core/src/agent/message-list/tests/anthropic-thinking-roundtrip.test.ts
@@ -91,6 +91,10 @@ describe('Anthropic signed thinking round-trip', () => {
           { type: 'text', text: 'Hello.' },
         ],
       },
+      // Real replay requests always end with a user (or tool) turn; a legacy
+      // assistant message followed by a new user turn is not protected from
+      // sanitization.
+      { role: 'user', content: [{ type: 'text', text: 'Continue.' }] },
     ];
 
     const result = await new ProviderHistoryCompat().processLLMRequest({

--- a/packages/core/src/processors/provider-history-compat.test.ts
+++ b/packages/core/src/processors/provider-history-compat.test.ts
@@ -3,6 +3,7 @@ import { APICallError } from '@internal/ai-sdk-v5';
 import { describe, expect, it } from 'vitest';
 import { MessageList } from '../agent/message-list';
 import {
+  anthropicStripEmptySignedReasoningContent,
   anthropicStripForeignReasoningContent,
   azureSystemReminderTransform,
   cerebrasStripReasoningContent,
@@ -466,6 +467,95 @@ describe('anthropicStripForeignReasoningContent', () => {
       model: { provider: 'openai.chat', modelId: 'gpt-4o' },
     });
     expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trailing assistant protection (Anthropic "thinking blocks in the latest
+// assistant message cannot be modified")
+// ---------------------------------------------------------------------------
+
+describe('trailing assistant message protection', () => {
+  const anthropicModel = { provider: 'anthropic.messages', modelId: 'claude-opus-4-6' };
+
+  /** Active tool-use continuation: last assistant is followed only by tool messages. */
+  function toolContinuationPrompt(): LanguageModelV2Prompt {
+    return [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      {
+        role: 'assistant',
+        content: [
+          // Historical assistant turn with a strippable part
+          { type: 'reasoning', text: 'old foreign reasoning' },
+          { type: 'text', text: 'earlier answer' },
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'do the thing' }] },
+      {
+        role: 'assistant',
+        content: [
+          // Unsigned interleaved thinking (no anthropic metadata) — must NOT be
+          // stripped from the latest assistant message.
+          { type: 'reasoning', text: 'live thinking' },
+          // Signed-but-empty block — must also survive untouched.
+          { type: 'reasoning', text: '', providerOptions: { anthropic: { signature: 'sig-live' } } },
+          { type: 'tool-call', toolCallId: 'call-1', toolName: 'doThing', input: {} },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          { type: 'tool-result', toolCallId: 'call-1', toolName: 'doThing', output: { type: 'text', value: 'ok' } },
+        ],
+      },
+    ];
+  }
+
+  it('foreign-reasoning strip skips the trailing assistant of a tool continuation', () => {
+    const result = anthropicStripForeignReasoningContent.applyToPrompt!({
+      prompt: toolContinuationPrompt(),
+      model: anthropicModel,
+    });
+
+    expect(result).toBeDefined();
+    // Historical assistant stripped
+    expect((result![1].content as any[]).map(p => p.type)).toEqual(['text']);
+    // Trailing assistant untouched
+    expect((result![3].content as any[]).map(p => p.type)).toEqual(['reasoning', 'reasoning', 'tool-call']);
+  });
+
+  it('empty-signed strip skips the trailing assistant of a tool continuation', () => {
+    const prompt = toolContinuationPrompt();
+    // Give the historical assistant an empty signed block so the rule has
+    // something to strip outside the protected message.
+    (prompt[1].content as any[]).unshift({
+      type: 'reasoning',
+      text: '',
+      providerOptions: { anthropic: { signature: 'sig-legacy' } },
+    });
+
+    const result = anthropicStripEmptySignedReasoningContent.applyToPrompt!({
+      prompt,
+      model: anthropicModel,
+    });
+
+    expect(result).toBeDefined();
+    expect((result![1].content as any[]).map(p => p.type)).toEqual(['reasoning', 'text']);
+    // Trailing assistant keeps its empty signed block untouched
+    expect((result![3].content as any[]).map(p => p.type)).toEqual(['reasoning', 'reasoning', 'tool-call']);
+  });
+
+  it('still strips the last assistant message when a new user turn follows it', () => {
+    const prompt = toolContinuationPrompt();
+    prompt.push({ role: 'user', content: [{ type: 'text', text: 'next question' }] });
+
+    const result = anthropicStripForeignReasoningContent.applyToPrompt!({
+      prompt,
+      model: anthropicModel,
+    });
+
+    expect(result).toBeDefined();
+    expect((result![3].content as any[]).map(p => p.type)).toEqual(['reasoning', 'tool-call']);
   });
 });
 

--- a/packages/core/src/processors/provider-history-compat.ts
+++ b/packages/core/src/processors/provider-history-compat.ts
@@ -249,8 +249,31 @@ export function isMaybeAzure(
 }
 
 /**
+ * Returns the index of the trailing assistant message whose thinking blocks
+ * Anthropic verifies byte-for-byte: the last message when it is an assistant
+ * message, or the assistant message that only has tool messages after it (an
+ * active tool-use continuation). Returns `-1` when no such message exists —
+ * e.g. when the prompt ends with a fresh user turn, in which case Anthropic
+ * ignores thinking blocks on earlier assistant messages.
+ */
+function getProtectedAssistantIndex(prompt: LanguageModelV2Prompt): number {
+  for (let i = prompt.length - 1; i >= 0; i--) {
+    const role = prompt[i]!.role;
+    if (role === 'assistant') return i;
+    if (role !== 'tool') return -1;
+  }
+  return -1;
+}
+
+/**
  * Returns a copy of the prompt with selected `reasoning` parts stripped from
  * assistant messages. Returns `undefined` if no changes were necessary.
+ *
+ * `skipIndex` excludes one message from stripping — used to protect the
+ * trailing assistant message of an active tool-use continuation, which
+ * Anthropic requires to be replayed unmodified ("`thinking` or
+ * `redacted_thinking` blocks in the latest assistant message cannot be
+ * modified").
  */
 function stripReasoningFromPrompt(
   prompt: LanguageModelV2Prompt,
@@ -260,9 +283,11 @@ function stripReasoningFromPrompt(
       { type: 'reasoning' }
     >,
   ) => boolean = () => true,
+  skipIndex = -1,
 ): LanguageModelV2Prompt | undefined {
   let mutated = false;
-  const next: LanguageModelV2Prompt = prompt.map(message => {
+  const next: LanguageModelV2Prompt = prompt.map((message, index) => {
+    if (index === skipIndex) return message;
     if (message.role !== 'assistant') return message;
     if (typeof message.content === 'string') return message;
     if (!Array.isArray(message.content)) return message;
@@ -350,7 +375,7 @@ export const anthropicStripEmptySignedReasoningContent: CompatRule = {
   name: 'anthropic-strip-empty-signed-reasoning-content',
   applyToPrompt({ prompt, model }) {
     if (!isMaybeAnthropic(model)) return undefined;
-    return stripReasoningFromPrompt(prompt, hasAnthropicSignatureWithoutText);
+    return stripReasoningFromPrompt(prompt, hasAnthropicSignatureWithoutText, getProtectedAssistantIndex(prompt));
   },
 };
 
@@ -364,7 +389,11 @@ export const anthropicStripForeignReasoningContent: CompatRule = {
   name: 'anthropic-strip-foreign-reasoning-content',
   applyToPrompt({ prompt, model }) {
     if (!isMaybeAnthropic(model)) return undefined;
-    return stripReasoningFromPrompt(prompt, part => !isAnthropicReasoningPart(part));
+    return stripReasoningFromPrompt(
+      prompt,
+      part => !isAnthropicReasoningPart(part),
+      getProtectedAssistantIndex(prompt),
+    );
   },
 };
 


### PR DESCRIPTION
## Summary

Fixes Anthropic 400 errors that permanently stick a thread:

```
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.
```

Anthropic verifies the thinking blocks of the **latest assistant message** byte-for-byte during tool-use continuations. Two `ProviderHistoryCompat` rules (`anthropic-strip-empty-signed-reasoning-content` and `anthropic-strip-foreign-reasoning-content`) could strip reasoning parts from that exact message — e.g. unsigned interleaved thinking parts from adaptive thinking, or signed parts whose text was lost — shifting the content array and triggering the 400 on every retry.

## Fix

`stripReasoningFromPrompt` now skips the trailing assistant message when it is only followed by tool messages (an active tool-use continuation). Historical assistant messages are still sanitized as before — Anthropic ignores thinking blocks on messages followed by a new user turn, so legacy cleanup keeps working there.

## Test plan

- New regression tests in `provider-history-compat.test.ts`: both strip rules leave the trailing assistant of a tool continuation untouched, and still strip once a new user turn follows it
- Updated `anthropic-thinking-roundtrip.test.ts` legacy-replay test to model a realistic prompt (ends with a user turn)
- `pnpm vitest run src/processors` — 1184 passed
- Existing #19445 regression suite (`tool-approval-reasoning-mutation.test.ts`) still green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Anthropic needs the latest assistant message to keep its reasoning details while it continues using tools. This change keeps those details in active tool-use requests but removes them from older messages.

## Changes

- Preserve thinking and redacted-thinking blocks in the trailing assistant message during Anthropic tool-use continuations.
- Continue stripping reasoning from historical assistant messages.
- Resume stripping when a user message follows the assistant message.
- Add regression tests for tool-only continuations, foreign reasoning, empty signed reasoning, and replay behavior.
- Add a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->