### PR TITLE
fix(factory): surface intake feed failures instead of an empty board

### DIFF
--- a/.changeset/nine-jokes-rush.md
+++ b/.changeset/nine-jokes-rush.md
@@ -1,0 +1,14 @@
+---
+'@mastra/factory': patch
+---
+
+Intake listings no longer fail as a whole when one provider is down. `GET /web/intake/sources` and `GET /web/intake/items` now query every connected provider concurrently and isolate the ones that error, returning what the healthy providers answered plus a `failures` entry per broken provider so the UI can show a per-source error instead of an empty board.
+
+```json
+{
+  "sources": [{ "integrationId": "github", "id": "repo-1", "name": "acme/app", "type": "repository" }],
+  "failures": [{ "integrationId": "linear", "message": "Linear token expired" }]
+}
+```
+
+A provider that fails mid-pagination keeps the cursor it came in with, so the next page resumes where it left off instead of replaying its first page.

--- a/.changeset/nine-jokes-rush.md
+++ b/.changeset/nine-jokes-rush.md
@@ -11,4 +11,6 @@ Intake listings no longer fail as a whole when one provider is down. `GET /web/i
 }
 ```
 
+A provider that hangs is given up on after 15 seconds and reported the same way, so an unresponsive one can't hold the request open either.
+
 A provider that fails mid-pagination keeps the cursor it came in with, so the next page resumes where it left off instead of replaying its first page.

