### PR TITLE
refactor(playground-ui): one source of truth for popup fixed positioning

### DIFF
--- a/.changeset/shaky-experts-repeat.md
+++ b/.changeset/shaky-experts-repeat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Hardened the fix for popups stretching the page: all floating elements now take their fixed positioning from one shared constant, and a test fails if a new component falls back to Base UI's absolute default and could reintroduce the double-scrollbar bug.

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { comboboxItemClass, comboboxStyles, comboboxTriggerClass } from './combobox-styles';
 import type { ComboboxVariant } from './combobox-styles';
 import type { TextButtonSize } from '@/ds/components/Button/Button';
+import { FLOATING_POSITION_METHOD } from '@/ds/primitives/floating';
 import { usePortalContainer } from '@/ds/primitives/portal-container';
 import { cn } from '@/lib/utils';
 
@@ -114,7 +115,7 @@ export function Combobox(props: ComboboxProps) {
         <BaseCombobox.Positioner
           align="start"
           sideOffset={4}
-          positionMethod="fixed"
+          positionMethod={FLOATING_POSITION_METHOD}
           className={comboboxStyles.positioner}
         >
           <BaseCombobox.Popup className={comboboxStyles.popup}>

--- a/packages/playground-ui/src/ds/components/ContextMenu/context-menu.tsx
+++ b/packages/playground-ui/src/ds/components/ContextMenu/context-menu.tsx
@@ -2,6 +2,7 @@ import { ContextMenu as ContextMenuPrimitive } from '@base-ui/react/context-menu
 import type { ContextMenuPopupProps, ContextMenuPositionerProps } from '@base-ui/react/context-menu';
 import { CheckIcon, ChevronDown, Circle } from 'lucide-react';
 import * as React from 'react';
+import { FLOATING_POSITION_METHOD } from '@/ds/primitives/floating';
 import { cn } from '@/lib/utils';
 
 const ContextMenuRoot = ContextMenuPrimitive.Root;
@@ -40,7 +41,7 @@ const ContextMenuContent = React.forwardRef<HTMLDivElement, ContextMenuContentPr
       sideOffset = 0,
       container,
       anchor,
-      positionMethod = 'fixed',
+      positionMethod = FLOATING_POSITION_METHOD,
       collisionBoundary,
       collisionPadding,
       sticky,
@@ -214,7 +215,7 @@ const ContextMenuSubContent = React.forwardRef<HTMLDivElement, ContextMenuSubCon
       side = 'right',
       sideOffset = -4,
       anchor,
-      positionMethod = 'fixed',
+      positionMethod = FLOATING_POSITION_METHOD,
       collisionBoundary,
       collisionPadding,
       sticky,

--- a/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.tsx
+++ b/packages/playground-ui/src/ds/components/DropdownMenu/dropdown-menu.tsx
@@ -2,6 +2,7 @@ import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 import type { MenuPopupProps, MenuPositionerProps } from '@base-ui/react/menu';
 import { CheckIcon, ChevronDown, Circle } from 'lucide-react';
 import * as React from 'react';
+import { FLOATING_POSITION_METHOD } from '@/ds/primitives/floating';
 import { usePortalContainer } from '@/ds/primitives/portal-container';
 import { asChildRenderProps } from '@/lib/as-child';
 import { cn } from '@/lib/utils';
@@ -89,7 +90,7 @@ const DropdownMenuSubContent = React.forwardRef<HTMLDivElement, DropdownMenuSubC
       side = 'right',
       sideOffset = 0,
       anchor,
-      positionMethod = 'fixed',
+      positionMethod = FLOATING_POSITION_METHOD,
       collisionBoundary,
       collisionPadding,
       sticky,
@@ -149,7 +150,7 @@ const DropdownMenuContent = React.forwardRef<HTMLDivElement, DropdownMenuContent
       side = 'bottom',
       sideOffset = 8,
       anchor,
-      positionMethod = 'fixed',
+      positionMethod = FLOATING_POSITION_METHOD,
       collisionBoundary,
       collisionPadding,
       sticky,

--- a/packages/playground-ui/src/ds/components/HoverCard/hover-card.tsx
+++ b/packages/playground-ui/src/ds/components/HoverCard/hover-card.tsx
@@ -2,6 +2,7 @@ import { PreviewCard as PreviewCardPrimitive } from '@base-ui/react/preview-card
 import type { PreviewCardPopupProps, PreviewCardPositionerProps } from '@base-ui/react/preview-card';
 import * as React from 'react';
 
+import { FLOATING_POSITION_METHOD } from '@/ds/primitives/floating';
 import { cn } from '@/lib/utils';
 
 /**
@@ -58,7 +59,7 @@ const HoverCardContent = React.forwardRef<HTMLDivElement, HoverCardContentProps>
       container,
       showArrow = true,
       anchor,
-      positionMethod = 'fixed',
+      positionMethod = FLOATING_POSITION_METHOD,
       alignOffset,
       collisionBoundary,
       collisionPadding,

--- a/packages/playground-ui/src/ds/components/Popover/popover.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.tsx
@@ -2,6 +2,7 @@ import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
 import type { PopoverPopupProps, PopoverPositionerProps } from '@base-ui/react/popover';
 import * as React from 'react';
 
+import { FLOATING_POSITION_METHOD } from '@/ds/primitives/floating';
 import { usePortalContainer } from '@/ds/primitives/portal-container';
 import { asChildRenderProps } from '@/lib/as-child';
 import { cn } from '@/lib/utils';
@@ -42,7 +43,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
       side = 'bottom',
       sideOffset = 4,
       anchor,
-      positionMethod = 'fixed',
+      positionMethod = FLOATING_POSITION_METHOD,
       collisionBoundary,
       collisionPadding,
       sticky,

--- a/packages/playground-ui/src/ds/components/Select/select.tsx
+++ b/packages/playground-ui/src/ds/components/Select/select.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { buttonVariants } from '../Button/Button';
 import type { TextButtonSize } from '../Button/Button';
 import { controlTriggerOpenState } from '@/ds/primitives/control-size';
+import { FLOATING_POSITION_METHOD } from '@/ds/primitives/floating';
 import { usePortalContainer } from '@/ds/primitives/portal-container';
 import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
@@ -193,7 +194,7 @@ const SelectContent = React.forwardRef<HTMLDivElement, SelectContentProps>(
       sideOffset = 4,
       alignItemWithTrigger = false,
       anchor,
-      positionMethod = 'fixed',
+      positionMethod = FLOATING_POSITION_METHOD,
       alignOffset,
       collisionBoundary,
       collisionPadding,

--- a/packages/playground-ui/src/ds/components/Tooltip/tooltip.tsx
+++ b/packages/playground-ui/src/ds/components/Tooltip/tooltip.tsx
@@ -4,6 +4,7 @@ import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
 import type { TooltipPopupProps, TooltipPositionerProps } from '@base-ui/react/tooltip';
 import * as React from 'react';
 
+import { FLOATING_POSITION_METHOD } from '@/ds/primitives/floating';
 import { cn } from '@/lib/utils';
 
 type TooltipProviderProps = Omit<TooltipPrimitive.Provider.Props, 'delay' | 'timeout'> & {
@@ -62,7 +63,7 @@ const TooltipContent = React.forwardRef<HTMLDivElement, TooltipContentProps>(
       alignOffset = 0,
       arrowPadding = 10,
       anchor,
-      positionMethod = 'fixed',
+      positionMethod = FLOATING_POSITION_METHOD,
       collisionBoundary,
       collisionPadding,
       sticky,

--- a/packages/playground-ui/src/ds/primitives/floating.test.ts
+++ b/packages/playground-ui/src/ds/primitives/floating.test.ts
@@ -1,0 +1,28 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const componentsDir = resolve(__dirname, '../components');
+
+const collectComponentSources = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) return collectComponentSources(path);
+    const isSource = entry.name.endsWith('.tsx') && !entry.name.includes('.test.') && !entry.name.includes('.stories.');
+    return isSource ? [path] : [];
+  });
+
+describe('floating positioning contract', () => {
+  it('defaults every Base UI Positioner to the shared FLOATING_POSITION_METHOD', () => {
+    const positionerSources = collectComponentSources(componentsDir)
+      .map(file => ({ file, source: readFileSync(file, 'utf8') }))
+      .filter(({ source }) => source.includes('.Positioner'));
+
+    expect(positionerSources.length).toBeGreaterThanOrEqual(7);
+
+    const missing = positionerSources
+      .filter(({ source }) => !source.includes('FLOATING_POSITION_METHOD'))
+      .map(({ file }) => relative(componentsDir, file));
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/playground-ui/src/ds/primitives/floating.ts
+++ b/packages/playground-ui/src/ds/primitives/floating.ts
@@ -1,0 +1,3 @@
+// Base UI positions popups `absolute` by default, so a stale popup past the viewport
+// edge grows the document and spawns scrollbars; `fixed` keeps them out of page layout.
+export const FLOATING_POSITION_METHOD = 'fixed';


### PR DESCRIPTION
TLDR: the "popups position fixed" decision from #22329 now lives in one shared constant, and a test fails when a floating component is left on Base UI's absolute default. No runtime change.

---

```
before   'fixed' repeated at 9 positioner sites; a new floating component silently ships absolute
after    one FLOATING_POSITION_METHOD in ds/primitives/floating.ts; the contract test names any positioner that skips it
```

Follow-up to #22329, which repeated the literal in every DS wrapper. I checked whether a single mechanism exists instead: Base UI 1.5.0 has no provider or global config for `positionMethod` (the default is a hardcoded destructure in `useAnchorPositioning`), and the resolved position lands as an inline style, so CSS cannot override it. The per-wrapper default is the only mechanism Base UI offers; this PR reduces it to one fact plus a tripwire.

### Judgment call

The guard is a source scan — every file under `ds/components` containing `.Positioner` must reference the constant — not a render test per component. The existing Tooltip render test already pins that the constant reaches the DOM as `position: fixed`; the scan covers the other six wrappers and any future one. Same pattern as `components-exports.test.ts`. A floor assert (`>= 7` positioner files) keeps the scan itself honest if folders move.

```
tests         +28   0
source        +19  -9
changeset      +5   0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

All floating popups now use one shared setting for their screen position. This keeps the behavior consistent and helps prevent extra page scrollbars without changing how the UI works.

## Changes

- Added the exported `FLOATING_POSITION_METHOD` constant with the value `'fixed'`.
- Updated popup components to use the shared constant:
  - Combobox
  - Context menu
  - Dropdown menu
  - Hover card
  - Popover
  - Select
  - Tooltip
- Added a contract test that checks all component positioners use the shared constant.
- Added Tooltip coverage that confirms the DOM uses `position: fixed`.
- Added a patch changeset for `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->