### PR TITLE
fix(docs): render workflow Mermaid diagrams

### DIFF
--- a/docs/src/content/en/docs/workflows/human-in-the-loop.mdx
+++ b/docs/src/content/en/docs/workflows/human-in-the-loop.mdx
@@ -112,7 +112,8 @@ As with [restarting a workflow](/docs/workflows/suspend-and-resume#restarting-a-
 flowchart LR
   accTitle: Resuming a workflow with human input
   accDescr: Human input resumes step1. The step then completes the workflow.
-  paused@{ shape: manual-input, label: "human input" } pending1@-. resume .-> step1([step1])
+  paused@{ shape: manual-input, label: "human input" }
+  paused pending1@-. resume .-> step1([step1])
   step1 -- out --> stop(( end ))
 
   class paused pending

--- a/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
+++ b/docs/src/content/en/docs/workflows/suspend-and-resume.mdx
@@ -75,7 +75,8 @@ Use `resume()` to restart a suspended workflow from the step where it paused. Pa
 flowchart LR
   accTitle: Resuming a workflow from a saved snapshot
   accDescr: Resume restores the saved snapshot and restarts step1. The step then completes the workflow.
-  snapshot@{ shape: cyl, label: "saved snapshot" } pending1@-. resume .-> step1([step1])
+  snapshot@{ shape: cyl, label: "saved snapshot" }
+  snapshot pending1@-. resume .-> step1([step1])
   step1 -- out --> stop(( end ))
 
   class snapshot pending


### PR DESCRIPTION
Fixes two workflow diagrams that failed to render because Mermaid could not parse a shaped node declaration and a named edge on the same line.

The node declarations and `resume` edges are now separate statements in the suspend-and-resume and human-in-the-loop guides.

Checked all six Mermaid diagrams on the local docs server. Each renders as an SVG without a Mermaid error boundary or parse error. MDX formatting, Remark lint, and the full docs build also pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The diagrams now use a format that Mermaid can read correctly. The workflow behavior does not change.

## Changes

- Updated the suspend-and-resume guide.
- Updated the human-in-the-loop guide.
- Separated shaped node declarations from named `resume` edges.

## Validation

- Verified all six Mermaid diagrams on the local docs server.
- Rendered all diagrams as SVGs without errors.
- Passed MDX formatting, Remark lint, and the full docs build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->