### PR TITLE
fix(factory-ui): refetch the session state when the stream reconnects

### DIFF
--- a/.changeset/steady-streams-return.md
+++ b/.changeset/steady-streams-return.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed chat state staying stale after a connection drop: when the event stream reconnects, the session state is refetched along with the messages, so a run that started or ended during the gap is reflected right away.

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
@@ -637,20 +637,19 @@ describe('useAgentControllerConnection', () => {
   it('given the stream drops and recovers, then the session state is refetched to close the event gap', async () => {
     const onStream = vi.fn();
     const onEvent = vi.fn();
-    let stateReadsAfterReconnect = 0;
 
     server.use(
       http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, () =>
         HttpResponse.json({ controllerId, resourceId, threadId: 'created-thread' }),
       ),
       http.get(sessionUrl, () => {
-        if (onStream.mock.calls.length >= 2) stateReadsAfterReconnect += 1;
+        const afterReconnect = onStream.mock.calls.length >= 2;
         return HttpResponse.json({
           controllerId,
           resourceId,
           modeId: 'build',
           modelId: 'openai/gpt-4o-mini',
-          threadId: 'state-thread',
+          threadId: afterReconnect ? 'state-thread-after-gap' : 'state-thread',
           running: false,
           settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
         });
@@ -678,6 +677,6 @@ describe('useAgentControllerConnection', () => {
     await waitFor(() => expect(onStream).toHaveBeenCalledTimes(2), { timeout: 2500 });
     await waitFor(() => expect(result.current.status).toBe('ready'));
 
-    await waitFor(() => expect(stateReadsAfterReconnect).toBeGreaterThanOrEqual(1), { timeout: 3000 });
+    await waitFor(() => expect(result.current.state?.threadId).toBe('state-thread-after-gap'), { timeout: 3000 });
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
@@ -578,11 +578,11 @@ describe('useAgentControllerConnection', () => {
     const { result } = renderHookWithProviders(() => useAgentControllerConnection({ ...hookArgs, onEvent }));
 
     await waitFor(() => expect(onStream).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(onReadState).toHaveBeenCalledTimes(2), { timeout: 2500 });
+    await waitFor(() => expect(onReadState.mock.calls.length).toBeGreaterThanOrEqual(2), { timeout: 2500 });
     await waitFor(() => expect(onStream).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(result.current.status).toBe('ready'));
 
-    expect(result.current.state?.threadId).toBe('state-thread-2');
+    await waitFor(() => expect(result.current.state?.threadId).toBe(`state-thread-${onReadState.mock.calls.length}`));
   });
 
   it('given the stream drops and recovers, then the resource message windows are invalidated to close the event gap', async () => {
@@ -633,5 +633,51 @@ describe('useAgentControllerConnection', () => {
 
     await waitFor(() => expect(client.getQueryState(messagesKey)?.isInvalidated).toBe(true));
     expect(client.getQueryState(otherResourceKey)?.isInvalidated).toBe(false);
+  });
+  it('given the stream drops and recovers, then the session state is refetched to close the event gap', async () => {
+    const onStream = vi.fn();
+    const onEvent = vi.fn();
+    let stateReadsAfterReconnect = 0;
+
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, () =>
+        HttpResponse.json({ controllerId, resourceId, threadId: 'created-thread' }),
+      ),
+      http.get(sessionUrl, () => {
+        if (onStream.mock.calls.length >= 2) stateReadsAfterReconnect += 1;
+        return HttpResponse.json({
+          controllerId,
+          resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: 'state-thread',
+          running: false,
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        });
+      }),
+      http.get(`${sessionUrl}/stream`, () => {
+        onStream();
+        if (onStream.mock.calls.length === 1) {
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                setTimeout(() => controller.error(new Error('stream dropped')), 0);
+              },
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          );
+        }
+        return new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useAgentControllerConnection({ ...hookArgs, onEvent }));
+
+    await waitFor(() => expect(onStream).toHaveBeenCalledTimes(2), { timeout: 2500 });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    await waitFor(() => expect(stateReadsAfterReconnect).toBeGreaterThanOrEqual(1), { timeout: 3000 });
   });
 });

--- a/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
+++ b/mastracode/factory-ui/src/ui/domains/chat/hooks/useAgentControllerConnection.ts
@@ -92,6 +92,14 @@ export function useAgentControllerConnection({
       queryKey: queryKeys.agentControllerResourceThreadMessages(agentControllerId, resourceId),
       predicate: query => reconnected || query.state.status === 'error',
     });
+    // The gap can also have eaten agent_start/agent_end, so the cached state
+    // snapshot is refetched the same way.
+    if (reconnected) {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.agentControllerConnectionState(agentControllerId, resourceId, scope, sessionThreadId),
+        exact: true,
+      });
+    }
   };
 
   const handleEvent = (event: AgentControllerEvent) => {


### PR DESCRIPTION
TLDR: when the chat's event stream reconnects after a gap, the session run state is now refetched along with the messages, so a run that started or ended during the gap shows right away.

---

```
before   gap eats agent_start/agent_end -> messages resync on reconnect, but the running flag stays stale until the next live event
after    reconnect refetches the state snapshot too -> composer matches the server as soon as the fetch lands
```

Reconnect already invalidated the message windows; the cached state snapshot was the one truth left unsynced. This adds the same invalidation for the state query — eight lines.

One existing reconnect test goes from an exact fetch count to at-least, since the refetch adds a state read.

```
tests        +48  -2
source        +8   0
changeset     +5   0
```
