### PR TITLE
fix(client-js): drop a silently dead SSE stream after 60s idle

### DIFF
--- a/.changeset/silent-pipes-reconnect.md
+++ b/.changeset/silent-pipes-reconnect.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fixed agent-controller event subscriptions hanging forever on a silently dead connection (laptop sleep, NAT timeout). A stream that delivers nothing for 60 seconds is now dropped and handled by the normal reconnect path, so `subscribe({ reconnect })` recovers on its own instead of staying "connected" with no events. The server's SSE heartbeats keep a healthy idle stream alive.

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -550,6 +550,94 @@ describe('AgentController Resource', () => {
     expect((global.fetch as any).mock.calls).toHaveLength(1);
   });
 
+  it('drops a silently dead stream after the idle timeout and reconnects', async () => {
+    // clearAllMocks keeps queued one-shot responses, so drop any leftovers.
+    (global.fetch as any).mockReset();
+    vi.useFakeTimers();
+    try {
+      const afterEvent = { type: 'agent_end', reason: 'complete' };
+      (global.fetch as any)
+        .mockResolvedValueOnce(
+          new Response(new ReadableStream({ start() {} }), {
+            status: 200,
+            headers: new Headers({ 'Content-Type': 'text/event-stream' }),
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(afterEvent)}\n\n`));
+              },
+            }),
+            { status: 200, headers: new Headers({ 'Content-Type': 'text/event-stream' }) },
+          ),
+        );
+
+      const received: AgentControllerEvent[] = [];
+      const onError = vi.fn();
+      const sub = await client
+        .getAgentController('code')
+        .session('user-1')
+        .subscribe({
+          onEvent: event => received.push(event),
+          onError,
+          reconnect: { maxRetries: 1, delayMs: 0 },
+        });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect((global.fetch as any).mock.calls).toHaveLength(2);
+      expect(received).toEqual([afterEvent]);
+      sub.unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a heartbeat-only stream alive past the idle timeout', async () => {
+    (global.fetch as any).mockReset();
+    vi.useFakeTimers();
+    try {
+      let sse!: ReadableStreamDefaultController<Uint8Array>;
+      (global.fetch as any).mockResolvedValueOnce(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              sse = controller;
+            },
+          }),
+          { status: 200, headers: new Headers({ 'Content-Type': 'text/event-stream' }) },
+        ),
+      );
+
+      const onError = vi.fn();
+      const sub = await client
+        .getAgentController('code')
+        .session('user-1')
+        .subscribe({
+          onEvent: () => {},
+          onError,
+          reconnect: { maxRetries: 1, delayMs: 0 },
+        });
+
+      // 100s of wall time, but never more than 25s between heartbeats.
+      for (let i = 0; i < 4; i++) {
+        await vi.advanceTimersByTimeAsync(25_000);
+        sse.enqueue(new TextEncoder().encode(': heartbeat\n\n'));
+        await vi.advanceTimersByTimeAsync(0);
+      }
+
+      expect((global.fetch as any).mock.calls).toHaveLength(1);
+      expect(onError).not.toHaveBeenCalled();
+      sub.unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not reconnect when the onEvent callback throws', async () => {
     mockSse([`data: ${JSON.stringify({ type: 'agent_start' })}\n\n`]);
 

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -172,6 +172,9 @@ export function isKnownAgentControllerEvent(event: AgentControllerEvent): event 
 
 const toDate = (value: Date | string): Date => (value instanceof Date ? value : new Date(value));
 
+// 2.4x the server's 25s SSE heartbeat interval.
+const STREAM_IDLE_TIMEOUT_MS = 60_000;
+
 function hydrateMessage(message: SerializedMastraDBMessage): MastraDBMessage {
   return { ...message, createdAt: toDate(message.createdAt) };
 }
@@ -386,6 +389,28 @@ export class AgentControllerSession extends BaseResource {
     };
 
     const streamEndedError = () => new Error('Agent controller session stream ended unexpectedly');
+    const streamIdleError = () =>
+      new Error(`Agent controller session stream idle for ${STREAM_IDLE_TIMEOUT_MS}ms, assuming a dead connection`);
+
+    /**
+     * A silently dead pipe (laptop sleep, NAT timeout) leaves read() pending
+     * forever while the subscription still reports connected. The server
+     * heartbeats every 25s, so any read taking over 60s means the pipe is gone;
+     * the race resolves 'idle' and the caller turns it into a transport error.
+     * A server that never heartbeats would see an idle stream reconnect once a
+     * minute — harmless churn, and every in-repo server heartbeats.
+     */
+    const readOrIdle = async (reader: ReadableStreamDefaultReader<Uint8Array>) => {
+      let watchdog: ReturnType<typeof setTimeout> | undefined;
+      const idle = new Promise<'idle'>(resolve => {
+        watchdog = setTimeout(() => resolve('idle'), STREAM_IDLE_TIMEOUT_MS);
+      });
+      try {
+        return await Promise.race([reader.read(), idle]);
+      } finally {
+        clearTimeout(watchdog);
+      }
+    };
 
     const findFrameSeparator = (text: string): { index: number; length: number } | null => {
       const candidates = [
@@ -411,7 +436,10 @@ export class AgentControllerSession extends BaseResource {
 
       try {
         while (!cancelled) {
-          const { done, value } = await reader.read();
+          const read = await readOrIdle(reader);
+          if (read === 'idle')
+            return cancelled ? { kind: 'cancelled' } : { kind: 'transport_error', error: streamIdleError() };
+          const { done, value } = read;
           if (done) return cancelled ? { kind: 'cancelled' } : { kind: 'done' };
           buffer += decoder.decode(value, { stream: true });
 

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -172,7 +172,6 @@ export function isKnownAgentControllerEvent(event: AgentControllerEvent): event 
 
 const toDate = (value: Date | string): Date => (value instanceof Date ? value : new Date(value));
 
-// 2.4x the server's 25s SSE heartbeat interval.
 const STREAM_IDLE_TIMEOUT_MS = 60_000;
 
 function hydrateMessage(message: SerializedMastraDBMessage): MastraDBMessage {


### PR DESCRIPTION
TLDR: an agent-controller SSE subscription now notices a silently dead pipe — a stream with no bytes for 60s is dropped and reconnected instead of hanging "connected" forever.

---

```
before   laptop sleep / NAT timeout kills the pipe -> read() pends forever, UI frozen until a tab hide/show rebuilds the stream
after    60s of silence -> transport error -> the existing reconnect path re-establishes and re-syncs
```

The server heartbeats every 25s (`: heartbeat` comments), so any read taking over 60s means the pipe is gone. Every read races an idle timer; any bytes — heartbeats included — reset it. On timeout the pump returns a transport error, and reconnect, backoff, and `onReconnect` re-sync all behave exactly as for any other drop.

### Judgment call

Default on, no flag. A server that never heartbeats would see an idle stream reconnect once a minute — every in-repo server heartbeats, and even that worst case is harmless churn. The 60s constant is 2.4 heartbeat intervals, named next to the reason.

### Not verified

Only fake-timer coverage here; the real sleep/NAT path is exercised by the end-to-end checks planned for the whole stack.

```
tests        +88   0
source       +29  -1
changeset     +5   0
```
