### PR TITLE
fix(factory): require approval for non-bug lifecycle gates

### DIFF
--- a/.changeset/easy-moles-cheat.md
+++ b/.changeset/easy-moles-cheat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory lifecycle automation so feature requests and other non-bug work require explicit human approval before entering Planning or Execute, including when automatic runs are enabled.

--- a/mastracode/factory/src/routes/work-items.test.ts
+++ b/mastracode/factory/src/routes/work-items.test.ts
@@ -1614,6 +1614,7 @@ describe('GET /web/factory/projects/:id/metrics', () => {
         actor,
         ingress: { type: 'rule', identity },
         cause: 'auto_triage',
+        ...(actor.type === 'agent' && actor.role === 'triage' ? { triageType: 'bug' as const } : {}),
       });
     const triaged = await move('triage', workItem.revision, 'auto-1', {
       type: 'system',

--- a/mastracode/factory/src/rules/start-coordinator.test.ts
+++ b/mastracode/factory/src/rules/start-coordinator.test.ts
@@ -132,6 +132,91 @@ function startRequest(
 }
 
 describe('FactoryStartCoordinator', () => {
+  it('uses authenticated run_start ingress to approve a classified feature into Planning', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = (
+      await storage.upsert({
+        orgId: 'org-1',
+        userId: 'user-1',
+        factoryProjectId: PROJECT_ID,
+        input: startRequest().workItem.input,
+      })
+    ).item;
+    const transitionService = new FactoryTransitionService({
+      storage,
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+    });
+    await transitionService.transition({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      board: 'work',
+      stage: 'intake',
+      expectedRevision: item.revision,
+      actor: { type: 'agent', bindingId: 'triage', role: 'triage' },
+      ingress: { type: 'agent', identity: 'triage-classify' },
+      cause: 'await approval',
+      triageType: 'feature request',
+    });
+    const { controller } = makeController();
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      transitionService,
+      makeSourceControl() as never,
+    );
+
+    const prepared = await coordinator.prepare({
+      ...startRequest({ id: item.id, role: 'plan' }),
+      destinationStage: 'planning',
+    });
+
+    expect(prepared.workItemId).toBe(item.id);
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['planning']);
+  });
+
+  it('uses authenticated run_start ingress to approve a classified feature into Execute', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = (
+      await storage.upsert({
+        orgId: 'org-1',
+        userId: 'user-1',
+        factoryProjectId: PROJECT_ID,
+        input: { ...startRequest().workItem.input, stages: ['planning'] },
+      })
+    ).item;
+    const transitionService = new FactoryTransitionService({
+      storage,
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+    });
+    await transitionService.transition({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      board: 'work',
+      stage: 'planning',
+      expectedRevision: item.revision,
+      actor: { type: 'agent', bindingId: 'triage', role: 'triage' },
+      ingress: { type: 'agent', identity: 'triage-classify-execute' },
+      cause: 'await approval',
+      triageType: 'feature request',
+    });
+    const { controller } = makeController();
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      transitionService,
+      makeSourceControl() as never,
+    );
+
+    await coordinator.prepare({
+      ...startRequest({ id: item.id, role: 'work' }),
+      destinationStage: 'execute',
+    });
+
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['execute']);
+  });
+
   it('commits the item session, exact binding, and durable pending start', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const { controller, sendMessage } = makeController();

--- a/mastracode/factory/src/rules/tools.test.ts
+++ b/mastracode/factory/src/rules/tools.test.ts
@@ -48,7 +48,11 @@ function crashResumedContext(
   return context;
 }
 
-async function prepareBoundItem(storage: WorkItemsStorage, source: 'github-issue' | 'github-pr' = 'github-issue') {
+async function prepareBoundItem(
+  storage: WorkItemsStorage,
+  source: 'github-issue' | 'github-pr' = 'github-issue',
+  role: 'triage' | 'work' | 'plan' | 'review' = source === 'github-pr' ? 'review' : 'work',
+) {
   return storage.prepareRunStart({
     orgId: 'org-1',
     userId: 'user-1',
@@ -66,7 +70,7 @@ async function prepareBoundItem(storage: WorkItemsStorage, source: 'github-issue
         metadata: {},
       },
     },
-    role: source === 'github-pr' ? 'review' : 'work',
+    role,
     session: { sessionId: 'resource-1', branch: 'factory/item', threadId: 'thread-1' },
     resourceId: 'resource-1',
     kickoffKey: 'kickoff-1',
@@ -135,6 +139,60 @@ describe('factory_transition_work_item', () => {
     });
 
     expect((tools.factory_transition_work_item as ExecutableTool).requireApproval).toBe(true);
+  });
+
+  it('requires triageType only for triage bindings', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    await prepareBoundItem(storage, 'github-issue', 'triage');
+    const tools = await createFactoryTransitionTools({
+      requestContext: requestContext(),
+      storage,
+      transitionService: new FactoryTransitionService({ storage, rules: defaultFactoryRules({ version: 'rules-v1' }) }),
+    });
+    const triageTool = tools.factory_transition_work_item as ExecutableTool;
+    expect(
+      triageTool.inputSchema.safeParse({ stage: 'intake', expectedRevision: 1, rationale: 'Await approval.' }).success,
+    ).toBe(false);
+    expect(
+      triageTool.inputSchema.safeParse({
+        stage: 'intake',
+        expectedRevision: 1,
+        rationale: 'Await approval.',
+        triageType: 'feature request',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('propagates a triage binding classification to the transition service', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const prepared = await prepareBoundItem(storage, 'github-issue', 'triage');
+    const transition = vi.fn(async () => ({
+      status: 'accepted' as const,
+      transitionId: 'transition-1',
+      itemId: prepared.item.id,
+      revision: 2,
+      stage: 'intake' as const,
+      decisions: [],
+    }));
+    const context = requestContext();
+    const tools = await createFactoryTransitionTools({
+      requestContext: context,
+      storage,
+      transitionService: { transition },
+    });
+    await execute(tools.factory_transition_work_item as ExecutableTool, context, {
+      stage: 'intake',
+      expectedRevision: 1,
+      rationale: 'Await approval.',
+      triageType: 'feature request',
+    });
+    expect(transition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workItemId: prepared.item.id,
+        actor: { type: 'agent', bindingId: prepared.binding.id, role: 'triage' },
+        triageType: 'feature request',
+      }),
+    );
   });
 
   it('derives the item, board, actor, and immutable ingress from the binding and tool call', async () => {

--- a/mastracode/factory/src/rules/tools.ts
+++ b/mastracode/factory/src/rules/tools.ts
@@ -8,7 +8,7 @@ import type { FactorySessionSourceLookup } from './binding-context.js';
 import { resolveFactorySessionAddress } from './binding-context.js';
 import type { FactoryTransitionService } from './transition-service.js';
 import { currentStage } from './transition-service.js';
-import { FACTORY_RULE_STAGES } from './types.js';
+import { FACTORY_RULE_STAGES, FACTORY_TRIAGE_TYPES, isFactoryTriageType } from './types.js';
 import type { FactoryRuleBoard } from './types.js';
 
 const MAX_RATIONALE_LENGTH = 1_000;
@@ -29,6 +29,10 @@ const transitionInputSchema = z
   })
   .strict();
 
+const triageTransitionInputSchema = transitionInputSchema.extend({
+  triageType: z.enum(FACTORY_TRIAGE_TYPES),
+});
+
 function boardForSource(type: string | undefined): FactoryRuleBoard {
   return type === 'pull-request' ? 'review' : 'work';
 }
@@ -47,15 +51,17 @@ export async function createFactoryTransitionTools(options: {
   if (!resolution) return {};
   const availableBinding = resolution.binding ?? (await options.storage.findActiveRunBinding(resolution.address));
   if (!availableBinding) return {};
+  const isTriage = availableBinding.role === 'triage';
 
   return {
     factory_transition_work_item: createTool({
       id: 'factory_transition_work_item',
-      description:
-        'Request a governed stage transition for the Factory work item exactly bound to this thread. Use the current revision from the factory-phase signal and explain why the transition is appropriate.',
-      inputSchema: transitionInputSchema,
+      description: isTriage
+        ? 'Report the triage classification and request a governed stage transition for the Factory work item exactly bound to this thread. Only bugs may request Planning autonomously; closure outcomes may request a terminal stage. Feature requests and other non-bug classifications that remain open must stay in their current Intake or Triage stage for maintainer approval.'
+        : 'Request a governed stage transition for the Factory work item exactly bound to this thread. Use the current revision from the factory-phase signal and explain why the transition is appropriate.',
+      inputSchema: isTriage ? triageTransitionInputSchema : transitionInputSchema,
       requireApproval: true,
-      execute: async ({ stage, expectedRevision, rationale }, execution) => {
+      execute: async ({ stage, expectedRevision, rationale, ...input }, execution) => {
         const currentResolution = await resolveFactorySessionAddress({
           requestContext: execution.requestContext,
           storage: options.storage,
@@ -78,6 +84,8 @@ export async function createFactoryTransitionTools(options: {
         }
         const item = await options.storage.get({ orgId: binding.orgId, id: binding.workItemId });
         if (!item) throw new Error('Bound Factory work item not found.');
+        const triageType =
+          'triageType' in input && isFactoryTriageType(input.triageType) ? input.triageType : undefined;
 
         const result = await options.transitionService.transition({
           orgId: binding.orgId,
@@ -89,6 +97,7 @@ export async function createFactoryTransitionTools(options: {
           actor: { type: 'agent', bindingId: binding.id, role: binding.role },
           ingress: { type: 'agent', identity: `${binding.id}:${toolCallId}` },
           cause: rationale,
+          ...(triageType ? { triageType } : {}),
         });
 
         // A phase EXIT is the natural moment to ask what was worth keeping:

--- a/mastracode/factory/src/rules/transition-service.test.ts
+++ b/mastracode/factory/src/rules/transition-service.test.ts
@@ -81,6 +81,198 @@ describe('FactoryTransitionService', () => {
     expect((await storage.get({ orgId: 'org-1', id: item.id }))?.revision).toBe(item.revision + 1);
   });
 
+  it('persists a feature classification without allowing a triage agent into Planning', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const planningRule = vi.fn();
+    const service = new FactoryTransitionService({
+      rules: defaultFactoryRules({
+        version: 'rules-v1',
+        overrides: { work: { planning: { issue: { onEnter: planningRule } } } },
+      }),
+      storage,
+    });
+    const classified = await service.transition({
+      ...request(item, { stage: 'intake', identity: 'triage-feature' }),
+      actor: { type: 'agent', bindingId: 'binding-1', role: 'triage' },
+      ingress: { type: 'agent', identity: 'triage-feature' },
+      triageType: 'feature request',
+    });
+
+    expect(classified).toMatchObject({ status: 'accepted', revision: item.revision + 1 });
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.triageType).toBe('feature request');
+    const rejected = await service.transition({
+      ...request({ id: item.id, revision: item.revision + 1 }, { stage: 'planning', identity: 'plan-agent' }),
+      actor: { type: 'agent', bindingId: 'binding-2', role: 'triage' },
+      ingress: { type: 'agent', identity: 'plan-agent' },
+      triageType: 'feature request',
+    });
+
+    expect(rejected).toMatchObject({ status: 'rejected', code: 'approval_required' });
+    expect(planningRule).not.toHaveBeenCalled();
+  });
+
+  it('allows a human to approve a classified feature into Planning', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const service = new FactoryTransitionService({ rules: defaultFactoryRules({ version: 'rules-v1' }), storage });
+    await service.transition({
+      ...request(item, { stage: 'intake', identity: 'triage-feature' }),
+      actor: { type: 'agent', bindingId: 'binding-1', role: 'triage' },
+      ingress: { type: 'agent', identity: 'triage-feature' },
+      triageType: 'feature request',
+    });
+
+    const approved = await service.transition(
+      request({ id: item.id, revision: item.revision + 1 }, { stage: 'planning' }),
+    );
+    expect(approved).toMatchObject({ status: 'accepted', stage: 'planning' });
+  });
+
+  it('rejects every non-human ingress at both protected gates even when autonomy is armed', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const planningRule = vi.fn();
+    const executeRule = vi.fn();
+    const service = new FactoryTransitionService({
+      rules: defaultFactoryRules({
+        version: 'rules-v1',
+        overrides: {
+          work: {
+            planning: { issue: { onEnter: planningRule } },
+            execute: { issue: { onEnter: executeRule } },
+          },
+        },
+      }),
+      storage,
+    });
+    const classified = await service.transition({
+      ...request(item, { stage: 'intake', identity: 'classify' }),
+      actor: { type: 'agent', bindingId: 'triage', role: 'triage' },
+      ingress: { type: 'agent', identity: 'classify' },
+      triageType: 'feature request',
+    });
+    const armed = await service.transition({
+      ...request(
+        { id: item.id, revision: (classified as { revision: number }).revision },
+        { stage: 'triage', identity: 'arm' },
+      ),
+      ingress: { type: 'human', identity: 'arm' },
+      cause: 'board_drag',
+    });
+    const revision = (armed as { revision: number }).revision;
+    for (const [actor, ingress] of [
+      [
+        { type: 'agent', bindingId: 'agent', role: 'triage' },
+        { type: 'agent', identity: 'agent-plan' },
+      ],
+      [
+        { type: 'system', id: 'dispatcher' },
+        { type: 'rule', identity: 'rule-plan' },
+      ],
+      [
+        { type: 'system', id: 'tool-result' },
+        { type: 'toolResult', identity: 'tool-plan' },
+      ],
+      [
+        { type: 'github', login: 'octocat', trusted: true, factoryAuthored: true },
+        { type: 'github', identity: 'github-plan' },
+      ],
+    ] as const) {
+      await expect(
+        service.transition({
+          ...request({ id: item.id, revision }, { stage: 'planning', identity: ingress.identity }),
+          actor,
+          ingress,
+          ...(actor.type === 'agent' && actor.role === 'triage' ? { triageType: 'feature request' as const } : {}),
+        }),
+      ).resolves.toMatchObject({ status: 'rejected', code: 'approval_required' });
+    }
+    const approved = await service.transition({
+      ...request({ id: item.id, revision }, { stage: 'planning', identity: 'human-plan' }),
+      cause: 'board_drag',
+    });
+    const planningRevision = (approved as { revision: number }).revision;
+    for (const [actor, ingress] of [
+      [
+        { type: 'agent', bindingId: 'agent', role: 'work' },
+        { type: 'agent', identity: 'agent-execute' },
+      ],
+      [
+        { type: 'system', id: 'dispatcher' },
+        { type: 'rule', identity: 'rule-execute' },
+      ],
+      [
+        { type: 'system', id: 'tool-result' },
+        { type: 'toolResult', identity: 'tool-execute' },
+      ],
+      [
+        { type: 'github', login: 'octocat', trusted: true, factoryAuthored: true },
+        { type: 'github', identity: 'github-execute' },
+      ],
+    ] as const) {
+      await expect(
+        service.transition({
+          ...request({ id: item.id, revision: planningRevision }, { stage: 'execute', identity: ingress.identity }),
+          actor,
+          ingress,
+        }),
+      ).resolves.toMatchObject({ status: 'rejected', code: 'approval_required' });
+    }
+    expect(planningRule).toHaveBeenCalledTimes(1);
+    expect(executeRule).not.toHaveBeenCalled();
+    const executed = await service.transition({
+      ...request({ id: item.id, revision: planningRevision }, { stage: 'execute', identity: 'human-execute' }),
+      cause: 'board_drag',
+    });
+    expect(executed).toMatchObject({ status: 'accepted', stage: 'execute' });
+    const reviewed = await service.transition(
+      request(
+        { id: item.id, revision: (executed as { revision: number }).revision },
+        { stage: 'review', identity: 'review' },
+      ),
+    );
+    expect(reviewed).toMatchObject({ status: 'accepted', stage: 'review' });
+  });
+
+  it('keeps bugs autonomous and leaves grandfathered work and terminal transitions unaffected', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const bug = await createItem(storage);
+    const service = new FactoryTransitionService({ rules: defaultFactoryRules({ version: 'rules-v1' }), storage });
+    const planned = await service.transition({
+      ...request(bug, { stage: 'planning', identity: 'bug-plan' }),
+      actor: { type: 'agent', bindingId: 'triage', role: 'triage' },
+      ingress: { type: 'agent', identity: 'bug-plan' },
+      triageType: 'bug',
+    });
+    const executed = await service.transition({
+      ...request(
+        { id: bug.id, revision: (planned as { revision: number }).revision },
+        { stage: 'execute', identity: 'bug-execute' },
+      ),
+      actor: { type: 'agent', bindingId: 'work', role: 'work' },
+      ingress: { type: 'agent', identity: 'bug-execute' },
+    });
+    expect(executed).toMatchObject({ status: 'accepted', stage: 'execute' });
+    const legacy = await createItem(storage, { stages: ['planning'], sourceKey: 'legacy' });
+    await expect(
+      service.transition({
+        ...request(legacy, { stage: 'execute', identity: 'legacy-execute' }),
+        actor: { type: 'agent', bindingId: 'work', role: 'work' },
+        ingress: { type: 'agent', identity: 'legacy-execute' },
+      }),
+    ).resolves.toMatchObject({ status: 'accepted', stage: 'execute' });
+    const closed = await createItem(storage, { sourceKey: 'closed-feature' });
+    await expect(
+      service.transition({
+        ...request(closed, { stage: 'done', identity: 'feature-close' }),
+        actor: { type: 'agent', bindingId: 'triage', role: 'triage' },
+        ingress: { type: 'agent', identity: 'feature-close' },
+        triageType: 'feature request',
+      }),
+    ).resolves.toMatchObject({ status: 'accepted', stage: 'done' });
+  });
+
   it('does not run GitHub issue rules against a Slack thread card', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const item = await createItem(storage, { source: 'slack-thread', stages: ['execute'] });

--- a/mastracode/factory/src/rules/transition-service.ts
+++ b/mastracode/factory/src/rules/transition-service.ts
@@ -9,6 +9,7 @@ import type {
   FactoryRuleCausalEntry,
   FactoryRuleRejectionCode,
   FactoryRuleStage,
+  FactoryTriageType,
   FactoryRules,
   FactoryStageRuleContext,
   FactoryTransitionResult,
@@ -44,6 +45,8 @@ export interface FactoryTransitionRequest {
   initialEntry?: boolean;
   /** Re-runs the stage's entry rules when the item already holds that stage, to restart work the entry invalidated. */
   reenter?: boolean;
+  /** Structured verdict required from a bound triage-agent terminal request. */
+  triageType?: FactoryTriageType;
 }
 
 export interface FactoryTransitionServiceOptions {
@@ -115,6 +118,18 @@ function roleForStage(board: FactoryRuleBoard, stage: FactoryRuleStage): string 
 
 function stageTransitionMessage(fromStage: FactoryRuleStage, toStage: FactoryRuleStage): string {
   return `This work was moved from the ${fromStage} stage to the ${toStage} stage.`;
+}
+
+function isTriageAgent(actor: FactoryRuleActor): actor is Extract<FactoryRuleActor, { type: 'agent' }> {
+  return actor.type === 'agent' && actor.role === 'triage';
+}
+
+function isHumanTransition(request: FactoryTransitionRequest): boolean {
+  return request.actor.type === 'human' && request.ingress.type === 'human';
+}
+
+function requiresHumanApproval(triageType: FactoryTriageType | null | undefined): boolean {
+  return triageType !== undefined && triageType !== null && triageType !== 'bug';
 }
 
 function ruleFailure(error: unknown): { code: FactoryRuleRejectionCode; reason: string } {
@@ -194,6 +209,36 @@ export class FactoryTransitionService {
         transitionId,
         'invalid_transition',
         'The work item does not have one canonical Factory stage.',
+      );
+    }
+
+    if (isTriageAgent(request.actor) && request.triageType === undefined) {
+      return this.#commitRejection(
+        request,
+        transitionId,
+        'invalid_transition',
+        'Triage transitions must report a structured triage classification.',
+      );
+    }
+    if (item.triageType && request.triageType && item.triageType !== request.triageType) {
+      return this.#commitRejection(
+        request,
+        transitionId,
+        'forbidden',
+        'The persisted triage classification cannot be changed by a later transition.',
+      );
+    }
+    const triageType = item.triageType ?? request.triageType;
+    if (
+      requiresHumanApproval(triageType) &&
+      (request.stage === 'planning' || request.stage === 'execute') &&
+      !isHumanTransition(request)
+    ) {
+      return this.#commitRejection(
+        request,
+        transitionId,
+        'approval_required',
+        'A maintainer must move this non-bug work item into Planning or Execute from the Factory UI.',
       );
     }
 
@@ -323,6 +368,7 @@ export class FactoryTransitionService {
       ruleSetVersion: this.#rules.version,
       causalChain: [...(request.causalChain ?? [])],
       evaluation,
+      ...(isTriageAgent(request.actor) && request.triageType ? { triageType: request.triageType } : {}),
     });
     if (committed.status === 'missing') {
       return rejection(transitionId, request.workItemId, 'invalid_transition', 'Work item not found.');

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -3,6 +3,25 @@ export type WorkItemSource = 'github-issue' | 'github-pr' | 'linear-issue' | 'ma
 export const FACTORY_RULE_STAGES = ['intake', 'triage', 'planning', 'execute', 'review', 'done', 'canceled'] as const;
 export type FactoryRuleStage = (typeof FACTORY_RULE_STAGES)[number];
 
+export const FACTORY_TRIAGE_TYPES = [
+  'bug',
+  'feature request',
+  'docs',
+  'question/support',
+  'maintenance',
+  'duplicate',
+  'resolved',
+  'invalid',
+  'spam',
+  'out-of-scope',
+  'other',
+] as const;
+export type FactoryTriageType = (typeof FACTORY_TRIAGE_TYPES)[number];
+
+export function isFactoryTriageType(value: unknown): value is FactoryTriageType {
+  return typeof value === 'string' && FACTORY_TRIAGE_TYPES.some(type => type === value);
+}
+
 export function isFactoryRuleStage(value: unknown): value is FactoryRuleStage {
   return typeof value === 'string' && FACTORY_RULE_STAGES.some(stage => stage === value);
 }
@@ -234,7 +253,8 @@ export type FactoryRuleRejectionCode =
   | 'timeout'
   | 'rule_error'
   | 'causal_depth_exceeded'
-  | 'repeated_transition';
+  | 'repeated_transition'
+  | 'approval_required';
 
 export interface FactoryRuleRejectDecision {
   type: 'reject';

--- a/mastracode/factory/src/storage/domains/work-items/base.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.test.ts
@@ -65,6 +65,32 @@ function interceptTransactionOps(backend: any, overridesFor: (ops: any) => Recor
 }
 
 describe('WorkItemsStorage', () => {
+  it('persists a triage classification atomically, revisions it once, and replays without changing it', async () => {
+    const storage = await makeStorage();
+    const created = await storage.upsert({ orgId: 'org1', userId: 'user1', factoryProjectId: 'project1', input });
+    const commit = (identity: string, expectedRevision: number, triageType: 'feature request' | 'bug') =>
+      storage.commitTransition({
+        orgId: 'org1',
+        factoryProjectId: 'project1',
+        workItemId: created.item.id,
+        expectedRevision,
+        destinationStage: 'intake',
+        actorId: 'triage-agent',
+        ingress: { identity, triggerType: 'agent', transitionId: identity },
+        ruleSetVersion: 'rules-v1',
+        causalChain: [],
+        evaluation: { outcome: 'accepted', decisions: [] },
+        triageType,
+      });
+
+    const classified = await commit('triage-1', created.item.revision, 'feature request');
+    expect(classified).toMatchObject({ status: 'committed', item: { triageType: 'feature request', revision: 2 } });
+    const replayed = await commit('triage-1', created.item.revision, 'feature request');
+    expect(replayed).toMatchObject({ status: 'replayed', item: { triageType: 'feature request', revision: 2 } });
+    const laterAgent = await commit('triage-2', 2, 'bug');
+    expect(laterAgent).toMatchObject({ status: 'committed', item: { triageType: 'feature request', revision: 2 } });
+  });
+
   it('deduplicates external sources within a Factory project, not across projects', async () => {
     const storage = await makeStorage();
 

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -13,6 +13,7 @@ import { createHash } from 'node:crypto';
 import { FactoryStorageDomain, UniqueViolationError } from '@mastra/core/storage';
 import type { CollectionSchema, CollectionWhere, FactoryStorageOps } from '@mastra/core/storage';
 import { isTerminalFactoryRuleStage } from '../../../rules/types.js';
+import type { FactoryTriageType } from '../../../rules/types.js';
 
 export type WorkItemStage = string;
 
@@ -364,6 +365,8 @@ export interface CommitFactoryTransitionInput {
     | { outcome: 'rejected'; code: string; reason: string };
   /** Arm autonomy in the same revision-checked update that commits the transition. */
   armAutonomy?: boolean;
+  /** Triage classification reported by an authenticated triage binding. */
+  triageType?: FactoryTriageType;
 }
 
 export type CommitFactoryTransitionResult =
@@ -412,6 +415,8 @@ export interface WorkItemRow {
   stageHistory: WorkItemStageEntry[];
   sessions: WorkItemSessions;
   metadata: Record<string, unknown> | null;
+  /** Authoritative verdict written by the bound triage run. */
+  triageType: FactoryTriageType | null;
   /**
    * When a person first committed this item to the Factory, by starting a run
    * on it or releasing one that was proposed. Projects that withhold auto-run
@@ -467,6 +472,7 @@ export const WORK_ITEMS_SCHEMA: CollectionSchema = {
     stage_history: { type: 'json' },
     sessions: { type: 'json' },
     metadata: { type: 'json', nullable: true },
+    triage_type: { type: 'text', nullable: true },
     autonomy_armed_at: { type: 'timestamp', nullable: true },
     revision: { type: 'integer', default: 1 },
     created_by: { type: 'text' },
@@ -503,6 +509,7 @@ interface WorkItemDbRow extends Record<string, unknown> {
   stage_history: WorkItemStageEntry[];
   sessions: WorkItemSessions;
   metadata: Record<string, unknown> | null;
+  triage_type: FactoryTriageType | null;
   autonomy_armed_at: Date | null;
   revision: number;
   created_by: string;
@@ -526,6 +533,7 @@ function toWorkItem(row: WorkItemDbRow): WorkItemRow {
     stageHistory: row.stage_history,
     sessions: row.sessions,
     metadata: row.metadata,
+    triageType: row.triage_type ?? null,
     autonomyArmedAt: row.autonomy_armed_at ?? null,
     revision: row.revision,
     createdBy: row.created_by,
@@ -544,6 +552,7 @@ function patchColumns(changes: Partial<WorkItemRow>): Partial<WorkItemDbRow> {
     ...(changes.stageHistory !== undefined ? { stage_history: changes.stageHistory } : {}),
     ...(changes.sessions !== undefined ? { sessions: changes.sessions } : {}),
     ...(changes.metadata !== undefined ? { metadata: changes.metadata } : {}),
+    ...(changes.triageType !== undefined ? { triage_type: changes.triageType } : {}),
     ...(changes.autonomyArmedAt !== undefined && changes.autonomyArmedAt !== null
       ? { autonomy_armed_at: changes.autonomyArmedAt }
       : {}),
@@ -1248,13 +1257,22 @@ export class WorkItemsStorage extends FactoryStorageDomain {
               return null;
             }
             const arm = input.armAutonomy === true && !existing.autonomyArmedAt;
+            const triageType = existing.triageType ?? input.triageType ?? null;
+            const classified = triageType !== existing.triageType;
             if (existing.stages.length === 1 && existing.stages[0] === input.destinationStage) {
-              // No stage change to commit; still honor arming without a revision
-              // bump, matching armAutonomy's standalone semantics.
-              return arm ? patchColumns({ autonomyArmedAt: now }) : null;
+              // Classification is part of a triage terminal handoff, so unlike
+              // arming alone it is a revisioned work-item change.
+              return arm || classified
+                ? patchColumns({
+                    ...(arm ? { autonomyArmedAt: now } : {}),
+                    ...(classified ? { triageType } : {}),
+                    ...(classified ? { revision: existing.revision + 1, updatedAt: now } : {}),
+                  })
+                : null;
             }
             return patchColumns({
               ...(arm ? { autonomyArmedAt: now } : {}),
+              ...(classified ? { triageType } : {}),
               stages: [input.destinationStage],
               stageHistory: applyStageTransition(
                 existing.stageHistory,

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -369,6 +369,8 @@ describe('getFactoryWorkspace', () => {
     expect(triage).toContain(
       'This records the classification without advancing; stop until a maintainer moves the card',
     );
+    expect(triage).toContain('triageType');
+    expect(triage).toContain('approval_required');
     const labelReconciliationIndex = handoff.indexOf(
       'After a GitHub comment is posted or updated, reconcile the labels',
     );


### PR DESCRIPTION
Factory now persists the triage classification and requires an authenticated human board move or run start before non-bug work can enter Planning or Execute. This keeps YOLO automation available for confirmed bugs while preventing feature requests from cascading through planning and build.

Verified with the Factory lifecycle test suite, `pnpm --filter @mastra/factory check`, `pnpm --filter @mastra/factory lint`, and `pnpm --filter @mastra/factory build:lib`. Manual UI verification remains pending an authenticated local Factory session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Factory now remembers whether work is a bug or a feature. Features need approval from an authenticated human before they can enter Planning or Execute, while confirmed bugs can still use YOLO automation.

## Changes

- Added persistent `triageType` support for work items.
- Added `FactoryTriageType`, validation, and the `approval_required` rejection code.
- Required triage agents to provide a valid classification.
- Blocked non-bug work from Planning and Execute without human approval.
- Preserved YOLO automation for confirmed bugs.
- Added authenticated `run_start` approval transitions.
- Prevented changes to an existing triage classification.
- Updated transition tools and Factory triage skill contracts.
- Added coverage for classification persistence, approval gates, replay handling, legacy transitions, and terminal feature transitions.
- Added a patch changeset for `@mastra/factory`.

## Verification

- Factory lifecycle tests passed.
- Package checks, linting, and library build passed.
- Manual UI verification remains pending an authenticated local Factory session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->