### PR TITLE
fix(factory): keep the sidebar still when you open a session

### DIFF
--- a/.changeset/twenty-suits-jam.md
+++ b/.changeset/twenty-suits-jam.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed the Factory sidebar reordering itself when you open a session. Opening a work or review session used to lift its row to the top of its group, so the list moved under your cursor as you clicked through it. Rows now keep their creation order, and a session that sorts below the collapsed fold is shown anyway, so a deep link or a hand-off from the board never lands you on a session with no row.
+Fixed the Factory sidebar reordering itself when you open a session. Opening a work or review session used to move its row to the top of its group, so the list shifted under your cursor as you clicked through it. Rows now keep their creation order, and a session that would sit past the first five rows is shown anyway, so you always see a row for the session you are in.

--- a/.changeset/twenty-suits-jam.md
+++ b/.changeset/twenty-suits-jam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the Factory sidebar reordering itself when you open a session. Opening a work or review session used to lift its row to the top of its group, so the list moved under your cursor as you clicked through it. Rows now keep their creation order, and a session that sorts below the collapsed fold is shown anyway, so a deep link or a hand-off from the board never lands you on a session with no row.

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -47,12 +47,13 @@ function watchRank(row: FactoryWorkspaceRow): number {
  * Explicit intent first, then whatever still has work in it, newest first inside a tier.
  * Sorting on creation rather than activity is what keeps a row still: every card write bumps
  * `updatedAt` and the board polls, so an activity order reshuffles the sidebar under the reader.
+ * Opening a session is that same reshuffle with the reader's own click behind it, so the row
+ * being read holds its place and is kept reachable by `latestRows` instead.
  * Session id closes it into a total order — the sessions endpoint sorts nothing, so anything
  * falling through to its order would still shuffle.
  */
 const bySessionPriority = (a: FactoryWorkspaceRow, b: FactoryWorkspaceRow) =>
   Number(b.pinned) - Number(a.pinned) ||
-  Number(b.active) - Number(a.active) ||
   watchRank(a) - watchRank(b) ||
   b.createdAt.localeCompare(a.createdAt) ||
   b.workspace.sessionId.localeCompare(a.workspace.sessionId);
@@ -141,7 +142,12 @@ export function WorkspacesSection() {
   });
   const latestRows = (review: boolean) => {
     const all = rows.filter(row => row.review === review).sort(bySessionPriority);
-    return { visible: all.slice(0, COLLAPSED_ROW_COUNT), all };
+    const visible = all.slice(0, COLLAPSED_ROW_COUNT);
+    // Deep links and board handoffs can open a session that sorts below the fold;
+    // show it rather than promote it, so the list never moves under the reader.
+    const open = all.find(row => row.active);
+    if (open && !visible.includes(open)) visible.push(open);
+    return { visible, all };
   };
   const workRows = latestRows(false);
   const reviewRows = latestRows(true);

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspacesSectionOrder.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspacesSectionOrder.msw.test.tsx
@@ -179,6 +179,29 @@ describe('Workspaces sidebar order', () => {
     expect(await reviewRowLabels(client)).toEqual(['factory/pr-403', 'factory/pr-402', 'factory/pr-401']);
   });
 
