### PR TITLE
fix(dsql): missing $ prefix in AgentsDSQL.update()

### DIFF
--- a/.changeset/fix-dsql-agents-update.md
+++ b/.changeset/fix-dsql-agents-update.md
@@ -1,0 +1,5 @@
+---
+'@mastra/dsql': patch
+---
+
+Fix missing $ prefix on the WHERE id placeholder in AgentsDSQL.update(), which caused "operator does not exist: text = integer" on every agent update.

--- a/stores/dsql/src/storage/domains/agents/index.ts
+++ b/stores/dsql/src/storage/domains/agents/index.ts
@@ -292,7 +292,7 @@ export class AgentsDSQL extends AgentsStorage {
       values.push(id);
 
       await withRetry(() =>
-        this.#db.client.none(`UPDATE ${tableName} SET ${setClauses.join(', ')} WHERE id = ${paramIndex}`, values),
+        this.#db.client.none(`UPDATE ${tableName} SET ${setClauses.join(', ')} WHERE id = $${paramIndex}`, values),
       );
 
       // Return the updated agent


### PR DESCRIPTION
## Description

Fixes the missing $ prefix on the WHERE id placeholder in AgentsDSQL.update() — every other placeholder in this file has it, this one was missed. Causes "operator does not exist: text = integer" on every call.

## Related issue(s)

Fixes #22388

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The update query used the wrong format for the record ID. This change fixes the format so `AgentsDSQL.update()` can update records successfully.

## Changes

- Added the missing `$` prefix to the `WHERE id` SQL placeholder.
- Added a patch changeset for `@mastra/dsql`.
- Prevents the `operator does not exist: text = integer` error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->