### PR TITLE
feat(workspaces): honor the sandbox runtime env in every provider

### DIFF
--- a/.changeset/workspaces-sandbox-env.md
+++ b/.changeset/workspaces-sandbox-env.md
@@ -1,0 +1,20 @@
+---
+'@mastra/agentcore': patch
+'@mastra/apple-container': patch
+'@mastra/blaxel': patch
+'@mastra/cloudflare-sandbox': patch
+'@mastra/daytona': patch
+'@mastra/docker': patch
+'@mastra/e2b': patch
+'@mastra/modal': patch
+'@mastra/platform-workspace': patch
+'@mastra/railway': patch
+'@mastra/vercel': patch
+---
+
+Honor the sandbox runtime environment (`setEnv()`/`getEnv()` from `@mastra/core`) in every workspace sandbox provider. Environment variables set after construction now reach subsequent commands on all providers:
+
+- Process-manager-routed providers (E2B, Blaxel, Cloudflare, Daytona, Docker, Modal, Vercel microVM spawns) inherit the merge from the core spawn wrapper; their duplicated per-manager env plumbing is removed.
+- Providers with their own exec transports (AgentCore, Apple Container, Railway, Vercel microVM and serverless `executeCommand`, Platform's private-network, WebSocket lease, and E2B lease paths) now merge `getEnv()` under per-call env.
+
+Constructor `env` continues to behave as before: it seeds the sandbox runtime environment, and providers that bake env into the VM or container at creation time (Docker, Modal, Railway, Apple Container, Vercel, Platform) still do so. Per-call `env` on `executeCommand` still takes precedence for that command only.

--- a/.changeset/workspaces-sandbox-env.md
+++ b/.changeset/workspaces-sandbox-env.md
@@ -1,14 +1,14 @@
 ---
 '@mastra/agentcore': patch
 '@mastra/apple-container': patch
-'@mastra/blaxel': patch
+'@mastra/blaxel': minor
 '@mastra/cloudflare-sandbox': patch
 '@mastra/daytona': patch
 '@mastra/docker': patch
 '@mastra/e2b': patch
 '@mastra/modal': patch
 '@mastra/platform-workspace': patch
-'@mastra/railway': patch
+'@mastra/railway': minor
 '@mastra/vercel': patch
 ---
 
@@ -18,3 +18,5 @@ Honor the sandbox runtime environment (`setEnv()`/`getEnv()` from `@mastra/core`
 - Providers with their own exec transports (AgentCore, Apple Container, Railway, Vercel microVM and serverless `executeCommand`, Platform's private-network, WebSocket lease, and E2B lease paths) now merge `getEnv()` under per-call env.
 
 Constructor `env` continues to behave as before: it seeds the sandbox runtime environment, and providers that bake env into the VM or container at creation time (Docker, Modal, Railway, Apple Container, Vercel, Platform) still do so. Per-call `env` on `executeCommand` still takes precedence for that command only.
+
+Removed exported types (minor bump for these two packages): `BlaxelProcessManagerOptions` from `@mastra/blaxel` and `RailwayProcessManagerOptions` from `@mastra/railway`. Both existed only to pass `env` into a process manager constructed by hand; the core spawn wrapper now owns that merge, so the option and its type are gone.

--- a/workspaces/agentcore/src/sandbox/index.test.ts
+++ b/workspaces/agentcore/src/sandbox/index.test.ts
@@ -238,6 +238,23 @@ describe('AgentCoreRuntimeSandbox', () => {
     );
   });
 
+  it('setEnv after construction reaches subsequent commands', async () => {
+    mockSend.mockResolvedValueOnce({
+      stream: streamEvents([{ stdout: 'ok' }, { exitCode: 0, status: 'COMPLETED' }]),
+    });
+
+    const sandbox = new AgentCoreRuntimeSandbox({
+      agentRuntimeArn: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-agent',
+      runtimeSessionId: '12345678-1234-1234-1234-123456789012',
+    });
+
+    sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+    await sandbox.executeCommand('echo ok');
+
+    const body = commandInputs[0]!.input.body as { command: string };
+    expect(body.command).toMatch(/GH_TOKEN='?tok_1'?/);
+  });
+
   it('rejects invalid environment variable names', async () => {
     const sandbox = new AgentCoreRuntimeSandbox({
       agentRuntimeArn: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-agent',

--- a/workspaces/agentcore/src/sandbox/index.ts
+++ b/workspaces/agentcore/src/sandbox/index.ts
@@ -297,7 +297,8 @@ export class AgentCoreRuntimeSandbox extends MastraSandbox {
   async executeCommand(command: string, args?: string[], options?: ExecuteCommandOptions): Promise<CommandResult> {
     await this.ensureRunning();
 
-    const fullCommand = buildCommand(command, args, options);
+    // Merge the sandbox env under per-call env — this exec path bypasses the process manager
+    const fullCommand = buildCommand(command, args, { ...options, env: { ...this.getEnv(), ...options?.env } });
     const timeoutMs = options?.timeout ?? this._commandTimeout;
     const timeoutSeconds = toAgentCoreTimeoutSeconds(timeoutMs);
     const startTime = Date.now();

--- a/workspaces/apple-container/src/sandbox/index.test.ts
+++ b/workspaces/apple-container/src/sandbox/index.test.ts
@@ -345,6 +345,22 @@ describe('AppleContainerSandbox', () => {
     );
   });
 
+  it('setEnv after construction reaches subsequent commands', async () => {
+    const runner = createRunner([missingContainerResult(), {}, inspectResult('running'), {}, { stdout: 'ok\n' }]);
+    const sandbox = new AppleContainerSandbox({ id: 'apple-test', runner });
+
+    await sandbox._start();
+    runner.run.mockClear();
+
+    sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+    await sandbox.executeCommand('echo', ['ok']);
+
+    const cliArgs = runner.run.mock.calls[0]![0] as string[];
+    expect(cliArgs).toEqual(expect.arrayContaining(['--env', 'GH_TOKEN']));
+    const runOptions = runner.run.mock.calls[0]![1] as { env?: Record<string, string> };
+    expect(runOptions.env).toEqual(expect.objectContaining({ GH_TOKEN: 'tok_1' }));
+  });
+
   it('executes commands with env, cwd, timeout, streaming and retained output options', async () => {
     const runner = createRunner([missingContainerResult(), {}, inspectResult('running'), {}, { stdout: 'hello\n' }]);
     const onStdout = vi.fn();

--- a/workspaces/apple-container/src/sandbox/index.ts
+++ b/workspaces/apple-container/src/sandbox/index.ts
@@ -370,7 +370,8 @@ export class AppleContainerSandbox extends MastraSandbox {
     const hasCommandTimeout = Number.isFinite(commandTimeout) && commandTimeout > 0;
     const fullCommand = buildShellCommand(command, args);
     const shellCommand = hasCommandTimeout ? buildTimeoutShellCommand(fullCommand, commandTimeout) : fullCommand;
-    const env = envFlags({ ...this._env, ...options.env });
+    // Constructor env seeds the sandbox env, so getEnv() covers it plus any setEnv updates
+    const env = envFlags({ ...this.getEnv(), ...options.env });
     const cliArgs = [
       'exec',
       ...env.args,

--- a/workspaces/blaxel/src/index.ts
+++ b/workspaces/blaxel/src/index.ts
@@ -1,3 +1,3 @@
 export { BlaxelSandbox, type BlaxelSandboxOptions, type SandboxRuntime } from './sandbox';
-export { BlaxelProcessManager, type BlaxelProcessManagerOptions } from './sandbox/process-manager';
+export { BlaxelProcessManager } from './sandbox/process-manager';
 export { type BlaxelS3MountConfig, type BlaxelGCSMountConfig, type BlaxelMountConfig } from './sandbox/mounts';

--- a/workspaces/blaxel/src/sandbox/index.test.ts
+++ b/workspaces/blaxel/src/sandbox/index.test.ts
@@ -369,6 +369,18 @@ describe('BlaxelSandbox', () => {
         }),
       );
     });
+
+    it('setEnv after construction reaches subsequent commands', async () => {
+      const sandbox = new BlaxelSandbox();
+      await sandbox._start();
+
+      sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+      await sandbox.executeCommand('echo', ['test']);
+
+      expect(mockSandbox.process.exec).toHaveBeenLastCalledWith(
+        expect.objectContaining({ env: expect.objectContaining({ GH_TOKEN: 'tok_1' }) }),
+      );
+    });
   });
 
   describe('Stop/Destroy', () => {

--- a/workspaces/blaxel/src/sandbox/index.ts
+++ b/workspaces/blaxel/src/sandbox/index.ts
@@ -168,7 +168,6 @@ export class BlaxelSandbox extends MastraSandbox {
   private readonly memory: number;
   private readonly timeout?: string;
   private readonly region: string;
-  private readonly env: Record<string, string>;
   private readonly labels: Record<string, string>;
   private readonly configuredRuntimes: SandboxRuntime[];
   private readonly ports: Array<{ name?: string; target: number; protocol?: 'HTTP' | 'TCP' | 'UDP' }>;
@@ -179,7 +178,7 @@ export class BlaxelSandbox extends MastraSandbox {
     super({
       ...options,
       name: 'BlaxelSandbox',
-      processes: new BlaxelProcessManager({ env: options.env }),
+      processes: new BlaxelProcessManager(),
     });
 
     this.id = options.id ?? this.generateId();
@@ -187,7 +186,6 @@ export class BlaxelSandbox extends MastraSandbox {
     this.memory = options.memory ?? 4096;
     this.timeout = options.timeout;
     this.region = options.region || process.env.BL_REGION || 'auto';
-    this.env = options.env ?? {};
     this.labels = options.labels ?? {};
     this.configuredRuntimes = options.runtimes ?? ['node', 'python', 'bash'];
     this.ports = options.ports ?? [];
@@ -954,7 +952,7 @@ export class BlaxelSandbox extends MastraSandbox {
     try {
       // Merge sandbox default env with per-command env (per-command overrides)
       // Filter out undefined values to get Record<string, string>
-      const mergedEnv = { ...this.env, ...options.env };
+      const mergedEnv = { ...this.getEnv(), ...options.env };
       const envRecord = Object.fromEntries(
         Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
       );

--- a/workspaces/blaxel/src/sandbox/process-manager.ts
+++ b/workspaces/blaxel/src/sandbox/process-manager.ts
@@ -132,25 +132,17 @@ class BlaxelProcessHandle extends ProcessHandle {
 // Blaxel Process Manager
 // =============================================================================
 
-export interface BlaxelProcessManagerOptions {
-  env?: Record<string, string | undefined>;
-}
-
 /**
  * Blaxel implementation of SandboxProcessManager.
  * Uses the Blaxel SDK's process API for background process management.
  */
 export class BlaxelProcessManager extends SandboxProcessManager<BlaxelSandbox> {
-  constructor(opts: BlaxelProcessManagerOptions = {}) {
-    super({ env: opts.env });
-  }
-
   async spawn(command: string, options: SpawnProcessOptions = {}): Promise<ProcessHandle> {
     return this.sandbox.retryOnDead(async () => {
       const blaxel = this.sandbox.blaxel;
 
-      // Merge default env with per-spawn env
-      const mergedEnv = { ...this.env, ...options.env };
+      // The base spawn wrapper already merged the sandbox env into options.env
+      const mergedEnv = { ...options.env };
       const envs = Object.fromEntries(
         Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
       );

--- a/workspaces/cloudflare-sandbox/src/sandbox.test.ts
+++ b/workspaces/cloudflare-sandbox/src/sandbox.test.ts
@@ -51,6 +51,17 @@ describe('CloudflareSandbox', () => {
     });
   });
 
+  it('setEnv after construction reaches subsequent commands', async () => {
+    const bridge = createFakeBridge({ apiToken: 'secret' });
+    const sandbox = createSandbox(bridge);
+    await sandbox._start();
+
+    sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+    await sandbox.executeCommand('echo', ['hi']);
+
+    expect(bridge.execs[0]!.argv).toEqual(['env', 'GH_TOKEN=tok_1', 'echo', 'hi']);
+  });
+
   it('decodes streamed output and reports the exit code', async () => {
     const bridge = createFakeBridge({ apiToken: 'secret' });
     bridge.onExec = () => ({ stdout: 'hello wörld\n', stderr: 'oops\n', exitCode: 2, stdoutChunks: 5 });

--- a/workspaces/cloudflare-sandbox/src/sandbox.ts
+++ b/workspaces/cloudflare-sandbox/src/sandbox.ts
@@ -75,7 +75,6 @@ export class CloudflareSandbox extends MastraSandbox {
   status: ProviderStatus = 'pending';
 
   private readonly client: BridgeClient;
-  private readonly env: Record<string, string>;
   private readonly workingDirectory?: string;
   private readonly commandTimeout: number;
   private readonly instructions?: InstructionsOption;
@@ -89,7 +88,6 @@ export class CloudflareSandbox extends MastraSandbox {
     this.id = options.id ?? `cloudflare-sandbox-${randomUUID()}`;
     this.name = name;
     this.sandboxId = options.sandboxId;
-    this.env = { ...options.env };
     this.workingDirectory = options.workingDirectory;
     this.commandTimeout = options.commandTimeout ?? DEFAULT_COMMAND_TIMEOUT_MS;
     this.instructions = options.instructions;
@@ -145,7 +143,7 @@ export class CloudflareSandbox extends MastraSandbox {
     let exitCode = 1;
 
     const env = Object.fromEntries(
-      Object.entries({ ...this.env, ...options?.env }).filter(
+      Object.entries({ ...this.getEnv(), ...options?.env }).filter(
         (entry): entry is [string, string] => entry[1] !== undefined,
       ),
     );

--- a/workspaces/daytona/src/sandbox/index.test.ts
+++ b/workspaces/daytona/src/sandbox/index.test.ts
@@ -606,6 +606,17 @@ describe('DaytonaSandbox', () => {
       expect(cmd).not.toContain('sandbox-value');
     });
 
+    it('setEnv after construction reaches subsequent commands', async () => {
+      const sandbox = new DaytonaSandbox();
+
+      await sandbox._start();
+      sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+      await sandbox.executeCommand('echo', ['test']);
+
+      const cmd: string = mockSandbox.process.executeSessionCommand.mock.calls[0]![1].command;
+      expect(cmd).toContain('export GH_TOKEN=tok_1');
+    });
+
     it('filters out undefined env values', async () => {
       const sandbox = new DaytonaSandbox({
         env: { KEEP: 'yes' },

--- a/workspaces/daytona/src/sandbox/index.ts
+++ b/workspaces/daytona/src/sandbox/index.ts
@@ -251,7 +251,7 @@ export class DaytonaSandbox extends MastraSandbox {
   private readonly timeout: number;
   private readonly language: 'typescript' | 'javascript' | 'python';
   private readonly resources?: DaytonaResources;
-  private readonly env: Record<string, string>;
+
   private readonly labels: Record<string, string>;
   private readonly snapshotId?: string;
   private readonly image?: string;
@@ -275,7 +275,6 @@ export class DaytonaSandbox extends MastraSandbox {
       ...options,
       name: 'DaytonaSandbox',
       processes: new DaytonaProcessManager({
-        env: options.env,
         defaultTimeout: options.timeout ?? 300_000,
       }),
     });
@@ -284,7 +283,6 @@ export class DaytonaSandbox extends MastraSandbox {
     this.timeout = options.timeout ?? 300_000;
     this.language = options.language ?? 'typescript';
     this.resources = options.resources;
-    this.env = options.env ?? {};
     this.labels = options.labels ?? {};
     this.snapshotId = options.snapshot;
     this.image = options.image;

--- a/workspaces/daytona/src/sandbox/process-manager.ts
+++ b/workspaces/daytona/src/sandbox/process-manager.ts
@@ -171,7 +171,6 @@ class DaytonaProcessHandle extends ProcessHandle {
 // =============================================================================
 
 export interface DaytonaProcessManagerOptions {
-  env?: Record<string, string | undefined>;
   /** Default timeout in milliseconds for commands that don't specify one. */
   defaultTimeout?: number;
 }
@@ -185,7 +184,7 @@ export class DaytonaProcessManager extends SandboxProcessManager<DaytonaSandbox>
   private readonly _defaultTimeout?: number;
 
   constructor(opts: DaytonaProcessManagerOptions = {}) {
-    super({ env: opts.env });
+    super();
     this._defaultTimeout = opts.defaultTimeout;
   }
 
@@ -198,8 +197,8 @@ export class DaytonaProcessManager extends SandboxProcessManager<DaytonaSandbox>
       cwd: options.cwd ?? this.sandbox.mounts?.entries?.keys().next().value,
     };
 
-    // Merge default env with per-spawn env
-    const mergedEnv = { ...this.env, ...effectiveOptions.env };
+    // The base spawn wrapper already merged the sandbox env into options.env
+    const mergedEnv = { ...effectiveOptions.env };
     const envs = Object.fromEntries(
       Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
     );

--- a/workspaces/docker/src/sandbox/index.test.ts
+++ b/workspaces/docker/src/sandbox/index.test.ts
@@ -906,6 +906,20 @@ describe('DockerSandbox', () => {
       );
     });
 
+    it('setEnv after construction reaches subsequent spawns', async () => {
+      const sandbox = new DockerSandbox();
+      await sandbox._start();
+
+      sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+      await sandbox.processes!.spawn('echo hello');
+
+      expect(mockContainer.exec).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Env: expect.arrayContaining(['GH_TOKEN=tok_1']),
+        }),
+      );
+    });
+
     it('should pass cwd option as WorkingDir', async () => {
       const sandbox = new DockerSandbox();
       await sandbox._start();

--- a/workspaces/docker/src/sandbox/index.ts
+++ b/workspaces/docker/src/sandbox/index.ts
@@ -191,7 +191,6 @@ export class DockerSandbox extends MastraSandbox {
 
   constructor(options: DockerSandboxOptions = {}) {
     const processManager = new DockerProcessManager({
-      env: options.env ?? {},
       defaultTimeout: options.timeout ?? 300_000,
     });
 

--- a/workspaces/docker/src/sandbox/process-manager.ts
+++ b/workspaces/docker/src/sandbox/process-manager.ts
@@ -192,8 +192,8 @@ export class DockerProcessManager extends SandboxProcessManager {
   private _container: Container | null = null;
   private readonly _defaultTimeout: number;
 
-  constructor(options: { env: Record<string, string>; defaultTimeout?: number }) {
-    super(options);
+  constructor(options: { defaultTimeout?: number } = {}) {
+    super();
     this._defaultTimeout = options.defaultTimeout ?? 0;
   }
 
@@ -213,9 +213,8 @@ export class DockerProcessManager extends SandboxProcessManager {
   async spawn(command: string, options: SpawnProcessOptions = {}): Promise<ProcessHandle> {
     const container = this.container;
 
-    // Merge default env with per-spawn env
-    const mergedEnv = { ...this.env, ...options.env };
-    const envArray = Object.entries(mergedEnv)
+    // The base spawn wrapper already merged the sandbox env into options.env
+    const envArray = Object.entries({ ...options.env })
       .filter((entry): entry is [string, string] => entry[1] !== undefined)
       .map(([k, v]) => `${k}=${v}`);
 

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -423,6 +423,27 @@ describe('E2BSandbox', () => {
         }),
       );
     });
+
+    it('setEnv after construction reaches subsequent commands', async () => {
+      const sandbox = new E2BSandbox();
+      await sandbox._start();
+
+      sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+      await sandbox.executeCommand('echo', ['test']);
+
+      expect(mockSandbox.commands.run).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.objectContaining({ envs: expect.objectContaining({ GH_TOKEN: 'tok_1' }) }),
+      );
+
+      sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_2' }));
+      await sandbox.executeCommand('echo', ['test']);
+
+      expect(mockSandbox.commands.run).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.objectContaining({ envs: expect.objectContaining({ GH_TOKEN: 'tok_2' }) }),
+      );
+    });
   });
 
   describe('Stop/Destroy', () => {

--- a/workspaces/e2b/src/sandbox/index.ts
+++ b/workspaces/e2b/src/sandbox/index.ts
@@ -208,7 +208,6 @@ export class E2BSandbox extends MastraSandbox {
   private _isRetrying = false;
   private readonly timeout: number;
   private readonly templateSpec?: TemplateSpec;
-  private readonly env: Record<string, string>;
   private readonly metadata: Record<string, unknown>;
   private readonly network?: SandboxNetworkOpts;
   private readonly lifecycle: SandboxLifecycle;
@@ -226,13 +225,12 @@ export class E2BSandbox extends MastraSandbox {
     super({
       ...options,
       name: 'E2BSandbox',
-      processes: new E2BProcessManager({ env: options.env ?? {} }),
+      processes: new E2BProcessManager(),
     });
 
     this.id = options.id ?? this.generateId();
     this.timeout = options.timeout ?? 300_000; // 5 minutes;
     this.templateSpec = options.template;
-    this.env = options.env ?? {};
     this.metadata = options.metadata ?? {};
     this.network = options.network;
     // Always sent explicitly: the E2B API defaults to 'kill' when lifecycle is omitted.

--- a/workspaces/e2b/src/sandbox/process-manager.ts
+++ b/workspaces/e2b/src/sandbox/process-manager.ts
@@ -116,8 +116,8 @@ export class E2BProcessManager extends SandboxProcessManager<E2BSandbox> {
     return this.sandbox.retryOnDead(async () => {
       const e2b = this.sandbox.e2b;
 
-      // Merge default env with per-spawn env
-      const mergedEnv = { ...this.env, ...options.env };
+      // The base spawn wrapper already merged the sandbox env into options.env
+      const mergedEnv = { ...options.env };
       const envs = Object.fromEntries(
         Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
       );

--- a/workspaces/modal/src/sandbox/index.ts
+++ b/workspaces/modal/src/sandbox/index.ts
@@ -102,7 +102,7 @@ export class ModalSandbox extends MastraSandbox {
     super({
       ...options,
       name: 'ModalSandbox',
-      processes: new ModalProcessManager({ env: options.env ?? {} }),
+      processes: new ModalProcessManager(),
     });
 
     this.id = options.id ?? this._generateId();

--- a/workspaces/modal/src/sandbox/process-manager.ts
+++ b/workspaces/modal/src/sandbox/process-manager.ts
@@ -167,10 +167,6 @@ class ModalProcessHandle extends ProcessHandle {
 // Modal Process Manager
 // =============================================================================
 
-export interface ModalProcessManagerOptions {
-  env?: Record<string, string | undefined>;
-}
-
 /**
  * Modal implementation of SandboxProcessManager.
  * Uses the Modal SDK's exec() API with one ContainerProcess per spawn.
@@ -178,15 +174,12 @@ export interface ModalProcessManagerOptions {
 export class ModalProcessManager extends SandboxProcessManager<ModalSandbox> {
   private _spawnCounter = 0;
 
-  constructor(opts: ModalProcessManagerOptions = {}) {
-    super({ env: opts.env });
-  }
-
   async spawn(command: string, options: SpawnProcessOptions = {}): Promise<ProcessHandle> {
     return this.sandbox.retryOnDead(async () => {
       const sb = this.sandbox.modal;
 
-      const mergedEnv = { ...this.env, ...options.env };
+      // The base spawn wrapper already merged the sandbox env into options.env
+      const mergedEnv = { ...options.env };
       const env = Object.fromEntries(
         Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
       );

--- a/workspaces/modal/src/sandbox/sandbox.test.ts
+++ b/workspaces/modal/src/sandbox/sandbox.test.ts
@@ -398,6 +398,20 @@ describe('ModalProcessManager', () => {
     );
   });
 
+  it('setEnv after construction reaches subsequent spawns', async () => {
+    const proc = makeProcess(0);
+    mockSandbox.exec = vi.fn().mockResolvedValue(proc);
+
+    const sandbox = await startedSandbox();
+    sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+    await sandbox.processes.spawn('true');
+
+    expect(mockSandbox.exec).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ env: { GH_TOKEN: 'tok_1' } }),
+    );
+  });
+
   it('spawn() filters undefined values from env', async () => {
     const proc = makeProcess(0);
     mockSandbox.exec = vi.fn().mockResolvedValue(proc);

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -139,6 +139,31 @@ describe('PlatformSandbox', () => {
     expect(init.data).toEqual({ command: 'echo ok', cwd: '/workspace', env: { A: '1' } });
   });
 
+  it('setEnv after construction reaches subsequent exec frames', async () => {
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }))
+      .mockResolvedValueOnce(leaseResponse());
+    const { factory, sockets } = fakeExecSocket({ exitCode: 0, stdout: 'ok' });
+
+    const sandbox = new PlatformSandbox({
+      accessToken: 'sk_test',
+      projectId: 'proj_123',
+      environmentId: 'env_123',
+      fetch: fetchMock,
+      webSocketFactory: factory,
+    });
+
+    await sandbox._start();
+    sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+    const result = await sandbox.executeCommand('echo', ['ok'], { env: { A: '1' } });
+
+    expect(result).toMatchObject({ success: true, exitCode: 0 });
+    const init = JSON.parse(sockets[0]!.sent[0]!) as { data: Record<string, unknown> };
+    expect(init.data).toEqual({ command: 'echo ok', env: { GH_TOKEN: 'tok_1', A: '1' } });
+  });
+
   it('uses E2B direct exec for E2B leases instead of the Railway WebSocket protocol', async () => {
     vi.stubEnv('SANDBOX_PROVIDER', 'e2b');
     vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -1050,6 +1050,13 @@ export class PlatformSandbox extends MastraSandbox {
     // the value is 0, which disables the client-side timer entirely.
     const effectiveTimeout = options?.timeout ?? this._timeout;
 
+    // Merge the sandbox env under per-call env once, up front — every exec
+    // transport below (private network, WebSocket lease, E2B lease) receives
+    // these options, and none of them route through the process manager.
+    const sandboxEnv = this.getEnv();
+    const execCallOptions =
+      Object.keys(sandboxEnv).length > 0 ? { ...options, env: { ...sandboxEnv, ...options?.env } } : options;
+
     // Wait for the transport to become ready before proceeding. During the
     // sidecar boot window (immediately after start()), concurrent execs all
     // await the same probe promise rather than each independently racing to
@@ -1070,7 +1077,12 @@ export class PlatformSandbox extends MastraSandbox {
     // `.scratch/factory-deploy/issue-platform-sandbox-exec-via-private-network.md`.
     const instanceUrl = this._addressRegistry?.get(this._sandboxId);
     if (instanceUrl) {
-      const privateNet = await this._tryExecViaPrivateNetwork(instanceUrl, fullCommand, effectiveTimeout, options);
+      const privateNet = await this._tryExecViaPrivateNetwork(
+        instanceUrl,
+        fullCommand,
+        effectiveTimeout,
+        execCallOptions,
+      );
       if (privateNet) {
         const privateExit = privateNet.exitCode ?? 124;
         return {
@@ -1095,7 +1107,7 @@ export class PlatformSandbox extends MastraSandbox {
     // `PlatformApiError` for other `/exec-lease` errors (404/500/501).
     // See ./direct-exec.ts and `docs/factory/direct-sandbox-connection.md`
     // in the Platform repo.
-    const result = await this._runDirectExec(fullCommand, effectiveTimeout, options);
+    const result = await this._runDirectExec(fullCommand, effectiveTimeout, execCallOptions);
     // `_runDirectExec` throws on transport failure (see its jsdoc), so a
     // `null` exitCode here can only mean `timedOut: true` — the sandbox
     // never got to send an exit frame because we cut the command short.

--- a/workspaces/railway/src/index.ts
+++ b/workspaces/railway/src/index.ts
@@ -1,4 +1,4 @@
 export { RailwaySandbox, type RailwaySandboxOptions } from './sandbox';
-export { RailwayProcessManager, type RailwayProcessManagerOptions } from './sandbox/process-manager';
+export { RailwayProcessManager } from './sandbox/process-manager';
 export { railwaySandboxProvider } from './provider';
 export { SandboxFileNotFoundError } from 'railway';

--- a/workspaces/railway/src/sandbox/index.test.ts
+++ b/workspaces/railway/src/sandbox/index.test.ts
@@ -590,6 +590,17 @@ describe('RailwaySandbox', () => {
       expect(sentOptions.timeoutSec).toBe(5);
     });
 
+    it('setEnv after construction reaches subsequent commands', async () => {
+      const sandbox = new RailwaySandbox({ token: 't' });
+      await sandbox._start();
+
+      sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+      await sandbox.executeCommand!('echo hello');
+
+      const sentOptions = mockSandbox.exec.mock.calls[0]![1] as { env?: Record<string, string> };
+      expect(sentOptions.env).toEqual(expect.objectContaining({ GH_TOKEN: 'tok_1' }));
+    });
+
     it('restarts a checkpoint-enabled sandbox when it is down before execution', async () => {
       const reconnectedSandbox = {
         ...mockSandbox,

--- a/workspaces/railway/src/sandbox/index.ts
+++ b/workspaces/railway/src/sandbox/index.ts
@@ -196,7 +196,7 @@ export class RailwaySandbox extends MastraSandbox {
     super({
       ...options,
       name: 'RailwaySandbox',
-      processes: new RailwayProcessManager({ env: options.env }),
+      processes: new RailwayProcessManager(),
     });
 
     this.id = options.id ?? this.generateId();
@@ -683,9 +683,10 @@ export class RailwaySandbox extends MastraSandbox {
 
     const fullCommand = args.length > 0 ? `${command} ${args.map(shellQuote).join(' ')}` : command;
     const timeout = options.timeout ?? this._timeout;
-    const env = options.env
+    const mergedEnv = { ...this.getEnv(), ...options.env };
+    const env = Object.keys(mergedEnv).length
       ? Object.fromEntries(
-          Object.entries(options.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+          Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
         )
       : undefined;
     const startedAt = Date.now();

--- a/workspaces/railway/src/sandbox/process-manager.ts
+++ b/workspaces/railway/src/sandbox/process-manager.ts
@@ -130,10 +130,6 @@ class RailwayProcessHandle extends ProcessHandle {
 // Railway Process Manager
 // =============================================================================
 
-export interface RailwayProcessManagerOptions {
-  env?: Record<string, string | undefined>;
-}
-
 /**
  * Railway implementation of SandboxProcessManager.
  * Uses the Railway SDK's `Sandbox.exec()` with one exec per spawned process.
@@ -141,15 +137,11 @@ export interface RailwayProcessManagerOptions {
 export class RailwayProcessManager extends SandboxProcessManager<RailwaySandbox> {
   private _spawnCounter = 0;
 
-  constructor(opts: RailwayProcessManagerOptions = {}) {
-    super({ env: opts.env });
-  }
-
   async spawn(command: string, options: SpawnProcessOptions = {}): Promise<ProcessHandle> {
     const railway = this.sandbox.railway;
 
-    // Merge default env with per-spawn env.
-    const mergedEnv = { ...this.env, ...options.env };
+    // The base spawn wrapper already merged the sandbox env into options.env
+    const mergedEnv = { ...options.env };
     const env = Object.fromEntries(
       Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
     );

--- a/workspaces/vercel/src/microvm/index.test.ts
+++ b/workspaces/vercel/src/microvm/index.test.ts
@@ -318,6 +318,20 @@ describe('VercelSandbox', () => {
       expect(runArgs.cwd).toBe('/app');
       expect(runArgs.env).toEqual({ BASE: '1', EXTRA: '2' });
     });
+
+    it('setEnv after construction reaches subsequent commands', async () => {
+      const fake = makeFakeSandbox({
+        runCommand: vi.fn().mockResolvedValue(makeFinished(0, '')),
+      });
+      createMock.mockResolvedValue(fake);
+
+      const sandbox = new VercelSandbox();
+      sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+      await sandbox.executeCommand('echo', ['ok']);
+
+      const runArgs = (fake.runCommand as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(runArgs.env).toEqual({ GH_TOKEN: 'tok_1' });
+    });
   });
 
   describe('getInfo()', () => {

--- a/workspaces/vercel/src/microvm/index.ts
+++ b/workspaces/vercel/src/microvm/index.ts
@@ -148,7 +148,7 @@ export class VercelSandbox extends MastraSandbox {
     super({
       ...options,
       name: 'VercelSandbox',
-      processes: new VercelSandboxProcessManager({ env: options.env ?? {} }),
+      processes: new VercelSandboxProcessManager(),
     });
 
     this.id = options.id ?? `vercel-sandbox-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
@@ -327,7 +327,8 @@ export class VercelSandbox extends MastraSandbox {
     const fullCommand = args?.length ? `${command} ${args.join(' ')}` : command;
     this.logger.debug(`${LOG_PREFIX} Executing: ${fullCommand}`, { cwd: options?.cwd });
 
-    const mergedEnv = { ...this._env, ...options?.env };
+    // Constructor env seeds the sandbox env, so getEnv() covers it plus any setEnv updates
+    const mergedEnv = { ...this.getEnv(), ...options?.env };
     const env = Object.fromEntries(
       Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
     );

--- a/workspaces/vercel/src/microvm/process-manager.test.ts
+++ b/workspaces/vercel/src/microvm/process-manager.test.ts
@@ -37,9 +37,10 @@ function makeFakeCommand(opts: {
 }
 
 /** Build a fake VercelSandbox exposing a sandbox with runCommand. */
-function makeSandboxStub(runCommand: ReturnType<typeof vi.fn>) {
+function makeSandboxStub(runCommand: ReturnType<typeof vi.fn>, env: Record<string, string> = {}) {
   return {
     ensureRunning: vi.fn().mockResolvedValue(undefined),
+    getEnv: () => ({ ...env }),
     sandbox: { runCommand },
   } as unknown as VercelSandbox;
 }
@@ -56,7 +57,7 @@ describe('VercelSandboxProcessManager', () => {
     });
     const runCommand = vi.fn().mockResolvedValue(command);
 
-    const pm = new VercelSandboxProcessManager({ env: {} });
+    const pm = new VercelSandboxProcessManager();
     pm.sandbox = makeSandboxStub(runCommand);
 
     const handle = await pm.spawn('echo hello');
@@ -101,12 +102,12 @@ describe('VercelSandboxProcessManager', () => {
     expect(kill).toHaveBeenCalledTimes(1);
   });
 
-  it('merges env from manager defaults and spawn options', async () => {
+  it('merges the sandbox env and spawn options env', async () => {
     const { command } = makeFakeCommand({ cmdId: 'cmd-4', exitCode: 0 });
     const runCommand = vi.fn().mockResolvedValue(command);
 
-    const pm = new VercelSandboxProcessManager({ env: { BASE: '1' } });
-    pm.sandbox = makeSandboxStub(runCommand);
+    const pm = new VercelSandboxProcessManager();
+    pm.sandbox = makeSandboxStub(runCommand, { BASE: '1' });
 
     await pm.spawn('node app.js', { cwd: '/app', env: { EXTRA: '2' } });
     const params = runCommand.mock.calls[0]![0];

--- a/workspaces/vercel/src/microvm/process-manager.ts
+++ b/workspaces/vercel/src/microvm/process-manager.ts
@@ -144,17 +144,14 @@ class VercelSandboxProcessHandle extends ProcessHandle {
 // Process Manager
 // =============================================================================
 
-export interface VercelSandboxProcessManagerOptions {
-  env?: Record<string, string | undefined>;
-}
-
 /**
  * Vercel Sandbox implementation of SandboxProcessManager. Uses one detached
  * `runCommand` per spawned process.
  */
 export class VercelSandboxProcessManager extends SandboxProcessManager<VercelSandbox> {
   async spawn(command: string, options: SpawnProcessOptions = {}): Promise<ProcessHandle> {
-    const mergedEnv = { ...this.env, ...options.env };
+    // The base spawn wrapper already merged the sandbox env into options.env
+    const mergedEnv = { ...options.env };
     const env = Object.fromEntries(
       Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
     );

--- a/workspaces/vercel/src/serverless/index.test.ts
+++ b/workspaces/vercel/src/serverless/index.test.ts
@@ -284,6 +284,33 @@ describe('VercelServerlessSandbox', () => {
       expect(executeCall[1]?.headers?.['x-vercel-protection-bypass']).toBe('bypass-token-abc');
     });
 
+    it('setEnv after construction reaches subsequent commands', async () => {
+      mockFetch
+        .mockResolvedValueOnce(createDeploymentResponse('dep-123', 'my-deploy.vercel.app', 'BUILDING'))
+        .mockResolvedValueOnce(createDeploymentResponse('dep-123', 'my-deploy.vercel.app', 'READY'))
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // warm-up
+
+      await startWithTimers(sandbox);
+
+      mockFetch.mockResolvedValueOnce(
+        createExecuteResponse({
+          success: true,
+          exitCode: 0,
+          stdout: 'ok',
+          stderr: '',
+          executionTimeMs: 5,
+          timedOut: false,
+        }),
+      );
+
+      sandbox.setEnv(env => ({ ...env, GH_TOKEN: 'tok_1' }));
+      await sandbox.executeCommand('echo', ['ok']);
+
+      const executeCall = mockFetch.mock.calls[3]!;
+      const body = JSON.parse(executeCall[1]!.body as string) as { env: Record<string, string> };
+      expect(body.env).toEqual({ GH_TOKEN: 'tok_1' });
+    });
+
     it('should skip bypass fetch when projectId is absent', async () => {
       mockFetch
         .mockResolvedValueOnce(createDeploymentResponse('dep-123', 'my-deploy.vercel.app', 'BUILDING'))

--- a/workspaces/vercel/src/serverless/index.ts
+++ b/workspaces/vercel/src/serverless/index.ts
@@ -89,7 +89,7 @@ export class VercelServerlessSandbox extends MastraSandbox {
   private _createdAt: Date | null = null;
 
   constructor(options: VercelServerlessSandboxOptions = {}) {
-    super({ name: 'VercelServerlessSandbox' });
+    super({ name: 'VercelServerlessSandbox', env: options.env });
 
     this.id = `vercel-serverless-sandbox-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
     this._token = options.token || process.env.VERCEL_TOKEN || '';
@@ -283,7 +283,9 @@ export class VercelServerlessSandbox extends MastraSandbox {
     const body = {
       command,
       args: args ?? [],
-      env: options?.env ?? {},
+      // Merge the sandbox env under per-call env — this exec path bypasses the process manager.
+      // JSON.stringify drops undefined values, so unset keys never reach the executor.
+      env: { ...this.getEnv(), ...options?.env },
       cwd: options?.cwd ?? '/tmp',
       timeout: options?.timeout ?? this._commandTimeout,
     };


### PR DESCRIPTION
Stacked on #22250. Makes `setEnv()` from the base `MastraSandbox` actually apply on every workspace sandbox provider.

## What changed

**Process-manager-routed providers** (E2B, Blaxel, Cloudflare, Daytona, Docker, Modal, Vercel microVM spawns): the core spawn wrapper already merges the sandbox env into every spawn, so their duplicated per-manager env plumbing is deleted (pm `env` options, `{ ...this.env, ...options.env }` merges, and redundant provider env fields where they only fed the pm).

**Direct-exec transports** (paths that bypass the process manager) now merge `getEnv()` under per-call env:
- AgentCore `executeCommand` (inline `KEY=value` shell assignments)
- Apple Container `executeCommand` (`--env` CLI flags)
- Railway `executeCommand` (SDK exec)
- Vercel microVM `executeCommand` + Vercel serverless executor POST body
- Platform: one up-front merge in `executeCommand` covers all three transports (private network, Railway WebSocket lease, E2B lease)

**Unchanged**: creation-time env baking (Docker/Modal/Railway/Apple/Vercel/Platform still send ctor env to the VM/container create call), and per-call `env` still wins for that command only. Constructor `env` seeds the runtime env via the base class, so existing merge/precedence tests pass untouched.

## Tests

One `setEnv after construction reaches subsequent commands` conformance test per provider (11 total), pinned against each provider's real wire shape (E2B `envs`, Daytona `export` assignments, Cloudflare argv, Docker `Env` array, Platform `init_exec` frame, etc.). All 11 packages green:

agentcore 19 · apple-container 43 · blaxel 90 · cloudflare 28 · daytona 128 · docker 77 · e2b 146 · modal 39 · platform-workspace 149 · railway 43 · vercel 84

tsc clean on all 11 (apple-container's 6 errors are a pre-existing baseline, verified via stash). oxfmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a sandbox environment changes, later commands now use the new values. Per-command values still override sandbox values.

## Changes

- Updated process-manager providers to use the core environment merge.
- Updated direct-execution providers to merge `getEnv()` with per-command `env`.
- Preserved constructor-time and per-command environment behavior.
- Added regression tests across workspace sandbox providers for `setEnv()` updates.
- Removed the exported `BlaxelProcessManagerOptions` and `RailwayProcessManagerOptions` types.
- Bumped Blaxel and Railway dependencies to minor versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->