### PR TITLE
feat(core): mark transient signals in the outbound prompt for cache-breakpoint exclusion

### DIFF
--- a/.changeset/transient-outbound-cache-marker.md
+++ b/.changeset/transient-outbound-cache-marker.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Mark transient signals in the outbound model prompt so consumers can keep them out of their prompt-cache breakpoints.
+
+A transient signal is delivered to the model but never persisted, so the next turn reloads a history without it. A consumer that places `cache_control` breakpoints therefore has to keep them *behind* transient rows: a cached prefix that includes one diverges from the reloaded history at exactly that position and is invalidated at the turn boundary, costing a full prefix rebuild on the first call of every turn.
+
+`MessageList.convertSignalForModelPrompt` now marks the projected parts of a transient signal, which surfaces as `providerOptions.mastra.transient` on the outbound message. Consumers can detect these rows there (or via `isTransientSignalMessage()` on a `MastraDBMessage`) instead of pattern-matching the rendered `<system-reminder>` tag, which would also catch reminders that *are* persisted. Behavior sent to the model is unchanged.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -448,18 +448,42 @@ export class MessageList {
       metadata: { createdAt },
     };
 
-    return [
-      convertInputToMastraDBMessage(promptMessage as MessageInput, 'input', {
-        memoryInfo: this.memoryInfo,
-        newMessageId: () => message.id,
-        generateCreatedAt: (_messageSource, start) => {
-          if (start instanceof Date) return start;
-          if (typeof start === 'string' || typeof start === 'number') return new Date(start);
-          return createdAt;
-        },
-        dbMessages: this.messages,
-      }),
-    ];
+    const projected = convertInputToMastraDBMessage(promptMessage as MessageInput, 'input', {
+      memoryInfo: this.memoryInfo,
+      newMessageId: () => message.id,
+      generateCreatedAt: (_messageSource, start) => {
+        if (start instanceof Date) return start;
+        if (typeof start === 'string' || typeof start === 'number') return new Date(start);
+        return createdAt;
+      },
+      dbMessages: this.messages,
+    });
+
+    // A transient signal is delivery-only: it is in the live prompt but never persisted, so the
+    // next turn reloads a history without it. A consumer that places prompt-cache breakpoints must
+    // therefore keep them behind these rows — a cached span that includes one is invalidated at the
+    // turn boundary, costing a full prefix rebuild every turn. Mark the projected parts so such a
+    // consumer can identify them (the marker surfaces as `providerOptions.mastra.transient` on the
+    // outbound message) instead of pattern-matching the rendered `<system-reminder>` tag, which
+    // would also catch reminders that ARE persisted. See `isTransientSignalMessage` in agent/signals.ts.
+    if (isTransientSignalMessage(message)) {
+      projected.content.parts = projected.content.parts.map(part =>
+        part.type === 'text'
+          ? {
+              ...part,
+              providerMetadata: {
+                ...part.providerMetadata,
+                mastra: {
+                  ...(part.providerMetadata?.mastra as Record<string, unknown> | undefined),
+                  transient: true,
+                },
+              },
+            }
+          : part,
+      );
+    }
+
+    return [projected];
   }
 
   public makeMessageSourceChecker(): {

--- a/packages/core/src/agent/message-list/tests/message-list-transient-marker.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-transient-marker.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createSignal } from '../../signals';
+import { MessageList } from '../index';
+
+// Follow-up to #22060: a transient signal is delivery-only and never persisted, so a consumer
+// placing prompt-cache breakpoints must keep them behind these rows. convertSignalForModelPrompt
+// marks the projected parts; the aiV5 prompt conversion surfaces that as
+// `providerOptions.mastra.transient` on the outbound message, which is how consumers identify the
+// row without pattern-matching the rendered `<system-reminder>` tag (that would also catch
+// reminders that ARE persisted).
+
+type OutboundTextPart = { type: string; providerOptions?: { mastra?: { transient?: boolean } } };
+
+function lastPromptParts(prompt: Awaited<ReturnType<MessageList['get']['all']['aiV5']['prompt']>>): OutboundTextPart[] {
+  const last = prompt.at(-1);
+  return Array.isArray(last?.content) ? (last!.content as OutboundTextPart[]) : [];
+}
+
+describe('transient signal outbound cache marker', () => {
+  it('marks a transient signal on the outbound prompt as providerOptions.mastra.transient', async () => {
+    const list = new MessageList();
+    list.add('hello', 'input');
+    list.addSignal(createSignal({ type: 'reactive', contents: 'Stay on the current task.', transient: true }));
+
+    const parts = lastPromptParts(await list.get.all.aiV5.prompt());
+    const textPart = parts.find(p => p.type === 'text');
+
+    expect(textPart).toBeDefined();
+    expect(textPart?.providerOptions?.mastra?.transient).toBe(true);
+  });
+
+  it('does not mark a non-transient reminder (so persisted rows stay cacheable)', async () => {
+    const list = new MessageList();
+    list.add('hello', 'input');
+    list.addSignal(createSignal({ type: 'reactive', contents: 'Persisted reminder.' }));
+
+    const parts = lastPromptParts(await list.get.all.aiV5.prompt());
+    const textPart = parts.find(p => p.type === 'text');
+
+    expect(textPart).toBeDefined();
+    expect(textPart?.providerOptions?.mastra?.transient).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description

Follow-up to #22104 (which fixed transient reminders duplicating within a turn, closing #22060). That fix stops the accumulation; this PR adds the missing **consumer-facing** piece.

A transient signal is delivered to the model but **never persisted**, so the next turn reloads a history without it. A consumer that places `cache_control` breakpoints therefore has to keep them **behind** transient rows: a cached prefix that includes one diverges from the reloaded history at exactly that position and is invalidated at the turn boundary — a full prefix rebuild on the first call of every turn.

Today there is no reliable way to identify these rows in the outbound prompt: the rendered `<system-reminder>` tag is shared with reminders that *are* persisted, so matching on it would wrongly exclude cacheable rows too.

This PR marks the projected parts of a transient signal in `MessageList.convertSignalForModelPrompt`, which surfaces as **`providerOptions.mastra.transient`** on the outbound message. Consumers can detect delivery-only rows there (or via the existing `isTransientSignalMessage()` on a `MastraDBMessage`) and keep their cache breakpoints behind them. The marker is applied only to transient signals — a persisted reminder's `providerOptions.mastra` carries no `transient` key — so it distinguishes the two cases. **What the model receives is unchanged.**

Includes a unit test asserting the marker is present on a transient signal's outbound prompt and absent on a non-transient reminder.

## Related issue(s)

Closes #22157

Follow-up to #22104 (which fixed #22060).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
