### PR TITLE
fix(memory): exclude working-memory state from OM observation

### DIFF
--- a/.changeset/tidy-wm-om-signal.md
+++ b/.changeset/tidy-wm-om-signal.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Observational Memory no longer treats injected Working Memory state as new conversation history, while the main agent and other state signals remain unchanged.

--- a/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
+++ b/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
@@ -261,6 +261,99 @@ describe('Observational Memory extracted metadata persistence', () => {
     );
   });
 
+  it('does not re-observe resource-scoped working memory state on an unrelated new-thread task', async () => {
+    const resourceId = randomUUID();
+    const seededThreadId = randomUUID();
+    const secondThreadId = randomUUID();
+    const seededValue = 'format-a; format-b';
+    let observerInput = '';
+    const model = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        observerInput = JSON.stringify(prompt);
+        const observerSawSeed = observerInput.includes(seededValue);
+        const observerOutput = observerSawSeed
+          ? `<observations>\n- unrelated task\n</observations>\n<working-memory>rewritten-by-observer</working-memory>`
+          : '<observations>\n- unrelated task\n</observations>';
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'obs-wm-cross-thread', modelId: 'mock-observer', timestamp: new Date() },
+            { type: 'text-start', id: 'text-wm-cross-thread' },
+            {
+              type: 'text-delta',
+              id: 'text-wm-cross-thread',
+              delta: observerOutput,
+            },
+            { type: 'text-end', id: 'text-wm-cross-thread' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+    const workingMemory = new Memory({
+      storage: memory.storage,
+      options: {
+        workingMemory: { enabled: true, agentManaged: false, template: '# User Profile\n- Value:' },
+        observationalMemory: {
+          enabled: true,
+          scope: 'resource',
+          observation: {
+            model,
+            manageWorkingMemory: true,
+            messageTokens: 1,
+            bufferTokens: false,
+            previousObserverTokens: 1000,
+          },
+        },
+      },
+    });
+
+    await workingMemory.createThread({ threadId: seededThreadId, resourceId, title: 'Seeded state' });
+    await workingMemory.createThread({ threadId: secondThreadId, resourceId, title: 'Unrelated task' });
+    await workingMemory.updateWorkingMemory({ threadId: seededThreadId, resourceId, workingMemory: seededValue });
+    await workingMemory.saveMessages({
+      messages: [
+        {
+          id: randomUUID(),
+          threadId: seededThreadId,
+          resourceId,
+          role: 'signal',
+          type: 'working-memory',
+          createdAt: new Date('2026-06-24T18:00:00.000Z'),
+          content: {
+            format: 2,
+            parts: [{ type: 'text', text: seededValue }],
+            metadata: { signal: { type: 'state', metadata: { state: { id: 'working-memory', mode: 'snapshot' } } } },
+          },
+        } as MastraDBMessage,
+        createMessage(
+          secondThreadId,
+          resourceId,
+          'user',
+          'Summarize the current project status.',
+          '2026-06-24T18:01:00.000Z',
+        ),
+      ],
+    });
+
+    const omEngine = await workingMemory.omEngine;
+    await omEngine!.observe({ threadId: secondThreadId, resourceId });
+    expect(observerInput).toContain('## New Message History to Observe');
+    expect(observerInput).toContain('Summarize the current project status.');
+    expect(observerInput).not.toContain(seededValue);
+    await expect(workingMemory.getWorkingMemory({ threadId: seededThreadId, resourceId })).resolves.toBe(seededValue);
+    expect((await memory.storage.listMessagesByResourceId({ resourceId, perPage: false })).messages).toHaveLength(2);
+    await expect(
+      omEngine!.pruneObserved({
+        threadId: secondThreadId,
+        resourceId,
+        messages: (await memory.storage.listMessagesByResourceId({ resourceId, perPage: false })).messages,
+      }),
+    ).resolves.toEqual(expect.arrayContaining([expect.objectContaining({ role: 'signal', type: 'working-memory' })]));
+  });
+
   it('persists extracted values from an end-to-end LibSQL observation run', async () => {
     const threadId = randomUUID();
     const resourceId = randomUUID();

--- a/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
+++ b/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
@@ -267,12 +267,24 @@ describe('Observational Memory extracted metadata persistence', () => {
     const secondThreadId = randomUUID();
     const seededValue = 'format-a; format-b';
     let observerInput = '';
+    let observerHistory = '';
+    const extractObserverHistory = (value: unknown): string => {
+      if (typeof value === 'string') {
+        const historyStart = value.indexOf('## New Message History to Observe');
+        if (historyStart === -1) return '';
+        const historyEnd = value.indexOf('\n\n---\n\n', historyStart);
+        return value.slice(historyStart, historyEnd === -1 ? undefined : historyEnd);
+      }
+      if (Array.isArray(value)) return value.map(extractObserverHistory).find(Boolean) ?? '';
+      if (value && typeof value === 'object') {
+        return Object.values(value).map(extractObserverHistory).find(Boolean) ?? '';
+      }
+      return '';
+    };
     const model = new MockLanguageModelV2({
       doStream: async ({ prompt }) => {
         observerInput = JSON.stringify(prompt);
-        const historyStart = observerInput.indexOf('## New Message History to Observe');
-        const historyEnd = observerInput.indexOf('\n\n---\n\n', historyStart);
-        const observerHistory = observerInput.slice(historyStart, historyEnd === -1 ? undefined : historyEnd);
+        observerHistory = extractObserverHistory(prompt);
         const observerSawSeed = observerHistory.includes(seededValue);
         const observerOutput = observerSawSeed
           ? `<observations>\n- unrelated task\n</observations>\n<working-memory>rewritten-by-observer</working-memory>`
@@ -345,7 +357,7 @@ describe('Observational Memory extracted metadata persistence', () => {
     await omEngine!.observe({ threadId: secondThreadId, resourceId });
     expect(observerInput).toContain('## New Message History to Observe');
     expect(observerInput).toContain('Summarize the current project status.');
-    expect(observerInput).not.toContain(seededValue);
+    expect(observerHistory).not.toContain(seededValue);
     await expect(workingMemory.getWorkingMemory({ threadId: seededThreadId, resourceId })).resolves.toBe(seededValue);
     expect((await memory.storage.listMessagesByResourceId({ resourceId, perPage: false })).messages).toHaveLength(2);
     await expect(

--- a/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
+++ b/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
@@ -268,23 +268,19 @@ describe('Observational Memory extracted metadata persistence', () => {
     const seededValue = 'format-a; format-b';
     let observerInput = '';
     let observerHistory = '';
-    const extractObserverHistory = (value: unknown): string => {
-      if (typeof value === 'string') {
-        const historyStart = value.indexOf('## New Message History to Observe');
-        if (historyStart === -1) return '';
-        const historyEnd = value.indexOf('\n\n---\n\n', historyStart);
-        return value.slice(historyStart, historyEnd === -1 ? undefined : historyEnd);
-      }
-      if (Array.isArray(value)) return value.map(extractObserverHistory).find(Boolean) ?? '';
-      if (value && typeof value === 'object') {
-        return Object.values(value).map(extractObserverHistory).find(Boolean) ?? '';
-      }
+    const flattenPromptText = (value: unknown): string => {
+      if (typeof value === 'string') return value;
+      if (Array.isArray(value)) return value.map(flattenPromptText).join('');
+      if (value && typeof value === 'object') return Object.values(value).map(flattenPromptText).join('');
       return '';
     };
     const model = new MockLanguageModelV2({
       doStream: async ({ prompt }) => {
         observerInput = JSON.stringify(prompt);
-        observerHistory = extractObserverHistory(prompt);
+        const promptText = flattenPromptText(prompt);
+        const historyStart = promptText.indexOf('## New Message History to Observe');
+        const historyEnd = promptText.indexOf('\n\n---\n\n', historyStart);
+        observerHistory = promptText.slice(historyStart, historyEnd === -1 ? undefined : historyEnd);
         const observerSawSeed = observerHistory.includes(seededValue);
         const observerOutput = observerSawSeed
           ? `<observations>\n- unrelated task\n</observations>\n<working-memory>rewritten-by-observer</working-memory>`

--- a/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
+++ b/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
@@ -362,12 +362,12 @@ describe('Observational Memory extracted metadata persistence', () => {
     expect(observerInput).toContain('Summarize the current project status.');
     expect(observerHistory).not.toContain(seededValue);
     await expect(workingMemory.getWorkingMemory({ threadId: seededThreadId, resourceId })).resolves.toBe(seededValue);
-    expect((await memory.storage.listMessagesByResourceId({ resourceId, perPage: false })).messages).toHaveLength(2);
+    expect((await memory.listMessagesByResourceId({ resourceId, perPage: false })).messages).toHaveLength(2);
     await expect(
       omEngine!.pruneObserved({
         threadId: secondThreadId,
         resourceId,
-        messages: (await memory.storage.listMessagesByResourceId({ resourceId, perPage: false })).messages,
+        messages: (await memory.listMessagesByResourceId({ resourceId, perPage: false })).messages,
       }),
     ).resolves.toEqual(expect.arrayContaining([expect.objectContaining({ role: 'signal', type: 'working-memory' })]));
   });

--- a/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
+++ b/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
@@ -270,7 +270,10 @@ describe('Observational Memory extracted metadata persistence', () => {
     const model = new MockLanguageModelV2({
       doStream: async ({ prompt }) => {
         observerInput = JSON.stringify(prompt);
-        const observerSawSeed = observerInput.includes(seededValue);
+        const historyStart = observerInput.indexOf('## New Message History to Observe');
+        const historyEnd = observerInput.indexOf('\n\n---\n\n', historyStart);
+        const observerHistory = observerInput.slice(historyStart, historyEnd === -1 ? undefined : historyEnd);
+        const observerSawSeed = observerHistory.includes(seededValue);
         const observerOutput = observerSawSeed
           ? `<observations>\n- unrelated task\n</observations>\n<working-memory>rewritten-by-observer</working-memory>`
           : '<observations>\n- unrelated task\n</observations>';
@@ -301,7 +304,7 @@ describe('Observational Memory extracted metadata persistence', () => {
           scope: 'resource',
           observation: {
             model,
-            manageWorkingMemory: false,
+            manageWorkingMemory: true,
             messageTokens: 1,
             bufferTokens: false,
             previousObserverTokens: 1000,

--- a/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
+++ b/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
@@ -274,13 +274,20 @@ describe('Observational Memory extracted metadata persistence', () => {
       if (value && typeof value === 'object') return Object.values(value).map(flattenPromptText).join('');
       return '';
     };
+    const findHistoryMessage = (value: unknown): string => {
+      if (!Array.isArray(value)) return flattenPromptText(value);
+      for (const item of value) {
+        const text = flattenPromptText(item);
+        if (text.includes('## New Message History to Observe')) return text;
+      }
+      return flattenPromptText(value);
+    };
     const model = new MockLanguageModelV2({
       doStream: async ({ prompt }) => {
         observerInput = JSON.stringify(prompt);
-        const promptText = flattenPromptText(prompt);
+        const promptText = findHistoryMessage(prompt);
         const historyStart = promptText.indexOf('## New Message History to Observe');
-        const historyEnd = promptText.indexOf('\n\n---\n\n', historyStart);
-        observerHistory = promptText.slice(historyStart, historyEnd === -1 ? undefined : historyEnd);
+        observerHistory = promptText.slice(historyStart);
         const observerSawSeed = observerHistory.includes(seededValue);
         const observerOutput = observerSawSeed
           ? `<observations>\n- unrelated task\n</observations>\n<working-memory>rewritten-by-observer</working-memory>`

--- a/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
+++ b/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
@@ -301,7 +301,7 @@ describe('Observational Memory extracted metadata persistence', () => {
           scope: 'resource',
           observation: {
             model,
-            manageWorkingMemory: true,
+            manageWorkingMemory: false,
             messageTokens: 1,
             bufferTokens: false,
             previousObserverTokens: 1000,

--- a/packages/memory/src/processors/observational-memory/__tests__/message-utils.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/message-utils.test.ts
@@ -60,11 +60,14 @@ describe('isWorkingMemoryStateSignalMessage', () => {
   it('preserves other state, lookalike, ordinary, and malformed messages', () => {
     expect(isWorkingMemoryStateSignalMessage(signal('browser-context'))).toBe(false);
     expect(
+      isWorkingMemoryStateSignalMessage(createMessage('ordinary-lookalike', '<working-memory>format-a; format-b')),
+    ).toBe(false);
+    expect(
       isWorkingMemoryStateSignalMessage({
         ...signal('working-memory'),
         content: {
           ...signal('working-memory').content,
-          metadata: { signal: { type: 'text', metadata: { state: { id: 'working-memory' } } } },
+          metadata: { signal: { type: 'reactive', metadata: { state: { id: 'working-memory' } } } },
         },
       } as MastraDBMessage),
     ).toBe(false);

--- a/packages/memory/src/processors/observational-memory/__tests__/message-utils.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/message-utils.test.ts
@@ -1,7 +1,7 @@
 import type { MastraDBMessage } from '@mastra/core/agent';
 import { MessageList } from '@mastra/core/agent';
 import { describe, it, expect } from 'vitest';
-import { getObservableMessages, stripThreadTags } from '../message-utils';
+import { getObservableMessages, isWorkingMemoryStateSignalMessage, stripThreadTags } from '../message-utils';
 
 const THREAD_ID = 'thread-1';
 const RESOURCE_ID = 'resource-1';
@@ -37,6 +37,44 @@ describe('getObservableMessages', () => {
     messageList.add(createMessage('response-1', 'hi', 'assistant'), 'response');
 
     expect(getObservableMessages(messageList).map(m => m.id)).toEqual(messageList.get.all.db().map(m => m.id));
+  });
+});
+
+describe('isWorkingMemoryStateSignalMessage', () => {
+  const signal = (stateId: string, type = 'state', mode = 'snapshot'): MastraDBMessage =>
+    ({
+      ...createMessage('signal-1', 'working-memory', 'user'),
+      role: 'signal',
+      content: {
+        format: 2,
+        parts: [{ type: 'text', text: 'format-a; format-b' }],
+        metadata: { signal: { type, metadata: { state: { id: stateId, mode } } } },
+      },
+    }) as MastraDBMessage;
+
+  it('matches snapshot and delta working-memory state signals by provenance', () => {
+    expect(isWorkingMemoryStateSignalMessage(signal('working-memory', 'state', 'snapshot'))).toBe(true);
+    expect(isWorkingMemoryStateSignalMessage(signal('working-memory', 'state', 'delta'))).toBe(true);
+  });
+
+  it('preserves other state, lookalike, ordinary, and malformed messages', () => {
+    expect(isWorkingMemoryStateSignalMessage(signal('browser-context'))).toBe(false);
+    expect(
+      isWorkingMemoryStateSignalMessage({
+        ...signal('working-memory'),
+        content: {
+          ...signal('working-memory').content,
+          metadata: { signal: { type: 'text', metadata: { state: { id: 'working-memory' } } } },
+        },
+      } as MastraDBMessage),
+    ).toBe(false);
+    expect(isWorkingMemoryStateSignalMessage(createMessage('ordinary', 'hello'))).toBe(false);
+    expect(
+      isWorkingMemoryStateSignalMessage({
+        ...signal('working-memory'),
+        content: { format: 2, parts: [] },
+      } as MastraDBMessage),
+    ).toBe(false);
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
@@ -45,6 +45,19 @@ function createTestMessage(
   };
 }
 
+function createWorkingMemorySignal(id: string, stateId = 'working-memory'): MastraDBMessage {
+  return {
+    ...createTestMessage('format-a; format-b', 'user', id),
+    role: 'signal',
+    type: 'working-memory',
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text: 'format-a; format-b' }],
+      metadata: { signal: { type: 'state', metadata: { state: { id: stateId } } } },
+    } as MastraMessageContentV2,
+  };
+}
+
 /** Generate N messages with padding to exceed token thresholds. */
 function createBulkMessages(count: number, threadId: string, startTime?: number): MastraDBMessage[] {
   const base = startTime ?? Date.now() - count * 1000;
@@ -3020,6 +3033,27 @@ describe('getUnobservedMessages filtering', () => {
     const unobserved = om.getUnobservedMessages(messages, record);
     // Messages at base+3000 and base+4000 should pass the > check
     expect(unobserved.length).toBe(2);
+  });
+
+  it('excludes working-memory state signals while retaining ordinary and other state messages', async () => {
+    const om = createOM(storage);
+    const record = await om.getOrCreateRecord(threadId);
+    const ordinary = createTestMessage('Summarize the current project status.', 'user', 'ordinary');
+    const workingMemory = createWorkingMemorySignal('working-memory');
+    const browserContext = createWorkingMemorySignal('browser-context', 'browser-context');
+
+    expect(
+      om.getUnobservedMessages([workingMemory, ordinary, browserContext], record).map(message => message.id),
+    ).toEqual(['ordinary', 'browser-context']);
+    expect(
+      om
+        .getUnobservedMessages([workingMemory], record, { includeWorkingMemoryStateSignals: true })
+        .map(message => message.id),
+    ).toEqual(['working-memory']);
+
+    (record as any).bufferedObservationChunks = [{ messageIds: ['ordinary'] }];
+    expect(om.getUnobservedMessages([workingMemory, ordinary], record, { excludeBuffered: true })).toEqual([]);
+    await expect(om.pruneObserved({ threadId, messages: [workingMemory] })).resolves.toEqual([workingMemory]);
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory-api.test.ts
@@ -3053,7 +3053,44 @@ describe('getUnobservedMessages filtering', () => {
 
     (record as any).bufferedObservationChunks = [{ messageIds: ['ordinary'] }];
     expect(om.getUnobservedMessages([workingMemory, ordinary], record, { excludeBuffered: true })).toEqual([]);
+    (record as any).lastObservedAt = new Date(Date.now() + 1_000);
+    workingMemory.createdAt = new Date(Date.now() - 1_000);
+    vi.spyOn(om, 'getOrCreateRecord').mockResolvedValue(record);
     await expect(om.pruneObserved({ threadId, messages: [workingMemory] })).resolves.toEqual([workingMemory]);
+  });
+
+  it('excludes working-memory state signals from other-thread context', async () => {
+    const resourceId = 'other-context-resource';
+    const currentThreadId = 'other-context-current';
+    const otherThreadId = 'other-context-source';
+    const om = createOM(storage, { scope: 'resource' });
+    const now = new Date();
+
+    for (const id of [currentThreadId, otherThreadId]) {
+      await storage.saveThread({
+        thread: {
+          id,
+          resourceId,
+          title: id,
+          createdAt: now,
+          updatedAt: now,
+          metadata: {},
+        },
+      });
+    }
+
+    const workingMemory = createWorkingMemorySignal('other-thread-working-memory');
+    workingMemory.threadId = otherThreadId;
+    workingMemory.resourceId = resourceId;
+    workingMemory.createdAt = new Date(now.getTime() - 1_000);
+    const ordinary = createTestMessage('ordinary other-thread message', 'user', 'other-thread-ordinary', now);
+    ordinary.threadId = otherThreadId;
+    ordinary.resourceId = resourceId;
+    await storage.saveMessages({ messages: [workingMemory, ordinary] });
+
+    const context = await om.getOtherThreadsContext(resourceId, currentThreadId);
+    expect(context).toContain('ordinary other-thread message');
+    expect(context).not.toContain('format-a; format-b');
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/message-utils.ts
+++ b/packages/memory/src/processors/observational-memory/message-utils.ts
@@ -1,5 +1,27 @@
 import type { MastraDBMessage, MessageList } from '@mastra/core/agent';
 import type { BufferedObservationChunk, ObservationalMemoryRecord } from '@mastra/core/storage';
+import { WORKING_MEMORY_STATE_ID } from '../working-memory-state';
+
+/** Return true only for the canonical persisted Working Memory state signal. */
+export function isWorkingMemoryStateSignalMessage(message: MastraDBMessage): boolean {
+  if (!message || typeof message !== 'object' || message.role !== 'signal') return false;
+
+  const metadata = message.content?.metadata;
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return false;
+  const signal = (metadata as { signal?: unknown }).signal;
+  if (!signal || typeof signal !== 'object' || Array.isArray(signal)) return false;
+  if ((signal as { type?: unknown }).type !== 'state') return false;
+
+  const signalMetadata = (signal as { metadata?: unknown }).metadata;
+  if (!signalMetadata || typeof signalMetadata !== 'object' || Array.isArray(signalMetadata)) return false;
+  const state = (signalMetadata as { state?: unknown }).state;
+  return (
+    !!state &&
+    typeof state === 'object' &&
+    !Array.isArray(state) &&
+    (state as { id?: unknown }).id === WORKING_MEMORY_STATE_ID
+  );
+}
 
 /**
  * Find the index of the last completed observation boundary (end marker) in a message's parts.

--- a/packages/memory/src/processors/observational-memory/observation-strategies/resource-scoped.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/resource-scoped.ts
@@ -16,7 +16,11 @@ import {
   createObservationStartMarker,
   createThreadUpdateMarker,
 } from '../markers';
-import { getLastObservedMessageCursor, sortThreadsByOldestMessage } from '../message-utils';
+import {
+  getLastObservedMessageCursor,
+  isWorkingMemoryStateSignalMessage,
+  sortThreadsByOldestMessage,
+} from '../message-utils';
 import { buildMessageRange } from '../observational-memory';
 import { formatMessagesForObserver } from '../observer-agent';
 import { getMaxThreshold } from '../thresholds';
@@ -104,7 +108,7 @@ export class ResourceScopedObservationStrategy extends ObservationStrategy {
         filter: startDate ? { dateRange: { start: startDate } } : undefined,
       });
 
-      const messages = result.messages.filter(msg => msg.role !== 'system');
+      const messages = result.messages.filter(msg => msg.role !== 'system' && !isWorkingMemoryStateSignalMessage(msg));
       if (messages.length > 0) {
         this.messagesByThread.set(thread.id, messages);
       }
@@ -125,7 +129,9 @@ export class ResourceScopedObservationStrategy extends ObservationStrategy {
     }
 
     for (const [tid, msgs] of this.messagesByThread) {
-      const filtered = msgs.filter(m => !this.deps.observedMessageIds.has(m.id));
+      const filtered = msgs.filter(
+        m => !isWorkingMemoryStateSignalMessage(m) && !this.deps.observedMessageIds.has(m.id),
+      );
       if (filtered.length > 0) {
         this.messagesByThread.set(tid, filtered);
       } else {

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -203,6 +203,7 @@ import {
   getUnobservedParts,
   getBufferedChunks,
   getObservableMessages,
+  isWorkingMemoryStateSignalMessage,
   stripThreadTags,
 } from './message-utils';
 import { ModelByInputTokens } from './model-by-input-tokens';
@@ -1417,7 +1418,7 @@ export class ObservationalMemory {
   getUnobservedMessages(
     allMessages: MastraDBMessage[],
     record: ObservationalMemoryRecord,
-    opts?: { excludeBuffered?: boolean },
+    opts?: { excludeBuffered?: boolean; includeWorkingMemoryStateSignals?: boolean },
   ): MastraDBMessage[] {
     const lastObservedAt = record.lastObservedAt;
     // Safeguard: track message IDs that were already observed to prevent re-observation
@@ -1443,6 +1444,9 @@ export class ObservationalMemory {
 
     for (const msg of allMessages) {
       if (msg.role === 'system') {
+        continue;
+      }
+      if (!opts?.includeWorkingMemoryStateSignals && isWorkingMemoryStateSignalMessage(msg)) {
         continue;
       }
 
@@ -1888,7 +1892,7 @@ export class ObservationalMemory {
       });
     }
 
-    return result.messages.filter(msg => msg.role !== 'system');
+    return result.messages.filter(msg => msg.role !== 'system' && !isWorkingMemoryStateSignalMessage(msg));
   }
 
   /**
@@ -3016,7 +3020,7 @@ ${formattedMessages}
   }): Promise<MastraDBMessage[]> {
     const { threadId, resourceId, messages } = opts;
     const record = await this.getOrCreateRecord(threadId, resourceId);
-    return this.getUnobservedMessages(messages, record);
+    return this.getUnobservedMessages(messages, record, { includeWorkingMemoryStateSignals: true });
   }
 
   /**

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -2712,7 +2712,7 @@ ${formattedMessages}
       });
 
       const filtered = result.messages.filter(
-        m => m.role !== 'system' && !isWorkingMemoryStateSignalMessage(m) && !this.observedMessageIds.has(m.id),
+        m => !isWorkingMemoryStateSignalMessage(m) && !this.observedMessageIds.has(m.id),
       );
 
       if (filtered.length > 0) {

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -1446,7 +1446,12 @@ export class ObservationalMemory {
       if (msg.role === 'system') {
         continue;
       }
-      if (!opts?.includeWorkingMemoryStateSignals && isWorkingMemoryStateSignalMessage(msg)) {
+      const isWorkingMemoryStateSignal = isWorkingMemoryStateSignalMessage(msg);
+      if (!opts?.includeWorkingMemoryStateSignals && isWorkingMemoryStateSignal) {
+        continue;
+      }
+      if (opts?.includeWorkingMemoryStateSignals && isWorkingMemoryStateSignal) {
+        result.push(msg);
         continue;
       }
 
@@ -2706,7 +2711,9 @@ ${formattedMessages}
         filter: startDate ? { dateRange: { start: startDate } } : undefined,
       });
 
-      const filtered = result.messages.filter(m => !this.observedMessageIds.has(m.id));
+      const filtered = result.messages.filter(
+        m => m.role !== 'system' && !isWorkingMemoryStateSignalMessage(m) && !this.observedMessageIds.has(m.id),
+      );
 
       if (filtered.length > 0) {
         messagesByThread.set(thread.id, filtered);


### PR DESCRIPTION
Fixes #21961

## Summary

Observational Memory currently feeds the Working Memory state it injects into the model back to its observer as fresh conversation content. On an unrelated turn in a new resource-scoped thread, that can make managed extraction rewrite or shorten stored Working Memory even though the user stated no new preference.

## Root cause

Managed Working Memory emits a persisted `role: signal` row with canonical `metadata.state.id: working-memory`. OM excludes system messages but not this injected state signal, and the observer formats it into a synthetic user history message. A storage-loaded observation path can also bypass the candidate filter.

## Changes

- `packages/memory/src/processors/observational-memory/message-utils.ts`: classify canonical Working Memory state signals by provenance.
- `packages/memory/src/processors/observational-memory/observational-memory.ts`: filter that signal before OM accounting and retain it for `pruneObserved()` main-agent context.
- `packages/memory/src/processors/observational-memory/observation-strategies/resource-scoped.ts`: apply the same filter to cross-thread storage reloads and current-thread merges.
- `packages/memory/integration-tests/src/om-extracted-metadata.test.ts`: cover the cross-thread LibSQL regression.
- `packages/memory/src/processors/observational-memory/__tests__/message-utils.test.ts`, `observational-memory-api.test.ts`: cover provenance, candidate/buffering boundaries, and main-agent pruning.
- `.changeset/`: patch release note for `@mastra/memory`.

## What is not changed

The `useStateSignals` default, `WorkingMemoryStateProcessor`, `@mastra/core` signal envelope, main-agent Working Memory delivery, other state signals, and the extractor write path remain unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Linked related issue
- [x] Added or updated tests
- [ ] Documentation updated (if applicable)
- [x] Added a changeset

## Test plan

- [ ] `pnpm --filter ./packages/memory test src/processors/observational-memory/__tests__/message-utils.test.ts` covers canonical snapshot/delta provenance, malformed envelopes, and non-state lookalikes.
- [ ] `pnpm --filter ./packages/memory test src/processors/observational-memory/__tests__/observational-memory-api.test.ts` covers candidate filtering, buffering, cursor-advanced pruning, other-thread context, and main-agent retention.
- [ ] `pnpm --filter ./packages/memory/integration-tests exec vitest run src/om-extracted-metadata.test.ts -t "does not re-observe resource-scoped working memory state on an unrelated new-thread task"` covers managed resource-scoped extraction across an unrelated thread.
- [ ] `pnpm --filter ./packages/memory check` covers the changed memory package types.

The focused tests and package check are blocked in this checkout by unavailable workspace dependency outputs; targeted oxlint passes for the changed source and regression test files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Observational Memory no longer mistakes saved Working Memory for a new user message. This prevents existing memory from being rewritten when a user has not stated a new preference.

## Changes

- Detect Working Memory state signals by provenance.
- Exclude these signals from Observational Memory observation and cross-thread resource loading.
- Keep Working Memory signals available for main-agent context and pruning.
- Preserve ordinary system messages and other state signals.
- Add unit and integration coverage for filtering, buffering, pruning, provenance detection, and resource-scoped cross-thread behavior.
- Add a patch release note for `@mastra/memory`.

## Validation

- Targeted oxlint checks pass.
- Focused tests and package checks are blocked by unavailable workspace dependency outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->