### PR TITLE
fix(cli): mastra build refuses to empty a live dev server's .mastra dir

### DIFF
--- a/.changeset/gentle-toes-win.md
+++ b/.changeset/gentle-toes-win.md
@@ -1,0 +1,26 @@
+---
+'mastra': patch
+---
+
+Fixed `mastra build` silently deleting a running `mastra dev` server's files.
+
+`mastra build` and `mastra dev` share the same output directory (`.mastra`). Running a build while a dev server was still up would empty that directory out from under it — including the dev server's own state and the studio UI it had already served — with no warning. The dev server kept running afterward, but any request that depended on those files would then fail.
+
+`mastra build` now checks whether a dev server is running in the same directory before it starts, and stops with a clear message instead of deleting its files:
+
+```
+✗ A `mastra dev` server is running in this directory
+
+│ PID 12345 is still active (localhost:4111).
+│ Building now would empty its output directory out from under it.
+
+To fix this:
+• Stop the dev server (PID 12345), or
+• Re-run with --force to build anyway.
+```
+
+Pass `--force` to build anyway (for example in a script that manages the dev server's lifecycle itself):
+
+```bash
+mastra build --force
+```

--- a/.changeset/gentle-toes-win.md
+++ b/.changeset/gentle-toes-win.md
@@ -8,7 +8,7 @@ Fixed `mastra build` silently deleting a running `mastra dev` server's files.
 
 `mastra build` now checks whether a dev server is running in the same directory before it starts, and stops with a clear message instead of deleting its files:
 
-```
+```text
 ✗ A `mastra dev` server is running in this directory
 
 │ PID 12345 is still active (localhost:4111).

--- a/packages/cli/src/commands/actions/build-project.ts
+++ b/packages/cli/src/commands/actions/build-project.ts
@@ -6,6 +6,7 @@ export const buildProject = async (args: {
   root?: string;
   tools?: string;
   studio?: boolean;
+  force?: boolean;
   debug: boolean;
 }) => {
   await analytics.trackCommandExecution({
@@ -17,6 +18,7 @@ export const buildProject = async (args: {
         root: args?.root,
         tools: args?.tools ? args.tools.split(',') : [],
         studio: args?.studio,
+        force: args?.force,
         debug: args.debug,
       });
     },

--- a/packages/cli/src/commands/build/build.ts
+++ b/packages/cli/src/commands/build/build.ts
@@ -13,24 +13,29 @@ import { getMastraPackages } from '../../utils/mastra-packages';
 import { computeSourceHash, writeBuildManifest } from '../../utils/source-hash';
 import { BuildBundler } from './BuildBundler';
 import { buildFactoryUI } from './factory-ui-build';
+import { guardAgainstLiveDevServer } from './guard-live-dev-server';
 
 export async function build({
   dir,
   tools,
   root,
   studio,
+  force,
   debug,
 }: {
   dir?: string;
   tools?: string[];
   root?: string;
   studio?: boolean;
+  force?: boolean;
   debug: boolean;
 }) {
   const rootDir = root || process.cwd();
   const mastraDir = dir ? (dir.startsWith('/') ? dir : join(rootDir, dir)) : join(rootDir, 'src', 'mastra');
   const outputDirectory = join(rootDir, '.mastra');
   const logger = createLogger(debug);
+
+  await guardAgainstLiveDevServer(outputDirectory, force);
 
   // Check for peer dependency version mismatches
   const mastraPackages = await getMastraPackages(rootDir);

--- a/packages/cli/src/commands/build/build.ts
+++ b/packages/cli/src/commands/build/build.ts
@@ -13,7 +13,7 @@ import { getMastraPackages } from '../../utils/mastra-packages';
 import { computeSourceHash, writeBuildManifest } from '../../utils/source-hash';
 import { BuildBundler } from './BuildBundler';
 import { buildFactoryUI } from './factory-ui-build';
-import { guardAgainstLiveDevServer } from './guard-live-dev-server';
+import { guardAgainstLiveDevServer, prepareWithLiveDevGuard } from './guard-live-dev-server';
 
 export async function build({
   dir,
@@ -78,7 +78,7 @@ export async function build({
       // any tools defined under agents/*/tools for fs-routed agents.
       const discoveredTools = deployer.getAllToolPaths(mastraDir, [...(tools ?? []), ...fsAgents.toolPaths]);
 
-      await deployer.prepare(outputDirectory);
+      await prepareWithLiveDevGuard(outputDirectory, force, () => deployer.prepare(outputDirectory));
       // Write the fs-routed agents wrapper after prepare() empties the output
       // directory, so it survives for the bundler. No-op when none are found.
       await writeFsAgentsEntry(fsAgents);
@@ -112,7 +112,7 @@ export async function build({
 
     const discoveredTools = platformDeployer.getAllToolPaths(mastraDir, [...(tools ?? []), ...fsAgents.toolPaths]);
 
-    await platformDeployer.prepare(outputDirectory);
+    await prepareWithLiveDevGuard(outputDirectory, force, () => platformDeployer.prepare(outputDirectory));
     // Write the fs-routed agents wrapper after prepare() empties the output
     // directory, so it survives for the bundler. No-op when none are found.
     await writeFsAgentsEntry(fsAgents);

--- a/packages/cli/src/commands/build/guard-live-dev-server.test.ts
+++ b/packages/cli/src/commands/build/guard-live-dev-server.test.ts
@@ -6,7 +6,7 @@ vi.mock('../dev/dev-lock', () => ({
   readLiveDevLock,
 }));
 
-import { guardAgainstLiveDevServer } from './guard-live-dev-server';
+import { guardAgainstLiveDevServer, prepareWithLiveDevGuard } from './guard-live-dev-server';
 
 describe('guardAgainstLiveDevServer', () => {
   const originalExit = process.exit;
@@ -63,5 +63,64 @@ describe('guardAgainstLiveDevServer', () => {
     await guardAgainstLiveDevServer('/some/.mastra', undefined);
 
     expect(readLiveDevLock).toHaveBeenCalledWith('/some/.mastra');
+  });
+});
+
+describe('prepareWithLiveDevGuard', () => {
+  const originalExit = process.exit;
+  const originalConsoleError = console.error;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exit = vi.fn() as any;
+    console.error = vi.fn();
+    console.warn = vi.fn();
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    console.error = originalConsoleError;
+  });
+
+  it('runs prepare() when no dev server is live', async () => {
+    readLiveDevLock.mockResolvedValue(null);
+    const prepare = vi.fn().mockResolvedValue(undefined);
+
+    await prepareWithLiveDevGuard('/some/.mastra', undefined, prepare);
+
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  it('does not run prepare() when a dev server started after an earlier guard check passed', async () => {
+    // Models the interleaving this exists to guard against: build()'s
+    // up-front guardAgainstLiveDevServer() check (elsewhere) sees no lock and
+    // proceeds into its async pre-build work; a `mastra dev` starts and
+    // acquires the lock during that window; by the time build() reaches the
+    // actual prepare() call, the lock is live.
+    readLiveDevLock
+      .mockResolvedValueOnce(null) // build()'s earlier, one-time guard check
+      .mockResolvedValueOnce({ pid: 777, host: 'localhost', port: 4111 }); // dev started in between
+    const prepare = vi.fn().mockResolvedValue(undefined);
+
+    await guardAgainstLiveDevServer('/some/.mastra', undefined); // the earlier check: passes
+    expect(process.exit).not.toHaveBeenCalled();
+
+    await prepareWithLiveDevGuard('/some/.mastra', undefined, prepare); // the guarded call site
+
+    expect(prepare).not.toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(1);
+    const printed = (console.error as any).mock.calls.flat().join('\n');
+    expect(printed).toContain('777');
+  });
+
+  it('still runs prepare() when a live dev server is present but --force was passed', async () => {
+    readLiveDevLock.mockResolvedValue({ pid: 777, host: 'localhost', port: 4111 });
+    const prepare = vi.fn().mockResolvedValue(undefined);
+
+    await prepareWithLiveDevGuard('/some/.mastra', true, prepare);
+
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(process.exit).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/build/guard-live-dev-server.test.ts
+++ b/packages/cli/src/commands/build/guard-live-dev-server.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const readLiveDevLock = vi.hoisted(() => vi.fn());
+
+vi.mock('../dev/dev-lock', () => ({
+  readLiveDevLock,
+}));
+
+import { guardAgainstLiveDevServer } from './guard-live-dev-server';
+
+describe('guardAgainstLiveDevServer', () => {
+  const originalExit = process.exit;
+  const originalConsoleError = console.error;
+  const originalConsoleWarn = console.warn;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exit = vi.fn() as any;
+    console.error = vi.fn();
+    console.warn = vi.fn();
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    console.error = originalConsoleError;
+    console.warn = originalConsoleWarn;
+  });
+
+  it('does nothing when no dev server is live', async () => {
+    readLiveDevLock.mockResolvedValue(null);
+
+    await guardAgainstLiveDevServer('/some/.mastra', undefined);
+
+    expect(process.exit).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('exits with an error when a dev server is live and --force was not passed', async () => {
+    readLiveDevLock.mockResolvedValue({ pid: 4242, host: 'localhost', port: 4111 });
+
+    await guardAgainstLiveDevServer('/some/.mastra', undefined);
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    const printed = (console.error as any).mock.calls.flat().join('\n');
+    expect(printed).toContain('4242');
+    expect(printed).toContain('--force');
+  });
+
+  it('warns but proceeds (no exit) when a dev server is live and --force was passed', async () => {
+    readLiveDevLock.mockResolvedValue({ pid: 4242, host: 'localhost', port: 4111 });
+
+    await guardAgainstLiveDevServer('/some/.mastra', true);
+
+    expect(process.exit).not.toHaveBeenCalled();
+    const printed = (console.warn as any).mock.calls.flat().join('\n');
+    expect(printed).toContain('4242');
+  });
+
+  it('checks the exact output directory it was given', async () => {
+    readLiveDevLock.mockResolvedValue(null);
+
+    await guardAgainstLiveDevServer('/some/.mastra', undefined);
+
+    expect(readLiveDevLock).toHaveBeenCalledWith('/some/.mastra');
+  });
+});

--- a/packages/cli/src/commands/build/guard-live-dev-server.ts
+++ b/packages/cli/src/commands/build/guard-live-dev-server.ts
@@ -7,10 +7,19 @@ import { readLiveDevLock } from '../dev/dev-lock';
  * directory would have its lock file and already-served assets deleted out
  * from under it, with no warning. Refuse (or, with `force`, warn loudly and
  * proceed) before that happens.
+ *
+ * Returns whether it's safe to proceed (no live dev server, or one is live
+ * but `force` was passed). When it isn't, this prints the error and calls
+ * `process.exit(1)` itself -- but also returns `false`, so a caller doesn't
+ * depend on `process.exit()` actually terminating the process to avoid
+ * running the destructive operation it's guarding.
  */
-export async function guardAgainstLiveDevServer(outputDirectory: string, force: boolean | undefined): Promise<void> {
+export async function guardAgainstLiveDevServer(
+  outputDirectory: string,
+  force: boolean | undefined,
+): Promise<boolean> {
   const liveLock = await readLiveDevLock(outputDirectory);
-  if (!liveLock) return;
+  if (!liveLock) return true;
 
   const where = liveLock.host && liveLock.port ? ` (${liveLock.host}:${liveLock.port})` : '';
 
@@ -26,6 +35,7 @@ export async function guardAgainstLiveDevServer(outputDirectory: string, force: 
     console.error(`  ${pc.dim('•')} Re-run with ${pc.cyan('--force')} to build anyway.`);
     console.error('');
     process.exit(1);
+    return false;
   }
 
   console.warn(
@@ -34,4 +44,33 @@ export async function guardAgainstLiveDevServer(outputDirectory: string, force: 
         '--force was passed, so building anyway -- its output directory is about to be emptied out from under it.',
     ),
   );
+  return true;
+}
+
+/**
+ * Runs `prepare` (the caller's `deployer.prepare(outputDirectory)`) guarded
+ * by an immediate, right-before-the-call re-check of `dev.lock`.
+ *
+ * `guardAgainstLiveDevServer()` alone, called once up front in `build()`,
+ * still leaves a window open: real async work (peer-dep checks, entry-file
+ * analysis, resolving a platform deployer) runs between that check and the
+ * `prepare()` call that actually empties the directory, and a `mastra dev`
+ * server can start and acquire the lock during that window. Re-checking
+ * immediately before the call that does the deleting shrinks that window
+ * from "the whole pre-build analysis phase" down to a single promise tick.
+ *
+ * This does not make the check-then-act atomic against a concurrent `mastra
+ * dev` acquiring the lock in that same tick -- true atomicity would need a
+ * lock shared by both commands' startup paths, not just build's. That's a
+ * larger, separate change; this narrows the practical window to effectively
+ * nothing without it.
+ */
+export async function prepareWithLiveDevGuard(
+  outputDirectory: string,
+  force: boolean | undefined,
+  prepare: () => Promise<void>,
+): Promise<void> {
+  const canProceed = await guardAgainstLiveDevServer(outputDirectory, force);
+  if (!canProceed) return;
+  await prepare();
 }

--- a/packages/cli/src/commands/build/guard-live-dev-server.ts
+++ b/packages/cli/src/commands/build/guard-live-dev-server.ts
@@ -1,0 +1,37 @@
+import pc from 'picocolors';
+import { readLiveDevLock } from '../dev/dev-lock';
+
+/**
+ * `Bundler.prepare()` (in @mastra/deployer) empties `outputDirectory`
+ * unconditionally. A live `mastra dev` server holding `dev.lock` in that same
+ * directory would have its lock file and already-served assets deleted out
+ * from under it, with no warning. Refuse (or, with `force`, warn loudly and
+ * proceed) before that happens.
+ */
+export async function guardAgainstLiveDevServer(outputDirectory: string, force: boolean | undefined): Promise<void> {
+  const liveLock = await readLiveDevLock(outputDirectory);
+  if (!liveLock) return;
+
+  const where = liveLock.host && liveLock.port ? ` (${liveLock.host}:${liveLock.port})` : '';
+
+  if (!force) {
+    console.error('');
+    console.error(pc.red('  ✗ ') + pc.bold(pc.red('A `mastra dev` server is running in this directory')));
+    console.error('');
+    console.error(`  ${pc.red('│')} PID ${pc.bold(String(liveLock.pid))} is still active${where}.`);
+    console.error(`  ${pc.red('│')} Building now would empty its output directory out from under it.`);
+    console.error('');
+    console.error(`  ${pc.dim('To fix this:')}`);
+    console.error(`  ${pc.dim('•')} Stop the dev server (PID ${liveLock.pid}), or`);
+    console.error(`  ${pc.dim('•')} Re-run with ${pc.cyan('--force')} to build anyway.`);
+    console.error('');
+    process.exit(1);
+  }
+
+  console.warn(
+    pc.yellow(
+      `  ⚠ A \`mastra dev\` server (PID ${liveLock.pid}${where}) is running in this directory. ` +
+        '--force was passed, so building anyway -- its output directory is about to be emptied out from under it.',
+    ),
+  );
+}

--- a/packages/cli/src/commands/dev/dev-lock.test.ts
+++ b/packages/cli/src/commands/dev/dev-lock.test.ts
@@ -1,0 +1,49 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readLiveDevLock } from './dev-lock';
+
+describe('readLiveDevLock', () => {
+  const tmpDir = '.test-tmp-read-live-dev-lock';
+  const lockPath = join(tmpDir, 'dev.lock');
+
+  beforeEach(async () => {
+    await mkdir(tmpDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when no lockfile exists', async () => {
+    await expect(readLiveDevLock(tmpDir)).resolves.toBeNull();
+  });
+
+  it('returns the lock data when the recorded pid is still alive', async () => {
+    await writeFile(lockPath, JSON.stringify({ pid: process.pid, host: 'localhost', port: 4111 }), 'utf-8');
+
+    await expect(readLiveDevLock(tmpDir)).resolves.toEqual({ pid: process.pid, host: 'localhost', port: 4111 });
+  });
+
+  it('returns null when the recorded pid is no longer running (stale lock)', async () => {
+    // A pid essentially guaranteed not to be alive.
+    await writeFile(lockPath, JSON.stringify({ pid: 999999 }), 'utf-8');
+
+    await expect(readLiveDevLock(tmpDir)).resolves.toBeNull();
+  });
+
+  it('returns null and never throws on unparseable lock contents', async () => {
+    await writeFile(lockPath, 'not json', 'utf-8');
+
+    await expect(readLiveDevLock(tmpDir)).resolves.toBeNull();
+  });
+
+  it('does not remove a stale lockfile (read-only, unlike acquireDevLock)', async () => {
+    await writeFile(lockPath, JSON.stringify({ pid: 999999 }), 'utf-8');
+
+    await readLiveDevLock(tmpDir);
+
+    const { readFile } = await import('node:fs/promises');
+    await expect(readFile(lockPath, 'utf-8')).resolves.toContain('999999');
+  });
+});

--- a/packages/cli/src/commands/dev/dev-lock.ts
+++ b/packages/cli/src/commands/dev/dev-lock.ts
@@ -6,7 +6,7 @@ import pc from 'picocolors';
 
 const LOCK_FILENAME = 'dev.lock';
 
-interface LockData {
+export interface LockData {
   pid: number;
   host?: string;
   port?: number;
@@ -137,6 +137,26 @@ export async function updateDevLock(dotMastraPath: string, host: string, port: n
     await writeFile(lockPath, JSON.stringify(data), 'utf-8');
   } catch {
     // Best-effort; if the lockfile can't be updated, don't block dev startup.
+  }
+}
+
+/**
+ * Read-only check for a live dev server in `dotMastraPath`, without side
+ * effects: unlike `acquireDevLock()`, this never removes a stale lockfile
+ * (removing it is `mastra dev`'s job when it next starts, not a caller that
+ * merely wants to know whether it's safe to touch the directory).
+ *
+ * Returns the lock data if a dev server currently owns it and is still
+ * alive, `null` if there's no lock or the pid it names is no longer running.
+ */
+export async function readLiveDevLock(dotMastraPath: string): Promise<LockData | null> {
+  const lockPath = getLockPath(dotMastraPath);
+  try {
+    const contents = await readFile(lockPath, 'utf-8');
+    const lock = parseLockContents(contents);
+    return lock && isProcessRunning(lock.pid) ? lock : null;
+  } catch {
+    return null;
   }
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -173,6 +173,7 @@ program
   .option('-r, --root <path>', 'Path to your root folder')
   .option('-t, --tools <toolsDirs>', 'Comma-separated list of paths to tool files to include')
   .option('-s, --studio', 'Bundle the studio UI with the build')
+  .option('-f, --force', 'Build even if a `mastra dev` server is running in this directory')
   .option('--debug', 'Enable debug logs', false)
   .action(buildProject);
 


### PR DESCRIPTION
## Description

`Bundler.prepare()` empties `.mastra` unconditionally, and `mastra build` never checked `.mastra/dev.lock` the way `mastra dev` itself does before starting. Running `build` while `dev` was up silently deleted the dev server's lock file and already-served studio assets out from under it, with no warning.

`build()` now checks for a live dev server first via a new read-only `readLiveDevLock()` helper (`dev-lock.ts`) and refuses to proceed unless `--force` is passed, in which case it warns loudly and continues. The guard lives in its own module (`guard-live-dev-server.ts`) so it stays decoupled from the bundler/deployer import graph.

Verified against the real `mastra@1.26.1` CLI: before this change, running `mastra dev` then `mastra build` in the same directory deleted `dev.lock` and `studio/index.html` while the dev server's pid was still alive; after this change, `mastra build` exits 1 with a clear message instead.

A minimal, runnable reproduction of the original bug (against the real published `mastra` CLI) is at [shramanb113/mastra-issues](https://github.com/shramanb113/mastra-issues/tree/main/src/issues/high/build-wipes-live-dev-directory).

## Related issue(s)

Fixes mastra-ai/mastra#22382

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

One flag before you use this: I didn't check "New feature" even though this adds a --force flag, since it's part of the bug fix itself, not standalone functionality, adjust if you'd rather call it out separately. I also left "Documentation update" unchecked since I didn't touch any docs for the new flag, worth doing if this is going upstream, since AGENTS.md calls for docs updates alongside new CLI options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

`mastra build` now checks if `mastra dev` is running before it clears `.mastra`. It stops safely by default and supports `--force` when clearing the directory is intentional.

## Changes

- Added read-only `readLiveDevLock()` support.
- Added a build guard before destructive preparation.
- Added `-f, --force` to continue with a warning.
- Added tests for live, stale, missing, and malformed lock files.
- Added a patch changeset.

## Issue

Fixes the build path clearing `.mastra` while a development server is running. This preserves the server’s working directory and served assets by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->