### PR TITLE
feat(core): track file-based agent usage

### DIFF
--- a/.changeset/lucky-files-lie.md
+++ b/.changeset/lucky-files-lie.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added anonymous feature usage telemetry that reports once per project when file-based agents are used.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -74,6 +74,7 @@ import type { Schedule, ScheduleUpdate, SchedulesStorage } from '../storage/doma
 import { WorkflowsInMemory } from '../storage/domains/workflows/inmemory';
 import { augmentWithInit } from '../storage/storageWithInit';
 import type { StorageResolvedPromptBlockType } from '../storage/types';
+import { trackFeatureUsage } from '../telemetry/feature-telemetry';
 import type { ToolLoopAgentLike } from '../tool-loop-agent';
 import { isToolLoopAgentLike, toolLoopAgentToMastraAgent } from '../tool-loop-agent';
 import type { ToolAction, ToolPayloadTransformPolicy } from '../tools';
@@ -755,6 +756,8 @@ export class Mastra<
    * batch of agents after startup triggers one sweep rather than one per agent.
    */
   #fsScheduleSyncPending = false;
+  /** Set once file-based agent usage has been reported for this Mastra instance. */
+  #fsAgentUsageTracked = false;
   /**
    * Set when an agent registers while a sweep is already in flight. That sweep
    * may have read the agent map before the agent landed, so it runs one more
@@ -2779,6 +2782,7 @@ export class Mastra<
     }
 
     const agents = this.#agents as Record<string, Agent<any>>;
+    let registeredCount = 0;
     for (const [key, agent] of Object.entries(fsAgents)) {
       if (agent == null) {
         continue;
@@ -2790,6 +2794,12 @@ export class Mastra<
         continue;
       }
       this.addAgent(agent, key, { source: 'fs' });
+      registeredCount++;
+    }
+
+    if (registeredCount > 0 && !this.#fsAgentUsageTracked) {
+      this.#fsAgentUsageTracked = true;
+      trackFeatureUsage('file_based_agents', { fs_agent_count: registeredCount });
     }
   }
 

--- a/packages/core/src/telemetry/feature-telemetry.test.ts
+++ b/packages/core/src/telemetry/feature-telemetry.test.ts
@@ -11,13 +11,23 @@ const { capture, flush, PostHog } = vi.hoisted(() => {
 
 vi.mock('posthog-node', () => ({ PostHog }));
 
-import type { Mastra } from '../mastra';
+import { Agent } from '../agent';
+import { Mastra } from '../mastra';
 import { InMemoryStore } from '../storage/mock';
 import { FEATURE_USAGE_EVENT, syncFeatureUsageTelemetry, trackFeatureUsage } from './feature-telemetry';
 import { hashTelemetryValue, resetEETelemetryForTests } from './posthog';
 
 class UnknownStore {
   stores = {};
+}
+
+function makeAgent(name: string): Agent {
+  return new Agent({
+    id: name,
+    name,
+    instructions: `You are ${name}`,
+    model: 'openai/gpt-4o',
+  });
 }
 
 function makeMastra(overrides: Partial<Record<keyof Mastra, unknown>> = {}): Mastra {
@@ -116,6 +126,66 @@ describe('feature usage telemetry', () => {
     process.env.MASTRA_TELEMETRY_DISABLED = 'true';
 
     trackFeatureUsage('agent_builder');
+
+    expect(PostHog).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('tracks file-based agent usage when an agent is registered', () => {
+    const mastra = new Mastra({});
+
+    mastra.__registerFsAgents({ weather: makeAgent('weather') });
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0]![0]).toMatchObject({
+      distinctId: 'cli-distinct-id',
+      event: FEATURE_USAGE_EVENT,
+      properties: {
+        feature_name: 'file_based_agents',
+        project_id: hashTelemetryValue('/tmp/feature-telemetry-project').slice(0, 16),
+        command: 'dev',
+        node_env: 'test',
+        fs_agent_count: 1,
+      },
+    });
+  });
+
+  it('tracks file-based agent usage only once per Mastra instance', () => {
+    const mastra = new Mastra({});
+
+    mastra.__registerFsAgents({ weather: makeAgent('weather') });
+    mastra.__registerFsAgents({ support: makeAgent('support') });
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0]![0].properties.fs_agent_count).toBe(1);
+  });
+
+  it('counts only file-based agents that are actually registered', () => {
+    const mastra = new Mastra({ agents: { weather: makeAgent('weather') } });
+
+    mastra.__registerFsAgents({
+      weather: makeAgent('weather-fs'),
+      missing: null as unknown as Agent,
+      support: makeAgent('support'),
+    });
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0]![0].properties.fs_agent_count).toBe(1);
+  });
+
+  it('does not track file-based agent usage when every entry collides', () => {
+    const mastra = new Mastra({ agents: { weather: makeAgent('weather') } });
+
+    mastra.__registerFsAgents({ weather: makeAgent('weather-fs') });
+
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not track file-based agent usage when telemetry is disabled', () => {
+    process.env.MASTRA_TELEMETRY_DISABLED = 'true';
+    const mastra = new Mastra({});
+
+    mastra.__registerFsAgents({ weather: makeAgent('weather') });
 
     expect(PostHog).not.toHaveBeenCalled();
     expect(capture).not.toHaveBeenCalled();


### PR DESCRIPTION
## Description

Adds anonymous feature telemetry for file-based agent usage. When `Mastra.__registerFsAgents()` successfully registers one or more file-based agents, it emits `mastra_feature_usage` with `feature_name: 'file_based_agents'` and `fs_agent_count`. A per-instance guard prevents duplicate events across repeated registration calls, while null entries and code-agent collisions are excluded from the count.

Includes tests for the event shape, fire-once behavior, registration filtering, collision-only registration, and telemetry opt-out behavior, plus a patch changeset for `@mastra/core`.

## Related issue(s)

N/A — this is an internal telemetry improvement without a linked issue.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra now sends anonymous usage data when file-based agents are registered. It reports the number of agents once per `Mastra` instance and respects telemetry opt-out settings.

## Changes

- Added `file_based_agents` feature telemetry to `Mastra`.
- Reports the number of successfully registered file-based agents.
- Emits telemetry once per `Mastra` instance.
- Excludes null entries and code-agent name collisions.
- Preserves telemetry opt-out behavior.
- Added tests for event shape, counts, repeated registration, filtering, collisions, and disabled telemetry.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->