### PR TITLE
docs(temporal): update worker setup guide

### DIFF
--- a/docs/src/content/en/integrations/deploy/temporal.mdx
+++ b/docs/src/content/en/integrations/deploy/temporal.mdx
@@ -1,15 +1,11 @@
 ---
-title: "Temporal | Deploy"
-description: "Deploy Mastra workflows with Temporal"
+title: 'Temporal | Deploy'
+description: 'Deploy Mastra workflows with Temporal'
 ---
 
 # Temporal
 
 [Temporal](https://temporal.io/) is a durable execution platform for orchestrating long-running, fault-tolerant workflows. The `@mastra/temporal` package lets you author workflows with the standard Mastra API and run them on a Temporal cluster.
-
-:::warning
-`@mastra/temporal` is experimental and not ready for production use. The API may change between releases. See the [package README](https://github.com/mastra-ai/mastra/tree/main/workflows/temporal) for the current state.
-:::
 
 ## How Temporal works with Mastra
 
@@ -126,11 +122,7 @@ const connection = await NativeConnection.connect({
   address: 'localhost:7233',
 })
 
-const mastraPlugin = new MastraPlugin()
-
-await mastraPlugin.prebuild({
-  entryFile: import.meta.resolve('./index.ts'),
-})
+const mastraPlugin = new MastraPlugin(import.meta.resolve('./index.ts'))
 
 const worker = await Worker.create({
   connection,
@@ -148,10 +140,11 @@ await worker.run()
 
 ### Running locally
 
-1. Start a local Temporal server. The simplest option is the `temporalio/auto-setup` Docker image:
+1. Start a local Temporal server. The simplest option is the `temporal dev server`
 
    ```bash
-   docker run --rm -p 7233:7233 -p 8080:8080 temporalio/auto-setup:latest
+   brew install temporal
+   temporal server start-dev --db-filename temporal.db
    ```
 
 1. Open the Temporal UI at [http://localhost:8080](http://localhost:8080) to inspect namespaces, workflows, and activities.

--- a/docs/src/content/en/integrations/deploy/temporal.mdx
+++ b/docs/src/content/en/integrations/deploy/temporal.mdx
@@ -25,7 +25,7 @@ Install the required packages:
 npm install @mastra/temporal@latest @temporalio/client @temporalio/worker @temporalio/envconfig
 ```
 
-You also need access to a Temporal cluster. For local development, you can run one with Docker (see [Running locally](#running-locally)).
+You also need access to a Temporal cluster. For local development, use the [Temporal CLI development server](https://docs.temporal.io/develop/run-a-development-server).
 
 ## Building a Temporal-backed workflow
 
@@ -140,7 +140,7 @@ await worker.run()
 
 ### Running locally
 
-1. Start a local Temporal server. The simplest option is the `temporal dev server`
+1. Start the local [Temporal CLI development server](https://docs.temporal.io/develop/run-a-development-server).
 
    ```bash
    brew install temporal

--- a/docs/src/content/en/integrations/deploy/temporal.mdx
+++ b/docs/src/content/en/integrations/deploy/temporal.mdx
@@ -112,7 +112,7 @@ export const mastra = new Mastra({
 
 ## Running the worker
 
-The worker is a long-lived Node.js process that polls a Temporal task queue. Install `MastraPlugin` and point its `src` option at the Mastra entry file that registers your workflows.
+The worker is a long-lived Node.js process that polls a Temporal task queue. Install `MastraPlugin` and pass it the path to the Mastra entry file that registers your workflows.
 
 ```ts title="src/mastra/worker.ts"
 import { MastraPlugin } from '@mastra/temporal/worker'

--- a/docs/src/content/en/integrations/deploy/temporal.mdx
+++ b/docs/src/content/en/integrations/deploy/temporal.mdx
@@ -146,7 +146,7 @@ await worker.run()
    temporal server start-dev --db-filename temporal.db
    ```
 
-1. Open the Temporal UI at [http://localhost:8080](http://localhost:8080) to inspect namespaces, workflows, and activities.
+1. Open the Temporal UI at [http://localhost:8233](http://localhost:8233) to inspect namespaces, workflows, and activities.
 
 1. In a new terminal, start the worker by running:
 

--- a/docs/src/content/en/integrations/deploy/temporal.mdx
+++ b/docs/src/content/en/integrations/deploy/temporal.mdx
@@ -140,10 +140,9 @@ await worker.run()
 
 ### Running locally
 
-1. Start the local [Temporal CLI development server](https://docs.temporal.io/develop/run-a-development-server).
+1. [Install the Temporal CLI](https://docs.temporal.io/cli/setup-cli), then start the local server:
 
    ```bash
-   brew install temporal
    temporal server start-dev --db-filename temporal.db
    ```
 


### PR DESCRIPTION
This is stacked on #22438. It updates the Temporal deployment guide to use automatic worker configuration, removes the outdated experimental warning, and documents starting a local server with the Temporal CLI.

```ts
const mastraPlugin = new MastraPlugin(import.meta.resolve("./index.ts"))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This update makes the Temporal deployment guide easier to follow. It shows automatic worker setup and explains how to run Temporal locally with the Temporal CLI.

## Changes

- Removed the outdated experimental warning.
- Simplified `MastraPlugin` setup:
  ```ts
  const mastraPlugin = new MastraPlugin(import.meta.resolve("./index.ts"))
  ```
- Replaced Docker instructions with Temporal CLI installation and startup commands.
- Added a link to the Temporal CLI installation instructions.
- Corrected the local Temporal development UI port.
- Updated frontmatter values to use single quotes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->