### PR TITLE
fix(core): stamp runs and their messages with the thread they run on

### DIFF
--- a/.changeset/shaggy-banks-spend.md
+++ b/.changeset/shaggy-banks-spend.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Added `runningThreadId` to the session state returned by `session.state()` and an optional `threadId` on `agent_start`/`agent_end` events, so consumers can scope run activity to a thread.

--- a/.changeset/smart-ears-burn.md
+++ b/.changeset/smart-ears-burn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The chat composer now only shows a run as busy when that run is on the thread being viewed. Messages streamed by a run on another thread of the same session no longer appear in the open transcript.

--- a/.changeset/tangy-brooms-drop.md
+++ b/.changeset/tangy-brooms-drop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+The session state endpoint now reports `runningThreadId`, the thread the active run is on, next to `running`. It is `null` while idle, so UIs can tell a run on the viewed thread from a run elsewhere in the session.

--- a/.changeset/yummy-towns-fry.md
+++ b/.changeset/yummy-towns-fry.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Streamed messages and run lifecycle events now name the thread they belong to. Assistant messages created during a run carry the session's active thread id, and `agent_start`/`agent_end` events include an optional `threadId`, so clients can tell which thread a run is on.
+Streamed messages and run lifecycle events now name the thread they belong to. Messages created during a run — assistant messages and echoed signals alike — carry the session's active thread id, and `agent_start`/`agent_end` events include an optional `threadId`, so clients can tell which thread a run is on.

--- a/.changeset/yummy-towns-fry.md
+++ b/.changeset/yummy-towns-fry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Streamed messages and run lifecycle events now name the thread they belong to. Assistant messages created during a run carry the session's active thread id, and `agent_start`/`agent_end` events include an optional `threadId`, so clients can tell which thread a run is on.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -20340,6 +20340,7 @@ export type GetAgentControllerControllerIdSessionsResourceId_Response = {
   modeId: string;
   modelId: string;
   running?: boolean | undefined;