--- a/.changeset/wacky-weeks-accept.md
+++ b/.changeset/wacky-weeks-accept.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the Factory board's Intake column claiming "Intake is clear" when a candidate feed had actually failed. A GitHub or Linear feed that errors now shows what went wrong with a Retry, and the Linear reconnect notice keeps its own message.

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageIntakeFeedFailure.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageIntakeFeedFailure.msw.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * A candidate feed that fails reads as an empty backlog unless the column says
+ * otherwise: "Intake is clear" next to a dead GitHub is a lie the board must
+ * not tell.
+ */
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../e2e/ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import { createAppRoutes } from '../router';
+
+const FACTORY_ID = 'fp-1';
+const REPO_ID = 'repo-1';
+
+const issue = {
+  number: 7,
+  title: 'Fix login',
+  url: 'https://github.com/acme/app/issues/7',
+  author: 'alice',
+  assignee: null,
+  labels: [],
+  createdAt: '2026-08-01T00:00:00.000Z',
+};
+
+function stubBoardEndpoints(issuesResponse: () => Response) {
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_ID, name: 'Acme Factory' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/source-control-connections`, () =>
+      HttpResponse.json({
+        connections: [
+          {
+            id: 'conn-1',
+            installationId: 'inst-1',
+            repositories: [
+              {
+                id: REPO_ID,
+                branch: 'main',
+                sandboxWorkdir: '/repo',
+                repository: { slug: 'acme/app', defaultBranch: 'main' },
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+      HttpResponse.json({ workItems: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions`, () =>
+      HttpResponse.json({ decisions: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/intake/config`, () =>
+      HttpResponse.json({
+        config: {
+          github: { enabled: true, sourceIds: ['acme/app'] },
+          linear: { enabled: false, sourceIds: null },
+        },
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/linear/status`, () =>
+      HttpResponse.json({ enabled: false, connected: false, workspace: null }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/issues`, () => issuesResponse()),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () => HttpResponse.json({ sessions: [] })),
+    http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () => HttpResponse.json({ ok: true })),
+  );
+}
+
+function renderWorkBoard() {
+  const router = createMemoryRouter(createAppRoutes(), { initialEntries: [`/factories/${FACTORY_ID}/work`] });
+  return renderWithProviders(<RouterProvider router={router} />);
+}
+
+describe('Intake column when the candidate feed fails', () => {
+  it('names the failure instead of claiming the backlog is clear, and recovers on retry', async () => {
+    let healthy = false;
+    stubBoardEndpoints(() =>
+      healthy
+        ? HttpResponse.json({ issues: [issue], nextPage: null })
+        : HttpResponse.json({ error: 'GitHub is unavailable' }, { status: 502 }),
+    );
+    renderWorkBoard();
+
+    const intake = await screen.findByTestId('board-column-intake');
+    const alert = await within(intake).findByRole('alert');
+    expect(alert).toHaveTextContent('GitHub is unavailable');
+    expect(within(intake).queryByText('Intake is clear')).not.toBeInTheDocument();
+
+    healthy = true;
+    await userEvent.click(within(intake).getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(within(intake).getByText('Fix login')).toBeInTheDocument());
+    expect(within(intake).queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageIntakeFeedFailure.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageIntakeFeedFailure.msw.test.tsx
@@ -3,14 +3,14 @@
  * otherwise: "Intake is clear" next to a dead GitHub is a lie the board must
  * not tell.
  */
-import { screen, waitFor, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../e2e/ui/msw-server';
-import { renderWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import { renderWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../e2e/ui/render';
 import { createAppRoutes } from '../router';
 
 const FACTORY_ID = 'fp-1';
@@ -88,7 +88,7 @@ describe('Intake column when the candidate feed fails', () => {
         ? HttpResponse.json({ issues: [issue], nextPage: null })
         : HttpResponse.json({ error: 'GitHub is unavailable' }, { status: 502 }),
     );
-    renderWorkBoard();
+    const { client } = renderWorkBoard();
 
     const intake = await screen.findByTestId('board-column-intake');
     const alert = await within(intake).findByRole('alert');
@@ -97,8 +97,9 @@ describe('Intake column when the candidate feed fails', () => {
 
     healthy = true;
     await userEvent.click(within(intake).getByRole('button', { name: 'Retry' }));
+    await waitForMutationsIdle(client);
 
-    await waitFor(() => expect(within(intake).getByText('Fix login')).toBeInTheDocument());
+    expect(within(intake).getByText('Fix login')).toBeInTheDocument();
     expect(within(intake).queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageIntakeFeedFailure.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageIntakeFeedFailure.msw.test.tsx
@@ -3,7 +3,7 @@
  * otherwise: "Intake is clear" next to a dead GitHub is a lie the board must
  * not tell.
  */
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
@@ -16,17 +16,23 @@ import { createAppRoutes } from '../router';
 const FACTORY_ID = 'fp-1';
 const REPO_ID = 'repo-1';
 
-const issue = {
-  number: 7,
-  title: 'Fix login',
-  url: 'https://github.com/acme/app/issues/7',
-  author: 'alice',
-  assignee: null,
-  labels: [],
-  createdAt: '2026-08-01T00:00:00.000Z',
-};
+const AUTO_TRIAGED = 'status: auto-triaged';
 
-function stubBoardEndpoints(issuesResponse: () => Response) {
+function githubIssue(number: number, title: string, labels: string[] = []) {
+  return {
+    number,
+    title,
+    url: `https://github.com/acme/app/issues/${number}`,
+    author: 'alice',
+    assignee: null,
+    labels,
+    createdAt: '2026-08-01T00:00:00.000Z',
+  };
+}
+
+const issue = githubIssue(7, 'Fix login');
+
+function stubBoardEndpoints(issuesResponse: (request: Request) => Response) {
   server.use(
     http.get(`${TEST_BASE_URL}/auth/me`, () =>
       HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
@@ -69,7 +75,7 @@ function stubBoardEndpoints(issuesResponse: () => Response) {
     http.get(`${TEST_BASE_URL}/web/linear/status`, () =>
       HttpResponse.json({ enabled: false, connected: false, workspace: null }),
     ),
-    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/issues`, () => issuesResponse()),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/issues`, ({ request }) => issuesResponse(request)),
     http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () => HttpResponse.json({ sessions: [] })),
     http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () => HttpResponse.json({ ok: true })),
   );
@@ -101,5 +107,45 @@ describe('Intake column when the candidate feed fails', () => {
 
     expect(within(intake).getByText('Fix login')).toBeInTheDocument();
     expect(within(intake).queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('reports a failing triage feed in the Triage column, not as nothing to triage', async () => {
+    stubBoardEndpoints(request =>
+      new URL(request.url).searchParams.get('label') === AUTO_TRIAGED
+        ? HttpResponse.json({ error: 'GitHub rate limit exceeded' }, { status: 502 })
+        : HttpResponse.json({ issues: [issue], nextPage: null }),
+    );
+    renderWorkBoard();
+
+    const triage = await screen.findByTestId('board-column-triage');
+    await waitFor(() => expect(within(triage).getByRole('alert')).toHaveTextContent('GitHub rate limit exceeded'));
+    expect(within(triage).queryByText('Nothing to triage')).not.toBeInTheDocument();
+    // The intake feed answered, so its own column keeps listing candidates.
+    expect(within(screen.getByTestId('board-column-intake')).getByText('Fix login')).toBeInTheDocument();
+  });
+
+  it('retries the page that failed, not the pages already loaded', async () => {
+    let secondPageHealthy = false;
+    stubBoardEndpoints(request => {
+      const params = new URL(request.url).searchParams;
+      if (params.get('label') === AUTO_TRIAGED) return HttpResponse.json({ issues: [], nextPage: null });
+      if (params.get('page') === '1') return HttpResponse.json({ issues: [issue], nextPage: 2 });
+      return secondPageHealthy
+        ? HttpResponse.json({ issues: [githubIssue(8, 'Fix signup')], nextPage: null })
+        : HttpResponse.json({ error: 'GitHub is unavailable' }, { status: 502 });
+    });
+    const { client } = renderWorkBoard();
+
+    const intake = await screen.findByTestId('board-column-intake');
+    await waitFor(() => expect(within(intake).getByText('Fix login')).toBeInTheDocument());
+    await userEvent.click(await within(intake).findByRole('button', { name: 'Load more candidates' }));
+    await waitFor(() => expect(within(intake).getByRole('alert')).toBeInTheDocument());
+
+    secondPageHealthy = true;
+    await userEvent.click(within(intake).getByRole('button', { name: 'Retry' }));
+    await waitForMutationsIdle(client);
+
+    expect(within(intake).getByText('Fix signup')).toBeInTheDocument();
+    expect(within(intake).getByText('Fix login')).toBeInTheDocument();
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCandidates.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCandidates.ts
@@ -21,6 +21,17 @@ export const INTAKE_SOURCES = [
 
 export type IntakeSource = (typeof INTAKE_SOURCES)[number]['id'];
 
+/** What a candidate feed exposes to the column rendering it. */
+export interface IntakeFeed {
+  error: Error | null;
+  /** Set when the failure came from paging, not from the stored pages. */
+  isFetchNextPageError?: boolean;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  fetchNextPage: () => unknown;
+  refetch: () => unknown;
+}
+
 /** A live GitHub/Linear issue or PR that has not been materialized as a work item. */
 export interface BoardCandidate {
   sourceKey: string;

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardColumn.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardColumn.tsx
@@ -69,6 +69,7 @@ export function BoardColumn({
   totalTaskCount,
   loading = false,
   composerOpen = false,
+  feedFailed = false,
   laneRef,
   onDrop,
   headerAction,
@@ -82,6 +83,8 @@ export function BoardColumn({
   /** While loading, the task badge is hidden so a false "0/0" never flashes. */
   loading?: boolean;
   composerOpen?: boolean;
+  /** An empty column whose candidate feed failed stays open to say so. */
+  feedFailed?: boolean;
   laneRef: (element: HTMLElement | null) => void;
   onDrop: (payload: DragPayload, toStage: BoardStageId) => void;
   headerAction?: React.ReactNode;
@@ -92,7 +95,7 @@ export function BoardColumn({
   const [dragOver, setDragOver] = useState(false);
   const [dropLineTop, setDropLineTop] = useState(0);
   const cardListRef = useRef<HTMLDivElement>(null);
-  const collapsed = stage !== 'intake' && !loading && !composerOpen && taskCount === 0;
+  const collapsed = stage !== 'intake' && !loading && !composerOpen && !feedFailed && taskCount === 0;
 
   return (
     <section

--- a/mastracode/factory-ui/src/ui/domains/factory/components/IntakeColumnExtras.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/IntakeColumnExtras.tsx
@@ -2,50 +2,54 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 
 import { useApiConfig } from '../../../../api/config';
-import type { useProjectIssuesQuery, useProjectPullRequestsQuery } from '../../../../hooks/useFactoryData';
-import type { useLinearIssuesQuery } from '../../../../hooks/useLinearData';
 import type { IntakeSource } from '../boardCandidates';
 import { connectLinear, isLinearReauthError } from '../services/linear';
 import { LoadMoreSentinel } from './LoadMoreSentinel';
 
+/** What the column tail needs from whichever candidate query is active. */
+export interface IntakeFeed {
+  error: Error | null;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  fetchNextPage: () => unknown;
+  refetch: () => unknown;
+}
+
 /**
- * Intake column tail for the ACTIVE candidate feed: loading state, Linear
+ * Intake column tail for the ACTIVE candidate feed: failure notice, Linear
  * reauth notice, and pagination. Only one feed is browsed at a time, so only
  * its states render.
  */
-export function IntakeColumnExtras({
-  source,
-  issues,
-  pulls,
-  linearIssues,
-}: {
-  source?: IntakeSource;
-  issues: ReturnType<typeof useProjectIssuesQuery>;
-  pulls: ReturnType<typeof useProjectPullRequestsQuery>;
-  linearIssues: ReturnType<typeof useLinearIssuesQuery>;
-}) {
+export function IntakeColumnExtras({ source, feed }: { source?: IntakeSource; feed?: IntakeFeed }) {
   const { baseUrl } = useApiConfig();
-  if (source === undefined) return null;
-  const feed = source === 'github' ? issues : source === 'github-prs' ? pulls : linearIssues;
+  if (source === undefined || !feed) return null;
 
-  return (
-    <>
-      {source === 'linear' && linearIssues.isError && isLinearReauthError(linearIssues.error) && (
-        <div className="flex flex-col gap-2 p-1">
-          <Txt as="span" variant="ui-xs" className="text-icon3">
-            Linear authorization expired. Reconnect to keep syncing issues.
-          </Txt>
+  if (feed.error) {
+    const expired = source === 'linear' && isLinearReauthError(feed.error);
+    return (
+      <div className="flex flex-col items-start gap-2 p-1">
+        <Txt as="p" role="alert" variant="ui-xs" className="text-notice-destructive-fg m-0">
+          {expired ? 'Linear authorization expired. Reconnect to keep syncing issues.' : feed.error.message}
+        </Txt>
+        {expired ? (
           <Button size="xs" onClick={() => connectLinear(baseUrl)}>
             Connect Linear
           </Button>
-        </div>
-      )}
-      <LoadMoreSentinel
-        hasNextPage={Boolean(feed.hasNextPage)}
-        isFetchingNextPage={Boolean(feed.isFetchingNextPage)}
-        onLoadMore={() => void feed.fetchNextPage()}
-        label="Load more candidates"
-      />
-    </>
+        ) : (
+          <Button size="xs" onClick={() => void feed.refetch()}>
+            Retry
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <LoadMoreSentinel
+      hasNextPage={Boolean(feed.hasNextPage)}
+      isFetchingNextPage={Boolean(feed.isFetchingNextPage)}
+      onLoadMore={() => void feed.fetchNextPage()}
+      label="Load more candidates"
+    />
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/components/IntakeColumnExtras.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/IntakeColumnExtras.tsx
@@ -1,36 +1,12 @@
-import { Button } from '@mastra/playground-ui/components/Button';
-import { Txt } from '@mastra/playground-ui/components/Txt';
-
-import { useApiConfig } from '../../../../api/config';
-import type { IntakeSource } from '../boardCandidates';
-import { connectLinear, isLinearReauthError } from '../services/linear';
+import type { IntakeFeed } from '../boardCandidates';
 import { LoadMoreSentinel } from './LoadMoreSentinel';
 
-/** What the column tail needs from whichever candidate query is active. */
-export interface IntakeFeed {
-  error: Error | null;
-  hasNextPage?: boolean;
-  isFetchingNextPage?: boolean;
-  fetchNextPage: () => unknown;
-  refetch: () => unknown;
-}
-
 /**
- * Intake column tail for the ACTIVE candidate feed: failure notice, Linear
- * reauth notice, or pagination. Only one feed is browsed at a time, so only
- * its states render.
+ * Pagination for the browsed candidate feed. A failed feed renders nothing: the
+ * sentinel auto-loads when it scrolls into view, which would retry forever.
  */
-export function IntakeColumnExtras({ source, feed }: { source?: IntakeSource; feed?: IntakeFeed }) {
-  const { baseUrl } = useApiConfig();
-  if (source === undefined || !feed) return null;
-
-  if (feed.error) {
-    return source === 'linear' && isLinearReauthError(feed.error) ? (
-      <LinearReauthNotice onConnect={() => connectLinear(baseUrl)} />
-    ) : (
-      <FeedFailureNotice message={feed.error.message} onRetry={() => void feed.refetch()} />
-    );
-  }
+export function IntakeColumnExtras({ feed }: { feed?: IntakeFeed }) {
+  if (!feed || feed.error) return null;
 
   return (
     <LoadMoreSentinel
@@ -39,31 +15,5 @@ export function IntakeColumnExtras({ source, feed }: { source?: IntakeSource; fe
       onLoadMore={() => void feed.fetchNextPage()}
       label="Load more candidates"
     />
-  );
-}
-
-function LinearReauthNotice({ onConnect }: { onConnect: () => void }) {
-  return (
-    <div className="flex flex-col items-start gap-2 p-1">
-      <Txt as="span" variant="ui-xs" className="text-icon3">
-        Linear authorization expired. Reconnect to keep syncing issues.
-      </Txt>
-      <Button size="xs" onClick={onConnect}>
-        Connect Linear
-      </Button>
-    </div>
-  );
-}
-
-function FeedFailureNotice({ message, onRetry }: { message: string; onRetry: () => void }) {
-  return (
-    <div className="flex flex-col items-start gap-2 p-1">
-      <Txt as="p" role="alert" variant="ui-xs" className="text-notice-destructive-fg m-0">
-        {message}
-      </Txt>
-      <Button size="xs" onClick={onRetry}>
-        Retry
-      </Button>
-    </div>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/components/IntakeColumnExtras.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/IntakeColumnExtras.tsx
@@ -17,7 +17,7 @@ export interface IntakeFeed {
 
 /**
  * Intake column tail for the ACTIVE candidate feed: failure notice, Linear
- * reauth notice, and pagination. Only one feed is browsed at a time, so only
+ * reauth notice, or pagination. Only one feed is browsed at a time, so only
  * its states render.
  */
 export function IntakeColumnExtras({ source, feed }: { source?: IntakeSource; feed?: IntakeFeed }) {
@@ -25,22 +25,10 @@ export function IntakeColumnExtras({ source, feed }: { source?: IntakeSource; fe
   if (source === undefined || !feed) return null;
 
   if (feed.error) {
-    const expired = source === 'linear' && isLinearReauthError(feed.error);
-    return (
-      <div className="flex flex-col items-start gap-2 p-1">
-        <Txt as="p" role="alert" variant="ui-xs" className="text-notice-destructive-fg m-0">
-          {expired ? 'Linear authorization expired. Reconnect to keep syncing issues.' : feed.error.message}
-        </Txt>
-        {expired ? (
-          <Button size="xs" onClick={() => connectLinear(baseUrl)}>
-            Connect Linear
-          </Button>
-        ) : (
-          <Button size="xs" onClick={() => void feed.refetch()}>
-            Retry
-          </Button>
-        )}
-      </div>
+    return source === 'linear' && isLinearReauthError(feed.error) ? (
+      <LinearReauthNotice onConnect={() => connectLinear(baseUrl)} />
+    ) : (
+      <FeedFailureNotice message={feed.error.message} onRetry={() => void feed.refetch()} />
     );
   }
 
@@ -51,5 +39,31 @@ export function IntakeColumnExtras({ source, feed }: { source?: IntakeSource; fe
       onLoadMore={() => void feed.fetchNextPage()}
       label="Load more candidates"
     />
+  );
+}
+
+function LinearReauthNotice({ onConnect }: { onConnect: () => void }) {
+  return (
+    <div className="flex flex-col items-start gap-2 p-1">
+      <Txt as="span" variant="ui-xs" className="text-icon3">
+        Linear authorization expired. Reconnect to keep syncing issues.
+      </Txt>
+      <Button size="xs" onClick={onConnect}>
+        Connect Linear
+      </Button>
+    </div>
+  );
+}
+
+function FeedFailureNotice({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-start gap-2 p-1">
+      <Txt as="p" role="alert" variant="ui-xs" className="text-notice-destructive-fg m-0">
+        {message}
+      </Txt>
+      <Button size="xs" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/factory/components/IntakeFeedNotice.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/IntakeFeedNotice.tsx
@@ -1,0 +1,51 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+
+import { useApiConfig } from '../../../../api/config';
+import type { IntakeFeed, IntakeSource } from '../boardCandidates';
+import { connectLinear, isLinearReauthError } from '../services/linear';
+
+/**
+ * Why a column has no candidates when its feed failed. Without it the column
+ * falls back to its empty state and reads as an empty backlog.
+ */
+export function IntakeFeedNotice({ source, feed }: { source?: IntakeSource; feed: IntakeFeed }) {
+  const { baseUrl } = useApiConfig();
+  if (!feed.error) return null;
+
+  return source === 'linear' && isLinearReauthError(feed.error) ? (
+    <LinearReauthNotice onConnect={() => connectLinear(baseUrl)} />
+  ) : (
+    // A page that failed is not stored, so only fetchNextPage requests it again.
+    <FeedFailureNotice
+      message={feed.error.message}
+      onRetry={() => void (feed.isFetchNextPageError ? feed.fetchNextPage() : feed.refetch())}
+    />
+  );
+}
+
+function LinearReauthNotice({ onConnect }: { onConnect: () => void }) {
+  return (
+    <div className="flex flex-col items-start gap-2 p-1">
+      <Txt as="span" variant="ui-xs" className="text-icon3">
+        Linear authorization expired. Reconnect to keep syncing issues.
+      </Txt>
+      <Button size="xs" onClick={onConnect}>
+        Connect Linear
+      </Button>
+    </div>
+  );
+}
+
+function FeedFailureNotice({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-start gap-2 p-1">
+      <Txt as="p" role="alert" variant="ui-xs" className="text-notice-destructive-fg m-0">
+        {message}
+      </Txt>
+      <Button size="xs" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardIntake.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardIntake.ts
@@ -6,9 +6,10 @@ import { useIntakeBindingsQuery, useIntakeConfigQuery } from '../../../../hooks/
 import { useLinearIssuesQuery, useLinearStatusQuery } from '../../../../hooks/useLinearData';
 import type { LinkedRepositoryPayload } from '../../workspaces/services/github';
 import { issueCandidate, linearCandidate, pullRequestCandidate } from '../boardCandidates';
-import type { BoardCandidate, IntakeSource } from '../boardCandidates';
+import type { BoardCandidate, IntakeFeed, IntakeSource } from '../boardCandidates';
 import { AUTO_TRIAGED_LABEL, hasLabel } from '../boardItems';
 import type { BoardKind } from '../boardStages';
+import type { BoardStageId } from '../stages';
 
 /**
  * The Intake swimlane's feed: which candidate source is browsed, the queries
@@ -93,8 +94,13 @@ export function useBoardIntake({
     return all.filter(candidate => !knownSourceKeys.has(candidate.sourceKey));
   }, [knownSourceKeys, participantCandidates, intakeIssues, triageIssues.data, linearIssues.data, active, review]);
 
-  const feeds = { github: issues, 'github-prs': pulls, linear: linearIssues };
-  const feed = active ? feeds[active] : undefined;
+  const browsed = { github: issues, 'github-prs': pulls, linear: linearIssues };
+  const feed = active ? browsed[active] : undefined;
+  // Triage is fed by its own labelled query, so it fails (and retries) on its own.
+  const feedByColumn: Partial<Record<BoardStageId, IntakeFeed>> = {
+    intake: feed,
+    triage: active === 'github' ? triageIssues : undefined,
+  };
 
   return {
     available,
@@ -103,7 +109,7 @@ export function useBoardIntake({
     select: setSelected,
     candidates,
     participantCandidates,
-    feed,
+    feedByColumn,
     isPending:
       (!review && (configQuery.isPending || ((config?.linear.enabled ?? false) && linearStatusQuery.isPending))) ||
       Boolean(feed?.isPending),

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardIntake.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardIntake.ts
@@ -93,6 +93,9 @@ export function useBoardIntake({
     return all.filter(candidate => !knownSourceKeys.has(candidate.sourceKey));
   }, [knownSourceKeys, participantCandidates, intakeIssues, triageIssues.data, linearIssues.data, active, review]);
 
+  const feeds = { github: issues, 'github-prs': pulls, linear: linearIssues };
+  const feed = active ? feeds[active] : undefined;
+
   return {
     available,
     active,
@@ -100,14 +103,10 @@ export function useBoardIntake({
     select: setSelected,
     candidates,
     participantCandidates,
-    issues,
-    pulls,
-    linearIssues,
+    feed,
     isPending:
       (!review && (configQuery.isPending || ((config?.linear.enabled ?? false) && linearStatusQuery.isPending))) ||
-      (active === 'github' && issues.isPending) ||
-      (active === 'github-prs' && pulls.isPending) ||
-      (active === 'linear' && linearIssues.isPending),
+      Boolean(feed?.isPending),
     isTriagePending: !review && active === 'github' && triageIssues.isPending,
   };
 }

--- a/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
@@ -375,7 +375,7 @@ function BoardContent({
                 {loading && (
                   <SkeletonRows label={`Loading ${stage.label} column`} rows={3} rowClassName="h-24 w-full" />
                 )}
-                {!loading && !composerOpen && taskCount === 0 && (
+                {!loading && !composerOpen && taskCount === 0 && !(stage.id === 'intake' && intake.feed?.error) && (
                   <BoardColumnEmptyState
                     stage={stage.id}
                     kind={kind}
@@ -384,12 +384,7 @@ function BoardContent({
                   />
                 )}
                 {stage.id === 'intake' && (
-                  <IntakeColumnExtras
-                    source={intake.active}
-                    issues={intake.issues}
-                    pulls={intake.pulls}
-                    linearIssues={intake.linearIssues}
-                  />
+                  <IntakeColumnExtras source={intake.active} feed={intake.feed} />
                 )}
               </BoardColumn>
             );

--- a/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
@@ -300,6 +300,8 @@ function BoardContent({
               const stageWorkItems = workItemsForStage(stage.id);
               const taskCount = stageContentCount(stage.id, stages, stageWorkItems, filteredCandidates);
               const composerOpen = composer.stage === stage.id;
+              const intakeFeedFailed = stage.id === 'intake' && Boolean(intake.feed?.error);
+              const showEmptyState = !loading && !composerOpen && taskCount === 0 && !intakeFeedFailed;
               return (
                 <BoardColumn
                   key={stage.id}
@@ -403,7 +405,7 @@ function BoardContent({
                   {loading && (
                     <SkeletonRows label={`Loading ${stage.label} column`} rows={3} rowClassName="h-24 w-full" />
                   )}
-                  {!loading && !composerOpen && taskCount === 0 && !(stage.id === 'intake' && intake.feed?.error) && (
+                  {showEmptyState && (
                     <BoardColumnEmptyState
                       stage={stage.id}
                       kind={kind}

--- a/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
@@ -23,6 +23,7 @@ import { CandidateCard } from '../domains/factory/components/CandidateCard';
 import { FactoryPageShell } from '../domains/factory/components/FactoryPageShell';
 import { InlineWorkItemComposer } from '../domains/factory/components/InlineWorkItemComposer';
 import { IntakeColumnExtras } from '../domains/factory/components/IntakeColumnExtras';
+import { IntakeFeedNotice } from '../domains/factory/components/IntakeFeedNotice';
 import { WorkItemCard } from '../domains/factory/components/WorkItemCard';
 import { useBoardComposer } from '../domains/factory/hooks/useBoardComposer';
 import { useBoardDecisions } from '../domains/factory/hooks/useBoardDecisions';
@@ -300,8 +301,8 @@ function BoardContent({
               const stageWorkItems = workItemsForStage(stage.id);
               const taskCount = stageContentCount(stage.id, stages, stageWorkItems, filteredCandidates);
               const composerOpen = composer.stage === stage.id;
-              const intakeFeedFailed = stage.id === 'intake' && Boolean(intake.feed?.error);
-              const showEmptyState = !loading && !composerOpen && taskCount === 0 && !intakeFeedFailed;
+              const columnFeed = intake.feedByColumn[stage.id];
+              const showEmptyState = !loading && !composerOpen && taskCount === 0 && !columnFeed?.error;
               return (
                 <BoardColumn
                   key={stage.id}
@@ -311,6 +312,7 @@ function BoardContent({
                   totalTaskCount={totalTaskCount}
                   loading={loading}
                   composerOpen={composerOpen}
+                  feedFailed={Boolean(columnFeed?.error)}
                   laneRef={scroll.registerLane(stage.id)}
                   onDrop={items.handleDrop}
                   headerAction={
@@ -413,7 +415,8 @@ function BoardContent({
                       filtersExcludeAll={filtersExcludeAll}
                     />
                   )}
-                  {stage.id === 'intake' && <IntakeColumnExtras source={intake.active} feed={intake.feed} />}
+                  {columnFeed && <IntakeFeedNotice source={intake.active} feed={columnFeed} />}
+                  {stage.id === 'intake' && <IntakeColumnExtras feed={columnFeed} />}
                 </BoardColumn>
               );
             })}

--- a/mastracode/factory/src/routes/intake.test.ts
+++ b/mastracode/factory/src/routes/intake.test.ts
@@ -257,6 +257,7 @@ describe('aggregated intake', () => {
         { integrationId: 'github', id: 'repo-1', name: 'acme/app', type: 'repository' },
         { integrationId: 'linear', id: 'team-1', name: 'Platform', type: 'project' },
       ],
+      failures: [],
     });
   });
 
@@ -297,6 +298,42 @@ describe('aggregated intake', () => {
     expect(typeof body.nextCursor).toBe('string');
   });
 
+  it('keeps listing sources from the capabilities that answer when one is unavailable', async () => {
+    vi.mocked(linear.listSources).mockRejectedValueOnce(new Error('Linear token expired'));
+
+    const response = await buildApp(orgUser).request('/web/intake/sources');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      sources: [{ integrationId: 'github', id: 'repo-1', name: 'acme/app', type: 'repository' }],
+      failures: [{ integrationId: 'linear', message: 'Linear token expired' }],
+    });
+  });
+
+  it('keeps listing items from the capabilities that answer and resumes an unavailable one at its cursor', async () => {
+    await seed.intake.saveConfig({
+      orgId: 'org1',
+      userId: 'u1',
+      config: {
+        github: { enabled: true, sourceIds: ['repo-1'] },
+        linear: { enabled: true, sourceIds: ['team-1'] },
+      },
+    });
+    vi.mocked(linear.listItems).mockRejectedValueOnce(new Error('Bad gateway'));
+    const cursor = Buffer.from(JSON.stringify({ linear: 'linear-page-2' })).toString('base64url');
+
+    const response = await buildApp(orgUser).request(`/web/intake/items?cursor=${cursor}`);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.items).toEqual([expect.objectContaining({ integrationId: 'github', title: 'Fix login' })]);
+    expect(body.failures).toEqual([{ integrationId: 'linear', message: 'Bad gateway' }]);
+    expect(JSON.parse(Buffer.from(body.nextCursor, 'base64url').toString('utf8'))).toEqual({
+      github: 'github-next',
+      linear: 'linear-page-2',
+    });
+  });
+
   it('does not call disabled or unselected capabilities', async () => {
     await seed.intake.saveConfig({
       orgId: 'org1',
@@ -307,7 +344,7 @@ describe('aggregated intake', () => {
       },
     });
     const response = await buildApp(orgUser).request('/web/intake/items');
-    expect(await response.json()).toEqual({ items: [], nextCursor: null });
+    expect(await response.json()).toEqual({ items: [], nextCursor: null, failures: [] });
     expect(github.listItems).not.toHaveBeenCalled();
     expect(linear.listItems).not.toHaveBeenCalled();
   });

--- a/mastracode/factory/src/routes/intake.test.ts
+++ b/mastracode/factory/src/routes/intake.test.ts
@@ -310,6 +310,21 @@ describe('aggregated intake', () => {
     });
   });
 
+  it('gives up on a capability that never answers instead of hanging the listing', async () => {
+    vi.useFakeTimers();
+    vi.mocked(linear.listSources).mockReturnValueOnce(new Promise(() => {}));
+
+    const pending = buildApp(orgUser).request('/web/intake/sources');
+    await vi.advanceTimersByTimeAsync(15_000);
+    const response = await pending;
+    vi.useRealTimers();
+
+    expect(await response.json()).toEqual({
+      sources: [{ integrationId: 'github', id: 'repo-1', name: 'acme/app', type: 'repository' }],
+      failures: [{ integrationId: 'linear', message: 'linear did not answer within 15s' }],
+    });
+  });
+
   it('keeps listing items from the capabilities that answer and resumes an unavailable one at its cursor', async () => {
     await seed.intake.saveConfig({
       orgId: 'org1',

--- a/mastracode/factory/src/routes/intake.ts
+++ b/mastracode/factory/src/routes/intake.ts
@@ -40,8 +40,23 @@ export interface IntakeIntegrationFailure {
 
 type SettledIntegration<T> = { integrationId: string; value: T } | IntakeIntegrationFailure;
 
+const PROVIDER_READ_TIMEOUT_MS = 15_000;
+
+/** The Intake contract takes no abort signal, so a slow read is abandoned, not cancelled. */
+function withTimeout<T>(integrationId: string, read: () => Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${integrationId} did not answer within ${PROVIDER_READ_TIMEOUT_MS / 1000}s`)),
+      PROVIDER_READ_TIMEOUT_MS,
+    );
+    read()
+      .then(resolve, reject)
+      .finally(() => clearTimeout(timer));
+  });
+}
+
 /**
- * Read every integration concurrently and isolate the ones that throw, so a single
+ * Read every integration concurrently and isolate the ones that throw or hang, so a single
  * unreachable provider degrades to a per-source error instead of failing the listing.
  */
 async function settleByIntegration<T>(
@@ -50,7 +65,7 @@ async function settleByIntegration<T>(
   const settled = await Promise.all(
     requests.map(async ({ integrationId, read }): Promise<SettledIntegration<T>> => {
       try {
-        return { integrationId, value: await read() };
+        return { integrationId, value: await withTimeout(integrationId, read) };
       } catch (error) {
         console.error(`[factory] intake integration ${integrationId} is unavailable:`, error);
         return { integrationId, message: error instanceof Error ? error.message : String(error) };

--- a/mastracode/factory/src/routes/intake.ts
+++ b/mastracode/factory/src/routes/intake.ts
@@ -32,6 +32,40 @@ export interface IntakeRoutesDeps extends RouteDependencies {
   integrations?: IntakeIntegration[];
 }
 
+/** One integration that failed while the rest of the aggregation succeeded. */
+export interface IntakeIntegrationFailure {
+  integrationId: string;
+  message: string;
+}
+
+type SettledIntegration<T> = { integrationId: string; value: T } | IntakeIntegrationFailure;
+
+/**
+ * Read every integration concurrently and isolate the ones that throw, so a single
+ * unreachable provider degrades to a per-source error instead of failing the listing.
+ */
+async function settleByIntegration<T>(
+  requests: Array<{ integrationId: string; read: () => Promise<T> }>,
+): Promise<{ pages: Array<{ integrationId: string; value: T }>; failures: IntakeIntegrationFailure[] }> {
+  const settled = await Promise.all(
+    requests.map(async ({ integrationId, read }): Promise<SettledIntegration<T>> => {
+      try {
+        return { integrationId, value: await read() };
+      } catch (error) {
+        console.error(`[factory] intake integration ${integrationId} is unavailable:`, error);
+        return { integrationId, message: error instanceof Error ? error.message : String(error) };
+      }
+    }),
+  );
+  const pages: Array<{ integrationId: string; value: T }> = [];
+  const failures: IntakeIntegrationFailure[] = [];
+  for (const entry of settled) {
+    if ('value' in entry) pages.push(entry);
+    else failures.push(entry);
+  }
+  return { pages, failures };
+}
+
 interface ParsedBinding {
   integrationId: string;
   sourceId: string;
@@ -255,16 +289,15 @@ export class IntakeRoutes extends Route<IntakeRoutesDeps> {
         handler: async c => {
           const tenant = await this.#resolveTenant(loose(c));
           if ('response' in tenant) return tenant.response;
-          const pages = await Promise.all(
-            integrations.map(async integration => ({
+          const { pages, failures } = await settleByIntegration(
+            integrations.map(integration => ({
               integrationId: integration.id,
-              sources: await integration.intake.listSources(tenant),
+              read: () => integration.intake.listSources(tenant),
             })),
           );
           return c.json({
-            sources: pages.flatMap(page =>
-              page.sources.map(source => ({ integrationId: page.integrationId, ...source })),
-            ),
+            sources: pages.flatMap(({ integrationId, value }) => value.map(source => ({ integrationId, ...source }))),
+            failures,
           });
         },
       }),
@@ -279,29 +312,38 @@ export class IntakeRoutes extends Route<IntakeRoutesDeps> {
 
           await intake.ensureReady();
           const config = await intake.getConfig({ ...tenant, integrationIds });
+          const { pages, failures } = await settleByIntegration(
+            integrations.flatMap(integration => {
+              const selection = config[integration.id];
+              if (!selection?.enabled || !selection.sourceIds?.length) return [];
+              const sourceIds = selection.sourceIds;
+              const cursor = cursors[integration.id];
+              return [
+                {
+                  integrationId: integration.id,
+                  read: () => integration.intake.listItems({ ...tenant, sourceIds, ...(cursor ? { cursor } : {}) }),
+                },
+              ];
+            }),
+          );
+
           const items: AggregatedIntakeItem[] = [];
           const nextCursors: Record<string, string> = {};
-          for (const integration of integrations) {
-            const selection = config[integration.id];
-            if (!selection?.enabled || !selection.sourceIds?.length) continue;
-            const page = await integration.intake.listItems({
-              ...tenant,
-              sourceIds: selection.sourceIds,
-              ...(cursors[integration.id] ? { cursor: cursors[integration.id] } : {}),
-            });
+          for (const { integrationId, value } of pages) {
             items.push(
-              ...page.items.map(item => {
+              ...value.items.map(item => {
                 const { source, ...candidate } = item;
-                return {
-                  ...candidate,
-                  integrationId: integration.id,
-                  externalSource: { integrationId: integration.id, ...source },
-                };
+                return { ...candidate, integrationId, externalSource: { integrationId, ...source } };
               }),
             );
-            if (page.nextCursor) nextCursors[integration.id] = page.nextCursor;
+            if (value.nextCursor) nextCursors[integrationId] = value.nextCursor;
           }
-          return c.json({ items, nextCursor: encodeCursor(nextCursors) });
+          // Keep the cursor an unavailable integration came in with, so the next page resumes there instead of replaying it.
+          for (const { integrationId } of failures) {
+            const cursor = cursors[integrationId];
+            if (cursor) nextCursors[integrationId] = cursor;
+          }
+          return c.json({ items, nextCursor: encodeCursor(nextCursors), failures });
         },
       }),
     ];


### PR DESCRIPTION
TLDR: the Intake column stops saying "Intake is clear" when GitHub or Linear is actually down, and the aggregated intake routes stop letting one dead provider take the whole listing with them.

---

```
before   Linear 502s  →  column renders "Intake is clear", user sees an empty backlog
after    Linear 502s  →  column names the failure, with a Retry
```

Two layers, same failure.

**The board (what a user sees).** `useBoardIntake` read every candidate feed as `.data ?? []`, so a feed that errored was indistinguishable from a feed that was empty. The hook now maps each candidate-fed column to its query — `intake` to the browsed feed, `triage` to its own labelled one — and every column reads its failure from there: the misleading empty state is suppressed, `IntakeFeedNotice` names the error with a Retry, and pagination stays where it was.

**The aggregated routes (contract, no consumer yet).** `/web/intake/sources` fanned out with `Promise.all`, `/web/intake/items` awaited providers in a bare loop; either way the first rejection was the response. Both now read providers concurrently, keep what the healthy ones answered, and return a `failures` array next to the data. Status stays 200.

| situation | before | after |
| --- | --- | --- |
| board's browsed feed errors | "Intake is clear" | error message + Retry |
| board's triage feed errors | column collapses, "Nothing to triage" | column stays open, message + Retry |
| a second page fails | Retry replayed page 1, the failed page never came | Retry asks for the page that failed |
| board's Linear token expired | reconnect notice | unchanged |
| a provider 502s on `/intake/*` | 500, nothing renders | the others' data, `failures` names the broken one |
| a provider never answers | request hangs | given up on at 15s, listed as a failure |
| a provider fails mid-pagination | n/a (whole page failed) | its incoming cursor carried into `nextCursor` |

### Judgment call

The two intake layers are not the same code and I did not merge them. The board reads per provider through `Intake.listIssues`, one feed at a time; `/web/intake/items` is the normalized cross-provider digest built on `listSources`/`listItems`, which nothing consumes yet. Migrating the board onto it would push typed provider facts — `issue.number`, `pr.headBranch`, labels driving column routing — into `IntakeItem.metadata`, an untyped bag. Wrong direction, so both layers stay and both get fixed.

On the aggregated route, a failed provider keeps the cursor it came in with: dropping it would replay page 1 on recovery and duplicate items. A permanently-down provider therefore keeps `nextCursor` non-null — the client sees it in `failures` and can stop.

The 15s bound came out of review. Linear bounds its calls with `AbortSignal.timeout`, but `getInstallationOctokit` builds an Octokit with no `request.timeout` and Node's fetch has no default, so the GitHub path could hang the listing forever. `Intake` takes no abort signal, so a timed-out read is abandoned, not cancelled.

### Side effects to check

Two of these came out of review and reach past the intake column. `BoardColumn` no longer collapses an empty non-intake column when its feed failed — otherwise the triage error had nowhere to render. And a paging failure retries with `fetchNextPage()` instead of `refetch()`, since the page that failed was never stored.

### Not verified

`/web/intake/sources` and `/web/intake/items` still have no consumer — checked this repo and the platform checkout. Their half is a contract, tested against fake providers, never against a real outage. The board half is covered end to end against a 502.

```
source     +164  -82
tests      +204   -1
changeset   +21    0
```
