### PR TITLE
feat(core): stream generated thread title with generateTitle.emitEvent

### DIFF
--- a/.changeset/goofy-schools-train.md
+++ b/.changeset/goofy-schools-train.md
@@ -26,3 +26,5 @@ for await (const chunk of stream.fullStream) {
 ```
 
 The chunk is transient, so it is never persisted as part of the conversation. The default stays fully non-blocking: without `emitEvent`, title generation still runs in the background and does not delay the stream.
+
+Durable and evented agents don't emit the chunk yet; the title is still generated and persisted, and a warning is logged when `emitEvent` is set.

--- a/.changeset/goofy-schools-train.md
+++ b/.changeset/goofy-schools-train.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/core': minor
-'@mastra/server': patch
 ---
 
 Added `generateTitle.emitEvent` so HTTP and stream clients receive the generated thread title without polling.

--- a/.changeset/goofy-schools-train.md
+++ b/.changeset/goofy-schools-train.md
@@ -1,0 +1,29 @@
+---
+'@mastra/core': minor
+'@mastra/server': patch
+---
+
+Added `generateTitle.emitEvent` so HTTP and stream clients receive the generated thread title without polling.
+
+Thread titles are generated in the background after a run finishes. The `onTitleGenerated` callback only works for in-process callers, so an app driving an agent over HTTP had no way to know when the title was ready ([#21203](https://github.com/mastra-ai/mastra/issues/21203)).
+
+With `emitEvent: true`, the run stream waits for the title and emits it as a transient `data-thread-title` chunk before `finish`:
+
+```typescript
+const memory = new Memory({
+  options: {
+    generateTitle: {
+      emitEvent: true,
+    },
+  },
+});
+
+// Any stream consumer (including over HTTP) now receives the title:
+for await (const chunk of stream.fullStream) {
+  if (chunk.type === 'data-thread-title') {
+    console.log(chunk.data.threadId, chunk.data.title);
+  }
+}
+```
+
+The chunk is transient, so it is never persisted as part of the conversation. The default stays fully non-blocking: without `emitEvent`, title generation still runs in the background and does not delay the stream.

--- a/.changeset/goofy-schools-train.md
+++ b/.changeset/goofy-schools-train.md
@@ -27,4 +27,4 @@ for await (const chunk of stream.fullStream) {
 
 The chunk is transient, so it is never persisted as part of the conversation. The default stays fully non-blocking: without `emitEvent`, title generation still runs in the background and does not delay the stream.
 
-Durable and evented agents don't emit the chunk yet; the title is still generated and persisted, and a warning is logged when `emitEvent` is set.
+Durable and evented agents don't emit the chunk yet; the title is still generated and persisted.

--- a/.changeset/shiny-wolves-build.md
+++ b/.changeset/shiny-wolves-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Accept the new `generateTitle` options (`minMessages`, `emitEvent`) in the serialized memory configuration type, and make `model` optional to match the server contract.

--- a/.changeset/sunny-planes-crash.md
+++ b/.changeset/sunny-planes-crash.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/server': patch
-'@mastra/core': patch
 ---
 
-Accept the new `minMessages` and `emitEvent` fields of `generateTitle` in the serialized memory configuration schema.
+Accept the new `generateTitle` options in the serialized memory configuration schema: `minMessages` (minimum thread messages before a title is generated) and `emitEvent` (stream the generated title as a transient `data-thread-title` chunk before `finish`). `model` is now optional, matching the in-code configuration where the agent's own model is the default.

--- a/.changeset/sunny-planes-crash.md
+++ b/.changeset/sunny-planes-crash.md
@@ -1,0 +1,6 @@
+---
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Accept the new `minMessages` and `emitEvent` fields of `generateTitle` in the serialized memory configuration schema.

--- a/.changeset/sunny-planes-crash.md
+++ b/.changeset/sunny-planes-crash.md
@@ -3,3 +3,14 @@
 ---
 
 Accept the new `generateTitle` options in the serialized memory configuration schema: `minMessages` (minimum thread messages before a title is generated) and `emitEvent` (stream the generated title as a transient `data-thread-title` chunk before `finish`). `model` is now optional, matching the in-code configuration where the agent's own model is the default.
+
+```typescript
+const memoryConfig = {
+  options: {
+    generateTitle: {
+      minMessages: 2,
+      emitEvent: true,
+    },
+  },
+};
+```

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -444,10 +444,14 @@ type Shared_Type_21 = {
 };
 
 type Shared_Type_22 = {
-  /** Model ID in format provider/model-name (ModelRouterModelId) */
-  model: string;
+  /** Model ID in format provider/model-name (ModelRouterModelId); defaults to the agent's own model */
+  model?: string | undefined;
   /** Custom instructions for title generation */
   instructions?: string | undefined;
+  /** Minimum number of thread messages required before a title is generated */
+  minMessages?: number | undefined;
+  /** Emit the generated title as a data-thread-title chunk on the run stream */
+  emitEvent?: boolean | undefined;
 };
 
 type Shared_Type_23 = {

--- a/client-sdks/client-js/src/serialized-memory-config.test.ts
+++ b/client-sdks/client-js/src/serialized-memory-config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { SerializedMemoryConfig, TitleGenerationConfig } from './types';
+
+describe('SerializedMemoryConfig generateTitle', () => {
+  it('accepts the full serialized title generation contract', () => {
+    // model is optional: the agent's own model is the default
+    const config: SerializedMemoryConfig = {
+      options: {
+        generateTitle: {
+          minMessages: 2,
+          emitEvent: true,
+        },
+      },
+    };
+
+    expect(config.options?.generateTitle).toEqual({ minMessages: 2, emitEvent: true });
+
+    const withModel: SerializedMemoryConfig = {
+      options: {
+        generateTitle: {
+          model: 'openai/gpt-4o-mini',
+          instructions: 'Generate a concise title',
+          minMessages: 2,
+          emitEvent: true,
+        },
+      },
+    };
+
+    expect(withModel.options?.generateTitle).toBeDefined();
+    expectTypeOf<TitleGenerationConfig>().toExtend<
+      boolean | { model?: string; instructions?: string; minMessages?: number; emitEvent?: boolean }
+    >();
+  });
+});

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -1082,8 +1082,12 @@ export interface SemanticRecallConfig {
 export type TitleGenerationConfig =
   | boolean
   | {
-      model: string; // Model ID in format provider/model-name
+      model?: string; // Model ID in format provider/model-name; defaults to the agent's own model
       instructions?: string;
+      /** Minimum number of thread messages required before a title is generated */
+      minMessages?: number;
+      /** Emit the generated title as a transient `data-thread-title` chunk on the run stream, before `finish` */
+      emitEvent?: boolean;
     };
 
 /**

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -147,6 +147,41 @@ export const supportAgent = new Agent({
 
 Title generation runs asynchronously after the agent responds and doesn't affect response time.
 
+### Streaming the generated title
+
+By default the title is written to storage after the run's stream has closed, so HTTP clients only see it on their next thread fetch. Set `emitEvent: true` to deliver the title on the run's stream instead: the stream waits for the title and emits a transient `data-thread-title` chunk before `finish`.
+
+```typescript title="src/mastra/agents/support-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { Memory } from '@mastra/memory'
+
+export const supportAgent = new Agent({
+  id: 'support-agent',
+  name: 'Support agent',
+  instructions: 'Answer customer support questions.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  memory: new Memory({
+    options: {
+      generateTitle: {
+        emitEvent: true,
+      },
+    },
+  }),
+})
+```
+
+Stream consumers receive the chunk with the persisted title, so a chat UI can rename its thread list entry without polling:
+
+```typescript
+for await (const chunk of stream.fullStream) {
+  if (chunk.type === 'data-thread-title') {
+    renameThreadInSidebar(chunk.data.threadId, chunk.data.title)
+  }
+}
+```
+
+The chunk is transient: it's delivered to stream consumers but never persisted as part of the conversation's messages. Because the stream waits for the title, `emitEvent` delays the stream's `finish` by the title model call on the first turn of a thread. Leave it off to keep title generation fully non-blocking.
+
 To optimize cost or behavior, provide a smaller [`model`](/models) and custom `instructions`:
 
 ```typescript title="src/mastra/agents/support-agent.ts"

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -184,7 +184,7 @@ The chunk is transient: it's delivered to stream consumers but never persisted a
 
 :::note
 
