### PR TITLE
feat(playground): pace a Studio reply on one clock

### DIFF
--- a/.changeset/eager-cooks-lick.md
+++ b/.changeset/eager-cooks-lick.md
@@ -1,0 +1,7 @@
+---
+'mastra': patch
+---
+
+Studio now reveals a streaming reply as one message instead of one text block at a time. A tool call, a reasoning block or a card waits its turn behind the sentence written before it, so the reply arrives in the order the model wrote it rather than rows landing while prose is still typing.
+
+Notices are handed over whole: a tripwire, an error and a completion check are statuses, not prose, so they appear at once.

--- a/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.test.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.test.tsx
@@ -138,6 +138,24 @@ describe('MessageRow', () => {
       expect(badge()).toBeTruthy();
     });
 
+    it('finishes one text block before starting the next', () => {
+      vi.useFakeTimers();
+      const first = `First. ${Array.from({ length: 30 }, (_, index) => `alpha${index}`).join(' ')}`;
+      const second = `Second. ${Array.from({ length: 30 }, (_, index) => `beta${index}`).join(' ')}`;
+      const twoBlocks = (a: string, b: string) =>
+        baseMessage({ content: { format: 2, parts: [streamingText(a), streamingText(b)] } });
+
+      const { container, rerender } = render(<MessageRow message={twoBlocks('First.', '')} />, { wrapper: Providers });
+      rerender(<MessageRow message={twoBlocks(first, second)} />);
+
+      for (let frames = 0; frames < 900 && !container.textContent?.includes('beta29'); frames++) {
+        if (container.textContent?.includes('beta0')) expect(container.textContent).toContain('alpha29');
+        act(() => void vi.advanceTimersByTime(16));
+      }
+
+      expect(container.textContent).toContain('beta29');
+    });
+
     it('hands over a notice whole instead of pacing it', () => {
       vi.useFakeTimers();
       const reason = `Blocked. ${Array.from({ length: 40 }, (_, index) => `word${index}`).join(' ')}`;

--- a/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.test.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.test.tsx
@@ -101,6 +101,56 @@ describe('MessageRow', () => {
 
       expect(container.textContent).toContain('word39');
     });
+
+    it('holds a tool row behind the prose written before it', () => {
+      vi.useFakeTimers();
+      const reply = `Ready. ${Array.from({ length: 40 }, (_, index) => `word${index}`).join(' ')}`;
+      const withTool = (text: string) =>
+        baseMessage({
+          content: {
+            format: 2,
+            parts: [
+              streamingText(text),
+              {
+                type: 'tool-invocation',
+                toolInvocation: {
+                  toolName: 'genericTool',
+                  toolCallId: 'call-1',
+                  state: 'result',
+                  args: {},
+                  result: { ok: true },
+                },
+              } as never,
+            ],
+          },
+        });
+      const badge = () => container.querySelector('[data-testid="tool-badge"]');
+
+      const { container, rerender } = render(<MessageRow message={withTool('Ready.')} />, { wrapper: Providers });
+      rerender(<MessageRow message={withTool(reply)} />);
+
+      expect(badge()).toBeNull();
+
+      for (let frames = 0; frames < 600 && !badge(); frames++) {
+        act(() => void vi.advanceTimersByTime(16));
+      }
+
+      expect(badge()).toBeTruthy();
+    });
+
+    it('hands over a notice whole instead of pacing it', () => {
+      vi.useFakeTimers();
+      const reason = `Blocked. ${Array.from({ length: 40 }, (_, index) => `word${index}`).join(' ')}`;
+      const failing = (text: string) =>
+        baseMessage({
+          content: { format: 2, metadata: { status: 'error' }, parts: [streamingText(text)] },
+        });
+
+      const { container, rerender } = render(<MessageRow message={failing('Blocked.')} />, { wrapper: Providers });
+      rerender(<MessageRow message={failing(reason)} />);
+
+      expect(container.textContent).toContain('word39');
+    });
   });
 
   it('renders user text', () => {

--- a/packages/playground/src/lib/ai-ui/messages/message-row.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/message-row.tsx
@@ -1,4 +1,5 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+import { useRevealedParts } from '@mastra/playground-ui/components/ai/message-reveal';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
 import { cn } from '@mastra/playground-ui/utils/cn';
@@ -12,6 +13,7 @@ import { DatasetSaveAction } from './dataset-save-action';
 import { AssistantTextPartRenderer } from './renderers/assistant-text-part-renderer';
 import { DataPartRenderer } from './renderers/data-part-renderer';
 import { DynamicToolPartRenderer } from './renderers/dynamic-tool-part-renderer';
+import { messageTextKind } from './renderers/message-text-kind';
 import { ReasoningPartRenderer } from './renderers/reasoning-part-renderer';
 import { messageStatusRenderers } from './renderers/status-renderers';
 import { ToolInvocationPartRenderer } from './renderers/tool-invocation-part-renderer';
@@ -77,6 +79,18 @@ const toDisplayMessage = (message: MastraDBMessage): MastraDBMessage | null => {
   if (displayRole === message.role) return message;
   return { ...message, role: displayRole };
 };
+
+const NO_PARTS: MessagePart[] = [];
+
+const isStreaming = (parts: MessagePart[]): boolean => parts.some(part => readField(part, 'state') === 'streaming');
+
+/** A notice (tripwire, error, completion check) is a status, so it is handed over whole rather than paced. */
+const isProse = (parts: MessagePart[], metadata: Record<string, unknown> | undefined): boolean =>
+  parts.every(part => {
+    if (part.type !== 'text') return true;
+    const text = readField(part, 'text');
+    return typeof text !== 'string' || messageTextKind(text, metadata) === 'prose';
+  });
 
 const getMessageMetadata = (message: MastraDBMessage): Record<string, unknown> | undefined =>
   isRecord(message.content.metadata) ? message.content.metadata : undefined;
@@ -195,6 +209,12 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
     const modelMetadata = hasModelList ? getModelMetadata(metadata) : undefined;
     const dataParts = useMemo(() => getDataParts(message), [message]);
 
+    // One clock for the whole message, so a tool row waits behind the sentence written before it.
+    const parts = dbMessage?.content.parts ?? NO_PARTS;
+    const revealed = useRevealedParts(parts, isStreaming(parts));
+    const shownParts = isProse(parts, metadata) ? revealed : parts;
+    const revealing = shownParts !== parts;
+
     const sharedRenderers = useMemo<MessageRenderers>(
       () => ({
         Reasoning: part => <ReasoningPartRenderer part={part} />,
@@ -217,13 +237,15 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
     const assistantRenderers = useMemo<MessageRenderers>(
       () => ({
         ...sharedRenderers,
-        Text: part => <AssistantTextPartRenderer part={part} metadata={metadata} />,
+        Text: part => <AssistantTextPartRenderer part={part} metadata={metadata} revealing={revealing} />,
       }),
-      [sharedRenderers, metadata],
+      [sharedRenderers, metadata, revealing],
     );
 
     if (dbMessage === null) return null;
 
+    // Same object once caught up, so the factory keeps the part it is filling in mounted.
+    const shownMessage = revealing ? { ...dbMessage, content: { ...dbMessage.content, parts: shownParts } } : dbMessage;
     const displayRole = dbMessage.role;
 
     if (displayRole === 'user') {
@@ -244,7 +266,7 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
               isPending && 'opacity-60 animate-pulse',
             )}
           >
-            <MessageFactory message={dbMessage} {...userRenderers} status={messageStatusRenderers} />
+            <MessageFactory message={shownMessage} {...userRenderers} status={messageStatusRenderers} />
           </div>
         </div>
       );
@@ -255,7 +277,7 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
     return (
       <div ref={ref} className={cn('max-w-full', className)} {...rootProps} data-message-id={message.id}>
         <div className="text-neutral6 text-ui-lg leading-ui-lg pt-2">
-          <MessageFactory message={dbMessage} {...assistantRenderers} status={messageStatusRenderers} />
+          <MessageFactory message={shownMessage} {...assistantRenderers} status={messageStatusRenderers} />
         </div>
         {showActionBar && (
           <div className="flex h-6 items-center gap-2 pt-4">

--- a/packages/playground/src/lib/ai-ui/messages/renderers/__tests__/assistant-text-part-renderer.test.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/__tests__/assistant-text-part-renderer.test.tsx
@@ -1,23 +1,9 @@
 import type { TextPart } from '@mastra/react';
-import { act, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 
 import type { MessageMetadata } from '../../message-metadata';
 import { AssistantTextPartRenderer } from '../assistant-text-part-renderer';
-
-const CHUNK = `Ready. ${Array.from({ length: 40 }, (_, index) => `word${index}`).join(' ')}`;
-
-const textPart = (text: string, state?: TextPart['state']): TextPart => ({ type: 'text', text, state });
-
-function drain(read: () => string | null, target: string) {
-  for (let frames = 0; frames < 300 && read() !== target; frames++) {
-    act(() => void vi.advanceTimersByTime(16));
-  }
-}
-
-afterEach(() => {
-  vi.useRealTimers();
-});
 
 describe('AssistantTextPartRenderer', () => {
   it('renders markdown text', () => {
@@ -54,31 +40,5 @@ describe('AssistantTextPartRenderer', () => {
 
     expect(screen.getByText('Complete')).not.toBeNull();
     expect(screen.getByText('all good')).not.toBeNull();
-  });
-
-  describe('when a chunk lands on a reply that is still streaming', () => {
-    it('reveals it over time instead of dumping it on arrival', () => {
-      vi.useFakeTimers();
-      const { container, rerender } = render(<AssistantTextPartRenderer part={textPart('Ready.', 'streaming')} />);
-
-      rerender(<AssistantTextPartRenderer part={textPart(CHUNK, 'streaming')} />);
-      expect(container.textContent?.length).toBeLessThan(CHUNK.length);
-
-      drain(() => container.textContent, CHUNK);
-      expect(container.textContent).toBe(CHUNK);
-    });
-  });
-
-  describe('when the reply ends on the chunk it is still revealing', () => {
-    it('finishes revealing it', () => {
-      vi.useFakeTimers();
-      const { container, rerender } = render(<AssistantTextPartRenderer part={textPart('Ready.', 'streaming')} />);
-
-      rerender(<AssistantTextPartRenderer part={textPart(CHUNK)} />);
-      expect(container.textContent?.length).toBeLessThan(CHUNK.length);
-
-      drain(() => container.textContent, CHUNK);
-      expect(container.textContent).toBe(CHUNK);
-    });
   });
 });

--- a/packages/playground/src/lib/ai-ui/messages/renderers/assistant-text-part-renderer.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/assistant-text-part-renderer.tsx
@@ -6,12 +6,14 @@ import { MessageText } from './message-text';
 export interface AssistantTextPartRendererProps {
   part: TextPart;
   metadata?: MessageMetadata;
+  /** The message's reveal has not caught up, so this part is still filling in. */
+  revealing?: boolean;
 }
 
 /**
  * Renders an assistant `MessageFactory` `Text` slot through `MessageText`, which
  * applies markdown plus the legacy error/completion-check handling.
  */
-export const AssistantTextPartRenderer = ({ part, metadata }: AssistantTextPartRendererProps) => (
-  <MessageText text={part.text ?? ''} metadata={metadata} streaming={part.state === 'streaming'} />
+export const AssistantTextPartRenderer = ({ part, metadata, revealing }: AssistantTextPartRendererProps) => (
+  <MessageText text={part.text ?? ''} metadata={metadata} streaming={part.state === 'streaming' || revealing} />
 );

--- a/packages/playground/src/lib/ai-ui/messages/renderers/message-text-kind.ts
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/message-text-kind.ts
@@ -1,0 +1,22 @@
+import type { MessageMetadata } from '../message-metadata';
+
+/** How a run that failed before the model wrote anything reaches the transcript. */
+const ERROR_PREFIXES = ['__ERROR__:', 'Error:'];
+
+export type MessageTextKind = 'tripwire' | 'warning' | 'error' | 'completion' | 'prose';
+
+export function messageTextKind(text: string, metadata: MessageMetadata | undefined): MessageTextKind {
+  if (metadata?.status === 'tripwire') return 'tripwire';
+  if (metadata?.status === 'warning') return 'warning';
+  if (metadata?.status === 'error') return 'error';
+  if (metadata?.completionResult) return 'completion';
+
+  return ERROR_PREFIXES.some(prefix => text.trim().startsWith(prefix)) ? 'error' : 'prose';
+}
+
+export function errorMessage(text: string): string {
+  const trimmed = text.trim();
+  const prefix = ERROR_PREFIXES.find(candidate => trimmed.startsWith(candidate));
+
+  return prefix ? trimmed.slice(prefix.length).trim() : text;
+}

--- a/packages/playground/src/lib/ai-ui/messages/renderers/message-text.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/message-text.tsx
@@ -1,9 +1,5 @@
 import { Badge } from '@mastra/playground-ui/components/Badge';
-import {
-  MarkdownRenderer,
-  useRevealedText,
-  type MarkdownExternalLinkTarget,
-} from '@mastra/playground-ui/components/MarkdownRenderer';
+import { MarkdownRenderer, type MarkdownExternalLinkTarget } from '@mastra/playground-ui/components/MarkdownRenderer';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
@@ -12,6 +8,7 @@ import { useState } from 'react';
 
 import type { MessageMetadata } from '../message-metadata';
 import { TripwireNotice } from '../tripwire-notice';
+import { errorMessage, messageTextKind } from './message-text-kind';
 
 export interface MessageTextProps {
   text: string;
@@ -27,66 +24,49 @@ export interface MessageTextProps {
  */
 export const MessageText = ({ text, metadata, externalLinkTarget, streaming }: MessageTextProps) => {
   const [collapsedCompletionCheck, setCollapsedCompletionCheck] = useState(false);
-  const shown = useRevealedText(text, Boolean(streaming));
 
-  if (metadata?.status === 'tripwire') {
-    return <TripwireNotice reason={text} tripwire={metadata.tripwire} />;
-  }
-  if (metadata?.status === 'warning') {
-    return (
-      <Notice variant="warning" title="Warning">
-        <Notice.Message>{text}</Notice.Message>
-      </Notice>
-    );
-  }
-  if (metadata?.status === 'error') {
-    return (
-      <Notice variant="destructive" title="Error">
-        <Notice.Message>{text}</Notice.Message>
-      </Notice>
-    );
-  }
+  switch (messageTextKind(text, metadata)) {
+    case 'tripwire':
+      return <TripwireNotice reason={text} tripwire={metadata?.tripwire} />;
 
-  const taskCompleteResult = metadata?.completionResult;
-  if (taskCompleteResult) {
-    return (
-      <div className="mb-2 space-y-2">
-        <button onClick={() => setCollapsedCompletionCheck(s => !s)} className="flex items-center gap-2">
-          <Icon>
-            <ChevronUpIcon className={cn('transition-all', collapsedCompletionCheck ? 'rotate-90' : 'rotate-180')} />
-          </Icon>
-          <Badge variant="info" icon={<CheckCircleIcon />}>
-            {collapsedCompletionCheck ? 'Show' : 'Hide'} completion check
-          </Badge>
-        </button>
-        {!collapsedCompletionCheck && (
-          <Notice variant="info" title={taskCompleteResult?.passed ? 'Complete' : 'Not Complete'}>
-            <MarkdownRenderer externalLinkTarget={externalLinkTarget}>{text}</MarkdownRenderer>
-          </Notice>
-        )}
-      </div>
-    );
-  }
+    case 'warning':
+      return (
+        <Notice variant="warning" title="Warning">
+          <Notice.Message>{text}</Notice.Message>
+        </Notice>
+      );
 
-  const trimmedText = text.trim();
-  if (trimmedText.startsWith('__ERROR__:')) {
-    return (
-      <Notice variant="destructive" title="Error">
-        <Notice.Message>{trimmedText.substring('__ERROR__:'.length)}</Notice.Message>
-      </Notice>
-    );
-  }
-  if (trimmedText.startsWith('Error:')) {
-    return (
-      <Notice variant="destructive" title="Error">
-        <Notice.Message>{trimmedText.substring('Error:'.length).trim()}</Notice.Message>
-      </Notice>
-    );
-  }
+    case 'error':
+      return (
+        <Notice variant="destructive" title="Error">
+          <Notice.Message>{errorMessage(text)}</Notice.Message>
+        </Notice>
+      );
 
-  return (
-    <MarkdownRenderer externalLinkTarget={externalLinkTarget} streaming={Boolean(streaming) || shown !== text}>
-      {shown}
-    </MarkdownRenderer>
-  );
+    case 'completion':
+      return (
+        <div className="mb-2 space-y-2">
+          <button onClick={() => setCollapsedCompletionCheck(s => !s)} className="flex items-center gap-2">
+            <Icon>
+              <ChevronUpIcon className={cn('transition-all', collapsedCompletionCheck ? 'rotate-90' : 'rotate-180')} />
+            </Icon>
+            <Badge variant="info" icon={<CheckCircleIcon />}>
+              {collapsedCompletionCheck ? 'Show' : 'Hide'} completion check
+            </Badge>
+          </button>
+          {!collapsedCompletionCheck && (
+            <Notice variant="info" title={metadata?.completionResult?.passed ? 'Complete' : 'Not Complete'}>
+              <MarkdownRenderer externalLinkTarget={externalLinkTarget}>{text}</MarkdownRenderer>
+            </Notice>
+          )}
+        </div>
+      );
+
+    default:
+      return (
+        <MarkdownRenderer externalLinkTarget={externalLinkTarget} streaming={Boolean(streaming)}>
+          {text}
+        </MarkdownRenderer>
+      );
+  }
 };


### PR DESCRIPTION
TLDR: a tool row in a Studio reply now waits for the sentence written before it to finish typing, instead of appearing the moment it arrives.

---

Studio revealed each text block on its own clock. A tool call, a reasoning block or a card was on no clock at all, so it landed the instant it arrived, often on top of a sentence still being typed out three lines above. The reply assembled itself out of order.

The whole message now goes through one reveal: the one Factory has used all along, moved into the design system by #22408. `MessageFactory` gets the parts as far as that clock has reached them.

### What changes

| watching a reply arrive | before | after |
| --- | --- | --- |
| a sentence, then a tool row | row appears while the sentence is still typing | row waits for the sentence |
| a reasoning block between two passages | lands whole, out of order | takes its turn, at its own words' pace |
| several text blocks in one reply | each block restarts its own clock | one continuous pace across the reply |
| an error, tripwire or completion check | shown whole, never paced | unchanged |

### Judgment call

Notices are the call. Nothing paced them before: `MessageText` ran the clock and then ignored it on every notice branch. Feeding them through the projection would have broken that, because the projection truncates text. `Error: the run failed` arrives as `Erro`, matches no prefix, renders as markdown, then swaps to a red Notice once the rest catches up.

So `isProse` keeps notices out of the projection, and both it and the renderer read the same `messageTextKind`. One classifier, so the pacing gate and what gets drawn cannot drift apart.

Second call: `AssistantTextPartRenderer` takes a `revealing` prop instead of the truncated part carrying `state: 'streaming'`. `state` is not on the core text part (it lives on `@mastra/react`'s `MastraTextPart`), so stamping it would need a cast. The row already knows the reveal is behind, so it says so.

### Not verified

I have not opened a preview yet. The agent chat page is where this is worth looking at.

```
source       +95  -69
tests        +70  -42
changeset     +7    0
```
