### PR TITLE
fix(agent-controller): order run-state truth with a server-stamped state version

### DIFF
--- a/.changeset/brave-clocks-agree.md
+++ b/.changeset/brave-clocks-agree.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+The session state endpoint now reports `stateVersion` and `stateEpoch`, the server's own ordering stamp for the snapshot, so UIs can merge it against stamped run events without relying on arrival order.

--- a/.changeset/fuzzy-queens-notice.md
+++ b/.changeset/fuzzy-queens-notice.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed chat busy-state races by ordering session-state snapshots and run events with the server's new `stateVersion` stamp instead of arrival order and local clocks. A stale snapshot can no longer resurrect an ended run, a late-delivered event can no longer hide a newer snapshot, and after a lost `agent_end` the composer leaves its busy state only on a snapshot that provably postdates the send.

--- a/.changeset/smart-dolls-build.md
+++ b/.changeset/smart-dolls-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Added optional `stateVersion` and `stateEpoch` fields to agent-controller session-state responses and to the `agent_start`, `agent_end`, and `task_updated` stream events.

--- a/.changeset/ten-badgers-ring.md
+++ b/.changeset/ten-badgers-ring.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added a monotonic `stateVersion` and a per-process `stateEpoch` to the agent-controller display state. Session-state snapshots and the `agent_start`, `agent_end`, and `task_updated` events all carry the stamp, so clients can tell which of two states is newer instead of guessing from arrival order or local clocks.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -20341,6 +20341,8 @@ export type GetAgentControllerControllerIdSessionsResourceId_Response = {
   modelId: string;
   running?: boolean | undefined;
   runningThreadId?: (string | null) | undefined;
+  stateVersion?: number | undefined;
+  stateEpoch?: string | undefined;
   tasks?:
     | {
         id: string;

--- a/mastracode/factory-ui/src/hooks/useAgentControllerSessionSync.ts
+++ b/mastracode/factory-ui/src/hooks/useAgentControllerSessionSync.ts
@@ -12,8 +12,14 @@ import { createAgentControllerClient } from '../ui/domains/chat/services/agentCo
  */
 export interface LiveStatePatch {
   generation: number;
-  running?: { value: boolean; threadId: string | null; generation: number };
-  tasks?: { value: AgentControllerTaskSnapshot[]; threadId?: string; generation: number };
+  running?: { value: boolean; threadId: string | null; generation: number; stateVersion?: number; stateEpoch?: string };
+  tasks?: {
+    value: AgentControllerTaskSnapshot[];
+    threadId?: string;
+    generation: number;
+    stateVersion?: number;
+    stateEpoch?: string;
+  };
 }
 
 interface UseAgentControllerSessionSyncArgs {
@@ -25,6 +31,20 @@ interface UseAgentControllerSessionSyncArgs {
   enabled?: boolean;
   sseConnected: boolean;
   livePatch: RefObject<LiveStatePatch>;
+}
+
+/**
+ * Orders two pieces of session-state truth by their server stamps. Same epoch:
+ * higher version wins. Different epochs (a restart sits between them): ordering
+ * is unknowable, so the side that arrived last wins — `incoming` outranks.
+ * `undefined` when either side is unstamped (server predates versioning).
+ */
+export function incomingStateOutranks(
+  incoming: { stateVersion?: number; stateEpoch?: string } | undefined,
+  held: { stateVersion?: number; stateEpoch?: string } | undefined,
+): boolean | undefined {
+  if (incoming?.stateVersion == null || held?.stateVersion == null) return undefined;
+  return incoming.stateEpoch !== held.stateEpoch || incoming.stateVersion > held.stateVersion;
 }
 
 export function reconnectRefetchInterval(sseConnected: boolean, fetchFailureCount: number): false | number {
@@ -57,12 +77,23 @@ export function useAgentControllerSessionSync({
       const generationAtRequestStart = livePatch.current.generation;
       const state = await session!.state({ threadId });
       const { running, tasks } = livePatch.current;
-      const runningOvertookRequest = running && running.generation > generationAtRequestStart;
-      const tasksOvertookRequest = tasks && tasks.generation > generationAtRequestStart && tasks.threadId === threadId;
+      const patchOutranksSnapshot = (patch: { generation: number; stateVersion?: number; stateEpoch?: string }) => {
+        const snapshotIsNewer = incomingStateOutranks(state, patch);
+        return snapshotIsNewer == null ? patch.generation > generationAtRequestStart : !snapshotIsNewer;
+      };
+      const runningOvertookRequest = running && patchOutranksSnapshot(running);
+      const tasksOvertookRequest = tasks && patchOutranksSnapshot(tasks) && tasks.threadId === threadId;
+      const overlayVersions = [
+        runningOvertookRequest ? running.stateVersion : undefined,
+        tasksOvertookRequest ? tasks.stateVersion : undefined,
+      ].filter((version): version is number => version != null);
       return {
         ...state,
         ...(runningOvertookRequest ? { running: running.value, runningThreadId: running.threadId } : {}),
         ...(tasksOvertookRequest ? { tasks: tasks.value } : {}),
+        ...(overlayVersions.length && state.stateVersion != null
+          ? { stateVersion: Math.max(state.stateVersion, ...overlayVersions) }
+          : {}),
       };
     },
     enabled: enabled && Boolean(session),

--- a/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerBusyReconcile.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/components/__tests__/ComposerBusyReconcile.msw.test.tsx
@@ -53,6 +53,88 @@ describe('Composer busy reconcile', () => {
     await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Ask Mastra Code…'));
   });
 
+  it('given an idle snapshot no newer than the send, then the composer stays busy until a newer one lands', async () => {
+    const session = stubPreparingSession({ autoAgentEnd: false });
+    let stateReads = 0;
+    let stateVersion = 3;
+    server.use(
+      http.get(`${API}/sessions/:resourceId`, ({ params }) => {
+        stateReads += 1;
+        return HttpResponse.json({
+          controllerId: 'code',
+          resourceId: params.resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: SESSION_ID,
+          running: false,
+          stateVersion,
+          stateEpoch: 'epoch-live',
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    const { client } = renderThread();
+    await releaseSession(session.finishWorkspace, client);
+
+    const composer = await screen.findByRole('textbox', { name: 'Message' });
+    await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Ask Mastra Code…'));
+    await waitFor(() => expect(stateReads).toBeGreaterThanOrEqual(1));
+
+    await user.type(composer, 'Check the failing build');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(session.delivered).toEqual(['Check the failing build']));
+    await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Steer the agent…'));
+
+    // A snapshot at the send's own version proves nothing about the run's fate.
+    await client.invalidateQueries({ queryKey: ['agent-controller', 'code', 'connection', SESSION_ID] });
+    await waitFor(() => expect(stateReads).toBeGreaterThanOrEqual(2));
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(composer).toHaveAttribute('placeholder', 'Steer the agent…');
+
+    // A strictly newer idle snapshot is proof, and releases the latch.
+    stateVersion = 5;
+    await client.invalidateQueries({ queryKey: ['agent-controller', 'code', 'connection', SESSION_ID] });
+    await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Ask Mastra Code…'));
+  });
+
+  it('given the server restarted since the send, then an idle snapshot from the new epoch releases the latch', async () => {
+    const session = stubPreparingSession({ autoAgentEnd: false });
+    let snapshot = { stateVersion: 90, stateEpoch: 'epoch-before-restart' };
+    server.use(
+      http.get(`${API}/sessions/:resourceId`, ({ params }) =>
+        HttpResponse.json({
+          controllerId: 'code',
+          resourceId: params.resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: SESSION_ID,
+          running: false,
+          ...snapshot,
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    const { client } = renderThread();
+    await releaseSession(session.finishWorkspace, client);
+
+    const composer = await screen.findByRole('textbox', { name: 'Message' });
+    await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Ask Mastra Code…'));
+
+    await user.type(composer, 'Check the failing build');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(session.delivered).toEqual(['Check the failing build']));
+    await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Steer the agent…'));
+
+    // The server restarts: versions reset, but the fresh epoch says idle — the run is gone.
+    snapshot = { stateVersion: 1, stateEpoch: 'epoch-after-restart' };
+    await client.invalidateQueries({ queryKey: ['agent-controller', 'code', 'connection', SESSION_ID] });
+    await waitFor(() => expect(composer).toHaveAttribute('placeholder', 'Ask Mastra Code…'));
+  });
+
   it('given a run on another thread of the session, then the composer stays idle', async () => {
     const session = stubPreparingSession({ autoAgentEnd: false });
     let stateReads = 0;

--- a/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/context/ChatTranscriptProvider.tsx
@@ -15,6 +15,7 @@ import type { ChatTranscriptApi, LoadMoreHistory } from './ChatTranscriptContext
 import { useChatConnection } from './useChatConnection';
 import { useChatMessagesError } from './useChatMessagesError';
 import { useChatMessagesInitializing } from './useChatMessagesInitializing';
+import { incomingStateOutranks } from '../../../../hooks/useAgentControllerSessionSync';
 import { useChatSessionContext } from './useChatSessionContext';
 
 export function ChatTranscriptProvider({
@@ -141,9 +142,16 @@ function ChatTranscriptValueProvider({
     omProgress: transcript.omProgress ?? connection.state?.omProgress,
     usage: transcript.usage ?? connection.state?.tokenUsage,
   };
-  const serverIdleSinceSend =
-    connection.state?.running === false &&
-    (connection.stateUpdatedAt ?? 0) > (effectiveTranscript.pendingSince ?? Infinity);
+  const state = connection.state;
+  const sendUser: ChatTranscriptApi['localUser'] = (text, steer, files) =>
+    localUser(text, steer, files, { stateVersion: state?.stateVersion, stateEpoch: state?.stateEpoch });
+  const snapshotOutranksSend = incomingStateOutranks(state, {
+    stateVersion: effectiveTranscript.pendingStateVersion,
+    stateEpoch: effectiveTranscript.pendingStateEpoch,
+  });
+  const snapshotProvesIdle =
+    snapshotOutranksSend ?? (connection.stateUpdatedAt ?? 0) > (effectiveTranscript.pendingSince ?? Infinity);
+  const serverIdleSinceSend = state?.running === false && snapshotProvesIdle;
   const runElsewhere =
     typeof connection.state?.runningThreadId === 'string' &&
     Boolean(effectiveThreadId) &&
@@ -154,7 +162,7 @@ function ChatTranscriptValueProvider({
     transcript: effectiveTranscript,
     busy,
     initialHistoryReady,
-    localUser,
+    localUser: sendUser,
     failLocalUser,
     reset,
     resolvePrompt,

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
@@ -400,6 +400,199 @@ describe('useAgentControllerConnection', () => {
     expect(result.current.state?.running).toBe(false);
   });
 
+  it('given a state refetch carrying a newer version, then a late lifecycle event does not clobber it', async () => {
+    const encoder = new TextEncoder();
+    const onEvent = vi.fn();
+    let emit: (event: AgentControllerEvent) => void = () => {};
+    let stateReads = 0;
+    let releaseRefetch: (() => void) | undefined;
+    const refetchGate = new Promise<void>(resolve => {
+      releaseRefetch = resolve;
+    });
+    // Read 1: run A active (v4). Read 2: run B active (v6) — run A ended at v5.
+    const snapshots = [
+      { running: true, stateVersion: 4 },
+      { running: true, stateVersion: 6 },
+    ];
+
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, () =>
+        HttpResponse.json({ controllerId, resourceId, threadId: 'thread-1' }),
+      ),
+      http.get(sessionUrl, async () => {
+        const snapshot = snapshots[Math.min(stateReads, snapshots.length - 1)];
+        stateReads += 1;
+        if (stateReads > 1) await refetchGate;
+        return HttpResponse.json({
+          controllerId,
+          resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: 'thread-1',
+          stateEpoch: 'epoch-1',
+          ...snapshot,
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        });
+      }),
+      http.get(
+        `${sessionUrl}/stream`,
+        () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                emit = event => controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+              },
+              cancel() {},
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          ),
+      ),
+    );
+
+    const { result, client } = renderHookWithProviders(() =>
+      useAgentControllerConnection({ ...hookArgs, sessionThreadId: 'thread-1', onEvent }),
+    );
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.state?.running).toBe(true);
+
+    void client.invalidateQueries({
+      queryKey: queryKeys.agentControllerConnectionState(controllerId, resourceId, undefined, 'thread-1'),
+      exact: true,
+    });
+    await waitFor(() => expect(stateReads).toBe(2));
+
+    // Run A's end (v5) is delivered while the refetch is in flight: true at v5.
+    emit({ type: 'agent_end', stateVersion: 5, stateEpoch: 'epoch-1' });
+    await waitFor(() => expect(result.current.state?.running).toBe(false));
+
+    // The refetch resolves with run B's truth (v6) — the older event must not outrank it.
+    releaseRefetch?.();
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    expect(result.current.state?.running).toBe(true);
+  });
+
+  it('given a snapshot from a fresh server epoch, then a pre-restart event does not outrank it', async () => {
+    const encoder = new TextEncoder();
+    const onEvent = vi.fn();
+    let emit: (event: AgentControllerEvent) => void = () => {};
+    let stateReads = 0;
+    let releaseRefetch: (() => void) | undefined;
+    const refetchGate = new Promise<void>(resolve => {
+      releaseRefetch = resolve;
+    });
+    const snapshots = [
+      { running: false, stateVersion: 50, stateEpoch: 'epoch-a' },
+      { running: false, stateVersion: 1, stateEpoch: 'epoch-b' },
+    ];
+
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, () =>
+        HttpResponse.json({ controllerId, resourceId, threadId: 'thread-1' }),
+      ),
+      http.get(sessionUrl, async () => {
+        const snapshot = snapshots[Math.min(stateReads, snapshots.length - 1)];
+        stateReads += 1;
+        if (stateReads > 1) await refetchGate;
+        return HttpResponse.json({
+          controllerId,
+          resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: 'thread-1',
+          ...snapshot,
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        });
+      }),
+      http.get(
+        `${sessionUrl}/stream`,
+        () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                emit = event => controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+              },
+              cancel() {},
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          ),
+      ),
+    );
+
+    const { result, client } = renderHookWithProviders(() =>
+      useAgentControllerConnection({ ...hookArgs, sessionThreadId: 'thread-1', onEvent }),
+    );
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.state?.running).toBe(false);
+
+    void client.invalidateQueries({
+      queryKey: queryKeys.agentControllerConnectionState(controllerId, resourceId, undefined, 'thread-1'),
+      exact: true,
+    });
+    await waitFor(() => expect(stateReads).toBe(2));
+
+    // A pre-restart run start arrives late; within its own epoch it is the freshest truth.
+    emit({ type: 'agent_start', stateVersion: 51, stateEpoch: 'epoch-a' });
+    await waitFor(() => expect(result.current.state?.running).toBe(true));
+
+    // The refetch answers from the restarted server: a new epoch always wins.
+    releaseRefetch?.();
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    expect(result.current.state?.running).toBe(false);
+  });
+
+  it('given a late event older than the cached snapshot, then the cache does not regress', async () => {
+    const encoder = new TextEncoder();
+    const onEvent = vi.fn();
+    let emit: (event: AgentControllerEvent) => void = () => {};
+
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, () =>
+        HttpResponse.json({ controllerId, resourceId, threadId: 'thread-1' }),
+      ),
+      http.get(sessionUrl, () =>
+        HttpResponse.json({
+          controllerId,
+          resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: 'thread-1',
+          running: true,
+          stateVersion: 6,
+          stateEpoch: 'epoch-1',
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        }),
+      ),
+      http.get(
+        `${sessionUrl}/stream`,
+        () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                emit = event => controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+              },
+              cancel() {},
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          ),
+      ),
+    );
+
+    const { result } = renderHookWithProviders(() =>
+      useAgentControllerConnection({ ...hookArgs, sessionThreadId: 'thread-1', onEvent }),
+    );
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.state?.running).toBe(true);
+
+    // The previous run's end lost the race against the snapshot fetch: old news.
+    emit({ type: 'agent_end', stateVersion: 5, stateEpoch: 'epoch-1' });
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(result.current.state?.running).toBe(true);
+
+    // A genuinely newer end still lands.
+    emit({ type: 'agent_end', stateVersion: 7, stateEpoch: 'epoch-1' });
+    await waitFor(() => expect(result.current.state?.running).toBe(false));
+  });
+
   it('given reconnect polling is disconnected, then it backs off and stops at the retry cap', () => {
     expect(reconnectRefetchInterval(true, 0)).toBe(false);
     expect(reconnectRefetchInterval(false, 0)).toBe(1000);

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
@@ -1,4 +1,4 @@
-import type { AgentControllerEvent, AgentControllerSessionState } from '@mastra/client-js';
+import type { AgentControllerEvent, AgentControllerSessionState, KnownAgentControllerEvent } from '@mastra/client-js';
 import { isKnownAgentControllerEvent } from '@mastra/client-js';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRef, useState } from 'react';
@@ -7,7 +7,11 @@ import type { FactorySessionState } from '../context/ChatSessionContext';
 import { createAgentControllerClient } from '../services/agentControllerClient';
 import { useAgentControllerEvents } from './useAgentControllerEvents';
 import { useAgentControllerSessionInit } from '../../../../hooks/useAgentControllerSessionInit';
-import { useAgentControllerSessionSync, type LiveStatePatch } from '../../../../hooks/useAgentControllerSessionSync';
+import {
+  incomingStateOutranks,
+  useAgentControllerSessionSync,
+  type LiveStatePatch,
+} from '../../../../hooks/useAgentControllerSessionSync';
 
 export type ConnectionStatus = 'connecting' | 'ready' | 'reconnecting' | 'error';
 type SseConnectionState = 'never' | 'connected' | 'dropped';
@@ -15,6 +19,24 @@ type SseConnectionState = 'never' | 'connected' | 'dropped';
 function nextSseConnectionState(previous: SseConnectionState, connected: boolean): SseConnectionState {
   if (connected) return 'connected';
   return previous === 'connected' ? 'dropped' : previous;
+}
+
+type DisplayStateSnapshot = Extract<KnownAgentControllerEvent, { type: 'display_state_changed' }>['displayState'];
+
+/** The server-stamped display-state version an event speaks for, when its server stamps one. */
+function stateStampOf(
+  known: KnownAgentControllerEvent | undefined,
+  displayState: DisplayStateSnapshot | undefined,
+): { stateVersion: number; stateEpoch?: string } | undefined {
+  if (displayState) {
+    return displayState.stateVersion != null
+      ? { stateVersion: displayState.stateVersion, stateEpoch: displayState.stateEpoch }
+      : undefined;
+  }
+  if (known?.type === 'agent_start' || known?.type === 'agent_end' || known?.type === 'task_updated') {
+    return known.stateVersion != null ? { stateVersion: known.stateVersion, stateEpoch: known.stateEpoch } : undefined;
+  }
+  return undefined;
 }
 
 interface UseAgentControllerConnectionArgs {
@@ -113,17 +135,20 @@ export function useAgentControllerConnection({
           : (displayState?.runningThreadId ?? null);
     const tasks = isKnownAgentControllerEvent(event) && event.type === 'task_updated' ? event.tasks : undefined;
     if (typeof running === 'boolean' || tasks) {
-      const patch = livePatch.current;
-      patch.generation += 1;
-      if (typeof running === 'boolean')
-        patch.running = { value: running, threadId: runningThreadId, generation: patch.generation };
-      if (tasks) patch.tasks = { value: tasks, threadId: sessionThreadId, generation: patch.generation };
+      const stamp = stateStampOf(known, displayState);
       const stateQueryKey = queryKeys.agentControllerConnectionState(
         agentControllerId,
         resourceId,
         scope,
         sessionThreadId,
       );
+      const cached = queryClient.getQueryData<AgentControllerSessionState>(stateQueryKey);
+      if (incomingStateOutranks(stamp, cached) === false) return;
+      const patch = livePatch.current;
+      patch.generation += 1;
+      if (typeof running === 'boolean')
+        patch.running = { value: running, threadId: runningThreadId, generation: patch.generation, ...stamp };
+      if (tasks) patch.tasks = { value: tasks, threadId: sessionThreadId, generation: patch.generation, ...stamp };
       const updatedAt = queryClient.getQueryState(stateQueryKey)?.dataUpdatedAt;
       queryClient.setQueryData<AgentControllerSessionState>(
         stateQueryKey,
@@ -133,6 +158,7 @@ export function useAgentControllerConnection({
                 ...current,
                 ...(typeof running === 'boolean' ? { running, runningThreadId } : {}),
                 ...(tasks ? { tasks } : {}),
+                ...stamp,
               }
             : current,
         { updatedAt },

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerTranscript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerTranscript.ts
@@ -47,11 +47,19 @@ export function useAgentControllerTranscript({
     dispatch({ type: 'event', event });
   }, []);
 
-  const localUser = useCallback((text: string, steer?: boolean, files?: OutgoingFile[]) => {
-    const id = createLocalMessageId();
-    dispatch({ type: 'localUser', id, text, steer, files });
-    return id;
-  }, []);
+  const localUser = useCallback(
+    (
+      text: string,
+      steer?: boolean,
+      files?: OutgoingFile[],
+      stateStamp?: { stateVersion?: number; stateEpoch?: string },
+    ) => {
+      const id = createLocalMessageId();
+      dispatch({ type: 'localUser', id, text, steer, files, ...stateStamp });
+      return id;
+    },
+    [],
+  );
 
   const failLocalUser = useCallback((id: string) => {
     dispatch({ type: 'failLocalUser', id });

--- a/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/services/transcript.ts
@@ -143,6 +143,9 @@ export interface TranscriptState {
   pending: boolean;
   /** When the latch was armed — a state snapshot fetched after this instant outranks it. */
   pendingSince?: number;
+  /** Display-state version/epoch when the latch armed — a snapshot outranking it is fresher truth. */
+  pendingStateVersion?: number;
+  pendingStateEpoch?: string;
   threadId?: string;
   /** Current task list from task_updated events. */
   tasks: AgentControllerTaskSnapshot[];
@@ -191,7 +194,15 @@ export interface OutgoingFile {
 
 type Action =
   | { type: 'event'; event: AgentControllerEvent }
-  | { type: 'localUser'; id?: string; text: string; steer?: boolean; files?: OutgoingFile[] }
+  | {
+      type: 'localUser';
+      id?: string;
+      text: string;
+      steer?: boolean;
+      files?: OutgoingFile[];
+      stateVersion?: number;
+      stateEpoch?: string;
+    }
   | { type: 'failLocalUser'; id: string }
   | { type: 'clearPending' }
   | { type: 'localNotice'; text: string; level: 'info' | 'error' }
@@ -235,6 +246,8 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
         ...state,
         pending: true,
         pendingSince: Date.now(),
+        pendingStateVersion: action.stateVersion,
+        pendingStateEpoch: action.stateEpoch,
         entries: [
           ...state.entries,
           toMessageEntry(

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -2282,6 +2282,7 @@ export class SessionDisplayState {
    */
   apply(event: AgentControllerEvent): void {
     const ds = this.#state;
+    ds.stateVersion += 1;
 
     switch (event.type) {
       // ── Agent lifecycle ────────────────────────────────────────────────
@@ -2738,6 +2739,14 @@ export class SessionBus {
       }
     }
     this.#displayState?.apply(event);
+    if (
+      this.#displayState &&
+      (event.type === 'agent_start' || event.type === 'agent_end' || event.type === 'task_updated')
+    ) {
+      const { stateVersion, stateEpoch } = this.#displayState.get();
+      event.stateVersion = stateVersion;
+      event.stateEpoch = stateEpoch;
+    }
 
     // A pending snapshot describes state that predates this event, so it must
     // reach listeners before the event itself does. Flushing here also means a

--- a/packages/core/src/agent-controller/state-version.test.ts
+++ b/packages/core/src/agent-controller/state-version.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryStore } from '../storage/mock';
+import { createTestSession } from './test-utils';
+import type { AgentControllerEvent } from './types';
+import { defaultDisplayState } from './types';
+
+type StampedEvent = Extract<AgentControllerEvent, { type: 'agent_start' | 'agent_end' | 'task_updated' }>;
+
+describe('display-state version', () => {
+  it('mints a fresh epoch per display state and starts the version at zero', () => {
+    const a = defaultDisplayState();
+    const b = defaultDisplayState();
+    expect(a.stateVersion).toBe(0);
+    expect(a.stateEpoch).toBeTruthy();
+    expect(a.stateEpoch).not.toBe(b.stateEpoch);
+  });
+
+  it('advances the version with every event folded into the display state', async () => {
+    const { session } = await createTestSession({ storage: new InMemoryStore() });
+    const before = session.displayState.get().stateVersion;
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'agent_end', reason: 'complete' });
+    expect(session.displayState.get().stateVersion).toBe(before + 2);
+  });
+
+  it('stamps run lifecycle and task events with the post-transition version and epoch', async () => {
+    const { session } = await createTestSession({ storage: new InMemoryStore() });
+    const seen: StampedEvent[] = [];
+    session.subscribe(event => {
+      if (event.type === 'agent_start' || event.type === 'agent_end' || event.type === 'task_updated') {
+        seen.push(event);
+      }
+    });
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'task_updated', tasks: [] });
+    session.emit({ type: 'agent_end', reason: 'complete' });
+
+    const ds = session.displayState.get();
+    expect(seen).toHaveLength(3);
+    expect(seen.map(event => event.stateEpoch)).toEqual([ds.stateEpoch, ds.stateEpoch, ds.stateEpoch]);
+    const versions = seen.map(event => event.stateVersion ?? -1);
+    expect([...versions].sort((x, y) => x - y)).toEqual(versions);
+    expect(new Set(versions).size).toBe(3);
+    expect(versions.at(-1)).toBe(ds.stateVersion);
+  });
+});

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -637,6 +637,12 @@ export interface AgentControllerDisplayState {
   /** Thread the active run is on (null when idle or the start event predates stamping). */
   runningThreadId: string | null;
 
+  /** Monotonic event counter: orders snapshots and stamped events from the same epoch. */
+  stateVersion: number;
+
+  /** Identity of this display-state instance; a new epoch (e.g. a server restart) restarts the count. */
+  stateEpoch: string;
+
   // ── Current streaming message ────────────────────────────────────────
   /**
    * The live message currently being streamed (null when idle). Its content
@@ -718,6 +724,8 @@ export function defaultDisplayState(): AgentControllerDisplayState {
   return {
     isRunning: false,
     runningThreadId: null,
+    stateVersion: 0,
+    stateEpoch: crypto.randomUUID(),
     currentMessage: null,
     queuedFollowUps: 0,
     tokenUsage: createEmptyTokenUsage(),
@@ -787,8 +795,14 @@ export type AgentControllerEvent =
   | { type: 'thread_created'; thread: AgentControllerThread }
   | { type: 'thread_deleted'; threadId: string }
   | { type: 'state_changed'; state: Record<string, unknown>; changedKeys: string[] }
-  | { type: 'agent_start'; threadId?: string }
-  | { type: 'agent_end'; reason?: 'complete' | 'aborted' | 'error' | 'suspended'; threadId?: string }
+  | { type: 'agent_start'; threadId?: string; stateVersion?: number; stateEpoch?: string }
+  | {
+      type: 'agent_end';
+      reason?: 'complete' | 'aborted' | 'error' | 'suspended';
+      threadId?: string;
+      stateVersion?: number;
+      stateEpoch?: string;
+    }
   | { type: 'message_start'; message: MastraDBMessage }
   | { type: 'message_update'; message: MastraDBMessage }
   | { type: 'message_end'; message: MastraDBMessage }
@@ -960,6 +974,8 @@ export type AgentControllerEvent =
   | {
       type: 'task_updated';
       tasks: TaskItemSnapshot[];
+      stateVersion?: number;
+      stateEpoch?: string;
     }
   | {
       type: 'goal_evaluation';

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -644,6 +644,30 @@ describe('agent-controller routes', () => {
       expect(res.runningThreadId).toBe('thread-run');
     });
 
+    it('exposes the display-state version and epoch for ordered client merges', async () => {
+      const controller = mastra.getAgentController('code')!;
+      await controller.init();
+      const session = await controller.createSession({ resourceId: 'user-1', id: 'user-1', ownerId: controller.id });
+
+      const before = (await GET_AGENT_CONTROLLER_SESSION_STATE_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-1',
+      } as any)) as { stateVersion?: number; stateEpoch?: string };
+      expect(typeof before.stateVersion).toBe('number');
+      expect(before.stateEpoch).toBeTruthy();
+
+      session.emit({ type: 'agent_start' });
+
+      const after = (await GET_AGENT_CONTROLLER_SESSION_STATE_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-1',
+      } as any)) as { stateVersion?: number; stateEpoch?: string };
+      expect(after.stateEpoch).toBe(before.stateEpoch);
+      expect(after.stateVersion!).toBeGreaterThan(before.stateVersion!);
+    });
+
     it('returns the durable task list for initial UI hydration', async () => {
       const controller = mastra.getAgentController('code')!;
       await controller.init();

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -312,6 +312,10 @@ const sessionStateResponseSchema = z.object({
   running: z.boolean().optional(),
   /** Thread the active run is on; null when idle or when the run predates thread stamping. */
   runningThreadId: z.string().nullable().optional(),
+  /** Monotonic display-state counter; with stateEpoch it orders this snapshot against stamped events. */
+  stateVersion: z.number().optional(),
+  /** Identity of the server-side display state; a new epoch restarts the count. */
+  stateEpoch: z.string().optional(),
   tasks: z.array(taskSnapshotSchema).optional(),
   omProgress: omProgressSummarySchema.optional(),
   tokenUsage: tokenUsageSchema.optional(),
@@ -841,6 +845,8 @@ export const GET_AGENT_CONTROLLER_SESSION_STATE_ROUTE = createRoute({
         modelId: session.model.get(),
         running: ds.isRunning === true,
         runningThreadId: ds.runningThreadId ?? null,
+        stateVersion: ds.stateVersion,
+        stateEpoch: ds.stateEpoch,
         tasks,
         omProgress: {
           status: om.status,


### PR DESCRIPTION
TLDR: the server now stamps its run state with a monotonic version, so the chat UI merges snapshots and events by proof instead of by arrival order and local clocks.

---

Every event already folds through one synchronous state machine on the server (`DisplayState.apply`). This gives that machine a counter: each fold bumps `stateVersion`, and `agent_start`, `agent_end`, `task_updated`, and state snapshots all carry it, next to a per-process `stateEpoch`. The client keeps whichever truth carries the higher version. This is the "server-stamped state version" follow-up named in #22412, delivered — the ordering the client-side guard there had to infer from arrival order is now a fact on the wire.

### What changes

| in the chat, during a race | before | after |
| --- | --- | --- |
| the previous run's `agent_end` is delivered after a snapshot that already sees the next run | composer flips to idle until the next event corrects it | the stale event is discarded |
| a state fetch started before a send resolves just after it, saying idle | the pending latch could clear mid-start (fetched-after-send was judged by local clock) | only a snapshot whose version postdates the send releases the latch |
| the server restarts mid-run and the client still caches a high pre-restart version | n/a (versions are new) | `stateEpoch` changes, fresh truth wins — versions cannot wedge the cache |

### Judgment call

- The fields are optional on the wire, and the arrival-order guard from #22412 stays as the fallback when either side is unstamped (deploy-window skew, older servers). The versioned path is preferred whenever both sides carry stamps.
- Epochs from different server processes cannot be ordered, so on an epoch mismatch the side that arrived last wins. That rule lives in one exported function (`incomingStateOutranks`) used by all three merge sites — overlay, event fold, pending latch — so the semantics cannot drift apart.
- A provably stale event is swallowed at the connection boundary: the transcript and runtime reducers never see it. I preferred one discard point over letting old truth in and correcting it downstream.
- The send route stays fire-and-ack, so the latch release compares against the version cached at send time rather than a version the POST could return. A message queued behind an active run can still see a ms-wide early release when that run ends; the next `agent_start` corrects it. Making that exact would mean restructuring the send acknowledgement, which is out of proportion here.

### On deploy

Nothing to migrate. Old clients ignore the new fields; against old servers the client behaves exactly as #22412 shipped.

### Side effects to check

- The version bumps on every folded event, including message deltas — a long streaming session reaches large counts, which plain JS numbers hold without issue.
- `display_state_changed` snapshots carry the stamp implicitly (the fields live on the display state itself), so snapshot-driven patches obey the same ordering as lifecycle events.

### Not verified

- Restart behavior is pinned by epoch tests at the unit level; no live restart-mid-run was staged.

```
tests        +345   -0
source       +140  -23
changeset     +20   -0
generated      +2   -0
```