-[Durable agents](/docs/harness/durable-agents) don't emit this chunk yet. The title is still generated and persisted, and the server logs a warning when `emitEvent` is set.
+[Durable agents](/docs/harness/durable-agents) don't emit this chunk yet. The title is still generated and persisted.
 
 :::
 

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -182,6 +182,12 @@ for await (const chunk of stream.fullStream) {
 
 The chunk is transient: it's delivered to stream consumers but never persisted as part of the conversation's messages. Because the stream waits for the title, `emitEvent` delays the stream's `finish` by the title model call on the first turn of a thread. Leave it off to keep title generation fully non-blocking.
 
+:::note
+
+[Durable agents](/docs/harness/durable-agents) don't emit this chunk yet. The title is still generated and persisted, and the server logs a warning when `emitEvent` is set.
+
+:::
+
 To optimize cost or behavior, provide a smaller [`model`](/models) and custom `instructions`:
 
 ```typescript title="src/mastra/agents/support-agent.ts"

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -180,11 +180,11 @@ for await (const chunk of stream.fullStream) {
 }
 ```
 
-The chunk is transient: it's delivered to stream consumers but never persisted as part of the conversation's messages. Because the stream waits for the title, `emitEvent` delays the stream's `finish` by the title model call on the first turn of a thread. Leave it off to keep title generation fully non-blocking.
+The chunk is transient: it's delivered to stream consumers but never persisted as part of the conversation's messages. Because the stream waits for the title, `emitEvent` delays the stream's `finish` on the turn that generates the title: the first turn of a thread, or a later turn when `minMessages` sets a higher threshold. Leave it off to keep title generation fully non-blocking.
 
 :::note
 
-[Durable agents](/docs/harness/durable-agents) don't emit this chunk yet. The title is still generated and persisted.
+[Durable and evented agents](/docs/harness/durable-agents) don't emit this chunk yet. The title is still generated and persisted.
 
 :::
 

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -184,7 +184,7 @@ The chunk is transient: it's delivered to stream consumers but never persisted a
 
 :::note
 
-[Durable and evented agents](/docs/harness/durable-agents) don't emit this chunk yet. The title is still generated and persisted.
+`emitEvent` applies to `stream()` runs. `generate()` returns JSON and can't carry the chunk, so it keeps non-blocking title generation. [Durable and evented agents](/docs/harness/durable-agents) don't emit this chunk yet. In all of these cases the title is still generated and persisted.
 
 :::
 

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -113,9 +113,9 @@ To enable `workingMemory` on an agent, you’ll need a storage provider configur
           },
           {
             name: 'generateTitle',
-            type: 'boolean | { model?: DynamicArgument<MastraLanguageModel>; instructions?: DynamicArgument<string>; minMessages?: number; emitEvent?: boolean }',
+            type: 'boolean | { model?: DynamicArgument<MastraModelConfig>; instructions?: DynamicArgument<string>; minMessages?: number; emitEvent?: boolean }',
             description:
-              "Controls automatic thread title generation from the conversation transcript. Can be a boolean or an object with a custom model, custom instructions, a minimum message count, and `emitEvent`. With `emitEvent: true` the run's stream waits for the title and emits it as a transient `data-thread-title` chunk before `finish`.",
+              'Controls automatic thread title generation from the conversation transcript. Accepts a boolean or an object with a custom model (any `MastraModelConfig`: a model instance, a `"provider/model"` ID, or an OpenAI-compatible config; defaults to the agent\'s own model), custom instructions, a minimum message count, and `emitEvent`. With `emitEvent: true` the run\'s stream waits for the title and emits it as a transient `data-thread-title` chunk before `finish`.',
             isOptional: true,
             defaultValue: 'false',
           },

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -113,9 +113,9 @@ To enable `workingMemory` on an agent, you’ll need a storage provider configur
           },
           {
             name: 'generateTitle',
-            type: 'boolean | { model: DynamicArgument<MastraLanguageModel>; instructions?: DynamicArgument<string> }',
+            type: 'boolean | { model?: DynamicArgument<MastraLanguageModel>; instructions?: DynamicArgument<string>; minMessages?: number; emitEvent?: boolean }',
             description:
-              'Controls automatic thread title generation from the conversation transcript. Can be a boolean or an object with custom model and instructions.',
+              "Controls automatic thread title generation from the conversation transcript. Can be a boolean or an object with a custom model, custom instructions, a minimum message count, and `emitEvent`. With `emitEvent: true` the run's stream waits for the title and emits it as a transient `data-thread-title` chunk before `finish`.",
             isOptional: true,
             defaultValue: 'false',
           },

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -115,7 +115,7 @@ To enable `workingMemory` on an agent, you’ll need a storage provider configur
             name: 'generateTitle',
             type: 'boolean | { model?: DynamicArgument<MastraModelConfig>; instructions?: DynamicArgument<string>; minMessages?: number; emitEvent?: boolean }',
             description:
-              "Controls automatic thread title generation from the conversation transcript. Accepts a boolean or an object with a custom model (any `MastraModelConfig`: a model instance, a `\"provider/model\"` ID, or an OpenAI-compatible config; defaults to the agent's own model), custom instructions, a minimum message count, and `emitEvent`. With `emitEvent: true` the run's stream waits for the title and emits it as a transient `data-thread-title` chunk before `finish` (durable agents persist the title but don't emit the chunk yet).",
+              "Controls automatic thread title generation from the conversation transcript. Accepts a boolean or an object with a custom model (any `MastraModelConfig`: a model instance, a `\"provider/model\"` ID, or an OpenAI-compatible config; defaults to the agent's own model), custom instructions, a minimum message count, and `emitEvent`. With `emitEvent: true` the run's stream waits for the title and emits it as a transient `data-thread-title` chunk before `finish` (durable and evented agents persist the title but don't emit the chunk yet).",
             isOptional: true,
             defaultValue: 'false',
           },

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -115,7 +115,7 @@ To enable `workingMemory` on an agent, you’ll need a storage provider configur
             name: 'generateTitle',
             type: 'boolean | { model?: DynamicArgument<MastraModelConfig>; instructions?: DynamicArgument<string>; minMessages?: number; emitEvent?: boolean }',
             description:
-              'Controls automatic thread title generation from the conversation transcript. Accepts a boolean or an object with a custom model (any `MastraModelConfig`: a model instance, a `"provider/model"` ID, or an OpenAI-compatible config; defaults to the agent\'s own model), custom instructions, a minimum message count, and `emitEvent`. With `emitEvent: true` the run\'s stream waits for the title and emits it as a transient `data-thread-title` chunk before `finish`.',
+              "Controls automatic thread title generation from the conversation transcript. Accepts a boolean or an object with a custom model (any `MastraModelConfig`: a model instance, a `\"provider/model\"` ID, or an OpenAI-compatible config; defaults to the agent's own model), custom instructions, a minimum message count, and `emitEvent`. With `emitEvent: true` the run's stream waits for the title and emits it as a transient `data-thread-title` chunk before `finish` (durable agents persist the title but don't emit the chunk yet).",
             isOptional: true,
             defaultValue: 'false',
           },

--- a/docs/src/content/en/reference/memory/serialized-memory-config.mdx
+++ b/docs/src/content/en/reference/memory/serialized-memory-config.mdx
@@ -85,9 +85,9 @@ new MastraEditor({
           },
           {
             name: 'generateTitle',
-            type: 'boolean | { model: ModelRouterModelId; instructions?: string; minMessages?: number; emitEvent?: boolean }',
+            type: 'boolean | { model?: ModelRouterModelId; instructions?: string; minMessages?: number; emitEvent?: boolean }',
             description:
-              'Title generation configuration. Pass an object with `model` (in `"provider/model"` form), optional `instructions`, an optional minimum message count, and optional `emitEvent` to stream the title as a `data-thread-title` chunk.',
+              'Title generation configuration. Pass an object with an optional `model` (in `"provider/model"` form, defaults to the agent\'s own model), optional `instructions`, an optional minimum message count, and optional `emitEvent` to stream the title as a `data-thread-title` chunk.',
             isOptional: true,
           },
         ],

--- a/docs/src/content/en/reference/memory/serialized-memory-config.mdx
+++ b/docs/src/content/en/reference/memory/serialized-memory-config.mdx
@@ -85,9 +85,9 @@ new MastraEditor({
           },
           {
             name: 'generateTitle',
-            type: 'boolean | { model: ModelRouterModelId; instructions?: string }',
+            type: 'boolean | { model: ModelRouterModelId; instructions?: string; minMessages?: number; emitEvent?: boolean }',
             description:
-              'Title generation configuration. Pass an object with `model` (in `"provider/model"` form) and optional `instructions`.',
+              'Title generation configuration. Pass an object with `model` (in `"provider/model"` form), optional `instructions`, an optional minimum message count, and optional `emitEvent` to stream the title as a `data-thread-title` chunk.',
             isOptional: true,
           },
         ],

