### PR TITLE
fix(core): stamp inference start on the step-start stream chunk

### DIFF
--- a/.changeset/red-nails-own.md
+++ b/.changeset/red-nails-own.md
@@ -1,0 +1,22 @@
+---
+'@mastra/core': minor
+---
+
+Added `startedAt` to the `step-start` stream chunk: the epoch-millisecond instant a step's model inference began, stamped immediately before the provider call on both the regular and the durable engine.
+
+Consumers that measure time to first token previously had to use the time the `step-start` chunk arrived. That does not work on durable agents, which emit `step-start` from inside their chunk loop, after the provider has already produced its first chunk. The gap between `step-start` and the first content chunk was microseconds, so the entire prefill window fell outside every measurement.
+
+```ts
+for await (const chunk of stream.fullStream) {
+  if (chunk.type === 'step-start') {
+    // before: only the arrival time was available, and on a durable agent
+    // that instant is already past the model's prefill
+    stepStartedAt = Date.now();
+
+    // after: the real inference start travels on the chunk
+    stepStartedAt = chunk.payload.startedAt ?? Date.now();
+  }
+}
+```
+
+The field is optional, so a replayed or persisted stream that lacks it can still fall back to arrival time.

--- a/docs/src/content/en/reference/streaming/ChunkType.mdx
+++ b/docs/src/content/en/reference/streaming/ChunkType.mdx
@@ -949,6 +949,13 @@ Signals the start of a processing step.
             isOptional: true,
             description: 'Any warnings from the language model call',
           },
+          {
+            name: 'startedAt',
+            type: 'number',
+            isOptional: true,
+            description:
+              "Epoch milliseconds at which this step's model inference started, stamped immediately before the provider call. Use this rather than the time the chunk arrives when measuring time to first token: durable agents emit step-start after the provider's first chunk, so arrival time excludes the whole prefill window. Absent on a replayed or persisted stream, in which case fall back to arrival time.",
+          },
         ],
       },
     ],

--- a/docs/src/content/en/reference/streaming/ChunkType.mdx
+++ b/docs/src/content/en/reference/streaming/ChunkType.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Reference: ChunkType | Streaming"
-description: "Documentation for the ChunkType type used in Mastra streaming responses, defining all possible chunk types and their payloads."
+title: 'Reference: ChunkType | Streaming'
+description: 'Documentation for the ChunkType type used in Mastra streaming responses, defining all possible chunk types and their payloads.'
 packages:
-  - "@mastra/core"
+  - '@mastra/core'
 ---
 
-import PropertiesTable from "@site/src/components/PropertiesTable";
+import PropertiesTable from '@site/src/components/PropertiesTable';
 
 # ChunkType
 

