### PR TITLE
Make Factory credential encryption opt-in instead of required at boot

### DIFF
--- a/.changeset/tidy-keys-relax.md
+++ b/.changeset/tidy-keys-relax.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Made secret encryption opt-in instead of mandatory when auth is enabled. `MastraFactory.prepare()` no longer throws when `secretEncryption` is omitted with auth on; it logs a boot-time warning and falls back to plaintext credential storage. Providing `secretEncryption` (for example via `FACTORY_CREDENTIAL_ENCRYPTION_KEY`) remains the recommended configuration for encrypting stored model-provider keys, custom-provider API keys, and integration secrets at rest.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -212,9 +212,15 @@ describe('MastraFactory constructor', () => {
 });
 
 describe('MastraFactory.prepare', () => {
-  it('requires secret encryption when auth is enabled', async () => {
-    const factory = new MastraFactory({ storage: fakeStorage(), auth: fakeProvider() });
-    await expect(factory.prepare()).rejects.toThrow(/secretEncryption.*required/);
+  it('warns and falls back to plaintext when auth is enabled without secret encryption', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const factory = new MastraFactory({ storage: fakeStorage(), auth: fakeProvider() });
+      await expect(factory.prepare()).resolves.toBeDefined();
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/secretEncryption.*not configured/));
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('allows auth-disabled local mode without secret encryption', async () => {

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -169,9 +169,9 @@ export interface MastraFactoryConfig {
   stateSecret?: string;
   /**
    * Encryption boundary for persisted model credentials, custom-provider API
-   * keys, integration connections, and integration settings. Required whenever
-   * auth is enabled. Local no-auth mode (`auth: null`) defaults to explicit
-   * plaintext compatibility when omitted.
+   * keys, integration connections, and integration settings. Strongly
+   * recommended whenever auth is enabled — omitting it falls back to explicit
+   * plaintext compatibility with a boot-time warning.
    */
   secretEncryption?: FactorySecretEncryption;
   /**
@@ -363,7 +363,11 @@ export class MastraFactory {
     const auth: IMastraAuthProvider | undefined =
       configuredAuth === null ? undefined : (configuredAuth ?? buildDefaultStudioAuth(publicOrigin));
     if (auth && !this.#config.secretEncryption) {
-      throw new Error("MastraFactory: 'secretEncryption' is required when auth is enabled.");
+      console.warn(
+        "[factory] auth is enabled but 'secretEncryption' is not configured. Persisted model credentials, " +
+          'custom-provider API keys, and integration secrets will be stored as plaintext. Provide ' +
+          "'secretEncryption' (e.g. via FACTORY_CREDENTIAL_ENCRYPTION_KEY) to encrypt them at rest.",
+      );
     }
     const secretEncryption = this.#config.secretEncryption ?? createPlaintextFactorySecretEncryption();
     // One RouteAuth seam per boot, closed over the resolved provider. Every

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -59,7 +59,12 @@ function decodeCredentialEncryptionKey(name: string, encodedKey: string): Buffer
 function credentialEncryption() {
   const encodedKey = process.env.FACTORY_CREDENTIAL_ENCRYPTION_KEY?.trim();
   if (!encodedKey) {
-    throw new Error('FACTORY_CREDENTIAL_ENCRYPTION_KEY is required when Factory auth is enabled.');
+    console.warn(
+      '[factory] FACTORY_CREDENTIAL_ENCRYPTION_KEY is not set. Stored model-provider keys, custom-provider ' +
+        'API keys, and integration secrets will be persisted as plaintext. Generate a key with ' +
+        '`openssl rand -base64 32` and set FACTORY_CREDENTIAL_ENCRYPTION_KEY to encrypt them at rest.',
+    );
+    return undefined;
   }
 
   const previousKeys: Record<string, unknown> = process.env.FACTORY_CREDENTIAL_ENCRYPTION_PREVIOUS_KEYS


### PR DESCRIPTION
## Summary

Enabling Factory auth previously hard-failed boot with `FACTORY_CREDENTIAL_ENCRYPTION_KEY is required when Factory auth is enabled` (and `MastraFactory: 'secretEncryption' is required when auth is enabled`). Local and self-hosted setups that just turned on sign-in were blocked from starting until they generated and wired an encryption key.

This makes the encryption boundary opt-in:

- `MastraFactory.prepare()` no longer throws when `secretEncryption` is omitted with auth enabled. It logs a loud boot-time warning and falls back to the existing explicit plaintext compatibility mode.
- The web app's `credentialEncryption()` no longer throws when `FACTORY_CREDENTIAL_ENCRYPTION_KEY` is unset; it warns with instructions (`openssl rand -base64 32`) and boots without encryption.
- Configuring the key remains the recommended, documented path for encrypting stored model-provider keys, custom-provider API keys, and integration secrets at rest. Key rotation behavior is unchanged.

## Test plan

- Updated `factory.test.ts`: auth-enabled boot without `secretEncryption` now resolves and emits the warning.
- `pnpm --filter @mastra/factory test src/factory.test.ts` — 74/74 passed.
- `pnpm --filter @mastra/factory build:lib` — passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The app can now start without setting up credential encryption. It warns users that credentials will be stored without encryption and explains how to enable protection.

## Changes

- Made factory credential encryption optional when authentication is enabled.
- Updated `MastraFactory.prepare()` to:
  - Warn when `secretEncryption` is not configured.
  - Use plaintext compatibility mode instead of failing at boot.
- Updated `credentialEncryption()` to:
  - Warn when `FACTORY_CREDENTIAL_ENCRYPTION_KEY` is not set.
  - Provide key-generation instructions.
  - Keep encryption enabled when a key is provided.
- Updated documentation and tests.
- Kept key rotation behavior unchanged.

## Validation

- Tests passed.
- Factory library build passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->