### PR TITLE
test(core): pin the lease renewal an evicted suspend must stop

### DIFF
--- a/packages/core/src/agent/__tests__/suspended-run-ttl.test.ts
+++ b/packages/core/src/agent/__tests__/suspended-run-ttl.test.ts
@@ -26,15 +26,20 @@ import type { MastraModelOutput } from '../../stream/base/output';
 import type { Agent } from '../agent';
 import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
 
-const { SUSPENDED_RUN_TTL_MS } = vi.hoisted(() => {
+const { SUSPENDED_RUN_TTL_MS, LEASE_RENEW_INTERVAL_MS } = vi.hoisted(() => {
   const ttlMs = 60_000;
   process.env.MASTRA_SUSPENDED_RUN_TTL_MS = String(ttlMs);
-  return { SUSPENDED_RUN_TTL_MS: ttlMs };
+  // Renewal is what keeps an abandoned lease alive; shrink the interval so a test
+  // can watch it tick without waiting the production five seconds for each one.
+  const renewIntervalMs = 20;
+  process.env.MASTRA_AGENT_THREAD_LEASE_RENEW_INTERVAL_MS = String(renewIntervalMs);
+  return { SUSPENDED_RUN_TTL_MS: ttlMs, LEASE_RENEW_INTERVAL_MS: renewIntervalMs };
 });
 // Vitest reuses a worker process across test files, so leave the default TTL in place
 // for whichever file this worker picks up next.
 afterAll(() => {
   delete process.env.MASTRA_SUSPENDED_RUN_TTL_MS;
+  delete process.env.MASTRA_AGENT_THREAD_LEASE_RENEW_INTERVAL_MS;
 });
 
 // Mirrors the runtime's thread key + topic encoding: how a subscriber on another
@@ -115,11 +120,13 @@ describe('suspended run in-memory TTL', () => {
   let runtime: AgentThreadStreamRuntime;
   let pubsub: EventEmitterPubSub;
   let releaseLease: ReturnType<typeof vi.spyOn>;
+  let renewLease: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     runtime = new AgentThreadStreamRuntime();
     pubsub = new EventEmitterPubSub();
     releaseLease = vi.spyOn(pubsub, 'releaseLease');
+    renewLease = vi.spyOn(pubsub, 'renewLease');
   });
 
   afterEach(async () => {
@@ -212,6 +219,23 @@ describe('suspended run in-memory TTL', () => {
     // mid-flight. An abandoned lease expires on its own once renewal stops.
     expect(releaseLease).not.toHaveBeenCalledWith(threadKey(RESOURCE_ID, 'thread-1'), 'run-1');
     expect(watcher.has('run-completed', 'run-1')).toBe(false);
+  });
+
+  it('stops renewing the evicted run’s lease, so an abandoned one expires on its own', async () => {
+    const watcher = await watchThread(pubsub, 'thread-1');
+    await registerSuspendedRun('run-1', 'thread-1', watcher);
+
+    // While the record is warm, the runtime keeps the thread owned: that renewal is
+    // the only reason an abandoned lease could outlive its 15s TTL.
+    await vi.waitFor(() =>
+      expect(renewLease).toHaveBeenCalledWith(threadKey(RESOURCE_ID, 'thread-1'), 'run-1', 15_000),
+    );
+
+    await sweepAfter(SUSPENDED_RUN_TTL_MS + 1);
+
+    renewLease.mockClear();
+    await new Promise(resolve => setTimeout(resolve, LEASE_RENEW_INTERVAL_MS * 4));
+    expect(renewLease).not.toHaveBeenCalled();
   });
 
   it('does not evict anything until a registration triggers the sweep', async () => {


### PR DESCRIPTION
TLDR: proves the claim #22220 left as reasoning — an evicted suspend's lease really does expire, because the runtime stops renewing it.

---

```
before   eviction stops renewal, and nothing checks it: remove the call and every test stays green
after    the renew tick has to go quiet after the sweep, or this fails
```

#22150 made TTL eviction stop releasing the cross-process lease, because another instance may have resumed that run and taken it. The safety of that rests on one thing: the abandoned lease expires on its own, in 15 seconds, because renewal stopped. That was true in the code and asserted nowhere — #22220 could only say it in a comment.

This watches the renewal directly. While the record is warm the runtime renews the lease; after the sweep the tick has to go silent. Deleting `#stopLeaseRenewal` from the sweep turns it red — verified — so the test fails for the reason it names.

The renew interval comes from `MASTRA_AGENT_THREAD_LEASE_RENEW_INTERVAL_MS`, set to 20 ms in the same hoisted block that already shortens the suspend TTL, so the test watches four intervals in under a tenth of a second instead of waiting the production five seconds each.

```
tests   +26  -2
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a suspended run is removed, it must stop renewing its lease. This change adds a test to confirm that the lease can then expire by itself.

## Changes

- Sets `MASTRA_AGENT_THREAD_LEASE_RENEW_INTERVAL_MS` to `20` ms during the test.
- Spies on `pubsub.renewLease`.
- Verifies that a warm record renews its lease.
- Verifies that renewal stops after suspended-run eviction.
- Confirms that the abandoned lease can expire independently.
- Cleans up the renewal interval environment variable after tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->