### PR TITLE
feat(playground-ui): add composable tool call component

### DIFF
--- a/.changeset/thick-socks-dance.md
+++ b/.changeset/thick-socks-dance.md
@@ -1,0 +1,14 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added a composable tool-call component for building accessible, collapsible tool activity rows with custom icons, details, status content, and expanded results.
+
+```tsx
+import { ToolCall, ToolCallContent, ToolCallTrigger } from '@mastra/playground-ui/components/ai/tool-call';
+
+<ToolCall status="running">
+  <ToolCallTrigger>Running command</ToolCallTrigger>
+  <ToolCallContent>Command output</ToolCallContent>
+</ToolCall>;
+```

--- a/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolCard.tsx
@@ -1,6 +1,17 @@
 import { CodeBlock as DsCodeBlock } from '@mastra/playground-ui/components/CodeBlock';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import {
+  ToolCall as ToolCallRoot,
+  ToolCallContent,
+  ToolCallDetail,
+  ToolCallDisclosure,
+  ToolCallHeader,
+  ToolCallIcon,
+  ToolCallLabel,
+  ToolCallSpacer,
+  ToolCallTrailing,
+  ToolCallTrigger,
+} from '@mastra/playground-ui/components/ai/tool-call';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { X } from 'lucide-react';
 import type { ReactNode } from 'react';
@@ -9,7 +20,6 @@ import { useState } from 'react';
 import { highlightCode, languageForPath } from '../../../../ui/highlight';
 import { stripSerializedAnsi } from '../../services/ansi';
 import type { ToolCall } from '../../services/transcript';
-import { ROW_RAIL, ROW_TRIGGER, TranscriptRow } from '../TranscriptRow';
 import { presentTool } from './tool-presentation';
 
 function truncate(s: string, max: number): string {
@@ -194,36 +204,37 @@ function ToolBody({ tool, command }: { tool: ToolCall; command?: string }) {
 }
 
 export function ToolCard({ tool }: { tool: ToolCall }) {
-  const [expanded, setExpanded] = useState(false);
   const { icon: Icon, label, detail, command } = presentTool(tool.toolName, tool.args);
   const failed = tool.status === 'error';
   // A card already on screen when the transcript loaded was not just called.
   const [arrivedLive] = useState(() => tool.status === 'running');
 
   return (
-    <Collapsible
-      open={expanded}
-      onOpenChange={setExpanded}
-      className={cn('max-w-full min-w-0', arrivedLive && 'motion-safe:animate-in fade-in-0 slide-in-from-bottom-1')}
-      role="group"
+    <ToolCallRoot
+      status={tool.status === 'running' ? 'running' : failed ? 'error' : 'idle'}
+      className={cn(arrivedLive && 'motion-safe:animate-in fade-in-0 slide-in-from-bottom-1')}
       aria-label={`Tool: ${tool.toolName}`}
       aria-busy={tool.status === 'running'}
     >
-      <CollapsibleTrigger className={ROW_TRIGGER}>
-        <TranscriptRow
-          icon={<Icon size={14} strokeWidth={1.75} aria-hidden className={failed ? 'text-error/80' : 'text-icon2'} />}
-          label={label}
-          detail={detail}
-          running={tool.status === 'running'}
-          expanded={expanded}
-          trailing={failed && <X size={13} role="img" aria-label="Failed" className="text-error shrink-0" />}
-        />
-      </CollapsibleTrigger>
-      <CollapsibleContent className="max-w-full min-w-0">
-        <div className={cn(ROW_RAIL, 'flex flex-col gap-1.5')}>
-          <ToolBody tool={tool} command={command} />
-        </div>
-      </CollapsibleContent>
-    </Collapsible>
+      <ToolCallTrigger>
+        <ToolCallHeader>
+          <ToolCallIcon>
+            <Icon size={14} strokeWidth={1.75} aria-hidden className={failed ? 'text-error/80' : 'text-icon2'} />
+          </ToolCallIcon>
+          <ToolCallLabel>{label}</ToolCallLabel>
+          {detail && <ToolCallDetail>{detail}</ToolCallDetail>}
+          <ToolCallSpacer />
+          {failed && (
+            <ToolCallTrailing>
+              <X size={13} role="img" aria-label="Failed" className="text-error shrink-0" />
+            </ToolCallTrailing>
+          )}
+          <ToolCallDisclosure />
+        </ToolCallHeader>
+      </ToolCallTrigger>
+      <ToolCallContent>
+        <ToolBody tool={tool} command={command} />
+      </ToolCallContent>
+    </ToolCallRoot>
   );
 }

--- a/packages/playground-ui/src/components-exports.test.ts
+++ b/packages/playground-ui/src/components-exports.test.ts
@@ -90,4 +90,13 @@ describe('components/* subpath exports', () => {
     const mod = await import('./ds/components/ai/task-list');
     expect(mod.TaskList).toBeDefined();
   });
+
+  it('AI tool-call entry exports its compound components', async () => {
+    const mod = await import('./ds/components/ai/tool-call');
+    expect(mod.ToolCall).toBeDefined();
+    expect(mod.ToolCallTrigger).toBeDefined();
+    expect(mod.ToolCallHeader).toBeDefined();
+    expect(mod.ToolCallContent).toBeDefined();
+    expect(mod.ToolCallDisclosure).toBeDefined();
+  });
 });

