### PR TITLE
fix(cloudflare): paginate KV key listing to avoid silent data loss

### DIFF
--- a/.changeset/full-heads-rhyme.md
+++ b/.changeset/full-heads-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@mastra/cloudflare': patch
+---
+
+Fixed Cloudflare KV storage silently dropping data once a table grows past 1000 keys. Listing threads, deleting threads, and clearing tables now read every page of keys from Cloudflare instead of only the first one, so large stores no longer lose threads or leave orphaned messages behind. Also fixed writes through the REST API, which Cloudflare rejected with a 'metadata must be valid json' error. Fixes https://github.com/mastra-ai/mastra/issues/22015

--- a/stores/cloudflare/src/kv/storage/db/index.test.ts
+++ b/stores/cloudflare/src/kv/storage/db/index.test.ts
@@ -1,0 +1,52 @@
+import type { KVNamespace } from '@cloudflare/workers-types';
+import { TABLE_THREADS } from '@mastra/core/storage';
+import { Miniflare } from 'miniflare';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import { CloudflareKVDB } from '.';
+
+describe('CloudflareKVDB listKV pagination', () => {
+  let mf: Miniflare;
+  let db: CloudflareKVDB;
+
+  beforeAll(async () => {
+    mf = new Miniflare({
+      script: 'export default {};',
+      modules: true,
+      kvNamespaces: [TABLE_THREADS],
+    });
+    const bindings = {
+      [TABLE_THREADS]: (await mf.getKVNamespace(TABLE_THREADS)) as KVNamespace,
+    } as Record<string, KVNamespace>;
+    db = new CloudflareKVDB({ bindings: bindings as any, namespacePrefix: '' });
+  });
+
+  afterAll(async () => {
+    await mf.dispose();
+  });
+
+  it('returns all keys across multiple pages', async () => {
+    const total = 15;
+    for (let i = 0; i < total; i++) {
+      await db.putKV({
+        tableName: TABLE_THREADS,
+        key: `${TABLE_THREADS}:thread-${String(i).padStart(3, '0')}`,
+        value: { id: `thread-${i}` },
+      });
+    }
+
+    const keys = await db.listKV(TABLE_THREADS, { limit: 10 });
+    expect(keys.length).toBe(total);
+  });
+
+  it('honors prefix while paginating', async () => {
+    const keys = await db.listKV(TABLE_THREADS, { limit: 10, prefix: `${TABLE_THREADS}:thread-01` });
+    expect(keys.map(k => k.name).sort()).toEqual([
+      `${TABLE_THREADS}:thread-010`,
+      `${TABLE_THREADS}:thread-011`,
+      `${TABLE_THREADS}:thread-012`,
+      `${TABLE_THREADS}:thread-013`,
+      `${TABLE_THREADS}:thread-014`,
+    ]);
+  });
+});

--- a/stores/cloudflare/src/kv/storage/db/index.test.ts
+++ b/stores/cloudflare/src/kv/storage/db/index.test.ts
@@ -1,11 +1,12 @@
 import type { KVNamespace } from '@cloudflare/workers-types';
 import { TABLE_THREADS } from '@mastra/core/storage';
+import type Cloudflare from 'cloudflare';
 import { Miniflare } from 'miniflare';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 
 import { CloudflareKVDB } from '.';
 
