### PR TITLE
fix(playground): refresh working memory after an om-observation cycle

### DIFF
--- a/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useChatMessages, useChatRunning, useChatSend } from '../chat-context';
 import { ChatProvider } from '../chat-provider';
-import { WorkingMemoryProvider } from '@/domains/agents/context/agent-working-memory-context';
+import { useWorkingMemory, WorkingMemoryProvider } from '@/domains/agents/context/agent-working-memory-context';
 import { PlaygroundModelProvider, usePlaygroundModel } from '@/domains/agents/context/playground-model-context';
 import { server } from '@/test/msw-server';
 
@@ -480,8 +480,10 @@ describe('ChatProvider', () => {
     ] satisfies MastraDBMessage[];
 
     const bufferStatusRequests: string[] = [];
+    // A separate use() call is required for the working-memory endpoint to
+    // outrank the base handler.
+    server.use(...baseHandlers([]));
     server.use(
-      ...baseHandlers([]),
       http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: { observationalMemory: true } })),
       http.post(`${BASE_URL}/api/memory/observational-memory/buffer-status`, ({ request }) => {
         bufferStatusRequests.push(request.url);
@@ -570,8 +572,10 @@ describe('ChatProvider', () => {
     ] satisfies MastraDBMessage[];
 
     const bufferStatusRequests: string[] = [];
+    // A separate use() call is required for the working-memory endpoint to
+    // outrank the base handler.
+    server.use(...baseHandlers([]));
     server.use(
-      ...baseHandlers([]),
       http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: { observationalMemory: true } })),
       http.post(`${BASE_URL}/api/memory/observational-memory/buffer-status`, ({ request }) => {
         bufferStatusRequests.push(request.url);
@@ -746,5 +750,59 @@ describe('ChatProvider', () => {
     expect(omRequests.length).toBeGreaterThan(1);
     expect(messageRequests.length).toBeGreaterThan(1);
     expect(messageRequests.every(url => url.includes('/threads/thread-1/messages'))).toBe(true);
+  });
+
+  it('refetches working memory after awaited OM buffering completes so the provider shows the persisted value without a remount', async () => {
+    // OM persists working memory asynchronously, after the chat stream ends.
+    // The endpoint serves the stale value until buffer-status resolves, then
+    // the persisted one.
+    let bufferingComplete = false;
+
+    const WorkingMemoryProbe = () => {
+      const { workingMemoryData } = useWorkingMemory();
+      return <div data-testid="wm-data">{workingMemoryData ?? 'no-working-memory'}</div>;
+    };
+
+    server.use(...baseHandlers([]));
+    server.use(
+      http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: { observationalMemory: true } })),
+      http.post(`${BASE_URL}/api/memory/observational-memory/buffer-status`, () => {
+        bufferingComplete = true;
+        return HttpResponse.json({ record: null });
+      }),
+      http.get(`${BASE_URL}/api/memory/threads/thread-1/working-memory`, () =>
+        HttpResponse.json(
+          bufferingComplete
+            ? {
+                workingMemory: 'responseFormat: bullet list',
+                source: 'resource',
+                workingMemoryTemplate: null,
+                threadExists: true,
+              }
+            : { workingMemory: null, source: 'resource', workingMemoryTemplate: null, threadExists: true },
+        ),
+      ),
+      http.post(`${BASE_URL}/api/agents/agent-1/stream`, () => omObservationEndResponse()),
+    );
+
+    await act(async () => {
+      render(
+        <Wrapper>
+          <ChatProvider agentId="agent-1" threadId="thread-1" initialMessages={[]}>
+            <WorkingMemoryProbe />
+            <SendOnMount text="trigger WM extraction" />
+          </ChatProvider>
+        </Wrapper>,
+      );
+    });
+
+    await screen.findByTestId('wm-data');
+    expect(screen.getByTestId('wm-data').textContent).not.toBe('responseFormat: bullet list');
+
+    // The inline observation-end refresh fires before buffer-status resolves,
+    // so only the awaited-buffering refresh can surface the new value.
+    await waitFor(() => expect(screen.getByTestId('wm-data').textContent).toBe('responseFormat: bullet list'), {
+      timeout: 2000,
+    });
   });
 });

