### PR TITLE
Stop internal agent workflows from warning on every resume about unclaimable resume de-duplication

### DIFF
--- a/.changeset/quiet-resume-warns.md
+++ b/.changeset/quiet-resume-warns.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Stopped internal agent-loop workflows from logging a `shouldPersistSnapshot excludes the "running" status` warning on every resume. Workflows can now set `options.allowUnclaimedResumes: true` to acknowledge that resume claims cannot be persisted (because `running` snapshots are intentionally not written) and suppress the per-resume warning; the built-in agentic-loop, agentic-execution, and agent-network workflows opt in. User workflows that exclude `running` without acknowledging still get the warning.

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -2022,6 +2022,9 @@ export async function createNetworkLoop({
     }),
     options: {
       shouldPersistSnapshot: ({ workflowStatus }) => workflowStatus === 'suspended',
+      // Excluding `running` means resume claims cannot persist; suppress the
+      // per-resume warning for this internal workflow.
+      allowUnclaimedResumes: true,
       // Agent-loop snapshots are pure resume artifacts — strip everything a
       // resume never reads before persisting.
       pruneSnapshot: pruneAgentLoopSnapshot,
@@ -2625,6 +2628,9 @@ export async function networkLoop<OUTPUT = undefined>({
     outputSchema: validationStep.outputSchema,
     options: {
       shouldPersistSnapshot: ({ workflowStatus }) => workflowStatus === 'suspended',
+      // Excluding `running` means resume claims cannot persist; suppress the
+      // per-resume warning for this internal workflow.
+      allowUnclaimedResumes: true,
       pruneSnapshot: pruneAgentLoopSnapshot,
       validateInputs: false,
       // Internal agent.network() plumbing — see networkWorkflow above.
@@ -2663,6 +2669,9 @@ export async function networkLoop<OUTPUT = undefined>({
     }),
     options: {
       shouldPersistSnapshot: ({ workflowStatus }) => workflowStatus === 'suspended',
+      // Excluding `running` means resume claims cannot persist; suppress the
+      // per-resume warning for this internal workflow.
+      allowUnclaimedResumes: true,
       pruneSnapshot: pruneAgentLoopSnapshot,
       validateInputs: false,
       // Internal agent.network() plumbing — see networkWorkflow above.

--- a/packages/core/src/loop/workflows/agentic-execution/index.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/index.ts
@@ -106,6 +106,9 @@ export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, 
           params.workflowStatus === 'suspended'
         );
       },
+      // Excluding `running` means resume claims cannot persist; the agent loop
+      // serializes its own resumes, so suppress the per-resume warning.
+      allowUnclaimedResumes: true,
       // Agent-loop snapshots are pure resume artifacts — strip everything a
       // resume never reads (stale suspend payloads, duplicated message
       // arrays, AI SDK step history) before persisting.

--- a/packages/core/src/loop/workflows/agentic-loop/index.ts
+++ b/packages/core/src/loop/workflows/agentic-loop/index.ts
@@ -85,6 +85,9 @@ export function createAgenticLoopWorkflow<Tools extends ToolSet = ToolSet, OUTPU
           params.workflowStatus === 'suspended'
         );
       },
+      // Excluding `running` means resume claims cannot persist; the agent loop
+      // serializes its own resumes, so suppress the per-resume warning.
+      allowUnclaimedResumes: true,
       // Agent-loop snapshots are pure resume artifacts — strip everything a
       // resume never reads (stale suspend payloads, duplicated message
       // arrays, AI SDK step history) before persisting.

--- a/packages/core/src/workflows/concurrent-resume.test.ts
+++ b/packages/core/src/workflows/concurrent-resume.test.ts
@@ -211,6 +211,88 @@ describe('concurrent resume', () => {
     expect(harness.getDownstreamExecutions()).toBe(1);
   });
 
+  function fakeLogger() {
+    return {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trackException: vi.fn(),
+    } as any;
+  }
+
+  function createUnclaimableWorkflow(options: { allowUnclaimedResumes?: boolean }) {
+    const approvalStep = createStep({
+      id: 'approval',
+      inputSchema: z.object({ item: z.string() }),
+      outputSchema: z.object({ approved: z.boolean() }),
+      suspendSchema: z.object({ reason: z.string() }),
+      resumeSchema: z.object({ approved: z.boolean() }),
+      execute: async ({ inputData, resumeData, suspend }) => {
+        if (!resumeData) {
+          await suspend({ reason: `Needs approval: ${inputData.item}` });
+          return { approved: false };
+        }
+        return { approved: resumeData.approved };
+      },
+    });
+
+    const workflow = createWorkflow({
+      id: 'unclaimable-resume-wf',
+      inputSchema: z.object({ item: z.string() }),
+      outputSchema: z.object({ approved: z.boolean() }),
+      options: {
+        validateInputs: false,
+        // Same persistence shape as the internal agent loop: never persist
+        // `running`, so the resume claim cannot be written.
+        shouldPersistSnapshot: ({ workflowStatus }) => workflowStatus !== 'running',
+        ...options,
+      },
+    })
+      .then(approvalStep)
+      .commit();
+    return { workflow };
+  }
+
+  it('warns when shouldPersistSnapshot excludes "running" and the resume cannot be claimed', async () => {
+    const harness = createUnclaimableWorkflow({});
+    const logger = fakeLogger();
+    new Mastra({
+      storage: new MockStore(),
+      workflows: { 'unclaimable-resume-wf': harness.workflow },
+      logger,
+    });
+
+    const run = await harness.workflow.createRun();
+    const started = await run.start({ inputData: { item: 'widget' } });
+    expect(started.status).toBe('suspended');
+
+    const result = await run.resume({ step: 'approval', resumeData: { approved: true } });
+    expect(result.status).toBe('success');
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('cannot be de-duplicated'));
+  });
+
+  it('does not warn when allowUnclaimedResumes acknowledges the unclaimable resume', async () => {
+    const harness = createUnclaimableWorkflow({ allowUnclaimedResumes: true });
+    const logger = fakeLogger();
+    new Mastra({
+      storage: new MockStore(),
+      workflows: { 'unclaimable-resume-wf': harness.workflow },
+      logger,
+    });
+
+    const run = await harness.workflow.createRun();
+    const started = await run.start({ inputData: { item: 'widget' } });
+    expect(started.status).toBe('suspended');
+
+    const result = await run.resume({ step: 'approval', resumeData: { approved: true } });
+    expect(result.status).toBe('success');
+
+    const warnings = logger.warn.mock.calls.map((c: any[]) => String(c[0]));
+    expect(warnings.filter((m: string) => m.includes('cannot be de-duplicated'))).toHaveLength(0);
+  });
+
   it('still resumes normally when there is no contention', async () => {
     const harness = createApprovalWorkflow();
     const { run } = await suspendRun(harness.workflow);

--- a/packages/core/src/workflows/execution-engine.ts
+++ b/packages/core/src/workflows/execution-engine.ts
@@ -37,6 +37,12 @@ export interface ExecutionEngineOptions {
   }) => boolean;
 
   /**
+   * Acknowledges that `resume()` calls cannot be de-duplicated via the persisted
+   * resume claim, suppressing the per-resume warning. See `WorkflowOptions.allowUnclaimedResumes`.
+   */
+  allowUnclaimedResumes?: boolean;
+
+  /**
    * Transforms the run snapshot immediately before it is persisted.
    * Must be pure and return JSON-safe data. Defaults to identity.
    */

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -513,6 +513,16 @@ export interface WorkflowOptions {
   }) => boolean;
 
   /**
+   * Acknowledges that `resume()` calls for this workflow cannot be de-duplicated
+   * via the persisted resume claim (for example because `shouldPersistSnapshot`
+   * excludes the `running` status), and suppresses the per-resume warning.
+   *
+   * Set by internal workflows that intentionally trade resume de-duplication
+   * for reduced snapshot writes and serialize their own resumes.
+   */
+  allowUnclaimedResumes?: boolean;
+
+  /**
    * Transforms the run snapshot immediately before it is persisted.
    * Called at every snapshot persist site (both engines). Must be a pure
    * function returning JSON-safe data — the snapshot may cross a pubsub

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1704,6 +1704,7 @@ export class Workflow<
       validateInputs: options.validateInputs ?? true,
       emitStepEvents: options.emitStepEvents ?? true,
       shouldPersistSnapshot: options.shouldPersistSnapshot ?? (() => true),
+      allowUnclaimedResumes: options.allowUnclaimedResumes,
       pruneSnapshot: options.pruneSnapshot,
       tracingPolicy: options.tracingPolicy,
       onStart: options.onStart,
@@ -4312,11 +4313,16 @@ export class Run<
     });
 
     if (!persistsRunningState) {
-      this.#mastra
-        ?.getLogger()
-        ?.warn(
-          `[Workflow ${this.workflowId}] shouldPersistSnapshot excludes the "running" status, so concurrent resume() calls for run ${this.runId} cannot be de-duplicated. Concurrent resumes may execute downstream steps more than once.`,
-        );
+      // Workflows that acknowledged the trade-off (internal agent loops that
+      // exclude `running` snapshots to avoid write amplification) opt out of
+      // the per-resume warning: it fires on every resume and is not actionable.
+      if (!this.executionEngine.options.allowUnclaimedResumes) {
+        this.#mastra
+          ?.getLogger()
+          ?.warn(
+            `[Workflow ${this.workflowId}] shouldPersistSnapshot excludes the "running" status, so concurrent resume() calls for run ${this.runId} cannot be de-duplicated. Concurrent resumes may execute downstream steps more than once.`,
+          );
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

Since the concurrent-resume claim landed (#21725), every `resume()` of a workflow whose `shouldPersistSnapshot` excludes the `running` status logs:

```
[Workflow agentic-loop] shouldPersistSnapshot excludes the "running" status, so concurrent resume() calls for run ... cannot be de-duplicated. Concurrent resumes may execute downstream steps more than once.
```

The built-in agentic-loop, agentic-execution, and agent-network workflows exclude `running` snapshots deliberately to avoid write amplification, so every agent tool-approval resume spams this unactionable warning twice (outer loop + inner execution workflow).

This adds `WorkflowOptions.allowUnclaimedResumes: true` — an explicit acknowledgment that resume claims cannot be persisted for the workflow, which suppresses the per-resume warning — and sets it on the internal agent-loop workflows. User workflows that exclude `running` without acknowledging keep getting the warning, so the safety signal from #21725 is preserved where it is actionable.

## Test plan

- New tests in `concurrent-resume.test.ts`: an unclaimable workflow still warns by default, and `allowUnclaimedResumes: true` suppresses the warning while resuming successfully (8/8 passed).
- `persist-step-update` and `processor-workflow-storage-noise` suites pass (17/17).
- `pnpm build:core` and ESLint on touched files pass.