### PR TITLE
feat(playground-ui): refresh the DataList look and simplify its cell API

### DIFF
--- a/.changeset/cool-forks-strive.md
+++ b/.changeset/cool-forks-strive.md
@@ -8,7 +8,7 @@ Refreshed the DataList look: rows no longer draw separators, the sticky header a
 
 **Typography follows the content.** Headers and name cells are medium weight instead of semibold, and the letter-spacing tightening is gone. IDs and timestamps left the monospace face — IDs get wider tracking to stay scannable, timestamps get tabular figures so their columns still line up.
 
-**Row controls only appear on hover.** Selection checkboxes on unselected rows, and the new `DataList.ActionsCell`, stay hidden until you hover the row or reach it with the keyboard, so a resting list reads as content. The column keeps its width, so nothing shifts.
+**Row controls only appear on hover.** Selection checkboxes on unselected rows, and the new `DataList.ActionsCell`, stay hidden until you hover the row or reach it with the keyboard, so a resting list reads as content. The column keeps its width, so nothing shifts. On a touch screen, where nothing ever hovers, they stay visible.
 
 ```tsx
 // Trailing row actions — alignment, spacing and the hover reveal come with the cell
@@ -24,7 +24,7 @@ Refreshed the DataList look: rows no longer draw separators, the sticky header a
 </DataList.RowWrapper>
 ```
 
