### PR TITLE
fix(factory): reorganize settings navigation

### DIFF
--- a/mastracode/factory-ui/src/hooks/useFactories.ts
+++ b/mastracode/factory-ui/src/hooks/useFactories.ts
@@ -84,7 +84,7 @@ export function useUnlinkRepositoryMutation() {
   });
 }
 
-export function useRemoveFactoryMutation() {
+export function useDeleteFactoryMutation() {
   const { baseUrl } = useApiConfig();
   const queryClient = useQueryClient();
   return useMutation({

--- a/mastracode/factory-ui/src/ui/domains/search/__tests__/GlobalSearch.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/search/__tests__/GlobalSearch.msw.test.tsx
@@ -351,7 +351,7 @@ describe('Global search', () => {
       'Rules',
       'Audit log',
       'Preferences',
-      'Factory',
+      'Manage Factory',
       'Connections',
       'Repositories',
       'Work Intake',

--- a/mastracode/factory-ui/src/ui/domains/settings/components/FactoryManagementSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/FactoryManagementSection.tsx
@@ -4,7 +4,7 @@ import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Trash2 } from 'lucide-react';
 import { useParams } from 'react-router';
 
-import { useFactoryQuery, useRemoveFactoryMutation } from '../../../../hooks/useFactories';
+import { useDeleteFactoryMutation, useFactoryQuery } from '../../../../hooks/useFactories';
 import { SettingsRow } from '@mastra/playground-ui/components/SettingsRow';
 import { SettingsCard } from './SettingsCard';
 import { SettingsSubsection } from './SettingsSubsection';
@@ -13,7 +13,7 @@ export function FactoryManagementSection() {
   const { factoryId } = useParams<{ factoryId: string }>();
   const factoryQuery = useFactoryQuery(factoryId);
   const factory = factoryQuery.data;
-  const removeMutation = useRemoveFactoryMutation();
+  const deleteMutation = useDeleteFactoryMutation();
 
   if (!factory) {
     return <Notice variant="info">Select a factory to manage its settings.</Notice>;
@@ -22,38 +22,38 @@ export function FactoryManagementSection() {
   return (
     <SettingsSubsection title="Danger zone">
       <SettingsCard>
-        <SettingsRow variant="factory" label={`Remove ${factory.name}`} description="Also unlinks its repositories.">
+        <SettingsRow variant="factory" label={`Delete ${factory.name}`} description="Also unlinks its repositories.">
           <AlertDialog>
             <AlertDialog.Trigger asChild>
               <Button
                 size="xs"
                 variant="outline"
                 className="text-notice-destructive border-notice-destructive/25 hover:bg-notice-destructive/10 hover:text-notice-destructive"
-                disabled={removeMutation.isPending}
-                aria-label={`Remove ${factory.name}`}
+                disabled={deleteMutation.isPending}
+                aria-label={`Delete ${factory.name}`}
               >
                 <Trash2 size={14} />
-                Remove
+                Delete
               </Button>
             </AlertDialog.Trigger>
             <AlertDialog.Content>
               <AlertDialog.Header>
-                <AlertDialog.Title>Remove {factory.name}?</AlertDialog.Title>
+                <AlertDialog.Title>Delete {factory.name}?</AlertDialog.Title>
                 <AlertDialog.Description>
                   This deletes the Factory and unlinks its repositories. It cannot be undone.
                 </AlertDialog.Description>
               </AlertDialog.Header>
               <AlertDialog.Footer>
                 <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-                <AlertDialog.Action onClick={() => removeMutation.mutate(factory.id)}>Remove</AlertDialog.Action>
+                <AlertDialog.Action onClick={() => deleteMutation.mutate(factory.id)}>Delete</AlertDialog.Action>
               </AlertDialog.Footer>
             </AlertDialog.Content>
           </AlertDialog>
         </SettingsRow>
-        {removeMutation.isError && (
+        {deleteMutation.isError && (
           <div className="p-4">
             <Notice variant="destructive">
-              {removeMutation.error instanceof Error ? removeMutation.error.message : 'Failed to remove factory'}
+              {deleteMutation.error instanceof Error ? deleteMutation.error.message : 'Failed to delete Factory'}
             </Notice>
           </div>
         )}

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsNavigation.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsNavigation.tsx
@@ -32,6 +32,7 @@ type SettingsNavItem = {
 type SettingsNavGroup = {
   id: string;
   label?: string;
+  ariaLabel?: string;
   items: SettingsNavItem[];
 };
 
@@ -110,6 +111,7 @@ const SETTINGS_GROUPS: SettingsNavGroup[] = [
   },
   {
     id: 'factory',
+    ariaLabel: SETTINGS_SECTION_LABELS.factory,
     items: [
       {
         id: 'factory',
@@ -169,7 +171,7 @@ export function SettingsNavigation() {
             <MainSidebar.NavSection
               key={group.id}
               aria-labelledby={headerId}
-              aria-label={headerId ? undefined : group.id}
+              aria-label={headerId ? undefined : (group.ariaLabel ?? group.id)}
             >
               {group.label && <MainSidebar.NavHeader id={headerId}>{group.label}</MainSidebar.NavHeader>}
               <MainSidebar.NavList>

--- a/mastracode/factory-ui/src/ui/domains/settings/components/SettingsNavigation.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/SettingsNavigation.tsx
@@ -51,36 +51,6 @@ const SETTINGS_GROUPS: SettingsNavGroup[] = [
         icon: Palette,
         searchText: 'preferences general theme appearance color scheme completion sound',
       },
-      {
-        id: 'factory',
-        label: SETTINGS_SECTION_LABELS.factory,
-        icon: Building2,
-        searchText: 'factory project organization remove delete danger',
-      },
-    ],
-  },
-  {
-    id: 'sources',
-    label: 'Sources',
-    items: [
-      {
-        id: 'repositories',
-        label: SETTINGS_SECTION_LABELS.repositories,
-        icon: GitBranch,
-        searchText: 'repositories source control git branches remotes code worktrees setup github',
-      },
-      {
-        id: 'intake',
-        label: SETTINGS_SECTION_LABELS.intake,
-        icon: Inbox,
-        searchText: 'work intake sources tasks issues pull requests github linear feed sync',
-      },
-      {
-        id: 'connections',
-        label: SETTINGS_SECTION_LABELS.connections,
-        icon: Cable,
-        searchText: 'connections connected accounts slack communication integrations',
-      },
     ],
   },
   {
@@ -111,6 +81,41 @@ const SETTINGS_GROUPS: SettingsNavGroup[] = [
         label: SETTINGS_SECTION_LABELS.behavior,
         icon: SlidersHorizontal,
         searchText: 'behavior auto approve tools smart editing notifications permissions read edit execute mcp',
+      },
+    ],
+  },
+  {
+    id: 'sources',
+    label: 'Sources',
+    items: [
+      {
+        id: 'repositories',
+        label: SETTINGS_SECTION_LABELS.repositories,
+        icon: GitBranch,
+        searchText: 'repositories source control git branches remotes code worktrees setup github',
+      },
+      {
+        id: 'intake',
+        label: SETTINGS_SECTION_LABELS.intake,
+        icon: Inbox,
+        searchText: 'work intake sources tasks issues pull requests github linear feed sync',
+      },
+      {
+        id: 'connections',
+        label: SETTINGS_SECTION_LABELS.connections,
+        icon: Cable,
+        searchText: 'connections connected accounts slack communication integrations',
+      },
+    ],
+  },
+  {
+    id: 'factory',
+    items: [
+      {
+        id: 'factory',
+        label: SETTINGS_SECTION_LABELS.factory,
+        icon: Building2,
+        searchText: 'factory project organization manage remove delete danger',
       },
     ],
   },

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsNavigation.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsNavigation.msw.test.tsx
@@ -33,9 +33,26 @@ describe('SettingsNavigation', () => {
     );
   });
 
-  it('separates code repositories, work intake, and agent settings into named groups', () => {
+  it('orders personal, agent, source, and Factory management settings by task', () => {
     renderNavigation();
-    expect(screen.getByRole('link', { name: 'Factory' })).toHaveAttribute('href', '/factories/fp-1/settings/factory');
+
+    expect(screen.getByRole('link', { name: 'Manage Factory' })).toHaveAttribute(
+      'href',
+      '/factories/fp-1/settings/factory',
+    );
+
+    expect(screen.getAllByRole('link').map(link => link.textContent)).toEqual([
+      'My account',
+      'Preferences',
+      'Models',
+      'Memory',
+      'Skills',
+      'Behavior',
+      'Repositories',
+      'Work Intake',
+      'Connections',
+      'Manage Factory',
+    ]);
 
     const sources = screen.getByRole('region', { name: 'Sources' });
     expect(within(sources).getByRole('link', { name: 'Connections' })).toHaveAttribute(

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsNavigation.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/SettingsNavigation.msw.test.tsx
@@ -40,6 +40,7 @@ describe('SettingsNavigation', () => {
       'href',
       '/factories/fp-1/settings/factory',
     );
+    expect(screen.getByRole('region', { name: 'Manage Factory' })).toBeInTheDocument();
 
     expect(screen.getAllByRole('link').map(link => link.textContent)).toEqual([
       'My account',

--- a/mastracode/factory-ui/src/ui/domains/settings/settingsSections.ts
+++ b/mastracode/factory-ui/src/ui/domains/settings/settingsSections.ts
@@ -13,7 +13,7 @@ export type SettingsSection =
 export const SETTINGS_SECTION_LABELS: Record<SettingsSection, string> = {
   account: 'My account',
   preferences: 'Preferences',
-  factory: 'Factory',
+  factory: 'Manage Factory',
   connections: 'Connections',
   repositories: 'Repositories',
   intake: 'Work Intake',


### PR DESCRIPTION
TLDR: settings now lead from the agent to its sources, while destructive Factory management sits last and says exactly what it deletes.

---

```
before   personal settings + Factory / Sources / Agent
after    personal settings / Agent / Sources / Manage Factory
```

Models, memory, skills, and behavior define how the agent works. Repositories, intake, and connections feed it, so that order is easier to scan.

The old Factory page only contained the irreversible action, but it sat beside My account and Preferences. It now has its own final section, and Remove is Delete throughout because the backend deletes the Factory.

### Judgment call

I kept Sources, Work Intake, and the existing order inside Agent. Those labels still match their pages; changing them here would turn an ordering fix into a taxonomy rewrite.

### Not verified

I could not capture a logged-in screenshot. The isolated browser reached sign-in, and the local Chrome harness could not attach to the authenticated profile.

```
source     +49  -42
tests      +21   -3
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The settings menu now uses a clearer order. Factory management appears last because it includes destructive actions, which now use “Delete” to match their behavior.

## Changes

- Reordered settings into Personal, Agent, Sources, and Manage Factory sections.
- Moved Factory management into a separate final section.
- Added an accessible name for the Factory navigation group.
- Renamed `useRemoveFactoryMutation` to `useDeleteFactoryMutation`.
- Updated Factory management labels, buttons, dialogs, pending states, and errors from “Remove” to “Delete”.
- Renamed the Factory section label to “Manage Factory”.
- Updated navigation and global search tests.
- Added an exact navigation link-order assertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->