### PR TITLE
test(playground-ui): cover remaining components in Storybook

### DIFF
--- a/.changeset/tricky-forks-feel.md
+++ b/.changeset/tricky-forks-feel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added Storybook examples for every published Playground UI component that did not already have coverage.

--- a/packages/playground-ui/.storybook/main.ts
+++ b/packages/playground-ui/.storybook/main.ts
@@ -1,6 +1,7 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { StorybookConfig } from '@storybook/react-vite';
+import { mergeConfig } from 'vite';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -16,6 +17,17 @@ const config: StorybookConfig = {
   typescript: {
     reactDocgen: 'react-docgen-typescript',
   },
+  viteFinal: config =>
+    mergeConfig(config, {
+      resolve: {
+        alias: [
+          {
+            find: /^@mastra\/react$/,
+            replacement: fileURLToPath(new URL('./mocks/mastra-react.ts', import.meta.url)),
+          },
+        ],
+      },
+    }),
 };
 
 export default config;

--- a/packages/playground-ui/.storybook/mocks/mastra-react.ts
+++ b/packages/playground-ui/.storybook/mocks/mastra-react.ts
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+
+interface MastraReactProviderProps {
+  children: ReactNode;
+}
+
+const client = {
+  options: {
+    baseUrl: 'http://localhost:4111',
+    apiPrefix: '/api',
+  },
+};
+
+export function MastraReactProvider({ children }: MastraReactProviderProps) {
+  return children;
+}
+
+export function useMastraClient() {
+  return client;
+}

