### PR TITLE
fix(core): resolve stdout trace correlation to an exportable span id

### DIFF
--- a/.changeset/seven-experts-smile.md
+++ b/.changeset/seven-experts-smile.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fixed stdout log lines carrying a span id that cannot be looked up.
+
+When trace correlation is enabled, `trace_id`/`span_id` are injected into structured stdout logs. A log emitted inside an internal span, or one dropped by `excludeSpanTypes`, was tagged with that span's own id — but such spans are never exported, so clicking through from the logs view found nothing, and the stdout line disagreed with the stored log record for the same event.
+
+Stdout lines now carry the nearest span id that actually reaches exporters, matching the stored record, and omit correlation entirely when nothing in the chain is exportable.

--- a/.changeset/seven-experts-smile.md
+++ b/.changeset/seven-experts-smile.md
@@ -6,4 +6,4 @@ Fixed stdout log lines carrying a span id that cannot be looked up.
 
 When trace correlation is enabled, `trace_id`/`span_id` are injected into structured stdout logs. A log emitted inside an internal span, or one dropped by `excludeSpanTypes`, was tagged with that span's own id — but such spans are never exported, so clicking through from the logs view found nothing, and the stdout line disagreed with the stored log record for the same event.
 
-Stdout lines now carry the nearest span id that actually reaches exporters, matching the stored record, and omit correlation entirely when nothing in the chain is exportable.
+Stdout lines now carry the nearest span id that actually reaches exporters, matching the stored record. When nothing in the chain is exportable, the line keeps `trace_id` and omits `span_id` — the trace is still addressable even though no individual span is. `span_id` is now optional on `TraceFields`, so consumers parsing these lines should treat it as possibly absent.

