### PR TITLE
fix(core): end agent span trees on terminal runs

### DIFF
--- a/.changeset/large-monkeys-wonder.md
+++ b/.changeset/large-monkeys-wonder.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent run traces retaining open descendant spans after errors, suspension, aborts, or prepare workflow failures.

--- a/observability/mastra/src/agent-terminal-tracing.test.ts
+++ b/observability/mastra/src/agent-terminal-tracing.test.ts
@@ -1,0 +1,93 @@
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import { SpanType, TracingEventType } from '@mastra/core/observability';
+import type { ProcessOutputStreamArgs, Processor } from '@mastra/core/processors';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Observability } from './default';
+import { TestExporter } from './exporters';
+
+class OpenChildOutputProcessor implements Processor {
+  readonly id = 'open-child-output-processor';
+  private childCreated = false;
+
+  async processOutputStream({ part, tracingContext }: ProcessOutputStreamArgs) {
+    if (!this.childCreated && tracingContext?.currentSpan) {
+      this.childCreated = true;
+      tracingContext.currentSpan.createChildSpan({
+        type: SpanType.GENERIC,
+        name: 'open output processor child',
+      });
+    }
+    return part;
+  }
+}
+
+describe('agent terminal tracing', () => {
+  let exporter: TestExporter;
+  let observability: Observability;
+
+  beforeEach(() => {
+    exporter = new TestExporter();
+  });
+
+  afterEach(async () => {
+    await observability?.shutdown();
+  });
+
+  it('ends open descendant spans when an agent stream terminates with an error', async () => {
+    const streamError = new Error('LLM mid-stream error');
+    const model = new MockLanguageModelV2({
+      doGenerate: async () => {
+        throw streamError;
+      },
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'partial response' },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'error' as const, error: streamError },
+        ]),
+      }),
+    });
+    const agent = new Agent({
+      id: 'terminal-error-agent',
+      name: 'Terminal Error Agent',
+      instructions: 'Test',
+      model,
+      outputProcessors: [new OpenChildOutputProcessor()],
+    });
+    observability = new Observability({
+      configs: {
+        default: { serviceName: 'agent-terminal-tracing', exporters: [exporter] },
+      },
+    });
+    const mastra = new Mastra({
+      logger: false,
+      agents: { agent },
+      observability,
+    });
+
+    const output = await mastra.getAgent('agent').stream('Hello', { modelSettings: { maxRetries: 0 } });
+    for await (const _chunk of output.fullStream) {
+      // Drain the stream so the error terminal and its tracing callbacks run.
+    }
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const startedNames = exporter.getByEventType(TracingEventType.SPAN_STARTED).map(event => event.exportedSpan.name);
+    expect(startedNames).toContain('open output processor child');
+    expect(
+      exporter.getIncompleteSpans().map(entry => entry.span?.name),
+      'spans left open after the agent error terminal',
+    ).toEqual([]);
+    const endedAgentSpan = exporter
+      .getByEventType(TracingEventType.SPAN_ENDED)
+      .find(event => event.exportedSpan.type === SpanType.AGENT_RUN)?.exportedSpan;
+    expect(endedAgentSpan?.errorInfo?.message).toBe(streamError.message);
+  });
+});

