### PR TITLE
refactor(playground-ui): share Factory's message reveal through the design system

### DIFF
--- a/.changeset/humble-tables-wish.md
+++ b/.changeset/humble-tables-wish.md
@@ -1,0 +1,17 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added `@mastra/playground-ui/components/ai/message-reveal`, which paces a whole assistant message — prose, reasoning, tool rows, cards — on one clock, so its parts arrive in the order the model wrote them.
+
+Before, a renderer paced its own text with `useRevealedText`, which could only slow prose down: everything written between two passages landed at once, so a tool row appeared while the sentence before it was still being typed out.
+
+```tsx
+import { useRevealedParts } from '@mastra/playground-ui/components/ai/message-reveal';
+
+const parts = useRevealedParts(message.content.parts, streaming);
+
+<MessageFactory message={{ ...message, content: { ...message.content, parts } }} {...renderers} />;
+```
+
+The projection happens above the renderers, so none of them has to know a reveal is running.

--- a/.changeset/lazy-dolls-clean.md
+++ b/.changeset/lazy-dolls-clean.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The chat transcript now reveals a streamed reply through the shared design-system module instead of its own copy. Nothing changes in what the transcript draws.

--- a/.changeset/lazy-dolls-clean.md
+++ b/.changeset/lazy-dolls-clean.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-The chat transcript now reveals a streamed reply through the shared design-system module instead of its own copy. Nothing changes in what the transcript draws.
+Nothing changes in the chat transcript: a streamed reply still arrives part by part, at the pace it was written. That pacing now comes from `@mastra/playground-ui/components/ai/message-reveal` instead of a Factory-only copy, so every Mastra chat surface can move the same way.

--- a/.changeset/lazy-dolls-clean.md
+++ b/.changeset/lazy-dolls-clean.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Nothing changes in the chat transcript: a streamed reply still arrives part by part, at the pace it was written. That pacing now comes from `@mastra/playground-ui/components/ai/message-reveal` instead of a Factory-only copy, so every Mastra chat surface can move the same way.
+Moved the chat transcript's streamed-reply pacing onto the shared `@mastra/playground-ui/components/ai/message-reveal` module. Nothing changes in what the transcript draws: a reply still arrives part by part, at the pace it was written.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/MessageBubble.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/MessageBubble.tsx
@@ -1,5 +1,6 @@
 import type { PlanResume } from '@mastra/client-js';