--- a/packages/_internal-core/src/logger/adapter.ts
+++ b/packages/_internal-core/src/logger/adapter.ts
@@ -11,8 +11,16 @@ import type { IMastraLogger } from './index';
 export interface TraceFields {
   /** 32-char lowercase hex W3C trace id */
   trace_id: string;
-  /** 16-char lowercase hex W3C span id */
-  span_id: string;
+  /**
+   * 16-char lowercase hex W3C span id.
+   *
+   * Optional, and omitted rather than emitted empty: the active span may be
+   * one observability never exports (an internal span, or one dropped by
+   * `excludeSpanTypes`), leaving no span id a consumer could look up. The
+   * trace is still addressable in that case, so the line keeps `trace_id` and
+   * drops only this field. Consumers must treat `span_id` as possibly absent.
+   */
+  span_id?: string;
 }
 
 /**

--- a/packages/core/src/logger/adapter.test.ts
+++ b/packages/core/src/logger/adapter.test.ts
@@ -72,7 +72,7 @@ describe('resolveTraceFields', () => {
     expect(fields?.span_id).not.toBe(VALID_SPAN_ID);
   });
 
-  it('returns undefined when no ancestor of the active span is exportable', async () => {
+  it('keeps trace_id and omits span_id when no ancestor of the active span is exportable', async () => {
     let fields: ReturnType<typeof resolveTraceFields>;
     await executeWithContext({
       span: makeSpan({ getExportedSpanId: () => undefined }),
@@ -81,8 +81,10 @@ describe('resolveTraceFields', () => {
       },
     });
 
-    // Better no correlation than a span_id that cannot be looked up.
-    expect(fields).toBeUndefined();
+    // No span is addressable, but the trace still is — so the line keeps
+    // trace_id and drops span_id rather than losing correlation entirely.
+    expect(fields).toEqual({ trace_id: VALID_TRACE_ID });
+    expect(fields && 'span_id' in fields).toBe(false);
   });
 
   it('returns undefined when the active span is missing ids', async () => {

--- a/packages/core/src/logger/adapter.test.ts
+++ b/packages/core/src/logger/adapter.test.ts
@@ -55,6 +55,36 @@ describe('resolveTraceFields', () => {
     expect(resolveTraceFields()).toBeUndefined();
   });
 
+  it('resolves span_id to the nearest exportable ancestor for a non-exportable span', async () => {
+    // The active span is internal/excluded, so its own id never reaches an
+    // exporter. The stored log record for this same event carries the resolved
+    // ancestor id, and the stdout line has to agree with it.
+    const ancestorSpanId = 'a1b2c3d4e5f60718';
+    let fields: ReturnType<typeof resolveTraceFields>;
+    await executeWithContext({
+      span: makeSpan({ getExportedSpanId: () => ancestorSpanId }),
+      fn: async () => {
+        fields = resolveTraceFields();
+      },
+    });
+
+    expect(fields).toEqual({ trace_id: VALID_TRACE_ID, span_id: ancestorSpanId });
+    expect(fields?.span_id).not.toBe(VALID_SPAN_ID);
+  });
+
+  it('returns undefined when no ancestor of the active span is exportable', async () => {
+    let fields: ReturnType<typeof resolveTraceFields>;
+    await executeWithContext({
+      span: makeSpan({ getExportedSpanId: () => undefined }),
+      fn: async () => {
+        fields = resolveTraceFields();
+      },
+    });
+
+    // Better no correlation than a span_id that cannot be looked up.
+    expect(fields).toBeUndefined();
+  });
+
   it('returns undefined when the active span is missing ids', async () => {
     let fields: ReturnType<typeof resolveTraceFields>;
     await executeWithContext({

--- a/packages/core/src/logger/adapter.ts
+++ b/packages/core/src/logger/adapter.ts
@@ -22,15 +22,17 @@ export {
  * `excludeSpanTypes`, in which case it never reaches an exporter and is never
  * stored — emitting its raw id would point the stdout line at a span that
  * cannot be looked up, and would disagree with the stored log record for the
- * same event, which carries the resolved id. Returns undefined when nothing in
- * the chain is exportable, so the line carries no correlation rather than a
- * dangling one.
+ * same event, which carries the resolved id.
+ *
+ * When nothing in the chain is exportable the line keeps trace_id and omits
+ * span_id, matching what the stored log record does for the same event: the
+ * trace is still addressable even though no individual span is.
  */
 export function resolveTraceFields(): TraceFields | undefined {
   const span = resolveCurrentSpan();
+  if (!span?.traceId) return undefined;
   const spanId = resolveExportedSpanId(span);
-  if (!span?.traceId || !spanId) return undefined;
-  return { trace_id: span.traceId, span_id: spanId };
+  return spanId ? { trace_id: span.traceId, span_id: spanId } : { trace_id: span.traceId };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/logger/adapter.ts
+++ b/packages/core/src/logger/adapter.ts
@@ -1,5 +1,5 @@
 import type { IMastraLogger, TraceFields } from '@internal/core/logger';
-import { resolveCurrentSpan } from '../observability/utils';
+import { resolveCurrentSpan, resolveExportedSpanId } from '../observability/utils';
 
 export {
   isAdaptableLogger,
@@ -16,11 +16,21 @@ export {
  * Resolve OpenTelemetry-compatible correlation fields for the currently
  * active span (AsyncLocalStorage-backed), or undefined when no span is
  * active. Span/trace ids are already W3C hex format internally.
+ *
+ * span_id is resolved through {@link resolveExportedSpanId} rather than read
+ * off the span directly. The active span may be internal or dropped by
+ * `excludeSpanTypes`, in which case it never reaches an exporter and is never
+ * stored — emitting its raw id would point the stdout line at a span that
+ * cannot be looked up, and would disagree with the stored log record for the
+ * same event, which carries the resolved id. Returns undefined when nothing in
+ * the chain is exportable, so the line carries no correlation rather than a
+ * dangling one.
  */
 export function resolveTraceFields(): TraceFields | undefined {
   const span = resolveCurrentSpan();
-  if (!span?.traceId || !span.id) return undefined;
-  return { trace_id: span.traceId, span_id: span.id };
+  const spanId = resolveExportedSpanId(span);
+  if (!span?.traceId || !spanId) return undefined;
+  return { trace_id: span.traceId, span_id: spanId };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`resolveTraceFields()` stamped the active span's raw id into the `trace_id`/`span_id` pair injected on structured stdout lines. When that span is internal, or dropped by `excludeSpanTypes`, it never reaches an exporter and is never stored — so the `span_id` on the line names something you can't look up. That's the same "Span not found." symptom #22286 just fixed for stored logs, showing up on the stdout path that trace correlation exists to enable. It also left the stdout line and the stored log record for the same event carrying different span ids.

Before:

```ts
const span = resolveCurrentSpan();
if (!span?.traceId || !span.id) return undefined;
return { trace_id: span.traceId, span_id: span.id };
```

After:

```ts
const span = resolveCurrentSpan();
if (!span?.traceId) return undefined;
const spanId = resolveExportedSpanId(span);
return spanId ? { trace_id: span.traceId, span_id: spanId } : { trace_id: span.traceId };
```

`resolveExportedSpanId()` is the resolver from #22286 that stored log/metric records and workflow resume linkage already go through, so every surface now names the same span.

The second commit makes `span_id` optional on `TraceFields`. Both fields were required before, so a span with no exportable ancestor dropped `trace_id` as well — even though the trace itself is still addressable. Now the line keeps `trace_id` and omits `span_id`, which is what the stored record already does. `TraceFields` is parsed by external consumers, so the field is documented as possibly absent and they should treat it that way.

Follows up on [epinzur's comment](https://github.com/mastra-ai/mastra/pull/22286#issuecomment-5424540917) on #22286.

## Related issue(s)

Follow-up to #22286 and #21753.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Stdout logs now use the same trace span ID as stored logs and metrics. If no usable span ID exists, they keep the trace ID and omit the span ID.

## Changes

- Updated `resolveTraceFields()` to use `resolveExportedSpanId()`.
- Made `TraceFields.span_id` optional.
- Added tests for exportable ancestor resolution and missing span IDs.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->