-**Breaking:** three props that no longer decide anything are gone.
+**Breaking:** a variant, three props and a component that no longer decide anything are gone.
 
 ```tsx
 // Before

--- a/.changeset/cool-forks-strive.md
+++ b/.changeset/cool-forks-strive.md
@@ -1,0 +1,46 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Refreshed the DataList look: rows no longer draw separators, the sticky header and group subheaders share one lighter, theme-tuned band, and every corner uses the same radius.
+
+**Every row in a list is now the same height.** Row height used to be whatever the tallest cell happened to be, so a list with an actions column or a roomier cell drifted a few pixels away from the list next to it. The row owns its height now, and skeleton rows match the real ones — no jump when data lands.
+
+**Typography follows the content.** Headers and name cells are medium weight instead of semibold, and the letter-spacing tightening is gone. IDs and timestamps left the monospace face — IDs get wider tracking to stay scannable, timestamps get tabular figures so their columns still line up.
+
+**Row controls only appear on hover.** Selection checkboxes on unselected rows, and the new `DataList.ActionsCell`, stay hidden until you hover the row or reach it with the keyboard, so a resting list reads as content. The column keeps its width, so nothing shifts.
+
+```tsx
+// Trailing row actions — alignment, spacing and the hover reveal come with the cell
+<DataList.RowWrapper>
+  <DataList.RowButton colEnd={-2} onClick={open}>
+    {cells}
+  </DataList.RowButton>
+  <DataList.ActionsCell>
+    <Button variant="ghost" size="icon-xs" aria-label="Delete">
+      <Trash2 />
+    </Button>
+  </DataList.ActionsCell>
+</DataList.RowWrapper>
+```
+
+**Breaking:** three props that no longer decide anything are gone.
+
+```tsx
+// Before
+<DataList columns={columns} variant="lined">
+  <DataList.RowButton flushLeft flushRight colEnd={-2}>
+    <DataList.Cell height="compact">{status}</DataList.Cell>
+    <DataList.MonoCell>{path}</DataList.MonoCell>
+
+// After — rows are borderless, full-bleed and uniformly tall by default
+<DataList columns={columns}>
+  <DataList.RowButton colEnd={-2}>
+    <DataList.Cell>{status}</DataList.Cell>
+    <DataList.TextCell font="mono">{path}</DataList.TextCell>
+```
+
+- `variant="lined"` existed only to draw row separators. Lists that want row banding can still ask for `variant="striped"`.
+- `height` on cells set row height one cell at a time, which is what let rows drift apart.
+- `flushLeft` / `flushRight` dropped a row margin that no longer exists.
+- `DataList.MonoCell` was a cell that only changed the typeface. `DataList.TextCell font="mono"` replaces it — same rendering, one less component.

--- a/packages/playground-ui/src/domains/metrics/components/memory-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/memory-card-view.tsx
@@ -114,9 +114,7 @@ export function MemoryCardView({
                     const href = getThreadRowHref?.(row);
                     const rowCells = (
                       <>
-                        <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                          {shortId(row.threadId)}
-                        </DataList.RowHeaderCell>
+                        <DataList.RowHeaderCell className="text-ui-sm">{shortId(row.threadId)}</DataList.RowHeaderCell>
                         <DataList.NumberCell>{row.resourceId ? shortId(row.resourceId) : '—'}</DataList.NumberCell>
                         <DataList.NumberCell highlight>{row.runs.toLocaleString()}</DataList.NumberCell>
                         <DataList.NumberCell>{row.tokens > 0 ? formatCompact(row.tokens) : '—'}</DataList.NumberCell>
@@ -152,7 +150,7 @@ export function MemoryCardView({
                     const href = getResourceRowHref?.(row);
                     const rowCells = (
                       <>
-                        <DataList.RowHeaderCell height="compact" className="text-ui-sm">
+                        <DataList.RowHeaderCell className="text-ui-sm">
                           {shortId(row.resourceId)}
                         </DataList.RowHeaderCell>
                         <DataList.NumberCell highlight>{row.threadCount.toLocaleString()}</DataList.NumberCell>

--- a/packages/playground-ui/src/domains/metrics/components/model-usage-cost-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/model-usage-cost-card-view.tsx
@@ -74,9 +74,7 @@ export function ModelUsageCostCardView({
                 const href = getRowHref?.(row);
                 const rowCells = (
                   <>
-                    <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                      {row.model}
-                    </DataList.RowHeaderCell>
+                    <DataList.RowHeaderCell className="text-ui-sm">{row.model}</DataList.RowHeaderCell>
                     <DataList.NumberCell>{row.input}</DataList.NumberCell>
                     <DataList.NumberCell>{row.output}</DataList.NumberCell>
                     <DataList.NumberCell>{row.cacheRead}</DataList.NumberCell>

--- a/packages/playground-ui/src/domains/metrics/components/scores-card-view.tsx
+++ b/packages/playground-ui/src/domains/metrics/components/scores-card-view.tsx
@@ -87,9 +87,7 @@ export function ScoresCardView({ data, isLoading, isError }: ScoresCardViewProps
                   </DataList.Top>
                   {data.summaryData.map(row => (
                     <DataList.RowStatic key={row.scorer}>
-                      <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                        {row.scorer}
-                      </DataList.RowHeaderCell>
+                      <DataList.RowHeaderCell className="text-ui-sm">{row.scorer}</DataList.RowHeaderCell>
                       <DataList.NumberCell highlight>{row.avg.toFixed(2)}</DataList.NumberCell>
                       <DataList.NumberCell>{row.min.toFixed(2)}</DataList.NumberCell>
                       <DataList.NumberCell>{row.max.toFixed(2)}</DataList.NumberCell>

--- a/packages/playground-ui/src/domains/traces/components/__tests__/traces-list-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/traces-list-view.test.tsx
@@ -161,8 +161,8 @@ describe('TracesListView — rows', () => {
     );
 
     const rows = screen.getAllByRole('button');
-    expect(rows[0]?.classList.contains('bg-surface4!')).toBe(false);
-    expect(rows[1]?.classList.contains('bg-surface4!')).toBe(true);
+    expect(rows[0]?.classList.contains('bg-surface-row-featured!')).toBe(false);
+    expect(rows[1]?.classList.contains('bg-surface-row-featured!')).toBe(true);
   });
 
   it('needs the span to match too when branch rows share a trace', () => {
@@ -179,8 +179,8 @@ describe('TracesListView — rows', () => {
     );
 
     const rows = screen.getAllByRole('button');
-    expect(rows[0]?.classList.contains('bg-surface4!')).toBe(false);
-    expect(rows[1]?.classList.contains('bg-surface4!')).toBe(true);
+    expect(rows[0]?.classList.contains('bg-surface-row-featured!')).toBe(false);
+    expect(rows[1]?.classList.contains('bg-surface-row-featured!')).toBe(true);
   });
 
   it('tints only the rows that just arrived', () => {
@@ -492,7 +492,7 @@ describe('TracesListView — featuring by trace alone', () => {
     );
 
     const rows = screen.getAllByRole('button');
-    expect(rows[0]?.classList.contains('bg-surface4!')).toBe(true);
-    expect(rows[1]?.classList.contains('bg-surface4!')).toBe(false);
+    expect(rows[0]?.classList.contains('bg-surface-row-featured!')).toBe(true);
+    expect(rows[1]?.classList.contains('bg-surface-row-featured!')).toBe(false);
   });
 });

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -218,7 +218,11 @@ export function TracesListView({
                 )}
                 {columnPreferences.metadataKeys.map(key => {
                   const value = formatTraceMetadataValue(trace.metadata, key);
-                  return <DataList.MonoCell key={key}>{value}</DataList.MonoCell>;
+                  return (
+                    <DataList.TextCell font="mono" key={key}>
+                      {value}
+                    </DataList.TextCell>
+                  );
                 })}
               </TracesDataList.RowButton>
             );

--- a/packages/playground-ui/src/ds/components/DataList/ScoresDataList/scores-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/ScoresDataList/scores-data-list-cells.tsx
@@ -21,7 +21,7 @@ export interface ScoresDataListDateCellProps {
 export function ScoresDataListDateCell({ timestamp }: ScoresDataListDateCellProps) {
   const date = toDate(timestamp);
   return (
-    <DataListCell height="compact" className="text-ui-smd text-neutral2">
+    <DataListCell className="text-ui-smd text-neutral2">
       {date ? (isToday(date) ? 'Today' : format(date, 'MMM dd')) : '-'}
     </DataListCell>
   );
@@ -37,11 +37,7 @@ export interface ScoresDataListTimeCellProps {
 
 export function ScoresDataListTimeCell({ timestamp }: ScoresDataListTimeCellProps) {
   const date = toDate(timestamp);
-  return (
-    <DataListCell height="compact" className="text-ui-smd text-neutral3">
-      {date ? format(date, 'h:mm:ss aaa') : '-'}
-    </DataListCell>
-  );
+  return <DataListCell className="text-ui-smd text-neutral3">{date ? format(date, 'h:mm:ss aaa') : '-'}</DataListCell>;
 }
 
 // ---------------------------------------------------------------------------
@@ -55,7 +51,7 @@ export interface ScoresDataListInputCellProps {
 export function ScoresDataListInputCell({ input }: ScoresDataListInputCellProps) {
   const display = input != null ? JSON.stringify(input) : '-';
   return (
-    <DataListCell height="compact">
+    <DataListCell>
       <span className="text-ui-smd text-neutral3 block max-w-full min-w-0 truncate font-mono" title={display}>
         {display}
       </span>
@@ -74,7 +70,7 @@ export interface ScoresDataListEntityCellProps {
 export function ScoresDataListEntityCell({ entityId }: ScoresDataListEntityCellProps) {
   const display = entityId || '-';
   return (
-    <DataListCell height="compact">
+    <DataListCell>
       <span className="text-ui-smd block max-w-full min-w-0 truncate" title={display}>
         {display}
       </span>
@@ -93,7 +89,7 @@ export interface ScoresDataListScoreCellProps {
 export function ScoresDataListScoreCell({ score }: ScoresDataListScoreCellProps) {
   const display = score == null ? '-' : typeof score === 'object' ? JSON.stringify(score) : String(score);
   return (
-    <DataListCell height="compact">
+    <DataListCell>
       <span className="text-ui-smd text-neutral3 block max-w-full min-w-0 truncate font-mono" title={display}>
         {display}
       </span>

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
@@ -1,5 +1,5 @@
 import { CornerDownRightIcon, ListTreeIcon } from 'lucide-react';
-import { DataListCell, DataListMonoCell } from '../data-list-cells';
+import { DataListCell, DataListTextCell } from '../data-list-cells';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { WorkflowIcon } from '@/ds/icons/WorkflowIcon';
@@ -29,7 +29,7 @@ export function TracesDataListNameCell({ name, parentSpanId, showLevelTooltip }:
     </span>
   );
   return (
-    <DataListCell height="compact" className="text-ui-smd text-neutral4 flex min-w-0 items-center gap-2">
+    <DataListCell className="text-ui-smd text-neutral4 flex min-w-0 items-center gap-2">
       {showLevelTooltip ? (
         <Tooltip>
           <TooltipTrigger asChild>{icon}</TooltipTrigger>
@@ -52,7 +52,7 @@ export interface TracesDataListInputCellProps {
 }
 
 export function TracesDataListInputCell({ input }: TracesDataListInputCellProps) {
-  return <DataListMonoCell>{input || '-'}</DataListMonoCell>;
+  return <DataListTextCell font="mono">{input || '-'}</DataListTextCell>;
 }
 
 // ---------------------------------------------------------------------------
@@ -83,7 +83,7 @@ export function TracesDataListEntityCell({ entityType, entityName }: TracesDataL
   const type = entityType ?? '';
 
   return (
-    <DataListCell height="compact" className="flex min-w-0 items-center gap-2">
+    <DataListCell className="flex min-w-0 items-center gap-2">
       <EntityTypeIcon entityType={type} />
       {entityName ? <span className="text-ui-smd min-w-0 truncate">{entityName}</span> : '-'}
     </DataListCell>
@@ -114,7 +114,7 @@ export function TracesDataListStatusCell({ status }: TracesDataListStatusCellPro
   const config = STATUS_CONFIG[key] ?? UNSET_STATUS_CONFIG;
 
   return (
-    <DataListCell height="compact">
+    <DataListCell>
       <span className="text-ui-sm font-semibold uppercase" style={{ color: config.color }}>
         {config.label}
       </span>

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.test.tsx
@@ -1,13 +1,12 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   DataListCell,
   DataListDateCell,
   DataListDescriptionCell,
   DataListIdCell,
-  DataListMonoCell,
   DataListNameCell,
   DataListNumberCell,
   DataListRowHeaderCell,
@@ -43,16 +42,17 @@ describe('DataListCell', () => {
     expect(cellOf(container).tagName).toBe('LABEL');
   });
 
-  it('takes the roomier padding by default and the tighter one on request', () => {
-    const { container } = render(<DataListCell>content</DataListCell>);
-    expect(cellOf(container).classList.contains('py-2.5')).toBe(true);
-    expect(cellOf(container).classList.contains('py-1.5')).toBe(false);
+  it('leaves vertical space to the row, so no cell can make one row taller than the next', () => {
+    const verticalPaddingOf = (ui: ReactElement) => {
+      const { container } = render(ui);
+      const padding = [...cellOf(container).classList].filter(name => /^(py|p)-/.test(name));
+      cleanup();
+      return padding;
+    };
 
-    cleanup();
-
-    const compact = render(<DataListCell height="compact">content</DataListCell>);
-    expect(cellOf(compact.container).classList.contains('py-1.5')).toBe(true);
-    expect(cellOf(compact.container).classList.contains('py-2.5')).toBe(false);
+    expect(verticalPaddingOf(<DataListCell>content</DataListCell>)).toEqual([]);
+    expect(verticalPaddingOf(<DataListNumberCell>1,200</DataListNumberCell>)).toEqual([]);
+    expect(verticalPaddingOf(<DataListTextCell font="mono">abc</DataListTextCell>)).toEqual([]);
   });
 
   it('pins itself to the start edge only when asked to', () => {
@@ -81,6 +81,14 @@ describe('DataListCell', () => {
 });
 
 describe('DataListTextCell', () => {
+  it('sets code text in mono, still truncating', () => {
+    const { container } = render(<DataListTextCell font="mono">a long identifier</DataListTextCell>);
+
+    expect(cellOf(container).classList.contains('font-mono')).toBe(true);
+    expect(container.querySelector('.truncate')).not.toBeNull();
+    expect(container.textContent).toBe('a long identifier');
+  });
+
   it('wraps bare text so it can truncate on its own', () => {
     const { container } = render(<DataListTextCell>a very long value</DataListTextCell>);
 
@@ -209,18 +217,11 @@ describe('DataListRowHeaderCell', () => {
 });
 
 describe('DataListNumberCell', () => {
-  it('sits tight and right-aligned by default', () => {
+  it('is right-aligned with tabular figures', () => {
     const { container } = render(<DataListNumberCell>1,200</DataListNumberCell>);
 
-    expect(cellOf(container).classList.contains('py-1.5')).toBe(true);
     expect(cellOf(container).classList.contains('text-right')).toBe(true);
     expect(cellOf(container).classList.contains('tabular-nums')).toBe(true);
-  });
-
-  it('takes the roomier padding when the caller asks', () => {
-    const { container } = render(<DataListNumberCell height="default">1,200</DataListNumberCell>);
-
-    expect(cellOf(container).classList.contains('py-2.5')).toBe(true);
   });
 
   it('stands out only when highlighted', () => {
@@ -329,33 +330,6 @@ describe('DataListSelectCell', () => {
     render(<DataListSelectCell checked onToggle={vi.fn()} aria-label="Select row" />);
 
     expect(screen.getByRole('checkbox', { name: 'Select row' }).getAttribute('aria-checked')).toBe('true');
-  });
-});
-
-describe('DataListMonoCell', () => {
-  it('sits tight by default and roomier on request', () => {
-    const { container } = render(<DataListMonoCell>abc</DataListMonoCell>);
-    expect(cellOf(container).classList.contains('py-1.5')).toBe(true);
-
-    cleanup();
-
-    const roomy = render(<DataListMonoCell height="default">abc</DataListMonoCell>);
-    expect(cellOf(roomy.container).classList.contains('py-2.5')).toBe(true);
-  });
-
-  it('sets its text in mono, truncated', () => {
-    const { container } = render(<DataListMonoCell>a long identifier</DataListMonoCell>);
-
-    const inner = container.querySelector('span > span');
-    expect(inner?.classList.contains('font-mono')).toBe(true);
-    expect(inner?.classList.contains('truncate')).toBe(true);
-    expect(container.textContent).toBe('a long identifier');
-  });
-
-  it('lets the caller swap the tone', () => {
-    const { container } = render(<DataListMonoCell className="text-neutral6">abc</DataListMonoCell>);
-
-    expect(container.querySelector('span > span')?.classList.contains('text-neutral6')).toBe(true);
   });
 });
 

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { ReactElement, ReactNode } from 'react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
+  DataListActionsCell,
   DataListCell,
   DataListDateCell,
   DataListDescriptionCell,
@@ -14,6 +15,7 @@ import {
   DataListTextCell,
   DataListTimeCell,
 } from './data-list-cells';
+import { DataListTopSelectCell } from './data-list-top-cell';
 
 // jsdom ships no PointerEvent; Base UI's Checkbox constructs one to decide
 // whether a click came from a pointer or the keyboard.
@@ -77,6 +79,22 @@ describe('DataListCell', () => {
 
     expect(cellOf(container).getAttribute('title')).toBe('a cell');
     expect(screen.getByTestId('cell')).toBeTruthy();
+  });
+});
+
+describe('controls revealed on hover', () => {
+  it('stay reachable on a device that cannot hover', () => {
+    const revealedWithoutHover = (ui: ReactElement) => {
+      const { container } = render(ui);
+      const hidden = container.querySelector('.opacity-0');
+      const reveals = hidden?.classList.contains('pointer-coarse:opacity-100') ?? false;
+      cleanup();
+      return reveals;
+    };
+
+    expect(revealedWithoutHover(<DataListActionsCell>action</DataListActionsCell>)).toBe(true);
+    expect(revealedWithoutHover(<DataListSelectCell checked={false} onToggle={() => {}} />)).toBe(true);
+    expect(revealedWithoutHover(<DataListTopSelectCell checked={false} onToggle={() => {}} />)).toBe(true);
   });
 });
 

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -1,7 +1,7 @@
 import { format, isToday } from 'date-fns';
 import { Children, cloneElement, isValidElement } from 'react';
 import type { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
-import { dataListStickyStartStyles } from './shared';
+import { dataListRowRevealStyles, dataListStickyStartStyles } from './shared';
 import type { DataListSticky } from './shared';
 import { Checkbox } from '@/ds/components/Checkbox';
 import { cn } from '@/lib/utils';
@@ -45,7 +45,12 @@ export function DataListCell({ children, className, as, sticky, ...rest }: DataL
 export function DataListActionsCell({ children, className, ...rest }: DataListCellProps) {
   return (
     <DataListCell className={className} {...rest}>
-      <span className="flex w-full items-center justify-end gap-1 pr-3 opacity-0 transition-opacity duration-200 group-focus-within/data-list-row:opacity-100 group-hover/data-list-row:opacity-100">
+      <span
+        className={cn(
+          'flex w-full items-center justify-end gap-1 pr-3 transition-opacity duration-200',
+          dataListRowRevealStyles,
+        )}
+      >
         {children}
       </span>
     </DataListCell>
@@ -198,8 +203,7 @@ export function DataListSelectCell({ checked, onToggle, disabled, ...rest }: Dat
       as="label"
       className={cn(
         'size-8 justify-items-center self-center overflow-visible px-0',
-        // Opacity, not display: the column keeps its width, so nothing shifts on hover.
-        !checked && 'opacity-0 group-focus-within/data-list-row:opacity-100 group-hover/data-list-row:opacity-100',
+        !checked && dataListRowRevealStyles,
         disabled ? 'cursor-not-allowed' : 'cursor-pointer',
       )}
       onClick={e => e.stopPropagation()}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -9,7 +9,6 @@ import { cn } from '@/lib/utils';
 export type DataListCellProps = {
   children?: ReactNode;
   className?: string;
-  height?: 'default' | 'compact';
   /**
    * HTML element rendered for the cell. Defaults to `span`. Use `'label'` when
    * the cell wraps a labelable control (e.g. a Checkbox), so the whole cell
@@ -23,13 +22,12 @@ export type DataListCellProps = {
   sticky?: DataListSticky;
 } & Omit<ComponentPropsWithoutRef<'div'>, 'children' | 'className'>;
 
-export function DataListCell({ children, className, height = 'default', as, sticky, ...rest }: DataListCellProps) {
+export function DataListCell({ children, className, as, sticky, ...rest }: DataListCellProps) {
   const Component = as || 'span';
   return (
     <Component
       className={cn(
         'relative grid max-w-full min-w-0 items-center overflow-hidden text-ui-md whitespace-nowrap text-neutral3 empty:before:text-neutral2 empty:before:content-["—"]',
-        height === 'compact' ? 'py-1.5' : 'py-2.5',
         sticky === 'start' && dataListStickyStartStyles,
         className,
       )}
@@ -37,6 +35,20 @@ export function DataListCell({ children, className, height = 'default', as, stic
     >
       {children}
     </Component>
+  );
+}
+
+/**
+ * Trailing cell for row actions, revealed on row hover or keyboard focus.
+ * Sits beside a `DataList.RowButton` inside a `DataList.RowWrapper`.
+ */
+export function DataListActionsCell({ children, className, ...rest }: DataListCellProps) {
+  return (
+    <DataListCell className={className} {...rest}>
+      <span className="flex w-full items-center justify-end gap-1 pr-3 opacity-0 transition-opacity duration-200 group-focus-within/data-list-row:opacity-100 group-hover/data-list-row:opacity-100">
+        {children}
+      </span>
+    </DataListCell>
   );
 }
 
@@ -71,9 +83,17 @@ function DataListTruncatedCellContent({ children }: { children: ReactNode }) {
   });
 }
 
-export function DataListTextCell({ children, className, ...rest }: DataListCellProps) {
+export type DataListTextCellProps = DataListCellProps & {
+  /**
+   * Typeface for the cell text. `mono` is for genuine code — paths, env values,
+   * serialized JSON — and drops a size step to match the sans columns optically.
+   */
+  font?: 'sans' | 'mono';
+};
+
+export function DataListTextCell({ children, className, font = 'sans', ...rest }: DataListTextCellProps) {
   return (
-    <DataListCell className={className} {...rest}>
+    <DataListCell className={cn(font === 'mono' && 'font-mono text-ui-smd', className)} {...rest}>
       <span className={dataListTruncateContentStyles}>
         <DataListTruncatedCellContent>{children}</DataListTruncatedCellContent>
       </span>
@@ -83,7 +103,7 @@ export function DataListTextCell({ children, className, ...rest }: DataListCellP
 
 export function DataListNameCell({ children, className }: DataListCellProps) {
   return (
-    <DataListCell className={cn('text-left text-neutral4', className)}>
+    <DataListCell className={cn('text-left font-medium text-neutral4', className)}>
       <span className={dataListTruncateContentStyles}>
         <DataListTruncatedCellContent>{children}</DataListTruncatedCellContent>
       </span>
@@ -108,7 +128,7 @@ export function DataListRowHeaderCell({ children, className, ...rest }: DataList
     <DataListCell
       sticky="start"
       className={cn(
-        'data-list-row-header -mr-4 -ml-5 w-auto max-w-none rounded-l-md pr-4 pl-5 text-left text-ui-sm font-semibold tracking-tight text-neutral2',
+        'data-list-row-header -mr-4 -ml-5 w-auto max-w-none rounded-l-lg pr-4 pl-5 text-left text-ui-sm font-medium text-neutral2',
         className,
       )}
       {...rest}
@@ -130,19 +150,11 @@ export type DataListNumberCellProps = DataListCellProps & {
 
 /**
  * Right-aligned numeric cell with tabular figures, for metric and summary
- * tables. Defaults to `compact` height to match those layouts; pass `highlight`
- * for the emphasized column.
+ * tables. Pass `highlight` for the emphasized column.
  */
-export function DataListNumberCell({
-  children,
-  className,
-  highlight,
-  height = 'compact',
-  ...rest
-}: DataListNumberCellProps) {
+export function DataListNumberCell({ children, className, highlight, ...rest }: DataListNumberCellProps) {
   return (
     <DataListCell
-      height={height}
       className={cn(
         'justify-items-end text-right text-ui-sm tabular-nums',
         highlight ? 'font-semibold text-neutral4' : 'text-neutral3',
@@ -164,11 +176,7 @@ export interface DataListIdCellProps {
 }
 
 export function DataListIdCell({ id }: DataListIdCellProps) {
-  return (
-    <DataListCell height="compact" className="text-ui-smd text-neutral3 font-mono">
-      {getShortId(id)}
-    </DataListCell>
-  );
+  return <DataListCell className="text-ui-smd text-neutral3 tracking-wide">{getShortId(id)}</DataListCell>;
 }
 
 export interface DataListSelectCellProps {
@@ -188,9 +196,10 @@ export function DataListSelectCell({ checked, onToggle, disabled, ...rest }: Dat
   return (
     <DataListCell
       as="label"
-      height="compact"
       className={cn(
-        'size-8 justify-items-center self-center overflow-visible px-0 py-0!',
+        'size-8 justify-items-center self-center overflow-visible px-0',
+        // Opacity, not display: the column keeps its width, so nothing shifts on hover.
+        !checked && 'opacity-0 group-focus-within/data-list-row:opacity-100 group-hover/data-list-row:opacity-100',
         disabled ? 'cursor-not-allowed' : 'cursor-pointer',
       )}
       onClick={e => e.stopPropagation()}
@@ -208,33 +217,6 @@ export function DataListSelectCell({ checked, onToggle, disabled, ...rest }: Dat
   );
 }
 
-export interface DataListMonoCellProps {
-  children: ReactNode;
-  /** Override classes on the inner span (e.g. swap the default `text-neutral3` tone). */
-  className?: string;
-  /** Cell vertical padding. Defaults to `compact` to match other identifier cells. */
-  height?: 'default' | 'compact';
-}
-
-/**
- * Mono-typography cell with truncation. Shared by any column that
- * shows code-like text (input previews, JSON summaries, identifiers, etc.).
- */
-export function DataListMonoCell({ children, className, height = 'compact' }: DataListMonoCellProps) {
-  return (
-    <DataListCell height={height}>
-      <span
-        className={cn(
-          'block max-w-full min-w-0 truncate font-mono text-ui-smd text-neutral3 empty:before:content-["—"]',
-          className,
-        )}
-      >
-        {children}
-      </span>
-    </DataListCell>
-  );
-}
-
 function toDate(value: Date | string): Date | null {
   const date = value instanceof Date ? value : new Date(value);
   return isNaN(date.getTime()) ? null : date;
@@ -248,7 +230,7 @@ export interface DataListDateCellProps {
 export function DataListDateCell({ timestamp }: DataListDateCellProps) {
   const date = toDate(timestamp);
   return (
-    <DataListCell height="compact" className="text-ui-smd text-neutral2">
+    <DataListCell className="text-ui-smd text-neutral2">
       {date ? (isToday(date) ? 'Today' : format(date, 'MMM dd')) : null}
     </DataListCell>
   );
@@ -261,7 +243,7 @@ export interface DataListTimeCellProps {
 export function DataListTimeCell({ timestamp }: DataListTimeCellProps) {
   const date = toDate(timestamp);
   return (
-    <DataListCell height="compact" className="text-ui-smd text-neutral3 flex font-mono">
+    <DataListCell className="text-ui-smd text-neutral3 flex tabular-nums">
       {date ? (
         <>
           {format(date, 'h:mm:ss')}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
@@ -23,8 +23,8 @@ const Header = () => (
 );
 
 describe('DataListRoot', () => {
-  describe('lined default variant — ScrollArea (overlay scrollbar + horizontal mask)', () => {
-    it('uses lined styling when no variant is provided', () => {
+  describe('default variant — ScrollArea (overlay scrollbar + horizontal mask)', () => {
+    it('leaves rows untinted and separator-free when no variant is provided', () => {
       const { container } = render(
         <DataList columns="1fr 1fr">
           <Header />
@@ -44,21 +44,12 @@ describe('DataListRoot', () => {
       expect(grid).not.toBe(container.firstElementChild);
       expect(grid?.className).not.toContain('overflow-auto');
       expect(grid?.className).toContain('gap-y-px');
-      expect(grid?.className).toContain('[&_.data-list-row]:after:absolute');
-      expect(grid?.className).toContain('[&_.data-list-row]:after:content-[""]');
-      expect(grid?.className).toContain('[&_.data-list-row]:after:inset-x-2');
-      expect(grid?.className).toContain('[&_.data-list-row]:after:-bottom-px');
-      expect(grid?.className).toContain('[&_.data-list-row]:after:bg-neutral6/10');
+      expect(grid?.className).not.toContain('[&_.data-list-row]:after:');
       expect(grid?.className).not.toContain('[&_.data-list-row]:even:bg-surface-overlay-soft');
-      expect(grid?.className).not.toContain('[&_.data-list-row]:after:hidden');
     });
 
     it.each([
-      [
-        'tinted',
-        'color-mix(in oklch, var(--surface1), var(--neutral6) 10%)',
-        'color-mix(in oklch, var(--surface1), var(--neutral6) 14%)',
-      ],
+      ['tinted', 'var(--surface-header)', 'var(--surface-header-hover)'],
       ['surface', 'var(--surface2)', 'color-mix(in oklch, var(--surface2), var(--neutral6) 10%)'],
       ['transparent', 'transparent', 'transparent'],
     ])('paints a %s sticky header with its own colour', (background, resting, hover) => {
@@ -81,9 +72,7 @@ describe('DataListRoot', () => {
       );
 
       const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
-      expect(grid?.style.getPropertyValue('--data-list-sticky-header-background')).toBe(
-        'color-mix(in oklch, var(--surface1), var(--neutral6) 10%)',
-      );
+      expect(grid?.style.getPropertyValue('--data-list-sticky-header-background')).toBe('var(--surface-header)');
     });
 
     it('forwards scrollRef to the scrolling viewport that contains the grid', () => {
@@ -178,10 +167,10 @@ describe('DataListRoot', () => {
     });
   });
 
-  describe('striped variant — ScrollArea (overlay scrollbar + horizontal mask)', () => {
+  describe('variants — ScrollArea (overlay scrollbar + horizontal mask)', () => {
     it('wraps the grid in a ScrollArea, which owns scrolling', () => {
       const { container } = render(
-        <DataList columns="1fr 1fr" variant="striped">
+        <DataList columns="1fr 1fr">
           <Header />
         </DataList>,
       );
@@ -193,83 +182,34 @@ describe('DataListRoot', () => {
       // the ScrollArea viewport owns scrolling, so the grid doesn't
       expect(grid?.className).not.toContain('overflow-auto');
       expect(grid?.className).toContain('gap-y-px');
-      expect(grid?.className).toContain('[&_.data-list-row]:after:hidden');
-      expect(grid?.className).toContain('[&_.data-list-row]:even:bg-surface-overlay-soft');
-      expect(grid?.className).not.toContain('[&_.data-list-row]:after:bg-neutral6/10');
-      expect(grid?.className).not.toContain('[&_.data-list-row]:after:-bottom-px');
+    });
+
+    it('zebra-tints alternating rows in `striped` only', () => {
+      const zebra = '[&_.data-list-row]:even:bg-surface-overlay-soft';
+      const renderGrid = (variant: 'plain' | 'striped') =>
+        render(
+          <DataList columns="1fr 1fr" variant={variant}>
+            <Header />
+          </DataList>,
+        ).container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
+
+      expect(renderGrid('striped')?.className).toContain(zebra);
+      expect(renderGrid('plain')?.className).not.toContain(zebra);
     });
   });
 
-  describe('lined variant — ScrollArea (overlay scrollbar + horizontal mask)', () => {
-    it('wraps the grid in a ScrollArea, which owns scrolling', () => {
-      const { container } = render(
-        <DataList columns="1fr 1fr" variant="lined">
-          <Header />
-        </DataList>,
-      );
-
-      const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
-      expect(grid).not.toBeNull();
-      expect(grid).not.toBe(container.firstElementChild);
-      expect(grid?.className).not.toContain('overflow-auto');
-    });
-
-    it('uses subtle row separators instead of zebra row backgrounds', () => {
-      const { container } = render(
-        <DataList columns="1fr 1fr" variant="lined">
-          <Header />
-          <DataList.RowButton>
-            <DataList.Cell>one</DataList.Cell>
-            <DataList.Cell>first row</DataList.Cell>
-          </DataList.RowButton>
-          <DataList.RowButton>
-            <DataList.Cell>two</DataList.Cell>
-            <DataList.Cell>second row</DataList.Cell>
-          </DataList.RowButton>
-        </DataList>,
-      );
-
-      const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
-      expect(grid?.className).toContain('gap-y-px');
-      expect(grid?.className).toContain('[&_.data-list-row]:after:absolute');
-      expect(grid?.className).toContain('[&_.data-list-row]:after:content-[""]');
-      expect(grid?.className).toContain('[&_.data-list-row]:after:inset-x-2');
-      expect(grid?.className).toContain('[&_.data-list-row]:after:-bottom-px');
-      expect(grid?.className).toContain('[&_.data-list-row]:after:bg-neutral6/10');
-      expect(grid?.className).not.toContain('[&_.data-list-row]:even:bg-surface-overlay-soft');
-      expect(grid?.className).not.toContain('[&_.data-list-row]:after:hidden');
-    });
-  });
-
-  describe('striped variant — virtualized (scrollRef forwarded to the viewport)', () => {
+  describe('virtualized (scrollRef forwarded to the viewport)', () => {
     it('points scrollRef at the scrolling viewport that contains the grid', () => {
       const scrollRef = createRef<HTMLDivElement>();
       const { container } = render(
-        <DataList columns="1fr 1fr" variant="striped" scrollRef={scrollRef}>
+        <DataList columns="1fr 1fr" scrollRef={scrollRef}>
           <Header />
         </DataList>,
       );
 
-      // scrollRef now resolves to the ScrollArea viewport (the scroll element the
+      // scrollRef resolves to the ScrollArea viewport (the scroll element the
       // virtualizer binds to via getScrollElement), not the grid — so the list
       // virtualizes against the overlay-scrollbar viewport.
-      expect(scrollRef.current).not.toBeNull();
-      const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
-      expect(grid).not.toBeNull();
-      expect(scrollRef.current).not.toBe(grid);
-      expect(scrollRef.current?.contains(grid)).toBe(true);
-    });
-  });
-
-  describe('lined variant — virtualized (scrollRef forwarded to the viewport)', () => {
-    it('points scrollRef at the scrolling viewport that contains the grid', () => {
-      const scrollRef = createRef<HTMLDivElement>();
-      const { container } = render(
-        <DataList columns="1fr 1fr" variant="lined" scrollRef={scrollRef}>
-          <Header />
-        </DataList>,
-      );
-
       expect(scrollRef.current).not.toBeNull();
       const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
       expect(grid).not.toBeNull();
@@ -365,7 +305,7 @@ describe('DataListRoot', () => {
         </DataList>,
       );
       const row = container.querySelector<HTMLButtonElement>('.data-list-row');
-      expect(row?.className).toContain('bg-surface4!');
+      expect(row?.className).toContain('bg-surface-row-featured!');
     });
 
     it('does not leak the variant prop onto the DOM element', () => {

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
@@ -7,12 +7,11 @@ import { cn } from '@/lib/utils';
 /**
  * Visual treatment for the whole list.
  *
- * - `striped`: borderless and full-bleed, zebra-striped rows (every other row
- *   tinted), contrasting sticky header band, no row separators.
- * - `lined`: borderless and full-bleed like `striped`, but rows stay transparent
- *   and use subtle separators instead of zebra tints.
+ * Both are borderless and full-bleed, with a contrasting sticky header band and
+ * no row separators. `striped` adds a zebra tint to every other row; `plain`
+ * leaves rows transparent so only hover and selection tint them.
  */
-export type DataListVariant = 'striped' | 'lined';
+export type DataListVariant = 'striped' | 'plain';
 
 /**
  * Horizontal sizing of the list grid.
@@ -35,8 +34,8 @@ export type DataListRootProps = Omit<ScrollAreaProps, 'children' | 'orientation'
   fit?: DataListFit;
   /**
    * Shared fill for the sticky top header and sticky row-header column.
-   * `tinted` is an opaque equivalent of the former `neutral6/10` tint, so sticky
-   * headers do not reveal scrolled content beneath them.
+   * `tinted` is the opaque `--surface-header` band, so sticky headers do not
+   * reveal scrolled content beneath them.
    */
   stickyHeaderBackground?: DataListStickyHeaderBackground;
   /**
@@ -54,8 +53,8 @@ export type DataListRootProps = Omit<ScrollAreaProps, 'children' | 'orientation'
 
 const stickyHeaderBackgroundValues = {
   tinted: {
-    background: 'color-mix(in oklch, var(--surface1), var(--neutral6) 10%)',
-    hoverBackground: 'color-mix(in oklch, var(--surface1), var(--neutral6) 14%)',
+    background: 'var(--surface-header)',
+    hoverBackground: 'var(--surface-header-hover)',
   },
   surface: {
     background: 'var(--surface2)',
@@ -87,11 +86,9 @@ function getDataListMask(mask: ScrollAreaMask | undefined): ScrollAreaMask {
  * per-row index:
  * - no container fill or border: rows composite over any view.
  * - `gap-y-px`: a uniform 1px gap between every grid track (header and rows).
- * - header: a contrasting band that owns the radius (the container no longer
- *   rounds/clips) — `rounded-t-xl` top, `rounded-b-md` bottom to match the rows
- *   sitting below the 1px gap, no hairline.
- * - rows: full-bleed, `rounded-md` (last row included); rows zero
- *   their own margins so the grid gap is the only spacing.
+ * - header: a contrasting band that owns its own radius, no hairline.
+ * - rows: full-bleed, so the grid gap is the only spacing. Header, rows and
+ *   subheader all share `rounded-lg`.
  * - striped adds translucent zebra tints with `:even`; hover & focus use `!` so
  *   they still win over root-level row styling.
  */
@@ -99,26 +96,15 @@ const borderlessTableStyles = [
   'gap-y-px',
   // A shared opaque tint gives both column headers and sticky row headers the
   // same treatment without revealing scrolled content beneath sticky surfaces.
-  '[&_.data-list-top]:mx-0 [&_.data-list-top]:bg-[var(--data-list-sticky-header-background)] [&_.data-list-top]:after:hidden',
-  '[&_.data-list-top]:rounded-t-xl [&_.data-list-top]:rounded-b-md',
-  // header column separators: a short, faint vertical line centered in the gap
-  // to the left of every header cell but the first. A `before` pseudo (not a
-  // `border-l` + padding) keeps header text aligned with the row cells below.
-  // The cell's default `overflow-hidden` would clip a gap-positioned pseudo, so
-  // these cells switch to `overflow-visible`; the title text still truncates via
-  // its inner `truncate` span, so nothing else spills.
-  '[&_.data-list-top>*:not(:first-child)]:relative [&_.data-list-top>*:not(:first-child)]:overflow-visible',
-  '[&_.data-list-top>*:not(:first-child)]:before:absolute [&_.data-list-top>*:not(:first-child)]:before:-left-4 [&_.data-list-top>*:not(:first-child)]:before:top-1/2 [&_.data-list-top>*:not(:first-child)]:before:-translate-y-1/2 [&_.data-list-top>*:not(:first-child)]:before:h-4 [&_.data-list-top>*:not(:first-child)]:before:w-px [&_.data-list-top>*:not(:first-child)]:before:bg-border2 [&_.data-list-top>*:not(:first-child)]:before:content-[""]',
-  '[&_.data-list-row]:mx-0 [&_.data-list-row]:my-0 [&_.data-list-row]:rounded-md',
+  '[&_.data-list-top]:bg-[var(--data-list-sticky-header-background)] [&_.data-list-top]:rounded-lg',
+  '[&_.data-list-row]:rounded-lg',
   '[&_.data-list-row]:hover:bg-surface-overlay-strong!',
-  '[&_.data-list-row]:focus-visible:bg-surface-overlay-strong!',
+  '[&_.data-list-row:focus-within]:bg-surface-overlay-strong!',
   '[&_.data-list-row>.data-list-sticky-start]:bg-[var(--data-list-sticky-header-background)]',
   '[&_.data-list-row>.data-list-sticky-start]:after:right-0',
   '[&_.data-list-row:hover>.data-list-sticky-start]:bg-[var(--data-list-sticky-header-hover-background)]',
-  '[&_.data-list-row:focus-visible>.data-list-sticky-start]:bg-[var(--data-list-sticky-header-hover-background)]',
   '[&_.data-list-row:focus-within>.data-list-sticky-start]:bg-[var(--data-list-sticky-header-hover-background)]',
   '[&_.data-list-top>.data-list-sticky-start]:after:right-0',
-  '[&_.data-list-top>.data-list-sticky-start+*]:before:hidden',
 ] as const;
 
 const dataListFitClasses: Record<DataListFit, string> = {
@@ -126,23 +112,15 @@ const dataListFitClasses: Record<DataListFit, string> = {
   container: 'w-full max-w-full',
 };
 
-const dataListRootVariants = cva(cn('grid content-start'), {
+const dataListRootVariants = cva(cn('grid content-start', ...borderlessTableStyles), {
   variants: {
     variant: {
-      striped: cn(
-        ...borderlessTableStyles,
-        '[&_.data-list-row]:after:hidden',
-        '[&_.data-list-row]:even:bg-surface-overlay-soft',
-      ),
-      lined: cn(
-        ...borderlessTableStyles,
-        '[&_.data-list-row]:after:pointer-events-none [&_.data-list-row]:after:absolute [&_.data-list-row]:after:h-px [&_.data-list-row]:after:content-[""]',
-        '[&_.data-list-row]:after:inset-x-2 [&_.data-list-row]:after:-bottom-px [&_.data-list-row]:after:bg-neutral6/10',
-      ),
+      striped: '[&_.data-list-row]:even:bg-surface-overlay-soft',
+      plain: '',
     },
   },
   defaultVariants: {
-    variant: 'lined',
+    variant: 'plain',
   },
 });
 
@@ -150,7 +128,7 @@ export function DataListRoot({
   children,
   columns,
   className,
-  variant = 'lined',
+  variant = 'plain',
   fit = 'content',
   stickyHeaderBackground = 'tinted',
   mask,
@@ -174,14 +152,10 @@ export function DataListRoot({
     </div>
   );
 
-  // DataList uses the DS ScrollArea: an overlay scrollbar (no reserved gutter,
-  // so the sticky header spans the full width and both top corners clip cleanly)
-  // plus the default edge fades. When the list virtualizes it passes a
-  // `scrollRef`; forwarding it as `viewportRef` makes the virtualizer scroll
-  // this viewport.
-  //
-  // `rounded-t-xl` clips the viewport top. Masks default to every overflowing
-  // edge except the top — a top fade would fade the opaque sticky header.
+  // DataList uses the DS ScrollArea: an overlay scrollbar, so the sticky header
+  // spans the full width. Masks default to every overflowing edge except the
+  // top — a top fade would fade the opaque sticky header. A virtualizing list
+  // passes `scrollRef`, forwarded as `viewportRef` so it scrolls this viewport.
   return (
     <ScrollArea
       {...props}
@@ -189,7 +163,7 @@ export function DataListRoot({
       mask={getDataListMask(mask)}
       viewportRef={scrollRef}
       viewPortClassName="max-h-[inherit]"
-      className={cn('size-full rounded-t-xl', className)}
+      className={cn('size-full', className)}
     >
       {grid}
     </ScrollArea>

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
@@ -12,22 +12,7 @@ export type DataListRowButtonProps = ComponentPropsWithoutRef<'button'> & DataLi
  * can attach a ref and `data-index` to each rendered row.
  */
 export const DataListRowButton = forwardRef<HTMLButtonElement, DataListRowButtonProps>(
-  (
-    {
-      children,
-      className,
-      type = 'button',
-      flushLeft,
-      flushRight,
-      colStart,
-      colEnd,
-      featured,
-      variant,
-      style,
-      ...rest
-    },
-    ref,
-  ) => {
+  ({ children, className, type = 'button', colStart, colEnd, featured, variant, style, ...rest }, ref) => {
     const isWrapped = useDataListRowWrapperContext();
     const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
     const resolvedStyle = hasColumnOverride ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` } : style;
