### PR TITLE
fix(core): skip disabled subagent background derivation

### DIFF
--- a/.changeset/silly-clubs-kneel.md
+++ b/.changeset/silly-clubs-kneel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed recursive tool preparation for cyclic sub-agent graphs when background tasks are disabled.

--- a/packages/core/src/agent/__tests__/subagent-background-config.test.ts
+++ b/packages/core/src/agent/__tests__/subagent-background-config.test.ts
@@ -1,5 +1,7 @@
 import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { createTool } from '../../tools';
 import { Agent } from '../agent';
 
 describe('sub-agent background config derivation', () => {
@@ -24,5 +26,38 @@ describe('sub-agent background config derivation', () => {
 
     expect(tools).toHaveProperty('agent-child');
     expect(getChildTools).not.toHaveBeenCalled();
+  });
+
+  it('derives sub-agent background config when background task dispatch is enabled', async () => {
+    const model = new MockLanguageModelV2();
+    const child = new Agent({
+      id: 'child',
+      name: 'child',
+      instructions: 'Help the parent.',
+      model,
+      tools: {
+        work: createTool({
+          id: 'work',
+          description: 'Do work.',
+          inputSchema: z.object({}),
+          outputSchema: z.object({ done: z.boolean() }),
+          execute: async () => ({ done: true }),
+          background: { enabled: true },
+        }),
+      },
+    });
+    const getChildTools = vi.spyOn(child, 'getToolsForExecution');
+    const parent = new Agent({
+      id: 'parent',
+      name: 'parent',
+      instructions: 'Delegate to the child.',
+      model,
+      agents: { child },
+    });
+
+    const tools = await parent.getToolsForExecution({ backgroundTaskEnabled: true });
+
+    expect(getChildTools).toHaveBeenCalledWith(expect.objectContaining({ backgroundTaskEnabled: true }));
+    expect(tools['agent-child']).toMatchObject({ backgroundConfig: { enabled: true } });
   });
 });

--- a/packages/core/src/agent/__tests__/subagent-background-config.test.ts
+++ b/packages/core/src/agent/__tests__/subagent-background-config.test.ts
@@ -1,0 +1,28 @@
+import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { Agent } from '../agent';
+
+describe('sub-agent background config derivation', () => {
+  it('does not inspect sub-agent tools when background task dispatch is disabled', async () => {
+    const model = new MockLanguageModelV2();
+    const child = new Agent({
+      id: 'child',
+      name: 'child',
+      instructions: 'Help the parent.',
+      model,
+    });
+    const getChildTools = vi.spyOn(child, 'getToolsForExecution');
+    const parent = new Agent({
+      id: 'parent',
+      name: 'parent',
+      instructions: 'Delegate to the child.',
+      model,
+      agents: { child },
+    });
+
+    const tools = await parent.getToolsForExecution({});
+
+    expect(tools).toHaveProperty('agent-child');
+    expect(getChildTools).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5768,7 +5768,9 @@ export class Agent<
         // Derive a ToolBackgroundConfig from the sub-agent's tools/config so the
         // parent can dispatch the entire sub-agent invocation as a background task
         // when appropriate.
-        const subAgentBackgroundConfig = await this.deriveSubAgentBackgroundConfig(agent, requestContext);
+        const subAgentBackgroundConfig = backgroundTaskEnabled
+          ? await this.deriveSubAgentBackgroundConfig(agent, requestContext)
+          : undefined;
 
         const options: ToolOptions = {
           name: `agent-${agentName}`,
@@ -6256,6 +6258,7 @@ export class Agent<
       ...observabilityContext,
       autoResumeSuspendedTools,
       delegation,
+      backgroundTaskEnabled,
     });
 
     const workflowTools = await this.listWorkflowTools({

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1205,12 +1205,15 @@ export class Agent<
         }
       }
 
-      // 2. Any of a full Agent sub-agent's tools has background.enabled === true
+      // 2. Any of a full Agent sub-agent's tools has backgroundConfig.enabled === true
       if (subAgent instanceof Agent) {
-        const subAgentTools = await subAgent.getToolsForExecution({ requestContext });
+        const subAgentTools = await subAgent.getToolsForExecution({
+          requestContext,
+          backgroundTaskEnabled: true,
+        });
         if (subAgentTools && typeof subAgentTools === 'object') {
           for (const tool of Object.values(subAgentTools)) {
-            const bg = (tool as any)?.background as ToolBackgroundConfig | undefined;
+            const bg = (tool as any)?.backgroundConfig as ToolBackgroundConfig | undefined;
             if (bg?.enabled === true) {
               return { enabled: true, waitTimeoutMs: subAgentBgConfig?.waitTimeoutMs };
             }
@@ -6100,6 +6103,7 @@ export class Agent<
     hooks?: ToolHooks;
     delegation?: DelegationConfig;
     methodType?: AgentMethodType;
+    backgroundTaskEnabled?: boolean;
   }): Promise<Record<string, CoreTool>> {
     const requestContext = options.requestContext ?? new RequestContext();
     const defaultOptions = await this.getDefaultOptions({ requestContext });
@@ -6135,6 +6139,7 @@ export class Agent<
       // survive when callers pass a partial per-call delegation override.
       delegation: mergedOptions.delegation,
       methodType: options.methodType ?? 'stream',
+      backgroundTaskEnabled: options.backgroundTaskEnabled,
     });
   }
 


### PR DESCRIPTION
## Description

Skip sub-agent background-config derivation when background task dispatch is disabled. The derivation resolves each sub-agent's full tool set, so cyclic native sub-agent graphs could recurse during tool preparation even though background tasks were not configured.

This change forwards `backgroundTaskEnabled` to agent-tool conversion and only inspects sub-agent tools for background configuration when dispatch is enabled. Native sub-agent delegation remains available in both cases.

## Related issue(s)

Fixes #22242

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Validation

- `pnpm build:core`
- `pnpm --filter @mastra/core exec vitest run src/agent/__tests__/subagent-background-config.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When background tasks are disabled, agents no longer inspect every nested agent for background-task settings. This prevents endless loops between cyclic sub-agents while keeping native sub-agent delegation available.

## Changes

- Forward `backgroundTaskEnabled` through nested sub-agent tool preparation.
- Skip sub-agent background configuration derivation when dispatch is disabled.
- Preserve background configuration derivation when dispatch is enabled.
- Add regression tests for enabled and disabled dispatch.
- Add a patch changeset for `@mastra/core`.

## Validation

- Core builds passed.
- Sub-agent background configuration tests passed.
- Type checks passed.
- Linting passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->