--- a/packages/core/src/agent/__tests__/resume-span-tracing.test.ts
+++ b/packages/core/src/agent/__tests__/resume-span-tracing.test.ts
@@ -201,6 +201,7 @@ describe('resumed AGENT_RUN span input and trace continuity', () => {
       parent: parentSpan,
 
       end: vi.fn(),
+      endTree: vi.fn(),
       error: vi.fn(),
       update: vi.fn(),
       exportSpan: vi.fn(),

--- a/packages/core/src/agent/__tests__/save-and-errors.test.ts
+++ b/packages/core/src/agent/__tests__/save-and-errors.test.ts
@@ -13,6 +13,7 @@ import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
 import type { ChunkType } from '../../stream/types';
 import { createTool } from '../../tools';
+import { Workflow } from '../../workflows/workflow';
 import { Agent } from '../agent';
 import type { MastraDBMessage } from '../message-list';
 
@@ -2105,6 +2106,7 @@ describe('AGENT_RUN span must be ended on LLM errors', () => {
       parent: parentSpan,
 
       end: vi.fn(),
+      endTree: vi.fn(),
       error: vi.fn(),
       update: vi.fn(),
       exportSpan: vi.fn(),
@@ -2141,6 +2143,33 @@ describe('AGENT_RUN span must be ended on LLM errors', () => {
     return { spy, getAgentRunSpan: () => agentRunSpan };
   }
 
+  it('should end the AGENT_RUN span tree when the prepare workflow fails to start', async () => {
+    const { spy, getAgentRunSpan } = await mockGetOrCreateSpan();
+    const prepareError = new Error('prepare workflow failed');
+    const createRunSpy = vi
+      .spyOn(Workflow.prototype as unknown as Record<string, any>, 'createRun')
+      .mockResolvedValue({ start: vi.fn().mockRejectedValue(prepareError) });
+
+    try {
+      const agent = new Agent({
+        id: 'test-prepare-workflow-error',
+        name: 'Test Prepare Workflow Error',
+        model: finishReasonErrorModelV3({ unified: 'error' }),
+        instructions: 'You are a helpful assistant.',
+      });
+
+      await expect(agent.stream('Hello')).rejects.toThrow(prepareError);
+
+      const agentRunSpan = getAgentRunSpan();
+      expect(agentRunSpan).toBeDefined();
+      expect(agentRunSpan.error).toHaveBeenCalledWith({ error: prepareError, endSpan: false });
+      expect(agentRunSpan.endTree).toHaveBeenCalledTimes(1);
+    } finally {
+      createRunSpy.mockRestore();
+      spy.mockRestore();
+    }
+  });
+
   it('should end the AGENT_RUN span when the model throws during doStream', async () => {
     const { spy, getAgentRunSpan } = await mockGetOrCreateSpan();
 
@@ -2172,7 +2201,8 @@ describe('AGENT_RUN span must be ended on LLM errors', () => {
       const agentRunSpan = getAgentRunSpan();
       expect(agentRunSpan).toBeDefined();
       expect(agentRunSpan.error).toHaveBeenCalled();
-      expect(agentRunSpan.error.mock.calls[0][0]).toMatchObject({ endSpan: true });
+      expect(agentRunSpan.error.mock.calls[0][0]).toMatchObject({ endSpan: false });
+      expect(agentRunSpan.endTree).toHaveBeenCalledTimes(1);
     } finally {
       spy.mockRestore();
     }
@@ -2239,7 +2269,8 @@ describe('AGENT_RUN span must be ended on LLM errors', () => {
       const agentRunSpan = getAgentRunSpan();
       expect(agentRunSpan).toBeDefined();
       expect(agentRunSpan.error).toHaveBeenCalled();
-      expect(agentRunSpan.error.mock.calls[0][0]).toMatchObject({ endSpan: true });
+      expect(agentRunSpan.error.mock.calls[0][0]).toMatchObject({ endSpan: false });
+      expect(agentRunSpan.endTree).toHaveBeenCalledTimes(1);
       expect(agentRunSpan.error.mock.calls[0][0].error).toBeInstanceOf(MastraError);
       expect(agentRunSpan.error.mock.calls[0][0].error.message).toBe(
         'Agent stream finished with finishReason "error" but no error payload was provided',
@@ -2404,7 +2435,8 @@ describe('AGENT_RUN span must be ended on LLM errors', () => {
       const agentRunSpan = getAgentRunSpan();
       expect(agentRunSpan).toBeDefined();
       expect(agentRunSpan.error).toHaveBeenCalled();
-      expect(agentRunSpan.error.mock.calls[0][0]).toMatchObject({ endSpan: true });
+      expect(agentRunSpan.error.mock.calls[0][0]).toMatchObject({ endSpan: false });
+      expect(agentRunSpan.endTree).toHaveBeenCalledTimes(1);
     } finally {
       spy.mockRestore();
     }
@@ -2517,9 +2549,9 @@ describe('AGENT_RUN span must be ended on LLM errors', () => {
 
       const agentRunSpan = getAgentRunSpan();
       expect(agentRunSpan).toBeDefined();
-      expect(agentRunSpan.end).toHaveBeenCalled();
+      expect(agentRunSpan.endTree).toHaveBeenCalled();
       expect(agentRunSpan.error).not.toHaveBeenCalled();
-      expect(agentRunSpan.end.mock.calls[0][0]).toMatchObject({
+      expect(agentRunSpan.endTree.mock.calls[0][0]).toMatchObject({
         output: {
           status: 'suspended',
           reason: 'tool-call-approval',
@@ -2594,9 +2626,9 @@ describe('AGENT_RUN span must be ended on LLM errors', () => {
 
       const agentRunSpan = getAgentRunSpan();
       expect(agentRunSpan).toBeDefined();
-      expect(agentRunSpan.end).toHaveBeenCalled();
+      expect(agentRunSpan.endTree).toHaveBeenCalled();
       expect(agentRunSpan.error).not.toHaveBeenCalled();
-      expect(agentRunSpan.end.mock.calls[0][0]).toMatchObject({
+      expect(agentRunSpan.endTree.mock.calls[0][0]).toMatchObject({
         output: {
           status: 'aborted',
           reason: 'abort',

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -7494,10 +7494,15 @@ export class Agent<
       executionWorkflow.__registerMastra(this.#mastra);
     }
 
-    const observabilityContext = createObservabilityContext({ currentSpan: agentSpan });
-    const run = await executionWorkflow.createRun();
-    const result = await run.start({ requestContext, actor: options.actor, ...observabilityContext });
-    return result;
+    try {
+      const observabilityContext = createObservabilityContext({ currentSpan: agentSpan });
+      const run = await executionWorkflow.createRun();
+      return await run.start({ requestContext, actor: options.actor, ...observabilityContext });
+    } catch (error) {
+      agentSpan?.error({ error: error as Error, endSpan: false });
+      agentSpan?.endTree();
+      throw error;
+    }
   }
 
   /**

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -306,15 +306,15 @@ export function createMapResultsStep<OUTPUT = undefined>({
               });
             }
 
-            // End the AGENT_RUN span so the trace is exported.
-            // Without this, the span is orphaned and exporters that wait
-            // for the root span to end (e.g. Datadog) never emit the trace.
-            agentSpan?.error({ error, endSpan: true });
+            // Record the error, then end the whole tree so exporters that wait
+            // for every span do not retain open descendants indefinitely.
+            agentSpan?.error({ error, endSpan: false });
+            agentSpan?.endTree();
             return;
           }
 
           if (payload.finishReason === 'suspended') {
-            agentSpan?.end({
+            agentSpan?.endTree({
               output: {
                 status: 'suspended',
                 reason: payload.suspendReason,
@@ -329,12 +329,12 @@ export function createMapResultsStep<OUTPUT = undefined>({
 
           if (aborted) {
             if (payload.finishReason === 'aborted') {
-              agentSpan?.end({ output: { status: 'aborted', reason: 'abort' } });
+              agentSpan?.endTree({ output: { status: 'aborted', reason: 'abort' } });
               // The aborted finish payload is synthetic; the caller already received onAbort.
               return;
             }
 
-            agentSpan?.end();
+            agentSpan?.endTree();
           } else {
             try {
               const outputText =


### PR DESCRIPTION
## Description

Agent error, suspension, and abort terminals currently end only the `AGENT_RUN` span. Any model, inference, processor, or other descendant still open at that point remains unfinished. Exporters that wait for every span to complete can retain the whole trace and its LLM payloads indefinitely, which can accumulate into production OOMs. A prepare-workflow `start()` rejection also escapes after the agent span is created without ending that span.

This change records terminal errors without ending the root first, then calls `endTree()` so open descendants close before the agent run. Suspension and abort paths use `endTree()` with their existing output. The prepare workflow creation/start is wrapped so a rejection records the error, closes the tree, and rethrows the original error.

Tests cover prepare `start()` rejection, error/suspend/abort calls, resume tracing mocks, and a real exporter scenario where an output processor leaves a child span open before an LLM error. That integration test verifies no spans remain incomplete and the agent span retains its error.

Implementation offered for the linked issue — happy to rebase or hand off per triage.

## Related issue(s)

Fixes #22392

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (not applicable; this changes an internal span lifecycle)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR (none posted at submission)

Tests run:

- `cd packages/core && pnpm vitest run src/agent/__tests__/save-and-errors.test.ts src/agent/__tests__/resume-span-tracing.test.ts` — 54 passed, 2 skipped
- `cd observability/mastra && pnpm vitest run src/agent-terminal-tracing.test.ts src/workflow-cancel-tracing.test.ts src/spans/end-tree.test.ts` — 20 passed
- `pnpm --filter ./packages/core check` — passed
- `pnpm build:core` — 14 tasks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an agent stops because of an error, suspension, or abort, this PR closes all related tracing data instead of leaving parts open. It also handles setup failures correctly and keeps the original error.

## Changes

- Use `endTree()` for error, suspension, and abort paths.
- Record errors before ending the span tree.
- Close the span tree when prepare-workflow startup fails.
- Rethrow the original preparation error.
- Add regression tests for terminal tracing, prepare failures, resume tracing, and open descendant spans.
- Add a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->