### PR TITLE
fix(factory): resolve pull request links instead of self-parenting cards

### DIFF
--- a/.changeset/heavy-maps-rescue.md
+++ b/.changeset/heavy-maps-rescue.md
@@ -1,0 +1,17 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed "A work item cannot relate to itself." filling the attention inbox, and taught Factory to link a pull request to the work item it implements.
+
+Refreshing the board replays every open issue and pull request through the rules. When a card already existed, Factory tried to make it its own parent, which failed and left one dead attention row per item — nothing a person could act on.
+
+**Links now come from the pull request itself**, resolved in order:
+
+- Factory's own provenance, when a run opened the pull request
+- the author's closing keyword (`Closes #12`, `fixes acme/repo#12`, issue URLs), read from the pull request body
+- the head branch, when it matches a work item's session branch
+
+A pull request opened by a person now lands under the issue it closes instead of sitting alone on the Review board. Cards that were already orphaned get linked the next time Factory sees their pull request.
+
+Invalid relationships are also marked non-retryable, so the inbox stops offering Retry on something that can never succeed.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -826,7 +826,8 @@ export class MastraFactory {
                 prepareBinding,
                 primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
                 resolveLinkedWorkItemParentId: async ({ orgId, factoryProjectId, decision }) => {
-                  const facts = decision.source === 'github-pr' ? pullRequestLinkFacts(decision.metadata) : null;
+                  if (decision.source !== 'github-pr') return null;
+                  const facts = pullRequestLinkFacts(decision.metadata);
                   if (!facts) return null;
                   return resolvePullRequestParentWorkItemId(
                     {

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -39,10 +39,8 @@ import {
 } from './auth.js';
 import type { FactoryIntegration, IntegrationPostToolContext, IntegrationTools } from './integrations/base.js';
 import type { GithubIntegration } from './integrations/github/integration.js';
-import {
-  recordFactoryPullRequestProvenance,
-  resolveFactoryPullRequestParentWorkItemId,
-} from './integrations/github/provenance.js';
+import { pullRequestLinkFacts, resolvePullRequestParentWorkItemId } from './integrations/github/links.js';
+import { recordFactoryPullRequestProvenance } from './integrations/github/provenance.js';
 import type { FactoryPullRequestProvenanceData } from './integrations/github/provenance.js';
 import { PlatformGithubIntegration } from './integrations/platform/github/integration.js';
 import { PlatformLinearIntegration } from './integrations/platform/linear/integration.js';
@@ -827,18 +825,19 @@ export class MastraFactory {
                 reconcileToolResults: () => factoryProcessor?.reconcileAllBoundThreads() ?? Promise.resolve(),
                 prepareBinding,
                 primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
-                resolveLinkedWorkItemParentId: async ({ orgId, decision }) => {
-                  if (decision.source !== 'github-pr') return null;
-                  const repositoryId = decision.metadata?.githubRepositoryId;
-                  const pullRequestNumber = decision.metadata?.githubPullRequestNumber;
-                  if (typeof repositoryId !== 'number' || typeof pullRequestNumber !== 'number') return null;
-                  return resolveFactoryPullRequestParentWorkItemId(
-                    integrationStorage.forIntegration<
-                      Record<string, unknown>,
-                      Record<string, unknown>,
-                      FactoryPullRequestProvenanceData
-                    >('github'),
-                    { orgId, repositoryId, pullRequestNumber },
+                resolveLinkedWorkItemParentId: async ({ orgId, factoryProjectId, decision }) => {
+                  const facts = decision.source === 'github-pr' ? pullRequestLinkFacts(decision.metadata) : null;
+                  if (!facts) return null;
+                  return resolvePullRequestParentWorkItemId(
+                    {
+                      integrationStorage: integrationStorage.forIntegration<
+                        Record<string, unknown>,
+                        Record<string, unknown>,
+                        FactoryPullRequestProvenanceData
+                      >('github'),
+                      workItems: storage.getDomain<WorkItemsStorage>('work-items'),
+                    },
+                    { orgId, factoryProjectId, ...facts },
                   );
                 },
               });

--- a/mastracode/factory/src/integrations/github/links.test.ts
+++ b/mastracode/factory/src/integrations/github/links.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WorkItemRow } from '../../storage/domains/work-items/base.js';
+import { closingIssueNumbers, pullRequestLinkFacts, pullRequestParentWorkItemId } from './links.js';
+
+function card(overrides: Partial<WorkItemRow> & Pick<WorkItemRow, 'id'>): WorkItemRow {
+  return {
+    orgId: 'org-1',
+    factoryProjectId: 'project-1',
+    externalSource: null,
+    parentWorkItemId: null,
+    title: 'Card',
+    stages: ['intake'],
+    stageHistory: [],
+    sessions: {},
+    metadata: { githubRepositoryId: 10 },
+    autonomyArmedAt: null,
+    revision: 1,
+    createdBy: 'user-1',
+    createdAt: new Date('2030-01-01T00:00:00Z'),
+    updatedAt: new Date('2030-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+function issueCard(id: string, number: number, repository = 'acme/repo', repositoryId = 10): WorkItemRow {
+  return card({
+    id,
+    externalSource: {
+      integrationId: 'github',
+      type: 'issue',
+      externalId: `github-issue:${number}`,
+      url: `https://github.com/${repository}/issues/${number}`,
+    },
+    metadata: { githubRepositoryId: repositoryId },
+  });
+}
+
+describe('closingIssueNumbers', () => {
+  it('reads every closing keyword GitHub honours, once each', () => {
+    const body = ['Closes #12', 'fixes #13', 'Resolved: #12', 'see #99'].join('\n');
+    expect(closingIssueNumbers(body, 'acme/repo')).toEqual([12, 13]);
+  });
+
+  it('keeps references to this repository and drops the ones naming another', () => {
+    const body = [
+      'closes acme/repo#20',
+      'closes other/repo#21',
+      'fixes https://github.com/acme/repo/issues/22',
+      'fixes https://github.com/other/repo/issues/23',
+    ].join('\n');
+    expect(closingIssueNumbers(body, 'acme/repo')).toEqual([20, 22]);
+  });
+
+  it('has nothing to say about an empty body', () => {
+    expect(closingIssueNumbers(null, 'acme/repo')).toEqual([]);
+  });
+});
+
+describe('pullRequestParentWorkItemId', () => {
+  it('prefers the issue the author declared closed over the branch the code came from', () => {
+    const declared = issueCard('issue-declared', 12);
+    const author = card({
+      id: 'issue-author',
+      sessions: { work: { sessionId: 's1', branch: 'factory/issue-13', threadId: 't1' } },
+    });
+    const parent = pullRequestParentWorkItemId([declared, author], {
+      repositoryId: 10,
+      repositoryFullName: 'acme/repo',
+      closesIssues: [12],
+      headBranch: 'factory/issue-13',
+    });
+    expect(parent).toBe(declared.id);
+  });
+
+  it('ignores a same-numbered issue belonging to another repository', () => {
+    const elsewhere = issueCard('issue-elsewhere', 12, 'other/repo', 99);
+    const parent = pullRequestParentWorkItemId([elsewhere], {
+      repositoryId: 10,
+      repositoryFullName: 'acme/repo',
+      closesIssues: [12],
+    });
+    expect(parent).toBeNull();
+  });
+
+  it('falls back to the work item whose session branch the pull request was pushed from', () => {
+    const author = card({
+      id: 'issue-author',
+      sessions: { work: { sessionId: 's1', branch: 'factory/issue-13', threadId: 't1' } },
+    });
+    const otherPullRequest = card({
+      id: 'pr-other',
+      externalSource: { integrationId: 'github', type: 'pull-request', externalId: 'github-pr:5' },
+      sessions: { work: { sessionId: 's2', branch: 'factory/issue-13', threadId: 't2' } },
+    });
+    const parent = pullRequestParentWorkItemId([otherPullRequest, author], {
+      repositoryId: 10,
+      repositoryFullName: 'acme/repo',
+      headBranch: 'factory/issue-13',
+    });
+    expect(parent).toBe(author.id);
+  });
+});
+
+describe('pullRequestLinkFacts', () => {
+  it('reads the pull request a decision names', () => {
+    expect(
+      pullRequestLinkFacts({
+        githubRepositoryId: 10,
+        githubPullRequestNumber: 17,
+        closesIssues: [12, 'nope'],
+        headBranch: 'feature',
+      }),
+    ).toEqual({ repositoryId: 10, pullRequestNumber: 17, closesIssues: [12], headBranch: 'feature' });
+  });
+
+  it('has no facts for a decision that names no pull request', () => {
+    expect(pullRequestLinkFacts({ githubRepositoryId: 10 })).toBeNull();
+  });
+});

--- a/mastracode/factory/src/integrations/github/links.ts
+++ b/mastracode/factory/src/integrations/github/links.ts
@@ -52,17 +52,24 @@ export function cardBelongsToRepository(
 const CLOSING_REFERENCE =
   /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s+(?:(?<slug>[\w.-]+\/[\w.-]+)#(?<crossRepo>\d+)|#(?<sameRepo>\d+)|https?:\/\/(?:www\.)?github\.com\/(?<urlSlug>[\w.-]+\/[\w.-]+)\/issues\/(?<urlNumber>\d+))/gi;
 
+function referencedIssueNumber(
+  groups: Record<string, string | undefined>,
+  repositoryFullName: string,
+): number | null {
+  const { slug, crossRepo, sameRepo, urlSlug, urlNumber } = groups;
+  const repository = slug ?? urlSlug;
+  if (repository && repository.toLowerCase() !== repositoryFullName.toLowerCase()) return null;
+  const issueNumber = Number(sameRepo ?? crossRepo ?? urlNumber);
+  return Number.isInteger(issueNumber) && issueNumber > 0 ? issueNumber : null;
+}
+
 /** Issue numbers a pull request body declares it closes, in this repository only. */
 export function closingIssueNumbers(body: string | null | undefined, repositoryFullName: string): number[] {
   if (!body) return [];
-  const belongsHere = (slug: string | undefined) =>
-    slug === undefined || slug.toLowerCase() === repositoryFullName.toLowerCase();
   const numbers = new Set<number>();
   for (const match of body.matchAll(CLOSING_REFERENCE)) {
-    const { slug, crossRepo, sameRepo, urlSlug, urlNumber } = match.groups ?? {};
-    const reference = Number(sameRepo ?? crossRepo ?? urlNumber);
-    if (!belongsHere(slug ?? urlSlug) || !Number.isInteger(reference) || reference < 1) continue;
-    numbers.add(reference);
+    const issueNumber = referencedIssueNumber(match.groups ?? {}, repositoryFullName);
+    if (issueNumber !== null) numbers.add(issueNumber);
   }
   return [...numbers];
 }
@@ -74,31 +81,55 @@ export interface PullRequestLinkFacts {
   headBranch?: string;
 }
 
+function issueCard(items: WorkItemRow[], issueNumber: number, facts: PullRequestLinkFacts): WorkItemRow | undefined {
+  return (
+    items.find(
+      item =>
+        item.externalSource?.externalId === canonicalSourceKey('issue', issueNumber) &&
+        cardBelongsToRepository(item, facts.repositoryId, facts.repositoryFullName),
+    ) ??
+    items.find(item => item.externalSource?.externalId === legacySourceKey(facts.repositoryId, 'issue', issueNumber))
+  );
+}
+
+function declaredClosedIssue(items: WorkItemRow[], facts: PullRequestLinkFacts): string | null {
+  for (const issueNumber of facts.closesIssues ?? []) {
+    const card = issueCard(items, issueNumber, facts);
+    if (card) return card.id;
+  }
+  return null;
+}
+
+/**
+ * Session branches are per-item (`factory/issue-N`), so a head-branch match
+ * names the item that wrote the code even when no provenance was recorded.
+ */
+function branchAuthor(items: WorkItemRow[], headBranch: string | undefined): string | null {
+  if (!headBranch) return null;
+  const author = items.find(
+    item =>
+      item.externalSource?.type !== 'pull-request' &&
+      Object.values(item.sessions).some(session => session.branch === headBranch),
+  );
+  return author?.id ?? null;
+}
+
 /**
  * The work item a pull request belongs to, from the facts the pull request
  * itself carries. Provenance is not consulted here — it is storage-backed and
  * asked first by {@link resolvePullRequestParentWorkItemId}.
  */
 export function pullRequestParentWorkItemId(items: WorkItemRow[], facts: PullRequestLinkFacts): string | null {
-  for (const issueNumber of facts.closesIssues ?? []) {
-    const issue =
-      items.find(
-        item =>
-          item.externalSource?.externalId === canonicalSourceKey('issue', issueNumber) &&
-          cardBelongsToRepository(item, facts.repositoryId, facts.repositoryFullName),
-      ) ??
-      items.find(item => item.externalSource?.externalId === legacySourceKey(facts.repositoryId, 'issue', issueNumber));
-    if (issue) return issue.id;
-  }
-  // Session branches are per-item (`factory/issue-N`), so a head-branch match
-  // names the item that wrote the code even when no provenance was recorded.
-  if (!facts.headBranch) return null;
-  const author = items.find(
-    item =>
-      item.externalSource?.type !== 'pull-request' &&
-      Object.values(item.sessions).some(session => session.branch === facts.headBranch),
-  );
-  return author?.id ?? null;
+  return declaredClosedIssue(items, facts) ?? branchAuthor(items, facts.headBranch);
+}
+
+/** The work item a recorded provenance names, when it still has a card here. */
+export function provenanceParentWorkItemId(
+  items: WorkItemRow[],
+  provenance: { workItemId: string } | null,
+): string | null {
+  if (!provenance) return null;
+  return items.some(item => item.id === provenance.workItemId) ? provenance.workItemId : null;
 }
 
 function numberList(value: unknown): number[] {

--- a/mastracode/factory/src/integrations/github/links.ts
+++ b/mastracode/factory/src/integrations/github/links.ts
@@ -1,0 +1,151 @@
+/**
+ * What a pull request implements.
+ *
+ * A Review card hangs off the Work item whose problem the pull request solves,
+ * and that link has three independent sources: Factory's own provenance when a
+ * run opened the pull request, the author's closing keyword (`Closes #12`), and
+ * the head branch when it is a Factory session branch. They are asked in that
+ * order — recorded fact, declared intent, then inference.
+ */
+
+import type { IntegrationStorageHandle } from '../../storage/domains/integrations/base.js';
+import type { WorkItemRow, WorkItemsStorage } from '../../storage/domains/work-items/base.js';
+import type { FactoryPullRequestProvenanceData } from './provenance.js';
+import { resolveFactoryPullRequestParentWorkItemId } from './provenance.js';
+
+export type GithubItemKind = 'issue' | 'pull-request';
+
+export function canonicalSourceKey(kind: GithubItemKind, itemNumber: number): string {
+  return kind === 'issue' ? `github-issue:${itemNumber}` : `github-pr:${itemNumber}`;
+}
+
+export function legacySourceKey(repositoryId: number, kind: GithubItemKind, itemNumber: number): string {
+  return `github:${repositoryId}:${kind}:${itemNumber}`;
+}
+
+/**
+ * A GitHub number only identifies a card together with its repository: a
+ * project linked to several repositories has a `#12` in each. The card's
+ * intake-stamped URL is authoritative; the intake-stamped `githubRepositoryId`
+ * covers URL-less cards. Callers that cannot name the repository (the
+ * dispatcher knows the id but not the slug) fall back to the id alone, which
+ * misses cards predating that stamp rather than attributing them wrongly.
+ */
+export function cardBelongsToRepository(
+  item: WorkItemRow,
+  repositoryId: number,
+  repositoryFullName: string | undefined,
+): boolean {
+  const url = item.externalSource?.url;
+  if (url && repositoryFullName) {
+    const match = /^https?:\/\/[^/]+\/(.+)\/(?:issues|pull)\/\d+(?:[/?#]|$)/.exec(url);
+    if (match && match[1] === repositoryFullName) return true;
+  }
+  // A renamed repository leaves the old owner/name in the card URL, so a URL
+  // mismatch still defers to the stable intake-stamped repository id.
+  return item.metadata?.githubRepositoryId === repositoryId;
+}
+
+// GitHub's own closing keywords. Cross-repository references (`owner/repo#12`,
+// and issue URLs) are matched too so they can be rejected when they name
+// another repository — a card only ever links inside its own.
+const CLOSING_REFERENCE =
+  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s+(?:(?<slug>[\w.-]+\/[\w.-]+)#(?<crossRepo>\d+)|#(?<sameRepo>\d+)|https?:\/\/(?:www\.)?github\.com\/(?<urlSlug>[\w.-]+\/[\w.-]+)\/issues\/(?<urlNumber>\d+))/gi;
+
+/** Issue numbers a pull request body declares it closes, in this repository only. */
+export function closingIssueNumbers(body: string | null | undefined, repositoryFullName: string): number[] {
+  if (!body) return [];
+  const belongsHere = (slug: string | undefined) =>
+    slug === undefined || slug.toLowerCase() === repositoryFullName.toLowerCase();
+  const numbers = new Set<number>();
+  for (const match of body.matchAll(CLOSING_REFERENCE)) {
+    const { slug, crossRepo, sameRepo, urlSlug, urlNumber } = match.groups ?? {};
+    const reference = Number(sameRepo ?? crossRepo ?? urlNumber);
+    if (!belongsHere(slug ?? urlSlug) || !Number.isInteger(reference) || reference < 1) continue;
+    numbers.add(reference);
+  }
+  return [...numbers];
+}
+
+export interface PullRequestLinkFacts {
+  repositoryId: number;
+  repositoryFullName?: string;
+  closesIssues?: number[];
+  headBranch?: string;
+}
+
+/**
+ * The work item a pull request belongs to, from the facts the pull request
+ * itself carries. Provenance is not consulted here — it is storage-backed and
+ * asked first by {@link resolvePullRequestParentWorkItemId}.
+ */
+export function pullRequestParentWorkItemId(items: WorkItemRow[], facts: PullRequestLinkFacts): string | null {
+  for (const issueNumber of facts.closesIssues ?? []) {
+    const issue =
+      items.find(
+        item =>
+          item.externalSource?.externalId === canonicalSourceKey('issue', issueNumber) &&
+          cardBelongsToRepository(item, facts.repositoryId, facts.repositoryFullName),
+      ) ??
+      items.find(item => item.externalSource?.externalId === legacySourceKey(facts.repositoryId, 'issue', issueNumber));
+    if (issue) return issue.id;
+  }
+  // Session branches are per-item (`factory/issue-N`), so a head-branch match
+  // names the item that wrote the code even when no provenance was recorded.
+  if (!facts.headBranch) return null;
+  const author = items.find(
+    item =>
+      item.externalSource?.type !== 'pull-request' &&
+      Object.values(item.sessions).some(session => session.branch === facts.headBranch),
+  );
+  return author?.id ?? null;
+}
+
+function numberList(value: unknown): number[] {
+  return Array.isArray(value) ? value.filter(entry => typeof entry === 'number' && Number.isInteger(entry)) : [];
+}
+
+/**
+ * The link facts a rule stamped on an `upsertLinkedWorkItem` decision. Returns
+ * nothing when the decision does not name a pull request in a repository, the
+ * one shape every link source needs.
+ */
+export function pullRequestLinkFacts(
+  metadata: Record<string, unknown> | undefined,
+): (PullRequestLinkFacts & { pullRequestNumber: number }) | null {
+  const repositoryId = metadata?.githubRepositoryId;
+  const pullRequestNumber = metadata?.githubPullRequestNumber;
+  if (typeof repositoryId !== 'number' || typeof pullRequestNumber !== 'number') return null;
+  const headBranch = metadata?.headBranch;
+  return {
+    repositoryId,
+    pullRequestNumber,
+    closesIssues: numberList(metadata?.closesIssues),
+    ...(typeof headBranch === 'string' && headBranch ? { headBranch } : {}),
+  };
+}
+
+export interface PullRequestParentDeps {
+  integrationStorage: IntegrationStorageHandle<
+    Record<string, unknown>,
+    Record<string, unknown>,
+    FactoryPullRequestProvenanceData
+  >;
+  workItems: Pick<WorkItemsStorage, 'list'>;
+}
+
+/** Every link source, in order, for one pull request in one project. */
+export async function resolvePullRequestParentWorkItemId(
+  deps: PullRequestParentDeps,
+  input: { orgId: string; factoryProjectId: string; pullRequestNumber: number } & PullRequestLinkFacts,
+): Promise<string | null> {
+  const provenance = await resolveFactoryPullRequestParentWorkItemId(deps.integrationStorage, {
+    orgId: input.orgId,
+    repositoryId: input.repositoryId,
+    pullRequestNumber: input.pullRequestNumber,
+  });
+  if (provenance) return provenance;
+  if (!input.closesIssues?.length && !input.headBranch) return null;
+  const items = await deps.workItems.list({ orgId: input.orgId, factoryProjectId: input.factoryProjectId });
+  return pullRequestParentWorkItemId(items, input);
+}

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -21,6 +21,7 @@ import { UniqueViolationError } from '@mastra/core/storage';
 import type { FactoryStorage } from '@mastra/core/storage';
 import type { Context } from 'hono';
 import { streamSSE } from 'hono/streaming';
+import type { PullRequest } from '../../capabilities/version-control.js';
 import type { RouteAuth } from '../../routes/route.js';
 import { baseCheckpointIsStale } from '../../sandbox/base-checkpoint-triggers.js';
 import { SandboxBudgetError } from '../../sandbox/fleet.js';
@@ -309,38 +310,27 @@ function polledIssueEvent(
   };
 }
 
-function polledPullRequestEvent(
-  project: ResolvedProjectRepository,
-  pullRequest: {
-    number: number;
-    title: string;
-    url: string;
-    author: string | null;
-    assignees: string[];
-    requestedReviewers: string[];
-    headBranch: string;
-    baseBranch: string;
-    createdAt: string;
-  },
-): ParsedGithubWebhook {
+function polledPullRequestEvent(project: ResolvedProjectRepository, pullRequest: PullRequest): ParsedGithubWebhook {
   const repositoryId = Number(project.repository.externalId);
+  const number = Number(pullRequest.id);
   return {
     event: 'pull_request',
-    deliveryId: `poll:${repositoryId}:pull-request:${pullRequest.number}:${pullRequest.createdAt}`,
+    deliveryId: `poll:${repositoryId}:pull-request:${number}:${pullRequest.createdAt}`,
     payload: {
       action: 'opened',
       installation: { id: Number(project.installation.externalId) },
       repository: { id: repositoryId, full_name: project.repository.slug },
       sender: { login: pullRequest.author ?? '__unknown__' },
       pull_request: {
-        number: pullRequest.number,
+        number,
         title: pullRequest.title,
         html_url: pullRequest.url,
+        body: pullRequest.body,
         created_at: pullRequest.createdAt,
         state: 'open',
         merged: false,
-        assignees: pullRequest.assignees.map(login => ({ login })),
-        requested_reviewers: pullRequest.requestedReviewers.map(login => ({ login })),
+        assignees: (pullRequest.assignees ?? []).map(login => ({ login })),
+        requested_reviewers: (pullRequest.requestedReviewers ?? []).map(login => ({ login })),
         head: { ref: pullRequest.headBranch },
         base: { ref: pullRequest.baseBranch },
       },
@@ -857,7 +847,7 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
             updatedAt: pr.updatedAt,
           }));
           await ingestPolledEvents(
-            responsePullRequests.map(pullRequest => polledPullRequestEvent(loaded.project, pullRequest)),
+            pullRequests.map(pullRequest => polledPullRequestEvent(loaded.project, pullRequest)),
             options.ingestFactoryEvent,
           );
           return c.json({

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -164,6 +164,7 @@ function pullRequest(
   deliveryId: string,
   merged = false,
   createdAt = '2030-01-01T00:00:00Z',
+  body: string | null = null,
 ) {
   return {
     event: 'pull_request',
@@ -180,6 +181,7 @@ function pullRequest(
         created_at: createdAt,
         state: merged ? 'closed' : 'open',
         merged,
+        body,
         head: { ref: 'feature' },
         base: { ref: 'main' },
       },
@@ -205,6 +207,42 @@ describe('GithubRules', () => {
     expect(decisions).toHaveLength(1);
     expect(decisions[0]?.actor).toMatchObject({ type: 'github', login: 'maintainer', trusted: true });
     expect(decisions[0]?.decision).toMatchObject({ type: 'upsertLinkedWorkItem', source: 'github-issue' });
+  });
+
+  it('links an orphaned review card to the issue its pull request closes, on any later sighting', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
+    const issue = await createLinkedIssue(workItems, project.id);
+    const orphan = (
+      await workItems.upsert({
+        orgId: 'org-1',
+        userId: 'user-1',
+        factoryProjectId: project.id,
+        input: {
+          externalSource: {
+            integrationId: 'github',
+            type: 'pull-request',
+            externalId: 'github-pr:17',
+            url: 'https://github.com/acme/repo/pull/17',
+          },
+          title: 'PR 17',
+          stages: ['intake'],
+          sessions: {},
+          metadata: { githubRepositoryId: 10 },
+        },
+      })
+    ).item;
+    const service = new GithubRules({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await service.ingest(pullRequest('opened', 'poll:10:pull-request:17', false, '2030-01-01T00:00:00Z', 'Closes #42'));
+
+    expect((await workItems.get({ orgId: 'org-1', id: orphan.id }))?.parentWorkItemId).toBe(issue.id);
   });
 
   it('moves an issue-backed work card to done when its issue closes as completed', async () => {
@@ -1611,7 +1649,7 @@ describe('GithubRules', () => {
       rules: builtInFactoryRules(),
     });
 
-    await service.ingest(pullRequest('opened', 'delivery-branch-link'));
+    await service.ingest(pullRequest('opened', 'delivery-branch-link', false, '2030-01-01T00:00:00Z', 'Closes #42'));
     const decisions = await workItems.listDeferredDecisions('org-1', project.id);
     expect(decisions).toEqual([
       expect.objectContaining({
@@ -1619,7 +1657,7 @@ describe('GithubRules', () => {
         decision: expect.objectContaining({
           type: 'upsertLinkedWorkItem',
           source: 'github-pr',
-          metadata: expect.objectContaining({ headBranch: 'feature' }),
+          metadata: expect.objectContaining({ headBranch: 'feature', closesIssues: [42] }),
         }),
       }),
     ]);

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -19,11 +19,13 @@ import { FACTORY_PULL_REQUEST_RECONCILIATION_KEY } from '../../storage/domains/w
 import type { IntegrationContext } from '../base.js';
 import type { GithubAppIdentity } from './app-identity.js';
 import type { GithubRepositoryPermission } from './integration.js';
+import type { PullRequestLinkFacts } from './links.js';
 import {
   canonicalSourceKey,
   cardBelongsToRepository,
   closingIssueNumbers,
   legacySourceKey,
+  provenanceParentWorkItemId,
   pullRequestParentWorkItemId,
 } from './links.js';
 import { changeRequestTargetKey } from './subscriptions.js';
@@ -114,6 +116,11 @@ function eventName(parsed: ParsedGithubWebhook): FactoryGithubEventName | undefi
 
 function provenanceTarget(repositoryId: number, pullRequestNumber: number): string {
   return `factory-pr-provenance:${repositoryId}:${pullRequestNumber}`;
+}
+
+/** A Review card with nothing recorded about what it implements. */
+function isUnlinkedReviewCard(item: WorkItemRow | undefined): item is WorkItemRow {
+  return item?.externalSource?.type === 'pull-request' && item.parentWorkItemId === null;
 }
 
 function workItemSource(item: WorkItemRow) {
@@ -283,16 +290,13 @@ export class GithubRules {
       reReviewEvent ? null : provenance,
       senderIsResponder && !reviewRequested,
     );
-    if (relatedItem?.externalSource?.type === 'pull-request' && relatedItem.parentWorkItemId === null) {
+    if (isUnlinkedReviewCard(relatedItem)) {
       relatedItem =
         (await this.#linkPullRequestCard({
           project,
           card: relatedItem,
           provenance,
-          repositoryId,
-          repositoryFullName: repositoryName,
-          closesIssues,
-          headBranch,
+          facts: { repositoryId, repositoryFullName: repositoryName, closesIssues, headBranch },
         })) ?? relatedItem;
     }
     const actor = await githubActor(this.options.github, {
@@ -503,18 +507,12 @@ export class GithubRules {
     project: ExternalRepositoryProjectTarget;
     card: WorkItemRow;
     provenance: FactoryPullRequestProvenanceData | null;
-    repositoryId: number;
-    repositoryFullName: string;
-    closesIssues: number[];
-    headBranch: string | undefined;
+    facts: PullRequestLinkFacts;
   }): Promise<WorkItemRow | undefined> {
     const { orgId, factoryProjectId } = input.project;
     const items = await this.options.storage.list({ orgId, factoryProjectId });
-    const authored =
-      input.provenance && items.some(item => item.id === input.provenance?.workItemId)
-        ? input.provenance.workItemId
-        : null;
-    const parentWorkItemId = authored ?? pullRequestParentWorkItemId(items, input);
+    const parentWorkItemId =
+      provenanceParentWorkItemId(items, input.provenance) ?? pullRequestParentWorkItemId(items, input.facts);
     if (!parentWorkItemId || parentWorkItemId === input.card.id) return undefined;
     const linked = await this.options.storage.setParentWorkItemIfMissing({
       orgId,

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -19,6 +19,13 @@ import { FACTORY_PULL_REQUEST_RECONCILIATION_KEY } from '../../storage/domains/w
 import type { IntegrationContext } from '../base.js';
 import type { GithubAppIdentity } from './app-identity.js';
 import type { GithubRepositoryPermission } from './integration.js';
+import {
+  canonicalSourceKey,
+  cardBelongsToRepository,
+  closingIssueNumbers,
+  legacySourceKey,
+  pullRequestParentWorkItemId,
+} from './links.js';
 import { changeRequestTargetKey } from './subscriptions.js';
 import type { ParsedGithubWebhook } from './webhook.js';
 
@@ -103,32 +110,6 @@ function eventName(parsed: ParsedGithubWebhook): FactoryGithubEventName | undefi
   if (parsed.event === 'pull_request' && action === 'review_requested') return 'pullRequestReviewRequested';
   if (parsed.event === 'pull_request_review' && action === 'submitted') return 'pullRequestReviewSubmitted';
   return undefined;
-}
-
-/**
- * Canonical source keys (`github-issue:N`, `github-pr:N`) do not identify a
- * repository, so a project linked to several repositories could bind repo A's
- * event to repo B's same-numbered card. The card's intake-stamped URL is
- * authoritative; the intake-stamped `githubRepositoryId` covers URL-less
- * cards. A card with neither signal cannot be attributed by number alone.
- */
-function cardBelongsToRepository(item: WorkItemRow, repositoryId: number, repositoryFullName: string): boolean {
-  const url = item.externalSource?.url;
-  if (url) {
-    const match = /^https?:\/\/[^/]+\/(.+)\/(?:issues|pull)\/\d+(?:[/?#]|$)/.exec(url);
-    if (match && match[1] === repositoryFullName) return true;
-  }
-  // A renamed repository leaves the old owner/name in the card URL, so a URL
-  // mismatch still defers to the stable intake-stamped repository id.
-  return item.metadata?.githubRepositoryId === repositoryId;
-}
-
-function canonicalSourceKey(kind: 'issue' | 'pull-request', itemNumber: number): string {
-  return kind === 'issue' ? `github-issue:${itemNumber}` : `github-pr:${itemNumber}`;
-}
-
-function legacySourceKey(repositoryId: number, kind: 'issue' | 'pull-request', itemNumber: number): string {
-  return `github:${repositoryId}:${kind}:${itemNumber}`;
 }
 
 function provenanceTarget(repositoryId: number, pullRequestNumber: number): string {
@@ -289,17 +270,31 @@ export class GithubRules {
       reviewRequested || event === 'pullRequestCommentCreated' || event === 'pullRequestReviewSubmitted';
     const reReviewEvent = reviewRequested || event === 'pullRequestUpdated';
     const requestedReviewer = string(object(parsed.payload.requested_reviewer)?.login);
-    const relatedItem = await this.#relatedItem(
+    const headBranch = string(object(pullRequest?.head)?.ref);
+    const closesIssues = closingIssueNumbers(string(pullRequest?.body), repositoryName);
+    let relatedItem = await this.#relatedItem(
       project.orgId,
       project.factoryProjectId,
       repositoryId,
       repositoryName,
       issueNumber,
       pullRequestNumber,
-      string(object(pullRequest?.head)?.ref),
+      headBranch,
       reReviewEvent ? null : provenance,
       senderIsResponder && !reviewRequested,
     );
+    if (relatedItem?.externalSource?.type === 'pull-request' && relatedItem.parentWorkItemId === null) {
+      relatedItem =
+        (await this.#linkPullRequestCard({
+          project,
+          card: relatedItem,
+          provenance,
+          repositoryId,
+          repositoryFullName: repositoryName,
+          closesIssues,
+          headBranch,
+        })) ?? relatedItem;
+    }
     const actor = await githubActor(this.options.github, {
       installationId,
       repository: repositoryName,
@@ -405,8 +400,9 @@ export class GithubRules {
                 assignees: actorLogins(pullRequest?.assignees),
                 requestedReviewers: actorLogins(pullRequest?.requested_reviewers),
                 labels: labelNames(pullRequest?.labels),
-                headBranch: string(object(pullRequest?.head)?.ref) ?? '',
+                headBranch: headBranch ?? '',
                 baseBranch: string(object(pullRequest?.base)?.ref) ?? '',
+                closesIssues,
               },
             }
           : {}),
@@ -494,6 +490,39 @@ export class GithubRules {
       if (primary.status === status || secondary.status === status) return { status };
     }
     return primary;
+  }
+
+  /**
+   * Give a Review card the link it never got. A pull request opened by a person,
+   * or before Factory tracked the repository, reaches the board with no parent,
+   * and the decision path cannot repair it later: its delivery is replay-guarded
+   * after the first sighting. Any later observation still carries the facts, so
+   * it resolves the link then.
+   */
+  async #linkPullRequestCard(input: {
+    project: ExternalRepositoryProjectTarget;
+    card: WorkItemRow;
+    provenance: FactoryPullRequestProvenanceData | null;
+    repositoryId: number;
+    repositoryFullName: string;
+    closesIssues: number[];
+    headBranch: string | undefined;
+  }): Promise<WorkItemRow | undefined> {
+    const { orgId, factoryProjectId } = input.project;
+    const items = await this.options.storage.list({ orgId, factoryProjectId });
+    const authored =
+      input.provenance && items.some(item => item.id === input.provenance?.workItemId)
+        ? input.provenance.workItemId
+        : null;
+    const parentWorkItemId = authored ?? pullRequestParentWorkItemId(items, input);
+    if (!parentWorkItemId || parentWorkItemId === input.card.id) return undefined;
+    const linked = await this.options.storage.setParentWorkItemIfMissing({
+      orgId,
+      id: input.card.id,
+      userId: 'factory-github-rules',
+      parentWorkItemId,
+    });
+    return linked ?? undefined;
   }
 
   /**

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -287,6 +287,7 @@ function pullRequestOpened(context: FactoryGithubRuleContext) {
       labels: context.pullRequest.labels ?? [],
       headBranch: context.pullRequest.headBranch,
       baseBranch: context.pullRequest.baseBranch,
+      ...(context.pullRequest.closesIssues?.length ? { closesIssues: context.pullRequest.closesIssues } : {}),
       ...(githubActorLogin(context) ? { author: githubActorLogin(context) } : {}),
     },
   } as const;

--- a/mastracode/factory/src/rules/dispatch-errors.ts
+++ b/mastracode/factory/src/rules/dispatch-errors.ts
@@ -1,3 +1,4 @@
+import { WorkItemRelationError } from '../storage/domains/work-items/base.js';
 import type { FactoryDispatchFailureCode } from '../storage/domains/work-items/base.js';
 
 interface FactoryDispatchFailureMetadata {
@@ -19,6 +20,7 @@ const FAILURE_METADATA = {
   repository_commit_failed: { canRetry: true, label: 'Repository commit failed' },
   repository_cli_missing: { canRetry: false, label: 'GitHub CLI is unavailable in the workspace' },
   repository_pr_failed: { canRetry: true, label: 'Pull request creation failed' },
+  invalid_work_item_relation: { canRetry: false, label: 'Work item relationship is invalid' },
   unknown: { canRetry: true, label: 'Factory automation failed' },
 } satisfies Record<FactoryDispatchFailureCode, FactoryDispatchFailureMetadata>;
 
@@ -34,7 +36,10 @@ export class FactoryDispatchError extends Error {
 }
 
 export function factoryDispatchFailureCode(error: unknown): FactoryDispatchFailureCode {
-  return error instanceof FactoryDispatchError ? error.code : 'unknown';
+  if (error instanceof FactoryDispatchError) return error.code;
+  // Retrying a relationship the storage layer just rejected re-runs the same
+  // rejection: the decision is wrong, not the moment.
+  return error instanceof WorkItemRelationError ? 'invalid_work_item_relation' : 'unknown';
 }
 
 export function factoryDispatchFailureMetadata(

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -27,6 +27,28 @@ async function createItem(storage: WorkItemsStorage, sourceKey = 'github-issue:1
   ).item;
 }
 
+async function createPullRequestCard(storage: WorkItemsStorage) {
+  return (
+    await storage.upsert({
+      orgId: 'org-1',
+      userId: 'webhook',
+      factoryProjectId: PROJECT_ID,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'pull-request',
+          externalId: 'github-pr:2',
+          url: 'https://github.com/acme/repo/pull/2',
+        },
+        title: 'Linked PR',
+        stages: ['intake'],
+        sessions: {},
+        metadata: {},
+      },
+    })
+  ).item;
+}
+
 function createSession(
   accepted?: Promise<unknown>,
   options?: {
@@ -2288,9 +2310,100 @@ describe('FactoryDecisionDispatcher', () => {
     );
     expect(resolveLinkedWorkItemParentId).toHaveBeenCalledWith({
       orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
       decision: expect.objectContaining({ source: 'github-pr', sourceKey: 'github-pr:2' }),
     });
     expect(linked?.parentWorkItemId).toBe(parent.id);
+  });
+
+  it('re-observing a card the rule was evaluated against leaves it unlinked instead of failing', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const card = await createPullRequestCard(storage);
+    await storage.commitRuleEvaluation({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: card.id,
+      ingress: { identity: 'poll:7:pull-request:2', triggerType: 'pull_request.opened' },
+      ruleSetVersion: 'rules-v1',
+      expectedRevision: card.revision,
+      actor: { type: 'system', id: 'rules' },
+      outcome: { status: 'accepted' },
+      decisions: [
+        {
+          type: 'upsertLinkedWorkItem',
+          idempotencyKey: 'linked-pr-reobserved',
+          board: 'review',
+          source: 'github-pr',
+          sourceKey: 'github-pr:2',
+          title: 'Linked PR',
+          url: 'https://github.com/acme/repo/pull/2',
+          stage: 'intake',
+          metadata: { githubRepositoryId: 7, githubPullRequestNumber: 2 },
+        },
+      ],
+      causalChain: [],
+      now: new Date('2030-01-01T00:00:00Z'),
+    });
+    const { controller } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      isAutoRunEnabled: async () => true,
+      transitionService: new FactoryTransitionService({ storage, rules: defaultFactoryRules({ version: 'rules-v1' }) }),
+      storage,
+      ownerId: 'worker-1',
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
+
+    const decisions = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(decisions.map(decision => ({ status: decision.status, lastError: decision.lastError }))).toEqual([
+      { status: 'succeeded', lastError: null },
+    ]);
+    expect((await storage.get({ orgId: 'org-1', id: card.id }))?.parentWorkItemId).toBeNull();
+  });
+
+  it('links a card re-observed without a parent to the work item its facts name', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const parent = await createItem(storage);
+    const card = await createPullRequestCard(storage);
+    await storage.commitRuleEvaluation({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: card.id,
+      ingress: { identity: 'poll:7:pull-request:2', triggerType: 'pull_request.opened' },
+      ruleSetVersion: 'rules-v1',
+      expectedRevision: card.revision,
+      actor: { type: 'system', id: 'rules' },
+      outcome: { status: 'accepted' },
+      decisions: [
+        {
+          type: 'upsertLinkedWorkItem',
+          idempotencyKey: 'linked-pr-reobserved-linkable',
+          board: 'review',
+          source: 'github-pr',
+          sourceKey: 'github-pr:2',
+          title: 'Linked PR',
+          url: 'https://github.com/acme/repo/pull/2',
+          stage: 'intake',
+          metadata: { githubRepositoryId: 7, githubPullRequestNumber: 2 },
+        },
+      ],
+      causalChain: [],
+      now: new Date('2030-01-01T00:00:00Z'),
+    });
+    const { controller } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      isAutoRunEnabled: async () => true,
+      transitionService: new FactoryTransitionService({ storage, rules: defaultFactoryRules({ version: 'rules-v1' }) }),
+      storage,
+      ownerId: 'worker-1',
+      resolveLinkedWorkItemParentId: async () => parent.id,
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
+
+    expect((await storage.get({ orgId: 'org-1', id: card.id }))?.parentWorkItemId).toBe(parent.id);
   });
 
   it('recovers linked-item materialization after an upsert crash and fires Intake onEnter exactly once', async () => {

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -100,6 +100,7 @@ export interface FactoryDecisionDispatcherOptions {
   primeCredentials?: (tenant: { orgId: string; userId: string }) => Promise<void>;
   resolveLinkedWorkItemParentId?: (input: {
     orgId: string;
+    factoryProjectId: string;
     decision: Extract<FactoryCommitDecision, { type: 'upsertLinkedWorkItem' }>;
   }) => Promise<string | null>;
   maxInFlight?: number;
@@ -715,25 +716,39 @@ export class FactoryDecisionDispatcher {
     }
   }
 
+  /**
+   * What the card hangs off. The card the rule acted on is the answer whenever
+   * the decision produced a *different* card — a work item's run opening a pull
+   * request. It is not an answer when the rule was evaluated against the very
+   * card the decision names, which is every re-observation of something already
+   * on the board: there the link, if any, comes from the pull request's facts.
+   */
+  async #linkedItemParentId(
+    record: FactoryDeferredDecisionRecord,
+    decision: Extract<FactoryCommitDecision, { type: 'upsertLinkedWorkItem' }>,
+    itemId: string,
+  ): Promise<string | null> {
+    if (record.workItemId && record.workItemId !== itemId) return record.workItemId;
+    const resolved = await this.#resolveLinkedWorkItemParentId?.({
+      orgId: record.orgId,
+      factoryProjectId: record.factoryProjectId,
+      decision,
+    });
+    return resolved && resolved !== itemId ? resolved : null;
+  }
+
   async #upsertLinkedItem(
     record: FactoryDeferredDecisionRecord,
     decision: Extract<FactoryCommitDecision, { type: 'upsertLinkedWorkItem' }>,
     causalChain: FactoryRuleCausalEntry[],
   ): Promise<void> {
-    const parentWorkItemId =
-      record.workItemId ??
-      (await this.#resolveLinkedWorkItemParentId?.({
-        orgId: record.orgId,
-        decision,
-      })) ??
-      null;
     let result = await this.#storage.upsert({
       orgId: record.orgId,
       userId: 'factory-rule-dispatcher',
       factoryProjectId: record.factoryProjectId,
       input: {
         externalSource: externalSourceForDecision(decision),
-        parentWorkItemId,
+        parentWorkItemId: null,
         title: decision.title,
         stages: ['intake'],
         sessions: {},
@@ -741,14 +756,17 @@ export class FactoryDecisionDispatcher {
       },
       reuseMode: 'preserve',
     });
-    if (!result.item.parentWorkItemId && parentWorkItemId) {
-      const item = await this.#storage.setParentWorkItemIfMissing({
-        orgId: record.orgId,
-        id: result.item.id,
-        userId: 'factory-rule-dispatcher',
-        parentWorkItemId,
-      });
-      if (item) result = { ...result, item };
+    if (!result.item.parentWorkItemId) {
+      const parentWorkItemId = await this.#linkedItemParentId(record, decision, result.item.id);
+      if (parentWorkItemId) {
+        const item = await this.#storage.setParentWorkItemIfMissing({
+          orgId: record.orgId,
+          id: result.item.id,
+          userId: 'factory-rule-dispatcher',
+          parentWorkItemId,
+        });
+        if (item) result = { ...result, item };
+      }
     }
     const materializedByDecision = result.item.metadata?.[FACTORY_RULE_MATERIALIZATION_KEY] === record.idempotencyKey;
     if (!materializedByDecision && (decision.stage === 'intake' || !result.item.stages.includes('intake'))) return;

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -155,6 +155,8 @@ export interface FactoryGithubRuleContext extends FactoryRuleContextBase {
     labels?: string[];
     headBranch: string;
     baseBranch: string;
+    /** Issue numbers the body declares closed, in this repository only. */
+    closesIssues?: number[];
   };
   /** Present on `pullRequestReviewRequested`: who review was (re-)requested from. */
   reviewRequest?: { reviewer: string; factoryReviewer: boolean };

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -153,6 +153,7 @@ const FACTORY_DISPATCH_FAILURE_CODES = [
   'repository_commit_failed',
   'repository_cli_missing',
   'repository_pr_failed',
+  'invalid_work_item_relation',
   'unknown',
 ] as const;
 


### PR DESCRIPTION
TLDR: a pull request now lands under the work item it implements — whoever opened it — and refreshing the board stops filling the attention inbox with "A work item cannot relate to itself."

---

Opening the board polls GitHub every 30s and replays each open issue and pull request through the rules. When the card already existed, the dispatcher took the card the rule was evaluated against as the parent. That is the same card. So every re-observation failed, retried five times, and left a dead attention row nobody could act on — 58 of them in my local project.

That binding only names a parent when the decision produced a *different* card: a work item's run opening a pull request. When it names the card itself, there is no parent in it, and the link has to come from the pull request's own facts:

```
provenance    Factory's own run opened it        already existed
Closes #12    the author's declared intent       sat unread in the body
head branch   matches a work item's session      only the UI guessed at it
```

### What changes

| someone on the board | before | after |
| --- | --- | --- |
| leaves the board open | one dead attention row per already-carded issue/PR | nothing |
| opens a PR saying `Closes #12` | Review card sits alone, no link | Review card under issue #12 |
| had an orphaned Review card | orphaned forever | linked on the next sighting of its PR |
| hits an invalid relation | inbox offers Retry that re-fails | marked non-retryable |

The repair had to move into the rules layer rather than the dispatcher: a delivery is replay-guarded after its first sighting, so the decision path can never revisit the cards that are already orphaned. Every later sighting still carries the facts, so that is where it resolves. In my project that is 1010 of 1020 Review cards with no parent — 1% linked today.

### Judgment call

The head-branch match was already client-side in `relationships.ts`, recomputed per render over whatever cards were loaded. I left it there rather than deleting it in this PR: it is the only thing still drawing links for closed and merged pull requests, which the intake poll does not list and therefore never re-observes. Deleting it belongs with a sweep that re-fetches those, which I did not write here.

### Not verified

- Closed and merged orphans stay orphaned. Nothing re-observes them.
- `Closes #N` is parsed from the raw body, so a reference inside a code fence or a quote counts — GitHub itself ignores those. Costs a wrong link only when someone quotes a closing keyword pointing at an issue that has a card.

```
source      +277  -81
tests       +273   -2
changeset    +17    0
```