--- a/packages/core/src/agent/durable/step-start-timing.test.ts
+++ b/packages/core/src/agent/durable/step-start-timing.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression tests for `step-start.payload.startedAt`.
+ *
+ * `step-start` carried no timestamp, so a consumer measuring time to first
+ * token had to use the chunk's arrival time. On the durable engine that is not
+ * a usable start instant: `step-start` is published from inside the chunk loop
+ * in `workflows/steps/llm-execution.ts`, which only runs once the provider has
+ * already produced its first chunk. The gap between `step-start` and the first
+ * content chunk is then microseconds, and the entire prefill window lands in no
+ * bucket at all.
+ *
+ * `startedAt` is stamped where the MODEL_INFERENCE span opens, immediately
+ * before the provider call, on both the durable and the regular engine.
+ */
+
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EventEmitterPubSub } from '../../events/event-emitter';
+import { Agent } from '../agent';
+import { createDurableAgent } from './create-durable-agent';
+
+/** Milliseconds the mock provider spends before yielding its first chunk. */
+const PREFILL_MS = 150;
+/** Slack for timer coarseness so the assertions do not flake under load. */
+const PREFILL_LOWER_BOUND_MS = 80;
+
+function createSlowModel(text: string) {
+  return new MockLanguageModelV2({
+    doStream: async () => {
+      // Stand in for provider prefill: the model is reached, and takes this
+      // long to produce anything.
+      await new Promise(resolve => setTimeout(resolve, PREFILL_MS));
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: text },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+      };
+    },
+  });
+}
+
+/** Reads a stream, recording when each chunk was observed. */
+async function collectWithArrival(stream: ReadableStream<any>) {
+  const chunks: { chunk: any; arrivedAt: number }[] = [];
+  for await (const chunk of stream) {
+    chunks.push({ chunk, arrivedAt: Date.now() });
+  }
+  return chunks;
+}
+
+describe('step-start startedAt', () => {
+  let pubsub: EventEmitterPubSub;
+
+  beforeEach(() => {
+    pubsub = new EventEmitterPubSub();
+  });
+
+  afterEach(async () => {
+    await pubsub.close();
+  });
+
+  it('durable step-start carries the inference start, not the emit time', async () => {
+    const agent = new Agent({
+      id: 'step-start-timing-durable',
+      name: 'Step Start Timing Durable',
+      instructions: 'Respond briefly.',
+      model: createSlowModel('Hello!'),
+    });
+    const durable = createDurableAgent({ agent, pubsub });
+
+    const startedStreaming = Date.now();
+    const { output, cleanup } = await durable.stream('Say hello');
+    const observed = await collectWithArrival(output.fullStream);
+    cleanup();
+
+    const stepStart = observed.find(entry => entry.chunk.type === 'step-start');
+    expect(stepStart).toBeDefined();
+
+    const startedAt = stepStart!.chunk.payload.startedAt;
+    expect(typeof startedAt).toBe('number');
+
+    // The stamp predates the chunk that carries it by roughly the prefill.
+    // This is the whole point: arrival time cannot recover this window,
+    // because the emit happens after the provider's first chunk.
+    expect(stepStart!.arrivedAt - startedAt).toBeGreaterThanOrEqual(PREFILL_LOWER_BOUND_MS);
+
+    // And it is a real instant from this run, not a stale or future value.
+    expect(startedAt).toBeGreaterThanOrEqual(startedStreaming);
+    expect(startedAt).toBeLessThanOrEqual(stepStart!.arrivedAt);
+  });
+
+  it('durable time to first token computed from startedAt is non-zero', async () => {
+    const agent = new Agent({
+      id: 'step-start-timing-ttft',
+      name: 'Step Start Timing TTFT',
+      instructions: 'Respond briefly.',
+      model: createSlowModel('Hello!'),
+    });
+    const durable = createDurableAgent({ agent, pubsub });
+
+    const { output, cleanup } = await durable.stream('Say hello');
+    const observed = await collectWithArrival(output.fullStream);
+    cleanup();
+
+    const stepStart = observed.find(entry => entry.chunk.type === 'step-start');
+    const firstText = observed.find(entry => entry.chunk.type === 'text-delta');
+    expect(stepStart).toBeDefined();
+    expect(firstText).toBeDefined();
+
+    const ttftFromStamp = firstText!.arrivedAt - stepStart!.chunk.payload.startedAt;
+    expect(ttftFromStamp).toBeGreaterThanOrEqual(PREFILL_LOWER_BOUND_MS);
+
+    // The value the same consumer would have computed before this change,
+    // kept as the contrast that motivates the field.
+    const ttftFromArrival = firstText!.arrivedAt - stepStart!.arrivedAt;
+    expect(ttftFromArrival).toBeLessThan(ttftFromStamp);
+  });
+
+  it('the regular engine stamps startedAt on step-start too', async () => {
+    const agent = new Agent({
+      id: 'step-start-timing-regular',
+      name: 'Step Start Timing Regular',
+      instructions: 'Respond briefly.',
+      model: createSlowModel('Hello!'),
+    });
+
+    const startedStreaming = Date.now();
+    const stream = await agent.stream('Say hello');
+    const observed = await collectWithArrival(stream.fullStream);
+
+    const stepStart = observed.find(entry => entry.chunk.type === 'step-start');
+    expect(stepStart).toBeDefined();
+
+    const startedAt = stepStart!.chunk.payload.startedAt;
+    expect(typeof startedAt).toBe('number');
+    expect(startedAt).toBeGreaterThanOrEqual(startedStreaming);
+    expect(startedAt).toBeLessThanOrEqual(stepStart!.arrivedAt);
+
+    // The regular engine emits step-start at stream open rather than after the
+    // first chunk, so the recoverable prefill is smaller than on the durable
+    // path, but the stamp still predates the provider's first output.
+    const firstText = observed.find(entry => entry.chunk.type === 'text-delta');
+    expect(firstText).toBeDefined();
+    expect(firstText!.arrivedAt - startedAt).toBeGreaterThanOrEqual(PREFILL_LOWER_BOUND_MS);
+  });
+});

