### PR TITLE
feat(factory): publish review verdicts through a governed tool

### DIFF
--- a/.changeset/cold-years-sleep.md
+++ b/.changeset/cold-years-sleep.md
@@ -1,0 +1,16 @@
+---
+'@mastra/factory': patch
+---
+
+Factory review verdicts are now published by `factory_publish_review` instead of composed by the reviewing agent and shelled out to `gh pr review`.
+
+The review and re-review skills supply the review as data — findings, verification, prior-pass and existing-review dispositions, adversarial check, requested changes, assumptions, open questions. The tool renders the body, submits the verdict on the pull request, and appends the runtime attribution it reads at publish time.
+
+**What this fixes**
+
+- Reviews published without the `Review runtime: <model>, reasoning setting: <level>` footer, because the model did not copy it.
+- A re-review in a session that switched model publishing the _previous_ pass's model, because the runtime was read once at the start of the thread.
+
+**Approval gates are now enforced, not requested**
+
+An approve without an adversarial check, or with no executed verification and no reason why, is rejected by the tool's schema. A request-changes verdict with no requested change is rejected too.

--- a/.changeset/cold-years-sleep.md
+++ b/.changeset/cold-years-sleep.md
@@ -14,3 +14,7 @@ The review and re-review skills supply the review as data — findings, verifica
 **Approval gates are now enforced, not requested**
 
 An approve without an adversarial check, or with no executed verification and no reason why, is rejected by the tool's schema. A request-changes verdict with no requested change is rejected too.
+
+**Self-authored pull requests keep their handoff**
+
+GitHub refuses a review verdict on a pull request its own token opened. The verdict then lands as a pull request comment, the channel the rule that wakes the authoring agent reads — a comment review would be classified as `commented` and dropped.

--- a/mastracode/factory/factory-skills/factory-rereview/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-rereview/SKILL.md
@@ -118,25 +118,17 @@ Do not hedge between the two — pick the verdict the evidence supports. When ge
 
 ## Phase 7: Handoff & Transition
 
-First, compose the **re-review handoff** — don't send it to the conversation yet; it must be published on the PR and the transition requested before your final message. It **must open with the verdict line**: `Verdict: approve` or `Verdict: request changes`, followed by:
+Publish the re-review with `factory_publish_review` — this is part of every pass, not something to wait to be asked for. You supply the re-review as data; the tool composes the body, orders its sections, appends the runtime attribution and submits the verdict on the PR. Fill every part your run produced:
 
-- **Prior pass disposition** — every substantive item from your previous review, classified: addressed, partially addressed, still open, refuted by the push, or invalidated by the push. Cite the commit or `file:line` proving each addressed/refuted/invalidated call. A prior blocking finding still open is called out plainly at the top of this section.
-- **Findings** — new-this-pass findings from the push and from the fresh whole-PR sweep, each labeled as `[push]` or `[fresh]` so the record is honest about where they came from. Distill — this is a handoff, not a transcript.
-- **Verification** — every command you executed against the current head (tests, typecheck, repros) with its outcome, or an explicit statement that nothing was executed and why. Verification the prior pass ran is not restated here — only what this pass ran counts.
-- **Other-reviewer disposition** — any substantive finding posted by another reviewer (bot or human) since the prior pass, with its classification: confirmed, addressed, or refuted with evidence. A major bot comment must never be silently dropped. Name each by subject and `file:line`, and remember the body lands as GitHub markdown — `#1` publishes as a link to issue 1.
-- **Adversarial check** (approve only) — the one-line record of why the strongest request-changes case fails.
-- **Requested changes** — one entry per change, concrete enough to act on (for a request-changes verdict). Prior-pass changes that remain open reappear here so the author has one current list, not two.
-- **Assumptions** — every recorded judgment call from this run.
-- **Open questions** — any decision that genuinely needs a human.
+- `priorPass` — every substantive item from your previous review, each addressed, partially-addressed, still-open, refuted or invalidated, citing the commit or `file:line` that proves the call.
+- `findings` — new this pass, each marked `origin: "push"` or `origin: "fresh"` so the record is honest about where it came from. Bodies land as GitHub markdown, so `#1` publishes as a link to issue 1.
+- `verification` — every command you executed against the current head, with its outcome. What the prior pass ran does not count; nothing executed this pass goes in `verificationGap`.
+- `existingSignal` — any substantive finding another reviewer, bot or human, posted since the prior pass, each confirmed, addressed or refuted with evidence.
+- `adversarialCheck` — why the strongest request-changes case fails. The tool refuses an approve without it.
+- `requestedChanges` — one entry per change. Prior-pass changes still open reappear here, so the author has one current list rather than two.
+- `assumptions`, `openQuestions` — the judgment calls from this run, and any decision that genuinely needs a human.
 
-End the handoff with `Review runtime: <model>, reasoning setting: <reasoning>.`, copying both values verbatim from the current `factory-phase` signal.
-
-Next, publish the re-review on the PR itself — this is part of every pass, not something to wait to be asked for. Write the handoff body to `.artifacts/factory-rereview/pr-<number>.md` and submit a PR review matching the verdict:
-
-- approve → `gh pr review <number> --approve --body-file <file>`
-- request changes → `gh pr review <number> --request-changes --body-file <file>`
-
-If GitHub rejects the review submission (e.g. the token authored the PR and cannot approve or request changes on it), fall back to `gh pr comment <number> --body-file <file>` so the verdict still lands on the PR, and report the fallback under **Verification** — how the verdict was published is an operational outcome, not an assumption.
+The tool returns the published body and how it landed: `event: "comment"` means GitHub refused the verdict event — the token authored the PR — and the verdict went up as a comment review instead. Report that in your final message; how the verdict was published is an operational outcome, not an assumption.
 
 **Non-blocking follow-ups become a PR, not homework.** After publishing the re-review, if it produced non-blocking findings with concrete mechanical fixes — typos, small hardening, a supplemental test case, doc touch-ups — implement them yourself instead of leaving them as a burden on the author. Supplemental means coverage beyond what the behavior-tested gate required: a test gap that failed that gate is a requested change on the reviewed PR, never follow-up work:
 
@@ -151,7 +143,7 @@ Then make your terminal `factory_transition_work_item` call. Take the current st
 
 `rationale` (max 1000 chars) — one or two sentences: re-review complete, verdict, and the headline reason (usually "prior findings addressed" or "push introduced X" or "prior blocking finding still open").
 
-The transition is governed by the server's rules. If it is rejected, read the stated reason, address it (re-check the revision from the latest `factory-phase` signal, re-examine contested findings, re-review if the PR changed again mid-run), and retry once corrected. Once the transition succeeds, post the handoff as your final conversation message — including how the verdict was published — and stop.
+The transition is governed by the server's rules. If it is rejected, read the stated reason, address it (re-check the revision from the latest `factory-phase` signal, re-examine contested findings, re-review if the PR changed again mid-run), and retry once corrected. Once the transition succeeds, post the body `factory_publish_review` returned as your final conversation message — including how the verdict was published — and stop.
 
 ## Behavior Rules
 

