### PR TITLE
feat(factory-ui): install banner

### DIFF
--- a/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallBanner.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallBanner.msw.test.tsx
@@ -111,6 +111,19 @@ describe('PwaInstallBanner', () => {
     expect(screen.queryByRole('region', { name: 'Install app' })).not.toBeInTheDocument();
   });
 
+  it('adapts the instructions wording to Chrome on iOS', async () => {
+    setUserAgent(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/126.0.6478.54 Mobile/15E148 Safari/604.1',
+    );
+    const user = userEvent.setup();
+    render(<PwaInstallBanner />);
+
+    await user.click(screen.getByRole('button', { name: 'Install' }));
+
+    expect(screen.getByText(/Chrome’s address bar/)).toBeInTheDocument();
+    expect(screen.queryByText(/Safari’s toolbar/)).not.toBeInTheDocument();
+  });
+
   it('renders nothing when running standalone', () => {
     setStandalone(true);
     render(<PwaInstallBanner />);

--- a/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallBanner.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallBanner.msw.test.tsx
@@ -1,0 +1,120 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BeforeInstallPromptEvent } from './usePwaInstall';
+import { PwaInstallBanner } from './PwaInstallBanner';
+
+const DISMISSED_KEY = 'mastracode.pwaInstallDismissedAt';
+const INSTALLED_KEY = 'mastracode.pwaInstalledManually';
+
+const IOS_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1';
+
+const originalUserAgent = navigator.userAgent;
+const originalMatchMedia = window.matchMedia;
+
+function setUserAgent(userAgent: string) {
+  Object.defineProperty(window.navigator, 'userAgent', { value: userAgent, configurable: true });
+}
+
+function setStandalone(standalone: boolean) {
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: standalone && query === '(display-mode: standalone)',
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }) as unknown as MediaQueryList) as typeof window.matchMedia;
+}
+
+function fireInstallPromptEvent() {
+  const event = new Event('beforeinstallprompt', { cancelable: true }) as BeforeInstallPromptEvent;
+  const prompt = vi.fn(() => Promise.resolve());
+  Object.assign(event, {
+    prompt,
+    userChoice: Promise.resolve({ outcome: 'accepted' as const, platform: 'web' }),
+  });
+  act(() => void window.dispatchEvent(event));
+  return { prompt };
+}
+
+beforeEach(() => {
+  localStorage.removeItem(DISMISSED_KEY);
+  localStorage.removeItem(INSTALLED_KEY);
+});
+
+afterEach(() => {
+  setUserAgent(originalUserAgent);
+  window.matchMedia = originalMatchMedia;
+});
+
+describe('PwaInstallBanner', () => {
+  it('renders nothing when no install path is available', () => {
+    render(<PwaInstallBanner />);
+    expect(screen.queryByRole('region', { name: 'Install app' })).not.toBeInTheDocument();
+  });
+
+  it('shows the banner once the native install prompt is available', () => {
+    render(<PwaInstallBanner />);
+    fireInstallPromptEvent();
+
+    expect(screen.getByRole('region', { name: 'Install app' })).toBeInTheDocument();
+    expect(screen.getByText('Install app')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Not now' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Install' })).toBeInTheDocument();
+  });
+
+  it('triggers the native prompt when Install is clicked', async () => {
+    const user = userEvent.setup();
+    render(<PwaInstallBanner />);
+    const { prompt } = fireInstallPromptEvent();
+
+    await user.click(screen.getByRole('button', { name: 'Install' }));
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides and persists the dismissal when Not now is clicked', async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<PwaInstallBanner />);
+    fireInstallPromptEvent();
+
+    await user.click(screen.getByRole('button', { name: 'Not now' }));
+
+    expect(screen.queryByRole('region', { name: 'Install app' })).not.toBeInTheDocument();
+    expect(localStorage.getItem(DISMISSED_KEY)).not.toBeNull();
+
+    // Still hidden on a fresh render, even if the browser refires the event.
+    unmount();
+    render(<PwaInstallBanner />);
+    fireInstallPromptEvent();
+    expect(screen.queryByRole('region', { name: 'Install app' })).not.toBeInTheDocument();
+  });
+
+  it('opens iOS instructions on Install and marks the app manually installed', async () => {
+    setUserAgent(IOS_UA);
+    const user = userEvent.setup();
+    const { unmount } = render(<PwaInstallBanner />);
+
+    expect(screen.getByRole('region', { name: 'Install app' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Install' }));
+
+    expect(screen.getByRole('dialog', { name: 'Install this app' })).toBeInTheDocument();
+    expect(screen.getByText(/Add to Home Screen/)).toBeInTheDocument();
+    expect(localStorage.getItem(INSTALLED_KEY)).toBe('true');
+
+    // Banner is gone on the next visit.
+    unmount();
+    render(<PwaInstallBanner />);
+    expect(screen.queryByRole('region', { name: 'Install app' })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when running standalone', () => {
+    setStandalone(true);
+    render(<PwaInstallBanner />);
+    fireInstallPromptEvent();
+    expect(screen.queryByRole('region', { name: 'Install app' })).not.toBeInTheDocument();
+  });
+});

--- a/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallBanner.tsx
+++ b/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallBanner.tsx
@@ -1,0 +1,63 @@
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { useState } from 'react';
+
+import { PwaInstallInstructions } from './PwaInstallInstructions';
+import { usePwaInstall } from './usePwaInstall';
+
+/**
+ * Mobile-only banner offering to install the app as a PWA. Self-aware: renders
+ * nothing unless an install path exists (native prompt or iOS manual install)
+ * and the user hasn't recently dismissed it. Hidden on desktop via CSS.
+ */
+export function PwaInstallBanner() {
+  const { canInstall, installationMethod, install, dismiss } = usePwaInstall();
+  const [instructionsOpen, setInstructionsOpen] = useState(false);
+
+  if (!canInstall && !instructionsOpen) return null;
+
+  const onInstall = () => {
+    if (installationMethod === 'manual') {
+      setInstructionsOpen(true);
+    }
+    void install();
+  };
+
+  return (
+    <>
+      {canInstall && (
+        <div
+          role="region"
+          aria-label="Install app"
+          className="border-border1 bg-surface3 fixed inset-x-0 bottom-0 z-50 border-t pb-[env(safe-area-inset-bottom)] lg:hidden"
+        >
+          <div className="flex items-center gap-3 px-4 py-3">
+            <img src="/pwa-192.png" alt="" className="size-10 shrink-0 rounded-lg" />
+            <div className="min-w-0 flex-1">
+              <Txt as="p" variant="ui-md" className="text-icon6 font-medium">
+                Install app
+              </Txt>
+              <Txt as="p" variant="ui-sm" className="text-icon4 truncate">
+                Get faster access from your home screen
+              </Txt>
+            </div>
+            <button
+              type="button"
+              onClick={dismiss}
+              className="text-icon4 hover:text-icon6 focus-visible:ring-accent1 shrink-0 rounded-md px-3 py-1.5 text-ui-sm focus-visible:ring-2 focus-visible:outline-none"
+            >
+              Not now
+            </button>
+            <button
+              type="button"
+              onClick={onInstall}
+              className="bg-accent1 text-ui-sm focus-visible:ring-accent1 shrink-0 rounded-md px-3 py-1.5 font-medium text-black focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+              Install
+            </button>
+          </div>
+        </div>
+      )}
+      <PwaInstallInstructions open={instructionsOpen} onOpenChange={setInstructionsOpen} />
+    </>
+  );
+}

--- a/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallBanner.tsx
+++ b/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallBanner.tsx
@@ -43,7 +43,7 @@ export function PwaInstallBanner() {
             <button
               type="button"
               onClick={dismiss}
-              className="text-icon4 hover:text-icon6 focus-visible:ring-accent1 shrink-0 rounded-md px-3 py-1.5 text-ui-sm focus-visible:ring-2 focus-visible:outline-none"
+              className="text-icon4 hover:text-icon6 focus-visible:ring-accent1 text-ui-sm shrink-0 rounded-md px-3 py-1.5 focus-visible:ring-2 focus-visible:outline-none"
             >
               Not now
             </button>

--- a/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallInstructions.tsx
+++ b/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallInstructions.tsx
@@ -7,23 +7,53 @@ import {
   DrawerTitle,
 } from '@mastra/playground-ui/components/Drawer';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { Share, Smartphone, SquarePlus } from 'lucide-react';
+import { Menu, Share, Smartphone, SquarePlus } from 'lucide-react';
 import type { ReactNode } from 'react';
+
+import type { IosBrowser } from './platform';
+import { detectIosBrowser } from './platform';
 
 interface PwaInstallInstructionsProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-const steps: Array<{ icon: ReactNode; label: ReactNode }> = [
-  {
-    icon: <Share className="size-4" aria-hidden="true" />,
-    label: (
-      <>
-        Tap the <span className="text-icon6 font-medium">Share</span> button in Safari&rsquo;s toolbar
-      </>
-    ),
-  },
+/** Where the share menu lives differs per iOS browser. */
+function shareStep(browser: IosBrowser): { icon: ReactNode; label: ReactNode } {
+  switch (browser) {
+    case 'chrome':
+      return {
+        icon: <Share className="size-4" aria-hidden="true" />,
+        label: (
+          <>
+            Tap the <span className="text-icon6 font-medium">Share</span> button in Chrome&rsquo;s address bar
+          </>
+        ),
+      };
+    case 'firefox':
+    case 'edge':
+    case 'opera':
+      return {
+        icon: <Menu className="size-4" aria-hidden="true" />,
+        label: (
+          <>
+            Open the browser menu and tap <span className="text-icon6 font-medium">Share</span>
+          </>
+        ),
+      };
+    case 'safari':
+      return {
+        icon: <Share className="size-4" aria-hidden="true" />,
+        label: (
+          <>
+            Tap the <span className="text-icon6 font-medium">Share</span> button in Safari&rsquo;s toolbar
+          </>
+        ),
+      };
+  }
+}
+
+const commonSteps: Array<{ icon: ReactNode; label: ReactNode }> = [
   {
     icon: <SquarePlus className="size-4" aria-hidden="true" />,
     label: (
@@ -42,8 +72,9 @@ const steps: Array<{ icon: ReactNode; label: ReactNode }> = [
   },
 ];
 
-/** iOS/iPadOS Safari has no install prompt; walk the user through Add to Home Screen. */
+/** iOS/iPadOS has no install prompt; walk the user through Add to Home Screen. */
 export function PwaInstallInstructions({ open, onOpenChange }: PwaInstallInstructionsProps) {
+  const steps = [shareStep(detectIosBrowser() ?? 'safari'), ...commonSteps];
   return (
     <Drawer open={open} onOpenChange={onOpenChange} side="bottom">
       <DrawerContent aria-label="Install this app">

--- a/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallInstructions.tsx
+++ b/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallInstructions.tsx
@@ -1,0 +1,37 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@mastra/playground-ui/components/Dialog';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+
+interface PwaInstallInstructionsProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** iOS/iPadOS Safari has no install prompt; walk the user through Add to Home Screen. */
+export function PwaInstallInstructions({ open, onOpenChange }: PwaInstallInstructionsProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-full max-w-md" aria-label="Install this app">
+        <DialogHeader className="px-5 pt-4 pb-2">
+          <DialogTitle>Install this app</DialogTitle>
+        </DialogHeader>
+        <ol className="flex list-decimal flex-col gap-2 px-5 pb-5 pl-9">
+          <li>
+            <Txt as="span" variant="ui-sm" className="text-icon5">
+              Tap the Share button in Safari&rsquo;s toolbar
+            </Txt>
+          </li>
+          <li>
+            <Txt as="span" variant="ui-sm" className="text-icon5">
+              Scroll down and tap &ldquo;Add to Home Screen&rdquo;
+            </Txt>
+          </li>
+          <li>
+            <Txt as="span" variant="ui-sm" className="text-icon5">
+              Tap &ldquo;Add&rdquo; to install the app
+            </Txt>
+          </li>
+        </ol>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallInstructions.tsx
+++ b/mastracode/factory-ui/src/ui/lib/pwa/PwaInstallInstructions.tsx
@@ -1,37 +1,82 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@mastra/playground-ui/components/Dialog';
+import {
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@mastra/playground-ui/components/Drawer';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { Share, Smartphone, SquarePlus } from 'lucide-react';
+import type { ReactNode } from 'react';
 
 interface PwaInstallInstructionsProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
+const steps: Array<{ icon: ReactNode; label: ReactNode }> = [
+  {
+    icon: <Share className="size-4" aria-hidden="true" />,
+    label: (
+      <>
+        Tap the <span className="text-icon6 font-medium">Share</span> button in Safari&rsquo;s toolbar
+      </>
+    ),
+  },
+  {
+    icon: <SquarePlus className="size-4" aria-hidden="true" />,
+    label: (
+      <>
+        Scroll down and tap <span className="text-icon6 font-medium">Add to Home Screen</span>
+      </>
+    ),
+  },
+  {
+    icon: <Smartphone className="size-4" aria-hidden="true" />,
+    label: (
+      <>
+        Tap <span className="text-icon6 font-medium">Add</span> to install the app
+      </>
+    ),
+  },
+];
+
 /** iOS/iPadOS Safari has no install prompt; walk the user through Add to Home Screen. */
 export function PwaInstallInstructions({ open, onOpenChange }: PwaInstallInstructionsProps) {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-full max-w-md" aria-label="Install this app">
-        <DialogHeader className="px-5 pt-4 pb-2">
-          <DialogTitle>Install this app</DialogTitle>
-        </DialogHeader>
-        <ol className="flex list-decimal flex-col gap-2 px-5 pb-5 pl-9">
-          <li>
-            <Txt as="span" variant="ui-sm" className="text-icon5">
-              Tap the Share button in Safari&rsquo;s toolbar
-            </Txt>
-          </li>
-          <li>
-            <Txt as="span" variant="ui-sm" className="text-icon5">
-              Scroll down and tap &ldquo;Add to Home Screen&rdquo;
-            </Txt>
-          </li>
-          <li>
-            <Txt as="span" variant="ui-sm" className="text-icon5">
-              Tap &ldquo;Add&rdquo; to install the app
-            </Txt>
-          </li>
-        </ol>
-      </DialogContent>
-    </Dialog>
+    <Drawer open={open} onOpenChange={onOpenChange} side="bottom">
+      <DrawerContent aria-label="Install this app">
+        <DrawerHeader>
+          <div className="flex items-center gap-3">
+            <div className="border-border1 bg-surface5 text-icon6 flex size-10 shrink-0 items-center justify-center rounded-lg border">
+              <Smartphone className="size-5" aria-hidden="true" />
+            </div>
+            <div className="min-w-0">
+              <DrawerTitle>Install this app</DrawerTitle>
+              <DrawerDescription>Add it to your home screen in three steps</DrawerDescription>
+            </div>
+          </div>
+        </DrawerHeader>
+        <DrawerBody>
+          <ol className="flex flex-col">
+            {steps.map((step, index) => (
+              <li key={index} className="flex items-center gap-3 py-3">
+                <span
+                  aria-hidden="true"
+                  className="bg-surface5 text-icon6 text-ui-xs flex size-6 shrink-0 items-center justify-center rounded-full font-medium tabular-nums"
+                >
+                  {index + 1}
+                </span>
+                <Txt as="span" variant="ui-md" className="text-icon5 min-w-0 flex-1">
+                  {step.label}
+                </Txt>
+                <span className="text-icon3 shrink-0">{step.icon}</span>
+              </li>
+            ))}
+          </ol>
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
   );
 }

--- a/mastracode/factory-ui/src/ui/lib/pwa/index.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/index.ts
@@ -1,0 +1,1 @@
+export { PwaInstallBanner } from './PwaInstallBanner';

--- a/mastracode/factory-ui/src/ui/lib/pwa/persistence.test.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/persistence.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  INSTALL_BANNER_DISMISS_DURATION_MS,
+  isManuallyInstalled,
+  markDismissed,
+  markManuallyInstalled,
+  wasRecentlyDismissed,
+} from './persistence';
+
+const DISMISSED_KEY = 'mastracode.pwaInstallDismissedAt';
+const INSTALLED_KEY = 'mastracode.pwaInstalledManually';
+
+function stubLocalStorage() {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, value),
+    removeItem: (key: string) => void store.delete(key),
+  });
+  return store;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-24T12:00:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('wasRecentlyDismissed', () => {
+  it('is false when nothing is stored', () => {
+    stubLocalStorage();
+    expect(wasRecentlyDismissed()).toBe(false);
+  });
+
+  it('is true within the dismiss window', () => {
+    const store = stubLocalStorage();
+    store.set(DISMISSED_KEY, String(Date.now() - INSTALL_BANNER_DISMISS_DURATION_MS + 60_000));
+    expect(wasRecentlyDismissed()).toBe(true);
+  });
+
+  it('is false once the dismiss window has expired', () => {
+    const store = stubLocalStorage();
+    store.set(DISMISSED_KEY, String(Date.now() - INSTALL_BANNER_DISMISS_DURATION_MS - 1));
+    expect(wasRecentlyDismissed()).toBe(false);
+  });
+
+  it('is false for a corrupt stored value', () => {
+    const store = stubLocalStorage();
+    store.set(DISMISSED_KEY, 'not-a-number');
+    expect(wasRecentlyDismissed()).toBe(false);
+  });
+
+  it('tolerates localStorage throwing', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('denied');
+      },
+    });
+    expect(wasRecentlyDismissed()).toBe(false);
+  });
+});
+
+describe('markDismissed', () => {
+  it('stores the current timestamp', () => {
+    const store = stubLocalStorage();
+    markDismissed();
+    expect(store.get(DISMISSED_KEY)).toBe(String(Date.now()));
+    expect(wasRecentlyDismissed()).toBe(true);
+  });
+
+  it('tolerates localStorage throwing', () => {
+    vi.stubGlobal('localStorage', {
+      setItem: () => {
+        throw new Error('denied');
+      },
+    });
+    expect(() => markDismissed()).not.toThrow();
+  });
+});
+
+describe('manual install flag', () => {
+  it('is false when unset', () => {
+    stubLocalStorage();
+    expect(isManuallyInstalled()).toBe(false);
+  });
+
+  it('round-trips through markManuallyInstalled', () => {
+    const store = stubLocalStorage();
+    markManuallyInstalled();
+    expect(store.get(INSTALLED_KEY)).toBe('true');
+    expect(isManuallyInstalled()).toBe(true);
+  });
+
+  it('tolerates localStorage throwing', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('denied');
+      },
+      setItem: () => {
+        throw new Error('denied');
+      },
+    });
+    expect(() => markManuallyInstalled()).not.toThrow();
+    expect(isManuallyInstalled()).toBe(false);
+  });
+});
+
+describe('INSTALL_BANNER_DISMISS_DURATION_MS', () => {
+  it('is 7 days', () => {
+    expect(INSTALL_BANNER_DISMISS_DURATION_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/mastracode/factory-ui/src/ui/lib/pwa/persistence.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/persistence.ts
@@ -21,6 +21,19 @@ export function wasRecentlyDismissed(): boolean {
   }
 }
 
+/** Milliseconds until the current dismissal expires, or 0 if not dismissed. */
+export function getDismissalRemainingMs(): number {
+  try {
+    const stored = localStorage.getItem(DISMISSED_AT_KEY);
+    if (!stored) return 0;
+    const dismissedAt = Number(stored);
+    if (!Number.isFinite(dismissedAt)) return 0;
+    return Math.max(0, dismissedAt + INSTALL_BANNER_DISMISS_DURATION_MS - Date.now());
+  } catch {
+    return 0;
+  }
+}
+
 export function markDismissed(): void {
   try {
     localStorage.setItem(DISMISSED_AT_KEY, String(Date.now()));

--- a/mastracode/factory-ui/src/ui/lib/pwa/persistence.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/persistence.ts
@@ -1,0 +1,50 @@
+/**
+ * localStorage persistence for the PWA install banner: "Not now" dismissals
+ * (re-eligible after a window) and the iOS manual-install flag. All access is
+ * guarded — storage failures must never break the app.
+ */
+
+export const INSTALL_BANNER_DISMISS_DURATION_MS = 7 * 24 * 60 * 60 * 1000;
+
+const DISMISSED_AT_KEY = 'mastracode.pwaInstallDismissedAt';
+const MANUALLY_INSTALLED_KEY = 'mastracode.pwaInstalledManually';
+
+export function wasRecentlyDismissed(): boolean {
+  try {
+    const stored = localStorage.getItem(DISMISSED_AT_KEY);
+    if (!stored) return false;
+    const dismissedAt = Number(stored);
+    if (!Number.isFinite(dismissedAt)) return false;
+    return Date.now() - dismissedAt < INSTALL_BANNER_DISMISS_DURATION_MS;
+  } catch {
+    return false;
+  }
+}
+
+export function markDismissed(): void {
+  try {
+    localStorage.setItem(DISMISSED_AT_KEY, String(Date.now()));
+  } catch {
+    /* non-fatal */
+  }
+}
+
+/**
+ * iOS has no `appinstalled` event; once the install instructions have been
+ * shown we assume the user followed them and stop prompting.
+ */
+export function isManuallyInstalled(): boolean {
+  try {
+    return localStorage.getItem(MANUALLY_INSTALLED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function markManuallyInstalled(): void {
+  try {
+    localStorage.setItem(MANUALLY_INSTALLED_KEY, 'true');
+  } catch {
+    /* non-fatal */
+  }
+}

--- a/mastracode/factory-ui/src/ui/lib/pwa/platform.test.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/platform.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { isIosSafariLike } from './platform';
+import { detectIosBrowser } from './platform';
 
 function stubNavigator(userAgent: string, maxTouchPoints = 0) {
   vi.stubGlobal('navigator', { userAgent, maxTouchPoints });
@@ -10,21 +10,21 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe('isIosSafariLike', () => {
+describe('detectIosBrowser', () => {
   it('detects iPhone Safari', () => {
     stubNavigator(
       'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
       5,
     );
-    expect(isIosSafariLike()).toBe(true);
+    expect(detectIosBrowser()).toBe('safari');
   });
 
-  it('detects iPad', () => {
+  it('detects iPad Safari', () => {
     stubNavigator(
       'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
       5,
     );
-    expect(isIosSafariLike()).toBe(true);
+    expect(detectIosBrowser()).toBe('safari');
   });
 
   it('detects iPadOS masquerading as macOS via touch points', () => {
@@ -32,67 +32,67 @@ describe('isIosSafariLike', () => {
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
       5,
     );
-    expect(isIosSafariLike()).toBe(true);
+    expect(detectIosBrowser()).toBe('safari');
   });
 
-  it('is false for desktop macOS Safari (no touch)', () => {
-    stubNavigator(
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
-      0,
-    );
-    expect(isIosSafariLike()).toBe(false);
-  });
-
-  it('is false for Chrome on iOS', () => {
+  it('detects Chrome on iOS', () => {
     stubNavigator(
       'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/126.0.6478.54 Mobile/15E148 Safari/604.1',
       5,
     );
-    expect(isIosSafariLike()).toBe(false);
+    expect(detectIosBrowser()).toBe('chrome');
   });
 
-  it('is false for Firefox on iOS', () => {
+  it('detects Firefox on iOS', () => {
     stubNavigator(
       'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/127.0 Mobile/15E148 Safari/605.1.15',
       5,
     );
-    expect(isIosSafariLike()).toBe(false);
+    expect(detectIosBrowser()).toBe('firefox');
   });
 
-  it('is false for Edge on iOS', () => {
+  it('detects Edge on iOS', () => {
     stubNavigator(
       'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/126.0.2592.56 Version/17.0 Mobile/15E148 Safari/604.1',
       5,
     );
-    expect(isIosSafariLike()).toBe(false);
+    expect(detectIosBrowser()).toBe('edge');
   });
 
-  it('is false for Opera on iOS', () => {
+  it('detects Opera on iOS', () => {
     stubNavigator(
       'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) OPT/4.5.1 Mobile/15E148 Safari/604.1',
       5,
     );
-    expect(isIosSafariLike()).toBe(false);
+    expect(detectIosBrowser()).toBe('opera');
   });
 
-  it('is false for Android Chrome', () => {
+  it('is null for desktop macOS Safari (no touch)', () => {
+    stubNavigator(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
+      0,
+    );
+    expect(detectIosBrowser()).toBeNull();
+  });
+
+  it('is null for Android Chrome', () => {
     stubNavigator(
       'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
       5,
     );
-    expect(isIosSafariLike()).toBe(false);
+    expect(detectIosBrowser()).toBeNull();
   });
 
-  it('is false for desktop Chrome', () => {
+  it('is null for desktop Chrome', () => {
     stubNavigator(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
       0,
     );
-    expect(isIosSafariLike()).toBe(false);
+    expect(detectIosBrowser()).toBeNull();
   });
 
-  it('is false when navigator is undefined', () => {
+  it('is null when navigator is undefined', () => {
     vi.stubGlobal('navigator', undefined);
-    expect(isIosSafariLike()).toBe(false);
+    expect(detectIosBrowser()).toBeNull();
   });
 });

--- a/mastracode/factory-ui/src/ui/lib/pwa/platform.test.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/platform.test.ts
@@ -43,6 +43,38 @@ describe('isIosSafariLike', () => {
     expect(isIosSafariLike()).toBe(false);
   });
 
+  it('is false for Chrome on iOS', () => {
+    stubNavigator(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/126.0.6478.54 Mobile/15E148 Safari/604.1',
+      5,
+    );
+    expect(isIosSafariLike()).toBe(false);
+  });
+
+  it('is false for Firefox on iOS', () => {
+    stubNavigator(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/127.0 Mobile/15E148 Safari/605.1.15',
+      5,
+    );
+    expect(isIosSafariLike()).toBe(false);
+  });
+
+  it('is false for Edge on iOS', () => {
+    stubNavigator(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/126.0.2592.56 Version/17.0 Mobile/15E148 Safari/604.1',
+      5,
+    );
+    expect(isIosSafariLike()).toBe(false);
+  });
+
+  it('is false for Opera on iOS', () => {
+    stubNavigator(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) OPT/4.5.1 Mobile/15E148 Safari/604.1',
+      5,
+    );
+    expect(isIosSafariLike()).toBe(false);
+  });
+
   it('is false for Android Chrome', () => {
     stubNavigator(
       'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',

--- a/mastracode/factory-ui/src/ui/lib/pwa/platform.test.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/platform.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isIosSafariLike } from './platform';
+
+function stubNavigator(userAgent: string, maxTouchPoints = 0) {
+  vi.stubGlobal('navigator', { userAgent, maxTouchPoints });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('isIosSafariLike', () => {
+  it('detects iPhone Safari', () => {
+    stubNavigator(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+      5,
+    );
+    expect(isIosSafariLike()).toBe(true);
+  });
+
+  it('detects iPad', () => {
+    stubNavigator(
+      'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+      5,
+    );
+    expect(isIosSafariLike()).toBe(true);
+  });
+
+  it('detects iPadOS masquerading as macOS via touch points', () => {
+    stubNavigator(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
+      5,
+    );
+    expect(isIosSafariLike()).toBe(true);
+  });
+
+  it('is false for desktop macOS Safari (no touch)', () => {
+    stubNavigator(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
+      0,
+    );
+    expect(isIosSafariLike()).toBe(false);
+  });
+
+  it('is false for Android Chrome', () => {
+    stubNavigator(
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
+      5,
+    );
+    expect(isIosSafariLike()).toBe(false);
+  });
+
+  it('is false for desktop Chrome', () => {
+    stubNavigator(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+      0,
+    );
+    expect(isIosSafariLike()).toBe(false);
+  });
+
+  it('is false when navigator is undefined', () => {
+    vi.stubGlobal('navigator', undefined);
+    expect(isIosSafariLike()).toBe(false);
+  });
+});

--- a/mastracode/factory-ui/src/ui/lib/pwa/platform.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/platform.ts
@@ -1,0 +1,12 @@
+/**
+ * iOS/iPadOS detection for the manual "Add to Home Screen" install path.
+ * UA sniffing is unavoidable here: there is no capability check for the iOS
+ * share-menu install flow. iPadOS can report a macOS user agent, so touch
+ * support disambiguates it from desktop Safari.
+ */
+export function isIosSafariLike(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const { userAgent, maxTouchPoints } = navigator;
+  if (/iPhone|iPad|iPod/.test(userAgent)) return true;
+  return /Macintosh/.test(userAgent) && maxTouchPoints > 1;
+}

--- a/mastracode/factory-ui/src/ui/lib/pwa/platform.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/platform.ts
@@ -7,6 +7,9 @@
 export function isIosSafariLike(): boolean {
   if (typeof navigator === 'undefined') return false;
   const { userAgent, maxTouchPoints } = navigator;
+  // Third-party iOS browsers (Chrome, Firefox, Edge, Opera) also report
+  // iPhone/iPad, but our instructions describe Safari's share-menu flow.
+  if (/CriOS|FxiOS|EdgiOS|OPiOS|OPT\//.test(userAgent)) return false;
   if (/iPhone|iPad|iPod/.test(userAgent)) return true;
   return /Macintosh/.test(userAgent) && maxTouchPoints > 1;
 }

--- a/mastracode/factory-ui/src/ui/lib/pwa/platform.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/platform.ts
@@ -1,15 +1,21 @@
+export type IosBrowser = 'safari' | 'chrome' | 'firefox' | 'edge' | 'opera';
+
 /**
- * iOS/iPadOS detection for the manual "Add to Home Screen" install path.
- * UA sniffing is unavoidable here: there is no capability check for the iOS
- * share-menu install flow. iPadOS can report a macOS user agent, so touch
- * support disambiguates it from desktop Safari.
+ * Detects iOS/iPadOS browsers for the manual "Add to Home Screen" install
+ * path (no `beforeinstallprompt` on iOS; all browsers support the share-menu
+ * install since iOS 16.4, but the entry point differs per browser). UA
+ * sniffing is unavoidable: there is no capability check for this flow.
+ * iPadOS can report a macOS user agent, so touch support disambiguates it
+ * from desktop Safari. Returns null off iOS.
  */
-export function isIosSafariLike(): boolean {
-  if (typeof navigator === 'undefined') return false;
+export function detectIosBrowser(): IosBrowser | null {
+  if (typeof navigator === 'undefined') return null;
   const { userAgent, maxTouchPoints } = navigator;
-  // Third-party iOS browsers (Chrome, Firefox, Edge, Opera) also report
-  // iPhone/iPad, but our instructions describe Safari's share-menu flow.
-  if (/CriOS|FxiOS|EdgiOS|OPiOS|OPT\//.test(userAgent)) return false;
-  if (/iPhone|iPad|iPod/.test(userAgent)) return true;
-  return /Macintosh/.test(userAgent) && maxTouchPoints > 1;
+  const isIos = /iPhone|iPad|iPod/.test(userAgent) || (/Macintosh/.test(userAgent) && maxTouchPoints > 1);
+  if (!isIos) return null;
+  if (/CriOS/.test(userAgent)) return 'chrome';
+  if (/FxiOS/.test(userAgent)) return 'firefox';
+  if (/EdgiOS/.test(userAgent)) return 'edge';
+  if (/OPiOS|OPT\//.test(userAgent)) return 'opera';
+  return 'safari';
 }

--- a/mastracode/factory-ui/src/ui/lib/pwa/standalone.test.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/standalone.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isRunningStandalone } from './standalone';
+
+function stubWindow(overrides: { displayModeStandalone?: boolean; navigatorStandalone?: boolean }) {
+  const matchMedia = vi.fn((query: string) => ({
+    matches: query === '(display-mode: standalone)' && Boolean(overrides.displayModeStandalone),
+  }));
+  vi.stubGlobal('window', {
+    matchMedia,
+    navigator: overrides.navigatorStandalone === undefined ? {} : { standalone: overrides.navigatorStandalone },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('isRunningStandalone', () => {
+  it('returns true when display-mode: standalone matches', () => {
+    stubWindow({ displayModeStandalone: true });
+    expect(isRunningStandalone()).toBe(true);
+  });
+
+  it('returns true when iOS navigator.standalone is true', () => {
+    stubWindow({ navigatorStandalone: true });
+    expect(isRunningStandalone()).toBe(true);
+  });
+
+  it('returns false in a regular browser tab', () => {
+    stubWindow({ navigatorStandalone: false });
+    expect(isRunningStandalone()).toBe(false);
+  });
+
+  it('returns false when window is undefined', () => {
+    vi.stubGlobal('window', undefined);
+    expect(isRunningStandalone()).toBe(false);
+  });
+});

--- a/mastracode/factory-ui/src/ui/lib/pwa/standalone.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/standalone.ts
@@ -1,0 +1,14 @@
+/**
+ * Detects whether the app is currently running as an installed PWA
+ * (Chromium standalone display mode, or iOS Home-Screen web app).
+ */
+export function isRunningStandalone(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    if (window.matchMedia('(display-mode: standalone)').matches) return true;
+  } catch {
+    /* matchMedia unavailable */
+  }
+  // iOS Safari exposes a non-standard `navigator.standalone` flag.
+  return (window.navigator as { standalone?: boolean }).standalone === true;
+}

--- a/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.msw.test.tsx
@@ -154,6 +154,23 @@ describe('usePwaInstall', () => {
     expect(result.current.canInstall).toBe(false);
   });
 
+  it('becomes eligible again when the dismissal window expires without a remount', () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => usePwaInstall());
+      const { event } = createInstallPromptEvent('accepted');
+      act(() => void window.dispatchEvent(event));
+
+      act(() => result.current.dismiss());
+      expect(result.current.canInstall).toBe(false);
+
+      act(() => void vi.advanceTimersByTime(INSTALL_BANNER_DISMISS_DURATION_MS + 1000));
+      expect(result.current.canInstall).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('becomes eligible again after the dismissal window expires', () => {
     localStorage.setItem(DISMISSED_KEY, String(Date.now() - INSTALL_BANNER_DISMISS_DURATION_MS - 1000));
     const { result } = renderHook(() => usePwaInstall());

--- a/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.msw.test.tsx
@@ -73,6 +73,15 @@ describe('usePwaInstall', () => {
     expect(result.current.installationMethod).toBe('manual');
   });
 
+  it('offers the manual method on Chrome iOS too', () => {
+    setUserAgent(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/126.0.6478.54 Mobile/15E148 Safari/604.1',
+    );
+    const { result } = renderHook(() => usePwaInstall());
+    expect(result.current.state).toBe('manual-install');
+    expect(result.current.installationMethod).toBe('manual');
+  });
+
   it('reports installed when running standalone', () => {
     setStandalone(true);
     const { result } = renderHook(() => usePwaInstall());

--- a/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.msw.test.tsx
@@ -1,0 +1,165 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BeforeInstallPromptEvent } from './usePwaInstall';
+import { INSTALL_BANNER_DISMISS_DURATION_MS } from './persistence';
+import { usePwaInstall } from './usePwaInstall';
+
+const DISMISSED_KEY = 'mastracode.pwaInstallDismissedAt';
+const INSTALLED_KEY = 'mastracode.pwaInstalledManually';
+
+const IOS_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1';
+
+const originalUserAgent = navigator.userAgent;
+const originalMatchMedia = window.matchMedia;
+
+function setUserAgent(userAgent: string) {
+  Object.defineProperty(window.navigator, 'userAgent', { value: userAgent, configurable: true });
+}
+
+function setStandalone(standalone: boolean) {
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: standalone && query === '(display-mode: standalone)',
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }) as unknown as MediaQueryList) as typeof window.matchMedia;
+}
+
+function createInstallPromptEvent(outcome: 'accepted' | 'dismissed') {
+  const event = new Event('beforeinstallprompt', { cancelable: true }) as BeforeInstallPromptEvent;
+  const prompt = vi.fn(() => Promise.resolve());
+  Object.assign(event, { prompt, userChoice: Promise.resolve({ outcome, platform: 'web' }) });
+  return { event, prompt };
+}
+
+beforeEach(() => {
+  localStorage.removeItem(DISMISSED_KEY);
+  localStorage.removeItem(INSTALLED_KEY);
+});
+
+afterEach(() => {
+  setUserAgent(originalUserAgent);
+  window.matchMedia = originalMatchMedia;
+});
+
+describe('usePwaInstall', () => {
+  it('starts unavailable on non-iOS browsers without a native prompt', () => {
+    const { result } = renderHook(() => usePwaInstall());
+    expect(result.current.state).toBe('unavailable');
+    expect(result.current.canInstall).toBe(false);
+    expect(result.current.installationMethod).toBeNull();
+  });
+
+  it('captures beforeinstallprompt, prevents the default mini-infobar, and enables native install', () => {
+    const { result } = renderHook(() => usePwaInstall());
+    const { event } = createInstallPromptEvent('accepted');
+
+    act(() => void window.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(result.current.state).toBe('native-prompt-available');
+    expect(result.current.canInstall).toBe(true);
+    expect(result.current.installationMethod).toBe('native');
+  });
+
+  it('offers the manual method on iOS-like Safari', () => {
+    setUserAgent(IOS_UA);
+    const { result } = renderHook(() => usePwaInstall());
+    expect(result.current.state).toBe('manual-install');
+    expect(result.current.canInstall).toBe(true);
+    expect(result.current.installationMethod).toBe('manual');
+  });
+
+  it('reports installed when running standalone', () => {
+    setStandalone(true);
+    const { result } = renderHook(() => usePwaInstall());
+    expect(result.current.state).toBe('installed');
+    expect(result.current.isInstalled).toBe(true);
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('reports installed when the iOS manual-install flag is set', () => {
+    setUserAgent(IOS_UA);
+    localStorage.setItem(INSTALLED_KEY, 'true');
+    const { result } = renderHook(() => usePwaInstall());
+    expect(result.current.state).toBe('installed');
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('install() prompts natively and becomes installed on accepted', async () => {
+    const { result } = renderHook(() => usePwaInstall());
+    const { event, prompt } = createInstallPromptEvent('accepted');
+    act(() => void window.dispatchEvent(event));
+
+    await act(() => result.current.install());
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(result.current.state).toBe('installed');
+  });
+
+  it('install() tolerates a dismissed prompt and never reuses the consumed event', async () => {
+    const { result } = renderHook(() => usePwaInstall());
+    const { event, prompt } = createInstallPromptEvent('dismissed');
+    act(() => void window.dispatchEvent(event));
+
+    await act(() => result.current.install());
+    expect(result.current.state).toBe('unavailable');
+
+    await act(() => result.current.install());
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('install() on iOS marks the app manually installed', async () => {
+    setUserAgent(IOS_UA);
+    const { result } = renderHook(() => usePwaInstall());
+
+    await act(() => result.current.install());
+
+    expect(localStorage.getItem(INSTALLED_KEY)).toBe('true');
+    expect(result.current.state).toBe('installed');
+  });
+
+  it('becomes installed on the appinstalled event', () => {
+    const { result } = renderHook(() => usePwaInstall());
+    const { event } = createInstallPromptEvent('accepted');
+    act(() => void window.dispatchEvent(event));
+
+    act(() => void window.dispatchEvent(new Event('appinstalled')));
+
+    expect(result.current.state).toBe('installed');
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('dismiss() hides the banner and persists the timestamp', () => {
+    const { result } = renderHook(() => usePwaInstall());
+    const { event } = createInstallPromptEvent('accepted');
+    act(() => void window.dispatchEvent(event));
+
+    act(() => result.current.dismiss());
+
+    expect(result.current.canInstall).toBe(false);
+    expect(localStorage.getItem(DISMISSED_KEY)).not.toBeNull();
+  });
+
+  it('stays hidden while a recent dismissal is in effect', () => {
+    localStorage.setItem(DISMISSED_KEY, String(Date.now() - 1000));
+    const { result } = renderHook(() => usePwaInstall());
+    const { event } = createInstallPromptEvent('accepted');
+    act(() => void window.dispatchEvent(event));
+
+    expect(result.current.state).toBe('native-prompt-available');
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('becomes eligible again after the dismissal window expires', () => {
+    localStorage.setItem(DISMISSED_KEY, String(Date.now() - INSTALL_BANNER_DISMISS_DURATION_MS - 1000));
+    const { result } = renderHook(() => usePwaInstall());
+    const { event } = createInstallPromptEvent('accepted');
+    act(() => void window.dispatchEvent(event));
+
+    expect(result.current.canInstall).toBe(true);
+  });
+});

--- a/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { isIosSafariLike } from './platform';
+import { detectIosBrowser } from './platform';
 import {
   getDismissalRemainingMs,
   isManuallyInstalled,
@@ -30,7 +30,7 @@ export interface PwaInstall {
 
 function computeInitialState(): PwaInstallState {
   if (isRunningStandalone() || isManuallyInstalled()) return 'installed';
-  if (isIosSafariLike()) return 'manual-install';
+  if (detectIosBrowser() !== null) return 'manual-install';
   // Chromium signals native installability later via `beforeinstallprompt`.
   return 'unavailable';
 }
@@ -38,7 +38,7 @@ function computeInitialState(): PwaInstallState {
 /**
  * Centralizes PWA install state: captures Chromium's `beforeinstallprompt`
  * for a user-gesture-triggered native prompt, falls back to the manual
- * "Add to Home Screen" method on iOS-like Safari, and tracks dismissal.
+ * "Add to Home Screen" method on iOS browsers, and tracks dismissal.
  */
 export function usePwaInstall(): PwaInstall {
   const [state, setState] = useState<PwaInstallState>(computeInitialState);

--- a/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.ts
@@ -1,7 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { isIosSafariLike } from './platform';
-import { isManuallyInstalled, markDismissed, markManuallyInstalled, wasRecentlyDismissed } from './persistence';
+import {
+  getDismissalRemainingMs,
+  isManuallyInstalled,
+  markDismissed,
+  markManuallyInstalled,
+  wasRecentlyDismissed,
+} from './persistence';
 import { isRunningStandalone } from './standalone';
 
 /** Non-standard Chromium event; not in lib.dom, so typed locally. */
@@ -58,7 +64,14 @@ export function usePwaInstall(): PwaInstall {
     };
   }, []);
 
-  const install = useCallback(async () => {
+  // While dismissed, schedule the banner to reappear when the window expires.
+  useEffect(() => {
+    if (!dismissed) return;
+    const timeout = setTimeout(() => setDismissed(false), getDismissalRemainingMs());
+    return () => clearTimeout(timeout);
+  }, [dismissed]);
+
+  const install = async () => {
     if (state === 'manual-install') {
       // No install API on iOS: showing the instructions is our best proxy.
       markManuallyInstalled();
@@ -72,12 +85,12 @@ export function usePwaInstall(): PwaInstall {
     await deferredPrompt.prompt();
     const { outcome } = await deferredPrompt.userChoice;
     setState(outcome === 'accepted' ? 'installed' : 'unavailable');
-  }, [state]);
+  };
 
-  const dismiss = useCallback(() => {
+  const dismiss = () => {
     markDismissed();
     setDismissed(true);
-  }, []);
+  };
 
   const isInstalled = state === 'installed';
   const installable = state === 'native-prompt-available' || state === 'manual-install';

--- a/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.ts
+++ b/mastracode/factory-ui/src/ui/lib/pwa/usePwaInstall.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { isIosSafariLike } from './platform';
+import { isManuallyInstalled, markDismissed, markManuallyInstalled, wasRecentlyDismissed } from './persistence';
+import { isRunningStandalone } from './standalone';
+
+/** Non-standard Chromium event; not in lib.dom, so typed locally. */
+export interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+export type PwaInstallState = 'installed' | 'native-prompt-available' | 'manual-install' | 'unavailable';
+
+export interface PwaInstall {
+  state: PwaInstallState;
+  /** True when the banner should be offered: an install path exists and it wasn't recently dismissed. */
+  canInstall: boolean;
+  isInstalled: boolean;
+  installationMethod: 'native' | 'manual' | null;
+  install: () => Promise<void>;
+  dismiss: () => void;
+}
+
+function computeInitialState(): PwaInstallState {
+  if (isRunningStandalone() || isManuallyInstalled()) return 'installed';
+  if (isIosSafariLike()) return 'manual-install';
+  // Chromium signals native installability later via `beforeinstallprompt`.
+  return 'unavailable';
+}
+
+/**
+ * Centralizes PWA install state: captures Chromium's `beforeinstallprompt`
+ * for a user-gesture-triggered native prompt, falls back to the manual
+ * "Add to Home Screen" method on iOS-like Safari, and tracks dismissal.
+ */
+export function usePwaInstall(): PwaInstall {
+  const [state, setState] = useState<PwaInstallState>(computeInitialState);
+  const [dismissed, setDismissed] = useState(wasRecentlyDismissed);
+  const deferredPromptRef = useRef<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    const onBeforeInstallPrompt = (event: Event) => {
+      // Suppress Chromium's mini-infobar; we prompt from our own banner.
+      event.preventDefault();
+      deferredPromptRef.current = event as BeforeInstallPromptEvent;
+      setState(previous => (previous === 'installed' ? previous : 'native-prompt-available'));
+    };
+    const onAppInstalled = () => {
+      deferredPromptRef.current = null;
+      setState('installed');
+    };
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+    window.addEventListener('appinstalled', onAppInstalled);
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', onAppInstalled);
+    };
+  }, []);
+
+  const install = useCallback(async () => {
+    if (state === 'manual-install') {
+      // No install API on iOS: showing the instructions is our best proxy.
+      markManuallyInstalled();
+      setState('installed');
+      return;
+    }
+    const deferredPrompt = deferredPromptRef.current;
+    if (!deferredPrompt) return;
+    // A BeforeInstallPromptEvent is single-use; consume it either way.
+    deferredPromptRef.current = null;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    setState(outcome === 'accepted' ? 'installed' : 'unavailable');
+  }, [state]);
+
+  const dismiss = useCallback(() => {
+    markDismissed();
+    setDismissed(true);
+  }, []);
+
+  const isInstalled = state === 'installed';
+  const installable = state === 'native-prompt-available' || state === 'manual-install';
+
+  return {
+    state,
+    canInstall: installable && !dismissed,
+    isInstalled,
+    installationMethod: state === 'native-prompt-available' ? 'native' : state === 'manual-install' ? 'manual' : null,
+    install,
+    dismiss,
+  };
+}

--- a/mastracode/factory-ui/src/ui/main.tsx
+++ b/mastracode/factory-ui/src/ui/main.tsx
@@ -8,6 +8,7 @@ import { RouterProvider } from 'react-router/dom';
 
 import { ApiConfigProvider } from '../api/config';
 import { createQueryClient } from '../query-client';
+import { PwaInstallBanner } from './lib/pwa';
 import { createAppRouter } from './router';
 import '@mastra/playground-ui/style.css';
 import './tailwind.css';
@@ -33,6 +34,7 @@ createRoot(document.getElementById('root')!).render(
         <QueryClientProvider client={queryClient}>
           <ApiConfigProvider baseUrl="">
             <RouterProvider router={router} />
+            <PwaInstallBanner />
             <Toaster position="bottom-right" />
           </ApiConfigProvider>
         </QueryClientProvider>


### PR DESCRIPTION
## Summary

Adds a mobile-only PWA install banner to the MastraCode web app (`mastracode/factory-ui`) so users can install the app to their home screen.

- **Chromium/Android**: captures `beforeinstallprompt` and triggers the native install prompt from the banner's Install button.
- **iOS/iPadOS Safari** (incl. iPad masquerading as macOS): shows an "Add to Home Screen" instructions dialog, since no native prompt exists.
- Banner is hidden on desktop (`lg:hidden`), when running standalone (already installed), or within 7 days of dismissal ("Not now", persisted in localStorage).
- Mounted once at the app root so it appears on every route, including login.
- No service worker required — relies on the existing web manifest.

New code lives in `src/ui/lib/pwa/`: `standalone.ts`, `persistence.ts`, `platform.ts`, `usePwaInstall.ts`, `PwaInstallBanner.tsx`, `PwaInstallInstructions.tsx`.

## Test plan

- Unit tests for standalone detection, dismissal persistence, and iOS platform detection
- jsdom/MSW tests for the `usePwaInstall` hook (native prompt flow, appinstalled, manual install, dismissal expiry) and banner UI (render states, Not now, iOS instructions dialog)
- `pnpm --filter ./mastracode/factory-ui test:unit` / `test:msw` / `typecheck` / `build` all green
- Manual: verify banner on Android Chrome (native prompt) and iOS Safari (instructions dialog); confirm hidden on desktop and in installed standalone mode

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

MastraCode helps mobile users install the app on their devices. It shows the correct install option for Android or iOS and remembers dismissed or completed install prompts.

## Changes

- Added a mobile-only `PwaInstallBanner`.
- Added Android and Chromium support for the native `beforeinstallprompt` flow.
- Added iOS and iPadOS instructions for Safari, Chrome, Firefox, Edge, and Opera.
- Adapted the first installation step to the detected iOS browser.
- Hid the banner on desktop and in standalone mode.
- Added seven-day dismissal persistence with expiry checks.
- Added manual-install persistence for iOS.
- Mounted the banner at the app root across all routes, including login.
- Reused the existing web manifest without adding a service worker.
- Added platform detection and standalone-mode utilities.
- Added unit and MSW tests for detection, persistence, installation flows, dismissal expiry, and UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->