### PR TITLE
feat(factory): retune the chat composer and tool output surfaces

### DIFF
--- a/.changeset/olive-moons-look.md
+++ b/.changeset/olive-moons-look.md
@@ -2,4 +2,6 @@
 '@mastra/playground-ui': patch
 ---
 
-Tool call output blocks now sit one step above the surface behind them instead of painting a fixed dark grey, so they stay visible on any chat background and in both themes.
+**Composer** — the ring's idle edge now reads `--composer-ring-edge`, so an app can set the colour its own chat surface needs. Unset, it keeps the current blend.
+
+**Tool call** — output blocks sit one step above the surface behind them instead of painting a fixed dark grey, so they stay visible on any chat background and in both themes.

--- a/.changeset/olive-moons-look.md
+++ b/.changeset/olive-moons-look.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Tool call output blocks now sit one step above the surface behind them instead of painting a fixed dark grey, so they stay visible on any chat background and in both themes.

--- a/.changeset/olive-moons-look.md
+++ b/.changeset/olive-moons-look.md
@@ -2,6 +2,6 @@
 '@mastra/playground-ui': patch
 ---
 
-**Composer** — the ring's idle edge now reads `--composer-ring-edge`, so an app can set the colour its own chat surface needs. Unset, it keeps the current blend.
+**Composer** — the ring keeps its geometry on the element, so a consumer can restyle its radius and width through `className` like any other component. Its idle edge colour now reads `--composer-ring-edge`, for apps whose chat surface needs a different one; unset, it keeps the current blend.
 
 **Tool call** — output blocks sit one step above the surface behind them instead of painting a fixed dark grey, so they stay visible on any chat background and in both themes.

--- a/.changeset/soft-pears-type.md
+++ b/.changeset/soft-pears-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Toned down the Factory chat composer: the text you type is now the same size as the transcript and sits at a softer contrast, so the input reads as part of the conversation instead of shouting over it.

--- a/.changeset/soft-pears-type.md
+++ b/.changeset/soft-pears-type.md
@@ -2,4 +2,9 @@
 '@mastra/factory': patch
 ---
 
-Toned down the Factory chat composer: the text you type is now the same size as the transcript and sits at a softer contrast, so the input reads as part of the conversation instead of shouting over it.
+Retuned the Factory chat so the composer and the tool output read as part of the conversation.
+
+- The text you type is now the same size as the transcript, in a softer grey, on a lighter box.
+- The composer sits slightly wider than the messages above it and closer to the bottom edge, at every screen width.
+- Slash command suggestions highlight the selected row against the lighter composer instead of blending into it.
+- Diff blocks inside a tool call sit one step above the chat surface, so they read as a block again.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
@@ -51,6 +51,8 @@ const composerVariantClass: Record<ComposerVariant, string> = {
   textarea: 'min-h-28',
 };
 
