### PR TITLE
chore(core): refresh suspended snapshot fix with main

### DIFF
--- a/.changeset/full-heads-rhyme.md
+++ b/.changeset/full-heads-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@mastra/cloudflare': patch
+---
+
+Fixed Cloudflare KV storage silently dropping data once a table grows past 1000 keys. Listing threads, deleting threads, and clearing tables now read every page of keys from Cloudflare instead of only the first one, so large stores no longer lose threads or leave orphaned messages behind. Also fixed writes through the REST API, which Cloudflare rejected with a 'metadata must be valid json' error. Fixes https://github.com/mastra-ai/mastra/issues/22015

--- a/.changeset/pgvector-skip-count-on-warmup.md
+++ b/.changeset/pgvector-skip-count-on-warmup.md
@@ -1,0 +1,18 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed `PgVector` scanning every vector table on startup. Constructing a `PgVector` warms an index cache in the background, and that warmup asked for full index statistics, which include `SELECT COUNT(*)` per table. On a large index that is a full table scan per index, per process start, and the warmup never used the count it paid for. `query()`, `upsert()`, `updateVector()` and the "has this index changed?" check in `createIndex()` paid for the same count.
+
+These paths now read only the index metadata they use (dimension, metric, index type, vector type, index configuration), all of which comes from the Postgres catalog at a cost that does not grow with the size of the table.
+
+`describeIndex()` is unchanged and still returns an exact `count`:
+
+```ts
+const stats = await pgVector.describeIndex({ indexName: 'embeddings' });
+console.log(stats.count); // exact row count, as before
+```
+
+Concurrent callers on a cold cache also no longer duplicate the lookup: the first call is shared with everyone waiting on it, and a failed lookup is not cached.
+
+Fixes [#21952](https://github.com/mastra-ai/mastra/issues/21952).

--- a/.changeset/scheduler-stale-build-fence.md
+++ b/.changeset/scheduler-stale-build-fence.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': patch
+---
+
+Prevent stale-build instances from executing scheduled workflow runs.
+
+A scheduled fire carries only a workflow id, so whichever process consumes it resolves the step graph from its *own* registry. During a rollout a not-yet-cycled instance from the previous deploy could therefore run an outdated step graph — skipping steps the current build had added, including gates meant to stop the workflow from running at all — while HTTP runs of the same workflow on the same deployment executed the current graph (#19169).
+
+This is now fenced on both sides:
+
+- Declarative schedule rows record a hash of the workflow's serialized step graph. The scheduler refuses to claim a due fire when its local definition doesn't match the row, leaving the fire for an instance running the current build. If no instance claims it for several consecutive ticks, the scheduler escalates to an error and records a failed trigger rather than stalling silently — it never forces a stale fire through.
+- When the claiming process also runs workflow execution, the fire is published `localOnly` so the instance that verified the definition is the instance that runs it. Scheduler-only deployments, where pinning locally would strand the fire, keep publishing to the shared topic.
+- Fires that do reach the shared topic now carry the schedule's definition hash, and a consumer whose locally registered workflow hashes differently refuses the run and records a failed trigger instead of executing an outdated graph.
+
+Rows without a hash (legacy or imperatively created schedules) and agent schedules fail open and are unaffected.

--- a/.changeset/slow-spoons-rush.md
+++ b/.changeset/slow-spoons-rush.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed dynamic prompt providers leaking prompts across authenticated callers.

--- a/docs/src/content/en/docs/deployment/mastra-server.mdx
+++ b/docs/src/content/en/docs/deployment/mastra-server.mdx
@@ -148,6 +148,24 @@ This list isn't exhaustive. To view all endpoints, run `mastra dev` and visit `h
 
 To add your own endpoints, see [Custom API Routes](/docs/server/custom-api-routes).
 
+## Graceful shutdown and rolling deploys
+
+By default, the generated server handles `SIGINT` and `SIGTERM`. It stops accepting connections, waits up to [`server.drainTimeout`](/reference/configuration#serverdraintimeout) for active requests and streams, then runs `mastra.shutdown()`. The drain timeout defaults to 5 seconds. A second signal terminates the process immediately. See [`server.handleShutdownSignals`](/reference/configuration#serverhandleshutdownsignals) if you need to manage signals yourself.
+
+Increase `drainTimeout` when your hosting platform's termination grace period can accommodate longer turns. Keep enough time after the drain for shutdown cleanup.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+
+export const mastra = new Mastra({
+  server: {
+    drainTimeout: 240_000,
+  },
+})
+```
+
+A plain `agent.stream()` call can't resume after its server process exits. If a stream ends without its expected terminal event, treat the turn as interrupted and let the client retry or reconcile it. Use [durable agents](/docs/harness/durable-agents) when turns must survive process replacement. [Crash recovery](/docs/harness/durable-agents#crash-recovery) requires shared persistent run storage and idempotent tools. Replaying missed events after a restart also requires a shared persistent cache such as Redis because the default event cache is in-memory. Multi-replica recovery doesn't yet use a distributed lease.
+
 ## Troubleshooting
 
 ### Memory errors during build
@@ -163,4 +181,5 @@ NODE_OPTIONS="--max-old-space-size=4096" mastra build
 - [Server Overview](/docs/server/overview): Configure server behavior, middleware, and authentication
 - [Server Adapters](/docs/server/server-adapters): Use Express or Hono instead of `mastra build`
 - [Custom API Routes](/docs/server/custom-api-routes): Add custom HTTP endpoints
+- [Durable Agents](/docs/harness/durable-agents): Persist agent runs so they survive process restarts
 - [Configuration Reference](/reference/configuration): Full configuration options

--- a/docs/src/content/en/docs/harness/durable-agents.mdx
+++ b/docs/src/content/en/docs/harness/durable-agents.mdx
@@ -251,7 +251,7 @@ await durableAgent.resume(runId, { approved: true })
 
 ## Crash recovery
 
-If the server process crashes while a durable agent run is in progress, that run remains in `running` status in storage with no automatic retry. On the next server start you can re-drive these orphaned runs so they pick up where they left off.
+If the server process crashes while a durable agent run is in progress, that run remains in `running` status in storage with no automatic retry. For orderly shutdowns such as rolling deploys, the generated server can also drain in-flight turns before exiting. See [graceful shutdown and rolling deploys](/docs/deployment/mastra-server#graceful-shutdown-and-rolling-deploys). On the next server start you can re-drive these orphaned runs so they pick up where they left off.
 
 ### Automatic recovery
 

--- a/docs/src/content/en/docs/mastra-platform/deploy.mdx
+++ b/docs/src/content/en/docs/mastra-platform/deploy.mdx
@@ -90,6 +90,8 @@ A local `.env` file is optional. Environment variables stored on the platform ar
   </StepItem>
 </Steps>
 
+Each deploy replaces the running server process, which affects agent turns that are still streaming when the new version goes live. Because Mastra Platform doesn't currently provide a configurable or guaranteed termination grace period, don't rely on a raised `server.drainTimeout` for turns that may run longer than the default drain window. Use [durable agents](/docs/harness/durable-agents) with persistent storage and cache when turns must survive a deploy, or handle an interrupted stream in the client. See [graceful shutdown and rolling deploys](/docs/deployment/mastra-server#graceful-shutdown-and-rolling-deploys) for the available strategies.
+
 The first deploy writes a `.mastra-project.json` file linking your directory to the platform project. Commit it so later deploys, CI runs, and [`mastra env`](/docs/mastra-platform/environments) commands target the same project without extra flags.
 
 ## Deploy to another environment

--- a/docs/src/content/en/integrations/deploy/render.mdx
+++ b/docs/src/content/en/integrations/deploy/render.mdx
@@ -3,6 +3,9 @@ title: "Render | Deploy"
 description: "Run distributed Mastra agent pipelines with Render Workflows"
 ---
 
+import Steps from "@site/src/components/Steps";
+import StepItem from "@site/src/components/StepItem";
+
 # Render
 
 Deploy Mastra applications on [Render](https://render.com/). Host the Mastra API as a [web service](https://render.com/docs/web-services), or use [Render Workflows](https://render.com/docs/workflows) for long-running tasks with independent retry policies.
@@ -15,7 +18,7 @@ Choose the deployment path that fits your application:
 
 This guide builds an editorial pipeline that reviews a draft from three perspectives in parallel, then passes the feedback to an editor agent. Use the links above if you want to deploy a Mastra API or execute an entire Mastra workflow as one task.
 
-## How Render Workflows works with Mastra
+## How Render Workflows integrate with Mastra
 
 Mastra supplies the agents and application logic, while Render Workflows defines the execution boundaries. A typical pipeline has three layers:
 
@@ -58,10 +61,6 @@ Install the Render SDK:
 npm install @renderinc/sdk tsx
 ```
 
-:::note
-Render Workflows requires `@renderinc/sdk@^0.5.0` or later.
-:::
-
 Set the API key for your model provider. This example uses OpenAI:
 
 ```text title=".env"
@@ -70,9 +69,9 @@ OPENAI_API_KEY=your_openai_api_key
 
 Any supported [Mastra model provider](/models) works.
 
-## Building a distributed agent pipeline
+## Build a distributed agent pipeline
 
-### Creating the agents
+### Create the agents
 
 In `src/mastra`, create an `agents` directory with `reviewer-agent.ts` and `editor-agent.ts`. Define both agents:
 
@@ -106,7 +105,7 @@ export const editorAgent = new Agent({
 })
 ```
 
-### Configuring the Mastra instance
+### Configure the Mastra instance
 
 Add both agents to the Mastra instance in `src/mastra/index.ts`:
 
@@ -125,7 +124,7 @@ export const mastra = new Mastra({
 
 Retrieving agents from the Mastra instance gives them access to shared application services such as logging, storage, and observability.
 
-### Creating the review task
+### Create the review task
 
 In `src`, create a `tasks` directory. The reviewer agent handles one area of focus. Its compute plan, five-minute timeout, and retry policy apply only to that analysis. A temporary model-provider failure can trigger another attempt without restarting the other reviewers.
 
@@ -166,7 +165,7 @@ export const reviewDraft = task(
 )
 ```
 
-### Creating the revision task
+### Create the revision task
 
 This task combines the feedback and produces a revised draft. It uses a larger compute plan and a longer timeout than each reviewer.
 
@@ -207,7 +206,7 @@ export const reviseDraft = task(
 )
 ```
 
-### Creating the orchestration task
+### Create the orchestration task
 
 The parent dispatches three reviews in parallel with `Promise.all()`, then sends their combined feedback to the revision step. Retries are disabled at this level because each child defines its own policy. If you enable orchestration retries, ensure that another attempt cannot duplicate external side effects or other non-idempotent work.
 
@@ -235,7 +234,7 @@ export const editorialPipeline = task(
 )
 ```
 
-### Registering the tasks
+### Register the tasks
 
 Create `src/index.ts` and import the editorial task:
 
@@ -245,7 +244,7 @@ import './tasks/editorial-task.js'
 
 Running the entry point loads the module and registers every task defined with `task()`.
 
-`create mastra` already wrote `tsconfig.json` and `package.json`. Keep those files. For the workflow start command, `tsc` must emit JavaScript into `dist`, so set these compiler options (do not leave `noEmit: true`):
+Change your `tsconfig.json`:
 
 ```json title="tsconfig.json"
 {
@@ -259,7 +258,7 @@ Running the entry point loads the module and registers every task defined with `
 }
 ```
 
-Add these scripts next to the ones `create mastra` already added. `create mastra` already sets `"type": "module"`:
+Add these scripts to `package.json`:
 
 ```json title="package.json"
 {
@@ -271,13 +270,11 @@ Add these scripts next to the ones `create mastra` already added. `create mastra
 }
 ```
 
-Relative imports in the examples above end in `.js` because Node resolves the compiled output as ES modules. Keep those extensions so the built entry point resolves its imports.
+Those files are the complete pipeline. [render-examples/render-workflows-mastra](https://github.com/render-examples/render-workflows-mastra) mirrors this `src/` layout and adds a web UI that starts the parent task.
 
-Those files are the complete pipeline. [render-examples/render-workflows-mastra](https://github.com/render-examples/render-workflows-mastra) mirrors this `src/` layout and adds a web UI that starts the parent task. Its agents use the provider-specific model ID `__GATEWAY_OPENAI_MODEL__`. In this page's source, that value is represented by a documentation token that is replaced during the docs build. Clone it to skip copying the snippets before you run it.
+## Run the pipeline
 
-## Running the pipeline
-
-### Running locally
+### Local
 
 Start the local Render Workflows development server:
 
@@ -301,56 +298,66 @@ render workflows tasks start editorial_pipeline \
 
 The local server keeps runs and their logs in memory, so you can inspect them after they finish with `render workflows runs list <task-name> --local`.
 
-### Running in production
+### Production
 
 Running the pipeline on Render requires a _workflow service_. This is the Render service that holds your task definitions: it builds your repository, registers every task it finds, and provisions an instance for each run.
 
-#### 1. Push the project to a Git repository
+<Steps>
+  <StepItem>
+    #### Push the project to a Git repository
 
-Render builds workflow services from a repository on GitHub, GitLab, or Bitbucket, so push your project to one of those providers. The first time you use a provider, Render asks for permission to access your repositories.
+    Render builds workflow services from a repository on GitHub, GitLab, or Bitbucket, so push your project to one of those providers. The first time you use a provider, Render asks for permission to access your repositories.
+  </StepItem>
 
-#### 2. Create the workflow service
+  <StepItem>
+    #### Create the workflow service
 
-In the [Render Dashboard](https://dashboard.render.com), click **New > Workflow** and link the repository from the previous step. Then complete the creation form:
+    In the [Render Dashboard](https://dashboard.render.com), click **New > Workflow** and link the repository from the previous step. Then complete the creation form:
 
-| Field | Value |
-| - | - |
-| **Language** | Node |
-| **Region** | The region of any other Render services your tasks connect to |
-| **Build Command** | `npm install && npm run build` |
-| **Start Command** | `npm run start:workflows` |
+    | Field | Value |
+    | - | - |
+    | **Language** | Node |
+    | **Region** | The region of any other Render services your tasks connect to |
+    | **Build Command** | `npm install && npm run build` |
+    | **Start Command** | `npm run start:workflows` |
 
-Click **Deploy Workflow**. Render builds the project and registers `review_draft`, `revise_draft`, and `editorial_pipeline`, which then appear on the workflow's **Tasks** page.
+    Click **Deploy Workflow**. Render builds the project and registers `review_draft`, `revise_draft`, and `editorial_pipeline`, which then appear on the workflow's **Tasks** page.
 
-The Render CLI creates the same service without leaving your terminal:
+    The Render CLI creates the same service without leaving your terminal:
 
-```bash
-render workflows create \
-  --name mastra-workflows \
-  --repo . \
-  --runtime node \
-  --build-command "npm install && npm run build" \
-  --run-command "npm run start:workflows"
-```
+    ```bash
+    render workflows create \
+      --name mastra-workflows \
+      --repo . \
+      --runtime node \
+      --build-command "npm install && npm run build" \
+      --run-command "npm run start:workflows"
+    ```
 
-`--repo .` reads the `origin` remote of your local repository, so the project must already be pushed.
+    `--repo .` reads the `origin` remote of your local repository, so the project must already be pushed.
+  </StepItem>
 
-#### 3. Set the workflow's environment variables
+  <StepItem>
+    #### Set the workflow's environment variables
 
-Add `OPENAI_API_KEY`, or the key for your chosen model provider, to the workflow service in the Dashboard before the first run.
+    Add `OPENAI_API_KEY`, or the key for your chosen model provider, to the workflow service in the Dashboard before the first run.
+  </StepItem>
 
-#### 4. Start a run
+  <StepItem>
+    #### Start a run
 
-```bash
-render workflows tasks start mastra-workflows/editorial_pipeline \
-  --input='["Render Workflows runs long-running tasks outside the request lifecycle."]'
-```
+    ```bash
+    render workflows tasks start mastra-workflows/editorial_pipeline \
+      --input='["Render Workflows runs long-running tasks outside the request lifecycle."]'
+    ```
 
-The first part of that identifier is your workflow's slug and the second is the task name. Both appear on the task's page in the Render Dashboard, so use the slug shown there if your workflow has a different name.
+    The first part of that identifier is your workflow's slug and the second is the task name. Both appear on the task's page in the Render Dashboard, so use the slug shown there if your workflow has a different name.
 
-Open the workflow in the Render Dashboard to inspect each task run, attempt, result, and log stream.
+    Open the workflow in the Render Dashboard to inspect each task run, attempt, result, and log stream.
+  </StepItem>
+</Steps>
 
-## Triggering from your application
+## Trigger from your application
 
 You can trigger the pipeline asynchronously from a Mastra application, web service, or script with the Render SDK.
 
@@ -382,17 +389,6 @@ The task continues running after `startTask()` returns. Call `await run.get()` w
 
 Returning the task run ID from a request handler lets the application respond without keeping the request open for the full pipeline.
 
-## Constraints
-
-These limits live in Render's docs and can change. Prefer those pages over this list:
-
-- Task arguments and return values must be JSON serializable. Arguments to a single run cannot exceed 4 MB. See [defining tasks](https://render.com/docs/workflows-defining#task-arguments) and [Workflows limits](https://render.com/docs/workflows-limits).
-- A task can run for up to 24 hours. The default timeout is two hours. See [timeouts](https://render.com/docs/workflows-defining#timeout).
-- A workflow service can register up to 500 task definitions. See [Workflows limits](https://render.com/docs/workflows-limits).
-- Render Workflows currently supports TypeScript and Python task definitions. See [defining tasks](https://render.com/docs/workflows-defining).
-
-To run the pipeline on a schedule, create a [Render cron job](https://render.com/docs/cronjobs) whose command calls `render workflows tasks start` or `startTask()`.
-
 ## Related
 
 - [Live demo](https://render-workflows-mastra.onrender.com)
@@ -401,3 +397,4 @@ To run the pipeline on a schedule, create a [Render cron job](https://render.com
 - [Triggering task runs](https://render.com/docs/workflows-running)
 - [Render Workflows TypeScript SDK](https://render.com/docs/workflows-sdk-typescript)
 - [Render Workflows limits and pricing](https://render.com/docs/workflows-limits)
+- [Render cron jobs](https://render.com/docs/cronjobs)

--- a/docs/src/content/en/reference/vectors/pg.mdx
+++ b/docs/src/content/en/reference/vectors/pg.mdx
@@ -405,6 +405,8 @@ interface PGIndexStats {
 }
 ```
 
+`count` is an exact `SELECT COUNT(*)`, which scans the whole table, so avoid calling `describeIndex()` on a hot path for a large index. Reads and writes never pay for it: they only use the index metadata, which comes from the Postgres catalog.
+
 ### `deleteIndex()`
 
 <PropertiesTable

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -85,7 +85,7 @@ import {
   toJsonSchemaOrUndefined,
 } from '../workflows/dynamic';
 import { WorkflowEventProcessor } from '../workflows/evented/workflow-event-processor';
-import { computeNextFireAt } from '../workflows/scheduler';
+import { computeNextFireAt, computeScheduleDefinitionHash } from '../workflows/scheduler';
 import type { WorkflowScheduleConfig, SchedulerConfig, Scheduler } from '../workflows/scheduler';
 import type { AnyWorkspace, RegisteredWorkspace, Workspace } from '../workspace';
 import {
@@ -1911,8 +1911,12 @@ export class Mastra<
     // have their old rows cleaned up.
     const declaredIdsByWorkflow = new Map<string, Set<string>>();
     const workflows = this.#workflows as Record<string, AnyWorkflow> | undefined;
+    // `#workflows` is keyed by registration key, which may differ from
+    // `workflow.id` — index by id for the definition-hash lookup below.
+    const workflowsById = new Map<string, AnyWorkflow>();
     for (const workflow of Object.values(workflows ?? {})) {
       declaredIdsByWorkflow.set(workflow.id, new Set());
+      workflowsById.set(workflow.id, workflow);
     }
     for (const { workflowId, scheduleId } of declared) {
       if (!declaredIdsByWorkflow.has(workflowId)) declaredIdsByWorkflow.set(workflowId, new Set());
@@ -1930,6 +1934,12 @@ export class Mastra<
           initialState: cfg.initialState,
           requestContext: cfg.requestContext,
         };
+        // Stamp the current build's step-graph hash so the scheduler can
+        // refuse to claim this row from an instance whose local workflow
+        // definition differs (stale-build fencing, #19169). `targetsEqual`
+        // below picks up hash changes and rewrites the row on redeploy.
+        const definitionHash = computeScheduleDefinitionHash(workflowsById.get(workflowId)?.serializedStepGraph);
+        if (definitionHash) target.definitionHash = definitionHash;
 
         if (!existing) {
           await schedulesStore.createSchedule({
@@ -3470,6 +3480,28 @@ export class Mastra<
     } else {
       this.#runScopeRefcounts.set(runId, next);
     }
+  }
+
+  /**
+   * Whether this process consumes workflow-execution events itself, i.e.
+   * whether a `workflow.start` published here would be handled here.
+   *
+   * True when a local OrchestrationWorker is pulling the `workflows` topic,
+   * or when a push-only pubsub has `handleWorkflowEvent` wired directly
+   * (`#wirePushWorkflowSubscription`).
+   *
+   * The scheduler uses this to keep a scheduled fire on the instance that
+   * claimed it (#19169). Scheduler and execution workers start through
+   * separate paths (`#startSchedulingWorkers` / `#startExecutionWorkers`),
+   * so a scheduler-only process is a supported topology and must keep
+   * publishing to the shared topic instead of stranding the fire locally.
+   *
+   * @internal
+   */
+  __hasLocalWorkflowExecution(): boolean {
+    if (this.#pushSubscription) return true;
+    const orchestration = this.#workers.find(w => w.name === 'orchestration');
+    return !!orchestration?.isRunning;
   }
 
   __hasInternalWorkflow(id: string, runId?: string): boolean {

--- a/packages/core/src/mastra/scheduler-integration.test.ts
+++ b/packages/core/src/mastra/scheduler-integration.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod/v4';
 import { MockStore } from '../storage/mock';
 import { createWorkflow as createDefaultWorkflow } from '../workflows';
 import { createStep, createWorkflow as createEventedWorkflow } from '../workflows/evented';
+import { computeScheduleDefinitionHash } from '../workflows/scheduler';
 import { Mastra } from './index';
 
 async function waitUntil(
@@ -306,6 +307,157 @@ describe('Mastra — workflow scheduler integration', () => {
       const after = await schedulesStore.getSchedule('wf_rolling-wf');
       expect(after?.updatedAt).toBe(initial?.updatedAt);
       await second.shutdown();
+    });
+
+    it('stamps the step-graph definition hash on create and rewrites it when the graph changes (#19169)', async () => {
+      const storage = new MockStore();
+
+      const buildWithSteps = (stepIds: string[]) => {
+        const wf = createEventedWorkflow({
+          id: 'rolling-wf',
+          inputSchema: z.object({}),
+          outputSchema: z.object({}),
+          schedule: { cron: '*/5 * * * *' } as any,
+        });
+        for (const id of stepIds) {
+          wf.then(
+            createStep({
+              id,
+              inputSchema: z.object({}),
+              outputSchema: z.object({}),
+              execute: async () => ({}),
+            }) as any,
+          );
+        }
+        wf.commit();
+        return wf;
+      };
+
+      const firstWf = buildWithSteps(['step-a']);
+      const first = await boot(storage, firstWf);
+      const schedulesStore = (await storage.getStore('schedules'))!;
+      const initial = await schedulesStore.getSchedule('wf_rolling-wf');
+      const initialHash = (initial!.target as any).definitionHash;
+      expect(initialHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(initialHash).toBe(computeScheduleDefinitionHash(firstWf.serializedStepGraph));
+      await first.shutdown();
+
+      // Same schedule config, different step graph (a gate step added in
+      // front) — reconcile must rewrite the stored hash on redeploy.
+      const second = await boot(storage, buildWithSteps(['gate', 'step-a']));
+      const updated = await schedulesStore.getSchedule('wf_rolling-wf');
+      const updatedHash = (updated!.target as any).definitionHash;
+      expect(updatedHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(updatedHash).not.toBe(initialHash);
+      await second.shutdown();
+    });
+
+    it('refuses to claim a due fire when the row hash does not match the local build (#19169)', async () => {
+      const storage = new MockStore();
+      const mastra = await boot(storage, buildScheduledWorkflow({ cron: '*/5 * * * *' }));
+      const schedulesStore = (await storage.getStore('schedules'))!;
+      const row = (await schedulesStore.getSchedule('wf_rolling-wf'))!;
+      const localHash = (row.target as any).definitionHash as string;
+      expect(localHash).toMatch(/^[0-9a-f]{16}$/);
+
+      // Simulate a *newer* deploy having rewritten the row hash while this
+      // (now stale) instance keeps ticking: the row carries a hash that no
+      // longer matches this instance's local step graph.
+      const due = Date.now() - 5_000;
+      await schedulesStore.updateSchedule('wf_rolling-wf', {
+        target: { ...(row.target as any), definitionHash: 'ffffffffffffffff' },
+        nextFireAt: due,
+      });
+
+      await mastra.scheduler!.tick();
+
+      // Fire left unclaimed for an instance running the current build.
+      let after = (await schedulesStore.getSchedule('wf_rolling-wf'))!;
+      expect(after.nextFireAt).toBe(due);
+      expect(after.lastRunId).toBeUndefined();
+
+      // Restore the matching hash (what reconcile does on the current
+      // build) — the same instance now claims the fire.
+      await schedulesStore.updateSchedule('wf_rolling-wf', {
+        target: { ...(after.target as any), definitionHash: localHash },
+      });
+      await mastra.scheduler!.tick();
+
+      after = (await schedulesStore.getSchedule('wf_rolling-wf'))!;
+      expect(after.nextFireAt).toBeGreaterThan(due);
+      expect(after.lastRunId).toBe(`sched_wf_rolling-wf_${due}`);
+
+      await mastra.shutdown();
+    });
+
+    it('a stale consumer refuses a fire published by a scheduler running the current build (#19169)', async () => {
+      // End-to-end split topology, which is the shape the issue was reported
+      // in: the scheduler process cannot pin the fire locally, so it lands on
+      // the shared topic where a not-yet-cycled instance from the previous
+      // deploy can pick it up. This asserts the two halves actually agree —
+      // the hash reconcile writes is the hash the consumer compares against.
+      const buildWithSteps = (stepIds: string[]) => {
+        const wf = createEventedWorkflow({
+          id: 'rolling-wf',
+          inputSchema: z.object({}),
+          outputSchema: z.object({}),
+          schedule: { cron: '*/5 * * * *' } as any,
+        });
+        for (const id of stepIds) {
+          wf.then(
+            createStep({
+              id,
+              inputSchema: z.object({}),
+              outputSchema: z.object({}),
+              execute: async () => ({}),
+            }) as any,
+          );
+        }
+        wf.commit();
+        return wf;
+      };
+
+      const storage = new MockStore();
+      // Current build reconciles the row, stamping its graph hash.
+      const current = await boot(storage, buildWithSteps(['gate', 'side-effect']));
+      const schedulesStore = (await storage.getStore('schedules'))!;
+      const rowHash = (await schedulesStore.getSchedule('wf_rolling-wf'))!.target as any;
+
+      // The straggler: same workflow id, older graph with no gate step.
+      const stale = new Mastra({
+        logger: false,
+        ...withoutNotificationDispatch,
+        storage: new MockStore(),
+        workflows: { wf: buildWithSteps(['side-effect']) } as any,
+      });
+
+      const runId = 'sched_wf_rolling-wf_1700000000000';
+      const started: unknown[] = [];
+      void stale.pubsub.subscribe(`workflow.events.v2.${runId}`, async event => {
+        if ((event.data as any)?.type === 'workflow-start') started.push(event);
+      });
+
+      await stale.handleWorkflowEvent({
+        type: 'workflow.start',
+        runId,
+        data: {
+          workflowId: 'rolling-wf',
+          runId,
+          executionPath: [0],
+          stepResults: {},
+          prevResult: { status: 'success', output: {} },
+          activeSteps: {},
+          requestContext: {},
+          scheduleDefinitionHash: rowHash.definitionHash,
+        },
+      } as any);
+
+      // The stale graph would have run `side-effect` without the gate the
+      // current build added — exactly the reported failure.
+      expect(started).toHaveLength(0);
+
+      await stale.shutdown();
+      await current.shutdown();
     });
   });
 

--- a/packages/core/src/storage/domains/schedules/base.ts
+++ b/packages/core/src/storage/domains/schedules/base.ts
@@ -19,6 +19,18 @@ export type WorkflowScheduleTarget = {
   inputData?: unknown;
   initialState?: unknown;
   requestContext?: Record<string, unknown>;
+  /**
+   * Content hash of the target workflow's serialized step graph, written by
+   * declarative schedule reconciliation on deploy. At claim time the
+   * scheduler compares this against the hash of its *locally registered*
+   * workflow and refuses to claim the fire on mismatch, fencing out
+   * not-yet-cycled instances from older builds that would otherwise execute
+   * a stale step graph (#19169). Absent on rows created by older versions
+   * and on imperative (API-created) schedules — those are unfenced.
+   *
+   * @internal — managed by `Mastra.registerDeclarativeSchedules()`.
+   */
+  definitionHash?: string;
 };
 
 // Agent-schedule semantic types are owned by the schedules feature module

--- a/packages/core/src/worker/workers/scheduler-worker.ts
+++ b/packages/core/src/worker/workers/scheduler-worker.ts
@@ -1,6 +1,7 @@
 import type { IMastraLogger } from '../../logger';
 import { resolveAgentById } from '../../mastra/resolve-agent';
 import type { ScheduleTarget } from '../../storage/domains/schedules/base';
+import { computeScheduleDefinitionHash } from '../../workflows/scheduler/definition-hash';
 import { Scheduler } from '../../workflows/scheduler/scheduler';
 import type { SchedulerConfig } from '../../workflows/scheduler/types';
 import { MastraWorker } from '../worker';
@@ -71,10 +72,40 @@ export class SchedulerWorker extends MastraWorker {
         }
       : undefined;
 
+    // Bind a stale-build fence (#19169): scheduled runs execute `localOnly`
+    // in the claiming process against its own workflow registry, so an
+    // instance whose local step graph differs from the hash recorded on the
+    // schedule row (a straggler from a previous deploy) must not claim the
+    // fire. Fails open for rows without a hash (legacy/imperative
+    // schedules) and for agent targets, which have no step graph.
+    const isTargetCurrent = mastra
+      ? (target: ScheduleTarget) => {
+          if (target.type !== 'workflow' || !target.definitionHash) return true;
+          try {
+            const workflow = mastra.getWorkflowById(target.workflowId);
+            const localHash = computeScheduleDefinitionHash(workflow.serializedStepGraph);
+            // Unhashable local graph → can't compare, fail open.
+            if (!localHash) return true;
+            return localHash === target.definitionHash;
+          } catch {
+            // Missing workflow is the readiness predicate's concern.
+            return true;
+          }
+        }
+      : undefined;
+
+    // Claim/execute affinity (#19169). Workers receive the *raw* pubsub, not
+    // the `Mastra.pubsub` proxy that tags run-scoped workflow events
+    // `localOnly`, so without this the scheduler's fire always fans out to
+    // every instance on the shared topic. Evaluated per fire rather than
+    // captured here because execution workers can start lazily
+    // (`__ensureExecutionWorkersStarted`) after the scheduler is already up.
+    const canExecuteLocally = mastra ? () => mastra.__hasLocalWorkflowExecution() : undefined;
+
     this.#scheduler = new Scheduler({
       schedulesStore,
       pubsub: deps.pubsub,
-      config: { ...this.#config, isTargetReady },
+      config: { ...this.#config, isTargetReady, isTargetCurrent, canExecuteLocally },
     });
     this.#scheduler.__setLogger(deps.logger as IMastraLogger);
 

--- a/packages/core/src/workflows/evented/workflow-event-processor/dispatch.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/dispatch.test.ts
@@ -5,6 +5,7 @@ import { EventEmitterPubSub } from '../../../events/event-emitter';
 import type { Event } from '../../../events/types';
 import { Mastra } from '../../../mastra';
 import { MockStore } from '../../../storage/mock';
+import { computeScheduleDefinitionHash } from '../../scheduler/definition-hash';
 
 function makeStartEvent(workflowId: string, runId: string): Event {
   return {
@@ -102,5 +103,128 @@ describe('WorkflowEventProcessor #dispatch', () => {
     expect(followUp).toEqual({ ok: true });
 
     await mastra.shutdown();
+  });
+
+  describe('stale scheduled-definition fence (#19169)', () => {
+    // Builds a workflow whose graph (and therefore hash) depends on `steps`,
+    // letting a test stand in for "this instance is running an older build".
+    const makeWorkflow = (steps: string[]) => {
+      const wf = createWorkflow({
+        id: 'fenced-wf',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+      });
+      let chain: any = wf;
+      for (const id of steps) {
+        chain = chain.then(
+          createStep({
+            id,
+            inputSchema: z.object({}),
+            outputSchema: z.object({}),
+            execute: async () => ({}),
+          }) as any,
+        );
+      }
+      chain.commit();
+      return wf;
+    };
+
+    const RUN_ID = 'sched_wf_fenced-wf_1700000000000';
+
+    /**
+     * Dispatch is event-driven: a fire that is allowed through emits the
+     * `workflow-start` watch event and begins stepping, while a refused fire
+     * emits nothing at all. Collecting published events is therefore the
+     * observable that actually distinguishes the two.
+     */
+    const makeMastra = (wf: any) => {
+      const pubsub = new EventEmitterPubSub();
+      const started: Event[] = [];
+      void pubsub.subscribe(`workflow.events.v2.${RUN_ID}`, async event => {
+        if ((event.data as any)?.type === 'workflow-start') started.push(event);
+      });
+      const mastra = new Mastra({
+        logger: false,
+        storage: new MockStore(),
+        workflows: { fencedWf: wf } as any,
+        pubsub,
+      });
+      return { mastra, started };
+    };
+
+    const fire = (mastra: Mastra, scheduleDefinitionHash?: string) => {
+      const event = makeStartEvent('fenced-wf', RUN_ID);
+      (event.data as any).scheduleDefinitionHash = scheduleDefinitionHash;
+      return mastra.handleWorkflowEvent(event);
+    };
+
+    it('refuses a fire whose hash does not match the locally registered definition', async () => {
+      // This instance is the straggler: it only knows the pre-gate graph.
+      const staleWf = makeWorkflow(['side-effect']);
+      const { mastra, started } = makeMastra(staleWf);
+
+      // The schedule row was written by the current build, which added a gate
+      // step ahead of the side effect — so its hash differs from ours.
+      const currentWf = makeWorkflow(['gate', 'side-effect']);
+      const currentHash = computeScheduleDefinitionHash(currentWf.serializedStepGraph);
+      expect(currentHash).toBeDefined();
+      expect(currentHash).not.toBe(computeScheduleDefinitionHash(staleWf.serializedStepGraph));
+
+      await fire(mastra, currentHash);
+
+      // The whole point of the issue: the old graph must not start executing
+      // just because the gate step didn't exist in this build.
+      expect(started).toHaveLength(0);
+
+      await mastra.shutdown();
+    });
+
+    it('runs the fire when the local definition matches the schedule row', async () => {
+      const wf = makeWorkflow(['side-effect']);
+      const { mastra, started } = makeMastra(wf);
+
+      await fire(mastra, computeScheduleDefinitionHash(wf.serializedStepGraph));
+
+      expect(started).toHaveLength(1);
+
+      await mastra.shutdown();
+    });
+
+    it('fails open when the event carries no definition hash', async () => {
+      const wf = makeWorkflow(['side-effect']);
+      const { mastra, started } = makeMastra(wf);
+
+      // Imperative/legacy schedules and every non-scheduled run land here.
+      await fire(mastra, undefined);
+
+      expect(started).toHaveLength(1);
+
+      await mastra.shutdown();
+    });
+
+    it('records a failed trigger so a refused fire is visible in schedule history', async () => {
+      const wf = makeWorkflow(['side-effect']);
+      const { mastra } = makeMastra(wf);
+      const store = await mastra.getStorage()!.getStore('schedules');
+      await store.createSchedule({
+        id: 'wf_fenced-wf',
+        target: { type: 'workflow', workflowId: 'fenced-wf' },
+        cron: '0 0 1 1 *',
+        status: 'active',
+        nextFireAt: Date.now(),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
+      await fire(mastra, 'ffffffffffffffff');
+
+      const triggers = await store.listTriggers('wf_fenced-wf');
+      expect(triggers).toHaveLength(1);
+      expect(triggers[0]!.outcome).toBe('failed');
+      expect(triggers[0]!.scheduledFireAt).toBe(1700000000000);
+      expect(triggers[0]!.error).toContain('Stale workflow definition');
+
+      await mastra.shutdown();
+    });
   });
 });

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -18,6 +18,7 @@ import type {
   WorkflowRunState,
 } from '../../../workflows/types';
 import type { Workflow } from '../../../workflows/workflow';
+import { computeScheduleDefinitionHash } from '../../scheduler/definition-hash';
 import {
   createRestartExecutionParams,
   createTimeTravelExecutionParams,
@@ -416,6 +417,64 @@ export class WorkflowEventProcessor extends EventProcessor {
     } catch {
       return undefined;
     }
+  }
+
+  /**
+   * Stale-build fence for scheduled fires (#19169).
+   *
+   * A `workflow.start` published by the scheduler carries no step graph —
+   * only a workflow id, which this process resolves against its *own*
+   * registry. When the scheduler cannot keep the fire local (scheduler-only
+   * topology) the event reaches every consumer on the shared topic, so a
+   * straggler from a previous deploy could execute an outdated graph and
+   * skip steps the current build added (e.g. a gate enforcing a disable).
+   *
+   * The scheduler stamps `scheduleDefinitionHash` from the schedule row.
+   * If our locally registered definition hashes differently, we refuse the
+   * fire and record a failed trigger so the mismatch is visible in schedule
+   * history rather than silently doing nothing.
+   *
+   * Fails open when the event carries no hash (imperative/legacy schedules
+   * and all non-scheduled runs) or when our own graph can't be hashed.
+   *
+   * @returns `true` to proceed with execution, `false` to abandon the fire.
+   */
+  async #ensureScheduledDefinitionMatches(data: unknown, workflow: Workflow): Promise<boolean> {
+    const expected = (data as { scheduleDefinitionHash?: unknown } | undefined)?.scheduleDefinitionHash;
+    if (typeof expected !== 'string' || !expected) return true;
+
+    const localHash = computeScheduleDefinitionHash(workflow.serializedStepGraph);
+    if (!localHash || localHash === expected) return true;
+
+    const { workflowId, runId } = data as { workflowId: string; runId: string };
+    this.mastra
+      .getLogger()
+      ?.error?.(
+        'Refusing scheduled workflow fire: local definition does not match the schedule row. This instance is running a different build of the workflow.',
+        { workflowId, runId, expectedDefinitionHash: expected, localDefinitionHash: localHash },
+      );
+
+    try {
+      const schedulesStore = await this.mastra.getStorage()?.getStore('schedules');
+      // The scheduler derives runId as `sched_<scheduleId>_<scheduledFireAt>`.
+      const match = /^sched_(.+)_(\d+)$/.exec(runId);
+      if (schedulesStore && match) {
+        await schedulesStore.recordTrigger({
+          scheduleId: match[1]!,
+          runId,
+          scheduledFireAt: Number(match[2]),
+          actualFireAt: Date.now(),
+          outcome: 'failed',
+          error: `Stale workflow definition on consuming instance (expected ${expected}, local ${localHash})`,
+          triggerKind: 'schedule-fire',
+        });
+      }
+    } catch (err) {
+      // History is diagnostic — never let it resurrect a refused fire.
+      this.mastra.getLogger()?.warn?.('Failed to record stale-definition schedule trigger', { runId, error: err });
+    }
+
+    return false;
   }
 
   private async errorWorkflow(
@@ -3043,6 +3102,10 @@ export class WorkflowEventProcessor extends EventProcessor {
           }),
         );
       }
+    }
+
+    if (type === 'workflow.start' && workflow && !(await this.#ensureScheduledDefinitionMatches(data, workflow))) {
+      return;
     }
 
     if (type === 'workflow.start' || type === 'workflow.resume') {

--- a/packages/core/src/workflows/scheduler/definition-hash.test.ts
+++ b/packages/core/src/workflows/scheduler/definition-hash.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { createStep, createWorkflow } from '../index';
+import { computeScheduleDefinitionHash } from './definition-hash';
+
+const step = (id: string) =>
+  createStep({
+    id,
+    inputSchema: z.object({}),
+    outputSchema: z.object({}),
+    execute: async () => ({}),
+  }) as any;
+
+const buildWorkflow = (stepIds: string[]) => {
+  const wf = createWorkflow({
+    id: 'hash-wf',
+    inputSchema: z.object({}),
+    outputSchema: z.object({}),
+  });
+  let chain: any = wf;
+  for (const id of stepIds) chain = chain.then(step(id));
+  chain.commit();
+  return wf;
+};
+
+describe('computeScheduleDefinitionHash', () => {
+  it('is stable across separately-built instances of the same graph', () => {
+    // This is the property the fence depends on: the schedule row is hashed by
+    // one process at reconcile time and compared by another at fire time. If
+    // two identical builds hashed differently, every fire would be refused.
+    const a = computeScheduleDefinitionHash(buildWorkflow(['one', 'two']).serializedStepGraph);
+    const b = computeScheduleDefinitionHash(buildWorkflow(['one', 'two']).serializedStepGraph);
+
+    expect(a).toBeDefined();
+    expect(a).toBe(b);
+  });
+
+  it('is stable across repeated calls on the same graph', () => {
+    const graph = buildWorkflow(['one']).serializedStepGraph;
+
+    expect(computeScheduleDefinitionHash(graph)).toBe(computeScheduleDefinitionHash(graph));
+  });
+
+  it('changes when a step is added', () => {
+    // The #19169 scenario: the current build inserts a gate step ahead of the
+    // side effect, and the stale build must not hash the same.
+    const before = computeScheduleDefinitionHash(buildWorkflow(['side-effect']).serializedStepGraph);
+    const after = computeScheduleDefinitionHash(buildWorkflow(['gate', 'side-effect']).serializedStepGraph);
+
+    expect(before).not.toBe(after);
+  });
+
+  it('changes when step order changes', () => {
+    const forward = computeScheduleDefinitionHash(buildWorkflow(['one', 'two']).serializedStepGraph);
+    const reversed = computeScheduleDefinitionHash(buildWorkflow(['two', 'one']).serializedStepGraph);
+
+    expect(forward).not.toBe(reversed);
+  });
+
+  it('produces a short hex digest', () => {
+    expect(computeScheduleDefinitionHash(buildWorkflow(['one']).serializedStepGraph)).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  describe('fail-open cases', () => {
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['an empty array', []],
+      ['an empty object', {}],
+    ])('returns undefined for %s so unfenced schedules keep firing', (_label, input) => {
+      expect(computeScheduleDefinitionHash(input)).toBeUndefined();
+    });
+
+    it('returns undefined for a non-serializable graph', () => {
+      const circular: any = { steps: [] };
+      circular.self = circular;
+
+      expect(computeScheduleDefinitionHash(circular)).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/workflows/scheduler/definition-hash.ts
+++ b/packages/core/src/workflows/scheduler/definition-hash.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Computes a stable content hash of a workflow's serialized step graph.
+ *
+ * Written onto declarative schedule rows (`WorkflowScheduleTarget.definitionHash`)
+ * by `Mastra.registerDeclarativeSchedules()` and compared at claim time by the
+ * scheduler so that an instance running a *different* build of the workflow
+ * (a not-yet-cycled straggler from a previous deploy) refuses to claim the
+ * fire and leaves it for an instance whose local definition matches the row.
+ *
+ * Scheduled runs execute `localOnly` in the claiming process against its own
+ * workflow registry, so without this fence a stale instance silently runs an
+ * outdated step graph (see #19169).
+ *
+ * Returns `undefined` when the graph is missing or not JSON-serializable —
+ * callers treat a missing hash as "unfenced" (fail open) so legacy rows and
+ * imperative schedules keep firing.
+ */
+export function computeScheduleDefinitionHash(serializedStepGraph: unknown): string | undefined {
+  if (serializedStepGraph == null) return undefined;
+  try {
+    const json = JSON.stringify(serializedStepGraph);
+    if (!json || json === '[]' || json === '{}') return undefined;
+    return createHash('sha256').update(json).digest('hex').slice(0, 16);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core/src/workflows/scheduler/index.ts
+++ b/packages/core/src/workflows/scheduler/index.ts
@@ -1,3 +1,4 @@
 export { computeNextFireAt, validateCron } from './cron';
+export { computeScheduleDefinitionHash } from './definition-hash';
 export { Scheduler, WorkflowScheduler } from './scheduler';
 export type { WorkflowScheduleConfig, WorkflowScheduleInput, SchedulerConfig, WorkflowSchedulerConfig } from './types';

--- a/packages/core/src/workflows/scheduler/scheduler.test.ts
+++ b/packages/core/src/workflows/scheduler/scheduler.test.ts
@@ -467,6 +467,395 @@ describe('Scheduler', () => {
     await scheduler.stop();
   });
 
+  describe('stale-build fencing (#19169)', () => {
+    const makeDueSchedule = (store: InMemorySchedulesStorage, definitionHash?: string) => {
+      const past = Date.now() - 5_000;
+      return store
+        .createSchedule({
+          id: 'sched-fence',
+          target: { type: 'workflow', workflowId: 'wf-fenced', definitionHash },
+          cron: '0 0 1 1 *',
+          status: 'active',
+          nextFireAt: past,
+          createdAt: past,
+          updatedAt: past,
+        })
+        .then(() => past);
+    };
+
+    it('does not claim the fire when isTargetCurrent reports a stale local definition', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const { events } = captureWorkflowsTopic(pubsub);
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: { tickIntervalMs: 60_000, isTargetCurrent: () => false },
+      });
+
+      const past = await makeDueSchedule(store, 'aaaaaaaaaaaaaaaa');
+      const casSpy = vi.spyOn(store, 'updateScheduleNextFire');
+
+      await scheduler.start();
+      await scheduler.tick();
+
+      // No publish, no CAS attempt, nextFireAt untouched so a current
+      // instance can still claim this fire, and the row is NOT deleted
+      // (unlike the missing-target grace window).
+      expect(events).toHaveLength(0);
+      expect(casSpy).not.toHaveBeenCalled();
+      const row = await store.getSchedule('sched-fence');
+      expect(row).not.toBeNull();
+      expect(row?.nextFireAt).toBe(past);
+
+      await scheduler.stop();
+    });
+
+    it('claims the fire once the local definition matches again', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const { events } = captureWorkflowsTopic(pubsub);
+      let current = false;
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: { tickIntervalMs: 60_000, isTargetCurrent: () => current },
+      });
+
+      const past = await makeDueSchedule(store, 'aaaaaaaaaaaaaaaa');
+
+      await scheduler.start();
+      expect(events).toHaveLength(0);
+
+      // Simulates the row being left for an instance running the current
+      // build — here the same instance "becomes" current (e.g. reconcile
+      // rewrote the row hash to match).
+      current = true;
+      await scheduler.tick();
+      expect(events).toHaveLength(1);
+      const row = await store.getSchedule('sched-fence');
+      expect(row?.nextFireAt).toBeGreaterThan(past);
+
+      await scheduler.stop();
+    });
+
+    it('fails open when the isTargetCurrent predicate throws', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const { events } = captureWorkflowsTopic(pubsub);
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: {
+          tickIntervalMs: 60_000,
+          isTargetCurrent: () => {
+            throw new Error('predicate boom');
+          },
+        },
+      });
+
+      await makeDueSchedule(store, 'aaaaaaaaaaaaaaaa');
+
+      await scheduler.start();
+      expect(events).toHaveLength(1);
+
+      await scheduler.stop();
+    });
+
+    it('fires normally when no isTargetCurrent predicate is configured', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const { events } = captureWorkflowsTopic(pubsub);
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: { tickIntervalMs: 60_000 },
+      });
+
+      await makeDueSchedule(store, 'aaaaaaaaaaaaaaaa');
+
+      await scheduler.start();
+      expect(events).toHaveLength(1);
+
+      await scheduler.stop();
+    });
+
+    it('escalates and records a failed trigger when the skip is never picked up', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const { events } = captureWorkflowsTopic(pubsub);
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: { tickIntervalMs: 60_000, isTargetCurrent: () => false, staleSkipsBeforeEscalation: 3 },
+      });
+
+      const past = await makeDueSchedule(store, 'aaaaaaaaaaaaaaaa');
+
+      await scheduler.start(); // tick 1
+      await scheduler.tick(); // tick 2
+      expect(await store.listTriggers('sched-fence')).toHaveLength(0);
+
+      await scheduler.tick(); // tick 3 — hits the escalation limit
+
+      const triggers = await store.listTriggers('sched-fence');
+      expect(triggers).toHaveLength(1);
+      expect(triggers[0]!.outcome).toBe('failed');
+      expect(triggers[0]!.error).toContain('no local target definition matches');
+
+      // Escalation is visibility only: the fire is still never published and
+      // the row stays claimable by an instance running the recorded build.
+      expect(events).toHaveLength(0);
+      const row = await store.getSchedule('sched-fence');
+      expect(row?.nextFireAt).toBe(past);
+
+      await scheduler.stop();
+    });
+
+    it('records the escalation only once rather than on every subsequent tick', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: { tickIntervalMs: 60_000, isTargetCurrent: () => false, staleSkipsBeforeEscalation: 2 },
+      });
+
+      await makeDueSchedule(store, 'aaaaaaaaaaaaaaaa');
+
+      await scheduler.start();
+      for (let i = 0; i < 5; i++) await scheduler.tick();
+
+      expect(await store.listTriggers('sched-fence')).toHaveLength(1);
+
+      await scheduler.stop();
+    });
+
+    it('resets the stale-skip counter once the definition matches again', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      let current = false;
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: { tickIntervalMs: 60_000, isTargetCurrent: () => current, staleSkipsBeforeEscalation: 3 },
+      });
+
+      await makeDueSchedule(store, 'aaaaaaaaaaaaaaaa');
+
+      await scheduler.start();
+      await scheduler.tick();
+
+      // A matching instance claims it before the limit is reached, so the
+      // stall never escalates.
+      current = true;
+      await scheduler.tick();
+
+      const triggers = await store.listTriggers('sched-fence');
+      expect(triggers.every(t => t.outcome !== 'failed')).toBe(true);
+
+      await scheduler.stop();
+    });
+
+    it('does not escalate while a current-build instance keeps claiming each fire', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        // Permanently stale straggler: its definition never becomes current.
+        config: { tickIntervalMs: 60_000, isTargetCurrent: () => false, staleSkipsBeforeEscalation: 2 },
+      });
+
+      let fireAt = await makeDueSchedule(store, 'aaaaaaaaaaaaaaaa');
+
+      await scheduler.start();
+
+      // Walk well past the escalation limit. Each round a healthy instance
+      // claims the fire the straggler just declined (`start()` runs a tick of
+      // its own), advancing nextFireAt, and the straggler then declines the
+      // fresh window.
+      for (let i = 0; i < 6; i++) {
+        const nextFireAt = fireAt + 1_000;
+        expect(
+          await store.updateScheduleNextFire('sched-fence', fireAt, nextFireAt, fireAt, `sched-sched-fence-${fireAt}`),
+        ).toBe(true);
+        fireAt = nextFireAt;
+        await scheduler.tick();
+      }
+
+      // Every fire was served, so nothing should have been recorded as failed.
+      const triggers = await store.listTriggers('sched-fence');
+      expect(triggers.filter(t => t.outcome === 'failed')).toHaveLength(0);
+
+      await scheduler.stop();
+    });
+
+    it('escalates when the same fire window goes unclaimed for consecutive ticks', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: { tickIntervalMs: 60_000, isTargetCurrent: () => false, staleSkipsBeforeEscalation: 2 },
+      });
+
+      // nextFireAt never advances: nobody in the fleet matches the row.
+      await makeDueSchedule(store, 'aaaaaaaaaaaaaaaa');
+
+      await scheduler.start();
+      for (let i = 0; i < 3; i++) await scheduler.tick();
+
+      const triggers = await store.listTriggers('sched-fence');
+      expect(triggers.filter(t => t.outcome === 'failed')).toHaveLength(1);
+
+      await scheduler.stop();
+    });
+
+    it('runs the fence after target-readiness so a missing target still uses the grace window', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const { events } = captureWorkflowsTopic(pubsub);
+      const isTargetCurrent = vi.fn(() => true);
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: {
+          tickIntervalMs: 60_000,
+          isTargetReady: () => false,
+          isTargetCurrent,
+          missesBeforeDelete: 3,
+        },
+      });
+
+      await makeDueSchedule(store, 'aaaaaaaaaaaaaaaa');
+
+      await scheduler.start();
+      expect(events).toHaveLength(0);
+      // Readiness failed first — the fence is never consulted.
+      expect(isTargetCurrent).not.toHaveBeenCalled();
+
+      await scheduler.stop();
+    });
+  });
+
+  describe('claim/execute affinity (#19169)', () => {
+    const capturePublishes = (pubsub: EventEmitterPubSub) => {
+      const calls: { topic: string; event: any; options?: { localOnly?: boolean } }[] = [];
+      const original = pubsub.publish.bind(pubsub);
+      vi.spyOn(pubsub, 'publish').mockImplementation(async (topic, event, options?) => {
+        calls.push({ topic, event, options });
+        return original(topic, event, options);
+      });
+      return calls;
+    };
+
+    const makeDue = (store: InMemorySchedulesStorage, definitionHash?: string) => {
+      const past = Date.now() - 5_000;
+      return store.createSchedule({
+        id: 'sched-affinity',
+        target: { type: 'workflow', workflowId: 'wf-affinity', definitionHash },
+        cron: '0 0 1 1 *',
+        status: 'active',
+        nextFireAt: past,
+        createdAt: past,
+        updatedAt: past,
+      });
+    };
+
+    it('keeps the fire local when this process can execute workflows itself', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const calls = capturePublishes(pubsub);
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: { tickIntervalMs: 60_000, canExecuteLocally: () => true },
+      });
+
+      await makeDue(store);
+      await scheduler.tick();
+
+      const start = calls.find(c => c.event.type === 'workflow.start');
+      expect(start).toBeDefined();
+      // The claimant runs the current build, so pinning execution here is what
+      // prevents a straggler from a previous deploy from picking up the fire.
+      expect(start!.options?.localOnly).toBe(true);
+
+      await scheduler.stop();
+    });
+
+    it('broadcasts on the shared topic when this process has no local execution', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const calls = capturePublishes(pubsub);
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: { tickIntervalMs: 60_000, canExecuteLocally: () => false },
+      });
+
+      await makeDue(store);
+      await scheduler.tick();
+
+      const start = calls.find(c => c.event.type === 'workflow.start');
+      expect(start).toBeDefined();
+      // Scheduler-only topology: pinning locally would strand the fire, so it
+      // must go out to the shared topic and rely on the hash fence instead.
+      expect(start!.options?.localOnly).toBeFalsy();
+
+      await scheduler.stop();
+    });
+
+    it('broadcasts when no canExecuteLocally predicate is configured', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const calls = capturePublishes(pubsub);
+      const scheduler = new Scheduler({ schedulesStore: store, pubsub, config: { tickIntervalMs: 60_000 } });
+
+      await makeDue(store);
+      await scheduler.tick();
+
+      const start = calls.find(c => c.event.type === 'workflow.start');
+      expect(start).toBeDefined();
+      expect(start!.options?.localOnly).toBeFalsy();
+
+      await scheduler.stop();
+    });
+
+    it('stamps the schedule definition hash on the fired event', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const { events } = captureWorkflowsTopic(pubsub);
+      const scheduler = new Scheduler({ schedulesStore: store, pubsub, config: { tickIntervalMs: 60_000 } });
+
+      await makeDue(store, 'abcdef0123456789');
+      await scheduler.tick();
+
+      expect(events).toHaveLength(1);
+      // Consumers compare this against their own registered definition.
+      expect((events[0]!.data as any).scheduleDefinitionHash).toBe('abcdef0123456789');
+
+      await scheduler.stop();
+    });
+
+    it('omits the hash when the schedule row has none', async () => {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const { events } = captureWorkflowsTopic(pubsub);
+      const scheduler = new Scheduler({ schedulesStore: store, pubsub, config: { tickIntervalMs: 60_000 } });
+
+      await makeDue(store);
+      await scheduler.tick();
+
+      expect(events).toHaveLength(1);
+      // Legacy/imperative schedules carry no hash — consumers must fail open.
+      expect((events[0]!.data as any).scheduleDefinitionHash).toBeUndefined();
+
+      await scheduler.stop();
+    });
+  });
+
   it('applies defaults when config values are explicitly undefined', async () => {
     const { store } = makeStore();
     const pubsub = new EventEmitterPubSub();

--- a/packages/core/src/workflows/scheduler/scheduler.ts
+++ b/packages/core/src/workflows/scheduler/scheduler.ts
@@ -10,6 +10,7 @@ export const TOPIC_AGENT_SCHEDULES = 'agent-schedules';
 const DEFAULT_TICK_INTERVAL_MS = 10_000;
 const DEFAULT_BATCH_SIZE = 100;
 const DEFAULT_MISSES_BEFORE_DELETE = 3;
+const DEFAULT_STALE_SKIPS_BEFORE_ESCALATION = 5;
 
 /**
  * Drives cron-based workflow triggers.
@@ -43,6 +44,20 @@ export class Scheduler extends MastraBase {
    */
   #missingWorkflowCounts = new Map<string, number>();
 
+  /**
+   * Consecutive ticks each schedule has been skipped because the local target
+   * definition is stale (see `#ensureTargetCurrent`). Doubles as the
+   * "already logged" marker so a straggler doesn't re-log every tick, and as
+   * the counter that escalates a skip that is never being picked up by anyone.
+   *
+   * Scoped to the fire window (`nextFireAt`) the skips were observed against.
+   * A window that advances is proof some other instance claimed and fired the
+   * previous one, so the count restarts rather than accumulating across
+   * unrelated fires — otherwise a long-lived straggler would escalate even
+   * though every fire is being served correctly by a current-build instance.
+   */
+  #staleDefinitionCounts = new Map<string, { fireAt: number; count: number }>();
+
   constructor({
     schedulesStore,
     pubsub,
@@ -71,6 +86,7 @@ export class Scheduler extends MastraBase {
     // over into a new start() since the workflow registry may now look
     // different.
     this.#missingWorkflowCounts.clear();
+    this.#staleDefinitionCounts.clear();
 
     try {
       // Run one tick immediately so newly-due schedules don't wait the full interval.
@@ -237,8 +253,97 @@ export class Scheduler extends MastraBase {
     return false;
   }
 
+  /**
+   * Stale-build fence (#19169). Scheduled runs execute `localOnly` in the
+   * claiming process against its own workflow registry, so an instance whose
+   * local target definition differs from the one recorded on the schedule
+   * row must not claim the fire — it would silently run an outdated step
+   * graph. Returning `false` skips the CAS claim entirely, leaving
+   * `nextFireAt` untouched so an instance with a matching definition can
+   * claim the fire on its own tick.
+   *
+   * Fails open when no predicate is configured or when the predicate
+   * throws — fencing is a safety net, not a reason to stop firing.
+   */
+  #ensureTargetCurrent(schedule: Schedule): boolean {
+    const predicate = this.#config.isTargetCurrent;
+    if (!predicate) return true;
+
+    let current: boolean;
+    try {
+      current = predicate(schedule.target);
+    } catch (err) {
+      this.logger.error('isTargetCurrent predicate threw; treating target as current', {
+        scheduleId: schedule.id,
+        error: err,
+      });
+      return true;
+    }
+
+    if (current) {
+      this.#staleDefinitionCounts.delete(schedule.id);
+      return true;
+    }
+
+    // Only count skips against the same unclaimed fire window. If `nextFireAt`
+    // has moved on, an instance with a matching definition claimed the last
+    // fire and this is a fresh window, not a continuing stall.
+    const prevEntry = this.#staleDefinitionCounts.get(schedule.id);
+    const prev = prevEntry?.fireAt === schedule.nextFireAt ? prevEntry.count : 0;
+    const next = prev + 1;
+    this.#staleDefinitionCounts.set(schedule.id, { fireAt: schedule.nextFireAt, count: next });
+
+    const targetSummary =
+      schedule.target.type === 'workflow'
+        ? { workflowId: schedule.target.workflowId }
+        : { agentId: schedule.target.agentId };
+    const limit = this.#config.staleSkipsBeforeEscalation ?? DEFAULT_STALE_SKIPS_BEFORE_ESCALATION;
+
+    if (prev === 0) {
+      this.logger.warn(
+        'Local target definition differs from the schedule row; leaving fire for an instance running the current build',
+        { scheduleId: schedule.id, targetType: schedule.target.type, ...targetSummary },
+      );
+    } else if (next === limit) {
+      // Nobody has claimed this fire for `limit` consecutive ticks, which
+      // means no running instance matches the row (bad rollout, or a hash the
+      // reconciler wrote that no build reproduces). We deliberately do NOT
+      // force the fire — running a stale graph is the bug this fence exists to
+      // prevent — but a schedule that silently never runs is just as bad, so
+      // escalate to an alertable error and leave a trail in schedule history.
+      this.logger.error(
+        'Schedule has been skipped repeatedly because no local target definition matches the schedule row; it will not fire until an instance running the recorded build is available',
+        { scheduleId: schedule.id, targetType: schedule.target.type, ...targetSummary, consecutiveStaleSkips: next },
+      );
+      void this.#recordStaleSkip(schedule, next);
+    }
+
+    return false;
+  }
+
+  /**
+   * Best-effort history entry for an escalated stale skip so the stall is
+   * visible to anyone inspecting the schedule, not just in process logs.
+   */
+  async #recordStaleSkip(schedule: Schedule, consecutiveStaleSkips: number): Promise<void> {
+    try {
+      await this.#schedulesStore.recordTrigger({
+        scheduleId: schedule.id,
+        runId: `sched_${schedule.id}_${schedule.nextFireAt}`,
+        scheduledFireAt: schedule.nextFireAt,
+        actualFireAt: Date.now(),
+        outcome: 'failed',
+        error: `Skipped: no local target definition matches the schedule row after ${consecutiveStaleSkips} consecutive ticks`,
+        triggerKind: 'schedule-fire',
+      });
+    } catch (err) {
+      this.logger.warn('Failed to record stale-definition skip', { scheduleId: schedule.id, error: err });
+    }
+  }
+
   async #fireSchedule(schedule: Schedule): Promise<void> {
     if (!(await this.#ensureTargetReady(schedule))) return;
+    if (!this.#ensureTargetCurrent(schedule)) return;
 
     const actualFireAt = Date.now();
 
@@ -348,18 +453,33 @@ export class Scheduler extends MastraBase {
   async #publishTargetStart(schedule: Schedule, claimId: string): Promise<void> {
     switch (schedule.target.type) {
       case 'workflow': {
-        const { workflowId, inputData, initialState, requestContext } = schedule.target;
-        await this.#pubsub.publish(TOPIC_WORKFLOWS, {
-          type: 'workflow.start',
-          runId: claimId,
-          data: {
-            workflowId,
+        const { workflowId, inputData, initialState, requestContext, definitionHash } = schedule.target;
+        // Claim/execute affinity (#19169). When this process also consumes
+        // workflow events, keep the fire local so the instance that proved
+        // the target ready and current is the one that runs it. A
+        // scheduler-only process has no local consumer, so it must publish
+        // to the shared topic — the `scheduleDefinitionHash` below is what
+        // protects that hop, letting a stale consumer refuse the fire
+        // instead of executing its own outdated graph.
+        const localOnly = this.#config.canExecuteLocally?.() === true;
+        await this.#pubsub.publish(
+          TOPIC_WORKFLOWS,
+          {
+            type: 'workflow.start',
             runId: claimId,
-            prevResult: { status: 'success', output: inputData ?? {} },
-            requestContext: requestContext ?? {},
-            initialState: initialState ?? {},
+            data: {
+              workflowId,
+              runId: claimId,
+              prevResult: { status: 'success', output: inputData ?? {} },
+              requestContext: requestContext ?? {},
+              initialState: initialState ?? {},
+              // Only stamped when the row carries a hash, so legacy and
+              // imperative schedules stay unfenced (fail open).
+              ...(definitionHash ? { scheduleDefinitionHash: definitionHash } : {}),
+            },
           },
-        });
+          localOnly ? { localOnly: true } : undefined,
+        );
         return;
       }
       case 'agent': {

--- a/packages/core/src/workflows/scheduler/types.ts
+++ b/packages/core/src/workflows/scheduler/types.ts
@@ -96,6 +96,41 @@ export type SchedulerConfig = {
    */
   isTargetReady?: (target: ScheduleTarget) => boolean | Promise<boolean>;
   /**
+   * Predicate used to check whether the *local build's* definition of a
+   * schedule's target matches the definition recorded on the schedule row
+   * (`WorkflowScheduleTarget.definitionHash`). Scheduled runs execute
+   * `localOnly` in the claiming process against its own workflow registry,
+   * so an instance whose local step graph differs from the row (a
+   * not-yet-cycled straggler from a previous deploy) must not claim the
+   * fire — it would silently execute a stale graph (#19169). When the
+   * predicate returns `false` the scheduler leaves the fire unclaimed for
+   * an instance whose definition matches.
+   *
+   * Fail open: rows without a `definitionHash` (legacy or imperative
+   * schedules) and configurations without this predicate always fire.
+   *
+   * Wired up by `SchedulerWorker` from the registered workflow's serialized
+   * step graph.
+   */
+  isTargetCurrent?: (target: ScheduleTarget) => boolean;
+  /**
+   * Whether the claiming process also consumes workflow-execution events,
+   * i.e. whether a fire published here would be executed here.
+   *
+   * When true the scheduler publishes `workflow.start` with `localOnly` so
+   * the instance that proved the target ready (and current) is the instance
+   * that runs it. Without this affinity the fire lands on the shared topic
+   * and any consumer — including a straggler from a previous deploy —
+   * can execute it against its own workflow registry (#19169).
+   *
+   * When false or absent the fire is published normally, because a
+   * scheduler-only process has no local consumer and `localOnly` would
+   * strand the event.
+   *
+   * Wired up by `SchedulerWorker` from `Mastra.__hasLocalWorkflowExecution()`.
+   */
+  canExecuteLocally?: () => boolean;
+  /**
    * Number of consecutive ticks a schedule's target workflow may be missing
    * before the scheduler deletes the row. Defaults to 3 (≈30s with the
    * default tick interval). Provides a grace window for deploy/startup
@@ -103,6 +138,16 @@ export type SchedulerConfig = {
    * registering.
    */
   missesBeforeDelete?: number;
+  /**
+   * Number of consecutive ticks a schedule may be skipped by the stale-build
+   * fence (`isTargetCurrent`) before the scheduler escalates from a warning to
+   * an error and records a failed trigger. Defaults to 5.
+   *
+   * The fire is never forced — executing a stale definition is precisely what
+   * the fence prevents — but a schedule that no running instance can claim is
+   * a stall that operators need to see.
+   */
+  staleSkipsBeforeEscalation?: number;
 };
 
 /**

--- a/packages/mcp/src/server/__tests__/server-prompt-cache.test.ts
+++ b/packages/mcp/src/server/__tests__/server-prompt-cache.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { MCPServer } from '../server';
+import { makeMockExtra } from './mock-extra';
+
+/**
+ * Regression tests for cross-tenant prompt leakage.
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/22208
+ */
+describe('MCPServer dynamic prompt provider does not leak across callers', () => {
+  const makeExtra = (subject: string) => makeMockExtra({ authInfo: { subject } });
+
+  const createTenantServer = () => {
+    const listPrompts = vi.fn(async ({ extra }: { extra: any }) => {
+      const tenant = extra.authInfo.subject;
+      return [
+        {
+          name: `${tenant}-prompt`,
+          description: `Prompt for ${tenant}`,
+          version: `${tenant}-version`,
+          arguments: [{ name: 'input', required: true }],
+        },
+      ];
+    });
+    const getPromptMessages = vi.fn(async ({ name, extra }: { name: string; extra: any }) => [
+      { role: 'user' as const, content: { type: 'text' as const, text: `${extra.authInfo.subject}:${name}` } },
+    ]);
+
+    const server = new MCPServer({
+      name: 'tenant-server',
+      version: '1.0.0',
+      tools: {},
+      prompts: { listPrompts, getPromptMessages },
+    });
+
+    return { server, listPrompts, getPromptMessages };
+  };
+
+  it('serves each caller their own prompts from prompts/list', async () => {
+    const { server, listPrompts } = createTenantServer();
+    const listHandler = (server.getServer() as any)._requestHandlers.get('prompts/list');
+
+    const tenantA = await listHandler({ method: 'prompts/list' }, makeExtra('tenant-A'));
+    const tenantB = await listHandler({ method: 'prompts/list' }, makeExtra('tenant-B'));
+
+    expect(tenantA.prompts[0]).toMatchObject({ name: 'tenant-A-prompt', description: 'Prompt for tenant-A' });
+    expect(tenantB.prompts[0]).toMatchObject({ name: 'tenant-B-prompt', description: 'Prompt for tenant-B' });
+    expect(listPrompts).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves prompts/get against the current caller after another caller lists prompts', async () => {
+    const { server, listPrompts, getPromptMessages } = createTenantServer();
+    const handlers = (server.getServer() as any)._requestHandlers;
+
+    await handlers.get('prompts/list')({ method: 'prompts/list' }, makeExtra('tenant-A'));
+    const result = await handlers.get('prompts/get')(
+      { method: 'prompts/get', params: { name: 'tenant-B-prompt', arguments: { input: 'hello' } } },
+      makeExtra('tenant-B'),
+    );
+
+    expect(result.description).toBe('Prompt for tenant-B');
+    expect(result.messages[0].content.text).toBe('tenant-B:tenant-B-prompt');
+    expect(listPrompts).toHaveBeenCalledTimes(2);
+    expect(getPromptMessages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'tenant-B-prompt',
+        version: 'tenant-B-version',
+        extra: expect.objectContaining({ authInfo: { subject: 'tenant-B' } }),
+      }),
+    );
+  });
+
+  it("does not let a caller resolve another caller's prompt", async () => {
+    const { server, getPromptMessages } = createTenantServer();
+    const getHandler = (server.getServer() as any)._requestHandlers.get('prompts/get');
+
+    await expect(
+      getHandler(
+        { method: 'prompts/get', params: { name: 'tenant-A-prompt', arguments: { input: 'hello' } } },
+        makeExtra('tenant-B'),
+      ),
+    ).rejects.toThrow('Prompt "tenant-A-prompt" not found');
+    expect(getPromptMessages).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp/src/server/promptActions.ts
+++ b/packages/mcp/src/server/promptActions.ts
@@ -5,7 +5,6 @@ import { broadcastNotification } from './notificationBroadcast';
 interface ServerPromptActionsDependencies {
   getLogger: () => IMastraLogger;
   getSdkServers: () => Server[];
-  clearDefinedPrompts: () => void;
   /**
    * Publish-side facade of the 2026-07-28 handler's subscription bus, when the
    * server is pinned to that revision and the handler exists. Modern clients
@@ -28,7 +27,6 @@ interface ServerPromptActionsDependencies {
 export class ServerPromptActions {
   private readonly getLogger: () => IMastraLogger;
   private readonly getSdkServers: () => Server[];
-  private readonly clearDefinedPrompts: () => void;
   private readonly getModernEraNotifier?: () => ServerNotifier | undefined;
 
   /**
@@ -37,15 +35,14 @@ export class ServerPromptActions {
   constructor(dependencies: ServerPromptActionsDependencies) {
     this.getLogger = dependencies.getLogger;
     this.getSdkServers = dependencies.getSdkServers;
-    this.clearDefinedPrompts = dependencies.clearDefinedPrompts;
     this.getModernEraNotifier = dependencies.getModernEraNotifier;
   }
 
   /**
    * Notifies clients that the overall list of available prompts has changed.
    *
-   * This clears the internal prompt cache and sends a `notifications/prompts/list_changed`
-   * message to all clients, prompting them to re-fetch the prompt list.
+   * This sends a `notifications/prompts/list_changed` message to all clients,
+   * prompting them to re-fetch the prompt list.
    *
    * @throws {MastraError} If sending the notification fails on all server instances
    *
@@ -56,8 +53,7 @@ export class ServerPromptActions {
    * ```
    */
   public async notifyListChanged(): Promise<void> {
-    this.getLogger().info('Prompt list change externally notified. Clearing definedPrompts and sending notification.');
-    this.clearDefinedPrompts();
+    this.getLogger().info('Prompt list change externally notified. Sending notification.');
     // Modern (2026-07-28) clients subscribe via subscriptions/listen; no-op when unset.
     this.getModernEraNotifier?.()?.promptsChanged();
     await broadcastNotification({

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -66,7 +66,6 @@ import type {
   MCPServerResources,
   MCPRequestHandlerExtra,
   ElicitationActions,
-  MastraPrompt,
   AppResources,
   MCPServerProtocolVersion,
   MCPServerCacheHints,
@@ -169,7 +168,6 @@ export class MCPServer extends MCPServerBase {
   // per-request server instances can advertise the MCP Apps extension without relying on
   // a shared, per-caller resource cache.
   private hasUiResources: boolean = false;
-  private definedPrompts?: MastraPrompt[];
   private promptOptions?: MCPServerPrompts;
   private jsonSchemaValidator?: jsonSchemaValidator;
   private mapAuthInfoToUser?: MCPAuthInfoToUserMapper;
@@ -527,9 +525,6 @@ export class MCPServer extends MCPServerBase {
     this.prompts = new ServerPromptActions({
       getLogger: () => this.logger,
       getSdkServers: () => this.getAllSdkServers(),
-      clearDefinedPrompts: () => {
-        this.definedPrompts = undefined;
-      },
       getModernEraNotifier,
     });
 
@@ -1415,27 +1410,18 @@ export class MCPServer extends MCPServerBase {
     if (capturedPromptOptions.listPrompts) {
       serverInstance.setRequestHandler('prompts/list', async (_request, ctx) => {
         this.logger.debug('Handling ListPrompts request');
-        if (this.definedPrompts) {
-          return {
-            prompts: this.definedPrompts,
-          };
-        } else {
-          try {
-            const prompts = await capturedPromptOptions.listPrompts({ extra: toMCPRequestHandlerExtra(ctx) });
-            for (const prompt of prompts) {
-              PromptSchema.parse(prompt);
-            }
-            this.definedPrompts = prompts;
-            this.logger.debug('Fetched and cached prompts', { count: this.definedPrompts.length });
-            return {
-              prompts: this.definedPrompts,
-            };
-          } catch (error) {
-            this.logger.error('Error fetching prompts via listPrompts():', {
-              error: error instanceof Error ? error.message : String(error),
-            });
-            throw error;
+        try {
+          const prompts = await capturedPromptOptions.listPrompts({ extra: toMCPRequestHandlerExtra(ctx) });
+          for (const prompt of prompts) {
+            PromptSchema.parse(prompt);
           }
+          this.logger.debug('Fetched prompts', { count: prompts.length });
+          return { prompts };
+        } catch (error) {
+          this.logger.error('Error fetching prompts via listPrompts():', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          throw error;
         }
       });
     }
@@ -1447,13 +1433,14 @@ export class MCPServer extends MCPServerBase {
         async (request: { params: { name: string; arguments?: any } }, ctx) => {
           const startTime = Date.now();
           const { name, arguments: args } = request.params;
-          if (!this.definedPrompts) {
-            const prompts = await this.promptOptions?.listPrompts?.({ extra: toMCPRequestHandlerExtra(ctx) });
-            if (!prompts) throw new Error('Failed to load prompts');
-            this.definedPrompts = prompts;
+          const extra = toMCPRequestHandlerExtra(ctx);
+          const prompts = await capturedPromptOptions.listPrompts?.({ extra });
+          if (!prompts) throw new Error('Failed to load prompts');
+          for (const definedPrompt of prompts) {
+            PromptSchema.parse(definedPrompt);
           }
           // Select prompt by name
-          const prompt = this.definedPrompts?.find(p => p.name === name);
+          const prompt = prompts.find(p => p.name === name);
           if (!prompt) throw new Error(`Prompt "${name}" not found`);
           // Validate required arguments
           if (prompt.arguments) {
@@ -1470,7 +1457,7 @@ export class MCPServer extends MCPServerBase {
                 name,
                 version: prompt.version,
                 args,
-                extra: toMCPRequestHandlerExtra(ctx),
+                extra,
               });
             }
             const duration = Date.now() - startTime;

--- a/stores/cloudflare/src/kv/storage/db/index.test.ts
+++ b/stores/cloudflare/src/kv/storage/db/index.test.ts
@@ -1,0 +1,83 @@
+import type { KVNamespace } from '@cloudflare/workers-types';
+import { TABLE_THREADS } from '@mastra/core/storage';
+import type Cloudflare from 'cloudflare';
+import { Miniflare } from 'miniflare';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+import { CloudflareKVDB } from '.';
+
+describe('CloudflareKVDB listKV pagination (Workers binding)', () => {
+  let mf: Miniflare;
+  let db: CloudflareKVDB;
+
+  beforeAll(async () => {
+    mf = new Miniflare({
+      script: 'export default {};',
+      modules: true,
+      kvNamespaces: [TABLE_THREADS],
+    });
+    const bindings = {
+      [TABLE_THREADS]: (await mf.getKVNamespace(TABLE_THREADS)) as KVNamespace,
+    } as Record<string, KVNamespace>;
+    db = new CloudflareKVDB({ bindings: bindings as any, namespacePrefix: '' });
+  });
+
+  afterAll(async () => {
+    await mf.dispose();
+  });
+
+  it('returns all keys across multiple pages', async () => {
+    const total = 15;
+    for (let i = 0; i < total; i++) {
+      await db.putKV({
+        tableName: TABLE_THREADS,
+        key: `${TABLE_THREADS}:thread-${String(i).padStart(3, '0')}`,
+        value: { id: `thread-${i}` },
+      });
+    }
+
+    const keys = await db.listKV(TABLE_THREADS, { limit: 10 });
+    expect(keys.length).toBe(total);
+  });
+
+  it('honors prefix while paginating', async () => {
+    const matching = Array.from({ length: 11 }, (_, i) => `prefixed:item-${String(i).padStart(2, '0')}`);
+    for (const key of matching) {
+      await db.putKV({ tableName: TABLE_THREADS, key, value: { key } });
+    }
+    for (let i = 0; i < 5; i++) {
+      await db.putKV({ tableName: TABLE_THREADS, key: `unrelated:item-${i}`, value: { i } });
+    }
+
+    const keys = await db.listKV(TABLE_THREADS, { limit: 5, prefix: 'prefixed:' });
+    expect(keys.map(k => k.name).sort()).toEqual(matching);
+  });
+});
+
+describe('CloudflareKVDB listKV pagination (REST API)', () => {
+  it('follows result_info.cursor across pages', async () => {
+    const page1 = Array.from({ length: 10 }, (_, i) => ({ name: `${TABLE_THREADS}:thread-${i}` }));
+    const page2 = Array.from({ length: 5 }, (_, i) => ({ name: `${TABLE_THREADS}:thread-${10 + i}` }));
+
+    const keysList = vi
+      .fn()
+      .mockResolvedValueOnce({ result: page1, result_info: { count: 10, cursor: 'cursor-1' } })
+      .mockResolvedValueOnce({ result: page2, result_info: { count: 5 } });
+    const client = {
+      kv: {
+        namespaces: {
+          list: vi.fn().mockResolvedValue({ result: [{ id: 'ns-1', title: TABLE_THREADS }] }),
+          keys: { list: keysList },
+        },
+      },
+    } as unknown as Cloudflare;
+
+    const db = new CloudflareKVDB({ client, accountId: 'acc-1', namespacePrefix: '' });
+    const keys = await db.listKV(TABLE_THREADS, { limit: 10 });
+
+    expect(keys.map(k => k.name)).toEqual([...page1, ...page2].map(k => k.name));
+    expect(keysList).toHaveBeenCalledTimes(2);
+    expect(keysList.mock.calls[0]?.[1]).not.toHaveProperty('cursor');
+    expect(keysList.mock.calls[1]?.[1]).toMatchObject({ cursor: 'cursor-1' });
+  });
+});

--- a/stores/cloudflare/src/kv/storage/db/index.ts
+++ b/stores/cloudflare/src/kv/storage/db/index.ts
@@ -492,7 +492,8 @@ export class CloudflareKVDB extends MastraBase {
         await this.client!.kv.namespaces.values.update(namespaceId, key, {
           account_id: this.accountId!,
           value: serializedValue,
-          metadata: serializedMetadata,
+          // The REST API rejects empty-string metadata as invalid JSON
+          ...(serializedMetadata ? { metadata: serializedMetadata } : {}),
         });
       }
     } catch (error) {
@@ -595,22 +596,40 @@ export class CloudflareKVDB extends MastraBase {
 
   async listNamespaceKeys(tableName: TABLE_NAMES, options?: ListOptions) {
     try {
+      // KV returns at most 1000 keys per page, so keep fetching until the
+      // cursor is exhausted; a single call silently truncates larger tables.
+      const pageSize = options?.limit || 1000;
+      const keys: Array<{ name: string }> = [];
       if (this.bindings) {
         const binding = this.getBinding(tableName);
-        const response = await binding.list({
-          limit: options?.limit || 1000,
-          prefix: options?.prefix,
-        });
-        return response.keys;
+        let cursor: string | undefined;
+        do {
+          const response = await binding.list({
+            limit: pageSize,
+            prefix: options?.prefix,
+            cursor,
+          });
+          keys.push(...response.keys);
+          cursor = response.list_complete ? undefined : response.cursor;
+        } while (cursor);
       } else {
         const namespaceId = await this.getNamespaceId(tableName);
-        const response = await this.client!.kv.namespaces.keys.list(namespaceId, {
-          account_id: this.accountId!,
-          limit: options?.limit || 1000,
-          prefix: options?.prefix,
-        });
-        return response.result;
+        // Manual cursor loop: the SDK's auto-pagination expects
+        // result_info.cursors.after, but this endpoint returns result_info.cursor,
+        // so `for await` stops after the first page.
+        let cursor: string | undefined;
+        do {
+          const page = await this.client!.kv.namespaces.keys.list(namespaceId, {
+            account_id: this.accountId!,
+            limit: pageSize,
+            prefix: options?.prefix,
+            ...(cursor ? { cursor } : {}),
+          });
+          keys.push(...page.result);
+          cursor = (page.result_info as { cursor?: string } | undefined)?.cursor || undefined;
+        } while (cursor);
       }
+      return keys;
     } catch (error: any) {
       throw new MastraError(
         {

--- a/stores/cloudflare/src/kv/storage/domains/memory/index.ts
+++ b/stores/cloudflare/src/kv/storage/domains/memory/index.ts
@@ -270,7 +270,8 @@ export class MemoryStorageCloudflare extends MemoryStorage {
       }
 
       // Get all message keys for this thread first
-      const messageKeys = await this.#db.listKV(TABLE_MESSAGES);
+      const prefix = this.#db.namespacePrefix ? `${this.#db.namespacePrefix}:` : '';
+      const messageKeys = await this.#db.listKV(TABLE_MESSAGES, { prefix: `${prefix}${TABLE_MESSAGES}:${threadId}:` });
       const threadMessageKeys = messageKeys.filter(key => key.name.includes(`${TABLE_MESSAGES}:${threadId}:`));
 
       // Delete all messages and their order atomically

--- a/stores/pg/src/vector/index.count-scan.test.ts
+++ b/stores/pg/src/vector/index.count-scan.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@mastra/core/error', () => ({
+  ErrorCategory: { USER: 'USER', THIRD_PARTY: 'THIRD_PARTY' },
+  ErrorDomain: { MASTRA_VECTOR: 'MASTRA_VECTOR' },
+  MastraError: class MastraError extends Error {
+    constructor(
+      public metadata: any,
+      error?: Error,
+    ) {
+      super(error?.message ?? 'MastraError');
+    }
+  },
+}));
+
+vi.mock('@mastra/core/utils', () => ({
+  parseSqlIdentifier: (name: string) => name,
+}));
+
+vi.mock('@mastra/core/vector', () => ({
+  MastraVector: class MastraVector {
+    id: string;
+    disableInit: boolean;
+    logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn(), warn: vi.fn(), trackException: vi.fn() };
+    constructor({ id, disableInit }: { id: string; disableInit?: boolean }) {
+      this.id = id;
+      this.disableInit = disableInit ?? false;
+    }
+  },
+  validateTopK: () => {},
+  validateUpsertInput: () => {},
+}));
+
+vi.mock('@mastra/core/vector/filter', () => ({
+  BaseFilterTranslator: class {
+    static DEFAULT_OPERATORS = {};
+    translate(filter: any) {
+      return filter;
+    }
+    isEmpty(filter: any) {
+      return !filter || (typeof filter === 'object' && Object.keys(filter).length === 0);
+    }
+    validateFilter() {}
+    isPrimitive() {
+      return false;
+    }
+  },
+}));
+
+import type { PgVectorConfig } from '../shared/config';
+import { PgVector } from '.';
+
+const mockClient = {
+  query: vi.fn(),
+  release: vi.fn(),
+};
+
+vi.mock('pg', () => {
+  class MockPool {
+    public options: any;
+    public connect = vi.fn(async () => mockClient);
+    public end = vi.fn(async () => {});
+    public on = vi.fn().mockReturnThis();
+
+    constructor(options: any) {
+      this.options = options;
+    }
+  }
+
+  return { Pool: MockPool };
+});
+
+const isCountQuery = (sql: string) => /COUNT\(\*\)/i.test(sql);
+
+const clearIndexCaches = (vectorStore: PgVector) => {
+  (vectorStore as any).describeIndexCache.clear();
+  (vectorStore as any).indexMetadataCache.clear();
+};
+
+describe('PgVector row counts', () => {
+  const indexName = 'memory_messages';
+  const baseConfig: PgVectorConfig & { id: string } = {
+    connectionString: 'postgresql://postgres:postgres@localhost:5432/mastra',
+    id: 'pg-vector-count-scan-test',
+  };
+
+  let statements: string[];
+  let rowCount: number;
+  let listIndexesSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    statements = [];
+    rowCount = 42;
+
+    mockClient.query.mockImplementation(async (text: any) => {
+      const sql = typeof text === 'string' ? text : text?.text || '';
+      statements.push(sql);
+
+      if (sql.includes('information_schema.columns') && sql.includes('udt_name')) {
+        return { rows: [{ udt_name: 'vector' }] };
+      }
+      if (sql.includes('pg_attribute') && sql.includes('atttypmod')) {
+        return { rows: [{ dimension: 3 }] };
+      }
+      if (isCountQuery(sql)) {
+        return { rows: [{ count: String(rowCount) }] };
+      }
+      return { rows: [] };
+    });
+    mockClient.release.mockReset();
+
+    listIndexesSpy = vi.spyOn(PgVector.prototype, 'listIndexes').mockResolvedValue([indexName]);
+  });
+
+  afterEach(() => {
+    listIndexesSpy.mockRestore();
+    mockClient.query.mockReset();
+  });
+
+  it('does not count rows while warming the index cache on construction', async () => {
+    const vectorStore = new PgVector(baseConfig);
+    await (vectorStore as any).cacheWarmupPromise;
+
+    // The warmup did read the catalog...
+    expect(statements.some(sql => sql.includes('information_schema.columns'))).toBe(true);
+    // ...but never scanned the table for a count it does not use.
+    expect(statements.filter(isCountQuery)).toEqual([]);
+    // And it still populated the caches it exists for.
+    expect((vectorStore as any).createdIndexes.has(indexName)).toBe(true);
+    expect((vectorStore as any).indexVectorTypes.get(indexName)).toBe('vector');
+  });
+
+  it('does not count rows when querying', async () => {
+    const vectorStore = new PgVector(baseConfig);
+    await (vectorStore as any).cacheWarmupPromise;
+    clearIndexCaches(vectorStore);
+    statements = [];
+
+    await vectorStore.query({ indexName, queryVector: [1, 2, 3] });
+
+    // The query had to look the index up for itself, and it read the catalog to do it.
+    expect(statements.some(sql => sql.includes('information_schema.columns'))).toBe(true);
+    expect(statements.filter(isCountQuery)).toEqual([]);
+  });
+
+  it('returns an exact, uncached row count from describeIndex', async () => {
+    const vectorStore = new PgVector(baseConfig);
+    await (vectorStore as any).cacheWarmupPromise;
+
+    await expect(vectorStore.describeIndex({ indexName })).resolves.toEqual({
+      dimension: 3,
+      count: 42,
+      metric: 'cosine',
+      type: 'flat',
+      vectorType: 'vector',
+      config: {},
+    });
+
+    // describeIndex reports the row count as it is now, not as it was on the first call.
+    rowCount = 43;
+    await expect(vectorStore.describeIndex({ indexName })).resolves.toMatchObject({ count: 43 });
+  });
+
+  it('returns an exact row count from getIndexInfo', async () => {
+    const vectorStore = new PgVector(baseConfig);
+    await (vectorStore as any).cacheWarmupPromise;
+    statements = [];
+
+    await expect(vectorStore.getIndexInfo({ indexName })).resolves.toEqual({
+      dimension: 3,
+      count: 42,
+      metric: 'cosine',
+      type: 'flat',
+      vectorType: 'vector',
+      config: {},
+    });
+    expect(statements.filter(isCountQuery)).toHaveLength(1);
+  });
+
+  it('makes a single round trip when getIndexInfo is called concurrently on a cold cache', async () => {
+    const describeIndexSpy = vi.spyOn(PgVector.prototype, 'describeIndex');
+    try {
+      const vectorStore = new PgVector(baseConfig);
+      await (vectorStore as any).cacheWarmupPromise;
+      clearIndexCaches(vectorStore);
+      statements = [];
+      describeIndexSpy.mockClear();
+
+      const results = await Promise.all(Array.from({ length: 10 }, () => vectorStore.getIndexInfo({ indexName })));
+
+      expect(describeIndexSpy).toHaveBeenCalledTimes(1);
+      expect(statements.filter(isCountQuery)).toHaveLength(1);
+      for (const result of results) {
+        expect(result.count).toBe(42);
+      }
+    } finally {
+      describeIndexSpy.mockRestore();
+    }
+  });
+
+  it('does not cache a failed index lookup', async () => {
+    const vectorStore = new PgVector(baseConfig);
+    await (vectorStore as any).cacheWarmupPromise;
+    clearIndexCaches(vectorStore);
+
+    mockClient.query.mockRejectedValueOnce(new Error('connection terminated'));
+    await expect(vectorStore.getIndexInfo({ indexName })).rejects.toThrow();
+    expect((vectorStore as any).describeIndexCache.size).toBe(0);
+    expect((vectorStore as any).indexMetadataCache.size).toBe(0);
+
+    await expect(vectorStore.getIndexInfo({ indexName })).resolves.toMatchObject({ count: 42 });
+  });
+});

--- a/stores/pg/src/vector/index.test.ts
+++ b/stores/pg/src/vector/index.test.ts
@@ -941,6 +941,14 @@ describe('PgVector', () => {
           });
         });
 
+        it('should report the current row count, not a cached one', async () => {
+          const before = await vectorDB.describeIndex({ indexName });
+          await vectorDB.upsert({ indexName, vectors: [[7, 8, 9]] });
+
+          const after = await vectorDB.describeIndex({ indexName });
+          expect(after.count).toBe(before.count + 1);
+        });
+
         it('should throw error for non-existent index', async () => {
           await expect(vectorDB.describeIndex({ indexName: 'non_existent' })).rejects.toThrow();
         });

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -45,6 +45,15 @@ export interface PGIndexStats extends IndexStats {
   };
 }
 
+/**
+ * The subset of {@link PGIndexStats} that can be read from the Postgres catalog alone.
+ *
+ * Everything here comes from `information_schema.columns`, `pg_attribute` and `pg_index`,
+ * which are cheap regardless of how large the table is. The row count is deliberately
+ * excluded: it requires `SELECT COUNT(*)`, a full heap scan on large indexes.
+ */
+type PGIndexMetadata = Omit<PGIndexStats, 'count'>;
+
 interface PgQueryVectorParams extends QueryVectorParams<PGVectorFilter> {
   namespace?: string;
   minScore?: number;
@@ -126,7 +135,16 @@ const MAX_UPSERT_ROWS_PER_STATEMENT = Math.floor(65535 / 4);
 
 export class PgVector extends MastraVector<PGVectorFilter> {
   public pool: pg.Pool;
-  private describeIndexCache: Map<string, PGIndexStats> = new Map();
+  /**
+   * Cache for the public `getIndexInfo()`. Holds the in-flight promise rather than the
+   * resolved value so concurrent callers on a cold cache share a single round trip.
+   */
+  private describeIndexCache: Map<string, Promise<PGIndexStats>> = new Map();
+  /**
+   * Cache for the catalog-only index metadata used by the internal hot paths
+   * (cache warmup, query, upsert, updateVector, setupIndex). Also memoizes the promise.
+   */
+  private indexMetadataCache: Map<string, Promise<PGIndexMetadata>> = new Map();
   private createdIndexes = new Map<string, number>();
   private namespaceReadyIndexes = new Set<string>();
   private indexVectorTypes = new Map<string, VectorType>();
@@ -206,7 +224,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
           const existingIndexes = await this.listIndexes();
           await Promise.all(
             existingIndexes.map(async indexName => {
-              const info = await this.getIndexInfo({ indexName });
+              const info = await this.getIndexMetadata({ indexName });
               const key = await this.getIndexCacheKey({
                 indexName,
                 metric: info.metric,
@@ -502,11 +520,49 @@ export class PgVector extends MastraVector<PGVectorFilter> {
     return translator.translate(filter);
   }
 
+  /**
+   * Cached variant of {@link describeIndex}, including the row count.
+   *
+   * Internal code paths do not use this - they use the catalog-only
+   * {@link getIndexMetadata}, which never scans the table.
+   */
   async getIndexInfo({ indexName }: DescribeIndexParams): Promise<PGIndexStats> {
-    if (!this.describeIndexCache.has(indexName)) {
-      this.describeIndexCache.set(indexName, await this.describeIndex({ indexName }));
+    return this.memoize(this.describeIndexCache, indexName, () => this.describeIndex({ indexName }));
+  }
+
+  /**
+   * Cached index metadata read from the Postgres catalog only.
+   *
+   * This is what every internal caller needs: none of them read `count`, and paying for
+   * `SELECT COUNT(*)` on a large index costs a full heap scan per call.
+   */
+  private getIndexMetadata({ indexName }: DescribeIndexParams): Promise<PGIndexMetadata> {
+    return this.memoize(this.indexMetadataCache, indexName, () => this.describeIndexMetadata({ indexName }));
+  }
+
+  /**
+   * Stores the in-flight promise in `cache` so concurrent callers on a cold cache share one
+   * round trip, and drops the entry if it rejects so a transient failure is not cached forever.
+   */
+  private memoize<T>(cache: Map<string, Promise<T>>, key: string, load: () => Promise<T>): Promise<T> {
+    const cached = cache.get(key);
+    if (cached) {
+      return cached;
     }
-    return this.describeIndexCache.get(indexName)!;
+    const pending = load();
+    cache.set(key, pending);
+    pending.catch(() => {
+      if (cache.get(key) === pending) {
+        cache.delete(key);
+      }
+    });
+    return pending;
+  }
+
+  /** Drops every cached view of an index, e.g. after its index definition or table changed. */
+  private invalidateIndexCaches(indexName: string) {
+    this.describeIndexCache.delete(indexName);
+    this.indexMetadataCache.delete(indexName);
   }
 
   async query({
@@ -603,7 +659,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       const { sql: filterQuery, values: filterValues } = buildFilterQuery(translatedFilter, minScore, topK);
 
       // Get index type and configuration
-      const indexInfo = await this.getIndexInfo({ indexName });
+      const indexInfo = await this.getIndexMetadata({ indexName });
 
       const metric = indexInfo.metric ?? 'cosine';
       const ops = this.getVectorOps(indexInfo.vectorType, metric);
@@ -749,7 +805,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       const vectorIds = ids || vectors.map(() => crypto.randomUUID());
 
       // Get the properly qualified vector type for this index
-      const indexInfo = await this.getIndexInfo({ indexName });
+      const indexInfo = await this.getIndexMetadata({ indexName });
       const qualifiedVectorType = this.getVectorTypeName(indexInfo.vectorType, indexInfo.dimension);
       const ops = this.getVectorOps(indexInfo.vectorType, indexInfo.metric ?? 'cosine');
 
@@ -1193,10 +1249,10 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       const { tableName, vectorIndexName } = this.getTableName(indexName);
 
       // Try to get existing index info to check if configuration has changed
-      let existingIndexInfo: PGIndexStats | null = null;
+      let existingIndexInfo: PGIndexMetadata | null = null;
       let dimension = 0;
       try {
-        existingIndexInfo = await this.getIndexInfo({ indexName });
+        existingIndexInfo = await this.getIndexMetadata({ indexName });
         dimension = existingIndexInfo.dimension;
 
         if (isConfigEmpty && existingIndexInfo.metric === metric) {
@@ -1252,13 +1308,13 @@ export class PgVector extends MastraVector<PGVectorFilter> {
         // Configuration changed, need to rebuild
         this.logger?.info(`Index ${vectorIndexName} configuration changed, rebuilding index`);
         await client.query(`DROP INDEX IF EXISTS ${vectorIndexName}`);
-        this.describeIndexCache.delete(indexName);
+        this.invalidateIndexCaches(indexName);
       } catch {
         this.logger?.debug(`Index ${indexName} doesn't exist yet, will create it`);
       }
 
       if (indexType === 'flat') {
-        this.describeIndexCache.delete(indexName);
+        this.invalidateIndexCaches(indexName);
         return;
       }
 
@@ -1471,6 +1527,17 @@ export class PgVector extends MastraVector<PGVectorFilter> {
    * @returns A promise that resolves to the index statistics including dimension, count and metric
    */
   async describeIndex({ indexName }: DescribeIndexParams): Promise<PGIndexStats> {
+    const metadata = await this.describeIndexMetadata({ indexName });
+    const count = await this.countIndexRows({ indexName });
+    return { ...metadata, count };
+  }
+
+  /**
+   * Reads the index metadata that lives in the Postgres catalog. Unlike
+   * {@link describeIndex} it issues no `COUNT(*)`, so its cost does not grow with the
+   * number of rows in the table.
+   */
+  private async describeIndexMetadata({ indexName }: DescribeIndexParams): Promise<PGIndexMetadata> {
     const client = await this.pool.connect();
     try {
       const { tableName } = this.getTableName(indexName);
@@ -1509,12 +1576,6 @@ export class PgVector extends MastraVector<PGVectorFilter> {
                 AND attname = 'embedding';
             `;
 
-      // Get row count
-      const countQuery = `
-                SELECT COUNT(*) as count
-                FROM ${tableName};
-            `;
-
       // Get index metric type
       const indexQuery = `
             SELECT
@@ -1531,7 +1592,6 @@ export class PgVector extends MastraVector<PGVectorFilter> {
             `;
 
       const dimResult = await client.query(dimensionQuery, [tableName]);
-      const countResult = await client.query(countQuery);
       const indexResult = await client.query(indexQuery, [`${indexName}_vector_idx`, this.schema || 'public']);
 
       const { index_method, index_def, operator_class } = indexResult.rows[0] || {
@@ -1566,7 +1626,6 @@ export class PgVector extends MastraVector<PGVectorFilter> {
 
       return {
         dimension: dimResult.rows[0].dimension,
-        count: parseInt(countResult.rows[0].count),
         metric: metric as PGIndexStats['metric'],
         type: index_method as 'flat' | 'hnsw' | 'ivfflat',
         vectorType,
@@ -1574,6 +1633,38 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       };
     } catch (e: any) {
       await client.query('ROLLBACK');
+      const mastraError = new MastraError(
+        {
+          id: createVectorErrorId('PG', 'DESCRIBE_INDEX', 'FAILED'),
+          domain: ErrorDomain.MASTRA_VECTOR,
+          category: ErrorCategory.THIRD_PARTY,
+          details: {
+            indexName,
+          },
+        },
+        e,
+      );
+      this.logger?.trackException(mastraError);
+      throw mastraError;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Exact row count for an index. This is a full scan of the table, so it is only issued
+   * for the public {@link describeIndex}, never from an internal code path.
+   */
+  private async countIndexRows({ indexName }: DescribeIndexParams): Promise<number> {
+    const client = await this.pool.connect();
+    try {
+      const { tableName } = this.getTableName(indexName);
+      const countResult = await client.query(`
+                SELECT COUNT(*) as count
+                FROM ${tableName};
+            `);
+      return parseInt(countResult.rows[0].count);
+    } catch (e: any) {
       const mastraError = new MastraError(
         {
           id: createVectorErrorId('PG', 'DESCRIBE_INDEX', 'FAILED'),
@@ -1601,7 +1692,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       this.createdIndexes.delete(indexName);
       this.namespaceReadyIndexes.delete(indexName);
       this.indexVectorTypes.delete(indexName);
-      this.describeIndexCache.delete(indexName);
+      this.invalidateIndexCaches(indexName);
     } catch (error: any) {
       await client.query('ROLLBACK');
       const mastraError = new MastraError(
@@ -1712,7 +1803,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       const { tableName } = this.getTableName(indexName);
 
       // Get the properly qualified vector type for this index
-      const indexInfo = await this.getIndexInfo({ indexName });
+      const indexInfo = await this.getIndexMetadata({ indexName });
       const qualifiedVectorType = this.getVectorTypeName(indexInfo.vectorType, indexInfo.dimension);
       const ops = this.getVectorOps(indexInfo.vectorType, indexInfo.metric ?? 'cosine');
 


### PR DESCRIPTION
Refreshes PR #21732 with the latest main branch so CI reruns against the current workspace state. The suspended snapshot changes remain unchanged; focused mirror and snapshot-growth tests pass locally, along with the core package check.