### PR TITLE
Add Comment compound components to the playground design system

### DIFF
--- a/.changeset/comment-compound-components.md
+++ b/.changeset/comment-compound-components.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added a `Comment` family of compound components for text-only comment threads: `Comment`, `CommentList`, `CommentItem` (with header, author, timestamp, body and actions slots) and `CommentComposer` (input + send button). The root `variant` prop switches between `default`, a flat thread with hover-revealed per-item actions, and `embed`, the same thread on a bordered card surface with a compact composer and no per-item actions.

--- a/packages/playground-ui/src/components-exports.test.ts
+++ b/packages/playground-ui/src/components-exports.test.ts
@@ -76,6 +76,14 @@ describe('components/* subpath exports', () => {
     expect(mod.ComposerActions).toBeDefined();
   });
 
+  it('Comment entry exports its compound components', async () => {
+    const mod = await import('./ds/components/Comment');
+    expect(mod.Comment).toBeDefined();
+    expect(mod.CommentList).toBeDefined();
+    expect(mod.CommentItem).toBeDefined();
+    expect(mod.CommentComposer).toBeDefined();
+  });
+
   it('AI plan entry exports Plan', async () => {
     const mod = await import('./ds/components/ai/plan');
     expect(mod.Plan).toBeDefined();

--- a/packages/playground-ui/src/ds/components/Comment/comment-composer.tsx
+++ b/packages/playground-ui/src/ds/components/Comment/comment-composer.tsx
@@ -1,0 +1,60 @@
+import { ArrowUp } from 'lucide-react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { forwardRef } from 'react';
+
+import { useCommentVariant } from './comment-context';
+import type { CommentVariant } from './comment-context';
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '@/ds/components/InputGroup';
+import type { InputGroupButtonProps, InputGroupInputProps } from '@/ds/components/InputGroup';
+import type { ControlSize } from '@/ds/primitives/control-size';
+import { cn } from '@/lib/utils';
+
+export type CommentComposerProps = ComponentPropsWithoutRef<'form'>;
+
+export const CommentComposer = forwardRef<HTMLFormElement, CommentComposerProps>(({ className, ...props }, ref) => (
+  <form ref={ref} data-slot="comment-composer" className={cn('flex w-full items-center gap-2', className)} {...props} />
+));
+CommentComposer.displayName = 'CommentComposer';
+
+const composerSize: Record<CommentVariant, ControlSize> = {
+  default: 'md',
+  embed: 'sm',
+};
+
+const composerInputVariant: Record<CommentVariant, 'default' | 'outline'> = {
+  default: 'outline',
+  embed: 'default',
+};
+
+export interface CommentComposerInputProps extends InputGroupInputProps {
+  /** Layout classes for the surrounding InputGroup. */
+  groupClassName?: string;
+  children?: ReactNode;
+}
+
+export const CommentComposerInput = forwardRef<HTMLInputElement, CommentComposerInputProps>(
+  ({ groupClassName, children, ...props }, ref) => {
+    const variant = useCommentVariant();
+
+    return (
+      <InputGroup size={composerSize[variant]} variant={composerInputVariant[variant]} className={groupClassName}>
+        <InputGroupInput ref={ref} data-slot="comment-composer-input" {...props} />
+        {children}
+      </InputGroup>
+    );
+  },
+);
+CommentComposerInput.displayName = 'CommentComposerInput';
+
+export type CommentComposerSendProps = Omit<InputGroupButtonProps, 'children'>;
+
+export const CommentComposerSend = forwardRef<HTMLButtonElement, CommentComposerSendProps>(
+  ({ 'aria-label': ariaLabel = 'Send comment', type = 'submit', ...props }, ref) => (
+    <InputGroupAddon align="inline-end">
+      <InputGroupButton ref={ref} data-slot="comment-composer-send" type={type} aria-label={ariaLabel} {...props}>
+        <ArrowUp />
+      </InputGroupButton>
+    </InputGroupAddon>
+  ),
+);
+CommentComposerSend.displayName = 'CommentComposerSend';

--- a/packages/playground-ui/src/ds/components/Comment/comment-context.ts
+++ b/packages/playground-ui/src/ds/components/Comment/comment-context.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+export type CommentVariant = 'default' | 'embed';
+
+export const CommentContext = createContext<CommentVariant | null>(null);
+
+export function useCommentVariant(): CommentVariant {
+  const variant = useContext(CommentContext);
+  if (!variant) throw new Error('Comment compounds must be rendered within Comment');
+  return variant;
+}

--- a/packages/playground-ui/src/ds/components/Comment/comment.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Comment/comment.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Check, MoreHorizontal, SmilePlus } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from '../Button';
+import {
+  Comment,
+  CommentItem,
+  CommentItemActions,
+  CommentItemAuthor,
+  CommentItemBody,
+  CommentItemHeader,
+  CommentItemTimestamp,
+  CommentList,
+} from './comment';
+import { CommentComposer, CommentComposerInput, CommentComposerSend } from './comment-composer';
+import type { CommentVariant } from './comment-context';
+
+const meta: Meta<typeof Comment> = {
+  title: 'Elements/Comment',
+  component: Comment,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Comment>;
+
+const threadItems = [
+  {
+    id: '1',
+    author: 'Marvin Frachet',
+    dateTime: '2026-08-26T09:00:00Z',
+    time: 'Just now',
+    body: 'Hello world, how are you?',
+  },
+  {
+    id: '2',
+    author: 'Marvin Frachet',
+    dateTime: '2026-08-26T09:01:00Z',
+    time: 'Just now',
+    body: 'Doing well, thanks!',
+  },
+];
+
+const Thread = ({ variant }: { variant: CommentVariant }) => (
+  <Comment variant={variant} className="max-w-2xl">
+    <CommentList>
+      {threadItems.map(item => (
+        <CommentItem key={item.id}>
+          <CommentItemHeader>
+            <CommentItemAuthor>{item.author}</CommentItemAuthor>
+            <CommentItemTimestamp dateTime={item.dateTime}>{item.time}</CommentItemTimestamp>
+            <CommentItemActions>
+              <Button size="icon-sm" variant="ghost" aria-label="React">
+                <SmilePlus />
+              </Button>
+              <Button size="icon-sm" variant="ghost" aria-label="Resolve">
+                <Check />
+              </Button>
+              <Button size="icon-sm" variant="ghost" aria-label="More actions">
+                <MoreHorizontal />
+              </Button>
+            </CommentItemActions>
+          </CommentItemHeader>
+          <CommentItemBody>{item.body}</CommentItemBody>
+        </CommentItem>
+      ))}
+    </CommentList>
+    <CommentComposer aria-label="Add a comment">
+      <CommentComposerInput aria-label="Comment" placeholder={variant === 'embed' ? 'Reply...' : 'Add a comment...'}>
+        <CommentComposerSend />
+      </CommentComposerInput>
+    </CommentComposer>
+  </Comment>
+);
+
+export const Default: Story = {
+  render: () => <Thread variant="default" />,
+};
+
+/** Card surface, compact composer, no per-item actions. */
+export const Embed: Story = {
+  render: () => <Thread variant="embed" />,
+};
+
+export const ComposerOnly: Story = {
+  render: () => (
+    <Comment className="max-w-2xl">
+      <CommentComposer aria-label="Add a comment">
+        <CommentComposerInput aria-label="Comment" placeholder="Add a comment...">
+          <CommentComposerSend disabled />
+        </CommentComposerInput>
+      </CommentComposer>
+    </Comment>
+  ),
+};
+
+const InteractiveThread = () => {
+  const [items, setItems] = useState([{ id: '1', body: 'Hello world, how are you?' }]);
+  const [value, setValue] = useState('');
+
+  return (
+    <Comment className="max-w-2xl">
+      <CommentList>
+        {items.map(item => (
+          <CommentItem key={item.id}>
+            <CommentItemHeader>
+              <CommentItemAuthor>Marvin Frachet</CommentItemAuthor>
+              <CommentItemTimestamp dateTime="2026-08-26T09:00:00Z">Just now</CommentItemTimestamp>
+            </CommentItemHeader>
+            <CommentItemBody>{item.body}</CommentItemBody>
+          </CommentItem>
+        ))}
+      </CommentList>
+      <CommentComposer
+        aria-label="Add a comment"
+        onSubmit={event => {
+          event.preventDefault();
+          if (!value.trim()) return;
+          setItems(current => [...current, { id: String(current.length + 1), body: value }]);
+          setValue('');
+        }}
+      >
+        <CommentComposerInput
+          aria-label="Comment"
+          placeholder="Add a comment..."
+          value={value}
+          onChange={event => {
+            setValue(event.target.value);
+          }}
+        >
+          <CommentComposerSend disabled={!value.trim()} />
+        </CommentComposerInput>
+      </CommentComposer>
+    </Comment>
+  );
+};
+
+export const Interactive: Story = {
+  render: () => <InteractiveThread />,
+};

--- a/packages/playground-ui/src/ds/components/Comment/comment.test.tsx
+++ b/packages/playground-ui/src/ds/components/Comment/comment.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  Comment,
+  CommentItem,
+  CommentItemActions,
+  CommentItemAuthor,
+  CommentItemBody,
+  CommentItemHeader,
+  CommentItemTimestamp,
+  CommentList,
+} from './comment';
+import { CommentComposer, CommentComposerInput, CommentComposerSend } from './comment-composer';
+import type { CommentVariant } from './comment-context';
+
+afterEach(() => {
+  cleanup();
+});
+
+const Thread = ({ variant }: { variant?: CommentVariant }) => (
+  <Comment variant={variant}>
+    <CommentList aria-label="Comments">
+      <CommentItem>
+        <CommentItemHeader>
+          <CommentItemAuthor>Marvin Frachet</CommentItemAuthor>
+          <CommentItemTimestamp dateTime="2026-08-26T09:00:00Z">Just now</CommentItemTimestamp>
+          <CommentItemActions aria-label="Comment actions">
+            <button type="button">Resolve</button>
+          </CommentItemActions>
+        </CommentItemHeader>
+        <CommentItemBody>Hello world</CommentItemBody>
+      </CommentItem>
+    </CommentList>
+  </Comment>
+);
+
+describe('Comment', () => {
+  it('renders the thread with stable slots', () => {
+    render(<Thread />);
+
+    const list = screen.getByRole('list', { name: 'Comments' });
+    expect(list.getAttribute('data-slot')).toBe('comment-list');
+    expect(list.closest('[data-slot="comment"]')?.getAttribute('data-variant')).toBe('default');
+    expect(screen.getByRole('listitem').getAttribute('data-slot')).toBe('comment-item');
+    expect(screen.getByText('Marvin Frachet').getAttribute('data-slot')).toBe('comment-item-author');
+    expect(screen.getByText('Just now').getAttribute('data-slot')).toBe('comment-item-timestamp');
+    expect(screen.getByText('Hello world').getAttribute('data-slot')).toBe('comment-item-body');
+  });
+
+  it('renders item actions in the default variant', () => {
+    render(<Thread />);
+
+    expect(screen.getByRole('button', { name: 'Resolve' })).toBeTruthy();
+  });
+
+  it('drops item actions in the embed variant', () => {
+    render(<Thread variant="embed" />);
+
+    expect(screen.queryByRole('button', { name: 'Resolve' })).toBeNull();
+    expect(document.querySelector('[data-slot="comment"]')?.getAttribute('data-variant')).toBe('embed');
+  });
+
+  it('throws when a compound is rendered outside Comment', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => render(<CommentList />)).toThrow('Comment compounds must be rendered within Comment');
+
+    consoleError.mockRestore();
+  });
+});
+
+describe('CommentComposer', () => {
+  const ControlledComposer = ({ onSend }: { onSend: (value: string) => void }) => {
+    const [value, setValue] = useState('');
+
+    return (
+      <Comment>
+        <CommentComposer
+          aria-label="Add a comment"
+          onSubmit={event => {
+            event.preventDefault();
+            onSend(value);
+          }}
+        >
+          <CommentComposerInput
+            aria-label="Comment"
+            placeholder="Add a comment..."
+            value={value}
+            onChange={event => {
+              setValue(event.target.value);
+            }}
+          >
+            <CommentComposerSend />
+          </CommentComposerInput>
+        </CommentComposer>
+      </Comment>
+    );
+  };
+
+  it('submits the typed comment through the send button', () => {
+    const onSend = vi.fn();
+    render(<ControlledComposer onSend={onSend} />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Comment' }), { target: { value: 'Ca va ?' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send comment' }));
+
+    expect(onSend).toHaveBeenCalledWith('Ca va ?');
+  });
+
+  it('exposes the composer as a form with a submit button', () => {
+    render(<ControlledComposer onSend={vi.fn()} />);
+
+    const form = screen.getByRole('form', { name: 'Add a comment' });
+    expect(form.getAttribute('data-slot')).toBe('comment-composer');
+    expect(screen.getByRole('button', { name: 'Send comment' }).getAttribute('type')).toBe('submit');
+  });
+});