--- a/mastracode/factory/factory-skills/factory-rereview/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-rereview/SKILL.md
@@ -128,7 +128,7 @@ Publish the re-review with `factory_publish_review` — this is part of every pa
 - `requestedChanges` — one entry per change. Prior-pass changes still open reappear here, so the author has one current list rather than two.
 - `assumptions`, `openQuestions` — the judgment calls from this run, and any decision that genuinely needs a human.
 
-The tool returns the published body and how it landed: `event: "comment"` means GitHub refused the verdict event — the token authored the PR — and the verdict went up as a comment review instead. Report that in your final message; how the verdict was published is an operational outcome, not an assumption.
+The tool returns the published body and how it landed: `event: "comment"` means GitHub refused the verdict event — the token authored the PR — and the verdict went up as a pull request comment instead. Report that in your final message; how the verdict was published is an operational outcome, not an assumption.
 
 **Non-blocking follow-ups become a PR, not homework.** After publishing the re-review, if it produced non-blocking findings with concrete mechanical fixes — typos, small hardening, a supplemental test case, doc touch-ups — implement them yourself instead of leaving them as a burden on the author. Supplemental means coverage beyond what the behavior-tested gate required: a test gap that failed that gate is a requested change on the reviewed PR, never follow-up work:
 

--- a/mastracode/factory/factory-skills/factory-review/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-review/SKILL.md
@@ -122,7 +122,7 @@ Publish the review with `factory_publish_review` — this is part of every pass,
 - `requestedChanges` — one entry per change, concrete enough to act on. The tool refuses a request-changes verdict without at least one.
 - `assumptions`, `openQuestions` — the judgment calls you recorded, and any decision that genuinely needs a human.
 
-The tool returns the published body and how it landed: `event: "comment"` means GitHub refused the verdict event — the token authored the PR — and the verdict went up as a comment review instead. Report that in your final message; how the verdict was published is an operational outcome, not an assumption.
+The tool returns the published body and how it landed: `event: "comment"` means GitHub refused the verdict event — the token authored the PR — and the verdict went up as a pull request comment instead. Report that in your final message; how the verdict was published is an operational outcome, not an assumption.
 
 **Non-blocking follow-ups become a PR, not homework.** After publishing the review, if it produced non-blocking findings with concrete mechanical fixes — typos, small hardening, a supplemental test case, doc touch-ups — implement them yourself instead of leaving them as a burden on the author. Supplemental means coverage beyond what the behavior-tested gate required: a test gap that failed that gate is a requested change on the reviewed PR, never follow-up work:
 

--- a/mastracode/factory/factory-skills/factory-review/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-review/SKILL.md
@@ -113,24 +113,16 @@ Do not hedge between the two — pick the verdict the evidence supports. When ge
 
 ## Phase 6: Handoff & Transition
 
-First, compose the **review handoff** — don't send it to the conversation yet; it must be published on the PR and the transition requested before your final message. It **must open with the verdict line**: `Verdict: approve` or `Verdict: request changes`, followed by:
+Publish the review with `factory_publish_review` — this is part of every pass, not something to wait to be asked for. You supply the review as data; the tool composes the body, orders its sections, appends the runtime attribution and submits the verdict on the PR. Fill every part your run produced:
 
-- **Findings** — correctness assessment, test assessment, scope assessment, pattern-consistency notes, each grounded in the history you traced. Distill — this is a handoff, not a transcript.
-- **Verification** — every command you executed (tests, typecheck, repros) with its outcome, or an explicit statement that nothing was executed and why.
-- **Existing review disposition** — every substantive finding from prior reviewers (bots included, your own earlier passes included) with its classification: confirmed, addressed, or refuted with evidence. A major bot comment must never be silently dropped. Name each by subject and `file:line`, and remember the body lands as GitHub markdown — `#1` publishes as a link to issue 1.
-- **Adversarial check** (approve only) — the one-line record of why the strongest request-changes case fails.
-- **Requested changes** — one entry per change, concrete enough to act on (for a request-changes verdict).
-- **Assumptions** — every recorded judgment call from the run.
-- **Open questions** — any decision that genuinely needs a human.
+- `findings` — correctness, tests, scope and pattern-consistency, each grounded in the history you traced. Distill — this is a handoff, not a transcript. Bodies land as GitHub markdown, so `#1` publishes as a link to issue 1.
+- `verification` — every command you executed with its outcome. Nothing executed? Say why in `verificationGap`.
+- `existingSignal` — every substantive prior finding, bots and your own earlier passes included, each confirmed, addressed or refuted with evidence. A major bot comment must never be silently dropped.
+- `adversarialCheck` — why the strongest request-changes case fails. The tool refuses an approve without it.
+- `requestedChanges` — one entry per change, concrete enough to act on. The tool refuses a request-changes verdict without at least one.
+- `assumptions`, `openQuestions` — the judgment calls you recorded, and any decision that genuinely needs a human.
 
-End the handoff with `Review runtime: <model>, reasoning setting: <reasoning>.`, copying both values verbatim from the current `factory-phase` signal.
-
-Next, publish the review on the PR itself — this is part of every pass, not something to wait to be asked for. Write the handoff body to `.artifacts/factory-review/pr-<number>.md` and submit a PR review matching the verdict:
-
-- approve → `gh pr review <number> --approve --body-file <file>`
-- request changes → `gh pr review <number> --request-changes --body-file <file>`
-
-If GitHub rejects the review submission (e.g. the token authored the PR and cannot approve or request changes on it), fall back to `gh pr comment <number> --body-file <file>` so the verdict still lands on the PR, and report the fallback under **Verification** — how the verdict was published is an operational outcome, not an assumption.
+The tool returns the published body and how it landed: `event: "comment"` means GitHub refused the verdict event — the token authored the PR — and the verdict went up as a comment review instead. Report that in your final message; how the verdict was published is an operational outcome, not an assumption.
 
 **Non-blocking follow-ups become a PR, not homework.** After publishing the review, if it produced non-blocking findings with concrete mechanical fixes — typos, small hardening, a supplemental test case, doc touch-ups — implement them yourself instead of leaving them as a burden on the author. Supplemental means coverage beyond what the behavior-tested gate required: a test gap that failed that gate is a requested change on the reviewed PR, never follow-up work:
 
@@ -145,7 +137,7 @@ Then make your terminal `factory_transition_work_item` call. Take the current st
 
 `rationale` (max 1000 chars) — one or two sentences: review complete, verdict, and the headline reason.
 
