### PR TITLE
fix(memory): restore reflector compression retries

### DIFF
--- a/.changeset/jolly-buckets-retire.md
+++ b/.changeset/jolly-buckets-retire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory reflection to keep retrying with stronger compression when a result remains above the token threshold.

--- a/packages/memory/src/processors/observational-memory/__tests__/reflector-compression-ladder.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/reflector-compression-ladder.test.ts
@@ -75,26 +75,21 @@ function createReflectorRunner(model: MockLanguageModelV2) {
 
 /** Long enough that countObservations (character length) never clears the 100 threshold. */
 const LONG_BODY = 'this observation is deliberately too long to ever pass the compression threshold '.repeat(3);
+const LONG_OBSERVATIONS = `* ${LONG_BODY.trim()}`;
 const SOURCE_OBSERVATIONS = `* original observation that must be compressed ${'x'.repeat(500)}`;
 
-describe('reflector compression ladder no-progress bail-out', () => {
-  it('stops after the first attempt that repeats the previous output', async () => {
-    // Every attempt returns the same over-threshold output, so escalating the
-    // compression level provably cannot help.
+describe('reflector compression retry ladder', () => {
+  it('keeps escalating when attempts repeat the same over-threshold output', async () => {
     const scripted = createScriptedModel([observationsPayload(LONG_BODY)]);
     const reflector = createReflectorRunner(scripted.model);
 
     const result = await reflector.call(SOURCE_OBSERVATIONS);
 
-    // Attempt #1 establishes the baseline, attempt #2 proves the level knob is
-    // being ignored. Without the bail-out this ran the full 4-attempt ladder.
-    expect(scripted.callCount).toBe(2);
-    expect(result.observations).toContain('deliberately too long');
+    expect(scripted.callCount).toBe(4);
+    expect(result.observations).toBe(LONG_OBSERVATIONS);
   });
 
-  it('keeps escalating while attempts return different output', async () => {
-    // Each attempt is still over threshold but different, so the ladder should
-    // run to exhaustion rather than bailing out early.
+  it('keeps escalating while attempts return different over-threshold output', async () => {
     const scripted = createScriptedModel([
       observationsPayload(`first ${LONG_BODY}`),
       observationsPayload(`second ${LONG_BODY}`),
@@ -108,13 +103,13 @@ describe('reflector compression ladder no-progress bail-out', () => {
     expect(scripted.callCount).toBe(4);
   });
 
-  it('still exits on a successful compression before any bail-out applies', async () => {
+  it('exits when a retry successfully compresses below the threshold', async () => {
     const scripted = createScriptedModel([observationsPayload(LONG_BODY), observationsPayload('short')]);
     const reflector = createReflectorRunner(scripted.model);
 
     const result = await reflector.call(SOURCE_OBSERVATIONS);
 
     expect(scripted.callCount).toBe(2);
-    expect(result.observations).toContain('short');
+    expect(result.observations).toBe('* short');
   });
 });

--- a/packages/memory/src/processors/observational-memory/__tests__/reflector-compression-ladder.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/reflector-compression-ladder.test.ts
@@ -89,6 +89,20 @@ describe('reflector compression retry ladder', () => {
     expect(result.observations).toBe(LONG_OBSERVATIONS);
   });
 
+  it('recovers when a stronger retry succeeds after identical over-threshold attempts', async () => {
+    const scripted = createScriptedModel([
+      observationsPayload(LONG_BODY),
+      observationsPayload(LONG_BODY),
+      observationsPayload('short'),
+    ]);
+    const reflector = createReflectorRunner(scripted.model);
+
+    const result = await reflector.call(SOURCE_OBSERVATIONS);
+
+    expect(scripted.callCount).toBe(3);
+    expect(result.observations).toBe('* short');
+  });
+
   it('keeps escalating while attempts return different over-threshold output', async () => {
     const scripted = createScriptedModel([
       observationsPayload(`first ${LONG_BODY}`),

--- a/packages/memory/src/processors/observational-memory/reflector-runner.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-runner.ts
@@ -370,8 +370,6 @@ export class ReflectorRunner {
     let parsed: ReturnType<typeof parseReflectorOutput> = { observations: '', suggestedContinuation: undefined };
     let reflectedTokens = 0;
     let attemptNumber = 0;
-    /** Observations from the previous attempt, used to detect a no-progress ladder. */
-    let previousObservations: string | undefined;
 
     while (currentLevel <= maxLevel) {
       attemptNumber++;
@@ -494,18 +492,6 @@ export class ReflectorRunner {
         omDebug(`[OM:callReflector] degenerate output persists at maxLevel=${maxLevel}, breaking`);
         break;
       }
-
-      // Escalating the level changes the prompt. If a changed prompt still produced
-      // byte-identical output, the model is not responding to the level knob and further
-      // attempts cannot improve the result — stop instead of burning the rest of the ladder
-      // on model calls, marker writes and nested runs that are known to be wasted.
-      if (!parsed.degenerate && previousObservations !== undefined && parsed.observations === previousObservations) {
-        omDebug(
-          `[OM:callReflector] attempt #${attemptNumber} returned output identical to the previous attempt; escalating cannot help, stopping the ladder`,
-        );
-        break;
-      }
-      previousObservations = parsed.observations;
 
       // Emit failed marker and start marker for next retry
       if (streamContext?.writer) {


### PR DESCRIPTION
PR #21708 added an identical-output short circuit to the observational-memory reflector. That can stop the compression ladder before stronger prompts have a chance to succeed, so this removes only that shortcut while keeping the bounded levels, degenerate handling, and `MastraMemory.settled()` behavior unchanged.

Before:
```ts
if (parsed.observations === previousObservations) {
  break;
}
```

After, an over-threshold result continues through the existing bounded retry flow:
```ts
currentLevel = Math.min(currentLevel + 1, maxLevel);
```

The focused tests cover identical and differing failures exhausting four default attempts, plus successful compression exiting on attempt two. The memory package typecheck and build pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When memory compression does not reduce the text enough, the reflector now tries all available stronger compression methods. This prevents it from stopping too early when repeated attempts produce the same result.

## What changed

- Removed the identical-output early exit from the observational-memory reflector.
- Restored the bounded compression retry ladder.
- Preserved existing retry limits, degenerate-output handling, and `MastraMemory.settled()` behavior.
- Updated tests for:
  - Four retries with repeated over-threshold output.
  - Differing failed outputs.
  - Successful compression on the second attempt.
  - Exact normalized observation output.
- Added a changeset for the next `@mastra/memory` patch release.

## Validation

- Focused reflector tests pass.
- Memory package typecheck passes.
- Memory package build passes.
- `git diff --check` passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->