--- a/packages/playground-ui/src/ds/components/Arrival/arrival.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Arrival/arrival.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Button } from '../Button';
+import { ArrivalScope, Arriving } from './arrival';
+
+const meta: Meta<typeof ArrivalScope> = {
+  title: 'Motion/Arrival',
+  component: ArrivalScope,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArrivalScope>;
+
+function ArrivalDemo() {
+  const [items, setItems] = useState(['Restored conversation', 'Existing tool result']);
+
+  return (
+    <div className="flex w-[min(24rem,calc(100vw-2rem))] flex-col gap-4">
+      <ArrivalScope>
+        <div className="flex flex-col gap-2">
+          {items.map(item => (
+            <Arriving
+              key={item}
+              className="border-border1 bg-surface2 text-ui-sm text-neutral5 rounded-lg border px-4 py-3"
+            >
+              {item}
+            </Arriving>
+          ))}
+        </div>
+      </ArrivalScope>
+      <Button
+        onClick={() => setItems(current => [...current, `New streamed item ${current.length - 1}`])}
+        disabled={items.length >= 5}
+      >
+        Add streamed item
+      </Button>
+    </div>
+  );
+}
+
+export const ExistingAndNewContent: Story = {
+  render: () => <ArrivalDemo />,
+};

--- a/packages/playground-ui/src/ds/components/Card/card.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Card/card.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Badge } from '../Badge';
+import { Button } from '../Button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardLink, CardTitle } from './Card';
+
+const meta: Meta<typeof Card> = {
+  title: 'Layout/Card',
+  component: Card,
+  parameters: { layout: 'centered' },
+  args: {
+    appearance: 'outlined',
+    elevation: 'flat',
+    interactive: false,
+  },
+  argTypes: {
+    appearance: { control: 'inline-radio', options: ['outlined', 'surface'] },
+    elevation: { control: 'inline-radio', options: ['flat', 'raised', 'elevated'] },
+    interactive: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {
+  render: args => (
+    <Card {...args} className="w-[min(24rem,calc(100vw-2rem))]">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle>Research agent</CardTitle>
+          <Badge variant="success">Active</Badge>
+        </div>
+        <CardDescription>Searches trusted sources and returns a cited summary.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-ui-sm text-neutral4">Last run completed 4 minutes ago with 12 sources.</p>
+      </CardContent>
+      <CardFooter className="gap-2">
+        <Button variant="primary">Open agent</Button>
+        <Button variant="ghost">Configure</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+export const AppearancesAndElevation: Story = {
+  render: () => (
+    <div className="grid w-[min(44rem,calc(100vw-2rem))] grid-cols-1 gap-5 sm:grid-cols-2">
+      {(['outlined', 'surface'] as const).flatMap(appearance =>
+        (['flat', 'raised', 'elevated'] as const).map(elevation => (
+          <Card key={`${appearance}-${elevation}`} appearance={appearance} elevation={elevation}>
+            <CardHeader>
+              <CardTitle className="capitalize">{elevation}</CardTitle>
+              <CardDescription>{appearance} appearance</CardDescription>
+            </CardHeader>
+            <CardContent density="compact">
+              <p className="text-ui-sm text-neutral4">Card content</p>
+            </CardContent>
+          </Card>
+        )),
+      )}
+    </div>
+  ),
+};
+
+export const InteractiveLinks: Story = {
+  render: () => (
+    <div className="grid w-[min(24rem,calc(100vw-2rem))] gap-3">
+      <Card interactive onClick={() => undefined}>
+        <CardContent>
+          <CardTitle>Button card</CardTitle>
+          <CardDescription className="mt-1">Keyboard-focusable and pressable.</CardDescription>
+        </CardContent>
+      </Card>
+      <CardLink href="#agent" onClick={event => event.preventDefault()}>
+        <CardContent>
+          <CardTitle>Link card</CardTitle>
+          <CardDescription className="mt-1">Keeps native link semantics.</CardDescription>
+        </CardContent>
+      </CardLink>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Columns/columns.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Columns/columns.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SlidersHorizontalIcon } from 'lucide-react';
+
+import { Button } from '../Button';
+import { Card, CardContent, CardHeader, CardTitle } from '../Card';
+import { Column, Columns, MultiColumn } from './index';
+
+const meta: Meta<typeof Columns> = {
+  title: 'Layout/Columns',
+  component: Columns,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof Columns>;
+
+const columnContent = [
+  ['Agent runs', '126'],
+  ['Success rate', '98.4%'],
+  ['Median latency', '842 ms'],
+] as const;
+
+function MetricsColumn({ title }: { title: string }) {
+  return (
+    <Column className="p-5" withRightSeparator>
+      <Column.Toolbar>
+        <h2 className="text-neutral5 text-lg">{title}</h2>
+        <Button size="sm" variant="ghost">
+          <SlidersHorizontalIcon />
+          Configure
+        </Button>
+      </Column.Toolbar>
+      <Column.Content className="gap-3">
+        {columnContent.map(([label, value]) => (
+          <Card key={label} appearance="surface">
+            <CardHeader>
+              <CardTitle>{value}</CardTitle>
+            </CardHeader>
+            <CardContent density="compact" className="text-ui-sm text-neutral3">
+              {label}
+            </CardContent>
+          </Card>
+        ))}
+      </Column.Content>
+    </Column>
+  );
+}
+
+export const ResponsiveGrid: Story = {
+  render: () => (
+    <div className="bg-surface1 h-[36rem] p-4">
+      <Columns className="md:grid-cols-2">
+        <MetricsColumn title="Production" />
+        <MetricsColumn title="Development" />
+      </Columns>
+    </div>
+  ),
+};
+
+export const HorizontallyScrollable: Story = {
+  render: () => (
+    <div className="bg-surface1 h-[32rem] w-full max-w-3xl p-4">
+      <MultiColumn numOfColumns={3} minColumnWidth="18rem">
+        <MetricsColumn title="Agents" />
+        <MetricsColumn title="Workflows" />
+        <MetricsColumn title="Tools" />
+      </MultiColumn>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/DataDetailsPanel/data-details-panel.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataDetailsPanel/data-details-panel.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { BracesIcon } from 'lucide-react';
+import { fn } from 'storybook/test';
+
+import { ThemeProvider } from '../ThemeProvider';
+import { TooltipProvider } from '../Tooltip';
+import { DataDetailsPanel } from './index';
+
+const meta: Meta<typeof DataDetailsPanel> = {
+  title: 'DataDisplay/DataDetailsPanel',
+  component: DataDetailsPanel,
+  parameters: { layout: 'centered' },
+  decorators: [
+    Story => (
+      <ThemeProvider defaultTheme="dark" storageKey="storybook-data-details-panel">
+        <TooltipProvider>
+          <Story />
+        </TooltipProvider>
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DataDetailsPanel>;
+
+const responseBody = JSON.stringify(
+  {
+    answer: 'The workflow completed successfully.\nAll three steps returned output.',
+    duration: 842,
+    cached: false,
+  },
+  null,
+  2,
+);
+
+export const Populated: Story = {
+  render: () => (
+    <div className="h-[34rem] w-160">
+      <DataDetailsPanel>
+        <DataDetailsPanel.Header>
+          <DataDetailsPanel.Heading>
+            Run <b>run_8f3a91b2</b>
+          </DataDetailsPanel.Heading>
+          <DataDetailsPanel.CloseButton onClick={fn()} />
+        </DataDetailsPanel.Header>
+        <DataDetailsPanel.Content>
+          <div className="grid gap-6">
+            <DataDetailsPanel.KeyValueList>
+              <DataDetailsPanel.KeyValueList.Header>Execution</DataDetailsPanel.KeyValueList.Header>
+              <DataDetailsPanel.KeyValueList.Key>Status</DataDetailsPanel.KeyValueList.Key>
+              <DataDetailsPanel.KeyValueList.Value>Completed</DataDetailsPanel.KeyValueList.Value>
+              <DataDetailsPanel.KeyValueList.Key>Agent</DataDetailsPanel.KeyValueList.Key>
+              <DataDetailsPanel.KeyValueList.Value>
+                Research agent with a realistically long display name
+              </DataDetailsPanel.KeyValueList.Value>
+              <DataDetailsPanel.KeyValueList.Key>Started</DataDetailsPanel.KeyValueList.Key>
+              <DataDetailsPanel.KeyValueList.Value>August 26, 2026 at 21:42</DataDetailsPanel.KeyValueList.Value>
+            </DataDetailsPanel.KeyValueList>
+            <DataDetailsPanel.CodeSection title="Response" icon={<BracesIcon />} codeStr={responseBody} />
+          </div>
+        </DataDetailsPanel.Content>
+      </DataDetailsPanel>
+    </div>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <div className="h-72 w-144">
+      <DataDetailsPanel>
+        <DataDetailsPanel.Header>
+          <DataDetailsPanel.Heading>Trace details</DataDetailsPanel.Heading>
+        </DataDetailsPanel.Header>
+        <DataDetailsPanel.LoadingData>Loading trace data...</DataDetailsPanel.LoadingData>
+      </DataDetailsPanel>
+    </div>
+  ),
+};
+
+export const Empty: Story = {
+  render: () => (
+    <div className="h-72 w-144">
+      <DataDetailsPanel>
+        <DataDetailsPanel.Header>
+          <DataDetailsPanel.Heading>Trace details</DataDetailsPanel.Heading>
+        </DataDetailsPanel.Header>
+        <DataDetailsPanel.NoData>No attributes were recorded for this span.</DataDetailsPanel.NoData>
+      </DataDetailsPanel>
+    </div>
+  ),
+};
+
+export const Collapsed: Story = {
+  render: () => (
+    <div className="w-144">
+      <DataDetailsPanel collapsed>
+        <DataDetailsPanel.Header>
+          <DataDetailsPanel.Heading>
+            Run <b>run_8f3a91b2</b>
+          </DataDetailsPanel.Heading>
+          <DataDetailsPanel.CloseButton onClick={fn()} />
+        </DataDetailsPanel.Header>
+      </DataDetailsPanel>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/DataFilter/select-data-filter.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DataFilter/select-data-filter.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { fn } from 'storybook/test';
+
+import { SelectDataFilter } from './select-data-filter';
+import type { SelectDataFilterCategory, SelectDataFilterProps, SelectDataFilterState } from './select-data-filter';
+
+const categories = [
+  {
+    id: 'status',
+    label: 'Status',
+    mode: 'multi',
+    values: [
+      { value: 'running', label: 'Running' },
+      { value: 'completed', label: 'Completed' },
+      { value: 'failed', label: 'Failed' },
+    ],
+  },
+  {
+    id: 'environment',
+    label: 'Environment',
+    mode: 'single',
+    values: [
+      { value: 'production', label: 'Production' },
+      { value: 'staging', label: 'Staging' },
+      { value: 'development', label: 'Development' },
+    ],
+  },
+  {
+    id: 'agent',
+    label: 'Agent',
+    group: 'Resources',
+    values: [
+      { value: 'research', label: 'Research agent' },
+      { value: 'support', label: 'Customer support agent' },
+      { value: 'sales', label: 'Sales qualification agent' },
+      { value: 'writing', label: 'Writing agent' },
+      { value: 'translation', label: 'Translation agent' },
+      { value: 'analysis', label: 'Data analysis agent' },
+    ],
+  },
+  {
+    id: 'workflow',
+    label: 'Workflow',
+    group: 'Resources',
+    values: [
+      { value: 'daily-report', label: 'Daily report' },
+      { value: 'lead-enrichment', label: 'Lead enrichment' },
+    ],
+  },
+] satisfies SelectDataFilterCategory[];
+
+const meta: Meta<typeof SelectDataFilter> = {
+  title: 'Forms/SelectDataFilter',
+  component: SelectDataFilter,
+  parameters: { layout: 'centered' },
+  args: {
+    categories,
+    value: {},
+    onChange: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SelectDataFilter>;
+
+function FilterPreview(props: SelectDataFilterProps) {
+  const [value, setValue] = useState<SelectDataFilterState>(props.value);
+
+  return (
+    <div className="flex min-h-64 w-120 flex-col items-start gap-4">
+      <SelectDataFilter
+        {...props}
+        value={value}
+        onChange={nextValue => {
+          setValue(nextValue);
+          props.onChange(nextValue);
+        }}
+      />
+      <pre className="border-border1 bg-surface2 text-ui-sm text-neutral4 w-full rounded-lg border p-4">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: args => <FilterPreview {...args} />,
+};
+
+export const WithActiveFilters: Story = {
+  args: {
+    value: {
+      status: ['running', 'failed'],
+      environment: ['production'],
+    },
+  },
+  render: args => <FilterPreview {...args} />,
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+  render: args => <FilterPreview {...args} />,
+};

--- a/packages/playground-ui/src/ds/components/DateRangeTimeline/date-range-timeline.stories.tsx
+++ b/packages/playground-ui/src/ds/components/DateRangeTimeline/date-range-timeline.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { fn } from 'storybook/test';
+
+import { DateRangeTimeline } from './DateRangeTimeline';
+import type { DateRangeValue } from './types';
+
+const meta: Meta<typeof DateRangeTimeline> = {
+  title: 'Forms/DateRangeTimeline',
+  component: DateRangeTimeline,
+  parameters: { layout: 'centered' },
+  args: {
+    min: '2026-01-01',
+    max: '2026-08-26',
+    value: { from: '2026-05-01', to: '2026-07-15' },
+    onCommit: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DateRangeTimeline>;
+
+function TimelinePreview({ value: initialValue, onCommit, ...props }: React.ComponentProps<typeof DateRangeTimeline>) {
+  const [value, setValue] = useState<DateRangeValue>(initialValue);
+
+  return (
+    <div className="border-border1 bg-surface2 grid w-[min(52rem,calc(100vw-3rem))] gap-5 rounded-xl border p-6">
+      <div className="text-ui-sm flex items-center justify-between gap-4">
+        <span className="text-neutral3">Selected range</span>
+        <span className="text-neutral5 font-mono">
+          {value.from} – {value.to}
+        </span>
+      </div>
+      <DateRangeTimeline
+        {...props}
+        value={value}
+        onCommit={nextValue => {
+          setValue(nextValue);
+          onCommit(nextValue);
+        }}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: args => <TimelinePreview {...args} />,
+};
+
+export const SingleDay: Story = {
+  args: {
+    min: '2026-08-26',
+    max: '2026-08-26',
+    value: { from: '2026-08-26', to: '2026-08-26' },
+  },
+  render: args => <TimelinePreview {...args} />,
+};
+
+export const MultiYear: Story = {
+  args: {
+    min: '2024-01-01',
+    max: '2026-08-26',
+    value: { from: '2025-02-01', to: '2026-04-15' },
+  },
+  render: args => <TimelinePreview {...args} />,
+};

--- a/packages/playground-ui/src/ds/components/ErrorState/error-state.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ErrorState/error-state.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { Button } from '../Button';
+import { ErrorState } from './ErrorState';
+
+const meta: Meta<typeof ErrorState> = {
+  title: 'Feedback/ErrorState',
+  component: ErrorState,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    title: 'Unable to load traces',
+    message: 'The observability store did not respond. Check the connection and try again.',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ErrorState>;
+
+export const Default: Story = {};
+
+export const WithRecoveryAction: Story = {
+  args: {
+    action: <Button onClick={fn()}>Try again</Button>,
+  },
+};

--- a/packages/playground-ui/src/ds/components/ListSearch/list-search.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ListSearch/list-search.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { fn } from 'storybook/test';
+
+import { ListSearch } from './list-search';
+import type { ListSearchProps } from './list-search';
+
+const meta: Meta<typeof ListSearch> = {
+  title: 'Forms/ListSearch',
+  component: ListSearch,
+  parameters: { layout: 'centered' },
+  args: {
+    label: 'Search agents',
+    placeholder: 'Search by name or description',
+    debounceMs: 300,
+    onSearch: fn(),
+    value: '',
+    variant: 'outline',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ListSearch>;
+
+function SearchPreview(props: ListSearchProps) {
+  const [value, setValue] = useState(props.value ?? '');
+  const [debouncedValue, setDebouncedValue] = useState(props.value ?? '');
+
+  return (
+    <div className="flex w-120 flex-col gap-3">
+      <ListSearch
+        {...props}
+        value={value}
+        onSearch={nextValue => {
+          setValue(nextValue);
+          setDebouncedValue(nextValue);
+          props.onSearch(nextValue);
+        }}
+      />
+      <p className="text-ui-sm text-neutral3">Debounced value: {debouncedValue || 'None'}</p>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: args => <SearchPreview {...args} />,
+};
+
+export const PresetValue: Story = {
+  args: {
+    value: 'research',
+    debounceMs: 0,
+    size: 'sm',
+    variant: 'unstyled',
+  },
+  render: args => <SearchPreview {...args} />,
+};

--- a/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { LogsDataList, LogsDataListSkeleton } from './index';
+
+const columns = '8rem 6rem 5rem minmax(10rem,14rem) minmax(18rem,1fr) minmax(14rem,1fr)';
+
+const logs = [
+  {
+    id: 'log-1',
+    timestamp: '2026-08-26T19:42:12.000Z',
+    level: 'info',
+    entityType: 'agent',
+    entityName: 'Research agent',
+    message: 'Agent run completed',
+    data: { durationMs: 842, tokens: 1240 },
+  },
+  {
+    id: 'log-2',
+    timestamp: '2026-08-26T19:41:59.000Z',
+    level: 'warn',
+    entityType: 'workflow',
+    entityName: 'Daily report workflow',
+    message: 'Retrying step after provider timeout',
+    data: { step: 'summarize', attempt: 2 },
+  },
+  {
+    id: 'log-3',
+    timestamp: '2026-08-26T19:41:42.000Z',
+    level: 'error',
+    entityType: 'tool',
+    entityName: 'web-search',
+    message: 'Tool execution failed with a realistically long message that must truncate inside the row',
+    data: { code: 'RATE_LIMITED' },
+  },
+] as const;
+
+const meta: Meta<typeof LogsDataList> = {
+  title: 'DataDisplay/LogsDataList',
+  component: LogsDataList,
+  parameters: { layout: 'padded' },
+};
+
+export default meta;
+type Story = StoryObj<typeof LogsDataList>;
+
+function Header() {
+  return (
+    <LogsDataList.Top>
+      <LogsDataList.TopCell>Date</LogsDataList.TopCell>
+      <LogsDataList.TopCell>Time</LogsDataList.TopCell>
+      <LogsDataList.TopCell>Level</LogsDataList.TopCell>
+      <LogsDataList.TopCell>Entity</LogsDataList.TopCell>
+      <LogsDataList.TopCell>Message</LogsDataList.TopCell>
+      <LogsDataList.TopCell>Data</LogsDataList.TopCell>
+    </LogsDataList.Top>
+  );
+}
+
+export const Populated: Story = {
+  render: () => (
+    <div className="h-80">
+      <LogsDataList columns={columns} variant="striped">
+        <Header />
+        {logs.map(log => (
+          <LogsDataList.RowButton key={log.id} onClick={fn()}>
+            <LogsDataList.DateCell timestamp={log.timestamp} />
+            <LogsDataList.TimeCell timestamp={log.timestamp} />
+            <LogsDataList.LevelCell level={log.level} />
+            <LogsDataList.EntityCell entityType={log.entityType} entityName={log.entityName} />
+            <LogsDataList.MessageCell message={log.message} />
+            <LogsDataList.DataCell data={log.data} />
+          </LogsDataList.RowButton>
+        ))}
+      </LogsDataList>
+    </div>
+  ),
+};
+
+export const NoMatches: Story = {
+  render: () => (
+    <div className="h-64">
+      <LogsDataList columns={columns}>
+        <Header />
+        <LogsDataList.NoMatch message="No logs match your filters" />
+      </LogsDataList>
+    </div>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <div className="h-72">
+      <LogsDataListSkeleton columns={columns} />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MessageScroller/message-scroller.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Button } from '../Button';
+import {
+  MessageScroller,
+  MessageScrollerButton,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerProvider,
+  MessageScrollerViewport,
+} from './message-scroller';
+
+type DemoMessage = {
+  id: string;
+  role: 'user' | 'assistant';
+  text: string;
+};
+
+const initialMessages: DemoMessage[] = [
+  { id: 'user-1', role: 'user', text: 'Summarize the latest production traces.' },
+  { id: 'assistant-1', role: 'assistant', text: 'I found 126 traces. Three failed during tool execution.' },
+  { id: 'user-2', role: 'user', text: 'Which tool caused those failures?' },
+  {
+    id: 'assistant-2',
+    role: 'assistant',
+    text: 'All three came from web-search after the provider returned rate limits.',
+  },
+  { id: 'user-3', role: 'user', text: 'Show me the affected run IDs.' },
+  { id: 'assistant-3', role: 'assistant', text: 'The affected runs are run_8f3a, run_9c12, and run_b772.' },
+];
+
+const meta: Meta<typeof MessageScroller> = {
+  title: 'Layout/MessageScroller',
+  component: MessageScroller,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof MessageScroller>;
+
+function MessageScrollerDemo({ autoScroll = false }: { autoScroll?: boolean }) {
+  const [messages, setMessages] = useState(initialMessages);
+
+  const addTurn = () => {
+    const turn = messages.filter(message => message.role === 'user').length + 1;
+    setMessages(current => [
+      ...current,
+      { id: `user-${turn}`, role: 'user', text: `Follow-up question ${turn}` },
+      { id: `assistant-${turn}`, role: 'assistant', text: 'A new answer arrived and extended the conversation.' },
+    ]);
+  };
+
+  const prependHistory = () => {
+    setMessages(current => [
+      {
+        id: `user-older-${current.length}`,
+        role: 'user',
+        text: 'An older question loaded above the current reading position.',
+      },
+      { id: `assistant-older-${current.length}`, role: 'assistant', text: 'Its earlier answer stays paired with it.' },
+      ...current,
+    ]);
+  };
+
+  return (
+    <div className="grid w-[min(34rem,calc(100vw-3rem))] gap-3">
+      <div className="flex flex-wrap gap-2">
+        <Button size="sm" onClick={addTurn}>
+          Add turn
+        </Button>
+        <Button size="sm" variant="ghost" onClick={prependHistory}>
+          Load older history
+        </Button>
+      </div>
+      <MessageScrollerProvider autoScroll={autoScroll} defaultScrollPosition="end" preserveScrollOnPrepend>
+        <MessageScroller className="border-border1 bg-surface2 h-96 rounded-xl border">
+          <MessageScrollerViewport aria-label="Conversation messages">
+            <MessageScrollerContent className="gap-4 p-4">
+              {messages.map(message => (
+                <MessageScrollerItem
+                  key={message.id}
+                  messageId={message.id}
+                  scrollAnchor={message.role === 'user'}
+                  className={message.role === 'user' ? 'bg-surface4 ml-12 rounded-xl p-3' : 'mr-12 p-3'}
+                >
+                  <p className="text-ui-sm text-neutral5">{message.text}</p>
+                </MessageScrollerItem>
+              ))}
+            </MessageScrollerContent>
+          </MessageScrollerViewport>
+          <MessageScrollerButton />
+        </MessageScroller>
+      </MessageScrollerProvider>
+    </div>
+  );
+}
+
+export const Conversation: Story = {
+  render: () => <MessageScrollerDemo />,
+};
+
+export const AutoFollow: Story = {
+  render: () => <MessageScrollerDemo autoScroll />,
+};

--- a/packages/playground-ui/src/ds/components/MetricsLineChart/metrics-line-chart.stories.tsx
+++ b/packages/playground-ui/src/ds/components/MetricsLineChart/metrics-line-chart.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { MetricsLineChart } from './metrics-line-chart';
+import type { MetricsLineChartSeries } from './metrics-line-chart';
+
+const data: Record<string, unknown>[] = [
+  { time: '09:00', requests: 42, errors: 2 },
+  { time: '10:00', requests: 58, errors: 4 },
+  { time: '11:00', requests: 51, errors: 1 },
+  { time: '12:00', requests: 76, errors: 6 },
+  { time: '13:00', requests: 83, errors: 3 },
+  { time: '14:00', requests: 91, errors: 5 },
+  { time: '15:00', requests: 72, errors: 2 },
+];
+
+const total = (key: string) => (points: Record<string, unknown>[]) => ({
+  value: String(points.reduce((sum, point) => sum + (typeof point[key] === 'number' ? point[key] : 0), 0)),
+  suffix: 'total',
+});
+
+const series = [
+  { dataKey: 'requests', label: 'Requests', color: '#60a5fa', aggregate: total('requests') },
+  { dataKey: 'errors', label: 'Errors', color: '#f87171', aggregate: total('errors') },
+] satisfies MetricsLineChartSeries[];
+
+const meta: Meta<typeof MetricsLineChart> = {
+  title: 'Metrics/MetricsLineChart',
+  component: MetricsLineChart,
+  parameters: { layout: 'centered' },
+  args: {
+    data,
+    series,
+    height: 260,
+    onPointClick: fn(),
+    xAxisInterval: 'preserveStartEnd',
+    xAxisMinTickGap: 28,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MetricsLineChart>;
+
+export const MultipleSeries: Story = {
+  render: args => (
+    <div className="w-[min(48rem,calc(100vw-3rem))]">
+      <MetricsLineChart {...args} />
+    </div>
+  ),
+};
+
+export const SinglePoint: Story = {
+  args: {
+    data: [{ time: 'Now', requests: 42 }],
+    series: [{ dataKey: 'requests', label: 'Requests', color: '#60a5fa' }],
+    showDots: true,
+  },
+  render: args => (
+    <div className="w-[min(48rem,calc(100vw-3rem))]">
+      <MetricsLineChart {...args} />
+    </div>
+  ),
+};
+
+export const FixedDomain: Story = {
+  args: {
+    data: [
+      { time: 'Mon', score: 0.72 },
+      { time: 'Tue', score: 0.81 },
+      { time: 'Wed', score: 0.76 },
+      { time: 'Thu', score: 0.93 },
+    ],
+    series: [{ dataKey: 'score', label: 'Answer relevancy', color: '#a78bfa' }],
+    yDomain: [0, 1],
+    showDots: true,
+  },
+  render: args => (
+    <div className="w-[min(48rem,calc(100vw-3rem))]">
+      <MetricsLineChart {...args} />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/PageHeader/page-header.stories.tsx
+++ b/packages/playground-ui/src/ds/components/PageHeader/page-header.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { BotIcon } from 'lucide-react';
+
+import { Badge } from '../Badge';
+import { PageHeader } from './page-header';
+
+const meta: Meta<typeof PageHeader> = {
+  title: 'Layout/PageHeader',
+  component: PageHeader,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof PageHeader>;
+
+export const Default: Story = {
+  render: () => (
+    <PageHeader className="w-[min(42rem,calc(100vw-3rem))]">
+      <PageHeader.Title>
+        <BotIcon />
+        Research agent <Badge variant="success">Active</Badge>
+      </PageHeader.Title>
+      <PageHeader.Description>
+        Searches trusted sources and writes cited summaries.
+        <span className="font-mono">agent_8f3a91b2</span>
+      </PageHeader.Description>
+    </PageHeader>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <PageHeader className="w-[min(42rem,calc(100vw-3rem))] overflow-x-auto">
+      <PageHeader.Title isLoading />
+      <PageHeader.Description isLoading />
+    </PageHeader>
+  ),
+};
+
+export const SmallerTitle: Story = {
+  render: () => (
+    <PageHeader className="w-[min(42rem,calc(100vw-3rem))]">
+      <PageHeader.Title size="smaller">Infrastructure</PageHeader.Title>
+      <PageHeader.Description>Runtime, storage, and observability configuration.</PageHeader.Description>
+    </PageHeader>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/PageLayout/page-layout.stories.tsx
+++ b/packages/playground-ui/src/ds/components/PageLayout/page-layout.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { PlusIcon, WrenchIcon } from 'lucide-react';
+
+import { Button } from '../Button';
+import { EmptyState } from '../EmptyState';
+import { PageHeader } from '../PageHeader';
+import { NoDataPageLayout, PageHeadingContext, PageLayout } from './index';
+
+const meta: Meta<typeof PageLayout> = {
+  title: 'Layout/PageLayout',
+  component: PageLayout,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof PageLayout>;
+
+const resources = ['Research agent', 'Support workflow', 'Knowledge search tool'];
+
+export const FullPage: Story = {
+  render: () => (
+    <PageHeadingContext value="Resources">
+      <div className="bg-surface1 h-[38rem]">
+        <PageLayout width="wide" height="full">
+          <PageLayout.TopArea>
+            <PageLayout.Row align="center" stack="responsive">
+              <PageLayout.Column>
+                <PageHeader>
+                  <PageHeader.Title>Resources</PageHeader.Title>
+                  <PageHeader.Description>
+                    Agents, workflows, and tools available in this workspace.
+                  </PageHeader.Description>
+                </PageHeader>
+              </PageLayout.Column>
+              <Button variant="primary">
+                <PlusIcon />
+                Create resource
+              </Button>
+            </PageLayout.Row>
+          </PageLayout.TopArea>
+          <PageLayout.MainArea>
+            <div className="grid gap-3 md:grid-cols-3">
+              {resources.map(resource => (
+                <div
+                  key={resource}
+                  className="border-border1 bg-surface2 text-ui-md text-neutral5 rounded-xl border p-5"
+                >
+                  {resource}
+                </div>
+              ))}
+            </div>
+          </PageLayout.MainArea>
+        </PageLayout>
+      </div>
+    </PageHeadingContext>
+  ),
+};
+
+export const NarrowSettings: Story = {
+  render: () => (
+    <div className="bg-surface1 min-h-[34rem]">
+      <PageLayout width="narrow">
+        <PageLayout.TopArea>
+          <PageHeader>
+            <PageHeader.Title>Settings</PageHeader.Title>
+            <PageHeader.Description>Defaults shared by every project in this workspace.</PageHeader.Description>
+          </PageHeader>
+        </PageLayout.TopArea>
+        <PageLayout.MainArea className="grid gap-3">
+          <div className="border-border1 bg-surface2 text-neutral4 rounded-xl border p-5">General settings</div>
+          <div className="border-border1 bg-surface2 text-neutral4 rounded-xl border p-5">Environment variables</div>
+        </PageLayout.MainArea>
+      </PageLayout>
+    </div>
+  ),
+};
+
+export const CenteredEmptyState: Story = {
+  render: () => (
+    <div className="bg-surface1 h-[34rem]">
+      <NoDataPageLayout>
+        <EmptyState
+          iconSlot={<WrenchIcon />}
+          titleSlot="No tools yet"
+          descriptionSlot="Add a tool to let agents act on external systems."
+        />
+      </NoDataPageLayout>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/PendingIndicator/pending-indicator.stories.tsx
+++ b/packages/playground-ui/src/ds/components/PendingIndicator/pending-indicator.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { PendingIndicator } from './pending-indicator';
+
+const meta: Meta<typeof PendingIndicator> = {
+  title: 'Feedback/PendingIndicator',
+  component: PendingIndicator,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof PendingIndicator>;
+
+export const Default: Story = {};
+
+export const InConversation: Story = {
+  render: () => (
+    <div className="border-border1 bg-surface2 flex w-[min(24rem,calc(100vw-2rem))] flex-col gap-3 rounded-xl border p-5">
+      <p className="text-ui-sm text-neutral5">Find the latest failed workflow runs.</p>
+      <PendingIndicator />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/PermissionDenied/permission-denied.stories.tsx
+++ b/packages/playground-ui/src/ds/components/PermissionDenied/permission-denied.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { Button } from '../Button';
+import { PermissionDenied } from './PermissionDenied';
+
+const meta: Meta<typeof PermissionDenied> = {
+  title: 'Feedback/PermissionDenied',
+  component: PermissionDenied,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof PermissionDenied>;
+
+export const Default: Story = {};
+
+export const ResourceSpecific: Story = {
+  args: {
+    resource: 'production workflows',
+  },
+};
+
+export const CustomRecovery: Story = {
+  args: {
+    title: 'Workspace access required',
+    description: 'Ask a workspace administrator to add you before opening these agents.',
+    actionSlot: <Button onClick={fn()}>Request access</Button>,
+  },
+};

--- a/packages/playground-ui/src/ds/components/PrevNextNav/prev-next-nav.stories.tsx
+++ b/packages/playground-ui/src/ds/components/PrevNextNav/prev-next-nav.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { PrevNextNav } from './prev-next-nav';
+
+const meta: Meta<typeof PrevNextNav> = {
+  title: 'Navigation/PrevNextNav',
+  component: PrevNextNav,
+  parameters: { layout: 'centered' },
+  args: {
+    onPrevious: fn(),
+    onNext: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PrevNextNav>;
+
+export const BetweenItems: Story = {};
+
+export const FirstItem: Story = {
+  args: { onPrevious: undefined },
+};
+
+export const LastItem: Story = {
+  args: { onNext: undefined },
+};

--- a/packages/playground-ui/src/ds/components/SessionExpired/session-expired.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SessionExpired/session-expired.stories.tsx
@@ -1,0 +1,29 @@
+import { MastraReactProvider } from '@mastra/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { SessionExpired } from './SessionExpired';
+
+const meta: Meta<typeof SessionExpired> = {
+  title: 'Feedback/SessionExpired',
+  component: SessionExpired,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    Story => (
+      <MastraReactProvider baseUrl="http://localhost:4111">
+        <Story />
+      </MastraReactProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SessionExpired>;
+
+export const Default: Story = {};
+
+export const CustomCopy: Story = {
+  args: {
+    title: 'Sign in to continue',
+    description: 'Your Studio session ended while this page was open.',
+  },
+};

--- a/packages/playground-ui/src/ds/components/Shimmer/shimmer.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Shimmer/shimmer.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Button } from '../Button';
+import { Shimmer } from './shimmer';
+
+const meta: Meta<typeof Shimmer> = {
+  title: 'Motion/Shimmer',
+  component: Shimmer,
+  parameters: { layout: 'centered' },
+  args: {
+    active: true,
+    children: 'Drafting a response from the available context',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Shimmer>;
+
+export const Default: Story = {};
+
+function StreamingPreview() {
+  const [active, setActive] = useState(true);
+
+  return (
+    <div className="flex w-120 flex-col items-start gap-4">
+      <Shimmer active={active} className="text-ui-md text-neutral5">
+        The assistant keeps the same text node while streaming settles.
+      </Shimmer>
+      <Button onClick={() => setActive(current => !current)}>{active ? 'Finish streaming' : 'Resume streaming'}</Button>
+    </div>
+  );
+}
+
+export const ActiveToSettled: Story = {
+  render: () => <StreamingPreview />,
+};

--- a/packages/playground-ui/src/ds/components/StatusBadge/status-badge.stories.tsx
+++ b/packages/playground-ui/src/ds/components/StatusBadge/status-badge.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { StatusBadge } from './StatusBadge';
+
+const meta: Meta<typeof StatusBadge> = {
+  title: 'Elements/StatusBadge',
+  component: StatusBadge,
+  parameters: { layout: 'centered' },
+  args: {
+    children: 'Running',
+    variant: 'success',
+    size: 'md',
+    withDot: true,
+    pulse: false,
+  },
+  argTypes: {
+    variant: { control: 'inline-radio', options: ['success', 'warning', 'error', 'info', 'neutral'] },
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StatusBadge>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-3">
+      <StatusBadge variant="success" withDot>
+        Completed
+      </StatusBadge>
+      <StatusBadge variant="warning" withDot>
+        Waiting
+      </StatusBadge>
+      <StatusBadge variant="error" withDot>
+        Failed
+      </StatusBadge>
+      <StatusBadge variant="info" withDot>
+        Running
+      </StatusBadge>
+      <StatusBadge variant="neutral" withDot>
+        Draft
+      </StatusBadge>
+    </div>
+  ),
+};
+
+export const SizesAndPulse: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <StatusBadge size="sm" variant="info" withDot pulse>
+        Streaming
+      </StatusBadge>
+      <StatusBadge size="md" variant="info" withDot pulse>
+        Streaming
+      </StatusBadge>
+      <StatusBadge size="lg" variant="info" withDot pulse>
+        Streaming
+      </StatusBadge>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/ThreadList/thread-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ThreadList/thread-list.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { PlusIcon } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  ThreadList,
+  ThreadListEmpty,
+  ThreadListItem,
+  ThreadListItems,
+  ThreadListNewItem,
+  ThreadListSeparator,
+} from './thread-list';
+
+const initialThreads = [
+  'Compare vector databases for semantic search',
+  'Draft the product launch brief',
+  'Investigate failed workflow runs',
+  'Plan customer support routing',
+];
+
+const meta: Meta<typeof ThreadList> = {
+  title: 'Navigation/ThreadList',
+  component: ThreadList,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof ThreadList>;
+
+function ThreadListPreview({ embedded = false }: { embedded?: boolean }) {
+  const [threads, setThreads] = useState(initialThreads);
+  const [active, setActive] = useState(initialThreads[0]);
+
+  return (
+    <div className="h-96 w-80">
+      <ThreadList embedded={embedded}>
+        <ThreadListNewItem as="a" href="#new">
+          <PlusIcon />
+          New thread
+        </ThreadListNewItem>
+        <ThreadListSeparator />
+        {threads.length === 0 ? (
+          <ThreadListEmpty>Your conversations will appear here.</ThreadListEmpty>
+        ) : (
+          <ThreadListItems>
+            {threads.map(thread => (
+              <ThreadListItem
+                key={thread}
+                isActive={active === thread}
+                onClick={() => setActive(thread)}
+                onDelete={() => setThreads(current => current.filter(candidate => candidate !== thread))}
+                deleteLabel={`Delete ${thread}`}
+              >
+                <span className="block truncate">{thread}</span>
+              </ThreadListItem>
+            ))}
+          </ThreadListItems>
+        )}
+      </ThreadList>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <ThreadListPreview />,
+};
+
+export const Embedded: Story = {
+  render: () => (
+    <div className="border-border1 bg-surface2 rounded-xl border p-3">
+      <ThreadListPreview embedded />
+    </div>
+  ),
+};
+
+export const Empty: Story = {
+  render: () => (
+    <div className="h-56 w-80">
+      <ThreadList>
+        <ThreadListEmpty>Your conversations will appear here.</ThreadListEmpty>
+      </ThreadList>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/ThreadRail/thread-rail.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ThreadRail/thread-rail.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { ThreadRail } from './thread-rail';
+import type { ThreadRailTurn } from './thread-rail-turns';
+
+const turns: ThreadRailTurn[] = [
+  {
+    key: 'turn-1',
+    messageId: 'message-1',
+    prompt: 'Compare vector databases for semantic search',
+    reply: 'Here is a comparison of latency, filtering, and operational tradeoffs.',
+    files: [],
+    hiddenFileCount: 0,
+  },
+  {
+    key: 'turn-2',
+    messageId: 'message-2',
+    prompt: 'Use the production requirements from the attached brief',
+    reply: 'The brief favors regional availability and predictable filtering performance.',
+    files: ['requirements.md', 'architecture.pdf'],
+    hiddenFileCount: 2,
+  },
+  {
+    key: 'turn-3',
+    messageId: 'message-3',
+    prompt: 'Turn that into a recommendation for the platform team',
+    reply: 'Start with the managed option and keep the storage adapter boundary explicit.',
+    files: [],
+    hiddenFileCount: 0,
+  },
+  {
+    key: 'turn-4',
+    messageId: 'message-4',
+    prompt: 'What would change at ten times the current traffic?',
+    reply: 'Index build time and cross-region replication become the main constraints.',
+    files: [],
+    hiddenFileCount: 0,
+  },
+];
+
+const meta: Meta<typeof ThreadRail> = {
+  title: 'Navigation/ThreadRail',
+  component: ThreadRail,
+  parameters: { layout: 'centered' },
+  args: {
+    turns,
+    currentAnchorId: 'message-2',
+    visibleMessageIds: ['message-2', 'message-3'],
+    onSelect: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ThreadRail>;
+
+export const ConversationTimeline: Story = {
+  render: args => (
+    <div className="border-border1 bg-surface2 flex h-80 w-112 items-center rounded-xl border px-10">
+      <ThreadRail {...args} maxHeight="16rem" />
+      <p className="text-ui-sm text-neutral3 ml-10">Hover or focus a rail stop to preview that turn.</p>
+    </div>
+  ),
+};
+
+export const Empty: Story = {
+  args: { turns: [] },
+  render: args => (
+    <div className="border-border1 h-40 w-80 rounded-xl border border-dashed">
+      <ThreadRail {...args} />
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/TokenBudget/token-budget.stories.tsx
+++ b/packages/playground-ui/src/ds/components/TokenBudget/token-budget.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { BrainIcon, MessagesSquareIcon } from 'lucide-react';
+
+import { TokenBudget } from './token-budget';
+import { TokenBudgetDetail } from './token-budget-detail';
+
+const meta: Meta<typeof TokenBudget> = {
+  title: 'DataDisplay/TokenBudget',
+  component: TokenBudget,
+  parameters: { layout: 'centered' },
+  args: {
+    label: 'Message window',
+    tokens: 14_900,
+    threshold: 30_000,
+    tone: 'messages',
+    working: false,
+  },
+  argTypes: {
+    tone: { control: 'inline-radio', options: ['messages', 'memory', 'warning'] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TokenBudget>;
+
+export const Default: Story = {};
+
+export const Budgets: Story = {
+  render: () => (
+    <div className="border-border1 bg-surface2 flex items-center gap-5 rounded-xl border p-4">
+      <TokenBudget label="Messages" tokens={5_200} threshold={8_000} tone="messages" />
+      <TokenBudget label="Observations" tokens={7_200} threshold={8_000} tone="warning" />
+      <TokenBudget label="Memory" tokens={1_200} threshold={8_000} tone="memory" working />
+    </div>
+  ),
+};
+
+export const Details: Story = {
+  render: () => (
+    <div className="border-border1 bg-surface2 grid w-112 gap-5 rounded-xl border p-5">
+      <TokenBudgetDetail
+        icon={<MessagesSquareIcon />}
+        label="Messages"
+        tokens={5_200}
+        threshold={8_000}
+        projected={2_000}
+        description="Compaction starts when this window fills."
+      />
+      <TokenBudgetDetail
+        icon={<BrainIcon />}
+        label="Observations"
+        tokens={1_900}
+        threshold={8_000}
+        tone="memory"
+        description="New observations replace older working context."
+      />
+    </div>
+  ),
+};


### PR DESCRIPTION
TLDR: every published Playground UI component now has Storybook coverage, without changing component code or existing stories.

---

before

22 published `components/*` entries had no dedicated Storybook page.

after

Those entries have 57 stories covering their normal, interactive, loading, empty, disabled, and responsive states. `RuleBuilder` and `Toaster` stay untouched because their re-exported implementations already have canonical stories.

`SessionExpired` uses a small Storybook-only `@mastra/react` mock so docgen does not parse the compiled client bundle. Runtime package behavior is unchanged.

stories       +1405  -0
storybook     +32    -0
changeset     +5     -0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds Storybook examples for 22 Playground UI components that did not have coverage. The examples show common states, such as loading, empty, disabled, interactive, and responsive states, without changing component code.

## Changes

- Added 57 Storybook stories across 22 previously uncovered components.
- Added examples for:
  - Layout and navigation components.
  - Data display and filtering components.
  - Feedback and status components.
  - Conversation and thread components.
  - Charts, timelines, and token budget components.
- Added interactive demos for streaming arrivals, message scrolling, search, thread management, and shimmer states.
- Added a Storybook-only `@mastra/react` mock for `SessionExpired`.
- Updated Storybook Vite configuration to use the mock.
- Added a patch changeset for `@mastra/playground-ui`.
- Left `RuleBuilder` and `Toaster` unchanged because canonical stories already exist for their re-exported implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->