### PR TITLE
fix(pg): read json columns holding non-object JSON values

### DIFF
--- a/.changeset/pg-json-scalar-roundtrip.md
+++ b/.changeset/pg-json-scalar-roundtrip.md
@@ -1,0 +1,9 @@
+---
+'@mastra/pg': patch
+---
+
+Fix `PgFactoryStorage` reads of `json` columns holding a JSON value that isn't an object.
+
+node-pg parses JSONB through its own type parsers, so the value reaching row deserialization is already a JS value. Deserialization parsed it a second time when it was a string, which threw and failed the whole read. Objects and arrays came back as JS objects and never hit that branch, so the defect stayed hidden until a caller stored a string.
+
+This surfaced through Factory credential encryption, which stores secrets as an opaque envelope string: saving or reading any credential on Postgres threw `Unexpected token ... is not valid JSON`, affecting model provider credentials, integrations, and custom providers. libsql was unaffected, since it stores `json` columns as text where parsing on read is correct.

--- a/stores/pg/src/storage/factory-storage.test.ts
+++ b/stores/pg/src/storage/factory-storage.test.ts
@@ -88,4 +88,41 @@ describe('PgFactoryStorage capabilities', () => {
     expect(db).toHaveProperty('pool');
     void storage.close();
   });
+
+  // A `json` column may hold any JSON value, not just an object. Encrypted
+  // secrets are stored as an opaque envelope string, which node-pg reads back
+  // as a JS string; a second JSON.parse on that value used to throw and take
+  // the whole row down with it.
+  it('round-trips every JSON value type through a json column', async () => {
+    const storage = new PgFactoryStorage({ connectionString });
+    const table = 'json_value_roundtrip';
+
+    try {
+      await storage.ensureCollections([
+        {
+          name: table,
+          columns: { id: { type: 'uuid-pk' }, label: { type: 'text' }, data: { type: 'json' } },
+        },
+      ]);
+      await storage.ops.deleteMany(table, {});
+      const cases: Array<[string, unknown]> = [
+        ['string', 'mastra:factory-secret:v1:eyJrZXlJZCI6InYxIn0'],
+        ['object', { type: 'api_key', key: 'sk-123' }],
+        ['array', [1, 2, 3]],
+        ['number', 42],
+        ['boolean', true],
+      ];
+
+      for (const [label, data] of cases) {
+        const inserted = await storage.ops.insertOne(table, { label, data });
+        expect(inserted.data, `insertOne returned the wrong value for ${label}`).toEqual(data);
+
+        const found = await storage.ops.findOne<{ data: unknown }>(table, { label });
+        expect(found?.data, `findOne returned the wrong value for ${label}`).toEqual(data);
+      }
+    } finally {
+      await storage.ops.deleteMany(table, {}).catch(() => {});
+      await storage.close();
+    }
+  });
 });

--- a/stores/pg/src/storage/factory-storage.ts
+++ b/stores/pg/src/storage/factory-storage.ts
@@ -156,7 +156,10 @@ class PgFactoryStorageOps implements FactoryStorageOps {
           row[name] = Boolean(value);
           break;
         case 'json':
-          row[name] = typeof value === 'string' ? JSON.parse(value) : value;
+          // node-pg parses JSONB through its type parsers, so `value` is
+          // already the stored JSON value. Parsing again would throw on a JSON
+          // string scalar (the whole column reads back as a JS string).
+          row[name] = value;
           break;
         case 'bigint':
         case 'integer':


### PR DESCRIPTION
Reading a `json` column whose value isn't an object throws in `PgFactoryStorage`, which currently breaks every Factory credential operation on Postgres.

## What's wrong

node-pg parses JSONB through its own type parsers, so the value arriving at `#deserializeRow` is already a JS value. The `json` branch parsed it a second time whenever it was a string:

```ts
row[name] = typeof value === 'string' ? JSON.parse(value) : value;
```

Objects and arrays come back as JS objects and never enter that branch, so the defect stayed invisible. A JSON string scalar comes back as a JS string, gets parsed again, and throws.

## Why it matters now

Factory credential encryption (#22152) is the first caller to store a string in one of these columns: secrets are written as an opaque `mastra:factory-secret:...` envelope. Saving or reading any credential on Postgres now fails with `Unexpected token 'm', "mastra:fac"... is not valid JSON`, across model provider credentials, integrations, and custom providers. In the app this surfaces as a `503 credentials_unavailable`, because the route reports a failed storage handle rather than the underlying error.

libsql is unaffected: it stores `json` columns as text, so parsing on read is correct there. That is also why the existing suites stayed green, since the credentials domain tests run on libsql.

A quieter variant is fixed too. A JSON string whose text happens to be valid JSON, such as `"123"`, was silently parsed into a number instead of returning the string.

## The change

Stop parsing, since node-pg already did it. The branch only ever executed for values that currently throw or decode wrongly, so no working path changes behaviour.

## Test plan

- New contract test round-trips a string, object, array, number, and boolean through a `json` column, asserting both the value returned by `insertOne` and a subsequent `findOne`.
- Verified red/green: with the fix reverted the test fails with the exact production error; with the fix, `pnpm --filter @mastra/pg exec vitest run src/storage/factory-storage.test.ts` passes 28/28.
- Verified against a real Factory database: the credentials domain now initializes, migrates existing plaintext rows to encrypted envelopes, and decrypts all of them back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

PostgreSQL already converts JSON values into normal data. This change stops the storage layer from converting string values a second time, so encrypted credentials and other JSON values work correctly.

## Changes

- Removed redundant `JSON.parse` calls from `PgFactoryStorage`.
- Added contract coverage for JSON strings, objects, arrays, numbers, and booleans.
- Added a patch release note for `@mastra/pg`.
- LibSQL behavior is unchanged.

## Testing

- Passed the PostgreSQL factory storage test suite.
- Verified credential reads against a real Factory database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->