### PR TITLE
chore: update Enterprise Edition license

### DIFF
--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,4 +1,5 @@
 Mastra Enterprise Edition (EE) License
+Version 1.0 (Effective August 24, 2026)
 
 Copyright (c) 2026 Kepler Software, Inc.
 
@@ -26,6 +27,11 @@ For purposes of the foregoing, "production" means any use of the Software
 beyond development and testing on your own systems. "Development and
 testing" includes running the Software locally or in a staging environment for the
 purpose of evaluating, developing, or testing modifications to the Software.
+
+If you (or any entity you represent) have entered into a written agreement with
+Kepler governing use of the Software, the limitation of liability, warranty, and
+termination provisions of that written agreement control over the corresponding
+provisions of this License to the extent of any conflict.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND “WITH ALL FAULTS” WITHOUT
 WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED


### PR DESCRIPTION
Updates the Mastra Enterprise Edition license to Version 1.0, effective August 24, 2026. It also clarifies that conflicting limitation-of-liability, warranty, and termination terms in a written agreement with Kepler take precedence over the license.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mastra-ai/mastra/pull/22336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The development server now shows a clear command for deployment. The Enterprise Edition license also includes its effective date and clearer agreement rules.

## Changes

- Added `Deploy: mastra deploy` to `DevLogger.ready()`.
- Added tests for the Studio URL, API URL, deploy command, order, and alignment.
- Updated the Enterprise Edition license:
  - Effective date: August 24, 2026.
  - Conflicting limitation-of-liability, warranty, and termination terms in a written agreement with Kepler take precedence.
- Added a patch changeset for `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->