-The transition is governed by the server's rules. If it is rejected, read the stated reason, address it (re-check the revision from the latest `factory-phase` signal, re-examine contested findings, re-review if the PR changed), and retry once corrected. Once the transition succeeds, post the handoff as your final conversation message — including how the verdict was published — and stop.
+The transition is governed by the server's rules. If it is rejected, read the stated reason, address it (re-check the revision from the latest `factory-phase` signal, re-examine contested findings, re-review if the PR changed), and retry once corrected. Once the transition succeeds, post the body `factory_publish_review` returned as your final conversation message — including how the verdict was published — and stop.
 
 ## Behavior Rules
 

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -44,6 +44,7 @@ import {
   resolveFactoryPullRequestParentWorkItemId,
 } from './integrations/github/provenance.js';
 import type { FactoryPullRequestProvenanceData } from './integrations/github/provenance.js';
+import { createGithubReviewPublisher } from './integrations/github/review-publisher.js';
 import { PlatformGithubIntegration } from './integrations/platform/github/integration.js';
 import { PlatformLinearIntegration } from './integrations/platform/linear/integration.js';
 import { createCustomProvidersPrimer, registerCustomProvidersSource } from './routes/custom-provider-source.js';
@@ -58,6 +59,7 @@ import {
 import { builtInFactoryRules } from './rules/defaults.js';
 import { FactoryDecisionDispatcher } from './rules/dispatcher.js';
 import { FactoryPhaseStateProcessor } from './rules/processor.js';
+import { createFactoryReviewTools } from './rules/review-tool.js';
 import { createTerminalStageCleanup } from './rules/terminal-cleanup.js';
 import { createFactoryTransitionTools } from './rules/tools.js';
 import { FactoryTransitionService } from './rules/transition-service.js';
@@ -727,6 +729,20 @@ export class MastraFactory {
                     tools[name] = tool;
                   }
                 };
