### PR TITLE
test(mastracode): navigate API key provider viewport

### DIFF
--- a/mastracode/tui/e2e/tui/api-key-multi-provider-delete.ts
+++ b/mastracode/tui/e2e/tui/api-key-multi-provider-delete.ts
@@ -58,18 +58,34 @@ export const apiKeyMultiProviderDeleteScenario = {
     terminal.submit('/api-keys');
     await runtime.waitForScreenText(/API Keys/i, terminal, 8_000);
     await runtime.waitForScreenText(/302ai\s+✓ \(stored\)/i, terminal, 8_000);
-    await runtime.waitForScreenText(/anthropic\s+✓ \(stored\)/i, terminal, 8_000);
 
-    const initialView = terminal.serialize().view;
-    const firstIndex = initialView.indexOf('302ai');
-    const secondIndex = initialView.indexOf('anthropic');
-    if (firstIndex < 0 || secondIndex < 0 || firstIndex >= secondIndex) {
-      throw new Error(`Expected /api-keys provider list to show 302ai before anthropic. Screen:\n${initialView}`);
+    const providerCountMatch = terminal.serialize().view.match(/\(\d+\/(\d+)\)/);
+    if (!providerCountMatch) throw new Error('Expected /api-keys to show the provider count');
+
+    const secondProviderStatus = /anthropic\s+✓ \(stored\)/i;
+    const providerCount = Number(providerCountMatch[1]);
+    let navigationSteps = 0;
+    while (navigationSteps < providerCount && !secondProviderStatus.test(terminal.serialize().view)) {
+      terminal.write('\x1b[B');
+      await terminal.flushInput?.();
+      navigationSteps += 1;
     }
+    await runtime.waitForScreenText(secondProviderStatus, terminal, 8_000);
+
+    for (let index = 0; index < navigationSteps; index += 1) {
+      terminal.write('\x1b[A');
+      await terminal.flushInput?.();
+    }
+    await runtime.waitForScreenText(/302ai\s+✓ \(stored\)/i, terminal, 8_000);
 
     terminal.write('\x7f');
     await runtime.waitForScreenText(/302ai\s+✗ \(not set\)/i, terminal, 8_000);
-    await runtime.waitForScreenText(/anthropic\s+✓ \(stored\)/i, terminal, 8_000);
+
+    for (let index = 0; index < navigationSteps; index += 1) {
+      terminal.write('\x1b[B');
+      await terminal.flushInput?.();
+    }
+    await runtime.waitForScreenText(secondProviderStatus, terminal, 8_000);
 
     terminal.write('\x1b');
     await runtime.waitForScreenTextAbsent(/API Keys/i, terminal, 8_000);

--- a/mastracode/tui/e2e/tui/api-key-multi-provider-delete.ts
+++ b/mastracode/tui/e2e/tui/api-key-multi-provider-delete.ts
@@ -10,6 +10,16 @@ const secondEnvVar = 'ANTHROPIC_API_KEY';
 const firstStoredKey = 'mc-e2e-302ai-delete-isolation-key';
 const secondStoredKey = 'mc-e2e-anthropic-preserved-key';
 
+function getProviderPosition(view: string) {
+  const match = view.match(/\((\d+)\/(\d+)\)/);
+  if (!match) throw new Error('Expected /api-keys to show the provider position');
+
+  return {
+    selected: Number(match[1]),
+    total: Number(match[2]),
+  };
+}
+
 export const apiKeyMultiProviderDeleteScenario = {
   name: 'api-key-multi-provider-delete',
   description: 'Keeps API key provider ordering stable and deletes only the selected stored provider key.',
@@ -57,29 +67,32 @@ export const apiKeyMultiProviderDeleteScenario = {
 
     terminal.submit('/api-keys');
     await runtime.waitForScreenText(/API Keys/i, terminal, 8_000);
-    await runtime.waitForScreenText(/302ai\s+✓ \(stored\)/i, terminal, 8_000);
+    const firstProviderStatus = /→\s+302ai\s+✓ \(stored\)/i;
+    const secondProviderStatus = /→\s+anthropic\s+✓ \(stored\)/i;
+    await runtime.waitForScreenText(firstProviderStatus, terminal, 8_000);
 
-    const providerCountMatch = terminal.serialize().view.match(/\(\d+\/(\d+)\)/);
-    if (!providerCountMatch) throw new Error('Expected /api-keys to show the provider count');
-
-    const secondProviderStatus = /anthropic\s+✓ \(stored\)/i;
-    const providerCount = Number(providerCountMatch[1]);
+    const firstProviderPosition = getProviderPosition(terminal.serialize().view);
     let navigationSteps = 0;
-    while (navigationSteps < providerCount && !secondProviderStatus.test(terminal.serialize().view)) {
+    while (navigationSteps < firstProviderPosition.total && !secondProviderStatus.test(terminal.serialize().view)) {
       terminal.write('\x1b[B');
       await terminal.flushInput?.();
       navigationSteps += 1;
     }
     await runtime.waitForScreenText(secondProviderStatus, terminal, 8_000);
 
+    const secondProviderPosition = getProviderPosition(terminal.serialize().view);
+    if (secondProviderPosition.selected <= firstProviderPosition.selected) {
+      throw new Error('Expected /api-keys to sort 302ai before anthropic');
+    }
+
     for (let index = 0; index < navigationSteps; index += 1) {
       terminal.write('\x1b[A');
       await terminal.flushInput?.();
     }
-    await runtime.waitForScreenText(/302ai\s+✓ \(stored\)/i, terminal, 8_000);
+    await runtime.waitForScreenText(firstProviderStatus, terminal, 8_000);
 
     terminal.write('\x7f');
-    await runtime.waitForScreenText(/302ai\s+✗ \(not set\)/i, terminal, 8_000);
+    await runtime.waitForScreenText(/→\s+302ai\s+✗ \(not set\)/i, terminal, 8_000);
 
     for (let index = 0; index < navigationSteps; index += 1) {
       terminal.write('\x1b[B');


### PR DESCRIPTION
PR #18102 added this scenario with an assertion that both `302ai` and `anthropic` are present in the initial `/api-keys` screen.

`/api-keys` renders at most 15 provider rows. The registry now returns 180 providers, so `anthropic` sits below the initial viewport and the test times out before it can test deletion.

PR #22186 did not change the TUI or this test. Any `mastracode/` change runs the full Mastra Code E2E suite, so its Factory UI change exposed the stale viewport assumption in [this job](https://github.com/mastra-ai/mastra/actions/runs/32715037011/job/97395093325). I removed the test change from that PR.

This PR keeps the original behavior coverage. It navigates until Anthropic is visible, returns to `302ai`, deletes that key, then navigates back and confirms Anthropic is still stored.

Verified with the focused E2E scenario (1 passed), TUI typecheck, lint, and format. The full suite runs in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The test now finds providers correctly even when the list contains many providers. It deletes only the `302ai` key and confirms that the Anthropic key remains stored.

## Changes

- Updated the API-key E2E test to navigate through provider pages until Anthropic is visible.
- Added provider-position parsing from the selected-row marker.
- Returned to `302ai` before deleting its key.
- Verified that the Anthropic key remains stored after deletion.
- Preserved the provider-order assertion using rendered positions.

## Validation

- Focused E2E scenario
- TUI typecheck
- Lint
- Formatting checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->