### PR TITLE
fix(factory): clear work-item session refs when their session is deleted

### DIFF
--- a/.changeset/six-islands-turn.md
+++ b/.changeset/six-islands-turn.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed the board's review flow around deleted and freshly minted sessions. Deleting a workspace now also removes the session links work items held on it, so a card stops offering a thread that no longer exists. Cards now trust their own session links instead of cross-checking the sidebar's workspace list, so the Review button flips to "Open session" as soon as an automated run binds its session — it used to stay stuck on "Review". While a run is underway its card now reads "Automated run in progress…" instead of "Starting an automated run…".
+Fixed the board's review flow around deleted and freshly minted sessions. Deleting a session now also removes the links work items held on it, so a card stops offering a thread that no longer exists. Cards now trust their own session links instead of cross-checking the sidebar's workspace list, so the Review button flips to "Open session" as soon as an automated run binds its session — it used to stay stuck on "Review". While a run is underway its card now reads "Automated run in progress…" instead of "Starting an automated run…".

--- a/.changeset/six-islands-turn.md
+++ b/.changeset/six-islands-turn.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed the board's review flow around deleted and freshly minted sessions. Deleting a session now also removes the links work items held on it, so a card stops offering a thread that no longer exists. Cards now trust their own session links instead of cross-checking the sidebar's workspace list, so the Review button flips to "Open session" as soon as an automated run binds its session — it used to stay stuck on "Review". While a run is underway its card now reads "Automated run in progress…" instead of "Starting an automated run…".
+Fixed the board's review flow around deleted and freshly minted sessions. Deleting a session now also removes the session references work items held on it, so a card stops offering a session that no longer exists. Cards now trust their own session links instead of cross-checking the sidebar's workspace list, so the Review button flips to "Open session" as soon as an automated run binds its session — it used to stay stuck on "Review". While a run is underway its card now reads "Automated run in progress…" instead of "Starting an automated run…".

--- a/.changeset/six-islands-turn.md
+++ b/.changeset/six-islands-turn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the board's review flow around deleted and freshly minted sessions. Deleting a workspace now also removes the session links work items held on it, so a card stops offering a thread that no longer exists. Cards now trust their own session links instead of cross-checking the sidebar's workspace list, so the Review button flips to "Open session" as soon as an automated run binds its session — it used to stay stuck on "Review". While a run is underway its card now reads "Automated run in progress…" instead of "Starting an automated run…".