--- a/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
@@ -15,6 +15,7 @@ import { useChatMessages, useChatRunning, useChatSend } from '../chat-context';
 import { ChatProvider } from '../chat-provider';
 import { useWorkingMemory, WorkingMemoryProvider } from '@/domains/agents/context/agent-working-memory-context';
 import { PlaygroundModelProvider, usePlaygroundModel } from '@/domains/agents/context/playground-model-context';
+import { useMemoryConfig } from '@/domains/memory/hooks/use-memory';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';
@@ -123,6 +124,14 @@ const workingMemoryResponse = (
   threadExists: false,
   ...options,
 });
+
+const createDeferred = () => {
+  let resolveRef: (() => void) | undefined;
+  const promise = new Promise<void>(resolve => {
+    resolveRef = () => resolve();
+  });
+  return { promise, resolve: () => resolveRef?.() };
+};
 
 // Background queries fired by the real provider stack (memory config, working
 // memory, thread-signal subscribe). They're not under test here but must be
@@ -767,11 +776,16 @@ describe('ChatProvider', () => {
     let bufferingComplete = false;
     const wmRequestPhases: string[] = [];
 
+    // Hold the observation-end event until the initial stale response has rendered.
+    const staleWmValueRendered = createDeferred();
+
     const WorkingMemoryProbe = () => {
       const { workingMemoryData } = useWorkingMemory();
       return <div data-testid="wm-data">{workingMemoryData ?? 'no-working-memory'}</div>;
     };
 
+    // The working-memory overrides need their own use() call; merged into one,
+    // the base param-route handler keeps winning over these literals.
     server.use(...baseHandlers([]));
     server.use(
       http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: { observationalMemory: true } })),
