### PR TITLE
fix(mastracode): stop recursive fatal handling

### DIFF
--- a/.changeset/floppy-emus-stand.md
+++ b/.changeset/floppy-emus-stand.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Prevent repeated fatal errors from trapping Mastra Code in a high-CPU crash loop.

--- a/mastracode/tui/src/__tests__/process-memory-diagnostics-lifecycle.test.ts
+++ b/mastracode/tui/src/__tests__/process-memory-diagnostics-lifecycle.test.ts
@@ -88,10 +88,11 @@ describe('createOneShotFatalErrorHandler', () => {
 
   it('prevents an asynchronous stderr error from recursively starving shutdown', async () => {
     // Isolate the real process-level error path so the unhandled stream error cannot escape into Vitest.
-    const factorySource = createOneShotFatalErrorHandler.toString();
+    const lifecycleModuleUrl = new URL('../process-memory-diagnostics-lifecycle.ts', import.meta.url).href;
     const script = `
-      const { EventEmitter } = require('node:events');
-      const createOneShotFatalErrorHandler = ${factorySource};
+      import { EventEmitter } from 'node:events';
+      import { createOneShotFatalErrorHandler } from ${JSON.stringify(lifecycleModuleUrl)};
+
       const stderr = new EventEmitter();
       let reports = 0;
 
@@ -117,10 +118,16 @@ describe('createOneShotFatalErrorHandler', () => {
     `;
 
     const result = await new Promise<{ code: number | null; stdout: string; timedOut: boolean }>(resolve => {
-      execFile(process.execPath, ['-e', script], { timeout: 1_000 }, (error, stdout) => {
-        const code = typeof (error as NodeJS.ErrnoException | null)?.code === 'number' ? error.code : error ? null : 0;
-        resolve({ code, stdout, timedOut: Boolean((error as NodeJS.ErrnoException | null)?.killed) });
-      });
+      execFile(
+        process.execPath,
+        ['--import', import.meta.resolve('tsx'), '--input-type=module', '-e', script],
+        { timeout: 1_000 },
+        (error, stdout) => {
+          const code =
+            typeof (error as NodeJS.ErrnoException | null)?.code === 'number' ? error.code : error ? null : 0;
+          resolve({ code, stdout, timedOut: Boolean((error as NodeJS.ErrnoException | null)?.killed) });
+        },
+      );
     });
 
     expect(result).toEqual({ code: 1, stdout: '1', timedOut: false });

--- a/mastracode/tui/src/__tests__/process-memory-diagnostics-lifecycle.test.ts
+++ b/mastracode/tui/src/__tests__/process-memory-diagnostics-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  createOneShotFatalErrorHandler,
   createShutdownCoordinator,
   startTuiProcessMemoryDiagnostics,
 } from '../process-memory-diagnostics-lifecycle.js';
@@ -62,6 +63,25 @@ describe('startTuiProcessMemoryDiagnostics', () => {
 
     expect(warn).toHaveBeenNthCalledWith(1, 'Process memory diagnostics were not started: sample interval is too low');
     expect(warn).toHaveBeenNthCalledWith(2, 'Process memory diagnostics were not started: inspector unavailable');
+  });
+});
+
+describe('createOneShotFatalErrorHandler', () => {
+  it('ignores fatal errors raised while reporting the first fatal error', () => {
+    const firstError = new Error('initial failure');
+    const reportingError = Object.assign(new Error('write EIO'), { code: 'EIO' });
+    const handled: unknown[] = [];
+    let handleFatalError!: (error: unknown) => void;
+
+    handleFatalError = createOneShotFatalErrorHandler(error => {
+      handled.push(error);
+      handleFatalError(reportingError);
+    });
+
+    handleFatalError(firstError);
+    handleFatalError(new Error('later failure'));
+
+    expect(handled).toEqual([firstError]);
   });
 });
 

--- a/mastracode/tui/src/__tests__/process-memory-diagnostics-lifecycle.test.ts
+++ b/mastracode/tui/src/__tests__/process-memory-diagnostics-lifecycle.test.ts
@@ -1,3 +1,5 @@
+import { execFile } from 'node:child_process';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -82,6 +84,46 @@ describe('createOneShotFatalErrorHandler', () => {
     handleFatalError(new Error('later failure'));
 
     expect(handled).toEqual([firstError]);
+  });
+
+  it('prevents an asynchronous stderr error from recursively starving shutdown', async () => {
+    // Isolate the real process-level error path so the unhandled stream error cannot escape into Vitest.
+    const factorySource = createOneShotFatalErrorHandler.toString();
+    const script = `
+      const { EventEmitter } = require('node:events');
+      const createOneShotFatalErrorHandler = ${factorySource};
+      const stderr = new EventEmitter();
+      let reports = 0;
+
+      stderr.write = () => {
+        process.nextTick(() => {
+          const error = Object.assign(new Error('write EIO'), { code: 'EIO' });
+          stderr.emit('error', error);
+        });
+      };
+      Object.defineProperty(process, 'stderr', { configurable: true, value: stderr });
+
+      const handleFatalError = createOneShotFatalErrorHandler(error => {
+        reports += 1;
+        process.stderr.write(\`Fatal error: \${error.message}\\n\`);
+        setTimeout(() => {
+          process.stdout.write(String(reports));
+          process.exit(1);
+        }, 20);
+      });
+
+      process.on('uncaughtException', handleFatalError);
+      handleFatalError(new Error('initial failure'));
+    `;
+
+    const result = await new Promise<{ code: number | null; stdout: string; timedOut: boolean }>(resolve => {
+      execFile(process.execPath, ['-e', script], { timeout: 1_000 }, (error, stdout) => {
+        const code = typeof (error as NodeJS.ErrnoException | null)?.code === 'number' ? error.code : error ? null : 0;
+        resolve({ code, stdout, timedOut: Boolean((error as NodeJS.ErrnoException | null)?.killed) });
+      });
+    });
+
+    expect(result).toEqual({ code: 1, stdout: '1', timedOut: false });
   });
 });
 

