### PR TITLE
fix(factory): show generated titles in work session sidebars

### DIFF
--- a/mastracode/factory-ui/src/hooks/useWorkspaces.test.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkspaces.test.ts
@@ -70,7 +70,12 @@ describe('updateCachedSessionTitle', () => {
     const queryKey = queryKeys.sessions(workspace.projectRepositoryId);
     client.setQueryData(queryKey, current);
 
-    await updateCachedSessionTitle(client, workspace.projectRepositoryId, workspace.sessionId, 'Generated workspace title');
+    await updateCachedSessionTitle(
+      client,
+      workspace.projectRepositoryId,
+      workspace.sessionId,
+      'Generated workspace title',
+    );
 
     const updated = client.getQueryData<WorkspacesData>(queryKey);
     expect(updated).toEqual(
@@ -87,7 +92,12 @@ describe('updateCachedSessionTitle', () => {
     const queryKey = queryKeys.sessions(userSession.projectRepositoryId);
     client.setQueryData(queryKey, data({ userSessions: [userSession] }));
 
-    await updateCachedSessionTitle(client, userSession.projectRepositoryId, userSession.sessionId, 'Generated user title');
+    await updateCachedSessionTitle(
+      client,
+      userSession.projectRepositoryId,
+      userSession.sessionId,
+      'Generated user title',
+    );
 
     expect(client.getQueryData<WorkspacesData>(queryKey)?.userSessions).toEqual([
       { ...userSession, title: 'Generated user title' },
@@ -114,7 +124,12 @@ describe('updateCachedSessionTitle', () => {
     await Promise.resolve();
     expect(client.getQueryState(queryKey)?.fetchStatus).toBe('fetching');
 
-    await updateCachedSessionTitle(client, workspace.projectRepositoryId, workspace.sessionId, 'Generated workspace title');
+    await updateCachedSessionTitle(
+      client,
+      workspace.projectRepositoryId,
+      workspace.sessionId,
+      'Generated workspace title',
+    );
     resolveFetch(current);
     await fetchResult;
 
@@ -133,7 +148,12 @@ describe('updateCachedSessionTitle', () => {
     await updateCachedSessionTitle(client, workspace.projectRepositoryId, 'missing-session', 'Other title');
     expect(client.getQueryData(queryKey)).toBe(current);
 
-    await updateCachedSessionTitle(client, workspace.projectRepositoryId, workspace.sessionId, 'Generated workspace title');
+    await updateCachedSessionTitle(
+      client,
+      workspace.projectRepositoryId,
+      workspace.sessionId,
+      'Generated workspace title',
+    );
     expect(client.getQueryData(queryKey)).toBe(current);
   });
 });

--- a/mastracode/factory-ui/src/hooks/useWorkspaces.test.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkspaces.test.ts
@@ -62,7 +62,7 @@ describe('sessionsRefetchInterval', () => {
 });
 
 describe('updateCachedSessionTitle', () => {
-  it('updates the matching workspace without replacing unrelated rows', () => {
+  it('updates the matching workspace without replacing unrelated rows', async () => {
     const client = createQueryClient();
     const workspace = session({ title: undefined });
     const unrelated = session({ id: 'row-2', sessionId: 'sess-2', title: 'Keep me' });
@@ -70,7 +70,7 @@ describe('updateCachedSessionTitle', () => {
     const queryKey = queryKeys.sessions(workspace.projectRepositoryId);
     client.setQueryData(queryKey, current);
 
-    updateCachedSessionTitle(client, workspace.projectRepositoryId, workspace.sessionId, 'Generated workspace title');
+    await updateCachedSessionTitle(client, workspace.projectRepositoryId, workspace.sessionId, 'Generated workspace title');
 
     const updated = client.getQueryData<WorkspacesData>(queryKey);
     expect(updated).toEqual(
@@ -81,30 +81,59 @@ describe('updateCachedSessionTitle', () => {
     expect(updated?.workspaces[1]).toBe(unrelated);
   });
 
-  it('updates the matching user session', () => {
+  it('updates the matching user session', async () => {
     const client = createQueryClient();
     const userSession = session({ sessionId: 'user-1', title: undefined, branch: 'user/session-user-1' });
     const queryKey = queryKeys.sessions(userSession.projectRepositoryId);
     client.setQueryData(queryKey, data({ userSessions: [userSession] }));
 
-    updateCachedSessionTitle(client, userSession.projectRepositoryId, userSession.sessionId, 'Generated user title');
+    await updateCachedSessionTitle(client, userSession.projectRepositoryId, userSession.sessionId, 'Generated user title');
 
     expect(client.getQueryData<WorkspacesData>(queryKey)?.userSessions).toEqual([
       { ...userSession, title: 'Generated user title' },
     ]);
   });
 
-  it('preserves the cached data when the session is absent or the title is unchanged', () => {
+  it('keeps the title when a canceled sessions fetch resolves with stale data', async () => {
+    const client = createQueryClient();
+    const workspace = session({ title: undefined });
+    const current = data({ workspaces: [workspace] });
+    const queryKey = queryKeys.sessions(workspace.projectRepositoryId);
+    client.setQueryData(queryKey, current);
+
+    let resolveFetch!: (value: WorkspacesData) => void;
+    const fetch = client.fetchQuery({
+      queryKey,
+      queryFn: () =>
+        new Promise<WorkspacesData>(resolve => {
+          resolveFetch = resolve;
+        }),
+      staleTime: 0,
+    });
+    const fetchResult = fetch.catch(() => undefined);
+    await Promise.resolve();
+    expect(client.getQueryState(queryKey)?.fetchStatus).toBe('fetching');
+
+    await updateCachedSessionTitle(client, workspace.projectRepositoryId, workspace.sessionId, 'Generated workspace title');
+    resolveFetch(current);
+    await fetchResult;
+
+    expect(client.getQueryData<WorkspacesData>(queryKey)?.workspaces).toEqual([
+      { ...workspace, title: 'Generated workspace title' },
+    ]);
+  });
+
+  it('preserves the cached data when the session is absent or the title is unchanged', async () => {
     const client = createQueryClient();
     const workspace = session({ title: 'Generated workspace title' });
     const current = data({ workspaces: [workspace] });
     const queryKey = queryKeys.sessions(workspace.projectRepositoryId);
     client.setQueryData(queryKey, current);
 
-    updateCachedSessionTitle(client, workspace.projectRepositoryId, 'missing-session', 'Other title');
+    await updateCachedSessionTitle(client, workspace.projectRepositoryId, 'missing-session', 'Other title');
     expect(client.getQueryData(queryKey)).toBe(current);
 
-    updateCachedSessionTitle(client, workspace.projectRepositoryId, workspace.sessionId, 'Generated workspace title');
+    await updateCachedSessionTitle(client, workspace.projectRepositoryId, workspace.sessionId, 'Generated workspace title');
     expect(client.getQueryData(queryKey)).toBe(current);
   });
 });

--- a/mastracode/factory-ui/src/hooks/useWorkspaces.test.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkspaces.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { queryKeys } from '../api/keys';
+import { createQueryClient } from '../query-client';
 import type { FactoryUserSession } from '../ui/domains/workspaces/services/user-sessions';
-import { sessionsRefetchInterval } from './useWorkspaces';
+import { sessionsRefetchInterval, updateCachedSessionTitle } from './useWorkspaces';
 import type { WorkspacesData } from './useWorkspaces';
 
 function session(overrides: Partial<FactoryUserSession>): FactoryUserSession {
@@ -56,5 +58,53 @@ describe('sessionsRefetchInterval', () => {
   it('stops polling once an un-materialized session has had no activity for the window', () => {
     const afterWindow = Date.parse('2026-07-20T00:10:00.000Z');
     expect(sessionsRefetchInterval(data({ workspaces: [session({ materializedAt: null })] }), afterWindow)).toBe(false);
+  });
+});
+
+describe('updateCachedSessionTitle', () => {
+  it('updates the matching workspace without replacing unrelated rows', () => {
+    const client = createQueryClient();
+    const workspace = session({ title: undefined });
+    const unrelated = session({ id: 'row-2', sessionId: 'sess-2', title: 'Keep me' });
+    const current = data({ workspaces: [workspace, unrelated] });
+    const queryKey = queryKeys.sessions(workspace.projectRepositoryId);
+    client.setQueryData(queryKey, current);
+
+    updateCachedSessionTitle(client, workspace.projectRepositoryId, workspace.sessionId, 'Generated workspace title');
+
+    const updated = client.getQueryData<WorkspacesData>(queryKey);
+    expect(updated).toEqual(
+      data({
+        workspaces: [{ ...workspace, title: 'Generated workspace title' }, unrelated],
+      }),
+    );
+    expect(updated?.workspaces[1]).toBe(unrelated);
+  });
+
+  it('updates the matching user session', () => {
+    const client = createQueryClient();
+    const userSession = session({ sessionId: 'user-1', title: undefined, branch: 'user/session-user-1' });
+    const queryKey = queryKeys.sessions(userSession.projectRepositoryId);
+    client.setQueryData(queryKey, data({ userSessions: [userSession] }));
+
+    updateCachedSessionTitle(client, userSession.projectRepositoryId, userSession.sessionId, 'Generated user title');
+
+    expect(client.getQueryData<WorkspacesData>(queryKey)?.userSessions).toEqual([
+      { ...userSession, title: 'Generated user title' },
+    ]);
+  });
+
+  it('preserves the cached data when the session is absent or the title is unchanged', () => {
+    const client = createQueryClient();
+    const workspace = session({ title: 'Generated workspace title' });
+    const current = data({ workspaces: [workspace] });
+    const queryKey = queryKeys.sessions(workspace.projectRepositoryId);
+    client.setQueryData(queryKey, current);
+
+    updateCachedSessionTitle(client, workspace.projectRepositoryId, 'missing-session', 'Other title');
+    expect(client.getQueryData(queryKey)).toBe(current);
+
+    updateCachedSessionTitle(client, workspace.projectRepositoryId, workspace.sessionId, 'Generated workspace title');
+    expect(client.getQueryData(queryKey)).toBe(current);
   });
 });

--- a/mastracode/factory-ui/src/hooks/useWorkspaces.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkspaces.ts
@@ -79,6 +79,36 @@ export function addCachedSession(queryClient: QueryClient, projectRepositoryId: 
   });
 }
 
+export function updateCachedSessionTitle(
+  queryClient: QueryClient,
+  projectRepositoryId: string | undefined,
+  sessionId: string,
+  title: string,
+) {
+  const trimmedTitle = title.trim();
+  if (!trimmedTitle) return;
+
+  const queryKey = queryKeys.sessions(projectRepositoryId);
+  if (!queryClient.getQueryData<WorkspacesData>(queryKey)) return;
+
+  // an in-flight list fetch can still carry the branch-only row and overwrite this title
+  void queryClient.cancelQueries({ queryKey });
+  queryClient.setQueryData<WorkspacesData>(queryKey, current => {
+    if (!current) return current;
+
+    let changed = false;
+    const updateTitle = (session: FactoryUserSession) => {
+      if (session.sessionId !== sessionId || session.title === trimmedTitle) return session;
+      changed = true;
+      return { ...session, title: trimmedTitle };
+    };
+    const workspaces = current.workspaces.map(updateTitle);
+    const userSessions = current.userSessions.map(updateTitle);
+
+    return changed ? { ...current, workspaces, userSessions } : current;
+  });
+}
+
 function invalidateSessionQueries(
   queryClient: QueryClient,
   projectRepositoryId: string | undefined,

--- a/mastracode/factory-ui/src/hooks/useWorkspaces.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkspaces.ts
@@ -79,7 +79,7 @@ export function addCachedSession(queryClient: QueryClient, projectRepositoryId: 
   });
 }
 
-export function updateCachedSessionTitle(
+export async function updateCachedSessionTitle(
   queryClient: QueryClient,
   projectRepositoryId: string | undefined,
   sessionId: string,
@@ -92,7 +92,7 @@ export function updateCachedSessionTitle(
   if (!queryClient.getQueryData<WorkspacesData>(queryKey)) return;
 
   // an in-flight list fetch can still carry the branch-only row and overwrite this title
-  void queryClient.cancelQueries({ queryKey });
+  await queryClient.cancelQueries({ queryKey });
   queryClient.setQueryData<WorkspacesData>(queryKey, current => {
     if (!current) return current;
 

--- a/mastracode/factory-ui/src/ui/domains/chat/components/PageTitle.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/PageTitle.tsx
@@ -46,7 +46,7 @@ export function PageTitle() {
 
   useEffect(() => {
     if (!routeSessionId || !threadTitle) return;
-    updateCachedSessionTitle(queryClient, projectRepositoryId, routeSessionId, threadTitle);
+    void updateCachedSessionTitle(queryClient, projectRepositoryId, routeSessionId, threadTitle);
   }, [projectRepositoryId, queryClient, routeSessionId, threadTitle]);
 
   useDocumentTitle(identifier ?? threadTitle);

--- a/mastracode/factory-ui/src/ui/domains/chat/components/PageTitle.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/PageTitle.tsx
@@ -1,7 +1,10 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { useParams } from 'react-router';
 
 import { useDocumentTitle } from '../../../../hooks/useDocumentTitle';
 import { useAgentControllerThreads } from '../../../../hooks/useAgentControllerThreads';
+import { updateCachedSessionTitle } from '../../../../hooks/useWorkspaces';
 import { useWorkItemsQuery } from '../../../../hooks/useWorkItems';
 import { workItemIdentifier } from '../../factory/services/relationships';
 import type { WorkItem } from '../../factory/services/workItems';
@@ -23,7 +26,10 @@ export function PageTitle() {
     sessionId?: string;
     threadId?: string;
   }>();
-  const { resourceId, projectPath, baseUrl, resourceReady } = useChatSessionContext();
+  const { resourceId, projectPath, baseUrl, resourceReady, factorySessionState } = useChatSessionContext();
+  const queryClient = useQueryClient();
+  const projectRepositoryId = factorySessionState?.projectRepositoryId;
+  const routeSessionId = sessionId ?? threadId;
 
   const workItems = useWorkItemsQuery(factoryId);
 
@@ -37,6 +43,11 @@ export function PageTitle() {
 
   const identifier = identifierForThread(workItems.data, sessionId, threadId);
   const threadTitle = threadsQuery.data?.find(thread => thread.id === threadId)?.title?.trim();
+
+  useEffect(() => {
+    if (!routeSessionId || !threadTitle) return;
+    updateCachedSessionTitle(queryClient, projectRepositoryId, routeSessionId, threadTitle);
+  }, [projectRepositoryId, queryClient, routeSessionId, threadTitle]);
 
   useDocumentTitle(identifier ?? threadTitle);
   return null;

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageDocumentTitle.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageDocumentTitle.msw.test.tsx
@@ -250,16 +250,17 @@ describe('ThreadPage document title', () => {
     await waitFor(() => expect(document.title).toBe('COR-210 | Mastra Factory'));
   });
 
-  it('leaves the default title when the thread has no title yet', async () => {
+  it('keeps the branch label when a work-session thread has no title yet', async () => {
     stubBase({
       workItems: [],
       threads: [{ id: THREAD_ID }],
     });
-    await renderRoute(`/factories/${FACTORY_ID}/user/threads/${THREAD_ID}`);
+    await renderRoute(`/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${THREAD_ID}`);
 
     // Give the session boundary a chance to resolve so we know we've reached
     // the branch that mounts <PageTitle/>; without a title/PR number the hook
-    // must leave the default in place.
+    // must leave the default in place and preserve the sidebar branch fallback.
     await waitFor(() => expect(document.title).toBe('Mastra Factory'), { timeout: 2000 });
+    expect(await screen.findByRole('button', { name: 'factory/pr-1567' })).toBeInTheDocument();
   });
 });

--- a/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageDocumentTitle.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/ThreadPageDocumentTitle.msw.test.tsx
@@ -6,7 +6,7 @@
  * Everything else — loading, no linked work item, no title yet — leaves the
  * default `Mastra Factory` in place.
  */
-import { waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -171,7 +171,7 @@ describe('ThreadPage document title', () => {
     await waitFor(() => expect(document.title).toBe('Investigate Pricing Bug | Mastra Factory'));
   });
 
-  it('shows the issue number for GitHub issue-backed work sessions', async () => {
+  it('uses the thread title in the work-session sidebar while the document title shows the issue number', async () => {
     stubBase({
       workItems: [
         {
@@ -208,6 +208,7 @@ describe('ThreadPage document title', () => {
     await renderRoute(`/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${THREAD_ID}`);
 
     await waitFor(() => expect(document.title).toBe('#42 | Mastra Factory'));
+    expect(await screen.findByRole('button', { name: 'Fix flaky login' })).toBeInTheDocument();
   });
 
   it('shows the team key for Linear issue-backed work sessions', async () => {


### PR DESCRIPTION
## Summary
- synchronize loaded agent-controller thread titles into the sessions-list React Query cache
- retain branch fallback for missing or empty titles and avoid stale in-flight list responses overwriting generated titles
- cover factory and user cache updates plus the work-session sidebar/document-title flow

## Test plan
- pnpm --filter ./mastracode/factory-ui exec vitest run --project unit:factory-ui src/hooks/useWorkspaces.test.ts
- pnpm --filter ./mastracode/factory-ui exec vitest run --project msw:factory-ui src/ui/pages/__tests__/ThreadPageDocumentTitle.msw.test.tsx
- pnpm --filter ./mastracode/factory-ui typecheck

Note: the package test:msw script ran the full MSW project and exposed an unrelated locale-sensitive failure in SlackConnectionPage.msw.test.tsx; the focused regression test passes when run directly through Vitest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an agent creates a thread title, the sidebar and browser tab show it immediately. If no title exists, the branch name remains the fallback.

## Changes

- Added `updateCachedSessionTitle` to update workspace and user session caches.
- Trimmed and validated titles before updating the cache.
- Cancelled in-flight session queries before applying titles.
- Updated `PageTitle` to synchronize thread titles with the session-list cache.
- Added coverage for cache updates, stale responses, sidebar titles, document titles, and branch-name fallbacks.

## Tests

- Focused regression tests pass.
- Typecheck is included in the test plan.
- A full MSW run has an unrelated locale-sensitive failure in `SlackConnectionPage.msw.test.tsx`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->