--- a/packages/playground-ui/src/ds/components/Comment/comment.tsx
+++ b/packages/playground-ui/src/ds/components/Comment/comment.tsx
@@ -1,0 +1,151 @@
+import { cva } from 'class-variance-authority';
+import type { ComponentPropsWithoutRef } from 'react';
+import { forwardRef } from 'react';
+
+import { CommentContext, useCommentVariant } from './comment-context';
+import type { CommentVariant } from './comment-context';
+import { Txt } from '@/ds/components/Txt';
+import { cn } from '@/lib/utils';
+
+const commentVariants = cva('flex flex-col', {
+  variants: {
+    variant: {
+      default: 'gap-2',
+      embed: 'gap-1 rounded-xl border border-border1 bg-surface3 p-3',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+export interface CommentProps extends ComponentPropsWithoutRef<'div'> {
+  variant?: CommentVariant;
+}
+
+export const Comment = forwardRef<HTMLDivElement, CommentProps>(({ className, variant = 'default', ...props }, ref) => (
+  <CommentContext.Provider value={variant}>
+    <div
+      ref={ref}
+      data-slot="comment"
+      data-variant={variant}
+      className={cn(commentVariants({ variant }), className)}
+      {...props}
+    />
+  </CommentContext.Provider>
+));
+Comment.displayName = 'Comment';
+
+const commentListGap: Record<CommentVariant, string> = {
+  default: 'gap-3',
+  embed: 'gap-2',
+};
+
+export type CommentListProps = ComponentPropsWithoutRef<'ul'>;
+
+export const CommentList = forwardRef<HTMLUListElement, CommentListProps>(({ className, ...props }, ref) => {
+  const variant = useCommentVariant();
+
+  return (
+    <ul
+      ref={ref}
+      data-slot="comment-list"
+      className={cn('flex flex-col', commentListGap[variant], className)}
+      {...props}
+    />
+  );
+});
+CommentList.displayName = 'CommentList';
+
+export type CommentItemProps = ComponentPropsWithoutRef<'li'>;
+
+export const CommentItem = forwardRef<HTMLLIElement, CommentItemProps>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    data-slot="comment-item"
+    className={cn('group/comment-item flex flex-col gap-1', className)}
+    {...props}
+  />
+));
+CommentItem.displayName = 'CommentItem';
+
+export type CommentItemHeaderProps = ComponentPropsWithoutRef<'div'>;
+
+export const CommentItemHeader = forwardRef<HTMLDivElement, CommentItemHeaderProps>(({ className, ...props }, ref) => (
+  <div ref={ref} data-slot="comment-item-header" className={cn('flex items-center gap-2', className)} {...props} />
+));
+CommentItemHeader.displayName = 'CommentItemHeader';
+
+export type CommentItemAuthorProps = ComponentPropsWithoutRef<'span'>;
+
+export const CommentItemAuthor = forwardRef<HTMLElement, CommentItemAuthorProps>(({ className, ...props }, ref) => (
+  <Txt
+    ref={ref}
+    as="span"
+    variant="ui-md"
+    data-slot="comment-item-author"
+    className={cn('font-medium text-neutral6', className)}
+    {...props}
+  />
+));
+CommentItemAuthor.displayName = 'CommentItemAuthor';
+
+export type CommentItemTimestampProps = ComponentPropsWithoutRef<'time'>;
+
+export const CommentItemTimestamp = forwardRef<HTMLTimeElement, CommentItemTimestampProps>(
+  ({ className, ...props }, ref) => (
+    <time
+      ref={ref}
+      data-slot="comment-item-timestamp"
+      className={cn('text-ui-sm leading-ui-sm text-neutral3', className)}
+      {...props}
+    />
+  ),
+);
+CommentItemTimestamp.displayName = 'CommentItemTimestamp';
+
+const commentItemBodyRule: Record<CommentVariant, string> = {
+  default: 'border-l border-border1 pl-3',
+  embed: '',
+};
+
+export type CommentItemBodyProps = ComponentPropsWithoutRef<'p'>;
+
+export const CommentItemBody = forwardRef<HTMLElement, CommentItemBodyProps>(({ className, ...props }, ref) => {
+  const variant = useCommentVariant();
+
+  return (
+    <Txt
+      ref={ref}
+      variant="ui-md"
+      data-slot="comment-item-body"
+      className={cn('whitespace-pre-wrap text-neutral6', commentItemBodyRule[variant], className)}
+      {...props}
+    />
+  );
+});
+CommentItemBody.displayName = 'CommentItemBody';
+
+export type CommentItemActionsProps = ComponentPropsWithoutRef<'div'>;
+
+/** Hidden in the `embed` variant, which drops per-item actions. */
+export const CommentItemActions = forwardRef<HTMLDivElement, CommentItemActionsProps>(
+  ({ className, ...props }, ref) => {
+    const variant = useCommentVariant();
+    if (variant === 'embed') return null;
+
+    return (
+      <div
+        ref={ref}
+        data-slot="comment-item-actions"
+        className={cn(
+          'flex items-center gap-1 opacity-0 group-focus-within/comment-item:opacity-100 group-hover/comment-item:opacity-100',
+          'motion-safe:transition-opacity',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+CommentItemActions.displayName = 'CommentItemActions';

--- a/packages/playground-ui/src/ds/components/Comment/index.ts
+++ b/packages/playground-ui/src/ds/components/Comment/index.ts
@@ -1,0 +1,23 @@
+export {
+  Comment,
+  CommentItem,
+  CommentItemActions,
+  CommentItemAuthor,
+  CommentItemBody,
+  CommentItemHeader,
+  CommentItemTimestamp,
+  CommentList,
+} from './comment';
+export type {
+  CommentItemActionsProps,
+  CommentItemAuthorProps,
+  CommentItemBodyProps,
+  CommentItemHeaderProps,
+  CommentItemProps,
+  CommentItemTimestampProps,
+  CommentListProps,
+  CommentProps,
+} from './comment';
+export { CommentComposer, CommentComposerInput, CommentComposerSend } from './comment-composer';
+export type { CommentComposerInputProps, CommentComposerProps, CommentComposerSendProps } from './comment-composer';
+export type { CommentVariant } from './comment-context';


### PR DESCRIPTION
variant default
<img width="1392" height="386" alt="CleanShot 2026-08-26 at 17 48 08@2x" src="https://github.com/user-attachments/assets/dd189303-2eb5-44d4-a782-01883a925502" />

variant embed
<img width="1382" height="340" alt="CleanShot 2026-08-26 at 17 48 23@2x" src="https://github.com/user-attachments/assets/d640f43a-5b79-426f-9a8a-39b1720cf0b2" />



## Summary

Comment threads are a recurring UI need (signals, reviews, inline discussion), but until now every feature would have had to hand-roll the thread surface, the author/timestamp line, and the single-line composer. That guarantees drift from the design system.

This PR adds a `Comment` compound component family to `@mastra/playground-ui`. Consumers write one tree; a top-level `variant` prop decides how it looks:

- `default` — a flat thread with per-item actions that reveal on hover or keyboard focus, plus a bare composer (input + send).
- `embed` — the same thread on a bordered card surface, with a compact composer and no per-item actions.

Comments are text only: no avatars, attachments, or mentions. Everything is built from existing DS primitives (`InputGroup`, `Txt`) and existing theme tokens — no new tokens, no hand-written colors or sizes.

### API

`Comment`, `CommentList`, `CommentItem`, `CommentItemHeader`, `CommentItemAuthor`, `CommentItemTimestamp`, `CommentItemBody`, `CommentItemActions`, `CommentComposer`, `CommentComposerInput`, `CommentComposerSend`.

## Test plan

- `pnpm --filter ./packages/playground-ui vitest run src/ds/components/Comment src/components-exports.test.ts` — 18 passing, covering slot structure, variant-driven actions, composer submit, and the entrypoint export contract.
- `pnpm --filter ./packages/playground-ui typecheck` — clean.
- ESLint clean for the new files.
- Storybook (`Elements/Comment`): `Default`, `Embed`, `ComposerOnly`, `Interactive` stories rendered and visually checked against the reference designs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds reusable comment threads to `@mastra/playground-ui`. It supports simple comments, embedded comment cards, comment actions, and comment submission.

## Changes

- Added the `Comment` compound component family.
- Added `default` and `embed` presentation variants.
- Added comment lists, items, metadata, bodies, and actions.
- Added composer components with variant-aware input and send-button styling.
- Added public exports and TypeScript prop types.
- Added Storybook stories for default, embedded, composer-only, and interactive states.
- Added tests for rendering, variants, context usage, actions, and submission behavior.
- Added a patch changeset for `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->