### PR TITLE
fix(core): stop silently defaulting embedding index to 1536 dims on probe failure

### DIFF
--- a/.changeset/great-ghosts-beg.md
+++ b/.changeset/great-ghosts-beg.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Memory silently falling back to the default 1536-dim vector index when the embedder's dimension probe fails. Semantic recall now fails loudly with a clear error instead of silently dropping writes or orphaning the vector index after an embedder switch.

--- a/packages/core/src/memory/embedding-dimension-probe.test.ts
+++ b/packages/core/src/memory/embedding-dimension-probe.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression tests for getEmbeddingDimension()'s failure handling.
+ *
+ * Previously, a failed dimension probe was swallowed (console.warn only) and treated as
+ * "this is the default 1536-dim embedder", silently baking a wrong vector index name into
+ * the SemanticRecall processor. See memory.ts getEmbeddingDimension()/getEmbeddingIndexName().
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { MastraEmbeddingModel, MastraVector } from '../vector';
+import { MockMemory } from './mock';
+
+function makeMemory({ rejectProbe }: { rejectProbe: boolean }) {
+  const memory = new MockMemory({ enableMessageHistory: false });
+
+  const vector = {
+    listIndexes: vi.fn().mockResolvedValue([]),
+    createIndex: vi.fn().mockResolvedValue(undefined),
+    upsert: vi.fn().mockResolvedValue([]),
+  } as unknown as MastraVector;
+
+  const embedder = {
+    modelId: 'test-embedder',
+    doEmbed: vi.fn(async ({ values }: { values: string[] }) => {
+      if (rejectProbe && values.length === 1 && values[0] === 'a') {
+        throw new Error('provider rejected embed request: input too short');
+      }
+      return { embeddings: values.map(() => [0.1, 0.2, 0.3]) };
+    }),
+  } as unknown as MastraEmbeddingModel<string>;
+
+  (memory as any).vector = vector;
+  (memory as any).embedder = embedder;
+  (memory as any).threadConfig = {
+    ...(memory as any).threadConfig,
+    semanticRecall: true,
+    lastMessages: false,
+  };
+
+  return { memory, embedder };
+}
+
+describe('MastraMemory embedding dimension probe failure handling', () => {
+  it('throws instead of silently falling back to the default 1536-dim index name when the probe fails', async () => {
+    const { memory } = makeMemory({ rejectProbe: true });
+
+    await expect(memory.getInputProcessors()).rejects.toThrow(
+      /Failed to determine the embedder's output dimension/,
+    );
+  });
+
+  it('clears the cached probe so a later call retries instead of staying permanently broken', async () => {
+    const { memory, embedder } = makeMemory({ rejectProbe: true });
+
+    await expect(memory.getInputProcessors()).rejects.toThrow();
+
+    // Embedder recovers (e.g. a transient network issue clears)
+    vi.mocked(embedder.doEmbed).mockImplementation(async ({ values }: { values: string[] }) => ({
+      embeddings: values.map(() => [0.1, 0.2, 0.3]),
+    }));
+
+    const processors = await memory.getInputProcessors();
+    expect(processors.find(p => p.id === 'semantic-recall')).toBeDefined();
+  });
+
+  it('still builds the SemanticRecall processor normally when the probe succeeds', async () => {
+    const { memory } = makeMemory({ rejectProbe: false });
+
+    const processors = await memory.getInputProcessors();
+    expect(processors.find(p => p.id === 'semantic-recall')).toBeDefined();
+  });
+});

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -288,14 +288,27 @@ https://mastra.ai/en/docs/memory/overview`,
    * Cached promise for the embedding dimension probe.
    * Stored as a promise to deduplicate concurrent calls.
    */
