### PR TITLE
fix(pg): make observational memory initialization atomic

### DIFF
--- a/.changeset/social-apes-dream.md
+++ b/.changeset/social-apes-dream.md
@@ -2,4 +2,6 @@
 '@mastra/pg': patch
 ---
 
-Make PostgreSQL observational-memory initialization atomic across processes and reject duplicate generation histories during schema upgrades.
+Made PostgreSQL observational-memory initialization atomic across processes, so concurrent callers receive the same generation-zero record.
+
+When upgrading, `init()` now stops with a `MIGRATION_REQUIRED` error if the database already contains duplicate `(lookupKey, generationCount)` rows. Reconcile those rows before restarting. Deployments with `disableInit: true` must add the unique `(lookupKey, generationCount)` index to their externally managed migration before updating.

--- a/.changeset/social-apes-dream.md
+++ b/.changeset/social-apes-dream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Make PostgreSQL observational-memory initialization atomic across processes and reject duplicate generation histories during schema upgrades.

--- a/.changeset/social-apes-dream.md
+++ b/.changeset/social-apes-dream.md
@@ -4,4 +4,4 @@
 
 Made PostgreSQL observational-memory initialization atomic across processes, so concurrent callers receive the same generation-zero record.
 
-When upgrading, `init()` now stops with a `MIGRATION_REQUIRED` error if the database already contains duplicate `(lookupKey, generationCount)` rows. Reconcile those rows before restarting. Deployments with `disableInit: true` must add the unique `(lookupKey, generationCount)` index to their externally managed migration before updating.
+When upgrading, `init()` now stops with a `MIGRATION_REQUIRED` error if the database already contains duplicate `(lookupKey, generationCount)` rows or an incompatible relation occupies the required index name. Reconcile the rows or replace the incompatible relation before restarting. Deployments with `disableInit: true` must add the unique `(lookupKey, generationCount)` index to their externally managed migration before updating.

--- a/docs/src/content/en/integrations/databases/postgresql.mdx
+++ b/docs/src/content/en/integrations/databases/postgresql.mdx
@@ -195,15 +195,15 @@ The storage implementation handles schema creation and updates automatically. It
 
 `PostgresStore` exposes notification storage through `getStore('notifications')`.
 
-### Observational memory generation safety
+### Observational Memory Generation Safety
 
 PostgreSQL storage enforces one observational-memory row per `(lookupKey, generationCount)`. This keeps initialization idempotent across multiple Mastra processes and prevents ambiguous reflection histories. The invariant is required even when `skipDefaultIndexes` is enabled because it protects correctness rather than query performance.
 
-When `init()` upgrades an existing database, it stops with a `MIGRATION_REQUIRED` error if duplicate generations already exist. Mastra does not delete either row automatically because they can contain different observations. Inspect all duplicate groups and reconcile their contents before restarting:
+When `init()` upgrades an existing database, it stops with a `MIGRATION_REQUIRED` error if duplicate generations already exist. Mastra does not delete either row automatically because they can contain different observations. Inspect all duplicate groups and reconcile their contents before restarting. Replace `public` below if you configured a different `schemaName`:
 
 ```sql
 SELECT "lookupKey", "generationCount", COUNT(*)
-FROM mastra_observational_memory
+FROM "public"."mastra_observational_memory"
 GROUP BY "lookupKey", "generationCount"
 HAVING COUNT(*) > 1;
 ```

