### PR TITLE
feat(factory): retune the sidebar for Mona Sans

### DIFF
--- a/.changeset/lucky-trams-share.md
+++ b/.changeset/lucky-trams-share.md
@@ -4,4 +4,4 @@
 
 Factory now uses Mona Sans across the whole app, matching Studio, instead of the system font.
 
-The sidebar was retuned to go with it: section headings share one component, each carries the icon of the page it lists (work, review, user sessions), and the Factory heading is gone since its links name themselves.
+The sidebar was retuned to go with it: each section is titled by what it lists, with an icon for work items, review sessions and user sessions, and the "Factory" title is gone since the links under it name themselves.

--- a/.changeset/lucky-trams-share.md
+++ b/.changeset/lucky-trams-share.md
@@ -3,3 +3,5 @@
 ---
 
 Factory now uses Mona Sans across the whole app, matching Studio, instead of the system font.
+
+The sidebar was retuned to go with it: section headings share one component, each carries the icon of the page it lists (work, review, user sessions), and the Factory heading is gone since its links name themselves.

--- a/.changeset/ready-radios-lick.md
+++ b/.changeset/ready-radios-lick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Sidebar nav labels now render at weight 450, so they hold their own against products that ship a variable font like Mona Sans.

--- a/.changeset/ready-radios-lick.md
+++ b/.changeset/ready-radios-lick.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Sidebar nav labels now render at weight 450, so they hold their own against products that ship a variable font like Mona Sans.
+Sidebar links read a touch heavier, so they stay legible next to their icons instead of looking washed out.

--- a/mastracode/factory-ui/src/ui/SidebarSectionHeading.tsx
+++ b/mastracode/factory-ui/src/ui/SidebarSectionHeading.tsx
@@ -1,0 +1,23 @@
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import type { ReactNode } from 'react';
+
+/** Title row above a sidebar nav list, with room for one trailing action. */
+export function SidebarSectionHeading({
+  children,
+  icon,
+  action,
+}: {
+  children: ReactNode;
+  icon?: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="text-neutral6/40 mt-4 flex min-h-6 items-center justify-between px-1">
+      <Txt as="span" variant="ui-sm" className="flex items-center gap-2 font-semibold [&_svg]:size-3.5">
+        {icon}
+        {children}
+      </Txt>
+      {action}
+    </div>
+  );
+}

