### PR TITLE
Focus the list search field with a keyboard shortcut in Studio

### DIFF
--- a/.changeset/list-search-focus-shortcut.md
+++ b/.changeset/list-search-focus-shortcut.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Add a Cmd+Shift+F (Ctrl+Shift+F on Windows/Linux) shortcut to `ListSearch` that focuses and selects the search field, so every Studio list page (agents, tools, workflows, MCP servers, processors, schedules, datasets, experiments, ...) can be filtered without reaching for the mouse. Pass `shortcutDisabled` on a secondary `ListSearch` if a page renders two at once.

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/search-field-block.tsx
@@ -1,5 +1,5 @@
 import { SearchIcon, XIcon } from 'lucide-react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type RefObject } from 'react';
 import { Button } from '../../Button';
 import { Input } from '../../Input';
 import type { InputProps } from '../../Input';
@@ -27,6 +27,8 @@ export type SearchFieldBlockProps = {
   variant?: InputProps['variant'];
   isMinimized?: boolean;
   onMinimizedChange?: (minimized: boolean) => void;
+  /** Gives the caller access to the underlying input, e.g. to focus it from a keyboard shortcut. */
+  inputRef?: RefObject<HTMLInputElement | null>;
 };
 
 export function SearchFieldBlock({
@@ -47,8 +49,14 @@ export function SearchFieldBlock({
   variant,
   isMinimized,
   onMinimizedChange,
+  inputRef: externalInputRef,
 }: SearchFieldBlockProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const setInputRef = (element: HTMLInputElement | null) => {
+    inputRef.current = element;
+    if (externalInputRef) externalInputRef.current = element;
+  };
   const buttonSize = size === 'default' ? 'lg' : size;
 
   useEffect(() => {
@@ -92,7 +100,7 @@ export function SearchFieldBlock({
         ) : null}
         <div className="group relative">
           <Input
-            ref={inputRef}
+            ref={setInputRef}
             id={`input-${name}`}
             name={name}
             disabled={disabled}

--- a/packages/playground-ui/src/ds/components/ListSearch/list-search.test.tsx
+++ b/packages/playground-ui/src/ds/components/ListSearch/list-search.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ListSearch } from './list-search';
+
+const setPlatform = (value: string) => {
+  Object.defineProperty(navigator, 'platform', { value, configurable: true });
+};
+
+const originalPlatform = navigator.platform;
+
+beforeEach(() => {
+  setPlatform(originalPlatform);
+});
+
+afterEach(() => {
+  cleanup();
+  setPlatform(originalPlatform);
+});
+
+const renderListSearch = (props: Partial<React.ComponentProps<typeof ListSearch>> = {}) =>
+  render(<ListSearch onSearch={vi.fn()} label="Filter agents" placeholder="Filter by name" {...props} />);
+
+describe('ListSearch keyboard shortcut', () => {
+  it('focuses the search field on Cmd+Shift+F on mac', () => {
+    setPlatform('MacIntel');
+    renderListSearch();
+
+    fireEvent.keyDown(window, { key: 'f', metaKey: true, shiftKey: true });
+
+    expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Filter agents' }));
+  });
+
+  it('focuses the search field on Ctrl+Shift+F off mac', () => {
+    setPlatform('Win32');
+    renderListSearch();
+
+    fireEvent.keyDown(window, { key: 'f', ctrlKey: true, shiftKey: true });
+
+    expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Filter agents' }));
+  });
+
+  it('ignores Cmd+F without shift so the browser find bar keeps working', () => {
+    setPlatform('MacIntel');
+    renderListSearch();
+
+    fireEvent.keyDown(window, { key: 'f', metaKey: true });
+
+    expect(document.activeElement).not.toBe(screen.getByRole('textbox', { name: 'Filter agents' }));
+  });
+
+  it('selects the existing value so the next keystroke replaces it', () => {
+    setPlatform('MacIntel');
+    renderListSearch({ value: 'agent' });
+
+    fireEvent.keyDown(window, { key: 'f', metaKey: true, shiftKey: true });
+
+    const input = screen.getByRole<HTMLInputElement>('textbox', { name: 'Filter agents' });
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe('agent'.length);
+  });
+
+  it('does not react to the shortcut when it is disabled', () => {
+    setPlatform('MacIntel');
+    renderListSearch({ shortcutDisabled: true });
+
+    fireEvent.keyDown(window, { key: 'f', metaKey: true, shiftKey: true });
+
+    expect(document.activeElement).not.toBe(screen.getByRole('textbox', { name: 'Filter agents' }));
+  });
+
+  it('leaves the disabled instance alone when two are mounted', () => {
+    setPlatform('MacIntel');
+    render(
+      <>
+        <ListSearch onSearch={vi.fn()} label="Filter agents" placeholder="Filter by name" />
+        <ListSearch onSearch={vi.fn()} label="Filter skills" placeholder="Filter by name" shortcutDisabled />
+      </>,
+    );
+
+    fireEvent.keyDown(window, { key: 'f', metaKey: true, shiftKey: true });
+
+    expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Filter agents' }));
+    expect(document.activeElement).not.toBe(screen.getByRole('textbox', { name: 'Filter skills' }));
+  });
+
+  it('still debounces search input', async () => {
+    vi.useFakeTimers();
+    const onSearch = vi.fn();
+    renderListSearch({ onSearch });
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Filter agents' }), { target: { value: 'abc' } });
+    expect(onSearch).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(300);
+    expect(onSearch).toHaveBeenCalledWith('abc');
+    vi.useRealTimers();
+  });
+});

--- a/packages/playground-ui/src/ds/components/ListSearch/list-search.tsx
+++ b/packages/playground-ui/src/ds/components/ListSearch/list-search.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useId, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { SearchFieldBlock } from '@/ds/components/FormFieldBlocks/fields/search-field-block';
 import type { InputProps } from '@/ds/components/Input';
+import { useKeydown } from '@/lib/keyboard';
 
 export type ListSearchProps = {
   onSearch: (search: string) => void;
@@ -16,6 +17,11 @@ export type ListSearchProps = {
    */
   value?: string;
   variant?: InputProps['variant'];
+  /**
+   * Opts out of the Cmd/Ctrl+Shift+F focus shortcut. Pass this on secondary
+   * instances so two search fields on the same page don't fight over focus.
+   */
+  shortcutDisabled?: boolean;
 };
 
 export const ListSearch = ({
@@ -26,9 +32,19 @@ export const ListSearch = ({
   size,
   value: controlledValue,
   variant = 'outline',
+  shortcutDisabled = false,
 }: ListSearchProps) => {
   const id = useId();
   const [internalValue, setInternalValue] = useState(controlledValue ?? '');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useKeydown({
+    'mod+shift+f': () => {
+      if (shortcutDisabled) return;
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    },
+  });
 
   const debouncedSearch = useDebouncedCallback((val: string) => {
     onSearch(val);
@@ -71,6 +87,7 @@ export const ListSearch = ({
       onReset={handleReset}
       size={size}
       variant={variant}
+      inputRef={inputRef}
       className="w-full max-w-120"
     />
   );


### PR DESCRIPTION
## Summary

Studio has a lot of list pages — agents, tools, workflows, MCP servers, processors, prompt blocks, schedules, datasets, experiments, agent builder. All of them show a search field at the top to filter the list, but reaching that field required clicking it with the mouse.

This adds a keyboard shortcut that puts the cursor straight into that search field: **Cmd+Shift+F** on macOS, **Ctrl+Shift+F** on Windows and Linux. If the field already has text in it, the text is selected so the next keystroke replaces it rather than appending.

Because every list page renders the same shared `ListSearch` component, the shortcut is registered once inside that component and every page gets it — no page-by-page wiring, and new list pages get it for free.

## Notes

- The shortcut is deliberately specific: plain `Cmd+F` still opens the browser's own find bar.
- `ListSearch` accepts a new optional `shortcutDisabled` prop so a page that ever renders two search fields can opt one of them out and avoid a focus fight. No page needs it today.
- `SearchFieldBlock` gained an optional `inputRef` prop so a caller can get a handle on the underlying input; its existing internal focus behaviour is untouched.

## Test plan

- New `list-search.test.tsx` covers the macOS and non-macOS combos, that plain `Cmd+F` is ignored, that existing text gets selected, the `shortcutDisabled` opt-out, the two-instance case, and that search debouncing still works.
- `pnpm --filter ./packages/playground-ui test` for ListSearch, FormFieldBlocks and keyboard: 74 passing.
- `pnpm --filter ./packages/playground-ui typecheck` and `lint`: clean (0 errors).
- Manual: open `/agents`, press Cmd+Shift+F, cursor lands in the filter field and the browser find bar does not open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

You can now press `Cmd+Shift+F` on macOS or `Ctrl+Shift+F` on Windows/Linux to quickly find the list search box. The current search text is selected so you can replace it immediately.

## Changes

- Added the shortcut to the shared `ListSearch` component.
- Added `shortcutDisabled` to disable the shortcut for specific instances.
- Added `inputRef` support to `SearchFieldBlock`.
- Kept plain `Cmd+F` available for the browser find bar.
- Added tests for platform modifiers, text selection, disabled instances, multiple search fields, debouncing, and ignored shortcuts.
- Added a patch changeset for `@mastra/playground-ui`.
- Typechecking and linting pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->