--- a/packages/playground-ui/src/ds/components/ai/tool-call/index.ts
+++ b/packages/playground-ui/src/ds/components/ai/tool-call/index.ts
@@ -1,0 +1,1 @@
+export * from './tool-call';

--- a/packages/playground-ui/src/ds/components/ai/tool-call/tool-call.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ai/tool-call/tool-call.stories.tsx
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Check, FileText, Terminal, X } from 'lucide-react';
+import { useState } from 'react';
+import {
+  ToolCall,
+  ToolCallContent,
+  ToolCallDetail,
+  ToolCallDisclosure,
+  ToolCallHeader,
+  ToolCallIcon,
+  ToolCallLabel,
+  ToolCallSpacer,
+  ToolCallTrailing,
+  ToolCallTrigger,
+} from './tool-call';
+
+const meta: Meta<typeof ToolCall> = {
+  title: 'AI/Tool Call',
+  component: ToolCall,
+  decorators: [
+    Story => (
+      <div className="w-full max-w-3xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof ToolCall>;
+
+const Code = ({ children }: { children: string }) => (
+  <pre className="text-icon4 bg-surface1 m-0 max-h-60 overflow-auto rounded-md px-3 py-2 font-mono text-xs leading-normal whitespace-pre-wrap">
+    {children}
+  </pre>
+);
+
+export const Completed: Story = {
+  render: () => (
+    <ToolCall defaultOpen aria-label="Tool: read file">
+      <ToolCallTrigger>
+        <ToolCallHeader>
+          <ToolCallIcon>
+            <FileText size={14} strokeWidth={1.75} aria-hidden />
+          </ToolCallIcon>
+          <ToolCallLabel>Read file</ToolCallLabel>
+          <ToolCallDetail>src/agent.ts</ToolCallDetail>
+          <ToolCallSpacer />
+          <ToolCallTrailing>
+            <Check size={13} aria-label="Completed" className="text-positive1" />
+          </ToolCallTrailing>
+          <ToolCallDisclosure />
+        </ToolCallHeader>
+      </ToolCallTrigger>
+      <ToolCallContent>
+        <Code>{`export const agent = new Agent({\n  name: 'Support agent',\n});`}</Code>
+      </ToolCallContent>
+    </ToolCall>
+  ),
+};
+
+export const Running: Story = {
+  render: () => (
+    <ToolCall status="running" aria-label="Tool: execute command">
+      <ToolCallTrigger>
+        <ToolCallHeader>
+          <ToolCallIcon>
+            <Terminal size={14} strokeWidth={1.75} aria-hidden />
+          </ToolCallIcon>
+          <ToolCallLabel>Running command</ToolCallLabel>
+          <ToolCallDetail>pnpm test</ToolCallDetail>
+          <ToolCallSpacer />
+          <ToolCallDisclosure />
+        </ToolCallHeader>
+      </ToolCallTrigger>
+      <ToolCallContent>
+        <Code>pnpm test</Code>
+      </ToolCallContent>
+    </ToolCall>
+  ),
+};
+
+export const Failed: Story = {
+  render: () => (
+    <ToolCall status="error" defaultOpen aria-label="Tool: write file">
+      <ToolCallTrigger>
+        <ToolCallHeader>
+          <ToolCallIcon className="text-error/80">
+            <FileText size={14} strokeWidth={1.75} aria-hidden />
+          </ToolCallIcon>
+          <ToolCallLabel>Write file</ToolCallLabel>
+          <ToolCallDetail>src/config.ts</ToolCallDetail>
+          <ToolCallSpacer />
+          <ToolCallTrailing>
+            <X size={13} role="img" aria-label="Failed" className="text-error" />
+          </ToolCallTrailing>
+          <ToolCallDisclosure />
+        </ToolCallHeader>
+      </ToolCallTrigger>
+      <ToolCallContent>
+        <Code>Permission denied: src/config.ts</Code>
+      </ToolCallContent>
+    </ToolCall>
+  ),
+};
+
+function ControlledExample() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <ToolCall open={open} onOpenChange={setOpen} aria-label="Tool: custom result">
+      <ToolCallTrigger>
+        <ToolCallHeader>
+          <ToolCallIcon>◆</ToolCallIcon>
+          <ToolCallLabel>Custom result</ToolCallLabel>
+          <ToolCallDetail>{open ? 'Expanded' : 'Collapsed'}</ToolCallDetail>
+          <ToolCallSpacer rule />
+          <ToolCallDisclosure />
+        </ToolCallHeader>
+      </ToolCallTrigger>
+      <ToolCallContent>
+        <div className="border-border1 bg-surface1 rounded-md border p-3 text-sm">
+          Arbitrary consumer-rendered content
+        </div>
+      </ToolCallContent>
+    </ToolCall>
+  );
+}
+
+export const Controlled: Story = {
+  render: () => <ControlledExample />,
+};

--- a/packages/playground-ui/src/ds/components/ai/tool-call/tool-call.test.tsx
+++ b/packages/playground-ui/src/ds/components/ai/tool-call/tool-call.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ToolCall,
+  ToolCallContent,
+  ToolCallDetail,
+  ToolCallDisclosure,
+  ToolCallHeader,
+  ToolCallIcon,
+  ToolCallLabel,
+  ToolCallSpacer,
+  ToolCallSummary,
+  ToolCallTrailing,
+  ToolCallTrigger,
+} from './tool-call';
+
+const Example = ({
+  open,
+  defaultOpen,
+  onOpenChange,
+  status = 'idle',
+}: {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  status?: 'idle' | 'running' | 'error';
+}) => (
+  <ToolCall
+    aria-label="Tool: execute_command"
+    className="root-class"
+    open={open}
+    defaultOpen={defaultOpen}
+    onOpenChange={onOpenChange}
+    status={status}
+  >
+    <ToolCallTrigger className="trigger-class" data-testid="trigger">
+      <ToolCallHeader data-testid="header">
+        <ToolCallIcon data-testid="icon">$</ToolCallIcon>
+        <ToolCallLabel>Ran command</ToolCallLabel>
+        <ToolCallDetail>pnpm test</ToolCallDetail>
+        <ToolCallSummary>2 files</ToolCallSummary>
+        <ToolCallSpacer />
+        <ToolCallTrailing>Done</ToolCallTrailing>
+        <ToolCallDisclosure data-testid="disclosure" />
+      </ToolCallHeader>
+    </ToolCallTrigger>
+    <ToolCallContent className="body-class" data-testid="content">
+      Command output
+    </ToolCallContent>
+  </ToolCall>
+);
+
+afterEach(cleanup);
+
+describe('ToolCall', () => {
+  it('renders composed custom content and forwards semantic props', () => {
+    render(<Example defaultOpen />);
+
+    const root = screen.getByRole('group', { name: 'Tool: execute_command' });
+    expect(root.className).toContain('max-w-full');
+    expect(root.className).toContain('root-class');
+    expect(root.getAttribute('aria-busy')).toBe('false');
+    expect(root.getAttribute('aria-invalid')).toBeNull();
+    expect(root.getAttribute('aria-describedby')).toBeNull();
+    expect(root.getAttribute('data-status')).toBe('idle');
+    expect(screen.queryByText(/Tool call (running|failed)/)).toBeNull();
+
+    const trigger = screen.getByTestId('trigger');
+    expect(trigger.className).toContain('group/row');
+    expect(trigger.className).toContain('trigger-class');
+    expect(screen.getByTestId('header').className).toContain('items-center');
+    expect(screen.getByTestId('icon').className).toContain('size-4');
+    expect(screen.getByTestId('icon').textContent).toBe('$');
+    expect(screen.getByText('Ran command').className).toContain('truncate');
+    expect(screen.getByText('pnpm test').className).toContain('text-icon3 min-w-0 truncate');
+    expect(screen.getByText('pnpm test').className).toContain('font-mono');
+    expect(screen.getByText('2 files').className).toContain('items-center');
+    expect(screen.getByText('Done').className).toContain('shrink-0');
+    expect(screen.getByTestId('disclosure').firstElementChild?.className).toContain(
+      'group-focus-visible/row:opacity-100',
+    );
+
+    const content = document.querySelector<HTMLDivElement>('.body-class');
+    expect(content?.className).toContain('before:bg-border1');
+    expect(content?.textContent).toBe('Command output');
+  });
+
+  it('is collapsed by default and exposes disclosure state', () => {
+    render(<Example />);
+
+    const trigger = screen.getByRole('button');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Command output')).toBeNull();
+    expect(screen.getByTestId('disclosure').firstElementChild?.className).not.toContain('rotate-90');
+  });
+
+  it('manages uncontrolled expansion', () => {
+    render(<Example />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('Command output')).toBeTruthy();
+    expect(screen.getByTestId('disclosure').firstElementChild?.className).toContain('rotate-90');
+  });
+
+  it('uses a focusable native button for keyboard disclosure', () => {
+    render(<Example />);
+
+    const trigger = screen.getByRole('button');
+    trigger.focus();
+
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger.className).toContain('focus-visible');
+  });
+
+  it('reports controlled expansion without changing its own state', () => {
+    const onOpenChange = vi.fn();
+    const { rerender } = render(<Example open={false} onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe('false');
+
+    rerender(<Example open onOpenChange={onOpenChange} />);
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('Command output')).toBeTruthy();
+
+    rerender(<Example />);
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Command output')).toBeNull();
+  });
+
+  it('exposes running state accessibly and renders a shimmering header', () => {
+    render(<Example status="running" />);
+
+    const root = screen.getByRole('group', { name: 'Tool: execute_command' });
+    expect(root.getAttribute('aria-busy')).toBe('true');
+    expect(root.getAttribute('data-status')).toBe('running');
+    expect(root.getAttribute('aria-describedby')).toBeTruthy();
+    expect(screen.getByText('Tool call running').className).toContain('sr-only');
+    expect(screen.getByText('Ran command').parentElement?.className).toContain('shimmer-text');
+  });
+
+  it('exposes failure state accessibly', () => {
+    render(<Example status="error" />);
+
+    const root = screen.getByRole('group', { name: 'Tool: execute_command' });
+    expect(root.getAttribute('aria-invalid')).toBe('true');
+    expect(root.getAttribute('data-status')).toBe('error');
+    expect(screen.getByText('Tool call failed').className).toContain('sr-only');
+  });
+
+  it('renders optional spacer rules and custom disclosure content', () => {
+    render(
+      <ToolCall aria-label="Tool: custom">
+        <ToolCallTrigger>
+          <ToolCallSpacer rule data-testid="spacer" />
+          <ToolCallDisclosure data-testid="custom-disclosure">Toggle</ToolCallDisclosure>
+        </ToolCallTrigger>
+      </ToolCall>,
+    );
+
+    expect(screen.getByRole('group', { name: 'Tool: custom' }).getAttribute('data-status')).toBe('idle');
+    expect(screen.getByTestId('spacer').className).toContain('min-w-2 flex-1');
+    expect(screen.getByTestId('spacer').className).toContain('bg-border1');
+    expect(screen.getByTestId('custom-disclosure').className).toContain('justify-center');
+    expect(screen.getByText('Toggle').className).toContain(
+      'text-icon3 flex shrink-0 items-center opacity-0 transition duration-150',
+    );
+    expect(screen.getByText('Toggle').textContent).toBe('Toggle');
+  });
+
+  it('rejects compounds rendered outside the root', () => {
+    expect(() => render(<ToolCallDisclosure />)).toThrow('ToolCall compounds must be rendered within ToolCall');
+  });
+});

