### PR TITLE
feat(factory): show session owner profiles

### DIFF
--- a/.changeset/lucky-squids-behave.md
+++ b/.changeset/lucky-squids-behave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Added display names and avatars to Factory user session owner information.

--- a/.changeset/silver-teeth-cover.md
+++ b/.changeset/silver-teeth-cover.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Improved Factory session hover cards to show owner names and avatars for user, work, and review sessions.

--- a/.changeset/silver-teeth-cover.md
+++ b/.changeset/silver-teeth-cover.md
@@ -1,5 +1,0 @@
----
-'mastra': patch
----
-
-Improved Factory session hover cards to show owner names and avatars for user, work, and review sessions.

--- a/mastracode/factory-ui/src/ui/domains/auth/services/auth.ts
+++ b/mastracode/factory-ui/src/ui/domains/auth/services/auth.ts
@@ -19,7 +19,7 @@ export interface FactoryAuthState {
   /** Whether the server has web auth configured (any provider). */
   authEnabled: boolean;
   authenticated: boolean;
-  user?: { userId?: string; email?: string; name?: string; organizationId?: string };
+  user?: { userId?: string; email?: string; name?: string; avatarUrl?: string; organizationId?: string };
   /** Active identity provider: 'workos' | 'better-auth' | custom adapter kind. */
   provider?: string;
   /** True when the provider hosts credential forms and sign-up is disabled. */

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -3,7 +3,6 @@ import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { HoverCard, HoverCardTrigger } from '@mastra/playground-ui/components/HoverCard';
 import { MainSidebar, useMaybeSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
-import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { GitBranch, MoreHorizontal, Pin, PinOff, RefreshCw, Trash2 } from 'lucide-react';
 import { useRef } from 'react';
@@ -33,7 +32,6 @@ export function SessionNavRow({
   merged,
   preview,
   pinned = false,
-  owner,
   onSelect,
   onPinChange,
   onDelete,
@@ -43,8 +41,6 @@ export function SessionNavRow({
   name: string;
   /** Hover tooltip, typically the branch name. */
   title?: string;
-  /** Owner marker shown on sessions the viewer does not own. */
-  owner?: string;
   url: string;
   active: boolean;
   disabled: boolean;
@@ -70,7 +66,7 @@ export function SessionNavRow({
     <button
       type="button"
       aria-current={active ? 'page' : undefined}
-      aria-label={owner ? `${name}, started by ${owner}` : name}
+      aria-label={name}
       disabled={disabled || loading}
       onClick={() => {
         sidebar?.setOpenMobile(false);
@@ -79,12 +75,7 @@ export function SessionNavRow({
       title={preview ? undefined : title}
     >
       <GitBranch />
-      <MainSidebar.NavLabel className="flex-initial">{name}</MainSidebar.NavLabel>
-      {owner ? (
-        <Txt as="span" variant="ui-xs" className="text-icon3 shrink-0 truncate">
-          {owner}
-        </Txt>
-      ) : null}
+      <MainSidebar.NavLabel>{name}</MainSidebar.NavLabel>
       {pinned && !loading ? (
         <Pin aria-label={`${name} pinned`} className="text-icon3/70 size-2 shrink-0 rotate-45" />
       ) : null}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionPreviewCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionPreviewCard.tsx
@@ -1,14 +1,18 @@
+import { Avatar } from '@mastra/playground-ui/components/Avatar';
 import { HoverCardContent } from '@mastra/playground-ui/components/HoverCard';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { CircleDot, GitBranch, GitMerge } from 'lucide-react';
 import type { ReactNode, RefObject } from 'react';
 
 import { relativeTime } from '../../../../lib/date/relativeTime';
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
 import type { SessionRowStatus } from './SessionNavRow';
+import type { SessionOwnerDetails } from '../services/sessionPresentation';
 
 export interface SessionPreviewDetails {
-  kind: 'Work session' | 'Review session';
+  kind: 'Work session' | 'Review session' | 'User session';
+  owner: SessionOwnerDetails;
   itemLabel?: string;
   itemTitle?: string;
   branch: string;
@@ -24,10 +28,20 @@ function getStatusLabel(status: SessionRowStatus | undefined) {
 }
 
 /** The icon carries the meaning visually, so `label` names the row for screen readers. */
-function DetailRow({ icon, label, children }: { icon: ReactNode; label: string; children: ReactNode }) {
+function DetailRow({
+  icon,
+  label,
+  children,
+  centered = false,
+}: {
+  icon: ReactNode;
+  label: string;
+  children: ReactNode;
+  centered?: boolean;
+}) {
   return (
-    <div className="flex items-start gap-2">
-      <span className="text-icon3 mt-0.5 flex shrink-0">{icon}</span>
+    <div className={cn('flex gap-2', centered ? 'items-center' : 'items-start')}>
+      <span className={cn('text-icon3 flex w-avatar-sm shrink-0 justify-center', !centered && 'mt-0.5')}>{icon}</span>
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <span className="sr-only">{label}</span>
         {children}
@@ -54,6 +68,7 @@ export function SessionPreviewCard({
   const itemTitle = details.itemTitle?.trim();
   const subtitle = itemTitle && itemTitle !== name ? itemTitle : undefined;
   const updated = relativeTime(details.updatedAt);
+  const ownerName = details.owner.name;
   const itemIcon =
     details.kind === 'Review session' ? (
       <PullRequestStatusIcon status={merged ? 'merged' : 'open'} size={14} decorative />
@@ -89,6 +104,11 @@ export function SessionPreviewCard({
           </Txt>
         </div>
         <div className="flex flex-col gap-1.5">
+          <DetailRow icon={<Avatar src={details.owner.avatarUrl} name={ownerName} size="sm" />} label="Owner" centered>
+            <Txt as="p" variant="ui-sm" className="text-icon5 m-0 truncate">
+              {ownerName}
+            </Txt>
+          </DetailRow>
           {(details.itemLabel || subtitle) && (
             <DetailRow icon={itemIcon} label={details.kind === 'Review session' ? 'Pull request' : 'Work item'}>
               {details.itemLabel && (

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -19,7 +19,7 @@ import { removeCachedSession, useWorkspacesQuery } from '../../../../hooks/useWo
 import { usePinnedSessions } from '../hooks/usePinnedSessions';
 import { deleteUserSession, regenerateSessionTitle } from '../services/user-sessions';
 import type { FactoryUserSession } from '../services/user-sessions';
-import { getUserSessionLabel, getUserSessionTooltip } from '../services/sessionPresentation';
+import { getSessionOwnerDetails, getUserSessionLabel } from '../services/sessionPresentation';
 import { SessionNavRow } from './SessionNavRow';
 import type { SessionRowStatus } from './SessionNavRow';
 
@@ -36,11 +36,6 @@ function userSessionStatus({
   if (!session.materializedAt) return 'initializing';
   if (attention) return 'ready';
   return undefined;
-}
-
-/** WorkOS user ids are long and opaque; keep enough to tell owners apart. */
-function truncateOwnerId(userId: string): string {
-  return userId.length > 13 ? `${userId.slice(0, 13)}…` : userId;
 }
 
 export function UserSessionsSection() {
@@ -156,10 +151,13 @@ export function UserSessionsSection() {
               <SessionNavRow
                 key={session.sessionId}
                 name={name}
-                title={getUserSessionTooltip(session)}
-                // No org-member display-name lookup exists in factory-ui yet, so
-                // non-owned sessions show a truncated owner id.
-                owner={viewerUserId && !isOwn(session) ? truncateOwnerId(session.userId) : undefined}
+                preview={{
+                  kind: 'User session',
+                  owner: getSessionOwnerDetails(session, auth.data?.user),
+                  branch: session.branch,
+                  baseBranch: session.baseBranch,
+                  updatedAt: session.updatedAt,
+                }}
                 url={url}
                 active={active}
                 disabled={pending}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -19,7 +19,8 @@ import type { WorkItem } from '../../factory/services/workItems';
 import { isTerminalStage } from '../../factory/stages';
 import { usePinnedSessions } from '../hooks/usePinnedSessions';
 import type { FactoryUserSession } from '../services/user-sessions';
-import { getFactorySessionKind } from '../services/sessionPresentation';
+import { getFactorySessionKind, getSessionOwnerDetails } from '../services/sessionPresentation';
+import type { SessionViewerProfile } from '../services/sessionPresentation';
 import { SessionNavRow } from './SessionNavRow';
 import type { SessionRowStatus } from './SessionNavRow';
 import type { SessionPreviewDetails } from './SessionPreviewCard';
@@ -194,6 +195,7 @@ export function WorkspacesSection() {
           pending={pending}
           mergedByPath={mergedByPath}
           viewerUserId={viewerUserId}
+          viewerProfile={auth.data?.user}
           onSelect={openWorkspaceThread}
           onPinChange={setPinned}
           onDelete={setConfirmDelete}
@@ -209,6 +211,7 @@ export function WorkspacesSection() {
           pending={pending}
           mergedByPath={mergedByPath}
           viewerUserId={viewerUserId}
+          viewerProfile={auth.data?.user}
           onSelect={openWorkspaceThread}
           onPinChange={setPinned}
           onDelete={setConfirmDelete}
@@ -275,6 +278,7 @@ function WorkspaceGroup({
   pending,
   mergedByPath,
   viewerUserId,
+  viewerProfile,
   onSelect,
   onPinChange,
   onDelete,
@@ -286,6 +290,7 @@ function WorkspaceGroup({
   pending: boolean;
   mergedByPath: Record<string, boolean>;
   viewerUserId: string | undefined;
+  viewerProfile: SessionViewerProfile | undefined;
   onSelect: (workspace: FactoryUserSession) => void;
   onPinChange: (sessionId: string, pinned: boolean) => void;
   onDelete: (workspace: FactoryUserSession) => void;
@@ -317,6 +322,7 @@ function WorkspaceGroup({
             pinned={row.pinned}
             preview={{
               kind,
+              owner: getSessionOwnerDetails(row.workspace, viewerProfile),
               itemLabel: row.itemLabel,
               itemTitle: row.itemTitle,
               branch: row.workspace.branch,

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/SessionHoverDetails.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/SessionHoverDetails.msw.test.tsx
@@ -100,6 +100,11 @@ describe('Workspace session hover details', () => {
       const card = await screen.findByLabelText(`${workName} session details`);
       expect(within(card).getByText(workName)).toBeInTheDocument();
       expect(within(card).getByText('Work session · Agent working')).toBeInTheDocument();
+      expect(within(card).getByText('Ada Lovelace')).toBeInTheDocument();
+      expect(within(card).getByRole('img', { name: 'Ada Lovelace' })).toHaveAttribute(
+        'src',
+        'https://example.com/ada.png',
+      );
       expect(within(card).getByText('Work item: Issue #42')).toBeInTheDocument();
       expect(within(card).getByText('Authentication fails after token refresh')).toBeInTheDocument();
       expect(within(card).getByText('factory/issue-42-authentication-regression')).toBeInTheDocument();
@@ -114,6 +119,7 @@ describe('Workspace session hover details', () => {
       await user.hover(workRow);
 
       const card = await screen.findByLabelText(`${workName} session details`);
+      expect(within(card).getByText('Owner')).toBeInTheDocument();
       expect(within(card).getByText('Work item')).toBeInTheDocument();
       expect(within(card).getByText('Branch')).toBeInTheDocument();
       expect(within(card).getByText('Base branch')).toBeInTheDocument();
@@ -142,6 +148,7 @@ describe('Workspace session hover details', () => {
       const card = await screen.findByLabelText(`${reviewName} session details`);
       expect(within(card).getByText(reviewName)).toBeInTheDocument();
       expect(within(card).getByText('Review session')).toBeInTheDocument();
+      expect(within(card).getByText('Ada Lovelace')).toBeInTheDocument();
       expect(within(card).getByText('Review: PR #99')).toBeInTheDocument();
       expect(within(card).getByText('Fix authentication refresh handling')).toBeInTheDocument();
       expect(within(card).getByText('factory/pr-99-authentication-refresh')).toBeInTheDocument();

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsAttribution.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsAttribution.msw.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter, Route, Routes } from 'react-router';
@@ -30,10 +30,14 @@ function userSession(overrides: Partial<FactoryUserSession>): FactoryUserSession
   };
 }
 
-function stubSessions(sessions: FactoryUserSession[], viewerUserId: string) {
+function stubSessions(
+  sessions: FactoryUserSession[],
+  viewerUserId: string,
+  viewerProfile: { name?: string; email?: string; avatarUrl?: string } = {},
+) {
   server.use(
     http.get(`${TEST_BASE_URL}/auth/me`, () =>
-      HttpResponse.json({ authEnabled: true, authenticated: true, user: { userId: viewerUserId } }),
+      HttpResponse.json({ authEnabled: true, authenticated: true, user: { userId: viewerUserId, ...viewerProfile } }),
     ),
     http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
       HttpResponse.json({ projects: [{ id: 'fp-1', name: 'Mastra' }] }),
@@ -78,31 +82,53 @@ describe('user session attribution', () => {
     // viewer's own; the sidebar must re-order and attribute it.
     stubSessions(
       [
-        userSession({ id: 'row-other', sessionId: 'sess-other', userId: 'user-owner-1', branch: 'user/alpha' }),
-        userSession({ id: 'row-mine', sessionId: 'sess-mine', userId: 'user-viewer-9', branch: 'user/mine' }),
+        userSession({
+          id: 'row-other',
+          sessionId: 'sess-other',
+          userId: 'user-owner-1',
+          owner: { id: 'user-owner-1', name: 'Grace Hopper', avatarUrl: 'https://example.com/grace.png' },
+          branch: 'user/alpha',
+        }),
+        userSession({
+          id: 'row-mine',
+          sessionId: 'sess-mine',
+          userId: 'user-viewer-9',
+          branch: 'user/mine',
+        }),
       ],
       'user-viewer-9',
+      { name: 'Ada Lovelace', avatarUrl: 'https://example.com/ada.png' },
     );
 
     const { client } = renderSection();
     await waitForMutationsIdle(client);
+    const user = userEvent.setup();
 
-    // The non-owned session carries its owner in the accessible name; the
-    // viewer's own does not.
     const mine = await screen.findByRole('button', { name: 'mine' });
-    const other = screen.getByRole('button', { name: 'alpha, started by user-owner-1' });
-    expect(mine).toBeInTheDocument();
-    expect(other).toBeInTheDocument();
-
+    const other = screen.getByRole('button', { name: 'alpha' });
     const labels = screen
       .getAllByRole('button')
       .map(button => button.getAttribute('aria-label'))
-      .filter(label => label === 'mine' || label === 'alpha, started by user-owner-1');
-    expect(labels).toEqual(['mine', 'alpha, started by user-owner-1']);
+      .filter(label => label === 'mine' || label === 'alpha');
+    expect(labels).toEqual(['mine', 'alpha']);
+    expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument();
+    expect(screen.queryByText('Grace Hopper')).not.toBeInTheDocument();
 
-    // The owner is still shown as visible text on the non-owned row only.
-    expect(screen.getByText('user-owner-1')).toBeInTheDocument();
-    expect(screen.queryByText('user-viewer-9')).not.toBeInTheDocument();
+    await user.hover(mine);
+    const mineCard = await screen.findByLabelText('mine session details');
+    expect(within(mineCard).getByText('Ada Lovelace')).toBeInTheDocument();
+    expect(within(mineCard).getByRole('img', { name: 'Ada Lovelace' })).toHaveAttribute(
+      'src',
+      'https://example.com/ada.png',
+    );
+
+    await user.hover(other);
+    const otherCard = await screen.findByLabelText('alpha session details');
+    expect(within(otherCard).getByText('Grace Hopper')).toBeInTheDocument();
+    expect(within(otherCard).getByRole('img', { name: 'Grace Hopper' })).toHaveAttribute(
+      'src',
+      'https://example.com/grace.png',
+    );
   });
 
   it('offers delete only on the viewer-owned session', async () => {
@@ -121,7 +147,13 @@ describe('user session attribution', () => {
     await waitForMutationsIdle(client);
     const user = userEvent.setup();
 
-    await user.click(await screen.findByRole('button', { name: 'Session actions for alpha' }));
+    const other = await screen.findByRole('button', { name: 'alpha' });
+    await user.hover(other);
+    const card = await screen.findByLabelText('alpha session details');
+    expect(within(card).getByText('user-owner-1')).toBeInTheDocument();
+    await user.unhover(other);
+
+    await user.click(screen.getByRole('button', { name: 'Session actions for alpha' }));
     expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument();
     await user.keyboard('{Escape}');
 

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsCreate.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsCreate.msw.test.tsx
@@ -160,7 +160,7 @@ describe('User sessions creation', () => {
 
     expect(await screen.findByRole('button', { name: 'Fix login' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'feature-readable' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'New session' })).toHaveAttribute('title', 'New session');
+    expect(screen.getByRole('button', { name: 'New session' })).toBeInTheDocument();
     expect(screen.queryByText(opaqueSessionId)).not.toBeInTheDocument();
   });
 

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/fixtures/sessionHoverDetails.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/fixtures/sessionHoverDetails.ts
@@ -26,6 +26,7 @@ function createWorkspace({
     projectRepositoryId,
     orgId: 'org-1',
     userId: 'user-1',
+    owner: { id: 'user-1', name: 'Ada Lovelace', avatarUrl: 'https://example.com/ada.png' },
     visibility: 'org' as const,
     title,
     branch,

--- a/mastracode/factory-ui/src/ui/domains/workspaces/services/sessionPresentation.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/services/sessionPresentation.ts
@@ -4,6 +4,32 @@ import type { FactoryUserSession } from './user-sessions';
 
 const REVIEW_BRANCH_PREFIX = 'factory/pr-';
 
+export interface SessionOwnerDetails {
+  name: string;
+  avatarUrl?: string;
+}
+
+export interface SessionViewerProfile {
+  userId?: string;
+  name?: string;
+  email?: string;
+  avatarUrl?: string;
+}
+
+export function getSessionOwnerDetails(
+  session: FactoryUserSession,
+  viewer: SessionViewerProfile | undefined,
+): SessionOwnerDetails {
+  const isViewer = Boolean(viewer?.userId) && session.userId === viewer?.userId;
+  const name =
+    (isViewer && (viewer?.name?.trim() || viewer?.email?.trim())) || session.owner?.name?.trim() || session.userId;
+  const avatarUrl = (isViewer && viewer?.avatarUrl?.trim()) || session.owner?.avatarUrl?.trim();
+  return {
+    name,
+    ...(avatarUrl ? { avatarUrl } : {}),
+  };
+}
+
 export function getFactorySessionKind(session: FactoryUserSession, workItem: WorkItem | undefined): 'work' | 'review' {
   if (workItem?.source === 'github-pr') return 'review';
   if (!workItem && session.branch.startsWith(REVIEW_BRANCH_PREFIX)) return 'review';
@@ -27,8 +53,4 @@ export function getUserSessionLabel(session: FactoryUserSession): string {
   if (!session.branch.startsWith(USER_SESSION_BRANCH_PREFIX)) return session.branch;
   if (isAutomaticUserSessionBranch(session)) return 'New session';
   return session.branch.slice(USER_SESSION_BRANCH_PREFIX.length);
-}
-
-export function getUserSessionTooltip(session: FactoryUserSession): string {
-  return isAutomaticUserSessionBranch(session) ? getUserSessionLabel(session) : session.branch;
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/services/user-sessions.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/services/user-sessions.ts
@@ -8,12 +8,19 @@ import { postRepositoryGitOp, readJsonOrThrow } from './http';
 
 export const USER_SESSION_BRANCH_PREFIX = 'user/';
 
+export interface FactoryUserSessionOwner {
+  id: string;
+  name: string;
+  avatarUrl?: string;
+}
+
 export interface FactoryUserSession {
   id: string;
   sessionId: string;
   projectRepositoryId: string;
   orgId: string;
   userId: string;
+  owner?: FactoryUserSessionOwner;
   visibility: 'org' | 'private';
   title?: string;
   branch: string;

--- a/mastracode/factory/src/auth.test.ts
+++ b/mastracode/factory/src/auth.test.ts
@@ -478,14 +478,25 @@ describe('mountFactoryAuth /auth routes (enabled)', () => {
   });
 
   it('/auth/me reports the user when authenticated', async () => {
-    mockAuthenticate.mockResolvedValue({ workosId: 'user_me', email: 'user@example.com', name: 'User' });
+    mockAuthenticate.mockResolvedValue({
+      workosId: 'user_me',
+      email: 'user@example.com',
+      name: 'User',
+      avatarUrl: 'https://avatars.example/user.png',
+    });
     const { app } = buildApp();
     const res = await app.request('/auth/me');
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       authenticated: true,
       // No-org accounts are bootstrapped into a personal org during /auth/me.
-      user: { userId: 'user_me', email: 'user@example.com', name: 'User', organizationId: 'org_new' },
+      user: {
+        userId: 'user_me',
+        email: 'user@example.com',
+        name: 'User',
+        avatarUrl: 'https://avatars.example/user.png',
+        organizationId: 'org_new',
+      },
       provider: 'workos',
     });
     expect(mockEnsureOrganization).toHaveBeenCalledWith('user_me');

--- a/mastracode/factory/src/auth.ts
+++ b/mastracode/factory/src/auth.ts
@@ -417,6 +417,7 @@ async function handleAuthMe(provider: IMastraAuthProvider, c: Context): Promise<
       userId: getFactoryAuthUserId(user),
       email: user.email,
       name: user.name,
+      avatarUrl: user.avatarUrl,
       organizationId: user.organizationId,
     },
     ...meta,

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -796,6 +796,7 @@ export class MastraFactory {
             controllerId: CONTROLLER_ID,
             controller,
             auth: routeAuth,
+            ...(auth && isUserProvider(auth) ? { users: auth } : {}),
             authStorage,
             audit: auditDomain,
             publicOrigin,

--- a/mastracode/factory/src/integrations/base.ts
+++ b/mastracode/factory/src/integrations/base.ts
@@ -20,7 +20,7 @@
 import type { MastraCodeConfig, MountedMastraCode } from '@mastra/code-sdk';
 import type { AgentControllerChannelsConfig, ChannelAdapterConfig } from '@mastra/core/channels';
 import type { RequestContext } from '@mastra/core/request-context';
-import type { ApiRoute } from '@mastra/core/server';
+import type { ApiRoute, IUserProvider } from '@mastra/core/server';
 import type { FactoryStorage } from '@mastra/core/storage';
 import type { MastraWorker } from '@mastra/core/worker';
 
@@ -69,6 +69,8 @@ export interface IntegrationPostToolContext {
 export interface IntegrationContext {
   /** Host auth seam — integration routes resolve callers through this. */
   auth: RouteAuth;
+  /** Optional user directory for resolving persisted user ids to display profiles. */
+  users?: Pick<IUserProvider, 'getUser' | 'getUsers'>;
   /**
    * Sandbox fleet for per-project sandboxes. Always constructed at boot; a
    * fleet built without a machine config reports `enabled: false` and

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -1146,6 +1146,7 @@ export class GithubIntegration implements FactoryIntegration {
     return buildGithubRoutes({
       github: this,
       auth: ctx.auth,
+      ...(ctx.users ? { users: ctx.users } : {}),
       fleet: ctx.fleet,
       storage: ctx.factoryStorage,
       stateSigner: ctx.stateSigner,
@@ -1177,12 +1178,15 @@ export class GithubIntegration implements FactoryIntegration {
     const reconcile = pullRequestEnabled
       ? attachGithubReconciler(this, ctx, input => this.fetchPullRequestState(input))
       : undefined;
-    const issues = issueEnabled ? attachGithubIssueReconciler(this, ctx, input => this.fetchIssueState(input)) : undefined;
+    const issues = issueEnabled
+      ? attachGithubIssueReconciler(this, ctx, input => this.fetchIssueState(input))
+      : undefined;
     if (!reconcile && !issues) return [];
 
     const legacyInterval = reconcileInterval(process.env.MASTRACODE_GITHUB_RECONCILE_INTERVAL_MS);
     const intervalMs = reconcileInterval(process.env.MASTRACODE_GITHUB_PR_RECONCILE_INTERVAL_MS) ?? legacyInterval;
-    const issueIntervalMs = reconcileInterval(process.env.MASTRACODE_GITHUB_ISSUE_RECONCILE_INTERVAL_MS) ?? legacyInterval;
+    const issueIntervalMs =
+      reconcileInterval(process.env.MASTRACODE_GITHUB_ISSUE_RECONCILE_INTERVAL_MS) ?? legacyInterval;
     return [
       new GithubReconcileWorker({
         ...(reconcile ? { reconcile } : {}),
@@ -1255,9 +1259,7 @@ export class GithubIntegration implements FactoryIntegration {
         url: issue.html_url,
         state: issue.state === 'closed' ? 'closed' : 'open',
         ...(issue.state_reason ? { stateReason: issue.state_reason } : {}),
-        assignees: (issue.assignees ?? [])
-          .map(user => user.login)
-          .filter((login): login is string => Boolean(login)),
+        assignees: (issue.assignees ?? []).map(user => user.login).filter((login): login is string => Boolean(login)),
         labels: (issue.labels ?? [])
           .map(label => (typeof label === 'string' ? label : label.name))
           .filter((name): name is string => Boolean(name)),
@@ -1278,7 +1280,12 @@ export class GithubIntegration implements FactoryIntegration {
     const parts = splitRepoFullName(input.repository);
     if (!parts) throw new Error('GitHub triage comments require an owner/repository source.');
     const octokit = this.getInstallationOctokit(input.installationId);
-    const comments = [] as Array<{ id: number; body?: string | null; user?: { login?: string } | null; html_url: string }>;
+    const comments = [] as Array<{
+      id: number;
+      body?: string | null;
+      user?: { login?: string } | null;
+      html_url: string;
+    }>;
     for (let page = 1; ; page += 1) {
       const response = await octokit.issues.listComments({
         ...parts,
@@ -1290,13 +1297,20 @@ export class GithubIntegration implements FactoryIntegration {
       if (response.data.length < 100) break;
     }
     const existing = comments
-      .filter(comment => comment.body?.includes('<!-- mastra-factory-triage -->') && this.isFactoryCommentAuthor(comment.user?.login))
+      .filter(
+        comment =>
+          comment.body?.includes('<!-- mastra-factory-triage -->') && this.isFactoryCommentAuthor(comment.user?.login),
+      )
       .sort((left, right) => left.id - right.id)[0];
     if (existing) {
       const { data } = await octokit.issues.updateComment({ ...parts, comment_id: existing.id, body: input.body });
       return { action: 'updated', commentId: String(data.id), url: data.html_url };
     }
-    const { data } = await octokit.issues.createComment({ ...parts, issue_number: input.issueNumber, body: input.body });
+    const { data } = await octokit.issues.createComment({
+      ...parts,
+      issue_number: input.issueNumber,
+      body: input.body,
+    });
     return { action: 'created', commentId: String(data.id), url: data.html_url };
   }
 
@@ -1377,9 +1391,7 @@ function parsePullRequest(pr: GithubPullRequestData): PullRequest {
     author: pr.user?.login ?? null,
     assignees: (pr.assignees ?? []).flatMap(assignee => (assignee.login ? [assignee.login] : [])),
     requestedReviewers: (pr.requested_reviewers ?? []).flatMap(reviewer => (reviewer.login ? [reviewer.login] : [])),
-    labels: (pr.labels ?? []).flatMap(label =>
-      typeof label === 'string' ? [label] : label.name ? [label.name] : [],
-    ),
+    labels: (pr.labels ?? []).flatMap(label => (typeof label === 'string' ? [label] : label.name ? [label.name] : [])),
     body: pr.body?.trim() ? pr.body : null,
     state: pr.state === 'closed' ? 'closed' : 'open',
     draft: pr.draft ?? false,

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -271,11 +271,7 @@ const listRepoOpenPullRequests = vi.fn(async (_installationId: number, _repoFull
   nextPage: null as number | null,
 }));
 const getIssueDetail = vi.fn(
-  async (
-    _installationId: number,
-    _repoFullName: string,
-    issueId: string,
-  ): Promise<Record<string, unknown> | null> =>
+  async (_installationId: number, _repoFullName: string, issueId: string): Promise<Record<string, unknown> | null> =>
     issueId === '12'
       ? {
           id: '12',
@@ -482,11 +478,9 @@ const ensureProjectSandbox = vi.fn(
     };
   },
 );
-const materializeRepo = vi.fn(
-  async (opts: { onProgress?: (e: any) => void; skipPullOnExistingCheckout?: boolean }) => {
-    opts.onProgress?.({ phase: 'cloning', message: 'Cloning octo/hello…' });
-  },
-);
+const materializeRepo = vi.fn(async (opts: { onProgress?: (e: any) => void; skipPullOnExistingCheckout?: boolean }) => {
+  opts.onProgress?.({ phase: 'cloning', message: 'Cloning octo/hello…' });
+});
 const reattachSandbox = vi.fn(async (_id: string, _options?: { actingUserId?: string }) => ({ id: 'sb' }));
 const recycleClaimedWorkdir = vi.fn(async (_sb: any, _workdir: string, _defaultBranch: string) => {});
 const ensureWorktree = vi.fn(async (_sb: any, _workdir: string, opts: { branch: string; baseBranch: string }) => ({
@@ -679,6 +673,7 @@ function buildApp(
   options: {
     controller?: NonNullable<Parameters<typeof buildGithubRoutes>[0]>['controller'];
     memorySettings?: Parameters<typeof buildGithubRoutes>[0]['memorySettings'];
+    users?: NonNullable<Parameters<typeof buildGithubRoutes>[0]>['users'];
     stateSigner?: typeof stateSigner | null;
     sessionRetirement?: SessionRetirementCoordinator;
   } = {},
@@ -865,7 +860,10 @@ describe('webhook route', () => {
     const controller = {
       // Delivery confirms this deployment holds the subscribed thread and reads
       // the resource that owns it; here that is the subscription's own resource.
-      queryThreadById: vi.fn(async ({ threadId }: { threadId: string }) => ({ id: threadId, resourceId: 'resource-1' })),
+      queryThreadById: vi.fn(async ({ threadId }: { threadId: string }) => ({
+        id: threadId,
+        resourceId: 'resource-1',
+      })),
       getSessionByResource: vi.fn(async () => session),
       createSession: vi.fn(),
     } as unknown as NonNullable<Parameters<typeof buildGithubRoutes>[0]>['controller'];
@@ -1419,9 +1417,7 @@ describe('ensure (materialize)', () => {
     expect(res.status).toBe(200);
     expect(ensureProjectSandbox).toHaveBeenCalledOnce();
     expect(ensureProjectSandbox).toHaveBeenCalledWith(expect.objectContaining({ seedCheckpointName: 'repo-p1' }));
-    expect(materializeRepo).toHaveBeenCalledWith(
-      expect.objectContaining({ skipPullOnExistingCheckout: true }),
-    );
+    expect(materializeRepo).toHaveBeenCalledWith(expect.objectContaining({ skipPullOnExistingCheckout: true }));
   });
 
   it('does not skip the pull when the provider restores the primary session checkpoint', async () => {
@@ -1443,9 +1439,7 @@ describe('ensure (materialize)', () => {
 
     expect(res.status).toBe(200);
     expect(ensureProjectSandbox).toHaveBeenCalledWith(expect.objectContaining({ seedCheckpointName: 'repo-p1' }));
-    expect(materializeRepo).toHaveBeenCalledWith(
-      expect.objectContaining({ skipPullOnExistingCheckout: false }),
-    );
+    expect(materializeRepo).toHaveBeenCalledWith(expect.objectContaining({ skipPullOnExistingCheckout: false }));
   });
 
   it('does not seed provisioning from a stale repo base checkpoint', async () => {
@@ -1467,9 +1461,7 @@ describe('ensure (materialize)', () => {
 
     expect(res.status).toBe(200);
     expect(ensureProjectSandbox.mock.calls[0]![0].seedCheckpointName).toBeUndefined();
-    expect(materializeRepo).toHaveBeenCalledWith(
-      expect.objectContaining({ skipPullOnExistingCheckout: false }),
-    );
+    expect(materializeRepo).toHaveBeenCalledWith(expect.objectContaining({ skipPullOnExistingCheckout: false }));
   });
 
   it('404s for a project the user does not own', async () => {
@@ -1943,6 +1935,106 @@ describe('Factory session routes', () => {
     expect(ensureProjectSandbox).not.toHaveBeenCalled();
   });
 
+  it('enriches listed sessions with owner names and avatars', async () => {
+    seedMaterializedProject();
+    const profiles = {
+      u1: { id: 'u1', name: 'Ada Lovelace', email: 'ada@example.com', avatarUrl: 'https://example.com/ada.png' },
+      u2: { id: 'u2', name: 'Grace Hopper', email: 'grace@example.com', avatarUrl: 'https://example.com/grace.png' },
+    };
+    const users = {
+      getUser: vi.fn(async (id: string) => profiles[id as keyof typeof profiles] ?? null),
+      getUsers: vi.fn(async (ids: string[]) => ids.map(id => profiles[id as keyof typeof profiles]).filter(Boolean)),
+    };
+    await postJson(buildApp({ workosId: 'u1' }, { users }), '/web/github/projects/p1/sessions', {
+      branch: 'feat/mine',
+    });
+    await postJson(buildApp({ workosId: 'u2' }, { users }), '/web/github/projects/p1/sessions', {
+      branch: 'feat/theirs',
+    });
+
+    const response = await buildApp({ workosId: 'u1' }, { users }).request('/web/github/projects/p1/sessions');
+
+    expect(response.status).toBe(200);
+    expect(users.getUsers).toHaveBeenCalledWith(expect.arrayContaining(['u1', 'u2']));
+    expect((await response.json()).sessions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userId: 'u1',
+          owner: { id: 'u1', name: 'Ada Lovelace', avatarUrl: 'https://example.com/ada.png' },
+        }),
+        expect.objectContaining({
+          userId: 'u2',
+          owner: { id: 'u2', name: 'Grace Hopper', avatarUrl: 'https://example.com/grace.png' },
+        }),
+      ]),
+    );
+  });
+
+  it('falls back to individual profile lookups without dropping successful owners', async () => {
+    seedMaterializedProject();
+    await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/sessions', { branch: 'feat/mine' });
+    await postJson(buildApp({ workosId: 'u2' }), '/web/github/projects/p1/sessions', { branch: 'feat/theirs' });
+    const users = {
+      getUser: vi.fn(async (id: string) => {
+        if (id === 'u1') return { id, email: 'ada@example.com' };
+        throw new Error('Profile unavailable');
+      }),
+    };
+
+    const response = await buildApp({ workosId: 'u1' }, { users }).request('/web/github/projects/p1/sessions');
+
+    expect(response.status).toBe(200);
+    expect(users.getUser).toHaveBeenCalledTimes(2);
+    const { sessions } = await response.json();
+    expect(sessions.find((session: { userId: string }) => session.userId === 'u1')).toEqual(
+      expect.objectContaining({ owner: { id: 'u1', name: 'ada@example.com' } }),
+    );
+    expect(sessions.find((session: { userId: string }) => session.userId === 'u2')).not.toHaveProperty('owner');
+  });
+
+  it('falls back to individual lookups when the bulk owner lookup fails', async () => {
+    seedMaterializedProject();
+    await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/sessions', { branch: 'feat/mine' });
+    await postJson(buildApp({ workosId: 'u2' }), '/web/github/projects/p1/sessions', { branch: 'feat/theirs' });
+    const users = {
+      getUsers: vi.fn(async () => {
+        throw new Error('Directory unavailable');
+      }),
+      getUser: vi.fn(async (id: string) => (id === 'u1' ? { id, name: 'Ada Lovelace' } : { id, name: '', email: '' })),
+    };
+
+    const response = await buildApp({ workosId: 'u1' }, { users }).request('/web/github/projects/p1/sessions');
+
+    expect(response.status).toBe(200);
+    expect(users.getUsers).toHaveBeenCalledOnce();
+    expect(users.getUser).toHaveBeenCalledTimes(2);
+    const { sessions } = await response.json();
+    expect(sessions.find((session: { userId: string }) => session.userId === 'u1')).toEqual(
+      expect.objectContaining({ owner: { id: 'u1', name: 'Ada Lovelace' } }),
+    );
+    expect(sessions.find((session: { userId: string }) => session.userId === 'u2')).not.toHaveProperty('owner');
+  });
+
+  it('caches session owner profiles between list requests', async () => {
+    seedMaterializedProject();
+    const users = {
+      getUser: vi.fn(async (id: string) => ({ id, name: 'Ada Lovelace' })),
+      getUsers: vi.fn(async (ids: string[]) => ids.map(id => ({ id, name: 'Ada Lovelace' }))),
+    };
+    const app = buildApp({ workosId: 'u1' }, { users });
+    await postJson(app, '/web/github/projects/p1/sessions', { branch: 'feat/mine' });
+
+    const first = await app.request('/web/github/projects/p1/sessions');
+    const second = await app.request('/web/github/projects/p1/sessions');
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(users.getUsers).toHaveBeenCalledOnce();
+    expect((await second.json()).sessions).toEqual([
+      expect.objectContaining({ owner: { id: 'u1', name: 'Ada Lovelace' } }),
+    ]);
+  });
+
   it('uses a supplied UUID for branch identity and persists a normalized title', async () => {
     seedMaterializedProject();
     const app = buildApp({ workosId: 'u1' });
@@ -2030,7 +2122,7 @@ describe('Factory session routes', () => {
     expect(allowed.status).toBe(200);
   });
 
-  it('lists org-visible sessions from other users plus the caller\'s own private ones', async () => {
+  it("lists org-visible sessions from other users plus the caller's own private ones", async () => {
     seedMaterializedProject();
     const now = new Date();
     const row = (overrides: Record<string, unknown>) => ({
@@ -2185,10 +2277,13 @@ describe('Factory session routes', () => {
     const app = buildApp({ workosId: 'u1' }, { controller, sessionRetirement });
     const created = await postJson(app, '/web/github/projects/p1/sessions', { branch: 'feat/x' });
     const sessionId = (await created.json()).session.sessionId;
-    Object.assign(tables.sessions.find(row => row.sessionId === sessionId)!, {
-      sandboxId: 'sb-live',
-      sandboxWorkdir: '/workspace/hello',
-    });
+    Object.assign(
+      tables.sessions.find(row => row.sessionId === sessionId)!,
+      {
+        sandboxId: 'sb-live',
+        sandboxWorkdir: '/workspace/hello',
+      },
+    );
     reattachSandbox.mockImplementationOnce(async () => {
       order.push('reattach');
       return { id: 'sb-live' } as any;
@@ -2388,9 +2483,7 @@ describe('Factory session routes', () => {
 
     expect(deleted.status).toBe(200);
     expect(tables.sessions).toHaveLength(0);
-    await vi.waitFor(() =>
-      expect(reattachSandbox).toHaveBeenCalledWith('sb-live', { actingUserId: 'u1' }),
-    );
+    await vi.waitFor(() => expect(reattachSandbox).toHaveBeenCalledWith('sb-live', { actingUserId: 'u1' }));
     error.mockRestore();
   });
 
@@ -2461,7 +2554,7 @@ describe('Factory session routes', () => {
     await vi.waitFor(() => expect(sourceControlStorage.sandboxPoolRows).toHaveLength(1));
   });
 
-  it('does not expose another organization\'s session regardless of visibility', async () => {
+  it("does not expose another organization's session regardless of visibility", async () => {
     seedMaterializedProject();
     const created = await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/sessions', {
       branch: 'feat/x',

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -15,7 +15,7 @@ import { randomUUID } from 'node:crypto';
 import type { MountedMastraCode } from '@mastra/code-sdk';
 import { resolveModel } from '@mastra/code-sdk/agents/model';
 import { RequestContext } from '@mastra/core/request-context';
-import type { ApiRoute } from '@mastra/core/server';
+import type { ApiRoute, IUserProvider } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 import { UniqueViolationError } from '@mastra/core/storage';
 import type { FactoryStorage } from '@mastra/core/storage';
@@ -100,6 +100,8 @@ function loose(c: unknown): RouteContext {
 export interface MountGithubRoutesOptions {
   /** Host auth seam — resolves the signed-in user/tenant for each request. */
   auth: RouteAuth;
+  /** Optional user directory used to resolve session-owner display profiles. */
+  users?: SessionOwnerUserProvider;
   /**
    * Sandbox fleet for per-project sandboxes. A fleet constructed without a
    * machine config reports `enabled: false` and the sandbox-backed routes
@@ -364,7 +366,7 @@ async function ingestPolledEvents(
  */
 export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[] {
   const routes: ApiRoute[] = [];
-  const { auth, fleet, storage, github, stateSigner, controller, memorySettings, emitAudit, sessionRetirement } =
+  const { auth, users, fleet, storage, github, stateSigner, controller, memorySettings, emitAudit, sessionRetirement } =
     options;
   const diagnostics = () =>
     getGithubFeatureDiagnostics({ github, auth, appDbConfigured: storage !== undefined, stateSigner, fleet });
@@ -1051,7 +1053,7 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
 
   // ── Sessions / commit / push / PR ────────────────────────────────────────
   routes.push(
-    ...buildProjectGitRoutes({ github, auth, fleet, controller, memorySettings, emitAudit, sessionRetirement }),
+    ...buildProjectGitRoutes({ github, auth, users, fleet, controller, memorySettings, emitAudit, sessionRetirement }),
   );
 
   return routes;
@@ -1307,9 +1309,90 @@ function titleModel(modelId: string) {
     resolveModel(modelId, { remapForCodexOAuth: true, requestContext });
 }
 
+interface SessionOwnerProfile {
+  id: string;
+  name: string;
+  avatarUrl?: string;
+}
+
+type SessionOwnerUserProvider = Pick<IUserProvider, 'getUser'> & Partial<Pick<IUserProvider, 'getUsers'>>;
+
+const MAX_SESSION_OWNER_PROFILES = 100;
+const MAX_SESSION_OWNER_PROFILE_CACHE_ENTRIES = 500;
+const SESSION_OWNER_PROFILE_TTL_MS = 5 * 60_000;
+
+function createSessionOwnerProfileResolver(users: SessionOwnerUserProvider | undefined) {
+  const cache = new Map<string, { profile?: SessionOwnerProfile; expiresAt: number }>();
+  const cacheProfile = (userId: string, profile: SessionOwnerProfile | undefined, expiresAt: number) => {
+    cache.delete(userId);
+    cache.set(userId, { profile, expiresAt });
+    if (cache.size > MAX_SESSION_OWNER_PROFILE_CACHE_ENTRIES) {
+      const oldestUserId = cache.keys().next().value;
+      if (oldestUserId !== undefined) cache.delete(oldestUserId);
+    }
+  };
+
+  return async (userIds: string[]): Promise<Map<string, SessionOwnerProfile>> => {
+    if (!users) return new Map();
+
+    const requestedUserIds = [...new Set(userIds)].slice(0, MAX_SESSION_OWNER_PROFILES);
+    const profiles = new Map<string, SessionOwnerProfile>();
+    const unresolvedUserIds: string[] = [];
+    const now = Date.now();
+
+    for (const userId of requestedUserIds) {
+      const cached = cache.get(userId);
+      if (!cached || cached.expiresAt <= now) {
+        cache.delete(userId);
+        unresolvedUserIds.push(userId);
+      } else if (cached.profile) {
+        profiles.set(userId, cached.profile);
+      }
+    }
+
+    if (unresolvedUserIds.length === 0) return profiles;
+
+    let resolvedUsers: Array<Awaited<ReturnType<SessionOwnerUserProvider['getUser']>>>;
+    if (users.getUsers) {
+      try {
+        resolvedUsers = await users.getUsers(unresolvedUserIds);
+      } catch (error) {
+        console.warn('[GitHub Sessions] Bulk session owner profile lookup failed; falling back to individual lookups', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        resolvedUsers = (await Promise.allSettled(unresolvedUserIds.map(userId => users.getUser(userId))))
+          .filter(result => result.status === 'fulfilled')
+          .map(result => result.value);
+      }
+    } else {
+      resolvedUsers = (await Promise.allSettled(unresolvedUserIds.map(userId => users.getUser(userId))))
+        .filter(result => result.status === 'fulfilled')
+        .map(result => result.value);
+    }
+
+    for (const user of resolvedUsers) {
+      if (!user) continue;
+      const name = user.name?.trim() || user.email?.trim();
+      if (!name) continue;
+      profiles.set(user.id, {
+        id: user.id,
+        name,
+        ...(user.avatarUrl ? { avatarUrl: user.avatarUrl } : {}),
+      });
+    }
+
+    const expiresAt = now + SESSION_OWNER_PROFILE_TTL_MS;
+    for (const userId of unresolvedUserIds) {
+      cacheProfile(userId, profiles.get(userId), expiresAt);
+    }
+    return profiles;
+  };
+}
+
 function buildProjectGitRoutes({
   github,
   auth,
+  users,
   fleet,
   controller,
   memorySettings,
@@ -1318,6 +1401,7 @@ function buildProjectGitRoutes({
 }: {
   github: GithubIntegration;
   auth: RouteAuth;
+  users?: SessionOwnerUserProvider;
   fleet: SandboxFleet;
   controller?: MountedMastraCode['controller'];
   memorySettings: MountGithubRoutesOptions['memorySettings'];
@@ -1325,6 +1409,7 @@ function buildProjectGitRoutes({
   sessionRetirement?: MountGithubRoutesOptions['sessionRetirement'];
 }): ApiRoute[] {
   const nameSession = createSessionNaming();
+  const resolveSessionOwnerProfiles = createSessionOwnerProfileResolver(users);
   return [
     // ── Create / list Factory sessions ──────────────────────────────────────
     registerApiRoute('/web/github/projects/:id/sessions', {
@@ -1343,7 +1428,13 @@ function buildProjectGitRoutes({
           projectRepositoryId: project.id,
           viewerUserId: userId,
         });
-        return c.json({ sessions });
+        const owners = await resolveSessionOwnerProfiles(sessions.map(session => session.userId));
+        return c.json({
+          sessions: sessions.map(session => {
+            const owner = owners.get(session.userId);
+            return { ...session, ...(owner ? { owner } : {}) };
+          }),
+        });
       },
     }),
     registerApiRoute('/web/github/projects/:id/sessions', {

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -1,7 +1,7 @@
 import type { AuthStorage } from '@mastra/code-sdk/auth/storage';
 import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentController } from '@mastra/core/agent-controller';
-import type { ApiRoute } from '@mastra/core/server';
+import type { ApiRoute, IUserProvider } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 import type { FactoryStorage } from '@mastra/core/storage';
 
@@ -73,6 +73,8 @@ export interface FactoryApiRoutesDeps {
   controller: AgentController<MastraCodeState>;
   /** Request-auth seam threaded from the host (no service locator). */
   auth: RouteAuth;
+  /** Optional user directory for resolving persisted owners to display profiles. */
+  users?: Pick<IUserProvider, 'getUser' | 'getUsers'>;
   authStorage: AuthStorage;
   audit: AuditEmitter;
   fsRoot?: string;
@@ -246,7 +248,14 @@ export async function prepareFactoryRuleBinding(
 export function buildIntegrationContext(
   deps: Pick<
     FactoryApiRoutesDeps,
-    'controller' | 'publicOrigin' | 'auth' | 'fleet' | 'factoryStorage' | 'integrationStorage' | 'sourceControlStorage'
+    | 'controller'
+    | 'publicOrigin'
+    | 'auth'
+    | 'users'
+    | 'fleet'
+    | 'factoryStorage'
+    | 'integrationStorage'
+    | 'sourceControlStorage'
   > & {
     stateSigner: StateSigner;
     emitAudit?: AuditEmitter['emit'];
@@ -269,6 +278,7 @@ export function buildIntegrationContext(
 ): IntegrationContext {
   return {
     auth: deps.auth,
+    ...(deps.users ? { users: deps.users } : {}),
     fleet: deps.fleet,
     ...(deps.baseCheckpoints ? { baseCheckpoints: deps.baseCheckpoints } : {}),
     factoryStorage: deps.factoryStorage,


### PR DESCRIPTION
Factory session hover cards now show the owner's resolved name and avatar across user, work, and review sessions. The session list resolves profiles through the configured user provider with bounded caching and graceful fallbacks, while personal sessions can use the authenticated viewer profile when directory enrichment is unavailable.

Before: `user_01KN...`

After: `Grace Hopper` with the owner's avatar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory session cards now show the session owner’s name and avatar instead of only an ID. The system uses the user directory when available and uses the signed-in user’s profile for personal sessions when needed.

## Changes

- Added session owner data to user sessions.
- Added owner name and avatar display to user, work, and review session hover cards.
- Added fallback logic for unavailable owner profiles.
- Added optional user-directory access to Factory routes and integration contexts.
- Added bounded, cached owner profile lookups with bulk and individual lookup fallbacks.
- Added authenticated user `avatarUrl` support.
- Updated session presentation types and removed the old tooltip helper.
- Updated UI and API tests for owner names, avatars, fallbacks, caching, and accessibility labels.
- Added patch changesets for `@mastra/factory` and `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->