### PR TITLE
fix(datasets): isolate experiment result metadata snapshots

### DIFF
--- a/.changeset/moody-items-wait.md
+++ b/.changeset/moody-items-wait.md
@@ -9,4 +9,4 @@
 '@mastra/pg': patch
 ---
 
-Round-trip dataset item metadata in experiment results.
+Experiment results now include isolated metadata snapshots from the dataset items that ran.

--- a/.changeset/thin-wings-attend.md
+++ b/.changeset/thin-wings-attend.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Experiment results now preserve item metadata when callbacks or in-memory result consumers mutate their copies.

--- a/.changeset/thin-wings-attend.md
+++ b/.changeset/thin-wings-attend.md
@@ -1,5 +1,0 @@
----
-'@mastra/core': patch
----
-
-Experiment results now preserve item metadata when callbacks or in-memory result consumers mutate their copies.

--- a/packages/core/src/datasets/__tests__/experiment.test.ts
+++ b/packages/core/src/datasets/__tests__/experiment.test.ts
@@ -105,6 +105,21 @@ describe('Experiment (via Dataset)', () => {
     expect(persisted.results.every(item => item.metadata?.source === 'test')).toBe(true);
   });
 
+  it('snapshots persisted metadata before task callbacks can mutate it', async () => {
+    const result = await ds.startExperiment({
+      task: ({ metadata }) => {
+        metadata!.source = 'mutated';
+        return 'ok';
+      },
+      scorers: [],
+    });
+
+    expect(result.results.every(item => item.metadata?.source === 'test')).toBe(true);
+
+    const persisted = await ds.listExperimentResults({ experimentId: result.experimentId });
+    expect(persisted.results.every(item => item.metadata?.source === 'test')).toBe(true);
+  });
+
   // 2. Inline task with generic type params
   it('inline task with generic type params compiles and completes', async () => {
     interface QA {

--- a/packages/core/src/datasets/experiment/__tests__/lifecycle-hooks.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/lifecycle-hooks.test.ts
@@ -61,6 +61,40 @@ describe('runExperiment lifecycle hooks', () => {
     );
   });
 
+  it('protects result metadata from callback mutations', async () => {
+    const sourceMetadata = { nested: { value: 'original' } };
+    const events: unknown[] = [];
+
+    const summary = await runExperiment(createMastra(), {
+      data: [{ id: 'a', input: 'one', metadata: sourceMetadata }],
+      beforeEach: ({ item }) => {
+        (item.metadata!.nested as { value: string }).value = 'beforeEach';
+      },
+      task: ({ input, metadata }) => {
+        expect(metadata).toEqual({ nested: { value: 'original' } });
+        (metadata!.nested as { value: string }).value = 'task';
+        return input;
+      },
+      afterEach: ({ item, result }) => {
+        (item.metadata!.nested as { value: string }).value = 'afterEach-item';
+        (result.metadata!.nested as { value: string }).value = 'afterEach-result';
+      },
+      onEvent: event => {
+        events.push(event);
+      },
+    });
+
+    expect(sourceMetadata).toEqual({ nested: { value: 'original' } });
+    expect(summary.results[0]?.metadata).toEqual({ nested: { value: 'original' } });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'experiment.item.completed',
+        itemId: 'a',
+        metadata: { nested: { value: 'original' } },
+      }),
+    );
+  });
+
   it('passes experimentId and mastra to run-level hooks', async () => {
     const mastra = createMastra();
     const beforeAll = vi.fn();

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -498,6 +498,13 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
           }
 
           const itemStartedAt = new Date();
+          const metadataSnapshot = item.metadata === undefined ? undefined : structuredClone(item.metadata);
+          const cloneMetadataSnapshot = () =>
+            metadataSnapshot === undefined ? undefined : structuredClone(metadataSnapshot);
+          const itemWithMetadataSnapshot = (): ExperimentItem => ({
+            ...item,
+            metadata: cloneMetadataSnapshot(),
+          });
           let itemScorers: MastraScorer<any, any, any, any>[];
           let itemStepScorers = {} as ReturnType<typeof resolveStepScorers>;
           let scorerConfigError: ExecutionResult['error'] = null;
@@ -537,7 +544,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
                   id: item.id,
                   input: item.input,
                   groundTruth: item.groundTruth,
-                  metadata: item.metadata,
+                  metadata: cloneMetadataSnapshot(),
                 },
               });
             } catch (hookError) {
@@ -555,7 +562,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
           const preflightError = scorerConfigError ?? beforeEachError;
           let execResult: ExecutionResult = preflightError
             ? { output: null, error: preflightError, traceId: null }
-            : await execFn(item, itemSignal);
+            : await execFn(itemWithMetadataSnapshot(), itemSignal);
 
           while (execResult.error && !preflightError && retryCount < maxRetries) {
             // Don't retry abort errors
@@ -581,7 +588,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
               throw new DOMException('Aborted', 'AbortError');
             }
 
-            execResult = await execFn(item, itemSignal);
+            execResult = await execFn(itemWithMetadataSnapshot(), itemSignal);
           }
 
           const itemCompletedAt = new Date();
