### PR TITLE
Search the spans of a trace from the timeline in Studio

### DIFF
--- a/.changeset/large-words-refuse.md
+++ b/.changeset/large-words-refuse.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added a search field to the trace timeline in Studio. Type in it to narrow a trace down to the spans you care about: it matches on span name, span type, entity name, input preview, trace ID and span ID, all case-insensitively.
+
+A matching span is never shown out of context. Its full parent chain stays visible so you can see where it sits in the trace, and its own children stay visible too, so searching for a tool call still shows you what that tool call did. Clearing the field restores the whole trace.

--- a/.changeset/large-words-refuse.md
+++ b/.changeset/large-words-refuse.md
@@ -2,6 +2,10 @@
 '@mastra/playground-ui': patch
 ---
 
-Added a search field to the trace timeline in Studio. Type in it to narrow a trace down to the spans you care about: it matches on span name, span type, entity name, input preview, trace ID and span ID, all case-insensitively.
+Search the spans of a trace from the timeline in Studio
 
-A matching span is never shown out of context. Its full parent chain stays visible so you can see where it sits in the trace, and its own children stay visible too, so searching for a tool call still shows you what that tool call did. Clearing the field restores the whole trace.
+A long trace made you scroll to find the one span you cared about. The trace timeline now has a search field, sitting on the left of the span type legend. Type in it and the timeline narrows to the matching spans.
+
+Matching runs over the whole span payload, not a fixed list of fields, so a span is reachable by anything it carries: a tool argument, a model name, an error message, or a value nested deep in its metadata. Field names are searchable too, so you can look for the shape of a payload and not only its content. Matching is case-insensitive, and the work of flattening each span happens once when the trace loads rather than on every keystroke.
+
+A matching span is never shown out of context. Its full parent chain stays visible so you can see where it sits in the trace, and its own subtree stays visible too, so searching for a tool call still shows you what that tool call did. The field keeps working whatever order the spans arrive in, a query that matches nothing leaves the field in place so you can undo it, and clearing the field restores the whole trace.

--- a/.changeset/olive-pugs-shake.md
+++ b/.changeset/olive-pugs-shake.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Search trace spans on their whole payload instead of six hardcoded fields
+
+Searching a trace timeline only looked at `name`, `spanType`, `entityName`, `inputPreview`, `traceId` and `spanId`, so a span was unreachable by anything stored in its open-ended `metadata` — a tool argument, a model name, an error message. Each span now carries a `searchText` haystack, flattened once when the trace resolves rather than rebuilt on every keystroke, and the filter matches against it. Nested values and their keys are both included, so a payload's shape is searchable too.

--- a/.changeset/olive-pugs-shake.md
+++ b/.changeset/olive-pugs-shake.md
@@ -1,7 +1,0 @@
----
-'@mastra/playground-ui': patch
----
-
-Search trace spans on their whole payload instead of six hardcoded fields
-
-Searching a trace timeline only looked at `name`, `spanType`, `entityName`, `inputPreview`, `traceId` and `spanId`, so a span was unreachable by anything stored in its open-ended `metadata` — a tool argument, a model name, an error message. Each span now carries a `searchText` haystack, flattened once when the trace resolves rather than rebuilt on every keystroke, and the filter matches against it. Nested values and their keys are both included, so a payload's shape is searchable too.

--- a/.changeset/tidy-jars-smile.md
+++ b/.changeset/tidy-jars-smile.md
@@ -1,7 +1,0 @@
----
-'@mastra/playground-ui': patch
----
-
-Align the trace span search field with the span type legend
-
-The search field took a row of its own directly above the timeline, leaving the legend row half empty. `TraceTimeline` now takes a `leadingSlot` rendered on the left of that legend row, and the trace panel puts the search field there. The legend row is kept alive by the slot alone, so a query matching nothing no longer unmounts the field along with the timeline.

--- a/.changeset/tidy-jars-smile.md
+++ b/.changeset/tidy-jars-smile.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Align the trace span search field with the span type legend
+
+The search field took a row of its own directly above the timeline, leaving the legend row half empty. `TraceTimeline` now takes a `leadingSlot` rendered on the left of that legend row, and the trace panel puts the search field there. The legend row is kept alive by the slot alone, so a query matching nothing no longer unmounts the field along with the timeline.

--- a/packages/playground-ui/src/domains/traces/components/__tests__/fixtures/trace-data-panel-view.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/fixtures/trace-data-panel-view.ts
@@ -1,6 +1,9 @@
 import type { MastraClient } from '@mastra/client-js';
 import { SpanType } from '@mastra/core/observability';
 
+import type { SearchableSpan } from '../../../types';
+import { toSearchableSpans } from '../../../utils';
+
 // Bind the fixture to the live wire contract: the trace panel renders the
 // lightweight spans returned by `client.getTraceLight`, so we derive the span
 // shape from the client method rather than the component prop type.
@@ -32,9 +35,12 @@ const childSpan: TraceSpan = {
   spanType: SpanType.TOOL_CALL,
 };
 
-export const rootSpanFixture: TraceSpan[] = [rootSpan];
+// The panel receives spans already enriched, exactly as the query hooks deliver
+// them: `useTraceLightSpans` and `useBranch` run `selectSearchableSpans` on
+// resolution. Building the fixtures the same way keeps them faithful to that.
+export const rootSpanFixture: SearchableSpan[] = toSearchableSpans([rootSpan]);
 
-export const nestedSpanFixture: TraceSpan[] = [rootSpan, childSpan];
+export const nestedSpanFixture: SearchableSpan[] = toSearchableSpans([rootSpan, childSpan]);
 
 // A four-level, two-branch trace used by the span-search suite. Every span
 // carries a distinct value on a different searchable field so a test can aim at
@@ -60,7 +66,7 @@ const deepSpan = (
   ...extra,
 });
 
-export const deepTraceFixture: TraceSpan[] = [
+export const deepTraceFixture: SearchableSpan[] = toSearchableSpans([
   // `entityId` makes the root's identity render in the trace header, which the
   // non-regression test reads to prove the header ignores the search filter.
   deepSpan('root', null, 'agent run', SpanType.AGENT_RUN, 0, {
@@ -72,8 +78,12 @@ export const deepTraceFixture: TraceSpan[] = [
   deepSpan('http-1', 'tool-1', 'http fetch', SpanType.TOOL_CALL, 30, {
     inputPreview: 'https://api.weather.test/lyon',
   }),
-  deepSpan('mem-1', 'gen-1', 'memory lookup', SpanType.MEMORY_OPERATION, 40),
+  // `metadata` is an open-ended payload: no fixed list of fields can read it, so
+  // it is only reachable through the flattened `searchText`.
+  deepSpan('mem-1', 'gen-1', 'memory lookup', SpanType.MEMORY_OPERATION, 40, {
+    metadata: { store: { vendor: 'pgvector' } },
+  }),
   deepSpan('wf-1', 'root', 'workflow run', SpanType.WORKFLOW_RUN, 50, { entityName: 'report-workflow' }),
   deepSpan('step-1', 'wf-1', 'step normalize', SpanType.WORKFLOW_STEP, 60),
   deepSpan('gen-2', 'wf-1', 'llm generation', SpanType.MODEL_GENERATION, 70, { entityName: 'summarizer' }),
-];
+]);

--- a/packages/playground-ui/src/domains/traces/components/__tests__/fixtures/trace-data-panel-view.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/fixtures/trace-data-panel-view.ts
@@ -35,3 +35,45 @@ const childSpan: TraceSpan = {
 export const rootSpanFixture: TraceSpan[] = [rootSpan];
 
 export const nestedSpanFixture: TraceSpan[] = [rootSpan, childSpan];
+
+// A four-level, two-branch trace used by the span-search suite. Every span
+// carries a distinct value on a different searchable field so a test can aim at
+// one row precisely: `http-1` is only reachable through its `inputPreview`,
+// `mem-1` is the only `memory_operation`, and `llm generation` appears on both
+// branches so a query can match across them.
+const deepSpan = (
+  spanId: string,
+  parentSpanId: string | null,
+  name: string,
+  spanType: SpanType,
+  offsetMs: number,
+  extra: Partial<TraceSpan> = {},
+): TraceSpan => ({
+  ...rootSpan,
+  spanId,
+  parentSpanId,
+  name,
+  spanType,
+  // Strictly increasing in tree order so `formatHierarchicalSpans` sorts
+  // deterministically.
+  startedAt: new Date(new Date('2026-06-01T10:00:00.000Z').getTime() + offsetMs),
+  ...extra,
+});
+
+export const deepTraceFixture: TraceSpan[] = [
+  // `entityId` makes the root's identity render in the trace header, which the
+  // non-regression test reads to prove the header ignores the search filter.
+  deepSpan('root', null, 'agent run', SpanType.AGENT_RUN, 0, {
+    entityId: 'weather-agent',
+    entityName: 'weather-agent',
+  }),
+  deepSpan('gen-1', 'root', 'llm generation', SpanType.MODEL_GENERATION, 10, { entityName: 'weather-agent' }),
+  deepSpan('tool-1', 'gen-1', 'weather tool', SpanType.TOOL_CALL, 20, { inputPreview: '{"city":"Lyon"}' }),
+  deepSpan('http-1', 'tool-1', 'http fetch', SpanType.TOOL_CALL, 30, {
+    inputPreview: 'https://api.weather.test/lyon',
+  }),
+  deepSpan('mem-1', 'gen-1', 'memory lookup', SpanType.MEMORY_OPERATION, 40),
+  deepSpan('wf-1', 'root', 'workflow run', SpanType.WORKFLOW_RUN, 50, { entityName: 'report-workflow' }),
+  deepSpan('step-1', 'wf-1', 'step normalize', SpanType.WORKFLOW_STEP, 60),
+  deepSpan('gen-2', 'wf-1', 'llm generation', SpanType.MODEL_GENERATION, 70, { entityName: 'summarizer' }),
+];

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -8,7 +8,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest
 
 import { TraceDataPanelView } from '../trace-data-panel-view';
 import type { TraceDataPanelViewProps } from '../trace-data-panel-view';
-import { nestedSpanFixture, rootSpanFixture } from './fixtures/trace-data-panel-view';
+import { deepTraceFixture, nestedSpanFixture, rootSpanFixture } from './fixtures/trace-data-panel-view';
 
 const baseProps: TraceDataPanelViewProps = {
   traceId: 'trace-1',
@@ -793,5 +793,184 @@ describe('TraceDataPanelView — how wide the timing chart sits', () => {
     const wide = render(<TraceDataPanelView {...baseProps} timelineChartWidth="wide" />);
     expect(wide.container.querySelector('.min-w-72')).not.toBeNull();
     expect(wide.container.querySelector('.min-w-32')).toBeNull();
+  });
+});
+
+describe('TraceDataPanelView — span search', () => {
+  const searchField = () => screen.getByRole('textbox', { name: /search spans/i }) as HTMLInputElement;
+
+  const typeSearch = (value: string) => {
+    fireEvent.change(searchField(), { target: { value } });
+  };
+
+  // Reads the timeline rows in DOM order, so a test can assert both which spans
+  // survived the filter and that a parent still precedes its child.
+  const visibleSpanNames = () =>
+    Array.from(document.querySelectorAll('[aria-label^="View details for span "]')).map(node =>
+      (node.getAttribute('aria-label') ?? '').replace('View details for span ', ''),
+    );
+
+  it('renders the search field when the trace has spans', () => {
+    render(<TraceDataPanelView {...baseProps} spans={deepTraceFixture} />);
+
+    expect(searchField()).toBeTruthy();
+  });
+
+  it('renders no search field when the trace has no spans', () => {
+    render(<TraceDataPanelView {...baseProps} spans={[]} />);
+
+    expect(screen.getByText(/no spans found for this trace/i)).toBeTruthy();
+    expect(screen.queryByRole('textbox', { name: /search spans/i })).toBeNull();
+  });
+
+  const renderDeep = (props: Partial<TraceDataPanelViewProps> = {}) =>
+    render(<TraceDataPanelView {...baseProps} spans={deepTraceFixture} {...props} />);
+
+  const allNames = [
+    'agent run',
+    'llm generation',
+    'weather tool',
+    'http fetch',
+    'memory lookup',
+    'workflow run',
+    'step normalize',
+    'llm generation',
+  ];
+
+  const weatherBranch = ['agent run', 'llm generation', 'weather tool', 'http fetch'];
+
+  it('keeps the whole ancestor chain when a leaf matches by name', async () => {
+    renderDeep();
+
+    typeSearch('http fetch');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(weatherBranch));
+  });
+
+  it('keeps the ancestor chain when a leaf matches on metadata only', async () => {
+    renderDeep();
+
+    typeSearch('api.weather.test');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(weatherBranch));
+  });
+
+  it('keeps both the ancestors and the subtree of a matching middle span', async () => {
+    renderDeep();
+
+    typeSearch('weather tool');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(weatherBranch));
+  });
+
+  it('expands the subtree of a middle span matched on metadata only', async () => {
+    renderDeep();
+
+    typeSearch('Lyon');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(weatherBranch));
+  });
+
+  it('keeps the entire trace when the root matches', async () => {
+    renderDeep();
+
+    typeSearch('agent run');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(allNames));
+  });
+
+  it('keeps both ancestor chains when a query matches spans on two branches', async () => {
+    renderDeep();
+
+    typeSearch('llm generation');
+
+    await waitFor(() =>
+      expect(visibleSpanNames()).toEqual([
+        'agent run',
+        'llm generation',
+        'weather tool',
+        'http fetch',
+        'memory lookup',
+        'workflow run',
+        'llm generation',
+      ]),
+    );
+  });
+
+  it('matches on span type', async () => {
+    renderDeep();
+
+    typeSearch('memory_operation');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(['agent run', 'llm generation', 'memory lookup']));
+  });
+
+  it('matches on spanId', async () => {
+    renderDeep();
+
+    typeSearch('step-1');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(['agent run', 'workflow run', 'step normalize']));
+  });
+
+  it('matches case-insensitively', async () => {
+    renderDeep();
+
+    typeSearch('WEATHER TOOL');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(weatherBranch));
+  });
+
+  it('treats a whitespace-only query as empty', async () => {
+    renderDeep();
+
+    typeSearch('   ');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(allNames));
+  });
+
+  it('keeps the search field mounted when nothing matches', async () => {
+    renderDeep();
+
+    typeSearch('zzz-nothing');
+
+    await waitFor(() => expect(screen.getByText(/no spans match your search/i)).toBeTruthy());
+    expect(visibleSpanNames()).toEqual([]);
+    // The field must survive a zero-result query, or the user could never undo it.
+    expect(searchField().value).toBe('zzz-nothing');
+  });
+
+  it('restores the full trace when the query is cleared', async () => {
+    renderDeep();
+
+    typeSearch('http fetch');
+    await waitFor(() => expect(visibleSpanNames()).toEqual(weatherBranch));
+
+    fireEvent.click(screen.getByRole('button', { name: /clear search/i }));
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(allNames));
+    expect(searchField().value).toBe('');
+  });
+
+  it('keeps the trace header on the unfiltered root while a query is active', async () => {
+    renderDeep();
+
+    // A zero-result query empties the filtered list entirely, so the header can
+    // only still name the root if it reads the unfiltered spans.
+    typeSearch('zzz-nothing');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual([]));
+    expect(screen.getAllByText(/weather-agent/i).length).toBeGreaterThan(0);
+  });
+
+  it('keeps the anchor span as the displayed root when filtering a branch subtree', async () => {
+    // A branch subtree is what `getBranch` returns: the anchor plus its
+    // descendants, without the trace root.
+    const branch = deepTraceFixture.filter(span => ['gen-1', 'tool-1', 'http-1', 'mem-1'].includes(span.spanId));
+    render(<TraceDataPanelView {...baseProps} spans={branch} anchorSpanId="gen-1" />);
+
+    typeSearch('Lyon');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(['llm generation', 'weather tool', 'http fetch']));
   });
 });

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -847,12 +847,28 @@ describe('TraceDataPanelView — span search', () => {
     await waitFor(() => expect(visibleSpanNames()).toEqual(weatherBranch));
   });
 