--- a/packages/core/src/agent/durable/step-start-timing.test.ts
+++ b/packages/core/src/agent/durable/step-start-timing.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitterPubSub } from '../../events/event-emitter';
 import { Agent } from '../agent';
 import { createDurableAgent } from './create-durable-agent';
@@ -56,6 +56,34 @@ async function collectWithArrival(stream: ReadableStream<any>) {
     chunks.push({ chunk, arrivedAt: Date.now() });
   }
   return chunks;
+}
+
+/** How much older than "now" the persisted cache entry pretends to be. */
+const CACHE_ENTRY_AGE_MS = 60_000;
+
+/**
+ * Cached chunks shaped like a real {@link ResponseCache} entry: post-transform
+ * Mastra chunks with runId/from stripped, including a `step-start` whose
+ * `startedAt` is the original invocation's (long-past) start instant.
+ */
+function createCachedChunks(startedAt: number) {
+  return [
+    { type: 'step-start', payload: { request: {}, warnings: [], messageId: 'msg-cached', startedAt } },
+    { type: 'stream-start', payload: { warnings: [] } },
+    { type: 'response-metadata', payload: { id: 'resp-cached', modelId: 'mock', timestamp: new Date(0) } },
+    { type: 'text-start', payload: { id: 'text-1' } },
+    { type: 'text-delta', payload: { id: 'text-1', text: 'cached response' } },
+    { type: 'text-end', payload: { id: 'text-1' } },
+    {
+      type: 'finish',
+      payload: {
+        stepResult: { reason: 'stop' },
+        output: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+        metadata: {},
+        messages: { all: [], user: [], nonUser: [] },
+      },
+    },
+  ];
 }
 
 describe('step-start startedAt', () => {
@@ -152,5 +180,82 @@ describe('step-start startedAt', () => {
     const firstText = observed.find(entry => entry.chunk.type === 'text-delta');
     expect(firstText).toBeDefined();
     expect(firstText!.arrivedAt - startedAt).toBeGreaterThanOrEqual(PREFILL_LOWER_BOUND_MS);
+  });
+
+  it('cache replay refreshes startedAt instead of replaying the cache entry age', async () => {
+    const persistedStartedAt = Date.now() - CACHE_ENTRY_AGE_MS;
+    const doStreamSpy = vi.fn();
+    const agent = new Agent({
+      id: 'step-start-cache-replay-durable',
+      name: 'Step Start Cache Replay Durable',
+      instructions: 'Respond briefly.',
+      model: new MockLanguageModelV2({ doStream: doStreamSpy }),
+      inputProcessors: [
+        {
+          id: 'response-cache-processor',
+          processLLMRequest: vi.fn().mockReturnValue({
+            response: {
+              chunks: createCachedChunks(persistedStartedAt),
+              warnings: [],
+              request: { body: 'cached-request' },
+              rawResponse: { status: 200 },
+            },
+          }),
+        },
+      ],
+    });
+    const durable = createDurableAgent({ agent, pubsub });
+
+    const beforeReplay = Date.now();
+    const { output, cleanup } = await durable.stream('Say hello');
+    const observed = await collectWithArrival(output.fullStream);
+    cleanup();
+
+    expect(doStreamSpy).not.toHaveBeenCalled();
+    const stepStarts = observed.filter(entry => entry.chunk.type === 'step-start');
+    expect(stepStarts.length).toBeGreaterThanOrEqual(1);
+    for (const entry of stepStarts) {
+      // The stamp must be the replay instant, not the persisted one: a
+      // consumer subtracting it from the first chunk's arrival would
+      // otherwise measure how old the cache entry is.
+      expect(entry.chunk.payload.startedAt).toBeGreaterThanOrEqual(beforeReplay);
+      expect(entry.chunk.payload.startedAt).not.toBe(persistedStartedAt);
+    }
+  });
+
+  it('regular engine cache replay refreshes startedAt too', async () => {
+    const persistedStartedAt = Date.now() - CACHE_ENTRY_AGE_MS;
+    const doStreamSpy = vi.fn();
+    const agent = new Agent({
+      id: 'step-start-cache-replay-regular',
+      name: 'Step Start Cache Replay Regular',
+      instructions: 'Respond briefly.',
+      model: new MockLanguageModelV2({ doStream: doStreamSpy }),
+      inputProcessors: [
+        {
+          id: 'response-cache-processor',
+          processLLMRequest: vi.fn().mockReturnValue({
+            response: {
+              chunks: createCachedChunks(persistedStartedAt),
+              warnings: [],
+              request: { body: 'cached-request' },
+              rawResponse: { status: 200 },
+            },
+          }),
+        },
+      ],
+    });
+
+    const beforeReplay = Date.now();
+    const stream = await agent.stream('Say hello');
+    const observed = await collectWithArrival(stream.fullStream);
+
+    expect(doStreamSpy).not.toHaveBeenCalled();
+    const stepStarts = observed.filter(entry => entry.chunk.type === 'step-start');
+    expect(stepStarts.length).toBeGreaterThanOrEqual(1);
+    for (const entry of stepStarts) {
+      expect(entry.chunk.payload.startedAt).toBeGreaterThanOrEqual(beforeReplay);
+      expect(entry.chunk.payload.startedAt).not.toBe(persistedStartedAt);
+    }
   });
 });

