### PR TITLE
fix(factory-ui): reconcile chat run state against stale fetches, stream gaps, and lost run-ends

### DIFF
--- a/.changeset/chatty-states-agree.md
+++ b/.changeset/chatty-states-agree.md
@@ -1,0 +1,9 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the chat composer losing track of whether the agent is running. Three ways the composer and the server could disagree are now reconciled:
+
+- A slow session-state fetch could finish after a newer run-start or run-end event and overwrite it, leaving the composer spinning on an idle agent or silent on a running one. Live events now win over stale fetches.
+- Reconnecting after a dropped stream now re-fetches the run state, so anything that happened during the gap is picked up.
+- A sent message used to keep the composer busy until a run-end event arrived; if that event was lost in a stream gap, it stayed busy forever. A fresh snapshot saying the agent is idle now releases it.

--- a/mastracode/factory-ui/src/hooks/useAgentControllerSessionSync.ts
+++ b/mastracode/factory-ui/src/hooks/useAgentControllerSessionSync.ts
@@ -5,6 +5,17 @@ import type { RefObject } from 'react';
 import { queryKeys } from '../api/keys';
 import { createAgentControllerClient } from '../ui/domains/chat/services/agentControllerClient';
 
+/**
+ * Freshest event-patched fields, stamped per field so a state fetch resolving
+ * after an event re-applies only what the event updated mid-flight instead of
+ * overwriting it with an older snapshot.
+ */
+export interface LiveStatePatch {
+  generation: number;
+  running?: { value: boolean; generation: number };
+  tasks?: { value: AgentControllerTaskSnapshot[]; threadId?: string; generation: number };
+}
+
 interface UseAgentControllerSessionSyncArgs {
   agentControllerId: string;
   resourceId: string;
@@ -13,8 +24,7 @@ interface UseAgentControllerSessionSyncArgs {
   baseUrl?: string;
   enabled?: boolean;
   sseConnected: boolean;
-  taskEventGeneration: RefObject<number>;
-  liveTasks: RefObject<{ threadId?: string; tasks: AgentControllerTaskSnapshot[] } | undefined>;
+  livePatch: RefObject<LiveStatePatch>;
 }
 
 export function reconnectRefetchInterval(sseConnected: boolean, fetchFailureCount: number): false | number {
@@ -31,8 +41,7 @@ export function useAgentControllerSessionSync({
   baseUrl = '',
   enabled = true,
   sseConnected,
-  taskEventGeneration,
-  liveTasks,
+  livePatch,
 }: UseAgentControllerSessionSyncArgs) {
   const { session } = createAgentControllerClient({
     agentControllerId,
@@ -45,13 +54,16 @@ export function useAgentControllerSessionSync({
   return useQuery({
     queryKey: queryKeys.agentControllerConnectionState(agentControllerId, resourceId, scope, threadId),
     queryFn: async () => {
-      const generationAtRequestStart = taskEventGeneration.current;
+      const generationAtRequestStart = livePatch.current.generation;
       const state = await session!.state({ threadId });
-      const latestTasks = liveTasks.current;
-      const liveEventOvertookRequest = generationAtRequestStart !== taskEventGeneration.current;
-      return liveEventOvertookRequest && latestTasks && latestTasks.threadId === threadId
-        ? { ...state, tasks: latestTasks.tasks }
-        : state;
+      const { running, tasks } = livePatch.current;
+      const runningOvertookRequest = running && running.generation > generationAtRequestStart;
+      const tasksOvertookRequest = tasks && tasks.generation > generationAtRequestStart && tasks.threadId === threadId;
+      return {
+        ...state,
+        ...(runningOvertookRequest ? { running: running.value } : {}),
+        ...(tasksOvertookRequest ? { tasks: tasks.value } : {}),
+      };
     },
     enabled: enabled && Boolean(session),
     staleTime: Infinity,

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerBusyReconcile.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerBusyReconcile.msw.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * BDD coverage for the composer's busy latch against server truth. Sending a
+ * message arms `pending` until an `agent_end` arrives; when the stream loses
+ * that event, only a session-state snapshot fetched after the send can say the
+ * run is over. In production that fetch comes from the disconnect poll or the
+ * reconnect invalidation — here the test invalidates the state query directly.
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../e2e/ui/msw-server';
+import { TEST_BASE_URL } from '../../../../../../e2e/ui/render';
+import { SESSION_ID, releaseSession, renderThread, stubPreparingSession } from './composer-session-test-fixture';
+
+const API = `${TEST_BASE_URL}/api/agent-controller/code`;
+
+describe('Composer busy reconcile', () => {
+  it('given a send whose agent_end never arrives, when a fresh snapshot says the run is over, then the composer returns to idle', async () => {
+    const session = stubPreparingSession({ autoAgentEnd: false });
+    let stateReads = 0;
+    server.use(
+      http.get(`${API}/sessions/:resourceId`, ({ params }) => {
+        stateReads += 1;
+        return HttpResponse.json({
+          controllerId: 'code',
+          resourceId: params.resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: SESSION_ID,
+          running: false,
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    const { client } = renderThread();
+    await releaseSession(session.finishWorkspace, client);
+
+    const composer = await screen.findByRole('textbox', { name: 'Message' });
+    await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Ask Mastra Code…'));
+
+    await user.type(composer, 'Check the failing build');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(session.delivered).toEqual(['Check the failing build']));
+    await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Steer the agent…'));
+
+    await client.invalidateQueries({ queryKey: ['agent-controller', 'code', 'connection', SESSION_ID] });
+    await waitFor(() => expect(stateReads).toBeGreaterThanOrEqual(2));
+
+    await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Ask Mastra Code…'));
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatConnectionContext.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatConnectionContext.ts
@@ -7,6 +7,8 @@ export type ChatConnectionState = ReturnType<typeof useAgentControllerConnection
 export interface ChatConnectionApi {
   status: ConnectionStatus;
   state?: ChatConnectionState;
+  /** Timestamp of the last real state fetch (event patches excluded). */
+  stateUpdatedAt?: number;
   threadId?: string;
   createdThreadId?: string;
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatConnectionProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatConnectionProvider.tsx
@@ -40,6 +40,7 @@ export function ChatConnectionProvider({
   const connectionValue: ChatConnectionApi = {
     status: connection.status,
     state: connection.state,
+    stateUpdatedAt: connection.stateUpdatedAt,
     threadId: connection.threadId,
     createdThreadId: connection.threadId,
   };

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
@@ -141,7 +141,10 @@ function ChatTranscriptValueProvider({
     omProgress: transcript.omProgress ?? connection.state?.omProgress,
     usage: transcript.usage ?? connection.state?.tokenUsage,
   };
-  const busy = connection.state?.running === true || effectiveTranscript.pending;
+  const serverIdleSinceSend =
+    connection.state?.running === false &&
+    (connection.stateUpdatedAt ?? 0) > (effectiveTranscript.pendingSince ?? Infinity);
+  const busy = connection.state?.running === true || (effectiveTranscript.pending && !serverIdleSinceSend);
   const transcriptValue: ChatTranscriptApi = {
     transcript: effectiveTranscript,
     busy,

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
@@ -338,6 +338,68 @@ describe('useAgentControllerConnection', () => {
     await waitFor(() => expect(result.current.state?.tasks).toEqual(liveTasks));
   });
 
+  it('given a state refetch started before a run-end event, then the stale response does not resurrect the running flag', async () => {
+    const encoder = new TextEncoder();
+    const onEvent = vi.fn();
+    let emit: (event: AgentControllerEvent) => void = () => {};
+    let stateReads = 0;
+    let releaseRefetch: (() => void) | undefined;
+    const refetchGate = new Promise<void>(resolve => {
+      releaseRefetch = resolve;
+    });
+
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, () =>
+        HttpResponse.json({ controllerId, resourceId, threadId: 'thread-1' }),
+      ),
+      http.get(sessionUrl, async () => {
+        stateReads += 1;
+        if (stateReads > 1) await refetchGate;
+        return HttpResponse.json({
+          controllerId,
+          resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: 'thread-1',
+          running: true,
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        });
+      }),
+      http.get(
+        `${sessionUrl}/stream`,
+        () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                emit = event => controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+              },
+              cancel() {},
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          ),
+      ),
+    );
+
+    const { result, client } = renderHookWithProviders(() =>
+      useAgentControllerConnection({ ...hookArgs, sessionThreadId: 'thread-1', onEvent }),
+    );
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.state?.running).toBe(true);
+
+    void client.invalidateQueries({
+      queryKey: queryKeys.agentControllerConnectionState(controllerId, resourceId, undefined, 'thread-1'),
+      exact: true,
+    });
+    await waitFor(() => expect(stateReads).toBe(2));
+
+    emit({ type: 'agent_end' });
+    await waitFor(() => expect(result.current.state?.running).toBe(false));
+
+    releaseRefetch?.();
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    expect(result.current.state?.running).toBe(false);
+  });
+
   it('given reconnect polling is disconnected, then it backs off and stops at the retry cap', () => {
     expect(reconnectRefetchInterval(true, 0)).toBe(false);
     expect(reconnectRefetchInterval(false, 0)).toBe(1000);
@@ -633,5 +695,52 @@ describe('useAgentControllerConnection', () => {
 
     await waitFor(() => expect(client.getQueryState(messagesKey)?.isInvalidated).toBe(true));
     expect(client.getQueryState(otherResourceKey)?.isInvalidated).toBe(false);
+  });
+
+  it('given the stream drops and recovers, then the session state is refetched to close the event gap', async () => {
+    const onStream = vi.fn();
+    const onEvent = vi.fn();
+    let stateReadsAfterReconnect = 0;
+
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, () =>
+        HttpResponse.json({ controllerId, resourceId, threadId: 'created-thread' }),
+      ),
+      http.get(sessionUrl, () => {
+        if (onStream.mock.calls.length >= 2) stateReadsAfterReconnect += 1;
+        return HttpResponse.json({
+          controllerId,
+          resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: 'state-thread',
+          running: false,
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        });
+      }),
+      http.get(`${sessionUrl}/stream`, () => {
+        onStream();
+        if (onStream.mock.calls.length === 1) {
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                setTimeout(() => controller.error(new Error('stream dropped')), 0);
+              },
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          );
+        }
+        return new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useAgentControllerConnection({ ...hookArgs, onEvent }));
+
+    await waitFor(() => expect(onStream).toHaveBeenCalledTimes(2), { timeout: 2500 });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await waitFor(() => expect(stateReadsAfterReconnect).toBeGreaterThanOrEqual(1), { timeout: 3000 });
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
@@ -640,11 +640,11 @@ describe('useAgentControllerConnection', () => {
     const { result } = renderHookWithProviders(() => useAgentControllerConnection({ ...hookArgs, onEvent }));
 
     await waitFor(() => expect(onStream).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(onReadState).toHaveBeenCalledTimes(2), { timeout: 2500 });
+    await waitFor(() => expect(onReadState.mock.calls.length).toBeGreaterThanOrEqual(2), { timeout: 2500 });
     await waitFor(() => expect(onStream).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(result.current.status).toBe('ready'));
 
-    expect(result.current.state?.threadId).toBe('state-thread-2');
+    await waitFor(() => expect(result.current.state?.threadId).toBe(`state-thread-${onReadState.mock.calls.length}`));
   });
 
   it('given the stream drops and recovers, then the resource message windows are invalidated to close the event gap', async () => {

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
@@ -7,7 +7,7 @@ import type { FactorySessionState } from '../context/ChatSessionContext';
 import { createAgentControllerClient } from '../services/agentControllerClient';
 import { useAgentControllerEvents } from './useAgentControllerEvents';
 import { useAgentControllerSessionInit } from '../../../../hooks/useAgentControllerSessionInit';
-import { useAgentControllerSessionSync } from '../../../../hooks/useAgentControllerSessionSync';
+import { useAgentControllerSessionSync, type LiveStatePatch } from '../../../../hooks/useAgentControllerSessionSync';
 
 export type ConnectionStatus = 'connecting' | 'ready' | 'reconnecting' | 'error';
 type SseConnectionState = 'never' | 'connected' | 'dropped';
@@ -42,8 +42,7 @@ export function useAgentControllerConnection({
   const queryClient = useQueryClient();
   const [sseConnectionState, setSseConnectionState] = useState<SseConnectionState>('never');
   const sseStateRef = useRef<SseConnectionState>('never');
-  const taskEventGeneration = useRef(0);
-  const liveTasks = useRef<{ threadId?: string; tasks: NonNullable<AgentControllerSessionState['tasks']> }>(undefined);
+  const livePatch = useRef<LiveStatePatch>({ generation: 0 });
   const sseConnected = sseConnectionState === 'connected';
   const hasEverConnected = sseConnectionState !== 'never';
   const { session } = createAgentControllerClient({
@@ -70,8 +69,7 @@ export function useAgentControllerConnection({
     baseUrl,
     enabled: enabled && initQuery.isSuccess,
     sseConnected,
-    taskEventGeneration,
-    liveTasks,
+    livePatch,
   });
   const handleConnectedChange = (connected: boolean) => {
     // Ref mirrors the state so back-to-back events see the true previous value
@@ -92,6 +90,14 @@ export function useAgentControllerConnection({
       queryKey: queryKeys.agentControllerResourceThreadMessages(agentControllerId, resourceId),
       predicate: query => reconnected || query.state.status === 'error',
     });
+    // The gap can also have eaten agent_start/agent_end, so the cached state
+    // snapshot is refetched the same way.
+    if (reconnected) {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.agentControllerConnectionState(agentControllerId, resourceId, scope, sessionThreadId),
+        exact: true,
+      });
+    }
   };
 
   const handleEvent = (event: AgentControllerEvent) => {
@@ -101,11 +107,11 @@ export function useAgentControllerConnection({
         : undefined;
     const running = event.type === 'agent_start' ? true : event.type === 'agent_end' ? false : displayStateRunning;
     const tasks = isKnownAgentControllerEvent(event) && event.type === 'task_updated' ? event.tasks : undefined;
-    if (tasks) {
-      taskEventGeneration.current += 1;
-      liveTasks.current = { threadId: sessionThreadId, tasks };
-    }
     if (typeof running === 'boolean' || tasks) {
+      const patch = livePatch.current;
+      patch.generation += 1;
+      if (typeof running === 'boolean') patch.running = { value: running, generation: patch.generation };
+      if (tasks) patch.tasks = { value: tasks, threadId: sessionThreadId, generation: patch.generation };
       const stateQueryKey = queryKeys.agentControllerConnectionState(
         agentControllerId,
         resourceId,
@@ -149,6 +155,8 @@ export function useAgentControllerConnection({
   return {
     status,
     state: syncQuery.data,
+    // Event patches keep dataUpdatedAt untouched, so this stamps real fetches only.
+    stateUpdatedAt: syncQuery.dataUpdatedAt,
     threadId: syncQuery.data?.threadId ?? initQuery.data?.threadId ?? undefined,
   };
 }

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -141,6 +141,8 @@ export interface TranscriptState {
    * when the run's start/end events arrive in a single batched flush.
    */
   pending: boolean;
+  /** When the latch was armed — a state snapshot fetched after this instant outranks it. */
+  pendingSince?: number;
   threadId?: string;
   /** Current task list from task_updated events. */
   tasks: AgentControllerTaskSnapshot[];
@@ -232,6 +234,7 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
       return {
         ...state,
         pending: true,
+        pendingSince: Date.now(),
         entries: [
           ...state.entries,
           toMessageEntry(


### PR DESCRIPTION
TLDR: the chat composer now agrees with the server about whether the agent is running — a stale state fetch can no longer overwrite a fresher event, a reconnect re-syncs the run state, and a lost run-end no longer leaves the composer spinning forever.

---

`busy` had four truths that stopped agreeing: the cached state snapshot, SSE events patching it, the transcript's pending latch, and nothing at all after a stream gap. Each fix applies the same rule — newer truth wins, in either direction.

### What changes

| in a chat session | before | after |
| --- | --- | --- |
| a state fetch resolves after a run-end event arrived mid-flight | stale snapshot resurrects `running: true`, composer spins on an idle agent | the event's value survives the fetch |
| a state fetch resolves after a run-start event arrived mid-flight | run invisible until the next event | same — the event's value survives |
| the stream drops and recovers | snapshot frozen from before the gap (staleTime is Infinity) | reconnect refetches the run state |
| a sent message's run-end event is lost in a gap | composer busy forever | a snapshot fetched after the send saying "idle" releases it |

### Judgment calls

The overtake guard stamps `running` and `tasks` with per-field generations instead of one overtaken flag. With a single flag, a task event during the fetch would re-apply a `running` value recorded long before it — resurrecting the exact stuck-busy bug this fixes, just rarer. It is a few extra lines to only re-apply what actually changed mid-flight.

The pending latch now yields when a state snapshot fetched after the send says the agent is idle. A snapshot can complete just after the send but before the server registered the run, flicking the composer idle for under a second; it self-heals on the next event or fetch. I took that flicker over the unrecoverable stuck-busy it replaces. #22423 upgrades this ordering to a server-stamped state version; the clock compare stays as the fallback for unstamped servers.

The existing resubscribe test pinned exact state-read counts; the reconnect refetch legitimately adds one, so it now asserts the latest read is the one exposed instead of counting reads.

### Cost

One extra `GET /sessions/:resourceId` per stream reconnect. Reconnects are rare and the fetch is the point.

### Not verified

The real network-kill path (laptop sleep, NAT timeout) is only staged with MSW stream errors here; a silently dead pipe still hangs until the next PR's client-js watchdog. End-to-end checks for the whole stack are listed in the plan.

```
tests        +166  -2    <- 74% of the additions
source        +49 -20
changeset      +9   0
```