+const composerInputTextClass = 'text-ui-md leading-ui-md text-neutral3 placeholder:text-neutral2';
+
 const composerVariantMaxHeight: Record<ComposerVariant, string> = {
   inline: '13rem',
   textarea: '16rem',
@@ -373,7 +375,7 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
             placeholder={placeholder}
             disabled={textareaDisabled}
             maxHeight={composerVariantMaxHeight[variant]}
-            className={composerVariantClass[variant]}
+            className={cn(composerInputTextClass, composerVariantClass[variant])}
             aria-label="Message"
             aria-keyshortcuts="Shift+Tab"
           />

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
@@ -353,8 +353,11 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
   return (
     <ComposerRoot onSubmit={onSubmit} onDrop={onDrop} onDragOver={e => e.preventDefault()}>
       <ComposerRing busy={busy || chatPreparing} className={modeColorClass}>
-        <ComposerBox ref={spotlightRef} className={cn('composer-spotlight bg-surface4', modeColorClass)}>
-          <div aria-hidden="true" className="composer-spotlight-surface" />
+        <ComposerBox ref={spotlightRef} className={cn('composer-spotlight isolate border-0', modeColorClass)}>
+          <div
+            aria-hidden="true"
+            className="composer-spotlight-surface bg-surface4 pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-[inherit]"
+          />
           <ComposerSuggestions
             items={suggestionItems}
             activeIndex={activeSuggestion}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
@@ -356,7 +356,7 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
         <ComposerBox ref={spotlightRef} className={cn('composer-spotlight isolate border-0', modeColorClass)}>
           <div
             aria-hidden="true"
-            className="composer-spotlight-surface bg-surface4 pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-[inherit]"
+            className="composer-spotlight-surface pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-[inherit] bg-(--composer-surface)"
           />
           <ComposerSuggestions
             items={suggestionItems}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/Composer.tsx
@@ -51,7 +51,7 @@ const composerVariantClass: Record<ComposerVariant, string> = {
   textarea: 'min-h-28',
 };
 
-const composerInputTextClass = 'text-ui-md leading-ui-md text-neutral3 placeholder:text-neutral2';
+const composerInputTextClass = 'text-ui-md leading-ui-md font-[450] text-neutral4 placeholder:text-neutral2';
 
 const composerVariantMaxHeight: Record<ComposerVariant, string> = {
   inline: '13rem',
@@ -353,7 +353,7 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
   return (
     <ComposerRoot onSubmit={onSubmit} onDrop={onDrop} onDragOver={e => e.preventDefault()}>
       <ComposerRing busy={busy || chatPreparing} className={modeColorClass}>
-        <ComposerBox ref={spotlightRef} className={cn('composer-spotlight', modeColorClass)}>
+        <ComposerBox ref={spotlightRef} className={cn('composer-spotlight bg-surface4', modeColorClass)}>
           <div aria-hidden="true" className="composer-spotlight-surface" />
           <ComposerSuggestions
             items={suggestionItems}

--- a/mastracode/factory-ui/src/ui/domains/chat/components/ComposerParts.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/ComposerParts.tsx
@@ -57,7 +57,7 @@ export function ComposerSuggestions({
           <div className="border-border1/60 border-b px-1.5 py-1">
             <button
               type="button"
-              className="text-icon3 hover:bg-surface4 hover:text-icon6 text-ui-sm flex items-center gap-1.5 rounded-xl px-2 py-1.5 transition-colors duration-150 ease-out motion-reduce:transition-none"
+              className="text-icon3 hover:bg-neutral6/5 hover:text-icon6 text-ui-sm flex items-center gap-1.5 rounded-xl px-2 py-1.5 transition-colors duration-150 ease-out motion-reduce:transition-none"
               aria-label="Back to slash commands"
               onMouseDown={event => {
                 event.preventDefault();
@@ -81,7 +81,9 @@ export function ComposerSuggestions({
                 aria-current={item.active ? 'true' : undefined}
                 className={cn(
                   'flex w-full cursor-pointer items-center justify-between gap-4 rounded-2xl px-2 py-1.5 text-left text-ui-sm transition-colors duration-150 ease-out motion-reduce:transition-none',
-                  index === activeIndex ? 'bg-surface4 text-icon6' : 'text-icon3 hover:bg-surface4 hover:text-icon6',
+                  index === activeIndex
+                    ? 'bg-neutral6/5 text-icon6'
+                    : 'text-icon3 hover:bg-neutral6/5 hover:text-icon6',
                 )}
                 onMouseDown={event => {
                   event.preventDefault();

--- a/mastracode/factory-ui/src/ui/domains/chat/components/composer.css
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/composer.css
@@ -38,7 +38,7 @@
 :root {
   --composer-surface: var(--surface4);
   --composer-edge: oklch(0% 0 0deg / 18%);
-  --composer-ring-edge: color-mix(in oklab, var(--neutral6) 5%, transparent);
+  --composer-ring-edge: color-mix(in oklab, var(--neutral1) 40%, transparent);
 }
 
 html.light {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/composer.css
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/composer.css
@@ -32,6 +32,22 @@
   color: var(--chat-mode-color, var(--neutral4));
 }
 
+/* The composer sits one step off the page in the dark theme, and stays the plain
+ * white card in the light one, where a raised surface reads as dirty. The 1px
+ * inner shade along its top edge is what makes it sit in the page. */
+:root {
+  --composer-surface: var(--surface4);
+  --composer-edge: oklch(0% 0 0deg / 18%);
+  --composer-ring-edge: color-mix(in oklab, var(--neutral6) 5%, transparent);
+}
+
+html.light {
+  --composer-surface: var(--surface3);
+  --composer-edge: transparent;
+  /* Light keeps the design system's own edge. */
+  --composer-ring-edge: initial;
+}
+
 .composer-spotlight {
   --composer-spotlight: var(--chat-mode-color, var(--accent1));
   --composer-spotlight-x: 50%;
@@ -47,6 +63,19 @@
 /* Spotlight owns idle, spinning ring owns the run — never both at once. */
 .composer-ring[data-busy='true'] .composer-spotlight {
   --composer-spotlight-strength: 0;
+}
+
+/* A directional inset shadow paints nothing where the edge runs vertical, so the
+ * lip dies before the corners. A full inner ring traces the whole curve; the mask
+ * keeps only its lit half. */
+.composer-spotlight-surface::after {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px var(--composer-edge);
+  mask-image: linear-gradient(to bottom, #000, transparent 45%);
+  content: '';
 }
 
 .composer-spotlight::before,
@@ -70,6 +99,19 @@
   border-radius: inherit;
 }
 
+/* A directional inset shadow paints nothing where the edge runs vertical, so the
+ * lip dies before the corners. A full inner ring traces the whole curve; the mask
+ * keeps only its lit half. */
+.composer-spotlight-surface::after {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px var(--composer-edge);
+  mask-image: linear-gradient(to bottom, #000, transparent 45%);
+  content: '';
+}
+
 .composer-spotlight-surface::before {
   background: radial-gradient(
     200px circle at var(--composer-spotlight-x) var(--composer-spotlight-y),
@@ -86,6 +128,19 @@
 
 @media (prefers-reduced-motion: reduce) {
   .composer-spotlight::before,
+  /* A directional inset shadow paints nothing where the edge runs vertical, so the
+ * lip dies before the corners. A full inner ring traces the whole curve; the mask
+ * keeps only its lit half. */
+.composer-spotlight-surface::after {
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    box-shadow: inset 0 0 0 1px var(--composer-edge);
+    mask-image: linear-gradient(to bottom, #000, transparent 45%);
+    content: '';
+  }
+
   .composer-spotlight-surface::before {
     transition: none;
   }

--- a/mastracode/factory-ui/src/ui/domains/chat/components/composer.css
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/composer.css
@@ -94,7 +94,7 @@
   z-index: -10;
   overflow: hidden;
   border-radius: 21px;
-  background: var(--surface3);
+  background: var(--surface4);
 }
 
 .composer-spotlight-surface::before {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/composer.css
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/composer.css
@@ -37,28 +37,11 @@
   --composer-spotlight-x: 50%;
   --composer-spotlight-y: 50%;
   --composer-spotlight-strength: 0;
-
-  @apply ring-border2/40 isolate border-0 ring-1 ring-inset;
 }
 
-.composer-spotlight:focus-within {
-  @apply ring-border2;
-}
-
-/* The ring wrapper owns the edge and the mode colour; the box keeps only its glow. */
+/* The ring owns the edge and the mode colour; the box keeps only its glow. */
 .composer-ring {
   --composer-ring-color: var(--chat-mode-color, var(--accent1));
-}
-
-.composer-ring .composer-spotlight {
-  @apply ring-0;
-}
-
-/* Ring owns the edge, spotlight the interior: the box clips at its own radius, so
-   the surface runs flush to the clip instead of insetting for a gone border. */
-.composer-ring .composer-spotlight-surface {
-  inset: 0;
-  border-radius: 22px;
 }
 
 /* Spotlight owns idle, spinning ring owns the run — never both at once. */
@@ -85,16 +68,6 @@
 .composer-spotlight::before {
   z-index: 0;
   border-radius: inherit;
-}
-
-.composer-spotlight-surface {
-  pointer-events: none;
-  position: absolute;
-  inset: 1px;
-  z-index: -10;
-  overflow: hidden;
-  border-radius: 21px;
-  background: var(--surface4);
 }
 
 .composer-spotlight-surface::before {

--- a/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/tool/ToolCard.tsx
@@ -55,7 +55,7 @@ function DiffView({ oldText, newText, path }: { oldText: string; newText: string
   const hidden = removed.hidden + added.hidden;
   return (
     <div
-      className="border-border1 bg-surface1 max-w-full min-w-0 overflow-x-auto rounded-md border font-mono text-xs leading-normal"
+      className="border-border1 bg-neutral6/5 max-w-full min-w-0 overflow-x-auto rounded-md border font-mono text-xs leading-normal"
       role="group"
       aria-label="File change"
     >

--- a/mastracode/factory-ui/src/ui/domains/workspace-viewer/layout.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspace-viewer/layout.ts
@@ -5,6 +5,11 @@ export const RAIL_MIN_REM = 58;
 export const threadGeometryClass = '[--thread-column:44rem] [--thread-gutter:1.5rem] [--workspace-card-width:21rem]';
 export const chatColumnClass = '[--chat-column:var(--thread-column)]';
 
+/** The composer sits a touch wider than the transcript, at every width: it keeps the
+ * reading column but gives back most of its gutter, so it reads as the page's input
+ * rather than another message. */
+export const composerColumnClass = 'px-1 md:px-1';
+
 export const cardWidthClass = {
   compact: '[--workspace-files-card:var(--workspace-card-width)]',
   expanded:

--- a/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
@@ -9,7 +9,7 @@ import { ChatLayout } from '../layouts/ChatLayout';
 import { useThreadWorkspacePath } from '../domains/workspace-viewer/hooks/useThreadWorkspacePath';
 import { WorkspaceFilesProvider } from '../domains/workspace-viewer/context/WorkspaceFilesProvider';
 import { WorkspaceFilesSurface } from '../domains/workspace-viewer/components/WorkspaceFilesSurface';
-import { chatColumnClass, RAIL_MIN_REM } from '../domains/workspace-viewer/layout';
+import { chatColumnClass, composerColumnClass, RAIL_MIN_REM } from '../domains/workspace-viewer/layout';
 import { useWiderThan } from '../domains/workspace-viewer/hooks/useWiderThan';
 import { useInvalidateWorkspaceChangesOnRunCompletion } from '../domains/workspace-viewer/useInvalidateWorkspaceChangesOnRunCompletion';
 import { ChatHeader } from '../domains/chat/components/ChatHeader';
@@ -37,7 +37,7 @@ import '../domains/chat/components/chat-enter.css';
 
 // The docked workspace card claims room on the end edge; the shell pads its own
 // scroller by it, so the column stays centred on what is left.
-const threadShellClass = `chat-surface-enter flex-1 ${chatColumnClass} [--chat-inset-end:var(--workspace-files-inset,0px)] md:[--chat-gutter:1.25rem]`;
+const threadShellClass = `chat-surface-enter flex-1 ${chatColumnClass} [--chat-inset-end:var(--workspace-files-inset,0px)] [--chat-gutter:0.25rem]`;
 
 export function ThreadPage() {
   const { factoryId, threadId } = useParams<{ factoryId: string; threadId?: string }>();
@@ -119,7 +119,7 @@ function ThreadPageMain({
             </ChatShell.Content>
             <ChatShell.Dock>
               <ChatShell.ScrollButton aria-label="Jump to latest message" />
-              <ChatShell.Column className="gap-2">
+              <ChatShell.Column className={`gap-2 ${composerColumnClass}`}>
                 <TaskPanel />
                 <div role="region" aria-label="Thread composer">
                   <ComposerPanel />

--- a/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/ThreadPage.tsx
@@ -1,5 +1,6 @@
 import { ChatShell } from '@mastra/playground-ui/components/ChatShell';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import type { ReactNode } from 'react';
 import { useRef } from 'react';
 import { useParams } from 'react-router';
@@ -37,7 +38,11 @@ import '../domains/chat/components/chat-enter.css';
 
 // The docked workspace card claims room on the end edge; the shell pads its own
 // scroller by it, so the column stays centred on what is left.
-const threadShellClass = `chat-surface-enter flex-1 ${chatColumnClass} [--chat-inset-end:var(--workspace-files-inset,0px)] [--chat-gutter:0.25rem]`;
+const threadShellClass = cn(
+  'chat-surface-enter flex-1',
+  chatColumnClass,
+  '[--chat-inset-end:var(--workspace-files-inset,0px)] [--chat-gutter:0.25rem]',
+);
 
 export function ThreadPage() {
   const { factoryId, threadId } = useParams<{ factoryId: string; threadId?: string }>();
@@ -119,7 +124,7 @@ function ThreadPageMain({
             </ChatShell.Content>
             <ChatShell.Dock>
               <ChatShell.ScrollButton aria-label="Jump to latest message" />
-              <ChatShell.Column className={`gap-2 ${composerColumnClass}`}>
+              <ChatShell.Column className={cn('gap-2', composerColumnClass)}>
                 <TaskPanel />
                 <div role="region" aria-label="Thread composer">
                   <ComposerPanel />

--- a/packages/playground-ui/src/ds/components/Composer/composer-ring.css
+++ b/packages/playground-ui/src/ds/components/Composer/composer-ring.css
@@ -23,9 +23,6 @@
 .composer-ring {
   --composer-ring-color: var(--accent1);
 
-  position: relative;
-  border-radius: 23px;
-  padding: 1px;
   background-color: var(--composer-ring-edge, color-mix(in oklab, var(--border2) 40%, transparent));
   background-image: conic-gradient(
     from calc(var(--composer-ring-angle) + var(--composer-ring-spin) - 60deg),

--- a/packages/playground-ui/src/ds/components/Composer/composer-ring.css
+++ b/packages/playground-ui/src/ds/components/Composer/composer-ring.css
@@ -26,7 +26,7 @@
   position: relative;
   border-radius: 23px;
   padding: 1px;
-  background-color: color-mix(in oklab, var(--border2) 40%, transparent);
+  background-color: var(--composer-ring-edge, color-mix(in oklab, var(--border2) 40%, transparent));
   background-image: conic-gradient(
     from calc(var(--composer-ring-angle) + var(--composer-ring-spin) - 60deg),
     transparent 0deg,

--- a/packages/playground-ui/src/ds/components/Composer/composer.tsx
+++ b/packages/playground-ui/src/ds/components/Composer/composer.tsx
@@ -61,7 +61,7 @@ export const ComposerRing = ({ busy = false, className, ...props }: ComposerRing
       ref={ringRef}
       data-slot="composer-ring"
       data-busy={busy ? 'true' : 'false'}
-      className={cn('composer-ring mx-auto w-full max-w-3xl', className)}
+      className={cn('composer-ring relative mx-auto w-full max-w-3xl rounded-[23px] p-px', className)}
       {...props}
     />
   );

--- a/packages/playground-ui/src/ds/components/ai/tool-call/tool-call.tsx
+++ b/packages/playground-ui/src/ds/components/ai/tool-call/tool-call.tsx
@@ -226,7 +226,7 @@ export const ToolCallMono = ({ copyText, className, children, ...props }: ToolCa
   <div className="group/block relative max-w-full min-w-0">
     <pre
       className={cn(
-        'm-0 max-h-60 max-w-full overflow-auto rounded-md bg-surface1 px-3 py-2 font-mono text-xs leading-normal break-words whitespace-pre-wrap',
+        'm-0 max-h-60 max-w-full overflow-auto rounded-md bg-neutral6/5 px-3 py-2 font-mono text-xs leading-normal break-words whitespace-pre-wrap',
         className,
       )}
       {...props}


### PR DESCRIPTION
TLDR: the Factory chat composer stops being the loudest thing on the page, and the blocks inside a tool call get their background back.

---

Mona Sans landed a step earlier in this stack and reads larger than the previous face at the same size, which left the composer bigger and brighter than the transcript it answers. Pulling it back exposed two surfaces that were painting the colour they sat on.

### What changes

| in the chat | before | after |
| --- | --- | --- |
| typing in the composer | 16px, near-white, on `surface3` | 14px at 450, `neutral4`, on `surface4` |
| picking a slash command | selection on `surface4`, invisible on the lighter box | 5% overlay, visible on any box |
| composer next to the messages | same width, same gutter | ~1rem wider each side, 0.25rem of air below |
| reading a tool result or a diff | `surface1` / `surface2`, flat against the page | 5% overlay, one step above it |

### Judgment call

The chat page is `--chat-surface: surface2`, and both the tool output block (`surface1`) and the diff block sat on fixed surface tokens either side of it — one below the page, one exactly on it. They move to a `neutral6/5` overlay instead of another fixed token, so they stay one step above whatever is behind them and cannot drift out of sync again when a surface moves. Same reason for the suggestion list.

The composer's own colours stay fixed tokens: it is a card with a deliberate weight, not a block that has to survive an unknown background.

Width comes from the gutter, not from `max-width`. The composer and the transcript share `ChatShell.Column` at 44rem, so a `max-width` bump does nothing on mobile, where the column never reaches its cap. Giving the composer column back its padding widens it at every size.

### Side effects to check

`ToolCallMono` is the design system's, so this is a `@mastra/playground-ui` change — Factory is its only consumer today, and the fixed `bg-surface1` was wrong for any host whose chat surface is not the body colour.

### Not verified

Light mode. Factory never sets `html.light`, so the whole retune was judged on dark; the overlay tokens invert by construction but nobody has looked at them.

### Stack

```
#22385  feat/factory-mona-sans       → main
#22399  feat/factory-sidebar-tuning  → #22385
this    feat/factory-composer-text   → #22399
```

```
source        +21  -10
changeset     +15    0
```