@@ -795,7 +809,7 @@ describe('ChatProvider', () => {
             new ReadableStream<Uint8Array>({
               async start(controller) {
                 const encoder = new TextEncoder();
-                await new Promise(resolve => setTimeout(resolve, 120));
+                await staleWmValueRendered.promise;
                 observationEndEmitted = true;
                 controller.enqueue(
                   encoder.encode(
@@ -825,6 +839,8 @@ describe('ChatProvider', () => {
     await screen.findByTestId('wm-data');
     expect(screen.getByTestId('wm-data').textContent).not.toBe('responseFormat: bullet list');
 
+    staleWmValueRendered.resolve();
+
     await waitFor(() => expect(screen.getByTestId('wm-data').textContent).toBe('responseFormat: bullet list'), {
       timeout: 2000,
     });
@@ -838,12 +854,27 @@ describe('ChatProvider', () => {
     // The endpoint serves the stale value until buffer-status resolves, then
     // the persisted one.
     let bufferingComplete = false;
+    let observationEndEmitted = false;
+    const wmServedValues: string[] = [];
+
+    // Hold the observation-end event until the initial stale response has
+    // rendered, then hold finish until that event's refetch has been served.
+    const staleWmValueRendered = createDeferred();
+    const obsEndRefetchServedStale = createDeferred();
 
     const WorkingMemoryProbe = () => {
       const { workingMemoryData } = useWorkingMemory();
       return <div data-testid="wm-data">{workingMemoryData ?? 'no-working-memory'}</div>;
     };
+    // The awaited-buffering path is gated on the memory config having loaded,
+    // so the gate below must not open before that response has landed either.
+    const OmConfigProbe = () => {
+      const { data } = useMemoryConfig('agent-1');
+      return <div data-testid="om-config">{String(data?.config?.observationalMemory)}</div>;
+    };
 
+    // The working-memory overrides need their own use() call; merged into one,
+    // the base param-route handler keeps winning over these literals.
     server.use(...baseHandlers([]));
     server.use(
       http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: { observationalMemory: true } })),
@@ -851,15 +882,41 @@ describe('ChatProvider', () => {
         bufferingComplete = true;
         return HttpResponse.json({ record: null });
       }),
-      http.get(`${BASE_URL}/api/memory/threads/thread-1/working-memory`, () =>
-        HttpResponse.json(
-          workingMemoryResponse(bufferingComplete ? 'responseFormat: bullet list' : null, {
+      http.get(`${BASE_URL}/api/memory/threads/thread-1/working-memory`, () => {
+        const value = bufferingComplete ? 'responseFormat: bullet list' : null;
+        wmServedValues.push(value === null ? 'stale' : 'fresh');
+        if (observationEndEmitted) {
+          obsEndRefetchServedStale.resolve();
+        }
+        return HttpResponse.json(
+          workingMemoryResponse(value, {
             source: 'resource',
             threadExists: true,
           }),
-        ),
+        );
+      }),
+      http.post(
+        `${BASE_URL}/api/agents/agent-1/stream`,
+        () =>
+          new HttpResponse(
+            new ReadableStream<Uint8Array>({
+              async start(controller) {
+                const encoder = new TextEncoder();
+                await staleWmValueRendered.promise;
+                observationEndEmitted = true;
+                controller.enqueue(
+                  encoder.encode(
+                    `data: ${JSON.stringify({ type: 'data-om-observation-end', data: { operationType: 'observation' } })}\n\n`,
+                  ),
+                );
+                await obsEndRefetchServedStale.promise;
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'finish', payload: {} })}\n\n`));
+                controller.close();
+              },
+            }),
+            { status: 200, headers: { 'content-type': 'text/event-stream' } },
+          ),
       ),
-      http.post(`${BASE_URL}/api/agents/agent-1/stream`, () => omObservationEndResponse()),
     );
 
     await act(async () => {
@@ -867,6 +924,7 @@ describe('ChatProvider', () => {
         <Wrapper>
           <ChatProvider agentId="agent-1" threadId="thread-1" initialMessages={[]}>
             <WorkingMemoryProbe />
+            <OmConfigProbe />
             <SendOnMount text="trigger WM extraction" />
           </ChatProvider>
         </Wrapper>,
@@ -875,11 +933,17 @@ describe('ChatProvider', () => {
 
     await screen.findByTestId('wm-data');
     expect(screen.getByTestId('wm-data').textContent).not.toBe('responseFormat: bullet list');
+    await screen.findByTestId('om-config');
+    expect(screen.getByTestId('om-config').textContent).toBe('true');
 
-    // The inline observation-end refresh fires before buffer-status resolves,
-    // so only the awaited-buffering refresh can surface the new value.
+    staleWmValueRendered.resolve();
+
     await waitFor(() => expect(screen.getByTestId('wm-data').textContent).toBe('responseFormat: bullet list'), {
       timeout: 2000,
     });
+    // The persisted value arrived via a separate post-buffering request: the
+    // mount and the observation-end refetch were both served stale.
+    expect(wmServedValues.filter(value => value === 'stale').length).toBeGreaterThanOrEqual(2);
+    expect(wmServedValues.at(-1)).toBe('fresh');
   });
 });

--- a/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
@@ -1,3 +1,4 @@
+import type { RouteResponse } from '@mastra/client-js';
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import { useMemoryThreadMessages } from '@mastra/playground-ui/domains/memory/hooks/use-memory-thread-messages';
 import { useObservationalMemory } from '@mastra/playground-ui/domains/memory/hooks/use-observational-memory';
@@ -110,8 +111,18 @@ const omObservationWithExtractionResponse = () =>
     headers: { 'content-type': 'text/event-stream' },
   });
 
-const workingMemoryResponse = () =>
-  HttpResponse.json({ workingMemory: null, source: 'thread', workingMemoryTemplate: null, threadExists: false });
+type WorkingMemoryResponse = RouteResponse<'GET /memory/threads/:threadId/working-memory'>;
+
+const workingMemoryResponse = (
+  workingMemory: unknown = null,
+  options: Partial<WorkingMemoryResponse> = {},
+): WorkingMemoryResponse => ({
+  workingMemory,
+  source: 'thread',
+  workingMemoryTemplate: null,
+  threadExists: false,
+  ...options,
+});
 
 // Background queries fired by the real provider stack (memory config, working
 // memory, thread-signal subscribe). They're not under test here but must be
@@ -119,7 +130,7 @@ const workingMemoryResponse = () =>
 const baseHandlers = (_captured: Captured[]) => [
   http.get(`${BASE_URL}/api/auth/me`, () => HttpResponse.json({ id: 'user-1' })),
   http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: {} })),
-  http.get(`${BASE_URL}/api/memory/threads/:threadId/working-memory`, () => workingMemoryResponse()),
+  http.get(`${BASE_URL}/api/memory/threads/:threadId/working-memory`, () => HttpResponse.json(workingMemoryResponse())),
   http.post(
     `${BASE_URL}/api/agents/:agentId/threads/subscribe`,
     () =>
@@ -748,6 +759,80 @@ describe('ChatProvider', () => {
     expect(messageRequests.every(url => url.includes('/threads/thread-1/messages'))).toBe(true);
   });
 
+  it('refetches working memory on an OM observation-end event so the provider shows the persisted value without a remount', async () => {
+    // OM can persist working memory server-side with no tool call in the
+    // stream. The endpoint flips once the observation-end event has been
+    // emitted, before buffer-status resolves.
+    let observationEndEmitted = false;
+    let bufferingComplete = false;
+    const wmRequestPhases: string[] = [];
+
+    const WorkingMemoryProbe = () => {
+      const { workingMemoryData } = useWorkingMemory();
+      return <div data-testid="wm-data">{workingMemoryData ?? 'no-working-memory'}</div>;
+    };
+
+    server.use(...baseHandlers([]));
+    server.use(
+      http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: { observationalMemory: true } })),
+      http.post(`${BASE_URL}/api/memory/observational-memory/buffer-status`, () => {
+        bufferingComplete = true;
+        return HttpResponse.json({ record: null });
+      }),
+      http.get(`${BASE_URL}/api/memory/threads/thread-1/working-memory`, () => {
+        wmRequestPhases.push(bufferingComplete ? 'buffered' : observationEndEmitted ? 'observed' : 'mount');
+        return HttpResponse.json(
+          workingMemoryResponse(observationEndEmitted ? 'responseFormat: bullet list' : null, {
+            source: 'resource',
+            threadExists: true,
+          }),
+        );
+      }),
+      http.post(
+        `${BASE_URL}/api/agents/agent-1/stream`,
+        () =>
+          new HttpResponse(
+            new ReadableStream<Uint8Array>({
+              async start(controller) {
+                const encoder = new TextEncoder();
+                await new Promise(resolve => setTimeout(resolve, 120));
+                observationEndEmitted = true;
+                controller.enqueue(
+                  encoder.encode(
+                    `data: ${JSON.stringify({ type: 'data-om-observation-end', data: { operationType: 'observation' } })}\n\n`,
+                  ),
+                );
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'finish', payload: {} })}\n\n`));
+                controller.close();
+              },
+            }),
+            { status: 200, headers: { 'content-type': 'text/event-stream' } },
+          ),
+      ),
+    );
+
+    await act(async () => {
+      render(
+        <Wrapper>
+          <ChatProvider agentId="agent-1" threadId="thread-1" initialMessages={[]}>
+            <WorkingMemoryProbe />
+            <SendOnMount text="trigger WM extraction" />
+          </ChatProvider>
+        </Wrapper>,
+      );
+    });
+
+    await screen.findByTestId('wm-data');
+    expect(screen.getByTestId('wm-data').textContent).not.toBe('responseFormat: bullet list');
+
+    await waitFor(() => expect(screen.getByTestId('wm-data').textContent).toBe('responseFormat: bullet list'), {
+      timeout: 2000,
+    });
+    // A fetch in the observed phase can only come from the observation-end
+    // refresh, so it must have fired before buffering completed.
+    expect(wmRequestPhases).toContain('observed');
+  });
+
   it('refetches working memory after awaited OM buffering completes so the provider shows the persisted value without a remount', async () => {
     // OM persists working memory asynchronously, after the chat stream ends.
     // The endpoint serves the stale value until buffer-status resolves, then
@@ -768,14 +853,10 @@ describe('ChatProvider', () => {
       }),
       http.get(`${BASE_URL}/api/memory/threads/thread-1/working-memory`, () =>
         HttpResponse.json(
-          bufferingComplete
-            ? {
-                workingMemory: 'responseFormat: bullet list',
-                source: 'resource',
-                workingMemoryTemplate: null,
-                threadExists: true,
-              }
-            : { workingMemory: null, source: 'resource', workingMemoryTemplate: null, threadExists: true },
+          workingMemoryResponse(bufferingComplete ? 'responseFormat: bullet list' : null, {
+            source: 'resource',
+            threadExists: true,
+          }),
         ),
       ),
       http.post(`${BASE_URL}/api/agents/agent-1/stream`, () => omObservationEndResponse()),

--- a/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
@@ -480,10 +480,8 @@ describe('ChatProvider', () => {
     ] satisfies MastraDBMessage[];
 
     const bufferStatusRequests: string[] = [];
-    // A separate use() call is required for the working-memory endpoint to
-    // outrank the base handler.
-    server.use(...baseHandlers([]));
     server.use(
+      ...baseHandlers([]),
       http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: { observationalMemory: true } })),
       http.post(`${BASE_URL}/api/memory/observational-memory/buffer-status`, ({ request }) => {
         bufferStatusRequests.push(request.url);
@@ -572,10 +570,8 @@ describe('ChatProvider', () => {
     ] satisfies MastraDBMessage[];
 
     const bufferStatusRequests: string[] = [];
-    // A separate use() call is required for the working-memory endpoint to
-    // outrank the base handler.
-    server.use(...baseHandlers([]));
     server.use(
+      ...baseHandlers([]),
       http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: { observationalMemory: true } })),
       http.post(`${BASE_URL}/api/memory/observational-memory/buffer-status`, ({ request }) => {
         bufferStatusRequests.push(request.url);

--- a/packages/playground/src/lib/ai-ui/chat/use-chat-send-handler.ts
+++ b/packages/playground/src/lib/ai-ui/chat/use-chat-send-handler.ts
@@ -201,10 +201,15 @@ export const useChatSendHandler = ({
           // Refetch the panel again once buffering completes, so any records that
           // only landed after awaitBufferStatus resolved are reflected immediately.
           refreshTimelinePanel(currentThreadId);
+          // OM's working-memory extractor persists server-side during this async
+          // buffering cycle, often after the chat stream has ended. Without this
+          // refresh the Working Memory sidebar keeps its pre-run value until a
+          // page reload.
+          void refreshWorkingMemory?.();
         })
         .catch(() => {});
     },
-    [agentId, baseClient, queryClient, refreshTimelinePanel, setMessages],
+    [agentId, baseClient, queryClient, refreshTimelinePanel, refreshWorkingMemory, setMessages],
   );
 
   const handleHandledChunk = useCallback(
@@ -228,8 +233,21 @@ export const useChatSendHandler = ({
       if (handled?.type === 'data-om-activation') {
         handleActivation(handled.data);
       }
+      // Observational Memory can persist working memory server-side via its
+      // working-memory extractor, with no tool call in the chat stream. Refresh
+      // it whenever an observation cycle lands so the sidebar stays current.
+      if (handled?.type === 'data-om-observation-end') {
+        void refreshWorkingMemory?.();
+      }
     },
-    [handleActivation, handleObservationStart, handleProgressUpdate, refreshObservationalMemory, setStreamErrors],
+    [
+      handleActivation,
+      handleObservationStart,
+      handleProgressUpdate,
+      refreshObservationalMemory,
+      refreshWorkingMemory,
+      setStreamErrors,
+    ],
   );
 
   const send = useCallback(


### PR DESCRIPTION
## Description

When OM manages working memory, the sidebar never refreshed — updates persist server-side without any tool call, so nothing in the stream told the UI to refetch and it stayed stale until a page reload.

Now refreshing on data-om-observation-end and again after awaited buffering completes, since extraction can land even after the stream ends. Added a couple of msw tests for both paths.

## Related issue(s)

Fixes #22226 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When observational memory changes working memory, the Playground now shows the new value automatically. Users no longer need to refresh the page.

## Changes

- Refresh working memory when `data-om-observation-end` is received.
- Refresh working memory after awaited observational-memory buffering completes.
- Add MSW tests for both refresh paths.
- Verify updates without remounting the provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->