@@ -595,7 +602,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
             input: item.input,
             output: execResult.output,
             groundTruth: item.groundTruth ?? null,
-            metadata: item.metadata,
+            metadata: cloneMetadataSnapshot(),
             error: execResult.error,
             startedAt: itemStartedAt,
             completedAt: itemCompletedAt,
@@ -620,7 +627,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
 
             const flatScores = await runScorersForItem(
               itemScorers,
-              item,
+              itemWithMetadataSnapshot(),
               execResult.output,
               storage ?? null,
               experimentId,
@@ -636,7 +643,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
 
             const stepScores = await runStepScorersForItem(
               itemStepScorers,
-              item,
+              itemWithMetadataSnapshot(),
               workflowData,
               storage ?? null,
               experimentId,
@@ -665,7 +672,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
                 input: item.input,
                 output: execResult.output,
                 groundTruth: item.groundTruth ?? null,
-                metadata: item.metadata,
+                metadata: cloneMetadataSnapshot(),
                 error: execResult.error,
                 startedAt: itemStartedAt,
                 completedAt: itemCompletedAt,
@@ -715,9 +722,12 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
                   id: item.id,
                   input: item.input,
                   groundTruth: item.groundTruth,
-                  metadata: item.metadata,
+                  metadata: cloneMetadataSnapshot(),
                 },
-                result: results[idx]!,
+                result: {
+                  ...results[idx]!,
+                  metadata: cloneMetadataSnapshot(),
+                },
               });
             } catch (hookError) {
               mastra

--- a/packages/core/src/storage/domains/experiments/__tests__/experiments.test.ts
+++ b/packages/core/src/storage/domains/experiments/__tests__/experiments.test.ts
@@ -419,6 +419,7 @@ describe('ExperimentsInMemory', () => {
         totalItems: 1,
       });
 
+      const metadata = { source: 'dataset-v3', nested: { value: 'original' } };
       const result = await storage.addExperimentResult({
         experimentId: experiment.id,
         itemId: 'item-1',
@@ -426,7 +427,7 @@ describe('ExperimentsInMemory', () => {
         input: { prompt: 'Hello' },
         output: { text: 'Hi there' },
         groundTruth: { text: 'Hello!' },
-        metadata: { source: 'dataset-v3' },
+        metadata,
         error: null,
         startedAt: new Date(),
         completedAt: new Date(),
@@ -438,7 +439,20 @@ describe('ExperimentsInMemory', () => {
       expect(result.itemDatasetVersion).toBe(3);
       expect(result.input).toEqual({ prompt: 'Hello' });
       expect(result.output).toEqual({ text: 'Hi there' });
-      expect(result.metadata).toEqual({ source: 'dataset-v3' });
+      expect(result.metadata).toEqual({ source: 'dataset-v3', nested: { value: 'original' } });
+
+      metadata.nested.value = 'mutated-input';
+      (result.metadata!.nested as { value: string }).value = 'mutated-result';
+
+      const stored = await storage.getExperimentResultById({ id: result.id });
+      expect(stored?.metadata).toEqual({ source: 'dataset-v3', nested: { value: 'original' } });
+
+      (stored!.metadata!.nested as { value: string }).value = 'mutated-read';
+      const listed = await storage.listExperimentResults({
+        experimentId: experiment.id,
+        pagination: { page: 0, perPage: 10 },
+      });
+      expect(listed.results[0]?.metadata).toEqual({ source: 'dataset-v3', nested: { value: 'original' } });
     });
 
     it('stores itemDatasetVersion as integer', async () => {
@@ -517,6 +531,53 @@ describe('ExperimentsInMemory', () => {
       expect(result.error).toEqual({ message: 'Agent timeout' });
       expect(result.output).toBeNull();
       expect(result.retryCount).toBe(2);
+    });
+  });
+
+  describe('upsertExperimentResult', () => {
+    it('isolates updated metadata from caller mutations', async () => {
+      const experiment = await storage.createExperiment({
+        datasetId: 'ds-1',
+        datasetVersion: 1,
+        targetType: 'agent',
+        targetId: 'a1',
+        totalItems: 1,
+      });
+
+      await storage.addExperimentResult({
+        experimentId: experiment.id,
+        itemId: 'item-1',
+        itemDatasetVersion: 1,
+        input: 'x',
+        output: 'initial',
+        groundTruth: null,
+        metadata: { nested: { value: 'initial' } },
+        error: null,
+        startedAt: new Date(),
+        completedAt: new Date(),
+        retryCount: 0,
+      });
+
+      const metadata = { nested: { value: 'updated' } };
+      const result = await storage.upsertExperimentResult({
+        experimentId: experiment.id,
+        itemId: 'item-1',
+        itemDatasetVersion: 1,
+        input: 'x',
+        output: 'updated',
+        groundTruth: null,
+        metadata,
+        error: null,
+        startedAt: new Date(),
+        completedAt: new Date(),
+        retryCount: 0,
+      });
+
+      metadata.nested.value = 'mutated-input';
+      (result.metadata!.nested as { value: string }).value = 'mutated-result';
+
+      const stored = await storage.getExperimentResultById({ id: result.id });
+      expect(stored?.metadata).toEqual({ nested: { value: 'updated' } });
     });
   });
 

--- a/packages/core/src/storage/domains/experiments/inmemory.ts
+++ b/packages/core/src/storage/domains/experiments/inmemory.ts
@@ -17,6 +17,13 @@ import type {
 import type { InMemoryDB } from '../inmemory-db';
 import { ExperimentsStorage } from './base';
 
+function cloneExperimentResultMetadata(result: ExperimentResult): ExperimentResult {
+  return {
+    ...result,
+    metadata: result.metadata === null ? null : structuredClone(result.metadata),
+  };
+}
+
 export class ExperimentsInMemory extends ExperimentsStorage {
   private db: InMemoryDB;
 
@@ -205,8 +212,8 @@ export class ExperimentsInMemory extends ExperimentsStorage {
       projectId: input.projectId ?? null,
       createdAt: now,
     };
-    this.db.experimentResults.set(result.id, result);
-    return result;
+    this.db.experimentResults.set(result.id, cloneExperimentResultMetadata(result));
+    return cloneExperimentResultMetadata(result);
   }
 
   async upsertExperimentResult(input: UpsertExperimentResultInput): Promise<ExperimentResult> {
@@ -241,8 +248,8 @@ export class ExperimentsInMemory extends ExperimentsStorage {
       projectId: input.projectId ?? null,
       createdAt: existing.createdAt,
     };
-    this.db.experimentResults.set(existing.id, replaced);
-    return replaced;
+    this.db.experimentResults.set(existing.id, cloneExperimentResultMetadata(replaced));
+    return cloneExperimentResultMetadata(replaced);
   }
 
   async updateExperimentResult(input: UpdateExperimentResultInput): Promise<ExperimentResult> {
@@ -259,8 +266,8 @@ export class ExperimentsInMemory extends ExperimentsStorage {
       tags: input.tags !== undefined ? input.tags : existing.tags,
       comment: input.comment !== undefined ? input.comment : existing.comment,
     };
-    this.db.experimentResults.set(input.id, updated);
-    return updated;
+    this.db.experimentResults.set(input.id, cloneExperimentResultMetadata(updated));
+    return cloneExperimentResultMetadata(updated);
   }
 
   async getExperimentResultById(args: {
@@ -275,7 +282,7 @@ export class ExperimentsInMemory extends ExperimentsStorage {
     if (args.filters?.projectId !== undefined && (row.projectId ?? null) !== args.filters.projectId) {
       return null;
     }
-    return row;
+    return cloneExperimentResultMetadata(row);
   }
 
   async listExperimentResults(args: ListExperimentResultsInput): Promise<ListExperimentResultsOutput> {
@@ -304,7 +311,7 @@ export class ExperimentsInMemory extends ExperimentsStorage {
     const end = perPageInput === false ? results.length : start + perPage;
 
     return {
-      results: results.slice(start, end),
+      results: results.slice(start, end).map(cloneExperimentResultMetadata),
       pagination: {
         total: results.length,
         page,


### PR DESCRIPTION
Follow-up to #22005. Experiment callbacks could receive the same item metadata object used by returned and persisted results, allowing nested mutations to rewrite the historical result context. This snapshots metadata before execution and gives hooks, targets, scorers, persistence, and in-memory result consumers isolated copies.

For example, a task can mutate `metadata.nested` without changing `summary.results[0].metadata` or the stored result. In-memory add, upsert, get, and list operations now isolate metadata while leaving other result fields unchanged.

Tested with 86 focused dataset/experiment tests, the `@mastra/core` check, core lint, formatting, and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The PR makes a safe copy of experiment metadata before execution. Later changes cannot alter the original results or saved history.

## Changes

- Snapshot experiment item metadata before callbacks, targets, scorers, persistence, retries, and completion results use it.
- Isolate metadata in in-memory experiment result add, upsert, update, get, and list operations.
- Preserve `null` metadata values.
- Add regression tests for nested metadata mutations across dataset execution, lifecycle hooks, and result storage.
- Update the existing changeset entry.

## Validation

- Focused dataset and experiment tests
- `@mastra/core` checks
- Linting
- Formatting
- `git diff --check`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->