### PR TITLE
fix(core): stop an already executing durable run from the agent abort APIs

### DIFF
--- a/.changeset/ten-ducks-run.md
+++ b/.changeset/ten-ducks-run.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': patch
+---
+
+Cancelling a durable agent run that is already executing now works through the agent APIs. `agent.abortThreadStream({ resourceId, threadId })` and `agent.abortRunStream(runId)` only ever reached the abort controller a regular run prepares, which a durable run does not have, so they recorded a cancellation nothing acted on while the run streamed on. The server route `POST /agents/:agentId/threads/abort` goes through the same call. Both now publish the durable abort request as well, the same one the `abort()` on a stream result publishes, so the run stops in whichever process is executing it.
+
+```ts
+const { runId } = await durableAgent.stream('...', { memory: { thread, resource } });
+
+// before: the cancellation was recorded and the run streamed on to completion
+// after: the run stops and onAbort fires
+durableAgent.abortRunStream(runId);
+```

--- a/packages/core/src/agent/durable/__tests__/durable-agent-abort.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-abort.test.ts
@@ -18,9 +18,11 @@ import { EventEmitterPubSub } from '../../../events/event-emitter';
 import { Agent } from '../../agent';
 import { createDurableAgent } from '../create-durable-agent';
 
-function createAbortableModel() {
+/** @param onCall - invoked as soon as the model starts streaming, to synchronize on a live run. */
+function createAbortableModel(onCall?: () => void) {
   return new MockLanguageModelV2({
     doStream: async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+      onCall?.();
       // If the caller already aborted before the call landed, fail fast with
       // the canonical AbortError name so the durable abort heuristic fires.
       if (abortSignal?.aborted) {
@@ -255,18 +257,24 @@ describe('DurableAgent abort signal', () => {
     // A durable run keeps its controller on the durable run registry, not in
     // the thread runtime's prepared-run map, so the base implementation reaches
     // neither: without the durable abort request the run streams on.
+    // Resolves when the model is actually streaming, so the abort below lands
+    // on a run under way rather than on one that has not started yet.
+    let streaming: () => void;
+    const modelCalled = new Promise<void>(resolve => {
+      streaming = resolve;
+    });
     const baseAgent = new Agent({
       id: 'abort-thread-stream-agent',
       name: 'Abort Thread Stream Agent',
       instructions: 'Test',
-      model: createAbortableModel() as LanguageModelV2,
+      model: createAbortableModel(() => streaming()) as LanguageModelV2,
     });
     const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
 
     const threadId = 'abort-thread-stream-thread';
     const resourceId = 'abort-thread-stream-resource';
 
-    let abortPayload: unknown;
+    let abortPayload: { steps: { finishReason?: string }[] } | undefined;
     const { output, cleanup } = await durableAgent.stream('Go', {
       memory: { thread: threadId, resource: resourceId },
       onAbort: data => {
@@ -274,31 +282,32 @@ describe('DurableAgent abort signal', () => {
       },
     });
 
-    // Give the workflow a tick to subscribe + call doStream before we abort.
-    await new Promise(r => setTimeout(r, 10));
+    await modelCalled;
     expect(durableAgent.abortThreadStream({ threadId, resourceId })).toBe(true);
 
-    try {
-      await output.consumeStream();
-    } catch {
-      // expected — the run never produced a normal finish
-    }
+    // Awaited without a catch: the run has to end through the abort path,
+    // rather than by surfacing some unrelated stream failure.
+    await output.consumeStream();
 
-    expect(abortPayload).toBeDefined();
+    expect(abortPayload?.steps.at(-1)?.finishReason).toBe('abort');
 
     cleanup();
   });
 
   it('abortRunStream stops a durable run that is already executing', async () => {
+    let streaming: () => void;
+    const modelCalled = new Promise<void>(resolve => {
+      streaming = resolve;
+    });
     const baseAgent = new Agent({
       id: 'abort-run-stream-agent',
       name: 'Abort Run Stream Agent',
       instructions: 'Test',
-      model: createAbortableModel() as LanguageModelV2,
+      model: createAbortableModel(() => streaming()) as LanguageModelV2,
     });
     const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
 
-    let abortPayload: unknown;
+    let abortPayload: { steps: { finishReason?: string }[] } | undefined;
     const { output, runId, cleanup } = await durableAgent.stream('Go', {
       memory: { thread: 'abort-run-stream-thread', resource: 'abort-run-stream-resource' },
       onAbort: data => {
@@ -306,16 +315,14 @@ describe('DurableAgent abort signal', () => {
       },
     });
 
-    await new Promise(r => setTimeout(r, 10));
+    await modelCalled;
     expect(durableAgent.abortRunStream(runId)).toBe(true);
 
-    try {
-      await output.consumeStream();
-    } catch {
-      // expected — the run never produced a normal finish
-    }
+    // Awaited without a catch: the run has to end through the abort path,
+    // rather than by surfacing some unrelated stream failure.
+    await output.consumeStream();
 
-    expect(abortPayload).toBeDefined();
+    expect(abortPayload?.steps.at(-1)?.finishReason).toBe('abort');
 
     cleanup();
   });

--- a/packages/core/src/agent/durable/__tests__/durable-agent-abort.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-abort.test.ts
@@ -251,6 +251,75 @@ describe('DurableAgent abort signal', () => {
     cleanup();
   });
 
+  it('abortThreadStream stops a durable run that is already executing', async () => {
+    // A durable run keeps its controller on the durable run registry, not in
+    // the thread runtime's prepared-run map, so the base implementation reaches
+    // neither: without the durable abort request the run streams on.
+    const baseAgent = new Agent({
+      id: 'abort-thread-stream-agent',
+      name: 'Abort Thread Stream Agent',
+      instructions: 'Test',
+      model: createAbortableModel() as LanguageModelV2,
+    });
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+    const threadId = 'abort-thread-stream-thread';
+    const resourceId = 'abort-thread-stream-resource';
+
+    let abortPayload: unknown;
+    const { output, cleanup } = await durableAgent.stream('Go', {
+      memory: { thread: threadId, resource: resourceId },
+      onAbort: data => {
+        abortPayload = data;
+      },
+    });
+
+    // Give the workflow a tick to subscribe + call doStream before we abort.
+    await new Promise(r => setTimeout(r, 10));
+    expect(durableAgent.abortThreadStream({ threadId, resourceId })).toBe(true);
+
+    try {
+      await output.consumeStream();
+    } catch {
+      // expected — the run never produced a normal finish
+    }
+
+    expect(abortPayload).toBeDefined();
+
+    cleanup();
+  });
+
+  it('abortRunStream stops a durable run that is already executing', async () => {
+    const baseAgent = new Agent({
+      id: 'abort-run-stream-agent',
+      name: 'Abort Run Stream Agent',
+      instructions: 'Test',
+      model: createAbortableModel() as LanguageModelV2,
+    });
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+    let abortPayload: unknown;
+    const { output, runId, cleanup } = await durableAgent.stream('Go', {
+      memory: { thread: 'abort-run-stream-thread', resource: 'abort-run-stream-resource' },
+      onAbort: data => {
+        abortPayload = data;
+      },
+    });
+
+    await new Promise(r => setTimeout(r, 10));
+    expect(durableAgent.abortRunStream(runId)).toBe(true);
+
+    try {
+      await output.consumeStream();
+    } catch {
+      // expected — the run never produced a normal finish
+    }
+
+    expect(abortPayload).toBeDefined();
+
+    cleanup();
+  });
+
   it('pre-aborted external abortSignal short-circuits the run', async () => {
     const mockModel = createAbortableModel();
     const baseAgent = new Agent({

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -1575,19 +1575,21 @@ export class DurableAgent<
   /**
    * Abort a run by id.
    *
-   * Same gap as {@link abortThreadStream}. A run that has not started yet is
-   * left to the base implementation, which records the intent the durable entry
-   * points consult when the run starts.
+   * Same gap as {@link abortThreadStream}. The abort request goes out whether
+   * or not this process knows the run: a durable run is routinely executed by
+   * another process, which is the one holding the controller that has to be
+   * flipped. A request nobody is listening for is a no-op, exactly like
+   * aborting a run that already finished, and a run that has not started yet
+   * is still covered by the intent the base implementation records.
    */
   abortRunStream(runId: string): boolean {
     const aborted = super.abortRunStream(runId);
-    if (!this.#isRunExecuting(runId)) return aborted;
-
     this.#abortDurableRun(runId);
-    return true;
+
+    return aborted || this.#isRunExecuting(runId);
   }
 
-  /** Whether `runId` is under way rather than queued, started or not by this process. */
+  /** Whether this process can see `runId` executing, in its registries or on the thread runtime. */
   #isRunExecuting(runId: string): boolean {
     return (
       this.#runRegistry.get(runId) !== undefined ||
@@ -1600,7 +1602,8 @@ export class DurableAgent<
    * Stop `runId` wherever it is executing: the controller this process holds
    * for it, if it holds one, plus the abort request that reaches the process
    * actually running the steps. Mirrors the `abort()` handed out with a stream
-   * result.
+   * result, which flips the same pair without gating on what this process
+   * happens to know about the run.
    */
   #abortDurableRun(runId: string): void {
     const controller = (this.#runRegistry.get(runId) ?? globalRunRegistry.get(runId))?.abortController;
@@ -1611,6 +1614,7 @@ export class DurableAgent<
     // abort synchronously and a failed publish is logged, not thrown.
     void this.requestRemoteAbort(runId);
   }
+
   /**
    * Abort a durable run, in this process and in whichever process is executing it.
    *

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -24,7 +24,7 @@ import type { MessageListInput } from '../message-list';
 import { SaveQueueManager } from '../save-queue';
 import { AgentThreadLeaseConflictError, agentThreadStreamRuntime } from '../thread-stream-runtime';
 import type { AgentThreadRunRegistration } from '../thread-stream-runtime';
-import type { ToolsInput } from '../types';
+import type { AgentSubscribeToThreadOptions, ToolsInput } from '../types';
 
 import { publishAbortRequest } from './abort-transport';
 import { AGENT_STREAM_TOPIC, DurableStepIds } from './constants';
@@ -1552,6 +1552,65 @@ export class DurableAgent<
     await emitErrorEvent(this.pubsub, runId, error);
   }
 
+  /**
+   * Abort the thread's active run.
+   *
+   * The base implementation flips the run's prepared `AbortController`, which a
+   * durable run never has: its controller lives on this agent's run registry,
+   * and the steps reading it may execute in another process. Without the abort
+   * request below, aborting a thread whose active run is durable records an
+   * intent nothing reads and lets the run stream on.
+   */
+  abortThreadStream(options: AgentSubscribeToThreadOptions): boolean {
+    // Resolve the run before the base call: aborting releases the thread lease,
+    // after which the thread no longer has an active run to look up.
+    const runId = agentThreadStreamRuntime.getActiveThreadRunId(options, this.getPubSub());
+    const aborted = super.abortThreadStream(options);
+    if (!runId) return aborted;
+
+    this.#abortDurableRun(runId);
+    return true;
+  }
+
+  /**
+   * Abort a run by id.
+   *
+   * Same gap as {@link abortThreadStream}. A run that has not started yet is
+   * left to the base implementation, which records the intent the durable entry
+   * points consult when the run starts.
+   */
+  abortRunStream(runId: string): boolean {
+    const aborted = super.abortRunStream(runId);
+    if (!this.#isRunExecuting(runId)) return aborted;
+
+    this.#abortDurableRun(runId);
+    return true;
+  }
+
+  /** Whether `runId` is under way rather than queued, started or not by this process. */
+  #isRunExecuting(runId: string): boolean {
+    return (
+      this.#runRegistry.get(runId) !== undefined ||
+      globalRunRegistry.get(runId) !== undefined ||
+      agentThreadStreamRuntime.hasThreadRun(runId, this.getPubSub())
+    );
+  }
+
+  /**
+   * Stop `runId` wherever it is executing: the controller this process holds
+   * for it, if it holds one, plus the abort request that reaches the process
+   * actually running the steps. Mirrors the `abort()` handed out with a stream
+   * result.
+   */
+  #abortDurableRun(runId: string): void {
+    const controller = (this.#runRegistry.get(runId) ?? globalRunRegistry.get(runId))?.abortController;
+    if (controller && !controller.signal.aborted) {
+      controller.abort(new Error('Aborted'));
+    }
+    // Best-effort, like `requestRemoteAbort` itself: the caller gets the local
+    // abort synchronously and a failed publish is logged, not thrown.
+    void this.requestRemoteAbort(runId);
+  }
   /**
    * Abort a durable run, in this process and in whichever process is executing it.
    *


### PR DESCRIPTION
## Description

Makes `agent.abortThreadStream({ resourceId, threadId })` and `agent.abortRunStream(runId)` stop a `DurableAgent` run that is already executing.

Both reach a run through the `AbortController` that `prepareRunOptions()` installs, which a durable run never has: its controller lives on the durable run registry, and the steps reading it may execute in another process. So both recorded a cancellation nothing acted on while the run streamed to completion and persisted its result. The server route `POST /agents/:agentId/threads/abort` goes through `abortThreadStream()`, so a Stop button wired to the HTTP API had the same problem.

`DurableAgent` now overrides both to do what the `abort()` on its stream result already does: flip the controller on its run registry if this process holds one, and publish the durable abort request that reaches the process actually running the steps. The run then unwinds the usual way and emits its terminal abort event, so `onAbort` fires and stream consumers are not left waiting.

```ts
const { runId } = await durableAgent.stream('...', { memory: { thread, resource } });

// before: the cancellation was recorded and the run streamed on to completion
// after: the run stops and onAbort fires
durableAgent.abortRunStream(runId);
```

Contained in `DurableAgent` — no change to the base agent or to `AgentThreadStreamRuntime`. A run that has not started yet is still left to the base implementation, which records the intent the durable entry points consult on startup since #22145.

### Notes for review

- `abortThreadStream()` resolves the runId *before* calling `super`, because aborting releases the thread lease and the thread then no longer has an active run to look up.
- `abortRunStream()` only takes over when the run is actually under way (`#isRunExecuting`), so a queued run keeps the existing behavior.
- The abort request is published best-effort, exactly like `requestRemoteAbort()` itself: the caller gets the local abort synchronously, and a failed publish is logged rather than thrown.

This is the second symptom of the durable cancellation gap. The first one, a run cancelled before it starts (#21776), was fixed in #22145; my PR for it (#21777) is closed in favor of that. This one is what remains.

## Related issue(s)

Fixes #22202

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test plan

Two regression tests in `durable-agent-abort.test.ts`, one per entry point. Both fail on `main` (the `abortThreadStream` one hangs until the test timeout, the `abortRunStream` one fails immediately) and pass with this change.

- `pnpm --filter @mastra/core exec vitest run src/agent/durable/__tests__/durable-agent-abort.test.ts` — 7 passed
- `pnpm --filter @mastra/core exec vitest run src/agent/durable/__tests__/` — 67 files, 587 passed
- `pnpm --filter @mastra/core exec vitest run src/agent/__tests__/agent-signals.test.ts` — 114 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Durable agent runs now stop when a user cancels them, even when another process runs them. The run ends with an abort event, calls `onAbort`, and does not save a normal result.

## Changes

- Updated `DurableAgent.abortThreadStream()` and `abortRunStream()` to cancel executing runs.
- Aborts local runs through their `AbortController`.
- Publishes abort requests for runs executing in another process.
- Preserves existing behavior for runs that have not started.
- Added a patch changeset.

## Tests

- Added regression tests for both abort entry points.
- Tests wait for active streaming before cancellation.
- Tests verify the terminal `finishReason` is `'abort'`, the methods return `true`, and `onAbort` runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->