### PR TITLE
fix(memory): make knowledge_update_node tool schema Gemini-compatible

### DIFF
--- a/.changeset/gentle-schemas-obey.md
+++ b/.changeset/gentle-schemas-obey.md
@@ -2,4 +2,4 @@
 '@mastra/memory': patch
 ---
 
-Fix curator knowledge_update_node tool schema so Gemini accepts it (drop top-level anyOf; enforce name/kind requirement at execute time).
+Knowledge curation no longer fails on Gemini models: the curator's `knowledge_update_node` tool schema was rejected by Google's API ("required only allowed for OBJECT type"), causing every curation attempt with a Gemini curator to fail before the model ran. The tool now accepts the same inputs with `name`/`kind` as optional properties (at least one required).

--- a/.changeset/gentle-schemas-obey.md
+++ b/.changeset/gentle-schemas-obey.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fix curator knowledge_update_node tool schema so Gemini accepts it (drop top-level anyOf; enforce name/kind requirement at execute time).

--- a/packages/memory/src/processors/observational-memory/subconscious/knowledge-write-tools.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/knowledge-write-tools.ts
@@ -103,7 +103,8 @@ export function createKnowledgeWriteTools(
     }),
     knowledge_update_node: createTool({
       id: 'knowledge_update_node',
-      description: 'Update a visible node name or kind using optimistic concurrency.',
+      description:
+        'Update a visible node name or kind using optimistic concurrency. Provide at least one of name or kind.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -113,11 +114,13 @@ export function createKnowledgeWriteTools(
           kind: { type: 'string', minLength: 1 },
         },
         required: ['node', 'expectedVersion'],
-        anyOf: [{ required: ['name'] }, { required: ['kind'] }],
         additionalProperties: false,
       } satisfies JSONSchema7,
       execute: async input => {
         const value = input as { node: string; expectedVersion: number; name?: string; kind?: string };
+        if (value.name === undefined && value.kind === undefined) {
+          throw new Error('knowledge_update_node requires at least one of: name, kind.');
+        }
         const store = await getStore(memory);
         const node = await store.getNode(value.node);
         if (!node || node.mergedInto) throw new Error(`Knowledge node not found: ${value.node}`);

--- a/packages/memory/src/tools/__tests__/knowledge-write-tools.test.ts
+++ b/packages/memory/src/tools/__tests__/knowledge-write-tools.test.ts
@@ -1,4 +1,5 @@
 import { InMemoryStore } from '@mastra/core/storage';
+import { standardSchemaToJSONSchema } from '@mastra/schema-compat/schema';
 import { describe, expect, it } from 'vitest';
 
 import { Memory } from '../..';
@@ -24,6 +25,39 @@ describe('Subconscious knowledge write tools', () => {
   it('keeps snapshots of all six public input schemas', async () => {
     const { tools } = await fixture();
     expect(Object.fromEntries(Object.entries(tools).map(([name, tool]) => [name, tool.inputSchema]))).toMatchSnapshot();
+  });
+
+  it('keeps tool schemas free of top-level composition keywords Gemini rejects', async () => {
+    // Google's API rejects `required` inside non-OBJECT anyOf branches, and the
+    // schema-compat Google layer preserves root-level unions as-is — so these
+    // tool schemas must not use top-level composition keywords (regression: the old
+    // knowledge_update_node `anyOf: [{ required: ['name'] }, { required: ['kind'] }]`
+    // made every Gemini curation fail with a 400 before the model ran).
+    const { tools } = await fixture();
+    expect(Object.keys(tools).length).toBeGreaterThan(0);
+    for (const [name, tool] of Object.entries(tools)) {
+      const schema = standardSchemaToJSONSchema(tool.inputSchema as never, { io: 'input' }) as Record<string, unknown>;
+      // Guard against the wrapper hiding the schema and this test passing vacuously.
+      expect(schema.type).toBe('object');
+      expect({ name, anyOf: schema.anyOf, oneOf: schema.oneOf, allOf: schema.allOf }).toEqual({
+        name,
+        anyOf: undefined,
+        oneOf: undefined,
+        allOf: undefined,
+      });
+    }
+  });
+
+  it('requires at least one of name/kind in knowledge_update_node execute', async () => {
+    const { target, tools } = await fixture();
+    await expect(
+      tools.knowledge_update_node!.execute?.({ node: target.id, expectedVersion: target.version }, {} as any),
+    ).rejects.toThrow('at least one');
+    const kindOnly = (await tools.knowledge_update_node!.execute?.(
+      { node: target.id, expectedVersion: target.version, kind: 'initiative' },
+      {} as any,
+    )) as any;
+    expect(kindOnly).toMatchObject({ kind: 'initiative', version: 2 });
   });
 
   it('supports CAS node/content writes and merge tombstones', async () => {


### PR DESCRIPTION
## Problem

The subconscious curator's `knowledge_update_node` tool declared its input schema with a top-level union:

```ts
anyOf: [{ required: ['name'] }, { required: ['kind'] }],
```

Google's API rejects `required` inside non-OBJECT `anyOf` branches (`...parameters.any_of[0].required: only allowed for OBJECT type`), and the schema-compat Google layer preserves root-level unions as-is — so **every curation run with a Gemini curator fails with a 400 before the model runs**. DeepSeek emits malformed tool-call args on the same shape.

Production impact: in a 2026-08-20 Shipyard snapshot, knowledge has never been curated — 0 curator actions across 1,801 `mastra_knowledge_activity` rows (all capture-side), with the default `google/gemini-3.5-flash` curator.

Found while replaying Shipyard threads through the #22058 simulator; no tracking issue was filed.

## Fix

- Drop the top-level `anyOf`; `name` and `kind` stay optional properties, and the tool description states the requirement.
- Enforce at-least-one-of-`name`/`kind` in `execute` instead — same pattern as the sibling `knowledge_read` tool (optional `id`/`name` in schema, requirement thrown in execute).

Verified end-to-end by replaying real Shipyard threads through the simulator with `google/gemini-3.5-flash` as curator: 100% curation failures before the patch, `outcome=ran advanced=true` after.

## Tests

- Regression: none of the knowledge write tool input schemas carry top-level `anyOf`/`oneOf`/`allOf` (asserted on the unwrapped JSON schema literal, with `type === 'object'` and non-empty-toolset guards). Fails on `main`, passes with this change.
- `execute` rejects a call with neither `name` nor `kind`; kind-only update still works.

## Notes

- A complementary schema-compat fix in the Google layer (type-stamp or flatten required-only union branches, covering the whole class) is a candidate follow-up; this PR unblocks curation now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Gemini rejected the previous tool format. This change uses a simpler format and checks that an update includes a name or kind when the tool runs.

## Changes

- Removed top-level `anyOf` from `knowledge_update_node`.
- Kept `name` and `kind` optional in the schema.
- Rejected requests that omit both fields during execution.
- Allowed kind-only updates.
- Added regression tests for schema compatibility and runtime validation.
- Added a patch changeset for `@mastra/memory`.

## Validation

- Prevents the Gemini API 400 error caused by the previous schema.
- Prevents malformed DeepSeek tool-call arguments.
- Replay testing with `google/gemini-3.5-flash` confirmed successful curation after the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->