-describe('CloudflareKVDB listKV pagination', () => {
+describe('CloudflareKVDB listKV pagination (Workers binding)', () => {
   let mf: Miniflare;
   let db: CloudflareKVDB;
 
@@ -40,13 +41,43 @@ describe('CloudflareKVDB listKV pagination', () => {
   });
 
   it('honors prefix while paginating', async () => {
-    const keys = await db.listKV(TABLE_THREADS, { limit: 10, prefix: `${TABLE_THREADS}:thread-01` });
-    expect(keys.map(k => k.name).sort()).toEqual([
-      `${TABLE_THREADS}:thread-010`,
-      `${TABLE_THREADS}:thread-011`,
-      `${TABLE_THREADS}:thread-012`,
-      `${TABLE_THREADS}:thread-013`,
-      `${TABLE_THREADS}:thread-014`,
-    ]);
+    const matching = Array.from({ length: 11 }, (_, i) => `prefixed:item-${String(i).padStart(2, '0')}`);
+    for (const key of matching) {
+      await db.putKV({ tableName: TABLE_THREADS, key, value: { key } });
+    }
+    for (let i = 0; i < 5; i++) {
+      await db.putKV({ tableName: TABLE_THREADS, key: `unrelated:item-${i}`, value: { i } });
+    }
+
+    const keys = await db.listKV(TABLE_THREADS, { limit: 5, prefix: 'prefixed:' });
+    expect(keys.map(k => k.name).sort()).toEqual(matching);
+  });
+});
+
+describe('CloudflareKVDB listKV pagination (REST API)', () => {
+  it('follows result_info.cursor across pages', async () => {
+    const page1 = Array.from({ length: 10 }, (_, i) => ({ name: `${TABLE_THREADS}:thread-${i}` }));
+    const page2 = Array.from({ length: 5 }, (_, i) => ({ name: `${TABLE_THREADS}:thread-${10 + i}` }));
+
+    const keysList = vi
+      .fn()
+      .mockResolvedValueOnce({ result: page1, result_info: { count: 10, cursor: 'cursor-1' } })
+      .mockResolvedValueOnce({ result: page2, result_info: { count: 5 } });
+    const client = {
+      kv: {
+        namespaces: {
+          list: vi.fn().mockResolvedValue({ result: [{ id: 'ns-1', title: TABLE_THREADS }] }),
+          keys: { list: keysList },
+        },
+      },
+    } as unknown as Cloudflare;
+
+    const db = new CloudflareKVDB({ client, accountId: 'acc-1', namespacePrefix: '' });
+    const keys = await db.listKV(TABLE_THREADS, { limit: 10 });
+
+    expect(keys.map(k => k.name)).toEqual([...page1, ...page2].map(k => k.name));
+    expect(keysList).toHaveBeenCalledTimes(2);
+    expect(keysList.mock.calls[0]?.[1]).not.toHaveProperty('cursor');
+    expect(keysList.mock.calls[1]?.[1]).toMatchObject({ cursor: 'cursor-1' });
   });
 });

--- a/stores/cloudflare/src/kv/storage/db/index.ts
+++ b/stores/cloudflare/src/kv/storage/db/index.ts
@@ -492,7 +492,8 @@ export class CloudflareKVDB extends MastraBase {
         await this.client!.kv.namespaces.values.update(namespaceId, key, {
           account_id: this.accountId!,
           value: serializedValue,
-          metadata: serializedMetadata,
+          // The REST API rejects empty-string metadata as invalid JSON
+          ...(serializedMetadata ? { metadata: serializedMetadata } : {}),
         });
       }
     } catch (error) {
@@ -595,22 +596,40 @@ export class CloudflareKVDB extends MastraBase {
 
   async listNamespaceKeys(tableName: TABLE_NAMES, options?: ListOptions) {
     try {
+      // KV returns at most 1000 keys per page, so keep fetching until the
+      // cursor is exhausted; a single call silently truncates larger tables.
+      const pageSize = options?.limit || 1000;
+      const keys: Array<{ name: string }> = [];
       if (this.bindings) {
         const binding = this.getBinding(tableName);
-        const response = await binding.list({
-          limit: options?.limit || 1000,
-          prefix: options?.prefix,
-        });
-        return response.keys;
+        let cursor: string | undefined;
+        do {
+          const response = await binding.list({
+            limit: pageSize,
+            prefix: options?.prefix,
+            cursor,
+          });
+          keys.push(...response.keys);
+          cursor = response.list_complete ? undefined : response.cursor;
+        } while (cursor);
       } else {
         const namespaceId = await this.getNamespaceId(tableName);
-        const response = await this.client!.kv.namespaces.keys.list(namespaceId, {
-          account_id: this.accountId!,
-          limit: options?.limit || 1000,
-          prefix: options?.prefix,
-        });
-        return response.result;
+        // Manual cursor loop: the SDK's auto-pagination expects
+        // result_info.cursors.after, but this endpoint returns result_info.cursor,
+        // so `for await` stops after the first page.
+        let cursor: string | undefined;
+        do {
+          const page = await this.client!.kv.namespaces.keys.list(namespaceId, {
+            account_id: this.accountId!,
+            limit: pageSize,
+            prefix: options?.prefix,
+            ...(cursor ? { cursor } : {}),
+          });
+          keys.push(...page.result);
+          cursor = (page.result_info as { cursor?: string } | undefined)?.cursor || undefined;
+        } while (cursor);
       }
+      return keys;
     } catch (error: any) {
       throw new MastraError(
         {

--- a/stores/cloudflare/src/kv/storage/domains/memory/index.ts
+++ b/stores/cloudflare/src/kv/storage/domains/memory/index.ts
@@ -270,7 +270,8 @@ export class MemoryStorageCloudflare extends MemoryStorage {
       }
 
       // Get all message keys for this thread first
-      const messageKeys = await this.#db.listKV(TABLE_MESSAGES);
+      const prefix = this.#db.namespacePrefix ? `${this.#db.namespacePrefix}:` : '';
+      const messageKeys = await this.#db.listKV(TABLE_MESSAGES, { prefix: `${prefix}${TABLE_MESSAGES}:${threadId}:` });
       const threadMessageKeys = messageKeys.filter(key => key.name.includes(`${TABLE_MESSAGES}:${threadId}:`));
 
       // Delete all messages and their order atomically


### PR DESCRIPTION
## Description

Cloudflare KV returns keys in pages of at most 1000, but `listNamespaceKeys` made a single `list` call and ignored the cursor. Once a table grew past 1000 keys, `listThreads` silently dropped threads, `deleteThread` left orphaned messages, and `clearTable`/`dropTable` only deleted the first 1000 keys, all without any error.

- Follow the pagination cursor in `listNamespaceKeys` for both the Workers binding path (`list_complete`/`cursor`) and the REST path, so every caller of `listKV` now sees all keys
- Use a manual cursor loop on the REST path because the `cloudflare` SDK's auto-pagination reads `result_info.cursors.after` while this endpoint returns `result_info.cursor`, so `for await` stops after the first page
- Stop sending empty-string `metadata` on REST writes, which the API rejects with a 400 `metadata must be valid json`, making every REST-path save fail
- Scope `deleteThread`'s message listing to the thread's key prefix instead of scanning every message in the store
- Add a Miniflare-based pagination test for `listKV`

Verified against a real Cloudflare KV namespace (page size reduced to 10 to stay within free-tier write limits): before the fix, saving 15 threads returned 10 from `listThreads`; after the fix, all 15. The Redis and Upstash stores mentioned in the issue are not affected, both already loop their `SCAN` cursors (checked live with 10,050 threads on Redis).

## Related Issue(s)

Fixes #22015

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Cloudflare returns KV keys in batches. This PR reads every batch, so the adapter does not miss data after the first 1,000 keys.

## Changes

- Added cursor-based pagination for KV key listings through:
  - Cloudflare Workers bindings.
  - Cloudflare REST APIs.
- Added a manual REST cursor loop for `result_info.cursor`.
- Preserved page size and prefix filters across pages.
- Omitted empty REST metadata to prevent `400` errors.
- Limited `deleteThread` message listings to the thread-specific key prefix.
- Added Miniflare and REST API tests for pagination and prefix filtering.
- Added a patch changeset for `@mastra/cloudflare`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->