### PR TITLE
fix(server,hono): run server.middleware in server adapters

### DIFF
--- a/.changeset/fifty-games-float.md
+++ b/.changeset/fifty-games-float.md
@@ -1,6 +1,8 @@
 ---
 '@mastra/hono': patch
 '@mastra/server': patch
+'@mastra/next': patch
+'@mastra/tanstack-start': patch
 ---
 
 Fixed `server.middleware` and middleware added via `mastra.setServerMiddleware()` being silently ignored when Mastra is served through a server adapter instead of `mastra dev` / `mastra build`.

--- a/.changeset/fifty-games-float.md
+++ b/.changeset/fifty-games-float.md
@@ -1,0 +1,12 @@
+---
+'@mastra/hono': patch
+'@mastra/server': patch
+---
+
+Fixed `server.middleware` and middleware added via `mastra.setServerMiddleware()` being silently ignored when Mastra is served through a server adapter instead of `mastra dev` / `mastra build`.
+
+Hono-based adapters (`@mastra/hono`, and `@mastra/next` / `@mastra/tanstack-start` which build on it) now register the configured middleware during `init()`, with the same guarantee as the built-in server: user middleware never runs on routes declared public with `requiresAuth: false`. Adapters for other frameworks (Express, Fastify, Koa) cannot run Hono middleware handlers and now log a warning at startup instead of silently ignoring the configuration.
+
+Also fixed custom routes with `requiresAuth: false` not being treated as framework-public when the adapter derives its route auth configuration from the Mastra instance instead of receiving it in the constructor.
+
+Fixes https://github.com/mastra-ai/mastra/issues/21869

--- a/.changeset/sweet-pigs-buy.md
+++ b/.changeset/sweet-pigs-buy.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Documented that `server.middleware` handlers use Hono's signature and which serving paths run them.

