### PR TITLE
fix(factory): feed issue intake from the repository picked in the create wizard

### DIFF
--- a/.changeset/factory-repo-issue-intake-default.md
+++ b/.changeset/factory-repo-issue-intake-default.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed the create-Factory wizard leaving the chosen repository out of issue intake. Its open issues now appear on the new board's Intake lane right away, instead of requiring a trip to Settings › Issue sources.

--- a/mastracode/factory-ui/src/ui/domains/factory/services/intake.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/intake.ts
@@ -33,6 +33,13 @@ function normalizeIntakeConfig(raw: Partial<Record<string, IntakeSelection>> | n
   };
 }
 
+/** Enable sync and pick `id`; returns the same object when nothing changes. */
+export function selectIntakeSource(selection: IntakeSelection, id: string): IntakeSelection {
+  if (selection.sourceIds === null) return { enabled: true, sourceIds: [id] };
+  if (!selection.sourceIds.includes(id)) return { enabled: true, sourceIds: [...selection.sourceIds, id] };
+  return selection.enabled ? selection : { ...selection, enabled: true };
+}
+
 async function requestIntakeConfig(baseUrl: string, init?: RequestInit): Promise<IntakeConfig> {
   const res = await fetch(`${baseUrl}/web/intake/config`, {
     headers: { Accept: 'application/json', ...(init?.body ? { 'content-type': 'application/json' } : {}) },

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/CreateFactoryFlow.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/CreateFactoryFlow.msw.test.tsx
@@ -220,6 +220,24 @@ describe('Create Factory wizard', () => {
     expect(sessionStorage.getItem(STEP_KEY)).toBeNull();
   });
 
+  it('skips the intake write when the repository already feeds issue intake', async () => {
+    const calls: string[] = [];
+    seedDraft('model-provider');
+    const { intakeConfigs } = stubModelStepEndpoints(calls, {
+      github: { enabled: true, sourceIds: ['octo/hello'] },
+    });
+    const user = userEvent.setup();
+
+    const { client } = renderFlow();
+
+    await user.click(await screen.findByRole('option', { name: /Anthropic/ }));
+    await user.click(await screen.findByRole('option', { name: /anthropic\/claude-sonnet-4-5/ }));
+
+    await waitForMutationsIdle(client);
+    // A retry or a second Factory over the same repo must not rewrite the selection.
+    expect(intakeConfigs).toEqual([]);
+  });
+
   it('resumes a failed commit without creating a second Factory', async () => {
     const calls: string[] = [];
     let linkFails = true;
@@ -522,13 +540,13 @@ const linkedRepository = {
  * Stub the intake config the last step reads and writes, collecting every
  * saved config body.
  */
-function stubIntakeConfig() {
+function stubIntakeConfig(config: Record<string, unknown> = {}) {
   const savedConfigs: unknown[] = [];
   server.use(
-    http.get(`${TEST_BASE_URL}/web/intake/config`, () => HttpResponse.json({ config: {} })),
+    http.get(`${TEST_BASE_URL}/web/intake/config`, () => HttpResponse.json({ config })),
     http.put(`${TEST_BASE_URL}/web/intake/config`, async ({ request }) => {
       savedConfigs.push(await request.json());
-      return HttpResponse.json({ config: {} });
+      return HttpResponse.json({ config });
     }),
   );
   return savedConfigs;
@@ -541,9 +559,9 @@ function stubIntakeConfig() {
  * records the write order; the returned arrays collect the PATCH and intake
  * bodies.
  */
-function stubModelStepEndpoints(calls: string[]) {
+function stubModelStepEndpoints(calls: string[], intakeConfig: Record<string, unknown> = {}) {
   const patchedBodies: unknown[] = [];
-  const intakeConfigs = stubIntakeConfig();
+  const intakeConfigs = stubIntakeConfig(intakeConfig);
   let savedModelId: string | null = null;
   let created = false;
   server.use(

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/CreateFactoryFlow.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/CreateFactoryFlow.msw.test.tsx
@@ -189,7 +189,7 @@ describe('Create Factory wizard', () => {
   it('creates the Factory, links the repository and saves the model on the last step', async () => {
     const calls: string[] = [];
     seedDraft('project-management');
-    const { patchedBodies } = stubModelStepEndpoints(calls);
+    const { patchedBodies, intakeConfigs } = stubModelStepEndpoints(calls);
     server.use(
       http.get(`${TEST_BASE_URL}/web/linear/status`, () =>
         HttpResponse.json({ enabled: true, connected: false, reason: 'not_connected' }),
@@ -212,6 +212,10 @@ describe('Create Factory wizard', () => {
     await waitForMutationsIdle(client);
     expect(calls).toEqual(['create', 'connect', 'link']);
     expect(patchedBodies).toEqual([{ defaultModelId: 'anthropic/claude-sonnet-4-5' }]);
+    // The picked repository feeds Work intake without a trip to Settings.
+    expect(intakeConfigs).toEqual([
+      { github: { enabled: true, sourceIds: ['octo/hello'] }, linear: { enabled: false, sourceIds: null } },
+    ]);
     expect(screen.getByTestId('pathname')).toHaveTextContent('/factories/fp-1');
     expect(sessionStorage.getItem(STEP_KEY)).toBeNull();
   });
@@ -381,17 +385,9 @@ describe('Create Factory wizard', () => {
     const calls: string[] = [];
     seedDraft('project-management');
     stubConnectedLinear();
-    stubModelStepEndpoints(calls);
+    const { intakeConfigs } = stubModelStepEndpoints(calls);
     const bindings: unknown[] = [];
-    const intakeConfigs: unknown[] = [];
     server.use(
-      http.get(`${TEST_BASE_URL}/web/intake/config`, () =>
-        HttpResponse.json({ config: { linear: { enabled: false, sourceIds: null } } }),
-      ),
-      http.put(`${TEST_BASE_URL}/web/intake/config`, async ({ request }) => {
-        intakeConfigs.push(await request.json());
-        return HttpResponse.json({ config: { linear: { enabled: true, sourceIds: null } } });
-      }),
       http.put(`${TEST_BASE_URL}/web/intake/bindings`, async ({ request }) => {
         bindings.push(await request.json());
         return HttpResponse.json({ bindings: [] });
@@ -407,16 +403,17 @@ describe('Create Factory wizard', () => {
 
     await waitForMutationsIdle(client);
     expect(bindings).toEqual([{ integrationId: 'linear', sourceId: 'lin-1', factoryProjectId: 'fp-1' }]);
-    // Its issues only reach the board once Linear intake is on.
-    expect(intakeConfigs).toHaveLength(1);
-    expect(intakeConfigs[0]).toMatchObject({ linear: { enabled: true, sourceIds: null } });
+    // Both picks land in one config write, each selected and switched on.
+    expect(intakeConfigs).toEqual([
+      { github: { enabled: true, sourceIds: ['octo/hello'] }, linear: { enabled: true, sourceIds: ['lin-1'] } },
+    ]);
   });
 
-  it('leaves intake untouched when Linear is skipped', async () => {
+  it('keeps Linear out of intake when it is skipped', async () => {
     const calls: string[] = [];
     seedDraft('project-management');
     stubConnectedLinear();
-    stubModelStepEndpoints(calls);
+    const { intakeConfigs } = stubModelStepEndpoints(calls);
     const bindings: unknown[] = [];
     server.use(
       http.put(`${TEST_BASE_URL}/web/intake/bindings`, async ({ request }) => {
@@ -434,7 +431,11 @@ describe('Create Factory wizard', () => {
 
     await waitForMutationsIdle(client);
     expect(screen.getByTestId('pathname')).toHaveTextContent('/factories/fp-1');
+    // No Linear routing without a picked project; only the repository feeds intake.
     expect(bindings).toEqual([]);
+    expect(intakeConfigs).toEqual([
+      { github: { enabled: true, sourceIds: ['octo/hello'] }, linear: { enabled: false, sourceIds: null } },
+    ]);
   });
 
   it('restarts at the name step when the stored draft has no repository to commit', async () => {
@@ -518,13 +519,31 @@ const linkedRepository = {
 };
 
 /**
+ * Stub the intake config the last step reads and writes, collecting every
+ * saved config body.
+ */
+function stubIntakeConfig() {
+  const savedConfigs: unknown[] = [];
+  server.use(
+    http.get(`${TEST_BASE_URL}/web/intake/config`, () => HttpResponse.json({ config: {} })),
+    http.put(`${TEST_BASE_URL}/web/intake/config`, async ({ request }) => {
+      savedConfigs.push(await request.json());
+      return HttpResponse.json({ config: {} });
+    }),
+  );
+  return savedConfigs;
+}
+
+/**
  * Stub everything the last step writes: the Factory create, the repository
- * link, the PATCH that saves the model pick and the hidden OM provider-defaults
- * save — plus the provider catalog the step lists. `calls` records the write
- * order; the returned array collects the PATCH bodies.
+ * link, the intake wiring, the PATCH that saves the model pick and the hidden
+ * OM provider-defaults save — plus the provider catalog the step lists. `calls`
+ * records the write order; the returned arrays collect the PATCH and intake
+ * bodies.
  */
 function stubModelStepEndpoints(calls: string[]) {
   const patchedBodies: unknown[] = [];
+  const intakeConfigs = stubIntakeConfig();
   let savedModelId: string | null = null;
   let created = false;
   server.use(
@@ -577,7 +596,7 @@ function stubModelStepEndpoints(calls: string[]) {
     ),
     http.post(`${TEST_BASE_URL}/web/config/om/provider-defaults`, () => HttpResponse.json({ ok: true, config: {} })),
   );
-  return { patchedBodies };
+  return { patchedBodies, intakeConfigs };
 }
 
 function stubConnectedLinear() {

--- a/mastracode/factory-ui/src/ui/domains/workspaces/hooks/useCreateFactoryFromDraft.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/hooks/useCreateFactoryFromDraft.ts
@@ -5,7 +5,7 @@ import { queryKeys } from '../../../../api/keys';
 import { useApplyProviderOMDefaults } from '../../../../hooks/use-om';
 import { useCreateFactoryMutation, useLinkRepositoryMutation } from '../../../../hooks/useFactories';
 import { useSaveIntakeBindingMutation, useSaveIntakeConfigMutation } from '../../../../hooks/useIntakeConfig';
-import { fetchIntakeConfig } from '../../factory/services/intake';
+import { fetchIntakeConfig, selectIntakeSource } from '../../factory/services/intake';
 import { updateFactoryDefaultModel } from '../services/github';
 import type { FactoryProjectPayload } from '../services/github';
 import type { CreateFactoryDraft } from './useCreateFactoryFlow';
@@ -19,10 +19,10 @@ export interface CreateFactoryFromDraftOptions {
 }
 
 /**
- * The wizard's single write: create the Factory, link the repository, route the
- * Linear project when one was picked, and save the model its runs start on.
- * Nothing before this touches the server, so an abandoned wizard leaves nothing
- * behind.
+ * The wizard's single write: create the Factory, link the repository, feed its
+ * issue intake (plus the Linear project when one was picked), and save the
+ * model its runs start on. Nothing before this touches the server, so an
+ * abandoned wizard leaves nothing behind.
  */
 export function useCreateFactoryFromDraft({
   draft,
@@ -38,15 +38,21 @@ export function useCreateFactoryFromDraft({
   const saveIntakeBinding = useSaveIntakeBindingMutation();
   const saveIntakeConfig = useSaveIntakeConfigMutation();
 
-  /** Route a Linear project to the new board, and turn its sync on if it was off. */
-  const feedBoardFromLinear = async (linearProjectId: string, factoryProjectId: string) => {
-    await saveIntakeBinding.mutateAsync({ integrationId: 'linear', sourceId: linearProjectId, factoryProjectId });
+  // One config write for both sources — two read-modify-writes would drop
+  // each other's selection.
+  const feedBoard = async (repositorySlug: string, linear?: { sourceId: string; factoryProjectId: string }) => {
+    if (linear) {
+      await saveIntakeBinding.mutateAsync({
+        integrationId: 'linear',
+        sourceId: linear.sourceId,
+        factoryProjectId: linear.factoryProjectId,
+      });
+    }
     const config = await fetchIntakeConfig(baseUrl);
-    const { enabled, sourceIds } = config.linear;
-    const nextSourceIds =
-      sourceIds === null || sourceIds.includes(linearProjectId) ? sourceIds : [...sourceIds, linearProjectId];
-    if (enabled && nextSourceIds === sourceIds) return;
-    await saveIntakeConfig.mutateAsync({ ...config, linear: { enabled: true, sourceIds: nextSourceIds } });
+    const githubSelection = selectIntakeSource(config.github, repositorySlug);
+    const linearSelection = linear ? selectIntakeSource(config.linear, linear.sourceId) : config.linear;
+    if (githubSelection === config.github && linearSelection === config.linear) return;
+    await saveIntakeConfig.mutateAsync({ ...config, github: githubSelection, linear: linearSelection });
   };
 
   return useMutation({
@@ -63,10 +69,13 @@ export function useCreateFactoryFromDraft({
         await onRepositoryLinked(linked.projectRepositoryId);
       }
 
+      const linearPick = draft.linearProjectId
+        ? { sourceId: draft.linearProjectId, factoryProjectId: factory.id }
+        : undefined;
       await Promise.all([
         updateFactoryDefaultModel(baseUrl, factory.id, modelId),
         applyOMDefaults.mutateAsync({ providerId, factoryModelId: modelId, factoryId: factory.id }),
-        draft.linearProjectId && feedBoardFromLinear(draft.linearProjectId, factory.id),
+        feedBoard(draft.repository.fullName, linearPick),
       ]);
       await queryClient.invalidateQueries({ queryKey: queryKeys.factories() });
       await onCreated(factory);


### PR DESCRIPTION
TLDR: the repository you pick in the create-Factory wizard now feeds issue intake, so its open issues land on the new board without a trip to Settings.

---

```
before   wizard links the repo, intake config untouched → Intake lane starts empty
after   wizard selects the repo under GitHub issue intake → open issues appear right away
```

The board only lists a repository's issues when its slug sits in your intake config, and fresh accounts start with nothing selected. The wizard wired Linear but never GitHub, so every new Factory began silent until you toggled the repo yourself in Settings › Issue sources.

### Judgment call

- If GitHub issue sync was switched off globally, creating a Factory turns it back on for the picked repo. The Linear path already did this; an explicit "set up my board" action beating an old toggle felt right. One line away if you disagree.
- Same fix rode along for Linear: picking a project with nothing previously selected now actually selects it. Before, the selection stayed empty and the board never offered the Linear feed despite binding and enabling it.

### Cost

One extra GET plus usually one PUT per Factory creation; an already-selected repo skips the write. Unlinking a repository later still leaves its slug selected (unchanged behavior), so with auto-select that stale slug becomes likelier — it keeps feeding the aggregated intake until removed in Settings.

```
tests        +38  -19   ← wizard flow tests pin both picks landing in one write
source       +30  -14
changeset     +5    0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you create a Factory, its selected repository is automatically connected to issue intake. Open GitHub issues can then appear on the new board without extra setup.

## Changes

- Enable GitHub issue sync when it is globally disabled.
- Add the selected GitHub repository to intake configuration.
- Persist the selected Linear project when no project is selected.
- Skip configuration writes when the selected sources are already configured.
- Add `selectIntakeSource` to manage intake source selections.
- Add wizard flow tests for GitHub-only, GitHub and Linear, skipped Linear, and unchanged selections.
- Add a patch changeset for `mastra`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->