### PR TITLE
test(server): allow additive agent serialization fields

### DIFF
--- a/packages/server/src/server/handlers/agent.test.ts
+++ b/packages/server/src/server/handlers/agent.test.ts
@@ -108,7 +108,7 @@ describe('Agent Handlers', () => {
         requestContext,
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         'test-agent': {
           id: 'test-agent',
           name: 'test-agent',


### PR DESCRIPTION
The agent list handler test compared the complete serialized response with an exact object. That makes unrelated core changes fail the server affected-test job whenever they add optional agent or model fields, which is what blocked #21947.

This switches the assertion to `toMatchObject`, preserving coverage for the established response fields while allowing additive serialization fields.

Verified against both current `main` and the head of #21947. The focused agent handler suite passes in both cases, the server build passes, and ESLint is clean.

No changeset is included because this only makes an internal test assertion less brittle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The test now checks the important response fields without requiring an exact match. New optional agent or model fields can be added without breaking this test.

## Changes

- Updated `packages/server/src/server/handlers/agent.test.ts` to use partial object matching.
- Preserved coverage for established serialized response fields.
- No public API or production code changes.

## Validation

- Focused agent handler tests pass.
- Server build passes.
- ESLint passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->