+  runningThreadId?: (string | null) | undefined;
   tasks?:
     | {
         id: string;

--- a/mastracode/factory-ui/src/hooks/useAgentControllerSessionSync.ts
+++ b/mastracode/factory-ui/src/hooks/useAgentControllerSessionSync.ts
@@ -12,7 +12,7 @@ import { createAgentControllerClient } from '../ui/domains/chat/services/agentCo
  */
 export interface LiveStatePatch {
   generation: number;
-  running?: { value: boolean; generation: number };
+  running?: { value: boolean; threadId: string | null; generation: number };
   tasks?: { value: AgentControllerTaskSnapshot[]; threadId?: string; generation: number };
 }
 
@@ -61,7 +61,7 @@ export function useAgentControllerSessionSync({
       const tasksOvertookRequest = tasks && tasks.generation > generationAtRequestStart && tasks.threadId === threadId;
       return {
         ...state,
-        ...(runningOvertookRequest ? { running: running.value } : {}),
+        ...(runningOvertookRequest ? { running: running.value, runningThreadId: running.threadId } : {}),
         ...(tasksOvertookRequest ? { tasks: tasks.value } : {}),
       };
     },

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerBusyReconcile.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerBusyReconcile.msw.test.tsx
@@ -52,4 +52,33 @@ describe('Composer busy reconcile', () => {
 
     await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Ask Mastra Code…'));
   });
+
+  it('given a run on another thread of the session, then the composer stays idle', async () => {
+    const session = stubPreparingSession({ autoAgentEnd: false });
+    let stateReads = 0;
+    server.use(
+      http.get(`${API}/sessions/:resourceId`, ({ params }) => {
+        stateReads += 1;
+        return HttpResponse.json({
+          controllerId: 'code',
+          resourceId: params.resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: SESSION_ID,
+          running: true,
+          runningThreadId: 'thread-elsewhere',
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        });
+      }),
+    );
+
+    const { client } = renderThread();
+    await releaseSession(session.finishWorkspace, client);
+
+    const composer = await screen.findByRole('textbox', { name: 'Message' });
+    await waitFor(() => expect(stateReads).toBeGreaterThanOrEqual(1));
+    // settle: let the loaded snapshot reach the composer before judging it
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(composer).toHaveAttribute('placeholder', 'Ask Mastra Code…');
+  });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
@@ -144,7 +144,12 @@ function ChatTranscriptValueProvider({
   const serverIdleSinceSend =
     connection.state?.running === false &&
     (connection.stateUpdatedAt ?? 0) > (effectiveTranscript.pendingSince ?? Infinity);
-  const busy = connection.state?.running === true || (effectiveTranscript.pending && !serverIdleSinceSend);
+  const runElsewhere =
+    typeof connection.state?.runningThreadId === 'string' &&
+    Boolean(effectiveThreadId) &&
+    connection.state.runningThreadId !== effectiveThreadId;
+  const busy =
+    (connection.state?.running === true && !runElsewhere) || (effectiveTranscript.pending && !serverIdleSinceSend);
   const transcriptValue: ChatTranscriptApi = {
     transcript: effectiveTranscript,
     busy,

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
@@ -101,16 +101,22 @@ export function useAgentControllerConnection({
   };
 
   const handleEvent = (event: AgentControllerEvent) => {
-    const displayStateRunning =
-      isKnownAgentControllerEvent(event) && event.type === 'display_state_changed'
-        ? event.displayState.isRunning
-        : undefined;
-    const running = event.type === 'agent_start' ? true : event.type === 'agent_end' ? false : displayStateRunning;
+    const known = isKnownAgentControllerEvent(event) ? event : undefined;
+    const displayState = known?.type === 'display_state_changed' ? known.displayState : undefined;
+    const running =
+      known?.type === 'agent_start' ? true : known?.type === 'agent_end' ? false : displayState?.isRunning;
+    const runningThreadId =
+      known?.type === 'agent_start'
+        ? (known.threadId ?? null)
+        : known?.type === 'agent_end'
+          ? null
+          : (displayState?.runningThreadId ?? null);
     const tasks = isKnownAgentControllerEvent(event) && event.type === 'task_updated' ? event.tasks : undefined;
     if (typeof running === 'boolean' || tasks) {
       const patch = livePatch.current;
       patch.generation += 1;
-      if (typeof running === 'boolean') patch.running = { value: running, generation: patch.generation };
+      if (typeof running === 'boolean')
+        patch.running = { value: running, threadId: runningThreadId, generation: patch.generation };
       if (tasks) patch.tasks = { value: tasks, threadId: sessionThreadId, generation: patch.generation };
       const stateQueryKey = queryKeys.agentControllerConnectionState(
         agentControllerId,
@@ -125,7 +131,7 @@ export function useAgentControllerConnection({
           current
             ? {
                 ...current,
-                ...(typeof running === 'boolean' ? { running } : {}),
+                ...(typeof running === 'boolean' ? { running, runningThreadId } : {}),
                 ...(tasks ? { tasks } : {}),
               }
             : current,

--- a/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -1581,3 +1581,25 @@ describe('transcript reducer entry identity', () => {
     expect(next.entries).toHaveLength(2);
   });
 });
+
+describe('thread scoping', () => {
+  it('ignores streamed message events addressed to another thread', () => {
+    let state = transcriptReducer(initialTranscript, { type: 'reset', threadId: 'thread-a' });
+
+    const foreign = {
+      ...dbMessage('m-foreign', 'assistant', [{ type: 'text', text: 'other thread' }]),
+      threadId: 'thread-b',
+    };
+    state = transcriptReducer(state, { type: 'event', event: { type: 'message_start', message: foreign } });
+    expect(state.entries).toHaveLength(0);
+
+    const local = {
+      ...dbMessage('m-local', 'assistant', [{ type: 'text', text: 'this thread' }]),
+      threadId: 'thread-a',
+    };
+    state = transcriptReducer(state, { type: 'event', event: { type: 'message_start', message: local } });
+    const unstamped = dbMessage('m-unstamped', 'assistant', [{ type: 'text', text: 'old server' }]);
+    state = transcriptReducer(state, { type: 'event', event: { type: 'message_start', message: unstamped } });
+    expect(state.entries).toHaveLength(2);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -275,6 +275,11 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
   }
 }
 
+/** Lenient on either side missing — old servers don't stamp messages. */
+function isForeignThreadMessage(state: TranscriptState, message: { threadId?: string }): boolean {
+  return Boolean(message.threadId && state.threadId && message.threadId !== state.threadId);
+}
+
 function applyEvent(state: TranscriptState, event: AgentControllerEvent): TranscriptState {
   if (!isKnownAgentControllerEvent(event)) return state;
   switch (event.type) {
@@ -291,6 +296,7 @@ function applyEvent(state: TranscriptState, event: AgentControllerEvent): Transc
     case 'message_start':
     case 'message_update': {
       const message = event.message;
+      if (isForeignThreadMessage(state, message)) return state;
       const next = upsertMessage(state, message, true);
       if (message.role !== 'assistant') return next;
       // Only streamed assistant content opens the decode window — empty or
@@ -307,6 +313,7 @@ function applyEvent(state: TranscriptState, event: AgentControllerEvent): Transc
       return { ...decoded, pending: false };
     }
     case 'message_end': {
+      if (isForeignThreadMessage(state, event.message)) return state;
       const next = upsertMessage(state, event.message, false);
       return event.message.role === 'assistant' ? { ...next, pending: false } : next;
     }

--- a/packages/core/src/agent-controller/__tests__/run-engine-abort-deadline.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-abort-deadline.test.ts
@@ -75,7 +75,7 @@ describe('SessionRunEngine — abort deadline', () => {
     await vi.advanceTimersByTimeAsync(5_000);
 
     const result = await processed;
-    expect(events).toContainEqual({ type: 'agent_end', reason: 'aborted' });
+    expect(events).toContainEqual(expect.objectContaining({ type: 'agent_end', reason: 'aborted' }));
     expect(session.run.isRunning()).toBe(false);
     expect(result?.message.content.parts).toEqual([{ type: 'text', text: 'partial' }]);
   });
@@ -118,13 +118,13 @@ describe('SessionRunEngine — abort deadline', () => {
 
     const processed = engine.processSubscribedThreadStream(subscription);
     await vi.advanceTimersByTimeAsync(0);
-    expect(events).toContainEqual({ type: 'agent_start' });
+    expect(events).toContainEqual(expect.objectContaining({ type: 'agent_start' }));
 
     session.abortRun();
     await vi.advanceTimersByTimeAsync(5_000);
 
     await processed;
-    expect(events).toContainEqual({ type: 'agent_end', reason: 'aborted' });
+    expect(events).toContainEqual(expect.objectContaining({ type: 'agent_end', reason: 'aborted' }));
     expect(session.run.isRunning()).toBe(false);
     expect(session.stream.isOpen()).toBe(false);
   });
@@ -164,7 +164,7 @@ describe('SessionRunEngine — abort deadline', () => {
     await vi.advanceTimersByTimeAsync(1_000);
     push(chunk({ type: 'finish', payload: { stepResult: { reason: 'stop' } } }));
     await vi.advanceTimersByTimeAsync(0);
-    expect(events).toContainEqual({ type: 'agent_end', reason: 'aborted' });
+    expect(events).toContainEqual(expect.objectContaining({ type: 'agent_end', reason: 'aborted' }));
 
     push(chunk({ type: 'text-start', payload: { id: 't2' } }));
     push(chunk({ type: 'text-delta', payload: { id: 't2', text: 'follow-up' } }));
@@ -173,7 +173,9 @@ describe('SessionRunEngine — abort deadline', () => {
     expect(session.run.isRunning()).toBe(true);
     expect(session.stream.isOpen()).toBe(true);
     expect(events.filter(event => event.type === 'agent_start')).toHaveLength(2);
-    expect(events.filter(event => event.type === 'agent_end')).toEqual([{ type: 'agent_end', reason: 'aborted' }]);
+    expect(events.filter(event => event.type === 'agent_end')).toEqual([
+      expect.objectContaining({ type: 'agent_end', reason: 'aborted' }),
+    ]);
   });
 
   it('Given an abort of a later run on the same subscription, When that run hangs, Then the re-armed deadline still bails it', async () => {
@@ -206,7 +208,7 @@ describe('SessionRunEngine — abort deadline', () => {
     push(chunk({ type: 'text-start', payload: { id: 't1' } }));
     push(chunk({ type: 'finish', payload: { stepResult: { reason: 'stop' } } }));
     await vi.advanceTimersByTimeAsync(0);
-    expect(events).toContainEqual({ type: 'agent_end', reason: 'complete' });
+    expect(events).toContainEqual(expect.objectContaining({ type: 'agent_end', reason: 'complete' }));
 
     push(chunk({ type: 'text-start', payload: { id: 't2' } }));
     await vi.advanceTimersByTimeAsync(0);
@@ -215,7 +217,7 @@ describe('SessionRunEngine — abort deadline', () => {
     await vi.advanceTimersByTimeAsync(5_000);
 
     await processed;
-    expect(events).toContainEqual({ type: 'agent_end', reason: 'aborted' });
+    expect(events).toContainEqual(expect.objectContaining({ type: 'agent_end', reason: 'aborted' }));
     expect(session.run.isRunning()).toBe(false);
     expect(session.stream.isOpen()).toBe(false);
   });
@@ -254,7 +256,7 @@ describe('SessionRunEngine — abort deadline', () => {
     session.abortRun();
     push(chunk({ type: 'finish', payload: { stepResult: { reason: 'stop' } } }));
     await vi.advanceTimersByTimeAsync(0);
-    expect(events).toContainEqual({ type: 'agent_end', reason: 'aborted' });
+    expect(events).toContainEqual(expect.objectContaining({ type: 'agent_end', reason: 'aborted' }));
 
     // Second run on the same subscription hangs after its abort.
     push(chunk({ type: 'text-start', payload: { id: 't2' } }));
@@ -270,8 +272,8 @@ describe('SessionRunEngine — abort deadline', () => {
     await vi.advanceTimersByTimeAsync(1);
     await processed;
     expect(events.filter(event => event.type === 'agent_end')).toEqual([
-      { type: 'agent_end', reason: 'aborted' },
-      { type: 'agent_end', reason: 'aborted' },
+      expect.objectContaining({ type: 'agent_end', reason: 'aborted' }),
+      expect.objectContaining({ type: 'agent_end', reason: 'aborted' }),
     ]);
     expect(session.run.isRunning()).toBe(false);
     expect(session.stream.isOpen()).toBe(false);
@@ -308,8 +310,8 @@ describe('SessionRunEngine — abort deadline', () => {
       },
     ]);
     expect(events.filter(event => event.type === 'agent_end')).toEqual([
-      { type: 'agent_end', reason: 'error' },
-      { type: 'agent_end', reason: 'complete' },
+      expect.objectContaining({ type: 'agent_end', reason: 'error' }),
+      expect.objectContaining({ type: 'agent_end', reason: 'complete' }),
     ]);
     expect(events.filter(event => event.type === 'agent_start')).toHaveLength(2);
     expect(session.run.isRunning()).toBe(false);
@@ -328,7 +330,7 @@ describe('SessionRunEngine — abort deadline', () => {
       })(),
     });
 
-    expect(events).toContainEqual({ type: 'agent_end', reason: 'aborted' });
+    expect(events).toContainEqual(expect.objectContaining({ type: 'agent_end', reason: 'aborted' }));
     expect(result?.message).toBeDefined();
   });
 });

--- a/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
@@ -564,6 +564,6 @@ describe('SessionRunEngine — MastraDBMessage contract', () => {
     expect(result?.message.content.metadata?.errorMessage).toEqual(expect.stringContaining('content filter'));
     const messageEnd = events.find(event => event.type === 'message_end');
     expect(messageEnd?.message.content.metadata?.stopReason).toBe('error');
-    expect(events).toContainEqual({ type: 'agent_end', reason: 'error' });
+    expect(events).toContainEqual(expect.objectContaining({ type: 'agent_end', reason: 'error' }));
   });
 });

--- a/packages/core/src/agent-controller/__tests__/session-abort-approval-suspension.test.ts
+++ b/packages/core/src/agent-controller/__tests__/session-abort-approval-suspension.test.ts
@@ -128,7 +128,9 @@ describe('session.abort() during approval / suspension (#20592)', () => {
     await ended;
 
     expect(events.filter(e => e.type === 'error')).toEqual([]);
-    expect(events.find(e => e.type === 'agent_end')).toEqual({ type: 'agent_end', reason: 'aborted' });
+    expect(events.find(e => e.type === 'agent_end')).toEqual(
+      expect.objectContaining({ type: 'agent_end', reason: 'aborted' }),
+    );
   });
 
   it('Given an aborted approval, When agent_end fires, Then the display state no longer shows the tool as pending', async () => {
@@ -171,7 +173,9 @@ describe('session.abort() during approval / suspension (#20592)', () => {
     await ended;
 
     expect(events.filter(e => e.type === 'error')).toEqual([]);
-    expect(events.find(e => e.type === 'agent_end')).toEqual({ type: 'agent_end', reason: 'aborted' });
+    expect(events.find(e => e.type === 'agent_end')).toEqual(
+      expect.objectContaining({ type: 'agent_end', reason: 'aborted' }),
+    );
   });
 
   it('Given an approved tool parked in suspend(), When abort() is called, Then the parked suspension is retracted from the display state', async () => {

--- a/packages/core/src/agent-controller/display-state.test.ts
+++ b/packages/core/src/agent-controller/display-state.test.ts
@@ -1724,3 +1724,20 @@ describe('Display state OMProgressState', () => {
     expect(omp).toHaveProperty('preReflectionTokens');
   });
 });
+
+describe('runningThreadId', () => {
+  let session: Session;
+
+  beforeEach(async () => {
+    const ctx = await createSession();
+    session = ctx.session;
+  });
+
+  it('tracks which thread the active run is on and clears it when the run ends', () => {
+    emit(session, { type: 'agent_start', threadId: 'thread-a' });
+    expect(session.displayState.get().runningThreadId).toBe('thread-a');
+
+    emit(session, { type: 'agent_end', reason: 'complete' });
+    expect(session.displayState.get().runningThreadId).toBeNull();
+  });
+});

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -297,6 +297,7 @@ export class SessionRunEngine {
         metadata: { signal: payload },
       },
       createdAt,
+      ...this.runThreadStamp(),
     };
   }
 

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -260,12 +260,18 @@ export class SessionRunEngine {
     this.#machinery = machinery;
   }
 
+  private runThreadStamp(): { threadId?: string } {
+    const threadId = this.#session.thread.getId();
+    return threadId ? { threadId } : {};
+  }
+
   private createEmptyAssistantMessage(): MastraDBMessage {
     return {
       id: this.#machinery.generateId(),
       role: 'assistant',
       content: { format: 2, parts: [] },
       createdAt: new Date(),
+      ...this.runThreadStamp(),
     };
   }
 
@@ -407,7 +413,7 @@ export class SessionRunEngine {
     const state = this.createStreamState();
     const requestContext = await this.#machinery.buildRequestContext(requestContextInput);
     this.#session.run.nextOperation();
-    this.#session.emit({ type: 'agent_start' });
+    this.#session.emit({ type: 'agent_start', ...this.runThreadStamp() });
 
     let result: { message: MastraDBMessage; suspended?: boolean } | undefined;
     let error = false;
@@ -1250,7 +1256,7 @@ export class SessionRunEngine {
           this.#session.run.setRunId({ runId });
           this.#session.run.setTraceId({ traceId: null });
           requestContext = await this.#machinery.buildRequestContext(subscription.__getCurrentRunRequestContext?.());
-          this.#session.emit({ type: 'agent_start' });
+          this.#session.emit({ type: 'agent_start', ...this.runThreadStamp() });
         }
 
         if (chunk.type === 'start') {

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -2287,6 +2287,7 @@ export class SessionDisplayState {
       // ── Agent lifecycle ────────────────────────────────────────────────
       case 'agent_start':
         ds.isRunning = true;
+        ds.runningThreadId = event.threadId ?? null;
         ds.activeTools = new Map();
         ds.toolInputBuffers = new Map();
         ds.currentMessage = null;
@@ -2298,6 +2299,7 @@ export class SessionDisplayState {
 
       case 'agent_end':
         ds.isRunning = false;
+        ds.runningThreadId = null;
         ds.pendingApproval = null;
         // A suspended run keeps its pending tool suspensions alive so the UI can
         // still render the prompts (e.g. `ask_user`, which pauses via the native
@@ -2967,7 +2969,12 @@ export class Session<TState = unknown> {
   async finishAgentRun(
     reason: NonNullable<Extract<AgentControllerEvent, { type: 'agent_end' }>['reason']>,
   ): Promise<void> {
-    const event = { type: 'agent_end', reason } as const;
+    const threadId = this.thread.getId();
+    const event: Extract<AgentControllerEvent, { type: 'agent_end' }> = {
+      type: 'agent_end',
+      reason,
+      ...(threadId ? { threadId } : {}),
+    };
     for (const listener of this.#beforeAgentEndListeners) {
       try {
         await listener(event);

--- a/packages/core/src/agent-controller/signal-messages.test.ts
+++ b/packages/core/src/agent-controller/signal-messages.test.ts
@@ -1205,6 +1205,7 @@ describe('AgentController signal messages', () => {
       id: 'signal-user-1',
       role: 'signal',
       createdAt: new Date('2026-05-04T00:00:00.000Z'),
+      threadId: session.thread.getId(),
       content: {
         format: 2,
         parts: [

--- a/packages/core/src/agent-controller/signal-messages.test.ts
+++ b/packages/core/src/agent-controller/signal-messages.test.ts
@@ -817,7 +817,9 @@ describe('AgentController signal messages', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(events.filter(event => event.type === 'agent_start')).toHaveLength(1);
-    expect(events.filter(event => event.type === 'agent_end')).toEqual([{ type: 'agent_end', reason: 'aborted' }]);
+    expect(events.filter(event => event.type === 'agent_end')).toEqual([
+      expect.objectContaining({ type: 'agent_end', reason: 'aborted' }),
+    ]);
   });
 
   it('starts a new idle signal after a subscription-owned run completes', async () => {

--- a/packages/core/src/agent-controller/thread-scoped-events.test.ts
+++ b/packages/core/src/agent-controller/thread-scoped-events.test.ts
@@ -22,6 +22,12 @@ function createController(storage = new InMemoryStore()) {
 
 async function* textStream() {
   yield {
+    type: 'data-user-message',
+    runId: 'run-1',
+    from: 'AGENT',
+    data: { id: 'signal-1', text: 'steer note' },
+  };
+  yield {
     type: 'text-start',
     runId: 'run-1',
     from: 'AGENT',
@@ -49,6 +55,10 @@ function findEvent<T extends AgentControllerEvent['type']>(events: AgentControll
   return events.find((event): event is Extract<AgentControllerEvent, { type: T }> => event.type === type);
 }
 
+function findEvents<T extends AgentControllerEvent['type']>(events: AgentControllerEvent[], type: T) {
+  return events.filter((event): event is Extract<AgentControllerEvent, { type: T }> => event.type === type);
+}
+
 describe('thread-scoped run events', () => {
   let controller: AgentController;
   let session: Awaited<ReturnType<AgentController['createSession']>>;
@@ -68,7 +78,7 @@ describe('thread-scoped run events', () => {
 
     expect(findEvent(events, 'agent_start')?.threadId).toBe(thread.id);
     expect(findEvent(events, 'agent_end')?.threadId).toBe(thread.id);
-    expect(findEvent(events, 'message_start')?.message.threadId).toBe(thread.id);
-    expect(findEvent(events, 'message_end')?.message.threadId).toBe(thread.id);
+    expect(findEvents(events, 'message_start').map(event => event.message.threadId)).toEqual([thread.id, thread.id]);
+    expect(findEvents(events, 'message_end').map(event => event.message.threadId)).toEqual([thread.id, thread.id]);
   });
 });

--- a/packages/core/src/agent-controller/thread-scoped-events.test.ts
+++ b/packages/core/src/agent-controller/thread-scoped-events.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { AgentController } from './agent-controller';
+import { createMockWorkspace } from './test-utils';
+import type { AgentControllerEvent } from './types';
+
+function createController(storage = new InMemoryStore()) {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  return new AgentController({
+    workspace: createMockWorkspace(),
+    id: 'test-controller',
+    storage,
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+}
+
+async function* textStream() {
+  yield {
+    type: 'text-start',
+    runId: 'run-1',
+    from: 'AGENT',
+    payload: { id: 't1' },
+  };
+  yield {
+    type: 'text-delta',
+    runId: 'run-1',
+    from: 'AGENT',
+    payload: { id: 't1', text: 'Hello there' },
+  };
+  yield {
+    type: 'finish',
+    runId: 'run-1',
+    from: 'AGENT',
+    payload: {
+      stepResult: { reason: 'stop' },
+      output: { usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+      metadata: {},
+    },
+  };
+}
+
+function findEvent<T extends AgentControllerEvent['type']>(events: AgentControllerEvent[], type: T) {
+  return events.find((event): event is Extract<AgentControllerEvent, { type: T }> => event.type === type);
+}
+
+describe('thread-scoped run events', () => {
+  let controller: AgentController;
+  let session: Awaited<ReturnType<AgentController['createSession']>>;
+
+  beforeEach(async () => {
+    controller = createController();
+    await controller.init();
+    session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+  });
+
+  it('stamps the run lifecycle events and streamed messages with the thread they run on', async () => {
+    const thread = await session.thread.create();
+    const events: AgentControllerEvent[] = [];
+    session.subscribe(event => events.push(event));
+
+    await (session as any).processStream({ fullStream: textStream() });
+
+    expect(findEvent(events, 'agent_start')?.threadId).toBe(thread.id);
+    expect(findEvent(events, 'agent_end')?.threadId).toBe(thread.id);
+    expect(findEvent(events, 'message_start')?.message.threadId).toBe(thread.id);
+    expect(findEvent(events, 'message_end')?.message.threadId).toBe(thread.id);
+  });
+});

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -634,6 +634,9 @@ export interface AgentControllerDisplayState {
   /** Whether an agent operation is currently in progress */
   isRunning: boolean;
 
+  /** Thread the active run is on (null when idle or the start event predates stamping). */
+  runningThreadId: string | null;
+
   // ── Current streaming message ────────────────────────────────────────
   /**
    * The live message currently being streamed (null when idle). Its content
@@ -714,6 +717,7 @@ export interface AgentControllerDisplayState {
 export function defaultDisplayState(): AgentControllerDisplayState {
   return {
     isRunning: false,
+    runningThreadId: null,
     currentMessage: null,
     queuedFollowUps: 0,
     tokenUsage: createEmptyTokenUsage(),
@@ -783,8 +787,8 @@ export type AgentControllerEvent =
   | { type: 'thread_created'; thread: AgentControllerThread }
   | { type: 'thread_deleted'; threadId: string }
   | { type: 'state_changed'; state: Record<string, unknown>; changedKeys: string[] }
-  | { type: 'agent_start' }
-  | { type: 'agent_end'; reason?: 'complete' | 'aborted' | 'error' | 'suspended' }
+  | { type: 'agent_start'; threadId?: string }
+  | { type: 'agent_end'; reason?: 'complete' | 'aborted' | 'error' | 'suspended'; threadId?: string }
   | { type: 'message_start'; message: MastraDBMessage }
   | { type: 'message_update'; message: MastraDBMessage }
   | { type: 'message_end'; message: MastraDBMessage }

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -629,6 +629,21 @@ describe('agent-controller routes', () => {
       expect(res.running).toBe(true);
     });
 
+    it('names the thread the active run is on', async () => {
+      const controller = mastra.getAgentController('code')!;
+      await controller.init();
+      const session = await controller.createSession({ resourceId: 'user-1', id: 'user-1', ownerId: controller.id });
+      session.displayState.apply({ type: 'agent_start', threadId: 'thread-run' } as any);
+
+      const res = (await GET_AGENT_CONTROLLER_SESSION_STATE_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-1',
+      } as any)) as { running?: boolean; runningThreadId?: string };
+      expect(res.running).toBe(true);
+      expect(res.runningThreadId).toBe('thread-run');
+    });
+
     it('returns the durable task list for initial UI hydration', async () => {
       const controller = mastra.getAgentController('code')!;
       await controller.init();

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -310,6 +310,8 @@ const sessionStateResponseSchema = z.object({
   modelId: z.string(),
   /** Whether the agent is currently executing a run (for initial UI hydration). */
   running: z.boolean().optional(),
+  /** Thread the active run is on; null when idle or when the run predates thread stamping. */
+  runningThreadId: z.string().nullable().optional(),
   tasks: z.array(taskSnapshotSchema).optional(),
   omProgress: omProgressSummarySchema.optional(),
   tokenUsage: tokenUsageSchema.optional(),
@@ -838,6 +840,7 @@ export const GET_AGENT_CONTROLLER_SESSION_STATE_ROUTE = createRoute({
         modeId: session.mode.get(),
         modelId: session.model.get(),
         running: ds.isRunning === true,
+        runningThreadId: ds.runningThreadId ?? null,
         tasks,
         omProgress: {
           status: om.status,


### PR DESCRIPTION
TLDR: a run now says which thread it is on, so viewing one thread of a session while another thread runs no longer shows a busy composer and no longer leaks the other thread's messages into the transcript.

---

Stacked on #22416. Last PR of the run-state truth stack.

The server tracked "running" per session, not per thread. Streamed messages carried no `threadId` either. So with two threads in one session, the mounted transcript upserted whatever the run streamed, and the composer spun for a run it could not show.

### What changes

| viewing thread A, session runs thread B | before | after |
| --- | --- | --- |
| composer | busy, silent rotation | idle, ready to send |
| the run streams messages | upserted into thread A's transcript | dropped, they belong to B |
| `session.state()` callers | `running: true`, no way to tell where | `runningThreadId: "B"` |

`agent_start`/`agent_end` carry an optional `threadId`, streamed messages are stamped with the session's active thread (assistant messages and the steer/notification echoes a run emits alike), and the state route reports `runningThreadId` (`null` while idle). factory-ui scopes `busy` to the viewed thread and ignores `message_*` events stamped for another thread. All additive: an unstamped event or message (old server) behaves exactly as today.

### Judgment call

Existing core tests pinned lifecycle events with exact equality (`toEqual({ type: 'agent_end', reason: 'aborted' })`); the new stamp broke 11 of them. I loosened those pins to `objectContaining` rather than adding the thread id to each — they pin type and reason, the stamp is not what they test.

### Not verified

The two-thread scenario end to end against a live factory (the plan's verification list); pinned with MSW and core unit tests only. One pre-existing failure on this machine, `ActivityLine.msw` "steps aside while the answer streams", fails identically without this diff.

```
tests        +193  -17    ← red-first pins + loosened lifecycle pins
source        +54  -15
changeset     +20    0    ← core, server, client-js, factory patches
generated      +1    0    ← route types
```