--- a/packages/playground-ui/src/ds/components/ai/tool-call/tool-call.tsx
+++ b/packages/playground-ui/src/ds/components/ai/tool-call/tool-call.tsx
@@ -1,0 +1,164 @@
+import { ChevronRight } from 'lucide-react';
+import { createContext, useContext, useId, useState } from 'react';
+import type { ComponentProps } from 'react';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/ds/components/Collapsible';
+import { Shimmer } from '@/ds/components/Shimmer';
+import { Txt } from '@/ds/components/Txt';
+import { cn } from '@/lib/utils';
+
+type ToolCallStatus = 'idle' | 'running' | 'error';
+
+interface ToolCallContextValue {
+  open: boolean;
+  status: ToolCallStatus;
+}
+
+const ToolCallContext = createContext<ToolCallContextValue | undefined>(undefined);
+
+// Stryker disable next-line ArrowFunction: the default callback is intentionally behaviorless.
+const noopOpenChange = () => {};
+
+function useToolCall() {
+  const context = useContext(ToolCallContext);
+  if (!context) throw new Error('ToolCall compounds must be rendered within ToolCall');
+  return context;
+}
+
+export interface ToolCallProps extends Omit<
+  ComponentProps<typeof Collapsible>,
+  'defaultOpen' | 'onOpenChange' | 'open'
+> {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  status?: ToolCallStatus;
+}
+
+export function ToolCall({
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange = noopOpenChange,
+  status = 'idle',
+  className,
+  children,
+  ...props
+}: ToolCallProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const open = controlledOpen ?? uncontrolledOpen;
+  const statusId = useId();
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (controlledOpen === undefined) setUncontrolledOpen(nextOpen);
+    onOpenChange(nextOpen);
+  };
+
+  return (
+    <ToolCallContext.Provider value={{ open, status }}>
+      <Collapsible
+        open={open}
+        onOpenChange={handleOpenChange}
+        className={cn('max-w-full min-w-0', className)}
+        role="group"
+        aria-busy={status === 'running'}
+        aria-invalid={status === 'error' || undefined}
+        aria-describedby={status === 'idle' ? undefined : statusId}
+        data-status={status}
+        {...props}
+      >
+        {children}
+        {status !== 'idle' && (
+          <span id={statusId} className="sr-only">
+            {status === 'running' ? 'Tool call running' : 'Tool call failed'}
+          </span>
+        )}
+      </Collapsible>
+    </ToolCallContext.Provider>
+  );
+}
+
+export const ToolCallTrigger = ({ className, ...props }: ComponentProps<typeof CollapsibleTrigger>) => (
+  <CollapsibleTrigger
+    className={cn(
+      'group/row w-full cursor-pointer rounded-md text-left transition-colors hover:bg-neutral6/5 focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:outline-hidden motion-reduce:transition-none',
+      className,
+    )}
+    {...props}
+  />
+);
+
+export const ToolCallHeader = ({ className, children, ...props }: ComponentProps<'span'>) => {
+  const { status } = useToolCall();
+  const Header = status === 'running' ? Shimmer : 'span';
+
+  return (
+    <Header className={cn('flex w-full min-w-0 items-center gap-2 px-1.5 py-1', className)} {...props}>
+      {children}
+    </Header>
+  );
+};
+
+export const ToolCallIcon = ({ className, ...props }: ComponentProps<'span'>) => (
+  <span className={cn('flex size-4 shrink-0 items-center justify-center', className)} {...props} />
+);
+
+export const ToolCallLabel = ({ className, ...props }: ComponentProps<typeof Txt>) => (
+  <Txt as="span" variant="ui-sm" className={cn('text-icon3 max-w-[55%] shrink-0 truncate', className)} {...props} />
+);
+
+export const ToolCallDetail = ({ className, ...props }: ComponentProps<typeof Txt>) => (
+  <Txt as="span" variant="ui-xs" font="mono" className={cn('text-icon3 min-w-0 truncate', className)} {...props} />
+);
+
+export const ToolCallSummary = ({ className, ...props }: ComponentProps<'span'>) => (
+  <span className={cn('flex min-w-0 items-center gap-1', className)} {...props} />
+);
+
+export interface ToolCallSpacerProps extends ComponentProps<'span'> {
+  rule?: boolean;
+}
+
+export const ToolCallSpacer = ({ rule, className, ...props }: ToolCallSpacerProps) => (
+  <span
+    aria-hidden
+    className={cn('min-w-2 flex-1', rule && 'h-px bg-border1 mask-r-from-[calc(100%-min(100%,160px))]', className)}
+    {...props}
+  />
+);
+
+export const ToolCallTrailing = ({ className, ...props }: ComponentProps<'span'>) => (
+  <span className={cn('flex shrink-0 items-center', className)} {...props} />
+);
+
+export const ToolCallDisclosure = ({ className, children, ...props }: ComponentProps<'span'>) => {
+  const { open } = useToolCall();
+
+  return (
+    <span className={cn('flex size-4 shrink-0 items-center justify-center', className)} {...props}>
+      <span
+        aria-hidden
+        className={cn(
+          'text-icon3 flex shrink-0 items-center opacity-0 transition duration-150 motion-reduce:transition-none',
+          'group-hover/row:opacity-100 group-focus-visible/row:opacity-100',
+          open && 'rotate-90 opacity-100',
+        )}
+      >
+        {children ?? <ChevronRight size={13} />}
+      </span>
+    </span>
+  );
+};
+
+export const ToolCallContent = ({ className, children, ...props }: ComponentProps<typeof CollapsibleContent>) => (
+  <CollapsibleContent className="max-w-full min-w-0" {...props}>
+    <div
+      className={cn(
+        "relative ml-[14px] flex max-w-full min-w-0 flex-col gap-1.5 py-1.5 pr-1 pl-4 before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-border1 before:mask-b-from-[calc(100%-min(40%,80px))] before:content-['']",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  </CollapsibleContent>
+);
+
+export type { ToolCallStatus };


### PR DESCRIPTION
Adds a public `@mastra/playground-ui/components/ai/tool-call` compound component for accessible, collapsible tool activity rows. Consumers can supply their own icons, labels, details, status content, trailing actions, and expanded results while the component owns disclosure state and row/rail presentation.

Factory chat now uses the shared component for its existing tool call rendering, keeping its command output, diffs, status mapping, and live-arrival behavior local. Storybook includes completed, running, failed, and controlled examples.

Test plan:
- `pnpm --filter ./packages/playground-ui test -- src/ds/components/ai/tool-call/tool-call.test.tsx src/components-exports.test.ts`
- `pnpm --filter ./packages/playground-ui typecheck`
- `pnpm --filter @mastra/factory build:lib`
- `pnpm --filter @internal/factory-ui typecheck`
- `pnpm --filter @internal/factory-ui exec vitest run --project msw:factory-ui src/ui/domains/chat/components/__tests__/TranscriptToolRows.msw.test.tsx`
- Storybook build and responsive/keyboard accessibility review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a reusable, accessible tool activity row. It lets users expand tool details and results while allowing apps to customize the row’s content. Factory chat now uses this shared component.

## Changes

- Added the public `@mastra/playground-ui/components/ai/tool-call` compound component.
- Added controlled and uncontrolled disclosure state.
- Added idle, running, and error statuses with accessible announcements.
- Added composable subcomponents for icons, labels, details, summaries, trailing actions, disclosure controls, and content.
- Updated Factory chat to use `ToolCall` while preserving command output, diffs, status mapping, and live-arrival behavior.
- Added Storybook stories for completed, running, failed, and controlled states.
- Added component export and behavior tests.
- Added a minor changeset for `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->