--- a/docs/src/content/en/reference/memory/serialized-memory-config.mdx
+++ b/docs/src/content/en/reference/memory/serialized-memory-config.mdx
@@ -87,7 +87,7 @@ new MastraEditor({
             name: 'generateTitle',
             type: 'boolean | { model?: ModelRouterModelId; instructions?: string; minMessages?: number; emitEvent?: boolean }',
             description:
-              'Title generation configuration. Pass an object with an optional `model` (in `"provider/model"` form, defaults to the agent\'s own model), optional `instructions`, an optional minimum message count, and optional `emitEvent` to stream the title as a `data-thread-title` chunk.',
+              'Title generation configuration. Pass an object with an optional `model` (in `"provider/model"` form, defaults to the agent\'s own model), optional `instructions`, an optional minimum message count, and optional `emitEvent` to stream the title as a `data-thread-title` chunk. Durable and evented agents persist the title but don\'t emit the chunk.',
             isOptional: true,
           },
         ],

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -533,7 +533,7 @@ const stream = await agent.stream('message for agent')
                     type: '(title: string) => void | Promise<void>',
                     isOptional: true,
                     description:
-                      'Callback fired asynchronously when a thread title is generated and persisted to storage. Title generation runs in the background and may complete after the stream ends. Only fires when `generateTitle` is enabled in memory options and the thread has no existing title.',
+                      'Callback fired asynchronously when a thread title is generated and persisted to storage. Title generation runs in the background and may complete after the stream ends, unless `generateTitle.emitEvent` is enabled — then the title is also emitted as a `data-thread-title` chunk on the stream before `finish`. Only fires when `generateTitle` is enabled in memory options and the thread has no existing title.',
                   },
                 ],
               },

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -3679,12 +3679,14 @@ describe('generateTitle emitEvent', () => {
     const { agent, mockMemory } = createAgentWithTitleGen(agentModel, titleModel, true);
 
     const controller = new AbortController();
+    const waitUntil = vi.fn();
     const result = await agent.stream('Hello', {
       memory: {
         resource: 'user-1',
         thread: { id: 'thread-ev-abort', title: '' },
       },
       abortSignal: controller.signal,
+      serverless: { waitUntil },
     });
 
     const drained = (async () => {
@@ -3699,9 +3701,24 @@ describe('generateTitle emitEvent', () => {
     controller.abort();
     await drained;
 
+    // Abort won the race: the detached title promise must get the serverless
+    // keep-alive, same as the fire-and-forget path.
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+
     // The detached title generation still completes and persists
     releaseTitle();
     expect(await waitForThreadTitle(mockMemory, 'thread-ev-abort')).toBe('Generated Title');
+
+    // Chunks are buffered for replay to new subscribers; an aborted run must
+    // never have buffered a late title chunk after finish.
+    const replayedTypes: string[] = [];
+    const replayDrain = (async () => {
+      for await (const chunk of result.fullStream) {
+        replayedTypes.push((chunk as any)?.type);
+      }
+    })().catch(() => {});
+    await Promise.race([replayDrain, new Promise(resolve => setTimeout(resolve, 500))]);
+    expect(replayedTypes).not.toContain('data-thread-title');
   });
 
   it('does not emit a title chunk when the thread already has a title', async () => {

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -3507,6 +3507,163 @@ describe('onTitleGenerated callback', () => {
   });
 });
 
+describe('generateTitle emitEvent', () => {
+  function createMockModels() {
+    const agentModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        content: [{ type: 'text' as const, text: 'Agent response' }],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start' as const, warnings: [] },
+          { type: 'response-metadata' as const, id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start' as const, id: 'text-1' },
+          { type: 'text-delta' as const, id: 'text-1', delta: 'Agent response' },
+          { type: 'text-end' as const, id: 'text-1' },
+          {
+            type: 'finish' as const,
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+      }),
+    });
+
+    const titleModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+        content: [{ type: 'text' as const, text: 'Generated Title' }],
+        warnings: [],
+      }),
+    });
+
+    return { agentModel, titleModel };
+  }
+
+  function createAgentWithTitleGen(
+    agentModel: MockLanguageModelV2,
+    titleModel: MockLanguageModelV2,
+    emitEvent?: boolean,
+  ) {
+    const mockMemory = new MockMemory();
+    mockMemory.getMergedThreadConfig = () => ({
+      generateTitle: { model: titleModel, ...(emitEvent !== undefined && { emitEvent }) },
+    });
+
+    const agent = new Agent({
+      id: 'emit-event-test',
+      name: 'EmitEvent Test',
+      instructions: 'test agent',
+      model: agentModel,
+      memory: mockMemory,
+    });
+
+    return { agent, mockMemory };
+  }
+
+  it('emits a data-thread-title chunk before finish when emitEvent is enabled', async () => {
+    const { agentModel, titleModel } = createMockModels();
+    const { agent, mockMemory } = createAgentWithTitleGen(agentModel, titleModel, true);
+
+    const result = await agent.stream('Hello', {
+      memory: {
+        resource: 'user-1',
+        thread: { id: 'thread-ev-1', title: '' },
+      },
+    });
+
+    const chunks: any[] = [];
+    for await (const chunk of result.fullStream) {
+      chunks.push(chunk);
+    }
+
+    const titleChunkIndex = chunks.findIndex(chunk => chunk.type === 'data-thread-title');
+    const finishChunkIndex = chunks.findIndex(chunk => chunk.type === 'finish');
+
+    expect(titleChunkIndex).toBeGreaterThan(-1);
+    expect(finishChunkIndex).toBeGreaterThan(-1);
+    expect(titleChunkIndex).toBeLessThan(finishChunkIndex);
+    expect(chunks[titleChunkIndex].data).toEqual({ threadId: 'thread-ev-1', title: 'Generated Title' });
+
+    // No timing race: the title is persisted before the stream finishes
+    const thread = await mockMemory.getThreadById({ threadId: 'thread-ev-1' });
+    expect(thread?.title).toBe('Generated Title');
+  });
+
+  it('does not emit a title chunk when emitEvent is not set (fire-and-forget default)', async () => {
+    const { agentModel, titleModel } = createMockModels();
+    const { agent } = createAgentWithTitleGen(agentModel, titleModel);
+
+    const result = await agent.stream('Hello', {
+      memory: {
+        resource: 'user-1',
+        thread: { id: 'thread-ev-2', title: '' },
+      },
+    });
+
+    const chunks: any[] = [];
+    for await (const chunk of result.fullStream) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.some(chunk => chunk.type === 'data-thread-title')).toBe(false);
+
+    // Title generation still runs detached
+    await new Promise(resolve => setTimeout(resolve, 200));
+  });
+
+  it('fires onTitleGenerated before the stream closes when emitEvent is enabled', async () => {
+    const { agentModel, titleModel } = createMockModels();
+    const { agent } = createAgentWithTitleGen(agentModel, titleModel, true);
+
+    let receivedTitle: string | undefined;
+
+    const result = await agent.stream('Hello', {
+      memory: {
+        resource: 'user-1',
+        thread: { id: 'thread-ev-3', title: '' },
+        onTitleGenerated: title => {
+          receivedTitle = title;
+        },
+      },
+    });
+
+    for await (const _ of result.fullStream) {
+      // drain
+    }
+
+    // No setTimeout needed: emitEvent awaits the title before finish
+    expect(receivedTitle).toBe('Generated Title');
+  });
+
+  it('does not emit a title chunk when the thread already has a title', async () => {
+    const { agentModel, titleModel } = createMockModels();
+    const { agent } = createAgentWithTitleGen(agentModel, titleModel, true);
+
+    const result = await agent.stream('Hello', {
+      memory: {
+        resource: 'user-1',
+        thread: { id: 'thread-ev-4', title: 'Existing Title' },
+      },
+    });
+
+    const chunks: any[] = [];
+    for await (const chunk of result.fullStream) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.some(chunk => chunk.type === 'data-thread-title')).toBe(false);
+  });
+});
+
 describe('title generation with resource-scoped memory recall', () => {
   it('derives the title only from the thread being titled, not from recalled messages of other threads', async () => {
     const capturedTitlePrompts: any[] = [];

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -3604,6 +3604,46 @@ describe('generateTitle emitEvent', () => {
     expect(receivedTitle).toBe('Generated Title');
   });
 
+  it('does not delay generate() when emitEvent is enabled', async () => {
+    const { agentModel } = createMockModels();
+
+    // Gate the title model: if generate() awaited the title, this test would
+    // hang until the vitest timeout because the gate is only released after
+    // generate() resolves.
+    let releaseTitle!: () => void;
+    const titleGate = new Promise<void>(resolve => {
+      releaseTitle = resolve;
+    });
+    const titleModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        await titleGate;
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          content: [{ type: 'text' as const, text: 'Generated Title' }],
+          warnings: [],
+        };
+      },
+    });
+    const { agent, mockMemory } = createAgentWithTitleGen(agentModel, titleModel, true);
+
+    await agent.generate('Hello', {
+      memory: {
+        resource: 'user-1',
+        thread: { id: 'thread-ev-gen', title: '' },
+      },
+    });
+
+    // generate() returned while the title model was still pending
+    expect((await mockMemory.getThreadById({ threadId: 'thread-ev-gen' }))?.title).toBeFalsy();
+
+    // The detached title generation still completes afterwards
+    releaseTitle();
+    await new Promise(resolve => setTimeout(resolve, 200));
+    expect((await mockMemory.getThreadById({ threadId: 'thread-ev-gen' }))?.title).toBe('Generated Title');
+  });
+
   it('does not emit a title chunk when the thread already has a title', async () => {
     const { agentModel, titleModel } = createMockModels();
     const { agent } = createAgentWithTitleGen(agentModel, titleModel, true);

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -3360,47 +3360,47 @@ describe('sub-agent title generation propagation (#18738)', () => {
   });
 });
 
