### PR TITLE
fix(core): build the workspace search index without starting the sandbox

### DIFF
--- a/.changeset/spicy-donuts-search.md
+++ b/.changeset/spicy-donuts-search.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Made Workspace.rebuildSearchIndex public so the search index can be built without init() starting the sandbox. Paths default to the configured autoIndexPaths.

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -1571,6 +1571,59 @@ Line 3 conclusion`;
       await workspace.destroy();
     });
 
+    it('should build the search index via rebuildSearchIndex without starting the sandbox', async () => {
+      await fs.mkdir(path.join(tempDir, 'docs'), { recursive: true });
+      await fs.writeFile(path.join(tempDir, 'docs', 'readme.txt'), 'Welcome to the project');
+
+      const start = vi.fn();
+      const mockSandbox = {
+        provider: 'test',
+        status: 'stopped',
+        start,
+        executeCommand: vi.fn(),
+      } as any;
+
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        sandbox: mockSandbox,
+        bm25: true,
+        autoIndexPaths: ['docs'],
+      });
+
+      // Defaults to the configured autoIndexPaths
+      await workspace.rebuildSearchIndex();
+
+      const results = await workspace.search('project');
+      expect(results.some(r => r.id === 'docs/readme.txt')).toBe(true);
+      expect(start).not.toHaveBeenCalled();
+
+      await workspace.destroy();
+    });
+
+    it('should rebuild the search index for explicit paths', async () => {
+      await fs.mkdir(path.join(tempDir, 'docs'), { recursive: true });
+      await fs.mkdir(path.join(tempDir, 'support'), { recursive: true });
+      await fs.writeFile(path.join(tempDir, 'docs', 'api.txt'), 'API reference documentation');
+      await fs.writeFile(path.join(tempDir, 'support', 'faq.txt'), 'Frequently asked questions');
+
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        bm25: true,
+        autoIndexPaths: ['docs'],
+      });
+
+      await workspace.rebuildSearchIndex(['support']);
+
+      // Explicit paths replace the configured ones for this rebuild
+      const faqResults = await workspace.search('frequently asked');
+      expect(faqResults.some(r => r.id === 'support/faq.txt')).toBe(true);
+
+      const docsResults = await workspace.search('API reference');
+      expect(docsResults.some(r => r.id === 'docs/api.txt')).toBe(false);
+
+      await workspace.destroy();
+    });
+
     it('should skip non-existent autoIndexPaths gracefully', async () => {
       const filesystem = new LocalFilesystem({ basePath: tempDir });
       const workspace = new Workspace({

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -1054,13 +1054,19 @@ export class Workspace<
 
   /**
    * Rebuild the search index from filesystem paths.
-   * Used internally for auto-indexing on init.
    *
-   * Paths can be plain directories, single files, or glob patterns.
-   * Uses resolvePathPattern for unified resolution: file matches are
-   * indexed directly, directory matches are recursed.
+   * Called by `init()` for auto-indexing, and callable directly to build the
+   * index without going through `init()`. Indexing only reads through the
+   * workspace filesystem, so unlike `init()` this never starts the sandbox.
+   * Useful for warming the search index ahead of the first search when the
+   * sandbox is a remote provider that is slow or costly to boot.
+   *
+   * Paths can be plain directories, single files, or glob patterns, and
+   * default to the configured `autoIndexPaths`. Uses resolvePathPattern for
+   * unified resolution: file matches are indexed directly, directory matches
+   * are recursed. No-op when search is not configured or no paths are given.
    */
-  private async rebuildSearchIndex(paths: string[]): Promise<void> {
+  async rebuildSearchIndex(paths: string[] = this._config.autoIndexPaths ?? []): Promise<void> {
     this.assertSearchWritable();
     if (!this._searchEngine || !this._fs || paths.length === 0) {
       return;


### PR DESCRIPTION
## Description

`Workspace.init()` is the only way to populate the search index for `autoIndexPaths`, and it starts the sandbox before indexing even though indexing only reads through the workspace filesystem. With a cloud sandbox provider that means booting a sandbox (and holding a concurrency slot) just to make `workspace.search()` return results. In our case, wiring the `workspace_search` tool to `init()` created one E2B sandbox per searching user and ran into E2B's concurrent sandbox limit, taking search down in production (details in the linked issue).

This makes `rebuildSearchIndex` public, with `paths` defaulting to the configured `autoIndexPaths`, so callers can build the index directly without going through `init()`. The method body is unchanged and `init()` behaves exactly as before; the diff is the visibility, the default parameter, and the doc comment.

Two tests added under the auto-indexing suite: one asserts the index is searchable after a direct `rebuildSearchIndex()` call while the sandbox's `start` was never invoked, the other covers passing explicit paths instead of the configured defaults.

## Related issue(s)

Fixes #22205

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

You can now rebuild the workspace search index without starting the sandbox. The method uses the configured paths by default, which avoids unnecessary sandbox creation.

## Changes

- Made `Workspace.rebuildSearchIndex` public.
- Defaulted `paths` to `autoIndexPaths`.
- Preserved `Workspace.init()` behavior.
- Added tests for default paths and explicit paths.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->