### PR TITLE
test(core): cover idempotent channel initialization

### DIFF
--- a/packages/core/src/channels/__tests__/agent-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-channels.test.ts
@@ -303,6 +303,77 @@ describe('AgentChannels', () => {
       expect(agentChannels.sdk).toBeNull();
     });
 
+    it('registers SDK handlers once per instance when initialized repeatedly', async () => {
+      const chatMod = await getChatModule();
+      const registrationMethods = [
+        'onDirectMessage',
+        'onNewMention',
+        'onSubscribedMessage',
+        'onSlashCommand',
+        'onAction',
+      ] as const;
+      const registeredHandlers = new Map<string, Array<(...args: any[]) => unknown>>(
+        registrationMethods.map(method => [method, []]),
+      );
+      const registrationSpies = registrationMethods.map(method =>
+        vi.spyOn(chatMod.Chat.prototype as any, method).mockImplementation((handler: (...args: any[]) => unknown) => {
+          registeredHandlers.get(method)!.push(handler);
+        }),
+      );
+      const db = new InMemoryDB();
+      const memoryStore = new InMemoryMemory({ db });
+      const mockMastra = {
+        getStorage: () => ({ getStore: () => memoryStore }),
+        getServer: () => null,
+      } as any;
+
+      try {
+        await agentChannels.initialize(mockMastra);
+        await agentChannels.initialize(mockMastra);
+
+        for (const method of registrationMethods) {
+          expect(registeredHandlers.get(method), method).toHaveLength(1);
+        }
+
+        const chatThread = {
+          id: 'channel-1:thread-1',
+          channelId: 'channel-1',
+          isDM: true,
+          adapter: agentChannels.adapters.discord,
+          isSubscribed: vi.fn().mockResolvedValue(true),
+          subscribe: vi.fn().mockResolvedValue(undefined),
+          mentionUser: vi.fn((userId: string) => `<@${userId}>`),
+          messages: (async function* () {})(),
+        } as any;
+        const message = {
+          id: 'message-1',
+          text: 'hello',
+          author: { userId: 'user-1', userName: 'tyler', fullName: 'Tyler Barnes' },
+          attachments: [],
+        } as any;
+
+        await registeredHandlers.get('onDirectMessage')![0]!(chatThread, message);
+        expect(mockAgent.sendMessage).toHaveBeenCalledTimes(1);
+
+        const secondAgent = createMockAgent('second-agent');
+        const secondChannels = new AgentChannels({ adapters: { discord: createMockAdapter('discord') } });
+        secondChannels.__setAgent(secondAgent);
+        await secondChannels.initialize(mockMastra);
+
+        for (const method of registrationMethods) {
+          expect(registeredHandlers.get(method), method).toHaveLength(2);
+        }
+        await registeredHandlers.get('onDirectMessage')![1]!(
+          { ...chatThread, adapter: secondChannels.adapters.discord },
+          message,
+        );
+        expect(secondAgent.sendMessage).toHaveBeenCalledTimes(1);
+        expect(mockAgent.sendMessage).toHaveBeenCalledTimes(1);
+      } finally {
+        for (const spy of registrationSpies) spy.mockRestore();
+      }
+    });
+
     it('returns Chat instance after initialization', async () => {
       const db = new InMemoryDB();
       const memoryStore = new InMemoryMemory({ db });


### PR DESCRIPTION
## Description

Adds focused regression coverage for idempotent `AgentChannels.initialize()` calls. The test verifies that the five Chat SDK handler types register once for repeated initialization of the same instance, exercises a captured direct-message handler once, and confirms a separate instance registers independently. No production code changes are included.

Validation:
- `pnpm --filter ./packages/core exec vitest run src/channels/__tests__/agent-channels.test.ts` (62 passed)
- `pnpm --filter ./packages/core check`
- focused Oxfmt, Oxlint, and ESLint checks

`pnpm build:core` emitted successful build completion output locally, but did not exit because `tsdown --no-dts` retained an idle process handle.

## Related issue(s)

Fixes #22199

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (not applicable for this test-only change)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds tests to ensure starting the same `AgentChannels` instance twice does not create duplicate handlers. It also confirms that separate instances work independently.

## Changes

- Added regression coverage for idempotent `AgentChannels.initialize()` calls.
- Verified all five Chat SDK handler types register once per instance.
- Verified direct messages invoke the owning agent once.
- Verified separate `AgentChannels` instances register independently.
- Added no production code changes.

## Validation

- Core tests
- Type checking
- Formatting
- Linting
- ESLint checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->