-  private _embeddingDimensionPromise?: Promise<number | undefined>;
+  private _embeddingDimensionPromise?: Promise<number>;
 
   /**
    * Probe the embedder to determine its actual output dimension.
    * The result is cached so subsequent calls are free.
+   *
+   * This is used to compute the vector index name (see getEmbeddingIndexName()), so a
+   * failed probe must never be treated as "this is a default-dimension embedder" -- doing
+   * so silently bakes the wrong index name into the SemanticRecall processor for the life
+   * of this Memory instance, which then either drops every write against a real,
+   * differently-dimensioned index, or silently orphans one. Fail loudly instead.
    */
-  protected async getEmbeddingDimension(): Promise<number | undefined> {
-    if (!this.embedder) return undefined;
+  protected async getEmbeddingDimension(): Promise<number> {
+    if (!this.embedder) {
+      throw new MastraError({
+        id: 'MASTRA_MEMORY_GET_EMBEDDING_DIMENSION_NO_EMBEDDER',
+        domain: ErrorDomain.MASTRA_VECTOR,
+        category: 'USER',
+        text: 'Cannot determine embedding dimension: no embedder is attached to this Memory instance.',
+      });
+    }
     if (!this._embeddingDimensionPromise) {
       this._embeddingDimensionPromise = (async () => {
         try {
@@ -303,13 +316,29 @@ https://mastra.ai/en/docs/memory/overview`,
             values: ['a'],
             ...(this.embedderOptions || {}),
           } as any);
-          return result.embeddings[0]?.length;
+          const dimension = result.embeddings[0]?.length;
+          if (!dimension) {
+            throw new Error('Embedder returned an empty embedding for the dimension probe.');
+          }
+          return dimension;
         } catch (e) {
-          console.warn(
-            `[Mastra Memory] Failed to probe embedder for dimension, falling back to default. ` +
-              `This may cause index name mismatches if the embedder uses non-default dimensions. Error: ${e}`,
+          // Clear the cache so a later call (e.g. after a transient network issue clears)
+          // gets to probe again instead of permanently failing for this Memory instance.
+          this._embeddingDimensionPromise = undefined;
+          throw new MastraError(
+            {
+              id: 'MASTRA_MEMORY_GET_EMBEDDING_DIMENSION_PROBE_FAILED',
+              domain: ErrorDomain.MASTRA_VECTOR,
+              category: 'THIRD_PARTY',
+              text:
+                `Failed to determine the embedder's output dimension by probing it. The semantic recall vector ` +
+                `index name is derived from this dimension, so Memory refuses to guess a default here -- doing so ` +
+                `has previously caused new writes to be silently dropped or an entire index to be silently ` +
+                `orphaned when the guessed dimension didn't match the embedder's real one. Check that the ` +
+                `embedder is reachable and correctly configured.`,
+            },
+            e,
           );
-          return undefined;
         }
       })();
     }


### PR DESCRIPTION
## Description

This PR makes `getEmbeddingDimension()` throw a descriptive `MastraError` on probe failure instead of guessing a default, matching the existing sibling checks in `getInputProcessors()`/`getOutputProcessors()` that already throw for a missing storage/vector/embedder adapter. It also clears the cached probe promise on failure so a transient issue doesn't permanently wedge the `Memory` instance -- the next call retries the probe.

A minimal, dependency-real reproduction of the original bug (against published `@mastra/core`/`@mastra/memory`/`@mastra/libsql`) is here: https://github.com/shramanb113/mastra-issues/tree/main/src/issues/high/silent-embedding-dimension-fallback

## Related issue(s)

Fixes #22143

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Memory now reports an error when it cannot determine the embedder’s vector size. It no longer guesses a default size, and it can retry after a temporary failure.

## Changes

- Throw a descriptive `MastraError` when the embedding-dimension probe fails.
- Require an attached embedder for dimension detection.
- Clear the cached probe promise after failure so later calls can retry.
- Prevent incorrect 1536-dimensional index selection, dropped writes, and orphaned indexes.
- Add regression tests for probe failures, retry recovery, and successful `SemanticRecall` setup.
- Add a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->