--- a/docs/src/content/en/docs/server/middleware.mdx
+++ b/docs/src/content/en/docs/server/middleware.mdx
@@ -16,6 +16,22 @@ A middleware receives the [Hono](https://hono.dev) `Context` (`c`) and a `next`
 function. If it returns a `Response` the request is short-circuited. Calling
 `next()` continues processing the next middleware or route handler.
 
+:::note
+
+Middleware handlers use Hono's signature, so they run on Hono-based serving
+paths: `mastra dev` and `mastra build`, the
+[Hono adapter](/reference/server/hono-adapter), and adapters built on it such as
+`@mastra/next` and `@mastra/tanstack-start`. Adapters for other frameworks
+(Express, Fastify, Koa) can't run Hono handlers and log a warning at startup
+when middleware is configured. Register middleware through the framework's own
+API there instead.
+
+User middleware never runs on routes declared public with
+`requiresAuth: false`, so it can't block endpoints the framework needs to keep
+reachable, such as the Studio sign-in routes.
+
+:::
+
 ```typescript
 import { Mastra } from '@mastra/core'
 

--- a/docs/src/content/en/docs/server/server-adapters.mdx
+++ b/docs/src/content/en/docs/server/server-adapters.mdx
@@ -226,10 +226,11 @@ Initialize your app as usual, then create a `MastraServer` by passing in the `ap
 
 ## Initialization flow
 
-Calling `init()` runs three steps in order. Understanding this flow helps when you need to insert your own middleware at specific points.
+Calling `init()` runs four steps in order. Understanding this flow helps when you need to insert your own middleware at specific points.
 
 1. `registerContextMiddleware()`: Attaches the Mastra instance, request context, tools, and abort signal to every request. This makes Mastra available to all subsequent middleware and route handlers.
 1. `registerAuthMiddleware()`: Runs the adapter auth hook during initialization. Official adapters enforce auth inline when Mastra registers built-in routes and `registerApiRoute()` routes, so raw framework routes should use the adapter's exported `createAuthMiddleware()` helper when they need Mastra auth.
+1. `registerUserMiddleware()`: Registers [middleware](/docs/server/middleware) from the `server.middleware` config and `mastra.setServerMiddleware()`. Middleware handlers use Hono's signature, so Hono-based adapters (`@mastra/hono` and the adapters built on it) mount them; other adapters log a warning instead of silently ignoring the config.
 1. `registerRoutes()`: Registers all Mastra API routes for agents, workflows, and other features. Also registers MCP routes if MCP servers are configured.
 
 ### Manual initialization
@@ -377,6 +378,7 @@ The adapter reads these settings from `mastra.getServer()`:
 | `auth` | Authentication config, used by `registerAuthMiddleware()`. |
 | `bodySizeLimit` | Default body size limit in bytes. Can be overridden per-adapter via `bodyLimitOptions`. |
 | `onError` | Custom error handler called when an unhandled error occurs in a route handler. See [server.onError](/reference/configuration#serveronerror). |
+| `middleware` | User [middleware](/docs/server/middleware), registered by `registerUserMiddleware()`. Hono-based adapters run it; Express, Fastify, and Koa log a warning because Hono handlers can't run there. |
 
 ### Adapter constructor only
 
@@ -401,7 +403,6 @@ These `server` config options are only used by `mastra build` and have no effect
 | `cors` | `mastra build` adds CORS middleware |
 | `timeout` | `mastra build` |
 | `apiRoutes` | `registerApiRoute()` for `mastra build` |
-| `middleware` | Middleware config for `mastra build` |
 
 When using adapters, configure these features directly with your framework. For example, add CORS middleware using Hono's or Express's built-in CORS packages, and set the port when calling your framework's listen function.
 

--- a/docs/src/content/en/docs/server/server-adapters.mdx
+++ b/docs/src/content/en/docs/server/server-adapters.mdx
@@ -248,6 +248,9 @@ server.registerContextMiddleware();
 // Middleware that needs Mastra context
 app.use(customMiddleware);
 
+// Registers `server.middleware` and `setServerMiddleware()` middleware
+server.registerUserMiddleware();
+
 await server.registerRoutes();
 
 // Routes after Mastra

--- a/docs/src/content/en/reference/server/express-adapter.mdx
+++ b/docs/src/content/en/reference/server/express-adapter.mdx
@@ -228,7 +228,7 @@ await server.init()
 
 Middleware added after `init()` never runs for Mastra's routes. Express dispatches handlers in registration order, so middleware registered after the routes only applies to routes added later.
 
-The [`server.middleware`](/docs/server/middleware) config isn't supported by this adapter: its handlers use Hono's signature, and the adapter logs a warning when it is set. To insert Express middleware between Mastra's context step and its routes, call each initialization method separately as shown in the next section.
+This adapter can't run [`server.middleware`](/docs/server/middleware) handlers because they use Hono's signature, and it logs a warning when that option is set. If you need Express middleware between Mastra's context step and its routes, use the manual initialization flow below.
 
 ## Manual initialization
 

--- a/docs/src/content/en/reference/server/express-adapter.mdx
+++ b/docs/src/content/en/reference/server/express-adapter.mdx
@@ -210,13 +210,13 @@ Available properties on `res.locals`:
 
 ## Adding middleware
 
-Add Express middleware before or after `init()`:
+Add Express middleware before `init()` to run it on every request. Mastra context isn't available at that point:
 
 ```typescript title="server.ts"
 const app = express()
 app.use(express.json())
 
-// Middleware before init
+// Runs on every request, before Mastra context exists
 app.use((req, res, next) => {
   console.log(`${req.method} ${req.url}`)
   next()
@@ -224,13 +224,11 @@ app.use((req, res, next) => {
 
 const server = new MastraServer({ app, mastra })
 await server.init()
-
-// Middleware after init has access to Mastra context
-app.use((req, res, next) => {
-  const mastra = res.locals.mastra
-  next()
-})
 ```
+
+Middleware added after `init()` never runs for Mastra's routes. Express dispatches handlers in registration order, so middleware registered after the routes only applies to routes added later.
+
+The [`server.middleware`](/docs/server/middleware) config isn't supported by this adapter: its handlers use Hono's signature, and the adapter logs a warning when it is set. To insert Express middleware between Mastra's context step and its routes, call each initialization method separately as shown in the next section.
 
 ## Manual initialization
 

--- a/docs/src/content/en/reference/server/hono-adapter.mdx
+++ b/docs/src/content/en/reference/server/hono-adapter.mdx
@@ -209,7 +209,7 @@ await server.init()
 
 Middleware added after `init()` never runs for Mastra's routes. Hono dispatches handlers in registration order, so middleware registered after the routes only applies to routes added later.
 
-To run middleware with Mastra context on Mastra's routes, use [`server.middleware`](/docs/server/middleware) in the Mastra config. The adapter registers it during `init()`, after the context step and before any route:
+To run middleware with Mastra context on Mastra's routes, use [`server.middleware`](/docs/server/middleware) in the Mastra config. The adapter registers it during `init()`, after the context step and before any route. These handlers are skipped for routes declared public with `requiresAuth: false`, so they can't block endpoints such as the Studio sign-in routes:
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'

--- a/docs/src/content/en/reference/server/hono-adapter.mdx
+++ b/docs/src/content/en/reference/server/hono-adapter.mdx
@@ -189,7 +189,7 @@ Available context keys:
 
 ## Adding middleware
 
-Add Hono middleware before or after `init()`:
+Add Hono middleware with `app.use()` before `init()` to run it on every request. Mastra context isn't available at that point:
 
 ```typescript title="server.ts"
 import { Hono } from 'hono'
@@ -197,7 +197,7 @@ import { HonoBindings, HonoVariables, MastraServer } from '@mastra/hono'
 
 const app = new Hono<{ Bindings: HonoBindings; Variables: HonoVariables }>()
 
-// Middleware before init
+// Runs on every request, before Mastra context exists
 app.use('*', async (c, next) => {
   console.log(`${c.req.method} ${c.req.url}`)
   await next()
@@ -205,11 +205,24 @@ app.use('*', async (c, next) => {
 
 const server = new MastraServer({ app, mastra })
 await server.init()
+```
 
-// Middleware after init has access to Mastra context
-app.use('*', async (c, next) => {
-  const mastra = c.get('mastra')
-  await next()
+Middleware added after `init()` never runs for Mastra's routes. Hono dispatches handlers in registration order, so middleware registered after the routes only applies to routes added later.
+
+To run middleware with Mastra context on Mastra's routes, use [`server.middleware`](/docs/server/middleware) in the Mastra config. The adapter registers it during `init()`, after the context step and before any route:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+
+export const mastra = new Mastra({
+  server: {
+    middleware: [
+      async (c, next) => {
+        c.get('requestContext').set('locale', c.req.header('accept-language') ?? 'en')
+        await next()
+      },
+    ],
+  },
 })
 ```
 

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -271,9 +271,12 @@ export type ServerConfig = {
    * Middleware for the server. Handlers use Hono's `(c, next)` signature and
    * run on Hono-based serving paths: `mastra dev` / `mastra build`,
    * `@mastra/hono`, and adapters built on it such as `@mastra/next` and
-   * `@mastra/tanstack-start`. Non-Hono adapters (Express, Fastify, Koa) cannot
-   * run Hono handlers and log a warning when this is set. Register middleware
-   * through the framework's own API there instead.
+   * `@mastra/tanstack-start`. Handlers are skipped for routes declared public
+   * with `requiresAuth: false` (see `skipIfFrameworkPublic` in `@mastra/hono`),
+   * so they cannot block endpoints such as the Studio sign-in routes.
+   * Non-Hono adapters (Express, Fastify, Koa) cannot run Hono handlers and log
+   * a warning when this is set. Register middleware through the framework's
+   * own API there instead.
    */
   middleware?: Middleware | Middleware[];
   /**

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -272,7 +272,7 @@ export type ServerConfig = {
    * run on Hono-based serving paths: `mastra dev` / `mastra build`,
    * `@mastra/hono`, and adapters built on it such as `@mastra/next` and
    * `@mastra/tanstack-start`. Non-Hono adapters (Express, Fastify, Koa) cannot
-   * run Hono handlers and log a warning when this is set — register middleware
+   * run Hono handlers and log a warning when this is set. Register middleware
    * through the framework's own API there instead.
    */
   middleware?: Middleware | Middleware[];

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -268,7 +268,12 @@ export type ServerConfig = {
    */
   apiRoutes?: ApiRoute[];
   /**
-   * Middleware for the server
+   * Middleware for the server. Handlers use Hono's `(c, next)` signature and
+   * run on Hono-based serving paths: `mastra dev` / `mastra build`,
+   * `@mastra/hono`, and adapters built on it such as `@mastra/next` and
+   * `@mastra/tanstack-start`. Non-Hono adapters (Express, Fastify, Koa) cannot
+   * run Hono handlers and log a warning when this is set — register middleware
+   * through the framework's own API there instead.
    */
   middleware?: Middleware | Middleware[];
   /**

--- a/packages/server/src/server/server-adapter/index.test.ts
+++ b/packages/server/src/server/server-adapter/index.test.ts
@@ -998,3 +998,60 @@ describe('validateCustomRoutePaths', () => {
     ).not.toThrow();
   });
 });
+
+describe('registerUserMiddleware default implementation', () => {
+  function createAdapterWithMiddleware({
+    configMiddleware,
+    instanceMiddleware,
+  }: {
+    configMiddleware?: unknown;
+    instanceMiddleware?: Array<{ path: string; handler: () => void }>;
+  }) {
+    const warn = vi.fn();
+    const adapter = new TestMastraServer({
+      app: {},
+      mastra: {
+        getServer: () => (configMiddleware === undefined ? undefined : { middleware: configMiddleware }),
+        getServerMiddleware: () => instanceMiddleware ?? [],
+        getLogger: () => ({ warn }),
+        setMastraServer: vi.fn(),
+      } as unknown as Mastra,
+    });
+    return { adapter, warn };
+  }
+
+  it('warns when `server.middleware` is configured but the adapter cannot run it', () => {
+    const { adapter, warn } = createAdapterWithMiddleware({ configMiddleware: [async () => {}] });
+
+    adapter.registerUserMiddleware();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('server.middleware');
+  });
+
+  it('warns when middleware was added via `setServerMiddleware()`', () => {
+    const { adapter, warn } = createAdapterWithMiddleware({
+      instanceMiddleware: [{ path: '/api/*', handler: () => {} }],
+    });
+
+    adapter.registerUserMiddleware();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays silent when no user middleware is configured', () => {
+    const { adapter, warn } = createAdapterWithMiddleware({});
+
+    adapter.registerUserMiddleware();
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('stays silent for an empty middleware array', () => {
+    const { adapter, warn } = createAdapterWithMiddleware({ configMiddleware: [] });
+
+    adapter.registerUserMiddleware();
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -792,8 +792,6 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
       pattern: `${prefix}${r.path}`,
     }));
 
-    const customAuthConfig = this.customRouteAuthConfig;
-
     return (path: string, method: string): boolean => {
       const upperMethod = method.toUpperCase();
 
@@ -803,7 +801,11 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
         }
       }
 
-      return isCustomRoutePublic(path, upperMethod, customAuthConfig);
+      // Read `customRouteAuthConfig` at request time, not at matcher build
+      // time: adapters constructed without an explicit map only populate it
+      // later, in registerCustomApiRoutes(), after the context middleware has
+      // already built this matcher.
+      return isCustomRoutePublic(path, upperMethod, this.customRouteAuthConfig);
     };
   }
 
@@ -818,6 +820,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
   async init() {
     this.registerContextMiddleware();
     this.registerAuthMiddleware();
+    this.registerUserMiddleware();
     this.registerHttpLoggingMiddleware();
     await this.validateEELicense();
     await this.validateAgentBuilderLicense();
@@ -937,6 +940,31 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
       routes: routeList,
       count: missingRoutes.length,
     });
+  }
+
+  /**
+   * Register user-provided middleware from the Mastra config (`server.middleware`)
+   * and from `mastra.setServerMiddleware()`. Called by init() between
+   * registerAuthMiddleware() and registerHttpLoggingMiddleware().
+   *
+   * Mastra middleware handlers use Hono's `(c, next)` signature, so only
+   * Hono-based adapters can run them. Those adapters override this method and
+   * MUST wrap each handler with `skipIfFrameworkPublic` (exported by
+   * `@mastra/hono`) so user middleware cannot block framework-public routes.
+   * The default implementation warns when middleware is configured so the
+   * config is not silently ignored on adapters that cannot honor it.
+   */
+  registerUserMiddleware(): void {
+    const instanceMiddleware = this.mastra.getServerMiddleware?.() ?? [];
+    const configMiddleware = this.mastra.getServer()?.middleware;
+    const hasConfigMiddleware = Array.isArray(configMiddleware) ? configMiddleware.length > 0 : !!configMiddleware;
+    if (instanceMiddleware.length === 0 && !hasConfigMiddleware) return;
+
+    this.mastra
+      .getLogger()
+      ?.warn(
+        'Mastra server middleware (`server.middleware` or `setServerMiddleware()`) is configured, but this server adapter cannot run Hono middleware handlers. The configured middleware will not run — register middleware through your server framework instead.',
+      );
   }
 
   /**

--- a/server-adapters/hono/src/__tests__/user-middleware.test.ts
+++ b/server-adapters/hono/src/__tests__/user-middleware.test.ts
@@ -1,0 +1,130 @@
+import { Mastra } from '@mastra/core';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { MastraServer } from '../index';
+
+/**
+ * `server.middleware` from the Mastra config and middleware added via
+ * `mastra.setServerMiddleware()` must run when the app is served through the
+ * adapter directly (`new MastraServer(...).init()`), matching the behavior of
+ * the deployer-built server.
+ */
+describe('user middleware registration', () => {
+  it('runs `server.middleware` from the Mastra config on custom API routes', async () => {
+    let middlewareRan = false;
+
+    const mastra = new Mastra({
+      logger: false,
+      server: {
+        middleware: [
+          async (c, next) => {
+            middlewareRan = true;
+            c.get('requestContext').set('currentDateTime', '2026-08-19 09:00:00 UTC');
+            await next();
+          },
+        ],
+        apiRoutes: [
+          {
+            method: 'GET',
+            path: '/probe',
+            handler: c =>
+              c.json({
+                middlewareRan,
+                currentDateTime: c.get('requestContext').get('currentDateTime') ?? null,
+              }),
+          },
+        ],
+      },
+    });
+
+    const app = new Hono();
+    await new MastraServer({ app, mastra }).init();
+
+    const response = await app.request('http://localhost/probe');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      middlewareRan: true,
+      currentDateTime: '2026-08-19 09:00:00 UTC',
+    });
+  });
+
+  it('supports the `{ path, handler }` middleware form and honors the path scope', async () => {
+    const calls: string[] = [];
+
+    const mastra = new Mastra({
+      logger: false,
+      server: {
+        middleware: [
+          {
+            path: '/scoped/*',
+            handler: async (_c, next) => {
+              calls.push('scoped');
+              await next();
+            },
+          },
+        ],
+        apiRoutes: [
+          { method: 'GET', path: '/scoped/probe', handler: c => c.json({ ok: true }) },
+          { method: 'GET', path: '/other/probe', handler: c => c.json({ ok: true }) },
+        ],
+      },
+    });
+
+    const app = new Hono();
+    await new MastraServer({ app, mastra }).init();
+
+    await app.request('http://localhost/scoped/probe');
+    expect(calls).toEqual(['scoped']);
+
+    await app.request('http://localhost/other/probe');
+    expect(calls).toEqual(['scoped']);
+  });
+
+  it('does not run user middleware on framework-public routes (`requiresAuth: false`)', async () => {
+    const hostileMiddleware = async () => new Response('unauthorized', { status: 401 });
+
+    const mastra = new Mastra({
+      logger: false,
+      server: {
+        middleware: [hostileMiddleware],
+        apiRoutes: [
+          {
+            method: 'GET',
+            path: '/public-probe',
+            requiresAuth: false,
+            handler: c => c.json({ ok: true }),
+          },
+        ],
+      },
+    });
+
+    const app = new Hono();
+    await new MastraServer({ app, mastra }).init();
+
+    const response = await app.request('http://localhost/public-probe');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it('runs middleware added via `mastra.setServerMiddleware()` on built-in routes', async () => {
+    const mastra = new Mastra({ logger: false });
+
+    // Function form defaults to the `/api/*` path.
+    let middlewareRan = false;
+    mastra.setServerMiddleware(async (_c, next) => {
+      middlewareRan = true;
+      await next();
+    });
+
+    const app = new Hono();
+    await new MastraServer({ app, mastra }).init();
+
+    const response = await app.request('http://localhost/api/agents');
+
+    expect(response.status).toBe(200);
+    expect(middlewareRan).toBe(true);
+  });
+});

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -829,6 +829,28 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
     // No global middleware needed
   }
 
+  registerUserMiddleware(): void {
+    // Middleware added at runtime via `mastra.setServerMiddleware()` — already
+    // normalized to `{ path, handler }` entries by core.
+    for (const m of this.mastra.getServerMiddleware?.() ?? []) {
+      this.app.use(m.path, skipIfFrameworkPublic(m.handler));
+    }
+
+    const configMiddleware = this.mastra.getServer()?.middleware;
+    if (!configMiddleware) {
+      return;
+    }
+
+    const normalizedMiddlewares = Array.isArray(configMiddleware) ? configMiddleware : [configMiddleware];
+    for (const middleware of normalizedMiddlewares) {
+      const { path, handler } = typeof middleware === 'function' ? { path: '*', handler: middleware } : middleware;
+      // Wrap with skipIfFrameworkPublic so user middleware cannot 401 routes
+      // the framework declared public via `requiresAuth: false`
+      // (e.g. Studio sign-in endpoints like /api/auth/capabilities).
+      this.app.use(path, skipIfFrameworkPublic(handler as unknown as MiddlewareHandler));
+    }
+  }
+
   registerHttpLoggingMiddleware(): void {
     if (!this.httpLoggingConfig?.enabled) {
       return;


### PR DESCRIPTION
## Description

`server.middleware` and middleware added via `mastra.setServerMiddleware()` were only registered by the deployer-built server (`mastra dev` / `mastra build`). Every server adapter silently ignored them: configured middleware never ran, with no warning. This PR registers user middleware in the adapter `init()` flow and warns on adapters that cannot run it.

- Added a `registerUserMiddleware()` step to the base adapter `init()` chain in `@mastra/server`, between `registerAuthMiddleware()` and `registerHttpLoggingMiddleware()`
- `@mastra/hono` overrides it to mount both middleware sources, each wrapped in `skipIfFrameworkPublic`, with the same normalization and public-route guarantee as the deployer; `@mastra/tanstack-start` and `@mastra/next` inherit the fix via `init()`
- Non-Hono adapters (Express, Fastify, Koa) keep the default implementation, which logs a startup warning instead of silently ignoring the config (Hono middleware handlers cannot run on those frameworks)
- Fixed the framework-public matcher capturing `customRouteAuthConfig` before it is populated: directly-constructed adapters derive route auth config during `registerCustomApiRoutes()`, so custom `requiresAuth: false` routes were never treated as public; the matcher now reads the map at request time
- Documented middleware behavior in the `ServerConfig.middleware` docstring, `/docs/server/middleware`, and `/docs/server/server-adapters` (moved `middleware` out of the "Not used by adapters" table)
- Deployer path is unchanged. It does not call `init()`, so there is no double registration and its ordering stays intact

**Upgrade note:** middleware that was configured but silently dead on the adapter path will start running after this patch. `skipIfFrameworkPublic` keeps framework-public routes (Studio sign-in) unreachable by it, matching the deployer's existing guarantee.

## Related Issue(s)

Fixes #21869

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Configured middleware now runs on supported server adapters instead of being silently ignored. Unsupported adapters show a startup warning.

## Changes

- Added `registerUserMiddleware()` to the server adapter initialization flow.
- Registered configured middleware in the Hono adapter.
- Skipped middleware for framework-public routes.
- Enabled TanStack Start and Next adapters to inherit the behavior.
- Added warnings for Express, Fastify, and Koa.
- Fixed request-time handling of `customRouteAuthConfig`.
- Preserved middleware ordering and deployer behavior without duplicate registration.
- Added tests for execution, path scoping, request-context changes, public routes, and warnings.
- Updated server configuration and adapter documentation.
- Added patch changesets for affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

