### PR TITLE
fix(core): strip reasoning for Bedrock Mantle GPT-OSS requests

### DIFF
--- a/.changeset/quiet-mantle-reasoning.md
+++ b/.changeset/quiet-mantle-reasoning.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Bedrock Mantle Chat GPT-OSS agents now strip unsupported outbound reasoning while preserving complete stored history.

--- a/packages/core/src/agent/__tests__/provider-boundary-compat.test.ts
+++ b/packages/core/src/agent/__tests__/provider-boundary-compat.test.ts
@@ -1,0 +1,79 @@
+import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { ProviderHistoryCompat } from '../../processors/provider-history-compat';
+import { Agent } from '../agent';
+
+describe('provider boundary compatibility', () => {
+  it('strips reasoning at the ordinary Agent provider boundary and preserves history', async () => {
+    let outboundPrompt: any;
+    const model = new MockLanguageModelV2({
+      provider: 'bedrock-mantle.chat',
+      modelId: 'openai.gpt-oss-20b',
+      doGenerate: async ({ prompt }) => {
+        outboundPrompt = prompt;
+        const hasReasoning = prompt.some(
+          message =>
+            message.role === 'assistant' &&
+            Array.isArray(message.content) &&
+            message.content.some(part => part.type === 'reasoning'),
+        );
+
+        if (hasReasoning) throw new Error("Invalid 'messages': Invalid 'content'");
+
+        return {
+          content: [{ type: 'text', text: 'ok' }],
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'provider-boundary-reproduction',
+      name: 'provider-boundary-reproduction',
+      instructions: 'Answer briefly.',
+      model,
+    });
+
+    const history = [
+      { role: 'user' as const, content: 'Explain this.' },
+      {
+        role: 'assistant' as const,
+        content: [
+          { type: 'reasoning' as const, text: 'private reasoning' },
+          { type: 'text' as const, text: 'A concise answer.' },
+        ],
+      },
+      { role: 'user' as const, content: 'Continue.' },
+    ];
+    const originalHistory = structuredClone(history);
+
+    const result = await agent.generate(history);
+
+    expect(result.text).toBe('ok');
+    expect(outboundPrompt.flatMap((message: any) => (Array.isArray(message.content) ? message.content : []))).not.toContainEqual(
+      expect.objectContaining({ type: 'reasoning' }),
+    );
+    expect(history).toEqual(originalHistory);
+  });
+
+  it('installs the narrow processor once and lets explicit full compat win', async () => {
+    const model = new MockLanguageModelV2({ provider: 'bedrock-mantle.chat', modelId: 'openai.gpt-oss-20b' });
+    const automatic = new Agent({ id: 'automatic', name: 'automatic', instructions: 'test', model });
+    expect((await automatic.__listLLMRequestProcessors()).map(processor => processor.id)).toContain(
+      'provider-boundary-compat',
+    );
+
+    const explicit = new Agent({
+      id: 'explicit',
+      name: 'explicit',
+      instructions: 'test',
+      model,
+      inputProcessors: [new ProviderHistoryCompat()],
+    });
+    const ids = (await explicit.__listLLMRequestProcessors()).map(processor => processor.id);
+    expect(ids).toContain('provider-history-compat');
+    expect(ids).not.toContain('provider-boundary-compat');
+  });
+});

--- a/packages/core/src/agent/__tests__/provider-boundary-compat.test.ts
+++ b/packages/core/src/agent/__tests__/provider-boundary-compat.test.ts
@@ -1,4 +1,4 @@
-import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it } from 'vitest';
 import { ProviderHistoryCompat } from '../../processors/provider-history-compat';
 import { Agent } from '../agent';
@@ -54,6 +54,65 @@ describe('provider boundary compatibility', () => {
     expect(result.text).toBe('ok');
     expect(outboundPrompt.flatMap((message: any) => (Array.isArray(message.content) ? message.content : []))).not.toContainEqual(
       expect.objectContaining({ type: 'reasoning' }),
+    );
+    expect(history).toEqual(originalHistory);
+  });
+
+  it('keeps reasoning in the Agent message list while filtering the stream prompt', async () => {
+    let outboundPrompt: any;
+    const model = new MockLanguageModelV2({
+      provider: 'bedrock-mantle.chat',
+      modelId: 'openai.gpt-oss-20b',
+      doStream: async ({ prompt }) => {
+        outboundPrompt = prompt;
+        const hasReasoning = prompt.some(
+          message =>
+            message.role === 'assistant' &&
+            Array.isArray(message.content) &&
+            message.content.some(part => part.type === 'reasoning'),
+        );
+
+        if (hasReasoning) throw new Error("Invalid 'messages': Invalid 'content'");
+
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'ok' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 } },
+          ]),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'provider-boundary-history',
+      name: 'provider-boundary-history',
+      instructions: 'Answer briefly.',
+      model,
+    });
+    const history = [
+      { role: 'user' as const, content: 'Explain this.' },
+      {
+        role: 'assistant' as const,
+        content: [
+          { type: 'reasoning' as const, text: 'durable-reasoning-sentinel' },
+          { type: 'text' as const, text: 'A concise answer.' },
+        ],
+      },
+      { role: 'user' as const, content: 'Continue.' },
+    ];
+    const originalHistory = structuredClone(history);
+
+    const response = await agent.stream(history);
+    await response.consumeStream();
+
+    expect(outboundPrompt.flatMap((message: any) => (Array.isArray(message.content) ? message.content : []))).not.toContainEqual(
+      expect.objectContaining({ type: 'reasoning' }),
+    );
+    expect(response.messageList.get.all.db().flatMap(message => message.content.parts)).toContainEqual(
+      expect.objectContaining({ type: 'reasoning', reasoning: 'durable-reasoning-sentinel' }),
     );
     expect(history).toEqual(originalHistory);
   });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -95,6 +95,7 @@ import type {
 import { ProcessorStepSchema, isProcessorWorkflow } from '../processors/index';
 import { SkillsProcessor } from '../processors/processors/skills';
 import { WorkspaceInstructionsProcessor } from '../processors/processors/workspace-instructions';
+import { providerBoundaryCompat } from '../processors/provider-history-compat';
 import type { ProcessorState } from '../processors/runner';
 import { ProcessorRunner } from '../processors/runner';
 import {
@@ -1930,7 +1931,14 @@ export class Agent<
     requestContext?: RequestContext,
     configuredProcessorOverrides?: InputProcessorOrWorkflow[],
   ): Promise<InputProcessorOrWorkflow[]> {
-    return this.resolveInputProcessors(requestContext, configuredProcessorOverrides);
+    const processors = await this.resolveInputProcessors(requestContext, configuredProcessorOverrides);
+    const hasCompat = processors.some(
+      processor =>
+        !isProcessorWorkflow(processor) &&
+        isProcessor(processor) &&
+        (processor.id === 'provider-boundary-compat' || processor.id === 'provider-history-compat'),
+    );
+    return hasCompat ? processors : [...processors, providerBoundaryCompat];
   }
 
   /**

--- a/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
+++ b/packages/core/src/coding-agent/__tests__/coding-agent.test.ts
@@ -32,6 +32,11 @@ function promptContext(overrides: Partial<PromptContext> = {}): PromptContext {
 }
 
 describe('createCodingAgent', () => {
+  it('keeps ProviderHistoryCompat in the default error processors', async () => {
+    const agent = createCodingAgent(baseConfig());
+    expect((await agent.listErrorProcessors()).map(processor => processor.id)).toContain('provider-history-compat');
+  });
+
   it('returns an Agent', () => {
     const agent = createCodingAgent(baseConfig());
     expect(agent).toBeInstanceOf(Agent);

--- a/packages/core/src/processors/provider-history-compat.test.ts
+++ b/packages/core/src/processors/provider-history-compat.test.ts
@@ -7,6 +7,8 @@ import {
   anthropicStripForeignReasoningContent,
   azureSystemReminderTransform,
   cerebrasStripReasoningContent,
+  bedrockMantleGptOssStripReasoningContent,
+  isMaybeBedrockMantleGptOss,
   isMaybeAnthropic,
   isMaybeAnthropicWithoutAssistantPrefill,
   isMaybeAzure,
@@ -757,6 +759,46 @@ describe('cerebrasStripReasoningContent', () => {
 });
 
 describe('ProviderHistoryCompat.processLLMRequest', () => {
+  it('matches only Bedrock Mantle Chat GPT-OSS models', () => {
+    expect(isMaybeBedrockMantleGptOss({ provider: 'bedrock-mantle.chat', modelId: 'openai.gpt-oss-20b' })).toBe(true);
+    expect(isMaybeBedrockMantleGptOss([{ model: { provider: 'bedrock-mantle.chat', modelId: 'openai.gpt-oss-120b' } }])).toBe(true);
+    expect(isMaybeBedrockMantleGptOss({ provider: 'bedrock-mantle.responses', modelId: 'openai.gpt-oss-20b' })).toBe(false);
+    expect(isMaybeBedrockMantleGptOss({ provider: 'bedrock-mantle.chat', modelId: 'openai.gpt-4o' })).toBe(false);
+    expect(isMaybeBedrockMantleGptOss({ provider: 'amazon-bedrock', modelId: 'openai.gpt-oss-20b' })).toBe(false);
+    expect(isMaybeBedrockMantleGptOss({ provider: 'bedrock-mantle.chat', modelId: 'vendor/openai.gpt-oss-20b' })).toBe(false);
+    expect(isMaybeBedrockMantleGptOss('bedrock-mantle.chat/openai.gpt-oss-20b')).toBe(false);
+    expect(isMaybeBedrockMantleGptOss(() => undefined)).toBe(false);
+  });
+
+  it('strips only outbound reasoning for Bedrock Mantle Chat GPT-OSS', () => {
+    const prompt = promptWithReasoning();
+    const result = bedrockMantleGptOssStripReasoningContent.applyToPrompt!({
+      prompt,
+      model: { provider: 'bedrock-mantle.chat', modelId: 'openai.gpt-oss-20b' },
+    });
+
+    expect(result).toBeDefined();
+    expect((result!.find(message => message.role === 'assistant')!.content as any[]).map(part => part.type)).toEqual(['text']);
+    expect((prompt.find(message => message.role === 'assistant')!.content as any[]).map(part => part.type)).toEqual([
+      'reasoning',
+      'text',
+    ]);
+  });
+
+  it.each([
+    ['bedrock-mantle.responses', 'openai.gpt-oss-20b'],
+    ['bedrock-mantle.chat', 'anthropic.claude-sonnet-4-5'],
+    ['amazon-bedrock', 'openai.gpt-oss-20b'],
+    ['bedrock-mantle.chat', 'vendor/openai.gpt-oss-20b'],
+  ])('preserves reasoning for %s %s', (provider, modelId) => {
+    expect(
+      bedrockMantleGptOssStripReasoningContent.applyToPrompt!({
+        prompt: promptWithReasoning(),
+        model: { provider, modelId },
+      }),
+    ).toBeUndefined();
+  });
+
   it('rewrites memory reminders in Azure-bound prompts', async () => {
     const handler = new ProviderHistoryCompat();
     const prompt: LanguageModelV2Prompt = [

--- a/packages/core/src/processors/provider-history-compat.ts
+++ b/packages/core/src/processors/provider-history-compat.ts
@@ -208,6 +208,7 @@ export function isMaybeBedrockMantleGptOss(model: unknown): boolean {
 
   if (typeof model !== 'object') return false;
   const { provider, modelId } = model as { provider?: unknown; modelId?: unknown };
+  // Keep the exact Chat route and case-sensitive model prefix; Responses is out of scope.
   return provider === 'bedrock-mantle.chat' && typeof modelId === 'string' && modelId.startsWith('openai.gpt-oss-');
 }
 
@@ -576,6 +577,9 @@ export const providerBoundaryCompat = new ProviderBoundaryCompat();
  * - **anthropic-strip-foreign-reasoning-content** — strips non-Anthropic
  *   `reasoning` parts from assistant messages in the outbound prompt when the
  *   resolved model is Anthropic. Anthropic-native reasoning parts are kept.
+ * - **bedrock-mantle-gpt-oss-strip-reasoning-content** — strips assistant
+ *   `reasoning` parts for Bedrock Mantle Chat GPT-OSS models in the outbound
+ *   prompt. Mantle Responses is not matched.
  *
  * To add custom rules, pass them to the constructor:
  * ```ts

--- a/packages/core/src/processors/provider-history-compat.ts
+++ b/packages/core/src/processors/provider-history-compat.ts
@@ -199,6 +199,18 @@ function matchesProviderPrefix(model: unknown, providerPrefix: string): boolean 
   return false;
 }
 
+export function isMaybeBedrockMantleGptOss(model: unknown): boolean {
+  if (model == null || typeof model === 'string' || typeof model === 'function') return false;
+
+  if (Array.isArray(model)) {
+    return model.some(entry => isMaybeBedrockMantleGptOss((entry as { model?: unknown }).model ?? entry));
+  }
+
+  if (typeof model !== 'object') return false;
+  const { provider, modelId } = model as { provider?: unknown; modelId?: unknown };
+  return provider === 'bedrock-mantle.chat' && typeof modelId === 'string' && modelId.startsWith('openai.gpt-oss-');
+}
+
 export function isMaybeCerebras(
   model:
     | string
@@ -481,6 +493,14 @@ export const azureSystemReminderTransform: CompatRule = {
   },
 };
 
+export const bedrockMantleGptOssStripReasoningContent: CompatRule = {
+  name: 'bedrock-mantle-gpt-oss-strip-reasoning-content',
+  applyToPrompt({ prompt, model }) {
+    if (!isMaybeBedrockMantleGptOss(model)) return undefined;
+    return stripReasoningFromPrompt(prompt);
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Default rule set
 // ---------------------------------------------------------------------------
@@ -495,7 +515,38 @@ export const DEFAULT_COMPAT_RULES: CompatRule[] = [
   anthropicStripEmptySignedReasoningContent,
   anthropicStripForeignReasoningContent,
   azureSystemReminderTransform,
+  bedrockMantleGptOssStripReasoningContent,
 ];
+
+function applyPromptCompatRules(
+  rules: CompatRule[],
+  prompt: LanguageModelV2Prompt,
+  model: unknown,
+): LanguageModelV2Prompt | undefined {
+  let current = prompt;
+  let mutated = false;
+  for (const rule of rules) {
+    if (!rule.applyToPrompt) continue;
+    const next = rule.applyToPrompt({ prompt: current, model });
+    if (next) {
+      current = next;
+      mutated = true;
+    }
+  }
+  return mutated ? current : undefined;
+}
+
+class ProviderBoundaryCompat implements Processor<'provider-boundary-compat'> {
+  readonly id = 'provider-boundary-compat' as const;
+  readonly name = 'Provider Boundary Compat';
+
+  processLLMRequest({ prompt, model }: ProcessLLMRequestArgs): ProcessLLMRequestResult {
+    const next = applyPromptCompatRules([bedrockMantleGptOssStripReasoningContent], prompt, model);
+    return next ? { prompt: next } : undefined;
+  }
+}
+
+export const providerBoundaryCompat = new ProviderBoundaryCompat();
 
 // ---------------------------------------------------------------------------
 // Processor
@@ -544,17 +595,8 @@ export class ProviderHistoryCompat implements Processor<'provider-history-compat
   }
 
   processLLMRequest({ prompt, model }: ProcessLLMRequestArgs): ProcessLLMRequestResult {
-    let current = prompt;
-    let mutated = false;
-    for (const rule of this.rules) {
-      if (!rule.applyToPrompt) continue;
-      const next = rule.applyToPrompt({ prompt: current, model });
-      if (next) {
-        current = next;
-        mutated = true;
-      }
-    }
-    return mutated ? { prompt: current } : undefined;
+    const next = applyPromptCompatRules(this.rules, prompt, model);
+    return next ? { prompt: next } : undefined;
   }
 
   async processAPIError({


### PR DESCRIPTION
Closes #19228

## Summary

Agents using Bedrock Mantle Chat with `openai.gpt-oss-*` models fail on later turns with `Invalid 'messages': Invalid 'content'`. Direct AI SDK calls succeed because they do not replay Mastra's assistant `reasoning` history.

## Root cause

Mastra reconstructs the full conversation into a `LanguageModelV2Prompt`, including assistant `reasoning` parts. The provider-boundary `processLLMRequest` hook has no Mantle GPT-OSS rule, and ordinary Agents do not receive `ProviderHistoryCompat` in that hook.

Mastra Platform confirmed the correct boundary and scope in [its triage comment](https://github.com/mastra-ai/mastra/issues/19228#issuecomment-5165369380): `bedrock-mantle.chat` only, `openai.gpt-oss-*` only, outbound reasoning removed transiently, durable reasoning preserved, and normal-Agent installation included.

## Changes

- `packages/core/src/processors/provider-history-compat.ts`: add the exact Mantle GPT-OSS rule and a narrow provider-boundary processor that reuses the existing immutable prompt rewrite.
- `packages/core/src/agent/agent.ts`: install that narrow processor in the uncombined LLM-request resolver, with explicit processor-id deduplication.
- `packages/core/src/processors/provider-history-compat.test.ts`: cover rule behavior, immutability, negative space, and the unchanged bare-runner invariant.
- `packages/core/src/agent/__tests__/provider-boundary-compat.test.ts`: cover the plain-Agent production path, outbound filtering, returned message-list history preservation, and explicit configuration deduplication. Mantle Responses and other-provider controls remain in the rule-level compatibility tests.
- `packages/core/src/coding-agent/__tests__/coding-agent.test.ts`: preserve CodingAgent's explicit full compatibility error processor.
- `.changeset/<generated>.md`: publish the `@mastra/core` patch outcome.

## Scope

This fixes only Bedrock Mantle Chat requests whose resolved model id starts with `openai.gpt-oss-`. Mantle Responses, standard Bedrock, non-GPT-OSS Mantle models, Anthropic, Cerebras, Azure, OpenAI, Studio, MastraCode, generic ProcessorRunner consumers, and the public processors barrel remain unchanged. Stored reasoning remains available to memory, UI history, and observability.

## Prior work

The design extends the existing Cerebras and Anthropic provider-history rewrite rules. The earlier broad attempt in [#19230](https://github.com/mastra-ai/mastra/pull/19230) was closed because it applied the policy at a generic stream layer and across broader Bedrock OpenAI models.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Linked related issue
- [x] Added or updated tests
- [ ] Documentation updated
- [ ] Addressed all CodeRabbit comments

## Test plan

- `pnpm --filter ./packages/core test src/processors/provider-history-compat.test.ts`: rule-level reproduction, exact provider/model matching, immutability, and negative-space controls.
- `pnpm --filter ./packages/core test src/agent/__tests__/provider-boundary-compat.test.ts`: plain-Agent reproduction, transient prompt filtering, returned message-list history preservation, and explicit processor deduplication.
- `pnpm --filter ./packages/core test src/coding-agent/__tests__/coding-agent.test.ts`: CodingAgent compatibility processor preservation.
- `pnpm --filter ./packages/core typecheck`, lint, and the package test command: package-level validation before publication.

## Validation results

- Provider history compatibility: 1 file, 52 tests passed.
- Ordinary Agent provider boundary: 1 file, 3 tests passed.
- CodingAgent: 1 file, 18 tests passed.
- Agentic execution loop: 1 file, 31 tests passed.
- Anthropic thinking roundtrip: 1 file, 4 tests passed.
- Typecheck and lint passed.
- The full package suite completed with 912 passed, 111 failed, 1 skipped, 33 todo, and 1 unhandled error. The failures were unrelated Windows socket, recording, filesystem, and network-environment failures; the focused checks above passed.
- Base reproduction: clean `origin/main` observed the mock error `Invalid 'messages': Invalid 'content'` when reasoning reached the outbound prompt; head strips only that outbound reasoning and preserves the input history.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Bedrock Mantle GPT-OSS requests can fail when they resend assistant reasoning. This change removes that reasoning from outgoing Chat requests while keeping it in the Agent’s stored history.

## Changes

- Added exact detection for `bedrock-mantle.chat` models with `openai.gpt-oss-*` IDs.
- Added `providerBoundaryCompat` to strip reasoning from matching outbound prompts.
- Kept stored reasoning history and input messages unchanged.
- Automatically installed the processor for Agents without duplicate compatibility processors.
- Preserved compatibility with explicit processors and `CodingAgent`.
- Added tests for matching rules, negative cases, streaming, non-streaming requests, Agent execution, history preservation, immutability, and processor precedence.
- Added a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->