### PR TITLE
fix(core): end output processor spans on stream teardown

### DIFF
--- a/.changeset/deep-cities-sell.md
+++ b/.changeset/deep-cities-sell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed output stream processor traces remaining open when streams close or are canceled before a finish chunk.

--- a/observability/mastra/src/processor-tracing.test.ts
+++ b/observability/mastra/src/processor-tracing.test.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { Agent } from '@mastra/core/agent';
-import type { MastraDBMessage, MessageList } from '@mastra/core/agent/message-list';
+import { MessageList } from '@mastra/core/agent/message-list';
+import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import { Mastra } from '@mastra/core/mastra';
 import { MockMemory } from '@mastra/core/memory';
 import { SpanType, TracingEventType, EntityType } from '@mastra/core/observability';
@@ -15,6 +16,7 @@ import type {
 import type { Processor, ProcessOutputStreamArgs } from '@mastra/core/processors';
 import { ModerationProcessor, ProcessorStepSchema } from '@mastra/core/processors';
 import { MockStore } from '@mastra/core/storage';
+import { ChunkFrom, MastraModelOutput } from '@mastra/core/stream';
 import type { ChunkType } from '@mastra/core/stream';
 import { createWorkflow, createStep } from '@mastra/core/workflows';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -102,6 +104,10 @@ class ProcessorTestExporter implements ObservabilityExporter {
 
   getProcessorSpans() {
     return this.getSpansByType(SpanType.PROCESSOR_RUN);
+  }
+
+  getSpanStatesByType(type: SpanType) {
+    return Array.from(this.spanStates.values()).filter(state => state.events[0]?.exportedSpan.type === type);
   }
 
   getAgentSpans() {
@@ -1091,6 +1097,49 @@ describe('Processor Tracing Tests', () => {
       expect(streamSpan2?.parentSpanId).toBe(agentSpan?.id);
 
       await testExporter.finalExpectations();
+    });
+
+    it('should end output stream processor spans when the stream is canceled before finish', async () => {
+      getBaseMastraConfig(testExporter);
+      const agentSpan = observability.getInstance('test')!.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'agent run: test-agent',
+      });
+      const source = new ReadableStream<ChunkType>({
+        start(controller) {
+          controller.enqueue({
+            type: 'text-delta',
+            payload: { id: 'text-1', text: 'partial response' },
+            runId: 'test-run',
+            from: ChunkFrom.AGENT,
+          });
+        },
+      });
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream: source,
+        messageList: new MessageList({ threadId: 'test-thread' }),
+        messageId: 'msg-1',
+        options: {
+          runId: 'test-run',
+          isLLMExecutionStep: true,
+          outputProcessors: [new OutputStreamProcessor('stream-first'), new OutputStreamProcessor('stream-second')],
+          tracingContext: { currentSpan: agentSpan },
+        },
+      });
+      const reader = output._getBaseStream().getReader();
+      await reader.read();
+      await reader.cancel('client disconnected');
+
+      let processorSpanStates = testExporter.getSpanStatesByType(SpanType.PROCESSOR_RUN);
+      for (let attempt = 0; attempt < 20 && processorSpanStates.some(state => !state.hasEnd); attempt++) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+        processorSpanStates = testExporter.getSpanStatesByType(SpanType.PROCESSOR_RUN);
+      }
+
+      expect(processorSpanStates).toHaveLength(2);
+      expect(processorSpanStates.every(state => state.hasStart && state.hasEnd)).toBe(true);
+      agentSpan.end();
     });
   });
 

