### PR TITLE
fix(memory): exclude OM continuation from persistence

### DIFF
--- a/.changeset/twelve-bars-camp.md
+++ b/.changeset/twelve-bars-camp.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory prompts appearing in stored conversation history.

--- a/packages/memory/src/processors/observational-memory/__tests__/idle-buffering.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/idle-buffering.test.ts
@@ -173,6 +173,41 @@ describe('turn.end() idle buffering', () => {
     expect(bufferedMessages).not.toContain(contextMessage);
   });
 
+  it('should exclude om-continuation from the idle buffer window', async () => {
+    const realMessages = createMessages(2);
+    const memoryMessage = createTestMessage('Durable memory context', 'user', 'memory-1');
+    const continuationMessage = createTestMessage(
+      '<system-reminder>Continue naturally</system-reminder>',
+      'user',
+      'om-continuation',
+      new Date(0),
+    );
+    const allMessages = [...realMessages, memoryMessage, continuationMessage];
+
+    const mockOM = createMockOM({ asyncEnabled: true });
+    mockOM.getUnobservedMessages = vi.fn((messages: MastraDBMessage[]) => messages);
+    const mockMessageList = createMockMessageList(allMessages);
+
+    const turn = new ObservationTurn({
+      om: mockOM as any,
+      threadId,
+      resourceId,
+      messageList: mockMessageList as any,
+      sendSignal: vi.fn(),
+      requestContext: { get: vi.fn() } as any,
+    });
+
+    (turn as any)._started = true;
+    (turn as any)._record = mockOM._mockRecord;
+
+    await turn.end();
+
+    expect(mockMessageList.get.all.db().map(m => m.id)).toContain('om-continuation');
+    expect(mockOM.buffer).toHaveBeenCalledTimes(1);
+    const bufferedMessages = (mockOM.buffer as any).mock.calls[0][0].messages as MastraDBMessage[];
+    expect(bufferedMessages.map(m => m.id)).toEqual([...realMessages.map(m => m.id), 'memory-1']);
+  });
+
   it('should NOT trigger buffer() when bufferOnIdle is disabled', async () => {
     const messages = createMessages(5);
     const mockOM = createMockOM({ asyncEnabled: true, bufferOnIdle: false, unobservedMessages: messages });

--- a/packages/memory/src/processors/observational-memory/__tests__/message-utils.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/message-utils.test.ts
@@ -31,12 +31,18 @@ describe('getObservableMessages', () => {
     expect(getObservableMessages(messageList).map(m => m.id)).toEqual(['input-1', 'response-1']);
   });
 
-  it('returns the full list when there are no context messages', () => {
+  it('keeps the synthetic continuation live while excluding it from the OM window', () => {
     const messageList = new MessageList({ threadId: THREAD_ID, resourceId: RESOURCE_ID });
     messageList.add(createMessage('input-1', 'hello'), 'input');
+    messageList.add(createMessage('memory-1', 'durable memory context'), 'memory');
+    messageList.add(
+      createMessage('om-continuation', '<system-reminder>Continue naturally</system-reminder>'),
+      'memory',
+    );
     messageList.add(createMessage('response-1', 'hi', 'assistant'), 'response');
 
-    expect(getObservableMessages(messageList).map(m => m.id)).toEqual(messageList.get.all.db().map(m => m.id));
+    expect(messageList.get.all.db().map(m => m.id)).toContain('om-continuation');
+    expect(getObservableMessages(messageList).map(m => m.id)).toEqual(['input-1', 'memory-1', 'response-1']);
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -17015,6 +17015,8 @@ describe('Message ordering regressions', () => {
   async function setupOrderingScenario(opts: {
     messageTokens: number;
     bufferTokens?: number | false;
+    bufferActivation?: number;
+    seedMessages?: boolean;
     observerDelay?: number;
   }) {
     const { MessageList } = await import('@mastra/core/agent');
@@ -17064,6 +17066,7 @@ describe('Message ordering regressions', () => {
       observation: {
         messageTokens: opts.messageTokens,
         ...(bufferTokensConfig !== false ? { bufferTokens: bufferTokensConfig } : { bufferTokens: false }),
+        ...(opts.bufferActivation !== undefined ? { bufferActivation: opts.bufferActivation } : {}),
       },
       reflection: { observationTokens: 200_000 },
     });
@@ -17093,7 +17096,9 @@ describe('Message ordering regressions', () => {
       type: 'text',
       createdAt: new Date(Date.UTC(2025, 0, 1, 8, 30 + i)),
     }));
-    await storage.saveMessages({ messages: seedMessages });
+    if (opts.seedMessages !== false) {
+      await storage.saveMessages({ messages: seedMessages });
+    }
 
     const state: Record<string, unknown> = {};
     const capturedParts: any[] = [];
@@ -17562,13 +17567,30 @@ describe('Message ordering regressions', () => {
   });
 
   it('om-continuation stays live but is excluded from synchronous persistence', async () => {
-    const s = await setupOrderingScenario({ messageTokens: 1 });
+    // Active observations with no completed observation cursor reproduce the window where
+    // a later buffering step can synchronously persist the injected continuation.
+    const s = await setupOrderingScenario({
+      messageTokens: 1000,
+      bufferTokens: 1,
+      bufferActivation: 1,
+      seedMessages: false,
+    });
+    const record = await s.om.getOrCreateRecord(s.threadId, s.resourceId);
+    await s.storage.updateActiveObservations({
+      id: record.id,
+      observations: '* 🟡 Existing observation enables continuation context',
+      tokenCount: 8,
+      lastObservedAt: null,
+    });
 
-    const firstUserId = s.addUserMessage('Start a conversation that activates observations');
+    const firstUserId = s.addUserMessage('Start a conversation with active observations');
     await s.runStep(0);
     expect(s.currentMessageList.get.all.db().map(m => m.id)).toContain('om-continuation');
+    expect((await s.getStoredMessages()).map(m => m.id)).not.toContain('om-continuation');
 
-    const secondUserId = s.addUserMessage('Continue after observational context is injected');
+    await s.om.waitForBuffering(s.threadId, s.resourceId, 5000);
+
+    const secondUserId = s.addUserMessage(`Continue after observational context is injected ${'word '.repeat(80)}`);
     await s.runStep(1);
 
     const liveIds = s.currentMessageList.get.all.db().map(m => m.id);

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -17561,6 +17561,25 @@ describe('Message ordering regressions', () => {
     expect(result.messages.some(m => m.id === 'seed-1')).toBe(true);
   });
 
+  it('om-continuation stays live but is excluded from synchronous persistence', async () => {
+    const s = await setupOrderingScenario({ messageTokens: 1 });
+
+    const firstUserId = s.addUserMessage('Start a conversation that activates observations');
+    await s.runStep(0);
+    expect(s.currentMessageList.get.all.db().map(m => m.id)).toContain('om-continuation');
+
+    const secondUserId = s.addUserMessage('Continue after observational context is injected');
+    await s.runStep(1);
+
+    const liveIds = s.currentMessageList.get.all.db().map(m => m.id);
+    const storedIds = (await s.getStoredMessages()).map(m => m.id);
+
+    expect(liveIds).toContain('om-continuation');
+    expect(storedIds).toContain(firstUserId);
+    expect(storedIds).toContain(secondUserId);
+    expect(storedIds).not.toContain('om-continuation');
+  });
+
   // ─── Test 4: all messages present in storage after processOutputResult ───
 
   it('4 — all messages present in storage immediately after processOutputResult', async () => {

--- a/packages/memory/src/processors/observational-memory/message-utils.ts
+++ b/packages/memory/src/processors/observational-memory/message-utils.ts
@@ -178,20 +178,20 @@ function getUnobservedPartsPreservingToolCallPairs(message: MastraDBMessage): Ma
 /**
  * Get the messages Observational Memory is allowed to work with.
  *
- * Messages supplied through the `context` option are per-run ephemeral input. Core's
- * persistence contract already treats them as never-persist: `MessageStateManager` routes
- * them into `userContextMessages`, and `drainUnsavedMessages` only drains input/response.
+ * Messages supplied through the `context` option and the synthetic `om-continuation`
+ * message are prompt-only input. Core's persistence contract already treats context as
+ * never-persist, while the continuation remains memory-sourced so it can stay in the live
+ * actor prompt.
  *
- * OM builds its windows from `get.all.db()`, which includes context messages, and then
- * seals and persists candidates directly — turning ephemeral context into durable user
- * messages. Excluding them here keeps OM's window, sealing, persistence and token
- * accounting consistent with that contract.
+ * OM builds its windows from `get.all.db()`, which includes both categories, and then seals
+ * and persists candidates directly. Excluding them here keeps OM's observation, buffering,
+ * persistence, and token accounting consistent with their ephemeral contract.
  */
 export function getObservableMessages(messageList: MessageList): MastraDBMessage[] {
-  const allMessages = messageList.get.all.db();
   const contextMessageIds = messageList.makeMessageSourceChecker().context;
-  if (contextMessageIds.size === 0) return allMessages;
-  return allMessages.filter(message => !contextMessageIds.has(message.id));
+  return messageList.get.all.db().filter(message => {
+    return message.id !== 'om-continuation' && !contextMessageIds.has(message.id);
+  });
 }
 
 /**


### PR DESCRIPTION
Observational memory injects a synthetic `om-continuation` message into the live prompt, but OM also included that message in its persistence windows. This could make internal continuation guidance appear in stored conversation history.

Before:

```ts
return allMessages.filter(message => !contextMessageIds.has(message.id));
```

After:

```ts
return messageList.get.all.db().filter(message => {
  return message.id !== 'om-continuation' && !contextMessageIds.has(message.id);
});
```

The continuation stays available to the live actor prompt while being excluded from OM observation, buffering, token accounting, and direct persistence. Normal memory messages and durable dynamic system reminders continue to persist.

Covered by the focused OM tests, the full memory unit suite, typecheck, build, lint, and a built-artifact red/green persistence demo. The storage integration harness did not collect because its documented local install is currently blocked by a lockfile override mismatch and missing `execa`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR stops an internal continuation message from being saved in conversation history. The message remains available while the actor runs, while normal memory messages continue to persist.

## Changes

- Exclude `om-continuation` from observational-memory messages, buffering, token accounting, and persistence.
- Continue to persist normal memory messages and durable dynamic system reminders.
- Add regression tests for observable messages, idle buffering, and persisted storage.
- Add a patch changeset for `@mastra/memory`.

## Validation

- Focused observational-memory tests
- Full memory unit suite: 40 files and 1,315 tests
- Typecheck
- Build
- Lint
- Built-artifact persistence demo

The storage integration harness did not collect because its documented local setup has a lockfile override mismatch and missing `execa`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->