### PR TITLE
feat(playground): give a Studio reply its entrance

### DIFF
--- a/.changeset/common-lemons-agree.md
+++ b/.changeset/common-lemons-agree.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Studio's chat transcript now animates what arrives during a run. A tool call, a card or a data block fades in as it lands instead of appearing at full opacity, and the first words of a reply fade in with the rest rather than snapping into place. This is the same entrance Mastra Factory uses, from the shared design system.

--- a/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.test.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/__tests__/message-row.test.tsx
@@ -1,5 +1,7 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import type { MastraTextPart } from '@mastra/react';
+import { ArrivalScope } from '@mastra/playground-ui/components/Arrival';
+import { ARRIVING_CLASS } from '@mastra/playground-ui/tokens';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, cleanup, render, screen } from '@testing-library/react';
@@ -154,6 +156,49 @@ describe('MessageRow', () => {
       }
 
       expect(container.textContent).toContain('beta29');
+    });
+
+    it('fades in a tool row that lands while the reader is watching', () => {
+      vi.useFakeTimers();
+      const reply = `Ready. ${Array.from({ length: 40 }, (_, index) => `word${index}`).join(' ')}`;
+      const withTool = (text: string) =>
+        baseMessage({
+          content: {
+            format: 2,
+            parts: [
+              streamingText(text),
+              {
+                type: 'tool-invocation',
+                toolInvocation: {
+                  toolName: 'genericTool',
+                  toolCallId: 'call-1',
+                  state: 'result',
+                  args: {},
+                  result: { ok: true },
+                },
+              } as never,
+            ],
+          },
+        });
+      const badge = () => container.querySelector('[data-testid="tool-badge"]');
+
+      const { container, rerender } = render(
+        <ArrivalScope>
+          <MessageRow message={withTool('Ready.')} />
+        </ArrivalScope>,
+        { wrapper: Providers },
+      );
+      rerender(
+        <ArrivalScope>
+          <MessageRow message={withTool(reply)} />
+        </ArrivalScope>,
+      );
+
+      for (let frames = 0; frames < 600 && !badge(); frames++) {
+        act(() => void vi.advanceTimersByTime(16));
+      }
+
+      expect(badge()?.closest(`.${ARRIVING_CLASS}`)).not.toBeNull();
     });
 
     it('hands over a notice whole instead of pacing it', () => {

--- a/packages/playground/src/lib/ai-ui/messages/message-row.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/message-row.tsx
@@ -1,6 +1,6 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
-import { Arriving } from '@mastra/playground-ui/components/Arrival';
 import { useRevealedParts } from '@mastra/playground-ui/components/ai/message-reveal';
+import { Arriving } from '@mastra/playground-ui/components/Arrival';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
 import { cn } from '@mastra/playground-ui/utils/cn';

--- a/packages/playground/src/lib/ai-ui/messages/message-row.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/message-row.tsx
@@ -1,4 +1,5 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+import { Arriving } from '@mastra/playground-ui/components/Arrival';
 import { useRevealedParts } from '@mastra/playground-ui/components/ai/message-reveal';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { useCopyToClipboard } from '@mastra/playground-ui/hooks/use-copy-to-clipboard';
@@ -218,9 +219,21 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
     const sharedRenderers = useMemo<MessageRenderers>(
       () => ({
         Reasoning: part => <ReasoningPartRenderer part={part} />,
-        Data: part => <DataPartRenderer part={part} />,
-        ToolInvocation: part => <ToolInvocationPartRenderer part={part} metadata={metadata} dataParts={dataParts} />,
-        DynamicTool: part => <DynamicToolPartRenderer part={part} metadata={metadata} dataParts={dataParts} />,
+        Data: part => (
+          <Arriving>
+            <DataPartRenderer part={part} />
+          </Arriving>
+        ),
+        ToolInvocation: part => (
+          <Arriving>
+            <ToolInvocationPartRenderer part={part} metadata={metadata} dataParts={dataParts} />
+          </Arriving>
+        ),
+        DynamicTool: part => (
+          <Arriving>
+            <DynamicToolPartRenderer part={part} metadata={metadata} dataParts={dataParts} />
+          </Arriving>
+        ),
       }),
       [metadata, dataParts],
     );

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -1,4 +1,5 @@
 import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+import { ArrivalScope } from '@mastra/playground-ui/components/Arrival';
 import { Avatar } from '@mastra/playground-ui/components/Avatar';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
@@ -19,7 +20,6 @@ import {
   MessageScrollerViewport,
 } from '@mastra/playground-ui/components/MessageScroller';
 import { PendingIndicator } from '@mastra/playground-ui/components/PendingIndicator';
-import { ArrivalScope } from '@mastra/playground-ui/components/Arrival';
 import { buildThreadRailTurns, getClientMessageKey, ThreadRail } from '@mastra/playground-ui/components/ThreadRail';
 import type { ThreadRailTurn } from '@mastra/playground-ui/components/ThreadRail';
 import { cn } from '@mastra/playground-ui/utils/cn';

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -19,6 +19,7 @@ import {
   MessageScrollerViewport,
 } from '@mastra/playground-ui/components/MessageScroller';
 import { PendingIndicator } from '@mastra/playground-ui/components/PendingIndicator';
+import { ArrivalScope } from '@mastra/playground-ui/components/Arrival';
 import { buildThreadRailTurns, getClientMessageKey, ThreadRail } from '@mastra/playground-ui/components/ThreadRail';
 import type { ThreadRailTurn } from '@mastra/playground-ui/components/ThreadRail';
 import { cn } from '@mastra/playground-ui/utils/cn';
@@ -177,38 +178,41 @@ export const Thread = ({
                     className="relative mx-auto w-full max-w-3xl px-4 pb-7 group-has-[[data-attachments-row]]/thread:pb-24"
                   >
                     <BracketOverlay containerRef={messagesContainerRef} />
-                    <MessageScrollerContent className="flex flex-col gap-6 py-6">
-                      {turnGroups.map((group, index) => {
-                        const isLiveTurn = index === turnGroups.length - 1;
-                        return (
-                          // The room a fresh turn scrolls up into is this min-height: pure
-                          // layout, filled by the streaming reply. It stays after the run —
-                          // collapsing it would shift the reader — and moves to the next
-                          // turn with the anchor scroll.
-                          <div
-                            key={group.key}
-                            className={cn('flex flex-col gap-6', isLiveTurn && group.opensTurn && 'min-h-[50cqh]')}
-                          >
-                            {group.messages.map(message => (
-                              <MessageScrollerItem
-                                key={getClientMessageKey(message)}
-                                messageId={message.id}
-                                scrollAnchor={threadRailAnchorIds.has(message.id)}
-                              >
-                                <MessageRow
-                                  message={message}
-                                  hasModelList={hasModelList}
-                                  isSpeaking={isSpeaking}
-                                  onReadAloud={readAloud}
-                                  onStopSpeaking={stopSpeaking}
-                                />
-                              </MessageScrollerItem>
-                            ))}
-                            {isLiveTurn && delayedPending && <PendingIndicator />}
-                          </div>
-                        );
-                      })}
-                    </MessageScrollerContent>
+                    {/* Everything already here when the reader arrived is theirs; what lands after fades in. */}
+                    <ArrivalScope>
+                      <MessageScrollerContent className="flex flex-col gap-6 py-6">
+                        {turnGroups.map((group, index) => {
+                          const isLiveTurn = index === turnGroups.length - 1;
+                          return (
+                            // The room a fresh turn scrolls up into is this min-height: pure
+                            // layout, filled by the streaming reply. It stays after the run —
+                            // collapsing it would shift the reader — and moves to the next
+                            // turn with the anchor scroll.
+                            <div
+                              key={group.key}
+                              className={cn('flex flex-col gap-6', isLiveTurn && group.opensTurn && 'min-h-[50cqh]')}
+                            >
+                              {group.messages.map(message => (
+                                <MessageScrollerItem
+                                  key={getClientMessageKey(message)}
+                                  messageId={message.id}
+                                  scrollAnchor={threadRailAnchorIds.has(message.id)}
+                                >
+                                  <MessageRow
+                                    message={message}
+                                    hasModelList={hasModelList}
+                                    isSpeaking={isSpeaking}
+                                    onReadAloud={readAloud}
+                                    onStopSpeaking={stopSpeaking}
+                                  />
+                                </MessageScrollerItem>
+                              ))}
+                              {isLiveTurn && delayedPending && <PendingIndicator />}
+                            </div>
+                          );
+                        })}
+                      </MessageScrollerContent>
+                    </ArrivalScope>
 
                     {!isRunning && <SaveFullConversationAction />}
                   </div>


### PR DESCRIPTION
TLDR: a tool call or a card now fades in as it lands in a Studio reply, instead of appearing at full opacity while the prose around it is still fading in word by word.

---

The design system has an entrance system, and Studio was not plugged into it. `ArrivalScope` marks what the reader was already handed; anything mounting after it painted is the run happening in front of them, and fades. Outside a scope the context default decides for you:

```ts
/** Outside any scope nothing is watched arriving, so nothing animates. */
export const SettledContext = createContext({ current: false });
```

Studio had zero references to `Arrival`, anywhere. So `useWatched()` was false in every message, and the machinery sat inert: rows popped, and `useSettledWords` treated each block's first burst of words as already read, so it skipped their fade too. Factory opens the scope in `Transcript.tsx` and wraps each row in `<Arriving>`, which is the whole reason its transcript feels smoother.

The transcript now opens the scope, and the non-prose parts wear the entrance.

### What changes

| watching a reply arrive | before | after |
| --- | --- | --- |
| a tool call lands | appears at full opacity, instantly | fades in as it lands |
| a card or data block lands | appears at full opacity | fades in |
| the first words of a passage | snap in, the rest fade | fade in with the rest |
| a transcript you just opened | nothing animates | unchanged |

### Judgment call

Reasoning stays unwrapped. It is prose, and `MarkdownRenderer` already gives it a word-level entrance; wrapping it would play a block entrance on top of a word one. Factory draws the same line.

No runtime guard. I looked at warning from `useRevealedParts` when it runs outside a scope, since forgetting the scope is silent and Studio proves it can happen. But `playground-ui` uses no dev flag anywhere, and a warning nobody reads is worse than a test that fails: the `Arriving` wrappers are pinned by a test that is red without them.

### Not verified

The scope in `thread.tsx` is not pinned by a test. Failing without it needs a part landing mid-run through the whole Thread and SSE harness, and I judged that harness too heavy for what it buys. If the scope is removed, the wrapper test still passes and the transcript quietly stops animating.

I have not opened the preview.

```
source       +52  -35   ← thread.tsx is +4 -0 under `git diff -w`; the rest is re-indent
tests        +45    0
changeset     +5    0
```
