### PR TITLE
fix(factory-ui): reveal restored history at once

### DIFF
--- a/.changeset/calm-waves-reveal.md
+++ b/.changeset/calm-waves-reveal.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed restored MastraCode threads revealing message fragments out of order during startup.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/SessionPreparationOverlay.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/SessionPreparationOverlay.tsx
@@ -1,0 +1,17 @@
+import { SessionPrepareSteps } from './SessionPrepareSteps';
+
+interface SessionPreparationOverlayProps {
+  historyInitializing: boolean;
+  preparing: boolean;
+}
+
+export function SessionPreparationOverlay({ historyInitializing, preparing }: SessionPreparationOverlayProps) {
+  return (
+    <div aria-hidden={!preparing} className="session-preparation-overlay" data-preparing={preparing}>
+      <div aria-hidden="true" className="session-preparation-veil" />
+      <div className="session-preparation-loader">
+        <SessionPrepareSteps finishing={!preparing} historyInitializing={historyInitializing} />
+      </div>
+    </div>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/SessionPreparationOverlay.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/SessionPreparationOverlay.tsx
@@ -7,9 +7,13 @@ interface SessionPreparationOverlayProps {
 
 export function SessionPreparationOverlay({ historyInitializing, preparing }: SessionPreparationOverlayProps) {
   return (
-    <div aria-hidden={!preparing} className="session-preparation-overlay" data-preparing={preparing}>
-      <div aria-hidden="true" className="session-preparation-veil" />
-      <div className="session-preparation-loader">
+    <div
+      aria-hidden={!preparing}
+      className="session-preparation-overlay pointer-events-none sticky top-0 z-5 [margin-block-end:-100cqh] h-[100cqh] flex-none overflow-hidden bg-(--chat-surface) data-[preparing=false]:bg-transparent"
+      data-preparing={preparing}
+    >
+      <div aria-hidden="true" className="session-preparation-veil absolute inset-x-0 opacity-0" />
+      <div className="session-preparation-loader invisible absolute inset-0 z-1 flex -translate-y-1 bg-(--chat-surface) opacity-0">
         <SessionPrepareSteps finishing={!preparing} historyInitializing={historyInitializing} />
       </div>
     </div>

--- a/mastracode/factory-ui/src/ui/domains/chat/components/SessionPrepareSteps.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/SessionPrepareSteps.tsx
@@ -41,26 +41,31 @@ function getStepStatus(index: number, activeIndex: number): StepStatus {
   return 'pending';
 }
 
-/**
- * Thread messages load in parallel with the `/ensure` warm-up (they are keyed
- * by resourceId, not by a live sandbox), so "messages are loading" must never
- * advance the stepper past sandbox work that is still running: the observed
- * warm-up phase is ground truth, and a warm-up that is in flight but has not
- * emitted its first event yet still pins the first step. Only when no warm-up
- * is running may message loading light up "Starting session".
- */
 function getActiveGroup(options: {
   observedGroup: GroupId | undefined;
   sandboxWarming: boolean;
-  loadingMessages: boolean;
+  startingSession: boolean;
 }): GroupId {
+  // Sandbox progress wins because history loads in parallel with warm-up.
   if (options.observedGroup) return options.observedGroup;
   if (options.sandboxWarming) return 'preparing-sandbox';
-  if (options.loadingMessages) return 'starting-session';
+  if (options.startingSession) return 'starting-session';
   return 'preparing-sandbox';
 }
 
-export function SessionPrepareSteps() {
+function getActiveDescription(observedPhase: PrepareProgress['phase'] | undefined, loadingMessages: boolean) {
+  if (observedPhase && observedPhase !== 'done') return PHASE_DESCRIPTION[observedPhase];
+  if (loadingMessages) return 'Loading messages…';
+  return 'Starting…';
+}
+
+export function SessionPrepareSteps({
+  finishing = false,
+  historyInitializing = false,
+}: {
+  finishing?: boolean;
+  historyInitializing?: boolean;
+}) {
   const { sandboxPreparing, sandboxProgress, sandboxWarming } = useChatSessionContext();
   const messagesInitializing = useChatMessagesInitializing();
 
@@ -68,19 +73,16 @@ export function SessionPrepareSteps() {
   const observedGroup = observedPhase ? PHASE_TO_GROUP[observedPhase] : undefined;
 
   const loadingMessages = !sandboxPreparing && messagesInitializing;
+  const startingSession = loadingMessages || (!sandboxPreparing && historyInitializing);
 
-  // The sandbox phase description wins while sandbox work is underway; the
-  // terminal `done` phase carries no work of its own, so message loading may
-  // take over the description there.
-  const activeDescription =
-    observedPhase && observedPhase !== 'done'
-      ? PHASE_DESCRIPTION[observedPhase]
-      : loadingMessages
-        ? 'Loading messages…'
-        : 'Starting…';
+  const activeDescription = getActiveDescription(observedPhase, loadingMessages);
 
-  const activeGroup = getActiveGroup({ observedGroup, sandboxWarming: sandboxWarming === true, loadingMessages });
-  const activeIndex = GROUPS.findIndex(group => group.id === activeGroup);
+  const activeGroup = getActiveGroup({
+    observedGroup,
+    sandboxWarming: sandboxWarming === true,
+    startingSession,
+  });
+  const activeIndex = finishing ? GROUPS.length : GROUPS.findIndex(group => group.id === activeGroup);
 
   const items: Array<{ step: ProcessStep; position: number }> = GROUPS.map((group, index) => {
     const status = getStepStatus(index, activeIndex);

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ThreadRailLayer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ThreadRailLayer.tsx
@@ -10,7 +10,7 @@ export function ThreadRailLayer() {
   if (turns.length === 0) return null;
 
   return (
-    <div className="pointer-events-none absolute inset-y-0 left-4 z-20">
+    <div className="pointer-events-none absolute inset-y-0 left-4 z-1">
       <ThreadRail turns={turns} className="pointer-events-auto sticky top-1/2 -translate-y-1/2" />
     </div>
   );

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Transcript.tsx
@@ -477,17 +477,10 @@ function SignalRow({ kind, label, message }: { kind: string; label: string; mess
 // ---------------------------------------------------------------------------
 // Transcript
 // ---------------------------------------------------------------------------
-const HISTORY_ENTRY_STAGGER_MS = 55;
-const HISTORY_ENTRY_STAGGER_LIMIT = 10;
 
 interface PreparedTranscriptEntry {
   entry: TimelineEntry;
   content: ReactNode;
-}
-
-function createHistoryRevealDelays(entries: PreparedTranscriptEntry[]): Record<string, number> {
-  const visibleEntries = entries.filter(({ content }) => content !== null).slice(-HISTORY_ENTRY_STAGGER_LIMIT);
-  return Object.fromEntries(visibleEntries.map(({ entry }, index) => [entry.id, index * HISTORY_ENTRY_STAGGER_MS]));
 }
 
 export function Transcript({ tail }: { tail?: ReactNode }) {
@@ -515,7 +508,7 @@ export function Transcript({ tail }: { tail?: ReactNode }) {
   return (
     <TranscriptEntries
       entries={transcript.entries}
-      revealInitialEntries
+      restoredHistory
       isSubmitting={approveMutation.isPending || respondMutation.isPending}
       onApprove={onApprove}
       onRespond={onRespond}
@@ -527,7 +520,7 @@ export function Transcript({ tail }: { tail?: ReactNode }) {
 
 export function TranscriptEntries({
   entries,
-  revealInitialEntries = false,
+  restoredHistory = false,
   isSubmitting = false,
   onApprove,
   onRespond,
@@ -535,7 +528,7 @@ export function TranscriptEntries({
   tail,
 }: {
   entries: TimelineEntry[];
-  revealInitialEntries?: boolean;
+  restoredHistory?: boolean;
   isSubmitting?: boolean;
   onApprove: (toolCallId: string, approved: boolean, promptId: string) => void;
   onRespond: (toolCallId: string, resumeData: string | string[] | PlanResume, promptId: string) => void;
@@ -556,7 +549,6 @@ export function TranscriptEntries({
         : [],
     ),
   );
-
   const renderEntry = (entry: TimelineEntry): ReactNode => {
     switch (entry.kind) {
       case 'message':
@@ -581,12 +573,8 @@ export function TranscriptEntries({
   };
 
   const preparedEntries = entries.map(entry => ({ entry, content: renderEntry(entry) }));
-  const [historyRevealDelays] = useState(() =>
-    revealInitialEntries ? createHistoryRevealDelays(preparedEntries) : {},
-  );
 
-  // A turn is what you can see: the run echoes the message you sent back as a signal
-  // that draws nothing, and letting that open a turn would take the room off your bubble.
+  // Ignore echoed user signals that render nothing when opening a turn.
   const drawsContent = (entry: MessageEntry): boolean =>
     entry.message.content.parts.some(part => isRenderablePart(part, suspensions, entry.runtimeTools));
   const opensTurn = (entry: TimelineEntry): boolean =>
@@ -609,38 +597,32 @@ export function TranscriptEntries({
       opensTurn: opens,
     });
   }
+  const [restoredTurnKey] = useState(() => (restoredHistory ? turnGroups.at(-1)?.key : undefined));
 
   return (
     <>
       {turnGroups.map((group, index) => {
         const isLiveTurn = index === turnGroups.length - 1;
-        // Every turn keeps `turn-room`: the one handing the room over closes on its curve.
+        // Closing turns keep their room class so reserved space releases through its transition.
         const holdsRoom = isLiveTurn && group.opensTurn && running;
+        const openRoomClass = group.key === restoredTurnKey ? 'turn-room-restored-open' : 'turn-room-open';
+
         return (
           <div
             key={group.key}
-            className={cn('flex flex-col', group.opensTurn && 'turn-room', holdsRoom && 'turn-room-open')}
+            className={cn('flex flex-col', group.opensTurn && 'turn-room', holdsRoom && openRoomClass)}
           >
-            {group.entries.map(({ entry, content }) => {
-              const historyRevealDelay = historyRevealDelays[entry.id];
-
-              return (
-                <MessageScrollerItem
-                  key={entry.id}
-                  messageId={entry.id}
-                  scrollAnchor={opensTurn(entry)}
-                  // Estimated off-screen heights would make the prepend anchor restore
-                  // the wrong offset — measure the real thing.
-                  className={cn(
-                    '[content-visibility:visible]',
-                    historyRevealDelay !== undefined && 'transcript-history-enter',
-                  )}
-                  style={historyRevealDelay === undefined ? undefined : { animationDelay: `${historyRevealDelay}ms` }}
-                >
-                  {content}
-                </MessageScrollerItem>
-              );
-            })}
+            {group.entries.map(({ entry, content }) => (
+              <MessageScrollerItem
+                key={entry.id}
+                messageId={entry.id}
+                scrollAnchor={opensTurn(entry)}
+                // Prepend anchoring needs real item heights, not off-screen estimates.
+                className="[content-visibility:visible]"
+              >
+                {content}
+              </MessageScrollerItem>
+            ))}
             {isLiveTurn && tail}
           </div>
         );

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/SessionPrepareSteps.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/SessionPrepareSteps.msw.test.tsx
@@ -19,13 +19,16 @@ const BASE_SESSION: ChatSessionContextApi = {
   kind: 'factory',
 };
 
-function renderSteps(session: Partial<ChatSessionContextApi>, options?: { loadingMessages?: boolean }) {
+function renderSteps(
+  session: Partial<ChatSessionContextApi>,
+  options?: { finishing?: boolean; historyInitializing?: boolean; loadingMessages?: boolean },
+) {
   const steps = options?.loadingMessages ? (
     <ChatThreadMessagesContext.Provider value={{ threadId: 'thread-1', isPending: true, error: undefined }}>
-      <SessionPrepareSteps />
+      <SessionPrepareSteps finishing={options.finishing} historyInitializing={options.historyInitializing} />
     </ChatThreadMessagesContext.Provider>
   ) : (
-    <SessionPrepareSteps />
+    <SessionPrepareSteps finishing={options?.finishing} historyInitializing={options?.historyInitializing} />
   );
   return render(
     <ChatSessionContext.Provider value={{ ...BASE_SESSION, ...session }}>{steps}</ChatSessionContext.Provider>,
@@ -166,6 +169,25 @@ describe('SessionPrepareSteps', () => {
     expect(stepByTitle('Cloning repository')).toHaveAttribute('data-status', 'success');
     expect(stepByTitle('Starting session')).toHaveAttribute('data-status', 'running');
     expect(within(stepByTitle('Starting session')).getByText('Loading messages…')).toBeInTheDocument();
+  });
+
+  it('keeps Starting session active while loaded history merges into the transcript', () => {
+    renderSteps(
+      { sandboxPreparing: false, sandboxWarming: false, sandboxProgress: undefined },
+      { historyInitializing: true },
+    );
+    expect(stepByTitle('Preparing sandbox')).toHaveAttribute('data-status', 'success');
+    expect(stepByTitle('Cloning repository')).toHaveAttribute('data-status', 'success');
+    expect(stepByTitle('Starting session')).toHaveAttribute('data-status', 'running');
+    expect(within(stepByTitle('Starting session')).getByText('Starting…')).toBeInTheDocument();
+  });
+
+  it('marks every step complete while the preparation loader exits', () => {
+    renderSteps({ sandboxPreparing: false, sandboxWarming: false, sandboxProgress: undefined }, { finishing: true });
+
+    for (const step of screen.getAllByTestId('session-prepare-step')) {
+      expect(step).toHaveAttribute('data-status', 'success');
+    }
   });
 
   it('shows Loading messages… on the done phase since done carries no sandbox work', () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/TranscriptTurnGroups.msw.test.tsx
@@ -207,23 +207,6 @@ describe('TranscriptEntries turn groups', () => {
     expect(state.entries[0]).toMatchObject({ message: { id: 'signal-steer' } });
   });
 
-  it('limits the history reveal to the latest ten visible entries', () => {
-    const history = Array.from({ length: 12 }, (_, index) =>
-      textEntry(`history-${index + 1}`, index % 2 === 0 ? 'user' : 'assistant', `history message ${index + 1}`),
-    );
-    renderWithProviders(
-      <TranscriptEntries entries={history} revealInitialEntries onApprove={() => {}} onRespond={() => {}} />,
-    );
-
-    const animatedEntries = Array.from(document.querySelectorAll<HTMLElement>('.transcript-history-enter'));
-    expect(animatedEntries).toHaveLength(10);
-    expect(animatedEntries.map(entry => entry.style.animationDelay)).toEqual(
-      Array.from({ length: 10 }, (_, index) => `${index * 55}ms`),
-    );
-    expect(document.querySelector('[data-message-id="history-1"]')).not.toHaveClass('transcript-history-enter');
-    expect(document.querySelector('[data-message-id="history-2"]')).not.toHaveClass('transcript-history-enter');
-  });
-
   it('takes the gap that introduces a turn into that turn, where the room absorbs it', () => {
     renderWithProviders(
       <TranscriptEntries

--- a/mastracode/factory-ui/src/ui/domains/chat/components/chat-enter.css
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/chat-enter.css
@@ -5,6 +5,73 @@
   animation: chat-surface-in 300ms cubic-bezier(0.2, 0, 0, 1) backwards;
 }
 
+.session-preparation-overlay {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  height: 100cqh;
+  margin-block-end: -100cqh;
+  flex: none;
+  overflow: hidden;
+  background: var(--chat-surface);
+  pointer-events: none;
+}
+
+.session-preparation-overlay[data-preparing='false'] {
+  background: transparent;
+}
+
+.session-preparation-veil {
+  --session-reveal-overhang: calc(clamp(10rem, 28cqh, 20rem) + 15cqw);
+  --session-reveal-travel: calc(100cqh + var(--session-reveal-overhang));
+
+  position: absolute;
+  inset-inline: 0;
+  top: calc(-1 * var(--session-reveal-overhang));
+  height: var(--session-reveal-travel);
+  opacity: 0;
+  background: linear-gradient(
+    172deg,
+    transparent,
+    var(--chat-surface) var(--session-reveal-overhang),
+    var(--chat-surface)
+  );
+  translate: 0 var(--session-reveal-travel);
+}
+
+.session-preparation-overlay[data-preparing='false'] .session-preparation-veil {
+  animation: session-transcript-reveal 900ms linear 48ms both;
+}
+
+.session-preparation-loader {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  background: var(--chat-surface);
+  opacity: 0;
+  visibility: hidden;
+  translate: 0 -0.25rem;
+  transition:
+    opacity 140ms linear,
+    translate 180ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    visibility 0s linear 180ms;
+}
+
+.session-preparation-overlay[data-preparing='true'] .session-preparation-loader {
+  opacity: 1;
+  visibility: visible;
+  translate: 0;
+  transition-delay: 80ms, 80ms, 0s;
+}
+
+@starting-style {
+  .session-preparation-overlay[data-preparing='true'] .session-preparation-loader {
+    opacity: 0;
+    translate: 0 0.25rem;
+  }
+}
+
 @keyframes chat-surface-in {
   from {
     opacity: 0;
@@ -15,21 +82,19 @@
   }
 }
 
-@keyframes transcript-history-in {
+@keyframes session-transcript-reveal {
   from {
-    opacity: 0;
-    transform: translate3d(0, 10px, 0);
+    opacity: 1;
+    translate: 0;
+  }
+
+  99.9% {
+    opacity: 1;
   }
 
   to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .transcript-history-enter {
-    animation: transcript-history-in 480ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
+    opacity: 0;
+    translate: 0 var(--session-reveal-travel);
   }
 }
 
@@ -77,6 +142,11 @@
   transition: min-height 440ms cubic-bezier(0.2, 0, 0.2, 1);
 }
 
+.turn-room-restored-open {
+  min-height: 70cqh;
+  transition: none;
+}
+
 /* A turn mounts with its room already due, and a transition alone has nothing to move from. */
 @starting-style {
   .turn-room-open {
@@ -86,12 +156,15 @@
 
 @media (prefers-reduced-motion: reduce) {
   .chat-surface-enter,
-  .composer-enter {
+  .composer-enter,
+  .session-preparation-overlay[data-preparing='false'] .session-preparation-veil {
     animation: none;
   }
 
+  .session-preparation-loader,
   .turn-room,
-  .turn-room-open {
+  .turn-room-open,
+  .turn-room-restored-open {
     transition: none;
   }
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/components/chat-enter.css
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/chat-enter.css
@@ -5,31 +5,12 @@
   animation: chat-surface-in 300ms cubic-bezier(0.2, 0, 0, 1) backwards;
 }
 
-.session-preparation-overlay {
-  position: sticky;
-  top: 0;
-  z-index: 5;
-  height: 100cqh;
-  margin-block-end: -100cqh;
-  flex: none;
-  overflow: hidden;
-  background: var(--chat-surface);
-  pointer-events: none;
-}
-
-.session-preparation-overlay[data-preparing='false'] {
-  background: transparent;
-}
-
 .session-preparation-veil {
   --session-reveal-overhang: calc(clamp(10rem, 28cqh, 20rem) + 15cqw);
   --session-reveal-travel: calc(100cqh + var(--session-reveal-overhang));
 
-  position: absolute;
-  inset-inline: 0;
   top: calc(-1 * var(--session-reveal-overhang));
   height: var(--session-reveal-travel);
-  opacity: 0;
   background: linear-gradient(
     172deg,
     transparent,
@@ -44,14 +25,6 @@
 }
 
 .session-preparation-loader {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  display: flex;
-  background: var(--chat-surface);
-  opacity: 0;
-  visibility: hidden;
-  translate: 0 -0.25rem;
   transition:
     opacity 140ms linear,
     translate 180ms cubic-bezier(0.2, 0.7, 0.2, 1),

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -17,9 +17,9 @@ import { ChatModelsProvider } from './ChatModelsProvider';
 import { ChatModesProvider } from './ChatModesProvider';
 import { ChatSessionContext } from './ChatSessionContext';
 import { ChatThreadMessagesContext } from './ChatThreadMessagesContext';
-import { ChatTranscriptContext } from './ChatTranscriptContext';
 import type { ChatThreadMessagesApi } from './ChatThreadMessagesContext';
 import { ChatTranscriptProvider } from './ChatTranscriptProvider';
+import { useChatMessagePreparation } from './useChatMessagePreparation';
 import { SessionPrepareSteps } from '../components/SessionPrepareSteps';
 import { useChatSessionContext } from './useChatSessionContext';
 
@@ -216,42 +216,26 @@ export function ChatSessionBoundary({
 }
 
 /** Limits delayed thread-history feedback to the transcript content region. */
-export function ChatMessageBoundary({ children }: { children: ReactNode }) {
+export function ChatMessageBoundary({
+  children,
+  showPreparation = true,
+}: {
+  children: ReactNode;
+  showPreparation?: boolean;
+}) {
   const value = useContext(ChatThreadMessagesContext);
   if (!value) throw new Error('ChatMessageBoundary must be used within a ChatSessionBoundary');
-  const { sessionError, warmupError, sandboxPreparing, sandboxWarming } = useChatSessionContext();
-  // Null-tolerant: the deferred branch of `ChatSessionBoundary` renders this
-  // boundary outside the transcript provider while messages are still pending.
-  const transcriptApi = useContext(ChatTranscriptContext);
+  const { sessionError, warmupError } = useChatSessionContext();
+  const { historyInitializing, preparing } = useChatMessagePreparation();
 
-  // A denied or missing session is fatal — replace the chat instead of
-  // spinning on the preparing loader. A failed workspace warm-up is
-  // non-fatal (the run path materializes lazily), so that stays a banner.
   if (sessionError) return <ChatMessageFeedback error={sessionError} source="session" />;
   const warmupBanner = warmupError ? <ChatMessageFeedback error={warmupError} source="warmup" /> : null;
 
-  // Any pre-transcript wait — session metadata resolution OR the initial
-  // thread messages fetch — is shown as the step loader. Splitting these into
-  // two different loaders would flicker between them on cold visits; keeping
-  // them under one loader keeps the composer's spinning ring continuously
-  // meaningful through the whole preparing window.
-  const messagesInitializing = Boolean(value.threadId) && value.isPending;
-  // Messages usually resolve before the `/ensure` warm-up, so a fresh session
-  // would drop the stepper on step 1/3 — which reads like a crash. An empty,
-  // idle transcript has nothing else to show, so it keeps the stepper until
-  // the warm-up finishes. Real history or a user-initiated run takes over
-  // immediately (the composer lives outside this boundary, so the warm-up
-  // still never blocks input).
-  const emptyIdleWarming =
-    sandboxWarming === true &&
-    transcriptApi !== null &&
-    transcriptApi.transcript.entries.length === 0 &&
-    !transcriptApi.busy;
-  if (sandboxPreparing || messagesInitializing || emptyIdleWarming) {
+  if (preparing) {
     return (
       <>
         {warmupBanner}
-        <SessionPrepareSteps />
+        {showPreparation && <SessionPrepareSteps historyInitializing={historyInitializing} />}
       </>
     );
   }

--- a/mastracode/factory-ui/src/ui/domains/chat/context/useChatMessagePreparation.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/useChatMessagePreparation.ts
@@ -1,0 +1,30 @@
+import { useContext } from 'react';
+
+import { ChatThreadMessagesContext } from './ChatThreadMessagesContext';
+import { ChatTranscriptContext } from './ChatTranscriptContext';
+import { useChatSessionContext } from './useChatSessionContext';
+
+interface ChatMessagePreparation {
+  historyInitializing: boolean;
+  preparing: boolean;
+}
+
+export function useChatMessagePreparation(): ChatMessagePreparation {
+  const messages = useContext(ChatThreadMessagesContext);
+  if (!messages) throw new Error('useChatMessagePreparation must be used within a ChatSessionBoundary');
+
+  const transcript = useContext(ChatTranscriptContext);
+  const { sessionError, sandboxPreparing, sandboxWarming } = useChatSessionContext();
+  const threadFailed = Boolean(messages.threadId && messages.error);
+  const messagesInitializing = Boolean(messages.threadId) && messages.isPending;
+  const historyInitializing =
+    Boolean(messages.threadId) && !threadFailed && transcript !== null && !transcript.initialHistoryReady;
+  const emptyIdleWarming =
+    sandboxWarming === true && transcript !== null && transcript.transcript.entries.length === 0 && !transcript.busy;
+
+  // One state prevents the loader from flickering or resetting between parallel startup work.
+  return {
+    historyInitializing,
+    preparing: !sessionError && (sandboxPreparing || messagesInitializing || historyInitializing || emptyIdleWarming),
+  };
+}

--- a/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
@@ -21,11 +21,12 @@ import { GoalPanel } from '../domains/chat/components/GoalPanel';
 import { TaskPanel } from '../domains/chat/components/TaskPanel';
 import { PageTitle } from '../domains/chat/components/PageTitle';
 import { SessionFavicon } from '../domains/chat/components/SessionFavicon';
-import { SessionPrepareSteps } from '../domains/chat/components/SessionPrepareSteps';
+import { SessionPreparationOverlay } from '../domains/chat/components/SessionPreparationOverlay';
 import { Transcript } from '../domains/chat/components/Transcript';
 import { TranscriptHistoryLoader } from '../domains/chat/components/TranscriptHistoryLoader';
 import { ThreadRailLayer } from '../domains/chat/components/ThreadRailLayer';
 import { ChatMessageBoundary, ChatSessionBoundary } from '../domains/chat/context/ChatSessionProvider';
+import { useChatMessagePreparation } from '../domains/chat/context/useChatMessagePreparation';
 import { useChatTranscript } from '../domains/chat/context/useChatTranscript';
 import { useGlobalShortcuts } from '../domains/chat/hooks/useGlobalShortcuts';
 import { useHandoffPrompt } from '../domains/chat/hooks/useHandoffPrompt';
@@ -106,11 +107,12 @@ function ThreadPageMain({
       </ChatShell.Bar>
       <ChatShell.Stage>
         <ChatShell.Viewport>
+          <ThreadPreparationOverlay />
           <div ref={railBoxRef} className="relative flex min-h-full min-w-0 flex-1 flex-col">
             {railFits && <ThreadRailLayer />}
             <ChatShell.Content className="gap-0 pt-6">
               <ChatShell.Column className="flex-1">
-                <ChatMessageBoundary>
+                <ChatMessageBoundary showPreparation={false}>
                   <ThreadTranscript />
                 </ChatMessageBoundary>
               </ChatShell.Column>
@@ -162,11 +164,13 @@ function ThreadShell({
   );
 }
 
+function ThreadPreparationOverlay() {
+  const { historyInitializing, preparing } = useChatMessagePreparation();
+  return <SessionPreparationOverlay historyInitializing={historyInitializing} preparing={preparing} />;
+}
+
 function ThreadTranscript() {
-  const { transcript, initialHistoryReady } = useChatTranscript();
-
-  if (!initialHistoryReady) return <SessionPrepareSteps />;
-
+  const { transcript } = useChatTranscript();
   return (
     <>
       <TranscriptHistoryLoader />

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageLoading.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageLoading.msw.test.tsx
@@ -218,7 +218,7 @@ describe('ThreadPage loading shell', () => {
     expect(renderedEmptyState).toBe(false);
   });
 
-  it('stagger-reveals loaded transcript entries in order', async () => {
+  it('reveals the complete loaded transcript when preparation finishes', async () => {
     const { sessionGate, messagesGate } = stubThreadRoute({ messages: threadRailMessagesWithEcho });
     renderThreadRoute();
     sessionGate.resolve();
@@ -227,9 +227,9 @@ describe('ThreadPage loading shell', () => {
     messagesGate.resolve();
     await screen.findByText('Run the focused checks');
 
-    const entries = Array.from(document.querySelectorAll<HTMLElement>('.transcript-history-enter'));
-    expect(entries).toHaveLength(3);
-    expect(entries.map(entry => entry.style.animationDelay)).toEqual(['0ms', '55ms', '110ms']);
+    expect(screen.getByText('Review the implementation plan')).toBeInTheDocument();
+    expect(document.body).toHaveTextContent('The implementation is ready to review.');
+    expect(screen.queryByRole('status', { name: 'Preparing session' })).not.toBeInTheDocument();
   });
 
   it('waits for sandbox readiness before synchronizing an existing route thread', async () => {


### PR DESCRIPTION
TLDR: restored MastraCode threads now arrive as one surface, so markdown and tool rows cannot appear half-built.

---

```
before   the last transcript rows fade in separately, exposing partial markdown and tool shells
after    the session loader hands off to one viewport sweep over the complete transcript
```

The old effect animated message containers one by one. Those containers are not visual boundaries: a list marker, code block shell, or tool row could become visible before the rest of the message. The loader now stays coherent through message and history setup, then reveals the rendered transcript as one surface.

### Judgment call

Kept this in Factory UI. The transition depends on sandbox, message, and transcript preparation state; Playground UI already supplies the generic size-container shell it needs.

### Not verified

No screenshot is attached. The wave was reviewed in the running app before static layout rules moved to equivalent Tailwind utilities; I did not rerun the visual path after that cleanup.

The `mastra-studio-preview` deployment is red. The exact preview build reproduces locally: the CLI and Factory UI build, then `mastra build` fails while installing unpublished `@mastra/editor@0.14.1-alpha.0` from npm, whose latest release is `0.14.0`. This PR does not change editor or preview dependency versions.

```
source       +176  -107   ← net +69
tests         +29   -24
changeset      +5     0
```