### PR TITLE
feat(playground-ui): keyboard shortcut hook with roving-tabindex table navigation

### DIFF
--- a/.changeset/brave-toys-scream.md
+++ b/.changeset/brave-toys-scream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added a `useKeydown` hook for keyboard shortcuts (single keys and modifier combos like `mod+k`) and a `useTableKeydown` hook for accessible roving-tabindex navigation in tables and lists (arrow keys, PageUp/PageDown, Home/End).

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -64,6 +64,16 @@
         "default": "./dist/primitives/*.cjs.js"
       }
     },
+    "./keyboard/*": {
+      "import": {
+        "types": "./dist/keyboard/*.d.ts",
+        "default": "./dist/keyboard/*.es.js"
+      },
+      "require": {
+        "types": "./dist/keyboard/*.d.ts",
+        "default": "./dist/keyboard/*.cjs.js"
+      }
+    },
     "./resize/*": {
       "import": {
         "types": "./dist/resize/*.d.ts",

--- a/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Columns3Icon, Pencil, Trash2 } from 'lucide-react';
-import { forwardRef, useCallback, useMemo, useState } from 'react';
+import { forwardRef, useCallback, useMemo, useRef, useState } from 'react';
 import { DataList } from './data-list';
 import type { DataListStickyHeaderBackground, DataListVariant } from './data-list-root';
 import { DataListSkeleton } from './data-list-skeleton';
@@ -9,6 +9,7 @@ import { Badge } from '@/ds/components/Badge';
 import { Button } from '@/ds/components/Button';
 import { DropdownMenu } from '@/ds/components/DropdownMenu';
 import type { LinkComponent } from '@/ds/types/link-component';
+import { useTableKeydown } from '@/lib/keyboard';
 
 type DataListStoryArgs = {
   variant: DataListVariant;
@@ -689,5 +690,52 @@ export const ScoresTable: Story = {
         </ScoresDataList>
       </div>
     );
+  },
+};
+
+/**
+ * Accessible keyboard navigation via `useTableKeydown` (roving tabindex).
+ * Tab into the list to land on the active row, then use ArrowUp/ArrowDown,
+ * Home/End, and PageUp/PageDown to move focus. Tab leaves the list in one stop.
+ */
+export const KeyboardNavigation: Story = {
+  render: ({ variant }) => {
+    const KeyboardNavExample = () => {
+      const containerRef = useRef<HTMLDivElement | null>(null);
+      const { activeIndex, getRowProps } = useTableKeydown({
+        count: SAMPLE_RUNS.length,
+        containerRef,
+      });
+
+      return (
+        <div ref={containerRef}>
+          <DataList columns={COMPACT_COLUMNS} variant={variant}>
+            <DataList.Top>
+              <DataList.TopCell>ID</DataList.TopCell>
+              <DataList.TopCell>Input</DataList.TopCell>
+              <DataList.TopCell>Status</DataList.TopCell>
+              <DataList.TopCell>Date</DataList.TopCell>
+              <DataList.TopCell>Time</DataList.TopCell>
+            </DataList.Top>
+            {SAMPLE_RUNS.map((run, index) => (
+              <DataList.RowButton
+                key={run.id}
+                featured={index === activeIndex}
+                onClick={() => {}}
+                {...getRowProps(index)}
+              >
+                <DataList.IdCell id={run.id} />
+                <DataList.MonoCell>{run.input}</DataList.MonoCell>
+                <DataList.Cell height="compact">{run.status}</DataList.Cell>
+                <DataList.DateCell timestamp={run.createdAt} />
+                <DataList.TimeCell timestamp={run.createdAt} />
+              </DataList.RowButton>
+            ))}
+          </DataList>
+        </div>
+      );
+    };
+
+    return <KeyboardNavExample />;
   },
 };

--- a/packages/playground-ui/src/lib/keyboard/index.ts
+++ b/packages/playground-ui/src/lib/keyboard/index.ts
@@ -1,0 +1,1 @@
+export * from './use-keydown';

