### PR TITLE
Fix docs-diagrams skill frontmatter so it loads under strict YAML parsing

### DIFF
--- a/.claude/skills/docs-diagrams/SKILL.md
+++ b/.claude/skills/docs-diagrams/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: docs-diagrams
-description: Convert existing docs diagram images to Mermaid, and author new Mermaid diagrams for Mastra docs. Use when replacing an Excalidraw or PNG/JPG/SVG diagram with Mermaid, when a docs page needs a new diagram, when a diagram renders wrong in light or dark mode, or when auditing which docs images should become Mermaid. Triggers on: convert diagram, Excalidraw, mermaid, flowchart, diagram image, diagram styling, diagram looks wrong.
+description: >-
+  Convert existing docs diagram images to Mermaid, and author new Mermaid diagrams for Mastra docs. Use when replacing an Excalidraw or PNG/JPG/SVG diagram with Mermaid, when a docs page needs a new diagram, when a diagram renders wrong in light or dark mode, or when auditing which docs images should become Mermaid. Triggers on: convert diagram, Excalidraw, mermaid, flowchart, diagram image, diagram styling, diagram looks wrong.
 ---
 
 # Docs Diagrams


### PR DESCRIPTION
## Summary

WorkspaceSkills failed to load the `docs-diagrams` skill:

```
[WorkspaceSkills] Failed to load skill from .claude/skills: bad indentation of a mapping entry (3:341)
```

The skill's single-line `description` contains `Triggers on:` — a colon followed by a space inside an unquoted YAML scalar — which strict YAML parsers reject as a nested mapping. This converts the description to a folded block scalar (`>-`) so the frontmatter parses cleanly and the skill loads.

## Test plan

- Verified the frontmatter parses with a strict YAML parser and the description value is unchanged.
- Content of the skill body is untouched.