+  it('keeps the open session visible when creation order puts it past the collapsed rows', async () => {
+    const sessions = [501, 502, 503, 504, 505, 506, 507].map((pr, i) =>
+      reviewSession(pr, `2026-07-23T0${i}:00:00.000Z`),
+    );
+    const [oldest] = sessions;
+
+    stubSidebar(
+      sessions,
+      sessions.map((session, i) => reviewCard(session, 501 + i)),
+    );
+    const { client } = renderSection(oldest.sessionId);
+
+    // Five newest, then the open one; the row it displaced stays behind "Show more".
+    expect(await reviewRowLabels(client)).toEqual([
+      'factory/pr-507',
+      'factory/pr-506',
+      'factory/pr-505',
+      'factory/pr-504',
+      'factory/pr-503',
+      'factory/pr-501',
+    ]);
+  });
+
   it('holds one order for sessions created at the same instant, whichever way the endpoint returns them', async () => {
     const first = reviewSession(201, '2026-07-23T09:00:00.000Z');
     const second = reviewSession(202, '2026-07-23T09:00:00.000Z');

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspacesSectionOrder.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspacesSectionOrder.msw.test.tsx
@@ -94,9 +94,13 @@ function stubSidebar(
   );
 }
 
-function renderSection() {
+function renderSection(openSessionId?: string) {
   return renderWithProviders(
-    <MemoryRouter initialEntries={[`/factories/${factoryProjectId}`]}>
+    <MemoryRouter
+      initialEntries={[
+        openSessionId ? `/factories/${factoryProjectId}/workspaces/${openSessionId}` : `/factories/${factoryProjectId}`,
+      ]}
+    >
       <ChatSessionContext.Provider
         value={{
           resourceId: 'resource-1',
@@ -113,6 +117,7 @@ function renderSection() {
       >
         <Routes>
           <Route path="/factories/:factoryId" element={<WorkspacesSection />} />
+          <Route path="/factories/:factoryId/workspaces/:sessionId" element={<WorkspacesSection />} />
         </Routes>
       </ChatSessionContext.Provider>
     </MemoryRouter>,
@@ -160,6 +165,18 @@ describe('Workspaces sidebar order', () => {
     const { client } = renderSection();
 
     expect(await reviewRowLabels(client)).toEqual(['factory/pr-302', 'factory/pr-301']);
+  });
+
+  it('leaves the open session where creation order put it', async () => {
+    const oldest = reviewSession(401, '2026-07-23T09:00:00.000Z');
+    const middle = reviewSession(402, '2026-07-23T10:00:00.000Z');
+    const newest = reviewSession(403, '2026-07-23T11:00:00.000Z');
+    const cards = [reviewCard(oldest, 401), reviewCard(middle, 402), reviewCard(newest, 403)];
+
+    stubSidebar([oldest, middle, newest], cards);
+    const { client } = renderSection(oldest.sessionId);
+
+    expect(await reviewRowLabels(client)).toEqual(['factory/pr-403', 'factory/pr-402', 'factory/pr-401']);
   });
 
   it('holds one order for sessions created at the same instant, whichever way the endpoint returns them', async () => {


### PR DESCRIPTION
TLDR: the Factory sidebar stops reordering itself when you open a session, so the
row you just clicked stays where it was.

---

Opening a work or review session lifted its row to the top of its group. The list
moved under the cursor on every click, and clicking down a list meant clicking a
different list each time. Creation order now holds, which is the rule that
comparator already follows for activity — it sorts on `createdAt` precisely
because the board polls and an activity order would reshuffle under the reader.
Being the open session was the last thing still allowed to jump the queue.

Dropping it alone would hide the session you are in: the group shows 5 rows
collapsed, so a deep link or a hand-off from the board can land you on a session
that sorts below the fold with no row anywhere. It is shown rather than promoted.

### What changes

| you open a session | before | after |
| --- | --- | --- |
| it is in the visible 5 | jumps to the top of its group | stays put |
| it sorts below the fold | group silently has no row for it | its row is appended, group stays collapsed |
| the board polls while you read | order already held | unchanged |

### Judgment call

An open session ranked, say, 12th shows up directly under the 5th row, then drops
to its real place when you expand the group. That is a move under the reader —
the one this PR is about — but it takes an explicit click on "Show N more" to
happen, and the alternative is a row that is nowhere.

```
source        +10  -2    ← net +8
tests         +21  -2
changeset      +5   0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Opening a session no longer moves it to the top of the Factory sidebar. This keeps the list stable while still showing opened sessions in collapsed groups.

## Changes

- Preserve creation-order sorting for work and review sessions.
- Append an opened session to a collapsed group when it is below the five-row visible limit.
- Return the session to its actual position when the group expands.
- Keep polling behavior unchanged.
- Add regression coverage for session ordering and collapsed groups.
- Add a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->