--- a/packages/playground-ui/src/lib/keyboard/use-keydown.test.tsx
+++ b/packages/playground-ui/src/lib/keyboard/use-keydown.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { renderHook, fireEvent } from '@testing-library/react';
+import { renderHook, render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { useRef } from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
 import { useKeydown, useTableKeydown } from './use-keydown';
@@ -9,6 +10,7 @@ const pressKey = (key: string, modifiers: Partial<KeyboardEventInit> = {}) => {
 };
 
 afterEach(() => {
+  cleanup();
   vi.unstubAllGlobals();
 });
 
@@ -151,41 +153,224 @@ describe('useKeydown', () => {
   });
 });
 
+describe('useKeydown with a scoped target', () => {
+  const ScopedHarness = ({ onHit }: { onHit: () => void }) => {
+    const ref = useRef<HTMLDivElement | null>(null);
+    useKeydown({ ArrowDown: onHit }, { target: ref });
+    return (
+      <div ref={ref} data-testid="scope">
+        <button data-testid="inside">inside</button>
+      </div>
+    );
+  };
+
+  it('fires when the key is pressed inside the target', () => {
+    const onHit = vi.fn();
+    render(
+      <div>
+        <ScopedHarness onHit={onHit} />
+        <button data-testid="outside">outside</button>
+      </div>,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('inside'), { key: 'ArrowDown' });
+
+    expect(onHit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when the key is pressed outside the target', () => {
+    const onHit = vi.fn();
+    render(
+      <div>
+        <ScopedHarness onHit={onHit} />
+        <button data-testid="outside">outside</button>
+      </div>,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('outside'), { key: 'ArrowDown' });
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+
+    expect(onHit).not.toHaveBeenCalled();
+  });
+});
+
+type TableHarnessProps = {
+  count: number;
+  pageSize?: number;
+  onActivate?: (index: number) => void;
+  onNavigate?: (index: number) => void;
+};
+
+const TableHarness = ({ count, pageSize, onActivate, onNavigate }: TableHarnessProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const { activeIndex, getRowProps, getContainerProps } = useTableKeydown({
+    count,
+    containerRef,
+    pageSize,
+    onActivate,
+    onNavigate,
+  });
+
+  return (
+    <div ref={containerRef} data-testid="table" {...getContainerProps()}>
+      <span data-testid="active-index">{activeIndex}</span>
+      {Array.from({ length: count }, (_, i) => (
+        <button key={i} data-testid={`row-${i}`} {...getRowProps(i)}>
+          Row {i}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+const row = (i: number) => screen.getByTestId(`row-${i}`);
+const activeIndexOf = () => Number(screen.getByTestId('active-index').textContent);
+const pressOnRow = (i: number, key: string, modifiers: Partial<KeyboardEventInit> = {}) => {
+  fireEvent.keyDown(row(i), { key, ...modifiers });
+};
+
 describe('useTableKeydown', () => {
-  it('starts at index 0', () => {
-    const { result } = renderHook(() => useTableKeydown(3));
+  it('starts at index 0 with only the active row tabbable', () => {
+    render(<TableHarness count={3} />);
 
-    expect(result.current.activeIndex).toBe(0);
+    expect(activeIndexOf()).toBe(0);
+    expect(row(0).tabIndex).toBe(0);
+    expect(row(1).tabIndex).toBe(-1);
+    expect(row(2).tabIndex).toBe(-1);
   });
 
-  it('moves down with ArrowDown and wraps around', () => {
-    const { result } = renderHook(() => useTableKeydown(3));
+  it('moves down with ArrowDown and moves DOM focus to the new row', () => {
+    render(<TableHarness count={3} />);
+    row(0).focus();
 
-    pressKey('ArrowDown');
-    expect(result.current.activeIndex).toBe(1);
+    pressOnRow(0, 'ArrowDown');
 
-    pressKey('ArrowDown');
-    pressKey('ArrowDown');
-    expect(result.current.activeIndex).toBe(0);
+    expect(activeIndexOf()).toBe(1);
+    expect(document.activeElement).toBe(row(1));
+    expect(row(1).tabIndex).toBe(0);
+    expect(row(0).tabIndex).toBe(-1);
   });
 
-  it('moves up with ArrowUp and wraps around', () => {
-    const { result } = renderHook(() => useTableKeydown(3));
+  it('moves up with ArrowUp', () => {
+    render(<TableHarness count={3} />);
+    row(0).focus();
+    pressOnRow(0, 'ArrowDown');
+    pressOnRow(1, 'ArrowUp');
 
-    pressKey('ArrowUp');
-    expect(result.current.activeIndex).toBe(2);
+    expect(activeIndexOf()).toBe(0);
+    expect(document.activeElement).toBe(row(0));
+  });
 
-    pressKey('ArrowUp');
-    expect(result.current.activeIndex).toBe(1);
+  it('clamps at the boundaries instead of wrapping', () => {
+    render(<TableHarness count={3} />);
+    row(0).focus();
+
+    pressOnRow(0, 'ArrowUp');
+    expect(activeIndexOf()).toBe(0);
+
+    pressOnRow(0, 'End');
+    pressOnRow(2, 'ArrowDown');
+    expect(activeIndexOf()).toBe(2);
   });
 
   it('jumps to the last row with End and the first row with Home', () => {
-    const { result } = renderHook(() => useTableKeydown(5));
+    render(<TableHarness count={5} />);
+    row(0).focus();
 
-    pressKey('End');
-    expect(result.current.activeIndex).toBe(4);
+    pressOnRow(0, 'End');
+    expect(activeIndexOf()).toBe(4);
+    expect(document.activeElement).toBe(row(4));
 
-    pressKey('Home');
-    expect(result.current.activeIndex).toBe(0);
+    pressOnRow(4, 'Home');
+    expect(activeIndexOf()).toBe(0);
+    expect(document.activeElement).toBe(row(0));
+  });
+
+  it('supports mod+Home and mod+End', () => {
+    vi.stubGlobal('navigator', { platform: 'MacIntel', userAgent: 'Mozilla (Macintosh)' });
+    render(<TableHarness count={5} />);
+    row(0).focus();
+
+    pressOnRow(0, 'End', { metaKey: true });
+    expect(activeIndexOf()).toBe(4);
+
+    pressOnRow(4, 'Home', { metaKey: true });
+    expect(activeIndexOf()).toBe(0);
+  });
+
+  it('moves by pageSize with PageDown/PageUp, clamped', () => {
+    render(<TableHarness count={25} pageSize={10} />);
+    row(0).focus();
+
+    pressOnRow(0, 'PageDown');
+    expect(activeIndexOf()).toBe(10);
+
+    pressOnRow(10, 'PageDown');
+    pressOnRow(20, 'PageDown');
+    expect(activeIndexOf()).toBe(24);
+
+    pressOnRow(24, 'PageUp');
+    expect(activeIndexOf()).toBe(14);
+  });
+
+  it('does not react to keys pressed outside the container', () => {
+    render(
+      <div>
+        <TableHarness count={3} />
+        <button data-testid="elsewhere">elsewhere</button>
+      </div>,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('elsewhere'), { key: 'ArrowDown' });
+
+    expect(activeIndexOf()).toBe(0);
+  });
+
+  it('keeps two tables independent', () => {
+    const Two = () => (
+      <div>
+        <TableHarness count={3} />
+        <TableHarness count={3} />
+      </div>
+    );
+    render(<Two />);
+    const [firstActive, secondActive] = screen.getAllByTestId('active-index');
+    const [firstRow0] = screen.getAllByTestId('row-0');
+
+    fireEvent.keyDown(firstRow0, { key: 'ArrowDown' });
+
+    expect(firstActive.textContent).toBe('1');
+    expect(secondActive.textContent).toBe('0');
+  });
+
+  it('syncs activeIndex when a row receives focus directly', () => {
+    render(<TableHarness count={3} />);
+
+    fireEvent.focus(row(2));
+
+    expect(activeIndexOf()).toBe(2);
+    expect(row(2).tabIndex).toBe(0);
+    expect(row(0).tabIndex).toBe(-1);
+  });
+
+  it('calls onNavigate with the next index before focusing', () => {
+    const onNavigate = vi.fn();
+    render(<TableHarness count={3} onNavigate={onNavigate} />);
+    row(0).focus();
+
+    pressOnRow(0, 'ArrowDown');
+
+    expect(onNavigate).toHaveBeenCalledWith(1);
+  });
+
+  it('clamps activeIndex when count shrinks', () => {
+    const { rerender } = render(<TableHarness count={5} />);
+    row(0).focus();
+    pressOnRow(0, 'End');
+    expect(activeIndexOf()).toBe(4);
+
+    rerender(<TableHarness count={2} />);
+
+    expect(activeIndexOf()).toBe(1);
   });
 });

--- a/packages/playground-ui/src/lib/keyboard/use-keydown.test.tsx
+++ b/packages/playground-ui/src/lib/keyboard/use-keydown.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+import { renderHook, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { useKeydown, useTableKeydown } from './use-keydown';
+
+const pressKey = (key: string, modifiers: Partial<KeyboardEventInit> = {}) => {
+  fireEvent.keyDown(window, { key, ...modifiers });
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useKeydown', () => {
+  it('fires the handler when a single key is pressed', () => {
+    const onArrowUp = vi.fn();
+    renderHook(() => useKeydown({ ArrowUp: onArrowUp }));
+
+    pressKey('ArrowUp');
+
+    expect(onArrowUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire the handler for a different key', () => {
+    const onArrowUp = vi.fn();
+    renderHook(() => useKeydown({ ArrowUp: onArrowUp }));
+
+    pressKey('ArrowDown');
+
+    expect(onArrowUp).not.toHaveBeenCalled();
+  });
+
+  it('matches the main key case-insensitively', () => {
+    const onK = vi.fn();
+    renderHook(() => useKeydown({ k: onK }));
+
+    pressKey('K');
+
+    expect(onK).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the handler when a modifier combo is pressed', () => {
+    const onCmdK = vi.fn();
+    renderHook(() => useKeydown({ 'cmd+k': onCmdK }));
+
+    pressKey('k', { metaKey: true });
+
+    expect(onCmdK).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports multiple modifiers in a combo', () => {
+    const onCtrlShiftP = vi.fn();
+    renderHook(() => useKeydown({ 'ctrl+shift+p': onCtrlShiftP }));
+
+    pressKey('p', { ctrlKey: true, shiftKey: true });
+
+    expect(onCtrlShiftP).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire a combo when a required modifier is missing', () => {
+    const onCmdK = vi.fn();
+    renderHook(() => useKeydown({ 'cmd+k': onCmdK }));
+
+    pressKey('k');
+
+    expect(onCmdK).not.toHaveBeenCalled();
+  });
+
+  it('does not fire a plain key handler when a modifier is held', () => {
+    const onK = vi.fn();
+    renderHook(() => useKeydown({ k: onK }));
+
+    pressKey('k', { metaKey: true });
+
+    expect(onK).not.toHaveBeenCalled();
+  });
+
+  it('supports modifier aliases (meta, control, option)', () => {
+    const onMeta = vi.fn();
+    const onControl = vi.fn();
+    const onOption = vi.fn();
+    renderHook(() =>
+      useKeydown({
+        'meta+a': onMeta,
+        'control+b': onControl,
+        'option+c': onOption,
+      }),
+    );
+
+    pressKey('a', { metaKey: true });
+    pressKey('b', { ctrlKey: true });
+    pressKey('c', { altKey: true });
+
+    expect(onMeta).toHaveBeenCalledTimes(1);
+    expect(onControl).toHaveBeenCalledTimes(1);
+    expect(onOption).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves "mod" to cmd on mac', () => {
+    vi.stubGlobal('navigator', { platform: 'MacIntel', userAgent: 'Mozilla (Macintosh)' });
+    const onModK = vi.fn();
+    renderHook(() => useKeydown({ 'mod+k': onModK }));
+
+    pressKey('k', { metaKey: true });
+
+    expect(onModK).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves "mod" to ctrl on non-mac platforms', () => {
+    vi.stubGlobal('navigator', { platform: 'Win32', userAgent: 'Mozilla (Windows NT 10.0)' });
+    const onModK = vi.fn();
+    renderHook(() => useKeydown({ 'mod+k': onModK }));
+
+    pressKey('k', { ctrlKey: true });
+
+    expect(onModK).toHaveBeenCalledTimes(1);
+  });
+
+  it('prevents the default behavior on match', () => {
+    renderHook(() => useKeydown({ 'cmd+k': vi.fn() }));
+
+    const event = new KeyboardEvent('keydown', { key: 'k', metaKey: true, cancelable: true });
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('uses the latest handler when the map changes between renders', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ handler }) => useKeydown({ ArrowUp: handler }), {
+      initialProps: { handler: first },
+    });
+
+    rerender({ handler: second });
+    pressKey('ArrowUp');
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops firing after unmount', () => {
+    const onArrowUp = vi.fn();
+    const { unmount } = renderHook(() => useKeydown({ ArrowUp: onArrowUp }));
+
+    unmount();
+    pressKey('ArrowUp');
+
+    expect(onArrowUp).not.toHaveBeenCalled();
+  });
+});
+
+describe('useTableKeydown', () => {
+  it('starts at index 0', () => {
+    const { result } = renderHook(() => useTableKeydown(3));
+
+    expect(result.current.activeIndex).toBe(0);
+  });
+
+  it('moves down with ArrowDown and wraps around', () => {
+    const { result } = renderHook(() => useTableKeydown(3));
+
+    pressKey('ArrowDown');
+    expect(result.current.activeIndex).toBe(1);
+
+    pressKey('ArrowDown');
+    pressKey('ArrowDown');
+    expect(result.current.activeIndex).toBe(0);
+  });
+
+  it('moves up with ArrowUp and wraps around', () => {
+    const { result } = renderHook(() => useTableKeydown(3));
+
+    pressKey('ArrowUp');
+    expect(result.current.activeIndex).toBe(2);
+
+    pressKey('ArrowUp');
+    expect(result.current.activeIndex).toBe(1);
+  });
+
+  it('jumps to the last row with End and the first row with Home', () => {
+    const { result } = renderHook(() => useTableKeydown(5));
+
+    pressKey('End');
+    expect(result.current.activeIndex).toBe(4);
+
+    pressKey('Home');
+    expect(result.current.activeIndex).toBe(0);
+  });
+});

--- a/packages/playground-ui/src/lib/keyboard/use-keydown.ts
+++ b/packages/playground-ui/src/lib/keyboard/use-keydown.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useState } from 'react';
+import { useEffect, useEffectEvent, useState, type RefObject } from 'react';
 
 export type UseKeydownArgs = {
   [keySet: string]: () => void;
@@ -54,7 +54,12 @@ export const matchesCombo = (event: KeyboardEvent, combo: ParsedKeyCombo): boole
   event.altKey === combo.alt &&
   event.key.toLowerCase() === combo.key;
 
-export const useKeydown = (opts: UseKeydownArgs) => {
+export type UseKeydownOptions = {
+  /** Attach the listener to this element instead of `window`. */
+  target?: RefObject<HTMLElement | null>;
+};
+
+export const useKeydown = (opts: UseKeydownArgs, options: UseKeydownOptions = {}) => {
   const handlers = useEffectEvent((event: KeyboardEvent) => {
     for (const [combo, handler] of Object.entries(opts)) {
       if (matchesCombo(event, parseKeyCombo(combo))) {
@@ -65,36 +70,93 @@ export const useKeydown = (opts: UseKeydownArgs) => {
     }
   });
 
+  const hasTarget = Boolean(options.target);
+
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      handlers(event);
+    const element: HTMLElement | Window | null = hasTarget ? (options.target?.current ?? null) : window;
+    if (!element) return;
+
+    const handleKeyDown = (event: Event) => {
+      handlers(event as KeyboardEvent);
     };
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
+    element.addEventListener('keydown', handleKeyDown);
+    return () => element.removeEventListener('keydown', handleKeyDown);
+  });
 };
 
-export const useTableKeydown = (tableCount: number) => {
-  const [activeIndex, setActiveIndex] = useState(0);
+export type UseTableKeydownArgs = {
+  /** Number of rows in the table. */
+  count: number;
+  /** The scroll/list container; keyboard shortcuts only fire when focus is inside it. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Rows moved by PageUp/PageDown. Defaults to 10. */
+  pageSize?: number;
+  /** Initially active row index. Defaults to 0. */
+  initialIndex?: number;
+  /** Called when a row should be activated (for non-interactive rows). */
+  onActivate?: (index: number) => void;
+  /** Called with the next index before focus moves (e.g. virtualizer.scrollToIndex). */
+  onNavigate?: (index: number) => void;
+};
 
-  useKeydown({
-    ArrowUp: () => {
-      setActiveIndex(current => (current - 1 + tableCount) % tableCount);
+export const useTableKeydown = ({
+  count,
+  containerRef,
+  pageSize = 10,
+  initialIndex = 0,
+  onActivate,
+  onNavigate,
+}: UseTableKeydownArgs) => {
+  const [activeIndex, setActiveIndex] = useState(initialIndex);
+
+  const clamp = (index: number) => Math.min(Math.max(index, 0), Math.max(count - 1, 0));
+
+  const navigateTo = (index: number) => {
+    const next = clamp(index);
+    setActiveIndex(next);
+    onNavigate?.(next);
+
+    const rowElement = containerRef.current?.querySelector<HTMLElement>(`[data-row-index="${next}"]`);
+    if (rowElement) {
+      rowElement.focus();
+      rowElement.scrollIntoView?.({ block: 'nearest' });
+    }
+  };
+
+  useKeydown(
+    {
+      ArrowUp: () => navigateTo(activeIndex - 1),
+      ArrowDown: () => navigateTo(activeIndex + 1),
+      PageUp: () => navigateTo(activeIndex - pageSize),
+      PageDown: () => navigateTo(activeIndex + pageSize),
+      Home: () => navigateTo(0),
+      End: () => navigateTo(count - 1),
+      'mod+Home': () => navigateTo(0),
+      'mod+End': () => navigateTo(count - 1),
     },
-    ArrowDown: () => {
-      setActiveIndex(current => (current + 1) % tableCount);
-    },
-    Home: () => {
-      setActiveIndex(0);
-    },
-    End: () => {
-      setActiveIndex(tableCount - 1);
-    },
+    { target: containerRef },
+  );
+
+  useEffect(() => {
+    if (activeIndex >= count) {
+      setActiveIndex(Math.max(count - 1, 0));
+    }
+  }, [activeIndex, count]);
+
+  const getRowProps = (index: number) => ({
+    tabIndex: index === activeIndex ? 0 : -1,
+    'data-row-index': index,
+    onFocus: () => setActiveIndex(index),
   });
+
+  const getContainerProps = () => ({});
 
   return {
     activeIndex,
     setActiveIndex,
+    activate: (index: number) => onActivate?.(index),
+    getRowProps,
+    getContainerProps,
   };
 };

--- a/packages/playground-ui/src/lib/keyboard/use-keydown.ts
+++ b/packages/playground-ui/src/lib/keyboard/use-keydown.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useState, type RefObject } from 'react';
+import { useEffect, useEffectEvent, useRef, useState, type RefObject } from 'react';
 
 export type UseKeydownArgs = {
   [keySet: string]: () => void;
@@ -70,10 +70,12 @@ export const useKeydown = (opts: UseKeydownArgs, options: UseKeydownOptions = {}
     }
   });
 
-  const hasTarget = Boolean(options.target);
+  const targetRef = useRef(options.target);
+  targetRef.current = options.target;
 
   useEffect(() => {
-    const element: HTMLElement | Window | null = hasTarget ? (options.target?.current ?? null) : window;
+    const target = targetRef.current;
+    const element: HTMLElement | Window | null = target ? (target.current ?? null) : window;
     if (!element) return;
 
     const handleKeyDown = (event: Event) => {
@@ -82,7 +84,7 @@ export const useKeydown = (opts: UseKeydownArgs, options: UseKeydownOptions = {}
 
     element.addEventListener('keydown', handleKeyDown);
     return () => element.removeEventListener('keydown', handleKeyDown);
-  });
+  }, []);
 };
 
 export type UseTableKeydownArgs = {

--- a/packages/playground-ui/src/lib/keyboard/use-keydown.ts
+++ b/packages/playground-ui/src/lib/keyboard/use-keydown.ts
@@ -1,0 +1,100 @@
+import { useEffect, useEffectEvent, useState } from 'react';
+
+export type UseKeydownArgs = {
+  [keySet: string]: () => void;
+};
+
+type ParsedKeyCombo = {
+  meta: boolean;
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+  key: string;
+};
+
+const isMacPlatform = () =>
+  typeof navigator !== 'undefined' && /mac/i.test(navigator.platform || navigator.userAgent || '');
+
+export const parseKeyCombo = (combo: string): ParsedKeyCombo => {
+  const parsed: ParsedKeyCombo = { meta: false, ctrl: false, shift: false, alt: false, key: '' };
+
+  for (const token of combo.split('+')) {
+    switch (token.toLowerCase()) {
+      case 'cmd':
+      case 'meta':
+        parsed.meta = true;
+        break;
+      case 'ctrl':
+      case 'control':
+        parsed.ctrl = true;
+        break;
+      case 'shift':
+        parsed.shift = true;
+        break;
+      case 'alt':
+      case 'option':
+        parsed.alt = true;
+        break;
+      case 'mod':
+        if (isMacPlatform()) parsed.meta = true;
+        else parsed.ctrl = true;
+        break;
+      default:
+        parsed.key = token.toLowerCase();
+    }
+  }
+
+  return parsed;
+};
+
+export const matchesCombo = (event: KeyboardEvent, combo: ParsedKeyCombo): boolean =>
+  event.metaKey === combo.meta &&
+  event.ctrlKey === combo.ctrl &&
+  event.shiftKey === combo.shift &&
+  event.altKey === combo.alt &&
+  event.key.toLowerCase() === combo.key;
+
+export const useKeydown = (opts: UseKeydownArgs) => {
+  const handlers = useEffectEvent((event: KeyboardEvent) => {
+    for (const [combo, handler] of Object.entries(opts)) {
+      if (matchesCombo(event, parseKeyCombo(combo))) {
+        event.preventDefault();
+        handler();
+        return;
+      }
+    }
+  });
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      handlers(event);
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+};
+
+export const useTableKeydown = (tableCount: number) => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useKeydown({
+    ArrowUp: () => {
+      setActiveIndex(current => (current - 1 + tableCount) % tableCount);
+    },
+    ArrowDown: () => {
+      setActiveIndex(current => (current + 1) % tableCount);
+    },
+    Home: () => {
+      setActiveIndex(0);
+    },
+    End: () => {
+      setActiveIndex(tableCount - 1);
+    },
+  });
+
+  return {
+    activeIndex,
+    setActiveIndex,
+  };
+};

--- a/packages/playground-ui/vite.config.ts
+++ b/packages/playground-ui/vite.config.ts
@@ -112,6 +112,7 @@ const createLibConfig = (isProduction: boolean): UserConfig => ({
         ...fileEntries('src/ee', 'ee'),
         ...fileEntries('src/ds/primitives', 'primitives'),
         ...fileEntries('src/lib/resize', 'resize'),
+        ...fileEntries('src/lib/keyboard', 'keyboard'),
         ...fileEntries('src/store', 'store'),
         ...fileEntries('src/ds/icons', 'icons'),
         ...fileEntries('src/hooks', 'hooks'),


### PR DESCRIPTION
## Summary

Adds a keyboard interaction layer to `@mastra/playground-ui`:

- **`useKeydown`**: a combo-shortcut hook supporting single keys and modifier combinations, with sequential/combo handling and proper cleanup.
- **`useTableKeydown`**: accessible roving-tabindex navigation for tables/lists, so arrow keys move focus between rows while keeping a single tab stop.
- Wires the new hooks into the DataList stories to demonstrate keyboard navigation.

## Test plan

- `use-keydown.test.tsx` covers key/combo matching, listener cleanup, and roving-tabindex focus behavior (376 lines of Vitest coverage)
- Verified interactively via the DataList Storybook stories

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets users control lists and tables with keyboard shortcuts. It keeps focus moving within the list so users can navigate without using a mouse.

## Changes

- Added `useKeydown` for:
  - Single-key shortcuts.
  - Modifier combinations such as `cmd+k`, `ctrl+shift+p`, and `mod+k`.
  - Sequential key handling.
  - Optional target elements.
  - Default prevention and listener cleanup.
- Added `useTableKeydown` for accessible roving-tabindex navigation:
  - Arrow, Home, End, and Page navigation.
  - Boundary clamping.
  - Focus and scroll management.
  - Row activation and navigation callbacks.
  - Separate state for multiple tables.
- Added keyboard navigation coverage with Vitest.
- Added a `KeyboardNavigation` DataList Storybook story.
- Exported the keyboard module through the package entry points.
- Included `src/lib/keyboard` in the Vite library build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->