### PR TITLE
Rebuild the Factory settings pages on the shared settings row

### DIFF
--- a/.changeset/hot-llamas-doubt.md
+++ b/.changeset/hot-llamas-doubt.md
@@ -1,0 +1,12 @@
+---
+'@mastra/factory': patch
+---
+
+Reworked the settings pages so every option reads as the same kind of row.
+
+- **Work Intake** is now one section per source — GitHub issues, Linear issues, and Linear routing — instead of both sources stacked in a single card. Linear's connection state (connect, reconnect, expired, workspace name) moved into its section header. Both sources now use the same picker: one search box that spans every Linear team instead of a search per collapsed team, with the repositories and projects listed straight away, inset from the card edges and scrolling in the same scroll area the rest of the app uses.
+- **Memory** renders observational-memory options as regular settings rows instead of a stacked block with its own padding.
+- **Models** shows the Provider access tabs above the card instead of inside it, and each provider is a settings row rather than a data-list row.
+- **Repositories** gives the setup and teardown commands one row each, per repository, with the command field on the right like every other setting and a line saying when it runs. Both save on their own when you leave the field, so there is no save button to hunt for.
+- **Repositories** lists the repositories you can link the same way — a standard search field, rows aligned with the card, and grouped under "Linked" and "Available" instead of each row drawing its own box.
+- Section actions such as "Manage GitHub connection" now sit on the right of the section title instead of below the description.

--- a/.changeset/sweet-peaches-take.md
+++ b/.changeset/sweet-peaches-take.md
@@ -1,0 +1,11 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added a `factory` variant to the `SettingsRow` component so settings rows can render the denser card-row layout (row padding, 12px description text) instead of only the studio spacing.
+
+```tsx
+<SettingsRow variant="factory" label="Observer model" description="Summarizes the conversation into observations">
+  <ModelCombobox />
+</SettingsRow>
+```

--- a/.changeset/sweet-peaches-take.md
+++ b/.changeset/sweet-peaches-take.md
@@ -5,7 +5,7 @@
 Added a `factory` variant to the `SettingsRow` component so settings rows can render the denser card-row layout (row padding, 12px description text) instead of only the studio spacing.
 
 ```tsx
-<SettingsRow variant="factory" label="Observer model" description="Summarizes the conversation into observations">
-  <ModelCombobox />
+<SettingsRow variant="factory" label="Auto-approve tools" description="Run tool calls without asking">
+  <Switch checked={autoApprove} onCheckedChange={setAutoApprove} />
 </SettingsRow>
 ```

--- a/mastracode/factory-ui/src/ui/domains/settings/components/AccountSettingsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/AccountSettingsSection.tsx
@@ -8,7 +8,8 @@ import { LogOut } from 'lucide-react';
 import { useApiConfig } from '../../../../api/config';
 import { useFactoryAuth } from '../../../../hooks/useFactoryAuth';
 import { clearMastraCodeStorage, redirectToLogout } from '../../auth/services/auth';