--- a/mastracode/tui/src/main.ts
+++ b/mastracode/tui/src/main.ts
@@ -17,7 +17,11 @@ import {
 import { setupDebugLogging, truncateLogFile } from '@mastra/code-sdk/utils/debug-log';
 import { drainPipedStdin, reopenStdinFromTTY } from '@mastra/code-sdk/utils/stdin-pipe';
 import { releaseAllThreadLocks } from '@mastra/code-sdk/utils/thread-lock';
-import { createShutdownCoordinator, startTuiProcessMemoryDiagnostics } from './process-memory-diagnostics-lifecycle.js';
+import {
+  createOneShotFatalErrorHandler,
+  createShutdownCoordinator,
+  startTuiProcessMemoryDiagnostics,
+} from './process-memory-diagnostics-lifecycle.js';
 import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
 import { applyThemeMode, restoreTerminalForeground } from './tui/theme.js';
@@ -294,9 +298,13 @@ function readFlag(args: string[], flag: string): string | undefined {
   return value;
 }
 
-function handleFatalError(error: unknown): void {
+const handleFatalError = createOneShotFatalErrorHandler((error: unknown): void => {
   // Always write to real stderr, even if console.error was overridden
-  const write = (msg: string) => process.stderr.write(msg + '\n');
+  const write = (msg: string) => {
+    try {
+      process.stderr.write(msg + '\n');
+    } catch {}
+  };
 
   if (hasEconnrefused(error)) {
     const settings = loadSettings();
@@ -333,7 +341,7 @@ function handleFatalError(error: unknown): void {
     tui?.stop();
   } catch {}
   void shutdownAndExit(1);
-}
+});
 
 async function main() {
   if (process.argv[2] === 'plugin') {

--- a/mastracode/tui/src/process-memory-diagnostics-lifecycle.ts
+++ b/mastracode/tui/src/process-memory-diagnostics-lifecycle.ts
@@ -16,6 +16,15 @@ export async function startTuiProcessMemoryDiagnostics(
   return startConfiguredProcessMemoryDiagnostics(createSetup(env), warn);
 }
 
+export function createOneShotFatalErrorHandler(handle: (error: unknown) => void): (error: unknown) => void {
+  let handlingFatalError = false;
+  return error => {
+    if (handlingFatalError) return;
+    handlingFatalError = true;
+    handle(error);
+  };
+}
+
 export function createShutdownCoordinator(
   cleanup: () => Promise<void>,
   exit: (exitCode: number) => never,

--- a/packages/cli/src/commands/build/guard-live-dev-server.ts
+++ b/packages/cli/src/commands/build/guard-live-dev-server.ts
@@ -14,10 +14,7 @@ import { readLiveDevLock } from '../dev/dev-lock';
  * depend on `process.exit()` actually terminating the process to avoid
  * running the destructive operation it's guarding.
  */
-export async function guardAgainstLiveDevServer(
-  outputDirectory: string,
-  force: boolean | undefined,
-): Promise<boolean> {
+export async function guardAgainstLiveDevServer(outputDirectory: string, force: boolean | undefined): Promise<boolean> {
   const liveLock = await readLiveDevLock(outputDirectory);
   if (!liveLock) return true;
 


### PR DESCRIPTION
#22368 caps the crash log, but a terminal `write EIO` can still re-enter `handleFatalError`, keep the process at high CPU, and starve shutdown.

Before, every fatal callback ran the reporting path again:

```ts
handleFatalError(error);
```

After, one process-lifetime guard runs fatal reporting once and ignores errors raised by that reporting:

```ts
const handleFatalError = createOneShotFatalErrorHandler(error => {
  // report, clean up, and exit
});
```

Synchronous stderr failures are also ignored so bounded crash logging and the existing shutdown coordinator remain reachable.

A child-process regression test imports the production lifecycle module through `tsx` and exercises the asynchronous stream-error path: a simulated stderr `EIO` reaches `uncaughtException`, fatal reporting runs once, and the process exits instead of recursively consuming CPU. The same test fails with hundreds of reports when the production guard is temporarily removed.

Verified with `pnpm build:mastracode`, the focused 8-test lifecycle suite, TUI typecheck, TUI lint, and the `process-shortcuts` TUI E2E scenario.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the terminal fails while MastraCode reports a crash, MastraCode reports the fatal error only once. It then shuts down safely without starting another crash handler.

## Changes

- Added `createOneShotFatalErrorHandler` for single-run fatal-error handling.
- Ignored errors that occur during fatal-error reporting.
- Guarded synchronous and asynchronous `stderr` failures, including `EIO`.
- Preserved PostgreSQL cleanup, crash logging, and shutdown behavior.
- Added a child-process regression test for asynchronous `stderr` failures and recursive handling.
- Added a patch changeset for `mastracode`.
- Applied repository formatting to the live development server guard.

## Validation

- MastraCode build
- Lifecycle tests
- TUI typecheck
- TUI lint
- `process-shortcuts` TUI E2E scenario
<!-- end of auto-generated comment: release notes by coderabbit.ai -->