### PR TITLE
fix(core): own the channel render driverPromise rejection

### DIFF
--- a/.changeset/olive-donkeys-shake.md
+++ b/.changeset/olive-donkeys-shake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a channel render driver failing early crashing the process. The `.catch()` on `driverPromise` in `ChatChannelOutputProcessor` logs and re-throws, and because `.catch()` returns a new promise, the re-throw rejected the promise handed back to the caller rather than the one it guarded. Nothing observes that promise until a terminal chunk (`step-finish`, `error`, `abort`) reaches `processOutputStream` and closes the queue. Text posts are defensively wrapped, but the tool-card post in `runStaticDriver` is not — so an adapter that rejects while a tool is running, such as an expired bot token, produced an unhandled rejection and took the process down with it. The rejection is now owned at creation; the `await session.driverPromise` at cleanup still observes the failure and still logs it.

--- a/packages/core/src/channels/__tests__/output-processor.test.ts
+++ b/packages/core/src/channels/__tests__/output-processor.test.ts
@@ -2116,6 +2116,54 @@ async function driveFallback(
   }
 }
 
+describe('render driver failure', () => {
+  beforeAll(async () => {
+    await getChatModule();
+  });
+
+  // `driverPromise` is only awaited in `processOutputStream`, and only once a
+  // terminal chunk closes the queue. Text posts are defensively wrapped, but the
+  // tool-card post in the static driver is not — so an adapter that rejects
+  // (expired bot token, uninstalled app) while a tool is running rejects the
+  // driver with no terminal chunk in sight. Drive tool chunks ONLY: adding a
+  // `step-finish` would reach the cleanup `await` and the test would pass either
+  // way.
+  it('does not leave the rejection unhandled before a terminal chunk arrives', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      const { channels, chatThread } = makeChannels({ streaming: false, toolDisplay: 'cards' });
+      chatThread.post = vi.fn().mockRejectedValue(new Error('invalid_auth'));
+
+      const render = (channels as any)._buildRenderContext(chatThread, 'test');
+      const processor = new ChatChannelOutputProcessor();
+      const requestContext = new Map<string, unknown>();
+      requestContext.set(CHAT_CHANNEL_RENDER_CONTEXT_KEY, render);
+      const state: Record<string, unknown> = {};
+
+      for (const part of [
+        { type: 'tool-call', payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } } },
+      ]) {
+        await processor.processOutputStream({
+          part,
+          state,
+          requestContext: { get: (key: string) => requestContext.get(key) } as any,
+        } as any);
+      }
+
+      // Let the driver reject and the rejection reach the macrotask turn where
+      // Node decides it went unhandled.
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+});
+
 describe('ChatChannelOutputProcessor fallback render context', () => {
   beforeAll(async () => {
     await getChatModule();

--- a/packages/core/src/channels/output-processor.ts
+++ b/packages/core/src/channels/output-processor.ts
@@ -288,6 +288,13 @@ export class ChatChannelOutputProcessor {
       throw err;
     });
 
+    // `.catch()` returns a NEW promise, and the `throw` above rejects it — so the
+    // rejection the handler means to prevent simply moves to the promise handed
+    // to the caller, which nothing observes until a terminal chunk arrives. Own
+    // it here. The `await session.driverPromise` in processOutputStream still
+    // sees the failure: attaching a handler does not consume a rejection.
+    driverPromise.catch(() => {});
+
     return { queue, driverPromise };
   }
 }


### PR DESCRIPTION
## Description

`ChatChannelOutputProcessor#openSession` guards the render driver with a `.catch()` whose comment states the intent exactly:

```ts
// Prevent unhandled rejection if the driver fails before a terminal chunk
// reaches processOutputStream. The error is re-thrown when awaited at cleanup.
render.logger?.error?.(`[${render.platform}] channel render driver failed early`, { error: err });
throw err;
```

The re-throw defeats it. `.catch()` returns a **new** promise, so throwing inside the handler rejects the promise that is stored as `driverPromise` and handed to the caller. The rejection is not prevented — it moves one link down the chain, onto the promise nothing is watching until a terminal chunk (`step-finish` with `isContinued !== true`, `error`, `abort`) closes the queue. Before that, Node's default `unhandledRejection` behaviour terminates the process.

Reaching it needs an unguarded post. Both drivers wrap their **text** posts defensively — `runStreamingDriver` even falls back to a buffered post and swallows that failure too — but the tool-card post in `runStaticDriver` is not wrapped:

```ts
// packages/core/src/channels/chat-driver-static.ts:235
const sent = await chatThread.post(running);
```

So a non-streaming channel whose adapter rejects while a tool is running — expired bot token, uninstalled app, revoked scope — rejects the driver mid-run.

The fix owns the rejection at creation without consuming it. A handler stops Node treating it as unhandled; it does not swallow it, so the `await session.driverPromise` at cleanup still throws and still logs:

```ts
driverPromise.catch(() => {});
```

## Related issue(s)

Fixes #22163

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Verification

The regression test drives tool chunks only. Adding a terminal chunk would reach the cleanup `await` and the test would pass with or without the fix — an earlier draft did exactly that and was useless, which is why the test carries a comment saying so.

Before the change:

```
× does not leave the rejection unhandled before a terminal chunk arrives
AssertionError: expected [ Error: invalid_auth ] to deeply equal []
```

After:

```
Test Files  1 passed (1)
     Tests  77 passed (77)
```

`pnpm --filter @mastra/core vitest run src/channels/__tests__/output-processor.test.ts`

## Notes

A patch-level changeset is included.

We have carried this as a `pnpm` patch on `@mastra/core` since 1.57 and re-verified it unfixed on 1.61.0. It surfaced in a multi-tenant service where the channel runtime is shared across tenants, so one workspace's stale token could end the process for all of them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

If a channel fails before it finishes rendering, the failure no longer looks like an unexpected process-wide crash. The cleanup code still receives and logs the original error.

## Changes

- Prevented unhandled rejections in `ChatChannelOutputProcessor#openSession`.
- Preserved error propagation through cleanup and `driverPromise`.
- Added a regression test for rejected tool-card posts before a terminal chunk.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->