### PR TITLE
fix(ci): speed up stable npm releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -251,9 +251,11 @@ jobs:
           git add -A
           git commit -m 'chore: version - exit prerelease mode' --no-verify
           pnpm install
-          pnpm build
         env:
           GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
+
+      - name: Build packages
+        run: pnpm build
 
       - name: Push version changes
         if: steps.check_files.outputs.files_exists == 'true' && !inputs.dry_run

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -204,21 +204,20 @@ jobs:
           permission-contents: write
           permission-issues: write
 
-      - name: Re-checkout with app token
+      - name: Re-checkout main with app token
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
         timeout-minutes: 20
         with:
           token: ${{ steps.app-auth.outputs.token }}
-          fetch-depth: 0
+          ref: main
+          fetch-depth: 1
+          fetch-tags: true
           persist-credentials: true
 
       - name: Check for pre.json file existence
         id: check_files
         shell: bash
         run: |
-          git fetch origin main
-          git merge --ff-only origin/main
-
           if [[ -f .changeset/pre.json ]]; then
             echo "files_exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -243,9 +242,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
-      - name: Build packages
-        run: pnpm build
 
       - name: Exit prerelease mode
         if: steps.check_files.outputs.files_exists == 'true'
@@ -332,9 +328,10 @@ jobs:
             --endpoint-url "${STUDIO_ENDPOINT_URL}" \
             --delete
 
-      - name: Updated alpha versions
-        if: ${{ !inputs.dry_run }}
-        run: node .github/scripts/publish-alpha-tags.js alpha
+      # Disabled: `npm dist-tag add` requires token authentication and cannot use npm OIDC.
+      # - name: Update alpha versions
+      #   if: ${{ !inputs.dry_run }}
+      #   run: node .github/scripts/publish-alpha-tags.js alpha
 
       - name: Publish packages - dry run
         if: ${{ inputs.dry_run }}


### PR DESCRIPTION
This speeds up stable npm releases by checking out the latest main commit and release tags instead of the full repository history. It also removes the duplicate build before versioning; the stable release path still builds after exiting prerelease mode.

The automatic alpha dist-tag update is disabled because npm OIDC does not authorize dist-tag changes, which caused the release workflow to fail with E401. Alpha dist-tags can continue to be updated manually with 2FA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The release workflow now downloads only the files it needs and avoids a release step that causes authentication errors. It also keeps the required build and allows alpha tags to be updated manually with 2FA.

## Changes

- Checks out the latest `main` commit and release tags with shallow history.
- Removes the duplicate build before versioning.
- Runs the build after prerelease exit.
- Disables automatic alpha dist-tag updates because npm OIDC authentication returns `E401`.
- Allows manual alpha dist-tag updates with 2FA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->