### PR TITLE
fix(mcp): preserve aggregate discovery error details

### DIFF
--- a/.changeset/eager-rooms-turn.md
+++ b/.changeset/eager-rooms-turn.md
@@ -1,0 +1,12 @@
+---
+'@mastra/mcp': patch
+---
+
+Preserve structured HTTP status and transport codes in aggregate MCP discovery errors while retaining legacy string errors.
+
+```typescript
+const { errorDetails } = await mcp.listToolsWithErrors()
+if (errorDetails.weather?.httpStatus === 503) {
+  // Apply a transient-failure policy without parsing the legacy error string.
+}
+```

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -351,15 +351,17 @@ Retrieves all tools from all configured servers, with tool names namespaced by t
 Set `perServerTimeoutMs` to limit how long discovery waits for each server. Servers that finish within the limit remain in `tools`. Timed-out servers appear in `errors`, and `durations` reports each server's discovery time in milliseconds.
 
 ```typescript
-const { tools, errors, durations } = await mcp.listToolsWithErrors({
+const { tools, errors, errorDetails, durations } = await mcp.listToolsWithErrors({
   perServerTimeoutMs: 3_000,
 })
 
 new Agent({ id: 'agent', tools })
-console.log(errors, durations)
+console.log(errors, errorDetails, durations)
 ```
 
-When called without options, the method returns only `tools` and `errors`.
+`errors` remains a string map for backward compatibility. `errorDetails` provides the same message plus machine-readable `httpStatus` and transport `code` fields when the underlying error exposes them. When an HTTP status is available, the legacy message also includes an `(HTTP nnn)` suffix.
+
+When called without options, the method omits only `durations`; `tools`, `errors`, and `errorDetails` are always returned.
 
 ### `listToolsets()`
 
