### PR TITLE
fix(duckdb): stop vss extension downloads from timing out store tests

### DIFF
--- a/stores/duckdb/vitest.config.ts
+++ b/stores/duckdb/vitest.config.ts
@@ -4,6 +4,11 @@ export default defineConfig({
   test: {
     name: 'e2e:stores/duckdb',
     environment: 'node',
+    // The first DuckDBVector operation runs `INSTALL vss;`, which downloads the
+    // extension over the network (once per worker process) and can exceed the
+    // default 10s/5s vitest timeouts in CI.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
     include: ['src/**/*.test.ts'],
     coverage: {
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

The `Combined Store Tests / test (duckdb)` job is intermittently failing (currently blocking the alpha release PR #22241) with:

```
FAIL src/__tests__/duckdb-vector.test.ts > DuckDBVector > Filter Operators - $contains
Error: Hook timed out in 10000ms.
```

Root cause: the first `DuckDBVector` operation in each vitest worker process runs `INSTALL vss;`, which downloads the DuckDB VSS extension over the network. In CI that download (plus extension-cache lock contention between parallel workers) can exceed vitest's default 10s hook timeout, so the `beforeEach` that calls `createIndex` times out before the extension finishes installing.

This raises `testTimeout`/`hookTimeout` to 60s in `stores/duckdb/vitest.config.ts`, matching the convention already used by the elasticsearch (30s), mongodb (30s), and redis/valkey (200s) store configs. No product code changes.

## Test plan

- `pnpm vitest run src/__tests__/duckdb-vector.test.ts` in `stores/duckdb`: 137/137 pass locally
- CI `Combined Store Tests / test (duckdb)` on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

DuckDB tests sometimes need extra time to download and install a required extension. This change gives those tests more time so they do not fail randomly.

## Changes

- Increased `testTimeout` from 10 seconds to 60 seconds.
- Increased `hookTimeout` from 10 seconds to 60 seconds.
- Updated `stores/duckdb/vitest.config.ts`.
- No product code changes.

## Validation

- DuckDB vector tests pass locally: 137/137.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->