### PR TITLE
docs: add partner UTM parameters to Render links

### DIFF
--- a/docs/src/content/en/integrations/deploy/render.mdx
+++ b/docs/src/content/en/integrations/deploy/render.mdx
@@ -8,12 +8,12 @@ import StepItem from "@site/src/components/StepItem";
 
 # Render
 
-Deploy Mastra applications on [Render](https://render.com/). Host the Mastra API as a [web service](https://render.com/docs/web-services), or use [Render Workflows](https://render.com/docs/workflows) for long-running tasks with independent retry policies.
+Deploy Mastra applications on [Render](https://render.com/?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra). Host the Mastra API as a [web service](https://render.com/docs/web-services?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra), or use [Render Workflows](https://render.com/docs/workflows?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra) for long-running tasks with independent retry policies.
 
 Choose the deployment path that fits your application:
 
-- **Mastra API**: Deploy Mastra's [server](/docs/server/overview) as a web service with a public endpoint. The [Web Services guide](https://render.com/docs/web-services) explains how to deploy custom code or a supported [server adapter](/docs/server/server-adapters).
-- **Mastra workflow**: Run an entire Mastra workflow within one task. Render controls the outer run, while Mastra manages its steps and state. See [Defining Workflow Tasks](https://render.com/docs/workflows-defining) for configuration details.
+- **Mastra API**: Deploy Mastra's [server](/docs/server/overview) as a web service with a public endpoint. The [Web Services guide](https://render.com/docs/web-services?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra) explains how to deploy custom code or a supported [server adapter](/docs/server/server-adapters).
+- **Mastra workflow**: Run an entire Mastra workflow within one task. Render controls the outer run, while Mastra manages its steps and state. See [Defining Workflow Tasks](https://render.com/docs/workflows-defining?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra) for configuration details.
 - **Distributed agent operations**: Give each operation its own compute plan, timeout, and retry policy. Render Workflows handles the execution queue and provides run observability.
 
 This guide builds an editorial pipeline that reviews a draft from three perspectives in parallel, then passes the feedback to an editor agent. Use the links above if you want to deploy a Mastra API or execute an entire Mastra workflow as one task.
@@ -42,7 +42,7 @@ render login
 ```
 
 :::note
-Requires Render CLI `v2.12.0` or later. For other installation methods, see the [Render CLI docs](https://render.com/docs/cli).
+Requires Render CLI `v2.12.0` or later. For other installation methods, see the [Render CLI docs](https://render.com/docs/cli?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra).
 :::
 
 Create an empty Mastra project named `render-workflows`:
@@ -312,7 +312,7 @@ Running the pipeline on Render requires a _workflow service_. This is the Render
   <StepItem>
     #### Create the workflow service
 
-    In the [Render Dashboard](https://dashboard.render.com), click **New > Workflow** and link the repository from the previous step. Then complete the creation form:
+    In the [Render Dashboard](https://dashboard.render.com?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra), click **New > Workflow** and link the repository from the previous step. Then complete the creation form:
 
     | Field | Value |
     | - | - |
@@ -361,7 +361,7 @@ Running the pipeline on Render requires a _workflow service_. This is the Render
 
 You can trigger the pipeline asynchronously from a Mastra application, web service, or script with the Render SDK.
 
-Triggering runs from code requires a Render API key, which you create in your [Render account settings](https://render.com/docs/api#1-create-an-api-key). Set it in the calling service:
+Triggering runs from code requires a Render API key, which you create in your [Render account settings](https://render.com/docs/api?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra#1-create-an-api-key). Set it in the calling service:
 
 ```text title=".env"
 RENDER_API_KEY=rnd_your_api_key
@@ -392,9 +392,9 @@ Returning the task run ID from a request handler lets the application respond wi
 ## Related
 
 - [Live demo](https://render-workflows-mastra.onrender.com)
-- [Render Workflows documentation](https://render.com/docs/workflows)
-- [Defining Render workflow tasks](https://render.com/docs/workflows-defining)
-- [Triggering task runs](https://render.com/docs/workflows-running)
-- [Render Workflows TypeScript SDK](https://render.com/docs/workflows-sdk-typescript)
-- [Render Workflows limits and pricing](https://render.com/docs/workflows-limits)
-- [Render cron jobs](https://render.com/docs/cronjobs)
+- [Render Workflows documentation](https://render.com/docs/workflows?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra)
+- [Defining Render workflow tasks](https://render.com/docs/workflows-defining?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra)
+- [Triggering task runs](https://render.com/docs/workflows-running?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra)
+- [Render Workflows TypeScript SDK](https://render.com/docs/workflows-sdk-typescript?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra)
+- [Render Workflows limits and pricing](https://render.com/docs/workflows-limits?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra)
+- [Render cron jobs](https://render.com/docs/cronjobs?utm_source=partner&utm_medium=partnerships&utm_campaign=2026_partnership_mastra)


### PR DESCRIPTION
## Summary
- Add partner UTM parameters to Render links on the Render deploy page.

## Test plan
- [ ] Confirm Render links on `/integrations/deploy/render` include the partner UTM parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Render links now include partner tracking information. This helps measure which links users follow without changing the deployment instructions.

## Changes

- Added partner UTM parameters to Render links on the Render deploy page.
- Updated links for introductory content, CLI instructions, dashboard instructions, API keys, and related resources.
- Kept the page behavior and deployment instructions unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->