+function createMockModels() {
+  const agentModel = new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [{ type: 'text' as const, text: 'Agent response' }],
+      warnings: [],
+    }),
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start' as const, warnings: [] },
+        { type: 'response-metadata' as const, id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start' as const, id: 'text-1' },
+        { type: 'text-delta' as const, id: 'text-1', delta: 'Agent response' },
+        { type: 'text-end' as const, id: 'text-1' },
+        {
+          type: 'finish' as const,
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        },
+      ]),
+    }),
+  });
+
+  const titleModel = new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+      content: [{ type: 'text' as const, text: 'Generated Title' }],
+      warnings: [],
+    }),
+  });
+
+  return { agentModel, titleModel };
+}
+
 describe('onTitleGenerated callback', () => {
-  function createMockModels() {
-    const agentModel = new MockLanguageModelV2({
-      doGenerate: async () => ({
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        finishReason: 'stop' as const,
-        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
-        content: [{ type: 'text' as const, text: 'Agent response' }],
-        warnings: [],
-      }),
-      doStream: async () => ({
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        warnings: [],
-        stream: convertArrayToReadableStream([
-          { type: 'stream-start' as const, warnings: [] },
-          { type: 'response-metadata' as const, id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
-          { type: 'text-start' as const, id: 'text-1' },
-          { type: 'text-delta' as const, id: 'text-1', delta: 'Agent response' },
-          { type: 'text-end' as const, id: 'text-1' },
-          {
-            type: 'finish' as const,
-            finishReason: 'stop' as const,
-            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
-          },
-        ]),
-      }),
-    });
-
-    const titleModel = new MockLanguageModelV2({
-      doGenerate: async () => ({
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        finishReason: 'stop' as const,
-        usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
-        content: [{ type: 'text' as const, text: 'Generated Title' }],
-        warnings: [],
-      }),
-    });
-
-    return { agentModel, titleModel };
-  }
-
   function createAgentWithTitleGen(agentModel: MockLanguageModelV2, titleModel: MockLanguageModelV2) {
     const mockMemory = new MockMemory();
     mockMemory.getMergedThreadConfig = () => ({
@@ -3508,46 +3508,6 @@ describe('onTitleGenerated callback', () => {
 });
 
 describe('generateTitle emitEvent', () => {
-  function createMockModels() {
-    const agentModel = new MockLanguageModelV2({
-      doGenerate: async () => ({
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        finishReason: 'stop' as const,
-        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
-        content: [{ type: 'text' as const, text: 'Agent response' }],
-        warnings: [],
-      }),
-      doStream: async () => ({
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        warnings: [],
-        stream: convertArrayToReadableStream([
-          { type: 'stream-start' as const, warnings: [] },
-          { type: 'response-metadata' as const, id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
-          { type: 'text-start' as const, id: 'text-1' },
-          { type: 'text-delta' as const, id: 'text-1', delta: 'Agent response' },
-          { type: 'text-end' as const, id: 'text-1' },
-          {
-            type: 'finish' as const,
-            finishReason: 'stop' as const,
-            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
-          },
-        ]),
-      }),
-    });
-
-    const titleModel = new MockLanguageModelV2({
-      doGenerate: async () => ({
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        finishReason: 'stop' as const,
-        usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
-        content: [{ type: 'text' as const, text: 'Generated Title' }],
-        warnings: [],
-      }),
-    });
-
-    return { agentModel, titleModel };
-  }
-
   function createAgentWithTitleGen(
     agentModel: MockLanguageModelV2,
     titleModel: MockLanguageModelV2,

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -3508,6 +3508,15 @@ describe('onTitleGenerated callback', () => {
 });
 
 describe('generateTitle emitEvent', () => {
+  async function waitForThreadTitle(memory: MockMemory, threadId: string, timeoutMs = 2000) {
+    const start = Date.now();
+    for (;;) {
+      const title = (await memory.getThreadById({ threadId }))?.title;
+      if (title || Date.now() - start > timeoutMs) return title;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
+
   function createAgentWithTitleGen(
     agentModel: MockLanguageModelV2,
     titleModel: MockLanguageModelV2,
@@ -3640,8 +3649,59 @@ describe('generateTitle emitEvent', () => {
 
     // The detached title generation still completes afterwards
     releaseTitle();
-    await new Promise(resolve => setTimeout(resolve, 200));
-    expect((await mockMemory.getThreadById({ threadId: 'thread-ev-gen' }))?.title).toBe('Generated Title');
+    expect(await waitForThreadTitle(mockMemory, 'thread-ev-gen')).toBe('Generated Title');
+  });
+
+  it('releases finish when the run aborts during the title wait', async () => {
+    const { agentModel } = createMockModels();
+
+    let releaseTitle!: () => void;
+    const titleGate = new Promise<void>(resolve => {
+      releaseTitle = resolve;
+    });
+    let signalTitleStarted!: () => void;
+    const titleStarted = new Promise<void>(resolve => {
+      signalTitleStarted = resolve;
+    });
+    const titleModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        signalTitleStarted();
+        await titleGate;
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          content: [{ type: 'text' as const, text: 'Generated Title' }],
+          warnings: [],
+        };
+      },
+    });
+    const { agent, mockMemory } = createAgentWithTitleGen(agentModel, titleModel, true);
+
+    const controller = new AbortController();
+    const result = await agent.stream('Hello', {
+      memory: {
+        resource: 'user-1',
+        thread: { id: 'thread-ev-abort', title: '' },
+      },
+      abortSignal: controller.signal,
+    });
+
+    const drained = (async () => {
+      for await (const _ of result.fullStream) {
+        // drain
+      }
+    })().catch(() => {});
+
+    // Abort while the finish chunk is held for the (gated) title model. Without
+    // the abort race, this drain would hang until the vitest timeout.
+    await titleStarted;
+    controller.abort();
+    await drained;
+
+    // The detached title generation still completes and persists
+    releaseTitle();
+    expect(await waitForThreadTitle(mockMemory, 'thread-ev-abort')).toBe('Generated Title');
   });
 
   it('does not emit a title chunk when the thread already has a title', async () => {

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -3589,7 +3589,7 @@ describe('generateTitle emitEvent', () => {
     await new Promise(resolve => setTimeout(resolve, 200));
   });
 
-  it('fires onTitleGenerated before the stream closes when emitEvent is enabled', async () => {
+  it('still fires onTitleGenerated when emitEvent is enabled', async () => {
     const { agentModel, titleModel } = createMockModels();
     const { agent } = createAgentWithTitleGen(agentModel, titleModel, true);
 
@@ -3609,7 +3609,55 @@ describe('generateTitle emitEvent', () => {
       // drain
     }
 
-    // No setTimeout needed: emitEvent awaits the title before finish
+    // The callback runs detached from the stream; wait for it deterministically
+    const start = Date.now();
+    while (receivedTitle === undefined && Date.now() - start < 2000) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    expect(receivedTitle).toBe('Generated Title');
+  });
+
+  it('does not hold finish for a slow onTitleGenerated callback', async () => {
+    const { agentModel, titleModel } = createMockModels();
+    const { agent } = createAgentWithTitleGen(agentModel, titleModel, true);
+
+    // Gate the callback: if the stream waited for it, the drain below would
+    // hang until the vitest timeout because the gate is only released after.
+    let releaseCallback!: () => void;
+    const callbackGate = new Promise<void>(resolve => {
+      releaseCallback = resolve;
+    });
+    let receivedTitle: string | undefined;
+
+    const result = await agent.stream('Hello', {
+      memory: {
+        resource: 'user-1',
+        thread: { id: 'thread-ev-slow-cb', title: '' },
+        onTitleGenerated: async title => {
+          await callbackGate;
+          receivedTitle = title;
+        },
+      },
+    });
+
+    const chunks: any[] = [];
+    for await (const chunk of result.fullStream) {
+      chunks.push(chunk);
+    }
+
+    // The stream finished with the title chunk in order, while the callback was still gated
+    const titleChunkIndex = chunks.findIndex(chunk => chunk.type === 'data-thread-title');
+    const finishChunkIndex = chunks.findIndex(chunk => chunk.type === 'finish');
+    expect(titleChunkIndex).toBeGreaterThan(-1);
+    expect(titleChunkIndex).toBeLessThan(finishChunkIndex);
+    expect(receivedTitle).toBeUndefined();
+
+    // The detached callback still completes afterwards
+    releaseCallback();
+    const start = Date.now();
+    while (receivedTitle === undefined && Date.now() - start < 2000) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
     expect(receivedTitle).toBe('Generated Title');
   });
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -7481,6 +7481,7 @@ export class Agent<
     onTitleGenerated,
     waitUntil,
     writer,
+    abortSignal,
   }: AgentExecuteOnFinishOptions) {
     const observabilityContext = createObservabilityContext({ currentSpan: agentSpan });
 
@@ -7627,11 +7628,26 @@ export class Agent<
                   this.logger.error('Error persisting generated title:', error);
                 });
 
-              if (emitEvent && writer) {
+              if (emitEvent && writer && !abortSignal?.aborted) {
                 // `generateTitle.emitEvent` trades finish latency for delivery: the run's
                 // `finish` chunk is held until the title is generated, persisted, and
-                // emitted as a transient `data-thread-title` chunk on this stream.
-                await titlePromise;
+                // emitted as a transient `data-thread-title` chunk on this stream. An
+                // abort during the wait releases `finish` immediately; the title keeps
+                // generating detached so it still persists.
+                if (abortSignal) {
+                  let onAbort!: () => void;
+                  const abortedDuringWait = new Promise<void>(resolve => {
+                    onAbort = () => resolve();
+                    abortSignal.addEventListener('abort', onAbort, { once: true });
+                  });
+                  try {
+                    await Promise.race([titlePromise, abortedDuringWait]);
+                  } finally {
+                    abortSignal.removeEventListener('abort', onAbort);
+                  }
+                } else {
+                  await titlePromise;
+                }
               } else if (typeof waitUntil === 'function') {
                 waitUntil(titlePromise);
               } else {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -7480,6 +7480,7 @@ export class Agent<
     overrideScorers,
     onTitleGenerated,
     waitUntil,
+    writer,
   }: AgentExecuteOnFinishOptions) {
     const observabilityContext = createObservabilityContext({ currentSpan: agentSpan });
 
@@ -7563,6 +7564,7 @@ export class Agent<
           model: titleModel,
           instructions: titleInstructions,
           minMessages,
+          emitEvent,
         } = this.resolveTitleGenerationConfig(
           config?.generateTitle as
             | boolean
@@ -7570,6 +7572,7 @@ export class Agent<
                 model?: DynamicArgument<MastraModelConfig, TRequestContext>;
                 instructions?: DynamicArgument<string>;
                 minMessages?: number;
+                emitEvent?: boolean;
               }
             | undefined,
         );
@@ -7604,6 +7607,17 @@ export class Agent<
                       title,
                       metadata: thread.metadata,
                     });
+                    if (emitEvent && writer) {
+                      try {
+                        await writer.custom({
+                          type: 'data-thread-title',
+                          data: { threadId: thread.id, title },
+                          transient: true,
+                        });
+                      } catch (error) {
+                        this.logger.debug('Could not emit thread title chunk; stream already closed', { error });
+                      }
+                    }
                     if (typeof onTitleGenerated === 'function') {
                       await onTitleGenerated(title);
                     }
@@ -7613,7 +7627,12 @@ export class Agent<
                   this.logger.error('Error persisting generated title:', error);
                 });
 
-              if (typeof waitUntil === 'function') {
+              if (emitEvent && writer) {
+                // `generateTitle.emitEvent` trades finish latency for delivery: the run's
+                // `finish` chunk is held until the title is generated, persisted, and
+                // emitted as a transient `data-thread-title` chunk on this stream.
+                await titlePromise;
+              } else if (typeof waitUntil === 'function') {
                 waitUntil(titlePromise);
               } else {
                 void titlePromise;
@@ -9698,6 +9717,7 @@ export class Agent<
           model?: DynamicArgument<MastraModelConfig, TRequestContext>;
           instructions?: DynamicArgument<string>;
           minMessages?: number;
+          emitEvent?: boolean;
         }
       | undefined,
   ): {
@@ -9705,6 +9725,7 @@ export class Agent<
     model?: DynamicArgument<MastraModelConfig, TRequestContext>;
     instructions?: DynamicArgument<string>;
     minMessages?: number;
+    emitEvent?: boolean;
   } {
     if (typeof generateTitleConfig === 'boolean') {
       return { shouldGenerate: generateTitleConfig };
@@ -9716,6 +9737,7 @@ export class Agent<
         model: generateTitleConfig.model,
         instructions: generateTitleConfig.instructions,
         minMessages: generateTitleConfig.minMessages,
+        emitEvent: generateTitleConfig.emitEvent,
       };
     }
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -7608,7 +7608,10 @@ export class Agent<
                       title,
                       metadata: thread.metadata,
                     });
-                    if (emitEvent && writer) {
+                    // Skip emission once the run aborted: `finish` has already been
+                    // released, and a late chunk would violate the guarantee that
+                    // `data-thread-title` precedes `finish`.
+                    if (emitEvent && writer && !abortSignal?.aborted) {
                       try {
                         await writer.custom({
                           type: 'data-thread-title',
@@ -7636,14 +7639,20 @@ export class Agent<
                 // generating detached so it still persists.
                 if (abortSignal) {
                   let onAbort!: () => void;
-                  const abortedDuringWait = new Promise<void>(resolve => {
-                    onAbort = () => resolve();
+                  const abortedDuringWait = new Promise<'abort'>(resolve => {
+                    onAbort = () => resolve('abort');
                     abortSignal.addEventListener('abort', onAbort, { once: true });
                   });
+                  let raceWinner: 'title' | 'abort';
                   try {
-                    await Promise.race([titlePromise, abortedDuringWait]);
+                    raceWinner = await Promise.race([titlePromise.then(() => 'title' as const), abortedDuringWait]);
                   } finally {
                     abortSignal.removeEventListener('abort', onAbort);
+                  }
+                  // Abort won: the title generation is now detached, so it needs the
+                  // same serverless keep-alive as the fire-and-forget path (#20682).
+                  if (raceWinner === 'abort' && typeof waitUntil === 'function') {
+                    waitUntil(titlePromise);
                   }
                 } else {
                   await titlePromise;

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -7591,7 +7591,7 @@ export class Agent<
               // Fire-and-forget so generate()/stream() stay fast. On serverless
               // runtimes that freeze after the response, pass
               // `serverless.waitUntil` so the platform keeps this promise alive (#20682).
-              const titlePromise = this.genTitle(
+              const persistAndEmitPromise = this.genTitle(
                 userMessage,
                 requestContext,
                 observabilityContext,
@@ -7622,13 +7622,25 @@ export class Agent<
                         this.logger.debug('Could not emit thread title chunk; stream already closed', { error });
                       }
                     }
-                    if (typeof onTitleGenerated === 'function') {
-                      await onTitleGenerated(title);
-                    }
                   }
+                  return title;
                 })
                 .catch(error => {
                   this.logger.error('Error persisting generated title:', error);
+                  return undefined;
+                });
+
+              // The user callback runs after persist + emission but never holds the
+              // stream's `finish` chunk: it is documented as able to complete after
+              // the stream ends, and it runs unbounded user code.
+              const titlePromise = persistAndEmitPromise
+                .then(async title => {
+                  if (title && typeof onTitleGenerated === 'function') {
+                    await onTitleGenerated(title);
+                  }
+                })
+                .catch(error => {
+                  this.logger.error('Error in onTitleGenerated callback:', error);
                 });
 
               if (emitEvent && writer && !abortSignal?.aborted) {
@@ -7639,23 +7651,22 @@ export class Agent<
                 // generating detached so it still persists.
                 if (abortSignal) {
                   let onAbort!: () => void;
-                  const abortedDuringWait = new Promise<'abort'>(resolve => {
-                    onAbort = () => resolve('abort');
+                  const abortedDuringWait = new Promise<void>(resolve => {
+                    onAbort = () => resolve();
                     abortSignal.addEventListener('abort', onAbort, { once: true });
                   });
-                  let raceWinner: 'title' | 'abort';
                   try {
-                    raceWinner = await Promise.race([titlePromise.then(() => 'title' as const), abortedDuringWait]);
+                    await Promise.race([persistAndEmitPromise, abortedDuringWait]);
                   } finally {
                     abortSignal.removeEventListener('abort', onAbort);
                   }
-                  // Abort won: the title generation is now detached, so it needs the
-                  // same serverless keep-alive as the fire-and-forget path (#20682).
-                  if (raceWinner === 'abort' && typeof waitUntil === 'function') {
-                    waitUntil(titlePromise);
-                  }
                 } else {
-                  await titlePromise;
+                  await persistAndEmitPromise;
+                }
+                // Whatever still runs detached — an abort-interrupted persist or the
+                // onTitleGenerated tail — needs the serverless keep-alive (#20682).
+                if (typeof waitUntil === 'function') {
+                  waitUntil(titlePromise);
                 }
               } else if (typeof waitUntil === 'function') {
                 waitUntil(titlePromise);

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -15,6 +15,7 @@ import type { ScoringFilter } from '../../evals/predicate';
 import type { SystemMessage } from '../../llm';
 import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
+import type { IMastraLogger } from '../../logger';
 import type { ToolCallConcurrency } from '../../loop/types';
 import type { Mastra } from '../../mastra';
 import type { MastraMemory } from '../../memory/memory';
@@ -703,6 +704,7 @@ export interface RunRegistryEntry {
     messageListState: SerializedMessageListState;
     requestContext?: RequestContext;
     tracingContext?: TracingContext;
+    logger?: IMastraLogger;
   }) => Promise<void>;
   /**
    * Signal messages already present in the `messageList` at run start (from

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -15,7 +15,6 @@ import type { ScoringFilter } from '../../evals/predicate';
 import type { SystemMessage } from '../../llm';
 import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { MastraLanguageModel } from '../../llm/model/shared.types';
-import type { IMastraLogger } from '../../logger';
 import type { ToolCallConcurrency } from '../../loop/types';
 import type { Mastra } from '../../mastra';
 import type { MastraMemory } from '../../memory/memory';
@@ -704,7 +703,6 @@ export interface RunRegistryEntry {
     messageListState: SerializedMessageListState;
     requestContext?: RequestContext;
     tracingContext?: TracingContext;
-    logger?: IMastraLogger;
   }) => Promise<void>;
   /**
    * Signal messages already present in the `messageList` at run start (from

--- a/packages/core/src/agent/durable/workflows/finalize-run.ts
+++ b/packages/core/src/agent/durable/workflows/finalize-run.ts
@@ -213,7 +213,6 @@ export async function runDurableFinishSideEffects({
       messageListState: messageList.serialize(),
       requestContext: effectiveRequestContext,
       tracingContext,
-      logger: effectiveLogger,
     };
 
     try {
@@ -251,23 +250,13 @@ export async function generateDurableThreadTitle({
   messageListState,
   requestContext,
   tracingContext,
-  logger,
 }: GenerateThreadTitleArgs & { agent: AnyAgent; memory: MastraMemory }): Promise<void> {
   const thread = await memory.getThreadById({ threadId });
   const mergedConfig = memory.getMergedThreadConfig(memoryConfig);
-  const { shouldGenerate, model, instructions, minMessages, emitEvent } = agent.resolveTitleGenerationConfig(
+  const { shouldGenerate, model, instructions, minMessages } = agent.resolveTitleGenerationConfig(
     mergedConfig.generateTitle,
   );
   if (!shouldGenerate || thread?.title) return;
-
-  // Durable finalization has no stream writer, so the `data-thread-title` chunk
-  // cannot be emitted here. The title is still generated and persisted.
-  if (emitEvent) {
-    logger?.warn(
-      '[DurableAgent] generateTitle.emitEvent is not supported for durable agents yet; the title is persisted but no data-thread-title chunk is emitted',
-      { threadId },
-    );
-  }
 
   const titleMessageList = new MessageList().deserialize(messageListState);
   const uiMessages = agent.filterUiMessagesByThread(titleMessageList, threadId, titleMessageList.get.all.ui());

--- a/packages/core/src/agent/durable/workflows/finalize-run.ts
+++ b/packages/core/src/agent/durable/workflows/finalize-run.ts
@@ -213,6 +213,7 @@ export async function runDurableFinishSideEffects({
       messageListState: messageList.serialize(),
       requestContext: effectiveRequestContext,
       tracingContext,
+      logger: effectiveLogger,
     };
 
     try {
@@ -250,13 +251,23 @@ export async function generateDurableThreadTitle({
   messageListState,
   requestContext,
   tracingContext,
+  logger,
 }: GenerateThreadTitleArgs & { agent: AnyAgent; memory: MastraMemory }): Promise<void> {
   const thread = await memory.getThreadById({ threadId });
   const mergedConfig = memory.getMergedThreadConfig(memoryConfig);
-  const { shouldGenerate, model, instructions, minMessages } = agent.resolveTitleGenerationConfig(
+  const { shouldGenerate, model, instructions, minMessages, emitEvent } = agent.resolveTitleGenerationConfig(
     mergedConfig.generateTitle,
   );
   if (!shouldGenerate || thread?.title) return;
+
+  // Durable finalization has no stream writer, so the `data-thread-title` chunk
+  // cannot be emitted here. The title is still generated and persisted.
+  if (emitEvent) {
+    logger?.warn(
+      '[DurableAgent] generateTitle.emitEvent is not supported for durable agents yet; the title is persisted but no data-thread-title chunk is emitted',
+      { threadId },
+    );
+  }
 
   const titleMessageList = new MessageList().deserialize(messageListState);
   const uiMessages = agent.filterUiMessagesByThread(titleMessageList, threadId, titleMessageList.get.all.ui());

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1196,6 +1196,12 @@ export type AgentExecuteOnFinishOptions = {
    * generated thread title) can reach stream consumers on the wire.
    */
   writer?: CustomChunkWriter;
+  /**
+   * The run's abort signal. When `generateTitle.emitEvent` holds the `finish`
+   * chunk for the title, an abort releases the wait immediately; the title
+   * keeps generating detached so it still persists.
+   */
+  abortSignal?: AbortSignal;
 };
 
 export type AgentMethodType = 'generate' | 'stream' | 'generateLegacy' | 'streamLegacy';

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -55,7 +55,12 @@ import type { PublicSchema, StandardSchemaWithJSON } from '../schema';
 import type { SignalProvider } from '../signals/signal-provider';
 import type { AgentSkillsInput } from '../skills/types';
 import type { MastraModelOutput } from '../stream/base/output';
-import type { AgentChunkType, MastraOnFinishCallbackArgs, ModelManagerModelConfig } from '../stream/types';
+import type {
+  AgentChunkType,
+  CustomChunkWriter,
+  MastraOnFinishCallbackArgs,
+  ModelManagerModelConfig,
+} from '../stream/types';
 import type { ToolAction, ToolHooks, VercelTool, VercelToolV5 } from '../tools';
 import type { WebSearchToolPlaceholder } from '../tools/builtin/web-search';
 import type { ToolPayloadTransformPolicy } from '../tools/types';
@@ -1185,6 +1190,12 @@ export type AgentExecuteOnFinishOptions = {
    * serverless freeze-after-response without blocking `generate()`/`stream()`.
    */
   waitUntil?: WaitUntilFn;
+  /**
+   * Writer for the run's stream. Chunks written during this callback are
+   * delivered before the `finish` chunk, so post-run side effects (e.g. a
+   * generated thread title) can reach stream consumers on the wire.
+   */
+  writer?: CustomChunkWriter;
 };
 
 export type AgentMethodType = 'generate' | 'stream' | 'generateLegacy' | 'streamLegacy';

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -8,6 +8,7 @@ import { createObservabilityContext } from '../../../observability';
 import type { Span, SpanType } from '../../../observability';
 import { StructuredOutputProcessor } from '../../../processors';
 import type { RequestContext } from '../../../request-context';
+import type { MastraOnFinishCallbackContext } from '../../../stream/types';
 import type { Step } from '../../../workflows/step';
 import type { InnerAgentExecutionOptions } from '../../agent.types';
 import type { MessageList } from '../../message-list';
@@ -264,7 +265,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
       experimentalTransform: options.experimentalTransform,
       options: {
         ...(options.prepareStep && { prepareStep: options.prepareStep }),
-        onFinish: async (payload: any) => {
+        onFinish: async (payload: any, context?: MastraOnFinishCallbackContext) => {
           if (payload.finishReason === 'error') {
             const provider = payload.model?.provider;
             const modelId = payload.model?.modelId;
@@ -359,6 +360,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
                 overrideScorers: options.scorers,
                 onTitleGenerated: options.memory?.onTitleGenerated,
                 waitUntil: options.serverless?.waitUntil,
+                writer: context?.writer,
               });
             } catch (e) {
               capabilities.logger.error('Error saving memory on finish', {

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -364,6 +364,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
                 // generate() returns JSON, so passing the writer would make
                 // `generateTitle.emitEvent` add title latency with no event.
                 writer: methodType === 'stream' ? context?.writer : undefined,
+                abortSignal: options.abortSignal,
               });
             } catch (e) {
               capabilities.logger.error('Error saving memory on finish', {

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -360,7 +360,10 @@ export function createMapResultsStep<OUTPUT = undefined>({
                 overrideScorers: options.scorers,
                 onTitleGenerated: options.memory?.onTitleGenerated,
                 waitUntil: options.serverless?.waitUntil,
-                writer: context?.writer,
+                // Only streaming runs can deliver a `data-thread-title` chunk;
+                // generate() returns JSON, so passing the writer would make
+                // `generateTitle.emitEvent` add title latency with no event.
+                writer: methodType === 'stream' ? context?.writer : undefined,
               });
             } catch (e) {
               capabilities.logger.error('Error saving memory on finish', {

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -305,7 +305,7 @@ export class MastraLLMVNext extends MastraBase {
             }
           },
 
-          onFinish: async props => {
+          onFinish: async (props, context) => {
             // End the model generation span BEFORE calling the user's onFinish callback
             // This ensures the model span ends before the agent span
             // Pass raw usage and providerMetadata - ModelSpanTracker will convert to UsageStats
@@ -333,7 +333,7 @@ export class MastraLLMVNext extends MastraBase {
             });
 
             try {
-              await options?.onFinish?.({ ...props, runId: runId! });
+              await options?.onFinish?.({ ...props, runId: runId! }, context);
             } catch (e: unknown) {
               const mastraError = new MastraError(
                 {

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -1013,6 +1013,10 @@ https://mastra.ai/en/docs/memory/overview`,
         // Extract ModelRouterModelId from various model configurations.
         // `model` is optional (the agent's own model is the default) and
         // dynamic functions cannot be serialized - both leave modelId unset.
+        // AI SDK LanguageModel instances are also left unset on purpose: their
+        // `modelId`/`provider` values are not valid `provider/model` router IDs,
+        // and serializing one would break hydration instead of falling back to
+        // the agent's own model.
         let modelId: string | undefined;
 
         if (typeof model === 'string') {

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -1008,16 +1008,15 @@ https://mastra.ai/en/docs/memory/overview`,
     if (generateTitle !== undefined && config.options) {
       if (typeof generateTitle === 'boolean') {
         config.options.generateTitle = generateTitle;
-      } else if (typeof generateTitle === 'object' && generateTitle.model) {
+      } else if (typeof generateTitle === 'object' && generateTitle !== null) {
         const model = generateTitle.model;
-        // Extract ModelRouterModelId from various model configurations
+        // Extract ModelRouterModelId from various model configurations.
+        // `model` is optional (the agent's own model is the default) and
+        // dynamic functions cannot be serialized - both leave modelId unset.
         let modelId: string | undefined;
 
         if (typeof model === 'string') {
           modelId = model;
-        } else if (typeof model === 'function') {
-          // Cannot serialize dynamic functions - skip
-          modelId = undefined;
         } else if (model && typeof model === 'object') {
           // Handle config objects with id field
           if ('id' in model && typeof model.id === 'string') {
@@ -1025,12 +1024,12 @@ https://mastra.ai/en/docs/memory/overview`,
           }
         }
 
-        if (modelId && config.options) {
-          config.options.generateTitle = {
-            model: modelId as ModelRouterModelId,
-            instructions: typeof generateTitle.instructions === 'string' ? generateTitle.instructions : undefined,
-          };
-        }
+        config.options.generateTitle = {
+          ...(modelId && { model: modelId as ModelRouterModelId }),
+          instructions: typeof generateTitle.instructions === 'string' ? generateTitle.instructions : undefined,
+          ...(typeof generateTitle.minMessages === 'number' && { minMessages: generateTitle.minMessages }),
+          ...(typeof generateTitle.emitEvent === 'boolean' && { emitEvent: generateTitle.emitEvent }),
+        };
       }
     }
 

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1028,7 +1028,8 @@ type BaseMemoryConfig = {
   /**
    * Automatically generate descriptive thread titles based on the first user message.
    * Can be a boolean to enable with defaults, or an object to customize the model and instructions.
-   * Title generation runs asynchronously and doesn't affect response time.
+   * Title generation runs asynchronously and doesn't affect response time, unless
+   * `emitEvent` is enabled - then the stream waits for the title before `finish`.
    *
    * @default false
    * @example
@@ -1302,8 +1303,8 @@ export type SerializedMemoryConfig = {
     generateTitle?:
       | boolean
       | {
-          /** Model ID in format provider/model-name */
-          model: ModelRouterModelId;
+          /** Model ID in format provider/model-name. Defaults to the agent's own model. */
+          model?: ModelRouterModelId;
           /** Custom instructions for title generation */
           instructions?: string;
           /** Minimum number of thread messages required before a title is generated */

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1047,13 +1047,31 @@ type BaseMemoryConfig = {
          * Language model to use for title generation.
          * Can be static or a function that receives request context for dynamic selection.
          * Accepts both Mastra models and standard AI SDK LanguageModelV1/V2.
+         * Defaults to the agent's own model.
          */
-        model: DynamicArgument<MastraModelConfig>;
+        model?: DynamicArgument<MastraModelConfig>;
         /**
          * Custom instructions for title generation.
          * Can be static or a function that receives request context for dynamic customization.
          */
         instructions?: DynamicArgument<string>;
+        /**
+         * Minimum number of thread messages required before a title is generated.
+         *
+         * @default 1
+         */
+        minMessages?: number;
+        /**
+         * Wait for the generated title and emit it as a transient `data-thread-title`
+         * chunk (`{ threadId, title }`) on the run's stream, before the `finish` chunk.
+         * Lets HTTP/stream consumers receive the title without polling the thread.
+         *
+         * Trade-off: the stream's `finish` is delayed by the title model call on the
+         * first turn of a thread.
+         *
+         * @default false
+         */
+        emitEvent?: boolean;
       };
 
   /**
@@ -1288,6 +1306,10 @@ export type SerializedMemoryConfig = {
           model: ModelRouterModelId;
           /** Custom instructions for title generation */
           instructions?: string;
+          /** Minimum number of thread messages required before a title is generated */
+          minMessages?: number;
+          /** Emit the generated title as a `data-thread-title` chunk on the run stream */
+          emitEvent?: boolean;
         };
   };
 

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1070,6 +1070,9 @@ type BaseMemoryConfig = {
          * Trade-off: the stream's `finish` is delayed by the title model call on the
          * first turn of a thread.
          *
+         * Durable and evented agents don't emit this chunk yet; the title is still
+         * generated and persisted, and a warning is logged.
+         *
          * @default false
          */
         emitEvent?: boolean;

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1071,7 +1071,7 @@ type BaseMemoryConfig = {
          * first turn of a thread.
          *
          * Durable and evented agents don't emit this chunk yet; the title is still
-         * generated and persisted, and a warning is logged.
+         * generated and persisted.
          *
          * @default false
          */

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1070,7 +1070,9 @@ type BaseMemoryConfig = {
          * Trade-off: the stream's `finish` is delayed by the title model call on the
          * first turn of a thread.
          *
-         * Durable and evented agents don't emit this chunk yet; the title is still
+         * Applies to `stream()` runs only: `generate()` returns JSON and cannot
+         * carry the chunk, so it keeps detached title generation. Durable and
+         * evented agents don't emit this chunk yet; the title is still
          * generated and persisted.
          *
          * @default false

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -935,7 +935,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               // Terminate the stream
               controller.terminate();
               return;
-            case 'finish':
+            case 'finish': {
               // 'suspended' is not terminal: a resume leg rehydrates the persisted 'suspended'
               // status and must be able to finish as 'success'. Only 'failed' and 'canceled'
               // block the success transition.
@@ -1246,6 +1246,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
 
               self.#closeTransportIfNeeded();
               break;
+            }
 
             case 'goal':
               // A continuing goal evaluation marks a safe truncation point for

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -1016,6 +1016,22 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 }),
               };
 
+              // Create a writer from the controller so processOutputResult and onFinish
+              // callbacks can emit custom chunks. Must use both #emitChunk (for
+              // fullStream/EventEmitter consumers) and controller.enqueue (for raw stream
+              // consumers) to ensure visibility. The finish chunk is enqueued after this
+              // case completes, so chunks written here are delivered before `finish`.
+              const outputResultWriter = {
+                custom: async (
+                  data: { type: string; data?: unknown; transient?: boolean },
+                  writerOptions?: { messageId?: string },
+                ) => {
+                  persistProcessorDataChunk(self.messageList, writerOptions?.messageId ?? self.messageId, data);
+                  self.#emitChunk(data as ChunkType<OUTPUT>);
+                  controller.enqueue(data as ChunkType<OUTPUT>);
+                },
+              };
+
               try {
                 if (self.processorRunner && !self.#options.isLLMExecutionStep) {
                   // Run output processors when NOT in LLM execution step context
@@ -1024,20 +1040,6 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                   // Capture original text before processing for comparison
                   const lastStep = self.#bufferedSteps[self.#bufferedSteps.length - 1];
                   const originalText = lastStep?.text || '';
-
-                  // Create a writer from the controller so processOutputResult can emit custom chunks.
-                  // Must use both #emitChunk (for fullStream/EventEmitter consumers) and
-                  // controller.enqueue (for raw stream consumers) to ensure visibility.
-                  const outputResultWriter = {
-                    custom: async (
-                      data: { type: string; data?: unknown; transient?: boolean },
-                      writerOptions?: { messageId?: string },
-                    ) => {
-                      persistProcessorDataChunk(self.messageList, writerOptions?.messageId ?? self.messageId, data);
-                      self.#emitChunk(data as ChunkType<OUTPUT>);
-                      controller.enqueue(data as ChunkType<OUTPUT>);
-                    },
-                  };
 
                   const outputResult: OutputResult = {
                     text: self.#bufferedText.join(''),
@@ -1238,7 +1240,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
 
                 if (!self.#finishCallbackSent) {
                   self.#finishCallbackSent = true;
-                  await options?.onFinish?.(onFinishPayload);
+                  await options?.onFinish?.(onFinishPayload, { writer: outputResultWriter });
                 }
               }
 

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -1134,8 +1134,25 @@ export type MastraOnFinishCallbackArgs<OUTPUT = undefined> = LLMStepResult<OUTPU
   runId?: string;
 };
 
+/**
+ * Writer for enqueueing custom `data-*` chunks onto a run stream. Chunks
+ * written while the `finish` chunk is being assembled (e.g. from onFinish
+ * callbacks) are delivered to consumers before `finish`.
+ */
+export type CustomChunkWriter = {
+  custom: (
+    data: { type: string; data?: unknown; transient?: boolean },
+    writerOptions?: { messageId?: string },
+  ) => Promise<void> | void;
+};
+
+export type MastraOnFinishCallbackContext = {
+  writer?: CustomChunkWriter;
+};
+
 export type MastraOnFinishCallback<OUTPUT = undefined> = (
   event: MastraOnFinishCallbackArgs<OUTPUT>,
+  context?: MastraOnFinishCallbackContext,
 ) => Promise<void> | void;
 
 /**

--- a/packages/server/src/server/schemas/memory-config.ts
+++ b/packages/server/src/server/schemas/memory-config.ts
@@ -33,6 +33,14 @@ export const titleGenerationSchema = z.union([
   z.object({
     model: z.string().describe('Model ID in format provider/model-name (ModelRouterModelId)'),
     instructions: z.string().optional().describe('Custom instructions for title generation'),
+    minMessages: z
+      .number()
+      .optional()
+      .describe('Minimum number of thread messages required before a title is generated'),
+    emitEvent: z
+      .boolean()
+      .optional()
+      .describe('Emit the generated title as a data-thread-title chunk on the run stream'),
   }),
 ]);
 

--- a/packages/server/src/server/schemas/memory-config.ts
+++ b/packages/server/src/server/schemas/memory-config.ts
@@ -31,7 +31,10 @@ export const semanticRecallSchema = z.object({
 export const titleGenerationSchema = z.union([
   z.boolean(),
   z.object({
-    model: z.string().describe('Model ID in format provider/model-name (ModelRouterModelId)'),
+    model: z
+      .string()
+      .optional()
+      .describe("Model ID in format provider/model-name (ModelRouterModelId); defaults to the agent's own model"),
     instructions: z.string().optional().describe('Custom instructions for title generation'),
     minMessages: z
       .number()

--- a/packages/server/src/server/schemas/memory-config.ts
+++ b/packages/server/src/server/schemas/memory-config.ts
@@ -38,6 +38,8 @@ export const titleGenerationSchema = z.union([
     instructions: z.string().optional().describe('Custom instructions for title generation'),
     minMessages: z
       .number()
+      .int()
+      .min(1)
       .optional()
       .describe('Minimum number of thread messages required before a title is generated'),
     emitEvent: z


### PR DESCRIPTION
## Description

Generated thread titles were unreachable from HTTP clients: `onTitleGenerated` is an in-process callback, so browser apps had to poll the thread endpoint on timers and guess when the title landed. This PR adds an opt-in `generateTitle.emitEvent` flag that delivers the title on the run's own stream, before the `finish` chunk.

- New `generateTitle: { emitEvent: true }` memory option: the stream waits for the title, persists it, and emits a transient `data-thread-title` chunk carrying `{ threadId, title }` right before `finish`
- Default behavior is unchanged: without the flag, title generation stays fire-and-forget with zero added latency (preserves #14751)
- The chunk is transient, so it is delivered to stream consumers but never persisted as a conversation message
- Plumbing: the stream engine's writer is threaded through `onFinish` (`output.ts` → `model.loop.ts` → `map-results-step.ts` → `#executeOnFinish`); the `model.loop.ts` wrapper previously dropped extra callback arguments
- Works with `@mastra/client-js` out of the box (chunks pass through `onChunk` unfiltered), and the chunk is also relayed to other tabs subscribed via `/agents/:agentId/threads/subscribe`, since it is emitted while the run is still active
- `generateTitle.model` is now optional in the config type (the runtime already falls back to the agent's model) and `minMessages` is typed
- Approach discussed with @wardpeet (data- chunk over a separate endpoint); verified live over raw SSE and client-js with real credentials

## Related Issue(s)

Fixes #21203

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a thread receives an automatic title, clients can now receive the title through the stream. This removes the need to poll for title updates.

## Changes

- Added opt-in `generateTitle.emitEvent`.
- Emits a transient `data-thread-title` chunk with `{ threadId, title }` before `finish`.
- Waits for title generation and persistence before emitting the chunk.
- Preserves fire-and-forget behavior when `emitEvent` is disabled.
- Makes title events available to HTTP clients, `@mastra/client-js`, and subscribed tabs.
- Prevents title events from being persisted as conversation messages.
- Makes `generateTitle.model` optional and adds `minMessages`.
- Limits `emitEvent` handling to standard agents.
- Makes title-generation waits abort-safe.
- Suppresses late title chunks after an abort while allowing `waitUntil` execution to continue.
- Threads the stream writer through the `onFinish` execution path.
- Adds tests, documentation, and changesets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