--- a/packages/core/src/processors/output-stream-processor-span-teardown.test.ts
+++ b/packages/core/src/processors/output-stream-processor-span-teardown.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ProcessorRunner, ProcessorState } from './runner';
+import type { Processor } from './index';
+
+const mockLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  trackException: () => {},
+} as any;
+
+describe('output stream processor span teardown', () => {
+  it('ends legacy and workflow processor spans when the stream closes without a finish chunk', async () => {
+    const legacyEnd = vi.fn();
+    const workflowEnd = vi.fn();
+    const createChildSpan = vi.fn(() => ({
+      end: legacyEnd,
+      error: vi.fn(),
+      createChildSpan: vi.fn(),
+    }));
+    const tracingContext = {
+      currentSpan: {
+        findParent: vi.fn(),
+        createChildSpan,
+      },
+    } as any;
+    const processor: Processor = {
+      id: 'stream-processor',
+      processOutputStream: async ({ part }) => part,
+    };
+    const runner = new ProcessorRunner({
+      inputProcessors: [],
+      outputProcessors: [processor],
+      logger: mockLogger,
+      agentName: 'test-agent',
+    });
+    const processorStates = new Map<string, ProcessorState>();
+
+    await runner.processPart(
+      {
+        type: 'tool-result',
+        payload: { toolCallId: 'call-1', toolName: 'search', result: { hits: 1 } },
+      } as any,
+      processorStates,
+      { tracingContext },
+    );
+    await runner.processPart(
+      { type: 'text-delta', payload: { text: 'hello world', id: 'text-1' } } as any,
+      processorStates,
+      { tracingContext },
+    );
+
+    const workflowState = new ProcessorState();
+    workflowState.customState.__outputStreamSpan_workflow = { end: workflowEnd };
+    processorStates.set('workflow', workflowState);
+
+    runner.endStreamProcessorSpans(processorStates);
+
+    expect(legacyEnd).toHaveBeenCalledTimes(1);
+    expect(legacyEnd).toHaveBeenCalledWith({
+      output: { totalChunks: 2, accumulatedText: 'hello world' },
+    });
+    expect(workflowEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -969,6 +969,18 @@ export class ProcessorRunner {
     }
   }
 
+  endStreamProcessorSpans<OUTPUT>(processorStates: Map<string, ProcessorState<OUTPUT>>): void {
+    for (const state of processorStates.values()) {
+      state.span?.end({ output: state.getFinalOutput() });
+
+      for (const [key, value] of Object.entries(state.customState)) {
+        if (key.startsWith('__outputStreamSpan_')) {
+          (value as Span<SpanType.PROCESSOR_RUN> | undefined)?.end();
+        }
+      }
+    }
+  }
+
   /**
    * Re-drive any parts that stream processors stashed for reprocessing through
    * the full output processor chain.

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -522,6 +522,12 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               }
             }
           },
+          flush() {
+            processorRunner.endStreamProcessorSpans(processorStates);
+          },
+          cancel() {
+            processorRunner.endStreamProcessorSpans(processorStates);
+          },
         }),
       );
     }


### PR DESCRIPTION
## Description

Output stream processor spans currently close only when a `finish` chunk reaches the processor chain. Streams that close or are canceled without that chunk leave both legacy and workflow-backed processor spans open. Exporters that wait for every span to finish can then retain the entire trace, including LLM payloads, and eventually drive production OOMs.

This change adds one processor-runner teardown that ends legacy spans and workflow spans kept in processor state. The `MastraModelOutput` processor transform calls it from both `flush()` and `cancel()`. Existing finish handling remains unchanged; span endings are idempotent.

Tests cover a `tool-result`/`text-delta` sequence with no finish chunk and a live `MastraModelOutput` canceled mid-stream. The latter verifies that every started output processor span emits its end event.

Implementation offered for the linked issue — happy to rebase or hand off per triage.

## Related issue(s)

Fixes #22391

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (not applicable; this changes an internal span lifecycle)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR (none posted at submission)

Tests run:

- `cd packages/core && pnpm vitest run src/processors/output-stream-processor-span-teardown.test.ts src/processors/llm-request-response-spans.test.ts src/processors/runner.test.ts src/stream/base/output.test.ts` — 123 passed
- `cd observability/mastra && pnpm vitest run src/processor-tracing.test.ts` — 25 passed, 2 skipped
- `pnpm --filter ./packages/core check` — passed
- `pnpm build:core` — 14 tasks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR closes output processor spans when a stream finishes or is canceled, even if no `finish` chunk arrives. This prevents unfinished spans from retaining complete traces and LLM data in memory.

## Changes

- Added `ProcessorRunner.endStreamProcessorSpans` to close legacy and workflow-backed processor spans.
- Called span teardown from output stream `flush()` and `cancel()` handlers.
- Preserved existing finish-chunk handling through idempotent span ending.
- Added regression tests for stream closure without a finish chunk and stream cancellation.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->