--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -670,6 +670,7 @@ export async function emitStepStartEvent(
     messageId?: string;
     request?: StepStartPayload['request'];
     warnings?: StepStartPayload['warnings'];
+    startedAt?: StepStartPayload['startedAt'];
   },
 ): Promise<void> {
   const chunk: Extract<ChunkType, { type: 'step-start' }> = {

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -927,6 +927,11 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               responseFormat: structuredOutput ? 'json_schema' : undefined,
             });
             modelSpanTracker?.startInference?.();
+            // The instant inference starts, carried on `step-start` below.
+            // This step emits `step-start` from inside the chunk loop (it needs
+            // the provider's `warnings`), which is already past the prefill
+            // window, so the chunk's arrival time cannot stand in for it.
+            const inferenceStartedAt = Date.now();
 
             // Collect chunks for post-stream message building (via
             // buildMessagesFromChunks) and for the processLLMResponse hook
@@ -1069,6 +1074,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                     stepId: DurableStepIds.LLM_EXECUTION,
                     messageId: currentMessageId,
                     warnings,
+                    startedAt: inferenceStartedAt,
                   });
                 }
 

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -958,6 +958,10 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 messageId: currentMessageId,
               });
               const replayChunks = cachedResponse.chunks;
+              // Cache replay skips the model call entirely, so the persisted
+              // `startedAt` would make TTFT consumers measure the cache entry's
+              // age. Stamp the replay instant instead.
+              const replayStartedAt = Date.now();
               modelResult = new ReadableStream({
                 start(ctrl) {
                   for (const chunk of replayChunks) {
@@ -965,6 +969,9 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                       ...chunk,
                       runId,
                       from: ChunkFrom.AGENT,
+                      ...(chunk.type === 'step-start'
+                        ? { payload: { ...chunk.payload, startedAt: replayStartedAt } }
+                        : {}),
                     });
                   }
                   ctrl.close();

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -6453,6 +6453,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
     "payload": {
       "messageId": "msg-0",
       "request": {},
+      "startedAt": 1704067200000,
       "warnings": [],
     },
     "runId": "test-run-id",
@@ -6801,6 +6802,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
     "payload": {
       "messageId": "msg-0",
       "request": {},
+      "startedAt": 1704067200000,
       "warnings": [],
     },
     "runId": "test-run-id",
@@ -7509,6 +7511,7 @@ exports[`Loop Tests > AISDK v5 > tools with custom schema > should send tool cal
     "payload": {
       "messageId": "id-0",
       "request": {},
+      "startedAt": 1704067200000,
       "warnings": [],
     },
     "runId": "test-run-id",

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -510,6 +510,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
               "payload": {
                 "messageId": "id-0",
                 "request": {},
+                "startedAt": 1704067200000,
                 "warnings": [],
               },
               "runId": "test-run-id",
@@ -940,6 +941,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
               "payload": {
                 "messageId": "id-0",
                 "request": {},
+                "startedAt": 1704067200000,
                 "warnings": [],
               },
               "runId": "test-run-id",
@@ -5068,7 +5070,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
           runId: 'test-run-id',
           from: 'AGENT',
           type: 'step-start',
-          payload: { request: {}, warnings: [], messageId: 'id-0' },
+          payload: { request: {}, warnings: [], messageId: 'id-0', startedAt: expect.any(Number) },
         },
         {
           type: 'error',
@@ -8276,6 +8278,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
               "payload": {
                 "messageId": "id-0",
                 "request": {},
+                "startedAt": 1704067200000,
                 "warnings": [],
               },
               "runId": "test-run-id",
@@ -8602,6 +8605,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
               "payload": {
                 "messageId": "msg-0",
                 "request": {},
+                "startedAt": 1704067200000,
                 "warnings": [],
               },
               "runId": "test-run-id",
@@ -8872,6 +8876,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
               "payload": {
                 "messageId": "msg-0",
                 "request": {},
+                "startedAt": 1704067200000,
                 "warnings": [],
               },
               "runId": "test-run-id",

--- a/packages/core/src/loop/test-utils/utils.ts
+++ b/packages/core/src/loop/test-utils/utils.ts
@@ -12,6 +12,13 @@ import { Mastra } from '../../mastra';
 import { InMemoryStore } from '../../storage';
 import { MastraLanguageModelV2Mock as MockLanguageModelV2 } from './MastraLanguageModelV2Mock';
 
+/**
+ * Keys whose value is a wall-clock instant from the run itself, so they differ
+ * on every execution and cannot live in a snapshot. `startedAt` is the
+ * inference start stamped onto `step-start`.
+ */
+const VOLATILE_TIMESTAMP_KEYS = new Set(['createdAt', 'startedAt']);
+
 export function stripMastraCreatedAt<T>(value: T): T {
   if (Array.isArray(value)) {
     return value.map(item => stripMastraCreatedAt(item)) as T;
@@ -23,7 +30,7 @@ export function stripMastraCreatedAt<T>(value: T): T {
 
   if (value && typeof value === 'object') {
     const normalizedEntries = Object.entries(value).map(([key, nestedValue]) => {
-      if (key === 'createdAt') {
+      if (VOLATILE_TIMESTAMP_KEYS.has(key)) {
         return null;
       }
 

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1712,6 +1712,10 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             responseFormat: currentStep.structuredOutput ? 'json_schema' : undefined,
           });
           modelSpanTracker?.startInference?.();
+          // Same instant the MODEL_INFERENCE span opens, carried on
+          // `step-start` below so consumers can measure prefill without
+          // relying on when the chunk reaches them.
+          const inferenceStartedAt = Date.now();
 
           modelResult = executeWithContextSync({
             span: modelSpanTracker?.getTracingContext()?.currentSpan,
@@ -1770,6 +1774,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                       request: request || {},
                       warnings: warnings || [],
                       messageId: currentStep.messageId,
+                      startedAt: inferenceStartedAt,
                     },
                   };
                 },

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1679,6 +1679,10 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             messageId: currentStep.messageId,
           });
           const replayChunks = cachedResponse.chunks;
+          // Cache replay skips the model call entirely, so the persisted
+          // `startedAt` would make TTFT consumers measure the cache entry's
+          // age. Stamp the replay instant instead.
+          const replayStartedAt = Date.now();
           modelResult = new ReadableStream({
             start(controller) {
               for (const chunk of replayChunks) {
@@ -1687,6 +1691,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                   ...chunk,
                   runId,
                   from: ChunkFrom.AGENT,
+                  ...(chunk.type === 'step-start' ? { payload: { ...chunk.payload, startedAt: replayStartedAt } } : {}),
                 });
               }
               controller.close();

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -299,6 +299,22 @@ export interface StepStartPayload {
   };
   inputMessages?: LanguageModelV2Prompt;
   warnings?: LanguageModelV2CallWarning[];
+  /**
+   * Epoch milliseconds at which this step's model inference started, stamped
+   * at the same point that opens the MODEL_INFERENCE span (immediately before
+   * the provider call, after input processors and `prepareStep`).
+   *
+   * Consumers that measure time to first token need a start instant that is
+   * independent of when the chunk reaches them. Arrival time does not work:
+   * the durable engine emits `step-start` from inside its chunk loop, once the
+   * provider has already produced its first chunk, so the gap between
+   * `step-start` and the first content chunk is microseconds and the whole
+   * prefill window falls outside every bucket.
+   *
+   * Optional because a replayed or persisted stream can reach a consumer
+   * without it; fall back to arrival time in that case.
+   */
+  startedAt?: number;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Description

Adds an optional `startedAt` (epoch milliseconds) to `StepStartPayload`, stamped at the point that already opens the MODEL_INFERENCE span, immediately before the provider call, on both the durable and the regular engine.

Without it the only start instant a stream consumer has is when the `step-start` chunk reached it. On `DurableAgent` that is unusable: the chunk is published from inside the LLM step's chunk loop, so the emit happens after the provider has already produced its first chunk, and the gap to the first `text-delta` is microseconds. Any time to first token computed from the stream is then structurally near zero, and the prefill window belongs to no bucket. Measured on a production thread (`@mastra/core` 1.58.0, Anthropic via OpenRouter): the consumer read `TTFT avg 0s` while the MODEL_INFERENCE spans for the same run showed 1.4s to 2.4s per step, 13.5s of a 21.2s turn. Details and a reproduction in #22323.

The stamp point is the same one whose existing comment explains that the inference span starts there so it excludes input processors and `prepareStep`. That is the boundary a TTFT measurement wants, and using it keeps the field's meaning identical to the span it mirrors.

The field is optional, so a replayed or persisted stream without it can still fall back to arrival time. `redactStreamChunk` in `@mastra/server` spreads the rest of the payload, so the field survives redaction and reaches HTTP consumers unchanged.

## Related issue(s)

Fixes #22323

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## What changed

`StepStartPayload` gains `startedAt?: number`. The durable LLM step captures the instant right after `startInference()` and passes it through `emitStepStartEvent`, whose parameter type widens to accept it; the payload already spreads, so nothing else in the adapter changes. The regular `llm-execution-step` captures the same instant at its own `startInference()` and includes it in the `step-start` chunk built in `onResult`.

Two test-side adjustments were needed because the value is a wall clock instant. `stripMastraCreatedAt` already exists to drop volatile timestamps before snapshotting, and now drops `startedAt` alongside `createdAt`; no existing snapshot asserted a `startedAt`, so nothing is hidden. Five snapshots taken under the suite's fake timers, plus one hardcoded expectation in `test-utils/options.ts`, were updated to include the field.

## How this was verified

- New `packages/core/src/agent/durable/step-start-timing.test.ts`, three tests: the durable stamp predates the chunk carrying it by roughly the mock provider's 150ms prefill; TTFT computed from the stamp is non-zero while the arrival-based value is strictly smaller; the regular engine stamps the field too. Reverting the two producer edits fails all three ("expected 'undefined' to be 'number'", and `NaN` for the TTFT assertion), so they fail for the reason claimed. Ran three times for flakiness, stable.
- `packages/core`: `src/loop`, `src/agent/durable` and `src/stream` all pass, 2094 tests over 227 files. `src/agent` passes, 3850 tests over 340 files.
- Three `TypeCheckError`s on `src/storage/domains/observability/inmemory.ts` show up in the `src/agent/durable` run. They are pre-existing: the same three appear on a clean tree at 892bf070b0, in a file this PR does not touch.
- `oxfmt --check` clean on the changed package files; `eslint` clean on them.
- Not verified: no end-to-end run against a real provider, and no check of `@mastra/ai-sdk`'s converter beyond reading it. The field is additive and optional, so an unaware consumer ignores it.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

`step-start` now records when model processing begins. Consumers can use this timestamp to measure time to first token accurately, including for durable agents and replayed responses.

## Changes

- Added optional `startedAt` epoch-millisecond field to `StepStartPayload`.
- Set `startedAt` immediately before provider inference starts in regular and durable engines.
- Refreshed `startedAt` when replaying cached `step-start` chunks.
- Preserved compatibility with older or persisted streams through arrival-time fallback.
- Updated documentation, snapshots, timestamp helpers, and expected payloads.
- Added timing and cache-replay tests for regular and durable engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->