--- a/docs/src/content/en/integrations/databases/postgresql.mdx
+++ b/docs/src/content/en/integrations/databases/postgresql.mdx
@@ -208,6 +208,8 @@ GROUP BY "lookupKey", "generationCount"
 HAVING COUNT(*) > 1;
 ```
 
+Initialization also validates the required index through the PostgreSQL catalog. If an incompatible relation already occupies its name, Mastra fails closed instead of assuming that `CREATE UNIQUE INDEX IF NOT EXISTS` produced the expected invariant. Review and replace the conflicting relation described by the error before restarting.
+
 If you set `disableInit: true`, include the unique `(lookupKey, generationCount)` index from the current `@mastra/pg` schema in your externally managed migration before deploying the package update.
 
 ### Observability

--- a/docs/src/content/en/integrations/databases/postgresql.mdx
+++ b/docs/src/content/en/integrations/databases/postgresql.mdx
@@ -195,6 +195,21 @@ The storage implementation handles schema creation and updates automatically. It
 
 `PostgresStore` exposes notification storage through `getStore('notifications')`.
 
+### Observational memory generation safety
+
+PostgreSQL storage enforces one observational-memory row per `(lookupKey, generationCount)`. This keeps initialization idempotent across multiple Mastra processes and prevents ambiguous reflection histories. The invariant is required even when `skipDefaultIndexes` is enabled because it protects correctness rather than query performance.
+
+When `init()` upgrades an existing database, it stops with a `MIGRATION_REQUIRED` error if duplicate generations already exist. Mastra does not delete either row automatically because they can contain different observations. Inspect all duplicate groups and reconcile their contents before restarting:
+
+```sql
+SELECT "lookupKey", "generationCount", COUNT(*)
+FROM mastra_observational_memory
+GROUP BY "lookupKey", "generationCount"
+HAVING COUNT(*) > 1;
+```
+
+If you set `disableInit: true`, include the unique `(lookupKey, generationCount)` index from the current `@mastra/pg` schema in your externally managed migration before deploying the package update.
+
 ### Observability
 
 PostgreSQL supports observability and can handle low trace volumes. Throughput capacity depends on deployment factors such as hardware, schema design, indexing, and retention policies, and should be validated for your specific environment. For high-volume production environments, consider:

--- a/docs/src/content/en/integrations/databases/postgresql.mdx
+++ b/docs/src/content/en/integrations/databases/postgresql.mdx
@@ -210,7 +210,9 @@ HAVING COUNT(*) > 1;
 
 Initialization also validates the required index through the PostgreSQL catalog. If an incompatible relation already occupies its name, Mastra fails closed instead of assuming that `CREATE UNIQUE INDEX IF NOT EXISTS` produced the expected invariant. Review and replace the conflicting relation described by the error before restarting.
 
-If you set `disableInit: true`, include the unique `(lookupKey, generationCount)` index from the current `@mastra/pg` schema in your externally managed migration before deploying the package update.
+If you set `disableInit: true`, include the unique `(lookupKey, generationCount)` index from the current `@mastra/pg` schema in your externally managed migration before deploying the package update. Calls that encounter a missing index fail with an actionable `MIGRATION_REQUIRED` error.
+
+Automatic upgrades use a regular `CREATE UNIQUE INDEX`, which takes a `SHARE` lock and can block writes to a large observational-memory table until the build finishes. For large production tables, pre-create the exported index with `CREATE UNIQUE INDEX CONCURRENTLY` before deploying this version; run that statement outside a transaction. Initialization validates and reuses a compatible pre-created index. The duplicate-generation `GROUP BY` scan runs only when index creation fails with a uniqueness violation.
 
 ### Observability
 

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -23,6 +23,7 @@ import {
  * versions that don't export TABLE_OBSERVATIONAL_MEMORY.
  */
 const OM_TABLE = 'mastra_observational_memory' as const;
+const OM_GENERATION_UNIQUE_INDEX = 'idx_om_lookup_key_generation_count_unique';
 const POSTGRES_MAX_BIND_PARAMETERS = 65535;
 // Keep in sync with the message INSERT column list in saveMessages.
 const MESSAGE_INSERT_BIND_PARAMETERS = 8;
@@ -103,6 +104,7 @@ import {
   getTableName as dbGetTableName,
 } from '../../db';
 import type { PgDomainConfig } from '../../db';
+import { isDuplicateRelationError } from '../../db/pg-errors';
 import { runPrune, runBatchedDelete, resolveTargets } from '../../retention';
 
 // Database row type that includes timezone-aware columns
@@ -142,6 +144,20 @@ function inPlaceholders(count: number, startIndex = 1): string {
  */
 function toUtcISOString(date: Date): string {
   return date.toISOString();
+}
+
+function hasPostgresErrorCode(error: unknown, code: string): boolean {
+  const seen = new Set<unknown>();
+  let current = error;
+
+  while (typeof current === 'object' && current !== null && !seen.has(current)) {
+    seen.add(current);
+    const errorLike = current as { code?: string; cause?: unknown };
+    if (errorLike.code === code) return true;
+    current = errorLike.cause;
+  }
+
+  return false;
 }
 
 function dedupeMessagesForSave(messages: MastraDBMessage[]): MastraDBMessage[] {
@@ -238,6 +254,7 @@ export class MemoryPG extends MemoryStorage {
         'idx_om_lookup_key',
         `CREATE INDEX IF NOT EXISTS idx_om_lookup_key ON ${omTableName} ("lookupKey")`,
       );
+      await this.ensureOMGenerationUniqueness(omTableName);
     }
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
@@ -326,6 +343,9 @@ export class MemoryPG extends MemoryStorage {
       statements.push(
         `CREATE INDEX IF NOT EXISTS "${idxPrefix}idx_om_lookup_key" ON ${fullOmTableName} ("lookupKey");`,
       );
+      statements.push(
+        `CREATE UNIQUE INDEX IF NOT EXISTS "${idxPrefix}${OM_GENERATION_UNIQUE_INDEX}" ON ${fullOmTableName} ("lookupKey", "generationCount");`,
+      );
     }
 
     // Default indexes
@@ -334,6 +354,70 @@ export class MemoryPG extends MemoryStorage {
     }
 
     return statements;
+  }
+
+  private async ensureOMGenerationUniqueness(tableName: string): Promise<void> {
+    const indexPrefix = this.#schema !== 'public' ? `${this.#schema}_` : '';
+    const indexName = `${indexPrefix}${OM_GENERATION_UNIQUE_INDEX}`;
+
+    try {
+      await this.#db.createIndexFromStatement(
+        indexName,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "${indexName}" ON ${tableName} ("lookupKey", "generationCount")`,
+      );
+    } catch (error) {
+      // Concurrent cold starts can race while creating the same index. Only
+      // accept the catalog collision after confirming that the other process
+      // actually created the expected index.
+      if (isDuplicateRelationError(error)) {
+        const existingIndex = await this.#db.client.oneOrNone(
+          `SELECT 1 FROM pg_indexes WHERE schemaname = $1 AND indexname = $2`,
+          [this.#schema, indexName],
+        );
+        if (existingIndex) return;
+      }
+
+      // Building a unique index over an upgraded database fails with 23505
+      // when historical duplicates exist. Do not choose a winner here: two
+      // rows can contain different observations, so automatic deletion would
+      // be data loss.
+      if (hasPostgresErrorCode(error, '23505')) {
+        const duplicate = await this.#db.client.oneOrNone<{
+          lookupKey: string;
+          generationCount: number;
+          duplicateCount: string;
+        }>(
+          `SELECT "lookupKey", "generationCount", COUNT(*)::text AS "duplicateCount"
+             FROM ${tableName}
+            GROUP BY "lookupKey", "generationCount"
+           HAVING COUNT(*) > 1
+            ORDER BY COUNT(*) DESC
+            LIMIT 1`,
+        );
+
+        if (duplicate) {
+          throw new MastraError({
+            id: createStorageErrorId('PG', 'MIGRATION_REQUIRED', 'DUPLICATE_OBSERVATIONAL_MEMORY_GENERATIONS'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.USER,
+            text:
+              `Duplicate observational-memory generations prevent a safe storage upgrade. ` +
+              `Found ${duplicate.duplicateCount} rows for lookupKey ${JSON.stringify(duplicate.lookupKey)} ` +
+              `at generation ${duplicate.generationCount}. Review and reconcile every duplicate ` +
+              `(lookupKey, generationCount) group before restarting. Mastra cannot select a winner ` +
+              `without potentially discarding memory.`,
+            details: {
+              tableName: OM_TABLE,
+              lookupKey: duplicate.lookupKey,
+              generationCount: duplicate.generationCount,
+              duplicateCount: duplicate.duplicateCount,
+            },
+          });
+        }
+      }
+
+      throw error;
+    }
   }
 
   /**
@@ -2218,7 +2302,7 @@ export class MemoryPG extends MemoryStorage {
         schemaName: getSchemaName(this.#schema),
       });
       const nowStr = now.toISOString();
-      await this.#db.client.none(
+      const inserted = await this.#db.client.oneOrNone<{ id: string }>(
         `INSERT INTO ${tableName} (
           id, "lookupKey", scope, "resourceId", "threadId",
           "activeObservations", "activeObservationsPendingUpdate",
@@ -2226,7 +2310,9 @@ export class MemoryPG extends MemoryStorage {
           "pendingMessageTokens", "totalTokensObserved", "observationTokenCount",
           "isObserving", "isReflecting", "isBufferingObservation", "isBufferingReflection", "lastBufferedAtTokens", "lastBufferedAtTime",
           "observedTimezone", "createdAt", "createdAtZ", "updatedAt", "updatedAtZ"
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)`,
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
+        ON CONFLICT ("lookupKey", "generationCount") DO NOTHING
+        RETURNING id`,
         [
           id,
           lookupKey,
@@ -2259,8 +2345,27 @@ export class MemoryPG extends MemoryStorage {
         ],
       );
 
-      return record;
+      if (inserted) return record;
+
+      // A conflicting insert can wait for another transaction whose row was
+      // not visible to this statement's READ COMMITTED snapshot. Fetch the
+      // winner in a separate statement so PostgreSQL takes a fresh snapshot.
+      const existing = await this.#db.client.oneOrNone(
+        `SELECT * FROM ${tableName} WHERE "lookupKey" = $1 AND "generationCount" = 0 LIMIT 1`,
+        [lookupKey],
+      );
+      if (!existing) {
+        throw new MastraError({
+          id: createStorageErrorId('PG', 'INITIALIZE_OBSERVATIONAL_MEMORY', 'CONFLICT_ROW_NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { threadId: input.threadId, resourceId: input.resourceId },
+        });
+      }
+
+      return this.parseOMRow(existing);
     } catch (error) {
+      if (error instanceof MastraError) throw error;
       throw new MastraError(
         {
           id: createStorageErrorId('PG', 'INITIALIZE_OBSERVATIONAL_MEMORY', 'FAILED'),

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -2469,6 +2469,23 @@ export class MemoryPG extends MemoryStorage {
       return this.parseOMRow(existing);
     } catch (error) {
       if (error instanceof MastraError) throw error;
+      if (hasPostgresErrorCode(error, '42P10')) {
+        const indexName = getOMGenerationUniqueIndexName(this.#schema);
+        throw new MastraError(
+          {
+            id: createStorageErrorId('PG', 'MIGRATION_REQUIRED', 'MISSING_OBSERVATIONAL_MEMORY_GENERATION_INDEX'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.USER,
+            text:
+              `Observational-memory initialization requires a valid unique index on ` +
+              `("lookupKey", "generationCount") for ${JSON.stringify(`${this.#schema}.${OM_TABLE}`)}. ` +
+              `Add ${JSON.stringify(indexName)} to the externally managed migration, or enable automatic ` +
+              `storage initialization before retrying.`,
+            details: { schemaName: this.#schema, tableName: OM_TABLE, indexName },
+          },
+          error,
+        );
+      }
       throw new MastraError(
         {
           id: createStorageErrorId('PG', 'INITIALIZE_OBSERVATIONAL_MEMORY', 'FAILED'),

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -169,6 +169,41 @@ function getOMGenerationUniqueIndexName(schemaName?: string): string {
   });
 }
 
+interface OMGenerationIndexMetadata {
+  isValid: boolean;
+  isReady: boolean;
+  isLive: boolean;
+  isUnique: boolean;
+  isImmediate: boolean;
+  isNonPartial: boolean;
+  hasNoExpressions: boolean;
+  tableName: string;
+  columns: string[];
+}
+
+function getOMGenerationIndexProblems(metadata: OMGenerationIndexMetadata | null | undefined): string[] {
+  if (!metadata) return ['the relation is missing or is not an index'];
+
+  const problems: string[] = [];
+  if (!metadata.isValid) problems.push('the index is invalid');
+  if (!metadata.isReady) problems.push('the index is not ready for inserts');
+  if (!metadata.isLive) problems.push('the index is being dropped');
+  if (!metadata.isUnique) problems.push('the index is not unique');
+  if (!metadata.isImmediate) problems.push('the index does not enforce uniqueness immediately');
+  if (!metadata.isNonPartial) problems.push('the index is partial');
+  if (!metadata.hasNoExpressions) problems.push('the index contains expressions');
+  if (metadata.tableName !== OM_TABLE)
+    problems.push(`the index belongs to table ${JSON.stringify(metadata.tableName)}`);
+  if (
+    metadata.columns.length !== 2 ||
+    metadata.columns[0] !== 'lookupKey' ||
+    metadata.columns[1] !== 'generationCount'
+  ) {
+    problems.push(`the key columns are (${metadata.columns.map(column => JSON.stringify(column)).join(', ')})`);
+  }
+  return problems;
+}
+
 function dedupeMessagesForSave(messages: MastraDBMessage[]): MastraDBMessage[] {
   const deduped = new Map<string, MastraDBMessage>();
   for (const message of messages) {
@@ -367,6 +402,11 @@ export class MemoryPG extends MemoryStorage {
 
   private async ensureOMGenerationUniqueness(tableName: string): Promise<void> {
     const indexName = getOMGenerationUniqueIndexName(this.#schema);
+    const existingIndex = await this.getOMGenerationIndexMetadata(indexName);
+    if (existingIndex) {
+      this.assertOMGenerationIndexCompatible(indexName, existingIndex);
+      return;
+    }
 
     try {
       await this.#db.createIndexFromStatement(
@@ -378,11 +418,9 @@ export class MemoryPG extends MemoryStorage {
       // accept the catalog collision after confirming that the other process
       // actually created the expected index.
       if (isDuplicateRelationError(error)) {
-        const existingIndex = await this.#db.client.oneOrNone(
-          `SELECT 1 FROM pg_indexes WHERE schemaname = $1 AND indexname = $2`,
-          [this.#schema, indexName],
-        );
-        if (existingIndex) return;
+        const racedIndex = await this.getOMGenerationIndexMetadata(indexName);
+        this.assertOMGenerationIndexCompatible(indexName, racedIndex);
+        return;
       }
 
       // Building a unique index over an upgraded database fails with 23505
@@ -426,6 +464,63 @@ export class MemoryPG extends MemoryStorage {
 
       throw error;
     }
+
+    const createdIndex = await this.getOMGenerationIndexMetadata(indexName);
+    this.assertOMGenerationIndexCompatible(indexName, createdIndex);
+  }
+
+  private async getOMGenerationIndexMetadata(indexName: string): Promise<OMGenerationIndexMetadata | null> {
+    return this.#db.client.oneOrNone<OMGenerationIndexMetadata>(
+      `SELECT i.indisvalid AS "isValid",
+              i.indisready AS "isReady",
+              i.indislive AS "isLive",
+              i.indisunique AS "isUnique",
+              i.indimmediate AS "isImmediate",
+              i.indpred IS NULL AS "isNonPartial",
+              i.indexprs IS NULL AS "hasNoExpressions",
+              table_class.relname AS "tableName",
+              ARRAY(
+                SELECT attribute.attname
+                  FROM unnest(i.indkey::smallint[]) WITH ORDINALITY AS index_key(attnum, ordinal_position)
+                  JOIN pg_catalog.pg_attribute attribute
+                    ON attribute.attrelid = i.indrelid
+                   AND attribute.attnum = index_key.attnum
+                 WHERE index_key.ordinal_position <= i.indnkeyatts
+                 ORDER BY index_key.ordinal_position
+              )::text[] AS columns
+         FROM pg_catalog.pg_index i
+         JOIN pg_catalog.pg_class index_class ON index_class.oid = i.indexrelid
+         JOIN pg_catalog.pg_class table_class ON table_class.oid = i.indrelid
+         JOIN pg_catalog.pg_namespace namespace ON namespace.oid = index_class.relnamespace
+        WHERE namespace.nspname = $1
+          AND index_class.relname = $2`,
+      [this.#schema, indexName],
+    );
+  }
+
+  private assertOMGenerationIndexCompatible(
+    indexName: string,
+    metadata: OMGenerationIndexMetadata | null | undefined,
+  ): void {
+    const problems = getOMGenerationIndexProblems(metadata);
+    if (problems.length === 0) return;
+
+    throw new MastraError({
+      id: createStorageErrorId('PG', 'MIGRATION_REQUIRED', 'INVALID_OBSERVATIONAL_MEMORY_GENERATION_INDEX'),
+      domain: ErrorDomain.STORAGE,
+      category: ErrorCategory.USER,
+      text:
+        `PostgreSQL relation ${JSON.stringify(`${this.#schema}.${indexName}`)} does not provide the required ` +
+        `observational-memory generation invariant: ${problems.join('; ')}. ` +
+        `Review and replace that relation with a valid, immediate, non-partial unique index on ` +
+        `("lookupKey", "generationCount") before restarting.`,
+      details: {
+        schemaName: this.#schema,
+        tableName: OM_TABLE,
+        indexName,
+        reason: problems.join('; '),
+      },
+    });
   }
 
   /**

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -104,6 +104,7 @@ import {
   getTableName as dbGetTableName,
 } from '../../db';
 import type { PgDomainConfig } from '../../db';
+import { buildConstraintName } from '../../db/constraint-utils';
 import { isDuplicateRelationError } from '../../db/pg-errors';
 import { runPrune, runBatchedDelete, resolveTargets } from '../../retention';
 
@@ -158,6 +159,14 @@ function hasPostgresErrorCode(error: unknown, code: string): boolean {
   }
 
   return false;
+}
+
+function getOMGenerationUniqueIndexName(schemaName?: string): string {
+  const parsedSchema = schemaName ? parseSqlIdentifier(schemaName, 'schema name') : '';
+  return buildConstraintName({
+    baseName: OM_GENERATION_UNIQUE_INDEX,
+    schemaName: parsedSchema && parsedSchema !== 'public' ? parsedSchema : undefined,
+  });
 }
 
 function dedupeMessagesForSave(messages: MastraDBMessage[]): MastraDBMessage[] {
@@ -344,7 +353,7 @@ export class MemoryPG extends MemoryStorage {
         `CREATE INDEX IF NOT EXISTS "${idxPrefix}idx_om_lookup_key" ON ${fullOmTableName} ("lookupKey");`,
       );
       statements.push(
-        `CREATE UNIQUE INDEX IF NOT EXISTS "${idxPrefix}${OM_GENERATION_UNIQUE_INDEX}" ON ${fullOmTableName} ("lookupKey", "generationCount");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "${getOMGenerationUniqueIndexName(parsedSchema)}" ON ${fullOmTableName} ("lookupKey", "generationCount");`,
       );
     }
 
@@ -357,8 +366,7 @@ export class MemoryPG extends MemoryStorage {
   }
 
   private async ensureOMGenerationUniqueness(tableName: string): Promise<void> {
-    const indexPrefix = this.#schema !== 'public' ? `${this.#schema}_` : '';
-    const indexName = `${indexPrefix}${OM_GENERATION_UNIQUE_INDEX}`;
+    const indexName = getOMGenerationUniqueIndexName(this.#schema);
 
     try {
       await this.#db.createIndexFromStatement(

--- a/stores/pg/src/storage/domains/memory/om-dist-schema.test.ts
+++ b/stores/pg/src/storage/domains/memory/om-dist-schema.test.ts
@@ -35,11 +35,15 @@ describe.skipIf(!existsSync(distEsm) || !existsSync(distCjs))('observational mem
     const ddl = exportSchemasFromEsm();
     expect(ddl).toContain('mastra_observational_memory');
     expect(ddl).toContain('idx_om_lookup_key');
+    expect(ddl).toContain('CREATE UNIQUE INDEX');
+    expect(ddl).toContain('idx_om_lookup_key_generation_count_unique');
   }, 30000);
 
   it('CJS build includes the observational memory table', () => {
     const ddl = exportSchemasFromCjs();
     expect(ddl).toContain('mastra_observational_memory');
     expect(ddl).toContain('idx_om_lookup_key');
+    expect(ddl).toContain('CREATE UNIQUE INDEX');
+    expect(ddl).toContain('idx_om_lookup_key_generation_count_unique');
   }, 30000);
 });

--- a/stores/pg/src/storage/domains/memory/om-initialization-concurrency.test.ts
+++ b/stores/pg/src/storage/domains/memory/om-initialization-concurrency.test.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from 'node:crypto';
+
+import type { ObservationalMemoryRecord } from '@mastra/core/storage';
+import { Pool } from 'pg';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { connectionString } from '../../test-utils';
+import { MemoryPG } from './index';
+
+const OM_TABLE = 'mastra_observational_memory';
+const UNIQUE_INDEX = 'idx_om_lookup_key_generation_count_unique';
+
+describe('MemoryPG observational-memory generation invariants', () => {
+  let pool: Pool;
+  let schemaName: string;
+  let memory: MemoryPG;
+
+  beforeAll(() => {
+    pool = new Pool({ connectionString, max: 30 });
+  });
+
+  beforeEach(async () => {
+    schemaName = `om_concurrency_${randomUUID().replaceAll('-', '')}`;
+    await pool.query(`CREATE SCHEMA "${schemaName}"`);
+    memory = new MemoryPG({ pool, schemaName, skipDefaultIndexes: true });
+    await memory.init();
+  });
+
+  afterEach(async () => {
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('returns one generation-zero record to concurrent initializers', async () => {
+    const input = {
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      scope: 'thread' as const,
+      config: { observation: { model: 'test-model' } },
+      observedTimezone: 'Europe/Bucharest',
+    };
+
+    const records = await Promise.all(Array.from({ length: 24 }, () => memory.initializeObservationalMemory(input)));
+
+    expect(new Set(records.map(record => record.id)).size).toBe(1);
+    expect(records.every(record => record.generationCount === 0)).toBe(true);
+
+    const stored = await pool.query<{ id: string; count: string }>(
+      `SELECT MIN(id) AS id, COUNT(*)::text AS count
+         FROM "${schemaName}"."${OM_TABLE}"
+        WHERE "lookupKey" = $1 AND "generationCount" = 0`,
+      ['thread:thread-1'],
+    );
+    expect(stored.rows[0]?.count).toBe('1');
+    expect(stored.rows[0]?.id).toBe(records[0]?.id);
+  });
+
+  it('rejects colliding reflections instead of creating an ambiguous history', async () => {
+    const initial = await memory.initializeObservationalMemory({
+      threadId: null,
+      resourceId: 'resource-1',
+      scope: 'resource',
+      config: {},
+    });
+
+    const createReflection = (reflection: string) =>
+      memory.createReflectionGeneration({ currentRecord: initial, reflection, tokenCount: 10 });
+    const results = await Promise.allSettled([createReflection('reflection-a'), createReflection('reflection-b')]);
+
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter(result => result.status === 'rejected')).toHaveLength(1);
+
+    const history = await memory.getObservationalMemoryHistory(null, 'resource-1');
+    expect(history.map((record: ObservationalMemoryRecord) => record.generationCount)).toEqual([1, 0]);
+  });
+
+  it('fails closed when an existing database contains duplicate generations', async () => {
+    await memory.initializeObservationalMemory({
+      threadId: 'thread-duplicate',
+      resourceId: 'resource-1',
+      scope: 'thread',
+      config: {},
+    });
+
+    await pool.query(`DROP INDEX "${schemaName}"."${schemaName}_${UNIQUE_INDEX}"`);
+
+    const columns = await pool.query<{ column_name: string }>(
+      `SELECT column_name
+         FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = $2
+        ORDER BY ordinal_position`,
+      [schemaName, OM_TABLE],
+    );
+    const quotedColumns = columns.rows.map(({ column_name }) => `"${column_name}"`).join(', ');
+    const selectedColumns = columns.rows
+      .map(({ column_name }) => (column_name === 'id' ? '$1' : `"${column_name}"`))
+      .join(', ');
+    await pool.query(
+      `INSERT INTO "${schemaName}"."${OM_TABLE}" (${quotedColumns})
+       SELECT ${selectedColumns} FROM "${schemaName}"."${OM_TABLE}" LIMIT 1`,
+      ['duplicate-id'],
+    );
+
+    const upgradedMemory = new MemoryPG({ pool, schemaName, skipDefaultIndexes: true });
+    await expect(upgradedMemory.init()).rejects.toMatchObject({
+      id: expect.stringContaining('MIGRATION_REQUIRED'),
+      message: expect.stringContaining('cannot select a winner'),
+    });
+  });
+});

--- a/stores/pg/src/storage/domains/memory/om-initialization-concurrency.test.ts
+++ b/stores/pg/src/storage/domains/memory/om-initialization-concurrency.test.ts
@@ -153,6 +153,23 @@ describe('MemoryPG observational-memory generation invariants', () => {
     expect(history.map((record: ObservationalMemoryRecord) => record.generationCount)).toEqual([1, 0]);
   });
 
+  it('reports an actionable migration error when externally managed schema omits the unique index', async () => {
+    const indexName = buildConstraintName({ baseName: UNIQUE_INDEX, schemaName });
+    await pool.query(`DROP INDEX "${schemaName}"."${indexName}"`);
+
+    await expect(
+      memory.initializeObservationalMemory({
+        threadId: 'thread-missing-index',
+        resourceId: 'resource-1',
+        scope: 'thread',
+        config: {},
+      }),
+    ).rejects.toMatchObject({
+      id: expect.stringContaining('MIGRATION_REQUIRED'),
+      message: expect.stringContaining('externally managed migration'),
+    });
+  });
+
   it('rejects an invalid index left by a failed concurrent build', async () => {
     await memory.initializeObservationalMemory({
       threadId: 'thread-invalid-index',

--- a/stores/pg/src/storage/domains/memory/om-initialization-concurrency.test.ts
+++ b/stores/pg/src/storage/domains/memory/om-initialization-concurrency.test.ts
@@ -11,6 +11,23 @@ import { MemoryPG } from './index';
 const OM_TABLE = 'mastra_observational_memory';
 const UNIQUE_INDEX = 'idx_om_lookup_key_generation_count_unique';
 
+async function duplicateFirstOMRow(pool: Pool, schemaName: string, id: string): Promise<void> {
+  const columns = await pool.query<{ column_name: string }>(
+    `SELECT column_name
+       FROM information_schema.columns
+      WHERE table_schema = $1 AND table_name = $2
+      ORDER BY ordinal_position`,
+    [schemaName, OM_TABLE],
+  );
+  const quotedColumns = columns.rows.map(({ column_name }) => `"${column_name}"`).join(', ');
+  const selectedColumns = columns.rows.map(({ column_name }) => (column_name === 'id' ? '$1' : `"${column_name}"`));
+  await pool.query(
+    `INSERT INTO "${schemaName}"."${OM_TABLE}" (${quotedColumns})
+     SELECT ${selectedColumns.join(', ')} FROM "${schemaName}"."${OM_TABLE}" LIMIT 1`,
+    [id],
+  );
+}
+
 describe('MemoryPG observational-memory generation invariants', () => {
   let pool: Pool;
   let schemaName: string;
@@ -79,6 +96,44 @@ describe('MemoryPG observational-memory generation invariants', () => {
     ]);
   });
 
+  it.each([
+    {
+      name: 'non-unique',
+      statements: (indexName: string) => [
+        `CREATE INDEX "${indexName}" ON "${schemaName}"."${OM_TABLE}" ("lookupKey", "generationCount")`,
+      ],
+    },
+    {
+      name: 'partial',
+      statements: (indexName: string) => [
+        `CREATE UNIQUE INDEX "${indexName}" ON "${schemaName}"."${OM_TABLE}" ("lookupKey", "generationCount") WHERE "generationCount" >= 0`,
+      ],
+    },
+    {
+      name: 'wrongly ordered',
+      statements: (indexName: string) => [
+        `CREATE UNIQUE INDEX "${indexName}" ON "${schemaName}"."${OM_TABLE}" ("generationCount", "lookupKey")`,
+      ],
+    },
+    {
+      name: 'attached to another table',
+      statements: (indexName: string) => [
+        `CREATE TABLE "${schemaName}"."om_index_collision" ("lookupKey" text NOT NULL, "generationCount" integer NOT NULL)`,
+        `CREATE UNIQUE INDEX "${indexName}" ON "${schemaName}"."om_index_collision" ("lookupKey", "generationCount")`,
+      ],
+    },
+  ])('fails closed when the generation index name is occupied by a $name index', async ({ statements }) => {
+    const indexName = buildConstraintName({ baseName: UNIQUE_INDEX, schemaName });
+    await pool.query(`DROP INDEX "${schemaName}"."${indexName}"`);
+    for (const statement of statements(indexName)) await pool.query(statement);
+
+    const upgradedMemory = new MemoryPG({ pool, schemaName, skipDefaultIndexes: true });
+    await expect(upgradedMemory.init()).rejects.toMatchObject({
+      id: expect.stringContaining('MIGRATION_REQUIRED'),
+      message: expect.stringContaining('does not provide the required observational-memory generation invariant'),
+    });
+  });
+
   it('rejects colliding reflections instead of creating an ambiguous history', async () => {
     const initial = await memory.initializeObservationalMemory({
       threadId: null,
@@ -98,6 +153,40 @@ describe('MemoryPG observational-memory generation invariants', () => {
     expect(history.map((record: ObservationalMemoryRecord) => record.generationCount)).toEqual([1, 0]);
   });
 
+  it('rejects an invalid index left by a failed concurrent build', async () => {
+    await memory.initializeObservationalMemory({
+      threadId: 'thread-invalid-index',
+      resourceId: 'resource-1',
+      scope: 'thread',
+      config: {},
+    });
+
+    const indexName = buildConstraintName({ baseName: UNIQUE_INDEX, schemaName });
+    await pool.query(`DROP INDEX "${schemaName}"."${indexName}"`);
+    await duplicateFirstOMRow(pool, schemaName, 'invalid-index-duplicate');
+    await expect(
+      pool.query(
+        `CREATE UNIQUE INDEX CONCURRENTLY "${indexName}" ON "${schemaName}"."${OM_TABLE}" ("lookupKey", "generationCount")`,
+      ),
+    ).rejects.toThrow();
+
+    const invalidIndex = await pool.query<{ indisvalid: boolean }>(
+      `SELECT i.indisvalid
+         FROM pg_catalog.pg_index i
+         JOIN pg_catalog.pg_class index_class ON index_class.oid = i.indexrelid
+         JOIN pg_catalog.pg_namespace namespace ON namespace.oid = index_class.relnamespace
+        WHERE namespace.nspname = $1 AND index_class.relname = $2`,
+      [schemaName, indexName],
+    );
+    expect(invalidIndex.rows).toEqual([{ indisvalid: false }]);
+
+    const upgradedMemory = new MemoryPG({ pool, schemaName, skipDefaultIndexes: true });
+    await expect(upgradedMemory.init()).rejects.toMatchObject({
+      id: expect.stringContaining('MIGRATION_REQUIRED'),
+      message: expect.stringContaining('the index is invalid'),
+    });
+  });
+
   it('fails closed when an existing database contains duplicate generations', async () => {
     await memory.initializeObservationalMemory({
       threadId: 'thread-duplicate',
@@ -108,23 +197,7 @@ describe('MemoryPG observational-memory generation invariants', () => {
 
     const indexName = buildConstraintName({ baseName: UNIQUE_INDEX, schemaName });
     await pool.query(`DROP INDEX "${schemaName}"."${indexName}"`);
-
-    const columns = await pool.query<{ column_name: string }>(
-      `SELECT column_name
-         FROM information_schema.columns
-        WHERE table_schema = $1 AND table_name = $2
-        ORDER BY ordinal_position`,
-      [schemaName, OM_TABLE],
-    );
-    const quotedColumns = columns.rows.map(({ column_name }) => `"${column_name}"`).join(', ');
-    const selectedColumns = columns.rows
-      .map(({ column_name }) => (column_name === 'id' ? '$1' : `"${column_name}"`))
-      .join(', ');
-    await pool.query(
-      `INSERT INTO "${schemaName}"."${OM_TABLE}" (${quotedColumns})
-       SELECT ${selectedColumns} FROM "${schemaName}"."${OM_TABLE}" LIMIT 1`,
-      ['duplicate-id'],
-    );
+    await duplicateFirstOMRow(pool, schemaName, 'duplicate-id');
 
     const upgradedMemory = new MemoryPG({ pool, schemaName, skipDefaultIndexes: true });
     await expect(upgradedMemory.init()).rejects.toMatchObject({

--- a/stores/pg/src/storage/domains/memory/om-initialization-concurrency.test.ts
+++ b/stores/pg/src/storage/domains/memory/om-initialization-concurrency.test.ts
@@ -4,6 +4,7 @@ import type { ObservationalMemoryRecord } from '@mastra/core/storage';
 import { Pool } from 'pg';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
+import { buildConstraintName } from '../../db/constraint-utils';
 import { connectionString } from '../../test-utils';
 import { MemoryPG } from './index';
 
@@ -58,6 +59,26 @@ describe('MemoryPG observational-memory generation invariants', () => {
     expect(stored.rows[0]?.id).toBe(records[0]?.id);
   });
 
+  it('uses one canonical index name during concurrent init with a long schema name', async () => {
+    const indexName = buildConstraintName({ baseName: UNIQUE_INDEX, schemaName });
+    await pool.query(`DROP INDEX "${schemaName}"."${indexName}"`);
+
+    const stores = Array.from({ length: 4 }, () => new MemoryPG({ pool, schemaName, skipDefaultIndexes: true }));
+    await expect(Promise.all(stores.map(store => store.init()))).resolves.toHaveLength(4);
+
+    const indexes = await pool.query<{ indexname: string; indexdef: string }>(
+      `SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = $1 AND indexname = $2`,
+      [schemaName, indexName],
+    );
+    expect(Buffer.byteLength(indexName, 'utf8')).toBeLessThanOrEqual(63);
+    expect(indexes.rows).toEqual([
+      expect.objectContaining({
+        indexname: indexName,
+        indexdef: expect.stringContaining('UNIQUE INDEX'),
+      }),
+    ]);
+  });
+
   it('rejects colliding reflections instead of creating an ambiguous history', async () => {
     const initial = await memory.initializeObservationalMemory({
       threadId: null,
@@ -85,7 +106,8 @@ describe('MemoryPG observational-memory generation invariants', () => {
       config: {},
     });
 
-    await pool.query(`DROP INDEX "${schemaName}"."${schemaName}_${UNIQUE_INDEX}"`);
+    const indexName = buildConstraintName({ baseName: UNIQUE_INDEX, schemaName });
+    await pool.query(`DROP INDEX "${schemaName}"."${indexName}"`);
 
     const columns = await pool.query<{ column_name: string }>(
       `SELECT column_name


### PR DESCRIPTION
Fixes #22188.

PostgreSQL observational-memory initialization currently inserts generation zero unconditionally, so concurrent requests can create duplicate generations and make the active history nondeterministic.

This adds a database invariant for `(lookupKey, generationCount)`, makes generation-zero insertion conflict-safe, and returns the winning record to every concurrent caller. Reflection collisions remain errors so a distinct reflection is never silently discarded. Existing databases with duplicate generations fail closed with a structured, actionable migration error instead of choosing a record to delete.

Initialization also validates the required relation through PostgreSQL's catalogs rather than trusting `CREATE UNIQUE INDEX IF NOT EXISTS` by name. Existing and concurrently created indexes must be valid, ready, live, immediate, non-partial, unique, attached to the expected table, and keyed by `lookupKey` then `generationCount`; incompatible relations fail closed with migration guidance. Missing external indexes surface the same actionable `MIGRATION_REQUIRED` contract instead of raw PostgreSQL `42P10`.

The change updates exported schema DDL and PostgreSQL guidance, including the write-lock behavior of automatic upgrades and a `CREATE UNIQUE INDEX CONCURRENTLY` path for large tables. It adds a patch changeset and covers concurrent initialization, reflection collisions, duplicate-history upgrades, canonical long-schema names, incompatible same-name relations, invalid concurrent index remnants, missing external indexes, and ESM/CJS schema exports. I validated the dependency-aware `@mastra/pg` build, package lint and formatting, and all 48 PostgreSQL memory-domain tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

PostgreSQL now makes observational-memory setup safe when multiple processes run it at the same time. It prevents duplicate history and reports existing database problems without deleting data.

## Changes

- Added a unique `(lookupKey, generationCount)` invariant.
- Made generation-zero creation conflict-safe with `ON CONFLICT DO NOTHING`.
- Returned the same winning record to concurrent initializers.
- Preserved reflection-collision errors.
- Added structured `MIGRATION_REQUIRED` errors for duplicate generations and missing/incompatible indexes.
- Validated the required index's complete PostgreSQL catalog definition before accepting it.
- Documented locking and concurrent pre-creation for large production tables.
- Updated PostgreSQL schema exports and documentation.
- Added a patch changeset for `@mastra/pg`.
- Added tests for concurrency, reflection collisions, duplicate-history upgrades, missing/incompatible/invalid indexes, and ESM/CJS schema exports.

## Validation

- Built `@mastra/pg` with dependencies.
- Ran package linting and formatting.
- Passed 48 PostgreSQL memory-domain tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