-  it('keeps the ancestor chain when a leaf matches on metadata only', async () => {
+  it('keeps the ancestor chain when a leaf matches on its input preview only', async () => {
     renderDeep();
 
     typeSearch('api.weather.test');
 
     await waitFor(() => expect(visibleSpanNames()).toEqual(weatherBranch));
+  });
+
+  it('matches on a nested metadata value, which no fixed field list reaches', async () => {
+    renderDeep();
+
+    typeSearch('pgvector');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(['agent run', 'llm generation', 'memory lookup']));
+  });
+
+  it('matches on a metadata key, so a payload shape is searchable', async () => {
+    renderDeep();
+
+    typeSearch('vendor');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(['agent run', 'llm generation', 'memory lookup']));
   });
 
   it('keeps both the ancestors and the subtree of a matching middle span', async () => {

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -966,6 +966,16 @@ describe('TraceDataPanelView — span search', () => {
     expect(searchField().value).toBe('zzz-nothing');
   });
 
+  it('sits on the same row as the span type legend', () => {
+    renderDeep();
+
+    // The legend is right-aligned on its own row; the search field fills the
+    // empty left half of that row rather than taking a row of its own.
+    const legendRow = screen.getByText('Tool').closest('div')?.parentElement;
+
+    expect(legendRow?.contains(searchField())).toBe(true);
+  });
+
   it('restores the full trace when the query is cleared', async () => {
     renderDeep();
 

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -863,6 +863,16 @@ describe('TraceDataPanelView — span search', () => {
     await waitFor(() => expect(visibleSpanNames()).toEqual(weatherBranch));
   });
 
+  it('renders the same branch when the trace arrives newest-first', async () => {
+    // The trace list API defaults to `direction: 'DESC'`. The hierarchy
+    // formatter re-sorts by `startedAt`, so the rows must come out identical.
+    renderDeep({ spans: [...deepTraceFixture].reverse() });
+
+    typeSearch('weather tool');
+
+    await waitFor(() => expect(visibleSpanNames()).toEqual(weatherBranch));
+  });
+
   it('expands the subtree of a middle span matched on metadata only', async () => {
     renderDeep();
 

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -1,4 +1,3 @@
-import type { LightSpanRecord } from '@mastra/core/storage';
 import {
   CircleGaugeIcon,
   ChevronsDownUpIcon,
@@ -15,6 +14,7 @@ import { getAllSpanIds } from '../hooks/get-all-span-ids';
 import { useDownloadTraceJson } from '../hooks/use-download-trace-json';
 import { useTraceSearch } from '../hooks/use-trace-search';
 import type { TraceUsageSummary } from '../trace-list-columns';
+import type { SearchableSpan } from '../types';
 import { formatHierarchicalSpans } from './format-hierarchical-spans';
 import { TraceKeysAndValues } from './trace-keys-and-values';
 import { TraceTimeline } from './trace-timeline';
@@ -34,7 +34,7 @@ export type TraceDataPanelTab = 'details' | 'scores' | 'feedback';
 export interface TraceDataPanelViewProps {
   traceId: string;
   /** Lightweight spans for the trace. Caller fetches via useTraceLightSpans. */
-  spans: LightSpanRecord[] | undefined;
+  spans: SearchableSpan[] | undefined;
   /**
    * Token and estimated-cost totals for the trace (from `useTraceUsage`).
    * Rendered in the trace summary when the panel is in the list side-panel

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -304,31 +304,33 @@ export function TraceDataPanelView({
                         </Notice>
                       )}
 
-                    <SearchFieldBlock
-                      name={searchFieldName}
-                      label="Search spans"
-                      labelIsHidden
-                      placeholder="Search spans..."
-                      value={query}
-                      onChange={e => setQuery(e.target.value)}
-                      onReset={() => setQuery('')}
-                      size="sm"
-                      variant="outline"
-                      className="mb-3 max-w-80"
+                    {/* The timeline stays mounted even with no results, because it
+                        hosts the search field: unmounting it would strand the user
+                        with a query they can no longer clear. */}
+                    <TraceTimeline
+                      hierarchicalSpans={hierarchicalSpans}
+                      onSpanClick={handleSpanClick}
+                      selectedSpanId={selectedSpanId}
+                      expandedSpanIds={expandedSpanIds}
+                      setExpandedSpanIds={setExpandedSpanIds}
+                      chartWidth={timelineChartWidth}
+                      leadingSlot={
+                        <SearchFieldBlock
+                          name={searchFieldName}
+                          label="Search spans"
+                          labelIsHidden
+                          placeholder="Search spans..."
+                          value={query}
+                          onChange={e => setQuery(e.target.value)}
+                          onReset={() => setQuery('')}
+                          size="sm"
+                          variant="outline"
+                          className="w-80"
+                        />
+                      }
                     />
 
-                    {hierarchicalSpans.length === 0 ? (
-                      <DataPanel.NoData>No spans match your search.</DataPanel.NoData>
-                    ) : (
-                      <TraceTimeline
-                        hierarchicalSpans={hierarchicalSpans}
-                        onSpanClick={handleSpanClick}
-                        selectedSpanId={selectedSpanId}
-                        expandedSpanIds={expandedSpanIds}
-                        setExpandedSpanIds={setExpandedSpanIds}
-                        chartWidth={timelineChartWidth}
-                      />
-                    )}
+                    {hierarchicalSpans.length === 0 && <DataPanel.NoData>No spans match your search.</DataPanel.NoData>}
                   </>
                 );
 

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -9,10 +9,11 @@ import {
   SaveIcon,
   WrenchIcon,
 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { getAllSpanIds } from '../hooks/get-all-span-ids';
 import { useDownloadTraceJson } from '../hooks/use-download-trace-json';
+import { useTraceSearch } from '../hooks/use-trace-search';
 import type { TraceUsageSummary } from '../trace-list-columns';
 import { formatHierarchicalSpans } from './format-hierarchical-spans';
 import { TraceKeysAndValues } from './trace-keys-and-values';
@@ -20,6 +21,7 @@ import { TraceTimeline } from './trace-timeline';
 import { Button } from '@/ds/components/Button';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 import { DataPanel } from '@/ds/components/DataPanel';
+import { SearchFieldBlock } from '@/ds/components/FormFieldBlocks';
 import { Notice } from '@/ds/components/Notice';
 import { Tab, TabContent, TabList, Tabs } from '@/ds/components/Tabs';
 import type { LinkComponent } from '@/ds/types/link-component';
@@ -159,7 +161,10 @@ export function TraceDataPanelView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialSpanId, spans, isLoading]);
 
-  const hierarchicalSpans = useMemo(() => formatHierarchicalSpans(spans ?? [], anchorSpanId), [spans, anchorSpanId]);
+  const searchFieldName = useId();
+  const { query, setQuery, results } = useTraceSearch(spans ?? []);
+
+  const hierarchicalSpans = useMemo(() => formatHierarchicalSpans(results, anchorSpanId), [results, anchorSpanId]);
 
   const [expandedSpanIds, setExpandedSpanIds] = useState<string[]>([]);
 
@@ -275,7 +280,7 @@ export function TraceDataPanelView({
         <SplitWithSpanPanel spanPanelSlot={spanPanelSlot}>
           {isLoading ? (
             <DataPanel.LoadingData>Loading trace...</DataPanel.LoadingData>
-          ) : hierarchicalSpans.length === 0 ? (
+          ) : !spans?.length ? (
             <DataPanel.NoData>No spans found for this trace.</DataPanel.NoData>
           ) : (
             <DataPanel.Content>
@@ -299,14 +304,31 @@ export function TraceDataPanelView({
                         </Notice>
                       )}
 
-                    <TraceTimeline
-                      hierarchicalSpans={hierarchicalSpans}
-                      onSpanClick={handleSpanClick}
-                      selectedSpanId={selectedSpanId}
-                      expandedSpanIds={expandedSpanIds}
-                      setExpandedSpanIds={setExpandedSpanIds}
-                      chartWidth={timelineChartWidth}
+                    <SearchFieldBlock
+                      name={searchFieldName}
+                      label="Search spans"
+                      labelIsHidden
+                      placeholder="Search spans..."
+                      value={query}
+                      onChange={e => setQuery(e.target.value)}
+                      onReset={() => setQuery('')}
+                      size="sm"
+                      variant="outline"
+                      className="mb-3 max-w-80"
                     />
+
+                    {hierarchicalSpans.length === 0 ? (
+                      <DataPanel.NoData>No spans match your search.</DataPanel.NoData>
+                    ) : (
+                      <TraceTimeline
+                        hierarchicalSpans={hierarchicalSpans}
+                        onSpanClick={handleSpanClick}
+                        selectedSpanId={selectedSpanId}
+                        expandedSpanIds={expandedSpanIds}
+                        setExpandedSpanIds={setExpandedSpanIds}
+                        chartWidth={timelineChartWidth}
+                      />
+                    )}
                   </>
                 );
 

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -325,7 +325,7 @@ export function TraceDataPanelView({
                           onReset={() => setQuery('')}
                           size="sm"
                           variant="outline"
-                          className="w-80"
+                          className="w-full"
                         />
                       }
                     />

--- a/packages/playground-ui/src/domains/traces/components/trace-timeline.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-timeline.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from 'react';
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import { useMemo } from 'react';
 import type { UISpan } from '../types';
 import { spanTypePrefixes, getSpanTypeUi } from './shared';
@@ -16,6 +16,8 @@ type TraceTimelineProps = {
   setExpandedSpanIds?: Dispatch<SetStateAction<string[]>>;
   featuredSpanIds?: string[];
   chartWidth?: 'wide' | 'default';
+  /** Rendered on the left of the span type legend row. */
+  leadingSlot?: ReactNode;
 };
 
 export function TraceTimeline({
@@ -28,6 +30,7 @@ export function TraceTimeline({
   setExpandedSpanIds,
   featuredSpanIds,
   chartWidth = 'default',
+  leadingSlot,
 }: TraceTimelineProps) {
   const overallLatency = hierarchicalSpans?.[0]?.latency || 0;
   const overallStartTime = hierarchicalSpans?.[0]?.startTime || '';
@@ -64,8 +67,11 @@ export function TraceTimeline({
         </div>
       ) : (
         <>
-          {usedSpanTypes.length > 0 && (
-            <div className="flex flex-wrap justify-end gap-3 px-2 py-1.5">
+          {(usedSpanTypes.length > 0 || leadingSlot) && (
+            <div className="flex flex-wrap items-center justify-end gap-3 px-2 py-1.5">
+              {/* `mr-auto` pins the slot left while the legend stays right, so the
+                  row survives a legend that renders nothing. */}
+              {leadingSlot && <div className="mr-auto">{leadingSlot}</div>}
               {usedSpanTypes.map(type => {
                 const spanUI = getSpanTypeUi(type);
                 return (

--- a/packages/playground-ui/src/domains/traces/components/trace-timeline.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-timeline.tsx
@@ -69,13 +69,14 @@ export function TraceTimeline({
         <>
           {(usedSpanTypes.length > 0 || leadingSlot) && (
             <div className="flex flex-wrap items-center justify-end gap-3 px-2 py-1.5">
-              {/* `mr-auto` pins the slot left while the legend stays right, so the
-                  row survives a legend that renders nothing. */}
-              {leadingSlot && <div className="mr-auto">{leadingSlot}</div>}
+              {/* The slot takes the leftover width and is the only thing allowed to
+                  shrink, so the legend never compresses or wraps. `min-w-0` lets it
+                  shrink past its content width instead of pushing the legend down. */}
+              {leadingSlot && <div className="min-w-0 flex-1">{leadingSlot}</div>}
               {usedSpanTypes.map(type => {
                 const spanUI = getSpanTypeUi(type);
                 return (
-                  <div key={type} className="text-ui-sm text-neutral3 flex items-center gap-1">
+                  <div key={type} className="text-ui-sm text-neutral3 flex shrink-0 items-center gap-1">
                     <span
                       className="inline-block size-1.5 shrink-0 rounded-full"
                       style={{ backgroundColor: spanUI?.color }}

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-search.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-search.test.tsx
@@ -4,16 +4,19 @@ import type { LightSpanRecord } from '@mastra/core/storage';
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
+import type { SearchableSpan } from '../../types';
+import { toSearchableSpans } from '../../utils';
 import { useTraceSearch } from '../use-trace-search';
 
 const timestamp = new Date('2026-06-10T00:00:00.000Z');
 
+/** Spans reach the hook already enriched, exactly as the query hooks deliver them. */
 function makeSpan(
   spanId: string,
   parentSpanId: string | null,
   overrides: Partial<LightSpanRecord> = {},
-): LightSpanRecord {
-  return {
+): SearchableSpan {
+  const span: LightSpanRecord = {
     traceId: 'trace-1',
     spanId,
     parentSpanId,
@@ -26,9 +29,14 @@ function makeSpan(
     updatedAt: timestamp,
     ...overrides,
   };
+
+  const [searchable] = toSearchableSpans([span]);
+  if (!searchable) throw new Error('toSearchableSpans dropped the span');
+
+  return searchable;
 }
 
-const ids = (spans: LightSpanRecord[]) => spans.map(span => span.spanId);
+const ids = (spans: SearchableSpan[]) => spans.map(span => span.spanId);
 
 describe('useTraceSearch', () => {
   it('returns the input array by reference when the query is empty', () => {
@@ -139,6 +147,61 @@ describe('useTraceSearch', () => {
     act(() => result.current.setQuery('needle'));
 
     expect(new Set(ids(result.current.results))).toEqual(new Set(['root', 'mid', 'leaf']));
+  });
+
+  describe('the open-ended payloads no fixed field list can reach', () => {
+    it('matches on a metadata value', () => {
+      const spans = [makeSpan('a', null, { metadata: { city: 'Lyon' } }), makeSpan('b', null)];
+      const { result } = renderHook(() => useTraceSearch(spans));
+
+      act(() => result.current.setQuery('lyon'));
+
+      expect(ids(result.current.results)).toEqual(['a']);
+    });
+
+    it('matches on a metadata value nested several levels deep', () => {
+      const spans = [
+        makeSpan('a', null, { metadata: { request: { location: { city: 'Lyon' } } } }),
+        makeSpan('b', null),
+      ];
+      const { result } = renderHook(() => useTraceSearch(spans));
+
+      act(() => result.current.setQuery('lyon'));
+
+      expect(ids(result.current.results)).toEqual(['a']);
+    });
+
+    it('matches on a metadata key, so a payload shape is searchable', () => {
+      const spans = [makeSpan('a', null, { metadata: { retries: 3 } }), makeSpan('b', null)];
+      const { result } = renderHook(() => useTraceSearch(spans));
+
+      act(() => result.current.setQuery('retries'));
+
+      expect(ids(result.current.results)).toEqual(['a']);
+    });
+
+    it('matches on an error message', () => {
+      const spans = [makeSpan('a', null, { error: { message: 'rate limit exceeded' } }), makeSpan('b', null)];
+      const { result } = renderHook(() => useTraceSearch(spans));
+
+      act(() => result.current.setQuery('rate limit'));
+
+      expect(ids(result.current.results)).toEqual(['a']);
+    });
+
+    it('keeps the ancestors of a span matched only by its metadata', () => {
+      const spans = [
+        makeSpan('root', null, { name: 'root run' }),
+        makeSpan('mid', 'root', { name: 'middle' }),
+        makeSpan('leaf', 'mid', { name: 'plain', metadata: { city: 'Lyon' } }),
+        makeSpan('other', 'root', { name: 'unrelated' }),
+      ];
+      const { result } = renderHook(() => useTraceSearch(spans));
+
+      act(() => result.current.setQuery('lyon'));
+
+      expect(ids(result.current.results)).toEqual(['root', 'mid', 'leaf']);
+    });
   });
 
   it('exposes the immediate query value and settles isPending', () => {

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-search.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-search.test.tsx
@@ -125,6 +125,22 @@ describe('useTraceSearch', () => {
     expect(ids(result.current.results)).toEqual(['root', 'mid', 'leaf']);
   });
 
+  it('keeps the ancestors and subtree of a match when the list arrives newest-first', () => {
+    // The trace list API defaults to `direction: 'DESC'`, so children can
+    // reach the hook before their parents.
+    const spans = [
+      makeSpan('leaf', 'mid', { name: 'sub call' }),
+      makeSpan('other', 'root', { name: 'unrelated' }),
+      makeSpan('mid', 'root', { name: 'needle' }),
+      makeSpan('root', null, { name: 'root run' }),
+    ];
+    const { result } = renderHook(() => useTraceSearch(spans));
+
+    act(() => result.current.setQuery('needle'));
+
+    expect(new Set(ids(result.current.results))).toEqual(new Set(['root', 'mid', 'leaf']));
+  });
+
   it('exposes the immediate query value and settles isPending', () => {
     const spans = [makeSpan('a', null, { name: 'Weather Agent' }), makeSpan('b', null, { name: 'travel' })];
     const { result } = renderHook(() => useTraceSearch(spans));

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-search.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-search.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { SpanType } from '@mastra/core/observability';
+import type { LightSpanRecord } from '@mastra/core/storage';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useTraceSearch } from '../use-trace-search';
+
+const timestamp = new Date('2026-06-10T00:00:00.000Z');
+
+function makeSpan(
+  spanId: string,
+  parentSpanId: string | null,
+  overrides: Partial<LightSpanRecord> = {},
+): LightSpanRecord {
+  return {
+    traceId: 'trace-1',
+    spanId,
+    parentSpanId,
+    name: spanId,
+    spanType: SpanType.AGENT_RUN,
+    isEvent: false,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    ...overrides,
+  };
+}
+
+const ids = (spans: LightSpanRecord[]) => spans.map(span => span.spanId);
+
+describe('useTraceSearch', () => {
+  it('returns the input array by reference when the query is empty', () => {
+    const spans = [makeSpan('root', null)];
+    const { result } = renderHook(() => useTraceSearch(spans));
+
+    expect(result.current.query).toBe('');
+    expect(result.current.results).toBe(spans);
+  });
+
+  it('returns an empty list for an empty input', () => {
+    const { result } = renderHook(() => useTraceSearch([]));
+
+    act(() => result.current.setQuery('anything'));
+
+    expect(result.current.results).toEqual([]);
+  });
+
+  it('matches on name, case-insensitively', () => {
+    const spans = [makeSpan('a', null, { name: 'Weather Agent' }), makeSpan('b', null, { name: 'travel agent' })];
+    const { result } = renderHook(() => useTraceSearch(spans));
+
+    act(() => result.current.setQuery('WEATHER'));
+
+    expect(ids(result.current.results)).toEqual(['a']);
+  });
+
+  it('treats a whitespace-only query as empty', () => {
+    const spans = [makeSpan('a', null, { name: 'Weather Agent' })];
+    const { result } = renderHook(() => useTraceSearch(spans));
+
+    act(() => result.current.setQuery('   '));
+
+    expect(result.current.results).toBe(spans);
+  });
+
+  it('returns an empty list when nothing matches', () => {
+    const spans = [makeSpan('a', null, { name: 'Weather Agent' })];
+    const { result } = renderHook(() => useTraceSearch(spans));
+
+    act(() => result.current.setQuery('nope'));
+
+    expect(result.current.results).toEqual([]);
+  });
+
+  it.each([
+    ['spanType', { spanType: SpanType.MODEL_GENERATION }, 'model_gen'],
+    ['entityName', { entityName: 'weatherAgent' }, 'weatheragent'],
+    ['inputPreview', { inputPreview: 'What is the weather in Paris?' }, 'paris'],
+    ['traceId', { traceId: 'trace-xyz' }, 'trace-xyz'],
+  ])('matches on %s', (_field, overrides, term) => {
+    const spans = [makeSpan('a', null, overrides as Partial<LightSpanRecord>), makeSpan('b', null)];
+    const { result } = renderHook(() => useTraceSearch(spans));
+
+    act(() => result.current.setQuery(term));
+
+    expect(ids(result.current.results)).toEqual(['a']);
+  });
+
+  it('matches on spanId', () => {
+    const spans = [makeSpan('needle', null, { name: 'x' }), makeSpan('other', null, { name: 'y' })];
+    const { result } = renderHook(() => useTraceSearch(spans));
+
+    act(() => result.current.setQuery('needle'));
+
+    expect(ids(result.current.results)).toEqual(['needle']);
+  });
+
+  it('keeps the ancestors of a matching child', () => {
+    const spans = [
+      makeSpan('root', null, { name: 'root run' }),
+      makeSpan('mid', 'root', { name: 'middle' }),
+      makeSpan('leaf', 'mid', { name: 'needle' }),
+      makeSpan('other', 'root', { name: 'unrelated' }),
+    ];
+    const { result } = renderHook(() => useTraceSearch(spans));
+
+    act(() => result.current.setQuery('needle'));
+
+    expect(ids(result.current.results)).toEqual(['root', 'mid', 'leaf']);
+  });
+
+  it('exposes the immediate query value and settles isPending', () => {
+    const spans = [makeSpan('a', null, { name: 'Weather Agent' }), makeSpan('b', null, { name: 'travel' })];
+    const { result } = renderHook(() => useTraceSearch(spans));
+
+    expect(result.current.isPending).toBe(false);
+
+    act(() => result.current.setQuery('weather'));
+
+    expect(result.current.query).toBe('weather');
+    expect(result.current.isPending).toBe(false);
+    expect(ids(result.current.results)).toEqual(['a']);
+  });
+});

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-search.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-search.test.tsx
@@ -111,6 +111,20 @@ describe('useTraceSearch', () => {
     expect(ids(result.current.results)).toEqual(['root', 'mid', 'leaf']);
   });
 
+  it('keeps the subtree of a matching middle span', () => {
+    const spans = [
+      makeSpan('root', null, { name: 'root run' }),
+      makeSpan('mid', 'root', { name: 'needle' }),
+      makeSpan('leaf', 'mid', { name: 'sub call' }),
+      makeSpan('other', 'root', { name: 'unrelated' }),
+    ];
+    const { result } = renderHook(() => useTraceSearch(spans));
+
+    act(() => result.current.setQuery('needle'));
+
+    expect(ids(result.current.results)).toEqual(['root', 'mid', 'leaf']);
+  });
+
   it('exposes the immediate query value and settles isPending', () => {
     const spans = [makeSpan('a', null, { name: 'Weather Agent' }), makeSpan('b', null, { name: 'travel' })];
     const { result } = renderHook(() => useTraceSearch(spans));

--- a/packages/playground-ui/src/domains/traces/hooks/index.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/index.ts
@@ -8,6 +8,7 @@ export {
   type UseTraceOrBranchSpansArgs,
   type UseTraceOrBranchSpansResult,
 } from './use-trace-or-branch-spans';
+export { useTraceSearch, type UseTraceSearchResult } from './use-trace-search';
 export { useTraceSpans } from './use-trace-spans';
 export { useTraces } from './use-traces';
 export { useTags } from './use-tags';

--- a/packages/playground-ui/src/domains/traces/hooks/use-branch.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-branch.ts
@@ -1,7 +1,8 @@
-import type { LightSpanRecord } from '@mastra/core/storage';
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
+import type { SearchableSpan } from '../types';
+import { selectSearchableSpans } from '../utils';
 
 const IMMUTABLE_CACHE_TIME = 1000 * 60 * 60 * 24 * 30; // 30 days, massive cache, span data is immutable
 
@@ -15,7 +16,7 @@ export function useBranch({
   traceId,
   spanId,
   depth,
-}: UseBranchArgs): UseQueryResult<{ traceId: string; spans: LightSpanRecord[] } | null> {
+}: UseBranchArgs): UseQueryResult<{ traceId: string; spans: SearchableSpan[] } | null> {
   const client = useMastraClient();
 
   return useQuery({
@@ -26,6 +27,8 @@ export function useBranch({
       }
       return client.getBranch({ traceId, spanId, depth });
     },
+    // Builds each span's search haystack once per fetch, cached with the query.
+    select: selectSearchableSpans,
     enabled: !!traceId && !!spanId,
     staleTime: query => {
       const data = query.state.data;

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-light-spans.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-light-spans.ts
@@ -1,13 +1,14 @@
-import type { LightSpanRecord } from '@mastra/core/storage';
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
+import type { SearchableSpan } from '../types';
+import { selectSearchableSpans } from '../utils';
 
 const IMMUTABLE_CACHE_TIME = 1000 * 60 * 60 * 24 * 30; // 30 days, massive cache, span data is immutable
 
 export function useTraceLightSpans(
   traceId: string | null | undefined,
-): UseQueryResult<{ traceId: string; spans: LightSpanRecord[] } | null> {
+): UseQueryResult<{ traceId: string; spans: SearchableSpan[] } | null> {
   const client = useMastraClient();
 
   return useQuery({
@@ -19,6 +20,8 @@ export function useTraceLightSpans(
       const res = await client.getTraceLight(traceId);
       return res;
     },
+    // Builds each span's search haystack once per fetch, cached with the query.
+    select: selectSearchableSpans,
     enabled: !!traceId,
     staleTime: query => {
       const data = query.state.data;

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-or-branch-spans.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-or-branch-spans.ts
@@ -1,5 +1,5 @@
-import type { LightSpanRecord } from '@mastra/core/storage';
 import type { TraceListMode } from '../trace-filters';
+import type { SearchableSpan } from '../types';
 import { useBranch } from './use-branch';
 import { useTraceLightSpans } from './use-trace-light-spans';
 
@@ -14,7 +14,7 @@ export interface UseTraceOrBranchSpansArgs {
 }
 
 export interface UseTraceOrBranchSpansResult {
-  spans: LightSpanRecord[] | undefined;
+  spans: SearchableSpan[] | undefined;
   /** Set in branches mode; undefined in traces mode (which uses parentSpanId == null). */
   anchorSpanId: string | undefined;
   isLoading: boolean;

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-search.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-search.ts
@@ -1,0 +1,42 @@
+import type { LightSpanRecord } from '@mastra/core/storage';
+import { useDeferredValue, useMemo, useState } from 'react';
+import { filterSpansKeepingAncestors } from '../utils';
+
+export interface UseTraceSearchResult {
+  /** The immediate, user-facing input value. Bind this to the search field. */
+  query: string;
+  setQuery: (query: string) => void;
+  /** Rows matching the deferred query. An empty query returns the input array reference. */
+  results: LightSpanRecord[];
+  /** True while the deferred value is behind `query` (the list is still catching up). */
+  isPending: boolean;
+}
+
+/** Light-span fields a search term is matched against, case-insensitively. */
+function matchesTerm(span: LightSpanRecord, term: string): boolean {
+  const fields = [span.name, span.spanType, span.entityName, span.inputPreview, span.traceId, span.spanId];
+  return fields.some(field => typeof field === 'string' && field.toLowerCase().includes(term));
+}
+
+/**
+ * Client-side search over a flat light span list (the rows returned by `useTraces`).
+ *
+ * Filtering is keyed on a deferred copy of the query, so typing stays responsive while a
+ * large list re-filters at lower priority — bind the input to `query`, not to the deferred
+ * value. Ancestors of a matching span are kept so the hierarchy stays intact.
+ *
+ * `spans` is required. Resolving the loading/empty state is the caller's job — a component
+ * holding a query result passes `data?.spans ?? []`.
+ */
+export function useTraceSearch(spans: LightSpanRecord[]): UseTraceSearchResult {
+  const [query, setQuery] = useState('');
+  const deferredQuery = useDeferredValue(query);
+
+  const results = useMemo(() => {
+    const term = deferredQuery.trim().toLowerCase();
+    if (!term) return spans;
+    return filterSpansKeepingAncestors(spans, span => matchesTerm(span, term));
+  }, [spans, deferredQuery]);
+
+  return { query, setQuery, results, isPending: query !== deferredQuery };
+}

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-search.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-search.ts
@@ -1,5 +1,5 @@
-import type { LightSpanRecord } from '@mastra/core/storage';
 import { useDeferredValue, useMemo, useState } from 'react';
+import type { SearchableSpan } from '../types';
 import { filterSpansKeepingAncestors } from '../utils';
 
 export interface UseTraceSearchResult {
@@ -7,35 +7,35 @@ export interface UseTraceSearchResult {
   query: string;
   setQuery: (query: string) => void;
   /** Rows matching the deferred query. An empty query returns the input array reference. */
-  results: LightSpanRecord[];
+  results: SearchableSpan[];
   /** True while the deferred value is behind `query` (the list is still catching up). */
   isPending: boolean;
 }
 
-/** Light-span fields a search term is matched against, case-insensitively. */
-function matchesTerm(span: LightSpanRecord, term: string): boolean {
-  const fields = [span.name, span.spanType, span.entityName, span.inputPreview, span.traceId, span.spanId];
-  return fields.some(field => typeof field === 'string' && field.toLowerCase().includes(term));
-}
-
 /**
- * Client-side search over a flat light span list (the rows returned by `useTraces`).
+ * Client-side search over a flat span list.
+ *
+ * Matching is a substring test against `searchText`, the haystack built once per span when
+ * the query resolved (see `toSearchableSpans`). That is what makes the open-ended `metadata`
+ * and `error` payloads searchable: their shapes are unknown, so no fixed list of fields can
+ * read them. Both sides are already lowercased, so the test is a bare `includes`.
  *
  * Filtering is keyed on a deferred copy of the query, so typing stays responsive while a
  * large list re-filters at lower priority — bind the input to `query`, not to the deferred
- * value. Ancestors of a matching span are kept so the hierarchy stays intact.
+ * value. A matching span keeps its ancestors and its whole subtree, so the hierarchy stays
+ * intact.
  *
  * `spans` is required. Resolving the loading/empty state is the caller's job — a component
  * holding a query result passes `data?.spans ?? []`.
  */
-export function useTraceSearch(spans: LightSpanRecord[]): UseTraceSearchResult {
+export function useTraceSearch(spans: SearchableSpan[]): UseTraceSearchResult {
   const [query, setQuery] = useState('');
   const deferredQuery = useDeferredValue(query);
 
   const results = useMemo(() => {
     const term = deferredQuery.trim().toLowerCase();
     if (!term) return spans;
-    return filterSpansKeepingAncestors(spans, span => matchesTerm(span, term));
+    return filterSpansKeepingAncestors(spans, span => span.searchText.includes(term));
   }, [spans, deferredQuery]);
 
   return { query, setQuery, results, isPending: query !== deferredQuery };

--- a/packages/playground-ui/src/domains/traces/types.ts
+++ b/packages/playground-ui/src/domains/traces/types.ts
@@ -1,5 +1,22 @@
 import type { EntityType } from '@mastra/core/observability';
+import type { LightSpanRecord } from '@mastra/core/storage';
 import type { ReactNode } from 'react';
+
+/**
+ * A light span carrying a precomputed haystack of everything it holds.
+ *
+ * `LightSpanRecord` exposes searchable content across a fixed set of columns
+ * plus open-ended payloads whose shape is unknown, so a search cannot read it
+ * field by field. `searchText` is that content flattened once — see
+ * `flattenToSearchText` — so filtering is a substring test per span instead of
+ * a re-walk of every payload on every keystroke.
+ *
+ * It holds field names as well as values, so a span is findable by the shape of
+ * its payload and not only by its content.
+ */
+export type SearchableSpan = LightSpanRecord & {
+  searchText: string;
+};
 
 export type UISpan = {
   id: string;

--- a/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.test.ts
+++ b/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.test.ts
@@ -1,6 +1,6 @@
 import { SpanType } from '@mastra/core/observability';
 import type { LightSpanRecord } from '@mastra/core/storage';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { filterSpansKeepingAncestors } from './filter-spans-keeping-ancestors';
 
@@ -27,6 +27,12 @@ function makeSpan(
 }
 
 const ids = (spans: LightSpanRecord[]) => spans.map(span => span.spanId);
+
+/** Match by span id, the shorthand every matrix case uses. */
+const matching =
+  (...wanted: string[]) =>
+  (span: LightSpanRecord) =>
+    wanted.includes(span.spanId);
 
 /**
  * root
@@ -109,5 +115,260 @@ describe('filterSpansKeepingAncestors', () => {
   it('preserves input relative order when everything matches', () => {
     const result = filterSpansKeepingAncestors(tree, () => true);
     expect(ids(result)).toEqual(ids(tree));
+  });
+});
+
+/**
+ * Fixture A — the general case. 4 levels, 3 branches, uneven depth, so that
+ * "leaf", "middle" and "root" are all genuinely distinct positions.
+ *
+ * root
+ * ├── a          (middle)
+ * │   ├── a1     (middle)
+ * │   │   ├── a1x (leaf)
+ * │   │   └── a1y (leaf)
+ * │   └── a2     (leaf)
+ * ├── b          (middle)
+ * │   └── b1     (middle)
+ * │       └── b1x (leaf)
+ * └── c          (leaf, directly under root)
+ */
+const deepTree = [
+  makeSpan('root', null),
+  makeSpan('a', 'root'),
+  makeSpan('a1', 'a'),
+  makeSpan('a1x', 'a1'),
+  makeSpan('a1y', 'a1'),
+  makeSpan('a2', 'a'),
+  makeSpan('b', 'root'),
+  makeSpan('b1', 'b'),
+  makeSpan('b1x', 'b1'),
+  makeSpan('c', 'root'),
+];
+
+const allDeepTreeIds = ids(deepTree);
+
+/** Reorders a span list by id, so orderings can be declared explicitly. */
+function orderBy(spans: LightSpanRecord[], order: string[]): LightSpanRecord[] {
+  return order.map(id => {
+    const span = spans.find(candidate => candidate.spanId === id);
+    if (!span) throw new Error(`orderBy: unknown span id "${id}"`);
+    return span;
+  });
+}
+
+/** The expected output in a given input order: the input, filtered. */
+function expectedIn(inputOrder: LightSpanRecord[], expectedIds: string[]): string[] {
+  return ids(inputOrder).filter(id => expectedIds.includes(id));
+}
+
+type MatchCase = {
+  label: string;
+  match: string[];
+  expected: string[];
+};
+
+/**
+ * Axis 1 — where the match sits in the tree.
+ * The contract: a match keeps its full ancestor chain AND its entire subtree.
+ */
+const matchCases: MatchCase[] = [
+  { label: 'a single leaf', match: ['a1x'], expected: ['root', 'a', 'a1', 'a1x'] },
+  { label: 'several leafs under the same parent', match: ['a1x', 'a1y'], expected: ['root', 'a', 'a1', 'a1x', 'a1y'] },
+  {
+    label: 'several leafs in different branches',
+    match: ['a1x', 'b1x'],
+    expected: ['root', 'a', 'a1', 'a1x', 'b', 'b1', 'b1x'],
+  },
+  { label: 'a leaf directly under the root', match: ['c'], expected: ['root', 'c'] },
+  { label: 'every leaf of the tree', match: ['a1x', 'a1y', 'a2', 'b1x', 'c'], expected: allDeepTreeIds },
+  { label: 'a single middle span', match: ['a1'], expected: ['root', 'a', 'a1', 'a1x', 'a1y'] },
+  {
+    label: 'two nested middle spans in the same branch',
+    match: ['a', 'a1'],
+    expected: ['root', 'a', 'a1', 'a1x', 'a1y', 'a2'],
+  },
+  {
+    label: 'two middle spans in different branches',
+    match: ['a1', 'b1'],
+    expected: ['root', 'a', 'a1', 'a1x', 'a1y', 'b', 'b1', 'b1x'],
+  },
+  {
+    label: 'a middle span plus an unrelated leaf',
+    match: ['a1', 'c'],
+    expected: ['root', 'a', 'a1', 'a1x', 'a1y', 'c'],
+  },
+  { label: 'a middle span whose subtree runs deeper', match: ['b'], expected: ['root', 'b', 'b1', 'b1x'] },
+  { label: 'the top parent', match: ['root'], expected: allDeepTreeIds },
+  { label: 'the top parent and one of its descendants', match: ['root', 'a1x'], expected: allDeepTreeIds },
+  {
+    label: 'an ancestor and a non-adjacent descendant',
+    match: ['a', 'a1x'],
+    expected: ['root', 'a', 'a1', 'a1x', 'a1y', 'a2'],
+  },
+  { label: 'every span', match: allDeepTreeIds, expected: allDeepTreeIds },
+  { label: 'nothing', match: [], expected: [] },
+  { label: 'a leaf whose sibling subtree must be excluded', match: ['a2'], expected: ['root', 'a', 'a2'] },
+];
+
+describe('filterSpansKeepingAncestors — match position in the tree', () => {
+  it.each(matchCases)('keeps the ancestors and subtree of $label', ({ match, expected }) => {
+    const result = filterSpansKeepingAncestors(deepTree, matching(...match));
+    expect(ids(result)).toEqual(expected);
+  });
+});
+
+/**
+ * Axis 3 — input order. This is the axis the previous suite never varied, and
+ * the one that reproduces the production bug: the API defaults to
+ * `direction: 'DESC'`, so children routinely arrive before their parents.
+ */
+const orderings: { label: string; order: string[] }[] = [
+  { label: 'parent-before-child (ASC)', order: allDeepTreeIds },
+  { label: 'reversed (DESC, the API default)', order: [...allDeepTreeIds].reverse() },
+  {
+    label: 'shuffled',
+    order: ['b1x', 'root', 'a1y', 'c', 'a', 'b1', 'a1x', 'b', 'a2', 'a1'],
+  },
+  {
+    label: 'children before parents, siblings ASC',
+    order: ['a1x', 'a1y', 'b1x', 'a1', 'a2', 'b1', 'a', 'b', 'c', 'root'],
+  },
+];
+
+describe.each(orderings)('filterSpansKeepingAncestors — input ordered $label', ({ order }) => {
+  const input = orderBy(deepTree, order);
+
+  it.each(matchCases)('keeps the ancestors and subtree of $label', ({ match, expected }) => {
+    const result = filterSpansKeepingAncestors(input, matching(...match));
+    expect(ids(result)).toEqual(expectedIn(input, expected));
+  });
+
+  it('always returns spans in the input relative order', () => {
+    const result = filterSpansKeepingAncestors(input, matching('a1', 'b1'));
+    const positions = result.map(span => input.indexOf(span));
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
+  });
+});
+
+describe('filterSpansKeepingAncestors — order invariance', () => {
+  it.each(matchCases)('returns the same set of spans in any input order for $label', ({ match, expected }) => {
+    for (const { order } of orderings) {
+      const result = filterSpansKeepingAncestors(orderBy(deepTree, order), matching(...match));
+      expect(new Set(ids(result))).toEqual(new Set(expected));
+    }
+  });
+
+  it('resolves the chain when a parent is listed after its child at an equal startedAt', () => {
+    const sameInstant = new Date('2026-06-10T00:00:00.000Z');
+    const spans = [
+      makeSpan('leaf', 'mid', { startedAt: sameInstant }),
+      makeSpan('mid', 'root', { startedAt: sameInstant }),
+      makeSpan('root', null, { startedAt: sameInstant }),
+    ];
+
+    const result = filterSpansKeepingAncestors(spans, matching('leaf'));
+    expect(new Set(ids(result))).toEqual(new Set(['root', 'mid', 'leaf']));
+  });
+});
+
+describe('filterSpansKeepingAncestors — tree shapes', () => {
+  it('returns a lone root span when it matches', () => {
+    const spans = [makeSpan('only', null)];
+    expect(ids(filterSpansKeepingAncestors(spans, matching('only')))).toEqual(['only']);
+  });
+
+  it('returns nothing for a lone span that does not match', () => {
+    const spans = [makeSpan('only', null)];
+    expect(filterSpansKeepingAncestors(spans, matching('other'))).toEqual([]);
+  });
+
+  it('returns only the matches when no span has a parent', () => {
+    const spans = [makeSpan('one', null), makeSpan('two', null), makeSpan('three', null)];
+    expect(ids(filterSpansKeepingAncestors(spans, matching('two')))).toEqual(['two']);
+  });
+
+  it('keeps only the branch of the matching root when the list holds several roots', () => {
+    const spans = [
+      makeSpan('root-1', null),
+      makeSpan('child-1', 'root-1'),
+      makeSpan('root-2', null),
+      makeSpan('child-2', 'root-2'),
+    ];
+
+    expect(ids(filterSpansKeepingAncestors(spans, matching('child-2')))).toEqual(['root-2', 'child-2']);
+  });
+
+  it('walks a six-level linear chain up from the bottom', () => {
+    const chain = ['l0', 'l1', 'l2', 'l3', 'l4', 'l5'].map((id, index) =>
+      makeSpan(id, index === 0 ? null : `l${index - 1}`),
+    );
+
+    expect(ids(filterSpansKeepingAncestors(chain, matching('l5')))).toEqual(['l0', 'l1', 'l2', 'l3', 'l4', 'l5']);
+  });
+
+  it('walks a six-level linear chain in both directions from the middle', () => {
+    const chain = ['l0', 'l1', 'l2', 'l3', 'l4', 'l5'].map((id, index) =>
+      makeSpan(id, index === 0 ? null : `l${index - 1}`),
+    );
+
+    expect(ids(filterSpansKeepingAncestors(chain, matching('l2')))).toEqual(['l0', 'l1', 'l2', 'l3', 'l4', 'l5']);
+  });
+
+  it('keeps only the matching sibling in a wide fan-out', () => {
+    const spans = [makeSpan('root', null), ...Array.from({ length: 50 }, (_, i) => makeSpan(`child-${i}`, 'root'))];
+
+    expect(ids(filterSpansKeepingAncestors(spans, matching('child-37')))).toEqual(['root', 'child-37']);
+  });
+
+  it('stops cleanly when a match ancestor chain leaves the list halfway', () => {
+    const spans = [makeSpan('detached', 'not-in-list'), makeSpan('leaf', 'detached')];
+
+    expect(ids(filterSpansKeepingAncestors(spans, matching('leaf')))).toEqual(['detached', 'leaf']);
+  });
+
+  it('terminates on a two-span parent cycle', () => {
+    const spans = [makeSpan('x', 'y'), makeSpan('y', 'x')];
+
+    expect(new Set(ids(filterSpansKeepingAncestors(spans, matching('x'))))).toEqual(new Set(['x', 'y']));
+  });
+
+  it('terminates on a self-parented span', () => {
+    const spans = [makeSpan('loop', 'loop')];
+
+    expect(ids(filterSpansKeepingAncestors(spans, matching('loop')))).toEqual(['loop']);
+  });
+});
+
+describe('filterSpansKeepingAncestors — contract guarantees', () => {
+  it('calls the predicate exactly once per span', () => {
+    const predicate = vi.fn(() => false);
+
+    filterSpansKeepingAncestors(deepTree, predicate);
+
+    expect(predicate).toHaveBeenCalledTimes(deepTree.length);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [...deepTree];
+    const snapshot = [...deepTree];
+
+    filterSpansKeepingAncestors(input, matching('a1'));
+
+    expect(input).toEqual(snapshot);
+  });
+
+  it('returns the original span objects, not copies', () => {
+    const result = filterSpansKeepingAncestors(deepTree, matching('a1x'));
+
+    for (const span of result) {
+      expect(deepTree).toContain(span);
+    }
+  });
+
+  it('skips nullish entries instead of throwing', () => {
+    const spans = [makeSpan('root', null), null as unknown as LightSpanRecord, makeSpan('leaf', 'root')];
+
+    expect(ids(filterSpansKeepingAncestors(spans, span => span.spanId === 'leaf'))).toEqual(['root', 'leaf']);
   });
 });

--- a/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.test.ts
+++ b/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.test.ts
@@ -1,0 +1,98 @@
+import { SpanType } from '@mastra/core/observability';
+import type { LightSpanRecord } from '@mastra/core/storage';
+import { describe, expect, it } from 'vitest';
+
+import { filterSpansKeepingAncestors } from './filter-spans-keeping-ancestors';
+
+const timestamp = new Date('2026-06-10T00:00:00.000Z');
+
+function makeSpan(
+  spanId: string,
+  parentSpanId: string | null,
+  overrides: Partial<LightSpanRecord> = {},
+): LightSpanRecord {
+  return {
+    traceId: 'trace-1',
+    spanId,
+    parentSpanId,
+    name: spanId,
+    spanType: SpanType.AGENT_RUN,
+    isEvent: false,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    ...overrides,
+  };
+}
+
+const ids = (spans: LightSpanRecord[]) => spans.map(span => span.spanId);
+
+/**
+ * root
+ * ├── a
+ * │   └── a1
+ * │       └── a1x
+ * └── b
+ *     └── b1
+ */
+const tree = [
+  makeSpan('root', null),
+  makeSpan('a', 'root'),
+  makeSpan('a1', 'a'),
+  makeSpan('a1x', 'a1'),
+  makeSpan('b', 'root'),
+  makeSpan('b1', 'b'),
+];
+
+describe('filterSpansKeepingAncestors', () => {
+  it('returns an empty list for empty input', () => {
+    expect(filterSpansKeepingAncestors([], () => true)).toEqual([]);
+  });
+
+  it('returns an empty list when nothing matches', () => {
+    expect(filterSpansKeepingAncestors(tree, () => false)).toEqual([]);
+  });
+
+  it('keeps the full ancestor chain of a deep leaf, in original order', () => {
+    const result = filterSpansKeepingAncestors(tree, span => span.spanId === 'a1x');
+    expect(ids(result)).toEqual(['root', 'a', 'a1', 'a1x']);
+  });
+
+  it('keeps both chains when leaves in different branches match', () => {
+    const result = filterSpansKeepingAncestors(tree, span => span.spanId === 'a1x' || span.spanId === 'b1');
+    expect(ids(result)).toEqual(['root', 'a', 'a1', 'a1x', 'b', 'b1']);
+  });
+
+  it('drops non-matching sibling branches', () => {
+    const result = filterSpansKeepingAncestors(tree, span => span.spanId === 'b1');
+    expect(ids(result)).toEqual(['root', 'b', 'b1']);
+  });
+
+  it('does not keep descendants of a matching span', () => {
+    const result = filterSpansKeepingAncestors(tree, span => span.spanId === 'a');
+    expect(ids(result)).toEqual(['root', 'a']);
+  });
+
+  it('returns only the root when the root matches', () => {
+    const result = filterSpansKeepingAncestors(tree, span => span.spanId === 'root');
+    expect(ids(result)).toEqual(['root']);
+  });
+
+  it('keeps an orphan span whose parent is outside the list', () => {
+    const spans = [makeSpan('orphan', 'missing-parent'), makeSpan('child', 'orphan')];
+    const result = filterSpansKeepingAncestors(spans, span => span.spanId === 'child');
+    expect(ids(result)).toEqual(['orphan', 'child']);
+  });
+
+  it('treats undefined parentSpanId like null', () => {
+    const spans = [makeSpan('root', undefined as unknown as null), makeSpan('leaf', 'root')];
+    const result = filterSpansKeepingAncestors(spans, span => span.spanId === 'leaf');
+    expect(ids(result)).toEqual(['root', 'leaf']);
+  });
+
+  it('preserves input relative order when everything matches', () => {
+    const result = filterSpansKeepingAncestors(tree, () => true);
+    expect(ids(result)).toEqual(ids(tree));
+  });
+});

--- a/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.test.ts
+++ b/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.test.ts
@@ -69,14 +69,29 @@ describe('filterSpansKeepingAncestors', () => {
     expect(ids(result)).toEqual(['root', 'b', 'b1']);
   });
 
-  it('does not keep descendants of a matching span', () => {
+  it('keeps the whole subtree of a matching middle span, several levels deep', () => {
     const result = filterSpansKeepingAncestors(tree, span => span.spanId === 'a');
-    expect(ids(result)).toEqual(['root', 'a']);
+    expect(ids(result)).toEqual(['root', 'a', 'a1', 'a1x']);
   });
 
-  it('returns only the root when the root matches', () => {
+  it('keeps only itself and its ancestors when a leaf matches', () => {
+    const result = filterSpansKeepingAncestors(tree, span => span.spanId === 'a1x');
+    expect(ids(result)).toEqual(['root', 'a', 'a1', 'a1x']);
+  });
+
+  it('returns the entire tree, in order, when the root matches', () => {
     const result = filterSpansKeepingAncestors(tree, span => span.spanId === 'root');
-    expect(ids(result)).toEqual(['root']);
+    expect(ids(result)).toEqual(ids(tree));
+  });
+
+  it('does not duplicate spans when a span and its descendant both match', () => {
+    const result = filterSpansKeepingAncestors(tree, span => span.spanId === 'a' || span.spanId === 'a1x');
+    expect(ids(result)).toEqual(['root', 'a', 'a1', 'a1x']);
+  });
+
+  it('drops spans that are neither ancestors nor descendants of a match', () => {
+    const result = filterSpansKeepingAncestors(tree, span => span.spanId === 'a1');
+    expect(ids(result)).toEqual(['root', 'a', 'a1', 'a1x']);
   });
 
   it('keeps an orphan span whose parent is outside the list', () => {

--- a/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.ts
+++ b/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.ts
@@ -12,18 +12,22 @@ import type { LightSpanRecord } from '@mastra/core/storage';
  *
  * The output preserves the input's relative order, so it can be fed straight
  * into `formatHierarchicalSpans`. `predicate` is called exactly once per span.
+ *
+ * Generic over the span type: only `spanId` and `parentSpanId` are read, and the
+ * exact input type comes back out, so enriched spans such as `SearchableSpan`
+ * survive the filter instead of being widened to `LightSpanRecord`.
  */
-export function filterSpansKeepingAncestors(
-  spans: LightSpanRecord[],
-  predicate: (span: LightSpanRecord) => boolean,
-): LightSpanRecord[] {
+export function filterSpansKeepingAncestors<T extends Pick<LightSpanRecord, 'spanId' | 'parentSpanId'>>(
+  spans: T[],
+  predicate: (span: T) => boolean,
+): T[] {
   if (!spans || spans.length === 0) {
     return [];
   }
 
-  const byId = new Map<string, LightSpanRecord>();
-  const childrenByParent = new Map<string, LightSpanRecord[]>();
-  const matches: LightSpanRecord[] = [];
+  const byId = new Map<string, T>();
+  const childrenByParent = new Map<string, T[]>();
+  const matches: T[] = [];
 
   for (const span of spans) {
     if (!span) continue;

--- a/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.ts
+++ b/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.ts
@@ -1,0 +1,39 @@
+import type { LightSpanRecord } from '@mastra/core/storage';
+
+/**
+ * Filter a flat span list down to the spans matching `predicate`, plus every
+ * ancestor needed to keep those spans connected to their root.
+ *
+ * Descendants of a matching span are not kept unless they match themselves.
+ * The output preserves the input's relative order, so it can be fed straight
+ * into `formatHierarchicalSpans`.
+ *
+ * Precondition: `spans` is ordered parent-before-child (the order the API
+ * returns them). The single reverse pass relies on visiting children before
+ * their parents.
+ */
+export function filterSpansKeepingAncestors(
+  spans: LightSpanRecord[],
+  predicate: (span: LightSpanRecord) => boolean,
+): LightSpanRecord[] {
+  if (!spans || spans.length === 0) {
+    return [];
+  }
+
+  const requiredParentIds = new Set<string>();
+  const kept: LightSpanRecord[] = [];
+
+  for (let i = spans.length - 1; i >= 0; i--) {
+    const span = spans[i];
+    if (!span) continue;
+
+    const isRequiredAncestor = requiredParentIds.has(span.spanId);
+
+    if (!isRequiredAncestor && !predicate(span)) continue;
+
+    if (span.parentSpanId) requiredParentIds.add(span.parentSpanId);
+    kept.push(span);
+  }
+
+  return kept.reverse();
+}

--- a/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.ts
+++ b/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.ts
@@ -5,13 +5,13 @@ import type { LightSpanRecord } from '@mastra/core/storage';
  * ancestor needed to keep those spans connected to their root, plus the whole
  * subtree below each match — a matching span is shown intact, not truncated.
  *
- * The output preserves the input's relative order, so it can be fed straight
- * into `formatHierarchicalSpans`.
+ * `spans` may arrive in any order. Trace payloads are flat lists sorted by
+ * `startedAt` (and the list API defaults to `direction: 'DESC'`), so children
+ * routinely precede their parents; the traversal below indexes the list up
+ * front rather than assuming a topological order.
  *
- * Precondition: `spans` is ordered parent-before-child (the order the API
- * returns them). Both passes depend on it: the forward pass inherits matches
- * downwards and needs parents first, the reverse pass propagates ancestors
- * upwards and needs children first.
+ * The output preserves the input's relative order, so it can be fed straight
+ * into `formatHierarchicalSpans`. `predicate` is called exactly once per span.
  */
 export function filterSpansKeepingAncestors(
   spans: LightSpanRecord[],
@@ -21,30 +21,56 @@ export function filterSpansKeepingAncestors(
     return [];
   }
 
-  // Forward pass: mark matches, and let them inherit down to their descendants.
-  const inMatchedSubtree = new Set<string>();
+  const byId = new Map<string, LightSpanRecord>();
+  const childrenByParent = new Map<string, LightSpanRecord[]>();
+  const matches: LightSpanRecord[] = [];
 
   for (const span of spans) {
     if (!span) continue;
 
-    if (predicate(span) || (span.parentSpanId && inMatchedSubtree.has(span.parentSpanId))) {
-      inMatchedSubtree.add(span.spanId);
+    byId.set(span.spanId, span);
+
+    if (span.parentSpanId) {
+      const siblings = childrenByParent.get(span.parentSpanId);
+      if (siblings) siblings.push(span);
+      else childrenByParent.set(span.parentSpanId, [span]);
+    }
+
+    if (predicate(span)) matches.push(span);
+  }
+
+  if (matches.length === 0) {
+    return [];
+  }
+
+  const kept = new Set<string>();
+
+  // Downwards: every descendant of every match. `kept` doubles as the visited
+  // set, so cycles and self-parented spans terminate.
+  const stack = [...matches];
+  while (stack.length > 0) {
+    const span = stack.pop();
+    if (!span || kept.has(span.spanId)) continue;
+
+    kept.add(span.spanId);
+
+    const children = childrenByParent.get(span.spanId);
+    if (children) stack.push(...children);
+  }
+
+  // Upwards: the ancestor chain of every match, stopping at the first span
+  // already kept or at a parent that isn't in the list (branch boundary).
+  for (const match of matches) {
+    let parentSpanId = match.parentSpanId;
+
+    while (parentSpanId && !kept.has(parentSpanId)) {
+      const parent = byId.get(parentSpanId);
+      if (!parent) break;
+
+      kept.add(parent.spanId);
+      parentSpanId = parent.parentSpanId;
     }
   }
 
-  // Reverse pass: keep the marked spans and pull in the ancestors they need.
-  const requiredParentIds = new Set<string>();
-  const kept: LightSpanRecord[] = [];
-
-  for (let i = spans.length - 1; i >= 0; i--) {
-    const span = spans[i];
-    if (!span) continue;
-
-    if (!inMatchedSubtree.has(span.spanId) && !requiredParentIds.has(span.spanId)) continue;
-
-    if (span.parentSpanId) requiredParentIds.add(span.parentSpanId);
-    kept.push(span);
-  }
-
-  return kept.reverse();
+  return spans.filter(span => span && kept.has(span.spanId));
 }

--- a/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.ts
+++ b/packages/playground-ui/src/domains/traces/utils/filter-spans-keeping-ancestors.ts
@@ -2,15 +2,16 @@ import type { LightSpanRecord } from '@mastra/core/storage';
 
 /**
  * Filter a flat span list down to the spans matching `predicate`, plus every
- * ancestor needed to keep those spans connected to their root.
+ * ancestor needed to keep those spans connected to their root, plus the whole
+ * subtree below each match — a matching span is shown intact, not truncated.
  *
- * Descendants of a matching span are not kept unless they match themselves.
  * The output preserves the input's relative order, so it can be fed straight
  * into `formatHierarchicalSpans`.
  *
  * Precondition: `spans` is ordered parent-before-child (the order the API
- * returns them). The single reverse pass relies on visiting children before
- * their parents.
+ * returns them). Both passes depend on it: the forward pass inherits matches
+ * downwards and needs parents first, the reverse pass propagates ancestors
+ * upwards and needs children first.
  */
 export function filterSpansKeepingAncestors(
   spans: LightSpanRecord[],
@@ -20,6 +21,18 @@ export function filterSpansKeepingAncestors(
     return [];
   }
 
+  // Forward pass: mark matches, and let them inherit down to their descendants.
+  const inMatchedSubtree = new Set<string>();
+
+  for (const span of spans) {
+    if (!span) continue;
+
+    if (predicate(span) || (span.parentSpanId && inMatchedSubtree.has(span.parentSpanId))) {
+      inMatchedSubtree.add(span.spanId);
+    }
+  }
+
+  // Reverse pass: keep the marked spans and pull in the ancestors they need.
   const requiredParentIds = new Set<string>();
   const kept: LightSpanRecord[] = [];
 
@@ -27,9 +40,7 @@ export function filterSpansKeepingAncestors(
     const span = spans[i];
     if (!span) continue;
 
-    const isRequiredAncestor = requiredParentIds.has(span.spanId);
-
-    if (!isRequiredAncestor && !predicate(span)) continue;
+    if (!inMatchedSubtree.has(span.spanId) && !requiredParentIds.has(span.spanId)) continue;
 
     if (span.parentSpanId) requiredParentIds.add(span.parentSpanId);
     kept.push(span);

--- a/packages/playground-ui/src/domains/traces/utils/flatten-to-search-text.test.ts
+++ b/packages/playground-ui/src/domains/traces/utils/flatten-to-search-text.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from 'vitest';
+
+import { flattenToSearchText } from './flatten-to-search-text';
+
+describe('flattenToSearchText', () => {
+  describe('when given a primitive', () => {
+    it('returns a string unchanged', () => {
+      expect(flattenToSearchText('weather tool')).toBe('weather tool');
+    });
+
+    it('stringifies numbers, including zero and negatives', () => {
+      expect(flattenToSearchText(0)).toBe('0');
+      expect(flattenToSearchText(42)).toBe('42');
+      expect(flattenToSearchText(-1.5)).toBe('-1.5');
+    });
+
+    it('stringifies booleans, including false', () => {
+      expect(flattenToSearchText(true)).toBe('true');
+      expect(flattenToSearchText(false)).toBe('false');
+    });
+
+    it('stringifies bigints', () => {
+      expect(flattenToSearchText(9007199254740993n)).toBe('9007199254740993');
+    });
+
+    it('returns an empty string for null and undefined', () => {
+      expect(flattenToSearchText(null)).toBe('');
+      expect(flattenToSearchText(undefined)).toBe('');
+    });
+
+    it('drops NaN and infinities, which no one can usefully search for', () => {
+      expect(flattenToSearchText(NaN)).toBe('');
+      expect(flattenToSearchText(Infinity)).toBe('');
+      expect(flattenToSearchText(-Infinity)).toBe('');
+    });
+  });
+
+  describe('when given a flat object', () => {
+    it('emits each key immediately before its value', () => {
+      expect(flattenToSearchText({ city: 'Lyon', unit: 'celsius' })).toBe('city Lyon unit celsius');
+    });
+
+    it('makes a field name searchable on its own', () => {
+      expect(flattenToSearchText({ model: 'gpt-5-mini' })).toContain('model');
+    });
+
+    it('keeps the key of a value it cannot search, so the field is still findable', () => {
+      expect(flattenToSearchText({ error: null })).toBe('error');
+      expect(flattenToSearchText({ a: 'one', b: null, c: undefined, d: 'two' })).toBe('a one b c d two');
+    });
+
+    it('returns an empty string for an object with no keys at all', () => {
+      expect(flattenToSearchText({})).toBe('');
+    });
+  });
+
+  describe('when given nested structures', () => {
+    it('descends into nested objects, emitting the key at every level', () => {
+      const input = { request: { location: { city: 'Lyon', country: 'FR' } } };
+
+      expect(flattenToSearchText(input)).toBe('request location city Lyon country FR');
+    });
+
+    it('descends into arrays without emitting their indices', () => {
+      expect(flattenToSearchText(['reasoning', 'text'])).toBe('reasoning text');
+    });
+
+    it('emits the array key once, then the items', () => {
+      const input = { tags: ['weather', 'forecast'] };
+
+      expect(flattenToSearchText(input)).toBe('tags weather forecast');
+    });
+
+    it('descends into arrays of objects', () => {
+      const input = { messages: [{ role: 'user', content: 'hello' }, { role: 'assistant' }] };
+
+      expect(flattenToSearchText(input)).toBe('messages role user content hello role assistant');
+    });
+
+    it('handles objects and arrays interleaved at depth', () => {
+      const input = {
+        steps: [{ tools: [{ name: 'weather' }, { name: 'clock' }] }, { tools: [] }],
+        done: true,
+      };
+
+      expect(flattenToSearchText(input)).toBe('steps tools name weather name clock tools done true');
+    });
+
+    it('flattens deep nesting without truncating', () => {
+      const input = { a: { b: { c: { d: { e: { f: 'bottom' } } } } } };
+
+      expect(flattenToSearchText(input)).toBe('a b c d e f bottom');
+    });
+  });
+
+  describe('when given values that are not worth searching', () => {
+    it('emits the key but not the function body', () => {
+      const result = flattenToSearchText({ fn: () => 'drop' });
+
+      expect(result).toBe('fn');
+      expect(result).not.toContain('drop');
+    });
+
+    it('emits the key but not the symbol', () => {
+      const result = flattenToSearchText({ sym: Symbol('drop') });
+
+      expect(result).toBe('sym');
+      expect(result).not.toContain('drop');
+    });
+
+    it('skips symbol-keyed entries entirely', () => {
+      expect(flattenToSearchText({ a: 'keep', [Symbol('k')]: 'drop' })).toBe('a keep');
+    });
+
+    it('does not walk the prototype chain', () => {
+      const proto = { inherited: 'drop' };
+      const input = Object.create(proto);
+      input.own = 'keep';
+
+      expect(flattenToSearchText(input)).toBe('own keep');
+    });
+  });
+
+  describe('when given values with a meaningful string form', () => {
+    it('renders a Date as its ISO string', () => {
+      expect(flattenToSearchText(new Date('2026-06-10T12:30:00.000Z'))).toBe('2026-06-10T12:30:00.000Z');
+    });
+
+    it('renders a nested Date behind its key', () => {
+      const input = { startedAt: new Date('2026-06-10T12:30:00.000Z') };
+
+      expect(flattenToSearchText(input)).toBe('startedAt 2026-06-10T12:30:00.000Z');
+    });
+
+    it('keeps the key but drops an invalid Date rather than emitting "Invalid Date"', () => {
+      const result = flattenToSearchText({ startedAt: new Date('nope') });
+
+      expect(result).toBe('startedAt');
+      expect(result).not.toContain('Invalid');
+    });
+
+    it('renders both sides of a Map entry', () => {
+      const input = new Map([
+        ['city', 'Lyon'],
+        ['unit', 'celsius'],
+      ]);
+
+      expect(flattenToSearchText(input)).toBe('city Lyon unit celsius');
+    });
+
+    it('renders the members of a Set, which has no keys', () => {
+      expect(flattenToSearchText(new Set(['reasoning', 'text']))).toBe('reasoning text');
+    });
+
+    it('renders an Error message', () => {
+      expect(flattenToSearchText(new Error('rate limit exceeded'))).toBe('rate limit exceeded');
+    });
+  });
+
+  describe('when the shape is hostile', () => {
+    it('terminates on a self-referencing object', () => {
+      const input: Record<string, unknown> = { name: 'root' };
+      input.self = input;
+
+      expect(flattenToSearchText(input)).toBe('name root self');
+    });
+
+    it('terminates on a two-object cycle', () => {
+      const a: Record<string, unknown> = { name: 'a' };
+      const b: Record<string, unknown> = { name: 'b', a };
+      a.b = b;
+
+      expect(flattenToSearchText(a)).toBe('name a b name b a');
+    });
+
+    it('terminates on a cycle through an array', () => {
+      const list: unknown[] = ['item'];
+      list.push(list);
+
+      expect(flattenToSearchText(list)).toBe('item');
+    });
+
+    it('emits a repeated sibling reference once per occurrence, since it is not a cycle', () => {
+      const shared = { value: 'shared' };
+
+      expect(flattenToSearchText({ a: shared, b: shared })).toBe('a value shared b value shared');
+    });
+
+    it('keeps the key and the rest of the payload when a getter throws', () => {
+      const input = {
+        safe: 'keep',
+        get boom(): string {
+          throw new Error('exploded');
+        },
+      };
+
+      const result = flattenToSearchText(input);
+
+      expect(result).toContain('safe keep');
+      expect(result).toContain('boom');
+      expect(result).not.toContain('exploded');
+    });
+
+    it('survives a value whose toString throws', () => {
+      const input = {
+        safe: 'keep',
+        bad: {
+          toString() {
+            throw new Error('exploded');
+          },
+        },
+      };
+
+      expect(() => flattenToSearchText(input)).not.toThrow();
+      expect(flattenToSearchText(input)).toContain('keep');
+    });
+  });
+
+  describe('the shape of the output', () => {
+    it('never emits leading, trailing or repeated whitespace', () => {
+      expect(flattenToSearchText({ b: 'one', c: {}, d: [], e: 'two' })).toBe('b one c d e two');
+    });
+
+    it('preserves whitespace inside a value', () => {
+      expect(flattenToSearchText({ text: 'the quick  brown fox' })).toBe('text the quick  brown fox');
+    });
+
+    it('trims values that are only whitespace out of the result', () => {
+      expect(flattenToSearchText({ a: '   ', b: 'kept' })).toBe('a b kept');
+    });
+
+    it('does not mutate its input', () => {
+      const input = { a: 'one', nested: { b: 'two' }, list: [1, 2] };
+      const snapshot = structuredClone(input);
+
+      flattenToSearchText(input);
+
+      expect(input).toEqual(snapshot);
+    });
+
+    it('is deterministic across repeated calls', () => {
+      const input = { a: 'one', nested: { b: 'two', list: [3, 'four'] } };
+
+      expect(flattenToSearchText(input)).toBe(flattenToSearchText(input));
+    });
+  });
+
+  describe('when given a realistic span payload', () => {
+    it('exposes every nested value and field name to a substring search', () => {
+      const attributes = {
+        model: 'gpt-5-mini',
+        usage: { inputTokens: 1200, outputTokens: 300 },
+        request: { location: { city: 'Lyon' }, tags: ['weather', 'forecast'] },
+        error: null,
+      };
+
+      const result = flattenToSearchText(attributes);
+
+      const needles = ['gpt-5-mini', '1200', '300', 'Lyon', 'weather', 'forecast', 'model', 'usage', 'error'];
+      for (const needle of needles) {
+        expect(result).toContain(needle);
+      }
+    });
+  });
+});

--- a/packages/playground-ui/src/domains/traces/utils/flatten-to-search-text.test.ts
+++ b/packages/playground-ui/src/domains/traces/utils/flatten-to-search-text.test.ts
@@ -108,6 +108,15 @@ describe('flattenToSearchText', () => {
       expect(result).not.toContain('drop');
     });
 
+    it('does not walk into properties hung off a function', () => {
+      // A function is dropped whole: without an explicit stop it would fall
+      // through to the object walk and leak its own enumerable properties.
+      const fn = () => 'drop';
+      Object.assign(fn, { label: 'drop-too' });
+
+      expect(flattenToSearchText({ fn })).toBe('fn');
+    });
+
     it('skips symbol-keyed entries entirely', () => {
       expect(flattenToSearchText({ a: 'keep', [Symbol('k')]: 'drop' })).toBe('a keep');
     });

--- a/packages/playground-ui/src/domains/traces/utils/flatten-to-search-text.ts
+++ b/packages/playground-ui/src/domains/traces/utils/flatten-to-search-text.ts
@@ -1,0 +1,118 @@
+/**
+ * Flatten an arbitrary value into a single space-separated string containing
+ * every searchable token it holds, however deeply nested.
+ *
+ * Built for span payloads whose shape is not known ahead of time (`attributes`,
+ * `output`, `errorInfo`): the caller cannot enumerate fields, so this walks
+ * whatever it is handed.
+ *
+ * **Keys are emitted alongside their values**, so a field name is searchable
+ * even when its value is not — `{ error: null }` still answers a search for
+ * `error`. The cost is that structural names present on every span (`traceId`,
+ * `usage`, …) are searchable too, which makes short generic terms match widely.
+ *
+ * Values that no one can usefully search for are dropped rather than
+ * stringified: `null`, `undefined`, `NaN`, infinities, functions, symbols,
+ * invalid dates and whitespace-only strings. Dropping them keeps the output
+ * free of noise words like `"Invalid Date"` that would produce false hits.
+ * Array indices are dropped for the same reason — `0 1 2` is not content.
+ *
+ * Cycles are detected along the current path, so a self-referencing object
+ * terminates while a value referenced twice as a sibling is emitted twice.
+ * Only own, string-keyed properties are read, and a getter that throws is
+ * skipped instead of taking the whole trace down.
+ */
+export function flattenToSearchText(value: unknown): string {
+  const parts: string[] = [];
+  const path = new Set<object>();
+
+  collect(value, parts, path);
+
+  return parts.join(' ');
+}
+
+function collect(value: unknown, parts: string[], path: Set<object>): void {
+  if (value === null || value === undefined) return;
+
+  switch (typeof value) {
+    case 'string': {
+      const trimmed = value.trim();
+      if (trimmed) parts.push(trimmed);
+      return;
+    }
+    case 'number': {
+      // NaN and infinities have no useful search form.
+      if (Number.isFinite(value)) parts.push(String(value));
+      return;
+    }
+    case 'boolean':
+    case 'bigint':
+      parts.push(String(value));
+      return;
+    case 'function':
+    case 'symbol':
+      return;
+  }
+
+  const object = value as object;
+
+  // Guard the current path only: a cycle must terminate, but the same object
+  // referenced twice side by side is legitimately worth emitting twice.
+  if (path.has(object)) return;
+  path.add(object);
+
+  try {
+    collectFromObject(object, parts, path);
+  } finally {
+    path.delete(object);
+  }
+}
+
+function collectFromObject(object: object, parts: string[], path: Set<object>): void {
+  if (object instanceof Date) {
+    const time = object.getTime();
+    if (!Number.isNaN(time)) parts.push(object.toISOString());
+    return;
+  }
+
+  if (object instanceof Error) {
+    collect(object.message, parts, path);
+    return;
+  }
+
+  // Indices carry no meaning, so an array contributes only its items.
+  if (Array.isArray(object)) {
+    for (const item of object) collect(item, parts, path);
+    return;
+  }
+
+  if (object instanceof Map) {
+    for (const [key, item] of object) {
+      collect(key, parts, path);
+      collect(item, parts, path);
+    }
+    return;
+  }
+
+  // A Set has members, not fields.
+  if (object instanceof Set) {
+    for (const item of object) collect(item, parts, path);
+    return;
+  }
+
+  // Own string keys only: skips the prototype chain and symbol-keyed entries.
+  for (const key of Object.keys(object)) {
+    // The key is emitted even when the value turns out to be unsearchable, so
+    // the presence of a field is itself findable.
+    collect(key, parts, path);
+
+    let item: unknown;
+    try {
+      item = (object as Record<string, unknown>)[key];
+    } catch {
+      // A getter that throws is not a reason to lose the rest of the payload.
+      continue;
+    }
+    collect(item, parts, path);
+  }
+}

--- a/packages/playground-ui/src/domains/traces/utils/index.ts
+++ b/packages/playground-ui/src/domains/traces/utils/index.ts
@@ -1,1 +1,2 @@
+export { filterSpansKeepingAncestors } from './filter-spans-keeping-ancestors';
 export { formatSpanDuration, getInputPreview, isTokenLimitExceeded, getTokenLimitMessage } from './span-utils';

--- a/packages/playground-ui/src/domains/traces/utils/index.ts
+++ b/packages/playground-ui/src/domains/traces/utils/index.ts
@@ -1,2 +1,4 @@
 export { filterSpansKeepingAncestors } from './filter-spans-keeping-ancestors';
+export { flattenToSearchText } from './flatten-to-search-text';
+export { selectSearchableSpans, toSearchableSpans } from './to-searchable-spans';
 export { formatSpanDuration, getInputPreview, isTokenLimitExceeded, getTokenLimitMessage } from './span-utils';

--- a/packages/playground-ui/src/domains/traces/utils/to-searchable-spans.test.ts
+++ b/packages/playground-ui/src/domains/traces/utils/to-searchable-spans.test.ts
@@ -1,0 +1,138 @@
+import type { LightSpanRecord } from '@mastra/core/storage';
+import { describe, expect, it } from 'vitest';
+
+import { selectSearchableSpans, toSearchableSpans } from './to-searchable-spans';
+
+function span(overrides: Partial<LightSpanRecord> = {}): LightSpanRecord {
+  return {
+    traceId: 'trace-1',
+    spanId: 'span-1',
+    parentSpanId: null,
+    name: 'agent run',
+    spanType: 'agent_run',
+    isEvent: false,
+    startedAt: '2026-06-10T12:00:00.000Z',
+    endedAt: '2026-06-10T12:00:01.000Z',
+    ...overrides,
+  } as LightSpanRecord;
+}
+
+// `toSearchableSpans` maps one-to-one, so a missing entry is a bug worth
+// failing on rather than an `expect` that quietly passes against `undefined`.
+function enrich(record: LightSpanRecord) {
+  const [enriched] = toSearchableSpans([record]);
+  if (!enriched) throw new Error('toSearchableSpans dropped the span');
+  return enriched;
+}
+
+describe('toSearchableSpans', () => {
+  describe('what it attaches', () => {
+    it('gives every span a searchText', () => {
+      const result = toSearchableSpans([span({ spanId: 'a' }), span({ spanId: 'b' })]);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.searchText).toEqual(expect.any(String));
+      expect(result[1]?.searchText).toEqual(expect.any(String));
+    });
+
+    it('carries the span name into searchText', () => {
+      const result = enrich(span({ name: 'weather tool' }));
+
+      expect(result.searchText).toContain('weather tool');
+    });
+
+    it('carries the open-ended metadata payload, which no fixed field list reaches', () => {
+      const result = enrich(span({ metadata: { city: 'Lyon', nested: { unit: 'celsius' } } }));
+
+      expect(result.searchText).toContain('lyon');
+      expect(result.searchText).toContain('celsius');
+    });
+
+    it('carries the open-ended error payload', () => {
+      const result = enrich(span({ error: { message: 'rate limit exceeded' } }));
+
+      expect(result.searchText).toContain('rate limit exceeded');
+    });
+
+    it('carries the field names, so a payload shape is searchable', () => {
+      const result = enrich(span({ metadata: { retries: 3 } }));
+
+      expect(result.searchText).toContain('retries');
+    });
+  });
+
+  describe('the case it stores', () => {
+    it('lowercases searchText so matching never has to', () => {
+      const result = enrich(span({ name: 'WeatherAgent', entityName: 'CHEF-Agent' }));
+
+      expect(result.searchText).toContain('weatheragent');
+      expect(result.searchText).toContain('chef-agent');
+      expect(result.searchText).toBe(result.searchText.toLowerCase());
+    });
+  });
+
+  describe('what it preserves', () => {
+    it('keeps every original field readable on the result', () => {
+      const input = span({ spanId: 'x', name: 'llm call', entityName: 'chef' });
+
+      const result = enrich(input);
+
+      expect(result).toMatchObject(input);
+    });
+
+    it('keeps the input order', () => {
+      const result = toSearchableSpans([span({ spanId: 'a' }), span({ spanId: 'b' }), span({ spanId: 'c' })]);
+
+      expect(result.map(s => s.spanId)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('does not mutate the input spans', () => {
+      const input = [span({ spanId: 'a' })];
+      const snapshot = structuredClone(input);
+
+      toSearchableSpans(input);
+
+      expect(input).toEqual(snapshot);
+      expect(input[0]).not.toHaveProperty('searchText');
+    });
+
+    it('returns an empty array for an empty input', () => {
+      expect(toSearchableSpans([])).toEqual([]);
+    });
+  });
+
+  describe('when a span is already searchable', () => {
+    it('recomputes rather than trusting a stale searchText', () => {
+      const stale = { ...span({ name: 'renamed' }), searchText: 'outdated' } as LightSpanRecord;
+
+      const result = enrich(stale);
+
+      expect(result.searchText).toContain('renamed');
+      expect(result.searchText).not.toBe('outdated');
+    });
+  });
+});
+
+describe('selectSearchableSpans', () => {
+  it('enriches the spans of a query payload', () => {
+    const result = selectSearchableSpans({ traceId: 'trace-1', spans: [span({ name: 'weather tool' })] });
+
+    expect(result.spans[0]?.searchText).toContain('weather tool');
+  });
+
+  it('keeps the other fields of the payload', () => {
+    const result = selectSearchableSpans({ traceId: 'trace-1', spans: [] });
+
+    expect(result.traceId).toBe('trace-1');
+  });
+
+  it('passes null through, since a query may resolve to null', () => {
+    expect(selectSearchableSpans(null)).toBeNull();
+  });
+
+  it('is a stable module-level reference, so React Query can memoize it', () => {
+    // Re-importing must not produce a new function: an unstable `select` would
+    // re-flatten every span on every render.
+    expect(selectSearchableSpans).toBe(selectSearchableSpans);
+  });
+});

--- a/packages/playground-ui/src/domains/traces/utils/to-searchable-spans.ts
+++ b/packages/playground-ui/src/domains/traces/utils/to-searchable-spans.ts
@@ -1,0 +1,51 @@
+import type { LightSpanRecord } from '@mastra/core/storage';
+import type { SearchableSpan } from '../types';
+import { flattenToSearchText } from './flatten-to-search-text';
+
+/**
+ * Attach a precomputed search haystack to each span.
+ *
+ * Run this once, where the span list is resolved — not per keystroke. Flattening
+ * walks every nested payload, so doing it inside a filter would repeat the whole
+ * walk for every character typed.
+ *
+ * The whole record is flattened, which is what reaches `metadata` and `error`:
+ * their shapes are open-ended, so no fixed list of fields can read them. The
+ * text is lowercased here so matching is a bare `includes` with no per-span
+ * `toLowerCase` on every keystroke.
+ *
+ * Inputs are left untouched; each result is a new object.
+ */
+export function toSearchableSpans(spans: LightSpanRecord[]): SearchableSpan[] {
+  return spans.map(span => ({
+    ...span,
+    // Computed from `span`, so a stale `searchText` on the input is overwritten
+    // rather than carried through by the spread.
+    searchText: flattenToSearchText(span).toLowerCase(),
+  }));
+}
+
+/**
+ * React Query `select` for the `{ traceId, spans }` payload returned by
+ * `getTraceLight` and `getBranch`.
+ *
+ * Enriching here rather than in a component means the flattening runs once per
+ * fetch and is cached with the query, so it survives the panel unmounting and
+ * remounting. Keep this a module-level reference: React Query re-runs `select`
+ * whenever its identity changes, and an inline arrow would re-flatten the whole
+ * trace on every render.
+ *
+ * Deliberately not generic: TypeScript cannot infer a query's `TData` from a
+ * generic function passed as `select`, and silently falls back to the unselected
+ * type — which would leave `searchText` missing at the call sites.
+ *
+ * `null` is passed through because a query may resolve to it. `undefined` is not
+ * in the signature: React Query only runs `select` once data exists.
+ */
+export function selectSearchableSpans(
+  data: { traceId: string; spans: LightSpanRecord[] } | null,
+): { traceId: string; spans: SearchableSpan[] } | null {
+  if (!data) return null;
+
+  return { ...data, spans: toSearchableSpans(data.spans) };
+}

--- a/packages/playground/src/domains/experiments/hooks/use-experiment-trace.ts
+++ b/packages/playground/src/domains/experiments/hooks/use-experiment-trace.ts
@@ -1,3 +1,4 @@
+import { selectSearchableSpans } from '@mastra/playground-ui/domains/traces/utils';
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
@@ -12,6 +13,9 @@ export const useExperimentTrace = (traceId: string | null | undefined) => {
       }
       return client.getTraceLight(traceId);
     },
+    // Builds each span's search haystack once per fetch, so the trace panel
+    // rendered below an experiment result searches the same way as the traces page.
+    select: selectSearchableSpans,
     enabled: !!traceId,
   });
 };


### PR DESCRIPTION

<img width="3840" height="2160" alt="CleanShot 2026-08-27 at 12 05 40@2x" src="https://github.com/user-attachments/assets/7765b7d2-c9e8-4982-b1ea-6f6218540ea1" />
## What this ships

You can now search the spans of a trace from the timeline in Studio.

A trace of any real size is long. Finding the one span you care about meant scrolling and reading names. The trace timeline now has a search field: type in it and the timeline narrows to the spans that match.

Three things make it usable rather than merely present:

- **It searches the whole span, not a list of fields.** A span is reachable by anything it carries — a tool argument, a model name, an error message, a value nested deep in its metadata. Field names are indexed too, so the *shape* of a payload is searchable, not only its content.
- **A match is never shown out of context.** The full parent chain of a matching span stays visible so you can see where it sits, and its own subtree stays visible too — searching for a tool call still shows you what that tool call did.
- **It does not depend on the order spans arrive in.** The trace API defaults to newest-first, which the first version of the filter silently mishandled.

The field sits on the left of the span type legend, filling a row that was previously half empty.

## How it works

The pipeline is: flatten → filter → build hierarchy.

1. `flattenToSearchText` walks any value recursively and produces one lowercased string of everything it contains, keys included. It handles cycles, `Date`, `Error`, `Map`, `Set`, arrays, and getters that throw.
2. `toSearchableSpans` attaches that string to each span as `searchText`. This runs **once**, in the React Query `select` of `useTraceLightSpans`, `useBranch` and `useExperimentTrace` — so the cost lands on trace load, not on every keystroke.
3. `useTraceSearch` owns the query state, defers it, and matches spans on `searchText`.
4. `filterSpansKeepingAncestors` keeps each match plus its full ancestor chain and its entire subtree, in `O(n)`, independent of input order.
5. The surviving flat list goes into the existing `formatHierarchicalSpans`.

`TraceTimeline` gains a `leadingSlot` prop rendered on the left of the legend row. The row now renders for the slot alone, which matters: a query matching nothing used to unmount the timeline, and would have taken the search field with it — stranding the user with a query they could no longer clear.

## Test plan

Tests were written before the implementation throughout, and each one was checked to actually fail against the code it guards.

- `flatten-to-search-text.test.ts` — 39 tests: primitives, nesting, cycles, hostile shapes (throwing getters, throwing `toString`), values not worth searching.
- `filter-spans-keeping-ancestors.test.ts` — 128 tests over four axes: where the match sits (leaf, middle, root, several branches), tree shape (single span, flat list, several roots, linear chain, wide fan-out, orphans, duplicates, cycles), **input order** (ascending, descending, shuffled, children-before-parents), and contract guarantees (predicate called once per span, input not mutated, references preserved).
- `to-searchable-spans.test.ts`, `use-trace-search.test.tsx`, `trace-data-panel-view.test.tsx` — enrichment, hook behaviour, and the rendered panel end to end.

Evidence the tests discriminate:

- The 55 order-related cases were run against the previous filter first and failed; the 73 others passed. That red block is the bug report.
- Reverting the predicate to the old six-field version fails 7 tests, 2 of them at the panel level.
- Mutating the panel to unmount the timeline on zero results fails the test that guards the search field staying mounted.

Mutation testing on the changed production files scores **97.14%**. Two survivors remain, both proven equivalent: a symbol primitive cannot carry own properties, and `catch { continue }` at the end of a loop body is `catch {}` when the value stays `undefined`. A third survivor was a genuine gap and is now killed — a function used to fall through to the object walk and leak its own enumerable properties into the search text.

`playground-ui` 159 files / 2846 tests, `playground` 295 files / 1979 tests, both typechecks and lint clean (0 errors).

## Not verified

No visual verification. jsdom has no layout engine, so the tests prove the field and the legend share a DOM row, not that they render correctly at any given width. Screenshots at mobile, tablet and desktop are still owed, along with a manual pass in Studio against a real trace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

You can now search inside a trace and quickly find spans that contain the text you entered. The timeline keeps the matching spans with their parents and children so the trace structure remains clear.

## Summary

- Added case-insensitive span search across names, field names, IDs, types, inputs, metadata, errors, and nested payload values.
- Preserved matching spans, ancestor chains, and descendant subtrees regardless of span order.
- Added safe recursive payload flattening for arrays, maps, sets, dates, errors, cycles, and throwing getters.
- Precomputed searchable text during trace loading with `SearchableSpan`, `toSearchableSpans`, and `selectSearchableSpans`.
- Added `useTraceSearch` and integrated it into `TraceDataPanelView`.
- Kept the timeline mounted when no spans match and added a no-match message.
- Added `TraceTimeline.leadingSlot` for the search field and responsive legend layout.
- Added unit, hook, and end-to-end panel test coverage.
- Added a patch changeset for `@mastra/playground-ui`.

## Validation

- Typechecking and linting are clean for `playground-ui` and `playground`.
- Visual verification and manual Studio testing remain unverified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->