### PR TITLE
feat(deployer): emit a ready standalone worker runtime

### DIFF
--- a/.changeset/gold-squids-spend.md
+++ b/.changeset/gold-squids-spend.md
@@ -1,0 +1,6 @@
+---
+'mastra': minor
+'@mastra/deployer': patch
+---
+
+Added a dedicated worker entry to standard build artifacts. The worker runtime exposes a /health endpoint that returns 503 during startup and 200 after workers initialize, so deployment platforms can gate rollout on worker readiness.

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -266,11 +266,19 @@ export default { createRequire };
     analyzedBundleInfo: Awaited<ReturnType<typeof analyzeBundle>>,
     toolsPaths: (string | string[])[],
     bundlerOptions: BundlerOptions,
+    additionalEntries: Record<string, string>,
   ) {
-    const inputOptions = await super.getBundlerOptions(serverFile, mastraEntryFile, analyzedBundleInfo, toolsPaths, {
-      ...bundlerOptions,
-      enableEsmShim: false,
-    });
+    const inputOptions = await super.getBundlerOptions(
+      serverFile,
+      mastraEntryFile,
+      analyzedBundleInfo,
+      toolsPaths,
+      {
+        ...bundlerOptions,
+        enableEsmShim: false,
+      },
+      additionalEntries,
+    );
 
     const hasPostgresStore = (await this.deps.checkDependencies(['@mastra/pg'])) === `ok`;
 

--- a/deployers/netlify/src/index.ts
+++ b/deployers/netlify/src/index.ts
@@ -108,11 +108,19 @@ export class NetlifyDeployer extends Deployer {
     analyzedBundleInfo: Awaited<ReturnType<typeof analyzeBundle>>,
     toolsPaths: (string | string[])[],
     bundlerOptions: BundlerOptions,
+    additionalEntries: Record<string, string>,
   ) {
-    const inputOptions = await super.getBundlerOptions(serverFile, mastraEntryFile, analyzedBundleInfo, toolsPaths, {
-      ...bundlerOptions,
-      enableEsmShim: this.target !== 'edge',
-    });
+    const inputOptions = await super.getBundlerOptions(
+      serverFile,
+      mastraEntryFile,
+      analyzedBundleInfo,
+      toolsPaths,
+      {
+        ...bundlerOptions,
+        enableEsmShim: this.target !== 'edge',
+      },
+      additionalEntries,
+    );
 
     if (this.target === 'edge' && Array.isArray(inputOptions.plugins)) {
       // Run before subpathExternalsResolver so the resolveId hooks win.

--- a/docs/src/content/en/docs/deployment/workers.mdx
+++ b/docs/src/content/en/docs/deployment/workers.mdx
@@ -378,6 +378,10 @@ kubectl scale deployment/background-task-worker --replicas=2
 
 Run exactly one scheduler worker. Multiple schedulers polling the same storage can publish duplicate events for a schedule.
 
+### Health checks
+
+Worker build artifacts expose `GET /health` on `PORT`, or port `4111` when `PORT` isn't set. The endpoint returns `503` while `startWorkers()` is initializing and `200` after every selected worker starts successfully. Use this endpoint for deployment readiness and liveness checks.
+
 ### Crash recovery
 
 A distributed PubSub backend persists unacknowledged events, which lets orchestration and background task workers resume after a restart. When the API is unavailable, a failed step-execution request causes the event to be delivered again. Because an event can be processed more than once, handlers should be idempotent when possible.
@@ -389,7 +393,6 @@ If the API crashes while a step is executing, that work can be lost and the work
 ## Known limitations
 
 - **No dead-letter queue**: Failed events are nacked and retried, but there's no DLQ for events that fail after all retries.
-- **No built-in health endpoint**: Workers don't expose an HTTP health check. Use container-level liveness probes or process monitoring.
 - **Scheduler is single-instance**: Running multiple scheduler processes causes duplicate schedule fires.
 - **Runs stuck in "running" after API crash**: If the API process crashes while executing a workflow step, the run remains in `running` status with no automatic retry. For [durable agents](/docs/harness/durable-agents), set `recovery.durableAgents` to `'auto'` in the Mastra config to automatically re-drive orphaned runs on server restart. See [Crash recovery](/docs/harness/durable-agents#crash-recovery) for details.
 

--- a/docs/src/content/en/docs/deployment/workers.mdx
+++ b/docs/src/content/en/docs/deployment/workers.mdx
@@ -380,7 +380,7 @@ Run exactly one scheduler worker. Multiple schedulers polling the same storage c
 
 ### Health checks
 
-Worker build artifacts expose `GET /health` on `PORT`, or port `4111` when `PORT` isn't set. The endpoint returns `503` while `startWorkers()` is initializing and `200` after every selected worker starts successfully. Use this endpoint for deployment readiness and liveness checks.
+Worker build artifacts expose `GET /health` on `PORT`, or port `4111` when `PORT` isn't set. The endpoint returns `503` while `startWorkers()` is initializing and `200` after every selected worker starts successfully. Use this endpoint for deployment readiness checks. If you also use it for liveness checks, configure a startup probe or an initial delay that allows worker initialization to finish.
 
 ### Crash recovery
 

--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -396,6 +396,14 @@ export const environmentRoute = registerApiRoute('/environment', {
       );
     });
 
+    it('should emit a worker runtime entry with a readiness endpoint', async () => {
+      const workerEntryPath = join(fixturePath, 'apps', 'custom', '.mastra', 'output', 'worker.mjs');
+      const workerEntry = await readFile(workerEntryPath, 'utf-8');
+
+      expect(workerEntry).toContain('/health');
+      expect(workerEntry).toContain('startWorkers');
+    });
+
     afterAll(async () => {
       if (proc) {
         try {

--- a/packages/cli/src/commands/build/BuildBundler.test.ts
+++ b/packages/cli/src/commands/build/BuildBundler.test.ts
@@ -152,6 +152,18 @@ describe('BuildBundler', () => {
   });
 
   describe('getEntry', () => {
+    it('emits a dedicated worker entry alongside the API entry', async () => {
+      const { BuildBundler } = await import('./BuildBundler');
+      const bundler = new BuildBundler();
+
+      const entries = (bundler as any).getAdditionalEntries();
+
+      expect(entries).toHaveProperty('worker');
+      expect(entries.worker).toContain("import { mastra } from '#mastra'");
+      expect(entries.worker).toContain("request.url !== '/health'");
+      expect(entries.worker).toContain('await mastra.startWorkers()');
+    });
+
     it('should include studio: true when studio is enabled', async () => {
       const { BuildBundler } = await import('./BuildBundler');
       const bundler = new BuildBundler({ studio: true });

--- a/packages/cli/src/commands/build/BuildBundler.test.ts
+++ b/packages/cli/src/commands/build/BuildBundler.test.ts
@@ -154,9 +154,14 @@ describe('BuildBundler', () => {
   describe('getEntry', () => {
     it('emits a dedicated worker entry alongside the API entry', async () => {
       const { BuildBundler } = await import('./BuildBundler');
-      const bundler = new BuildBundler();
+      class TestBuildBundler extends BuildBundler {
+        getAdditionalEntriesForTest() {
+          return this.getAdditionalEntries();
+        }
+      }
+      const bundler = new TestBuildBundler();
 
-      const entries = (bundler as any).getAdditionalEntries();
+      const entries = bundler.getAdditionalEntriesForTest();
 
       expect(entries).toHaveProperty('worker');
       expect(entries.worker).toContain("import { mastra } from '#mastra'");

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -5,6 +5,7 @@ import { FileService } from '@mastra/deployer/build';
 import { Bundler } from '@mastra/deployer/bundler';
 import { copy } from 'fs-extra';
 import { shouldSkipDotenvLoading } from '../utils.js';
+import { getWorkerEntry } from '../worker/WorkerBundler.js';
 
 export class BuildBundler extends Bundler {
   private studio: boolean;
@@ -65,6 +66,10 @@ export class BuildBundler extends Bundler {
     { toolsPaths, projectRoot }: { toolsPaths: (string | string[])[]; projectRoot: string },
   ): Promise<void> {
     return this._bundle(this.getEntry(), entryFile, { outputDirectory, projectRoot }, toolsPaths);
+  }
+
+  protected getAdditionalEntries(): Record<string, string> {
+    return { worker: getWorkerEntry() };
   }
 
   protected getEntry(): string {

--- a/packages/cli/src/commands/build/guard-live-dev-server.ts
+++ b/packages/cli/src/commands/build/guard-live-dev-server.ts
@@ -14,10 +14,7 @@ import { readLiveDevLock } from '../dev/dev-lock';
  * depend on `process.exit()` actually terminating the process to avoid
  * running the destructive operation it's guarding.
  */
-export async function guardAgainstLiveDevServer(
-  outputDirectory: string,
-  force: boolean | undefined,
-): Promise<boolean> {
+export async function guardAgainstLiveDevServer(outputDirectory: string, force: boolean | undefined): Promise<boolean> {
   const liveLock = await readLiveDevLock(outputDirectory);
   if (!liveLock) return true;
 

--- a/packages/cli/src/commands/worker/WorkerBundler.test.ts
+++ b/packages/cli/src/commands/worker/WorkerBundler.test.ts
@@ -1,3 +1,10 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('fs-extra/esm', () => ({
@@ -26,6 +33,32 @@ vi.mock('../utils.js', () => ({
   shouldSkipDotenvLoading: vi.fn().mockReturnValue(false),
 }));
 
+async function getAvailablePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Could not reserve a port for the worker health test');
+  }
+  await new Promise<void>((resolve, reject) => server.close(error => (error ? reject(error) : resolve())));
+  return address.port;
+}
+
+async function waitForHealthStatus(port: number, expectedStatus: number): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      if (response.status === expectedStatus) return;
+    } catch {}
+    await delay(25);
+  }
+  throw new Error(`Worker health endpoint did not return ${expectedStatus}`);
+}
+
 describe('WorkerBundler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -44,8 +77,13 @@ describe('WorkerBundler', () => {
       const entry = (bundler as any).getEntry();
 
       expect(entry).toContain("import { mastra } from '#mastra'");
-      expect(entry).toContain('mastra.startWorkers()');
-      expect(entry).toContain('mastra.stopWorkers()');
+      expect(entry).toContain("import { createServer } from 'node:http'");
+      expect(entry).toContain("request.url !== '/health'");
+      expect(entry).toContain('response.statusCode = workersReady ? 200 : 503');
+      expect(entry).toContain("process.env.PORT ?? '4111'");
+      expect(entry).toContain('await mastra.startWorkers()');
+      expect(entry).toContain('workersReady = true');
+      expect(entry).toContain('await mastra.stopWorkers()');
       expect(entry).toContain("process.on('SIGINT'");
       expect(entry).toContain("process.on('SIGTERM'");
     });
@@ -59,6 +97,44 @@ describe('WorkerBundler', () => {
       // role is determined at runtime via MASTRA_WORKERS, not baked into the bundle
       expect(entry).not.toMatch(/startWorkers\(['"`]/);
     });
+  });
+
+  it('reports starting until workers are ready, then reports healthy', async () => {
+    const { getWorkerEntry } = await import('./WorkerBundler');
+    const tempDir = await mkdtemp(join(tmpdir(), 'mastra-worker-health-'));
+    const port = await getAvailablePort();
+    const workerEntry = getWorkerEntry().replace("from '#mastra'", "from './mastra.mjs'");
+    await writeFile(
+      join(tempDir, 'mastra.mjs'),
+      `export const mastra = {
+        async startWorkers() { await new Promise(resolve => setTimeout(resolve, 500)); },
+        async stopWorkers() {},
+      };`,
+    );
+    await writeFile(join(tempDir, 'worker.mjs'), workerEntry);
+
+    const child = spawn(process.execPath, ['worker.mjs'], {
+      cwd: tempDir,
+      env: { ...process.env, PORT: String(port) },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    const childExit = once(child, 'exit');
+    let stderr = '';
+    child.stderr.setEncoding('utf-8');
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+
+    try {
+      await waitForHealthStatus(port, 503);
+      await waitForHealthStatus(port, 200);
+    } finally {
+      child.kill('SIGTERM');
+      await childExit;
+      await rm(tempDir, { recursive: true, force: true });
+    }
+
+    expect(stderr).toBe('');
   });
 
   it('layers default dotenv files from base to production override', async () => {

--- a/packages/cli/src/commands/worker/WorkerBundler.test.ts
+++ b/packages/cli/src/commands/worker/WorkerBundler.test.ts
@@ -107,7 +107,7 @@ describe('WorkerBundler', () => {
     await writeFile(
       join(tempDir, 'mastra.mjs'),
       `export const mastra = {
-        async startWorkers() { await new Promise(resolve => setTimeout(resolve, 500)); },
+        async startWorkers() { await new Promise(resolve => process.stdin.once('data', resolve)); },
         async stopWorkers() {},
       };`,
     );
@@ -116,7 +116,7 @@ describe('WorkerBundler', () => {
     const child = spawn(process.execPath, ['worker.mjs'], {
       cwd: tempDir,
       env: { ...process.env, PORT: String(port) },
-      stdio: ['ignore', 'ignore', 'pipe'],
+      stdio: ['pipe', 'ignore', 'pipe'],
     });
     const childExit = once(child, 'exit');
     let stderr = '';
@@ -127,6 +127,7 @@ describe('WorkerBundler', () => {
 
     try {
       await waitForHealthStatus(port, 503);
+      child.stdin.write('ready');
       await waitForHealthStatus(port, 200);
     } finally {
       child.kill('SIGTERM');

--- a/packages/cli/src/commands/worker/WorkerBundler.ts
+++ b/packages/cli/src/commands/worker/WorkerBundler.ts
@@ -2,6 +2,60 @@ import { FileService } from '@mastra/deployer/build';
 import { Bundler } from '@mastra/deployer/bundler';
 import { shouldSkipDotenvLoading } from '../utils.js';
 
+export function getWorkerEntry(): string {
+  return `
+    import { createServer } from 'node:http';
+    import { mastra } from '#mastra';
+
+    let workersReady = false;
+    let shuttingDown = false;
+
+    const healthServer = createServer((request, response) => {
+      response.setHeader('content-type', 'application/json');
+
+      if (request.url !== '/health') {
+        response.statusCode = 404;
+        response.end(JSON.stringify({ status: 'not_found' }));
+        return;
+      }
+
+      response.statusCode = workersReady ? 200 : 503;
+      response.end(JSON.stringify({ status: workersReady ? 'ready' : 'starting' }));
+    });
+
+    const port = Number.parseInt(process.env.PORT ?? '4111', 10);
+    await new Promise((resolve, reject) => {
+      const onError = error => reject(error);
+      healthServer.once('error', onError);
+      healthServer.listen(port, '0.0.0.0', () => {
+        healthServer.off('error', onError);
+        resolve();
+      });
+    });
+
+    try {
+      await mastra.startWorkers();
+      workersReady = true;
+      console.log('[mastra] Workers started');
+    } catch (error) {
+      healthServer.close();
+      throw error;
+    }
+
+    const shutdown = async () => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      workersReady = false;
+      console.log('[mastra] Shutting down workers...');
+      healthServer.close();
+      await mastra.stopWorkers();
+      process.exit(0);
+    };
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+    `;
+}
+
 export class WorkerBundler extends Bundler {
   constructor({ outputDir }: { outputDir?: string } = {}) {
     super('Worker');
@@ -28,20 +82,6 @@ export class WorkerBundler extends Bundler {
   }
 
   protected getEntry(): string {
-    return `
-    import { mastra } from '#mastra';
-
-    await mastra.startWorkers();
-
-    console.log('[mastra] Workers started');
-
-    const shutdown = async () => {
-      console.log('[mastra] Shutting down workers...');
-      await mastra.stopWorkers();
-      process.exit(0);
-    };
-    process.on('SIGINT', shutdown);
-    process.on('SIGTERM', shutdown);
-    `;
+    return getWorkerEntry();
   }
 }

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -385,6 +385,10 @@ export abstract class Bundler extends MastraBundler {
 
   protected pnpmNodeLinker?: 'hoisted';
 
+  protected getAdditionalEntries(): Record<string, string> {
+    return {};
+  }
+
   protected async installDependencies(
     outputDirectory: string,
     rootDir = process.cwd(),
@@ -494,6 +498,7 @@ export abstract class Bundler extends MastraBundler {
     analyzedBundleInfo: Awaited<ReturnType<typeof analyzeBundle>>,
     toolsPaths: (string | string[])[],
     { enableSourcemap, enableMinify, enableEsmShim, externals }: BundlerOptions,
+    additionalEntries: Record<string, string>,
   ) {
     const { workspaceRoot } = await getWorkspaceInformation({ mastraEntryFile });
     const closestPkgJson = pkg.up({ cwd: dirname(mastraEntryFile) });
@@ -515,19 +520,29 @@ export abstract class Bundler extends MastraBundler {
         externalsPreset: externals === true,
       },
     );
-    const isVirtual = serverFile.includes('\n') || !existsSync(serverFile);
     const toolsInputOptions = await this.listToolsInputOptions(toolsPaths);
+    const entryInputs: Record<string, string> = {};
+    const virtualEntries: Record<string, string> = {};
+    const entries = { index: serverFile, ...additionalEntries };
 
-    if (isVirtual) {
-      inputOptions.input = { index: '#entry', ...toolsInputOptions };
-
-      if (Array.isArray(inputOptions.plugins)) {
-        inputOptions.plugins.unshift(virtual({ '#entry': serverFile }));
+    for (const [name, entry] of Object.entries(entries)) {
+      if (entry.includes('\n') || !existsSync(entry)) {
+        const virtualId = name === 'index' ? '#entry' : `#entry-${name}`;
+        entryInputs[name] = virtualId;
+        virtualEntries[virtualId] = entry;
       } else {
-        inputOptions.plugins = [virtual({ '#entry': serverFile })];
+        entryInputs[name] = entry;
       }
-    } else {
-      inputOptions.input = { index: serverFile, ...toolsInputOptions };
+    }
+
+    inputOptions.input = { ...entryInputs, ...toolsInputOptions };
+
+    if (Object.keys(virtualEntries).length > 0) {
+      if (Array.isArray(inputOptions.plugins)) {
+        inputOptions.plugins.unshift(virtual(virtualEntries));
+      } else {
+        inputOptions.plugins = [virtual(virtualEntries)];
+      }
     }
 
     return inputOptions;
@@ -609,6 +624,7 @@ export abstract class Bundler extends MastraBundler {
     bundleLocation: string = join(outputDirectory, this.outputDir),
   ): Promise<void> {
     const analyzeDir = join(outputDirectory, this.analyzeOutputDir);
+    const additionalEntries = this.getAdditionalEntries();
 
     const bundlerOptions = await this.getUserBundlerOptions(mastraEntryFile, outputDirectory);
     const internalBundlerOptions: BundlerOptions = {
@@ -623,7 +639,7 @@ export abstract class Bundler extends MastraBundler {
     try {
       const resolvedToolsPaths = await this.listToolsInputOptions(toolsPaths);
       analyzedBundleInfo = await analyzeBundle(
-        [serverFile, ...Object.values(resolvedToolsPaths)],
+        [serverFile, ...Object.values(additionalEntries), ...Object.values(resolvedToolsPaths)],
         mastraEntryFile,
         {
           outputDir: analyzeDir,
@@ -710,6 +726,7 @@ export abstract class Bundler extends MastraBundler {
         analyzedBundleInfo,
         toolsPaths,
         internalBundlerOptions,
+        additionalEntries,
       );
 
       const bundler = await this.createBundler(


### PR DESCRIPTION
## Summary

- emit a dedicated `worker.mjs` alongside the standard API entry in deployer build output
- expose `/health` from the standalone worker runtime, returning `503` during startup and `200` after workers initialize
- preserve the existing in-process worker path because `index.mjs` remains the API entrypoint
- document worker runtime health checks and cover the generated artifact in the monorepo E2E suite

## Test plan

- `pnpm vitest run packages/cli/src/commands/worker/WorkerBundler.test.ts packages/cli/src/commands/build/BuildBundler.test.ts packages/deployer/src/bundler/index.test.ts`
- `pnpm build:cli`
- `pnpm exec prettier --check packages/cli/src/commands/worker/WorkerBundler.ts packages/cli/src/commands/worker/WorkerBundler.test.ts packages/cli/src/commands/build/BuildBundler.ts packages/cli/src/commands/build/BuildBundler.test.ts packages/deployer/src/bundler/index.ts docs/src/content/en/docs/deployment/workers.mdx .changeset/gold-squids-spend.md`

## Changeset

Exactly one: `.changeset/gold-squids-spend.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR gives deployed workers their own startup file and health check. Deployment platforms can use the health check to wait until the worker is ready.

## Changes

- Added a standalone `worker.mjs` runtime alongside the existing `index.mjs` API entrypoint.
- Added `GET /health`:
  - Returns `503` during startup.
  - Returns `200` after workers initialize.
- Added configurable `PORT` handling and graceful shutdown.
- Updated bundlers to support additional named entry points.
- Preserved adapter-specific bundler options for Cloudflare and Netlify.
- Documented worker health checks, port selection, and readiness behavior.
- Added unit, integration, CLI build, formatting, and monorepo E2E coverage for:
  - Generated `worker.mjs` output.
  - Health status transitions.
  - Worker startup and shutdown.
  - Bundle entry generation.
- Added a changeset for `mastra` and `@mastra/deployer`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->