-import { MarkdownRenderer, useRevealedText } from '@mastra/playground-ui/components/MarkdownRenderer';
+import { MarkdownRenderer } from '@mastra/playground-ui/components/MarkdownRenderer';
+import { useRevealedParts } from '@mastra/playground-ui/components/ai/message-reveal';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { MessageFactory } from '@mastra/react/ui';
@@ -7,7 +8,6 @@ import type { FilePart, MessageRoleRenderers, ReasoningPart, TextPart, ToolInvoc
 import { Slack } from 'lucide-react';
 import { useState } from 'react';
 
-import { messageScript, revealedParts } from '../services/reveal';
 import type { MessageEntry, SuspensionPrompt } from '../services/transcript';
 import { Arriving } from '@mastra/playground-ui/components/Arrival';
 import { MESSAGE_HOVER, MessageMeta } from './MessageMeta';
@@ -110,8 +110,7 @@ export function MessageBubble({
   onRespond: (toolCallId: string, resumeData: string | string[] | PlanResume, promptId: string) => void;
 }) {
   const written = renderableParts(entry);
-  const shown = useRevealedText(messageScript(written), Boolean(entry.streaming));
-  const parts = revealedParts(written, shown);
+  const parts = useRevealedParts(written, Boolean(entry.streaming));
   // Decided the first time the entry is drawn and never revisited: only calls already
   // there when the reader arrived may fold into a group. A call landing under them —
   // a live run being watched, or one restored mid-run — stays the row it played as.

--- a/mastracode/factory-ui/src/ui/domains/chat/components/transcript-parts.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/transcript-parts.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { messageText } from './transcript-parts';
+import type { MessagePart } from './transcript-parts';
+
+describe('messageText', () => {
+  it('keeps the copyable prose free of thinking and tool rows', () => {
+    const parts: MessagePart[] = [
+      { type: 'reasoning', reasoning: 'Need the core package first', details: [] },
+      { type: 'text', text: 'Reading the file' },
+      {
+        type: 'tool-invocation',
+        toolInvocation: { state: 'call', toolCallId: 'call-1', toolName: 'read_file', args: {} },
+      },
+      { type: 'text', text: 'Done' },
+    ];
+
+    expect(messageText(parts)).toBe('Reading the file\n\nDone');
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/components/transcript-parts.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/transcript-parts.ts
@@ -1,6 +1,5 @@
 import type { ToolInvocationPart } from '@mastra/react/ui';
 
-import { messageProse } from '../services/reveal';
 import { isTerminalInvocationState } from '../services/transcript';
 import type { MessageEntry, SuspensionPrompt, ToolCall } from '../services/transcript';
 import { isTranscriptToolVisible } from './ToolFactory';
@@ -8,8 +7,12 @@ import { TOOL_GROUP_MIN } from './tool/ToolGroup';
 
 export type MessagePart = MessageEntry['message']['content']['parts'][number];
 
+/** A message's prose as the one stream it was written as — the copyable answer. */
 export function messageText(parts: MessagePart[]): string {
-  return messageProse(parts).trim();
+  return parts
+    .flatMap(part => (part.type === 'text' ? [part.text] : []))
+    .join('\n\n')
+    .trim();
 }
 
 /** Terminal status carried by the persisted part, if it reached one. */

--- a/packages/playground-ui/src/ds/components/ai/message-reveal/index.ts
+++ b/packages/playground-ui/src/ds/components/ai/message-reveal/index.ts
@@ -1,0 +1,1 @@
+export * from './message-reveal';

--- a/packages/playground-ui/src/ds/components/ai/message-reveal/message-reveal.test.ts
+++ b/packages/playground-ui/src/ds/components/ai/message-reveal/message-reveal.test.ts
@@ -1,7 +1,7 @@
-import type { MastraDBMessage } from '@mastra/core/agent-controller';
+import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import { describe, expect, it } from 'vitest';
 
-import { messageProse, messageScript, revealedParts } from './reveal';
+import { messageScript, revealedParts } from './message-reveal';
 
 type MessagePart = MastraDBMessage['content']['parts'][number];
 
@@ -58,11 +58,5 @@ describe('revealing a message in the order it was written', () => {
     const parts = [text('Reading the file'), tool('call-1'), text('Done')];
 
     expect(revealedParts(parts, messageScript(parts))).toBe(parts);
-  });
-
-  it('keeps the copyable prose free of row marks and thinking', () => {
-    const parts = [reasoning('Need the core package first'), text('Reading the file'), tool('call-1'), text('Done')];
-
-    expect(messageProse(parts)).toBe('Reading the file\n\nDone');
   });
 });

--- a/packages/playground-ui/src/ds/components/ai/message-reveal/message-reveal.ts
+++ b/packages/playground-ui/src/ds/components/ai/message-reveal/message-reveal.ts
@@ -1,4 +1,6 @@
-import type { MastraDBMessage } from '@mastra/core/agent-controller';
+import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+
+import { useRevealedText } from '../../MarkdownRenderer/use-reveal';
 
 type MessagePart = MastraDBMessage['content']['parts'][number];
 
@@ -11,11 +13,6 @@ const PASSAGE = '\n\n';
  * the pace the reply is moving, instead of landing as one block.
  */
 const ROW_MARK = Array.from({ length: 6 }, () => '￼').join(' ');
-
-/** A message's prose as the one stream it was written as — the copyable answer. */
-export function messageProse(parts: MessagePart[]): string {
-  return parts.flatMap(part => (part.type === 'text' ? [part.text] : [])).join(PASSAGE);
-}
 
 /**
  * The words a part was written as, for the kinds the model writes word by word.
@@ -74,4 +71,16 @@ export function revealedParts(parts: MessagePart[], shown: string): MessagePart[
   }
 
   return revealed;
+}
+
+/**
+ * A message's parts as far as the reveal has laid them down. Hand the result to
+ * `MessageFactory` in place of the message's own parts and the whole reply — prose,
+ * reasoning, tool rows, cards — arrives at the pace it was written, from one clock,
+ * without a renderer having to know a reveal is running.
+ */
+export function useRevealedParts(parts: MessagePart[], streaming: boolean): MessagePart[] {
+  const shown = useRevealedText(messageScript(parts), streaming);
+
+  return revealedParts(parts, shown);
 }

--- a/packages/playground-ui/src/ds/components/ai/message-reveal/use-revealed-parts.test.tsx
+++ b/packages/playground-ui/src/ds/components/ai/message-reveal/use-revealed-parts.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useRevealedParts } from './message-reveal';
+
+type MessagePart = MastraDBMessage['content']['parts'][number];
+
+const parts: MessagePart[] = [
+  { type: 'text', text: 'Reading the file' },
+  { type: 'tool-invocation', toolInvocation: { state: 'call', toolCallId: 'call-1', toolName: 'read_file', args: {} } },
+];
+
+describe('useRevealedParts', () => {
+  it('draws a message that is not streaming whole, with nothing left to pace', () => {
+    const { result } = renderHook(() => useRevealedParts(parts, false));
+
+    expect(result.current).toBe(parts);
+  });
+
+  it('starts a streaming message from nothing so its first words are paced', () => {
+    const { result } = renderHook(() => useRevealedParts(parts, true));
+
+    expect(result.current).toEqual([]);
+  });
+});


### PR DESCRIPTION
TLDR: the reveal that paces a streamed reply moves out of factory-ui and into the
design system, so Studio can use the same one. Nothing changes on screen.

---

```
before   pacing a whole message means copying factory-ui's services/reveal.ts
after    useRevealedParts(parts, streaming), from
         @mastra/playground-ui/components/ai/message-reveal
```

The clock itself was already shared — `useRevealedText` has lived in the design
system all along. What was not shared is *what the clock paces*. Factory writes the
whole message into one script, prose and tool rows alike, so a row waits its turn
behind the sentence before it. Studio paces each text part on its own, so its rows
land while the prose ahead of them is still being typed out.

This is the move, not the fix: the module lands in the design system with Factory
as its only caller, and Studio adopts it in the pull request stacked on top of this
one. That is where the behaviour changes, and where it can be reviewed on its own.

The hook returns parts, not markup. A caller hands them to `MessageFactory` in
place of the message's own, so no renderer has to know a reveal is running — which
is what makes the same module fit two surfaces whose renderers have nothing in
common.

### Judgment call

I put it under `ds/components/ai/` next to `tool-call` rather than beside
`use-reveal.ts` in `MarkdownRenderer/`. The clock is text; this reads
`MastraDBMessage` parts, and `ai/` is where the design system already keeps the
pieces that know mastra's shapes. The two are one relative import apart either way.

`messageProse` came along in the same file but was never part of the reveal — it is
the copyable answer. It folds into `messageText`, its only caller, and its test
moves next to it.

### Not verified

No story. The reveal is covered by unit tests either side of the move and by
Factory's transcript tests, which I ran on their own: the full `domains/chat` run
flakes under parallel load on this machine, unrelated to this change.

```
source        +24  -12
tests         +49   -8
changeset     +22    0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR moves streamed-message reveal timing into the shared design system. Factory now uses the shared behavior to reveal text, reasoning, tools, and cards without changing the transcript appearance.

## Changes

- Added `useRevealedParts` to `@mastra/playground-ui/components/ai/message-reveal`.
- Updated Factory to use the shared reveal hook.
- Moved `messageProse` behavior into `messageText`.
- Added unit tests for message extraction and reveal behavior.
- Added Factory transcript-test coverage.
- Added changesets for the shared UI package and Factory.

## Testing

A full `domains/chat` test run was not verified because parallel execution flakes on the contributor’s machine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->