### PR TITLE
Fix score details panel scrolling on the scorer page

### DIFF
--- a/.changeset/score-panel-internal-scroll.md
+++ b/.changeset/score-panel-internal-scroll.md
@@ -1,5 +1,0 @@
----
-'@mastra/playground': patch
----
-
-Fixed the score details panel on the scorer page so it scrolls inside the panel instead of stretching the whole page. The panel now fills the available height and keeps its header and navigation visible while you scroll through a score, matching the behavior of the trace details panel.

--- a/.changeset/score-panel-internal-scroll.md
+++ b/.changeset/score-panel-internal-scroll.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground': patch
+---
+
+Fixed the score details panel on the scorer page so it scrolls inside the panel instead of stretching the whole page. The panel now fills the available height and keeps its header and navigation visible while you scroll through a score, matching the behavior of the trace details panel.

--- a/packages/playground/src/domains/scores/components/scores-list.tsx
+++ b/packages/playground/src/domains/scores/components/scores-list.tsx
@@ -153,7 +153,7 @@ export function ScoresList({
 
   return (
     <div
-      className={cn('grid h-full min-h-0 gap-4 items-start', hasSidePanel ? 'grid-cols-[1fr_1fr]' : 'grid-cols-[1fr]')}
+      className={cn('grid h-full max-h-full min-h-0 gap-4', hasSidePanel ? 'grid-cols-[1fr_1fr]' : 'grid-cols-[1fr]')}
     >
       <div className="flex h-full min-h-0 min-w-0 flex-col gap-0">
         <div className="flex shrink-0 items-center justify-end pb-2">
@@ -206,12 +206,14 @@ export function ScoresList({
       </div>
 
       {selectedScore && (
-        <ScoreDataPanel
-          score={mapScore(selectedScore)}
-          onClose={handleClose}
-          onPrevious={handlePrevious}
-          onNext={handleNext}
-        />
+        <div className="grid h-full max-h-full min-h-0 grid-rows-[1fr] overflow-hidden">
+          <ScoreDataPanel
+            score={mapScore(selectedScore)}
+            onClose={handleClose}
+            onPrevious={handlePrevious}
+            onNext={handleNext}
+          />
+        </div>
       )}
     </div>
   );

--- a/packages/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/playground/src/pages/scorers/scorer/index.tsx
@@ -206,7 +206,7 @@ export default function Scorer() {
   }
 
   return (
-    <PageLayout width="wide">
+    <PageLayout width="wide" height="full">
       {scorerHeaderActions}
       <PageLayout.TopArea>
         <div className="flex items-center justify-between gap-3">


### PR DESCRIPTION
## Summary

On the scorer detail page (`/scorers/:scorerId`), opening a score rendered the details panel in a column that grew with its content, so long scores pushed the entire page into a document-level scroll and the panel header scrolled out of view. The trace details panel does not behave this way.

This constrains the scorer page to the available height and gives the score panel column a bounded box, so the panel body becomes its own scroll container — the header and prev/next navigation stay pinned, and the page itself no longer scrolls.

## Changes

- `packages/playground/src/pages/scorers/scorer/index.tsx`: `PageLayout` now uses `height="full"`, matching the traces page.
- `packages/playground/src/domains/scores/components/scores-list.tsx`: the split grid stretches its columns and the score panel is wrapped in a bounded, overflow-hidden column.
- Patch changeset for `@mastra/playground`.

## Test plan

- `scores-list.keyboard.test.tsx` passes.
- `tsc --noEmit` and eslint clean for the touched files.
- Manual: open a score with long input/output — the panel body scrolls internally, the list column still scrolls and paginates independently, and no page-level scrollbar appears.

cc @damien-schneider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The scorer page now keeps its header and navigation visible while the score details panel scrolls inside its own area. This prevents the entire page from scrolling unexpectedly.

## Changes

- Set the scorer page `PageLayout` to `height="full"`.
- Constrained the scores grid and score panel column to the available height.
- Enabled internal scrolling for the score details panel.
- Added a patch changeset for `@mastra/playground`.
- Verified keyboard tests, TypeScript checks, ESLint checks, and manual scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->