@@ -38,11 +23,9 @@ export const DataListRowButton = forwardRef<HTMLButtonElement, DataListRowButton
         className={cn(
           ...(isWrapped ? dataListRowInteractiveStyles : dataListRowStyles),
           'text-left',
-          !isWrapped && flushLeft && 'ml-0!',
-          !isWrapped && flushRight && 'mr-0!',
           // `!` so the selection fill wins over borderless table root styling
           // (higher-specificity descendant rules); same color in `default`.
-          featured && 'bg-surface4!',
+          featured && 'bg-surface-row-featured!',
           dataListRowVariants({ variant }),
           className,
         )}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
@@ -19,8 +19,6 @@ export function DataListRowLink({
   className,
   style,
   LinkComponent: Link = 'a',
-  flushLeft,
-  flushRight,
   colStart,
   colEnd,
   featured,
@@ -35,11 +33,9 @@ export function DataListRowLink({
       href={to}
       className={cn(
         ...(isWrapped ? dataListRowInteractiveStyles : dataListRowStyles),
-        !isWrapped && flushLeft && 'ml-0!',
-        !isWrapped && flushRight && 'mr-0!',
         // `!` so the selection fill wins over borderless table root styling
         // (higher-specificity descendant rules); same color in `default`.
-        featured && 'bg-surface4!',
+        featured && 'bg-surface-row-featured!',
         dataListRowVariants({ variant }),
         className,
       )}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-static.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-static.tsx
@@ -12,7 +12,7 @@ export type DataListRowStaticProps = ComponentPropsWithoutRef<'div'> & DataListR
  * has no link target or click handler
  */
 export const DataListRowStatic = forwardRef<HTMLDivElement, DataListRowStaticProps>(
-  ({ children, className, flushLeft, flushRight, colStart, colEnd, featured, variant, style, ...rest }, ref) => {
+  ({ children, className, colStart, colEnd, featured, variant, style, ...rest }, ref) => {
     const isWrapped = useDataListRowWrapperContext();
     const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
     const resolvedStyle = hasColumnOverride ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` } : style;
@@ -23,11 +23,9 @@ export const DataListRowStatic = forwardRef<HTMLDivElement, DataListRowStaticPro
           isWrapped
             ? 'grid grid-cols-subgrid gap-8 rounded-lg px-5 transition-colors duration-200'
             : dataListRowStaticStyles,
-          !isWrapped && flushLeft && 'ml-0!',
-          !isWrapped && flushRight && 'mr-0!',
           // `!` so the selection fill wins over borderless table root styling
           // (higher-specificity descendant rules); same color in `default`.
-          featured && 'bg-surface4!',
+          featured && 'bg-surface-row-featured!',
           dataListRowVariants({ variant }),
           className,
         )}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-wrapper.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-wrapper.tsx
@@ -12,18 +12,14 @@ export type DataListRowWrapperProps = ComponentPropsWithoutRef<'div'>;
  * hover/focus/click only apply to the button portion. For standalone
  * interactive rows, use `DataList.RowButton` directly without this wrapper.
  *
- * Carries the row-level border + `.data-list-row` marker so separators and
- * sibling-aware rules behave the same in wrapped and standalone rows.
+ * Carries the `.data-list-row` marker so root-level row styling behaves the
+ * same in wrapped and standalone rows.
  */
 export const DataListRowWrapper = forwardRef<HTMLDivElement, DataListRowWrapperProps>(
   ({ children, className, ...rest }, ref) => {
     return (
       <DataListRowWrapperContext.Provider value>
-        <div
-          ref={ref}
-          className={cn('mx-1 grid grid-cols-subgrid gap-0', ...dataListRowOuterStyles, className)}
-          {...rest}
-        >
+        <div ref={ref} className={cn('grid grid-cols-subgrid gap-0', ...dataListRowOuterStyles, className)} {...rest}>
           {children}
         </div>
       </DataListRowWrapperContext.Provider>

--- a/packages/playground-ui/src/ds/components/DataList/data-list-skeleton.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-skeleton.tsx
@@ -1,6 +1,8 @@
 import { DataListCell } from './data-list-cells';
 import { DataListRoot } from './data-list-root';
 import type { DataListFit } from './data-list-root';
+import { dataListRowOuterStyles } from './shared';
+import { cn } from '@/lib/utils';
 
 const widths = ['75%', '50%', '65%', '90%', '60%', '80%'];
 
@@ -25,12 +27,15 @@ export function DataListSkeleton({ columns = 'auto 1fr auto auto', numberOfRows 
       {Array.from({ length: numberOfRows }).map((_, rowIdx) => (
         <div
           key={rowIdx}
-          className="data-list-row border-b-border1 3xl:gap-14 col-span-full grid grid-cols-subgrid gap-6 rounded-lg border-y border-t-transparent px-5 transition-colors duration-200 lg:gap-8 xl:gap-10 2xl:gap-12"
+          className={cn(
+            '3xl:gap-14 grid grid-cols-subgrid gap-6 px-5 lg:gap-8 xl:gap-10 2xl:gap-12',
+            ...dataListRowOuterStyles,
+          )}
         >
           {Array.from({ length: columnCount }).map((_, colIdx) => (
             <DataListCell key={colIdx}>
               <div
-                className="bg-surface4 h-4 animate-pulse rounded-md text-transparent select-none"
+                className="bg-surface6 h-4 animate-pulse rounded-lg text-transparent select-none"
                 style={{ width: getPseudoRandomWidth(rowIdx, colIdx) }}
               />
             </DataListCell>

--- a/packages/playground-ui/src/ds/components/DataList/data-list-skeleton.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-skeleton.tsx
@@ -28,7 +28,7 @@ export function DataListSkeleton({ columns = 'auto 1fr auto auto', numberOfRows 
         <div
           key={rowIdx}
           className={cn(
-            '3xl:gap-14 grid grid-cols-subgrid gap-6 px-5 lg:gap-8 xl:gap-10 2xl:gap-12',
+            'grid grid-cols-subgrid gap-6 px-5 2xl:gap-12 3xl:gap-14 lg:gap-8 xl:gap-10',
             ...dataListRowOuterStyles,
           )}
         >

--- a/packages/playground-ui/src/ds/components/DataList/data-list-subheader.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-subheader.tsx
@@ -10,8 +10,8 @@ export const DataListSubheader = forwardRef<HTMLDivElement, DataListSubheaderPro
       <div
         ref={ref}
         className={cn(
-          'data-list-subheader relative isolate col-span-full mx-1 border-none px-4 py-3 text-ui-md font-medium text-neutral4',
-          'before:absolute before:inset-x-0 before:inset-y-1 before:-z-1 before:rounded-md before:bg-surface4',
+          'relative isolate col-span-full mt-2 border-none px-5 py-3 text-ui-md font-medium text-neutral4',
+          'before:absolute before:inset-0 before:-z-1 before:rounded-lg before:bg-[var(--data-list-sticky-header-background)]',
           className,
         )}
         {...rest}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
 import { forwardRef } from 'react';
-import { dataListStickyStartStyles } from './shared';
+import { dataListStickyStartStyles, dataListTopRevealStyles } from './shared';
 import type { DataListSticky } from './shared';
 import { Checkbox } from '@/ds/components/Checkbox';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/ds/components/Tooltip';
@@ -117,9 +117,7 @@ export function DataListTopSelectCell({ checked, onToggle, ...rest }: DataListTo
       as="label"
       className={cn(
         'w-8 cursor-pointer justify-center overflow-visible px-0 py-0!',
-        // Matches the row checkboxes: hidden until the header is hovered or focused.
-        checked === false &&
-          'opacity-0 group-focus-within/data-list-top:opacity-100 group-hover/data-list-top:opacity-100',
+        checked === false && dataListTopRevealStyles,
       )}
       onClick={e => e.stopPropagation()}
     >

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
@@ -26,9 +26,9 @@ export const DataListTopCell = forwardRef<HTMLSpanElement, DataListTopCellProps>
       <Component
         ref={ref}
         className={cn(
-          'flex h-8 max-w-full min-w-0 items-center overflow-hidden py-1 text-ui-sm font-semibold tracking-tight whitespace-nowrap text-neutral2',
+          'flex h-10 max-w-full min-w-0 items-center overflow-hidden py-1 text-ui-sm font-medium whitespace-nowrap text-neutral2',
           sticky === 'start' && dataListStickyStartStyles,
-          sticky === 'start' && '-mr-4 -ml-5 w-auto max-w-none rounded-tl-xl rounded-bl-md pr-4 pl-5',
+          sticky === 'start' && '-mr-4 -ml-5 w-auto max-w-none rounded-l-lg pr-4 pl-5',
           sticky === 'start' && 'z-20 bg-[var(--data-list-sticky-header-background)]',
           className,
         )}
@@ -115,7 +115,12 @@ export function DataListTopSelectCell({ checked, onToggle, ...rest }: DataListTo
   return (
     <DataListTopCell
       as="label"
-      className="w-8 cursor-pointer justify-center overflow-visible px-0 py-0!"
+      className={cn(
+        'w-8 cursor-pointer justify-center overflow-visible px-0 py-0!',
+        // Matches the row checkboxes: hidden until the header is hovered or focused.
+        checked === false &&
+          'opacity-0 group-focus-within/data-list-top:opacity-100 group-hover/data-list-top:opacity-100',
+      )}
       onClick={e => e.stopPropagation()}
     >
       <Checkbox checked={checked} onCheckedChange={() => onToggle()} aria-label={rest['aria-label']} />

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top.tsx
@@ -15,7 +15,7 @@ export function DataListTop({ children, className, hasLeadingCell, ...props }: D
   return (
     <div
       className={cn(
-        'data-list-top sticky top-0 z-20 col-span-full mx-1 grid grid-cols-subgrid gap-8 bg-surface2 px-5 after:pointer-events-none after:absolute after:-inset-x-1 after:bottom-0 after:h-px after:bg-border1 after:content-[""]',
+        'group/data-list-top data-list-top sticky top-0 z-20 col-span-full grid grid-cols-subgrid gap-8 px-5',
         hasLeadingCell && 'gap-0 pl-0!',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.stories.tsx
@@ -16,7 +16,7 @@ type DataListStoryArgs = {
   stickyHeaderBackground: DataListStickyHeaderBackground;
 };
 
-const VARIANT_OPTIONS: DataListVariant[] = ['lined', 'striped'];
+const VARIANT_OPTIONS: DataListVariant[] = ['plain', 'striped'];
 const STICKY_HEADER_BACKGROUND_OPTIONS: DataListStickyHeaderBackground[] = ['tinted', 'surface', 'transparent'];
 
 const meta: Meta<DataListStoryArgs> = {
@@ -25,7 +25,7 @@ const meta: Meta<DataListStoryArgs> = {
     layout: 'padded',
   },
   args: {
-    variant: 'lined',
+    variant: 'plain',
     stickyHeaderBackground: 'tinted',
   },
   argTypes: {
@@ -93,8 +93,8 @@ export const Compact: Story = {
       {SAMPLE_RUNS.map(run => (
         <DataList.RowButton key={run.id} onClick={() => {}}>
           <DataList.IdCell id={run.id} />
-          <DataList.MonoCell>{run.input}</DataList.MonoCell>
-          <DataList.Cell height="compact">{run.status}</DataList.Cell>
+          <DataList.TextCell>{run.input}</DataList.TextCell>
+          <DataList.Cell>{run.status}</DataList.Cell>
           <DataList.DateCell timestamp={run.createdAt} />
           <DataList.TimeCell timestamp={run.createdAt} />
         </DataList.RowButton>
@@ -123,7 +123,7 @@ export const Default: Story = {
         { name: 'Translation Agent', description: 'Translates text between supported languages.', status: 'idle' },
       ].map(item => (
         <DataList.RowButton key={item.name} onClick={() => {}}>
-          <DataList.NameCell className="font-medium">
+          <DataList.NameCell>
             <span className="flex items-center">{item.name}</span>
           </DataList.NameCell>
           <DataList.DescriptionCell>{item.description}</DataList.DescriptionCell>
@@ -155,8 +155,8 @@ export const WithErrorRows: Story = {
         return (
           <DataList.RowButton key={`${run.id}-${index}`} onClick={() => {}} variant={failed ? 'error' : 'default'}>
             <DataList.IdCell id={`${run.id}_${index}`} />
-            <DataList.MonoCell>{run.input}</DataList.MonoCell>
-            <DataList.Cell height="compact">{run.status}</DataList.Cell>
+            <DataList.TextCell>{run.input}</DataList.TextCell>
+            <DataList.Cell>{run.status}</DataList.Cell>
             <DataList.DateCell timestamp={run.createdAt} />
             <DataList.TimeCell timestamp={run.createdAt} />
           </DataList.RowButton>
@@ -198,8 +198,8 @@ export const WithRowLink: Story = {
       {SAMPLE_RUNS.map(run => (
         <DataList.RowLink key={run.id} to={`/runs/${run.id}`} LinkComponent={StoryLink}>
           <DataList.IdCell id={run.id} />
-          <DataList.MonoCell>{run.input}</DataList.MonoCell>
-          <DataList.Cell height="compact">{run.status}</DataList.Cell>
+          <DataList.TextCell>{run.input}</DataList.TextCell>
+          <DataList.Cell>{run.status}</DataList.Cell>
           <DataList.DateCell timestamp={run.createdAt} />
           <DataList.TimeCell timestamp={run.createdAt} />
         </DataList.RowLink>
@@ -252,10 +252,10 @@ export const WithSelection: Story = {
               onToggle={() => toggle(run.id)}
               aria-label={`Select ${run.id}`}
             />
-            <DataList.RowButton flushLeft colStart={2} onClick={() => toggle(run.id)}>
+            <DataList.RowButton colStart={2} onClick={() => toggle(run.id)}>
               <DataList.IdCell id={run.id} />
-              <DataList.MonoCell>{run.input}</DataList.MonoCell>
-              <DataList.Cell height="compact">{run.status}</DataList.Cell>
+              <DataList.TextCell>{run.input}</DataList.TextCell>
+              <DataList.Cell>{run.status}</DataList.Cell>
               <DataList.DateCell timestamp={run.createdAt} />
               <DataList.TimeCell timestamp={run.createdAt} />
             </DataList.RowButton>
@@ -266,7 +266,7 @@ export const WithSelection: Story = {
   },
 };
 
-/** Trailing actions column: the row click area is bounded by `colEnd={-2}` + `flushRight`, and the last cell hosts per-row controls. */
+/** Trailing actions column: the row click area is bounded by `colEnd={-2}`, and the last cell hosts per-row controls. */
 export const WithTrailingCell: Story = {
   render: ({ variant }) => (
     <DataList columns="minmax(8rem,auto) minmax(8rem,1fr) minmax(0,2fr) auto" variant={variant}>
@@ -282,37 +282,35 @@ export const WithTrailingCell: Story = {
         { name: 'database', path: '/skills/database', description: 'Query the connected SQL database.' },
       ].map(item => (
         <DataList.RowWrapper key={item.path}>
-          <DataList.RowButton flushLeft flushRight colEnd={-2} onClick={() => {}}>
+          <DataList.RowButton colEnd={-2} onClick={() => {}}>
             <DataList.Cell className="text-neutral6 font-medium">{item.name}</DataList.Cell>
-            <DataList.MonoCell height="default">{item.path}</DataList.MonoCell>
+            <DataList.TextCell font="mono">{item.path}</DataList.TextCell>
             <DataList.Cell className="min-w-0">
               <span className="block truncate">{item.description}</span>
             </DataList.Cell>
           </DataList.RowButton>
-          <DataList.Cell className="py-0">
-            <div className="flex w-full items-center justify-end gap-1 pr-3">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                tooltip={`Edit ${item.name}`}
-                aria-label={`Edit ${item.name}`}
-                onClick={e => e.stopPropagation()}
-              >
-                <Pencil className="size-4" />
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                tooltip={`Delete ${item.name}`}
-                aria-label={`Delete ${item.name}`}
-                onClick={e => e.stopPropagation()}
-              >
-                <Trash2 className="size-4" />
-              </Button>
-            </div>
-          </DataList.Cell>
+          <DataList.ActionsCell>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              tooltip={`Edit ${item.name}`}
+              aria-label={`Edit ${item.name}`}
+              onClick={e => e.stopPropagation()}
+            >
+              <Pencil className="size-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              tooltip={`Delete ${item.name}`}
+              aria-label={`Delete ${item.name}`}
+              onClick={e => e.stopPropagation()}
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          </DataList.ActionsCell>
         </DataList.RowWrapper>
       ))}
     </DataList>
@@ -333,8 +331,8 @@ export const Featured: Story = {
       {SAMPLE_RUNS.map((run, idx) => (
         <DataList.RowButton key={run.id} featured={idx === 1} onClick={() => {}}>
           <DataList.IdCell id={run.id} />
-          <DataList.MonoCell>{run.input}</DataList.MonoCell>
-          <DataList.Cell height="compact">{run.status}</DataList.Cell>
+          <DataList.TextCell>{run.input}</DataList.TextCell>
+          <DataList.Cell>{run.status}</DataList.Cell>
           <DataList.DateCell timestamp={run.createdAt} />
           <DataList.TimeCell timestamp={run.createdAt} />
         </DataList.RowButton>
@@ -358,7 +356,7 @@ export const WithDateAndTimeCells: Story = {
         { event: 'workflow.completed', timestamp: '2025-12-03T09:00:00.000Z' },
       ].map(row => (
         <DataList.RowButton key={row.event + row.timestamp} onClick={() => {}}>
-          <DataList.MonoCell>{row.event}</DataList.MonoCell>
+          <DataList.TextCell>{row.event}</DataList.TextCell>
           <DataList.DateCell timestamp={row.timestamp} />
           <DataList.TimeCell timestamp={row.timestamp} />
         </DataList.RowButton>
@@ -406,21 +404,23 @@ export const WideColumnsOverflow: Story = {
           return (
             <DataList.RowButton key={`${run.id}-${index}`} onClick={() => {}}>
               <DataList.IdCell id={`${run.id}_${index}`} />
-              <DataList.MonoCell>
+              <DataList.TextCell>
                 {run.input} with enough extra context to verify truncation in a narrow scrolling grid
-              </DataList.MonoCell>
-              <DataList.Cell height="compact" className="min-w-0">
+              </DataList.TextCell>
+              <DataList.Cell className="min-w-0">
                 <Badge variant={index % 3 === 0 ? 'warning' : 'success'} className="max-w-full min-w-0 overflow-hidden">
                   <span className="min-w-0 truncate">{index === 2 ? VERY_LONG_BADGE : run.status}</span>
                 </Badge>
               </DataList.Cell>
-              <DataList.MonoCell>{MODEL_TOKEN_PLACEHOLDERS[index % MODEL_TOKEN_PLACEHOLDERS.length]}</DataList.MonoCell>
-              <DataList.MonoCell>daily-evaluation-pipeline-{index + 1}</DataList.MonoCell>
-              <DataList.Cell height="compact">Team {index % 5}</DataList.Cell>
-              <DataList.Cell height="compact">{index % 2 === 0 ? 'production' : 'staging'}</DataList.Cell>
-              <DataList.Cell height="compact">{120 + index * 37}ms</DataList.Cell>
+              <DataList.TextCell font="mono">
+                {MODEL_TOKEN_PLACEHOLDERS[index % MODEL_TOKEN_PLACEHOLDERS.length]}
+              </DataList.TextCell>
+              <DataList.TextCell font="mono">daily-evaluation-pipeline-{index + 1}</DataList.TextCell>
+              <DataList.Cell>Team {index % 5}</DataList.Cell>
+              <DataList.Cell>{index % 2 === 0 ? 'production' : 'staging'}</DataList.Cell>
+              <DataList.Cell>{120 + index * 37}ms</DataList.Cell>
               <DataList.DateCell timestamp={run.createdAt} />
-              <DataList.MonoCell>trace_{String(index + 1).padStart(4, '0')}</DataList.MonoCell>
+              <DataList.TextCell font="mono">trace_{String(index + 1).padStart(4, '0')}</DataList.TextCell>
             </DataList.RowButton>
           );
         })}
@@ -454,9 +454,7 @@ export const StickyRowHeaders: Story = {
           const model = MODEL_TOKEN_PLACEHOLDERS[index % MODEL_TOKEN_PLACEHOLDERS.length];
           return (
             <DataList.RowButton key={`${model}-${index}`} onClick={() => {}}>
-              <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                {model}
-              </DataList.RowHeaderCell>
+              <DataList.RowHeaderCell className="text-ui-sm">{model}</DataList.RowHeaderCell>
               <DataList.NumberCell>{(index * 1300 + 6200).toLocaleString()}</DataList.NumberCell>
               <DataList.NumberCell>{(index * 840 + 2100).toLocaleString()}</DataList.NumberCell>
               <DataList.NumberCell>{(index * 260 + 900).toLocaleString()}</DataList.NumberCell>
@@ -499,8 +497,8 @@ export const WithPagination: Story = {
         {SAMPLE_RUNS.map(run => (
           <DataList.RowButton key={run.id} onClick={() => {}}>
             <DataList.IdCell id={run.id} />
-            <DataList.MonoCell>{run.input}</DataList.MonoCell>
-            <DataList.Cell height="compact">{run.status}</DataList.Cell>
+            <DataList.TextCell>{run.input}</DataList.TextCell>
+            <DataList.Cell>{run.status}</DataList.Cell>
             <DataList.DateCell timestamp={run.createdAt} />
             <DataList.TimeCell timestamp={run.createdAt} />
           </DataList.RowButton>
@@ -534,8 +532,8 @@ export const WithSubheader: Story = {
       {SAMPLE_RUNS.slice(0, 2).map(run => (
         <DataList.RowButton key={run.id} onClick={() => {}}>
           <DataList.IdCell id={run.id} />
-          <DataList.MonoCell>{run.input}</DataList.MonoCell>
-          <DataList.Cell height="compact">{run.status}</DataList.Cell>
+          <DataList.TextCell>{run.input}</DataList.TextCell>
+          <DataList.Cell>{run.status}</DataList.Cell>
           <DataList.DateCell timestamp={run.createdAt} />
           <DataList.TimeCell timestamp={run.createdAt} />
         </DataList.RowButton>
@@ -547,8 +545,8 @@ export const WithSubheader: Story = {
       {SAMPLE_RUNS.slice(2).map(run => (
         <DataList.RowButton key={run.id} onClick={() => {}}>
           <DataList.IdCell id={run.id} />
-          <DataList.MonoCell>{run.input}</DataList.MonoCell>
-          <DataList.Cell height="compact">{run.status}</DataList.Cell>
+          <DataList.TextCell>{run.input}</DataList.TextCell>
+          <DataList.Cell>{run.status}</DataList.Cell>
           <DataList.DateCell timestamp={run.createdAt} />
           <DataList.TimeCell timestamp={run.createdAt} />
         </DataList.RowButton>
@@ -725,8 +723,8 @@ export const KeyboardNavigation: Story = {
                 {...getRowProps(index)}
               >
                 <DataList.IdCell id={run.id} />
-                <DataList.MonoCell>{run.input}</DataList.MonoCell>
-                <DataList.Cell height="compact">{run.status}</DataList.Cell>
+                <DataList.TextCell>{run.input}</DataList.TextCell>
+                <DataList.Cell>{run.status}</DataList.Cell>
                 <DataList.DateCell timestamp={run.createdAt} />
                 <DataList.TimeCell timestamp={run.createdAt} />
               </DataList.RowButton>

--- a/packages/playground-ui/src/ds/components/DataList/data-list.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.tsx
@@ -1,4 +1,5 @@
 import {
+  DataListActionsCell,
   DataListCell,
   DataListTextCell,
   DataListNameCell,
@@ -7,7 +8,6 @@ import {
   DataListRowHeaderCell,
   DataListNumberCell,
   DataListSelectCell,
-  DataListMonoCell,
   DataListDateCell,
   DataListTimeCell,
 } from './data-list-cells';
@@ -44,13 +44,13 @@ export const DataList = Object.assign(DataListRoot, {
   RowLink: DataListRowLink,
   RowStatic: DataListRowStatic,
   Cell: DataListCell,
+  ActionsCell: DataListActionsCell,
   TextCell: DataListTextCell,
   NameCell: DataListNameCell,
   DescriptionCell: DataListDescriptionCell,
   IdCell: DataListIdCell,
   RowHeaderCell: DataListRowHeaderCell,
   NumberCell: DataListNumberCell,
-  MonoCell: DataListMonoCell,
   DateCell: DataListDateCell,
   TimeCell: DataListTimeCell,
   SelectCell: DataListSelectCell,

--- a/packages/playground-ui/src/ds/components/DataList/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataList/shared.ts
@@ -3,25 +3,26 @@
  * chain — applied to `DataList.RowButton` / `DataList.RowLink` when used
  * standalone, and to `DataList.RowWrapper` when used as a shell around them.
  *
- * Contains the `.data-list-row` marker class (used by the sibling-aware
- * separator rules), the full-width separator treatment, and rounded corners.
+ * Carries the `.data-list-row` marker class the root styles target.
  */
 export const dataListRowOuterStyles = [
-  'data-list-row col-span-full relative mt-[3px] mb-1',
-  'after:absolute after:inset-x-[-0.25rem] after:bottom-[-0.25rem] after:h-px after:bg-border1 after:content-[""] after:pointer-events-none',
-  '[&:has(+.data-list-subheader)]:after:hidden [&:not(:has(~.data-list-row))]:after:hidden',
+  'group/data-list-row data-list-row col-span-full relative min-h-9',
   'transition-colors duration-200 rounded-lg',
 ] as const;
 
+/**
+ * Layout + focus ring only. The root paints the hover/focus fill on
+ * `.data-list-row`, so a wrapped row and its button never show two tints.
+ */
 export const dataListRowInteractiveStyles = [
   'grid grid-cols-subgrid gap-8 px-5 outline-none cursor-pointer',
-  'hover:bg-surface4 focus-visible:bg-surface4 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent1',
+  'focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent1',
   'transition-colors duration-200 rounded-lg',
 ] as const;
 
-export const dataListRowStyles = ['mx-1', ...dataListRowInteractiveStyles, ...dataListRowOuterStyles] as const;
+export const dataListRowStyles = [...dataListRowInteractiveStyles, ...dataListRowOuterStyles] as const;
 
-export const dataListRowStaticStyles = ['mx-1 grid grid-cols-subgrid gap-8 px-5', ...dataListRowOuterStyles] as const;
+export const dataListRowStaticStyles = ['grid grid-cols-subgrid gap-8 px-5', ...dataListRowOuterStyles] as const;
 
 import { cva } from 'class-variance-authority';
 
@@ -60,18 +61,6 @@ export const dataListRowVariants = cva('', {
 export type DataListRowSharedProps = {
   /** Row tone — `error` applies a subtle destructive background tint. */
   variant?: DataListRowVariant;
-  /**
-   * Drop the row's default left margin. Use when the row is wrapped in a
-   * `DataList.RowWrapper` that owns the leading inset (e.g. for selection rows where
-   * the checkbox cell sits on the left).
-   */
-  flushLeft?: boolean;
-  /**
-   * Drop the row's default right margin. Use when the row is wrapped in a
-   * `DataList.RowWrapper` that owns the trailing inset (e.g. for rows with a
-   * trailing actions cell on the right).
-   */
-  flushRight?: boolean;
   /**
    * Place the row starting at this column line. Defaults to column 1. Use
    * when the row sits beside a leading cell that owns column 1.

--- a/packages/playground-ui/src/ds/components/DataList/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataList/shared.ts
@@ -24,6 +24,19 @@ export const dataListRowStyles = [...dataListRowInteractiveStyles, ...dataListRo
 
 export const dataListRowStaticStyles = ['grid grid-cols-subgrid gap-8 px-5', ...dataListRowOuterStyles] as const;
 
+/**
+ * Row controls that stay out of the way until the row is hovered or focused.
+ * Opacity, not display, so the column keeps its width and nothing shifts. A
+ * coarse pointer never hovers, so there they stay visible — hidden controls
+ * that still take taps would be worse than no reveal at all.
+ */
+export const dataListRowRevealStyles =
+  'opacity-0 pointer-coarse:opacity-100 group-focus-within/data-list-row:opacity-100 group-hover/data-list-row:opacity-100';
+
+/** Header counterpart of {@link dataListRowRevealStyles}. */
+export const dataListTopRevealStyles =
+  'opacity-0 pointer-coarse:opacity-100 group-focus-within/data-list-top:opacity-100 group-hover/data-list-top:opacity-100';
+
 import { cva } from 'class-variance-authority';
 
 export type DataListSticky = 'start';

--- a/packages/playground-ui/src/ds/components/EnvironmentVariablesEditor/environment-variables-editor-read-only-item.tsx
+++ b/packages/playground-ui/src/ds/components/EnvironmentVariablesEditor/environment-variables-editor-read-only-item.tsx
@@ -51,18 +51,18 @@ export function EnvironmentVariablesEditorReadOnlyItem({
   return (
     <DataList.RowStatic className={cn('min-h-14', className)} {...props}>
       {showIcon && (
-        <DataList.Cell height="compact" className="justify-items-center overflow-visible">
+        <DataList.Cell className="justify-items-center overflow-visible">
           <span className="border-border1 text-neutral3 flex size-7 items-center justify-center rounded-full border [&>svg]:size-3.5">
             {leadingIcon}
           </span>
         </DataList.Cell>
       )}
 
-      <DataList.MonoCell height="compact" className="text-ui-sm text-neutral6">
+      <DataList.TextCell font="mono" className="text-ui-sm text-neutral6">
         {name}
-      </DataList.MonoCell>
+      </DataList.TextCell>
 
-      <DataList.Cell height="compact" className="min-w-0">
+      <DataList.Cell className="min-w-0">
         {value !== undefined && (
           <span className="flex min-w-0 items-center gap-2">
             <Button
@@ -101,7 +101,7 @@ export function EnvironmentVariablesEditorReadOnlyItem({
         )}
       </DataList.Cell>
 
-      <DataList.Cell height="compact" className="text-ui-xs text-neutral3 min-w-0 justify-items-end">
+      <DataList.Cell className="text-ui-xs text-neutral3 min-w-0 justify-items-end">
         {(updatedAt || actor) && (
           <span className="flex min-w-0 items-center gap-2">
             <span className="truncate">{updatedAt}</span>

--- a/packages/playground-ui/src/ds/components/EnvironmentVariablesEditor/environment-variables-editor-read-only-list.tsx
+++ b/packages/playground-ui/src/ds/components/EnvironmentVariablesEditor/environment-variables-editor-read-only-list.tsx
@@ -19,7 +19,7 @@ export function EnvironmentVariablesEditorReadOnlyList({
   nameLabel,
   valueLabel,
   updatedAtLabel,
-  variant = 'lined',
+  variant = 'plain',
   scrollRef,
   ...props
 }: EnvironmentVariablesEditorReadOnlyListProps) {

--- a/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list-cells.tsx
@@ -1,4 +1,4 @@
-import { DataListCell, DataListMonoCell } from '../DataList/data-list-cells';
+import { DataListCell, DataListTextCell } from '../DataList/data-list-cells';
 type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { ToolsIcon } from '@/ds/icons/ToolsIcon';
@@ -25,7 +25,7 @@ export function LogsDataListLevelCell({ level }: LogsDataListLevelCellProps) {
   const config = LEVEL_CONFIG[level];
 
   return (
-    <DataListCell height="compact">
+    <DataListCell>
       <span className="text-ui-sm font-semibold uppercase" style={{ color: config.color }}>
         {config.label}
       </span>
@@ -63,7 +63,7 @@ export function LogsDataListEntityCell({ entityType, entityName }: LogsDataListE
   const type = entityType ?? '';
 
   return (
-    <DataListCell height="compact" className="flex min-w-0 items-center gap-2">
+    <DataListCell className="flex min-w-0 items-center gap-2">
       <EntityTypeIcon entityType={type} />
       {entityName ? <span className="text-ui-smd min-w-0 truncate">{entityName}</span> : '-'}
     </DataListCell>
@@ -79,11 +79,7 @@ export interface LogsDataListMessageCellProps {
 }
 
 export function LogsDataListMessageCell({ message }: LogsDataListMessageCellProps) {
-  return (
-    <DataListCell height="compact" className="text-ui-smd text-neutral4 min-w-0 truncate font-mono">
-      {message}
-    </DataListCell>
-  );
+  return <DataListCell className="text-ui-smd text-neutral4 min-w-0 truncate font-mono">{message}</DataListCell>;
 }
 
 // ---------------------------------------------------------------------------
@@ -96,7 +92,7 @@ export interface LogsDataListDataCellProps {
 
 export function LogsDataListDataCell({ data }: LogsDataListDataCellProps) {
   if (!data || Object.keys(data).length === 0) {
-    return <DataListCell height="compact">{null}</DataListCell>;
+    return <DataListCell>{null}</DataListCell>;
   }
 
   const summary = Object.entries(data)
@@ -110,5 +106,5 @@ export function LogsDataListDataCell({ data }: LogsDataListDataCellProps) {
     })
     .join(', ');
 
-  return <DataListMonoCell>{summary}</DataListMonoCell>;
+  return <DataListTextCell font="mono">{summary}</DataListTextCell>;
 }

--- a/packages/playground-ui/theme.css
+++ b/packages/playground-ui/theme.css
@@ -46,6 +46,9 @@
   --border2: oklch(100% 0 0deg / 11%);
   --surface-overlay-soft: oklch(100% 0 0deg / 4%);
   --surface-overlay-strong: oklch(100% 0 0deg / 7%);
+  --surface-header: oklch(15% 0 0deg);
+  --surface-header-hover: oklch(19% 0 0deg);
+  --surface-row-featured: oklch(100% 0 0deg / 12%);
   --shadow-main-frame: 0 14px 48px -36px oklch(0% 0 0deg / 85%);
   --sidebar-nav-hover: oklch(100% 0 0deg / 7%);
   --sidebar-nav-active: oklch(100% 0 0deg / 11%);
@@ -130,6 +133,9 @@ html.light {
   --border2: oklch(20.8% 0 0deg / 16%);
   --surface-overlay-soft: oklch(20.8% 0 0deg / 4%);
   --surface-overlay-strong: oklch(20.8% 0 0deg / 7%);
+  --surface-header: oklch(92.6% 0 0deg);
+  --surface-header-hover: oklch(90% 0 0deg);
+  --surface-row-featured: oklch(20.8% 0 0deg / 11%);
   --shadow-main-frame: 0 1px 2px oklch(24% 0 0deg / 4%), 0 18px 48px -34px oklch(24% 0 0deg / 22%);
   --sidebar-nav-hover: oklch(20.8% 0 0deg / 5.5%);
   --sidebar-nav-active: oklch(20.8% 0 0deg / 8.5%);
@@ -328,6 +334,7 @@ html.light {
   --color-border2: var(--border2);
   --color-surface-overlay-soft: var(--surface-overlay-soft);
   --color-surface-overlay-strong: var(--surface-overlay-strong);
+  --color-surface-row-featured: var(--surface-row-featured);
 
   /* Semantic color aliases */
   --color-text1: var(--text1);

--- a/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
+++ b/packages/playground/src/domains/agents/components/agent-list/agents-list.tsx
@@ -83,16 +83,16 @@ export function AgentsList({ agents, isLoading, hasSearch }: AgentsListProps) {
                 </span>
               </EntityList.Cell>
             </EntityList.RowLink>
-            <EntityList.Cell className="justify-center overflow-visible py-0">
+            <EntityList.Cell className="justify-center overflow-visible">
               <AgentProviderDetails agentName={agent.name} provider={agent.provider} modelId={agent.modelId} />
             </EntityList.Cell>
-            <EntityList.Cell className="justify-center overflow-visible py-0">
+            <EntityList.Cell className="justify-center overflow-visible">
               <AgentWorkflowDetails agentName={agent.name} workflows={agent.workflows} />
             </EntityList.Cell>
-            <EntityList.Cell className="justify-center overflow-visible py-0">
+            <EntityList.Cell className="justify-center overflow-visible">
               <AgentSubagentDetails agentName={agent.name} agents={agent.agents} />
             </EntityList.Cell>
-            <EntityList.Cell className="justify-center overflow-visible py-0">
+            <EntityList.Cell className="justify-center overflow-visible">
               <AgentToolsDetails agentName={agent.name} tools={agent.tools} />
             </EntityList.Cell>
           </EntityList.RowWrapper>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
@@ -543,26 +543,24 @@ export function AgentPlaygroundEvaluate({
               {...getExperimentRowProps(index)}
             >
               <DataList.IdCell id={exp.id} />
-              <DataList.Cell height="compact" className="min-w-0">
+              <DataList.Cell className="min-w-0">
                 <span className="block truncate">{dsName}</span>
               </DataList.Cell>
-              <DataList.Cell height="compact">
+              <DataList.Cell>
                 <StatusBadge variant={STATUS_VARIANT[status] ?? 'neutral'} withDot>
                   {status}
                 </StatusBadge>
               </DataList.Cell>
-              <DataList.Cell height="compact" className="text-center">
-                {total}
-              </DataList.Cell>
-              <DataList.Cell height="compact" className="text-center">
+              <DataList.Cell className="text-center">{total}</DataList.Cell>
+              <DataList.Cell className="text-center">
                 <span className={succeeded > 0 ? 'text-accent1' : ''}>
                   {succeeded} ({successPct}%)
                 </span>
               </DataList.Cell>
-              <DataList.Cell height="compact" className="text-center">
+              <DataList.Cell className="text-center">
                 <span className={failed > 0 ? 'text-accent2' : ''}>{failed}</span>
               </DataList.Cell>
-              <DataList.Cell height="compact">{formatDate(exp.startedAt)}</DataList.Cell>
+              <DataList.Cell>{formatDate(exp.startedAt)}</DataList.Cell>
             </DataList.RowButton>
           );
         })}
@@ -610,10 +608,10 @@ export function AgentPlaygroundEvaluate({
               onClick={() => setDetailView({ type: 'dataset', id: ds.id })}
               {...getDatasetRowProps(index)}
             >
-              <DataList.Cell height="compact" className="text-neutral4 min-w-0">
+              <DataList.Cell className="text-neutral4 min-w-0">
                 <span className="block truncate">{ds.name}</span>
               </DataList.Cell>
-              <DataList.Cell height="compact">
+              <DataList.Cell>
                 {ds.tags?.length ? (
                   <div className="flex gap-1">
                     {ds.tags.slice(0, 2).map(tag => (
@@ -627,10 +625,10 @@ export function AgentPlaygroundEvaluate({
                   <span className="text-neutral2">—</span>
                 )}
               </DataList.Cell>
-              <DataList.Cell height="compact">
+              <DataList.Cell>
                 {exp ? <ExperimentBadge experiment={exp} /> : <span className="text-neutral2">No experiments</span>}
               </DataList.Cell>
-              <DataList.Cell height="compact">
+              <DataList.Cell>
                 {isGenerating ? (
                   <div className="flex items-center gap-1">
                     <Spinner className="size-3" />
@@ -646,7 +644,7 @@ export function AgentPlaygroundEvaluate({
                   <span className="text-neutral2">—</span>
                 )}
               </DataList.Cell>
-              <DataList.Cell height="compact">{formatDate(ds.updatedAt)}</DataList.Cell>
+              <DataList.Cell>{formatDate(ds.updatedAt)}</DataList.Cell>
             </DataList.RowButton>
           );
         })}
@@ -697,18 +695,18 @@ export function AgentPlaygroundEvaluate({
               onClick={() => setDetailView({ type: 'scorer', id })}
               {...getScorerRowProps(index)}
             >
-              <DataList.Cell height="compact" className="text-neutral4 min-w-0">
+              <DataList.Cell className="text-neutral4 min-w-0">
                 <span className="block truncate">{name}</span>
               </DataList.Cell>
-              <DataList.Cell height="compact">
+              <DataList.Cell>
                 <Badge variant={source === 'code' ? 'default' : 'success'}>{source}</Badge>
               </DataList.Cell>
-              <DataList.Cell height="compact" className="min-w-0">
+              <DataList.Cell className="min-w-0">
                 <span className="block max-w-[200px] truncate">
                   {description || <span className="text-neutral2">—</span>}
                 </span>
               </DataList.Cell>
-              <DataList.Cell height="compact">
+              <DataList.Cell>
                 {linkedCount > 0 ? `${linkedCount} dataset${linkedCount > 1 ? 's' : ''}` : '—'}
               </DataList.Cell>
             </DataList.RowButton>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
@@ -769,12 +769,12 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                 const rowCells = (
                   <>
                     {/* Input preview */}
-                    <DataList.Cell height="compact" className="text-neutral4 min-w-0">
+                    <DataList.Cell className="text-neutral4 min-w-0">
                       <span className="block truncate">{truncateInput(item.input, 80)}</span>
                     </DataList.Cell>
 
                     {/* Comment preview */}
-                    <DataList.Cell height="compact" className="min-w-0">
+                    <DataList.Cell className="min-w-0">
                       {item.comment ? (
                         <Txt variant="ui-xs" className="text-neutral3 truncate">
                           {item.comment}
@@ -787,7 +787,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                     </DataList.Cell>
 
                     {/* Tags */}
-                    <DataList.Cell height="compact" className="min-w-0">
+                    <DataList.Cell className="min-w-0">
                       {item.tags.length > 0 ? (
                         <Txt variant="ui-xs" className="text-neutral4 truncate">
                           {item.tags.join(', ')}
@@ -800,7 +800,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                     </DataList.Cell>
 
                     {/* Rating */}
-                    <DataList.Cell height="compact">
+                    <DataList.Cell>
                       {item.rating === 'positive' && (
                         <Icon size="sm" className="text-positive1">
                           <ThumbsUp />
@@ -819,7 +819,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                     </DataList.Cell>
 
                     {/* Scores */}
-                    <DataList.Cell height="compact">
+                    <DataList.Cell>
                       {scoreEntries.length > 0 ? (
                         <span className="flex items-center gap-1">
                           <Icon size="sm" className="text-neutral3">
@@ -848,7 +848,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                         aria-label={`Select item ${item.id}`}
                       />
                     ) : (
-                      <DataList.Cell height="compact" className="justify-items-center px-4">
+                      <DataList.Cell className="justify-items-center px-4">
                         <div
                           role="img"
                           aria-label={item.error ? 'Error' : 'Success'}
@@ -858,7 +858,6 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                       </DataList.Cell>
                     )}
                     <DataList.RowButton
-                      flushLeft
                       colStart={2}
                       featured={isFeatured}
                       onClick={() => handleRowClick(item.id)}

--- a/packages/playground/src/domains/datasets/components/csv-import/csv-preview-table.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/csv-preview-table.tsx
@@ -31,7 +31,7 @@ export function CSVPreviewTable({ headers, data, maxRows = 5 }: CSVPreviewTableP
       {headers.length > 0 ? (
         <DataList
           columns={columns}
-          variant="lined"
+          variant="striped"
           className="border-border1 max-h-80 rounded-lg border"
           mask={{ left: false }}
           stickyHeaderBackground="tinted"
@@ -53,7 +53,7 @@ export function CSVPreviewTable({ headers, data, maxRows = 5 }: CSVPreviewTableP
                     return (
                       <DataList.RowHeaderCell
                         key={`${index}-${header}`}
-                        height="compact"
+
                         className="text-ui-sm max-w-[14rem]"
                       >
                         {value}
@@ -62,7 +62,7 @@ export function CSVPreviewTable({ headers, data, maxRows = 5 }: CSVPreviewTableP
                   }
 
                   return (
-                    <DataList.Cell key={`${index}-${header}`} height="compact" className="text-ui-sm max-w-[12rem]">
+                    <DataList.Cell key={`${index}-${header}`} className="text-ui-sm max-w-[12rem]">
                       <span className="block truncate">{value}</span>
                     </DataList.Cell>
                   );

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -139,7 +139,6 @@ export function DatasetsList({
         return (
           <EntityList.RowWrapper key={ds.id}>
             <EntityList.RowLink
-              flushRight
               colEnd={rowLayout.rowLinkColEnd}
               to={paths.datasetLink(ds.id)}
               LinkComponent={Link}

--- a/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
@@ -87,13 +87,7 @@ export function DatasetExperimentsList({
               onToggle={() => onToggleSelection(experiment.id)}
               aria-label={`Select experiment ${experiment.id}`}
             />
-            <DataList.RowButton
-              flushLeft
-              colStart={2}
-              featured={isSelected}
-              onClick={handleRowClick}
-              {...getRowProps(index)}
-            >
+            <DataList.RowButton colStart={2} featured={isSelected} onClick={handleRowClick} {...getRowProps(index)}>
               {rowCells}
             </DataList.RowButton>
           </DataList.RowWrapper>

--- a/packages/playground/src/domains/datasets/components/items/dataset-items-list.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items-list.tsx
@@ -144,9 +144,11 @@ export function DatasetItemsList({
             const rowCells = (
               <>
                 <DataList.IdCell id={item.id} />
-                <DataList.MonoCell>{truncateValue(item.input, 150)}</DataList.MonoCell>
-                <DataList.MonoCell>{item.groundTruth ? truncateValue(item.groundTruth, 150) : '-'}</DataList.MonoCell>
-                <DataList.Cell height="compact" className="min-w-0">
+                <DataList.TextCell font="mono">{truncateValue(item.input, 150)}</DataList.TextCell>
+                <DataList.TextCell font="mono">
+                  {item.groundTruth ? truncateValue(item.groundTruth, 150) : '-'}
+                </DataList.TextCell>
+                <DataList.Cell className="min-w-0">
                   {item.expectedTrajectory ? (
                     <span className="text-ui-smd text-neutral3">
                       {Array.isArray((item.expectedTrajectory as Record<string, unknown>)?.steps)
@@ -157,7 +159,7 @@ export function DatasetItemsList({
                     <span className="text-neutral4">—</span>
                   )}
                 </DataList.Cell>
-                <DataList.Cell height="compact" className="min-w-0">
+                <DataList.Cell className="min-w-0">
                   <span className="text-ui-smd text-neutral2 block truncate">{formatDate(createdAtDate)}</span>
                 </DataList.Cell>
               </>
@@ -185,7 +187,6 @@ export function DatasetItemsList({
                   aria-label={`Select item ${item.id}`}
                 />
                 <DataList.RowButton
-                  flushLeft
                   colStart={2}
                   featured={isFeatured}
                   data-selected={isFeatured || undefined}

--- a/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
@@ -133,8 +133,8 @@ export function ExperimentResultPanel({
                     featured={featuredScoreId === score.id}
                     onClick={() => onScoreClick?.(score.id)}
                   >
-                    <DataList.Cell height="compact">{score.scorerId}</DataList.Cell>
-                    <DataList.MonoCell>{score.score.toFixed(3)}</DataList.MonoCell>
+                    <DataList.Cell>{score.scorerId}</DataList.Cell>
+                    <DataList.TextCell font="mono">{score.score.toFixed(3)}</DataList.TextCell>
                   </DataList.RowButton>
                 ))}
               </DataList>

--- a/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
@@ -71,7 +71,7 @@ export function ExperimentResultsList({
             const rowCells = (
               <>
                 <DataList.IdCell id={result.itemId} />
-                <DataList.Cell height="compact">
+                <DataList.Cell>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <div className="relative flex h-full w-10 items-center justify-center bg-transparent">
@@ -86,13 +86,15 @@ export function ExperimentResultsList({
                   </Tooltip>
                 </DataList.Cell>
 
-                {hasInputColumn && <DataList.MonoCell>{truncate(formatValue(result.input), 200)}</DataList.MonoCell>}
+                {hasInputColumn && (
+                  <DataList.TextCell font="mono">{truncate(formatValue(result.input), 200)}</DataList.TextCell>
+                )}
 
                 {scorerIds?.map(scorerId => {
                   const scores = scoresByItemId?.[result.itemId];
                   const score = scores?.find(s => s.scorerId === scorerId);
                   return (
-                    <DataList.Cell key={scorerId} height="compact" className="text-neutral3 text-ui-smd font-mono">
+                    <DataList.Cell key={scorerId} className="text-neutral3 text-ui-smd font-mono">
                       {score != null ? score.score.toFixed(3) : '-'}
                     </DataList.Cell>
                   );
@@ -122,7 +124,6 @@ export function ExperimentResultsList({
                   aria-label={`Select result ${result.itemId}`}
                 />
                 <DataList.RowButton
-                  flushLeft
                   colStart={2}
                   featured={isFeatured}
                   data-selected={isFeatured || undefined}

--- a/packages/playground/src/domains/experiments/components/experiment-row-cells.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-row-cells.tsx
@@ -34,35 +34,33 @@ export function ExperimentRowCells({ experiment: exp, datasetName, review }: Exp
 
   return (
     <>
-      <EntityList.Cell height="compact">
+      <EntityList.Cell>
         <ExperimentNameLabel experiment={exp} />
       </EntityList.Cell>
-      {datasetName !== undefined && <EntityList.TextCell height="compact">{datasetName}</EntityList.TextCell>}
-      <EntityList.Cell height="compact">
+      {datasetName !== undefined && <EntityList.TextCell>{datasetName}</EntityList.TextCell>}
+      <EntityList.Cell>
         <span className="truncate">
           {exp.targetType && exp.targetId ? `${exp.targetType} ${exp.targetId}` : 'external'}
         </span>
       </EntityList.Cell>
-      <EntityList.Cell height="compact">
+      <EntityList.Cell>
         <StatusBadge variant={STATUS_VARIANT[status] ?? 'neutral'} withDot>
           {status}
         </StatusBadge>
       </EntityList.Cell>
-      <EntityList.TextCell height="compact" className="text-center">
-        {total}
-      </EntityList.TextCell>
-      <EntityList.TextCell height="compact" className="text-center">
+      <EntityList.TextCell className="text-center">{total}</EntityList.TextCell>
+      <EntityList.TextCell className="text-center">
         <span className={succeeded > 0 ? 'text-accent1' : ''}>
           {succeeded} ({successPct}%)
         </span>
       </EntityList.TextCell>
-      <EntityList.TextCell height="compact" className="text-center">
+      <EntityList.TextCell className="text-center">
         <span className={failed > 0 ? 'text-accent2' : ''}>{failed}</span>
       </EntityList.TextCell>
-      <EntityList.Cell height="compact" className="text-center">
+      <EntityList.Cell className="text-center">
         <ExperimentReviewCell review={review} />
       </EntityList.Cell>
-      <EntityList.TextCell height="compact">{formatExperimentDate(exp.createdAt)}</EntityList.TextCell>
+      <EntityList.TextCell>{formatExperimentDate(exp.createdAt)}</EntityList.TextCell>
     </>
   );
 }

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -793,12 +793,12 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                 const rowCells = (
                   <>
                     {/* Input preview */}
-                    <DataList.Cell height="compact" className="text-neutral4 min-w-0">
+                    <DataList.Cell className="text-neutral4 min-w-0">
                       <span className="block truncate">{truncateInput(item.input, 200)}</span>
                     </DataList.Cell>
 
                     {/* Comment preview */}
-                    <DataList.Cell height="compact" className="min-w-0">
+                    <DataList.Cell className="min-w-0">
                       {item.comment ? (
                         <Txt variant="ui-xs" className="text-neutral3 truncate">
                           {item.comment}
@@ -811,7 +811,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                     </DataList.Cell>
 
                     {/* Tags */}
-                    <DataList.Cell height="compact" className="min-w-0">
+                    <DataList.Cell className="min-w-0">
                       {item.tags.length > 0 ? (
                         <Txt variant="ui-xs" className="text-neutral4 truncate">
                           {item.tags.join(', ')}
@@ -824,7 +824,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                     </DataList.Cell>
 
                     {/* Rating */}
-                    <DataList.Cell height="compact">
+                    <DataList.Cell>
                       {item.rating === 'positive' && (
                         <Icon size="sm" className="text-positive1">
                           <ThumbsUp />
@@ -843,7 +843,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                     </DataList.Cell>
 
                     {/* Scores */}
-                    <DataList.Cell height="compact">
+                    <DataList.Cell>
                       {scoreEntries.length > 0 ? (
                         <div className="flex items-center gap-1">
                           <Icon size="sm" className="text-neutral3">
@@ -872,7 +872,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                         aria-label={`Select item ${item.id}`}
                       />
                     ) : (
-                      <DataList.Cell height="compact" className="justify-items-center px-4">
+                      <DataList.Cell className="justify-items-center px-4">
                         <div
                           role="img"
                           aria-label={item.error ? 'Error' : 'Success'}
@@ -882,7 +882,6 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                       </DataList.Cell>
                     )}
                     <DataList.RowButton
-                      flushLeft
                       colStart={2}
                       featured={isFeatured}
                       onClick={() => handleRowClick(item.id)}

--- a/packages/playground/src/domains/schedules/components/schedule-triggers-list.tsx
+++ b/packages/playground/src/domains/schedules/components/schedule-triggers-list.tsx
@@ -104,9 +104,9 @@ export function ScheduleTriggersList({
 
         const cells = (
           <>
-            <DataList.Cell height="compact">{runIdLabel}</DataList.Cell>
+            <DataList.Cell>{runIdLabel}</DataList.Cell>
 
-            <DataList.Cell height="compact">
+            <DataList.Cell>
               <span className="inline-flex items-center gap-2">
                 {isPublishFailure ? (
                   <span className="text-ui-sm text-accent2 inline-flex items-center gap-1.5 whitespace-nowrap">
@@ -133,7 +133,7 @@ export function ScheduleTriggersList({
               </span>
             </DataList.Cell>
 
-            <DataList.Cell height="compact">
+            <DataList.Cell>
               <span className="inline-flex items-center gap-2 whitespace-nowrap">
                 <span title={startedTooltip}>{formatRelativeTime(t.actualFireAt)}</span>
                 {showDriftWarning ? (
@@ -149,10 +149,10 @@ export function ScheduleTriggersList({
               </span>
             </DataList.Cell>
 
-            <DataList.Cell height="compact">
+            <DataList.Cell>
               {t.run ? <span>{formatDuration(t.run.durationMs)}</span> : <span className="text-neutral4">—</span>}
             </DataList.Cell>
-            <DataList.Cell height="compact"> </DataList.Cell>
+            <DataList.Cell> </DataList.Cell>
           </>
         );
 

--- a/packages/playground/src/domains/schedules/components/schedules-list.tsx
+++ b/packages/playground/src/domains/schedules/components/schedules-list.tsx
@@ -48,26 +48,26 @@ export function SchedulesList({ schedules, isLoading, search = '' }: SchedulesLi
       {filtered.map((s, index) => (
         <DataList.RowLink key={s.id} to={paths.scheduleLink(s.id)} LinkComponent={Link} {...getRowProps(index)}>
           <DataList.NameCell>{s.workflowId ?? s.agentId}</DataList.NameCell>
-          <DataList.Cell height="compact" className="min-w-0">
+          <DataList.Cell className="min-w-0">
             <span className="text-ui-smd text-neutral3 block truncate font-mono" title={s.id}>
               {s.id}
             </span>
           </DataList.Cell>
-          <DataList.Cell height="compact">
+          <DataList.Cell>
             <span className="inline-flex items-center gap-2 whitespace-nowrap">
               <code className="text-ui-sm font-mono">{s.cron}</code>
               {s.timezone ? <span className="text-neutral4 text-ui-xs">{s.timezone}</span> : null}
             </span>
           </DataList.Cell>
-          <DataList.Cell height="compact">
+          <DataList.Cell>
             <ScheduleStatusText status={s.status} />
           </DataList.Cell>
-          <DataList.Cell height="compact">
+          <DataList.Cell>
             <span className="whitespace-nowrap" title={formatScheduleTimestamp(s.nextFireAt)}>
               {formatRelativeTime(s.nextFireAt)}
             </span>
           </DataList.Cell>
-          <DataList.Cell height="compact">
+          <DataList.Cell>
             {s.lastRun ? (
               <span className="inline-flex items-center gap-2 whitespace-nowrap">
                 <WorkflowRunStatusInline status={s.lastRun.status} />

--- a/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
+++ b/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
@@ -94,7 +94,7 @@ export function ScorersList({ scorers, isLoading, search = '', sourceFilter = 'a
               </span>
             </EntityList.NameCell>
             <EntityList.DescriptionCell>{description}</EntityList.DescriptionCell>
-            <EntityList.Cell className="py-0">
+            <EntityList.Cell>
               <Chip size="small" color={scorer.source === 'code' ? 'blue' : 'gray'}>
                 {scorer.source}
               </Chip>

--- a/packages/playground/src/domains/scores/components/scores-over-time-card.tsx
+++ b/packages/playground/src/domains/scores/components/scores-over-time-card.tsx
@@ -89,9 +89,7 @@ export function ScoresOverTimeCard({
                   </DataList.Top>
                   {summaryData.map(row => (
                     <DataList.RowStatic key={row.scorer}>
-                      <DataList.RowHeaderCell height="compact" className="text-ui-sm">
-                        {row.scorer}
-                      </DataList.RowHeaderCell>
+                      <DataList.RowHeaderCell className="text-ui-sm">{row.scorer}</DataList.RowHeaderCell>
                       <DataList.NumberCell highlight>{row.avg.toFixed(2)}</DataList.NumberCell>
                       <DataList.NumberCell>{row.min.toFixed(2)}</DataList.NumberCell>
                       <DataList.NumberCell>{row.max.toFixed(2)}</DataList.NumberCell>

--- a/packages/playground/src/domains/traces/components/span-feedback-list.tsx
+++ b/packages/playground/src/domains/traces/components/span-feedback-list.tsx
@@ -85,11 +85,11 @@ export function SpanFeedbackList({ feedbackData, isLoadingFeedbackData, onPageCh
                 onClick={() => handleOnFeedback(index)}
                 {...getRowProps(index)}
               >
-                <DataList.Cell height="compact">{source}</DataList.Cell>
+                <DataList.Cell>{source}</DataList.Cell>
                 <DataList.DateCell timestamp={ts} />
-                <DataList.Cell height="compact">{format(ts, 'h:mm:ss aaa')}</DataList.Cell>
-                <DataList.Cell height="compact">{formatValue(fb)}</DataList.Cell>
-                <DataList.Cell height="compact">{formatComment(fb)}</DataList.Cell>
+                <DataList.Cell>{format(ts, 'h:mm:ss aaa')}</DataList.Cell>
+                <DataList.Cell>{formatValue(fb)}</DataList.Cell>
+                <DataList.Cell>{formatComment(fb)}</DataList.Cell>
               </DataList.RowButton>
             );
           })

--- a/packages/playground/src/domains/traces/components/span-scores-list.tsx
+++ b/packages/playground/src/domains/traces/components/span-scores-list.tsx
@@ -48,19 +48,17 @@ export function SpanScoresList({ scoresData, isLoadingScoresData, onPageChange, 
 
           return (
             <DataList.RowButton key={score.id} onClick={() => onScoreSelect?.(score)} {...getRowProps(index)}>
-              <DataList.Cell height="compact" className="text-neutral3 text-ui-smd font-mono">
+              <DataList.Cell className="text-neutral3 text-ui-smd font-mono">
                 {getShortId(score?.id) || 'n/a'}
               </DataList.Cell>
-              <DataList.Cell height="compact" className="text-neutral2 text-ui-smd">
+              <DataList.Cell className="text-neutral2 text-ui-smd">
                 {isTodayDate ? 'Today' : format(createdAtDate, 'MMM dd')}
               </DataList.Cell>
-              <DataList.Cell height="compact" className="text-neutral3 text-ui-smd font-mono">
+              <DataList.Cell className="text-neutral3 text-ui-smd font-mono">
                 {format(createdAtDate, 'h:mm:ss aaa')}
               </DataList.Cell>
-              <DataList.Cell height="compact" className="text-ui-smd">
-                {String(score?.score ?? '')}
-              </DataList.Cell>
-              <DataList.Cell height="compact" className="text-ui-smd">
+              <DataList.Cell className="text-ui-smd">{String(score?.score ?? '')}</DataList.Cell>
+              <DataList.Cell className="text-ui-smd">
                 {String(score?.scorer?.name || score?.scorer?.id || '')}
               </DataList.Cell>
             </DataList.RowButton>

--- a/packages/playground/src/domains/workspace/components/skills-table.tsx
+++ b/packages/playground/src/domains/workspace/components/skills-table.tsx
@@ -116,7 +116,7 @@ export function SkillsTable({
             const rowContent = (
               <>
                 <DataList.Cell className="text-neutral6 font-medium">{skill.name}</DataList.Cell>
-                <DataList.MonoCell height="default">{skill.path}</DataList.MonoCell>
+                <DataList.TextCell font="mono">{skill.path}</DataList.TextCell>
                 <DataList.Cell className="min-w-0">
                   <span className="block truncate">{skill.description || '—'}</span>
                 </DataList.Cell>
@@ -133,31 +133,29 @@ export function SkillsTable({
 
             return (
               <DataList.RowWrapper key={skill.path}>
-                <DataList.RowButton flushRight flushLeft colEnd={-2} onClick={onClick} {...getRowProps(index)}>
+                <DataList.RowButton colEnd={-2} onClick={onClick} {...getRowProps(index)}>
                   {rowContent}
                 </DataList.RowButton>
-                <DataList.Cell className="py-0">
-                  <div className="flex w-full items-center justify-end gap-1 pr-3 pl-2">
-                    {isDownloaded(skill) && (
-                      <>
-                        {onUpdateSkill && (
-                          <SkillUpdateButton
-                            skillName={skill.name}
-                            onUpdate={() => onUpdateSkill(skill.name)}
-                            isUpdating={updatingSkillName === skill.name}
-                          />
-                        )}
-                        {onRemoveSkill && (
-                          <SkillRemoveButton
-                            skillName={skill.name}
-                            onRemove={() => onRemoveSkill(skill.name)}
-                            isRemoving={removingSkillName === skill.name}
-                          />
-                        )}
-                      </>
-                    )}
-                  </div>
-                </DataList.Cell>
+                <DataList.ActionsCell className="pl-2">
+                  {isDownloaded(skill) && (
+                    <>
+                      {onUpdateSkill && (
+                        <SkillUpdateButton
+                          skillName={skill.name}
+                          onUpdate={() => onUpdateSkill(skill.name)}
+                          isUpdating={updatingSkillName === skill.name}
+                        />
+                      )}
+                      {onRemoveSkill && (
+                        <SkillRemoveButton
+                          skillName={skill.name}
+                          onRemove={() => onRemoveSkill(skill.name)}
+                          isRemoving={removingSkillName === skill.name}
+                        />
+                      )}
+                    </>
+                  )}
+                </DataList.ActionsCell>
               </DataList.RowWrapper>
             );
           })


### PR DESCRIPTION
## Description

DataList gets the plain, borderless look: no separators between rows, one lighter band shared by the sticky header and the group subheaders, and every row in a list the same height.

```
before   row height = whichever cell the author tagged `height="compact"`   (37 / 45 / 32px in one product)
after    every row 36px, header 40px, skeleton matches
```

Row height used to be a per-cell prop, which is why a list with an actions column or a badge sat a few pixels off the list next to it. The row owns its height now and cells contribute no vertical padding, so nothing a cell holds can push its row out of line.

| what you see | before | after |
| --- | --- | --- |
| a list at rest | hairline under every row, boxed header | rows float on the page, header reads as a band |
| two lists side by side | rows 37 or 45px depending on the cells used | both 36px |
| skeleton turning into data | rows jump 32 → 37px | no jump |
| a row with actions or a checkbox | always visible | revealed on hover or keyboard focus, column width reserved |
| an ID, a timestamp, an event name | monospace | sans, wider tracking for IDs, tabular figures for times |

Four props are gone, all of them things that no longer decide anything. `variant="lined"` only drew the separators. `height` on cells is what let rows drift. `flushLeft`/`flushRight` dropped a row margin the borderless root already zeroes, and every call site passed them on a wrapped row where they were ignored outright. `DataList.MonoCell` was a component whose only job was a typeface, so it folds into `DataList.TextCell font="mono"`.

```tsx
// before
<DataList columns={columns} variant="lined">
  <DataList.RowButton flushLeft flushRight colEnd={-2}>
    <DataList.Cell height="compact">{status}</DataList.Cell>
    <DataList.MonoCell>{path}</DataList.MonoCell>

// after
<DataList columns={columns}>
  <DataList.RowButton colEnd={-2}>
    <DataList.Cell>{status}</DataList.Cell>
    <DataList.TextCell font="mono">{path}</DataList.TextCell>
```

Trailing row actions were hand-rolled in the story and in `skills-table` — same wrapper, same alignment, same spacing. That is now `DataList.ActionsCell`, which also owns the hover reveal, since behaviour cannot live in copy-paste.

I kept monospace where the content really is code: paths, env values, serialized JSON, span attribute values. IDs and timestamps left it, which also lines them up with `ItemListIdCell`, already sans.

Worth a look in Storybook: `DataList / With Subheader`, `With Trailing Cell`, `Wide Columns Overflow`, `Loading`.

The one thing I would flag: rows are 36px against a 40px header, and that gap is a design call rather than a constraint. If you want them level again it is one class.

Not verified: I checked every DataList story in both themes and measured the heights in the browser, but I did not walk the product screens that consume these lists — the playground suites cover them, no visual pass.

```
source        +234  -326    ← net -92
tests          +48  -134
stories        +60   -62
changeset      +46     0
```

## Related issue(s)

None — design work on the shared list, no issue filed.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactoring

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes `DataList` rows and headers look and align more consistently. It also replaces older styling options with simpler components for text and row actions.

## Changes

- Added borderless `DataList` styling with:
  - 36px data and skeleton rows.
  - 40px headers.
  - Shared styling for sticky headers and group subheaders.
  - Updated light and dark theme surface tokens.
- Moved row height control from individual cells to rows.
- Replaced the default `lined` variant with `plain`.
- Retained `striped` for zebra row styling.
- Added `DataList.ActionsCell` with reserved width and hover or keyboard-focus visibility.
- Added `font="sans"` and `font="mono"` support to `DataList.TextCell`.
- Removed:
  - `DataList.MonoCell`.
  - Cell-level `height`.
  - `flushLeft` and `flushRight`.
  - The `lined` variant.
- Updated consuming lists, stories, and tests:
  - Code-like content uses monospace styling.
  - IDs and timestamps use sans-serif styling.
  - Workspace skill actions use `DataList.ActionsCell`.
  - Featured-row tests and styling use `bg-surface-row-featured!`.
- Added a changeset describing the visual and API updates.

Product screens using these lists were not visually reviewed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->