### PR TITLE
feat(factory-ui): center the device-code sign-in dialog

### DIFF
--- a/.changeset/device-code-sign-in-dialog.md
+++ b/.changeset/device-code-sign-in-dialog.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved the provider device-code sign-in dialog. The code is now the main element with an inline copy button, and copy failures show an error instead of failing silently.

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ProviderOAuthDialog.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ProviderOAuthDialog.tsx
@@ -158,9 +158,7 @@ function DeviceCodeDialog({ provider, session, onClose, onComplete }: ProviderOA
         <DialogBody className="flex flex-col items-center gap-4 text-center">
           {session.userCode && (
             <div className="flex items-center justify-center gap-2">
-              <span className="font-mono text-header-lg tracking-widest break-all select-all">
-                {session.userCode}
-              </span>
+              <span className="text-header-lg font-mono tracking-widest break-all select-all">{session.userCode}</span>
               <CopyButton content={session.userCode} variant="ghost" size="icon-sm" tooltip="Copy code" />
             </div>
           )}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ProviderOAuthDialog.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ProviderOAuthDialog.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import {
   Dialog,
@@ -11,7 +10,7 @@ import {
 } from '@mastra/playground-ui/components/Dialog';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { Copy, ExternalLink, Loader2 } from 'lucide-react';
+import { Check, Copy, ExternalLink, Loader2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import type { OAuthStartResponse } from '../../../../api/types';
@@ -112,6 +111,7 @@ function DeviceCodeDialog({ provider, session, onClose, onComplete }: ProviderOA
   const onCompleteRef = useRef(onComplete);
   const [nextPollAt, setNextPollAt] = useState(() => Date.now() + (session.nextPollMs ?? 1000));
   const [flowError, setFlowError] = useState<string>();
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
@@ -145,7 +145,10 @@ function DeviceCodeDialog({ provider, session, onClose, onComplete }: ProviderOA
   }, [nextPollAt, poll, provider, session.sessionId]);
 
   const copyCode = async () => {
-    if (session.userCode) await navigator.clipboard.writeText(session.userCode);
+    if (!session.userCode) return;
+    await navigator.clipboard.writeText(session.userCode);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
   };
 
   const close = () => {
@@ -155,29 +158,33 @@ function DeviceCodeDialog({ provider, session, onClose, onComplete }: ProviderOA
   return (
     <Dialog open onOpenChange={open => !open && close()}>
       <DialogContent>
-        <DialogHeader>
+        <DialogHeader className="items-center text-center">
           <DialogTitle>Sign in to {displayName}</DialogTitle>
           <DialogDescription>Enter the device code on the provider authorization page.</DialogDescription>
         </DialogHeader>
-        <DialogBody className="flex flex-col gap-4">
-          <Txt as="p" variant="ui-sm" className="text-icon4">
-            {session.instructions}
-          </Txt>
+        <DialogBody className="flex flex-col items-center gap-4 text-center">
           {session.userCode && (
-            <div className="flex items-center justify-between gap-3">
-              <Badge size="md" variant="info">
+            <div className="flex items-center justify-center gap-2">
+              <span className="font-mono text-header-lg tracking-widest break-all select-all">
                 {session.userCode}
-              </Badge>
-              <Button size="sm" onClick={() => void copyCode()}>
-                <Copy />
-                Copy code
+              </span>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Copy code"
+                tooltip="Copy code"
+                onClick={() => void copyCode()}
+              >
+                {copied ? <Check /> : <Copy />}
               </Button>
             </div>
           )}
-          <Button variant="outline" onClick={() => openAuthorizationUrl(session.url)}>
+          <Button variant="outline" className="w-full" onClick={() => openAuthorizationUrl(session.url)}>
             <ExternalLink />
             Open authorization page
           </Button>
+        </DialogBody>
+        <DialogFooter className="sm:justify-between">
           {flowError ? (
             <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg">
               {flowError}
@@ -190,8 +197,6 @@ function DeviceCodeDialog({ provider, session, onClose, onComplete }: ProviderOA
               </Txt>
             </div>
           )}
-        </DialogBody>
-        <DialogFooter>
           <Button disabled={pollMutation.isPending} onClick={close}>
             Cancel
           </Button>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ProviderOAuthDialog.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ProviderOAuthDialog.tsx
@@ -157,8 +157,10 @@ function DeviceCodeDialog({ provider, session, onClose, onComplete }: ProviderOA
         </DialogHeader>
         <DialogBody className="flex flex-col items-center gap-4 text-center">
           {session.userCode && (
-            <div className="flex items-center justify-center gap-2">
-              <span className="text-header-lg font-mono tracking-widest break-all select-all">{session.userCode}</span>
+            <div className="flex w-full min-w-0 items-center justify-center gap-2">
+              <span className="text-header-lg min-w-0 flex-1 font-mono tracking-widest break-all select-all">
+                {session.userCode}
+              </span>
               <CopyButton content={session.userCode} variant="ghost" size="icon-sm" tooltip="Copy code" />
             </div>
           )}
@@ -169,7 +171,7 @@ function DeviceCodeDialog({ provider, session, onClose, onComplete }: ProviderOA
         </DialogBody>
         <DialogFooter className="sm:justify-between">
           {flowError ? (
-            <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg">
+            <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg min-w-0 break-words">
               {flowError}
             </Txt>
           ) : (

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ProviderOAuthDialog.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ProviderOAuthDialog.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@mastra/playground-ui/components/Button';
+import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
 import {
   Dialog,
   DialogBody,
@@ -10,7 +11,7 @@ import {
 } from '@mastra/playground-ui/components/Dialog';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { Check, Copy, ExternalLink, Loader2 } from 'lucide-react';
+import { ExternalLink, Loader2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import type { OAuthStartResponse } from '../../../../api/types';
@@ -111,7 +112,6 @@ function DeviceCodeDialog({ provider, session, onClose, onComplete }: ProviderOA
   const onCompleteRef = useRef(onComplete);
   const [nextPollAt, setNextPollAt] = useState(() => Date.now() + (session.nextPollMs ?? 1000));
   const [flowError, setFlowError] = useState<string>();
-  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
@@ -144,13 +144,6 @@ function DeviceCodeDialog({ provider, session, onClose, onComplete }: ProviderOA
     return () => window.clearTimeout(timer);
   }, [nextPollAt, poll, provider, session.sessionId]);
 
-  const copyCode = async () => {
-    if (!session.userCode) return;
-    await navigator.clipboard.writeText(session.userCode);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 2000);
-  };
-
   const close = () => {
     if (!pollMutation.isPending) onClose();
   };
@@ -168,15 +161,7 @@ function DeviceCodeDialog({ provider, session, onClose, onComplete }: ProviderOA
               <span className="font-mono text-header-lg tracking-widest break-all select-all">
                 {session.userCode}
               </span>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label="Copy code"
-                tooltip="Copy code"
-                onClick={() => void copyCode()}
-              >
-                {copied ? <Check /> : <Copy />}
-              </Button>
+              <CopyButton content={session.userCode} variant="ghost" size="icon-sm" tooltip="Copy code" />
             </div>
           )}
           <Button variant="outline" className="w-full" onClick={() => openAuthorizationUrl(session.url)}>

--- a/mastracode/tui/e2e/tui/api-key-multi-provider-delete.ts
+++ b/mastracode/tui/e2e/tui/api-key-multi-provider-delete.ts
@@ -58,34 +58,18 @@ export const apiKeyMultiProviderDeleteScenario = {
     terminal.submit('/api-keys');
     await runtime.waitForScreenText(/API Keys/i, terminal, 8_000);
     await runtime.waitForScreenText(/302ai\s+✓ \(stored\)/i, terminal, 8_000);
+    await runtime.waitForScreenText(/anthropic\s+✓ \(stored\)/i, terminal, 8_000);
 
-    const providerCountMatch = terminal.serialize().view.match(/\(\d+\/(\d+)\)/);
-    if (!providerCountMatch) throw new Error('Expected /api-keys to show the provider count');
-
-    const secondProviderStatus = /anthropic\s+✓ \(stored\)/i;
-    const providerCount = Number(providerCountMatch[1]);
-    let navigationSteps = 0;
-    while (navigationSteps < providerCount && !secondProviderStatus.test(terminal.serialize().view)) {
-      terminal.write('\x1b[B');
-      await terminal.flushInput?.();
-      navigationSteps += 1;
+    const initialView = terminal.serialize().view;
+    const firstIndex = initialView.indexOf('302ai');
+    const secondIndex = initialView.indexOf('anthropic');
+    if (firstIndex < 0 || secondIndex < 0 || firstIndex >= secondIndex) {
+      throw new Error(`Expected /api-keys provider list to show 302ai before anthropic. Screen:\n${initialView}`);
     }
-    await runtime.waitForScreenText(secondProviderStatus, terminal, 8_000);
-
-    for (let index = 0; index < navigationSteps; index += 1) {
-      terminal.write('\x1b[A');
-      await terminal.flushInput?.();
-    }
-    await runtime.waitForScreenText(/302ai\s+✓ \(stored\)/i, terminal, 8_000);
 
     terminal.write('\x7f');
     await runtime.waitForScreenText(/302ai\s+✗ \(not set\)/i, terminal, 8_000);
-
-    for (let index = 0; index < navigationSteps; index += 1) {
-      terminal.write('\x1b[B');
-      await terminal.flushInput?.();
-    }
-    await runtime.waitForScreenText(secondProviderStatus, terminal, 8_000);
+    await runtime.waitForScreenText(/anthropic\s+✓ \(stored\)/i, terminal, 8_000);
 
     terminal.write('\x1b');
     await runtime.waitForScreenTextAbsent(/API Keys/i, terminal, 8_000);

--- a/mastracode/tui/e2e/tui/api-key-multi-provider-delete.ts
+++ b/mastracode/tui/e2e/tui/api-key-multi-provider-delete.ts
@@ -12,8 +12,8 @@ const secondStoredKey = 'mc-e2e-anthropic-preserved-key';
 
 export const apiKeyMultiProviderDeleteScenario = {
   name: 'api-key-multi-provider-delete',
-  description: 'Deletes only the selected stored provider key from a long provider list.',
-  testName: 'deletes one stored key without affecting another provider',
+  description: 'Keeps API key provider ordering stable and deletes only the selected stored provider key.',
+  testName: 'sorts providers and deletes one stored key without affecting another provider',
   prepare({ appDataDir }) {
     const settingsPath = join(appDataDir, 'settings.json');
     const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as any;
@@ -59,15 +59,29 @@ export const apiKeyMultiProviderDeleteScenario = {
     await runtime.waitForScreenText(/API Keys/i, terminal, 8_000);
     await runtime.waitForScreenText(/302ai\s+✓ \(stored\)/i, terminal, 8_000);
 
-    terminal.write('\x7f');
-    await runtime.waitForScreenText(/302ai\s+✗ \(not set\)/i, terminal, 8_000);
-
     const providerCountMatch = terminal.serialize().view.match(/\(\d+\/(\d+)\)/);
     if (!providerCountMatch) throw new Error('Expected /api-keys to show the provider count');
 
     const secondProviderStatus = /anthropic\s+✓ \(stored\)/i;
     const providerCount = Number(providerCountMatch[1]);
-    for (let index = 0; index < providerCount && !secondProviderStatus.test(terminal.serialize().view); index += 1) {
+    let navigationSteps = 0;
+    while (navigationSteps < providerCount && !secondProviderStatus.test(terminal.serialize().view)) {
+      terminal.write('\x1b[B');
+      await terminal.flushInput?.();
+      navigationSteps += 1;
+    }
+    await runtime.waitForScreenText(secondProviderStatus, terminal, 8_000);
+
+    for (let index = 0; index < navigationSteps; index += 1) {
+      terminal.write('\x1b[A');
+      await terminal.flushInput?.();
+    }
+    await runtime.waitForScreenText(/302ai\s+✓ \(stored\)/i, terminal, 8_000);
+
+    terminal.write('\x7f');
+    await runtime.waitForScreenText(/302ai\s+✗ \(not set\)/i, terminal, 8_000);
+
+    for (let index = 0; index < navigationSteps; index += 1) {
       terminal.write('\x1b[B');
       await terminal.flushInput?.();
     }

--- a/mastracode/tui/e2e/tui/api-key-multi-provider-delete.ts
+++ b/mastracode/tui/e2e/tui/api-key-multi-provider-delete.ts
@@ -12,8 +12,8 @@ const secondStoredKey = 'mc-e2e-anthropic-preserved-key';
 
 export const apiKeyMultiProviderDeleteScenario = {
   name: 'api-key-multi-provider-delete',
-  description: 'Keeps API key provider ordering stable and deletes only the selected stored provider key.',
-  testName: 'sorts providers and deletes one stored key without affecting another provider',
+  description: 'Deletes only the selected stored provider key from a long provider list.',
+  testName: 'deletes one stored key without affecting another provider',
   prepare({ appDataDir }) {
     const settingsPath = join(appDataDir, 'settings.json');
     const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as any;
@@ -58,18 +58,20 @@ export const apiKeyMultiProviderDeleteScenario = {
     terminal.submit('/api-keys');
     await runtime.waitForScreenText(/API Keys/i, terminal, 8_000);
     await runtime.waitForScreenText(/302ai\s+✓ \(stored\)/i, terminal, 8_000);
-    await runtime.waitForScreenText(/anthropic\s+✓ \(stored\)/i, terminal, 8_000);
-
-    const initialView = terminal.serialize().view;
-    const firstIndex = initialView.indexOf('302ai');
-    const secondIndex = initialView.indexOf('anthropic');
-    if (firstIndex < 0 || secondIndex < 0 || firstIndex >= secondIndex) {
-      throw new Error(`Expected /api-keys provider list to show 302ai before anthropic. Screen:\n${initialView}`);
-    }
 
     terminal.write('\x7f');
     await runtime.waitForScreenText(/302ai\s+✗ \(not set\)/i, terminal, 8_000);
-    await runtime.waitForScreenText(/anthropic\s+✓ \(stored\)/i, terminal, 8_000);
+
+    const providerCountMatch = terminal.serialize().view.match(/\(\d+\/(\d+)\)/);
+    if (!providerCountMatch) throw new Error('Expected /api-keys to show the provider count');
+
+    const secondProviderStatus = /anthropic\s+✓ \(stored\)/i;
+    const providerCount = Number(providerCountMatch[1]);
+    for (let index = 0; index < providerCount && !secondProviderStatus.test(terminal.serialize().view); index += 1) {
+      terminal.write('\x1b[B');
+      await terminal.flushInput?.();
+    }
+    await runtime.waitForScreenText(secondProviderStatus, terminal, 8_000);
 
     terminal.write('\x1b');
     await runtime.waitForScreenTextAbsent(/API Keys/i, terminal, 8_000);


### PR DESCRIPTION
TLDR: signing in through a device code now shows a centered dialog with the code
as the main element and copy feedback, instead of a small badge in a stack of
left-aligned rows.

---

```
before   code in a small info badge, provider instructions echoing the same code
         above it, copy / open / waiting each on their own row
after    centered title, the code as the largest element with an inline copy
         button (icon flips to a check for 2s), full-width open button, and the
         waiting/error status in the footer next to Cancel so rows stop shifting
```

### Judgment call

The dialog no longer renders `session.instructions`. Every shipped provider
builds that string as `Enter code: <code>`, so it repeated the code directly
under the hero. The TUI still renders the field as before — there it is the only
place the code appears.

### Not verified

The error path (flow errors now render footer-left, where the spinner sat) and
narrow widths were not visually exercised. The happy path was reviewed in the
running app.

```
source   +22  -17
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The sign-in dialog now makes the device code easier to see and copy. It also shows waiting or error status next to Cancel, while the TUI remains unchanged.

## Changes

- Centered the dialog around the device code.
- Added an inline `CopyButton` with copied-state feedback.
- Displayed the device code as selectable monospace text.
- Constrained long device codes and OAuth errors.
- Made the authorization action span the dialog width.
- Removed the repeated `session.instructions` text.
- Moved waiting and error status into the footer.
- Added a patch changeset for the `mastracode` package.
- Updated the TUI API key deletion test to navigate long provider lists without assuming provider order.
- Preserved the existing TUI device-code field.

## Validation

- Reviewed the successful sign-in flow in the running app.
- Error states and narrow widths were not visually verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->