### PR TITLE
fix(mastracode): hide user email at startup

### DIFF
--- a/.changeset/quiet-users-hide.md
+++ b/.changeset/quiet-users-hide.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Stopped showing the Git user email address in the startup header.

--- a/mastracode/tui/e2e/tui/startup.ts
+++ b/mastracode/tui/e2e/tui/startup.ts
@@ -15,7 +15,7 @@ export const startupScenario: McE2eScenario = {
     await runtime.waitForScreenText(/Project:\s+mastra/i, terminal);
     await runtime.waitForScreenText(/Resource ID:/i, terminal);
     await runtime.waitForScreenText(/Branch:\s+\S+/i, terminal);
-    await runtime.waitForScreenText(/User:\s+mc-e2e/i, terminal);
+    await runtime.waitForScreenTextAbsent(/User:/i, terminal, 2_000);
     runtime.printScreen('after startup', terminal);
 
     terminal.submit('/help');

--- a/mastracode/tui/src/tui/__tests__/setup-layout.test.ts
+++ b/mastracode/tui/src/tui/__tests__/setup-layout.test.ts
@@ -125,12 +125,9 @@ describe('buildLayout startup header', () => {
     expect(textOf(uiChildren[1])).toBe('BANNER v1.2.3');
     const projectDetails = textOf(uiChildren[2]);
     expect(projectDetails).toBe(
-      [
-        'Project: demo-project',
-        'Resource ID: resource-123',
-        'Branch: feature/banner',
-        'Worktree of: /repos/main',
-      ].join('\n'),
+      ['Project: demo-project', 'Resource ID: resource-123', 'Branch: feature/banner', 'Worktree of: /repos/main'].join(
+        '\n',
+      ),
     );
     expect(projectDetails).not.toContain('User:');
     expect(projectDetails).not.toContain('@');

--- a/mastracode/tui/src/tui/__tests__/setup-layout.test.ts
+++ b/mastracode/tui/src/tui/__tests__/setup-layout.test.ts
@@ -1,10 +1,9 @@
 import stripAnsi from 'strip-ansi';
 import { describe, expect, it, vi } from 'vitest';
 
-const { renderBannerMock, updateStatusLineMock, getUserIdMock } = vi.hoisted(() => ({
+const { renderBannerMock, updateStatusLineMock } = vi.hoisted(() => ({
   renderBannerMock: vi.fn(),
   updateStatusLineMock: vi.fn(),
-  getUserIdMock: vi.fn(),
 }));
 
 vi.mock('node:child_process', () => ({
@@ -57,10 +56,6 @@ vi.mock('../components/idle-counter.js', () => ({
 
 vi.mock('../status-line.js', () => ({
   updateStatusLine: updateStatusLineMock,
-}));
-
-vi.mock('@mastra/code-sdk/utils/project', () => ({
-  getUserId: getUserIdMock,
 }));
 
 import { renderBanner } from '../components/banner.js';
@@ -121,7 +116,6 @@ function createState(modeCount = 2) {
 describe('buildLayout startup header', () => {
   it('renders banner, project frontmatter, startup hints, containers, footer, and editor focus in order', () => {
     renderBannerMock.mockReturnValue('BANNER v1.2.3');
-    getUserIdMock.mockReturnValue('user-abc');
     const refreshModelAuthStatus = vi.fn();
     const { state, uiChildren, editorChildren, footerChildren, editor } = createState();
 
@@ -129,15 +123,17 @@ describe('buildLayout startup header', () => {
 
     expect(renderBanner).toHaveBeenCalledWith('1.2.3', 'Acme Code');
     expect(textOf(uiChildren[1])).toBe('BANNER v1.2.3');
-    expect(textOf(uiChildren[2])).toBe(
+    const projectDetails = textOf(uiChildren[2]);
+    expect(projectDetails).toBe(
       [
         'Project: demo-project',
         'Resource ID: resource-123',
         'Branch: feature/banner',
         'Worktree of: /repos/main',
-        'User: user-abc',
       ].join('\n'),
     );
+    expect(projectDetails).not.toContain('User:');
+    expect(projectDetails).not.toContain('@');
     expect(textOf(uiChildren[4])).toBe('  ⇧+Tab cycle modes · /help info & shortcuts');
     expect(uiChildren[6]).toBe(state.chatContainer);
     expect(uiChildren[7]).toBe(state.taskProgress);
@@ -153,7 +149,6 @@ describe('buildLayout startup header', () => {
 
   it('omits the mode-cycle startup hint when there is only one mode', () => {
     renderBannerMock.mockReturnValue('BANNER v1.2.3');
-    getUserIdMock.mockReturnValue('user-abc');
     const { state, uiChildren } = createState(1);
 
     buildLayout(state, vi.fn());

--- a/mastracode/tui/src/tui/setup.ts
+++ b/mastracode/tui/src/tui/setup.ts
@@ -6,7 +6,6 @@ import { execFileSync } from 'node:child_process';
 import { CombinedAutocompleteProvider, Spacer, Text } from '@earendil-works/pi-tui';
 import type { SlashCommand } from '@earendil-works/pi-tui';
 import { THINK_COMMAND_DESCRIPTOR } from '@mastra/code-sdk/thinking';
-import { getUserId } from '@mastra/code-sdk/utils/project';
 import { loadCustomCommands } from '@mastra/code-sdk/utils/slash-command-loader';
 import { ThreadLockError } from '@mastra/code-sdk/utils/thread-lock';
 import type { AgentControllerEventListener } from '@mastra/core/agent-controller';
@@ -257,7 +256,6 @@ export function buildLayout(state: TUIState, refreshModelAuthStatus: () => Promi
     `Resource ID: ${state.projectInfo.resourceId}`,
     state.projectInfo.gitBranch ? `Branch: ${state.projectInfo.gitBranch}` : null,
     state.projectInfo.isWorktree ? `Worktree of: ${state.projectInfo.mainRepoPath}` : null,
-    `User: ${getUserId(state.projectInfo.rootPath)}`,
   ]
     .filter(Boolean)
     .map(line => theme.fg('muted', line as string))


### PR DESCRIPTION
## Summary

- stop reading the Git user email for the startup header
- remove the user field from displayed project details
- keep project, resource, branch, and worktree information

## Testing

- 3 startup layout tests
- MastraCode dependency build
- diff validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

MastraCode no longer shows Git email or user information when it starts. It still shows the project, resource, branch, and worktree details.

## Changes

- Removed `getUserId` from startup layout generation.
- Removed the `User:` field from displayed project details.
- Updated startup layout tests and the startup scenario to verify that user data and email addresses are not displayed.
- Added a patch changeset for `mastracode`.

## Validation

- Ran three startup layout tests.
- Built the MastraCode dependency.
- Validated the diff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->