@@ -377,15 +379,15 @@ const res = await agent.stream(prompt, {
 Returns toolsets grouped by server name, along with per-server discovery errors. Set `perServerTimeoutMs` to limit each server independently and include per-server `durations` in milliseconds.
 
 ```typescript
-const { toolsets, errors, durations } = await mcp.listToolsetsWithErrors({
+const { toolsets, errors, errorDetails, durations } = await mcp.listToolsetsWithErrors({
   perServerTimeoutMs: 3_000,
 })
 
 const res = await agent.stream(prompt, { toolsets })
-console.log(errors, durations)
+console.log(errors, errorDetails, durations)
 ```
 
-When called without options, the method returns only `toolsets` and `errors`.
+When called without options, the method omits only `durations`; `toolsets`, `errors`, and `errorDetails` are always returned.
 
 ### `listToolDefinitions()`
 
@@ -406,7 +408,7 @@ Like `listToolDefinitions()`, but also returns per-server errors for servers tha
 Set `perServerTimeoutMs` to limit each server independently. When options are provided, `durations` reports each server's discovery time in milliseconds.
 
 ```typescript
-const { definitions, errors, durations } = await mcp.listToolDefinitionsWithErrors({
+const { definitions, errors, errorDetails, durations } = await mcp.listToolDefinitionsWithErrors({
   perServerTimeoutMs: 3_000,
 })
 
@@ -414,10 +416,10 @@ if (Object.keys(errors).length === 0) {
   await cache.set('mcp-tools', JSON.stringify(definitions))
 }
 
-console.log(durations)
+console.log(errorDetails, durations)
 ```
 
-When called without options, the method returns only `definitions` and `errors`.
+When called without options, the method omits only `durations`; `definitions`, `errors`, and `errorDetails` are always returned.
 
 ### `toolFromDefinition()`
 
@@ -561,6 +563,18 @@ for (const serverName in resourcesByServer) {
 }
 ```
 
+#### `resources.listWithErrors(options?)`
+
+Preserves successful resources while reporting failed servers through legacy string `errors` and structured `errorDetails`. Pass `perServerTimeoutMs` to bound each server independently and include `durations`.
+
+```typescript
+const { resources, errors, errorDetails, durations } = await mcpClient.resources.listWithErrors({
+  perServerTimeoutMs: 3_000,
+})
+
+console.log(resources, errors, errorDetails, durations)
+```
+
 #### `resources.templates()`
 
 Retrieves all available resource templates from all connected MCP servers, grouped by server name.
@@ -576,6 +590,15 @@ const templatesByServer = await mcpClient.resources.templates()
 for (const serverName in templatesByServer) {
   console.log(`Templates from ${serverName}:`, templatesByServer[serverName])
 }
+```
+
+#### `resources.templatesWithErrors(options?)`
+
+Returns successful resource templates together with per-server string `errors`, structured `errorDetails`, and optional `durations`.
+
+```typescript
+const { templates, errors, errorDetails } = await mcpClient.resources.templatesWithErrors()
+console.log(templates, errors, errorDetails)
 ```
 
 #### `resources.read(serverName: string, uri: string)`
@@ -829,6 +852,15 @@ const promptsByServer = await mcpClient.prompts.list()
 for (const serverName in promptsByServer) {
   console.log(`Prompts from ${serverName}:`, promptsByServer[serverName])
 }
+```
+
+#### `prompts.listWithErrors(options?)`
+
+Returns successful prompts together with per-server string `errors`, structured `errorDetails`, and optional `durations`.
+
+```typescript
+const { prompts, errors, errorDetails } = await mcpClient.prompts.listWithErrors()
+console.log(prompts, errors, errorDetails)
 ```
 
 #### `prompts.get({ serverName, name, args?, version? })`

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,7 +26,7 @@
     "build:lib": "tsdown --silent --config tsdown.config.ts",
     "prepack": "tsx ../../scripts/generate-package-docs.ts",
     "build:watch": "pnpm build:lib --watch",
-    "test:client": "vitest run ./src/client/client.test.ts ./src/client/configuration.test.ts ./src/client/oauth.test.ts ./src/client/oauth-callback-server.test.ts ./src/client/oauth-flow.test.ts ./src/client/url-policy.test.ts ./src/client/stdio-env.test.ts",
+    "test:client": "vitest run ./src/client/client.test.ts ./src/client/configuration.test.ts ./src/client/error-utils.test.ts ./src/client/oauth.test.ts ./src/client/oauth-callback-server.test.ts ./src/client/oauth-flow.test.ts ./src/client/url-policy.test.ts ./src/client/stdio-env.test.ts",
     "test:server": "vitest run ./src/server",
     "test:integration": "cd integration-tests && pnpm test:mcp",
     "test": "pnpm test:server && pnpm test:client && pnpm test:integration",

--- a/packages/mcp/src/client/configuration.test.ts
+++ b/packages/mcp/src/client/configuration.test.ts
@@ -61,6 +61,7 @@ describe('MCPClient tool discovery retries', () => {
         weather_getWeather: toolset.getWeather,
       },
       errors: {},
+      errorDetails: {},
     });
     expect(internalClient.tools).toHaveBeenCalledTimes(1);
   });
@@ -88,9 +89,104 @@ describe('MCPClient tool discovery retries', () => {
       errors: {
         stock: 'Validation failed',
       },
+      errorDetails: {
+        stock: { message: 'Validation failed' },
+      },
     });
     expect(weatherClient.tools).toHaveBeenCalledTimes(1);
     expect(stockClient.tools).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns structured transport details without removing legacy string errors', async () => {
+    const client = createClient();
+    const transportError = Object.assign(new Error('Error POSTing to endpoint'), {
+      status: 503,
+      code: 'CLIENT_HTTP_NOT_IMPLEMENTED',
+    });
+    const connectError = new Error('Failed to connect to MCP server weather', { cause: transportError });
+
+    vi.spyOn(client as any, 'getConnectedClientForServer').mockRejectedValue(connectError);
+
+    const result = await client.listToolDefinitionsWithErrors();
+
+    expect(result).toEqual({
+      definitions: {},
+      errors: {
+        weather: 'Failed to connect to MCP server weather (HTTP 503)',
+      },
+      errorDetails: {
+        weather: {
+          message: 'Failed to connect to MCP server weather (HTTP 503)',
+          httpStatus: 503,
+          code: 'CLIENT_HTTP_NOT_IMPLEMENTED',
+        },
+      },
+    });
+  });
+
+  it('exposes structured failures for resource, template, and prompt discovery', async () => {
+    const client = createMultiServerClient();
+    const weatherResources = [{ uri: 'weather://current', name: 'Current weather' }] as any;
+    const weatherTemplates = [{ uriTemplate: 'weather://forecast/{city}', name: 'Forecast' }] as any;
+    const weatherPrompts = [{ name: 'forecast', description: 'Create a forecast' }] as any;
+    const weatherClient = {
+      resources: {
+        list: vi.fn().mockResolvedValue(weatherResources),
+        templates: vi.fn().mockResolvedValue(weatherTemplates),
+      },
+      prompts: {
+        list: vi.fn().mockResolvedValue(weatherPrompts),
+      },
+    } as any;
+    const transportError = Object.assign(new Error('service unavailable'), {
+      status: 503,
+      code: 'CLIENT_HTTP_NOT_IMPLEMENTED',
+    });
+    const stockError = new Error('Failed to connect to MCP server stock', { cause: transportError });
+
+    vi.spyOn(client as any, 'getConnectedClientForServer').mockImplementation(async (serverName: string) => {
+      if (serverName === 'stock') throw stockError;
+      return weatherClient;
+    });
+
+    const resources = await client.resources.listWithErrors();
+    const templates = await client.resources.templatesWithErrors();
+    const prompts = await client.prompts.listWithErrors();
+    const expectedDiagnostics = {
+      errors: { stock: 'Failed to connect to MCP server stock (HTTP 503)' },
+      errorDetails: {
+        stock: {
+          message: 'Failed to connect to MCP server stock (HTTP 503)',
+          httpStatus: 503,
+          code: 'CLIENT_HTTP_NOT_IMPLEMENTED',
+        },
+      },
+    };
+
+    expect(resources).toEqual({ resources: { weather: weatherResources }, ...expectedDiagnostics });
+    expect(templates).toEqual({ templates: { weather: weatherTemplates }, ...expectedDiagnostics });
+    expect(prompts).toEqual({ prompts: { weather: weatherPrompts }, ...expectedDiagnostics });
+
+    await expect(client.resources.list()).resolves.toEqual({ weather: weatherResources });
+    await expect(client.resources.templates()).resolves.toEqual({ weather: weatherTemplates });
+    await expect(client.prompts.list()).resolves.toEqual({ weather: weatherPrompts });
+  });
+
+  it('keeps aggregate discovery isolated when an error metadata accessor throws', async () => {
+    const client = createClient();
+    const hostileError = new Proxy(Object.create(null) as object, {
+      get() {
+        throw new Error('metadata accessor failed');
+      },
+    });
+
+    vi.spyOn(client as any, 'getConnectedClientForServer').mockRejectedValue(hostileError);
+
+    await expect(client.listToolsWithErrors()).resolves.toEqual({
+      tools: {},
+      errors: { weather: 'Unknown error' },
+      errorDetails: { weather: { message: 'Unknown error' } },
+    });
   });
 
   it('returns healthy tools and timing diagnostics when another server exceeds its discovery budget', async () => {
@@ -119,6 +215,9 @@ describe('MCPClient tool discovery retries', () => {
       errors: {
         stock: 'Discovery timed out after 50ms',
       },
+      errorDetails: {
+        stock: { message: 'Discovery timed out after 50ms' },
+      },
       durations: {
         weather: 0,
         stock: 50,
@@ -145,11 +244,13 @@ describe('MCPClient tool discovery retries', () => {
     expect(toolsetsResult).toEqual({
       toolsets: { weather: toolset },
       errors: {},
+      errorDetails: {},
       durations: { weather: 0 },
     });
     expect(definitionsResult).toEqual({
       definitions: { weather: definitions },
       errors: {},
+      errorDetails: {},
       durations: { weather: 0 },
     });
     expect(vi.getTimerCount()).toBe(0);
@@ -172,6 +273,7 @@ describe('MCPClient tool discovery retries', () => {
         weather_getWeather: toolset.getWeather,
       },
       errors: {},
+      errorDetails: {},
     });
     expect(internalClient.tools).toHaveBeenCalledTimes(2);
     expect(reconnectSpy).toHaveBeenCalledTimes(1);
@@ -201,6 +303,7 @@ describe('MCPClient tool discovery retries', () => {
         stock_search: stockTools.search,
       },
       errors: {},
+      errorDetails: {},
     });
   });
 
@@ -221,6 +324,7 @@ describe('MCPClient tool discovery retries', () => {
         weather: toolset,
       },
       errors: {},
+      errorDetails: {},
     });
     expect(internalClient.tools).toHaveBeenCalledTimes(2);
     expect(reconnectSpy).toHaveBeenCalledTimes(1);
@@ -242,6 +346,9 @@ describe('MCPClient tool discovery retries', () => {
       toolsets: {},
       errors: {
         weather: 'Validation failed',
+      },
+      errorDetails: {
+        weather: { message: 'Validation failed' },
       },
     });
     expect(internalClient.tools).toHaveBeenCalledTimes(1);

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -18,7 +18,8 @@ import type { OAuthClientInformationFull } from '../shared/oauth-types';
 import { UnauthorizedError } from '../shared/oauth-types';
 import { InternalMastraMCPClient } from './client';
 import type { MastraMCPServerDefinition, MCPServerAuthState } from './client';
-import { isReconnectableMCPError } from './error-utils';
+import { getMCPDiscoveryErrorDetails, isReconnectableMCPError } from './error-utils';
+import type { MCPDiscoveryErrorDetails } from './error-utils';
 import { createOAuthCallbackServer, getCallbackUrlCandidates } from './oauth-callback-server';
 import type { OAuthCallbackServer } from './oauth-callback-server';
 import { MCPOAuthClientProvider } from './oauth-provider';
@@ -34,7 +35,7 @@ const TOOL_DISCOVERY_MAX_ATTEMPTS = 2;
 // widen the two branches into independent optional props and break the fold.
 type ServerDiscoveryResult<T> =
   | { serverName: string; value: T; error: undefined; duration: number }
-  | { serverName: string; value: undefined; error: string; duration: number };
+  | { serverName: string; value: undefined; error: MCPDiscoveryErrorDetails; duration: number };
 
 /** Options for aggregate discovery across configured MCP servers. */
 export interface MCPDiscoveryOptions {
@@ -334,20 +335,13 @@ To fix this you have three different options:
        * const resources = await mcp.resources.list();
        * console.log(resources.weatherServer); // Array of resources
        * ```
+      */
+      list: async (): Promise<Record<string, Resource[]>> => (await this.listResourcesWithErrors()).resources,
+      /**
+       * Lists resources while preserving per-server discovery failures.
+       * The existing `list()` method remains the success-only convenience API.
        */
-      list: async (): Promise<Record<string, Resource[]>> => {
-        const allResources: Record<string, Resource[]> = {};
-        const settled = await this.discoverAcrossServers(
-          async serverName => (await this.getConnectedClientForServer(serverName)).resources.list(),
-          { errorId: 'MCP_CLIENT_LIST_RESOURCES_FAILED', logMessage: 'Failed to list resources from server:' },
-        );
-        for (const { serverName, value, error } of settled) {
-          if (error === undefined) {
-            allResources[serverName] = value;
-          }
-        }
-        return allResources;
-      },
+      listWithErrors: (options?: MCPDiscoveryOptions) => this.listResourcesWithErrors(options),
       /**
        * Lists all available resource templates from all configured servers.
        *
@@ -362,22 +356,13 @@ To fix this you have three different options:
        * console.log(templates.weatherServer); // Array of resource templates
        * ```
        */
-      templates: async (): Promise<Record<string, ResourceTemplateType[]>> => {
-        const allTemplates: Record<string, ResourceTemplateType[]> = {};
-        const settled = await this.discoverAcrossServers(
-          async serverName => (await this.getConnectedClientForServer(serverName)).resources.templates(),
-          {
-            errorId: 'MCP_CLIENT_LIST_RESOURCE_TEMPLATES_FAILED',
-            logMessage: 'Failed to list resource templates from server:',
-          },
-        );
-        for (const { serverName, value, error } of settled) {
-          if (error === undefined) {
-            allTemplates[serverName] = value;
-          }
-        }
-        return allTemplates;
-      },
+      templates: async (): Promise<Record<string, ResourceTemplateType[]>> =>
+        (await this.listResourceTemplatesWithErrors()).templates,
+      /**
+       * Lists resource templates while preserving per-server discovery failures.
+       * The existing `templates()` method remains the success-only convenience API.
+       */
+      templatesWithErrors: (options?: MCPDiscoveryOptions) => this.listResourceTemplatesWithErrors(options),
       /**
        * Reads the content of a specific resource from a server.
        *
@@ -585,19 +570,12 @@ To fix this you have three different options:
        * console.log(prompts.weatherServer); // Array of prompts
        * ```
        */
-      list: async (): Promise<Record<string, Prompt[]>> => {
-        const allPrompts: Record<string, Prompt[]> = {};
-        const settled = await this.discoverAcrossServers(
-          async serverName => (await this.getConnectedClientForServer(serverName)).prompts.list(),
-          { errorId: 'MCP_CLIENT_LIST_PROMPTS_FAILED', logMessage: 'Failed to list prompts from server:' },
-        );
-        for (const { serverName, value, error } of settled) {
-          if (error === undefined) {
-            allPrompts[serverName] = value;
-          }
-        }
-        return allPrompts;
-      },
+      list: async (): Promise<Record<string, Prompt[]>> => (await this.listPromptsWithErrors()).prompts,
+      /**
+       * Lists prompts while preserving per-server discovery failures.
+       * The existing `list()` method remains the success-only convenience API.
+       */
+      listWithErrors: (options?: MCPDiscoveryOptions) => this.listPromptsWithErrors(options),
       /**
        * Retrieves a specific prompt with its messages from a server.
        *
@@ -1057,25 +1035,27 @@ To fix this you have three different options:
    * Like listTools(), but also returns errors for servers that failed to connect
    * or list tools. This allows callers to report specific failure reasons per server.
    *
-   * @returns Object with `tools` (successful tools) and `errors` (failed servers with error messages).
+   * @returns Object with successful `tools`, legacy string `errors`, and structured `errorDetails`.
    * Transient connection failures are retried once after reconnecting the affected server.
    *
    * @example
    * ```typescript
-   * const { tools, errors } = await mcp.listToolsWithErrors();
+   * const { tools, errors, errorDetails } = await mcp.listToolsWithErrors();
    * for (const [name, err] of Object.entries(errors)) {
-   *   console.error(`Server ${name} failed: ${err}`);
+   *   console.error(`Server ${name} failed: ${err}`, errorDetails[name]);
    * }
    * ```
    */
   public async listToolsWithErrors(options?: MCPDiscoveryOptions): Promise<{
     tools: Record<string, Tool<any, any, any, any>>;
     errors: Record<string, string>;
+    errorDetails: Record<string, MCPDiscoveryErrorDetails>;
     durations?: Record<string, number>;
   }> {
     this.addToInstanceCache();
     const connectedTools: Record<string, Tool<any, any, any, any>> = {};
     const errors: Record<string, string> = {};
+    const errorDetails: Record<string, MCPDiscoveryErrorDetails> = {};
     const durations: Record<string, number> = {};
 
     const settled = await this.discoverAcrossServers(
@@ -1090,7 +1070,8 @@ To fix this you have three different options:
     for (const { serverName, value, error, duration } of settled) {
       durations[serverName] = duration;
       if (error !== undefined) {
-        errors[serverName] = error;
+        errors[serverName] = error.message;
+        errorDetails[serverName] = error;
         continue;
       }
       for (const [toolName, toolConfig] of Object.entries(value)) {
@@ -1098,7 +1079,7 @@ To fix this you have three different options:
       }
     }
 
-    const result = { tools: connectedTools, errors };
+    const result = { tools: connectedTools, errors, errorDetails };
     return options ? { ...result, durations } : result;
   }
 
@@ -1136,25 +1117,27 @@ To fix this you have three different options:
    * Like listToolsets(), but also returns errors for servers that failed to connect
    * or list tools. This allows callers to report specific failure reasons per server.
    *
-   * @returns Object with `toolsets` (successful servers) and `errors` (failed servers with error messages).
+   * @returns Object with successful `toolsets`, legacy string `errors`, and structured `errorDetails`.
    * Transient connection failures are retried once after reconnecting the affected server.
    *
    * @example
    * ```typescript
-   * const { toolsets, errors } = await mcp.listToolsetsWithErrors();
+   * const { toolsets, errors, errorDetails } = await mcp.listToolsetsWithErrors();
    * for (const [name, err] of Object.entries(errors)) {
-   *   console.error(`Server ${name} failed: ${err}`);
+   *   console.error(`Server ${name} failed: ${err}`, errorDetails[name]);
    * }
    * ```
    */
   public async listToolsetsWithErrors(options?: MCPDiscoveryOptions): Promise<{
     toolsets: Record<string, Record<string, Tool<any, any, any, any>>>;
     errors: Record<string, string>;
+    errorDetails: Record<string, MCPDiscoveryErrorDetails>;
     durations?: Record<string, number>;
   }> {
     this.addToInstanceCache();
     const connectedToolsets: Record<string, Record<string, Tool<any, any, any, any>>> = {};
     const errors: Record<string, string> = {};
+    const errorDetails: Record<string, MCPDiscoveryErrorDetails> = {};
     const durations: Record<string, number> = {};
 
     const settled = await this.discoverAcrossServers(
@@ -1169,13 +1152,14 @@ To fix this you have three different options:
     for (const { serverName, value, error, duration } of settled) {
       durations[serverName] = duration;
       if (error !== undefined) {
-        errors[serverName] = error;
+        errors[serverName] = error.message;
+        errorDetails[serverName] = error;
         continue;
       }
       connectedToolsets[serverName] = value;
     }
 
-    const result = { toolsets: connectedToolsets, errors };
+    const result = { toolsets: connectedToolsets, errors, errorDetails };
     return options ? { ...result, durations } : result;
   }
 
@@ -1212,15 +1196,19 @@ To fix this you have three different options:
    *
    * Useful when caching a catalog, since it lets you avoid persisting a partial manifest that
    * silently omits a server which happened to be down at discovery time.
+   * `errors` remains a string map for compatibility; `errorDetails` preserves
+   * machine-readable transport status and error codes when available.
    */
   public async listToolDefinitionsWithErrors(options?: MCPDiscoveryOptions): Promise<{
     definitions: SerializableMCPToolCatalog;
     errors: Record<string, string>;
+    errorDetails: Record<string, MCPDiscoveryErrorDetails>;
     durations?: Record<string, number>;
   }> {
     this.addToInstanceCache();
     const definitions: SerializableMCPToolCatalog = {};
     const errors: Record<string, string> = {};
+    const errorDetails: Record<string, MCPDiscoveryErrorDetails> = {};
     const durations: Record<string, number> = {};
 
     const settled = await this.discoverAcrossServers(
@@ -1238,13 +1226,14 @@ To fix this you have three different options:
     for (const { serverName, value, error, duration } of settled) {
       durations[serverName] = duration;
       if (error !== undefined) {
-        errors[serverName] = error;
+        errors[serverName] = error.message;
+        errorDetails[serverName] = error;
         continue;
       }
       definitions[serverName] = value;
     }
 
-    const result = { definitions, errors };
+    const result = { definitions, errors, errorDetails };
     return options ? { ...result, durations } : result;
   }
 
@@ -1317,6 +1306,81 @@ To fix this you have three different options:
     return tools;
   }
 
+  private async listResourcesWithErrors(options?: MCPDiscoveryOptions): Promise<{
+    resources: Record<string, Resource[]>;
+    errors: Record<string, string>;
+    errorDetails: Record<string, MCPDiscoveryErrorDetails>;
+    durations?: Record<string, number>;
+  }> {
+    const { values, ...diagnostics } = await this.discoverValuesWithErrors(
+      async serverName => (await this.getConnectedClientForServer(serverName)).resources.list(),
+      { errorId: 'MCP_CLIENT_LIST_RESOURCES_FAILED', logMessage: 'Failed to list resources from server:' },
+      options,
+    );
+    return { resources: values, ...diagnostics };
+  }
+
+  private async listResourceTemplatesWithErrors(options?: MCPDiscoveryOptions): Promise<{
+    templates: Record<string, ResourceTemplateType[]>;
+    errors: Record<string, string>;
+    errorDetails: Record<string, MCPDiscoveryErrorDetails>;
+    durations?: Record<string, number>;
+  }> {
+    const { values, ...diagnostics } = await this.discoverValuesWithErrors(
+      async serverName => (await this.getConnectedClientForServer(serverName)).resources.templates(),
+      {
+        errorId: 'MCP_CLIENT_LIST_RESOURCE_TEMPLATES_FAILED',
+        logMessage: 'Failed to list resource templates from server:',
+      },
+      options,
+    );
+    return { templates: values, ...diagnostics };
+  }
+
+  private async listPromptsWithErrors(options?: MCPDiscoveryOptions): Promise<{
+    prompts: Record<string, Prompt[]>;
+    errors: Record<string, string>;
+    errorDetails: Record<string, MCPDiscoveryErrorDetails>;
+    durations?: Record<string, number>;
+  }> {
+    const { values, ...diagnostics } = await this.discoverValuesWithErrors(
+      async serverName => (await this.getConnectedClientForServer(serverName)).prompts.list(),
+      { errorId: 'MCP_CLIENT_LIST_PROMPTS_FAILED', logMessage: 'Failed to list prompts from server:' },
+      options,
+    );
+    return { prompts: values, ...diagnostics };
+  }
+
+  private async discoverValuesWithErrors<T>(
+    operation: (serverName: string) => Promise<T>,
+    onError: { errorId: Uppercase<string>; logMessage: string },
+    options?: MCPDiscoveryOptions,
+  ): Promise<{
+    values: Record<string, T>;
+    errors: Record<string, string>;
+    errorDetails: Record<string, MCPDiscoveryErrorDetails>;
+    durations?: Record<string, number>;
+  }> {
+    const values: Record<string, T> = {};
+    const errors: Record<string, string> = {};
+    const errorDetails: Record<string, MCPDiscoveryErrorDetails> = {};
+    const durations: Record<string, number> = {};
+    const settled = await this.discoverAcrossServers(operation, onError, options);
+
+    for (const { serverName, value, error, duration } of settled) {
+      durations[serverName] = duration;
+      if (error !== undefined) {
+        errors[serverName] = error.message;
+        errorDetails[serverName] = error;
+      } else {
+        values[serverName] = value;
+      }
+    }
+
+    const result = { values, errors, errorDetails };
+    return options ? { ...result, durations } : result;
+  }
+
   /**
    * Runs a per-server discovery `operation` against every configured server
    * concurrently, isolating and logging per-server failures. Results are
@@ -1358,21 +1422,38 @@ To fix this you have three different options:
 
           return { serverName, value, error: undefined, duration: performance.now() - startedAt };
         } catch (error) {
-          const mastraError = new MastraError(
-            {
+          const discoveryError = getMCPDiscoveryErrorDetails(error);
+
+          try {
+            const mastraError = new MastraError(
+              {
+                id: onError.errorId,
+                domain: ErrorDomain.MCP,
+                category: ErrorCategory.THIRD_PARTY,
+                details: { serverName },
+              },
+              error,
+            );
+            this.logger.trackException(mastraError);
+            this.logger.error(onError.logMessage, { error: mastraError.toString() });
+          } catch {
+            // Error inspection performed by telemetry must not make aggregate
+            // discovery reject. Preserve the normalized message even when a
+            // hostile third-party Error uses throwing getters or Proxy traps.
+            const fallbackError = new MastraError({
               id: onError.errorId,
               domain: ErrorDomain.MCP,
               category: ErrorCategory.THIRD_PARTY,
+              text: discoveryError.message,
               details: { serverName },
-            },
-            error,
-          );
-          this.logger.trackException(mastraError);
-          this.logger.error(onError.logMessage, { error: mastraError.toString() });
+            });
+            this.logger.trackException(fallbackError);
+            this.logger.error(onError.logMessage, { error: fallbackError.toString() });
+          }
           return {
             serverName,
             value: undefined,
-            error: error instanceof Error ? error.message : String(error),
+            error: discoveryError,
             duration: performance.now() - startedAt,
           };
         } finally {

--- a/packages/mcp/src/client/error-utils.test.ts
+++ b/packages/mcp/src/client/error-utils.test.ts
@@ -1,0 +1,112 @@
+import { SdkErrorCode, SdkHttpError } from '@modelcontextprotocol/client';
+import { describe, expect, it } from 'vitest';
+
+import { getMCPDiscoveryErrorDetails } from './error-utils';
+
+describe('getMCPDiscoveryErrorDetails', () => {
+  it('preserves MCP SDK 2 HTTP status and transport code through wrapped causes', () => {
+    const transportError = new SdkHttpError(
+      SdkErrorCode.ClientHttpNotImplemented,
+      'Error POSTing to endpoint: temporarily unavailable',
+      { status: 503 },
+    );
+    const wrapped = new Error('Failed to connect to MCP server unavailable', { cause: transportError });
+
+    expect(getMCPDiscoveryErrorDetails(wrapped)).toEqual({
+      message: 'Failed to connect to MCP server unavailable (HTTP 503)',
+      httpStatus: 503,
+      code: SdkErrorCode.ClientHttpNotImplemented,
+    });
+  });
+
+  it('recognizes legacy status fields and data-wrapped status', () => {
+    expect(
+      getMCPDiscoveryErrorDetails(
+        Object.assign(new Error('legacy status'), { statusCode: 429, code: 'RATE_LIMITED' }),
+      ),
+    ).toEqual({
+      message: 'legacy status (HTTP 429)',
+      httpStatus: 429,
+      code: 'RATE_LIMITED',
+    });
+
+    expect(
+      getMCPDiscoveryErrorDetails(
+        Object.assign(new Error('serialized SDK error'), {
+          data: { status: 401, code: 'CLIENT_HTTP_UNAUTHORIZED' },
+        }),
+      ),
+    ).toEqual({
+      message: 'serialized SDK error (HTTP 401)',
+      httpStatus: 401,
+      code: 'CLIENT_HTTP_UNAUTHORIZED',
+    });
+  });
+
+  it('preserves numeric codes without treating them as HTTP status fields', () => {
+    expect(getMCPDiscoveryErrorDetails(Object.assign(new Error('payment required'), { code: 402 }))).toEqual({
+      message: 'payment required',
+      code: 402,
+    });
+
+    expect(getMCPDiscoveryErrorDetails(Object.assign(new Error('method missing'), { code: -32601 }))).toEqual({
+      message: 'method missing',
+      code: -32601,
+    });
+  });
+
+  it('does not duplicate an existing HTTP marker', () => {
+    expect(
+      getMCPDiscoveryErrorDetails(Object.assign(new Error('endpoint failed (HTTP 503)'), { status: 503 })),
+    ).toEqual({
+      message: 'endpoint failed (HTTP 503)',
+      httpStatus: 503,
+    });
+  });
+
+  it('stops at cause cycles and the maximum cause depth', () => {
+    const first = new Error('cycle root') as Error & { cause?: unknown };
+    const second = Object.assign(new Error('cycle child'), { status: 502, cause: first });
+    first.cause = second;
+
+    expect(getMCPDiscoveryErrorDetails(first)).toEqual({
+      message: 'cycle root (HTTP 502)',
+      httpStatus: 502,
+    });
+
+    const root = new Error('deep root') as Error & { cause?: unknown };
+    let cursor = root;
+    for (let depth = 0; depth < 8; depth++) {
+      const next = new Error(`cause ${depth}`) as Error & { cause?: unknown; status?: number };
+      cursor.cause = next;
+      cursor = next;
+    }
+    (cursor as Error & { status?: number }).status = 504;
+
+    expect(getMCPDiscoveryErrorDetails(root)).toEqual({ message: 'deep root' });
+  });
+
+  it('does not throw when third-party error accessors or string conversion throw', () => {
+    const inaccessible = new Proxy(Object.create(null) as object, {
+      get() {
+        throw new Error('access denied');
+      },
+    });
+
+    expect(getMCPDiscoveryErrorDetails(inaccessible)).toEqual({ message: 'Unknown error' });
+
+    const partial = new Error('request failed');
+    Object.defineProperty(partial, 'status', {
+      get() {
+        throw new Error('status unavailable');
+      },
+    });
+    Object.defineProperty(partial, 'code', {
+      get() {
+        throw new Error('code unavailable');
+      },
+    });
+
+    expect(getMCPDiscoveryErrorDetails(partial)).toEqual({ message: 'request failed' });
+  });
+});

--- a/packages/mcp/src/client/error-utils.ts
+++ b/packages/mcp/src/client/error-utils.ts
@@ -22,3 +22,110 @@ export function isReconnectableMCPError(error: unknown): boolean {
     errorMessage.includes('typeerror: terminated')
   );
 }
+
+/** Structured transport metadata for a failed aggregate MCP discovery. */
+export interface MCPDiscoveryErrorDetails {
+  /** Human-readable failure message. Includes `(HTTP nnn)` when an HTTP status is available. */
+  message: string;
+  /** HTTP response status reported by the MCP transport. */
+  httpStatus?: number;
+  /** Deepest error code in the cause chain, such as an MCP SDK, network, or application error code. */
+  code?: string | number;
+}
+
+const MAX_DISCOVERY_ERROR_CAUSE_DEPTH = 8;
+
+function isHttpStatus(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 100 && value <= 599;
+}
+
+function asErrorRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function getErrorProperty(record: Record<string, unknown> | undefined, property: string): unknown {
+  if (!record) return undefined;
+
+  try {
+    return record[property];
+  } catch {
+    // Third-party errors can expose values through getters or Proxy traps.
+    // Discovery error reporting must never turn one server failure into an
+    // aggregate rejection merely because inspecting that failure throws.
+    return undefined;
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  const message = getErrorProperty(asErrorRecord(error), 'message');
+  if (typeof message === 'string') return message;
+
+  try {
+    return String(error);
+  } catch {
+    return 'Unknown error';
+  }
+}
+
+/**
+ * Preserve machine-readable transport metadata before aggregate discovery turns
+ * a thrown error into its legacy per-server string.
+ *
+ * MCP SDK 2 keeps an HTTP response status on `SdkHttpError.status` while
+ * `code` is a string SDK code. Older transports and wrappers have also used
+ * `statusCode`; only explicit status fields are treated as HTTP metadata so a
+ * numeric SDK or application `code` is not mislabeled. The walk is bounded and
+ * cycle-safe because application errors may wrap arbitrary third-party causes.
+ */
+export function getMCPDiscoveryErrorDetails(error: unknown): MCPDiscoveryErrorDetails {
+  let message = getErrorMessage(error);
+  let httpStatus: number | undefined;
+  let code: string | number | undefined;
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+
+  for (
+    let depth = 0;
+    depth < MAX_DISCOVERY_ERROR_CAUSE_DEPTH && current !== undefined && current !== null && !seen.has(current);
+    depth++
+  ) {
+    seen.add(current);
+    const record = asErrorRecord(current);
+    if (!record) break;
+
+    const data = asErrorRecord(getErrorProperty(record, 'data'));
+    if (httpStatus === undefined) {
+      for (const candidate of [
+        getErrorProperty(record, 'status'),
+        getErrorProperty(record, 'statusCode'),
+        getErrorProperty(data, 'status'),
+        getErrorProperty(data, 'statusCode'),
+      ]) {
+        if (isHttpStatus(candidate)) {
+          httpStatus = candidate;
+          break;
+        }
+      }
+    }
+
+    for (const candidate of [getErrorProperty(record, 'code'), getErrorProperty(data, 'code')]) {
+      if (typeof candidate === 'string' || typeof candidate === 'number') {
+        // Prefer the deepest code: outer Mastra errors describe the aggregate
+        // operation, while the innermost SDK/network code classifies the cause.
+        code = candidate;
+      }
+    }
+
+    current = getErrorProperty(record, 'cause');
+  }
+
+  if (httpStatus !== undefined && !message.includes(`(HTTP ${httpStatus})`)) {
+    message += ` (HTTP ${httpStatus})`;
+  }
+
+  return {
+    message,
+    ...(httpStatus !== undefined ? { httpStatus } : {}),
+    ...(code !== undefined ? { code } : {}),
+  };
+}

--- a/packages/mcp/src/client/index.ts
+++ b/packages/mcp/src/client/index.ts
@@ -15,6 +15,7 @@ export type {
 } from './types';
 export * from './client';
 export * from './configuration';
+export type { MCPDiscoveryErrorDetails } from './error-utils';
 export * from './oauth-provider';
 export * from './oauth-callback-server';
 export { MCPClientServerProxy } from './server-proxy';


### PR DESCRIPTION
## Summary

- preserve machine-readable HTTP status and transport codes when MCP discovery aggregates per-server failures
- retain the existing string `errors` maps for compatibility while adding structured `errorDetails`
- expose partial-failure diagnostics for resource, resource-template, and prompt discovery
- document the expanded discovery result contracts and add a patch changeset

Closes #22192.

Reported by @rares04.

## Test plan

- `pnpm turbo build --filter ./packages/mcp`
- `pnpm --filter ./packages/mcp test:client`
- `pnpm --filter ./packages/mcp lint`
- `pnpm --dir docs exec remark --no-stdout --frail --quiet src/content/en/reference/tools/mcp-client.mdx`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When one MCP server fails, discovery now keeps useful details such as the HTTP status and error code instead of keeping only text. Existing string errors still work, so current users do not need to change their code.

## Changes

- Added structured `errorDetails` to aggregate tool, toolset, tool-definition, resource, resource-template, and prompt discovery results.
- Preserved legacy per-server `errors` maps for backward compatibility.
- Added `MCPDiscoveryErrorDetails` and `getMCPDiscoveryErrorDetails`.
- Safely extracts bounded, cycle-free error causes, HTTP statuses from 100–599, and SDK or transport codes.
- Added `listWithErrors` and `templatesWithErrors` APIs for resources and prompts.
- Re-exported `MCPDiscoveryErrorDetails` from the client package.
- Added tests for partial failures, transport metadata, nested causes, cyclic errors, invalid metadata, and hostile getters.
- Updated MCP client documentation and added a patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->