### PR TITLE
refactor(factory): stop clipping the app layout shells

### DIFF
--- a/.changeset/layout-shell-clipping.md
+++ b/.changeset/layout-shell-clipping.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Removed the app shell's blanket overflow clipping. Every scroll region already declares its own scroll container, so the shell-level clipping only hid layout bugs by silently cutting content; a genuine overflow now shows up as a visible scrollbar instead.

--- a/mastracode/factory-ui/src/ui/layouts/ChatLayout.tsx
+++ b/mastracode/factory-ui/src/ui/layouts/ChatLayout.tsx
@@ -13,7 +13,7 @@ type ChatLayoutProps = {
 export function ChatLayout({ sidebar, header, main }: ChatLayoutProps) {
   return (
     <ViewportLayout sidebar={sidebar} header={header}>
-      <div className="flex h-full min-w-0 flex-1 flex-col overflow-hidden">{main}</div>
+      <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">{main}</div>
     </ViewportLayout>
   );
 }

--- a/mastracode/factory-ui/src/ui/layouts/PageLayout.tsx
+++ b/mastracode/factory-ui/src/ui/layouts/PageLayout.tsx
@@ -11,7 +11,7 @@ const PAGE_HEADER_HEIGHT_CLASS = '[--page-header-height:3.5rem] lg:[--page-heade
 export function PageLayout({ sidebar, header, children }: PageLayoutProps) {
   return (
     <div className="bg-surface1 relative z-1 flex min-h-dvh">
-      <aside className="sticky top-0 h-dvh min-h-0 shrink-0 overflow-hidden py-2">{sidebar}</aside>
+      <aside className="sticky top-0 h-dvh min-h-0 shrink-0 py-2">{sidebar}</aside>
       <div
         className={`${PAGE_HEADER_HEIGHT_CLASS} border-border1 bg-surface2 relative z-1 flex min-w-0 flex-1 flex-col border-l [--page-sticky-top:0rem] has-[>[data-page-header]:not(:empty)]:[--page-sticky-top:var(--page-header-height)]`}
       >
@@ -30,13 +30,13 @@ export function PageLayout({ sidebar, header, children }: PageLayoutProps) {
 /** Fixed application viewport for views that own nested scroll regions. */
 export function ViewportLayout({ sidebar, header, children }: PageLayoutProps) {
   return (
-    <div className="bg-surface1 relative z-1 flex h-dvh overflow-hidden">
-      <aside className="h-full min-h-0 shrink-0 overflow-hidden py-2">{sidebar}</aside>
+    <div className="bg-surface1 relative z-1 flex h-dvh">
+      <aside className="h-full min-h-0 shrink-0 py-2">{sidebar}</aside>
       <div
-        className={`${PAGE_HEADER_HEIGHT_CLASS} border-border1 bg-surface2 relative z-1 flex min-w-0 flex-1 flex-col overflow-hidden border-l`}
+        className={`${PAGE_HEADER_HEIGHT_CLASS} border-border1 bg-surface2 relative z-1 flex min-w-0 flex-1 flex-col border-l`}
       >
         {header}
-        <main className="isolate flex min-h-0 flex-1 flex-col overflow-hidden">{children}</main>
+        <main className="isolate flex min-h-0 flex-1 flex-col">{children}</main>
       </div>
     </div>
   );


### PR DESCRIPTION
TLDR: the app layout shells stop clipping their content — a real layout overflow now shows up as a visible scrollbar instead of being silently cut off.

---

```
before   6 overflow-hidden wrappers across PageLayout / ViewportLayout / ChatLayout
after    0 — the shells clip nothing; each scroll region still owns its scroller
```

Every actual scroll surface already declares itself: the sidebar scrolls through MainSidebar's ScrollArea, the board through its own `overflow-auto` container, chat through ChatShell's single MessageScroller. `overflow-hidden` never provided any of that scrolling — hidden boxes don't scroll. What it did was two other jobs:

- On one wrapper (ChatLayout's), it was quietly doing flex min-size duty — a non-visible overflow value zeroes the automatic minimum, which is what let the transcript column shrink. That job is now stated outright as `min-h-0`.
- Everywhere else it was a safety net that swallowed layout mistakes: content past the shell edge was cut with no scrollbar, no signal, and — because a hidden box is still a scroll container — `scrollIntoView` or focus could silently shift the whole app frame with no way to scroll back.

### Judgment call

This deliberately trades silent containment for fail-loud: if a page ever overflows the viewport shell, users see a scrollbar until it's fixed, instead of content being invisibly clipped. I think that's the right default for an app whose scroll regions are all explicit — the recent board phantom-scrollbar bug is exactly the kind of defect these nets keep invisible on developer machines with overlay scrollbars.

### Not verified

No visual pass on a running app (local MastraCode server down). Verified by typecheck and the factory-ui suite; flaky files re-run in isolation and green.

```
source        +6  -6
changeset     +5   0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The app layout no longer hides content that extends beyond its container. Users now see a scrollbar when content overflows, while existing scroll areas continue to work.

## Changes

- Removed six `overflow-hidden` wrappers from `PageLayout`, `ViewportLayout`, and `ChatLayout`.
- Added `min-h-0` to `ChatLayout` to preserve flex shrinking.
- Added a patch changeset for `@mastra/factory`.

## Validation

- Typechecking passed.
- Factory UI tests passed, including isolated reruns of flaky files.
- Visual verification was not performed because the local MastraCode server was unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->