-import { SettingsCard, SettingsRow } from './SettingsCard';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
+import { SettingsCard } from './SettingsCard';
 import { SettingsSubsection } from './SettingsSubsection';
 
 const AUTH_PROVIDER_LABELS: Record<string, string> = {
@@ -48,13 +49,13 @@ function CopyableAccountValue({ value, label }: { value: string; label: string }
 function AccountSettingsSkeleton() {
   return (
     <SettingsCard>
-      <SettingsRow label="Name">
+      <SettingsRow variant="factory" label="Name">
         <Skeleton className="h-4 w-28" />
       </SettingsRow>
-      <SettingsRow label="Email">
+      <SettingsRow variant="factory" label="Email">
         <Skeleton className="h-4 w-40" />
       </SettingsRow>
-      <SettingsRow label="Authentication">
+      <SettingsRow variant="factory" label="Authentication">
         <Skeleton className="h-4 w-24" />
       </SettingsRow>
     </SettingsCard>
@@ -97,22 +98,26 @@ export function AccountSettingsSection() {
     <div className="flex flex-col gap-8">
       <SettingsSubsection title="Profile" description="Your signed-in identity for this MastraCode deployment.">
         <SettingsCard>
-          <SettingsRow label="Name">
+          <SettingsRow variant="factory" label="Name">
             <AccountValue>{user?.name ?? 'Not provided'}</AccountValue>
           </SettingsRow>
-          <SettingsRow label="Email">
+          <SettingsRow variant="factory" label="Email">
             <AccountValue>{user?.email ?? 'Not provided'}</AccountValue>
           </SettingsRow>
-          <SettingsRow label="Authentication">
+          <SettingsRow variant="factory" label="Authentication">
             <AccountValue>{authProviderLabel(state.provider)}</AccountValue>
           </SettingsRow>
           {user?.userId && (
-            <SettingsRow label="Account ID" hint="Useful when contacting support.">
+            <SettingsRow variant="factory" label="Account ID" description="Useful when contacting support.">
               <CopyableAccountValue value={user.userId} label="account ID" />
             </SettingsRow>
           )}
           {user?.organizationId && (
-            <SettingsRow label="Organization ID" hint="The organization that owns this Factory.">
+            <SettingsRow
+              variant="factory"
+              label="Organization ID"
+              description="The organization that owns this Factory."
+            >
               <CopyableAccountValue value={user.organizationId} label="organization ID" />
             </SettingsRow>
           )}
@@ -120,7 +125,7 @@ export function AccountSettingsSection() {
       </SettingsSubsection>
       <SettingsSubsection title="Session">
         <SettingsCard>
-          <SettingsRow label="Log out" hint="End your MastraCode session on this device.">
+          <SettingsRow variant="factory" label="Log out" description="End your MastraCode session on this device.">
             <Button type="button" variant="outline" size="sm" aria-label="Log out of MastraCode" onClick={logOut}>
               <LogOut aria-hidden="true" />
               Log out

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ConnectedAccountsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ConnectedAccountsSection.tsx
@@ -7,7 +7,8 @@ import { SkeletonRows } from '../../../ui/SkeletonRows';
 import { useApiConfig } from '../../../../api/config';
 import { useChannelAccountsQuery } from '../../../../hooks/useChannelAccounts';
 import { connectSlackUrl } from '../services/channelAccounts';
-import { SettingsCard, SettingsRow } from './SettingsCard';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
+import { SettingsCard } from './SettingsCard';
 
 /**
  * Shown when Slack isn't available on this server, instead of a Connect button
@@ -21,6 +22,7 @@ export function SlackNotConfigured() {
   return (
     <SettingsCard>
       <SettingsRow
+        variant="factory"
         label={
           <span className="flex items-center gap-3">
             <SlackIcon className="size-7 shrink-0 opacity-50" />
@@ -101,7 +103,7 @@ export function ConnectedAccountsSection() {
           to={`/factories/${factoryId}/settings/connections/slack`}
           className="group hover:bg-surface4 focus-visible:ring-accent1 block cursor-pointer rounded-xl outline-hidden transition-colors focus-visible:ring-2"
         >
-          <SettingsRow label={slackLabel}>
+          <SettingsRow variant="factory" label={slackLabel}>
             <span className="text-ui-sm text-icon4 group-hover:text-icon5 flex items-center gap-2">
               Configure
               <ChevronRight aria-hidden="true" />
@@ -115,7 +117,7 @@ export function ConnectedAccountsSection() {
           onClick={connectSlack}
           className="group hover:bg-surface4 focus-visible:ring-accent1 block w-full cursor-pointer rounded-xl text-left outline-hidden transition-colors focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          <SettingsRow label={slackLabel}>
+          <SettingsRow variant="factory" label={slackLabel}>
             <span className="text-ui-sm text-icon4 group-hover:text-icon5 flex items-center gap-2">
               Connect
               <ChevronRight aria-hidden="true" />

--- a/mastracode/factory-ui/src/ui/domains/settings/components/FactoryDefaultModelSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/FactoryDefaultModelSection.tsx
@@ -6,7 +6,7 @@ import { useFactoryProjectQuery, useSetFactoryDefaultModelMutation } from '../..
 import { useParams } from 'react-router';
 
 import { ModelCombobox } from './ModelCombobox';
-import { SettingsRow } from './SettingsCard';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
 import { SharedCredentialNotice } from './SharedCredentialNotice';
 
 /**
@@ -26,8 +26,9 @@ export function FactoryDefaultModelSection({ models }: { models: AvailableModelO
 
   return (
     <SettingsRow
+      variant="factory"
       label="Factory default model"
-      hint={
+      description={
         <>
           <span>
             Factory runs (triage, board work items) start on this model and use the Factory observational-memory

--- a/mastracode/factory-ui/src/ui/domains/settings/components/FactoryManagementSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/FactoryManagementSection.tsx
@@ -5,7 +5,8 @@ import { Trash2 } from 'lucide-react';
 import { useParams } from 'react-router';
 
 import { useFactoryQuery, useRemoveFactoryMutation } from '../../../../hooks/useFactories';
-import { SettingsCard, SettingsRow } from './SettingsCard';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
+import { SettingsCard } from './SettingsCard';
 import { SettingsSubsection } from './SettingsSubsection';
 
 export function FactoryManagementSection() {
@@ -21,7 +22,7 @@ export function FactoryManagementSection() {
   return (
     <SettingsSubsection title="Danger zone">
       <SettingsCard>
-        <SettingsRow label={`Remove ${factory.name}`} hint="Also unlinks its repositories.">
+        <SettingsRow variant="factory" label={`Remove ${factory.name}`} description="Also unlinks its repositories.">
           <AlertDialog>
             <AlertDialog.Trigger asChild>
               <Button

--- a/mastracode/factory-ui/src/ui/domains/settings/components/FactorySetupSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/FactorySetupSection.tsx
@@ -1,9 +1,5 @@
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from '@mastra/playground-ui/components/InputGroup';
+import { Input } from '@mastra/playground-ui/components/Input';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
 import { toast } from '@mastra/playground-ui/components/Toaster';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useState } from 'react';
@@ -13,82 +9,101 @@ import type { FactoryProject } from '../../workspaces/services/github';
 import { SettingsCard } from './SettingsCard';
 import { SettingsSubsection } from './SettingsSubsection';
 
-function RepositoryLifecycleRow({ projectRepositoryId, label }: { projectRepositoryId: string; label: string }) {
+function CommandInput({
+  label,
+  value,
+  placeholder,
+  disabled,
+  onCommit,
+}: {
+  label: string;
+  value: string;
+  placeholder: string;
+  disabled: boolean;
+  onCommit: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState<string>();
+  const current = draft ?? value;
+
+  const commit = () => {
+    setDraft(undefined);
+    if (current.trim() !== value) onCommit(current.trim());
+  };
+
+  return (
+    <Input
+      size="sm"
+      aria-label={label}
+      placeholder={placeholder}
+      className="font-mono"
+      value={current}
+      disabled={disabled}
+      onChange={event => setDraft(event.target.value)}
+      onBlur={commit}
+      onKeyDown={event => {
+        if (event.key === 'Enter') event.currentTarget.blur();
+      }}
+    />
+  );
+}
+
+function RepositoryCommands({ projectRepositoryId, label }: { projectRepositoryId: string; label: string }) {
   const settingsQuery = useRepositorySettingsQuery(projectRepositoryId);
   const saveMutation = useSaveRepositorySettingsMutation();
 
-  const savedSetup = settingsQuery.data?.setupCommand ?? '';
-  const savedTeardown = settingsQuery.data?.teardownCommand ?? '';
-  const [setupDraft, setSetupDraft] = useState<string>();
-  const [teardownDraft, setTeardownDraft] = useState<string>();
-  const currentSetup = setupDraft ?? savedSetup;
-  const currentTeardown = teardownDraft ?? savedTeardown;
-  const dirty = currentSetup.trim() !== savedSetup || currentTeardown.trim() !== savedTeardown;
-  const save = () => {
+  const setupCommand = settingsQuery.data?.setupCommand ?? '';
+  const teardownCommand = settingsQuery.data?.teardownCommand ?? '';
+  const busy = settingsQuery.isPending || saveMutation.isPending;
+
+  const save = (settings: { setupCommand: string; teardownCommand: string }) => {
     saveMutation.mutate(
       {
         projectRepositoryId,
         settings: {
-          setupCommand: currentSetup.trim() || null,
-          teardownCommand: currentTeardown.trim() || null,
+          setupCommand: settings.setupCommand || null,
+          teardownCommand: settings.teardownCommand || null,
         },
       },
       {
-        onSuccess: () => {
-          setSetupDraft(undefined);
-          setTeardownDraft(undefined);
-          toast.success('Worktree commands saved');
-        },
+        onSuccess: () => toast.success('Worktree commands saved'),
         onError: err => toast.error(err instanceof Error ? err.message : 'Failed to save worktree commands'),
       },
     );
   };
 
   return (
-    <div className="flex flex-col gap-1.5 px-4 py-3">
-      <Txt as="span" variant="ui-md" className="text-icon5">
+    <div className="flex flex-col gap-2">
+      <Txt as="p" variant="ui-xs" className="text-icon3 font-mono">
         {label}
       </Txt>
-      <div className="grid gap-2">
-        <InputGroup size="sm">
-          <InputGroupAddon align="inline-start">Setup</InputGroupAddon>
-          <InputGroupInput
-            aria-label={`Setup command for ${label}`}
-            placeholder="e.g. pnpm i && pnpm build"
-            className="font-mono"
-            value={currentSetup}
-            disabled={settingsQuery.isPending || saveMutation.isPending}
-            onChange={e => setSetupDraft(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter' && dirty) save();
-            }}
-          />
-        </InputGroup>
-        <InputGroup size="sm">
-          <InputGroupAddon align="inline-start">Teardown</InputGroupAddon>
-          <InputGroupInput
-            aria-label={`Teardown command for ${label}`}
-            placeholder="e.g. pnpm local worktree teardown"
-            className="font-mono"
-            value={currentTeardown}
-            disabled={settingsQuery.isPending || saveMutation.isPending}
-            onChange={e => setTeardownDraft(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter' && dirty) save();
-            }}
-          />
-          <InputGroupAddon align="inline-end">
-            <InputGroupButton
-              size="sm"
-              variant="default"
-              disabled={!dirty || settingsQuery.isPending || saveMutation.isPending}
-              onClick={save}
-            >
-              Save
-            </InputGroupButton>
-          </InputGroupAddon>
-        </InputGroup>
-      </div>
+      <SettingsCard>
+        <SettingsRow variant="factory" label="Setup" description="Runs once the worktree is created, before the agent.">
+          <div className="w-full lg:max-w-96">
+            <CommandInput
+              label={`Setup command for ${label}`}
+              value={setupCommand}
+              placeholder="e.g. pnpm i && pnpm build"
+              disabled={busy}
+              onCommit={value => save({ setupCommand: value, teardownCommand })}
+            />
+          </div>
+        </SettingsRow>
+        <SettingsRow
+          variant="factory"
+          label="Teardown"
+          description="Runs when the worktree is discarded, and again if setup fails."
+        >
+          <div className="w-full lg:max-w-96">
+            <CommandInput
+              label={`Teardown command for ${label}`}
+              value={teardownCommand}
+              placeholder="e.g. pnpm local worktree teardown"
+              disabled={busy}
+              onCommit={value => save({ setupCommand, teardownCommand: value })}
+            />
+          </div>
+        </SettingsRow>
+      </SettingsCard>
     </div>
   );
 }
@@ -101,19 +116,16 @@ export function FactorySetupSection({ factory }: { factory: FactoryProject }) {
   if (rows.length === 0) return null;
 
   return (
-    <SettingsSubsection
-      title="Worktree lifecycle"
-      description="Setup runs before agent work. Teardown may be retried during retirement, so keep it idempotent."
-    >
-      <SettingsCard>
+    <SettingsSubsection title="Worktree commands" description="Shell commands each session runs in its own worktree.">
+      <div className="flex flex-col gap-4">
         {rows.map(row => (
-          <RepositoryLifecycleRow
+          <RepositoryCommands
             key={row.projectRepositoryId}
             projectRepositoryId={row.projectRepositoryId}
             label={row.label}
           />
         ))}
-      </SettingsCard>
+      </div>
     </SettingsSubsection>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/settings/components/FactorySetupSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/FactorySetupSection.tsx
@@ -20,14 +20,22 @@ function CommandInput({
   value: string;
   placeholder: string;
   disabled: boolean;
-  onCommit: (value: string) => void;
+  onCommit: (value: string) => Promise<unknown>;
 }) {
   const [draft, setDraft] = useState<string>();
   const current = draft ?? value;
 
+  // The draft survives a failed save, so a rejected command is still there to retry.
   const commit = () => {
-    setDraft(undefined);
-    if (current.trim() !== value) onCommit(current.trim());
+    if (current.trim() === value) {
+      setDraft(undefined);
+      return;
+    }
+    onCommit(current.trim()).then(
+      () => setDraft(undefined),
+      // The mutation's onError already reports it; keeping the draft is the retry.
+      () => {},
+    );
   };
 
   return (
@@ -55,8 +63,8 @@ function RepositoryCommands({ projectRepositoryId, label }: { projectRepositoryI
   const teardownCommand = settingsQuery.data?.teardownCommand ?? '';
   const busy = settingsQuery.isPending || saveMutation.isPending;
 
-  const save = (settings: { setupCommand: string; teardownCommand: string }) => {
-    saveMutation.mutate(
+  const save = (settings: { setupCommand: string; teardownCommand: string }) =>
+    saveMutation.mutateAsync(
       {
         projectRepositoryId,
         settings: {
@@ -69,7 +77,6 @@ function RepositoryCommands({ projectRepositoryId, label }: { projectRepositoryI
         onError: err => toast.error(err instanceof Error ? err.message : 'Failed to save worktree commands'),
       },
     );
-  };
 
   return (
     <div className="flex flex-col gap-2">

--- a/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
@@ -1,30 +1,21 @@
 import { Button } from '@mastra/playground-ui/components/Button';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@mastra/playground-ui/components/Collapsible';
-import { Select, SelectContent, SelectItem, SelectTrigger } from '@mastra/playground-ui/components/Select';
-import { DataList } from '@mastra/playground-ui/components/DataList';
-import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
-import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
 import { Switch } from '@mastra/playground-ui/components/Switch';
 import { toast } from '@mastra/playground-ui/components/Toaster';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { ChevronRight } from 'lucide-react';
-import { useState } from 'react';
-import type { ReactNode } from 'react';
 
 import { useApiConfig } from '../../../../api/config';
 import { SkeletonRows } from '../../../ui/SkeletonRows';
-import {
-  useIntakeBindingsQuery,
-  useIntakeConfigQuery,
-  useSaveIntakeBindingMutation,
-  useSaveIntakeConfigMutation,
-} from '../../../../hooks/useIntakeConfig';
+import { useIntakeConfigQuery, useSaveIntakeConfigMutation } from '../../../../hooks/useIntakeConfig';
 import { useLinearProjectsQuery, useLinearStatusQuery } from '../../../../hooks/useLinearData';
 import { connectLinear, isLinearReauthError } from '../../factory/services/linear';
-import type { LinearProject } from '../../factory/services/linear';
+import type { LinearProject, LinearStatus } from '../../factory/services/linear';
 import type { IntakeConfig } from '../../factory/services/intake';
 import { useFactoriesQuery } from '../../../../hooks/useFactories';
-import { SettingsCard, SettingsRow } from './SettingsCard';
+import { SourcePicker } from './IntakeSourcePicker';
+import type { SourcePickerGroup } from './IntakeSourcePicker';
+import { LinearRouting } from './LinearRouting';
+import { SettingsCard } from './SettingsCard';
 import { SettingsSubsection } from './SettingsSubsection';
 
 /**
@@ -38,184 +29,145 @@ function toggleId(ids: string[] | null, id: string): string[] | null {
   return next.length ? next : null;
 }
 
-interface SourcePickerItem {
-  id: string;
-  label: string;
+interface SourceSectionProps {
+  config: IntakeConfig;
+  busy: boolean;
+  update: (next: IntakeConfig) => void;
 }
 
-function SourcePickerGroup({ children }: { children: ReactNode }) {
-  return <div className="divide-border1 divide-y">{children}</div>;
-}
-
-/**
- * Collapsible picker for one source section (a Linear team or the GitHub
- * repository list). Collapsed by default with a "n selected" hint; expanded it
- * shows a client-side search bar scoped to this section plus a checkbox row
- * per item. Collapsing resets the search (the panel unmounts, so the input
- * remounts empty on reopen).
- */
-function SourcePickerSection({
-  label,
-  items,
-  selectedIds,
-  disabled,
-  pending,
-  onToggleItem,
-}: {
-  label: string;
-  items: SourcePickerItem[];
-  selectedIds: string[] | null;
-  disabled: boolean;
-  /** True while the selection save is in flight — shows the section spinner. */
-  pending: boolean;
-  onToggleItem: (id: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState('');
-
-  const selectedCount = items.filter(item => selectedIds?.includes(item.id)).length;
-  const normalizedQuery = query.trim().toLowerCase();
-  const visibleItems = items.filter(item => item.label.toLowerCase().includes(normalizedQuery));
-
-  const toggle = (id: string) => {
-    if (disabled) return;
-    onToggleItem(id);
-  };
-
+function GithubIntakeSection({
+  config,
+  busy,
+  update,
+  repositories,
+}: SourceSectionProps & { repositories: { slug: string }[] }) {
   return (
-    <div role="group" aria-label={label}>
-      <Collapsible
-        open={open}
-        onOpenChange={next => {
-          setOpen(next);
-          if (!next) setQuery('');
-        }}
-      >
-        <CollapsibleTrigger className="text-icon4 flex w-full items-center gap-1.5 py-2">
-          <ChevronRight className="size-3.5 shrink-0" aria-hidden="true" />
-          <Txt as="span" variant="ui-sm">
-            {label}
-          </Txt>
-          {selectedCount > 0 && (
-            <Txt as="span" variant="ui-xs" className="text-accent1">
-              {selectedCount} selected
+    <SettingsSubsection
+      title="GitHub issues"
+      description="Open issues from the selected repositories. Pull requests always appear in Review."
+    >
+      <SettingsCard>
+        <SettingsRow variant="factory" label="Sync GitHub issues">
+          <Switch
+            aria-label="Sync GitHub issues"
+            checked={config.github.enabled}
+            disabled={busy}
+            onCheckedChange={enabled => update({ ...config, github: { ...config.github, enabled } })}
+          />
+        </SettingsRow>
+
+        {config.github.enabled &&
+          (repositories.length === 0 ? (
+            <Txt as="p" variant="ui-sm" className="text-icon3 px-4 py-3">
+              No linked repositories yet — link a repository to a factory to add one.
             </Txt>
-          )}
-          {pending && (
-            // Wrapped in a span so the trigger's `[&>svg]` chevron-rotation
-            // rules don't apply to the spinner svg.
-            <span className="ml-auto flex shrink-0">
-              <Spinner size="sm" aria-label={`Saving ${label} selection`} />
-            </span>
-          )}
-        </CollapsibleTrigger>
-        <CollapsibleContent className="flex flex-col gap-2 pb-3">
-          <ListSearch label={`Search ${label}`} placeholder="Search…" size="sm" value={query} onSearch={setQuery} />
-          <DataList columns="auto minmax(0,1fr)" variant="lined" className="max-h-64">
-            {visibleItems.length === 0 ? (
-              <DataList.NoMatch message="No matches" />
-            ) : (
-              visibleItems.map(item => (
-                <DataList.RowWrapper key={item.id}>
-                  <DataList.SelectCell
-                    checked={selectedIds?.includes(item.id) ?? false}
-                    onToggle={() => toggle(item.id)}
-                    disabled={disabled}
-                    aria-label={item.label}
-                  />
-                  <DataList.RowButton
-                    flushLeft
-                    colStart={2}
-                    disabled={disabled}
-                    onClick={() => toggle(item.id)}
-                    // The whole row is one action here, so drop the button's own
-                    // hover/focus fill and let the root's uniform `.data-list-row`
-                    // hover overlay be the only highlight (no stacked fills).
-                    className="hover:bg-transparent focus-visible:bg-transparent"
-                  >
-                    <DataList.NameCell>{item.label}</DataList.NameCell>
-                  </DataList.RowButton>
-                </DataList.RowWrapper>
-              ))
-            )}
-          </DataList>
-        </CollapsibleContent>
-      </Collapsible>
-    </div>
+          ) : (
+            <SourcePicker
+              label="Repositories"
+              groups={[
+                {
+                  id: 'repositories',
+                  items: repositories.map(repository => ({ id: repository.slug, label: repository.slug })),
+                },
+              ]}
+              selectedIds={config.github.sourceIds}
+              disabled={busy}
+              pending={busy}
+              onToggleItem={slug =>
+                update({
+                  ...config,
+                  github: { ...config.github, sourceIds: toggleId(config.github.sourceIds, slug) },
+                })
+              }
+            />
+          ))}
+      </SettingsCard>
+    </SettingsSubsection>
   );
 }
-
-const UNROUTED = '__unrouted__';
 
 /**
- * Routing for the selected Linear projects. A Linear project feeds exactly one
- * Factory; until it is routed its issues are not picked up by any board.
+ * Linear needs an OAuth workspace before anything can sync, so the connection
+ * state is the section header: the description says what is missing and the
+ * action connects or reconnects.
  */
-function LinearRouting({
-  sourceIds,
+function LinearIntakeSection({
+  config,
+  busy,
+  update,
+  status,
+  connected,
   projects,
-  factories,
-}: {
-  sourceIds: string[];
+  reauthRequired,
+  baseUrl,
+}: SourceSectionProps & {
+  status: LinearStatus | undefined;
+  connected: boolean;
   projects: LinearProject[];
-  factories: { id: string; name: string }[];
+  reauthRequired: boolean;
+  baseUrl: string;
 }) {
-  const bindingsQuery = useIntakeBindingsQuery();
-  const saveBinding = useSaveIntakeBindingMutation();
-  const bindings = bindingsQuery.data ?? [];
-  const busy = saveBinding.isPending;
+  const serverConfigured = status?.enabled !== false;
+  const description = !serverConfigured
+    ? 'Linear is not configured on this server.'
+    : !connected
+      ? 'Connect a Linear workspace to sync its issues.'
+      : reauthRequired
+        ? 'Linear authorization expired. Reconnect to keep syncing issues.'
+        : 'Active issues from the selected projects.';
 
-  const route = (sourceId: string, value: string) => {
-    saveBinding.mutate(
-      { integrationId: 'linear', sourceId, factoryProjectId: value === UNROUTED ? null : value },
-      {
-        onSuccess: () => toast.success('Linear routing updated'),
-        onError: err => toast.error(err instanceof Error ? err.message : 'Failed to save Linear routing'),
-      },
-    );
-  };
+  const action = !serverConfigured ? undefined : !connected ? (
+    <Button size="sm" onClick={() => connectLinear(baseUrl)}>
+      Connect Linear
+    </Button>
+  ) : reauthRequired ? (
+    <Button size="sm" onClick={() => connectLinear(baseUrl)}>
+      Reconnect Linear
+    </Button>
+  ) : (
+    <span className="flex items-center gap-2">
+      <Txt as="span" variant="ui-sm" className="text-icon3">
+        Connected to {status?.workspace?.name ?? 'a Linear workspace'}
+      </Txt>
+      <Button size="xs" variant="ghost" onClick={() => connectLinear(baseUrl)}>
+        Reconnect
+      </Button>
+    </span>
+  );
+
+  const showPickers = connected && config.linear.enabled && !reauthRequired && projects.length > 0;
 
   return (
-    <div className="flex flex-col">
-      {sourceIds.map(sourceId => {
-        const name = projects.find(project => project.id === sourceId)?.name ?? sourceId;
-        const factoryProjectId = bindings.find(
-          binding => binding.integrationId === 'linear' && binding.sourceId === sourceId,
-        )?.factoryProjectId;
-        return (
-          <SettingsRow
-            key={sourceId}
-            label={name}
-            hint={factoryProjectId ? undefined : "Not routed — this project's issues won't be picked up."}
-          >
-            <Select
-              value={factoryProjectId ?? UNROUTED}
-              disabled={busy || factories.length === 0}
-              onValueChange={value => route(sourceId, value)}
-            >
-              <SelectTrigger variant="outline" size="sm" aria-label={`Factory for ${name}`} className="w-auto">
-                <Txt as="span" variant="ui-sm">
-                  {factories.find(factory => factory.id === factoryProjectId)?.name ?? 'Not routed'}
-                </Txt>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={UNROUTED}>Not routed</SelectItem>
-                {factories.map(factory => (
-                  <SelectItem key={factory.id} value={factory.id}>
-                    {factory.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </SettingsRow>
-        );
-      })}
-    </div>
+    <SettingsSubsection title="Linear issues" description={description} action={action}>
+      <SettingsCard>
+        <SettingsRow variant="factory" label="Sync Linear issues">
+          <Switch
+            aria-label="Sync Linear issues"
+            checked={config.linear.enabled}
+            disabled={busy || !connected}
+            onCheckedChange={enabled => update({ ...config, linear: { ...config.linear, enabled } })}
+          />
+        </SettingsRow>
+
+        {showPickers && (
+          <SourcePicker
+            label="Linear projects"
+            groups={groupLinearProjectsByTeam(projects)}
+            selectedIds={config.linear.sourceIds}
+            disabled={busy}
+            pending={busy}
+            onToggleItem={projectId =>
+              update({
+                ...config,
+                linear: { ...config.linear, sourceIds: toggleId(config.linear.sourceIds, projectId) },
+              })
+            }
+          />
+        )}
+      </SettingsCard>
+    </SettingsSubsection>
   );
 }
-
-const INTAKE_INTRO =
-  'Which sources feed issues into Intake, for your whole account. Code access is set under Repositories.';
 
 export function IntakeSection() {
   const { baseUrl } = useApiConfig();
@@ -232,19 +184,13 @@ export function IntakeSection() {
   const linkedRepositories = (factoriesQuery.data ?? []).flatMap(factory => factory.repositories);
 
   if (configQuery.isPending) {
-    return (
-      <SettingsSubsection title="Issue sources" description={INTAKE_INTRO}>
-        <SkeletonRows label="Loading intake sources" rows={4} />
-      </SettingsSubsection>
-    );
+    return <SkeletonRows label="Loading intake sources" rows={4} />;
   }
   if (configQuery.isError || !config) {
     return (
-      <SettingsSubsection title="Issue sources" description={INTAKE_INTRO}>
-        <Txt as="p" variant="ui-sm" className="text-icon3">
-          Intake configuration is unavailable. Connect GitHub or Linear first.
-        </Txt>
-      </SettingsSubsection>
+      <Txt as="p" variant="ui-sm" className="text-icon3">
+        Intake configuration is unavailable. Connect GitHub or Linear first.
+      </Txt>
     );
   }
 
@@ -255,142 +201,47 @@ export function IntakeSection() {
     });
   };
   const busy = saveMutation.isPending;
+  const linearProjects = linearProjectsQuery.data ?? [];
+  const reauthRequired = isLinearReauthError(linearProjectsQuery.error);
+  const routedProjectIds = config.linear.sourceIds ?? [];
 
   return (
-    <SettingsSubsection title="Issue sources" description={INTAKE_INTRO}>
-      <SettingsCard>
-        <SettingsRow
-          label="GitHub issues"
-          hint="Open issues from the selected repositories. Pull requests always appear in Review."
+    <div className="flex flex-col gap-8">
+      <GithubIntakeSection config={config} busy={busy} update={update} repositories={linkedRepositories} />
+      <LinearIntakeSection
+        config={config}
+        busy={busy}
+        update={update}
+        status={linearStatus}
+        connected={linearConnected}
+        projects={linearProjects}
+        reauthRequired={reauthRequired}
+        baseUrl={baseUrl}
+      />
+      {linearConnected && config.linear.enabled && routedProjectIds.length > 0 && (
+        <SettingsSubsection
+          title="Linear routing"
+          description="Each selected project feeds one factory. Until a project is routed, its issues are not picked up."
         >
-          <Switch
-            aria-label="Sync GitHub issues"
-            checked={config.github.enabled}
-            disabled={busy}
-            onCheckedChange={enabled => update({ ...config, github: { ...config.github, enabled } })}
-          />
-        </SettingsRow>
-
-        {config.github.enabled && (
-          <div className="px-4">
-            {linkedRepositories.length === 0 ? (
-              <Txt as="p" variant="ui-sm" className="text-icon3 py-3">
-                No linked repositories yet — link a repository to a factory to add one.
-              </Txt>
-            ) : (
-              <SourcePickerGroup>
-                <SourcePickerSection
-                  label="Repositories"
-                  items={linkedRepositories.map(repository => ({ id: repository.slug, label: repository.slug }))}
-                  selectedIds={config.github.sourceIds}
-                  disabled={busy}
-                  pending={busy}
-                  onToggleItem={slug =>
-                    update({
-                      ...config,
-                      github: {
-                        ...config.github,
-                        sourceIds: toggleId(config.github.sourceIds, slug),
-                      },
-                    })
-                  }
-                />
-              </SourcePickerGroup>
-            )}
-          </div>
-        )}
-
-        <SettingsRow label="Linear issues" hint="Active issues from the selected projects.">
-          <Switch
-            aria-label="Sync Linear issues"
-            checked={config.linear.enabled}
-            disabled={busy || !linearConnected}
-            onCheckedChange={enabled => update({ ...config, linear: { ...config.linear, enabled } })}
-          />
-        </SettingsRow>
-
-        {!linearConnected ? (
-          <div className="flex flex-col items-start gap-2 px-4 py-3 lg:flex-row lg:items-center lg:gap-3">
-            <Txt as="span" variant="ui-sm" className="text-icon3">
-              {linearStatus?.enabled === false
-                ? 'Linear is not configured on this server.'
-                : 'Connect a Linear workspace to sync its issues.'}
-            </Txt>
-            {linearStatus?.enabled !== false && (
-              <Button size="xs" onClick={() => connectLinear(baseUrl)}>
-                Connect Linear
-              </Button>
-            )}
-          </div>
-        ) : config.linear.enabled && isLinearReauthError(linearProjectsQuery.error) ? (
-          // Expired token still reports connected; offer OAuth again.
-          <div className="flex flex-col items-start gap-2 px-4 py-3 lg:flex-row lg:items-center lg:gap-3">
-            <Txt as="span" variant="ui-sm" className="text-icon3">
-              Linear authorization expired. Reconnect to keep syncing issues.
-            </Txt>
-            <Button size="xs" onClick={() => connectLinear(baseUrl)}>
-              Reconnect Linear
-            </Button>
-          </div>
-        ) : (
-          config.linear.enabled && (
-            <div className="flex flex-col gap-2.5 px-4 py-3">
-              <div className="flex items-center gap-2">
-                <Txt as="span" variant="ui-sm" className="text-icon3">
-                  Connected to {linearStatus?.workspace?.name ?? 'a Linear workspace'}
-                </Txt>
-                <Button size="xs" variant="ghost" onClick={() => connectLinear(baseUrl)}>
-                  Reconnect
-                </Button>
-              </div>
-              {(linearProjectsQuery.data ?? []).length > 0 && (
-                <SourcePickerGroup>
-                  {groupLinearProjectsByTeam(linearProjectsQuery.data ?? []).map(group => (
-                    <SourcePickerSection
-                      key={group.id}
-                      label={group.label}
-                      items={group.projects.map(project => ({ id: project.id, label: project.name }))}
-                      selectedIds={config.linear.sourceIds}
-                      disabled={busy}
-                      pending={busy}
-                      onToggleItem={projectId =>
-                        update({
-                          ...config,
-                          linear: { ...config.linear, sourceIds: toggleId(config.linear.sourceIds, projectId) },
-                        })
-                      }
-                    />
-                  ))}
-                </SourcePickerGroup>
-              )}
-              {(config.linear.sourceIds?.length ?? 0) > 0 && (
-                <LinearRouting
-                  sourceIds={config.linear.sourceIds ?? []}
-                  projects={linearProjectsQuery.data ?? []}
-                  factories={factoriesQuery.data ?? []}
-                />
-              )}
-            </div>
-          )
-        )}
-      </SettingsCard>
-    </SettingsSubsection>
+          <SettingsCard>
+            <LinearRouting
+              sourceIds={routedProjectIds}
+              projects={linearProjects}
+              factories={factoriesQuery.data ?? []}
+            />
+          </SettingsCard>
+        </SettingsSubsection>
+      )}
+    </div>
   );
 }
-
-interface LinearTeamGroup {
-  id: string;
-  label: string;
-  projects: LinearProject[];
-}
-
 /**
  * Group Linear projects under each team they belong to (shared projects appear
- * in every team), sorted by team key. Team-less projects land in a trailing
+ * in every team), sorted by team name. Team-less projects land in a trailing
  * "No team" group.
  */
-function groupLinearProjectsByTeam(projects: LinearProject[]): LinearTeamGroup[] {
-  const byTeam = new Map<string, LinearTeamGroup>();
+function groupLinearProjectsByTeam(projects: LinearProject[]): SourcePickerGroup[] {
+  const byTeam = new Map<string, SourcePickerGroup>();
   const orphans: LinearProject[] = [];
   for (const project of projects) {
     if (project.teams.length === 0) {
@@ -398,12 +249,18 @@ function groupLinearProjectsByTeam(projects: LinearProject[]): LinearTeamGroup[]
       continue;
     }
     for (const team of project.teams) {
-      const group = byTeam.get(team.id) ?? { id: team.id, label: `${team.key} · ${team.name}`, projects: [] };
-      group.projects.push(project);
+      const group = byTeam.get(team.id) ?? { id: team.id, label: team.name, items: [] };
+      group.items.push({ id: project.id, label: project.name });
       byTeam.set(team.id, group);
     }
   }
-  const groups = [...byTeam.values()].sort((a, b) => a.label.localeCompare(b.label));
-  if (orphans.length) groups.push({ id: 'no-team', label: 'No team', projects: orphans });
+  const groups = [...byTeam.values()].sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''));
+  if (orphans.length) {
+    groups.push({
+      id: 'no-team',
+      label: 'No team',
+      items: orphans.map(project => ({ id: project.id, label: project.name })),
+    });
+  }
   return groups;
 }

--- a/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSection.tsx
@@ -35,12 +35,7 @@ interface SourceSectionProps {
   update: (next: IntakeConfig) => void;
 }
 
-function GithubIntakeSection({
-  config,
-  busy,
-  update,
-  repositories,
-}: SourceSectionProps & { repositories: { slug: string }[] }) {
+function GithubIntakeSection({ config, busy, update, slugs }: SourceSectionProps & { slugs: string[] }) {
   return (
     <SettingsSubsection
       title="GitHub issues"
@@ -57,7 +52,7 @@ function GithubIntakeSection({
         </SettingsRow>
 
         {config.github.enabled &&
-          (repositories.length === 0 ? (
+          (slugs.length === 0 ? (
             <Txt as="p" variant="ui-sm" className="text-icon3 px-4 py-3">
               No linked repositories yet — link a repository to a factory to add one.
             </Txt>
@@ -67,7 +62,7 @@ function GithubIntakeSection({
               groups={[
                 {
                   id: 'repositories',
-                  items: repositories.map(repository => ({ id: repository.slug, label: repository.slug })),
+                  items: slugs.map(slug => ({ id: slug, label: slug })),
                 },
               ]}
               selectedIds={config.github.sourceIds}
@@ -99,12 +94,15 @@ function LinearIntakeSection({
   connected,
   projects,
   reauthRequired,
+  showPickers,
   baseUrl,
 }: SourceSectionProps & {
   status: LinearStatus | undefined;
   connected: boolean;
   projects: LinearProject[];
   reauthRequired: boolean;
+  /** Projects can only be picked — and routed — once Linear answers with them. */
+  showPickers: boolean;
   baseUrl: string;
 }) {
   const serverConfigured = status?.enabled !== false;
@@ -134,8 +132,6 @@ function LinearIntakeSection({
       </Button>
     </span>
   );
-
-  const showPickers = connected && config.linear.enabled && !reauthRequired && projects.length > 0;
 
   return (
     <SettingsSubsection title="Linear issues" description={description} action={action}>
@@ -181,7 +177,10 @@ export function IntakeSection() {
   const linearProjectsQuery = useLinearProjectsQuery(linearConnected);
 
   const config = configQuery.data;
-  const linkedRepositories = (factoriesQuery.data ?? []).flatMap(factory => factory.repositories);
+  // The same repository can be linked to several factories; Intake picks it once.
+  const linkedSlugs = [
+    ...new Set((factoriesQuery.data ?? []).flatMap(factory => factory.repositories.map(r => r.slug))),
+  ];
 
   if (configQuery.isPending) {
     return <SkeletonRows label="Loading intake sources" rows={4} />;
@@ -204,10 +203,11 @@ export function IntakeSection() {
   const linearProjects = linearProjectsQuery.data ?? [];
   const reauthRequired = isLinearReauthError(linearProjectsQuery.error);
   const routedProjectIds = config.linear.sourceIds ?? [];
+  const linearReady = linearConnected && config.linear.enabled && !reauthRequired && linearProjects.length > 0;
 
   return (
     <div className="flex flex-col gap-8">
-      <GithubIntakeSection config={config} busy={busy} update={update} repositories={linkedRepositories} />
+      <GithubIntakeSection config={config} busy={busy} update={update} slugs={linkedSlugs} />
       <LinearIntakeSection
         config={config}
         busy={busy}
@@ -216,9 +216,10 @@ export function IntakeSection() {
         connected={linearConnected}
         projects={linearProjects}
         reauthRequired={reauthRequired}
+        showPickers={linearReady}
         baseUrl={baseUrl}
       />
-      {linearConnected && config.linear.enabled && routedProjectIds.length > 0 && (
+      {linearReady && routedProjectIds.length > 0 && (
         <SettingsSubsection
           title="Linear routing"
           description="Each selected project feeds one factory. Until a project is routed, its issues are not picked up."

--- a/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSourcePicker.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSourcePicker.tsx
@@ -1,0 +1,106 @@
+import { Checkbox } from '@mastra/playground-ui/components/Checkbox';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
+import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { Fragment, useState } from 'react';
+
+export interface SourcePickerItem {
+  id: string;
+  label: string;
+}
+
+export interface SourcePickerGroup {
+  id: string;
+  /** Rendered as a heading above the group; omitted for a single flat list. */
+  label?: string;
+  items: SourcePickerItem[];
+}
+
+/**
+ * Searchable checkbox list of the items one source can feed Intake with.
+ * Groups (Linear teams) only add a heading — the search spans every group so a
+ * project can be found without knowing which team owns it.
+ */
+export function SourcePicker({
+  label,
+  groups,
+  selectedIds,
+  disabled,
+  pending,
+  onToggleItem,
+}: {
+  /** Names the list for assistive tech and the search field, e.g. "Repositories". */
+  label: string;
+  groups: SourcePickerGroup[];
+  selectedIds: string[] | null;
+  disabled: boolean;
+  /** True while the selection save is in flight — shows the spinner. */
+  pending: boolean;
+  onToggleItem: (id: string) => void;
+}) {
+  const [query, setQuery] = useState('');
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const matchingGroups = groups
+    .map(group => ({
+      ...group,
+      items: group.items.filter(item => item.label.toLowerCase().includes(normalizedQuery)),
+    }))
+    .filter(group => group.items.length > 0);
+  const selectedCount = groups.flatMap(group => group.items).filter(item => selectedIds?.includes(item.id)).length;
+
+  return (
+    <>
+      <div className="flex items-center gap-3 px-4 py-2">
+        <div className="min-w-0 flex-1">
+          <ListSearch label={`Search ${label}`} placeholder="Search…" size="sm" value={query} onSearch={setQuery} />
+        </div>
+        {pending ? (
+          <Spinner size="sm" aria-label={`Saving ${label} selection`} />
+        ) : (
+          selectedCount > 0 && (
+            <Txt as="span" variant="ui-xs" className="text-icon3 shrink-0">
+              {selectedCount} selected
+            </Txt>
+          )
+        )}
+      </div>
+
+      <ScrollArea orientation="vertical" maxHeight="20rem">
+        <div role="group" aria-label={label} className="flex flex-col gap-px p-2">
+          {matchingGroups.length === 0 ? (
+            <Txt as="p" variant="ui-sm" className="text-icon3 px-2 py-2">
+              No matches
+            </Txt>
+          ) : (
+            matchingGroups.map(group => (
+              <Fragment key={group.id}>
+                {group.label && (
+                  <Txt as="p" variant="ui-xs" className="text-icon3 px-2 pt-3 pb-1 first:pt-0">
+                    {group.label}
+                  </Txt>
+                )}
+                {group.items.map(item => (
+                  <label
+                    key={`${group.id}:${item.id}`}
+                    className="hover:bg-surface-overlay-soft flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 has-data-[disabled]:cursor-not-allowed"
+                  >
+                    <Checkbox
+                      checked={selectedIds?.includes(item.id) ?? false}
+                      disabled={disabled}
+                      onCheckedChange={() => onToggleItem(item.id)}
+                    />
+                    <Txt as="span" variant="ui-md" className="text-icon5 truncate">
+                      {item.label}
+                    </Txt>
+                  </label>
+                ))}
+              </Fragment>
+            ))
+          )}
+        </div>
+      </ScrollArea>
+    </>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSourcePicker.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSourcePicker.tsx
@@ -48,7 +48,10 @@ export function SourcePicker({
       items: group.items.filter(item => item.label.toLowerCase().includes(normalizedQuery)),
     }))
     .filter(group => group.items.length > 0);
-  const selectedCount = groups.flatMap(group => group.items).filter(item => selectedIds?.includes(item.id)).length;
+  // A shared Linear project appears under every team it belongs to, so count ids, not rows.
+  const selectedCount = new Set(
+    groups.flatMap(group => group.items).filter(item => selectedIds?.includes(item.id)).map(item => item.id),
+  ).size;
 
   return (
     <>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSourcePicker.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/IntakeSourcePicker.tsx
@@ -50,7 +50,10 @@ export function SourcePicker({
     .filter(group => group.items.length > 0);
   // A shared Linear project appears under every team it belongs to, so count ids, not rows.
   const selectedCount = new Set(
-    groups.flatMap(group => group.items).filter(item => selectedIds?.includes(item.id)).map(item => item.id),
+    groups
+      .flatMap(group => group.items)
+      .filter(item => selectedIds?.includes(item.id))
+      .map(item => item.id),
   ).size;
 
   return (

--- a/mastracode/factory-ui/src/ui/domains/settings/components/LinearRouting.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/LinearRouting.tsx
@@ -1,0 +1,77 @@
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@mastra/playground-ui/components/Select';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
+import { toast } from '@mastra/playground-ui/components/Toaster';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+
+import { useIntakeBindingsQuery, useSaveIntakeBindingMutation } from '../../../../hooks/useIntakeConfig';
+import type { LinearProject } from '../../factory/services/linear';
+
+const UNROUTED = '__unrouted__';
+
+/**
+ * Routing for the selected Linear projects. A Linear project feeds exactly one
+ * Factory; until it is routed its issues are not picked up by any board.
+ */
+export function LinearRouting({
+  sourceIds,
+  projects,
+  factories,
+}: {
+  sourceIds: string[];
+  projects: LinearProject[];
+  factories: { id: string; name: string }[];
+}) {
+  const bindingsQuery = useIntakeBindingsQuery();
+  const saveBinding = useSaveIntakeBindingMutation();
+  const bindings = bindingsQuery.data ?? [];
+  const busy = saveBinding.isPending;
+
+  const route = (sourceId: string, value: string) => {
+    saveBinding.mutate(
+      { integrationId: 'linear', sourceId, factoryProjectId: value === UNROUTED ? null : value },
+      {
+        onSuccess: () => toast.success('Linear routing updated'),
+        onError: err => toast.error(err instanceof Error ? err.message : 'Failed to save Linear routing'),
+      },
+    );
+  };
+
+  return (
+    <div className="flex flex-col">
+      {sourceIds.map(sourceId => {
+        const name = projects.find(project => project.id === sourceId)?.name ?? sourceId;
+        const factoryProjectId = bindings.find(
+          binding => binding.integrationId === 'linear' && binding.sourceId === sourceId,
+        )?.factoryProjectId;
+        return (
+          <SettingsRow
+            variant="factory"
+            key={sourceId}
+            label={name}
+            description={factoryProjectId ? undefined : "Not routed — this project's issues won't be picked up."}
+          >
+            <Select
+              value={factoryProjectId ?? UNROUTED}
+              disabled={busy || factories.length === 0}
+              onValueChange={value => route(sourceId, value)}
+            >
+              <SelectTrigger variant="outline" size="sm" aria-label={`Factory for ${name}`} className="w-auto">
+                <Txt as="span" variant="ui-sm">
+                  {factories.find(factory => factory.id === factoryProjectId)?.name ?? 'Not routed'}
+                </Txt>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={UNROUTED}>Not routed</SelectItem>
+                {factories.map(factory => (
+                  <SelectItem key={factory.id} value={factory.id}>
+                    {factory.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </SettingsRow>
+        );
+      })}
+    </div>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/LinearRouting.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/LinearRouting.tsx
@@ -40,24 +40,26 @@ export function LinearRouting({
     <div className="flex flex-col">
       {sourceIds.map(sourceId => {
         const name = projects.find(project => project.id === sourceId)?.name ?? sourceId;
-        const factoryProjectId = bindings.find(
+        const boundFactoryId = bindings.find(
           binding => binding.integrationId === 'linear' && binding.sourceId === sourceId,
         )?.factoryProjectId;
+        // A binding can outlive the factory it points at; such a project is unrouted again.
+        const routedFactory = factories.find(candidate => candidate.id === boundFactoryId);
         return (
           <SettingsRow
             variant="factory"
             key={sourceId}
             label={name}
-            description={factoryProjectId ? undefined : "Not routed — this project's issues won't be picked up."}
+            description={routedFactory ? undefined : "Not routed — this project's issues won't be picked up."}
           >
             <Select
-              value={factoryProjectId ?? UNROUTED}
+              value={routedFactory?.id ?? UNROUTED}
               disabled={busy || factories.length === 0}
               onValueChange={value => route(sourceId, value)}
             >
               <SelectTrigger variant="outline" size="sm" aria-label={`Factory for ${name}`} className="w-auto">
                 <Txt as="span" variant="ui-sm">
-                  {factories.find(factory => factory.id === factoryProjectId)?.name ?? 'Not routed'}
+                  {routedFactory?.name ?? 'Not routed'}
                 </Txt>
               </SelectTrigger>
               <SelectContent>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/OMSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/OMSection.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 import { Input } from '@mastra/playground-ui/components/Input';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useState } from 'react';
 
@@ -27,22 +28,6 @@ function choiceToAttachment(choice: AttachmentChoice): 'auto' | boolean {
   if (choice === 'on') return true;
   if (choice === 'off') return false;
   return 'auto';
-}
-
-function Field({ label, hint, children }: { label: string; hint: string; children: React.ReactNode }) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex flex-col">
-        <Txt as="span" variant="ui-sm" className="text-icon5">
-          {label}
-        </Txt>
-        <Txt as="span" variant="ui-xs" className="text-icon3">
-          {hint}
-        </Txt>
-      </div>
-      {children}
-    </div>
-  );
 }
 
 function ThresholdInput({
@@ -130,7 +115,11 @@ export function OMSection({
   };
 
   if (loading) {
-    return <SkeletonRows label="Loading observational-memory settings" rows={4} rowClassName="h-10 w-full" />;
+    return (
+      <div className="px-4 py-3">
+        <SkeletonRows label="Loading observational-memory settings" rows={4} rowClassName="h-10 w-full" />
+      </div>
+    );
   }
 
   const attachmentChoice = attachmentToChoice(config?.observeAttachments ?? 'auto');
@@ -141,15 +130,15 @@ export function OMSection({
   ];
 
   return (
-    <div className="flex flex-col gap-4">
+    <>
       {error && (
-        <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg">
+        <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg px-4 py-3">
           {error}
         </Txt>
       )}
 
       {config && !modelsAvailable && (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 px-4 py-3">
           <Badge size="md" variant="warning">
             Model credentials required
           </Badge>
@@ -159,53 +148,77 @@ export function OMSection({
         </div>
       )}
 
-      <Field label="Observer model" hint="Summarizes the conversation into observations">
-        <ModelCombobox
-          models={models}
-          value={config?.observerModelId ?? ''}
-          placeholder="Select observer model…"
-          disabled={busy}
-          onValueChange={modelId => switchModel('observer', modelId)}
-        />
-      </Field>
-
-      <Field label="Reflector model" hint="Distills observations into longer-term memory">
-        <ModelCombobox
-          models={models}
-          value={config?.reflectorModelId ?? ''}
-          placeholder="Select reflector model…"
-          disabled={busy}
-          onValueChange={modelId => switchModel('reflector', modelId)}
-        />
-      </Field>
-
-      <Field label="Messages before observation" hint="Message tokens processed before the observer runs.">
-        {config && (
-          <ThresholdInput
-            key={config.observationThreshold}
-            value={config.observationThreshold}
+      <SettingsRow variant="factory" label="Observer model" description="Summarizes the conversation into observations">
+        <div className="w-full max-w-72">
+          <ModelCombobox
+            models={models}
+            value={config?.observerModelId ?? ''}
+            placeholder="Select observer model…"
             disabled={busy}
-            onCommit={observationThreshold => {
-              thresholdsMutation.mutate({ observationThreshold });
-            }}
+            onValueChange={modelId => switchModel('observer', modelId)}
           />
-        )}
-      </Field>
+        </div>
+      </SettingsRow>
 
-      <Field label="Observations before reflection" hint="Observation tokens accumulated before the reflector runs.">
-        {config && (
-          <ThresholdInput
-            key={config.reflectionThreshold}
-            value={config.reflectionThreshold}
+      <SettingsRow
+        variant="factory"
+        label="Reflector model"
+        description="Distills observations into longer-term memory"
+      >
+        <div className="w-full max-w-72">
+          <ModelCombobox
+            models={models}
+            value={config?.reflectorModelId ?? ''}
+            placeholder="Select reflector model…"
             disabled={busy}
-            onCommit={reflectionThreshold => {
-              thresholdsMutation.mutate({ reflectionThreshold });
-            }}
+            onValueChange={modelId => switchModel('reflector', modelId)}
           />
-        )}
-      </Field>
+        </div>
+      </SettingsRow>
 
-      <Field label="Observe attachments" hint="Whether attached files are included in observations">
+      <SettingsRow
+        variant="factory"
+        label="Messages before observation"
+        description="Message tokens processed before the observer runs."
+      >
+        {config && (
+          <div className="w-full max-w-40">
+            <ThresholdInput
+              key={config.observationThreshold}
+              value={config.observationThreshold}
+              disabled={busy}
+              onCommit={observationThreshold => {
+                thresholdsMutation.mutate({ observationThreshold });
+              }}
+            />
+          </div>
+        )}
+      </SettingsRow>
+
+      <SettingsRow
+        variant="factory"
+        label="Observations before reflection"
+        description="Observation tokens accumulated before the reflector runs."
+      >
+        {config && (
+          <div className="w-full max-w-40">
+            <ThresholdInput
+              key={config.reflectionThreshold}
+              value={config.reflectionThreshold}
+              disabled={busy}
+              onCommit={reflectionThreshold => {
+                thresholdsMutation.mutate({ reflectionThreshold });
+              }}
+            />
+          </div>
+        )}
+      </SettingsRow>
+
+      <SettingsRow
+        variant="factory"
+        label="Observe attachments"
+        description="Whether attached files are included in observations"
+      >
         <ButtonsGroup spacing="close" role="group" aria-label="Observe attachments">
           {attachmentOptions.map(option => (
             <Button
@@ -220,7 +233,7 @@ export function OMSection({
             </Button>
           ))}
         </ButtonsGroup>
-      </Field>
-    </div>
+      </SettingsRow>
+    </>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ProviderAccessSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ProviderAccessSection.tsx
@@ -1,7 +1,7 @@
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
-import { DataList } from '@mastra/playground-ui/components/DataList';
 import { Input } from '@mastra/playground-ui/components/Input';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
 import {
   Dialog,
   DialogBody,
@@ -31,6 +31,7 @@ import { SkeletonRows } from '../../../ui/SkeletonRows';
 import { AddApiKeyDialog } from './AddApiKeyDialog';
 import { ProviderOAuthDialog } from './ProviderOAuthDialog';
 import { providerDisplayName } from './provider-display-name';
+import { SettingsCard } from './SettingsCard';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 
 const SOURCE_LABEL: Record<ProviderInfo['source'], string> = {
@@ -59,9 +60,6 @@ interface ActiveOAuthSession {
   provider: string;
   session: OAuthStartResponse;
 }
-
-const API_KEY_LIST_MAX_HEIGHT = 280;
-const PROVIDER_LIST_COLUMNS = '1fr auto auto';
 
 function mutationErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
@@ -295,69 +293,60 @@ export function ProviderAccessSection() {
         </TabList>
 
         <TabContent value="oauth" className="flex flex-col gap-3">
-          {providersQuery.isPending ? (
-            <SkeletonRows label="Loading providers" rows={3} rowClassName="h-9 w-full" />
-          ) : oauthProviders.length === 0 ? (
-            <Txt as="p" variant="ui-sm" className="text-icon3">
-              No providers support sign in.
-            </Txt>
-          ) : (
-            <DataList aria-label="Sign in providers" variant="lined" columns={PROVIDER_LIST_COLUMNS}>
-              {oauthProviders.map(provider => {
+          <SettingsCard>
+            {providersQuery.isPending ? (
+              <div className="px-4 py-3">
+                <SkeletonRows label="Loading providers" rows={3} rowClassName="h-9 w-full" />
+              </div>
+            ) : oauthProviders.length === 0 ? (
+              <Txt as="p" variant="ui-sm" className="text-icon3 px-4 py-3">
+                No providers support sign in.
+              </Txt>
+            ) : (
+              oauthProviders.map(provider => {
                 const displayName = providerDisplayName(provider.provider);
                 const scopes = oauthScopes(provider);
                 const showScopeLabels = scopes.length > 0 && authEnabled;
                 return (
-                  <DataList.RowStatic key={provider.provider}>
-                    <DataList.NameCell>{displayName}</DataList.NameCell>
-                    <DataList.Cell>
+                  <SettingsRow key={provider.provider} variant="factory" label={displayName}>
+                    <span className="flex items-center gap-2">
                       <SourceBadges provider={provider} />
-                    </DataList.Cell>
-                    <DataList.Cell className="justify-end">
-                      <span className="flex items-center gap-2">
-                        {scopes.map(scope => {
-                          // Removing the shared org sign-in is admin-only.
-                          if (scope === 'org' && !canWriteOrgKey) return null;
-                          const label = showScopeLabels
-                            ? scope === 'org'
-                              ? 'Sign out org'
-                              : 'Sign out me'
-                            : 'Sign out';
-                          return (
-                            <Button
-                              key={scope}
-                              variant="outline"
-                              size="sm"
-                              aria-label={
-                                scope === 'org'
-                                  ? `Sign out of ${displayName} for the org`
-                                  : `Sign out of ${displayName}`
-                              }
-                              disabled={isSigningOut(provider)}
-                              onClick={() => signOut(provider, scope)}
-                            >
-                              {isSigningOut(provider) ? 'Signing out…' : label}
-                            </Button>
-                          );
-                        })}
-                        {canSignIn(provider) && (
+                      {scopes.map(scope => {
+                        // Removing the shared org sign-in is admin-only.
+                        if (scope === 'org' && !canWriteOrgKey) return null;
+                        const label = showScopeLabels ? (scope === 'org' ? 'Sign out org' : 'Sign out me') : 'Sign out';
+                        return (
                           <Button
-                            variant={scopes.length === 0 ? 'primary' : 'outline'}
+                            key={scope}
+                            variant="outline"
                             size="sm"
-                            aria-label={`Sign in to ${displayName}`}
-                            disabled={startOAuthMutation.isPending}
-                            onClick={() => requestSignIn(provider)}
+                            aria-label={
+                              scope === 'org' ? `Sign out of ${displayName} for the org` : `Sign out of ${displayName}`
+                            }
+                            disabled={isSigningOut(provider)}
+                            onClick={() => signOut(provider, scope)}
                           >
-                            {startingProvider === provider.provider ? 'Starting…' : 'Sign in'}
+                            {isSigningOut(provider) ? 'Signing out…' : label}
                           </Button>
-                        )}
-                      </span>
-                    </DataList.Cell>
-                  </DataList.RowStatic>
+                        );
+                      })}
+                      {canSignIn(provider) && (
+                        <Button
+                          variant={scopes.length === 0 ? 'primary' : 'outline'}
+                          size="sm"
+                          aria-label={`Sign in to ${displayName}`}
+                          disabled={startOAuthMutation.isPending}
+                          onClick={() => requestSignIn(provider)}
+                        >
+                          {startingProvider === provider.provider ? 'Starting…' : 'Sign in'}
+                        </Button>
+                      )}
+                    </span>
+                  </SettingsRow>
                 );
-              })}
-            </DataList>
-          )}
+              })
+            )}
+          </SettingsCard>
         </TabContent>
 
         <TabContent value="api-key" className="flex flex-col gap-3">
@@ -373,58 +362,49 @@ export function ProviderAccessSection() {
             />
           </div>
 
-          {providersQuery.isPending ? (
-            <SkeletonRows label="Loading providers" rows={3} rowClassName="h-9 w-full" />
-          ) : results.length === 0 ? (
-            <Txt as="p" variant="ui-sm" className="text-icon3">
-              {query ? `No providers match “${search.trim()}”.` : 'No API key providers are available.'}
-            </Txt>
-          ) : (
-            <DataList
-              aria-label="API key providers"
-              variant="lined"
-              columns={PROVIDER_LIST_COLUMNS}
-              maxHeight={`${API_KEY_LIST_MAX_HEIGHT}px`}
-              className="min-h-0"
-            >
-              {results.map(provider => {
+          <SettingsCard className="max-h-[280px] overflow-y-auto">
+            {providersQuery.isPending ? (
+              <div className="px-4 py-3">
+                <SkeletonRows label="Loading providers" rows={3} rowClassName="h-9 w-full" />
+              </div>
+            ) : results.length === 0 ? (
+              <Txt as="p" variant="ui-sm" className="text-icon3 px-4 py-3">
+                {query ? `No providers match “${search.trim()}”.` : 'No API key providers are available.'}
+              </Txt>
+            ) : (
+              results.map(provider => {
                 const displayName = providerDisplayName(provider.provider);
                 const storedKey =
                   provider.source === 'stored' || provider.source === 'stored-user' || provider.source === 'stored-org';
                 return (
-                  <DataList.RowStatic key={provider.provider}>
-                    <DataList.NameCell>{displayName}</DataList.NameCell>
-                    <DataList.Cell>
+                  <SettingsRow key={provider.provider} variant="factory" label={displayName}>
+                    <span className="flex items-center gap-2">
                       <SourceBadges provider={provider} />
-                    </DataList.Cell>
-                    <DataList.Cell className="justify-end">
-                      <span className="flex items-center gap-2">
+                      <Button
+                        size="sm"
+                        aria-label={`${storedKey ? 'Update key' : 'Add API key'} for ${displayName}`}
+                        disabled={isRemoving(provider)}
+                        onClick={() => setKeyDialogProvider(provider)}
+                      >
+                        {storedKey ? 'Update key' : 'Add API key'}
+                      </Button>
+                      {storedKey && (
                         <Button
+                          variant="outline"
                           size="sm"
-                          aria-label={`${storedKey ? 'Update key' : 'Add API key'} for ${displayName}`}
+                          aria-label={`Remove key for ${displayName}`}
                           disabled={isRemoving(provider)}
-                          onClick={() => setKeyDialogProvider(provider)}
+                          onClick={() => removeKey(provider)}
                         >
-                          {storedKey ? 'Update key' : 'Add API key'}
+                          {isRemoving(provider) ? 'Removing…' : 'Remove'}
                         </Button>
-                        {storedKey && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            aria-label={`Remove key for ${displayName}`}
-                            disabled={isRemoving(provider)}
-                            onClick={() => removeKey(provider)}
-                          >
-                            {isRemoving(provider) ? 'Removing…' : 'Remove'}
-                          </Button>
-                        )}
-                      </span>
-                    </DataList.Cell>
-                  </DataList.RowStatic>
+                      )}
+                    </span>
+                  </SettingsRow>
                 );
-              })}
-            </DataList>
-          )}
+              })
+            )}
+          </SettingsCard>
         </TabContent>
       </Tabs>
 

--- a/mastracode/factory-ui/src/ui/domains/settings/components/RepositoriesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/RepositoriesSection.tsx
@@ -38,7 +38,7 @@ export function RepositoriesSection() {
           )
         }
       >
-        <SettingsCard className="p-4">
+        <SettingsCard>
           <ConnectRepositoriesPanel factory={activeFactory} />
         </SettingsCard>
       </SettingsSubsection>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsCard.tsx
@@ -1,24 +1,9 @@
-import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import type { ReactNode } from 'react';
 
 export function SettingsCard({ className, children }: { className?: string; children: ReactNode }) {
   return (
     <div className={cn('border-border1 bg-surface3 divide-border1 divide-y rounded-xl border', className)}>
-      {children}
-    </div>
-  );
-}
-
-export function SettingsRow({ label, hint, children }: { label: ReactNode; hint?: ReactNode; children?: ReactNode }) {
-  return (
-    <div className="flex flex-col gap-2 px-4 py-3 lg:flex-row lg:items-center lg:justify-between lg:gap-4">
-      <div className="flex min-w-0 flex-col gap-0.5">
-        <Txt as="span" variant="ui-md" className="text-icon5">
-          {label}
-        </Txt>
-        {hint && <div className="text-ui-sm text-icon3 flex flex-col gap-0.5">{hint}</div>}
-      </div>
       {children}
     </div>
   );

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.parts.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.parts.tsx
@@ -18,7 +18,8 @@ import { useEffect, useRef, useState } from 'react';
 
 import { DONE_SOUND_OPTIONS, loadDoneSound, playDoneSound, saveDoneSound } from '../services/doneSound';
 import type { DoneSound } from '../services/doneSound';
-import { SettingsCard, SettingsRow } from './SettingsCard';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
+import { SettingsCard } from './SettingsCard';
 import { SettingsSubsection } from './SettingsSubsection';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@mastra/playground-ui/components/Select';
 
@@ -54,28 +55,34 @@ export function GeneralSettings({ theme, onThemeChange }: GeneralSettingsProps) 
     playDoneSound(next);
   };
   return (
-    <SettingsCard>
-      <SettingsRow label="Theme" hint="Color scheme for the interface">
-        <Segmented
-          ariaLabel="Theme"
-          value={theme}
-          options={[
-            { value: 'system', label: 'System' },
-            { value: 'light', label: 'Light' },
-            { value: 'dark', label: 'Dark' },
-          ]}
-          onChange={onThemeChange}
-        />
-      </SettingsRow>
-      <SettingsRow label="Completion sound" hint="Played when an agent run finishes in a workspace">
-        <Segmented
-          ariaLabel="Completion sound"
-          value={doneSound}
-          options={DONE_SOUND_OPTIONS}
-          onChange={changeDoneSound}
-        />
-      </SettingsRow>
-    </SettingsCard>
+    <SettingsSubsection title="General">
+      <SettingsCard>
+        <SettingsRow variant="factory" label="Theme" description="Color scheme for the interface">
+          <Segmented
+            ariaLabel="Theme"
+            value={theme}
+            options={[
+              { value: 'system', label: 'System' },
+              { value: 'light', label: 'Light' },
+              { value: 'dark', label: 'Dark' },
+            ]}
+            onChange={onThemeChange}
+          />
+        </SettingsRow>
+        <SettingsRow
+          variant="factory"
+          label="Completion sound"
+          description="Played when an agent run finishes in a workspace"
+        >
+          <Segmented
+            ariaLabel="Completion sound"
+            value={doneSound}
+            options={DONE_SOUND_OPTIONS}
+            onChange={changeDoneSound}
+          />
+        </SettingsRow>
+      </SettingsCard>
+    </SettingsSubsection>
   );
 }
 
@@ -87,7 +94,7 @@ interface ModelSettingsProps {
 
 export function ModelSettings({ settings, updating, onBehaviorChange }: ModelSettingsProps) {
   return (
-    <SettingsRow label="Thinking level" hint="Extended-reasoning budget for the agent">
+    <SettingsRow variant="factory" label="Thinking level" description="Extended-reasoning budget for the agent">
       <div className="w-full lg:hidden">
         <SegmentedSelect
           ariaLabel="Thinking level"
@@ -130,33 +137,35 @@ export function BehaviorSettings({
   const notificationMode = settings?.notifications ?? 'off';
   return (
     <div className="flex flex-col gap-8">
-      <SettingsCard>
-        <SettingsRow label="Auto-approve tools" hint="Run tool calls without asking (YOLO)">
-          <Toggle
-            ariaLabel="Auto-approve tools"
-            checked={!!settings?.yolo}
-            disabled={!settings || updating}
-            onChange={v => onBehaviorChange({ yolo: v })}
-          />
-        </SettingsRow>
-        <SettingsRow label="Smart editing" hint="Use AST-aware edits when available">
-          <Toggle
-            ariaLabel="Smart editing"
-            checked={!!settings?.smartEditing}
-            disabled={!settings || updating}
-            onChange={v => onBehaviorChange({ smartEditing: v })}
-          />
-        </SettingsRow>
-        <SettingsRow label="Notifications" hint="How completion alerts are delivered">
-          <Segmented
-            ariaLabel="Notifications"
-            value={notificationMode}
-            disabled={!settings || updating}
-            options={NOTIFICATION_MODES}
-            onChange={v => onBehaviorChange({ notifications: v })}
-          />
-        </SettingsRow>
-      </SettingsCard>
+      <SettingsSubsection title="General">
+        <SettingsCard>
+          <SettingsRow variant="factory" label="Auto-approve tools" description="Run tool calls without asking (YOLO)">
+            <Toggle
+              ariaLabel="Auto-approve tools"
+              checked={!!settings?.yolo}
+              disabled={!settings || updating}
+              onChange={v => onBehaviorChange({ yolo: v })}
+            />
+          </SettingsRow>
+          <SettingsRow variant="factory" label="Smart editing" description="Use AST-aware edits when available">
+            <Toggle
+              ariaLabel="Smart editing"
+              checked={!!settings?.smartEditing}
+              disabled={!settings || updating}
+              onChange={v => onBehaviorChange({ smartEditing: v })}
+            />
+          </SettingsRow>
+          <SettingsRow variant="factory" label="Notifications" description="How completion alerts are delivered">
+            <Segmented
+              ariaLabel="Notifications"
+              value={notificationMode}
+              disabled={!settings || updating}
+              options={NOTIFICATION_MODES}
+              onChange={v => onBehaviorChange({ notifications: v })}
+            />
+          </SettingsRow>
+        </SettingsCard>
+      </SettingsSubsection>
       <PermissionsSection
         permissions={permissions}
         pendingPermissionCategory={pendingPermissionCategory}
@@ -195,7 +204,7 @@ function PermissionsSection({
     >
       <SettingsCard>
         {TOOL_CATEGORIES.map(({ value, label, hint }) => (
-          <SettingsRow key={value} label={label} hint={hint}>
+          <SettingsRow variant="factory" key={value} label={label} description={hint}>
             <Segmented
               ariaLabel={`${label} permission`}
               value={permissions?.categories?.[value] ?? 'ask'}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsPanel.tsx
@@ -7,7 +7,6 @@ import { buttonVariants } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { useMainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { toast } from '@mastra/playground-ui/components/Toaster';
-import { Txt } from '@mastra/playground-ui/components/Txt';
 
 import { useChatPermissions } from '../../chat/context/useChatPermissions';
 import { useChatSessionContext } from '../../chat/context/useChatSessionContext';
@@ -93,12 +92,9 @@ export function SettingsPanel() {
         {section === 'preferences' && <GeneralSettings theme={theme} onThemeChange={setTheme} />}
         {section === 'factory' && <FactoryManagementSection />}
         {section === 'connections' && (
-          <div className="flex flex-col gap-2">
-            <Txt as="p" variant="ui-sm" className="text-icon3">
-              Connect your account to use Factory from Slack.
-            </Txt>
+          <SettingsSubsection title="Connected accounts" description="Connect your account to use Factory from Slack.">
             <ConnectedAccountsSection />
-          </div>
+          </SettingsSubsection>
         )}
         {section === 'repositories' && <RepositoriesSection />}
         {section === 'intake' && <IntakeSection />}
@@ -187,7 +183,7 @@ function MemorySettingsSection({ factoryId, models, sessionResourceId, sessionSc
           title="Factory observational memory"
           description="Models and token thresholds used to summarize and retain context in Factory runs."
         >
-          <SettingsCard className="p-4">
+          <SettingsCard>
             <OMSection factoryId={factoryId} models={models} />
           </SettingsCard>
         </SettingsSubsection>
@@ -196,7 +192,7 @@ function MemorySettingsSection({ factoryId, models, sessionResourceId, sessionSc
         title="Your observational memory"
         description="Models and token thresholds used to summarize and retain context in your interactive chats."
       >
-        <SettingsCard className="p-4">
+        <SettingsCard>
           <OMSection resourceId={sessionResourceId} scope={sessionScope} models={models} />
         </SettingsCard>
       </SettingsSubsection>
@@ -225,9 +221,7 @@ function ModelsSettingsSection({ models, settings, updating, onBehaviorChange }:
           anyConnected ? undefined : 'Connect a provider to unlock model selection and observational-memory settings.'
         }
       >
-        <SettingsCard className="p-4">
-          <ProviderAccessSection />
-        </SettingsCard>
+        <ProviderAccessSection />
       </SettingsSubsection>
       <SettingsSubsection title="Custom providers">
         <SettingsCard className="p-4">

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsSubsection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsSubsection.tsx
@@ -17,16 +17,18 @@ export function SettingsSubsection({
 }) {
   return (
     <section id={id} className="flex min-w-0 scroll-mt-4 flex-col gap-2">
-      <div className="flex flex-col gap-1">
-        <Txt as="h2" variant="ui-sm" className="text-icon6 leading-ui-md font-semibold">
-          {title}
-        </Txt>
-        {description && (
-          <Txt as="p" variant="ui-sm" className="text-icon3">
-            {description}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+        <div className="flex min-w-0 flex-col gap-1">
+          <Txt as="h2" variant="ui-sm" className="text-icon6 leading-ui-md font-semibold">
+            {title}
           </Txt>
-        )}
-        {action && <div className="mt-1 flex">{action}</div>}
+          {description && (
+            <Txt as="p" variant="ui-sm" className="text-icon3">
+              {description}
+            </Txt>
+          )}
+        </div>
+        {action && <div className="shrink-0">{action}</div>}
       </div>
       {children}
     </section>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsSubsection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsSubsection.tsx
@@ -1,5 +1,6 @@
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import type { ReactNode } from 'react';
+import { useId } from 'react';
 
 export function SettingsSubsection({
   id,
@@ -15,11 +16,13 @@ export function SettingsSubsection({
   action?: ReactNode;
   children?: ReactNode;
 }) {
+  const titleId = useId();
+
   return (
-    <section id={id} className="flex min-w-0 scroll-mt-4 flex-col gap-2">
+    <section id={id} aria-labelledby={titleId} className="flex min-w-0 scroll-mt-4 flex-col gap-2">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
         <div className="flex min-w-0 flex-col gap-1">
-          <Txt as="h2" variant="ui-sm" className="text-icon6 leading-ui-md font-semibold">
+          <Txt as="h2" id={titleId} variant="ui-sm" className="text-icon6 leading-ui-md font-semibold">
             {title}
           </Txt>
           {description && (

--- a/mastracode/factory-ui/src/ui/domains/settings/components/ThinkingDefaultsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/ThinkingDefaultsSection.tsx
@@ -2,7 +2,7 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 
 import { useThinkingConfigQuery, useUpdateThinkingMutation } from '../../../../hooks/use-thinking';
 import type { ThinkingLevelValue } from '../../../../hooks/use-thinking';
-import { SettingsRow } from './SettingsCard';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
 import { Segmented, SegmentedSelect, THINKING_LEVELS } from './SettingsPanel.parts';
 
 /** Sentinel for "no per-mode override — use the global default". */
@@ -36,7 +36,11 @@ export function BaseThinkingSection() {
   return (
     <>
       <ThinkingError error={error} />
-      <SettingsRow label="Base thinking level" hint="Used by every run without a session or mode override">
+      <SettingsRow
+        variant="factory"
+        label="Base thinking level"
+        description="Used by every run without a session or mode override"
+      >
         <div className="w-full lg:hidden">
           <SegmentedSelect
             ariaLabel="Base thinking level"
@@ -73,7 +77,7 @@ export function ModeThinkingDefaultsSection() {
     <>
       <ThinkingError error={error} />
       {(config?.modes ?? []).map(mode => (
-        <SettingsRow key={mode} label={`${mode[0]?.toUpperCase()}${mode.slice(1)} mode`}>
+        <SettingsRow variant="factory" key={mode} label={`${mode[0]?.toUpperCase()}${mode.slice(1)} mode`}>
           <div className="w-full lg:hidden">
             <SegmentedSelect
               ariaLabel={`${mode} mode thinking level`}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/UserGithubConnectionRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/UserGithubConnectionRow.tsx
@@ -4,7 +4,8 @@ import { GithubIcon } from '@mastra/playground-ui/icons/GithubIcon';
 import { useApiConfig } from '../../../../api/config';
 import { useGithubStatusQuery } from '../../../../hooks/useGithubStatus';
 import { connectUserGithub } from '../../workspaces/services/github';
-import { SettingsCard, SettingsRow } from './SettingsCard';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
+import { SettingsCard } from './SettingsCard';
 import { SettingsSubsection } from './SettingsSubsection';
 
 /**
@@ -29,13 +30,14 @@ export function UserGithubConnectionRow() {
       <SettingsSubsection title="GitHub account">
         <SettingsCard>
           <SettingsRow
+            variant="factory"
             label={
               <span className="flex items-center gap-2">
                 <GithubIcon className="text-icon3 size-4 shrink-0" />
                 {`@${status.userGithubUsername ?? 'unknown'}`}
               </span>
             }
-            hint="Issues and PRs you create are authored as you."
+            description="Issues and PRs you create are authored as you."
           />
         </SettingsCard>
       </SettingsSubsection>
@@ -47,7 +49,11 @@ export function UserGithubConnectionRow() {
   return (
     <SettingsSubsection title="GitHub account">
       <SettingsCard>
-        <SettingsRow label="Not connected" hint="Connect it so issues and PRs you create are authored as you.">
+        <SettingsRow
+          variant="factory"
+          label="Not connected"
+          description="Connect it so issues and PRs you create are authored as you."
+        >
           <Button size="xs" variant="outline" onClick={() => connectUserGithub(baseUrl)}>
             <GithubIcon className="size-3.5" />
             Connect GitHub

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/FactorySetupSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/FactorySetupSection.msw.test.tsx
@@ -45,21 +45,20 @@ function renderSection(factoryProject: FactoryProject = emptyFactory) {
 describe('FactorySetupSection', () => {
   it('given no github projects, when rendered, then the section is hidden', () => {
     renderSection();
-    expect(screen.queryByText('Worktree lifecycle')).not.toBeInTheDocument();
+    expect(screen.queryByText('Worktree commands')).not.toBeInTheDocument();
   });
 
-  it('given a stored setup command, when rendered, then the field shows it', async () => {
+  it('given stored commands, when rendered, then each command has its own row', async () => {
     useSettingsHandlers({ setupCommand: 'pnpm i && pnpm build', teardownCommand: 'pnpm local teardown' });
 
     renderSection(factory);
 
-    expect(await screen.findByText('Worktree lifecycle')).toBeInTheDocument();
+    expect(await screen.findByText('Worktree commands')).toBeInTheDocument();
     await waitFor(() => expect(screen.getByRole('textbox', { name: FIELD })).toHaveValue('pnpm i && pnpm build'));
     expect(screen.getByRole('textbox', { name: TEARDOWN_FIELD })).toHaveValue('pnpm local teardown');
-    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 
-  it('given an edited command, when saving, then it persists and the button disables again', async () => {
+  it('given an edited setup command, when the field is left, then it persists on its own', async () => {
     const saved = useSettingsHandlers();
     const user = userEvent.setup();
 
@@ -68,17 +67,27 @@ describe('FactorySetupSection', () => {
     const input = await screen.findByRole('textbox', { name: FIELD });
     await waitFor(() => expect(input).toBeEnabled());
     await user.type(input, 'pnpm i && pnpm build');
-    await user.type(screen.getByRole('textbox', { name: TEARDOWN_FIELD }), 'pnpm local teardown');
-    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await user.tab();
 
-    await waitFor(() =>
-      expect(saved).toEqual([{ setupCommand: 'pnpm i && pnpm build', teardownCommand: 'pnpm local teardown' }]),
-    );
+    await waitFor(() => expect(saved).toEqual([{ setupCommand: 'pnpm i && pnpm build', teardownCommand: null }]));
     expect(await screen.findByText('Worktree commands saved')).toBeInTheDocument();
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled());
   });
 
-  it('given a stored command, when cleared and saved, then null is persisted', async () => {
+  it('given an unchanged field, when it is left, then nothing is saved', async () => {
+    const saved = useSettingsHandlers({ setupCommand: 'pnpm i', teardownCommand: null });
+    const user = userEvent.setup();
+
+    renderSection(factory);
+
+    const input = await screen.findByRole('textbox', { name: FIELD });
+    await waitFor(() => expect(input).toHaveValue('pnpm i'));
+    await user.click(input);
+    await user.tab();
+
+    expect(saved).toEqual([]);
+  });
+
+  it('given a stored command, when cleared, then null is persisted and the other command is kept', async () => {
     const saved = useSettingsHandlers({ setupCommand: 'pnpm i', teardownCommand: 'pnpm local teardown' });
     const user = userEvent.setup();
 
@@ -87,7 +96,7 @@ describe('FactorySetupSection', () => {
     const input = await screen.findByRole('textbox', { name: FIELD });
     await waitFor(() => expect(input).toHaveValue('pnpm i'));
     await user.clear(input);
-    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await user.tab();
 
     await waitFor(() => expect(saved).toEqual([{ setupCommand: null, teardownCommand: 'pnpm local teardown' }]));
   });
@@ -104,7 +113,7 @@ describe('FactorySetupSection', () => {
     const input = await screen.findByRole('textbox', { name: FIELD });
     await waitFor(() => expect(input).toBeEnabled());
     await user.type(input, 'rm -rf oops');
-    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await user.tab();
 
     expect(await screen.findByText('Invalid setupCommand')).toBeInTheDocument();
   });

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/FactorySetupSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/FactorySetupSection.msw.test.tsx
@@ -84,7 +84,12 @@ describe('FactorySetupSection', () => {
     await user.click(input);
     await user.tab();
 
-    expect(saved).toEqual([]);
+    // A real save on the other field lands after any request the untouched one
+    // could have fired, so a stray save shows up as a second entry here.
+    await user.type(screen.getByRole('textbox', { name: TEARDOWN_FIELD }), 'pnpm local teardown');
+    await user.tab();
+
+    await waitFor(() => expect(saved).toEqual([{ setupCommand: 'pnpm i', teardownCommand: 'pnpm local teardown' }]));
   });
 
   it('given a stored command, when cleared, then null is persisted and the other command is kept', async () => {
@@ -99,6 +104,25 @@ describe('FactorySetupSection', () => {
     await user.tab();
 
     await waitFor(() => expect(saved).toEqual([{ setupCommand: null, teardownCommand: 'pnpm local teardown' }]));
+  });
+
+  it('given the server rejects the save, when saving fails, then the typed command stays in the field', async () => {
+    server.use(
+      http.get(SETTINGS_URL, () => HttpResponse.json({ setupCommand: 'pnpm i', teardownCommand: null })),
+      http.post(SETTINGS_URL, () => HttpResponse.json({ error: 'Invalid setupCommand' }, { status: 400 })),
+    );
+    const user = userEvent.setup();
+
+    renderSection(factory);
+
+    const input = await screen.findByRole('textbox', { name: FIELD });
+    await waitFor(() => expect(input).toHaveValue('pnpm i'));
+    await user.clear(input);
+    await user.type(input, 'pnpm i --frozen-lockfile');
+    await user.tab();
+
+    expect(await screen.findByText('Invalid setupCommand')).toBeInTheDocument();
+    expect(input).toHaveValue('pnpm i --frozen-lockfile');
   });
 
   it('given the server rejects the save, when saving fails, then an error toast appears', async () => {

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/IntakeSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/IntakeSection.msw.test.tsx
@@ -91,24 +91,18 @@ function renderIntakeSection() {
 
 describe('IntakeSection', () => {
   describe('given a config with both sources enabled', () => {
-    it('renders the GitHub repository and Linear project pickers behind collapsible sections', async () => {
+    it('lists the GitHub repositories and Linear projects without an extra expand step', async () => {
       seedGithubProject();
       useIntakeHandlers();
 
       renderIntakeSection();
 
-      expect(await screen.findByText(/feed issues into Intake/)).toBeInTheDocument();
       expect(await screen.findByRole('switch', { name: 'Sync GitHub issues' })).toBeChecked();
       expect(await screen.findByRole('switch', { name: 'Sync Linear issues' })).toBeChecked();
 
-      await userEvent.click(await screen.findByRole('button', { name: 'Repositories' }));
       expect(await screen.findByRole('checkbox', { name: 'mastra' })).toBeInTheDocument();
-
-      await userEvent.click(await screen.findByRole('button', { name: 'ENG · Engineering' }));
       expect(await screen.findByRole('checkbox', { name: 'Q3 Roadmap' })).toBeInTheDocument();
-
-      await userEvent.click(screen.getByRole('button', { name: 'No team' }));
-      expect(await screen.findByRole('checkbox', { name: 'Design refresh' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'Design refresh' })).toBeInTheDocument();
     });
 
     it('groups Linear projects by team, listing shared projects under each team', async () => {
@@ -117,33 +111,16 @@ describe('IntakeSection', () => {
 
       renderIntakeSection();
 
-      const eng = await screen.findByRole('group', { name: 'ENG · Engineering' });
-      await userEvent.click(within(eng).getByRole('button', { name: 'ENG · Engineering' }));
-      expect(within(eng).getByRole('checkbox', { name: 'Q3 Roadmap' })).toBeInTheDocument();
-      expect(within(eng).getByRole('checkbox', { name: 'Shared initiative' })).toBeInTheDocument();
+      const projects = await screen.findByRole('group', { name: 'Linear projects' });
 
-      const design = screen.getByRole('group', { name: 'DES · Design' });
-      await userEvent.click(within(design).getByRole('button', { name: 'DES · Design' }));
-      expect(within(design).getByRole('checkbox', { name: 'Shared initiative' })).toBeInTheDocument();
-
-      const noTeam = screen.getByRole('group', { name: 'No team' });
-      await userEvent.click(within(noTeam).getByRole('button', { name: 'No team' }));
-      expect(within(noTeam).getByRole('checkbox', { name: 'Design refresh' })).toBeInTheDocument();
+      expect(within(projects).getByText('Engineering')).toBeInTheDocument();
+      expect(within(projects).getByText('Design')).toBeInTheDocument();
+      expect(within(projects).getByText('No team')).toBeInTheDocument();
+      // Shared across Engineering and Design, so it is listed under both.
+      expect(within(projects).getAllByRole('checkbox', { name: 'Shared initiative' })).toHaveLength(2);
     });
 
-    it('starts every section collapsed, hiding the checkboxes until expanded', async () => {
-      seedGithubProject();
-      useIntakeHandlers();
-
-      renderIntakeSection();
-
-      expect(await screen.findByRole('button', { name: 'ENG · Engineering' })).toBeInTheDocument();
-      expect(await screen.findByRole('button', { name: 'Repositories' })).toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: 'Q3 Roadmap' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: 'mastra' })).not.toBeInTheDocument();
-    });
-
-    it('shows a selected count on the collapsed trigger', async () => {
+    it('shows how many items are selected', async () => {
       seedGithubProject();
       useIntakeHandlers({
         config: {
@@ -154,58 +131,29 @@ describe('IntakeSection', () => {
 
       renderIntakeSection();
 
-      const eng = await screen.findByRole('group', { name: 'ENG · Engineering' });
-      expect(within(eng).getByText('1 selected')).toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: 'Q3 Roadmap' })).not.toBeInTheDocument();
-
-      const repos = screen.getByRole('group', { name: 'Repositories' });
-      expect(within(repos).getByText('1 selected')).toBeInTheDocument();
-
-      const design = screen.getByRole('group', { name: 'DES · Design' });
-      expect(within(design).queryByText(/selected/)).not.toBeInTheDocument();
+      // One count per source picker: the selected repository and the selected project.
+      await waitFor(() => expect(screen.getAllByText('1 selected')).toHaveLength(2));
     });
 
-    it('filters the section list from its search bar', async () => {
+    it('filters every team from one search bar', async () => {
       useIntakeHandlers();
 
       renderIntakeSection();
 
-      const eng = await screen.findByRole('group', { name: 'ENG · Engineering' });
-      await userEvent.click(within(eng).getByRole('button', { name: 'ENG · Engineering' }));
-      expect(within(eng).getByRole('checkbox', { name: 'Shared initiative' })).toBeInTheDocument();
+      const search = await screen.findByRole('textbox', { name: 'Search Linear projects' });
+      expect(await screen.findByRole('checkbox', { name: 'Design refresh' })).toBeInTheDocument();
 
-      await userEvent.type(within(eng).getByRole('textbox', { name: 'Search ENG · Engineering' }), 'road');
+      await userEvent.type(search, 'road');
 
       // ListSearch debounces before filtering.
-      await waitFor(() =>
-        expect(within(eng).queryByRole('checkbox', { name: 'Shared initiative' })).not.toBeInTheDocument(),
-      );
-      expect(within(eng).getByRole('checkbox', { name: 'Q3 Roadmap' })).toBeInTheDocument();
+      await waitFor(() => expect(screen.queryByRole('checkbox', { name: 'Design refresh' })).not.toBeInTheDocument());
+      expect(screen.getByRole('checkbox', { name: 'Q3 Roadmap' })).toBeInTheDocument();
+      // The match lives in Engineering, so only that team heading survives.
+      expect(screen.queryByText('No team')).not.toBeInTheDocument();
 
-      await userEvent.clear(within(eng).getByRole('textbox', { name: 'Search ENG · Engineering' }));
-      await userEvent.type(within(eng).getByRole('textbox', { name: 'Search ENG · Engineering' }), 'zzz');
-      expect(await within(eng).findByText('No matches')).toBeInTheDocument();
-    });
-
-    it('clears the search when the section is collapsed', async () => {
-      useIntakeHandlers();
-
-      renderIntakeSection();
-
-      const eng = await screen.findByRole('group', { name: 'ENG · Engineering' });
-      const trigger = within(eng).getByRole('button', { name: 'ENG · Engineering' });
-      await userEvent.click(trigger);
-      await userEvent.type(within(eng).getByRole('textbox', { name: 'Search ENG · Engineering' }), 'road');
-      await waitFor(() =>
-        expect(within(eng).queryByRole('checkbox', { name: 'Shared initiative' })).not.toBeInTheDocument(),
-      );
-
-      await userEvent.click(trigger); // collapse
-      await userEvent.click(trigger); // reopen
-
-      expect(within(eng).getByRole('textbox', { name: 'Search ENG · Engineering' })).toHaveValue('');
-      expect(within(eng).getByRole('checkbox', { name: 'Q3 Roadmap' })).toBeInTheDocument();
-      expect(within(eng).getByRole('checkbox', { name: 'Shared initiative' })).toBeInTheDocument();
+      await userEvent.clear(search);
+      await userEvent.type(search, 'zzz');
+      expect(await screen.findByText('No matches')).toBeInTheDocument();
     });
   });
 
@@ -231,7 +179,6 @@ describe('IntakeSection', () => {
 
       renderIntakeSection();
 
-      await userEvent.click(await screen.findByRole('button', { name: 'ENG · Engineering' }));
       await userEvent.click(await screen.findByRole('checkbox', { name: 'Q3 Roadmap' }));
 
       await waitFor(() => expect(saved).toHaveLength(1));
@@ -253,34 +200,26 @@ describe('IntakeSection', () => {
 
       renderIntakeSection();
 
-      const eng = await screen.findByRole('group', { name: 'ENG · Engineering' });
-      await userEvent.click(within(eng).getByRole('button', { name: 'ENG · Engineering' }));
-      await userEvent.click(within(eng).getByRole('checkbox', { name: 'Q3 Roadmap' }));
+      await userEvent.click(await screen.findByRole('checkbox', { name: 'Q3 Roadmap' }));
 
-      expect(
-        await within(eng).findByRole('status', { name: 'Saving ENG · Engineering selection' }),
-      ).toBeInTheDocument();
+      expect(await screen.findByRole('status', { name: 'Saving Linear projects selection' })).toBeInTheDocument();
       // Base UI's checkbox root is a span, so disabled state is exposed via aria-disabled.
-      expect(within(eng).getByRole('checkbox', { name: 'Q3 Roadmap' })).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByRole('checkbox', { name: 'Q3 Roadmap' })).toHaveAttribute('aria-disabled', 'true');
 
       releaseSave();
 
       await waitFor(() =>
-        expect(
-          within(eng).queryByRole('status', { name: 'Saving ENG · Engineering selection' }),
-        ).not.toBeInTheDocument(),
+        expect(screen.queryByRole('status', { name: 'Saving Linear projects selection' })).not.toBeInTheDocument(),
       );
-      expect(within(eng).getByRole('checkbox', { name: 'Q3 Roadmap' })).not.toHaveAttribute('aria-disabled');
+      expect(screen.getByRole('checkbox', { name: 'Q3 Roadmap' })).not.toHaveAttribute('aria-disabled');
     });
 
-    it('persists the selection when the row itself is clicked instead of the checkbox', async () => {
+    it('persists the selection when the row label is clicked instead of the checkbox', async () => {
       const saved = useIntakeHandlers();
 
       renderIntakeSection();
 
-      const eng = await screen.findByRole('group', { name: 'ENG · Engineering' });
-      await userEvent.click(within(eng).getByRole('button', { name: 'ENG · Engineering' }));
-      await userEvent.click(within(eng).getByRole('button', { name: 'Q3 Roadmap' }));
+      await userEvent.click(await screen.findByText('Q3 Roadmap'));
 
       await waitFor(() => expect(saved).toHaveLength(1));
       expect(saved[0]!.linear.sourceIds).toEqual(['lproj-1']);
@@ -296,7 +235,6 @@ describe('IntakeSection', () => {
 
       renderIntakeSection();
 
-      await userEvent.click(await screen.findByRole('button', { name: 'Repositories' }));
       await userEvent.click(await screen.findByRole('checkbox', { name: 'mastra' }));
 
       await waitFor(() => expect(saved).toHaveLength(1));
@@ -374,7 +312,6 @@ describe('IntakeSection', () => {
 
       renderIntakeSection();
 
-      expect(await screen.findByText(/feed issues into Intake/)).toBeInTheDocument();
       // GitHub defaults to enabled; Linear stays off until it's connected here.
       expect(await screen.findByRole('switch', { name: 'Sync GitHub issues' })).toBeChecked();
       expect(screen.getByRole('switch', { name: 'Sync Linear issues' })).not.toBeChecked();

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/IntakeSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/IntakeSection.msw.test.tsx
@@ -118,6 +118,11 @@ describe('IntakeSection', () => {
       expect(within(projects).getByText('No team')).toBeInTheDocument();
       // Shared across Engineering and Design, so it is listed under both.
       expect(within(projects).getAllByRole('checkbox', { name: 'Shared initiative' })).toHaveLength(2);
+
+      // Listed twice, selected once: the count follows ids, not rows.
+      const linearSection = screen.getByRole('region', { name: 'Linear issues' });
+      await userEvent.click(within(projects).getAllByRole('checkbox', { name: 'Shared initiative' })[0]!);
+      await waitFor(() => expect(within(linearSection).getByText('1 selected')).toBeInTheDocument());
     });
 
     it('shows how many items are selected', async () => {
@@ -220,11 +225,13 @@ describe('IntakeSection', () => {
       renderIntakeSection();
 
       await userEvent.click(await screen.findByText('Q3 Roadmap'));
-
       await waitFor(() => expect(saved).toHaveLength(1));
       expect(saved[0]!.linear.sourceIds).toEqual(['lproj-1']);
-      // Row click and checkbox click share one toggle — no duplicate PUT.
-      expect(saved).toHaveLength(1);
+
+      // A second, different pick lands after any duplicate the first click could
+      // have fired, so a doubled label toggle shows up as a third request here.
+      await userEvent.click(await screen.findByText('Design refresh'));
+      await waitFor(() => expect(saved).toHaveLength(2));
     });
   });
 

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ProviderAccessSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ProviderAccessSection.msw.test.tsx
@@ -21,7 +21,7 @@ function providersResponse(providers: ProviderInfo[]) {
 }
 
 function rowFor(provider: string): HTMLElement {
-  const row = screen.getByText(providerDisplayName(provider)).closest('.data-list-row');
+  const row = screen.getByText(providerDisplayName(provider)).closest('[data-slot="settings-row"]');
   if (!(row instanceof HTMLElement)) throw new Error(`Provider row not found for ${provider}`);
   return row;
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/ConnectRepositoriesPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/ConnectRepositoriesPanel.tsx
@@ -1,14 +1,16 @@
-import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
+import { ListSearch } from '@mastra/playground-ui/components/ListSearch';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { GithubIcon } from '@mastra/playground-ui/icons/GithubIcon';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import { useApiConfig } from '../../../../api/config';
 import { useGithubReposQuery } from '../../../../hooks/useGithubRepos';
 import { useGithubStatusQuery } from '../../../../hooks/useGithubStatus';
 import { useLinkRepositoryMutation, useUnlinkRepositoryMutation } from '../../../../hooks/useFactories';
-import { FolderIcon, SearchIcon } from '../../../ui/icons';
+import { FolderIcon } from '../../../ui/icons';
 import { SkeletonRows } from '../../../ui/SkeletonRows';
 import type { FactoryProject, GithubStatus } from '../services/github';
 import { connectGithub } from '../services/github';
@@ -49,7 +51,7 @@ export function ConnectRepositoriesPanel({ factory }: { factory: FactoryProject 
   }
 
   return (
-    <div className="flex flex-col gap-4" aria-label="Connect repositories">
+    <div className="flex min-w-0 flex-col" aria-label="Connect repositories">
       {status && (
         <StatusCallout
           status={status}
@@ -62,7 +64,7 @@ export function ConnectRepositoriesPanel({ factory }: { factory: FactoryProject 
         status &&
         status.reason !== 'missing_config' &&
         status.reason !== 'organization_required' && (
-          <div>
+          <div className="px-4 py-3">
             <Button variant="primary" onClick={() => connectGithub(baseUrl)}>
               <GithubIcon className="size-4" />
               Connect GitHub
@@ -71,87 +73,90 @@ export function ConnectRepositoriesPanel({ factory }: { factory: FactoryProject 
         )
       ) : (
         <>
-          <div className="border-border1 bg-surface1 flex items-center gap-2 rounded-lg border px-3 py-2">
-            <SearchIcon size={15} className="text-icon2 shrink-0" />
-            <input
-              className="text-ui-sm text-icon6 placeholder:text-icon2 min-w-0 flex-1 bg-transparent focus:outline-none"
-              type="text"
-              placeholder="Filter repositories…"
-              value={query}
-              onChange={event => setQuery(event.target.value)}
-            />
+          <div className="px-4 py-2">
+            <ListSearch label="Search repositories" placeholder="Search…" size="sm" value={query} onSearch={setQuery} />
           </div>
 
           {error && (
-            <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg m-0">
+            <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg px-4 pb-2">
               {error.message}
             </Txt>
           )}
 
-          <div className="flex max-h-80 min-h-0 flex-col gap-2 overflow-y-auto">
-            {visibleLinked.map(repo => (
-              <div
-                key={repo.projectRepositoryId}
-                className="border-border1 flex w-full items-center gap-3 rounded-xl border px-3 py-2"
-              >
-                <span className="min-w-0 flex-1">
-                  <span className="text-ui-md text-icon6 flex items-center gap-1.5">
-                    <GithubIcon className="text-icon5 size-3.5 shrink-0" />
-                    <span className="min-w-0 truncate">{repo.slug}</span>
-                    <Badge size="sm" variant="success">
-                      Linked
-                    </Badge>
-                  </span>
-                  {repo.gitBranch && <span className="text-ui-sm text-icon3 block truncate">{repo.gitBranch}</span>}
-                </span>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={unlinkingId !== null}
-                  onClick={() =>
-                    unlinkRepository.mutate({ factoryProjectId, projectRepositoryId: repo.projectRepositoryId })
-                  }
-                >
-                  {unlinkingId === repo.projectRepositoryId ? 'Unlinking…' : 'Unlink'}
-                </Button>
-              </div>
-            ))}
-
-            {reposQuery.isPending ? (
-              <SkeletonRows label="Loading repositories" rows={3} rowClassName="h-12 w-full rounded-xl" />
-            ) : available.length === 0 ? (
-              visibleLinked.length === 0 && (
-                <Txt as="p" variant="ui-sm" className="text-icon3 m-0">
-                  {repos.length > 0 ? 'All available repositories are linked.' : 'No repositories found.'}
-                </Txt>
-              )
-            ) : (
-              available.map(repo => (
-                <button
-                  type="button"
-                  key={repo.id}
-                  className="hover:bg-surface3 flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left disabled:cursor-not-allowed disabled:opacity-50"
-                  title={repo.fullName}
-                  disabled={busyRepoId !== null}
-                  onClick={() => linkRepository.mutate({ factoryProjectId, repo })}
-                >
+          <ScrollArea orientation="vertical" maxHeight="20rem">
+            <div className="flex min-w-0 flex-col gap-px p-2">
+              {visibleLinked.length > 0 && <ListHeading>Linked</ListHeading>}
+              {visibleLinked.map(repo => (
+                <div key={repo.projectRepositoryId} className="flex w-full items-center gap-3 rounded-md px-2 py-2">
                   <span className="min-w-0 flex-1">
-                    <span className="text-ui-md text-icon5 flex items-center gap-1.5">
-                      <FolderIcon size={14} className="text-icon3 shrink-0" />
-                      <span className="min-w-0 truncate">{repo.fullName}</span>
+                    <span className="text-ui-md text-icon6 flex items-center gap-1.5">
+                      <GithubIcon className="text-icon5 size-3.5 shrink-0" />
+                      <span className="min-w-0 truncate">{repo.slug}</span>
                     </span>
-                    <span className="text-ui-sm text-icon3 block truncate">
-                      {repo.private ? 'private' : 'public'} · {repo.defaultBranch}
-                    </span>
+                    {repo.gitBranch && <span className="text-ui-sm text-icon3 block truncate">{repo.gitBranch}</span>}
                   </span>
-                  {busyRepoId === repo.id && <span className="text-ui-sm text-icon3">Linking…</span>}
-                </button>
-              ))
-            )}
-          </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={unlinkingId !== null}
+                    onClick={() =>
+                      unlinkRepository.mutate({ factoryProjectId, projectRepositoryId: repo.projectRepositoryId })
+                    }
+                  >
+                    {unlinkingId === repo.projectRepositoryId ? 'Unlinking…' : 'Unlink'}
+                  </Button>
+                </div>
+              ))}
+
+              {reposQuery.isPending ? (
+                <div className="px-2 py-2">
+                  <SkeletonRows label="Loading repositories" rows={3} rowClassName="h-8 w-full rounded-md" />
+                </div>
+              ) : available.length === 0 ? (
+                visibleLinked.length === 0 && (
+                  <Txt as="p" variant="ui-sm" className="text-icon3 px-2 py-2">
+                    {repos.length > 0 ? 'All available repositories are linked.' : 'No repositories found.'}
+                  </Txt>
+                )
+              ) : (
+                <>
+                  {visibleLinked.length > 0 && <ListHeading>Available</ListHeading>}
+                  {available.map(repo => (
+                    <button
+                      type="button"
+                      key={repo.id}
+                      className="hover:bg-surface-overlay-soft flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-2 text-left disabled:cursor-not-allowed disabled:opacity-50"
+                      title={repo.fullName}
+                      disabled={busyRepoId !== null}
+                      onClick={() => linkRepository.mutate({ factoryProjectId, repo })}
+                    >
+                      <span className="min-w-0 flex-1">
+                        <span className="text-ui-md text-icon5 flex items-center gap-1.5">
+                          <FolderIcon size={14} className="text-icon3 shrink-0" />
+                          <span className="min-w-0 truncate">{repo.fullName}</span>
+                        </span>
+                        <span className="text-ui-sm text-icon3 block truncate">
+                          {repo.private ? 'private' : 'public'} · {repo.defaultBranch}
+                        </span>
+                      </span>
+                      {busyRepoId === repo.id && <span className="text-ui-sm text-icon3">Linking…</span>}
+                    </button>
+                  ))}
+                </>
+              )}
+            </div>
+          </ScrollArea>
         </>
       )}
     </div>
+  );
+}
+
+function ListHeading({ children }: { children: ReactNode }) {
+  return (
+    <Txt as="p" variant="ui-xs" className="text-icon3 px-2 pt-3 pb-1 first:pt-0">
+      {children}
+    </Txt>
   );
 }
 
@@ -161,7 +166,7 @@ export function ConnectRepositoriesPanel({ factory }: { factory: FactoryProject 
  * booleans, and public URLs.
  */
 function StatusCallout({ status, connected, empty }: { status: GithubStatus; connected: boolean; empty: boolean }) {
-  const calloutClass = 'rounded-lg border border-border1 bg-surface3 px-3 py-2 text-ui-sm leading-relaxed text-icon3';
+  const calloutClass = 'px-4 py-3 text-ui-sm leading-relaxed text-icon3';
 
   // Auth required: the session expired or was never established.
   if (status.authRequired) {

--- a/mastracode/factory-ui/src/ui/pages/SlackConnectionPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/SlackConnectionPage.tsx
@@ -17,7 +17,8 @@ import { useSetFactorySlackWorkItemsMutation } from '../../hooks/useFactorySlack
 import { useFactoriesQuery } from '../../hooks/useFactories';
 import { ConnectionSettingsShell } from '../domains/settings/components/ConnectionSettingsShell';
 import { IdentityWithTooltip } from '../domains/settings/components/IdentityWithTooltip';
-import { SettingsCard, SettingsRow } from '../domains/settings/components/SettingsCard';
+import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
+import { SettingsCard } from '../domains/settings/components/SettingsCard';
 import { SlackNotConfigured } from '../domains/settings/components/ConnectedAccountsSection';
 import { SettingsSubsection } from '../domains/settings/components/SettingsSubsection';
 import { connectSlackUrl, type ConnectedChannelAccount } from '../domains/settings/services/channelAccounts';
@@ -122,7 +123,11 @@ export function SlackConnectionSettings() {
               onClick={connectSlack}
               className="group hover:bg-surface4 focus-visible:ring-accent1 block w-full cursor-pointer rounded-xl text-left outline-hidden transition-colors focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              <SettingsRow label="Slack" hint={canConnect ? 'Not connected' : 'Slack connection is not configured'}>
+              <SettingsRow
+                variant="factory"
+                label="Slack"
+                description={canConnect ? 'Not connected' : 'Slack connection is not configured'}
+              >
                 <span className="text-ui-sm text-icon4 group-hover:text-icon5 flex items-center gap-2">
                   Connect Slack
                   <ChevronRight aria-hidden="true" />
@@ -138,6 +143,7 @@ export function SlackConnectionSettings() {
               {accounts.map(account => (
                 <SettingsCard key={`${account.externalTeamId}:${account.externalUserId}`}>
                   <SettingsRow
+                    variant="factory"
                     label={
                       <span className="flex items-center gap-1.5">
                         <IdentityWithTooltip
@@ -153,7 +159,7 @@ export function SlackConnectionSettings() {
                         />
                       </span>
                     }
-                    hint={
+                    description={
                       <Txt as="span" variant="ui-xs" className="text-icon2">
                         Connected {linkedDateFormatter.format(new Date(account.linkedAt))}
                       </Txt>
@@ -168,13 +174,14 @@ export function SlackConnectionSettings() {
             <SettingsCard>
               {accounts.map(account => (
                 <SettingsRow
+                  variant="factory"
                   key={`${account.externalTeamId}:${account.externalUserId}`}
                   label={
                     accounts.length > 1
                       ? `Default factory for ${account.externalUserName ?? account.externalUserId}`
                       : 'Default factory'
                   }
-                  hint="New Slack sessions are routed to this Factory."
+                  description="New Slack sessions are routed to this Factory."
                 >
                   <Select
                     value={account.defaultFactoryProjectId ?? ''}
@@ -203,8 +210,9 @@ export function SlackConnectionSettings() {
                 </SettingsRow>
               ))}
               <SettingsRow
+                variant="factory"
                 label="Create work items for new Slack threads"
-                hint="Add new Slack thread sessions to this Factory's Work board in Building."
+                description="Add new Slack thread sessions to this Factory's Work board in Building."
               >
                 <Switch
                   aria-label="Create work items for new Slack threads"
@@ -226,9 +234,10 @@ export function SlackConnectionSettings() {
             <SettingsCard>
               {accounts.map(account => (
                 <SettingsRow
+                  variant="factory"
                   key={`${account.externalTeamId}:${account.externalUserId}`}
                   label="Disconnect Slack"
-                  hint={
+                  description={
                     <span>
                       Slack messages from{' '}
                       <strong className="font-medium">

--- a/packages/playground-ui/src/ds/components/SettingsRow/settings-row.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SettingsRow/settings-row.stories.tsx
@@ -130,3 +130,31 @@ export const Stacked: Story = {
     </SectionCard>
   ),
 };
+
+export const FactoryVariant: Story = {
+  render: () => (
+    <SectionCard
+      title="Factory observational memory"
+      description="Models and thresholds used to summarize and retain context."
+      contentClassName="px-0 pb-0"
+    >
+      <SettingsRow variant="factory" label="Observer model" description="Summarizes the conversation into observations">
+        <Select defaultValue="dark">
+          <SelectTrigger className="w-full lg:w-72">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="dark">claude-opus-5</SelectItem>
+          </SelectContent>
+        </Select>
+      </SettingsRow>
+      <SettingsRow
+        variant="factory"
+        label="Observe attachments"
+        description="Whether attached files are included in observations"
+      >
+        <Button>Auto</Button>
+      </SettingsRow>
+    </SectionCard>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/SettingsRow/settings-row.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SettingsRow/settings-row.stories.tsx
@@ -138,9 +138,14 @@ export const FactoryVariant: Story = {
       description="Models and thresholds used to summarize and retain context."
       contentClassName="px-0 pb-0"
     >
-      <SettingsRow variant="factory" label="Observer model" description="Summarizes the conversation into observations">
+      <SettingsRow
+        variant="factory"
+        htmlFor="factory-observer-model"
+        label="Observer model"
+        description="Summarizes the conversation into observations"
+      >
         <Select defaultValue="dark">
-          <SelectTrigger className="w-full lg:w-72">
+          <SelectTrigger id="factory-observer-model" className="w-full lg:w-72">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/packages/playground-ui/src/ds/components/SettingsRow/settings-row.tsx
+++ b/packages/playground-ui/src/ds/components/SettingsRow/settings-row.tsx
@@ -2,29 +2,53 @@ import type { ReactNode } from 'react';
 import { Label } from '@/ds/components/Label/label';
 import { cn } from '@/lib/utils';
 
+type SettingsRowVariant = 'default' | 'factory';
+
+const VARIANTS: Record<SettingsRowVariant, { row: string; labelBlock: string; label: string; description: string }> = {
+  default: {
+    row: 'gap-3 sm:flex-row sm:items-center sm:justify-between',
+    labelBlock: '',
+    label: 'text-sm font-medium',
+    description: 'text-neutral3 text-sm',
+  },
+  factory: {
+    row: 'gap-2 px-4 py-3 lg:flex-row lg:items-center lg:justify-between lg:gap-4',
+    labelBlock: 'gap-0.5',
+    label: 'text-ui-md leading-ui-md text-neutral5',
+    description: 'text-ui-sm text-neutral3',
+  },
+};
+
 export type SettingsRowProps = {
   label: ReactNode;
   description?: ReactNode;
   htmlFor?: string;
+  variant?: SettingsRowVariant;
   className?: string;
-  children: ReactNode;
+  children?: ReactNode;
 };
 
-export function SettingsRow({ label, description, htmlFor, className, children }: SettingsRowProps) {
+export function SettingsRow({
+  label,
+  description,
+  htmlFor,
+  variant = 'default',
+  className,
+  children,
+}: SettingsRowProps) {
+  const styles = VARIANTS[variant];
+
   return (
-    <div
-      className={cn('flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between', className)}
-      data-slot="settings-row"
-    >
-      <div>
+    <div className={cn('flex min-w-0 flex-col', styles.row, className)} data-slot="settings-row">
+      <div className={cn('flex min-w-0 flex-col', styles.labelBlock)}>
         {htmlFor ? (
-          <Label htmlFor={htmlFor} className="text-sm font-medium">
+          <Label htmlFor={htmlFor} className={styles.label}>
             {label}
           </Label>
         ) : (
-          <p className="text-sm font-medium">{label}</p>
+          <span className={styles.label}>{label}</span>
         )}
-        {description && <p className="text-neutral3 text-sm">{description}</p>}
+        {description && <div className={cn('flex flex-col gap-0.5', styles.description)}>{description}</div>}
       </div>
       {children}
     </div>

--- a/packages/playground-ui/src/ds/components/SettingsRow/settings-row.tsx
+++ b/packages/playground-ui/src/ds/components/SettingsRow/settings-row.tsx
@@ -1,54 +1,60 @@
+import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
 import type { ReactNode } from 'react';
 import { Label } from '@/ds/components/Label/label';
 import { cn } from '@/lib/utils';
 
-type SettingsRowVariant = 'default' | 'factory';
+const settingsRowVariants = cva('flex min-w-0 flex-col', {
+  variants: {
+    variant: {
+      default: 'gap-3 sm:flex-row sm:items-center sm:justify-between',
+      factory: 'gap-2 px-4 py-3 lg:flex-row lg:items-center lg:justify-between lg:gap-4',
+    },
+  },
+  defaultVariants: { variant: 'default' },
+});
 
-const VARIANTS: Record<SettingsRowVariant, { row: string; labelBlock: string; label: string; description: string }> = {
-  default: {
-    row: 'gap-3 sm:flex-row sm:items-center sm:justify-between',
-    labelBlock: '',
-    label: 'text-sm font-medium',
-    description: 'text-neutral3 text-sm',
+const settingsRowLabelBlockVariants = cva('flex min-w-0 flex-col', {
+  variants: {
+    variant: { default: '', factory: 'gap-0.5' },
   },
-  factory: {
-    row: 'gap-2 px-4 py-3 lg:flex-row lg:items-center lg:justify-between lg:gap-4',
-    labelBlock: 'gap-0.5',
-    label: 'text-ui-md leading-ui-md text-neutral5',
-    description: 'text-ui-sm text-neutral3',
+  defaultVariants: { variant: 'default' },
+});
+
+const settingsRowLabelVariants = cva('', {
+  variants: {
+    variant: { default: 'text-sm font-medium', factory: 'text-ui-md leading-ui-md text-neutral5' },
   },
-};
+  defaultVariants: { variant: 'default' },
+});
+
+const settingsRowDescriptionVariants = cva('flex flex-col gap-0.5', {
+  variants: {
+    variant: { default: 'text-sm text-neutral3', factory: 'text-ui-sm text-neutral3' },
+  },
+  defaultVariants: { variant: 'default' },
+});
 
 export type SettingsRowProps = {
   label: ReactNode;
   description?: ReactNode;
   htmlFor?: string;
-  variant?: SettingsRowVariant;
   className?: string;
   children?: ReactNode;
-};
+} & VariantProps<typeof settingsRowVariants>;
 
-export function SettingsRow({
-  label,
-  description,
-  htmlFor,
-  variant = 'default',
-  className,
-  children,
-}: SettingsRowProps) {
-  const styles = VARIANTS[variant];
-
+export function SettingsRow({ label, description, htmlFor, variant, className, children }: SettingsRowProps) {
   return (
-    <div className={cn('flex min-w-0 flex-col', styles.row, className)} data-slot="settings-row">
-      <div className={cn('flex min-w-0 flex-col', styles.labelBlock)}>
+    <div className={cn(settingsRowVariants({ variant }), className)} data-slot="settings-row">
+      <div className={settingsRowLabelBlockVariants({ variant })}>
         {htmlFor ? (
-          <Label htmlFor={htmlFor} className={styles.label}>
+          <Label htmlFor={htmlFor} className={settingsRowLabelVariants({ variant })}>
             {label}
           </Label>
         ) : (
-          <span className={styles.label}>{label}</span>
+          <span className={settingsRowLabelVariants({ variant })}>{label}</span>
         )}
-        {description && <div className={cn('flex flex-col gap-0.5', styles.description)}>{description}</div>}
+        {description && <div className={settingsRowDescriptionVariants({ variant })}>{description}</div>}
       </div>
       {children}
     </div>


### PR DESCRIPTION
TLDR: every option on the settings pages is now the same row — label and hint on
the left, control on the right — instead of each section inventing its own
layout inside the card.

---

Sections had drifted apart. Memory stacked its fields in a padded block, Provider
access rendered a data table, Work Intake put both sources in one card behind
collapsibles, and Repositories crammed setup and teardown into one row's right
side with a Save button floating underneath. The design system already had
`SettingsRow`; it just did not match Factory's denser text, so nobody used it.

It does now, through a `factory` variant, and every section renders through it.

### What changes

| on a settings page | before | after |
| --- | --- | --- |
| Memory | fields in a block with its own padding, ignoring the card | one row per setting, separators drawn by the card |
| Models → Provider access | providers as data-table rows, tabs inside the card | tabs above the card, one settings row per provider |
| Work Intake | GitHub and Linear stacked in one card | one section per source, Linear's connect state in its header |
| picking Linear projects | a search box per collapsed team | one search across every team, projects listed straight away |
| picking GitHub repos | an open group next to nine closed ones | the same list, same search, same rows |
| Repositories → worktree commands | setup + teardown in one row, one Save under both | a row each, field on the right, saves on blur |
| Repositories → linking a repo | each row drawing its own bordered box | rows aligned with the card, grouped Linked / Available |
| Behavior, Preferences, Connections | first card had no heading, later ones did | every card sits under a named group |

### Judgment call

Two calls worth disagreeing with.

I removed the Save button from the worktree commands. It saved both fields at
once, which is why it could not sit next to either one. Each field now commits on
blur or Enter, like the memory thresholds already did. If you want a Save button
back, it has to be one per field.

I dropped `DataList` from the intake picker. It is a table component: its rows are
deliberately full-bleed and its viewport rounds its own top corner, so rows can
never line up with the group headings above them and the radius clips against
nothing mid-card. The picker uses `ScrollArea` directly and pads its own rows.

### Not verified

No visual check ran from here — the pages were reviewed in the browser by hand
during the rework, not by me. Two states nothing exercised: the Linear
reauth-expired header and the "GitHub App has no repo access" callout. Both are
copy and layout only, no logic changed under them.

```
source     +869  -749
tests       +54  -108   ← intake tests lost the collapse mechanics they described
changeset   +23     0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes Factory settings pages more consistent and easier to use. It improves how users search, group, and save work-intake, repository, and worktree settings.

## Changes

- Rebuilt Factory settings pages with the shared `SettingsRow` component and new `factory` styling variant.
- Added consistent descriptions, accessible section names, and headings for settings groups.
- Split Work Intake into GitHub and Linear sections.
- Added a shared, searchable intake source picker.
- Added Linear project routing with handling for unavailable projects and deleted factories.
- Deduplicated repository sources across factories.
- Replaced the intake `DataList` with `ScrollArea`.
- Standardized repository rows and grouped linked and available repositories.
- Saved worktree setup and teardown commands on blur or Enter.
- Preserved rejected worktree commands so users can retry them.
- Updated provider access, memory, model, account, connection, and Slack settings layouts.
- Added stories, tests, and patch changesets for `@mastra/factory` and `@mastra/playground-ui`.

## Testing

- Updated MSW tests for worktree commands, intake settings, and provider access.
- Reviewed the pages manually in a browser.
- Linear reauthentication-expired and GitHub App access-warning states were not verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->