### PR TITLE
fix(ai-sdk): preserve tool result provider metadata

### DIFF
--- a/.changeset/late-dolls-yell.md
+++ b/.changeset/late-dolls-yell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed AI SDK streams to preserve tool result provider metadata in UI message chunks.

--- a/client-sdks/ai-sdk/src/helpers.test.ts
+++ b/client-sdks/ai-sdk/src/helpers.test.ts
@@ -148,6 +148,47 @@ describe('tool payload transform conversion', () => {
   });
 });
 
+describe('tool result provider metadata conversion (issue #22012)', () => {
+  it('forwards model output metadata to the UI chunk', () => {
+    const providerMetadata = {
+      mastra: {
+        modelOutput: {
+          runId: 'run-1',
+          proposalCount: 1,
+        },
+      },
+    };
+    const part = convertMastraChunkToAISDKv6({
+      chunk: {
+        type: 'tool-result',
+        runId: 'run-1',
+        from: ChunkFrom.AGENT,
+        payload: {
+          toolCallId: 'call-1',
+          toolName: 'propose',
+          result: {
+            runId: 'run-1',
+            proposals: [{ id: 'proposal-1', internalDetails: 'large raw payload' }],
+          },
+          providerMetadata,
+        },
+      },
+    }) as any;
+
+    expect(part.providerMetadata).toEqual(providerMetadata);
+    expect(
+      convertFullStreamChunkToUIMessageStream({
+        part,
+        onError: String,
+      }),
+    ).toMatchObject({
+      type: 'tool-output-available',
+      toolCallId: 'call-1',
+      providerMetadata,
+    });
+  });
+});
+
 describe('client observability carrier propagation', () => {
   it('preserves observability on tool-call and tool-input-start conversion', () => {
     const carrier = { traceparent: '00-cccccccccccccccccccccccccccccccc-dddddddddddddddd-01' };

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -16,7 +16,7 @@ import type {
   UIMessage as UIMessageV6,
 } from '@internal/ai-v6';
 import { DefaultGeneratedFile, DefaultGeneratedFileWithType } from '@mastra/core/stream';
-import type { DataChunkType, ChunkType, MastraFinishReason } from '@mastra/core/stream';
+import type { DataChunkType, ChunkType, MastraFinishReason, ProviderMetadata } from '@mastra/core/stream';
 import { isDataChunkType } from './utils';
 
 /**
@@ -39,8 +39,14 @@ export function toAISDKFinishReason(reason: MastraFinishReason): FinishReason {
   return reason;
 }
 
+type MastraToolResultStreamPart = Extract<TextStreamPart<ToolSet>, { type: 'tool-result' }> & {
+  providerMetadata?: ProviderMetadata;
+};
+
+type MastraTextStreamPart = Exclude<TextStreamPart<ToolSet>, { type: 'tool-result' }> | MastraToolResultStreamPart;
+
 export type OutputChunkType<OUTPUT = undefined> =
-  | TextStreamPart<ToolSet>
+  | MastraTextStreamPart
   | ObjectStreamPart<Partial<OUTPUT>>
   | ToolApprovalRequest
   | DataChunkType
@@ -374,7 +380,7 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
         output: hasTransformedToolPayload(displayOutputTransform)
           ? displayOutputTransform.transformed
           : chunk.payload.result,
-        // providerMetadata: chunk.payload.providerMetadata, // AI v5 types don't show this?
+        providerMetadata: chunk.payload.providerMetadata,
       };
     case 'tool-error':
       return {
@@ -574,7 +580,7 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
 }: {
   // tool-output is a custom mastra chunk type used in ToolStream
   part:
-    | TextStreamPart<ToolSet>
+    | MastraTextStreamPart
     | AISDKToolOutputDenied
     | DataChunkType
     | ToolApprovalRequest
@@ -739,6 +745,7 @@ export function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMes
         toolCallId: part.toolCallId,
         output: part.output,
         ...(part.providerExecuted != null ? { providerExecuted: part.providerExecuted } : {}),
+        ...(part.providerMetadata != null ? { providerMetadata: part.providerMetadata } : {}),
         ...(part.dynamic != null ? { dynamic: part.dynamic } : {}),
       };
     }


### PR DESCRIPTION
Previously, providerMetadata was dropped first when converting a Mastra tool-result and again when producing tool-output-available. That prevented mastra.modelOutput from surviving a useChat round trip, so later turns received the raw tool result.

The conversion now carries providerMetadata through both stages, matching the existing tool-call behavior.

Before:

```ts
{ type: "tool-output-available", toolCallId, output }
```

After:

```ts
{ type: "tool-output-available", toolCallId, output, providerMetadata }
```

Validated with the complete @mastra/ai-sdk test suite (30 files, 236 passing), package typecheck, lint, and build.

Fixes #22012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Tool results can carry extra information that helps later chat messages use the correct output. This change keeps that information when tool results move through the AI SDK.

## Changes

- Preserve `providerMetadata` when converting Mastra `tool-result` chunks.
- Forward `providerMetadata` to `tool-output-available` UI message chunks.
- Extend tool-result types to support optional provider metadata.
- Add tests for `mastra.modelOutput`, `runId`, and `proposalCount`.
- Add a patch changeset for `@mastra/ai-sdk`.

## Validation

- Full test suite: 30 files and 236 tests passed.
- Typecheck, lint, and build passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->