+                if (workItemsStorage && githubIntegration?.versionControl && storage.isDomainReady('source-control')) {
+                  mergeTools(
+                    'factory-review',
+                    await createFactoryReviewTools({
+                      requestContext,
+                      storage: workItemsStorage,
+                      publisher: createGithubReviewPublisher({
+                        storage: sourceControlStorage.forIntegration('github'),
+                        versionControl: githubIntegration.versionControl,
+                      }),
+                      sessions: sourceControlStorage.forIntegration('github').sessions,
+                    }),
+                  );
+                }
                 if (workItemsStorage && transitionService) {
                   mergeTools(
                     'factory',

--- a/mastracode/factory/src/integrations/github/review-publisher.test.ts
+++ b/mastracode/factory/src/integrations/github/review-publisher.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createGithubReviewPublisher } from './review-publisher.js';
+
+const PR_URL = 'https://github.com/acme/repo/pull/17';
+const ITEM = { externalSource: { type: 'pull-request' as const, externalId: 'github-pr:17', url: PR_URL } };
+
+const storage = {
+  connections: {
+    list: async () => [
+      {
+        id: 'connection-1',
+        factoryProjectId: 'project-1',
+        integrationId: 'github',
+        installationId: 'installation-1',
+        createdByUserId: 'user-1',
+        createdAt: new Date('2026-08-01T00:00:00Z'),
+      },
+    ],
+  },
+  installations: {
+    get: async () => ({
+      id: 'installation-1',
+      integrationId: 'github',
+      orgId: 'org-1',
+      connectedByUserId: 'user-1',
+      externalId: '4242',
+      accountName: 'acme',
+      accountType: 'organization',
+      providerMetadata: null,
+      createdAt: new Date('2026-08-01T00:00:00Z'),
+    }),
+  },
+  projectRepositories: {
+    list: async () => [{ id: 'project-repository-1', connectionId: 'connection-1', repositoryId: 'repository-1' }],
+  },
+  repositories: {
+    get: async () => ({ id: 'repository-1', installationId: 'installation-1', externalId: '99', slug: 'acme/repo' }),
+  },
+};
+
+function publisherWith(createReview: () => Promise<{ url: string }>) {
+  const createComment = vi.fn(async () => ({ url: `${PR_URL}#issuecomment-1` }));
+  const versionControl = { createReview: vi.fn(createReview), createComment };
+  return {
+    versionControl,
+    publish: createGithubReviewPublisher({ storage, versionControl }).publish,
+  };
+}
+
+const INPUT = {
+  orgId: 'org-1',
+  factoryProjectId: 'project-1',
+  item: ITEM,
+  verdict: 'request-changes' as const,
+  body: 'Verdict: request changes\n',
+};
+
+describe('github review publisher', () => {
+  it('submits the verdict as a review against the repository the card pins', async () => {
+    const { versionControl, publish } = publisherWith(async () => ({ url: `${PR_URL}#pullrequestreview-1` }));
+
+    expect(await publish(INPUT)).toEqual({ url: `${PR_URL}#pullrequestreview-1`, event: 'request-changes' });
+    expect(versionControl.createReview).toHaveBeenCalledWith({
+      connection: { type: 'app-installation', installationId: 4242 },
+      sourceId: 'acme/repo',
+      pullRequestId: '17',
+      event: 'request-changes',
+      body: INPUT.body,
+    });
+    expect(versionControl.createComment).not.toHaveBeenCalled();
+  });
+
+  // A comment *review* would land on `pullRequestReviewSubmitted`, which ignores
+  // anything but `changes_requested`, and the author would never be woken.
+  it('falls back to a pull request comment when GitHub refuses a self-review', async () => {
+    const { versionControl, publish } = publisherWith(async () => {
+      throw Object.assign(new Error('Unprocessable Entity'), { status: 422 });
+    });
+
+    expect(await publish(INPUT)).toEqual({ url: `${PR_URL}#issuecomment-1`, event: 'comment' });
+    expect(versionControl.createReview).toHaveBeenCalledOnce();
+    expect(versionControl.createComment).toHaveBeenCalledWith({
+      connection: { type: 'app-installation', installationId: 4242 },
+      sourceId: 'acme/repo',
+      pullRequestId: '17',
+      body: INPUT.body,
+    });
+  });
+
+  it('rethrows anything that is not GitHub refusing the verdict', async () => {
+    const { versionControl, publish } = publisherWith(async () => {
+      throw Object.assign(new Error('Bad credentials'), { status: 401 });
+    });
+
+    await expect(publish(INPUT)).rejects.toThrow('Bad credentials');
+    expect(versionControl.createComment).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/factory/src/integrations/github/review-publisher.ts
+++ b/mastracode/factory/src/integrations/github/review-publisher.ts
@@ -6,7 +6,7 @@ import type { WorkItemRow } from '../../storage/domains/work-items/base.js';
 type PullRequestTarget = { slug: string; pullRequestNumber: number };
 
 /** Card URLs pin the repository; a canonical key alone does not, so it is not trusted here. */
-function pullRequestTarget(item: WorkItemRow): PullRequestTarget | null {
+function pullRequestTarget(item: Pick<WorkItemRow, 'externalSource'>): PullRequestTarget | null {
   const url = item.externalSource?.url;
   if (!url) return null;
   const match = /^https?:\/\/[^/]+\/(.+)\/pull\/(\d+)(?:[/?#]|$)/.exec(url);
@@ -20,8 +20,8 @@ function refusedTheVerdict(error: unknown): boolean {
 }
 
 export function createGithubReviewPublisher(options: {
-  storage: SourceControlStorageHandle;
-  versionControl: VersionControl;
+  storage: Pick<SourceControlStorageHandle, 'connections' | 'installations' | 'projectRepositories' | 'repositories'>;
+  versionControl: Pick<VersionControl, 'createReview' | 'createComment'>;
 }): FactoryReviewPublisher {
   return {
     async publish({ orgId, factoryProjectId, item, verdict, body }): Promise<PublishedReview> {
@@ -49,8 +49,11 @@ export function createGithubReviewPublisher(options: {
             return { url: review.url, event: verdict };
           } catch (error) {
             if (!refusedTheVerdict(error)) throw error;
-            const review = await options.versionControl.createReview({ ...ref, event: 'comment', body });
-            return { url: review.url, event: 'comment' };
+            // A comment review would reach `pullRequestReviewSubmitted`, which only
+            // acts on `changes_requested`; the handoff rule reading the verdict off
+            // the first line runs on issue comments, so the fallback posts one.
+            const comment = await options.versionControl.createComment({ ...ref, body });
+            return { url: comment.url, event: 'comment' };
           }
         }
       }

--- a/mastracode/factory/src/integrations/github/review-publisher.ts
+++ b/mastracode/factory/src/integrations/github/review-publisher.ts
@@ -1,0 +1,60 @@
+import type { VersionControl } from '../../capabilities/version-control.js';
+import type { FactoryReviewPublisher, PublishedReview } from '../../rules/review-tool.js';
+import type { SourceControlStorageHandle } from '../../storage/domains/source-control/base.js';
+import type { WorkItemRow } from '../../storage/domains/work-items/base.js';
+
+type PullRequestTarget = { slug: string; pullRequestNumber: number };
+
+/** Card URLs pin the repository; a canonical key alone does not, so it is not trusted here. */
+function pullRequestTarget(item: WorkItemRow): PullRequestTarget | null {
+  const url = item.externalSource?.url;
+  if (!url) return null;
+  const match = /^https?:\/\/[^/]+\/(.+)\/pull\/(\d+)(?:[/?#]|$)/.exec(url);
+  return match ? { slug: match[1]!, pullRequestNumber: Number(match[2]) } : null;
+}
+
+// GitHub answers 422 when the token authored the PR and cannot vote on it.
+function refusedTheVerdict(error: unknown): boolean {
+  const status = (error as { status?: number } | undefined)?.status;
+  return status === 422;
+}
+
+export function createGithubReviewPublisher(options: {
+  storage: SourceControlStorageHandle;
+  versionControl: VersionControl;
+}): FactoryReviewPublisher {
+  return {
+    async publish({ orgId, factoryProjectId, item, verdict, body }): Promise<PublishedReview> {
+      const target = pullRequestTarget(item);
+      if (!target) throw new Error('The bound work item does not carry a pull request URL to publish against.');
+
+      const connections = await options.storage.connections.list({ orgId, factoryProjectId });
+      for (const connection of connections) {
+        const [installation, projectRepositories] = await Promise.all([
+          options.storage.installations.get({ orgId, id: connection.installationId }),
+          options.storage.projectRepositories.list({ orgId, connectionId: connection.id }),
+        ]);
+        if (!installation) continue;
+        for (const projectRepository of projectRepositories) {
+          const repository = await options.storage.repositories.get({ orgId, id: projectRepository.repositoryId });
+          if (repository?.slug !== target.slug) continue;
+
+          const ref = {
+            connection: { type: 'app-installation' as const, installationId: Number(installation.externalId) },
+            sourceId: repository.slug,
+            pullRequestId: String(target.pullRequestNumber),
+          };
+          try {
+            const review = await options.versionControl.createReview({ ...ref, event: verdict, body });
+            return { url: review.url, event: verdict };
+          } catch (error) {
+            if (!refusedTheVerdict(error)) throw error;
+            const review = await options.versionControl.createReview({ ...ref, event: 'comment', body });
+            return { url: review.url, event: 'comment' };
+          }
+        }
+      }
+      throw new Error(`No configured repository in this Factory project matches ${target.slug}.`);
+    },
+  };
+}

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { defaultFactoryRules, mergeFactoryRuleOverrides } from './defaults.js';
+import { renderReviewReport, reviewReportSchema } from './review-report.js';
 import type {
   FactoryBoardRuleLeaf,
   FactoryGithubRuleContext,
@@ -715,6 +716,27 @@ describe('defaultFactoryRules', () => {
             url: 'https://github.test/acme/repo/pull/17#issuecomment-556',
             author: 'factory[bot]',
           },
+        }),
+      );
+      expect(decision).toMatchObject({ type: 'sendMessage', role: 'work', priority: 'high' });
+    });
+
+    it('wakes on the body the review tool composes, not only on the hand-written shape', async () => {
+      // `factory_publish_review` falls back to a comment on a Factory-authored PR,
+      // and this rule is the only thing that carries the verdict back to the author.
+      const rule = defaultFactoryRules({ version: 'deployment-7' }).github.pullRequestCommentCreated?.onEvent;
+      const body = renderReviewReport(
+        reviewReportSchema.parse({
+          verdict: 'request-changes',
+          requestedChanges: [{ subject: 'Retry loop', location: 'src/run.ts:12', body: 'It never terminates.' }],
+          verification: [{ command: 'pnpm test', outcome: 'pass' }],
+        }),
+        { modelId: 'anthropic/claude-opus-5', thinkingLevel: 'high' },
+      );
+      const decision = await rule?.(
+        commentContext({
+          actor: { type: 'github', login: 'factory[bot]', trusted: true, factoryAuthored: true },
+          issueComment: { id: 559, body, author: 'factory[bot]' },
         }),
       );
       expect(decision).toMatchObject({ type: 'sendMessage', role: 'work', priority: 'high' });

--- a/mastracode/factory/src/rules/processor.ts
+++ b/mastracode/factory/src/rules/processor.ts
@@ -1,10 +1,6 @@
 import { createHash } from 'node:crypto';
 
-import { resolveRequestThinkingLevel } from '@mastra/code-sdk/agents/model';
-import type { ThinkingLevel } from '@mastra/code-sdk/providers/openai-codex';
-import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { MastraDBMessage, MessageList } from '@mastra/core/agent/message-list';
-import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
 import type {
   ComputeStateSignalArgs,
   ComputeStateSignalResult,
@@ -15,6 +11,8 @@ import type {
 import type { FactoryRunBindingRecord, WorkItemsStorage, WorkItemRow } from '../storage/domains/work-items/base.js';
 import { getFactorySessionCoordinates } from './binding-context.js';
 import { resolveFactoryToolRule } from './resolve.js';
+import type { ReviewRuntime } from './review-runtime.js';
+import { reviewRuntimeFromRequestContext } from './review-runtime.js';
 import { workItemSource } from './transition-service.js';
 import type { FactoryTransitionService } from './transition-service.js';
 import { factoryRuleStage } from './types.js';
@@ -72,11 +70,6 @@ type CompletedToolResult = {
   value: FactoryRuleJsonValue;
 };
 
-type RuntimeSnapshot = {
-  modelId: string;
-  thinkingLevel: ThinkingLevel;
-};
-
 type ActivePhaseSnapshotBase = {
   bindingId: string;
   itemId: string;
@@ -89,20 +82,14 @@ type ActivePhaseSnapshotBase = {
 
 type ActivePhaseSnapshotValue =
   | (ActivePhaseSnapshotBase & { board: 'work' })
-  | (ActivePhaseSnapshotBase & { board: 'review' } & RuntimeSnapshot);
+  | (ActivePhaseSnapshotBase & { board: 'review' } & ReviewRuntime);
 
 type PhaseSnapshotValue = ActivePhaseSnapshotValue | { bindingId?: string; status: 'none' };
 
-function reviewRuntimeFromRequestContext(requestContext: ComputeStateSignalArgs['requestContext']): RuntimeSnapshot {
-  if (!requestContext || typeof requestContext.get !== 'function') {
-    throw new Error('Factory review phase requires a controller request context.');
-  }
-  const context = requestContext.get<'controller', AgentControllerRequestContext<MastraCodeState>>('controller');
-  const modelId = context?.session?.modelId.trim();
-  if (!modelId) {
-    throw new Error('Factory review phase requires a selected session model.');
-  }
-  return { modelId, thinkingLevel: resolveRequestThinkingLevel(context) };
+function requireReviewRuntime(requestContext: ComputeStateSignalArgs['requestContext']): ReviewRuntime {
+  const runtime = reviewRuntimeFromRequestContext(requestContext);
+  if (!runtime) throw new Error('Factory review phase requires a selected session model.');
+  return runtime;
 }
 
 function workItemSourceKey(item: WorkItemRow): string | null {
@@ -309,7 +296,7 @@ export class FactoryPhaseStateProcessor implements Processor<'factory-phase'> {
     };
     const value: ActivePhaseSnapshotValue =
       board === 'review'
-        ? { ...baseValue, board, ...reviewRuntimeFromRequestContext(args.requestContext) }
+        ? { ...baseValue, board, ...requireReviewRuntime(args.requestContext) }
         : { ...baseValue, board };
     const cacheKey = phaseCacheKey(value, linked);
     if (hasBase && (args.tracking?.currentCacheKey ?? args.lastSnapshot?.metadata?.state?.cacheKey) === cacheKey)

--- a/mastracode/factory/src/rules/review-report.test.ts
+++ b/mastracode/factory/src/rules/review-report.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderReviewReport, reviewReportSchema } from './review-report.js';
+
+const RUNTIME = { modelId: 'anthropic/claude-opus-5', thinkingLevel: 'high' } as const;
+
+const APPROVE = {
+  verdict: 'approve',
+  findings: [
+    { subject: 'Reconcile sweep', location: 'src/rules.ts:42', body: 'Covers the merged-after-approve case.' },
+  ],
+  verification: [{ command: 'pnpm test', outcome: 'pass' }],
+  adversarialCheck: 'The strongest request-changes case rests on a path the tests cover.',
+};
+
+describe('review report', () => {
+  it('opens with the verdict and closes with the runtime that published it', () => {
+    const body = renderReviewReport(reviewReportSchema.parse(APPROVE), RUNTIME);
+
+    expect(body.startsWith('Verdict: approve\n')).toBe(true);
+    expect(body.trimEnd().endsWith('Review runtime: anthropic/claude-opus-5, reasoning setting: high.')).toBe(true);
+  });
+
+  // The line is composed, never copied: a session that switches model mid-thread
+  // published its second review under the first review's model.
+  it('attributes each render to the runtime it is given', () => {
+    const report = reviewReportSchema.parse(APPROVE);
+
+    const first = renderReviewReport(report, { modelId: 'anthropic/claude-opus-4-8', thinkingLevel: 'low' });
+    const second = renderReviewReport(report, RUNTIME);
+
+    expect(first).toContain('Review runtime: anthropic/claude-opus-4-8, reasoning setting: low.');
+    expect(second).toContain('Review runtime: anthropic/claude-opus-5, reasoning setting: high.');
+  });
+
+  it('drops the footer rather than inventing a runtime', () => {
+    expect(renderReviewReport(reviewReportSchema.parse(APPROVE), null)).not.toContain('Review runtime');
+  });
+
+  it('keeps empty sections out of the body', () => {
+    const body = renderReviewReport(reviewReportSchema.parse(APPROVE), RUNTIME);
+
+    expect(body).toContain('## Findings');
+    expect(body).not.toContain('## Open questions');
+  });
+
+  it('refuses an approve with no adversarial check', () => {
+    expect(reviewReportSchema.safeParse({ ...APPROVE, adversarialCheck: undefined }).success).toBe(false);
+  });
+
+  it('refuses an approve that ran nothing and says nothing about it', () => {
+    expect(reviewReportSchema.safeParse({ ...APPROVE, verification: [] }).success).toBe(false);
+    expect(
+      reviewReportSchema.safeParse({ ...APPROVE, verification: [], verificationGap: 'The sandbox had no toolchain.' })
+        .success,
+    ).toBe(true);
+  });
+
+  it('refuses a request-changes verdict that requests nothing', () => {
+    expect(reviewReportSchema.safeParse({ verdict: 'request-changes' }).success).toBe(false);
+    expect(
+      reviewReportSchema.safeParse({
+        verdict: 'request-changes',
+        requestedChanges: [{ subject: 'Cover the reopen path', body: 'Add a case for a reopened pull request.' }],
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/mastracode/factory/src/rules/review-report.ts
+++ b/mastracode/factory/src/rules/review-report.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod';
+
+import type { ReviewRuntime } from './review-runtime.js';
+
+const text = z.string().trim().min(1);
+
+const findingSchema = z
+  .object({
+    subject: text.describe('What the finding is about, in a few words.'),
+    location: text.optional().describe('Where it lives, as `path/to/file.ts:42`.'),
+    body: text.describe('The finding itself, as markdown. Ground it in the history you traced.'),
+    origin: z
+      .enum(['push', 'fresh'])
+      .optional()
+      .describe('Re-review only: whether the push raised it, or the fresh whole-PR sweep did.'),
+  })
+  .strict();
+
+const verificationSchema = z
+  .object({
+    command: text.describe('The command exactly as it was executed.'),
+    outcome: text.describe('What it reported: pass, fail, or the qualification that applies.'),
+  })
+  .strict();
+
+const dispositionSchema = z
+  .object({
+    subject: text.describe('The prior finding, named by its subject.'),
+    location: text.optional(),
+    disposition: z.enum(['confirmed', 'addressed', 'refuted']),
+    evidence: text.describe('Why it holds that disposition.'),
+  })
+  .strict();
+
+const priorPassSchema = z
+  .object({
+    subject: text.describe('The prior-pass item, named by its subject.'),
+    location: text.optional(),
+    disposition: z.enum(['addressed', 'partially-addressed', 'still-open', 'refuted', 'invalidated']),
+    evidence: text.describe('The commit or `file:line` proving the call.'),
+  })
+  .strict();
+
+export const reviewReportSchema = z
+  .object({
+    verdict: z.enum(['approve', 'request-changes']),
+    priorPass: z
+      .array(priorPassSchema)
+      .default([])
+      .describe('Re-review only: every substantive item from the previous pass.'),
+    findings: z.array(findingSchema).default([]),
+    verification: z.array(verificationSchema).default([]),
+    verificationGap: text.optional().describe('Why nothing was executed. Required to approve when no command ran.'),
+    existingSignal: z
+      .array(dispositionSchema)
+      .default([])
+      .describe('Every substantive prior finding — bots and your own earlier passes included.'),
+    adversarialCheck: text.optional().describe('Why the strongest request-changes case fails. Required to approve.'),
+    requestedChanges: z.array(findingSchema).default([]),
+    assumptions: z.array(text).default([]),
+    openQuestions: z.array(text).default([]),
+  })
+  .strict()
+  .superRefine((report, ctx) => {
+    if (report.verdict === 'approve') {
+      if (!report.adversarialCheck) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['adversarialCheck'],
+          message: 'An approve requires the adversarial check that survived.',
+        });
+      }
+      if (report.verification.length === 0 && !report.verificationGap) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['verification'],
+          message: 'An approve requires executed verification, or verificationGap saying why none ran.',
+        });
+      }
+      return;
+    }
+    if (report.requestedChanges.length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['requestedChanges'],
+        message: 'A request-changes verdict requires at least one requested change.',
+      });
+    }
+  });
+
+export type ReviewReport = z.infer<typeof reviewReportSchema>;
+
+function entry({
+  subject,
+  location,
+  body,
+  origin,
+}: {
+  subject: string;
+  location?: string;
+  body: string;
+  origin?: string;
+}): string {
+  const head = `- **${subject}**${origin ? ` \`[${origin}]\`` : ''}${location ? ` — \`${location}\`` : ''}`;
+  return `${head}\n\n  ${body.replaceAll('\n', '\n  ')}`;
+}
+
+function section(heading: string, lines: readonly string[]): string | null {
+  return lines.length === 0 ? null : `## ${heading}\n\n${lines.join('\n\n')}`;
+}
+
+/** The published body. Its shape is this function's, never the model's. */
+export function renderReviewReport(report: ReviewReport, runtime: ReviewRuntime | null): string {
+  const verification = report.verification.map(({ command, outcome }) => `- \`${command}\` — ${outcome}`);
+  const blocks = [
+    `Verdict: ${report.verdict === 'approve' ? 'approve' : 'request changes'}`,
+    section(
+      'Prior pass disposition',
+      report.priorPass.map(({ subject, location, disposition, evidence }) =>
+        entry({ subject, location, body: `${disposition} — ${evidence}` }),
+      ),
+    ),
+    section('Findings', report.findings.map(entry)),
+    section('Verification', report.verificationGap ? [...verification, report.verificationGap] : verification),
+    section(
+      'Existing review disposition',
+      report.existingSignal.map(({ subject, location, disposition, evidence }) =>
+        entry({ subject, location, body: `${disposition} — ${evidence}` }),
+      ),
+    ),
+    report.adversarialCheck === undefined ? null : section('Adversarial check', [report.adversarialCheck]),
+    section('Requested changes', report.requestedChanges.map(entry)),
+    section(
+      'Assumptions',
+      report.assumptions.map(assumption => `- ${assumption}`),
+    ),
+    section(
+      'Open questions',
+      report.openQuestions.map(question => `- ${question}`),
+    ),
+    runtime === null ? null : `Review runtime: ${runtime.modelId}, reasoning setting: ${runtime.thinkingLevel}.`,
+  ];
+  return `${blocks.filter(block => block !== null).join('\n\n')}\n`;
+}

--- a/mastracode/factory/src/rules/review-runtime.ts
+++ b/mastracode/factory/src/rules/review-runtime.ts
@@ -1,0 +1,20 @@
+import { resolveRequestThinkingLevel } from '@mastra/code-sdk/agents/model';
+import type { ThinkingLevel } from '@mastra/code-sdk/providers/openai-codex';
+import type { MastraCodeState } from '@mastra/code-sdk/schema';
+import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
+import type { RequestContext } from '@mastra/core/request-context';
+
+export type ReviewRuntime = {
+  modelId: string;
+  thinkingLevel: ThinkingLevel;
+};
+
+// Read at the moment it is needed: a thread that switches model mid-session must
+// not attribute the new turn to the model that answered the previous one.
+export function reviewRuntimeFromRequestContext(requestContext: RequestContext | undefined): ReviewRuntime | null {
+  if (!requestContext || typeof requestContext.get !== 'function') return null;
+  const context = requestContext.get<'controller', AgentControllerRequestContext<MastraCodeState>>('controller');
+  const modelId = context?.session?.modelId.trim();
+  if (!modelId) return null;
+  return { modelId, thinkingLevel: resolveRequestThinkingLevel(context) };
+}

--- a/mastracode/factory/src/rules/review-tool.test.ts
+++ b/mastracode/factory/src/rules/review-tool.test.ts
@@ -1,0 +1,126 @@
+import { RequestContext } from '@mastra/core/request-context';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import { createFactoryReviewTools } from './review-tool.js';
+
+const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
+const PR_URL = 'https://github.com/acme/app/pull/7';
+
+type ExecutableTool = {
+  execute: (input: unknown, context: unknown) => Promise<{ event: string; url: string | null; body: string }>;
+};
+
+function requestContext(modelId: string) {
+  const context = new RequestContext();
+  context.set('user', { workosId: 'user-1', organizationId: 'org-1' });
+  context.set('controller', {
+    resourceId: 'resource-1',
+    threadId: 'thread-1',
+    scope: '/worktree',
+    session: { id: 'session-1', ownerId: 'code', modeId: 'review', modelId },
+    getState: () => ({ factoryProjectId: PROJECT_ID }),
+  });
+  return context;
+}
+
+async function bindReviewItem(storage: WorkItemsStorage, type: 'pull-request' | 'issue' = 'pull-request') {
+  return storage.prepareRunStart({
+    orgId: 'org-1',
+    userId: 'user-1',
+    factoryProjectId: PROJECT_ID,
+    workItem: {
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type,
+          externalId: type === 'pull-request' ? 'github-pr:7' : 'github-issue:7',
+          ...(type === 'pull-request' ? { url: PR_URL } : {}),
+        },
+        title: 'Factory item',
+        stages: ['review'],
+        sessions: {},
+        metadata: {},
+      },
+    },
+    role: 'review',
+    session: { sessionId: 'resource-1', branch: 'factory/item', threadId: 'thread-1' },
+    resourceId: 'resource-1',
+    kickoffKey: 'kickoff-1',
+    kickoffMessage: null,
+  });
+}
+
+function publisher(result: { url: string | null; event: 'approve' | 'request-changes' | 'comment' }) {
+  return { publish: vi.fn().mockResolvedValue(result) };
+}
+
+const APPROVE = {
+  verdict: 'approve',
+  verification: [{ command: 'pnpm test', outcome: 'pass' }],
+  adversarialCheck: 'The damaging reading does not survive the covered path.',
+};
+
+describe('factory_publish_review', () => {
+  it('publishes the verdict with a body composed here', async () => {
+    const { workItems } = await createFactoryStorageForTests();
+    await bindReviewItem(workItems);
+    const publish = publisher({ url: 'https://github.com/acme/app/pull/7#review', event: 'approve' });
+
+    const tools = await createFactoryReviewTools({
+      requestContext: requestContext('anthropic/claude-opus-5'),
+      storage: workItems,
+      publisher: publish,
+    });
+    const result = await (tools.factory_publish_review as unknown as ExecutableTool).execute(APPROVE, {
+      requestContext: requestContext('anthropic/claude-opus-5'),
+    });
+
+    expect(publish.publish).toHaveBeenCalledWith(
+      expect.objectContaining({ verdict: 'approve', orgId: 'org-1', factoryProjectId: PROJECT_ID }),
+    );
+    expect(result.body).toContain('Verdict: approve');
+    expect(result.event).toBe('approve');
+  });
+
+  // A re-review runs in the same thread after the pass closed its binding, and
+  // published the previous pass's model because the runtime was read once.
+  it('attributes a re-review to the model running it, not the one that ran before', async () => {
+    const { workItems } = await createFactoryStorageForTests();
+    const prepared = await bindReviewItem(workItems);
+    const publish = publisher({ url: null, event: 'approve' });
+
+    const tools = await createFactoryReviewTools({
+      requestContext: requestContext('anthropic/claude-opus-4-8'),
+      storage: workItems,
+      publisher: publish,
+    });
+    await workItems.revokeRunBinding({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      bindingId: prepared.binding.id,
+      revokedAt: new Date(),
+    });
+
+    const result = await (tools.factory_publish_review as unknown as ExecutableTool).execute(APPROVE, {
+      requestContext: requestContext('anthropic/claude-opus-5'),
+    });
+
+    expect(result.body).toContain('Review runtime: anthropic/claude-opus-5');
+    expect(result.body).not.toContain('opus-4-8');
+  });
+
+  it('stays unregistered for a work item that tracks no pull request', async () => {
+    const { workItems } = await createFactoryStorageForTests();
+    await bindReviewItem(workItems, 'issue');
+
+    const tools = await createFactoryReviewTools({
+      requestContext: requestContext('anthropic/claude-opus-5'),
+      storage: workItems,
+      publisher: publisher({ url: null, event: 'comment' }),
+    });
+
+    expect(tools.factory_publish_review).toBeUndefined();
+  });
+});

--- a/mastracode/factory/src/rules/review-tool.ts
+++ b/mastracode/factory/src/rules/review-tool.ts
@@ -18,7 +18,8 @@ export interface FactoryReviewPublisher {
   publish(input: {
     orgId: string;
     factoryProjectId: string;
-    item: WorkItemRow;
+    /** Only its external source is read: the pull request the review lands on. */
+    item: Pick<WorkItemRow, 'externalSource'>;
     verdict: 'approve' | 'request-changes';
     body: string;
   }): Promise<PublishedReview>;

--- a/mastracode/factory/src/rules/review-tool.ts
+++ b/mastracode/factory/src/rules/review-tool.ts
@@ -1,0 +1,70 @@
+import type { RequestContext } from '@mastra/core/request-context';
+import { createTool } from '@mastra/core/tools';
+
+import type { IntegrationTools } from '../integrations/base.js';
+import type { WorkItemRow, WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import type { FactorySessionSourceLookup } from './binding-context.js';
+import { resolveFactorySessionAddress } from './binding-context.js';
+import { renderReviewReport, reviewReportSchema } from './review-report.js';
+import { reviewRuntimeFromRequestContext } from './review-runtime.js';
+
+export type PublishedReview = {
+  url: string | null;
+  /** What the platform accepted — `comment` means it refused the verdict event. */
+  event: 'approve' | 'request-changes' | 'comment';
+};
+
+export interface FactoryReviewPublisher {
+  publish(input: {
+    orgId: string;
+    factoryProjectId: string;
+    item: WorkItemRow;
+    verdict: 'approve' | 'request-changes';
+    body: string;
+  }): Promise<PublishedReview>;
+}
+
+export async function createFactoryReviewTools(options: {
+  requestContext: RequestContext;
+  storage: WorkItemsStorage;
+  publisher: FactoryReviewPublisher;
+  sessions?: FactorySessionSourceLookup;
+}): Promise<IntegrationTools> {
+  const resolution = await resolveFactorySessionAddress({
+    requestContext: options.requestContext,
+    storage: options.storage,
+    sessions: options.sessions,
+  });
+  if (!resolution) return {};
+  // Any binding the thread has held, not only an active one: the review pass
+  // closes its binding on transition, and a re-review in the same thread must
+  // still publish through the tool rather than compose the body by hand.
+  const binding = await options.storage.findRunBindingBySession(resolution.address);
+  if (!binding) return {};
+  const item = await options.storage.get({ orgId: binding.orgId, id: binding.workItemId });
+  if (item?.externalSource?.type !== 'pull-request') return {};
+
+  return {
+    factory_publish_review: createTool({
+      id: 'factory_publish_review',
+      description:
+        'Publish the review verdict on the pull request bound to this thread. Supply the review as data — the body, its section order and the runtime attribution are composed here.',
+      inputSchema: reviewReportSchema,
+      execute: async (report, execution) => {
+        const current = await options.storage.get({ orgId: binding.orgId, id: binding.workItemId });
+        if (current?.externalSource?.type !== 'pull-request') {
+          throw new Error('The bound Factory work item no longer tracks a pull request.');
+        }
+        const body = renderReviewReport(report, reviewRuntimeFromRequestContext(execution.requestContext));
+        const published = await options.publisher.publish({
+          orgId: binding.orgId,
+          factoryProjectId: binding.factoryProjectId,
+          item: current,
+          verdict: report.verdict,
+          body,
+        });
+        return { ...published, body };
+      },
+    }),
+  };
+}

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -304,12 +304,14 @@ describe('getFactoryWorkspace', () => {
     expect(triage).toContain('.artifacts/factory-triage/issue-<number>.md');
     expect(plan).toContain('Write it to `.artifacts/plans/issue-<number>.md`');
     expect(plan).toContain('include the same plan in the conversation');
-    expect(review).toContain('.artifacts/factory-review/pr-<number>.md');
     expect(review).toContain('.artifacts/factory-review/follow-up-pr-<number>.md');
-    expect(review).toContain('Review runtime: <model>, reasoning setting: <reasoning>.');
-    expect(rereview).toContain('.artifacts/factory-rereview/pr-<number>.md');
     expect(rereview).toContain('.artifacts/factory-rereview/follow-up-pr-<number>.md');
-    expect(rereview).toContain('Review runtime: <model>, reasoning setting: <reasoning>.');
+    // The verdict body is the tool's to compose — neither skill dictates its shape.
+    for (const skill of [review, rereview]) {
+      expect(skill).toContain('`factory_publish_review`');
+      expect(skill).not.toContain('Review runtime: <model>');
+      expect(skill).not.toContain('gh pr review <number>');
+    }
   });
 
   it('keeps the autonomous Factory skills on the terminal-handoff contract', async () => {
@@ -397,12 +399,11 @@ describe('getFactoryWorkspace', () => {
     expect(plan).toContain('Do not call `submit_plan`');
 
     const review = await read('factory-review');
-    expect(review).toContain('Verdict: approve');
-    expect(review).toContain('Verdict: request changes');
-    // The verdict must be published on the PR itself, unprompted.
-    expect(review).toContain('gh pr review <number> --approve --body-file');
-    expect(review).toContain('gh pr review <number> --request-changes --body-file');
-    expect(review).toContain('gh pr comment <number> --body-file');
+    // The verdict must be published on the PR itself, unprompted — through the
+    // tool that owns the body, so the shape can't drift with the generation.
+    expect(review).toContain('Publish the review with `factory_publish_review`');
+    expect(review).toContain('appends the runtime attribution');
+    expect(review).toContain('`event: "comment"` means GitHub refused the verdict event');
     // Existing review signal (bot and human) must be collected from every
     // source — submitted reviews, unresolved inline threads with their
     // metadata, and top-level comments — and dispositioned, and a confirmed
@@ -412,7 +413,7 @@ describe('getFactoryWorkspace', () => {
     expect(review).toContain('reviewThreads');
     expect(review).toContain('isResolved isOutdated path line');
     expect(review).toContain('--json comments');
-    expect(review).toContain('Existing review disposition');
+    expect(review).toContain('`existingSignal`');
     expect(review).toContain('confirmed major finding from an existing reviewer that remains unaddressed');
     expect(review).toContain('Approval is earned, not the default');
     // Verdict calibration: severity rubric, the actionable-change test, borderline
@@ -432,7 +433,7 @@ describe('getFactoryWorkspace', () => {
     expect(review).toContain('Never resolve the conflicts yourself');
     // Terminal ordering: publish the verdict and transition before the final
     // conversation message, so the pass can't stop early with an unpublished review.
-    expect(review).toContain('post the handoff as your final conversation message');
+    expect(review).toContain('post the body `factory_publish_review` returned as your final conversation message');
     // Rigor: approval requires every gate affirmatively demonstrated, and the
     // reviewer waits for pending bot reviews before forming a verdict.
     expect(review).toContain('Approval gates');
@@ -482,11 +483,9 @@ describe('getFactoryWorkspace', () => {
     // publish the verdict on the PR, request the transition, and only then send
     // the final conversation message.
     inOrder(
-      "don't send it to the conversation yet",
-      'gh pr review <number> --approve --body-file',
-      'gh pr review <number> --request-changes --body-file',
+      'Publish the review with `factory_publish_review`',
       'Then make your terminal `factory_transition_work_item` call',
-      'post the handoff as your final conversation message',
+      'post the body `factory_publish_review` returned as your final conversation message',
     );
 
     // Every approval gate lives inside the gates block, a pending bot fails the


### PR DESCRIPTION
TLDR: the Factory publishes its review verdict through a tool that composes the
body, so the runtime attribution and the approval gates stop depending on the
model remembering to type them.

---

```
before   the agent wrote the whole review body and ran `gh pr review --body-file`
after    the agent supplies the review as data; the tool renders it and submits it
```

Two reviews on #22257 went up with no `Review runtime:` footer at all. Two reviews
on #22289 went up with the same footer twice — the second was written by opus 5
and published `opus-4-8`, because the runtime was read once at the start of the
thread and copied from the transcript afterwards.

Both are the same flaw: every mandated line of the review body was prose the model
retyped, and nothing in code touched what got published.

### What changes

| the reviewing agent | before | after |
| --- | --- | --- |
| publishes a verdict | writes the body, shells out to `gh pr review` | calls `factory_publish_review` with the review as data |
| attributes the runtime | copies the model from the `factory-phase` signal | tool appends it, read from the request context at publish |
| re-reviews after a model switch | publishes the previous pass's model | publishes the model that ran the pass |
| approves with no adversarial check | body ships without it | the tool's schema rejects the call |
| requests changes with no change | body ships without one | the tool's schema rejects the call |
| GitHub refuses the verdict event | falls back to `gh pr comment` | tool posts the same body as a pull request comment, returns `event: "comment"` |

### Side effect I nearly shipped

GitHub refuses a verdict on a pull request opened by the same app, so that
fallback is the normal path on every Factory-authored PR, not an edge. My first
version re-submitted it as a *comment review*, which reaches
`pullRequestReviewSubmitted` — and `addressReviewFeedback` drops anything whose
state is not `changes_requested`. The authoring agent would have stopped being
woken by its own review.

The shelled-out fallback used `gh pr comment`, an issue comment, which is what
`addressPullRequestComment` reads: it parses `Verdict: request changes` off the
first line and makes that the one exception to the ignore-Factory's-own-comments
guard. The publisher posts a comment again, and `defaults.test.ts` now runs that
rule against the body the renderer composes rather than a hand-written copy of
its shape — so a change to the first line fails there.

### Judgment call

The tool registers on **any** binding the thread has held, not only an active one.
The review pass closes its binding when it transitions, so requiring an active one
would leave the re-review composing bodies by hand — which is where the stale
attribution came from. Publishing targets only the pull request the thread is
bound to, so this widens what can publish, not what it can publish to.

The section list now lives in the schema and nowhere else. The skills say what to
judge and what each field means; they no longer name the order or the headings.
That is what takes ~35 lines of format prose out of both review skills.

### Side effects to check

`reviewRuntimeFromRequestContext` moved out of `processor.ts` into
`rules/review-runtime.ts` and now returns `null` instead of throwing. The
processor keeps the old behaviour behind `requireReviewRuntime`, so the
`factory-phase` signal still fails loudly when a review-board run has no session
model.

### Not verified

Nothing ran against real GitHub. `review-publisher.test.ts` pins the repository
resolution, the 422 fallback and the rethrow against a fake, so what is unproven
is that GitHub answers 422 on a self-review with that status and nothing else.

The skills' new instructions are pinned by `workspace.test.ts` as text, which
proves what they say, not that a model follows them.

```
tests         +330  -16    ← 48% of the additions
source        +322  -21
changeset     +20    0
skills        +19   -35    ← net -16
```