--- a/mastracode/factory-ui/src/hooks/useWorkItems.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkItems.ts
@@ -42,6 +42,8 @@ function patchCards(queryClient: QueryClient, listKey: QueryKey, patch: (cards: 
 
 /** Drop every card ref to a deleted session so the board stops advertising it before the next poll. */
 export function stripCachedSessionRefs(queryClient: QueryClient, factoryProjectId: string, sessionId: string) {
+  // an in-flight list fetch still carries the stale refs and would clobber the edit below
+  void queryClient.cancelQueries({ queryKey: queryKeys.workItems(factoryProjectId) });
   patchCards(queryClient, queryKeys.workItems(factoryProjectId), cards =>
     cards.map(card => {
       const kept = Object.entries(card.sessions).filter(([, ref]) => ref.sessionId !== sessionId);

--- a/mastracode/factory-ui/src/hooks/useWorkItems.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkItems.ts
@@ -40,6 +40,16 @@ function patchCards(queryClient: QueryClient, listKey: QueryKey, patch: (cards: 
   );
 }
 
+/** Drop every card ref to a deleted session so the board stops advertising it before the next poll. */
+export function stripCachedSessionRefs(queryClient: QueryClient, factoryProjectId: string, sessionId: string) {
+  patchCards(queryClient, queryKeys.workItems(factoryProjectId), cards =>
+    cards.map(card => {
+      const kept = Object.entries(card.sessions).filter(([, ref]) => ref.sessionId !== sessionId);
+      return kept.length === Object.keys(card.sessions).length ? card : { ...card, sessions: Object.fromEntries(kept) };
+    }),
+  );
+}
+
 // Module-level so React Query can cache each derived value instead of
 // rebuilding it (and, for the set, breaking referential equality) per render.
 const selectCards = (board: BoardSnapshot) => board.workItems;

--- a/mastracode/factory-ui/src/hooks/useWorkspaces.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkspaces.ts
@@ -12,6 +12,7 @@ import { useNavigate, useParams } from 'react-router';
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
+import { stripCachedSessionRefs } from './useWorkItems';
 import {
   createUserSession,
   deleteUserSession,
@@ -220,6 +221,9 @@ export function useDeleteWorkspaceMutation(
     },
     onSuccess: workspace => {
       removeCachedSession(queryClient, projectRepositoryId, workspace.sessionId);
+      // The server strips the work-item refs with the row; mirror it in the cache
+      // so the board's cards drop their session links before the next poll.
+      if (factoryId) stripCachedSessionRefs(queryClient, factoryId, workspace.sessionId);
       invalidateSessionQueries(queryClient, projectRepositoryId, scope, workspace.sessionId);
       void queryClient.invalidateQueries({ queryKey: queryKeys.userSession(workspace.sessionId) });
       void queryClient.invalidateQueries({

--- a/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
@@ -43,6 +43,10 @@ function deferred() {
   return { promise, resolve };
 }
 
+const workItemSessions: Record<string, { sessionId: string; branch: string; threadId: string; startedBy: string }> = {
+  chat: { sessionId: SESSION_ID, branch: 'factory/issue-1', threadId: SESSION_ID, startedBy: 'user-1' },
+};
+
 const workItem = {
   id: ITEM_ID,
   orgId: 'org-1',
@@ -55,9 +59,7 @@ const workItem = {
   url: null,
   stages: ['triage'],
   stageHistory: [],
-  sessions: {
-    chat: { sessionId: SESSION_ID, branch: 'factory/issue-1', threadId: SESSION_ID, startedBy: 'user-1' },
-  },
+  sessions: workItemSessions,
   metadata: {},
   revision: 1,
   createdAt: '2026-07-18T00:00:00.000Z',
@@ -71,6 +73,7 @@ const workItem = {
  */
 function stubFactoryWithBoundSession() {
   let sessions = [boundSession];
+  let items = [{ ...workItem, sessions: { ...workItemSessions } }];
   const deleted: string[] = [];
   // Held open after the delete so the test proves the card stops advertising a
   // dead thread on its own, rather than riding on the reconciling refetch.
@@ -103,7 +106,7 @@ function stubFactoryWithBoundSession() {
       }),
     ),
     http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
-      HttpResponse.json({ workItems: [workItem] }),
+      HttpResponse.json({ workItems: items }),
     ),
     http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions`, () =>
       HttpResponse.json({ decisions: [] }),
@@ -128,6 +131,13 @@ function stubFactoryWithBoundSession() {
     http.delete(`${TEST_BASE_URL}/web/user-sessions/:sessionId`, ({ params }) => {
       deleted.push(String(params.sessionId));
       sessions = sessions.filter(session => session.sessionId !== params.sessionId);
+      // The server strips the deleted session's work-item refs with the row.
+      items = items.map(item => ({
+        ...item,
+        sessions: Object.fromEntries(
+          Object.entries(item.sessions).filter(([, ref]) => ref.sessionId !== params.sessionId),
+        ),
+      }));
       return HttpResponse.json({ removed: true });
     }),
   );
@@ -151,9 +161,7 @@ describe('Board card session liveness', () => {
     // refetch sees them: the card must trust its own ref, not the intersection.
     stubFactoryWithBoundSession();
     server.use(
-      http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
-        HttpResponse.json({ sessions: [] }),
-      ),
+      http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () => HttpResponse.json({ sessions: [] })),
     );
     const user = userEvent.setup();
     renderWorkBoard();
@@ -164,7 +172,6 @@ describe('Board card session liveness', () => {
     await user.click(screen.getByRole('button', { name: 'Details for Fix login bug' }));
     expect(await screen.findByRole('link', { name: 'Open session' })).toBeInTheDocument();
   });
-
 
   it('drops the session indicator as soon as its session is deleted from the sidebar', async () => {
     const { deleted, refetchGate } = stubFactoryWithBoundSession();

--- a/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
@@ -146,6 +146,26 @@ function renderWorkBoard() {
 }
 
 describe('Board card session liveness', () => {
+  it('advertises a bound session the workspaces list does not know about', async () => {
+    // Dispatcher-minted sessions appear on the work item before any sidebar
+    // refetch sees them: the card must trust its own ref, not the intersection.
+    stubFactoryWithBoundSession();
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+        HttpResponse.json({ sessions: [] }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWorkBoard();
+
+    const card = await screen.findByTestId('work-item-card');
+    await waitFor(() => expect(card.querySelector('[data-live-session-indicator]')).not.toBeNull());
+
+    await user.click(screen.getByRole('button', { name: 'Details for Fix login bug' }));
+    expect(await screen.findByRole('link', { name: 'Open session' })).toBeInTheDocument();
+  });
+
+
   it('drops the session indicator as soon as its session is deleted from the sidebar', async () => {
     const { deleted, refetchGate } = stubFactoryWithBoundSession();
     const user = userEvent.setup();

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageCardClickStartsRun.msw.test.tsx
@@ -286,13 +286,13 @@ describe('Board card details open the default run', () => {
   // die silently — no run, no toast, nothing. It must surface an error.
   it('shows an error toast instead of failing silently when the pre-start refetch fails', async () => {
     const { startRequests } = stubBoardEndpoints();
-    // First sessions read (board load) succeeds; later refetches 401 like an
-    // expired session would.
-    let sessionsCalls = 0;
+    // First work-items read (board load) succeeds; the click's pre-start
+    // refetch 401s like an expired session would.
+    let itemsCalls = 0;
     server.use(
-      http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () => {
-        sessionsCalls += 1;
-        if (sessionsCalls === 1) return HttpResponse.json({ sessions: [] });
+      http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () => {
+        itemsCalls += 1;
+        if (itemsCalls === 1) return HttpResponse.json({ workItems: [issueWorkItem] });
         return HttpResponse.json({ error: 'unauthorized' }, { status: 401 });
       }),
     );
@@ -307,7 +307,8 @@ describe('Board card details open the default run', () => {
 
     await startRunFromCardDetails('Fix login bug');
 
-    await waitFor(() => expect(screen.getByText(/failed to (list sessions|refresh)/i)).toBeInTheDocument());
+    // Both the click's toast and the poll's retry can surface the same message.
+    await waitFor(() => expect(screen.getAllByText(/unauthorized/i).length).toBeGreaterThanOrEqual(1));
     expect(startRequests).toHaveLength(0);
   });
 });

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -424,8 +424,7 @@ describe('Board card pending states', () => {
     expect(relatedLink).not.toHaveAttribute('target');
   });
 
-  it('keeps an unresolved related session on the board, then opens its thread once liveness resolves', async () => {
-    const workspacesGate = deferred();
+  it('links a related card straight to its bound session thread', async () => {
     const liveRelatedPullRequest = {
       ...relatedPullRequest,
       sessions: {
@@ -442,39 +441,10 @@ describe('Board card pending states', () => {
       http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
         HttpResponse.json({ workItems: [workItem, liveRelatedPullRequest] }),
       ),
-      http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, async () => {
-        await workspacesGate.promise;
-        return HttpResponse.json({
-          sessions: [
-            {
-              id: 'review-session-row',
-              sessionId: 'review-session',
-              projectRepositoryId: REPO_ID,
-              orgId: 'org-1',
-              userId: 'user-1',
-              branch: 'review-pr',
-              baseBranch: 'main',
-              sandboxId: null,
-              sandboxWorkdir: '/repo-review',
-              materializedAt: '2026-07-18T00:00:00.000Z',
-              createdAt: '2026-07-18T00:00:00.000Z',
-              updatedAt: '2026-07-18T00:00:00.000Z',
-            },
-          ],
-        });
-      }),
     );
     const user = userEvent.setup();
-    const { client } = renderWorkBoard();
+    renderWorkBoard();
     const card = await screen.findByRole('article', { name: 'Fix login bug' });
-    const unresolvedLink = within(card).getByRole('link', {
-      name: 'Open Review: PR #21565 — Review login fix, Open pull request',
-    });
-    expect(unresolvedLink).toHaveAttribute('href', `/factories/${FACTORY_ID}/review`);
-    expect(unresolvedLink).not.toHaveAttribute('target');
-
-    workspacesGate.resolve();
-    await waitForMutationsIdle(client);
     const relatedLink = await within(card).findByRole('link', {
       name: 'Open live session for Review: PR #21565 — Review login fix, Open pull request',
     });

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.test.ts
@@ -103,6 +103,17 @@ describe('boardCardStatus', () => {
     ).toEqual({ kind: 'error', label: 'Linked card could not be filed — retrying…', detail: undefined });
   });
 
+  it('tells a run that is underway apart from one still waiting to start', () => {
+    expect(boardCardStatus({ decision: decision({ status: 'pending', attempts: 0 }) })).toEqual({
+      kind: 'busy',
+      label: 'Starting an automated run…',
+    });
+    expect(boardCardStatus({ decision: decision({ status: 'leased' }) })).toEqual({
+      kind: 'busy',
+      label: 'Automated run in progress…',
+    });
+  });
+
   it('describes a queued rule effect in terms of what it does, not the queue', () => {
     expect(boardCardStatus({ decision: decision({ type: 'transition', status: 'pending' }) })).toEqual({
       kind: 'busy',

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.ts
@@ -24,20 +24,32 @@ export interface BoardCardStatusInput {
   transitionReason?: string;
 }
 
-/** Human phrasing for a rule effect, by decision type. */
-function automationCopy(type: string): { busy: string; failed: string } {
+/** Human phrasing for a rule effect, by decision type. `underway` speaks for a leased decision. */
+function automationCopy(type: string): { busy: string; underway: string; failed: string } {
   switch (type) {
     case 'invokeSkill':
-      return { busy: 'Starting an automated run…', failed: 'Automated run could not start' };
-    case 'transition':
-      return { busy: 'Moving this card automatically…', failed: 'Automatic move failed' };
-    case 'upsertLinkedWorkItem':
-      return { busy: 'Filing a linked card…', failed: 'Linked card could not be filed' };
+      return {
+        busy: 'Starting an automated run…',
+        underway: 'Automated run in progress…',
+        failed: 'Automated run could not start',
+      };
+    case 'transition': {
+      const busy = 'Moving this card automatically…';
+      return { busy, underway: busy, failed: 'Automatic move failed' };
+    }
+    case 'upsertLinkedWorkItem': {
+      const busy = 'Filing a linked card…';
+      return { busy, underway: busy, failed: 'Linked card could not be filed' };
+    }
     case 'sendMessage':
-    case 'notify':
-      return { busy: 'Notifying the session…', failed: 'Session could not be notified' };
-    default:
-      return { busy: 'Automation is working on this card…', failed: 'Automation failed' };
+    case 'notify': {
+      const busy = 'Notifying the session…';
+      return { busy, underway: busy, failed: 'Session could not be notified' };
+    }
+    default: {
+      const busy = 'Automation is working on this card…';
+      return { busy, underway: busy, failed: 'Automation failed' };
+    }
   }
 }
 
@@ -78,7 +90,10 @@ export function boardCardStatus(input: BoardCardStatusInput): BoardCardStatus {
       detail: decision.lastError ?? undefined,
     };
   }
-  if (decision) return { kind: 'busy', label: automationCopy(decision.type).busy };
+  if (decision) {
+    const copy = automationCopy(decision.type);
+    return { kind: 'busy', label: decision.status === 'leased' ? copy.underway : copy.busy };
+  }
   // Nothing is moving on its own, so a parked run is the card's live question.
   if (input.proposal) {
     return { kind: 'waiting', label: input.proposal.label, decisionId: input.proposal.decisionId };

--- a/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
@@ -111,11 +111,3 @@ export function persistedSourceKeys(items: readonly WorkItem[]): ReadonlySet<str
   }
   return keys;
 }
-
-/** Session refs whose worktree was deleted are stale: their thread went with it. */
-export function liveSessions(
-  sessions: Record<string, WorkItemSessionRef>,
-  liveWorktreePaths: ReadonlySet<string>,
-): Record<string, WorkItemSessionRef> {
-  return Object.fromEntries(Object.entries(sessions).filter(([, session]) => liveWorktreePaths.has(session.sessionId)));
-}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -8,7 +8,7 @@ import { useParams } from 'react-router';
 import type { FactoryRunPhase } from '../../../../hooks/useStartFactoryRun';
 import { boardCardStatus } from '../boardCardStatus';
 import { setDragPayload } from '../boardDrag';
-import { itemThreadSession, liveSessions, metadataLabels, pullRequestStatusForItem, workItemMeta } from '../boardItems';
+import { itemThreadSession, metadataLabels, pullRequestStatusForItem, workItemMeta } from '../boardItems';
 import { itemRunSpec } from '../boardRunSpecs';
 import type { ItemRunSpec, RunAction } from '../boardRunSpecs';
 import { itemStageLabel } from '../boardStages';
@@ -44,8 +44,6 @@ export function WorkItemCard({
   relatedItems,
   projectRepositoryId,
   activityPage,
-  liveWorktreePaths,
-  sessionLivenessResolved,
   runDisabled,
   preparing,
   evaluatingStage,
@@ -74,9 +72,6 @@ export function WorkItemCard({
   /** Repository id resolving GitHub descriptions in the detail panel. */
   projectRepositoryId: string;
   activityPage?: AuditEventPage;
-  /** Worktrees that still exist; session refs outside this set are stale. */
-  liveWorktreePaths: ReadonlySet<string>;
-  sessionLivenessResolved: boolean;
   runDisabled: boolean;
   /** Status text while a run trigger is resolving, before the run mutation starts. */
   preparing?: string;
@@ -107,7 +102,7 @@ export function WorkItemCard({
   const runPending = pendingRunRoles.size > 0 || busyLabel !== undefined;
   const otherStages = item.stages.filter(stage => stage !== columnStage);
   const runSpec = itemRunSpec(item);
-  const sessions = liveSessions(item.sessions, liveWorktreePaths);
+  const sessions = item.sessions;
   // Offer only runs whose session slot hasn't been used yet on this card.
   const runActions = runSpec === undefined ? [] : runSpec.actions.filter(action => !(action.role in sessions));
   const defaultRunAction = runActions[0];
@@ -215,9 +210,7 @@ export function WorkItemCard({
   };
 
   const relatedLink = (related: WorkItem): ReactElement => {
-    const relatedSession = sessionLivenessResolved
-      ? itemThreadSession(liveSessions(related.sessions, liveWorktreePaths))
-      : undefined;
+    const relatedSession = itemThreadSession(related.sessions);
 
     if (relatedSession !== undefined) {
       return (
@@ -230,7 +223,7 @@ export function WorkItemCard({
       );
     }
 
-    if (sessionLivenessResolved && related.url !== null) {
+    if (related.url !== null) {
       return <RelatedWorkItemLink key={related.id} item={related} href={related.url} kind="external" />;
     }
 

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardRuns.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardRuns.ts
@@ -1,13 +1,12 @@
 import { toast } from '@mastra/playground-ui/components/Toaster';
-import { useMemo, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { useStartFactoryRun } from '../../../../hooks/useStartFactoryRun';
 import type { FactoryRunPhase } from '../../../../hooks/useStartFactoryRun';
 import type { useWorkItemsQuery } from '../../../../hooks/useWorkItems';
-import { useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
 import type { BoardCandidate } from '../boardCandidates';
-import { itemThreadSession, liveSessions } from '../boardItems';
+import { itemThreadSession } from '../boardItems';
 import { itemRunSpec, itemSessionSpec } from '../boardRunSpecs';
 import type { RunAction } from '../boardRunSpecs';
 import { inferredParentWorkItemId } from '../services/relationships';
@@ -20,31 +19,20 @@ type PendingRoles = ReadonlyMap<string, FactoryRunPhase | undefined>;
 /** Starting agent runs from cards and candidates, and reopening the threads they left behind. */
 export function useBoardRuns({
   factoryProjectId,
-  projectRepositoryId,
   workItems,
   refetchItems,
 }: {
   factoryProjectId: string;
-  projectRepositoryId: string | undefined;
   workItems: readonly WorkItem[];
   refetchItems: ReturnType<typeof useWorkItemsQuery>['refetch'];
 }) {
   const { start, pendingRuns, enabled } = useStartFactoryRun();
   const navigate = useNavigate();
 
-  // Workspaces that still exist. A card's session ref whose workspace was
-  // deleted is stale: its thread is gone (workspace deletion cascades onto its
-  // threads), so it neither renders a Thread link nor blocks re-running.
-  const workspaces = useWorkspacesQuery(projectRepositoryId);
-  const liveWorktreePaths = useMemo(
-    () => new Set((workspaces.data?.workspaces ?? []).map(workspace => workspace.sessionId)),
-    [workspaces.data],
-  );
-
-  // A card click refetches worktrees and items before it can decide whether to
-  // open an existing thread or mint a new session. That wait is several round
-  // trips long and the run mutation isn't pending yet, so without this the card
-  // sits completely silent after the click.
+  // A card click refetches items before it can decide whether to open an
+  // existing thread or mint a new session. That wait is a round trip long and
+  // the run mutation isn't pending yet, so without this the card sits
+  // completely silent after the click.
   const [preparingItems, setPreparingItems] = useState<Record<string, string>>({});
   // Guarded by a ref, not by preparingItems: two clicks landing in the same
   // render both read the pre-click state, so the state value can't reject the
@@ -73,10 +61,10 @@ export function useBoardRuns({
 
   // Refetch failures here used to be silent: an expired auth cookie made every
   // board click a no-op with no feedback. Toast so the click never dies quietly.
-  const refreshItemAndWorktrees = async (itemId: string) => {
-    const [refreshedWorkspaces, refreshedItems] = await Promise.all([workspaces.refetch(), refetchItems()]);
-    if (!refreshedWorkspaces.isSuccess || !refreshedItems.isSuccess) {
-      const cause = refreshedWorkspaces.error ?? refreshedItems.error;
+  const refreshItem = async (itemId: string) => {
+    const refreshedItems = await refetchItems();
+    if (!refreshedItems.isSuccess) {
+      const cause = refreshedItems.error;
       toast.error(cause instanceof Error ? cause.message : 'Failed to refresh the board — try reloading the page');
       return;
     }
@@ -85,33 +73,30 @@ export function useBoardRuns({
       toast.error('This card no longer exists — the board may be out of date');
       return;
     }
-    return {
-      item,
-      paths: new Set(refreshedWorkspaces.data.workspaces.map(workspace => workspace.sessionId)),
-    };
+    return item;
   };
 
   const openOrCreateSession = async (item: WorkItem, destinationStage: string) => {
     if (!beginPreparingItem(item.id, 'Preparing session…')) return;
     try {
-      const refreshed = await refreshItemAndWorktrees(item.id);
+      const refreshed = await refreshItem(item.id);
       if (!refreshed) return;
-      const existingSession = itemThreadSession(liveSessions(refreshed.item.sessions, refreshed.paths));
+      const existingSession = itemThreadSession(refreshed.sessions);
       if (existingSession) {
         await openThread(existingSession);
         return;
       }
-      const spec = itemSessionSpec(refreshed.item);
+      const spec = itemSessionSpec(refreshed);
       await start.mutateAsync({
         branch: spec.branch,
         threadTitle: spec.threadTitle,
         workItem: {
-          id: refreshed.item.id,
+          id: refreshed.id,
           role: 'chat',
           stages: [destinationStage],
-          source: refreshed.item.source,
-          sourceKey: refreshed.item.sourceKey,
-          title: refreshed.item.title,
+          source: refreshed.source,
+          sourceKey: refreshed.sourceKey,
+          title: refreshed.title,
         },
       });
     } finally {
@@ -146,14 +131,14 @@ export function useBoardRuns({
     role: RunAction['role'],
     { openExisting }: { openExisting: boolean },
   ) => {
-    const refreshed = await refreshItemAndWorktrees(item.id);
+    const refreshed = await refreshItem(item.id);
     if (!refreshed) return;
-    const existingSession = refreshed.item.sessions[role];
-    if (openExisting && existingSession && refreshed.paths.has(existingSession.sessionId)) {
+    const existingSession = refreshed.sessions[role];
+    if (openExisting && existingSession) {
       await openThread(existingSession);
       return;
     }
-    const spec = itemRunSpec(refreshed.item);
+    const spec = itemRunSpec(refreshed);
     const action = spec?.actions.find(candidate => candidate.role === role);
     if (!spec || !action) {
       toast.error(`This card can't start a ${role} run from its current state`);
@@ -165,13 +150,13 @@ export function useBoardRuns({
       threadTags: action.threadTags,
       invocation: action.invocation,
       workItem: {
-        id: refreshed.item.id,
+        id: refreshed.id,
         role: action.role,
-        existingRoles: Object.keys(refreshed.item.sessions),
+        existingRoles: Object.keys(refreshed.sessions),
         stages: [action.stage],
-        source: refreshed.item.source,
-        sourceKey: refreshed.item.sourceKey,
-        title: refreshed.item.title,
+        source: refreshed.source,
+        sourceKey: refreshed.sourceKey,
+        title: refreshed.title,
       },
     });
   };
@@ -211,12 +196,7 @@ export function useBoardRuns({
 
   return {
     enabled,
-    // Until the worktree listing settles, liveness is unknown and every session
-    // ref looks stale — a card title would render as a create button and a click
-    // would mint a replacement session for a perfectly live thread.
-    disabled: !enabled || !workspaces.isSuccess,
-    sessionLivenessResolved: workspaces.isSuccess,
-    liveWorktreePaths,
+    disabled: !enabled,
     error: start.error,
     pendingRolesFor: (itemId: string): PendingRoles => pendingByItem.get(itemId) ?? EMPTY_PENDING_ROLES,
     preparingFor: (itemId: string): string | undefined => preparingItems[itemId],

--- a/mastracode/factory-ui/src/ui/domains/search/components/FactoryGlobalSearchContent.tsx
+++ b/mastracode/factory-ui/src/ui/domains/search/components/FactoryGlobalSearchContent.tsx
@@ -42,7 +42,6 @@ export function FactoryGlobalSearchContent({ factoryId, closeSearch }: { factory
   const intake = useGlobalSearchIntake(projectRepositoryId);
   const runs = useBoardRuns({
     factoryProjectId: factoryId,
-    projectRepositoryId,
     workItems: workItems.items,
     refetchItems: workItems.refetch,
   });

--- a/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
@@ -124,7 +124,6 @@ function BoardContent({
   const intake = useBoardIntake({ factoryProjectId, repository, kind, knownSourceKeys: items.knownSourceKeys });
   const runs = useBoardRuns({
     factoryProjectId,
-    projectRepositoryId: repository.projectRepositoryId,
     workItems: items.all,
     refetchItems: items.refetch,
   });
@@ -391,8 +390,6 @@ function BoardContent({
                           relatedItems={relatedItemsFor(item)}
                           projectRepositoryId={repository.projectRepositoryId}
                           activityPage={activityPage}
-                          liveWorktreePaths={runs.liveWorktreePaths}
-                          sessionLivenessResolved={runs.sessionLivenessResolved}
                           runDisabled={runs.disabled}
                           preparing={runs.preparingFor(item.id)}
                           evaluatingStage={items.evaluatingStages.get(item.id)}

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -624,6 +624,7 @@ export class MastraFactory {
         .filter(integration => integration.versionControl)
         .map(integration => integration.id),
       ...(sessionRetirement ? { sessionRetirement } : {}),
+      ...(workItemsReady ? { workItems: workItemsStorage } : {}),
       onProjectRepositoryLinked: args => baseCheckpoints?.onProjectRepositoryLinked(args),
     });
     const factoryProcessor = workItemsReady

--- a/mastracode/factory/src/integrations/base.ts
+++ b/mastracode/factory/src/integrations/base.ts
@@ -100,6 +100,8 @@ export interface IntegrationContext {
   stateSigner?: StateSigner;
   /** Shared source-control session retirement lifecycle used by integration routes. */
   sessionRetirement?: SessionRetirementCoordinator;
+  /** Work-items domain slice — deleting a session strips the refs work items hold on it. */
+  workItems?: Pick<WorkItemsStorage, 'clearSessionReferences'>;
   /** Persistence handles pre-scoped to this integration's stable id. */
   storage: {
     generic: IntegrationStorageHandle;

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -1157,6 +1157,7 @@ export class GithubIntegration implements FactoryIntegration {
       projects: ctx.storage.projects,
       ingestFactoryEvent,
       sessionRetirement: ctx.sessionRetirement,
+      ...(ctx.workItems ? { workItems: ctx.workItems } : {}),
     });
   }
 

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -1594,8 +1594,8 @@ function buildProjectGitRoutes({
             deleteSession: true,
           });
         } else {
-          await github.sourceControlStorage.sessions.delete(session.id);
           await workItems?.clearSessionReferences({ orgId: session.orgId, sessionId: session.sessionId });
+          await github.sourceControlStorage.sessions.delete(session.id);
           void reclaimDeletedSessionSandbox({
             fleet,
             sourceControl: github.sourceControlStorage,

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -138,6 +138,8 @@ export interface MountGithubRoutesOptions {
   /** Factory projects domain — resolves a project's default triage model. */
   projects?: FactoryProjectsStorage;
   sessionRetirement?: import('../../sandbox/session-retirement.js').SessionRetirementCoordinator;
+  /** Work-items domain — session deletion strips the refs work items hold on it. */
+  workItems?: Pick<import('../../storage/domains/work-items/base.js').WorkItemsStorage, 'clearSessionReferences'>;
   /** Authoritative Factory rule ingress for normalized, signature-verified GitHub deliveries. */
   ingestFactoryEvent?: (event: ParsedGithubWebhook) => Promise<unknown>;
 }
@@ -366,8 +368,19 @@ async function ingestPolledEvents(
  */
 export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[] {
   const routes: ApiRoute[] = [];
-  const { auth, users, fleet, storage, github, stateSigner, controller, memorySettings, emitAudit, sessionRetirement } =
-    options;
+  const {
+    auth,
+    users,
+    fleet,
+    storage,
+    github,
+    stateSigner,
+    controller,
+    memorySettings,
+    emitAudit,
+    sessionRetirement,
+    workItems,
+  } = options;
   const diagnostics = () =>
     getGithubFeatureDiagnostics({ github, auth, appDbConfigured: storage !== undefined, stateSigner, fleet });
 
@@ -1053,7 +1066,7 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
 
   // ── Sessions / commit / push / PR ────────────────────────────────────────
   routes.push(
-    ...buildProjectGitRoutes({ github, auth, users, fleet, controller, memorySettings, emitAudit, sessionRetirement }),
+    ...buildProjectGitRoutes({ github, auth, users, fleet, controller, memorySettings, emitAudit, sessionRetirement, workItems }),
   );
 
   return routes;
@@ -1398,6 +1411,7 @@ function buildProjectGitRoutes({
   memorySettings,
   emitAudit,
   sessionRetirement,
+  workItems,
 }: {
   github: GithubIntegration;
   auth: RouteAuth;
@@ -1407,6 +1421,7 @@ function buildProjectGitRoutes({
   memorySettings: MountGithubRoutesOptions['memorySettings'];
   emitAudit?: AuditEmitter['emit'];
   sessionRetirement?: MountGithubRoutesOptions['sessionRetirement'];
+  workItems?: MountGithubRoutesOptions['workItems'];
 }): ApiRoute[] {
   const nameSession = createSessionNaming();
   const resolveSessionOwnerProfiles = createSessionOwnerProfileResolver(users);
@@ -1573,12 +1588,14 @@ function buildProjectGitRoutes({
         if (sessionRetirement) {
           await sessionRetirement.retireSession({
             sourceControl: github.sourceControlStorage,
+            ...(workItems ? { workItems } : {}),
             orgId: session.orgId,
             sessionId: session.sessionId,
             deleteSession: true,
           });
         } else {
           await github.sourceControlStorage.sessions.delete(session.id);
+          await workItems?.clearSessionReferences({ orgId: session.orgId, sessionId: session.sessionId });
           void reclaimDeletedSessionSandbox({
             fleet,
             sourceControl: github.sourceControlStorage,

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -589,6 +589,8 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         projects: ctx.storage.projects,
         emitAudit: ctx.hooks?.emitAudit,
         ingestFactoryEvent,
+        ...(ctx.sessionRetirement ? { sessionRetirement: ctx.sessionRetirement } : {}),
+        ...(ctx.workItems ? { workItems: ctx.workItems } : {}),
       }).filter(
         route =>
           route.path !== '/web/github/status' &&

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -589,7 +589,6 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         projects: ctx.storage.projects,
         emitAudit: ctx.hooks?.emitAudit,
         ingestFactoryEvent,
-        ...(ctx.sessionRetirement ? { sessionRetirement: ctx.sessionRetirement } : {}),
         ...(ctx.workItems ? { workItems: ctx.workItems } : {}),
       }).filter(
         route =>

--- a/mastracode/factory/src/routes/projects.ts
+++ b/mastracode/factory/src/routes/projects.ts
@@ -14,6 +14,7 @@ import type {
   SourceControlStorageHandle,
   UpdateProjectRepositoryInput,
 } from '../storage/domains/source-control/base.js';
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import type { RouteDependencies } from './route.js';
 import { Route } from './route.js';
 
@@ -191,6 +192,8 @@ export interface ProjectRoutesDeps extends RouteDependencies {
   onProjectRepositoryLinked?: (args: { orgId: string; projectRepository: ProjectRepository }) => void;
   /** Shared lifecycle for retiring sessions before their owning records are deleted. */
   sessionRetirement?: SessionRetirementCoordinator;
+  /** Work-items domain — retired sessions drop the refs work items hold on them. */
+  workItems?: Pick<WorkItemsStorage, 'clearSessionReferences'>;
 }
 
 export class ProjectRoutes extends Route<ProjectRoutesDeps> {
@@ -253,6 +256,7 @@ export class ProjectRoutes extends Route<ProjectRoutesDeps> {
     if (!this.deps.sessionRetirement) return false;
     await this.deps.sessionRetirement.retireProjectRepositorySessions({
       sourceControl: handle,
+      ...(this.deps.workItems ? { workItems: this.deps.workItems } : {}),
       orgId,
       projectRepositoryId,
     });

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -256,7 +256,6 @@ export function buildIntegrationContext(
     | 'factoryStorage'
     | 'integrationStorage'
     | 'sourceControlStorage'
-    | 'sessionRetirement'
   > & {
     stateSigner: StateSigner;
     emitAudit?: AuditEmitter['emit'];
@@ -297,7 +296,6 @@ export function buildIntegrationContext(
       channelIdentity: deps.domains.channelIdentity,
       memorySettings: deps.domains.memorySettings,
     },
-    ...(deps.sessionRetirement ? { sessionRetirement: deps.sessionRetirement } : {}),
     ...(deps.factoryReady ? { workItems: deps.domains.workItems } : {}),
     ...(deps.factoryReady ? { rules: { config: deps.rules, workItems: deps.domains.workItems } } : {}),
     ...(deps.emitAudit ? { hooks: { emitAudit: deps.emitAudit } } : {}),

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -256,6 +256,7 @@ export function buildIntegrationContext(
     | 'factoryStorage'
     | 'integrationStorage'
     | 'sourceControlStorage'
+    | 'sessionRetirement'
   > & {
     stateSigner: StateSigner;
     emitAudit?: AuditEmitter['emit'];
@@ -296,6 +297,8 @@ export function buildIntegrationContext(
       channelIdentity: deps.domains.channelIdentity,
       memorySettings: deps.domains.memorySettings,
     },
+    ...(deps.sessionRetirement ? { sessionRetirement: deps.sessionRetirement } : {}),
+    ...(deps.factoryReady ? { workItems: deps.domains.workItems } : {}),
     ...(deps.factoryReady ? { rules: { config: deps.rules, workItems: deps.domains.workItems } } : {}),
     ...(deps.emitAudit ? { hooks: { emitAudit: deps.emitAudit } } : {}),
   };

--- a/mastracode/factory/src/sandbox/session-retirement.test.ts
+++ b/mastracode/factory/src/sandbox/session-retirement.test.ts
@@ -248,6 +248,31 @@ describe('SessionRetirementCoordinator', () => {
     expect(clearSessionReferences).toHaveBeenCalledWith({ orgId: 'org-1', sessionId: session.sessionId });
   });
 
+  it('clears work-item references before the row dies, so a failed delete leaves nothing dangling', async () => {
+    const storage = new SourceControlStorageInMemory();
+    seedRepositoryLink(storage);
+    const session = await seedSession(storage);
+    const clearSessionReferences = vi.fn(async () => 1);
+    vi.spyOn(storage.sessions, 'delete').mockRejectedValueOnce(new Error('db down'));
+    const coordinator = new SessionRetirementCoordinator({
+      fleet: { provider: 'local', reattachSandbox: vi.fn(async () => sandbox([])), teardownSandbox: vi.fn() },
+      invalidateSession: vi.fn(),
+    });
+
+    await expect(
+      coordinator.retireSession({
+        sourceControl: storage,
+        workItems: { clearSessionReferences },
+        orgId: 'org-1',
+        sessionId: session.sessionId,
+        deleteSession: true,
+      }),
+    ).rejects.toThrow('db down');
+
+    expect(clearSessionReferences).toHaveBeenCalledTimes(1);
+    expect(await storage.sessions.getBySessionId(session.sessionId)).not.toBeNull();
+  });
+
   it('still pools, clears, and invalidates when the remote sandbox cannot be reattached', async () => {
     const storage = new SourceControlStorageInMemory();
     seedRepositoryLink(storage);

--- a/mastracode/factory/src/sandbox/session-retirement.test.ts
+++ b/mastracode/factory/src/sandbox/session-retirement.test.ts
@@ -219,6 +219,35 @@ describe('SessionRetirementCoordinator', () => {
     expect(storage.sandboxPoolRows).toEqual([]);
   });
 
+  it('clears work-item session references when the session row is deleted, and leaves them when it is not', async () => {
+    const storage = new SourceControlStorageInMemory();
+    seedRepositoryLink(storage);
+    const session = await seedSession(storage);
+    const clearSessionReferences = vi.fn(async () => 1);
+    const coordinator = new SessionRetirementCoordinator({
+      fleet: { provider: 'local', reattachSandbox: vi.fn(async () => sandbox([])), teardownSandbox: vi.fn() },
+      invalidateSession: vi.fn(),
+    });
+
+    await coordinator.retireSession({
+      sourceControl: storage,
+      workItems: { clearSessionReferences },
+      orgId: 'org-1',
+      sessionId: session.sessionId,
+      deleteSession: false,
+    });
+    expect(clearSessionReferences).not.toHaveBeenCalled();
+
+    await coordinator.retireSession({
+      sourceControl: storage,
+      workItems: { clearSessionReferences },
+      orgId: 'org-1',
+      sessionId: session.sessionId,
+      deleteSession: true,
+    });
+    expect(clearSessionReferences).toHaveBeenCalledWith({ orgId: 'org-1', sessionId: session.sessionId });
+  });
+
   it('still pools, clears, and invalidates when the remote sandbox cannot be reattached', async () => {
     const storage = new SourceControlStorageInMemory();
     seedRepositoryLink(storage);

--- a/mastracode/factory/src/sandbox/session-retirement.ts
+++ b/mastracode/factory/src/sandbox/session-retirement.ts
@@ -176,8 +176,9 @@ export class SessionRetirementCoordinator {
       }
 
       if (input.deleteSession) {
-        await input.sourceControl.sessions.delete(session.id);
+        // Refs first: clearing again is a no-op, but refs on a deleted row would dangle forever.
         await input.workItems?.clearSessionReferences({ orgId: input.orgId, sessionId: input.sessionId });
+        await input.sourceControl.sessions.delete(session.id);
       }
     }
   }

--- a/mastracode/factory/src/sandbox/session-retirement.ts
+++ b/mastracode/factory/src/sandbox/session-retirement.ts
@@ -19,6 +19,8 @@ export interface SessionRetirementCoordinatorOptions {
 
 export interface RetireSessionInput {
   sourceControl: SourceControlStorageHandle;
+  /** When provided, deleting the session row also strips its work-item refs. */
+  workItems?: Pick<WorkItemsStorage, 'clearSessionReferences'>;
   orgId: string;
   sessionId: string;
   deleteSession: boolean;
@@ -82,6 +84,7 @@ export class SessionRetirementCoordinator {
 
   async retireProjectRepositorySessions(options: {
     sourceControl: SourceControlStorageHandle;
+    workItems?: Pick<WorkItemsStorage, 'clearSessionReferences'>;
     orgId: string;
     projectRepositoryId: string;
   }): Promise<void> {
@@ -92,6 +95,7 @@ export class SessionRetirementCoordinator {
       sessions.map(session =>
         this.retireSession({
           sourceControl: options.sourceControl,
+          ...(options.workItems ? { workItems: options.workItems } : {}),
           orgId: options.orgId,
           sessionId: session.sessionId,
           deleteSession: true,
@@ -171,7 +175,10 @@ export class SessionRetirementCoordinator {
         });
       }
 
-      if (input.deleteSession) await input.sourceControl.sessions.delete(session.id);
+      if (input.deleteSession) {
+        await input.sourceControl.sessions.delete(session.id);
+        await input.workItems?.clearSessionReferences({ orgId: input.orgId, sessionId: input.sessionId });
+      }
     }
   }
 

--- a/mastracode/factory/src/storage/domains/work-items/base.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.test.ts
@@ -65,6 +65,44 @@ function interceptTransactionOps(backend: any, overridesFor: (ops: any) => Recor
 }
 
 describe('WorkItemsStorage', () => {
+  it('clears every reference to a deleted session without touching other refs, items, or orgs', async () => {
+    const storage = await makeStorage();
+    const ref = (sessionId: string) => ({ sessionId, branch: `factory/${sessionId}`, threadId: `${sessionId}-thread` });
+    const touched = await storage.upsert({
+      orgId: 'org1',
+      userId: 'user1',
+      factoryProjectId: 'project1',
+      input: { ...input, sessions: { work: ref('sess-dead'), review: ref('sess-live') } },
+    });
+    const untouched = await storage.upsert({
+      orgId: 'org1',
+      userId: 'user1',
+      factoryProjectId: 'project1',
+      input: {
+        ...input,
+        externalSource: { ...input.externalSource, externalId: '43' },
+        sessions: { review: ref('sess-live') },
+      },
+    });
+    const otherOrg = await storage.upsert({
+      orgId: 'org2',
+      userId: 'user1',
+      factoryProjectId: 'project2',
+      input: { ...input, sessions: { work: ref('sess-dead') } },
+    });
+
+    const cleared = await storage.clearSessionReferences({ orgId: 'org1', sessionId: 'sess-dead' });
+
+    expect(cleared).toBe(1);
+    const touchedAfter = await storage.get({ orgId: 'org1', id: touched.item.id });
+    expect(Object.keys(touchedAfter!.sessions)).toEqual(['review']);
+    expect(touchedAfter!.revision).toBe(touched.item.revision + 1);
+    const untouchedAfter = await storage.get({ orgId: 'org1', id: untouched.item.id });
+    expect(untouchedAfter!.revision).toBe(untouched.item.revision);
+    const otherOrgAfter = await storage.get({ orgId: 'org2', id: otherOrg.item.id });
+    expect(otherOrgAfter!.sessions.work?.sessionId).toBe('sess-dead');
+  });
+
   it('persists a triage classification atomically, revisions it once, and replays without changing it', async () => {
     const storage = await makeStorage();
     const created = await storage.upsert({ orgId: 'org1', userId: 'user1', factoryProjectId: 'project1', input });

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -1189,6 +1189,28 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     return rows.map(toWorkItem);
   }
 
+  /**
+   * Strip every ref to a retired session; matching happens in app code because
+   * `findMany` cannot reach inside the `sessions` JSON column.
+   * ponytail: org-wide scan per session delete; JSON-path query if it measures.
+   */
+  async clearSessionReferences({ orgId, sessionId }: { orgId: string; sessionId: string }): Promise<number> {
+    const rows = await this.#db.findMany<WorkItemDbRow>('work_items', { org_id: orgId });
+    const holding = rows.filter(row => Object.values(row.sessions).some(ref => ref.sessionId === sessionId));
+    let cleared = 0;
+    for (const row of holding) {
+      let changed = false;
+      await this.#db.updateAtomic<WorkItemDbRow>('work_items', { id: row.id }, current => {
+        const kept = Object.entries(current.sessions).filter(([, ref]) => ref.sessionId !== sessionId);
+        if (kept.length === Object.keys(current.sessions).length) return null;
+        changed = true;
+        return { sessions: Object.fromEntries(kept), revision: current.revision + 1, updated_at: new Date() };
+      });
+      if (changed) cleared += 1;
+    }
+    return cleared;
+  }
+
   async get({ orgId, id }: { orgId: string; id: string }): Promise<WorkItemRow | null> {
     const row = await this.#db.findOne<WorkItemDbRow>('work_items', { org_id: orgId, id });
     return row ? toWorkItem(row) : null;


### PR DESCRIPTION
TLDR: deleting a session now also deletes the work-item refs pointing at it, so board cards can finally trust their own session refs — the Review button flips to "Open session" when an automated run binds its session, and a leased run stops claiming it is still starting.

---

Approving a Review decision worked server-side (session materialized, ref written on the work item), but the card never showed it: the card only believed a session ref if the sidebar's workspaces query also listed it, and that query stops polling once every *listed* session is materialized — so a dispatcher-minted session never appeared. The filter existed because `DELETE /web/user-sessions/:id` retired the session but left its work-item refs dangling. This fixes the root and deletes the filter.

### What changes

| on the board | before | after |
| --- | --- | --- |
| an automated run binds its session to the card | popover stuck on "Review" | "Open session" within one 5s poll |
| a decision holds the lease while its run is in flight | "Starting an automated run…" for the whole run | "Automated run in progress…" |
| you delete a workspace a card links to | link hidden client-side, ref dangling in the DB forever | ref deleted with the session (indicator still drops instantly, now via a cache patch) |
| a related card has a bound session | link appears only after the workspaces query settles | links straight to the thread |

### Judgment call

The DELETE route has two branches, and the retirement-coordinator one has always been dead (`buildIntegrationContext` never forwarded `sessionRetirement`). I first wired it live here, then reverted that: the coordinator reattaches the sandbox and runs teardown in-request, and `reclaimDeletedSessionSandbox`'s doc argues explicitly for delete-fast-then-reclaim on this route. So the live fallback branch carries the fix, and the coordinator also clears refs for the paths where it already runs (project delete, repo unlink).

`clearSessionReferences` scans the org's work items in app code because the generic storage ops can't match inside the `sessions` JSON column. One scan per session delete; a JSON-path query is the upgrade if it ever measures.

### On deploy

Refs left dangling by deletes that predate this fix stop being hidden: those cards show an "Open session" link that 404s. The ref heals at the item's next run — the prepare re-mints and re-stamps it (#22410). No backfill; if Cloud data shows many of these, a one-shot sweep is the follow-up.

### Side effects to check

- The deleted filter had a second job: it hid other users' private sessions (Slack-DM-minted ones bound to org-visible cards). A non-owner now sees "Open session" and gets a 404; before, their "Review" click silently minted a duplicate session that clobbered the ref. Honest dead link over silent clobber, but it is visible.
- A session deleted while a dispatch is writing its ref can re-dangle (clear runs before the write lands). Seconds-wide window, no janitor.
- `useBoardRuns` no longer consumes the workspaces query at all: the pre-click refetch drops its workspaces round-trip, and run buttons are no longer disabled while that query loads.

```
tests        +144  -43
source       +136  -87   ← −91 of it front-side deletions
changeset      +5   -0
```
