### PR TITLE
fix(core): treat falsy resume payloads as present in the tool-call step

### DIFF
--- a/.changeset/eager-singers-enter.md
+++ b/.changeset/eager-singers-enter.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': patch
+---
+
+Fixed resuming a tool with a falsy resume payload.
+
+A tool whose `resumeSchema` is a primitive can be resumed with `false`, `0` or `""`, and `false` is how a boolean human-in-the-loop tool declines. Those payloads were read as "no resume data".
+
+**Background tasks no longer start a second run**
+
+Resuming a suspended background task with one of those payloads left the task suspended forever and dispatched a new one. It now resumes the existing task.
+
+**Same-run resumes keep their tool call**
+
+A reloading client now still receives the replayed tool-call chunk, and the tool call is still recorded to memory when no matching invocation is on the message list.

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -42,6 +42,212 @@ const makeBaseExecuteParams = (suspend: Mock, overrides: any = {}) => ({
   ...overrides,
 });
 
+describe('createToolCallStep background task resume with falsy payload', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  const runBackgroundResume = async (resumeData: unknown) => {
+    const controller = { enqueue: vi.fn() };
+    const streamState = { serialize: vi.fn().mockReturnValue('serialized-state') };
+    const messageList = createMessageList();
+    const backgroundTaskManager = {
+      // A suspended task already exists for this tool call, so the step should
+      // resume it rather than dispatch a brand new one.
+      listTasks: vi.fn(async () => ({ tasks: [{ id: 'suspended-task-1' }], total: 1 })),
+      resume: vi.fn(async () => ({ id: 'suspended-task-1' })),
+      enqueue: vi.fn(async () => ({ task: { id: 'brand-new-task' }, fallbackToSync: false })),
+      cancel: vi.fn(),
+      waitForNextTask: vi.fn(),
+    };
+    const tools = {
+      'background-tool': {
+        backgroundConfig: { enabled: true },
+        execute: vi.fn(async () => ({ ok: true })),
+      },
+    } as any;
+
+    const toolCallStep = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      runId: 'current-run',
+      streamState,
+      _internal: {
+        backgroundTaskManager,
+        backgroundTaskManagerConfig: { enabled: true },
+        agentBackgroundConfig: { tools: 'all' },
+      },
+    } as any);
+
+    await toolCallStep.execute(
+      makeBaseExecuteParams(vi.fn(), {
+        resumeData,
+        inputData: { toolCallId: 'call-1', toolName: 'background-tool', args: { query: 'customers' } },
+      }),
+    );
+
+    return backgroundTaskManager;
+  };
+
+  const runBackgroundDispatchOnResume = async (resumeData: unknown) => {
+    const controller = { enqueue: vi.fn() };
+    const streamState = { serialize: vi.fn().mockReturnValue('serialized-state') };
+    const messageList = createMessageList();
+    const backgroundTaskManager = {
+      // No suspended task, so this resume turn dispatches instead. The chunk comes
+      // back on the CURRENT run id, which is the case the replay gate guards.
+      listTasks: vi.fn(async () => ({ tasks: [], total: 0 })),
+      resume: vi.fn(),
+      enqueue: vi.fn(async (_payload: any, context: any) => {
+        context.onChunk?.({
+          type: 'background-task-completed',
+          payload: {
+            taskId: 'task-1',
+            toolCallId: 'call-1',
+            toolName: 'background-tool',
+            agentId: 'agent-1',
+            runId: 'current-run',
+            result: { ok: true },
+            completedAt: new Date(),
+          },
+        });
+        return { task: { id: 'task-1' }, fallbackToSync: false };
+      }),
+      cancel: vi.fn(),
+      waitForNextTask: vi.fn(),
+    };
+    const tools = {
+      'background-tool': { backgroundConfig: { enabled: true }, execute: vi.fn() },
+    } as any;
+
+    const toolCallStep = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      runId: 'current-run',
+      streamState,
+      _internal: {
+        backgroundTaskManager,
+        backgroundTaskManagerConfig: { enabled: true },
+        agentBackgroundConfig: { tools: 'all' },
+      },
+    } as any);
+
+    await toolCallStep.execute(
+      makeBaseExecuteParams(vi.fn(), {
+        resumeData,
+        inputData: { toolCallId: 'call-1', toolName: 'background-tool', args: { query: 'customers' } },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(controller.enqueue).toHaveBeenCalled();
+    });
+    return controller;
+  };
+
+  it('replays the tool-call chunk on a same-run resume with a falsy payload', async () => {
+    // The replay exists so a reloading UI still renders the invocation that was streamed
+    // in the earlier turn. A falsy resume payload is still a resume, so it must replay.
+    const controller = await runBackgroundDispatchOnResume(false);
+
+    const replayed = controller.enqueue.mock.calls
+      .map(([chunk]: [any]) => chunk)
+      .filter((chunk: any) => chunk.type === 'tool-call');
+    expect(replayed).toHaveLength(1);
+  });
+
+  it('records the background result to memory on a same-run resume with a falsy payload', async () => {
+    // When no matching tool-invocation is on the list, the result is appended as a standalone
+    // tool message so memory still records it. A falsy resume payload must not skip that.
+    const streamState = { serialize: vi.fn().mockReturnValue('serialized-state') };
+    const added: any[] = [];
+    const messageList = {
+      get: {
+        input: { aiV5: { model: () => [] } },
+        response: { db: () => [] },
+        all: { db: () => [], aiV5: { model: () => [] } },
+      },
+      updateToolInvocation: vi.fn(() => false),
+      updateMessageMetadataByToolCallId: vi.fn(() => true),
+      add: vi.fn((messages: any) => {
+        added.push(messages);
+      }),
+    } as unknown as MessageList;
+
+    const backgroundTaskManager = {
+      listTasks: vi.fn(async () => ({ tasks: [], total: 0 })),
+      resume: vi.fn(),
+      enqueue: vi.fn(async (_payload: any, context: any) => {
+        await context.onResult?.({
+          taskId: 'task-1',
+          toolCallId: 'call-1',
+          toolName: 'background-tool',
+          runId: 'current-run',
+          status: 'completed',
+          result: { ok: true },
+          startedAt: new Date(0),
+          completedAt: new Date(0),
+        });
+        return { task: { id: 'task-1' }, fallbackToSync: false };
+      }),
+      cancel: vi.fn(),
+      waitForNextTask: vi.fn(),
+    };
+
+    const toolCallStep = createToolCallStep({
+      tools: { 'background-tool': { backgroundConfig: { enabled: true }, execute: vi.fn() } } as any,
+      messageList,
+      controller: { enqueue: vi.fn() },
+      runId: 'current-run',
+      streamState,
+      _internal: {
+        backgroundTaskManager,
+        backgroundTaskManagerConfig: { enabled: true },
+        agentBackgroundConfig: { tools: 'all' },
+      },
+    } as any);
+
+    await toolCallStep.execute(
+      makeBaseExecuteParams(vi.fn(), {
+        resumeData: false,
+        inputData: { toolCallId: 'call-1', toolName: 'background-tool', args: { query: 'customers' } },
+      }),
+    );
+
+    // Distinguish the standalone tool-CALL record (the gated fallback) from the
+    // tool-RESULT message that is appended unconditionally a few lines below it.
+    const callRecords = added
+      .flat()
+      .filter((message: any) => message?.role === 'tool')
+      .filter((message: any) => (message.content ?? []).some((part: any) => part.type === 'tool-call'));
+    expect(callRecords).toHaveLength(1);
+  });
+
+  it('resumes the suspended task when the resume payload is an object', async () => {
+    const manager = await runBackgroundResume({ confirmed: true });
+
+    expect(manager.resume).toHaveBeenCalledWith('suspended-task-1', { confirmed: true });
+    expect(manager.enqueue).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['false', false],
+    ['zero', 0],
+    ['an empty string', ''],
+  ])('resumes the suspended task when the resume payload is %s', async (_label, resumeData) => {
+    // A primitive resumeSchema makes these valid payloads; `false` is how a boolean
+    // human-in-the-loop tool declines. Treating them as "no resume data" silently
+    // dispatches a second task while the first stays suspended forever.
+    const manager = await runBackgroundResume(resumeData);
+
+    expect(manager.resume).toHaveBeenCalledWith('suspended-task-1', resumeData);
+    expect(manager.enqueue).not.toHaveBeenCalled();
+  });
+});
+
 describe('createToolCallStep background task stream replay', () => {
   afterEach(() => {
     vi.clearAllMocks();

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -1053,7 +1053,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                       const bgRunId = chunk.payload.runId;
                       const replayKey = `${bgRunId}:${chunk.payload.toolCallId}`;
                       if (
-                        (bgRunId !== runId || (bgRunId === runId && workflowResumeData)) &&
+                        (bgRunId !== runId || (bgRunId === runId && workflowResumeData != null)) &&
                         !emittedReplayedToolCalls.has(replayKey)
                       ) {
                         safeEnqueue(
@@ -1273,7 +1273,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                   // message so memory still records the result, even if it
                   // means a duplicate entry for that toolCallId.
                   if (!updated) {
-                    if (params.runId !== runId || (params.runId === runId && workflowResumeData)) {
+                    if (params.runId !== runId || (params.runId === runId && workflowResumeData != null)) {
                       messageList.add(
                         [
                           {
@@ -1355,7 +1355,10 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               resourceId: readScoped(scopeCtx, RESOURCE_ID_KEY, 'resourceId'),
               toolName: inputData.toolName,
             });
-            if (isSuspended && resumeDataToPassToToolOptions) {
+            // Nullish, not truthy: a tool with a primitive resumeSchema can be resumed with
+            // `false` / `0` / `''`, and treating those as "no resume data" would fall through to
+            // `dispatch()` below, leaving the suspended task stranded and starting a second one.
+            if (isSuspended && resumeDataToPassToToolOptions != null) {
               const task = await bgTask.resume(resumeDataToPassToToolOptions);
 
               return {


### PR DESCRIPTION
## Summary

- Resume a suspended background task when the resume payload is `false`, `0` or `""` instead of dispatching a second task and stranding the first.
- Replay the tool-call chunk and record the tool call to memory on a same-run resume with one of those payloads.
- Add regression coverage for all three, plus an object-payload control.

Fixes #22362

A tool whose `resumeSchema` is a primitive can be resumed with a falsy value. `false` is how a boolean human-in-the-loop tool declines. Three conditions in `tool-call-step.ts` tested the payload for truthiness, so those values read as "no resume data".

The background-task one is the damaging case. `checkIfSuspended` finds the suspended task, the truthiness test fails, and control falls through to `dispatch()`. The suspended task stays suspended and a second task starts. I measured it against `main` by counting calls on the task manager: `resume` 0, `enqueue` 1. With the fix, `resume` is called once with the falsy payload and `enqueue` is not called at all.

The other two conditions gate the replayed tool-call chunk and the standalone tool-call record written when no matching invocation is on the message list. On a same-run resume with a falsy payload, a reloading client loses the rendered invocation and memory loses the call record. I found both by inspection and then wrote failing tests for them, so they are demonstrated rather than observed in production. My first attempt at the memory test passed against unpatched `main` because it was picking up the tool-result message that is appended unconditionally a few lines below, so the assertion distinguishes the call record from the result message.

This is the same class of bug as #19083, fixed in #21319, which corrected the suspension-metadata cleanup and the delegated run-id lookup in this file. These are the remaining instances of the pattern.

## Test plan

```sh
pnpm --filter ./packages/core exec vitest run src/loop/workflows/agentic-execution/tool-call-step.test.ts
pnpm --filter ./packages/core exec vitest run --project unit:packages/core src/loop src/agent src/tools src/background-tasks
```

- 53 tests in `tool-call-step.test.ts`, no type errors.
- Counter-test: reverting the three conditions on the same tree fails exactly the 5 new tests, so they pin the behavior rather than passing either way.
- Wider unit run: 467 files, 5142 tests.
- `oxlint` and `oxfmt --check` clean on both changed files.
- Changeset added for `@mastra/core`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a tool resumes with `false`, `0`, or an empty string, the system now recognizes that value as real data. It resumes the existing task instead of starting a duplicate task and preserves the tool call in the client and memory.

## Changes

- Replaced truthiness checks with nullish checks in `tool-call-step.ts`.
- Replays tool-call chunks for same-run resumes with falsy payloads.
- Records standalone tool calls in memory when no matching invocation exists.
- Resumes suspended background tasks without duplicate dispatches.
- Added regression tests for `false`, `0`, `""`, and object payloads.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->