--- a/mastracode/factory-ui/src/ui/SidebarSectionHeading.tsx
+++ b/mastracode/factory-ui/src/ui/SidebarSectionHeading.tsx
@@ -12,8 +12,8 @@ export function SidebarSectionHeading({
   action?: ReactNode;
 }) {
   return (
-    <div className="text-neutral6/40 mt-4 flex min-h-6 items-center justify-between px-1">
-      <Txt as="span" variant="ui-sm" className="flex items-center gap-2 font-semibold [&_svg]:size-3.5">
+    <div className="text-neutral6/40 mt-4 flex min-h-6 items-center justify-between pr-1 pl-3">
+      <Txt as="span" variant="ui-sm" className="flex items-center gap-2 font-semibold [&_svg]:size-4">
         {icon}
         {children}
       </Txt>

--- a/mastracode/factory-ui/src/ui/domains/factory/components/FactorySection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/FactorySection.tsx
@@ -1,5 +1,4 @@
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
-import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Brain, Gauge, GitPullRequest, ListChecks, ScrollText, SquareKanban } from 'lucide-react';
 import type { ComponentType, ReactNode } from 'react';
 import { NavLink, useLocation, useParams } from 'react-router';
@@ -22,11 +21,6 @@ export function FactorySection({ children }: { children?: ReactNode }) {
 
   return (
     <nav className="flex flex-col gap-2" aria-label="Factory">
-      <div className="flex items-center justify-between px-1">
-        <Txt as="span" variant="ui-xs" className="text-icon3 tracking-wide uppercase">
-          Factory
-        </Txt>
-      </div>
       <MainSidebar.NavList>
         <FactoryLink to={`/factories/${factoryId}/overview`} icon={Gauge} label="Overview" />
         <FactoryLink to={`/factories/${factoryId}/work`} icon={SquareKanban} label="Work" />

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -300,13 +300,13 @@ export function WorkItemCard({
               )}
               {relatedItems.map(relatedLink)}
             </div>
-            <div className="flex min-w-0 items-center gap-1.5">
+            <div className="flex min-w-0 items-center gap-1.5 tracking-tight">
               {item.source === 'github-pr' ? (
                 <PullRequestStatusIcon status={pullRequestStatusForItem(item)} />
               ) : (
                 <SourceIcon source={item.source} />
               )}
-              <span className="text-ui-smd text-icon6 min-w-0 flex-1 truncate font-semibold">
+              <span className="text-ui-smd text-icon6 min-w-0 flex-1 truncate font-[550]">
                 <SourceTitle source={item.source} title={item.title} />
               </span>
             </div>

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -4,7 +4,7 @@ import { HoverCard, HoverCardTrigger } from '@mastra/playground-ui/components/Ho
 import { MainSidebar, useMaybeSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { GitBranch, MoreHorizontal, Pin, PinOff, RefreshCw, Trash2 } from 'lucide-react';
+import { MoreHorizontal, Pin, PinOff, RefreshCw, Trash2 } from 'lucide-react';
 import { useRef } from 'react';
 import type { RefObject } from 'react';
 
@@ -74,7 +74,6 @@ export function SessionNavRow({
       }}
       title={preview ? undefined : title}
     >
-      <GitBranch />
       <MainSidebar.NavLabel>{name}</MainSidebar.NavLabel>
       {pinned && !loading ? (
         <Pin aria-label={`${name} pinned`} className="text-icon3/70 size-2 shrink-0 rotate-45" />

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -3,8 +3,9 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@mastra/playgr
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { toast } from '@mastra/playground-ui/components/Toaster';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { SidebarSectionHeading } from '../../../SidebarSectionHeading';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Plus } from 'lucide-react';
+import { MessageSquare, Plus } from 'lucide-react';
 import { useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 
@@ -119,21 +120,23 @@ export function UserSessionsSection() {
   const pending = deleteSession.isPending;
 
   return (
-    <section className="flex flex-col gap-2" aria-label="User sessions">
-      <div className="flex items-center justify-between px-1">
-        <Txt as="span" variant="ui-xs" className="text-icon3 tracking-wide uppercase">
-          User Sessions
-        </Txt>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          aria-label="New user session"
-          onClick={() => void navigate(`/factories/${factoryId}/user/new/${crypto.randomUUID()}`)}
-          disabled={pending}
-        >
-          <Plus size={15} />
-        </Button>
-      </div>
+    <section className="flex flex-col gap-1" aria-label="User sessions">
+      <SidebarSectionHeading
+        icon={<MessageSquare />}
+        action={
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="New user session"
+            onClick={() => void navigate(`/factories/${factoryId}/user/new/${crypto.randomUUID()}`)}
+            disabled={pending}
+          >
+            <Plus size={15} />
+          </Button>
+        }
+      >
+        User Sessions
+      </SidebarSectionHeading>
 
       <div className="flex flex-col gap-1">
         <MainSidebar.NavList>

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -2,6 +2,8 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@mastra/playground-ui/components/Dialog';
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { GitPullRequest, SquareKanban } from 'lucide-react';
+import { SidebarSectionHeading } from '../../../SidebarSectionHeading';
 import { useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 
@@ -299,12 +301,10 @@ function WorkspaceGroup({
   const visibleRows = expanded ? allRows : rows;
   const hiddenCount = allRows.length - rows.length;
   return (
-    <section className="flex flex-col gap-2" aria-label={title}>
-      <div className="flex items-center px-1">
-        <Txt as="span" variant="ui-xs" className="text-icon3 tracking-wide uppercase">
-          {title}
-        </Txt>
-      </div>
+    <section className="flex flex-col gap-1" aria-label={title}>
+      <SidebarSectionHeading icon={kind === 'Review session' ? <GitPullRequest /> : <SquareKanban />}>
+        {title}
+      </SidebarSectionHeading>
       <MainSidebar.NavList>
         {visibleRows.map(row => (
           <SessionNavRow

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -342,7 +342,7 @@ function WorkspaceGroup({
       {hiddenCount > 0 && (
         <button
           type="button"
-          className="text-icon3 hover:text-icon5 px-1 text-left text-xs"
+          className="text-icon3 hover:text-icon5 pl-3 text-left text-xs"
           onClick={() => setExpanded(value => !value)}
         >
           {expanded ? 'Show less' : `Show ${hiddenCount} more`}

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-label.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-label.tsx
@@ -27,7 +27,7 @@ export function MainSidebarNavLabel({ children, className, state: stateProp, ...
     return <VisuallyHidden>{children}</VisuallyHidden>;
   }
   return (
-    <span {...rest} className={cn('min-w-0 flex-1 truncate text-left', className)}>
+    <span {...rest} className={cn('min-w-0 flex-1 truncate text-left font-[450]', className)}>
       {children}
     </span>
   );


### PR DESCRIPTION
TLDR: sidebar section headings become one component with a per-section icon, and the type weights are retuned for Mona Sans.

Stacked on #22385 — merge that first.

---

Mona Sans reads heavier and wider than system-ui at the same nominal weight, so the sidebar needed a pass once the font landed.

### What changes

| section headings | before | after |
| --- | --- | --- |
| markup | the same title row pasted in three files | one `SidebarSectionHeading`, with an `action` slot for the + button |
| look | 10px uppercase, letter-spaced | 12px sentence case, `text-neutral6/40`, semibold |
| icon | none | the icon of the page it lists — Work, Review, User sessions |
| the "Factory" heading | above Overview / Work / Review / Rules | gone: those links name themselves |

Nav labels move to weight 450. The work item card title drops from semibold to 550 and its row gets `tracking-tight`.

### Judgment call

The heading icons come off the `preview.kind` each row already carries, so the three lists cannot drift apart again — that drift is what put a different heading style in `WorkspacesSection` than in the other two.

I did not use the design system's `MainSidebar.NavHeader`: it has no trailing-action slot for the + button, and it hides itself on the collapsed rail, which would change more than the look.

The label weight lives in `MainSidebarNavLabel`, so Studio's sidebar gets it too. That is the design system doing its job, but it is a second product changing.

### Not verified

Eyeballed in the local factory UI, not in Studio.

```
factory-ui        +55  -35
playground-ui      +1   -1
changeset          +7    0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the Factory sidebar easier to scan. It adds consistent headings, icons, spacing, and text weights for a cleaner interface.

## Changes

- Added the reusable `SidebarSectionHeading` component.
- Updated Factory sidebar headings to 12px sentence-case semibold text.
- Added section-specific icons and action slots.
- Removed the “Factory” heading.
- Updated work item titles to weight 550 with tighter tracking.
- Removed branch icons from session rows.
- Updated shared sidebar navigation labels to font weight 450.
- Added patch-release changesets for `@mastra/factory` and `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->