### PR TITLE
feat(factory): store work item comments and route mentions to attention

### DIFF
--- a/.changeset/olive-spoons-go.md
+++ b/.changeset/olive-spoons-go.md
@@ -7,4 +7,5 @@ Added comments to Factory work items. Every work item now stores a comment threa
 - Posts are idempotent: a client token means a retried send never duplicates a comment
 - Edits carry the revision they were written against, so two people editing the same comment get a conflict instead of silent last-write-wins
 - Deletes are tombstones, so ordering and replies stay stable
+- Listing accepts `?around=<commentId>`, returning the page that holds that comment plus everything newer, so a link to a comment opens on it in one request
 - A mention writes an attention record, and the attention inbox now merges mentions with automation failures instead of serving one hardcoded kind

--- a/.changeset/olive-spoons-go.md
+++ b/.changeset/olive-spoons-go.md
@@ -1,0 +1,10 @@
+---
+'@mastra/factory': minor
+---
+
+Added comments to Factory work items. Every work item now stores a comment thread with quoted replies and @mentions, served by new routes for listing, posting, editing and deleting.
+
+- Posts are idempotent: a client token means a retried send never duplicates a comment
+- Edits carry the revision they were written against, so two people editing the same comment get a conflict instead of silent last-write-wins
+- Deletes are tombstones, so ordering and replies stay stable
+- A mention writes an attention record, and the attention inbox now merges mentions with automation failures instead of serving one hardcoded kind

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -392,6 +392,7 @@ describe('MastraFactory.prepare', () => {
       'filesystem',
       'source-control',
       'channel-identity',
+      'work-item-comments',
     ]);
     expect(storage.domainNames().every(name => storage.isDomainReady(name))).toBe(true);
   });

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -85,6 +85,8 @@ import { observeAgentGitAction } from './storage/domains/audit/agent-audit.js';
 import { AuditStorage } from './storage/domains/audit/base.js';
 import { AuditDomain } from './storage/domains/audit/domain.js';
 import { ChannelIdentityStorage } from './storage/domains/channel-identity/base.js';
+import { WorkItemCommentsStorage } from './storage/domains/comments/base.js';
+import { CommentsDomain } from './storage/domains/comments/domain.js';
 import { ModelCredentialsStorage } from './storage/domains/credentials/base.js';
 import { CustomProvidersStorage } from './storage/domains/custom-providers/base.js';
 import { FilesystemStorage } from './storage/domains/filesystem/base.js';
@@ -417,6 +419,7 @@ export class MastraFactory {
     // Reverse index from a platform sender (Slack/Discord/...) to a Mastra
     // tenant, so inbound channel events can resolve the sender's model creds.
     const channelIdentityStorage = storage.registerDomain(new ChannelIdentityStorage());
+    const workItemCommentsStorage = storage.registerDomain(new WorkItemCommentsStorage());
     // Every app-table domain handle the route builders and integrations need,
     // threaded explicitly (no service locator).
     const domains = {
@@ -430,6 +433,7 @@ export class MastraFactory {
       queueHealth: queueHealthStorage,
       workItems: workItemsStorage,
       channelIdentity: channelIdentityStorage,
+      comments: workItemCommentsStorage,
     };
     // Assigned once the fleet and integrations exist below; the routes only
     // dereference it at request time, so the late assignment is safe.
@@ -444,6 +448,14 @@ export class MastraFactory {
         const user = getFactoryAuthUserFromContext(requestContext);
         return { orgId: getFactoryAuthOrgId(user), userId: getFactoryAuthUserId(user) };
       },
+    });
+    const commentsDomain = new CommentsDomain({
+      auth: routeAuth,
+      comments: workItemCommentsStorage,
+      workItems: workItemsStorage,
+      projects: factoryProjectsStorage,
+      channelIdentity: channelIdentityStorage,
+      audit: auditDomain,
     });
 
     // Repository execution needs one sandbox per project-repository link,
@@ -848,6 +860,7 @@ export class MastraFactory {
           }),
           ...projectRoutes.routes(),
           ...auditDomain.routes(),
+          ...commentsDomain.routes(),
         ],
         buildServerConfig: () => {
           const cors = allowedOrigins.length ? { cors: { origin: allowedOrigins, credentials: true } } : {};

--- a/mastracode/factory/src/routes/attention-providers.ts
+++ b/mastracode/factory/src/routes/attention-providers.ts
@@ -1,0 +1,511 @@
+/**
+ * Per-kind attention providers. Each kind owns its counts, its bounded page
+ * scan, and its wire item shape; the route layer k-way merges provider pages
+ * on `occurredAt desc` with one resumable cursor per kind.
+ */
+
+import { factoryDispatchFailureMetadata } from '../rules/dispatch-errors.js';
+import type {
+  WorkItemCommentRow,
+  WorkItemCommentsStorage,
+  WorkItemMentionRow,
+} from '../storage/domains/comments/base.js';
+import type {
+  FactoryAttentionIdentity,
+  FactoryAttentionKind,
+  FactoryAttentionReceiptRecord,
+  FactoryDeferredDecisionRecord,
+  WorkItemRow,
+  WorkItemsStorage,
+} from '../storage/domains/work-items/base.js';
+import {
+  factoryAttentionKey,
+  factoryDecisionAttentionIdentity,
+  factoryMentionAttentionIdentity,
+} from '../storage/domains/work-items/base.js';
+
+export type FactoryAttentionView = 'open' | 'unread' | 'archived';
+
+export interface AttentionScope {
+  orgId: string;
+  userId: string;
+  factoryProjectId: string;
+}
+
+export interface AttentionStreamPosition {
+  occurredAt: Date;
+  id: string;
+}
+
+export interface AttentionEntry {
+  occurredAt: Date;
+  /** Position resuming the provider's stream right after this entry. */
+  resumeCursor: AttentionStreamPosition;
+  item: Record<string, unknown>;
+}
+
+export interface AttentionPageArgs {
+  view: FactoryAttentionView;
+  search?: string;
+  before?: AttentionStreamPosition;
+  limit: number;
+}
+
+export interface AttentionPageResult {
+  entries: AttentionEntry[];
+  /** More rows behind the scan once every returned entry is consumed. */
+  hasMore: boolean;
+  /** Resume point for a scan-budget stop past the last returned entry. */
+  continuation?: AttentionStreamPosition;
+}
+
+export interface AttentionCounts {
+  open: number;
+  unread: number;
+}
+
+export interface AttentionLatest {
+  key: string;
+  at: Date;
+  unread: boolean;
+}
+
+export interface AttentionProvider {
+  kind: FactoryAttentionKind;
+  counts(scope: AttentionScope): Promise<AttentionCounts>;
+  latest(scope: AttentionScope): Promise<AttentionLatest | null>;
+  page(scope: AttentionScope, args: AttentionPageArgs): Promise<AttentionPageResult>;
+  markAllRead(
+    scope: AttentionScope,
+    args: { before?: AttentionStreamPosition; now: Date },
+  ): Promise<{ hasMore: boolean; continuation?: AttentionStreamPosition }>;
+}
+
+const SCAN_PAGE_SIZE = 50;
+// Receipt filtering is bounded per request; the response cursor resumes after the last scan.
+const MAX_RECEIPT_SCAN_PAGES = 4;
+
+interface ScanBatch<T> {
+  rows: T[];
+  /** Set only when the page budget stopped a scan that still had rows behind it. */
+  continuation?: AttentionStreamPosition;
+}
+
+/**
+ * One bounded keyset scan, shared by every provider read. Walks newest-first
+ * from `before` until the stream runs dry or the page budget is spent; the
+ * final batch of a budget stop carries the position to resume from.
+ */
+async function* scanBatches<T>(
+  fetchBatch: (before?: AttentionStreamPosition) => Promise<{ rows: T[]; hasMore: boolean }>,
+  positionOf: (row: T) => AttentionStreamPosition,
+  before?: AttentionStreamPosition,
+): AsyncGenerator<ScanBatch<T>> {
+  let cursor = before;
+  for (let scanned = 1; scanned <= MAX_RECEIPT_SCAN_PAGES; scanned += 1) {
+    const { rows, hasMore } = await fetchBatch(cursor);
+    const last = rows.at(-1);
+    if (!last) return;
+    const position = positionOf(last);
+    yield { rows, ...(hasMore && scanned === MAX_RECEIPT_SCAN_PAGES ? { continuation: position } : {}) };
+    if (!hasMore) return;
+    cursor = position;
+  }
+}
+
+/** Fills a page from the scan, stopping at `limit` entries or at the scan budget. */
+async function collectPage<T>(
+  batches: AsyncGenerator<ScanBatch<T>>,
+  limit: number,
+  toEntries: (rows: T[]) => Promise<AttentionEntry[]>,
+): Promise<AttentionPageResult> {
+  const entries: AttentionEntry[] = [];
+  for await (const batch of batches) {
+    for (const entry of await toEntries(batch.rows)) {
+      if (entries.length === limit) return { entries, hasMore: true };
+      entries.push(entry);
+    }
+    if (batch.continuation) return { entries, hasMore: true, continuation: batch.continuation };
+  }
+  return { entries, hasMore: false };
+}
+
+/** Marks every scanned batch read, reporting where a budget stop left off. */
+async function markScanRead<T>(
+  batches: AsyncGenerator<ScanBatch<T>>,
+  markBatch: (rows: T[]) => Promise<void>,
+): Promise<{ hasMore: boolean; continuation?: AttentionStreamPosition }> {
+  for await (const batch of batches) {
+    await markBatch(batch.rows);
+    if (batch.continuation) return { hasMore: true, continuation: batch.continuation };
+  }
+  return { hasMore: false };
+}
+
+export function factoryDecisionType(decision: FactoryDeferredDecisionRecord): string {
+  return typeof decision.decision.type === 'string' ? decision.decision.type.slice(0, 64) : 'unknown';
+}
+
+function failureOccurredAt(decision: FactoryDeferredDecisionRecord): Date {
+  return decision.completedAt ?? decision.updatedAt;
+}
+
+function matchesView(view: FactoryAttentionView, receipt: FactoryAttentionReceiptRecord | undefined): boolean {
+  if (view === 'archived') return receipt?.state === 'archived';
+  if (view === 'unread') return receipt === undefined;
+  return receipt?.state !== 'archived';
+}
+
+function attentionTarget(decision: FactoryDeferredDecisionRecord, item: WorkItemRow | undefined) {
+  if (!item) return { kind: 'rules' as const };
+  const role = typeof decision.decision.role === 'string' ? decision.decision.role : undefined;
+  const session = role ? item.sessions[role] : undefined;
+  if (session) {
+    return {
+      kind: 'thread' as const,
+      sessionId: session.sessionId,
+      threadId: session.threadId,
+    };
+  }
+  return {
+    kind: 'work-item' as const,
+    workItemId: item.id,
+    board: workItemBoard(item),
+  };
+}
+
+function workItemBoard(item: WorkItemRow): 'review' | 'work' {
+  const review = item.externalSource?.integrationId === 'github' && item.externalSource.type === 'pull-request';
+  return review ? 'review' : 'work';
+}
+
+export class AutomationFailedAttentionProvider implements AttentionProvider {
+  readonly kind = 'automation-failed' as const;
+  readonly #workItems: WorkItemsStorage;
+
+  constructor({ workItems }: { workItems: WorkItemsStorage }) {
+    this.#workItems = workItems;
+  }
+
+  async counts(scope: AttentionScope): Promise<AttentionCounts> {
+    const [failedCount, receiptCount, archivedCount] = await Promise.all([
+      this.#workItems.countDeferredDecisionsByStatuses({
+        orgId: scope.orgId,
+        factoryProjectId: scope.factoryProjectId,
+        statuses: ['failed'],
+      }),
+      this.#workItems.countAttentionReceipts({ ...receiptScope(scope), kind: this.kind }),
+      this.#workItems.countAttentionReceipts({ ...receiptScope(scope), kind: this.kind, state: 'archived' }),
+    ]);
+    return {
+      open: Math.max(0, failedCount - archivedCount),
+      unread: Math.max(0, failedCount - receiptCount),
+    };
+  }
+
+  async latest(scope: AttentionScope): Promise<AttentionLatest | null> {
+    const page = await this.#workItems.listFailedDecisionPage({
+      orgId: scope.orgId,
+      factoryProjectId: scope.factoryProjectId,
+      limit: 1,
+    });
+    const newest = page.decisions[0];
+    if (!newest) return null;
+    const identity = factoryDecisionAttentionIdentity(newest.id, newest.failureOccurrence);
+    const receipts = await this.#workItems.listAttentionReceipts({
+      ...receiptScope(scope),
+      identities: [identity],
+    });
+    return {
+      key: factoryAttentionKey(scope.factoryProjectId, identity),
+      at: failureOccurredAt(newest),
+      unread: receipts.length === 0,
+    };
+  }
+
+  #scan(scope: AttentionScope, before?: AttentionStreamPosition) {
+    return scanBatches<FactoryDeferredDecisionRecord>(
+      async cursor => {
+        const page = await this.#workItems.listFailedDecisionPage({
+          orgId: scope.orgId,
+          factoryProjectId: scope.factoryProjectId,
+          before: cursor,
+          limit: SCAN_PAGE_SIZE,
+        });
+        return { rows: page.decisions, hasMore: page.hasMore };
+      },
+      decision => ({ occurredAt: failureOccurredAt(decision), id: decision.id }),
+      before,
+    );
+  }
+
+  async page(scope: AttentionScope, { view, search, before, limit }: AttentionPageArgs): Promise<AttentionPageResult> {
+    return collectPage(this.#scan(scope, before), limit, async decisions => {
+      const [receiptByKey, itemById] = await Promise.all([
+        this.#receiptsFor(scope, decisions),
+        this.#linkedItems(scope, decisions),
+      ]);
+      const entries: AttentionEntry[] = [];
+      for (const decision of decisions) {
+        const identity = factoryDecisionAttentionIdentity(decision.id, decision.failureOccurrence);
+        const receipt = receiptByKey.get(factoryAttentionKey(scope.factoryProjectId, identity));
+        if (!matchesView(view, receipt)) continue;
+        const item = decision.workItemId ? itemById.get(decision.workItemId) : undefined;
+        if (search && !matchesFailureSearch(decision, item, search)) continue;
+        entries.push({
+          occurredAt: failureOccurredAt(decision),
+          resumeCursor: { occurredAt: failureOccurredAt(decision), id: decision.id },
+          item: toFailureItem(scope, decision, item, receipt),
+        });
+      }
+      return entries;
+    });
+  }
+
+  async #receiptsFor(
+    scope: AttentionScope,
+    decisions: FactoryDeferredDecisionRecord[],
+  ): Promise<Map<string, FactoryAttentionReceiptRecord>> {
+    const receipts = await this.#workItems.listAttentionReceipts({
+      ...receiptScope(scope),
+      identities: decisions.map(decision => factoryDecisionAttentionIdentity(decision.id, decision.failureOccurrence)),
+    });
+    return new Map(receipts.map(receipt => [factoryAttentionKey(scope.factoryProjectId, receipt), receipt]));
+  }
+
+  async #linkedItems(
+    scope: AttentionScope,
+    decisions: FactoryDeferredDecisionRecord[],
+  ): Promise<Map<string, WorkItemRow>> {
+    const items = await this.#workItems.listByIds({
+      orgId: scope.orgId,
+      factoryProjectId: scope.factoryProjectId,
+      ids: decisions.flatMap(decision => (decision.workItemId ? [decision.workItemId] : [])),
+    });
+    return new Map(items.map(item => [item.id, item]));
+  }
+
+  async markAllRead(
+    scope: AttentionScope,
+    { before, now }: { before?: AttentionStreamPosition; now: Date },
+  ): Promise<{ hasMore: boolean; continuation?: AttentionStreamPosition }> {
+    return markScanRead(this.#scan(scope, before), async decisions => {
+      await this.#workItems.markAttentionReceiptsRead({
+        ...receiptScope(scope),
+        identities: decisions.map(decision =>
+          factoryDecisionAttentionIdentity(decision.id, decision.failureOccurrence),
+        ),
+        now,
+      });
+    });
+  }
+}
+
+interface ResolvedMention {
+  mention: WorkItemMentionRow;
+  comment: WorkItemCommentRow;
+  item: WorkItemRow;
+  identity: FactoryAttentionIdentity;
+  receipt: FactoryAttentionReceiptRecord | undefined;
+}
+
+export class MentionAttentionProvider implements AttentionProvider {
+  readonly kind = 'mention' as const;
+  readonly #workItems: WorkItemsStorage;
+  readonly #comments: WorkItemCommentsStorage;
+
+  constructor({ workItems, comments }: { workItems: WorkItemsStorage; comments: WorkItemCommentsStorage }) {
+    this.#workItems = workItems;
+    this.#comments = comments;
+  }
+
+  #scan(scope: AttentionScope, before?: AttentionStreamPosition) {
+    return scanBatches<WorkItemMentionRow>(
+      async cursor => {
+        const rows = await this.#comments.listMentionsForUser({
+          ...receiptScope(scope),
+          ...(cursor ? { before: cursor } : {}),
+          limit: SCAN_PAGE_SIZE + 1,
+        });
+        return { rows: rows.slice(0, SCAN_PAGE_SIZE), hasMore: rows.length > SCAN_PAGE_SIZE };
+      },
+      mention => ({ occurredAt: mention.occurredAt, id: mention.id }),
+      before,
+    );
+  }
+
+  /**
+   * Mention rows joined to what the inbox needs to show one — dropping the
+   * ones it cannot: a deleted comment, or a work item gone from the project.
+   */
+  async #resolve(scope: AttentionScope, mentions: WorkItemMentionRow[]): Promise<ResolvedMention[]> {
+    const [receipts, comments, items] = await Promise.all([
+      this.#workItems.listAttentionReceipts({
+        ...receiptScope(scope),
+        identities: mentions.map(mention => factoryMentionAttentionIdentity(mention.commentId)),
+      }),
+      this.#comments.listByIds({
+        orgId: scope.orgId,
+        ids: [...new Set(mentions.map(mention => mention.commentId))],
+      }),
+      this.#workItems.listByIds({
+        orgId: scope.orgId,
+        factoryProjectId: scope.factoryProjectId,
+        ids: [...new Set(mentions.map(mention => mention.workItemId))],
+      }),
+    ]);
+    const receiptByKey = new Map(
+      receipts.map(receipt => [factoryAttentionKey(scope.factoryProjectId, receipt), receipt]),
+    );
+    const commentById = new Map(comments.map(comment => [comment.id, comment]));
+    const itemById = new Map(items.map(item => [item.id, item]));
+
+    const resolved: ResolvedMention[] = [];
+    for (const mention of mentions) {
+      const comment = commentById.get(mention.commentId);
+      const item = itemById.get(mention.workItemId);
+      if (!comment || comment.deletedAt || !item) continue;
+      const identity = factoryMentionAttentionIdentity(mention.commentId);
+      resolved.push({
+        mention,
+        comment,
+        item,
+        identity,
+        receipt: receiptByKey.get(factoryAttentionKey(scope.factoryProjectId, identity)),
+      });
+    }
+    return resolved;
+  }
+
+  /**
+   * Derived from the same bounded scan as `page`, never from raw aggregates:
+   * the badge must count exactly what the views can show, down to stopping at
+   * the same scan budget. Aggregates would count orphan mention rows the list
+   * can never display or clear.
+   */
+  async counts(scope: AttentionScope): Promise<AttentionCounts> {
+    let open = 0;
+    let unread = 0;
+    for await (const batch of this.#scan(scope)) {
+      for (const { receipt } of await this.#resolve(scope, batch.rows)) {
+        if (receipt?.state !== 'archived') open += 1;
+        if (receipt === undefined) unread += 1;
+      }
+    }
+    return { open, unread };
+  }
+
+  async latest(scope: AttentionScope): Promise<AttentionLatest | null> {
+    const mentions = await this.#comments.listMentionsForUser({ ...receiptScope(scope), limit: 10 });
+    const newest = (await this.#resolve(scope, mentions))[0];
+    if (!newest) return null;
+    return {
+      key: factoryAttentionKey(scope.factoryProjectId, newest.identity),
+      at: newest.mention.occurredAt,
+      unread: newest.receipt === undefined,
+    };
+  }
+
+  async page(scope: AttentionScope, { view, search, before, limit }: AttentionPageArgs): Promise<AttentionPageResult> {
+    return collectPage(this.#scan(scope, before), limit, async mentions => {
+      const entries: AttentionEntry[] = [];
+      for (const resolved of await this.#resolve(scope, mentions)) {
+        if (!matchesView(view, resolved.receipt)) continue;
+        if (search && !matchesMentionSearch(resolved, search)) continue;
+        entries.push({
+          occurredAt: resolved.mention.occurredAt,
+          resumeCursor: { occurredAt: resolved.mention.occurredAt, id: resolved.mention.id },
+          item: toMentionItem(scope, resolved),
+        });
+      }
+      return entries;
+    });
+  }
+
+  async markAllRead(
+    scope: AttentionScope,
+    { before, now }: { before?: AttentionStreamPosition; now: Date },
+  ): Promise<{ hasMore: boolean; continuation?: AttentionStreamPosition }> {
+    return markScanRead(this.#scan(scope, before), async mentions => {
+      await this.#workItems.markAttentionReceiptsRead({
+        ...receiptScope(scope),
+        identities: mentions.map(mention => factoryMentionAttentionIdentity(mention.commentId)),
+        now,
+      });
+    });
+  }
+}
+
+function matchesFailureSearch(
+  decision: FactoryDeferredDecisionRecord,
+  item: WorkItemRow | undefined,
+  search: string,
+): boolean {
+  return (
+    item?.title.toLowerCase().includes(search) === true ||
+    decision.lastError?.toLowerCase().includes(search) === true ||
+    factoryDecisionType(decision).toLowerCase().includes(search)
+  );
+}
+
+function toFailureItem(
+  scope: AttentionScope,
+  decision: FactoryDeferredDecisionRecord,
+  item: WorkItemRow | undefined,
+  receipt: FactoryAttentionReceiptRecord | undefined,
+) {
+  const failure = factoryDispatchFailureMetadata(decision.failureCode);
+  const identity = factoryDecisionAttentionIdentity(decision.id, decision.failureOccurrence);
+  return {
+    key: factoryAttentionKey(scope.factoryProjectId, identity),
+    kind: 'automation-failed' as const,
+    decisionId: decision.id,
+    occurrence: decision.failureOccurrence,
+    workItemId: decision.workItemId,
+    title: item?.title ?? failure.label,
+    detail: decision.lastError?.slice(0, 512) ?? failure.label,
+    decisionType: factoryDecisionType(decision),
+    failureCode: decision.failureCode,
+    canRetry: failure.canRetry,
+    occurredAt: failureOccurredAt(decision).toISOString(),
+    read: receipt !== undefined,
+    archived: receipt?.state === 'archived',
+    target: attentionTarget(decision, item),
+  };
+}
+
+function matchesMentionSearch({ item, comment }: ResolvedMention, search: string): boolean {
+  return (
+    item.title.toLowerCase().includes(search) ||
+    comment.body.toLowerCase().includes(search) ||
+    comment.author.displayName?.toLowerCase().includes(search) === true
+  );
+}
+
+function toMentionItem(scope: AttentionScope, { mention, comment, item, identity, receipt }: ResolvedMention) {
+  const authorName = comment.author.displayName;
+  return {
+    key: factoryAttentionKey(scope.factoryProjectId, identity),
+    kind: 'mention' as const,
+    commentId: mention.commentId,
+    occurrence: 0,
+    workItemId: mention.workItemId,
+    title: item.title,
+    detail: comment.body.slice(0, 512),
+    authorId: comment.author.id,
+    ...(authorName ? { authorName } : {}),
+    occurredAt: mention.occurredAt.toISOString(),
+    read: receipt !== undefined,
+    archived: receipt?.state === 'archived',
+    target: {
+      kind: 'work-item' as const,
+      workItemId: mention.workItemId,
+      board: workItemBoard(item),
+      commentId: mention.commentId,
+    },
+  };
+}
+
+function receiptScope(scope: AttentionScope): { orgId: string; factoryProjectId: string; userId: string } {
+  return { orgId: scope.orgId, factoryProjectId: scope.factoryProjectId, userId: scope.userId };
+}

--- a/mastracode/factory/src/routes/attention.test.ts
+++ b/mastracode/factory/src/routes/attention.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Attention over HTTP with both providers live: mention items and counts, the
+ * per-kind receipt currency, read-all across kinds, and the merged two-stream
+ * cursor.
+ */
+
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { builtInFactoryRules } from '../rules/defaults.js';
+import { FactoryTransitionService } from '../rules/transition-service.js';
+import type { FactoryDeferredDecisionRecord, WorkItemRow } from '../storage/domains/work-items/base.js';
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
+import { fakeRouteAuth, mountApiRoutes } from './test-utils.js';
+import { WorkItemRoutes } from './work-items.js';
+
+const orgUser = { workosId: 'u1', organizationId: 'org1' };
+
+let seed: FactoryStorageTestSeed;
+let PROJECT_ID = '';
+
+function buildApp(user: typeof orgUser | null = orgUser) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (user) c.set('factoryAuthUser' as never, user as never);
+    await next();
+  });
+  mountApiRoutes(
+    app as never,
+    new WorkItemRoutes({
+      auth: fakeRouteAuth(),
+      audit: { emit: async () => {} },
+      projects: seed.projects,
+      workItems: seed.workItems,
+      comments: seed.comments,
+      queueHealth: seed.queueHealth,
+      transitionService: new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems }),
+      liveSessions: { isRunning: () => false },
+    }).routes(),
+  );
+  return app;
+}
+
+function request(method: string, path: string, user: typeof orgUser | null = orgUser) {
+  return buildApp(user).request(path, { method });
+}
+
+async function seedWorkItem(title = 'Fix login'): Promise<WorkItemRow> {
+  const { item } = await seed.workItems.upsert({
+    orgId: 'org1',
+    userId: 'u1',
+    factoryProjectId: PROJECT_ID,
+    input: { title, stages: ['intake'], sessions: {}, metadata: {} },
+  });
+  return item;
+}
+
+async function seedMention({
+  workItemId,
+  body,
+  occurredAt,
+  mentionedId = 'u1',
+  authorId = 'user-author',
+}: {
+  workItemId: string;
+  body: string;
+  occurredAt: Date;
+  mentionedId?: string;
+  authorId?: string;
+}) {
+  return seed.comments.create({
+    orgId: 'org1',
+    factoryProjectId: PROJECT_ID,
+    workItemId,
+    author: { kind: 'user', id: authorId, displayName: 'Author' },
+    body,
+    occurredAt,
+    mentions: [{ kind: 'user', id: mentionedId }],
+  });
+}
+
+async function seedFailure(workItem: WorkItemRow, now: Date): Promise<FactoryDeferredDecisionRecord> {
+  await seed.workItems.commitRuleEvaluation({
+    orgId: 'org1',
+    factoryProjectId: PROJECT_ID,
+    workItemId: workItem.id,
+    ingress: { identity: `attention-failure-${now.getTime()}`, triggerType: 'test' },
+    ruleSetVersion: 'rules-v1',
+    expectedRevision: (await seed.workItems.get({ orgId: 'org1', id: workItem.id }))?.revision ?? workItem.revision,
+    actor: { type: 'system', id: 'rules' },
+    outcome: { status: 'accepted' },
+    decisions: [
+      {
+        type: 'sendMessage',
+        role: 'work',
+        message: 'Notify the session.',
+        idempotencyKey: `attention-failure-${now.getTime()}`,
+      },
+    ],
+    causalChain: [],
+    now,
+  });
+  const [claimed] = await seed.workItems.claimDeferredDecisions({
+    ownerId: 'worker-1',
+    now,
+    leaseExpiresAt: new Date(now.getTime() + 60_000),
+    limit: 1,
+  });
+  if (!claimed) throw new Error('Expected a deferred decision');
+  const failed = await seed.workItems.failDeferredDecision({
+    id: claimed.id,
+    orgId: claimed.orgId,
+    factoryProjectId: claimed.factoryProjectId,
+    ownerId: 'worker-1',
+    now,
+    availableAt: now,
+    lastError: 'No active Factory binding for role work.',
+    failureCode: 'source_control_missing',
+    terminal: true,
+  });
+  if (!failed) throw new Error('Expected a failed deferred decision');
+  return failed;
+}
+
+beforeEach(async () => {
+  seed = await createFactoryStorageForTests();
+  const project = await seed.projects.create({ orgId: 'org1', userId: 'u1', input: { name: 'org1 project' } });
+  PROJECT_ID = project.id;
+});
+
+describe('mention attention items', () => {
+  it('lists a mention in every view with per-kind read and archive receipts', async () => {
+    const item = await seedWorkItem();
+    const comment = await seedMention({
+      workItemId: item.id,
+      body: 'Hey @you, look at this',
+      occurredAt: new Date('2030-01-01T00:00:00.000Z'),
+    });
+
+    const open = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json();
+    expect(open).toMatchObject({
+      items: [
+        {
+          kind: 'mention',
+          commentId: comment.id,
+          workItemId: item.id,
+          title: 'Fix login',
+          detail: 'Hey @you, look at this',
+          authorName: 'Author',
+          read: false,
+          target: { kind: 'work-item', workItemId: item.id, commentId: comment.id },
+        },
+      ],
+      openCount: 1,
+      unreadCount: 1,
+      badgeCount: 1,
+      latestOccurrenceUnread: true,
+    });
+
+    const receiptPath = `/web/factory/projects/${PROJECT_ID}/attention/mention/${comment.id}/0`;
+    expect((await request('POST', `${receiptPath}/read`)).status).toBe(200);
+    await expect(
+      (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?view=unread`)).json(),
+    ).resolves.toMatchObject({ items: [], unreadCount: 0, openCount: 1 });
+
+    expect((await request('POST', `${receiptPath}/archive`)).status).toBe(200);
+    await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
+      { items: [], openCount: 0 },
+    );
+    await expect(
+      (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?view=archived`)).json(),
+    ).resolves.toMatchObject({ items: [{ kind: 'mention', commentId: comment.id, archived: true }] });
+
+    expect((await request('POST', `${receiptPath}/restore`)).status).toBe(200);
+    await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
+      { items: [{ kind: 'mention', read: true, archived: false }], openCount: 1 },
+    );
+  });
+
+  it('never surfaces self-mentions', async () => {
+    const item = await seedWorkItem();
+    await seedMention({
+      workItemId: item.id,
+      body: 'note to self',
+      occurredAt: new Date('2030-01-01T00:00:00.000Z'),
+      mentionedId: 'u1',
+      authorId: 'u1',
+    });
+
+    await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
+      { items: [], openCount: 0, unreadCount: 0 },
+    );
+  });
+
+  it('rejects receipts for deleted comments with 409', async () => {
+    const item = await seedWorkItem();
+    const comment = await seedMention({
+      workItemId: item.id,
+      body: 'soon gone',
+      occurredAt: new Date('2030-01-01T00:00:00.000Z'),
+    });
+    await seed.comments.softDelete({ orgId: 'org1', commentId: comment.id, deletedBy: 'user-author' });
+
+    const stale = await request('POST', `/web/factory/projects/${PROJECT_ID}/attention/mention/${comment.id}/0/read`);
+    expect(stale.status).toBe(409);
+    await expect(stale.json()).resolves.toEqual({ error: 'attention_item_not_current' });
+  });
+
+  it('409s a mention receipt when the caller was never mentioned or the occurrence is off', async () => {
+    const item = await seedWorkItem();
+    const comment = await seedMention({
+      workItemId: item.id,
+      body: 'for someone else',
+      occurredAt: new Date('2030-01-01T00:00:00.000Z'),
+      mentionedId: 'user-other',
+    });
+
+    const notMentioned = await request(
+      'POST',
+      `/web/factory/projects/${PROJECT_ID}/attention/mention/${comment.id}/0/read`,
+    );
+    expect(notMentioned.status).toBe(409);
+    await expect(notMentioned.json()).resolves.toEqual({ error: 'attention_item_not_current' });
+
+    const mine = await seedMention({
+      workItemId: item.id,
+      body: 'for me',
+      occurredAt: new Date('2030-01-01T00:00:01.000Z'),
+    });
+    const wrongOccurrence = await request(
+      'POST',
+      `/web/factory/projects/${PROJECT_ID}/attention/mention/${mine.id}/1/read`,
+    );
+    expect(wrongOccurrence.status).toBe(409);
+  });
+
+  it('ignores garbage mention receipts in the counts', async () => {
+    const item = await seedWorkItem();
+    await seedMention({ workItemId: item.id, body: 'real', occurredAt: new Date('2030-01-01T00:00:00.000Z') });
+    const now = new Date('2030-01-01T00:00:05.000Z');
+    for (const [sourceId, state, archivedAt] of [
+      ['11111111-1111-4111-8111-111111111111', 'read', null],
+      ['22222222-2222-4222-8222-222222222222', 'archived', now],
+    ] as const) {
+      await seed.storage.ops.insertOne('factory_attention_receipts', {
+        org_id: 'org1',
+        factory_project_id: PROJECT_ID,
+        user_id: 'u1',
+        kind: 'mention',
+        source_id: sourceId,
+        occurrence: 0,
+        state,
+        read_at: now,
+        archived_at: archivedAt,
+        created_at: now,
+        updated_at: now,
+      });
+    }
+
+    await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
+      { items: [{ kind: 'mention', detail: 'real' }], openCount: 1, unreadCount: 1, badgeCount: 1 },
+    );
+  });
+
+  it('keeps the latest pointer on an unread item even when a read one is newer', async () => {
+    const item = await seedWorkItem();
+    await seedMention({ workItemId: item.id, body: 'older unread', occurredAt: new Date('2030-01-01T00:00:05.000Z') });
+    const failure = await seedFailure(item, new Date('2030-01-01T00:00:10.000Z'));
+
+    expect(
+      (await request('POST', `/web/factory/projects/${PROJECT_ID}/attention/automation-failed/${failure.id}/1/read`))
+        .status,
+    ).toBe(200);
+
+    await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
+      {
+        latestOccurrenceAt: '2030-01-01T00:00:05.000Z',
+        latestOccurrenceUnread: true,
+        unreadCount: 1,
+        openCount: 2,
+      },
+    );
+  });
+
+  it('sums counts across kinds for badge math', async () => {
+    const item = await seedWorkItem();
+    await seedFailure(item, new Date('2030-01-01T00:00:10.000Z'));
+    await seedMention({ workItemId: item.id, body: 'one', occurredAt: new Date('2030-01-01T00:00:05.000Z') });
+    await seedMention({ workItemId: item.id, body: 'two', occurredAt: new Date('2030-01-01T00:00:15.000Z') });
+
+    await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
+      {
+        openCount: 3,
+        unreadCount: 3,
+        badgeCount: 3,
+        latestOccurrenceAt: '2030-01-01T00:00:15.000Z',
+      },
+    );
+  });
+
+  it('merges kinds newest-first and resumes both streams through the cursor', async () => {
+    const item = await seedWorkItem();
+    const failure = await seedFailure(item, new Date('2030-01-01T00:00:10.000Z'));
+    const m1 = await seedMention({
+      workItemId: item.id,
+      body: 'oldest',
+      occurredAt: new Date('2030-01-01T00:00:05.000Z'),
+    });
+    const m2 = await seedMention({
+      workItemId: item.id,
+      body: 'middle',
+      occurredAt: new Date('2030-01-01T00:00:15.000Z'),
+    });
+    const m3 = await seedMention({
+      workItemId: item.id,
+      body: 'newest',
+      occurredAt: new Date('2030-01-01T00:00:20.000Z'),
+    });
+
+    const first = await (await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?limit=2`)).json();
+    expect(first.items.map((entry: any) => entry.commentId ?? entry.decisionId)).toEqual([m3.id, m2.id]);
+    expect(first.hasMore).toBe(true);
+    expect(typeof first.nextCursor).toBe('string');
+
+    const second = await (
+      await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?limit=2&before=${first.nextCursor}`)
+    ).json();
+    expect(second.items.map((entry: any) => entry.commentId ?? entry.decisionId)).toEqual([failure.id, m1.id]);
+    expect(second.hasMore).toBe(false);
+  });
+
+  it('read-all marks both kinds read', async () => {
+    const item = await seedWorkItem();
+    await seedFailure(item, new Date('2030-01-01T00:00:10.000Z'));
+    const comment = await seedMention({
+      workItemId: item.id,
+      body: 'ping',
+      occurredAt: new Date('2030-01-01T00:00:20.000Z'),
+    });
+
+    const readAll = await request('POST', `/web/factory/projects/${PROJECT_ID}/attention/read-all`);
+    expect(readAll.status).toBe(200);
+    await expect(readAll.json()).resolves.toEqual({ ok: true, hasMore: false });
+
+    await expect((await request('GET', `/web/factory/projects/${PROJECT_ID}/attention`)).json()).resolves.toMatchObject(
+      { unreadCount: 0, openCount: 2 },
+    );
+    await expect(
+      seed.workItems.listAttentionReceipts({
+        orgId: 'org1',
+        factoryProjectId: PROJECT_ID,
+        userId: 'u1',
+        identities: [{ kind: 'mention', sourceId: comment.id, occurrence: 0 }],
+      }),
+    ).resolves.toMatchObject([{ kind: 'mention', state: 'read' }]);
+  });
+});

--- a/mastracode/factory/src/routes/attention.test.ts
+++ b/mastracode/factory/src/routes/attention.test.ts
@@ -330,6 +330,21 @@ describe('mention attention items', () => {
     expect(second.hasMore).toBe(false);
   });
 
+  it('resumes a cursor minted before the inbox merged kinds instead of rejecting it', async () => {
+    const item = await seedWorkItem();
+    const older = await seedFailure(item, new Date('2030-01-01T00:00:05.000Z'));
+    const newer = await seedFailure(item, new Date('2030-01-01T00:00:10.000Z'));
+    await seedMention({ workItemId: item.id, body: 'ping', occurredAt: new Date('2030-01-01T00:00:20.000Z') });
+
+    // The shape #22021 minted: a bare [occurredAt, id] over the only stream there was.
+    const legacy = Buffer.from(JSON.stringify(['2030-01-01T00:00:10.000Z', newer.id]), 'utf8').toString('base64url');
+    const response = await request('GET', `/web/factory/projects/${PROJECT_ID}/attention?before=${legacy}`);
+
+    expect(response.status).toBe(200);
+    const page = await response.json();
+    expect(page.items.map((entry: any) => entry.decisionId ?? entry.commentId)).toEqual([older.id]);
+  });
+
   it('read-all marks both kinds read', async () => {
     const item = await seedWorkItem();
     await seedFailure(item, new Date('2030-01-01T00:00:10.000Z'));

--- a/mastracode/factory/src/routes/attention.ts
+++ b/mastracode/factory/src/routes/attention.ts
@@ -1,38 +1,42 @@
+/**
+ * Attention routes: k-way merge of the per-kind providers on `occurredAt desc`.
+ * The wire cursor is a per-kind map — each kind's stream resumes independently,
+ * `null` meaning "not started yet", an absent kind meaning "exhausted".
+ */
+
 import type { ApiRoute } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 
-import { factoryDispatchFailureMetadata } from '../rules/dispatch-errors.js';
+import type { WorkItemCommentsStorage } from '../storage/domains/comments/base.js';
 import type {
+  FactoryAttentionKind,
   FactoryAttentionReceiptAction,
-  FactoryAttentionReceiptRecord,
-  FactoryDeferredDecisionRecord,
-  WorkItemRow,
   WorkItemsStorage,
 } from '../storage/domains/work-items/base.js';
-import { factoryAttentionKey, factoryDecisionAttentionIdentity } from '../storage/domains/work-items/base.js';
+import { factoryAttentionKey } from '../storage/domains/work-items/base.js';
+import type {
+  AttentionLatest,
+  AttentionPageResult,
+  AttentionProvider,
+  AttentionScope,
+  AttentionStreamPosition,
+  FactoryAttentionView,
+} from './attention-providers.js';
+import { AutomationFailedAttentionProvider, MentionAttentionProvider } from './attention-providers.js';
+
+export { factoryDecisionType } from './attention-providers.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const DEFAULT_PAGE_SIZE = 25;
 const MAX_PAGE_SIZE = 50;
-// Receipt filtering is bounded to 200 failed decisions per request; the response cursor resumes after the last scan.
-const MAX_RECEIPT_SCAN_PAGES = 4;
-
-type FactoryAttentionView = 'open' | 'unread' | 'archived';
-
-interface ResolvedAttentionProject {
-  orgId: string;
-  userId: string;
-  factoryProjectId: string;
-}
 
 interface AttentionRouteDependencies {
   workItems: WorkItemsStorage;
-  resolveProject(context: unknown): Promise<ResolvedAttentionProject | { response: Response }>;
+  comments: WorkItemCommentsStorage;
+  resolveProject(context: unknown): Promise<AttentionScope | { response: Response }>;
 }
 
-export function factoryDecisionType(decision: FactoryDeferredDecisionRecord): string {
-  return typeof decision.decision.type === 'string' ? decision.decision.type.slice(0, 64) : 'unknown';
-}
+type AttentionCursorMap = Map<FactoryAttentionKind, AttentionStreamPosition | undefined>;
 
 function parseAttentionView(raw: string | undefined): FactoryAttentionView | undefined {
   if (!raw || raw === 'open') return 'open';
@@ -46,92 +50,116 @@ function parseAttentionLimit(raw: string | undefined): number {
   return Math.max(1, Math.min(MAX_PAGE_SIZE, parsed));
 }
 
-function attentionIdentity(decision: FactoryDeferredDecisionRecord) {
-  return factoryDecisionAttentionIdentity(decision.id, decision.failureOccurrence);
+function isAttentionKind(value: string): value is FactoryAttentionKind {
+  return value === 'automation-failed' || value === 'mention';
 }
 
-function attentionKey(factoryProjectId: string, decision: FactoryDeferredDecisionRecord): string {
-  return factoryAttentionKey(factoryProjectId, attentionIdentity(decision));
+function encodeAttentionCursor(cursors: AttentionCursorMap): string {
+  const wire: Record<string, [string, string] | null> = {};
+  for (const [kind, position] of cursors) {
+    wire[kind] = position ? [position.occurredAt.toISOString(), position.id] : null;
+  }
+  return Buffer.from(JSON.stringify(wire), 'utf8').toString('base64url');
 }
 
-function failureOccurredAt(decision: FactoryDeferredDecisionRecord): Date {
-  return decision.completedAt ?? decision.updatedAt;
-}
-
-function encodeAttentionCursor(decision: FactoryDeferredDecisionRecord): string {
-  return Buffer.from(JSON.stringify([failureOccurredAt(decision).toISOString(), decision.id]), 'utf8').toString(
-    'base64url',
-  );
-}
-
-function parseAttentionCursor(raw: string | undefined): { occurredAt: Date; id: string } | undefined {
+function parseAttentionCursor(raw: string | undefined): AttentionCursorMap | undefined {
   if (!raw) return undefined;
   try {
     const decoded: unknown = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
-    if (
-      !Array.isArray(decoded) ||
-      decoded.length !== 2 ||
-      typeof decoded[0] !== 'string' ||
-      typeof decoded[1] !== 'string'
-    ) {
-      return undefined;
+    if (!decoded || typeof decoded !== 'object' || Array.isArray(decoded)) return undefined;
+    const cursors: AttentionCursorMap = new Map();
+    for (const [kind, value] of Object.entries(decoded)) {
+      if (!isAttentionKind(kind)) return undefined;
+      if (value === null) {
+        cursors.set(kind, undefined);
+        continue;
+      }
+      if (!Array.isArray(value) || value.length !== 2 || typeof value[0] !== 'string' || typeof value[1] !== 'string') {
+        return undefined;
+      }
+      const occurredAt = new Date(value[0]);
+      if (Number.isNaN(occurredAt.getTime()) || !UUID_RE.test(value[1])) return undefined;
+      cursors.set(kind, { occurredAt, id: value[1] });
     }
-    const occurredAt = new Date(decoded[0]);
-    if (Number.isNaN(occurredAt.getTime()) || !UUID_RE.test(decoded[1])) return undefined;
-    return { occurredAt, id: decoded[1] };
+    return cursors.size > 0 ? cursors : undefined;
   } catch {
     return undefined;
   }
 }
 
-function parseFailureOccurrence(raw: string | undefined): number | undefined {
+function parseOccurrence(raw: string | undefined): number | undefined {
   if (!raw || !/^(0|[1-9]\d*)$/.test(raw)) return undefined;
   const occurrence = Number(raw);
   return Number.isSafeInteger(occurrence) ? occurrence : undefined;
 }
 
-function attentionTarget(decision: FactoryDeferredDecisionRecord, item: WorkItemRow | undefined) {
-  if (!item) return { kind: 'rules' as const };
-  const role = typeof decision.decision.role === 'string' ? decision.decision.role : undefined;
-  const session = role ? item.sessions[role] : undefined;
-  if (session) {
-    return {
-      kind: 'thread' as const,
-      sessionId: session.sessionId,
-      threadId: session.threadId,
-    };
+interface MergedAttentionPage {
+  items: Array<Record<string, unknown>>;
+  hasMore: boolean;
+  nextCursor?: string;
+}
+
+/**
+ * Take the newest `limit` entries across provider pages. Each kind's next
+ * cursor is the resume position of its last consumed entry; a kind consumed to
+ * the end inherits the provider's own continuation.
+ */
+function mergeAttentionPages(
+  pages: Array<{
+    kind: FactoryAttentionKind;
+    incoming: AttentionStreamPosition | undefined;
+    result: AttentionPageResult;
+  }>,
+  limit: number,
+): MergedAttentionPage {
+  const consumed = new Map(pages.map(page => [page.kind, 0]));
+  const items: Array<Record<string, unknown>> = [];
+  while (items.length < limit) {
+    let best: { kind: FactoryAttentionKind; at: number } | undefined;
+    for (const page of pages) {
+      const next = page.result.entries[consumed.get(page.kind) ?? 0];
+      if (!next) continue;
+      const at = next.occurredAt.getTime();
+      if (!best || at > best.at) best = { kind: page.kind, at };
+    }
+    if (!best) break;
+    const index = consumed.get(best.kind) ?? 0;
+    const entry = pages.find(page => page.kind === best.kind)?.result.entries[index];
+    if (!entry) break;
+    items.push(entry.item);
+    consumed.set(best.kind, index + 1);
   }
-  const review = item.externalSource?.integrationId === 'github' && item.externalSource.type === 'pull-request';
+
+  const nextCursors: AttentionCursorMap = new Map();
+  let hasMore = false;
+  for (const page of pages) {
+    const used = consumed.get(page.kind) ?? 0;
+    const entries = page.result.entries;
+    if (used < entries.length) {
+      hasMore = true;
+      const lastConsumed = used > 0 ? entries[used - 1] : undefined;
+      nextCursors.set(page.kind, lastConsumed ? lastConsumed.resumeCursor : page.incoming);
+      continue;
+    }
+    if (page.result.hasMore) {
+      hasMore = true;
+      nextCursors.set(page.kind, page.result.continuation ?? entries.at(-1)?.resumeCursor ?? page.incoming);
+    }
+  }
   return {
-    kind: 'work-item' as const,
-    workItemId: item.id,
-    board: review ? ('review' as const) : ('work' as const),
+    items,
+    hasMore,
+    ...(hasMore && nextCursors.size > 0 ? { nextCursor: encodeAttentionCursor(nextCursors) } : {}),
   };
 }
 
-function attentionItem(
-  factoryProjectId: string,
-  decision: FactoryDeferredDecisionRecord,
-  item: WorkItemRow | undefined,
-  receipt: FactoryAttentionReceiptRecord | undefined,
-) {
-  const failure = factoryDispatchFailureMetadata(decision.failureCode);
-  return {
-    key: attentionKey(factoryProjectId, decision),
-    kind: 'automation-failed' as const,
-    decisionId: decision.id,
-    occurrence: decision.failureOccurrence,
-    workItemId: decision.workItemId,
-    title: item?.title ?? failure.label,
-    detail: decision.lastError?.slice(0, 512) ?? failure.label,
-    decisionType: factoryDecisionType(decision),
-    failureCode: decision.failureCode,
-    canRetry: failure.canRetry,
-    occurredAt: failureOccurredAt(decision).toISOString(),
-    read: receipt !== undefined,
-    archived: receipt?.state === 'archived',
-    target: attentionTarget(decision, item),
-  };
+function newestLatest(latests: Array<AttentionLatest | null>): AttentionLatest | null {
+  let newest: AttentionLatest | null = null;
+  for (const latest of latests) {
+    if (!latest) continue;
+    if (!newest || latest.at.getTime() > newest.at.getTime()) newest = latest;
+  }
+  return newest;
 }
 
 function receiptRoute(
@@ -139,15 +167,16 @@ function receiptRoute(
   verb: 'read' | 'archive' | 'restore',
   action: FactoryAttentionReceiptAction,
 ): ApiRoute {
-  return registerApiRoute(`/web/factory/projects/:id/attention/automation-failed/:decisionId/:occurrence/${verb}`, {
+  return registerApiRoute(`/web/factory/projects/:id/attention/:kind/:sourceId/:occurrence/${verb}`, {
     method: 'POST',
     requiresAuth: false,
     handler: async context => {
       const resolved = await dependencies.resolveProject(context);
       if ('response' in resolved) return resolved.response;
-      const decisionId = context.req.param('decisionId');
-      const failureOccurrence = parseFailureOccurrence(context.req.param('occurrence'));
-      if (!decisionId || !UUID_RE.test(decisionId) || failureOccurrence === undefined) {
+      const kind = context.req.param('kind');
+      const sourceId = context.req.param('sourceId');
+      const occurrence = parseOccurrence(context.req.param('occurrence'));
+      if (!kind || !isAttentionKind(kind) || !sourceId || !UUID_RE.test(sourceId) || occurrence === undefined) {
         return context.json({ error: 'invalid_attention_item' }, 422);
       }
       await dependencies.workItems.ensureReady();
@@ -155,8 +184,7 @@ function receiptRoute(
         orgId: resolved.orgId,
         factoryProjectId: resolved.factoryProjectId,
         userId: resolved.userId,
-        decisionId,
-        failureOccurrence,
+        identity: { kind, sourceId, occurrence },
         action,
         now: new Date(),
       });
@@ -174,7 +202,12 @@ function receiptRoute(
 }
 
 export function buildAttentionRoutes(dependencies: AttentionRouteDependencies): ApiRoute[] {
-  const { workItems } = dependencies;
+  const { workItems, comments } = dependencies;
+  const providers: AttentionProvider[] = [
+    new AutomationFailedAttentionProvider({ workItems }),
+    new MentionAttentionProvider({ workItems, comments }),
+  ];
+
   return [
     registerApiRoute('/web/factory/projects/:id/attention', {
       method: 'GET',
@@ -188,141 +221,53 @@ export function buildAttentionRoutes(dependencies: AttentionRouteDependencies): 
         const before = parseAttentionCursor(cursorRaw);
         if (cursorRaw && !before) return context.json({ error: 'invalid_cursor' }, 400);
         await workItems.ensureReady();
-        const [failedCount, approvalCount, receiptCount, archivedCount, newestPage] = await Promise.all([
-          workItems.countDeferredDecisionsByStatuses({
-            orgId: resolved.orgId,
-            factoryProjectId: resolved.factoryProjectId,
-            statuses: ['failed'],
-          }),
+        await comments.ensureReady();
+
+        const search = context.req.query('search')?.trim().toLowerCase().slice(0, 200);
+        const limit = parseAttentionLimit(context.req.query('limit'));
+        const active = providers.filter(provider => !before || before.has(provider.kind));
+
+        const [approvalCount, counts, latests, pages] = await Promise.all([
           workItems.countDeferredDecisionsByStatuses({
             orgId: resolved.orgId,
             factoryProjectId: resolved.factoryProjectId,
             statuses: ['proposed'],
           }),
-          workItems.countAttentionReceipts({
-            orgId: resolved.orgId,
-            factoryProjectId: resolved.factoryProjectId,
-            userId: resolved.userId,
-          }),
-          workItems.countAttentionReceipts({
-            orgId: resolved.orgId,
-            factoryProjectId: resolved.factoryProjectId,
-            userId: resolved.userId,
-            state: 'archived',
-          }),
-          workItems.listFailedDecisionPage({
-            orgId: resolved.orgId,
-            factoryProjectId: resolved.factoryProjectId,
-            limit: 1,
-          }),
+          Promise.all(providers.map(provider => provider.counts(resolved))),
+          Promise.all(providers.map(provider => provider.latest(resolved))),
+          Promise.all(
+            active.map(async provider => ({
+              kind: provider.kind,
+              incoming: before?.get(provider.kind),
+              result: await provider.page(resolved, {
+                view,
+                ...(search ? { search } : {}),
+                before: before?.get(provider.kind),
+                limit,
+              }),
+            })),
+          ),
         ]);
-        const failureOpenCount = Math.max(0, failedCount - archivedCount);
-        const openCount = failureOpenCount + approvalCount;
-        const unreadCount = Math.max(0, failedCount - receiptCount);
-        const badgeCount = unreadCount + approvalCount;
-        const newestFailure = newestPage.decisions[0];
-        const newestReceipt = newestFailure
-          ? (
-              await workItems.listAttentionReceipts({
-                orgId: resolved.orgId,
-                factoryProjectId: resolved.factoryProjectId,
-                userId: resolved.userId,
-                identities: [attentionIdentity(newestFailure)],
-              })
-            )[0]
-          : undefined;
-        const search = context.req.query('search')?.trim().toLowerCase().slice(0, 200);
-        const requestedLimit = parseAttentionLimit(context.req.query('limit'));
-        const visible: Array<{
-          decision: FactoryDeferredDecisionRecord;
-          item: WorkItemRow | undefined;
-          receipt: FactoryAttentionReceiptRecord | undefined;
-        }> = [];
-        let scanBefore = before;
-        let cursorDecision: FactoryDeferredDecisionRecord | undefined;
-        let continuationDecision: FactoryDeferredDecisionRecord | undefined;
-        let scannedPages = 0;
-        let hasMore = false;
 
-        scan: while (
-          (view === 'open' && failureOpenCount > 0) ||
-          (view === 'unread' && unreadCount > 0) ||
-          (view === 'archived' && archivedCount > 0)
-        ) {
-          const page = await workItems.listFailedDecisionPage({
-            orgId: resolved.orgId,
-            factoryProjectId: resolved.factoryProjectId,
-            before: scanBefore,
-            limit: MAX_PAGE_SIZE,
-          });
-          scannedPages += 1;
-          if (page.decisions.length === 0) break;
-          const receipts = await workItems.listAttentionReceipts({
-            orgId: resolved.orgId,
-            factoryProjectId: resolved.factoryProjectId,
-            userId: resolved.userId,
-            identities: page.decisions.map(attentionIdentity),
-          });
-          const receiptByKey = new Map(
-            receipts.map(receipt => [factoryAttentionKey(resolved.factoryProjectId, receipt), receipt]),
-          );
-          const linkedItems = await workItems.listByIds({
-            orgId: resolved.orgId,
-            factoryProjectId: resolved.factoryProjectId,
-            ids: page.decisions.flatMap(decision => (decision.workItemId ? [decision.workItemId] : [])),
-          });
-          const itemById = new Map(linkedItems.map(item => [item.id, item]));
-          for (const decision of page.decisions) {
-            const receipt = receiptByKey.get(attentionKey(resolved.factoryProjectId, decision));
-            if (
-              view === 'archived'
-                ? receipt?.state !== 'archived'
-                : view === 'unread'
-                  ? receipt
-                  : receipt?.state === 'archived'
-            ) {
-              continue;
-            }
-            const item = decision.workItemId ? itemById.get(decision.workItemId) : undefined;
-            if (
-              search &&
-              item?.title.toLowerCase().includes(search) !== true &&
-              decision.lastError?.toLowerCase().includes(search) !== true &&
-              !factoryDecisionType(decision).toLowerCase().includes(search)
-            ) {
-              continue;
-            }
-            if (visible.length === requestedLimit) {
-              hasMore = true;
-              continuationDecision = cursorDecision;
-              break scan;
-            }
-            visible.push({ decision, item, receipt });
-            if (visible.length === requestedLimit) cursorDecision = decision;
-          }
-          const lastScanned = page.decisions.at(-1);
-          if (!page.hasMore || !lastScanned) break;
-          if (scannedPages === MAX_RECEIPT_SCAN_PAGES) {
-            hasMore = true;
-            continuationDecision = lastScanned;
-            break;
-          }
-          scanBefore = { occurredAt: failureOccurredAt(lastScanned), id: lastScanned.id };
-        }
+        const openCount = counts.reduce((sum, count) => sum + count.open, 0) + approvalCount;
+        const unreadCount = counts.reduce((sum, count) => sum + count.unread, 0);
+        // An unread item must never be masked by a newer already-read one of
+        // another kind — the streams are independent.
+        const unreadLatests = latests.filter(latest => latest?.unread ?? false);
+        const latest = unreadLatests.length > 0 ? newestLatest(unreadLatests) : newestLatest(latests);
+        const merged = mergeAttentionPages(pages, limit);
 
         return context.json({
-          items: visible.map(({ decision, item, receipt }) =>
-            attentionItem(resolved.factoryProjectId, decision, item, receipt),
-          ),
+          items: merged.items,
           openCount,
           approvalCount,
-          badgeCount,
+          badgeCount: unreadCount + approvalCount,
           unreadCount,
-          latestOccurrenceKey: newestFailure ? attentionKey(resolved.factoryProjectId, newestFailure) : null,
-          latestOccurrenceAt: newestFailure ? failureOccurredAt(newestFailure).toISOString() : null,
-          latestOccurrenceUnread: newestFailure !== undefined && newestReceipt === undefined,
-          hasMore,
-          ...(hasMore && continuationDecision ? { nextCursor: encodeAttentionCursor(continuationDecision) } : {}),
+          latestOccurrenceKey: latest?.key ?? null,
+          latestOccurrenceAt: latest?.at.toISOString() ?? null,
+          latestOccurrenceUnread: latest?.unread ?? false,
+          hasMore: merged.hasMore,
+          ...(merged.nextCursor ? { nextCursor: merged.nextCursor } : {}),
         });
       },
     }),
@@ -333,42 +278,27 @@ export function buildAttentionRoutes(dependencies: AttentionRouteDependencies): 
         const resolved = await dependencies.resolveProject(context);
         if ('response' in resolved) return resolved.response;
         const cursorRaw = context.req.query('before');
-        const initialBefore = parseAttentionCursor(cursorRaw);
-        if (cursorRaw && !initialBefore) return context.json({ error: 'invalid_cursor' }, 400);
+        const before = parseAttentionCursor(cursorRaw);
+        if (cursorRaw && !before) return context.json({ error: 'invalid_cursor' }, 400);
         await workItems.ensureReady();
-        let before = initialBefore;
-        let pages = 0;
+        await comments.ensureReady();
+
+        const now = new Date();
+        const active = providers.filter(provider => !before || before.has(provider.kind));
+        const nextCursors: AttentionCursorMap = new Map();
         let hasMore = false;
-        let nextCursor: string | undefined;
-        while (pages < MAX_RECEIPT_SCAN_PAGES) {
-          const page = await workItems.listFailedDecisionPage({
-            orgId: resolved.orgId,
-            factoryProjectId: resolved.factoryProjectId,
-            before,
-            limit: MAX_PAGE_SIZE,
-          });
-          pages += 1;
-          if (page.decisions.length === 0) break;
-          await workItems.markAttentionReceiptsRead({
-            orgId: resolved.orgId,
-            factoryProjectId: resolved.factoryProjectId,
-            userId: resolved.userId,
-            occurrences: page.decisions.map(decision => ({
-              decisionId: decision.id,
-              failureOccurrence: decision.failureOccurrence,
-            })),
-            now: new Date(),
-          });
-          const last = page.decisions.at(-1);
-          if (!page.hasMore || !last) break;
-          if (pages === MAX_RECEIPT_SCAN_PAGES) {
+        for (const provider of active) {
+          const result = await provider.markAllRead(resolved, { before: before?.get(provider.kind), now });
+          if (result.hasMore) {
             hasMore = true;
-            nextCursor = encodeAttentionCursor(last);
-            break;
+            if (result.continuation) nextCursors.set(provider.kind, result.continuation);
           }
-          before = { occurredAt: failureOccurredAt(last), id: last.id };
         }
-        return context.json({ ok: true, hasMore, ...(nextCursor ? { nextCursor } : {}) });
+        return context.json({
+          ok: true,
+          hasMore,
+          ...(hasMore && nextCursors.size > 0 ? { nextCursor: encodeAttentionCursor(nextCursors) } : {}),
+        });
       },
     }),
     receiptRoute(dependencies, 'read', 'read'),

--- a/mastracode/factory/src/routes/attention.ts
+++ b/mastracode/factory/src/routes/attention.ts
@@ -62,11 +62,27 @@ function encodeAttentionCursor(cursors: AttentionCursorMap): string {
   return Buffer.from(JSON.stringify(wire), 'utf8').toString('base64url');
 }
 
+function parseStreamPosition(value: unknown): AttentionStreamPosition | undefined {
+  if (!Array.isArray(value) || value.length !== 2 || typeof value[0] !== 'string' || typeof value[1] !== 'string') {
+    return undefined;
+  }
+  const occurredAt = new Date(value[0]);
+  if (Number.isNaN(occurredAt.getTime()) || !UUID_RE.test(value[1])) return undefined;
+  return { occurredAt, id: value[1] };
+}
+
 function parseAttentionCursor(raw: string | undefined): AttentionCursorMap | undefined {
   if (!raw) return undefined;
   try {
     const decoded: unknown = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
-    if (!decoded || typeof decoded !== 'object' || Array.isArray(decoded)) return undefined;
+    // Cursors minted before the inbox merged kinds are a bare position over the
+    // only stream there was. Held by anyone mid-list when this deploys, so they
+    // resume that stream rather than 400: mentions arrive on their next load.
+    if (Array.isArray(decoded)) {
+      const legacy = parseStreamPosition(decoded);
+      return legacy ? new Map([['automation-failed', legacy]]) : undefined;
+    }
+    if (!decoded || typeof decoded !== 'object') return undefined;
     const cursors: AttentionCursorMap = new Map();
     for (const [kind, value] of Object.entries(decoded)) {
       if (!isAttentionKind(kind)) return undefined;
@@ -74,12 +90,9 @@ function parseAttentionCursor(raw: string | undefined): AttentionCursorMap | und
         cursors.set(kind, undefined);
         continue;
       }
-      if (!Array.isArray(value) || value.length !== 2 || typeof value[0] !== 'string' || typeof value[1] !== 'string') {
-        return undefined;
-      }
-      const occurredAt = new Date(value[0]);
-      if (Number.isNaN(occurredAt.getTime()) || !UUID_RE.test(value[1])) return undefined;
-      cursors.set(kind, { occurredAt, id: value[1] });
+      const position = parseStreamPosition(value);
+      if (!position) return undefined;
+      cursors.set(kind, position);
     }
     return cursors.size > 0 ? cursors : undefined;
   } catch {

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -26,6 +26,7 @@ import { LiveSessions } from '../session/live-sessions.js';
 import type { StateSigner } from '../state-signing.js';
 import type { AuditEmitter } from '../storage/domains/audit/domain.js';
 import type { ChannelIdentityStorage } from '../storage/domains/channel-identity/base.js';
+import type { WorkItemCommentsStorage } from '../storage/domains/comments/base.js';
 import type { ModelCredentialsStorage } from '../storage/domains/credentials/base.js';
 import type { CustomProvidersStorage } from '../storage/domains/custom-providers/base.js';
 import type { FilesystemStorage } from '../storage/domains/filesystem/base.js';
@@ -100,6 +101,7 @@ export interface FactoryApiRoutesDeps {
     queueHealth: QueueHealthStorage;
     workItems: WorkItemsStorage;
     channelIdentity: ChannelIdentityStorage;
+    comments: WorkItemCommentsStorage;
   };
   integrations?: IntegrationRegistration[];
   intakeReady: boolean;
@@ -503,6 +505,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
           audit: deps.audit,
           projects: deps.domains.projects,
           workItems: deps.domains.workItems,
+          comments: deps.domains.comments,
           queueHealth: deps.domains.queueHealth,
           transitionService,
           startCoordinator,

--- a/mastracode/factory/src/routes/work-items.test.ts
+++ b/mastracode/factory/src/routes/work-items.test.ts
@@ -65,6 +65,7 @@ function buildApp(
       audit,
       projects: seed.projects,
       workItems: seed.workItems,
+      comments: seed.comments,
       queueHealth: seed.queueHealth,
       transitionService: new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems }),
       startCoordinator,
@@ -852,8 +853,11 @@ describe('GET /web/factory/projects/:id/attention', () => {
       orgId: 'org1',
       factoryProjectId: PROJECT_ID,
       userId: 'u2',
-      decisionId: firstFailure.id,
-      failureOccurrence: firstFailure.failureOccurrence,
+      identity: {
+        kind: 'automation-failed',
+        sourceId: firstFailure.id,
+        occurrence: firstFailure.failureOccurrence,
+      },
       action: 'archive',
       now,
     });
@@ -907,8 +911,11 @@ describe('GET /web/factory/projects/:id/attention', () => {
         orgId: 'org1',
         factoryProjectId: PROJECT_ID,
         userId: 'u3',
-        decisionId: secondFailure.id,
-        failureOccurrence: secondFailure.failureOccurrence,
+        identity: {
+          kind: 'automation-failed',
+          sourceId: secondFailure.id,
+          occurrence: secondFailure.failureOccurrence,
+        },
         action: 'archive',
         now,
       }),
@@ -1183,8 +1190,7 @@ describe('GET /web/factory/projects/:id/attention', () => {
       orgId: 'org1',
       factoryProjectId: PROJECT_ID,
       userId: 'u1',
-      decisionId: failedSkill.id,
-      failureOccurrence: 0,
+      identity: { kind: 'automation-failed', sourceId: failedSkill.id, occurrence: 0 },
       action: 'archive',
       now,
     });
@@ -1449,8 +1455,7 @@ describe('GET /web/factory/projects/:id/attention', () => {
         orgId: 'org1',
         factoryProjectId: PROJECT_ID,
         userId: 'u1',
-        decisionId: decision.id,
-        failureOccurrence: decision.failureOccurrence,
+        identity: { kind: 'automation-failed', sourceId: decision.id, occurrence: decision.failureOccurrence },
         action: 'archive',
         now,
       });
@@ -1507,10 +1512,9 @@ describe('GET /web/factory/projects/:id/attention', () => {
     expect(scannedPages).toBe(4);
     expect(bounded).toMatchObject({ items: [], hasMore: true });
     expect(typeof bounded.nextCursor).toBe('string');
-    expect(JSON.parse(Buffer.from(bounded.nextCursor, 'base64url').toString('utf8'))).toEqual([
-      lastScanned?.completedAt?.toISOString(),
-      lastScanned?.id,
-    ]);
+    expect(JSON.parse(Buffer.from(bounded.nextCursor, 'base64url').toString('utf8'))).toEqual({
+      'automation-failed': [lastScanned?.completedAt?.toISOString(), lastScanned?.id],
+    });
   });
 });
 

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -23,6 +23,7 @@ import type { FactoryRuleBoard } from '../rules/types.js';
 import { FACTORY_RULE_BOARDS, isFactoryRuleStage } from '../rules/types.js';
 import type { LiveSessions } from '../session/live-sessions.js';
 import type { AuditEmitter } from '../storage/domains/audit/domain.js';
+import type { WorkItemCommentsStorage } from '../storage/domains/comments/base.js';
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type { QueueHealthStorage } from '../storage/domains/queue-health/base.js';
 import { thresholdsOrDefault } from '../storage/domains/queue-health/base.js';
@@ -54,6 +55,8 @@ export interface WorkItemRoutesDeps extends RouteDependencies {
   projects: FactoryProjectsStorage;
   /** Work-items domain backing the kanban board. */
   workItems: WorkItemsStorage;
+  /** Comments domain — backs the mention attention provider. */
+  comments: WorkItemCommentsStorage;
   /** Per-project queue-health threshold config. */
   queueHealth: QueueHealthStorage;
   /** Governed stage-transition service. Stage moves 503 when absent. */
@@ -658,6 +661,7 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
 
       ...buildAttentionRoutes({
         workItems,
+        comments: this.deps.comments,
         resolveProject: context => this.#resolveProject(loose(context)),
       }),
 

--- a/mastracode/factory/src/storage/domains/audit/domain.ts
+++ b/mastracode/factory/src/storage/domains/audit/domain.ts
@@ -4,6 +4,7 @@ import type { ApiRoute, IUserProvider } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
 
+import { getFactoryAuthUser } from '../../../auth.js';
 import type { RouteAuth } from '../../../routes/route.js';
 import type { FactoryProjectsStorage } from '../projects/base.js';
 import type {
@@ -80,14 +81,6 @@ function readStoredActorProfile(metadata: Record<string, unknown> | undefined): 
     typeof profile.avatarUrl === 'string' && profile.avatarUrl.trim() ? profile.avatarUrl.trim() : undefined;
   if (!name && !avatarUrl) return undefined;
   return { ...(name ? { name } : {}), ...(avatarUrl ? { avatarUrl } : {}) };
-}
-
-/** Read the auth gate's stashed user directly from the Hono context. */
-function readFactoryAuthUserFromContext(
-  context: Context,
-): { name?: string; email?: string; avatarUrl?: string } | undefined {
-  const user = context.get('factoryAuthUser') as { name?: string; email?: string; avatarUrl?: string } | undefined;
-  return user ?? undefined;
 }
 
 function buildActorProfileMetadata(user: {
@@ -232,7 +225,7 @@ export class AuditDomain implements AuditEmitter, AuditAgentEmitter {
     try {
       const tenant = this.#auth.tenant(context);
       if (!tenant?.orgId) return;
-      const user = readFactoryAuthUserFromContext(context);
+      const user = getFactoryAuthUser(context);
       const actorProfile = user ? buildActorProfileMetadata(user) : undefined;
       const metadata = actorProfile
         ? { ...input.metadata, [ACTOR_PROFILE_METADATA_KEY]: actorProfile }

--- a/mastracode/factory/src/storage/domains/channel-identity/base.ts
+++ b/mastracode/factory/src/storage/domains/channel-identity/base.ts
@@ -69,8 +69,8 @@ export const CHANNEL_ACCOUNT_LINKS_SCHEMA: CollectionSchema = {
   ],
   indexes: [
     {
-      name: 'channel_account_links_org_idx',
-      columns: ['org_id'],
+      name: 'channel_account_links_org_linked_at_id_idx',
+      columns: ['org_id', 'linked_at', 'id'],
     },
   ],
 };

--- a/mastracode/factory/src/storage/domains/channel-identity/base.ts
+++ b/mastracode/factory/src/storage/domains/channel-identity/base.ts
@@ -67,6 +67,12 @@ export const CHANNEL_ACCOUNT_LINKS_SCHEMA: CollectionSchema = {
       columns: ['platform', 'external_team_id', 'external_user_id'],
     },
   ],
+  indexes: [
+    {
+      name: 'channel_account_links_org_idx',
+      columns: ['org_id'],
+    },
+  ],
 };
 
 interface ChannelAccountLinkDbRow extends Record<string, unknown> {
@@ -214,6 +220,25 @@ export class ChannelIdentityStorage extends FactoryStorageDomain {
    */
   async listAccountLinksForUser(userId: string): Promise<ChannelAccountLinkEntry[]> {
     const rows = await this.#db.findMany<ChannelAccountLinkDbRow>('channel_account_links', { user_id: userId });
+    return rows.map(toEntry);
+  }
+
+  /** All links bound to an organization, for the mention-roster fallback. */
+  async listAccountLinksForOrg(
+    orgId: string,
+    { limit = 200 }: { limit?: number } = {},
+  ): Promise<ChannelAccountLinkEntry[]> {
+    const rows = await this.#db.findMany<ChannelAccountLinkDbRow>(
+      'channel_account_links',
+      { org_id: orgId },
+      {
+        orderBy: [
+          ['linked_at', 'desc'],
+          ['id', 'desc'],
+        ],
+        limit,
+      },
+    );
     return rows.map(toEntry);
   }
 

--- a/mastracode/factory/src/storage/domains/comments/actor.ts
+++ b/mastracode/factory/src/storage/domains/comments/actor.ts
@@ -1,0 +1,85 @@
+/**
+ * FactoryActorRef — the one author contract for everything a person, agent, or
+ * integration writes into a factory (comment rows today; thread-message
+ * attribution and agent-authored entries reuse it later).
+ *
+ * Conventions:
+ * - Agent actor ids are `agent:<bindingId>` (the transition-service convention):
+ *   a binding id routes back to the live session via run bindings. Audit's
+ *   `agent:<threadId>` form diverges; both satisfy `isAgentActor`.
+ * - `id` is a namespaced string: only bare WorkOS ids (no `:`) are resolvable
+ *   or mentionable. External senders get `<platform>:<externalUserId>` plus a
+ *   display snapshot captured at write time.
+ */
+
+import type { ChannelAccountLink } from '../channel-identity/base.js';
+
+export type FactoryActorKind = 'user' | 'agent' | 'integration';
+
+/**
+ * Superset of core's channel author metadata — deliberately NOT that exact
+ * shape: `teamId` lives on the raw platform event (never on the author), and
+ * `channel_account_links` keys on `(platform, teamId, userId)`, so ingest must
+ * capture it here or the identity is unlinkable.
+ */
+export interface FactoryActorExternalIdentity {
+  platform: string;
+  teamId?: string;
+  messageId?: string;
+  userId: string;
+  userName?: string;
+  fullName?: string;
+  mention?: string;
+  isBot?: boolean | 'unknown';
+}
+
+export interface FactoryActorRef {
+  kind: FactoryActorKind;
+  id: string;
+  displayName?: string;
+  avatarUrl?: string;
+  external?: FactoryActorExternalIdentity;
+}
+
+export function isMentionableActorId(id: string): boolean {
+  return id.length > 0 && !id.includes(':');
+}
+
+export function actorFromAuthUser(
+  userId: string,
+  user?: { name?: string; email?: string; avatarUrl?: string },
+): FactoryActorRef {
+  const displayName = user?.name?.trim() || user?.email?.trim();
+  const avatarUrl = user?.avatarUrl?.trim();
+  return {
+    kind: 'user',
+    id: userId,
+    ...(displayName ? { displayName } : {}),
+    ...(avatarUrl ? { avatarUrl } : {}),
+  };
+}
+
+export function actorFromAgentBinding(bindingId: string, displayName?: string): FactoryActorRef {
+  return {
+    kind: 'agent',
+    id: `agent:${bindingId}`,
+    ...(displayName ? { displayName } : {}),
+  };
+}
+
+/**
+ * A linked platform sender becomes the linked tenant user; an unlinked one
+ * stays a namespaced external identity with its display snapshot.
+ */
+export function actorFromChannelAuthor(
+  external: FactoryActorExternalIdentity,
+  link?: Pick<ChannelAccountLink, 'userId'> | null,
+): FactoryActorRef {
+  const displayName = external.fullName?.trim() || external.userName?.trim();
+  return {
+    kind: 'user',
+    id: link?.userId ?? `${external.platform}:${external.userId}`,
+    ...(displayName ? { displayName } : {}),
+    external,
+  };
+}

--- a/mastracode/factory/src/storage/domains/comments/base.test.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.test.ts
@@ -391,6 +391,25 @@ describe('WorkItemCommentsStorage', () => {
     expect(afterReplay?.feedActivityAt?.getTime()).toBe(landed?.getTime());
   });
 
+  it('drops a refresh whose snapshot is older than the one already stored', async () => {
+    const seed = await createFactoryStorageForTests();
+    const { item } = await seed.workItems.upsert({
+      orgId: scope.orgId,
+      userId: alice.id,
+      factoryProjectId: scope.factoryProjectId,
+      input: { title: 'Fix login', stages: ['intake'], sessions: {}, metadata: {} },
+    });
+    const itemScope = { ...scope, workItemId: item.id };
+    await seed.comments.refreshWorkItemFeedActivity({ ...itemScope, now: new Date('2030-01-01T00:00:00.000Z') });
+
+    // Two refreshes interleaving: one reads its snapshot, a second completes
+    // first, and the first writes last. Writing last must not undo the newer.
+    await seed.comments.refreshWorkItemFeedActivity({ ...itemScope, now: new Date('2029-01-01T00:00:00.000Z') });
+
+    const after = await seed.workItems.get({ orgId: scope.orgId, id: item.id });
+    expect(after?.feedActivityAt?.toISOString()).toBe('2030-01-01T00:00:00.000Z');
+  });
+
   it('purges comments and mention rows when the work item is hard-deleted', async () => {
     const seed = await createFactoryStorageForTests();
     const { item } = await seed.workItems.upsert({

--- a/mastracode/factory/src/storage/domains/comments/base.test.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.test.ts
@@ -7,8 +7,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { createFactoryStorageForTests } from '../../test-utils.js';
-import { supersedesFeedActivity } from './base.js';
 import type { FactoryActorRef } from './actor.js';
+import { supersedesFeedActivity } from './base.js';
 
 const scope = { orgId: 'org-1', factoryProjectId: 'project-1', workItemId: 'item-1' };
 

--- a/mastracode/factory/src/storage/domains/comments/base.test.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Comments storage over a real backend (libsql `:memory:`): feed keyset
+ * ordering, source-key idempotency, mention join maintenance, and the
+ * recount-based work-item counters.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createFactoryStorageForTests } from '../../test-utils.js';
+import type { FactoryActorRef } from './actor.js';
+
+const scope = { orgId: 'org-1', factoryProjectId: 'project-1', workItemId: 'item-1' };
+
+const alice: FactoryActorRef = {
+  kind: 'user',
+  id: 'user-alice',
+  displayName: 'Alice',
+  avatarUrl: 'https://avatars.example/alice.png',
+};
+const bob: FactoryActorRef = { kind: 'user', id: 'user-bob', displayName: 'Bob' };
+
+describe('WorkItemCommentsStorage', () => {
+  it('round-trips a comment including the flattened author and reply columns', async () => {
+    const seed = await createFactoryStorageForTests();
+    const parent = await seed.comments.create({ ...scope, author: bob, body: 'original take' });
+    const created = await seed.comments.create({
+      ...scope,
+      author: alice,
+      body: 'I disagree, see the trace',
+      replyTo: { commentId: parent.id, quote: 'original take', authorId: bob.id, authorName: 'Bob' },
+      mentions: [{ kind: 'user', id: bob.id }],
+    });
+
+    const fetched = await seed.comments.get({ orgId: scope.orgId, commentId: created.id });
+    expect(fetched).toMatchObject({
+      body: 'I disagree, see the trace',
+      bodyFormat: 'markdown',
+      kind: 'comment',
+      author: { kind: 'user', id: 'user-alice', displayName: 'Alice', avatarUrl: 'https://avatars.example/alice.png' },
+      replyTo: { commentId: parent.id, quote: 'original take', authorId: 'user-bob', authorName: 'Bob' },
+      mentions: [{ kind: 'user', id: 'user-bob' }],
+      deletedAt: null,
+      revision: 1,
+    });
+  });
+
+  it('pages newest-first across a tied-timestamp boundary without skips or duplicates', async () => {
+    const seed = await createFactoryStorageForTests();
+    const tied = new Date('2026-08-01T10:00:00.000Z');
+    const ids = [];
+    for (let i = 0; i < 3; i++) {
+      ids.push((await seed.comments.create({ ...scope, author: alice, body: `tied ${i}`, occurredAt: tied })).id);
+    }
+
+    const first = await seed.comments.list({ ...scope, limit: 2 });
+    expect(first.comments).toHaveLength(2);
+    expect(first.nextCursor).toBeDefined();
+    const second = await seed.comments.list({ ...scope, limit: 2, before: first.nextCursor });
+    expect(second.comments).toHaveLength(1);
+    expect(second.nextCursor).toBeUndefined();
+
+    const seen = [...first.comments, ...second.comments].map(comment => comment.id);
+    expect(new Set(seen).size).toBe(3);
+    expect(new Set(ids)).toEqual(new Set(seen));
+  });
+
+  it('orders by caller-set occurred_at, not insert time', async () => {
+    const seed = await createFactoryStorageForTests();
+    await seed.comments.create({ ...scope, author: alice, body: 'posted first, happened last' });
+    await seed.comments.create({
+      ...scope,
+      author: bob,
+      body: 'backdated platform ingest',
+      occurredAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    const { comments } = await seed.comments.list(scope);
+    expect(comments.map(comment => comment.body)).toEqual(['posted first, happened last', 'backdated platform ingest']);
+  });
+
+  it('replays a source-keyed create without clobbering a later edit', async () => {
+    const seed = await createFactoryStorageForTests();
+    const token = 'client-token-0001';
+    const created = await seed.comments.create({ ...scope, author: alice, body: 'hello', clientToken: token });
+    await seed.comments.edit({ orgId: scope.orgId, commentId: created.id, body: 'hello, edited' });
+
+    const replayed = await seed.comments.create({ ...scope, author: alice, body: 'hello', clientToken: token });
+    expect(replayed.id).toBe(created.id);
+    expect(replayed.body).toBe('hello, edited');
+    expect((await seed.comments.list(scope)).comments).toHaveLength(1);
+  });
+
+  it('rejects a clientToken replay that targets another work item or author', async () => {
+    const seed = await createFactoryStorageForTests();
+    const token = 'client-token-0009';
+    const created = await seed.comments.create({ ...scope, author: alice, body: 'on item 1', clientToken: token });
+
+    await expect(
+      seed.comments.create({ ...scope, workItemId: 'item-2', author: alice, body: 'on item 2', clientToken: token }),
+    ).rejects.toThrow('Client token already used by a different comment.');
+    await expect(
+      seed.comments.create({ ...scope, author: bob, body: 'as someone else', clientToken: token }),
+    ).rejects.toThrow('Client token already used by a different comment.');
+
+    const replayed = await seed.comments.create({ ...scope, author: alice, body: 'on item 1', clientToken: token });
+    expect(replayed.id).toBe(created.id);
+    expect((await seed.comments.list(scope)).comments).toHaveLength(1);
+  });
+
+  it('stamps a mention added by editing with the edit time, not the comment time', async () => {
+    const seed = await createFactoryStorageForTests();
+    const created = await seed.comments.create({
+      ...scope,
+      author: alice,
+      body: 'old comment',
+      occurredAt: new Date('2026-08-01T10:00:00.000Z'),
+    });
+
+    const before = Date.now();
+    await seed.comments.edit({
+      orgId: scope.orgId,
+      commentId: created.id,
+      body: 'old comment @Bob',
+      mentions: [{ kind: 'user', id: bob.id }],
+    });
+
+    const [mention] = await seed.comments.listMentionsForUser({ ...scope, userId: bob.id, limit: 1 });
+    expect(mention?.occurredAt.getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it('write-back keeps the first external source and the local source key', async () => {
+    const seed = await createFactoryStorageForTests();
+    const created = await seed.comments.create({
+      ...scope,
+      author: alice,
+      body: 'mirror me',
+      clientToken: 'client-token-0010',
+    });
+
+    const slack = { integrationId: 'slack', type: 'message', externalId: 'C1:1.0' };
+    const attached = await seed.comments.attachExternalSource({
+      orgId: scope.orgId,
+      commentId: created.id,
+      source: slack,
+    });
+    expect(attached?.externalSource).toEqual(slack);
+    expect(attached?.sourceKey).toBe('local:comment:client-token-0010');
+
+    const second = await seed.comments.attachExternalSource({
+      orgId: scope.orgId,
+      commentId: created.id,
+      source: { integrationId: 'linear', type: 'comment', externalId: 'L1' },
+    });
+    expect(second?.externalSource).toEqual(slack);
+  });
+
+  it('creates distinct rows for tokenless creates with identical bodies', async () => {
+    const seed = await createFactoryStorageForTests();
+    await seed.comments.create({ ...scope, author: alice, body: 'same words' });
+    await seed.comments.create({ ...scope, author: alice, body: 'same words' });
+    expect((await seed.comments.list(scope)).comments).toHaveLength(2);
+  });
+
+  it('soft delete clears body and mentions, keeps ordering and the source key', async () => {
+    const seed = await createFactoryStorageForTests();
+    const token = 'client-token-0002';
+    const created = await seed.comments.create({
+      ...scope,
+      author: alice,
+      body: 'to be removed',
+      clientToken: token,
+      mentions: [{ kind: 'user', id: bob.id }],
+    });
+
+    const deleted = await seed.comments.softDelete({
+      orgId: scope.orgId,
+      commentId: created.id,
+      deletedBy: alice.id,
+    });
+    expect(deleted).toMatchObject({ body: '', mentions: [], deletedBy: alice.id });
+    expect(deleted?.deletedAt).toBeInstanceOf(Date);
+    expect(await seed.comments.listMentionsForComment(created.id)).toEqual([]);
+
+    const { comments } = await seed.comments.list(scope);
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.deletedAt).toBeInstanceOf(Date);
+
+    const redelivered = await seed.comments.create({
+      ...scope,
+      author: alice,
+      body: 'to be removed',
+      clientToken: token,
+    });
+    expect(redelivered.id).toBe(created.id);
+    expect(redelivered.deletedAt).toBeInstanceOf(Date);
+
+    expect(
+      await seed.comments.softDelete({ orgId: scope.orgId, commentId: created.id, deletedBy: alice.id }),
+    ).toBeNull();
+  });
+
+  it('never writes a self-mention row', async () => {
+    const seed = await createFactoryStorageForTests();
+    const created = await seed.comments.create({
+      ...scope,
+      author: alice,
+      body: 'note to self and Bob',
+      mentions: [
+        { kind: 'user', id: alice.id },
+        { kind: 'user', id: bob.id },
+      ],
+    });
+
+    const rows = await seed.comments.listMentionsForComment(created.id);
+    expect(rows.map(row => row.mentionedId)).toEqual([bob.id]);
+    expect(await seed.comments.listMentionsForUser({ ...scope, userId: alice.id, limit: 10 })).toHaveLength(0);
+    expect(await seed.comments.listMentionsForUser({ ...scope, userId: bob.id, limit: 10 })).toHaveLength(1);
+  });
+
+  it('diffs mention rows on edit: added get rows, removed lose theirs, kept stay', async () => {
+    const seed = await createFactoryStorageForTests();
+    const created = await seed.comments.create({
+      ...scope,
+      author: alice,
+      body: 'v1',
+      mentions: [
+        { kind: 'user', id: 'user-bob' },
+        { kind: 'user', id: 'user-carol' },
+      ],
+    });
+
+    const edited = await seed.comments.edit({
+      orgId: scope.orgId,
+      commentId: created.id,
+      body: 'v2',
+      mentions: [
+        { kind: 'user', id: 'user-carol' },
+        { kind: 'user', id: 'user-dave' },
+      ],
+    });
+
+    expect(edited?.addedMentions).toEqual([{ kind: 'user', id: 'user-dave' }]);
+    expect(edited?.removedMentions).toEqual([{ kind: 'user', id: 'user-bob' }]);
+    expect(edited?.comment).toMatchObject({ body: 'v2', revision: 2 });
+    expect(edited?.comment.editedAt).toBeInstanceOf(Date);
+
+    const rows = await seed.comments.listMentionsForComment(created.id);
+    expect(new Set(rows.map(row => row.mentionedId))).toEqual(new Set(['user-carol', 'user-dave']));
+  });
+
+  it('refuses to edit a deleted comment', async () => {
+    const seed = await createFactoryStorageForTests();
+    const created = await seed.comments.create({ ...scope, author: alice, body: 'gone soon' });
+    await seed.comments.softDelete({ orgId: scope.orgId, commentId: created.id, deletedBy: alice.id });
+    expect(await seed.comments.edit({ orgId: scope.orgId, commentId: created.id, body: 'necromancy' })).toBeNull();
+  });
+
+  it('pages the mention inbox newest-first for a user', async () => {
+    const seed = await createFactoryStorageForTests();
+    for (let i = 0; i < 3; i++) {
+      await seed.comments.create({
+        ...scope,
+        author: alice,
+        body: `ping ${i}`,
+        occurredAt: new Date(Date.parse('2026-08-01T10:00:00.000Z') + i * 60_000),
+        mentions: [{ kind: 'user', id: bob.id }],
+      });
+    }
+
+    const firstPage = await seed.comments.listMentionsForUser({
+      orgId: scope.orgId,
+      factoryProjectId: scope.factoryProjectId,
+      userId: bob.id,
+      limit: 2,
+    });
+    expect(firstPage).toHaveLength(2);
+    const last = firstPage[1]!;
+    const secondPage = await seed.comments.listMentionsForUser({
+      orgId: scope.orgId,
+      factoryProjectId: scope.factoryProjectId,
+      userId: bob.id,
+      limit: 2,
+      before: { occurredAt: last.occurredAt, id: last.id },
+    });
+    expect(firstPage[0]!.occurredAt.getTime()).toBeGreaterThan(last.occurredAt.getTime());
+    expect(secondPage).toHaveLength(1);
+    expect(firstPage.map(row => row.id)).not.toContain(secondPage[0]!.id);
+  });
+
+  it('maintains work-item counters by recount and never touches the transition token', async () => {
+    const seed = await createFactoryStorageForTests();
+    const { item } = await seed.workItems.upsert({
+      orgId: scope.orgId,
+      userId: alice.id,
+      factoryProjectId: scope.factoryProjectId,
+      input: { title: 'Fix login', stages: ['intake'], sessions: {}, metadata: {} },
+    });
+    const itemScope = { ...scope, workItemId: item.id };
+    expect(item.commentCount).toBe(0);
+    expect(item.feedActivityAt).toBeNull();
+
+    const first = await seed.comments.create({ ...itemScope, author: alice, body: 'one' });
+    await seed.comments.bumpWorkItemFeedActivity(itemScope);
+    await seed.comments.create({ ...itemScope, author: bob, body: 'two' });
+    await seed.comments.bumpWorkItemFeedActivity(itemScope);
+
+    const afterCreates = await seed.workItems.get({ orgId: scope.orgId, id: item.id });
+    expect(afterCreates?.commentCount).toBe(2);
+    expect(afterCreates?.feedActivityAt).toBeInstanceOf(Date);
+    expect(afterCreates?.revision).toBe(item.revision);
+    expect(afterCreates?.updatedAt.getTime()).toBe(item.updatedAt.getTime());
+
+    // Replayed bump is idempotent: the recount cannot drift the counter.
+    await seed.comments.bumpWorkItemFeedActivity(itemScope);
+    expect((await seed.workItems.get({ orgId: scope.orgId, id: item.id }))?.commentCount).toBe(2);
+
+    await seed.comments.softDelete({ orgId: scope.orgId, commentId: first.id, deletedBy: alice.id });
+    await seed.comments.bumpWorkItemFeedActivity(itemScope);
+    const afterDelete = await seed.workItems.get({ orgId: scope.orgId, id: item.id });
+    expect(afterDelete?.commentCount).toBe(1);
+    expect(afterDelete?.feedActivityAt!.getTime()).toBeGreaterThanOrEqual(afterCreates!.feedActivityAt!.getTime());
+  });
+
+  it('purges comments and mention rows when the work item is hard-deleted', async () => {
+    const seed = await createFactoryStorageForTests();
+    const { item } = await seed.workItems.upsert({
+      orgId: scope.orgId,
+      userId: alice.id,
+      factoryProjectId: scope.factoryProjectId,
+      input: { title: 'Doomed item', stages: ['intake'], sessions: {}, metadata: {} },
+    });
+    const itemScope = { ...scope, workItemId: item.id };
+    await seed.comments.create({
+      ...itemScope,
+      author: alice,
+      body: 'about to be orphaned',
+      mentions: [{ kind: 'user', id: bob.id }],
+    });
+
+    await seed.workItems.delete({ orgId: scope.orgId, id: item.id });
+
+    expect((await seed.comments.list(itemScope)).comments).toEqual([]);
+    expect(await seed.comments.listMentionsForUser({ ...scope, userId: bob.id, limit: 10 })).toHaveLength(0);
+  });
+
+  it('dedupes recent authors newest-first for the roster fallback', async () => {
+    const seed = await createFactoryStorageForTests();
+    await seed.comments.create({ ...scope, author: bob, body: 'older', occurredAt: new Date(Date.now() - 60_000) });
+    await seed.comments.create({ ...scope, author: alice, body: 'newer' });
+    await seed.comments.create({ ...scope, author: alice, body: 'newest' });
+
+    const authors = await seed.comments.listRecentAuthors({
+      orgId: scope.orgId,
+      factoryProjectId: scope.factoryProjectId,
+    });
+    expect(authors.map(author => author.id)).toEqual(['user-alice', 'user-bob']);
+  });
+});

--- a/mastracode/factory/src/storage/domains/comments/base.test.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { createFactoryStorageForTests } from '../../test-utils.js';
+import { supersedesFeedActivity } from './base.js';
 import type { FactoryActorRef } from './actor.js';
 
 const scope = { orgId: 'org-1', factoryProjectId: 'project-1', workItemId: 'item-1' };
@@ -391,23 +392,20 @@ describe('WorkItemCommentsStorage', () => {
     expect(afterReplay?.feedActivityAt?.getTime()).toBe(landed?.getTime());
   });
 
-  it('drops a refresh whose snapshot is older than the one already stored', async () => {
-    const seed = await createFactoryStorageForTests();
-    const { item } = await seed.workItems.upsert({
-      orgId: scope.orgId,
-      userId: alice.id,
-      factoryProjectId: scope.factoryProjectId,
-      input: { title: 'Fix login', stages: ['intake'], sessions: {}, metadata: {} },
-    });
-    const itemScope = { ...scope, workItemId: item.id };
-    await seed.comments.refreshWorkItemFeedActivity({ ...itemScope, now: new Date('2030-01-01T00:00:00.000Z') });
+  it('keeps a refresh from undoing a newer one, ties included', async () => {
+    const at = (iso: string) => ({ feedActivityAt: new Date(iso) });
+    const older = { commentCount: 1, ...at('2030-01-01T00:00:00.000Z') };
+    const newer = { commentCount: 2, ...at('2030-01-01T00:00:01.000Z') };
+    expect(supersedesFeedActivity(newer, older)).toBe(true);
+    expect(supersedesFeedActivity(older, newer)).toBe(false);
 
-    // Two refreshes interleaving: one reads its snapshot, a second completes
-    // first, and the first writes last. Writing last must not undo the newer.
-    await seed.comments.refreshWorkItemFeedActivity({ ...itemScope, now: new Date('2029-01-01T00:00:00.000Z') });
-
-    const after = await seed.workItems.get({ orgId: scope.orgId, id: item.id });
-    expect(after?.feedActivityAt?.toISOString()).toBe('2030-01-01T00:00:00.000Z');
+    // Same stamp, different counts: the snapshot that saw fewer comments read
+    // first and must not land its count over the fuller one.
+    const thin = { commentCount: 1, ...at('2030-01-01T00:00:00.000Z') };
+    const full = { commentCount: 2, ...at('2030-01-01T00:00:00.000Z') };
+    expect(supersedesFeedActivity(full, thin)).toBe(true);
+    expect(supersedesFeedActivity(thin, full)).toBe(false);
+    expect(supersedesFeedActivity(full, full)).toBe(true);
   });
 
   it('purges comments and mention rows when the work item is hard-deleted', async () => {

--- a/mastracode/factory/src/storage/domains/comments/base.test.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.test.ts
@@ -346,9 +346,9 @@ describe('WorkItemCommentsStorage', () => {
     expect(item.feedActivityAt).toBeNull();
 
     const first = await seed.comments.create({ ...itemScope, author: alice, body: 'one' });
-    await seed.comments.bumpWorkItemFeedActivity(itemScope);
+    await seed.comments.refreshWorkItemFeedActivity(itemScope);
     await seed.comments.create({ ...itemScope, author: bob, body: 'two' });
-    await seed.comments.bumpWorkItemFeedActivity(itemScope);
+    await seed.comments.refreshWorkItemFeedActivity(itemScope);
 
     const afterCreates = await seed.workItems.get({ orgId: scope.orgId, id: item.id });
     expect(afterCreates?.commentCount).toBe(2);
@@ -357,14 +357,38 @@ describe('WorkItemCommentsStorage', () => {
     expect(afterCreates?.updatedAt.getTime()).toBe(item.updatedAt.getTime());
 
     // Replayed bump is idempotent: the recount cannot drift the counter.
-    await seed.comments.bumpWorkItemFeedActivity(itemScope);
+    await seed.comments.refreshWorkItemFeedActivity(itemScope);
     expect((await seed.workItems.get({ orgId: scope.orgId, id: item.id }))?.commentCount).toBe(2);
 
     await seed.comments.softDelete({ orgId: scope.orgId, commentId: first.id, deletedBy: alice.id });
-    await seed.comments.bumpWorkItemFeedActivity(itemScope);
+    await seed.comments.refreshWorkItemFeedActivity(itemScope);
     const afterDelete = await seed.workItems.get({ orgId: scope.orgId, id: item.id });
     expect(afterDelete?.commentCount).toBe(1);
     expect(afterDelete?.feedActivityAt!.getTime()).toBeGreaterThanOrEqual(afterCreates!.feedActivityAt!.getTime());
+  });
+
+  it('leaves feed activity where it was when a create is replayed', async () => {
+    const seed = await createFactoryStorageForTests();
+    const { item } = await seed.workItems.upsert({
+      orgId: scope.orgId,
+      userId: alice.id,
+      factoryProjectId: scope.factoryProjectId,
+      input: { title: 'Fix login', stages: ['intake'], sessions: {}, metadata: {} },
+    });
+    const itemScope = { ...scope, workItemId: item.id };
+    const token = 'token-replayed';
+    await seed.comments.create({ ...itemScope, author: alice, body: 'hello', clientToken: token });
+    await seed.comments.refreshWorkItemFeedActivity(itemScope);
+    const landed = (await seed.workItems.get({ orgId: scope.orgId, id: item.id }))?.feedActivityAt;
+
+    // A lost response and a retry: the row is recovered, so the feed has not
+    // moved and the work item must not jump on a wall clock much later.
+    await seed.comments.create({ ...itemScope, author: alice, body: 'hello', clientToken: token });
+    await seed.comments.refreshWorkItemFeedActivity({ ...itemScope, now: new Date('2031-01-01T00:00:00.000Z') });
+
+    const afterReplay = await seed.workItems.get({ orgId: scope.orgId, id: item.id });
+    expect(afterReplay?.commentCount).toBe(1);
+    expect(afterReplay?.feedActivityAt?.getTime()).toBe(landed?.getTime());
   });
 
   it('purges comments and mention rows when the work item is hard-deleted', async () => {

--- a/mastracode/factory/src/storage/domains/comments/base.test.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.test.ts
@@ -64,6 +64,52 @@ describe('WorkItemCommentsStorage', () => {
     expect(new Set(ids)).toEqual(new Set(seen));
   });
 
+  it('anchors a page on a deep-linked comment, holding it and everything newer', async () => {
+    const seed = await createFactoryStorageForTests();
+    const ids = [];
+    for (let i = 0; i < 5; i++) {
+      ids.push(
+        (
+          await seed.comments.create({
+            ...scope,
+            author: alice,
+            body: `comment ${i}`,
+            occurredAt: new Date(`2026-08-0${i + 1}T10:00:00.000Z`),
+          })
+        ).id,
+      );
+    }
+
+    const page = await seed.comments.list({ ...scope, limit: 2, around: ids[1] });
+    // The limit never truncates the anchor away: the target plus its three newer.
+    expect(page.comments.map(comment => comment.body)).toEqual(['comment 4', 'comment 3', 'comment 2', 'comment 1']);
+    const older = await seed.comments.list({ ...scope, before: page.nextCursor });
+    expect(older.comments.map(comment => comment.body)).toEqual(['comment 0']);
+  });
+
+  it('drops the anchor for the oldest comment and for one that does not exist', async () => {
+    const seed = await createFactoryStorageForTests();
+    const oldest = await seed.comments.create({
+      ...scope,
+      author: alice,
+      body: 'oldest',
+      occurredAt: new Date('2026-08-01T10:00:00.000Z'),
+    });
+    await seed.comments.create({
+      ...scope,
+      author: bob,
+      body: 'newest',
+      occurredAt: new Date('2026-08-02T10:00:00.000Z'),
+    });
+
+    const anchored = await seed.comments.list({ ...scope, around: oldest.id });
+    expect(anchored.comments.map(comment => comment.body)).toEqual(['newest', 'oldest']);
+    expect(anchored.nextCursor).toBeUndefined();
+
+    const missing = await seed.comments.list({ ...scope, around: '00000000-0000-4000-8000-000000000000' });
+    expect(missing.comments.map(comment => comment.body)).toEqual(['newest', 'oldest']);
+  });
+
   it('orders by caller-set occurred_at, not insert time', async () => {
     const seed = await createFactoryStorageForTests();
     await seed.comments.create({ ...scope, author: alice, body: 'posted first, happened last' });

--- a/mastracode/factory/src/storage/domains/comments/base.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.ts
@@ -1,0 +1,705 @@
+/**
+ * Work-item comments domain — one message list per work item, materialized
+ * from every source. Local creates and platform mirrors (Slack, Linear,
+ * GitHub) share one idempotency story: `external_source` json + derived
+ * `source_key` under a partial unique index, a local retry token being just
+ * another source (`local:comment:<uuid>`).
+ *
+ * Ordering is caller-settable `occurred_at`, never insert time — ingest
+ * backdates to the platform timestamp and retries arrive out of order.
+ * Deletes are soft: the tombstone holds the ordering and its kept
+ * `source_key` stops a redelivery from resurrecting the row.
+ */
+
+import { FactoryStorageDomain, UniqueViolationError } from '@mastra/core/storage';
+
+import type { ExternalWorkItemSource } from '../work-items/base.js';
+import type { FactoryActorExternalIdentity, FactoryActorRef } from './actor.js';
+import { WORK_ITEM_COMMENT_MENTIONS_SCHEMA, WORK_ITEM_COMMENTS_SCHEMA } from './schema.js';
+
+export { WORK_ITEM_COMMENT_MENTIONS_SCHEMA, WORK_ITEM_COMMENTS_SCHEMA } from './schema.js';
+
+export type WorkItemCommentKind = 'comment';
+
+export interface FactoryMentionRef {
+  kind: 'user';
+  id: string;
+}
+
+export interface WorkItemCommentReplyRef {
+  commentId: string;
+  quote?: string;
+  authorId?: string;
+  authorName?: string;
+}
+
+export interface WorkItemCommentRow {
+  id: string;
+  orgId: string;
+  factoryProjectId: string;
+  workItemId: string;
+  kind: WorkItemCommentKind;
+  body: string;
+  bodyFormat: string;
+  author: FactoryActorRef;
+  replyTo: WorkItemCommentReplyRef | null;
+  mentions: FactoryMentionRef[];
+  externalSource: ExternalWorkItemSource | null;
+  sourceKey: string | null;
+  occurredAt: Date;
+  editedAt: Date | null;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  revision: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateWorkItemCommentInput {
+  orgId: string;
+  factoryProjectId: string;
+  workItemId: string;
+  author: FactoryActorRef;
+  body: string;
+  bodyFormat?: string;
+  replyTo?: WorkItemCommentReplyRef;
+  mentions?: FactoryMentionRef[];
+  externalSource?: ExternalWorkItemSource;
+  /** Local idempotent-retry token; mutually exclusive with `externalSource`. */
+  clientToken?: string;
+  occurredAt?: Date;
+}
+
+export interface EditWorkItemCommentInput {
+  orgId: string;
+  commentId: string;
+  body: string;
+  mentions?: FactoryMentionRef[];
+  /** The acting user; their own handle never becomes a mention row. */
+  editorId?: string;
+  /** When set, the edit only lands if the row is still at this revision. */
+  expectedRevision?: number;
+  now?: Date;
+}
+
+export interface EditWorkItemCommentResult {
+  comment: WorkItemCommentRow;
+  addedMentions: FactoryMentionRef[];
+  removedMentions: FactoryMentionRef[];
+}
+
+export interface ListWorkItemCommentsInput {
+  orgId: string;
+  factoryProjectId: string;
+  workItemId: string;
+  before?: string;
+  limit?: number;
+}
+
+export interface WorkItemCommentPage {
+  comments: WorkItemCommentRow[];
+  nextCursor?: string;
+}
+
+export interface WorkItemMentionRow {
+  id: string;
+  commentId: string;
+  mentionedKind: 'user';
+  mentionedId: string;
+  authorId: string;
+  orgId: string;
+  factoryProjectId: string;
+  workItemId: string;
+  occurredAt: Date;
+}
+
+export const MAX_COMMENT_BODY_LENGTH = 16_000;
+export const MAX_COMMENT_QUOTE_LENGTH = 500;
+export const MAX_COMMENT_MENTIONS = 20;
+
+/** The one body policy: HTTP parsing and the service both reject on it. */
+export function commentBodyError(body: string): string | undefined {
+  if (!body.trim()) return 'Comment body must not be empty.';
+  if (body.length > MAX_COMMENT_BODY_LENGTH)
+    return `Comment body must be at most ${MAX_COMMENT_BODY_LENGTH} characters.`;
+  return undefined;
+}
+
+const DEFAULT_PAGE_SIZE = 30;
+const MAX_PAGE_SIZE = 100;
+
+export function clampCommentLimit(limit: number | undefined): number {
+  const normalized = typeof limit === 'number' && Number.isFinite(limit) ? Math.trunc(limit) : DEFAULT_PAGE_SIZE;
+  return Math.min(Math.max(normalized, 1), MAX_PAGE_SIZE);
+}
+
+export function encodeCommentCursor(row: WorkItemCommentRow): string {
+  return `${row.occurredAt.toISOString()}_${row.id}`;
+}
+
+export function decodeCommentCursor(cursor: string): { occurredAt: Date; id: string } | undefined {
+  const sep = cursor.lastIndexOf('_');
+  if (sep <= 0) return undefined;
+  const occurredAt = new Date(cursor.slice(0, sep));
+  const id = cursor.slice(sep + 1);
+  if (Number.isNaN(occurredAt.getTime()) || !id) return undefined;
+  return { occurredAt, id };
+}
+
+export function commentSourceKey(input: {
+  externalSource?: ExternalWorkItemSource;
+  clientToken?: string;
+}): string | null {
+  if (input.externalSource) {
+    const source = input.externalSource;
+    return `${source.integrationId}:${source.type}:${source.externalId}`;
+  }
+  if (input.clientToken) return `local:comment:${input.clientToken}`;
+  return null;
+}
+
+/** A `clientToken` replay that resolved to a different work item or author. */
+export class CommentTokenConflictError extends Error {
+  constructor() {
+    super('Client token already used by a different comment.');
+    this.name = 'CommentTokenConflictError';
+  }
+}
+
+interface WorkItemCommentDbRow extends Record<string, unknown> {
+  id: string;
+  org_id: string;
+  factory_project_id: string;
+  work_item_id: string;
+  kind: WorkItemCommentKind;
+  body: string;
+  body_format: string;
+  author_kind: FactoryActorRef['kind'];
+  author_id: string;
+  author_display_name: string | null;
+  author_avatar_url: string | null;
+  author_external: FactoryActorExternalIdentity | null;
+  reply_to_comment_id: string | null;
+  reply_quote: string | null;
+  reply_to_author_id: string | null;
+  reply_to_author_name: string | null;
+  mentions: FactoryMentionRef[];
+  external_source: ExternalWorkItemSource | null;
+  source_key: string | null;
+  occurred_at: Date;
+  edited_at: Date | null;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  revision: number;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface WorkItemMentionDbRow extends Record<string, unknown> {
+  id: string;
+  comment_id: string;
+  mentioned_kind: 'user';
+  mentioned_id: string;
+  author_id: string;
+  org_id: string;
+  factory_project_id: string;
+  work_item_id: string;
+  occurred_at: Date;
+}
+
+function toComment(row: WorkItemCommentDbRow): WorkItemCommentRow {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    factoryProjectId: row.factory_project_id,
+    workItemId: row.work_item_id,
+    kind: row.kind,
+    body: row.body,
+    bodyFormat: row.body_format,
+    author: {
+      kind: row.author_kind,
+      id: row.author_id,
+      ...(row.author_display_name ? { displayName: row.author_display_name } : {}),
+      ...(row.author_avatar_url ? { avatarUrl: row.author_avatar_url } : {}),
+      ...(row.author_external ? { external: row.author_external } : {}),
+    },
+    replyTo: row.reply_to_comment_id
+      ? {
+          commentId: row.reply_to_comment_id,
+          ...(row.reply_quote ? { quote: row.reply_quote } : {}),
+          ...(row.reply_to_author_id ? { authorId: row.reply_to_author_id } : {}),
+          ...(row.reply_to_author_name ? { authorName: row.reply_to_author_name } : {}),
+        }
+      : null,
+    mentions: row.mentions,
+    externalSource: row.external_source,
+    sourceKey: row.source_key,
+    occurredAt: row.occurred_at,
+    editedAt: row.edited_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    revision: row.revision,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function toMention(row: WorkItemMentionDbRow): WorkItemMentionRow {
+  return {
+    id: row.id,
+    commentId: row.comment_id,
+    mentionedKind: row.mentioned_kind,
+    mentionedId: row.mentioned_id,
+    authorId: row.author_id,
+    orgId: row.org_id,
+    factoryProjectId: row.factory_project_id,
+    workItemId: row.work_item_id,
+    occurredAt: row.occurred_at,
+  };
+}
+
+function toMentionRef(row: WorkItemMentionRow): FactoryMentionRef {
+  return { kind: row.mentionedKind, id: row.mentionedId };
+}
+
+function mentionKey(mention: { kind: string; id: string }): string {
+  return `${mention.kind}\0${mention.id}`;
+}
+
+function dedupeMentions(mentions: FactoryMentionRef[] | undefined): FactoryMentionRef[] {
+  if (!mentions?.length) return [];
+  return [...new Map(mentions.map(mention => [mentionKey(mention), mention])).values()];
+}
+
+export class WorkItemCommentsStorage extends FactoryStorageDomain {
+  constructor() {
+    super('work-item-comments');
+  }
+
+  async init(): Promise<void> {
+    await this.ensureCollections([WORK_ITEM_COMMENTS_SCHEMA, WORK_ITEM_COMMENT_MENTIONS_SCHEMA]);
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.ops.deleteMany('work_item_comment_mentions', {});
+    await this.ops.deleteMany('work_item_comments', {});
+  }
+
+  async create(input: CreateWorkItemCommentInput): Promise<WorkItemCommentRow> {
+    const now = new Date();
+    const occurredAt = input.occurredAt ?? now;
+    const sourceKey = commentSourceKey(input);
+    const author = input.author;
+    const row: Partial<WorkItemCommentDbRow> = {
+      org_id: input.orgId,
+      factory_project_id: input.factoryProjectId,
+      work_item_id: input.workItemId,
+      kind: 'comment',
+      body: input.body,
+      body_format: input.bodyFormat ?? 'markdown',
+      author_kind: author.kind,
+      author_id: author.id,
+      author_display_name: author.displayName ?? null,
+      author_avatar_url: author.avatarUrl ?? null,
+      author_external: author.external ?? null,
+      reply_to_comment_id: input.replyTo?.commentId ?? null,
+      reply_quote: input.replyTo?.quote ?? null,
+      reply_to_author_id: input.replyTo?.authorId ?? null,
+      reply_to_author_name: input.replyTo?.authorName ?? null,
+      mentions: dedupeMentions(input.mentions),
+      external_source: input.externalSource ?? null,
+      source_key: sourceKey,
+      occurred_at: occurredAt,
+      edited_at: null,
+      deleted_at: null,
+      deleted_by: null,
+      revision: 1,
+      created_at: now,
+      updated_at: now,
+    };
+
+    // Insert-or-recover, never upsert: a replayed create must return the
+    // existing row untouched (an upsert would clobber a later edit's body).
+    // A local token resolving to another item or author is a conflict, not a
+    // recovery. External keys stay lenient: a redelivery after a thread
+    // re-link maps to a new item id and must still no-op.
+    if (sourceKey) {
+      const sourceWhere = { factory_project_id: input.factoryProjectId, source_key: sourceKey };
+      const recover = (found: WorkItemCommentDbRow): WorkItemCommentRow => {
+        if (!input.externalSource && (found.work_item_id !== input.workItemId || found.author_id !== author.id)) {
+          throw new CommentTokenConflictError();
+        }
+        return toComment(found);
+      };
+      const existing = await this.ops.findOne<WorkItemCommentDbRow>('work_item_comments', sourceWhere);
+      if (existing) return recover(existing);
+      try {
+        return await this.#insertWithMentions(row);
+      } catch (error) {
+        if (!(error instanceof UniqueViolationError)) throw error;
+        const raced = await this.ops.findOne<WorkItemCommentDbRow>('work_item_comments', sourceWhere);
+        if (!raced) throw error;
+        return recover(raced);
+      }
+    }
+
+    return this.#insertWithMentions(row);
+  }
+
+  async #insertWithMentions(row: Partial<WorkItemCommentDbRow>): Promise<WorkItemCommentRow> {
+    const comment = toComment(await this.ops.insertOne<WorkItemCommentDbRow>('work_item_comments', row));
+    await this.#writeMentionRows(comment, comment.mentions);
+    return comment;
+  }
+
+  /**
+   * Idempotent counter refresh on the parent work item: an absolute recount
+   * (never an increment — replays and races double an increment; a recount
+   * can't drift). Counted BEFORE `updateAtomic`: its mutator runs inside an
+   * open transaction holding a pool connection, and a query in there checks
+   * out a second one — concurrent posts would exhaust the pool. A count gone
+   * stale by write time converges on the next feed mutation. Touches ONLY the
+   * counter columns: `revision`/`updated_at` are the stage-transition
+   * concurrency token.
+   */
+  async bumpWorkItemFeedActivity({
+    orgId,
+    factoryProjectId,
+    workItemId,
+    now = new Date(),
+  }: {
+    orgId: string;
+    factoryProjectId: string;
+    workItemId: string;
+    now?: Date;
+  }): Promise<void> {
+    const commentCount = await this.countForWorkItem({ orgId, factoryProjectId, workItemId });
+    await this.ops.updateAtomic<Record<string, unknown>>(
+      'work_items',
+      { id: workItemId, org_id: orgId, factory_project_id: factoryProjectId },
+      () => ({
+        comment_count: commentCount,
+        feed_activity_at: now,
+      }),
+    );
+  }
+
+  async get({ orgId, commentId }: { orgId: string; commentId: string }): Promise<WorkItemCommentRow | null> {
+    const row = await this.ops.findOne<WorkItemCommentDbRow>('work_item_comments', {
+      id: commentId,
+      org_id: orgId,
+    });
+    return row ? toComment(row) : null;
+  }
+
+  async listByIds({ orgId, ids }: { orgId: string; ids: string[] }): Promise<WorkItemCommentRow[]> {
+    if (ids.length === 0) return [];
+    const rows = await this.ops.findMany<WorkItemCommentDbRow>('work_item_comments', {
+      org_id: orgId,
+      id: { in: ids },
+    });
+    return rows.map(toComment);
+  }
+
+  async list(input: ListWorkItemCommentsInput): Promise<WorkItemCommentPage> {
+    const limit = clampCommentLimit(input.limit);
+    const cursor = input.before ? decodeCommentCursor(input.before) : undefined;
+    const rows = await this.ops.findMany<WorkItemCommentDbRow>(
+      'work_item_comments',
+      {
+        org_id: input.orgId,
+        factory_project_id: input.factoryProjectId,
+        work_item_id: input.workItemId,
+      },
+      {
+        orderBy: [
+          ['occurred_at', 'desc'],
+          ['id', 'desc'],
+        ],
+        limit: limit + 1,
+        ...(cursor ? { cursor: { values: [cursor.occurredAt, cursor.id] } } : {}),
+      },
+    );
+    const comments = rows.slice(0, limit).map(toComment);
+    const hasMore = rows.length > limit;
+    const last = comments[comments.length - 1];
+    return {
+      comments,
+      ...(hasMore && last ? { nextCursor: encodeCommentCursor(last) } : {}),
+    };
+  }
+
+  /**
+   * Newest non-deleted comments for run-context injection, newest-first (the
+   * caller reverses for display order).
+   */
+  async listRecent({
+    orgId,
+    factoryProjectId,
+    workItemId,
+    limit,
+  }: {
+    orgId: string;
+    factoryProjectId: string;
+    workItemId: string;
+    limit: number;
+  }): Promise<WorkItemCommentRow[]> {
+    const rows = await this.ops.findMany<WorkItemCommentDbRow>(
+      'work_item_comments',
+      {
+        org_id: orgId,
+        factory_project_id: factoryProjectId,
+        work_item_id: workItemId,
+        deleted_at: null,
+      },
+      {
+        orderBy: [
+          ['occurred_at', 'desc'],
+          ['id', 'desc'],
+        ],
+        limit,
+      },
+    );
+    return rows.map(toComment);
+  }
+
+  async edit(input: EditWorkItemCommentInput): Promise<EditWorkItemCommentResult | 'conflict' | null> {
+    const now = input.now ?? new Date();
+    let rejection: 'deleted' | 'conflict' | undefined;
+    const updated = await this.ops.updateAtomic<WorkItemCommentDbRow>(
+      'work_item_comments',
+      { id: input.commentId, org_id: input.orgId },
+      current => {
+        if (current.deleted_at) {
+          rejection = 'deleted';
+          return null;
+        }
+        if (input.expectedRevision !== undefined && Number(current.revision) !== input.expectedRevision) {
+          rejection = 'conflict';
+          return null;
+        }
+        return {
+          body: input.body,
+          mentions: dedupeMentions(input.mentions ?? current.mentions),
+          edited_at: now,
+          revision: Number(current.revision) + 1,
+          updated_at: now,
+        };
+      },
+    );
+    if (rejection === 'conflict') return 'conflict';
+    if (!updated || rejection) return null;
+    const comment = toComment(updated);
+
+    const existing = await this.#listMentionRows(comment.id);
+    const existingKeys = new Set(existing.map(mention => mentionKey(toMentionRef(mention))));
+    const nextKeys = new Set(comment.mentions.map(mentionKey));
+    // Self-mentions (author, or the acting editor) never become rows, so they
+    // must not report as "added" either — they would re-report on every edit.
+    const skippedIds = new Set([comment.author.id, ...(input.editorId ? [input.editorId] : [])]);
+    const addedMentions = comment.mentions.filter(
+      mention => !existingKeys.has(mentionKey(mention)) && !skippedIds.has(mention.id),
+    );
+    const removedMentions = existing.map(toMentionRef).filter(mention => !nextKeys.has(mentionKey(mention)));
+
+    // Stamped with the edit time, not the comment's creation time: the inbox
+    // is a keyset on `occurred_at`, and a backdated row lands buried under
+    // everything the user already saw.
+    await this.#writeMentionRows(comment, addedMentions, now);
+    for (const mention of removedMentions) {
+      await this.ops.deleteMany('work_item_comment_mentions', {
+        comment_id: comment.id,
+        mentioned_kind: mention.kind,
+        mentioned_id: mention.id,
+      });
+    }
+    return { comment, addedMentions, removedMentions };
+  }
+
+  async softDelete({
+    orgId,
+    commentId,
+    deletedBy,
+    now = new Date(),
+  }: {
+    orgId: string;
+    commentId: string;
+    deletedBy: string;
+    now?: Date;
+  }): Promise<WorkItemCommentRow | null> {
+    let alreadyDeleted = false;
+    const updated = await this.ops.updateAtomic<WorkItemCommentDbRow>(
+      'work_item_comments',
+      { id: commentId, org_id: orgId },
+      current => {
+        if (current.deleted_at) {
+          alreadyDeleted = true;
+          return null;
+        }
+        return {
+          body: '',
+          mentions: [],
+          deleted_at: now,
+          deleted_by: deletedBy,
+          updated_at: now,
+        };
+      },
+    );
+    if (!updated || alreadyDeleted) return null;
+    await this.ops.deleteMany('work_item_comment_mentions', { comment_id: commentId });
+    return toComment(updated);
+  }
+
+  /**
+   * Provenance write-back after an outbound publish. First platform wins, and
+   * an existing `source_key` is kept: replacing a `local:comment:<token>` one
+   * would let a client retry duplicate the row. So a web-born comment is never
+   * key-deduped against its own platform echo — the host's bot-sender check is
+   * the only echo layer for those rows (COR-1174).
+   */
+  async attachExternalSource({
+    orgId,
+    commentId,
+    source,
+  }: {
+    orgId: string;
+    commentId: string;
+    source: ExternalWorkItemSource;
+  }): Promise<WorkItemCommentRow | null> {
+    const updated = await this.ops.updateAtomic<WorkItemCommentDbRow>(
+      'work_item_comments',
+      { id: commentId, org_id: orgId },
+      current => {
+        if (current.external_source) return null;
+        return {
+          external_source: source,
+          source_key: current.source_key ?? commentSourceKey({ externalSource: source }),
+          updated_at: new Date(),
+        };
+      },
+    );
+    return updated ? toComment(updated) : null;
+  }
+
+  async listMentionsForComment(commentId: string): Promise<WorkItemMentionRow[]> {
+    return this.#listMentionRows(commentId);
+  }
+
+  /** Keyset inbox read for the mention attention provider, newest-first. */
+  async listMentionsForUser({
+    orgId,
+    factoryProjectId,
+    userId,
+    before,
+    limit,
+  }: {
+    orgId: string;
+    factoryProjectId: string;
+    userId: string;
+    before?: { occurredAt: Date; id: string };
+    limit: number;
+  }): Promise<WorkItemMentionRow[]> {
+    const rows = await this.ops.findMany<WorkItemMentionDbRow>(
+      'work_item_comment_mentions',
+      {
+        org_id: orgId,
+        factory_project_id: factoryProjectId,
+        mentioned_id: userId,
+      },
+      {
+        orderBy: [
+          ['occurred_at', 'desc'],
+          ['id', 'desc'],
+        ],
+        limit,
+        ...(before ? { cursor: { values: [before.occurredAt, before.id] } } : {}),
+      },
+    );
+    return rows.map(toMention);
+  }
+
+  async countForWorkItem({
+    orgId,
+    factoryProjectId,
+    workItemId,
+  }: {
+    orgId: string;
+    factoryProjectId: string;
+    workItemId: string;
+  }): Promise<number> {
+    if (!this.ops.count) {
+      throw new Error('[WorkItemCommentsStorage] storage backend does not support collection counts.');
+    }
+    return this.ops.count('work_item_comments', {
+      org_id: orgId,
+      factory_project_id: factoryProjectId,
+      work_item_id: workItemId,
+      deleted_at: null,
+    });
+  }
+
+  /** Recent distinct comment authors of a project, for the roster fallback. */
+  async listRecentAuthors({
+    orgId,
+    factoryProjectId,
+    limit = 200,
+  }: {
+    orgId: string;
+    factoryProjectId: string;
+    limit?: number;
+  }): Promise<FactoryActorRef[]> {
+    const rows = await this.ops.findMany<WorkItemCommentDbRow>(
+      'work_item_comments',
+      { org_id: orgId, factory_project_id: factoryProjectId },
+      {
+        orderBy: [
+          ['occurred_at', 'desc'],
+          ['id', 'desc'],
+        ],
+        limit,
+      },
+    );
+    const authors = new Map<string, FactoryActorRef>();
+    for (const row of rows) {
+      if (authors.has(row.author_id)) continue;
+      authors.set(row.author_id, toComment(row).author);
+    }
+    return [...authors.values()];
+  }
+
+  async #listMentionRows(commentId: string): Promise<WorkItemMentionRow[]> {
+    const rows = await this.ops.findMany<WorkItemMentionDbRow>('work_item_comment_mentions', {
+      comment_id: commentId,
+    });
+    return rows.map(toMention);
+  }
+
+  /**
+   * Self-mentions never get rows: the join exists solely for the attention
+   * inbox, and `CollectionWhere` cannot express `author_id != userId` at read
+   * time, so the filter happens at write time.
+   */
+  async #writeMentionRows(
+    comment: WorkItemCommentRow,
+    mentions: FactoryMentionRef[],
+    occurredAt = comment.occurredAt,
+  ): Promise<void> {
+    for (const mention of mentions) {
+      if (mention.id === comment.author.id) continue;
+      await this.ops.upsertOne<WorkItemMentionDbRow>(
+        'work_item_comment_mentions',
+        ['comment_id', 'mentioned_kind', 'mentioned_id'],
+        {
+          comment_id: comment.id,
+          mentioned_kind: mention.kind,
+          mentioned_id: mention.id,
+          author_id: comment.author.id,
+          org_id: comment.orgId,
+          factory_project_id: comment.factoryProjectId,
+          work_item_id: comment.workItemId,
+          occurred_at: occurredAt,
+        },
+      );
+    }
+  }
+}

--- a/mastracode/factory/src/storage/domains/comments/base.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.ts
@@ -102,6 +102,12 @@ export interface ListWorkItemCommentsInput {
   around?: string;
 }
 
+/** The only two work-item columns the feed refresh reads or writes. */
+interface WorkItemFeedColumns extends Record<string, unknown> {
+  comment_count: number;
+  feed_activity_at: Date | null;
+}
+
 export interface WorkItemCommentPage {
   comments: WorkItemCommentRow[];
   nextCursor?: string;
@@ -369,9 +375,11 @@ export class WorkItemCommentsStorage extends FactoryStorageDomain {
    * work item in the feed without adding a comment; a read-back can't drift).
    * Read BEFORE `updateAtomic`: its mutator runs inside an open transaction
    * holding a pool connection, and a query in there checks out a second one —
-   * concurrent posts would exhaust the pool. A value gone stale by write time
-   * converges on the next feed mutation. Touches ONLY the counter columns:
-   * `revision`/`updated_at` are the stage-transition concurrency token.
+   * concurrent posts would exhaust the pool. Reading outside means two
+   * refreshes can interleave, so the write is monotonic: a snapshot older than
+   * the stored one is dropped rather than allowed to undo a newer refresh.
+   * Touches ONLY the counter columns: `revision`/`updated_at` are the
+   * stage-transition concurrency token.
    */
   async refreshWorkItemFeedActivity({
     orgId,
@@ -392,13 +400,15 @@ export class WorkItemCommentsStorage extends FactoryStorageDomain {
       { org_id: orgId, factory_project_id: factoryProjectId, work_item_id: workItemId },
       { orderBy: [['updated_at', 'desc']], limit: 1 },
     );
-    await this.ops.updateAtomic<Record<string, unknown>>(
+    const feedActivityAt = latest?.updated_at ?? now;
+    await this.ops.updateAtomic<WorkItemFeedColumns>(
       'work_items',
       { id: workItemId, org_id: orgId, factory_project_id: factoryProjectId },
-      () => ({
-        comment_count: commentCount,
-        feed_activity_at: latest?.updated_at ?? now,
-      }),
+      row => {
+        const stored = row.feed_activity_at;
+        if (stored && feedActivityAt.getTime() < stored.getTime()) return null;
+        return { comment_count: commentCount, feed_activity_at: feedActivityAt };
+      },
     );
   }
 

--- a/mastracode/factory/src/storage/domains/comments/base.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.ts
@@ -363,16 +363,17 @@ export class WorkItemCommentsStorage extends FactoryStorageDomain {
   }
 
   /**
-   * Idempotent counter refresh on the parent work item: an absolute recount
-   * (never an increment — replays and races double an increment; a recount
-   * can't drift). Counted BEFORE `updateAtomic`: its mutator runs inside an
-   * open transaction holding a pool connection, and a query in there checks
-   * out a second one — concurrent posts would exhaust the pool. A count gone
-   * stale by write time converges on the next feed mutation. Touches ONLY the
-   * counter columns: `revision`/`updated_at` are the stage-transition
-   * concurrency token.
+   * Idempotent counter refresh on the parent work item: both columns are read
+   * back off the comments (never incremented or stamped with the wall clock —
+   * replays and races double an increment, and a replayed create would move a
+   * work item in the feed without adding a comment; a read-back can't drift).
+   * Read BEFORE `updateAtomic`: its mutator runs inside an open transaction
+   * holding a pool connection, and a query in there checks out a second one —
+   * concurrent posts would exhaust the pool. A value gone stale by write time
+   * converges on the next feed mutation. Touches ONLY the counter columns:
+   * `revision`/`updated_at` are the stage-transition concurrency token.
    */
-  async bumpWorkItemFeedActivity({
+  async refreshWorkItemFeedActivity({
     orgId,
     factoryProjectId,
     workItemId,
@@ -384,12 +385,19 @@ export class WorkItemCommentsStorage extends FactoryStorageDomain {
     now?: Date;
   }): Promise<void> {
     const commentCount = await this.countForWorkItem({ orgId, factoryProjectId, workItemId });
+    // Every feed mutation stamps `updated_at`, edits and tombstones included,
+    // so the newest one is when this feed last moved.
+    const [latest] = await this.ops.findMany<WorkItemCommentDbRow>(
+      'work_item_comments',
+      { org_id: orgId, factory_project_id: factoryProjectId, work_item_id: workItemId },
+      { orderBy: [['updated_at', 'desc']], limit: 1 },
+    );
     await this.ops.updateAtomic<Record<string, unknown>>(
       'work_items',
       { id: workItemId, org_id: orgId, factory_project_id: factoryProjectId },
       () => ({
         comment_count: commentCount,
-        feed_activity_at: now,
+        feed_activity_at: latest?.updated_at ?? now,
       }),
     );
   }

--- a/mastracode/factory/src/storage/domains/comments/base.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.ts
@@ -108,6 +108,28 @@ interface WorkItemFeedColumns extends Record<string, unknown> {
   feed_activity_at: Date | null;
 }
 
+/** A feed snapshot: how many comments the item had, and when it last moved. */
+export interface FeedActivitySnapshot {
+  commentCount: number;
+  feedActivityAt: Date;
+}
+
+/**
+ * The refresh reads its snapshot outside the write transaction, so two of them
+ * can interleave and the loser can write last. This is the one rule that keeps
+ * that from undoing a newer refresh: feed activity never moves backwards, and
+ * on the same stamp the fuller count wins.
+ *
+ * Known ceiling: a soft delete sharing a millisecond with a create leaves the
+ * count one high until the next feed mutation recounts. Closing that needs the
+ * aggregate read inside the write transaction, which the ops layer cannot do
+ * without checking out a second pool connection per open transaction.
+ */
+export function supersedesFeedActivity(next: FeedActivitySnapshot, stored: FeedActivitySnapshot): boolean {
+  const drift = next.feedActivityAt.getTime() - stored.feedActivityAt.getTime();
+  return drift > 0 || (drift === 0 && next.commentCount >= stored.commentCount);
+}
+
 export interface WorkItemCommentPage {
   comments: WorkItemCommentRow[];
   nextCursor?: string;
@@ -376,8 +398,8 @@ export class WorkItemCommentsStorage extends FactoryStorageDomain {
    * Read BEFORE `updateAtomic`: its mutator runs inside an open transaction
    * holding a pool connection, and a query in there checks out a second one —
    * concurrent posts would exhaust the pool. Reading outside means two
-   * refreshes can interleave, so the write is monotonic: a snapshot older than
-   * the stored one is dropped rather than allowed to undo a newer refresh.
+   * refreshes can interleave, so the write goes through
+   * {@link supersedesFeedActivity} rather than landing whatever it read.
    * Touches ONLY the counter columns: `revision`/`updated_at` are the
    * stage-transition concurrency token.
    */
@@ -405,8 +427,11 @@ export class WorkItemCommentsStorage extends FactoryStorageDomain {
       'work_items',
       { id: workItemId, org_id: orgId, factory_project_id: factoryProjectId },
       row => {
+        const next = { commentCount, feedActivityAt };
         const stored = row.feed_activity_at;
-        if (stored && feedActivityAt.getTime() < stored.getTime()) return null;
+        if (stored && !supersedesFeedActivity(next, { commentCount: row.comment_count, feedActivityAt: stored })) {
+          return null;
+        }
         return { comment_count: commentCount, feed_activity_at: feedActivityAt };
       },
     );

--- a/mastracode/factory/src/storage/domains/comments/base.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.ts
@@ -324,7 +324,11 @@ export class WorkItemCommentsStorage extends FactoryStorageDomain {
     // recovery. External keys stay lenient: a redelivery after a thread
     // re-link maps to a new item id and must still no-op.
     if (sourceKey) {
-      const sourceWhere = { factory_project_id: input.factoryProjectId, source_key: sourceKey };
+      const sourceWhere = {
+        org_id: input.orgId,
+        factory_project_id: input.factoryProjectId,
+        source_key: sourceKey,
+      };
       const recover = (found: WorkItemCommentDbRow): WorkItemCommentRow => {
         if (!input.externalSource && (found.work_item_id !== input.workItemId || found.author_id !== author.id)) {
           throw new CommentTokenConflictError();

--- a/mastracode/factory/src/storage/domains/comments/base.ts
+++ b/mastracode/factory/src/storage/domains/comments/base.ts
@@ -94,6 +94,12 @@ export interface ListWorkItemCommentsInput {
   workItemId: string;
   before?: string;
   limit?: number;
+  /**
+   * Anchor the first page on this comment: it and every comment newer than it,
+   * so a deep link opens on the target instead of paging back to find it.
+   * Ignored when the comment is gone, or sits further back than one page holds.
+   */
+  around?: string;
 }
 
 export interface WorkItemCommentPage {
@@ -406,6 +412,8 @@ export class WorkItemCommentsStorage extends FactoryStorageDomain {
   }
 
   async list(input: ListWorkItemCommentsInput): Promise<WorkItemCommentPage> {
+    const anchored = input.around ? await this.#listAround(input, input.around) : undefined;
+    if (anchored) return anchored;
     const limit = clampCommentLimit(input.limit);
     const cursor = input.before ? decodeCommentCursor(input.before) : undefined;
     const rows = await this.ops.findMany<WorkItemCommentDbRow>(
@@ -430,6 +438,35 @@ export class WorkItemCommentsStorage extends FactoryStorageDomain {
     return {
       comments,
       ...(hasMore && last ? { nextCursor: encodeCommentCursor(last) } : {}),
+    };
+  }
+
+  async #listAround(
+    { orgId, factoryProjectId, workItemId }: ListWorkItemCommentsInput,
+    commentId: string,
+  ): Promise<WorkItemCommentPage | undefined> {
+    const target = await this.get({ orgId, commentId });
+    if (!target || target.factoryProjectId !== factoryProjectId || target.workItemId !== workItemId) return undefined;
+
+    const newer = await this.ops.findMany<WorkItemCommentDbRow>(
+      'work_item_comments',
+      { org_id: orgId, factory_project_id: factoryProjectId, work_item_id: workItemId },
+      {
+        orderBy: [
+          ['occurred_at', 'asc'],
+          ['id', 'asc'],
+        ],
+        limit: MAX_PAGE_SIZE + 1,
+        cursor: { values: [target.occurredAt, target.id] },
+      },
+    );
+    if (newer.length > MAX_PAGE_SIZE) return undefined;
+
+    const before = encodeCommentCursor(target);
+    const older = await this.list({ orgId, factoryProjectId, workItemId, before, limit: 1 });
+    return {
+      comments: [...newer.map(toComment).reverse(), target],
+      ...(older.comments.length > 0 ? { nextCursor: before } : {}),
     };
   }
 

--- a/mastracode/factory/src/storage/domains/comments/domain.test.ts
+++ b/mastracode/factory/src/storage/domains/comments/domain.test.ts
@@ -1,0 +1,451 @@
+/**
+ * Comments domain over HTTP: tenancy guards, authorization, caps, reply
+ * snapshots, idempotent create, counters on the wire, and the mention roster.
+ */
+
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fakeRouteAuth, mountApiRoutes } from '../../../routes/test-utils.js';
+import type { TestAuthUser } from '../../../routes/test-utils.js';
+import { createFactoryStorageForTests } from '../../test-utils.js';
+import type { AuditEmitter } from '../audit/domain.js';
+import type { CommentsDomainOptions } from './domain.js';
+import { CommentsDomain } from './domain.js';
+
+type Seed = Awaited<ReturnType<typeof createFactoryStorageForTests>>;
+
+const ORG = 'org-1';
+
+function commentsDomain(seed: Seed, options?: Partial<CommentsDomainOptions>) {
+  return new CommentsDomain({
+    auth: fakeRouteAuth(),
+    comments: seed.comments,
+    workItems: seed.workItems,
+    projects: seed.projects,
+    channelIdentity: seed.channelIdentity,
+    ...options,
+  });
+}
+
+function buildApp(domain: CommentsDomain, user?: TestAuthUser & { name?: string }) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (user) c.set('factoryAuthUser' as never, user as never);
+    await next();
+  });
+  mountApiRoutes(app as never, domain.routes());
+  return app;
+}
+
+async function seedWorkItem(seed: Seed, { orgId = ORG, factoryProjectId = 'project-1', title = 'Fix login' } = {}) {
+  const { item } = await seed.workItems.upsert({
+    orgId,
+    userId: 'user-alice',
+    factoryProjectId,
+    input: { title, stages: ['intake'], sessions: {}, metadata: {} },
+  });
+  return item;
+}
+
+const asAlice = { workosId: 'user-alice', organizationId: ORG, name: 'Alice' };
+const asBob = { workosId: 'user-bob', organizationId: ORG, name: 'Bob' };
+
+async function postComment(
+  app: Hono,
+  workItemId: string,
+  body: Record<string, unknown>,
+): Promise<{ status: number; json: any }> {
+  const response = await app.request(`/web/factory/work-items/${workItemId}/comments`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { status: response.status, json: await response.json().catch(() => undefined) };
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CommentsDomain routes', () => {
+  it('guards the feed by auth, organization, and work-item ownership', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed, { orgId: 'other-org' });
+    const domain = commentsDomain(seed);
+    const path = `/web/factory/work-items/${item.id}/comments`;
+
+    expect((await buildApp(domain).request(path)).status).toBe(401);
+    expect((await buildApp(domain, { workosId: 'user-alice' }).request(path)).status).toBe(403);
+    expect((await buildApp(domain, asAlice).request('/web/factory/work-items/not-a-uuid/comments')).status).toBe(404);
+    expect((await buildApp(domain, asAlice).request(path)).status).toBe(404);
+  });
+
+  it('creates a comment with the auth actor snapshot and surfaces the counters on the work item', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed);
+    const app = buildApp(commentsDomain(seed), asAlice);
+
+    const { status, json } = await postComment(app, item.id, {
+      body: 'First!',
+      mentions: [{ kind: 'user', id: 'user-bob' }],
+    });
+    expect(status).toBe(201);
+    expect(json.comment).toMatchObject({
+      workItemId: item.id,
+      body: 'First!',
+      author: { kind: 'user', id: 'user-alice', displayName: 'Alice' },
+      mentions: [{ kind: 'user', id: 'user-bob' }],
+    });
+
+    const updated = await seed.workItems.get({ orgId: ORG, id: item.id });
+    expect(updated?.commentCount).toBe(1);
+    expect(updated?.feedActivityAt).toBeInstanceOf(Date);
+    expect(updated?.revision).toBe(item.revision);
+  });
+
+  it('replays a clientToken create as the same comment', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed);
+    const app = buildApp(commentsDomain(seed), asAlice);
+    const payload = { body: 'posted once', clientToken: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' };
+
+    const first = await postComment(app, item.id, payload);
+    const replay = await postComment(app, item.id, payload);
+    expect(replay.json.comment.id).toBe(first.json.comment.id);
+    expect((await seed.workItems.get({ orgId: ORG, id: item.id }))?.commentCount).toBe(1);
+  });
+
+  it('409s a clientToken replay that targets another work item or another author', async () => {
+    const seed = await createFactoryStorageForTests();
+    const itemA = await seedWorkItem(seed, { title: 'Item A' });
+    const itemB = await seedWorkItem(seed, { title: 'Item B' });
+    const domain = commentsDomain(seed);
+    const payload = { body: 'posted once', clientToken: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' };
+
+    expect((await postComment(buildApp(domain, asAlice), itemA.id, payload)).status).toBe(201);
+
+    const crossItem = await postComment(buildApp(domain, asAlice), itemB.id, payload);
+    expect(crossItem.status).toBe(409);
+    expect(crossItem.json).toEqual({ error: 'comment_token_conflict' });
+
+    const crossAuthor = await postComment(buildApp(domain, asBob), itemA.id, payload);
+    expect(crossAuthor.status).toBe(409);
+    expect(crossAuthor.json).toEqual({ error: 'comment_token_conflict' });
+  });
+
+  it('rejects oversized bodies, oversized mention lists, and unmentionable ids', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed);
+    const app = buildApp(commentsDomain(seed), asAlice);
+
+    expect((await postComment(app, item.id, { body: '' })).status).toBe(422);
+    expect((await postComment(app, item.id, { body: '   ' })).status).toBe(422);
+    expect((await postComment(app, item.id, { body: 'x'.repeat(16_001) })).status).toBe(422);
+    expect(
+      (
+        await postComment(app, item.id, {
+          body: 'crowd',
+          mentions: Array.from({ length: 21 }, (_, i) => ({ kind: 'user', id: `user-${i}` })),
+        })
+      ).status,
+    ).toBe(422);
+    expect(
+      (await postComment(app, item.id, { body: 'hi', mentions: [{ kind: 'user', id: 'slack:U123' }] })).status,
+    ).toBe(422);
+  });
+
+  it('snapshots the reply quote so it survives parent edit and delete', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed);
+    const domain = commentsDomain(seed);
+    const aliceApp = buildApp(domain, asAlice);
+    const bobApp = buildApp(domain, asBob);
+
+    const parent = (await postComment(bobApp, item.id, { body: 'the original claim' })).json.comment;
+    const reply = (
+      await postComment(aliceApp, item.id, {
+        body: 'quoting you',
+        replyTo: { commentId: parent.id, quote: 'the original claim' },
+      })
+    ).json.comment;
+    expect(reply.replyTo).toMatchObject({
+      commentId: parent.id,
+      quote: 'the original claim',
+      authorId: 'user-bob',
+      authorName: 'Bob',
+    });
+
+    await bobApp.request(`/web/factory/work-items/${item.id}/comments/${parent.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ body: 'revised claim' }),
+    });
+    await bobApp.request(`/web/factory/work-items/${item.id}/comments/${parent.id}`, { method: 'DELETE' });
+
+    const kept = await seed.comments.get({ orgId: ORG, commentId: reply.id });
+    expect(kept?.replyTo?.quote).toBe('the original claim');
+    expect(kept?.replyTo?.authorName).toBe('Bob');
+  });
+
+  it('rejects a reply targeting a comment on another work item', async () => {
+    const seed = await createFactoryStorageForTests();
+    const itemA = await seedWorkItem(seed, { title: 'Item A' });
+    const itemB = await seedWorkItem(seed, { title: 'Item B' });
+    const app = buildApp(commentsDomain(seed), asAlice);
+
+    const foreign = (await postComment(app, itemA.id, { body: 'on A' })).json.comment;
+    const { status } = await postComment(app, itemB.id, { body: 'on B', replyTo: { commentId: foreign.id } });
+    expect(status).toBe(422);
+  });
+
+  it('lets only the author or an org admin edit, and admins delete', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed);
+    const memberDomain = commentsDomain(seed, {
+      auth: fakeRouteAuth({ isOrganizationAdmin: async (_org, userId) => userId === 'user-admin' }),
+    });
+
+    const comment = (await postComment(buildApp(memberDomain, asAlice), item.id, { body: 'mine' })).json.comment;
+    const path = `/web/factory/work-items/${item.id}/comments/${comment.id}`;
+    const patch = (app: Hono, body: string) =>
+      app.request(path, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ body }),
+      });
+
+    expect((await patch(buildApp(memberDomain, asBob), 'hijacked')).status).toBe(403);
+    expect((await patch(buildApp(memberDomain, asAlice), 'still mine')).status).toBe(200);
+    const adminEdit = await patch(
+      buildApp(memberDomain, { workosId: 'user-admin', organizationId: ORG, name: 'Admin' }),
+      'moderated',
+    );
+    expect(adminEdit.status).toBe(200);
+
+    expect((await buildApp(memberDomain, asBob).request(path, { method: 'DELETE' })).status).toBe(403);
+    const adminDelete = await buildApp(memberDomain, {
+      workosId: 'user-admin',
+      organizationId: ORG,
+    }).request(path, { method: 'DELETE' });
+    expect(adminDelete.status).toBe(200);
+    expect((await buildApp(memberDomain, asAlice).request(path, { method: 'DELETE' })).status).toBe(409);
+  });
+
+  it('409s an edit whose expectedRevision is stale, and lands it when current', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed);
+    const app = buildApp(commentsDomain(seed), asAlice);
+
+    const comment = (await postComment(app, item.id, { body: 'v1' })).json.comment;
+    expect(comment.revision).toBe(1);
+    const path = `/web/factory/work-items/${item.id}/comments/${comment.id}`;
+    const patch = (body: Record<string, unknown>) =>
+      app.request(path, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+    const first = await patch({ body: 'v2', expectedRevision: 1 });
+    expect(first.status).toBe(200);
+    expect((await first.json()).comment.revision).toBe(2);
+
+    const stale = await patch({ body: 'v2-lost-race', expectedRevision: 1 });
+    expect(stale.status).toBe(409);
+    expect(await stale.json()).toEqual({ error: 'comment_conflict' });
+
+    const list = await (await app.request(`/web/factory/work-items/${item.id}/comments`)).json();
+    expect(list.comments[0].body).toBe('v2');
+  });
+
+  it('diffs mention rows on edit and lists the tombstone after delete', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed);
+    const app = buildApp(commentsDomain(seed), asAlice);
+
+    const comment = (await postComment(app, item.id, { body: 'ping', mentions: [{ kind: 'user', id: 'user-bob' }] }))
+      .json.comment;
+    await app.request(`/web/factory/work-items/${item.id}/comments/${comment.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ body: 'ping Carol instead', mentions: [{ kind: 'user', id: 'user-carol' }] }),
+    });
+    const scope = { orgId: ORG, factoryProjectId: 'project-1' };
+    expect(await seed.comments.listMentionsForUser({ ...scope, userId: 'user-bob', limit: 10 })).toHaveLength(0);
+    expect(await seed.comments.listMentionsForUser({ ...scope, userId: 'user-carol', limit: 10 })).toHaveLength(1);
+
+    await app.request(`/web/factory/work-items/${item.id}/comments/${comment.id}`, { method: 'DELETE' });
+    const list = await (await app.request(`/web/factory/work-items/${item.id}/comments`)).json();
+    expect(list.comments).toHaveLength(1);
+    expect(list.comments[0]).toMatchObject({ body: '' });
+    expect(list.comments[0].deletedAt).toBeTruthy();
+    expect((await seed.workItems.get({ orgId: ORG, id: item.id }))?.commentCount).toBe(0);
+  });
+
+  it('emits audit events for create, mention, edit, and delete', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed);
+    const emit = vi.fn<AuditEmitter['emit']>(async () => {});
+    const app = buildApp(commentsDomain(seed, { audit: { emit } }), asAlice);
+
+    const comment = (await postComment(app, item.id, { body: 'hello', mentions: [{ kind: 'user', id: 'user-bob' }] }))
+      .json.comment;
+    await app.request(`/web/factory/work-items/${item.id}/comments/${comment.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ body: 'hello v2' }),
+    });
+    await app.request(`/web/factory/work-items/${item.id}/comments/${comment.id}`, { method: 'DELETE' });
+
+    const actions = emit.mock.calls.map(([call]) => call.input.action);
+    expect(actions).toEqual([
+      'factory.work_item.comment_created',
+      'factory.work_item.comment_mentioned',
+      'factory.work_item.comment_edited',
+      'factory.work_item.comment_deleted',
+    ]);
+  });
+
+  it('serves the roster from the members hook when wired', async () => {
+    const seed = await createFactoryStorageForTests();
+    const project = await seed.projects.create({ orgId: ORG, userId: 'user-alice', input: { name: 'Acme' } });
+    const listOrganizationMembers = vi.fn(async () => [
+      { id: 'user-alice', name: 'Alice' },
+      { id: 'user-bob', name: 'Bob' },
+      { id: 'slack:U99', name: 'Unlinked' },
+    ]);
+    const app = buildApp(commentsDomain(seed, { members: { listOrganizationMembers } }), asAlice);
+
+    const response = await app.request(`/web/factory/projects/${project.id}/mention-roster`);
+    expect(response.status).toBe(200);
+    expect((await response.json()).members).toEqual([
+      { id: 'user-alice', name: 'Alice' },
+      { id: 'user-bob', name: 'Bob' },
+    ]);
+
+    await app.request(`/web/factory/projects/${project.id}/mention-roster`);
+    expect(listOrganizationMembers).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to recent comment authors and channel links, with prefix filtering', async () => {
+    const seed = await createFactoryStorageForTests();
+    const project = await seed.projects.create({ orgId: ORG, userId: 'user-alice', input: { name: 'Acme' } });
+    await seed.comments.create({
+      orgId: ORG,
+      factoryProjectId: project.id,
+      workItemId: 'item-1',
+      author: { kind: 'user', id: 'user-alice', displayName: 'Alice' },
+      body: 'seen recently',
+    });
+    await seed.comments.create({
+      orgId: ORG,
+      factoryProjectId: project.id,
+      workItemId: 'item-1',
+      author: {
+        kind: 'user',
+        id: 'slack:U42',
+        displayName: 'External Sam',
+        external: { platform: 'slack', userId: 'U42' },
+      },
+      body: 'external voice',
+    });
+    await seed.channelIdentity.saveAccountLink({
+      platform: 'slack',
+      externalTeamId: 'T1',
+      externalUserId: 'U7',
+      orgId: ORG,
+      userId: 'user-carol',
+      externalUserName: 'Carol',
+    });
+    const app = buildApp(commentsDomain(seed), asAlice);
+
+    const all = await (await app.request(`/web/factory/projects/${project.id}/mention-roster`)).json();
+    expect(all.members).toEqual([
+      { id: 'user-alice', name: 'Alice' },
+      { id: 'user-carol', name: 'Carol' },
+    ]);
+
+    const filtered = await (await app.request(`/web/factory/projects/${project.id}/mention-roster?q=ca`)).json();
+    expect(filtered.members).toEqual([{ id: 'user-carol', name: 'Carol' }]);
+  });
+
+  it('404s the roster for a project outside the caller organization', async () => {
+    const seed = await createFactoryStorageForTests();
+    const project = await seed.projects.create({ orgId: 'other-org', userId: 'user-x', input: { name: 'Foreign' } });
+    const app = buildApp(commentsDomain(seed), asAlice);
+    expect((await app.request(`/web/factory/projects/${project.id}/mention-roster`)).status).toBe(404);
+  });
+});
+
+describe('feed publishers', () => {
+  const alice = { kind: 'user' as const, id: 'user-alice', displayName: 'Alice' };
+
+  function slackPublisher(publish = vi.fn()) {
+    publish.mockImplementation(async (comment: { id: string }) => ({
+      source: { integrationId: 'slack', type: 'message', externalId: `C1:${comment.id}` },
+    }));
+    return { publisher: { id: 'slack', publish }, publish };
+  }
+
+  it('mirrors a created comment and writes the platform source back onto the row', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed);
+    const { publisher, publish } = slackPublisher();
+    const domain = commentsDomain(seed, { publishers: [publisher] });
+
+    const result = await domain.createComment({ orgId: ORG, workItemId: item.id, author: alice, body: 'ship it' });
+    expect(result.status).toBe('created');
+    if (result.status !== 'created') return;
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ id: result.comment.id, body: 'ship it' }),
+      expect.objectContaining({ id: item.id }),
+    );
+    const stored = await seed.comments.get({ orgId: ORG, commentId: result.comment.id });
+    expect(stored?.externalSource).toEqual({
+      integrationId: 'slack',
+      type: 'message',
+      externalId: `C1:${result.comment.id}`,
+    });
+  });
+
+  it('keeps a local retry idempotent after the write-back, without re-publishing', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed);
+    const { publisher, publish } = slackPublisher();
+    const domain = commentsDomain(seed, { publishers: [publisher] });
+    const input = { orgId: ORG, workItemId: item.id, author: alice, body: 'once', clientToken: 'token-1' };
+
+    const first = await domain.createComment(input);
+    const replay = await domain.createComment(input);
+
+    expect(first.status).toBe('created');
+    expect(replay.status).toBe('created');
+    if (first.status !== 'created' || replay.status !== 'created') return;
+    expect(replay.comment.id).toBe(first.comment.id);
+    expect(publish).toHaveBeenCalledTimes(1);
+    const page = await seed.comments.list({ orgId: ORG, factoryProjectId: item.factoryProjectId, workItemId: item.id });
+    expect(page.comments).toHaveLength(1);
+  });
+
+  it('never fails the create when a publisher throws', async () => {
+    const seed = await createFactoryStorageForTests();
+    const item = await seedWorkItem(seed);
+    const publish = vi.fn(async () => {
+      throw new Error('slack is down');
+    });
+    const domain = commentsDomain(seed, { publishers: [{ id: 'slack', publish }] });
+
+    const result = await domain.createComment({ orgId: ORG, workItemId: item.id, author: alice, body: 'still lands' });
+
+    expect(result.status).toBe('created');
+    if (result.status !== 'created') return;
+    expect((await seed.comments.get({ orgId: ORG, commentId: result.comment.id }))?.externalSource).toBeNull();
+  });
+});

--- a/mastracode/factory/src/storage/domains/comments/domain.ts
+++ b/mastracode/factory/src/storage/domains/comments/domain.ts
@@ -218,6 +218,7 @@ export class CommentsDomain {
 
   async editComment(input: EditCommentServiceInput): Promise<EditCommentServiceResult> {
     await this.#comments.ensureReady();
+    await this.#workItems.ensureReady();
 
     const bodyError = commentBodyError(input.body);
     if (bodyError) return { status: 'invalid', message: bodyError };
@@ -254,6 +255,7 @@ export class CommentsDomain {
 
   async deleteComment(input: DeleteCommentServiceInput): Promise<DeleteCommentServiceResult> {
     await this.#comments.ensureReady();
+    await this.#workItems.ensureReady();
 
     const existing = await this.#comments.get({ orgId: input.orgId, commentId: input.commentId });
     if (!existing || existing.workItemId !== input.workItemId) return { status: 'not_found' };

--- a/mastracode/factory/src/storage/domains/comments/domain.ts
+++ b/mastracode/factory/src/storage/domains/comments/domain.ts
@@ -1,0 +1,379 @@
+/**
+ * Comments domain — feed orchestration behind service methods; the HTTP layer
+ * lives in `routes.ts` and only maps their result statuses. Service methods
+ * take the author as a `FactoryActorRef` (never derived from the request
+ * inside), so agent-authored comments later become a thin tool over
+ * `createComment` instead of a re-implementation.
+ */
+
+import type { ApiRoute } from '@mastra/core/server';
+
+import type { RouteAuth } from '../../../routes/route.js';
+import type { AuditEmitter } from '../audit/domain.js';
+import type { ChannelIdentityStorage } from '../channel-identity/base.js';
+import type { FactoryProjectsStorage } from '../projects/base.js';
+import type { WorkItemRow, WorkItemsStorage } from '../work-items/base.js';
+import { factoryMentionAttentionIdentity } from '../work-items/base.js';
+import type { FactoryActorRef } from './actor.js';
+import { isMentionableActorId } from './actor.js';
+import type {
+  EditWorkItemCommentResult,
+  FactoryMentionRef,
+  WorkItemCommentReplyRef,
+  WorkItemCommentRow,
+  WorkItemCommentsStorage,
+} from './base.js';
+import { CommentTokenConflictError, commentBodyError, MAX_COMMENT_MENTIONS, MAX_COMMENT_QUOTE_LENGTH } from './base.js';
+import type { WorkItemFeedPublisher } from './feed-sync.js';
+import { buildCommentRoutes } from './routes.js';
+
+export interface FactoryRosterMember {
+  id: string;
+  name?: string;
+  avatarUrl?: string;
+}
+
+export interface OrganizationMembersProvider {
+  listOrganizationMembers(orgId: string): Promise<FactoryRosterMember[]>;
+}
+
+export interface CommentsDomainOptions {
+  auth: RouteAuth;
+  comments: WorkItemCommentsStorage;
+  workItems: WorkItemsStorage;
+  projects: FactoryProjectsStorage;
+  channelIdentity?: ChannelIdentityStorage;
+  /** Host-wired org membership listing for the mention roster (e.g. WorkOS). */
+  members?: OrganizationMembersProvider;
+  audit?: AuditEmitter;
+  /** Outbound platform mirrors (COR-1174); empty until a platform wires one. */
+  publishers?: WorkItemFeedPublisher[];
+}
+
+export interface CreateCommentServiceInput {
+  orgId: string;
+  workItemId: string;
+  author: FactoryActorRef;
+  body: string;
+  replyTo?: { commentId: string; quote?: string };
+  mentions?: FactoryMentionRef[];
+  clientToken?: string;
+}
+
+export type CreateCommentServiceResult =
+  | { status: 'created'; comment: WorkItemCommentRow; workItem: WorkItemRow }
+  | { status: 'work_item_not_found' }
+  | { status: 'token_conflict' }
+  | { status: 'invalid'; message: string };
+
+export interface CommentEditor {
+  userId: string;
+  /** Lazily checked, only when the caller is not the author. */
+  canModerate: () => Promise<boolean>;
+}
+
+export interface EditCommentServiceInput {
+  orgId: string;
+  workItemId: string;
+  commentId: string;
+  editor: CommentEditor;
+  body: string;
+  mentions?: FactoryMentionRef[];
+  expectedRevision?: number;
+}
+
+export type EditCommentServiceResult =
+  | ({ status: 'edited'; previousBody: string } & EditWorkItemCommentResult)
+  | { status: 'not_found' }
+  | { status: 'forbidden' }
+  | { status: 'not_editable' }
+  | { status: 'conflict' }
+  | { status: 'invalid'; message: string };
+
+export interface DeleteCommentServiceInput {
+  orgId: string;
+  workItemId: string;
+  commentId: string;
+  editor: CommentEditor;
+}
+
+export type DeleteCommentServiceResult =
+  | { status: 'deleted'; comment: WorkItemCommentRow }
+  | { status: 'not_found' }
+  | { status: 'forbidden' }
+  | { status: 'not_editable' };
+
+const MAX_ROSTER_SIZE = 100;
+const ROSTER_CACHE_TTL_MS = 60_000;
+
+export class CommentsDomain {
+  readonly #auth: RouteAuth;
+  readonly #comments: WorkItemCommentsStorage;
+  readonly #workItems: WorkItemsStorage;
+  readonly #projects: FactoryProjectsStorage;
+  readonly #channelIdentity: ChannelIdentityStorage | undefined;
+  readonly #members: OrganizationMembersProvider | undefined;
+  readonly #audit: AuditEmitter | undefined;
+  readonly #publishers: WorkItemFeedPublisher[];
+  readonly #rosterCache = new Map<string, { at: number; members: FactoryRosterMember[] }>();
+
+  constructor({
+    auth,
+    comments,
+    workItems,
+    projects,
+    channelIdentity,
+    members,
+    audit,
+    publishers,
+  }: CommentsDomainOptions) {
+    this.#auth = auth;
+    this.#comments = comments;
+    this.#workItems = workItems;
+    this.#projects = projects;
+    this.#channelIdentity = channelIdentity;
+    this.#members = members;
+    this.#audit = audit;
+    this.#publishers = publishers ?? [];
+  }
+
+  async createComment(input: CreateCommentServiceInput): Promise<CreateCommentServiceResult> {
+    await this.#comments.ensureReady();
+    await this.#workItems.ensureReady();
+
+    const bodyError = commentBodyError(input.body);
+    if (bodyError) return { status: 'invalid', message: bodyError };
+    if ((input.mentions?.length ?? 0) > MAX_COMMENT_MENTIONS) {
+      return { status: 'invalid', message: `At most ${MAX_COMMENT_MENTIONS} mentions per comment.` };
+    }
+
+    const workItem = await this.#workItems.get({ orgId: input.orgId, id: input.workItemId });
+    if (!workItem) return { status: 'work_item_not_found' };
+
+    let replyTo: WorkItemCommentReplyRef | undefined;
+    if (input.replyTo) {
+      const parent = await this.#comments.get({ orgId: input.orgId, commentId: input.replyTo.commentId });
+      if (!parent || parent.workItemId !== input.workItemId) {
+        return { status: 'invalid', message: 'Reply target is not a comment on this work item.' };
+      }
+      replyTo = {
+        commentId: parent.id,
+        ...(input.replyTo.quote ? { quote: input.replyTo.quote.slice(0, MAX_COMMENT_QUOTE_LENGTH) } : {}),
+        authorId: parent.author.id,
+        ...(parent.author.displayName ? { authorName: parent.author.displayName } : {}),
+      };
+    }
+
+    let comment: WorkItemCommentRow;
+    try {
+      comment = await this.#comments.create({
+        orgId: input.orgId,
+        factoryProjectId: workItem.factoryProjectId,
+        workItemId: input.workItemId,
+        author: input.author,
+        body: input.body,
+        ...(replyTo ? { replyTo } : {}),
+        ...(input.mentions ? { mentions: input.mentions } : {}),
+        ...(input.clientToken ? { clientToken: input.clientToken } : {}),
+      });
+    } catch (error) {
+      if (error instanceof CommentTokenConflictError) return { status: 'token_conflict' };
+      throw error;
+    }
+    await this.#comments.bumpWorkItemFeedActivity({
+      orgId: input.orgId,
+      factoryProjectId: workItem.factoryProjectId,
+      workItemId: input.workItemId,
+    });
+    await this.#mirrorComment(comment, workItem);
+    return { status: 'created', comment, workItem };
+  }
+
+  /**
+   * Best-effort: a failed publish never fails the create. The write-back is
+   * the replay guard — a replayed create sees its own platform on the row and
+   * skips it. Known ceiling, single publisher only: `external_source` is
+   * single-valued, so with two publishers a replayed create re-publishes to
+   * the one that is not recorded, and nothing persists a failed attempt for a
+   * later pass to retry. Both need an outbox if a second publisher ever lands.
+   */
+  async #mirrorComment(comment: WorkItemCommentRow, workItem: WorkItemRow): Promise<void> {
+    let current = comment;
+    for (const publisher of this.#publishers) {
+      if (current.externalSource?.integrationId === publisher.id) continue;
+      try {
+        const { source } = await publisher.publish(current, workItem);
+        current =
+          (await this.#comments.attachExternalSource({ orgId: current.orgId, commentId: current.id, source })) ??
+          current;
+      } catch (err) {
+        console.warn('[Comments] Failed to mirror a comment to a platform', {
+          publisherId: publisher.id,
+          commentId: current.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  async editComment(input: EditCommentServiceInput): Promise<EditCommentServiceResult> {
+    await this.#comments.ensureReady();
+
+    const bodyError = commentBodyError(input.body);
+    if (bodyError) return { status: 'invalid', message: bodyError };
+    if ((input.mentions?.length ?? 0) > MAX_COMMENT_MENTIONS) {
+      return { status: 'invalid', message: `At most ${MAX_COMMENT_MENTIONS} mentions per comment.` };
+    }
+
+    const existing = await this.#comments.get({ orgId: input.orgId, commentId: input.commentId });
+    if (!existing || existing.workItemId !== input.workItemId) return { status: 'not_found' };
+    if (existing.deletedAt) return { status: 'not_editable' };
+    if (existing.author.id !== input.editor.userId && !(await input.editor.canModerate())) {
+      return { status: 'forbidden' };
+    }
+
+    const edited = await this.#comments.edit({
+      orgId: input.orgId,
+      commentId: input.commentId,
+      body: input.body,
+      editorId: input.editor.userId,
+      ...(input.mentions ? { mentions: input.mentions } : {}),
+      ...(input.expectedRevision !== undefined ? { expectedRevision: input.expectedRevision } : {}),
+    });
+    if (edited === 'conflict') return { status: 'conflict' };
+    if (!edited) return { status: 'not_editable' };
+
+    await this.#cleanupMentionReceipts(existing, edited.removedMentions);
+    await this.#comments.bumpWorkItemFeedActivity({
+      orgId: existing.orgId,
+      factoryProjectId: existing.factoryProjectId,
+      workItemId: existing.workItemId,
+    });
+    return { status: 'edited', previousBody: existing.body, ...edited };
+  }
+
+  async deleteComment(input: DeleteCommentServiceInput): Promise<DeleteCommentServiceResult> {
+    await this.#comments.ensureReady();
+
+    const existing = await this.#comments.get({ orgId: input.orgId, commentId: input.commentId });
+    if (!existing || existing.workItemId !== input.workItemId) return { status: 'not_found' };
+    if (existing.deletedAt) return { status: 'not_editable' };
+    if (existing.author.id !== input.editor.userId && !(await input.editor.canModerate())) {
+      return { status: 'forbidden' };
+    }
+
+    const deleted = await this.#comments.softDelete({
+      orgId: input.orgId,
+      commentId: input.commentId,
+      deletedBy: input.editor.userId,
+    });
+    if (!deleted) return { status: 'not_editable' };
+
+    await this.#workItems.deleteAttentionReceipts({
+      orgId: existing.orgId,
+      factoryProjectId: existing.factoryProjectId,
+      identities: [factoryMentionAttentionIdentity(existing.id)],
+    });
+    await this.#comments.bumpWorkItemFeedActivity({
+      orgId: existing.orgId,
+      factoryProjectId: existing.factoryProjectId,
+      workItemId: existing.workItemId,
+    });
+    return { status: 'deleted', comment: deleted };
+  }
+
+  /**
+   * A removed mention deletes only that user's receipt: the receipt identity
+   * is per-comment, and other still-mentioned users must keep their read state.
+   */
+  async #cleanupMentionReceipts(comment: WorkItemCommentRow, removed: FactoryMentionRef[]): Promise<void> {
+    for (const mention of removed) {
+      await this.#workItems.deleteAttentionReceipts({
+        orgId: comment.orgId,
+        factoryProjectId: comment.factoryProjectId,
+        userId: mention.id,
+        identities: [factoryMentionAttentionIdentity(comment.id)],
+      });
+    }
+  }
+
+  /**
+   * Mentionable people: the host's org roster when it answers, otherwise the
+   * people the project has actually seen (comment authors, linked channel
+   * accounts). Cached per project so a dropdown session costs one read.
+   */
+  async mentionRoster({
+    orgId,
+    factoryProjectId,
+  }: {
+    orgId: string;
+    factoryProjectId: string;
+  }): Promise<FactoryRosterMember[]> {
+    const cacheKey = `${orgId}\0${factoryProjectId}`;
+    const cached = this.#rosterCache.get(cacheKey);
+    if (cached && Date.now() - cached.at < ROSTER_CACHE_TTL_MS) return cached.members;
+
+    const members = await this.#organizationRoster(orgId);
+    if (members.size === 0) await this.#seenRoster(orgId, factoryProjectId, members);
+
+    const roster = [...members.values()].slice(0, MAX_ROSTER_SIZE);
+    // Sweep on write: a long-lived server would otherwise hold one roster per
+    // project it ever served.
+    const cutoff = Date.now() - ROSTER_CACHE_TTL_MS;
+    for (const [key, entry] of this.#rosterCache) {
+      if (entry.at < cutoff) this.#rosterCache.delete(key);
+    }
+    this.#rosterCache.set(cacheKey, { at: Date.now(), members: roster });
+    return roster;
+  }
+
+  /** Empty when no provider is wired, or when the host listing fails. */
+  async #organizationRoster(orgId: string): Promise<Map<string, FactoryRosterMember>> {
+    const members = new Map<string, FactoryRosterMember>();
+    if (!this.#members) return members;
+    try {
+      for (const member of await this.#members.listOrganizationMembers(orgId)) {
+        if (isMentionableActorId(member.id)) members.set(member.id, member);
+      }
+    } catch (err) {
+      console.warn('[Comments] Failed to list organization members for the mention roster', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return members;
+  }
+
+  async #seenRoster(orgId: string, factoryProjectId: string, members: Map<string, FactoryRosterMember>): Promise<void> {
+    for (const author of await this.#comments.listRecentAuthors({ orgId, factoryProjectId })) {
+      if (author.kind !== 'user' || !isMentionableActorId(author.id)) continue;
+      members.set(author.id, {
+        id: author.id,
+        ...(author.displayName ? { name: author.displayName } : {}),
+        ...(author.avatarUrl ? { avatarUrl: author.avatarUrl } : {}),
+      });
+    }
+    if (!this.#channelIdentity) return;
+    await this.#channelIdentity.ensureReady();
+    for (const link of await this.#channelIdentity.listAccountLinksForOrg(orgId)) {
+      if (members.has(link.userId)) continue;
+      members.set(link.userId, {
+        id: link.userId,
+        ...(link.externalUserName ? { name: link.externalUserName } : {}),
+      });
+    }
+  }
+
+  routes(): ApiRoute[] {
+    return buildCommentRoutes({
+      domain: this,
+      auth: this.#auth,
+      comments: this.#comments,
+      workItems: this.#workItems,
+      projects: this.#projects,
+      ...(this.#audit ? { audit: this.#audit } : {}),
+    });
+  }
+}
+
+export { toWireComment } from './wire.js';
+export type { WireComment, WireCommentPage } from './wire.js';

--- a/mastracode/factory/src/storage/domains/comments/domain.ts
+++ b/mastracode/factory/src/storage/domains/comments/domain.ts
@@ -180,7 +180,7 @@ export class CommentsDomain {
       if (error instanceof CommentTokenConflictError) return { status: 'token_conflict' };
       throw error;
     }
-    await this.#comments.bumpWorkItemFeedActivity({
+    await this.#comments.refreshWorkItemFeedActivity({
       orgId: input.orgId,
       factoryProjectId: workItem.factoryProjectId,
       workItemId: input.workItemId,
@@ -245,7 +245,7 @@ export class CommentsDomain {
     if (!edited) return { status: 'not_editable' };
 
     await this.#cleanupMentionReceipts(existing, edited.removedMentions);
-    await this.#comments.bumpWorkItemFeedActivity({
+    await this.#comments.refreshWorkItemFeedActivity({
       orgId: existing.orgId,
       factoryProjectId: existing.factoryProjectId,
       workItemId: existing.workItemId,
@@ -276,7 +276,7 @@ export class CommentsDomain {
       factoryProjectId: existing.factoryProjectId,
       identities: [factoryMentionAttentionIdentity(existing.id)],
     });
-    await this.#comments.bumpWorkItemFeedActivity({
+    await this.#comments.refreshWorkItemFeedActivity({
       orgId: existing.orgId,
       factoryProjectId: existing.factoryProjectId,
       workItemId: existing.workItemId,

--- a/mastracode/factory/src/storage/domains/comments/feed-sync.ts
+++ b/mastracode/factory/src/storage/domains/comments/feed-sync.ts
@@ -1,0 +1,34 @@
+/**
+ * Two-way platform sync seam (COR-1174). Interfaces only — no platform code
+ * ships here. Echo prevention is two layers: `source_key` idempotency for rows
+ * born on the platform, and the host's bot-sender check for the window between
+ * an outbound publish and its `attachExternalSource` write-back.
+ */
+
+import type { ExternalWorkItemSource, WorkItemRow } from '../work-items/base.js';
+import type { FactoryActorRef } from './actor.js';
+import type { WorkItemCommentRow } from './base.js';
+
+/**
+ * Inbound: platform messages become comments, keyed by a stable source
+ * (e.g. `slack:message:<channel>:<ts>` — `ts` survives edits, so an edit
+ * re-upserts the same row and a delete tombstones it).
+ */
+export interface WorkItemFeedIngest {
+  upsertMessage(input: {
+    orgId: string;
+    workItemId: string;
+    author: FactoryActorRef;
+    body: string;
+    occurredAt: Date;
+    source: ExternalWorkItemSource;
+  }): Promise<WorkItemCommentRow>;
+  deleteMessage(input: { orgId: string; factoryProjectId: string; source: ExternalWorkItemSource }): Promise<void>;
+}
+
+/** Outbound: mirrors a created comment to one platform. */
+export interface WorkItemFeedPublisher {
+  /** Matches `ExternalWorkItemSource.integrationId`; fan-out skips a comment's own platform. */
+  readonly id: string;
+  publish(comment: WorkItemCommentRow, workItem: WorkItemRow): Promise<{ source: ExternalWorkItemSource }>;
+}

--- a/mastracode/factory/src/storage/domains/comments/parse.ts
+++ b/mastracode/factory/src/storage/domains/comments/parse.ts
@@ -1,0 +1,111 @@
+/** Request-body parsing for the comment routes: unknown JSON in, a typed input or `null` out. */
+
+import type { Context } from 'hono';
+
+import { isMentionableActorId } from './actor.js';
+import type { FactoryMentionRef } from './base.js';
+import { commentBodyError, MAX_COMMENT_MENTIONS, MAX_COMMENT_QUOTE_LENGTH } from './base.js';
+
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const CLIENT_TOKEN_RE = /^[A-Za-z0-9-]{8,64}$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export async function readJson(c: Context): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    return undefined;
+  }
+}
+
+/** `undefined` when the field is absent, `null` when it is present but malformed. */
+function parseMentions(raw: unknown): FactoryMentionRef[] | null | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw) || raw.length > MAX_COMMENT_MENTIONS) return null;
+  const mentions: FactoryMentionRef[] = [];
+  for (const entry of raw) {
+    if (!isRecord(entry)) return null;
+    if (entry.kind !== 'user' || typeof entry.id !== 'string' || !isMentionableActorId(entry.id)) return null;
+    mentions.push({ kind: 'user', id: entry.id });
+  }
+  return mentions;
+}
+
+function parseBody(raw: unknown): string | null {
+  if (typeof raw !== 'string' || commentBodyError(raw)) return null;
+  return raw;
+}
+
+function parseClientToken(raw: unknown): string | null | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== 'string' || !CLIENT_TOKEN_RE.test(raw)) return null;
+  return raw;
+}
+
+function parseExpectedRevision(raw: unknown): number | null | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== 'number' || !Number.isInteger(raw)) return null;
+  return raw;
+}
+
+function parseReplyTo(raw: unknown): { commentId: string; quote?: string } | null | undefined {
+  if (raw === undefined) return undefined;
+  if (!isRecord(raw)) return null;
+  if (typeof raw.commentId !== 'string' || !UUID_RE.test(raw.commentId)) return null;
+  if (raw.quote !== undefined && typeof raw.quote !== 'string') return null;
+  const quote = typeof raw.quote === 'string' ? raw.quote.slice(0, MAX_COMMENT_QUOTE_LENGTH) : undefined;
+  return { commentId: raw.commentId, ...(quote ? { quote } : {}) };
+}
+
+export interface ParsedCreateComment {
+  body: string;
+  clientToken?: string;
+  replyTo?: { commentId: string; quote?: string };
+  mentions?: FactoryMentionRef[];
+}
+
+export function parseCreateCommentBody(raw: unknown): ParsedCreateComment | null {
+  if (!isRecord(raw)) return null;
+
+  const body = parseBody(raw.body);
+  if (body === null) return null;
+  const mentions = parseMentions(raw.mentions);
+  if (mentions === null) return null;
+  const replyTo = parseReplyTo(raw.replyTo);
+  if (replyTo === null) return null;
+  const clientToken = parseClientToken(raw.clientToken);
+  if (clientToken === null) return null;
+
+  return {
+    body,
+    ...(clientToken ? { clientToken } : {}),
+    ...(replyTo ? { replyTo } : {}),
+    ...(mentions ? { mentions } : {}),
+  };
+}
+
+export interface ParsedEditComment {
+  body: string;
+  mentions?: FactoryMentionRef[];
+  expectedRevision?: number;
+}
+
+export function parseEditCommentBody(raw: unknown): ParsedEditComment | null {
+  if (!isRecord(raw)) return null;
+
+  const body = parseBody(raw.body);
+  if (body === null) return null;
+  const mentions = parseMentions(raw.mentions);
+  if (mentions === null) return null;
+  const expectedRevision = parseExpectedRevision(raw.expectedRevision);
+  if (expectedRevision === null) return null;
+
+  return {
+    body,
+    ...(mentions ? { mentions } : {}),
+    ...(expectedRevision !== undefined ? { expectedRevision } : {}),
+  };
+}

--- a/mastracode/factory/src/storage/domains/comments/routes.ts
+++ b/mastracode/factory/src/storage/domains/comments/routes.ts
@@ -100,11 +100,14 @@ export function buildCommentRoutes(dependencies: CommentRouteDependencies): ApiR
         const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
         const before = c.req.query('before') || undefined;
         if (before && !decodeCommentCursor(before)) return c.json({ error: 'invalid_cursor' }, 422);
+        const around = c.req.query('around') || undefined;
+        if (around && !UUID_RE.test(around)) return c.json({ error: 'invalid_comment_id' }, 422);
         const page = await comments.list({
           orgId: tenant.orgId,
           factoryProjectId: workItem.factoryProjectId,
           workItemId,
           before,
+          ...(around ? { around } : {}),
           ...(limit !== undefined && Number.isFinite(limit) ? { limit } : {}),
         });
         const wirePage: WireCommentPage = {

--- a/mastracode/factory/src/storage/domains/comments/routes.ts
+++ b/mastracode/factory/src/storage/domains/comments/routes.ts
@@ -1,0 +1,277 @@
+/**
+ * HTTP for the item feed. Every handler is the same shape: resolve the tenant,
+ * validate the path ids, delegate to a `CommentsDomain` service method, map its
+ * result status to a status code, then emit audit.
+ */
+
+import type { ApiRoute } from '@mastra/core/server';
+import { registerApiRoute } from '@mastra/core/server';
+import type { Context } from 'hono';
+
+import { getFactoryAuthUser } from '../../../auth.js';
+import type { RouteAuth } from '../../../routes/route.js';
+import type { AuditEmitter } from '../audit/domain.js';
+import type { FactoryProjectsStorage } from '../projects/base.js';
+import type { WorkItemsStorage } from '../work-items/base.js';
+import { actorFromAuthUser } from './actor.js';
+import type { WorkItemCommentsStorage } from './base.js';
+import { decodeCommentCursor } from './base.js';
+import type { CommentEditor, CommentsDomain } from './domain.js';
+import { parseCreateCommentBody, parseEditCommentBody, readJson, UUID_RE } from './parse.js';
+import { toWireComment } from './wire.js';
+import type { WireCommentPage } from './wire.js';
+
+const MAX_AUDIT_BODY_SNAPSHOT = 1024;
+
+export interface CommentRouteDependencies {
+  domain: CommentsDomain;
+  auth: RouteAuth;
+  comments: WorkItemCommentsStorage;
+  workItems: WorkItemsStorage;
+  projects: FactoryProjectsStorage;
+  audit?: AuditEmitter;
+}
+
+interface Tenant {
+  orgId: string;
+  userId: string;
+}
+
+function loose(c: unknown): Context {
+  return c as Context;
+}
+
+export function buildCommentRoutes(dependencies: CommentRouteDependencies): ApiRoute[] {
+  const { domain, auth, comments, workItems, projects, audit } = dependencies;
+
+  async function resolveTenant(c: Context): Promise<Tenant | { response: Response }> {
+    await auth.ensureUser(c);
+    const tenant = auth.tenant(c);
+    if (!tenant) return { response: c.json({ error: 'unauthorized' }, 401) };
+    if (!tenant.orgId) {
+      return {
+        response: c.json({ error: 'organization_required', message: 'The item feed requires an organization.' }, 403),
+      };
+    }
+    return { orgId: tenant.orgId, userId: tenant.userId };
+  }
+
+  function editorFor(c: Context, tenant: Tenant): CommentEditor {
+    return {
+      userId: tenant.userId,
+      canModerate: () => auth.isOrganizationAdmin(c, tenant.orgId),
+    };
+  }
+
+  async function emitMentionAudit(
+    c: Context,
+    target: { factoryProjectId: string; workItemId: string; title?: string },
+    commentId: string,
+    mentionedIds: string[],
+  ): Promise<void> {
+    if (mentionedIds.length === 0) return;
+    await audit?.emit({
+      context: c,
+      input: {
+        action: 'factory.work_item.comment_mentioned',
+        factoryProjectId: target.factoryProjectId,
+        targets: [{ type: 'work_item', id: target.workItemId, ...(target.title ? { name: target.title } : {}) }],
+        metadata: { commentId, mentionedIds },
+      },
+    });
+  }
+
+  return [
+    registerApiRoute('/web/factory/work-items/:workItemId/comments', {
+      method: 'GET',
+      handler: async cc => {
+        const c = loose(cc);
+        const tenant = await resolveTenant(c);
+        if ('response' in tenant) return tenant.response;
+
+        const workItemId = c.req.param('workItemId');
+        if (!workItemId || !UUID_RE.test(workItemId)) return c.json({ error: 'Work item not found' }, 404);
+        await workItems.ensureReady();
+        const workItem = await workItems.get({ orgId: tenant.orgId, id: workItemId });
+        if (!workItem) return c.json({ error: 'Work item not found' }, 404);
+
+        await comments.ensureReady();
+        const limitRaw = c.req.query('limit');
+        const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+        const before = c.req.query('before') || undefined;
+        if (before && !decodeCommentCursor(before)) return c.json({ error: 'invalid_cursor' }, 422);
+        const page = await comments.list({
+          orgId: tenant.orgId,
+          factoryProjectId: workItem.factoryProjectId,
+          workItemId,
+          before,
+          ...(limit !== undefined && Number.isFinite(limit) ? { limit } : {}),
+        });
+        const wirePage: WireCommentPage = {
+          comments: page.comments.map(comment => toWireComment(comment, tenant.userId)),
+          ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+        };
+        return c.json(wirePage);
+      },
+    }),
+
+    registerApiRoute('/web/factory/work-items/:workItemId/comments', {
+      method: 'POST',
+      handler: async cc => {
+        const c = loose(cc);
+        const tenant = await resolveTenant(c);
+        if ('response' in tenant) return tenant.response;
+
+        const workItemId = c.req.param('workItemId');
+        if (!workItemId || !UUID_RE.test(workItemId)) return c.json({ error: 'Work item not found' }, 404);
+
+        const parsed = parseCreateCommentBody(await readJson(c));
+        if (!parsed) return c.json({ error: 'invalid_comment' }, 422);
+
+        const result = await domain.createComment({
+          orgId: tenant.orgId,
+          workItemId,
+          author: actorFromAuthUser(tenant.userId, getFactoryAuthUser(c)),
+          body: parsed.body,
+          ...(parsed.replyTo ? { replyTo: parsed.replyTo } : {}),
+          ...(parsed.mentions ? { mentions: parsed.mentions } : {}),
+          ...(parsed.clientToken ? { clientToken: parsed.clientToken } : {}),
+        });
+        if (result.status === 'work_item_not_found') return c.json({ error: 'Work item not found' }, 404);
+        if (result.status === 'token_conflict') return c.json({ error: 'comment_token_conflict' }, 409);
+        if (result.status === 'invalid') return c.json({ error: 'invalid_comment', message: result.message }, 422);
+
+        const { comment, workItem } = result;
+        await audit?.emit({
+          context: c,
+          input: {
+            action: 'factory.work_item.comment_created',
+            factoryProjectId: workItem.factoryProjectId,
+            targets: [{ type: 'work_item', id: workItem.id, name: workItem.title }],
+            metadata: { commentId: comment.id },
+          },
+        });
+        await emitMentionAudit(
+          c,
+          { factoryProjectId: workItem.factoryProjectId, workItemId: workItem.id, title: workItem.title },
+          comment.id,
+          comment.mentions.map(mention => mention.id).filter(id => id !== comment.author.id),
+        );
+        return c.json({ comment: toWireComment(comment, tenant.userId) }, 201);
+      },
+    }),
+
+    registerApiRoute('/web/factory/work-items/:workItemId/comments/:commentId', {
+      method: 'PATCH',
+      handler: async cc => {
+        const c = loose(cc);
+        const tenant = await resolveTenant(c);
+        if ('response' in tenant) return tenant.response;
+
+        const workItemId = c.req.param('workItemId');
+        const commentId = c.req.param('commentId');
+        if (!workItemId || !UUID_RE.test(workItemId) || !commentId || !UUID_RE.test(commentId)) {
+          return c.json({ error: 'Comment not found' }, 404);
+        }
+
+        const parsed = parseEditCommentBody(await readJson(c));
+        if (!parsed) return c.json({ error: 'invalid_comment' }, 422);
+
+        const result = await domain.editComment({
+          orgId: tenant.orgId,
+          workItemId,
+          commentId,
+          editor: editorFor(c, tenant),
+          body: parsed.body,
+          ...(parsed.mentions ? { mentions: parsed.mentions } : {}),
+          ...(parsed.expectedRevision !== undefined ? { expectedRevision: parsed.expectedRevision } : {}),
+        });
+        if (result.status === 'not_found') return c.json({ error: 'Comment not found' }, 404);
+        if (result.status === 'forbidden') return c.json({ error: 'not_comment_author' }, 403);
+        if (result.status === 'not_editable') return c.json({ error: 'comment_not_editable' }, 409);
+        if (result.status === 'conflict') return c.json({ error: 'comment_conflict' }, 409);
+        if (result.status === 'invalid') return c.json({ error: 'invalid_comment', message: result.message }, 422);
+
+        const { comment } = result;
+        await audit?.emit({
+          context: c,
+          input: {
+            action: 'factory.work_item.comment_edited',
+            factoryProjectId: comment.factoryProjectId,
+            targets: [{ type: 'work_item', id: comment.workItemId }],
+            metadata: {
+              commentId: comment.id,
+              previousBody: result.previousBody.slice(0, MAX_AUDIT_BODY_SNAPSHOT),
+            },
+          },
+        });
+        await emitMentionAudit(
+          c,
+          { factoryProjectId: comment.factoryProjectId, workItemId: comment.workItemId },
+          comment.id,
+          result.addedMentions.map(mention => mention.id),
+        );
+        return c.json({ comment: toWireComment(comment, tenant.userId) });
+      },
+    }),
+
+    registerApiRoute('/web/factory/work-items/:workItemId/comments/:commentId', {
+      method: 'DELETE',
+      handler: async cc => {
+        const c = loose(cc);
+        const tenant = await resolveTenant(c);
+        if ('response' in tenant) return tenant.response;
+
+        const workItemId = c.req.param('workItemId');
+        const commentId = c.req.param('commentId');
+        if (!workItemId || !UUID_RE.test(workItemId) || !commentId || !UUID_RE.test(commentId)) {
+          return c.json({ error: 'Comment not found' }, 404);
+        }
+
+        const result = await domain.deleteComment({
+          orgId: tenant.orgId,
+          workItemId,
+          commentId,
+          editor: editorFor(c, tenant),
+        });
+        if (result.status === 'not_found') return c.json({ error: 'Comment not found' }, 404);
+        if (result.status === 'forbidden') return c.json({ error: 'not_comment_author' }, 403);
+        if (result.status === 'not_editable') return c.json({ error: 'comment_not_editable' }, 409);
+
+        await audit?.emit({
+          context: c,
+          input: {
+            action: 'factory.work_item.comment_deleted',
+            factoryProjectId: result.comment.factoryProjectId,
+            targets: [{ type: 'work_item', id: result.comment.workItemId }],
+            metadata: { commentId: result.comment.id },
+          },
+        });
+        return c.json({ comment: toWireComment(result.comment, tenant.userId) });
+      },
+    }),
+
+    registerApiRoute('/web/factory/projects/:id/mention-roster', {
+      method: 'GET',
+      handler: async cc => {
+        const c = loose(cc);
+        const tenant = await resolveTenant(c);
+        if ('response' in tenant) return tenant.response;
+
+        const projectId = c.req.param('id');
+        if (!projectId || !UUID_RE.test(projectId)) return c.json({ error: 'Project not found' }, 404);
+        await projects.ensureReady();
+        const project = await projects.get({ orgId: tenant.orgId, id: projectId });
+        if (!project) return c.json({ error: 'Project not found' }, 404);
+
+        await comments.ensureReady();
+        const roster = await domain.mentionRoster({ orgId: tenant.orgId, factoryProjectId: projectId });
+        const query = c.req.query('q')?.trim().toLowerCase();
+        const members = query
+          ? roster.filter(member => (member.name ?? member.id).toLowerCase().startsWith(query))
+          : roster;
+        return c.json({ members });
+      },
+    }),
+  ];
+}

--- a/mastracode/factory/src/storage/domains/comments/schema.ts
+++ b/mastracode/factory/src/storage/domains/comments/schema.ts
@@ -1,0 +1,77 @@
+import type { CollectionSchema } from '@mastra/core/storage';
+
+export const WORK_ITEM_COMMENTS_SCHEMA: CollectionSchema = {
+  name: 'work_item_comments',
+  columns: {
+    id: { type: 'uuid-pk' },
+    org_id: { type: 'text' },
+    factory_project_id: { type: 'text' },
+    work_item_id: { type: 'text' },
+    kind: { type: 'text', default: 'comment' },
+    body: { type: 'text' },
+    body_format: { type: 'text', default: 'markdown' },
+    author_kind: { type: 'text' },
+    author_id: { type: 'text' },
+    author_display_name: { type: 'text', nullable: true },
+    author_avatar_url: { type: 'text', nullable: true },
+    author_external: { type: 'json', nullable: true },
+    reply_to_comment_id: { type: 'text', nullable: true },
+    reply_quote: { type: 'text', nullable: true },
+    reply_to_author_id: { type: 'text', nullable: true },
+    reply_to_author_name: { type: 'text', nullable: true },
+    mentions: { type: 'json' },
+    external_source: { type: 'json', nullable: true },
+    source_key: { type: 'text', nullable: true },
+    occurred_at: { type: 'timestamp' },
+    edited_at: { type: 'timestamp', nullable: true },
+    deleted_at: { type: 'timestamp', nullable: true },
+    deleted_by: { type: 'text', nullable: true },
+    revision: { type: 'integer', default: 1 },
+    created_at: { type: 'timestamp' },
+    updated_at: { type: 'timestamp' },
+  },
+  uniqueIndexes: [
+    {
+      name: 'work_item_comments_project_source_key_unique',
+      columns: ['factory_project_id', 'source_key'],
+      whereNotNull: 'source_key',
+    },
+  ],
+  indexes: [
+    {
+      name: 'work_item_comments_feed_idx',
+      columns: ['org_id', 'factory_project_id', 'work_item_id', 'occurred_at', 'id'],
+    },
+  ],
+};
+
+export const WORK_ITEM_COMMENT_MENTIONS_SCHEMA: CollectionSchema = {
+  name: 'work_item_comment_mentions',
+  columns: {
+    id: { type: 'uuid-pk' },
+    comment_id: { type: 'text' },
+    mentioned_kind: { type: 'text' },
+    mentioned_id: { type: 'text' },
+    author_id: { type: 'text' },
+    org_id: { type: 'text' },
+    factory_project_id: { type: 'text' },
+    work_item_id: { type: 'text' },
+    occurred_at: { type: 'timestamp' },
+  },
+  uniqueIndexes: [
+    {
+      name: 'work_item_comment_mentions_comment_target_unique',
+      columns: ['comment_id', 'mentioned_kind', 'mentioned_id'],
+    },
+  ],
+  indexes: [
+    {
+      name: 'work_item_comment_mentions_inbox_idx',
+      columns: ['org_id', 'factory_project_id', 'mentioned_id', 'occurred_at', 'id'],
+    },
+    {
+      name: 'work_item_comment_mentions_item_idx',
+      columns: ['org_id', 'factory_project_id', 'work_item_id'],
+    },
+  ],
+};

--- a/mastracode/factory/src/storage/domains/comments/wire.ts
+++ b/mastracode/factory/src/storage/domains/comments/wire.ts
@@ -1,5 +1,17 @@
-import type { FactoryActorRef } from './actor.js';
+import type { FactoryActorKind, FactoryActorRef } from './actor.js';
 import type { FactoryMentionRef, WorkItemCommentReplyRef, WorkItemCommentRow } from './base.js';
+
+/**
+ * Display-only author. The stored `FactoryActorRef` also carries the platform
+ * join keys (team, message, bot flag) that linked a sender to a tenant user;
+ * those never reach a thread reader.
+ */
+export interface WireCommentAuthor {
+  kind: FactoryActorKind;
+  id: string;
+  displayName?: string;
+  avatarUrl?: string;
+}
 
 export interface WireComment {
   id: string;
@@ -7,7 +19,7 @@ export interface WireComment {
   kind: string;
   body: string;
   bodyFormat: string;
-  author: FactoryActorRef;
+  author: WireCommentAuthor;
   replyTo?: WorkItemCommentReplyRef;
   mentions: FactoryMentionRef[];
   /** The viewer's own local sends only, so their client can match pending rows. */
@@ -26,6 +38,15 @@ export interface WireCommentPage {
 
 const LOCAL_SOURCE_KEY_PREFIX = 'local:comment:';
 
+function toWireAuthor({ kind, id, displayName, avatarUrl }: FactoryActorRef): WireCommentAuthor {
+  return {
+    kind,
+    id,
+    ...(displayName ? { displayName } : {}),
+    ...(avatarUrl ? { avatarUrl } : {}),
+  };
+}
+
 export function toWireComment(comment: WorkItemCommentRow, viewerId: string): WireComment {
   const clientToken =
     comment.author.id === viewerId && comment.sourceKey?.startsWith(LOCAL_SOURCE_KEY_PREFIX)
@@ -37,7 +58,7 @@ export function toWireComment(comment: WorkItemCommentRow, viewerId: string): Wi
     kind: comment.kind,
     body: comment.body,
     bodyFormat: comment.bodyFormat,
-    author: comment.author,
+    author: toWireAuthor(comment.author),
     ...(comment.replyTo ? { replyTo: comment.replyTo } : {}),
     mentions: comment.mentions,
     ...(clientToken ? { clientToken } : {}),

--- a/mastracode/factory/src/storage/domains/comments/wire.ts
+++ b/mastracode/factory/src/storage/domains/comments/wire.ts
@@ -27,8 +27,8 @@ export interface WireComment {
   origin?: { integrationId: string; type: string; url?: string };
   revision: number;
   occurredAt: string;
-  editedAt: string | null;
-  deletedAt: string | null;
+  editedAt?: string;
+  deletedAt?: string;
 }
 
 export interface WireCommentPage {
@@ -73,7 +73,7 @@ export function toWireComment(comment: WorkItemCommentRow, viewerId: string): Wi
       : {}),
     revision: comment.revision,
     occurredAt: comment.occurredAt.toISOString(),
-    editedAt: comment.editedAt?.toISOString() ?? null,
-    deletedAt: comment.deletedAt?.toISOString() ?? null,
+    ...(comment.editedAt ? { editedAt: comment.editedAt.toISOString() } : {}),
+    ...(comment.deletedAt ? { deletedAt: comment.deletedAt.toISOString() } : {}),
   };
 }

--- a/mastracode/factory/src/storage/domains/comments/wire.ts
+++ b/mastracode/factory/src/storage/domains/comments/wire.ts
@@ -1,0 +1,58 @@
+import type { FactoryActorRef } from './actor.js';
+import type { FactoryMentionRef, WorkItemCommentReplyRef, WorkItemCommentRow } from './base.js';
+
+export interface WireComment {
+  id: string;
+  workItemId: string;
+  kind: string;
+  body: string;
+  bodyFormat: string;
+  author: FactoryActorRef;
+  replyTo?: WorkItemCommentReplyRef;
+  mentions: FactoryMentionRef[];
+  /** The viewer's own local sends only, so their client can match pending rows. */
+  clientToken?: string;
+  origin?: { integrationId: string; type: string; url?: string };
+  revision: number;
+  occurredAt: string;
+  editedAt: string | null;
+  deletedAt: string | null;
+}
+
+export interface WireCommentPage {
+  comments: WireComment[];
+  nextCursor?: string;
+}
+
+const LOCAL_SOURCE_KEY_PREFIX = 'local:comment:';
+
+export function toWireComment(comment: WorkItemCommentRow, viewerId: string): WireComment {
+  const clientToken =
+    comment.author.id === viewerId && comment.sourceKey?.startsWith(LOCAL_SOURCE_KEY_PREFIX)
+      ? comment.sourceKey.slice(LOCAL_SOURCE_KEY_PREFIX.length)
+      : undefined;
+  return {
+    id: comment.id,
+    workItemId: comment.workItemId,
+    kind: comment.kind,
+    body: comment.body,
+    bodyFormat: comment.bodyFormat,
+    author: comment.author,
+    ...(comment.replyTo ? { replyTo: comment.replyTo } : {}),
+    mentions: comment.mentions,
+    ...(clientToken ? { clientToken } : {}),
+    ...(comment.externalSource
+      ? {
+          origin: {
+            integrationId: comment.externalSource.integrationId,
+            type: comment.externalSource.type,
+            ...(comment.externalSource.url ? { url: comment.externalSource.url } : {}),
+          },
+        }
+      : {}),
+    revision: comment.revision,
+    occurredAt: comment.occurredAt.toISOString(),
+    editedAt: comment.editedAt?.toISOString() ?? null,
+    deletedAt: comment.deletedAt?.toISOString() ?? null,
+  };
+}

--- a/mastracode/factory/src/storage/domains/work-items/base.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.test.ts
@@ -6,7 +6,13 @@
 import { LibSQLFactoryStorage } from '@mastra/libsql';
 import { describe, expect, it, vi } from 'vitest';
 
-import { applyStageTransition, isAgentActor, WorkItemRelationError, WorkItemsStorage } from './base.js';
+import {
+  applyStageTransition,
+  factoryDecisionAttentionIdentity,
+  isAgentActor,
+  WorkItemRelationError,
+  WorkItemsStorage,
+} from './base.js';
 import type { WorkItemStageEntry } from './base.js';
 
 const input = {
@@ -479,8 +485,7 @@ describe('WorkItemsStorage', () => {
     await storage.setAttentionReceipt({
       ...scope,
       userId: 'u',
-      decisionId: failed.id,
-      failureOccurrence: failed.failureOccurrence,
+      identity: factoryDecisionAttentionIdentity(failed.id, failed.failureOccurrence),
       action: 'read',
       now,
     });
@@ -493,8 +498,7 @@ describe('WorkItemsStorage', () => {
       storage.setAttentionReceipt({
         ...scope,
         userId: 'u',
-        decisionId: failed.id,
-        failureOccurrence: failed.failureOccurrence,
+        identity: factoryDecisionAttentionIdentity(failed.id, failed.failureOccurrence),
         action: 'archive',
         now,
       }),

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -14,6 +14,7 @@ import { FactoryStorageDomain, UniqueViolationError } from '@mastra/core/storage
 import type { CollectionSchema, CollectionWhere, FactoryStorageOps } from '@mastra/core/storage';
 import { isTerminalFactoryRuleStage } from '../../../rules/types.js';
 import type { FactoryTriageType } from '../../../rules/types.js';
+import { WORK_ITEM_COMMENT_MENTIONS_SCHEMA, WORK_ITEM_COMMENTS_SCHEMA } from '../comments/schema.js';
 
 export type WorkItemStage = string;
 
@@ -213,7 +214,7 @@ export interface FactoryDeferredDecisionRecord {
   updatedAt: Date;
 }
 
-export type FactoryAttentionKind = 'automation-failed';
+export type FactoryAttentionKind = 'automation-failed' | 'mention';
 export type FactoryAttentionReceiptState = 'read' | 'archived';
 export type FactoryAttentionReceiptAction = 'read' | 'archive' | 'restore';
 
@@ -239,8 +240,7 @@ interface SetAttentionReceiptInput {
   orgId: string;
   factoryProjectId: string;
   userId: string;
-  decisionId: string;
-  failureOccurrence: number;
+  identity: FactoryAttentionIdentity;
   action: FactoryAttentionReceiptAction;
   now: Date;
 }
@@ -250,6 +250,10 @@ export function factoryDecisionAttentionIdentity(
   failureOccurrence: number,
 ): FactoryAttentionIdentity {
   return { kind: 'automation-failed', sourceId: decisionId, occurrence: failureOccurrence };
+}
+
+export function factoryMentionAttentionIdentity(commentId: string): FactoryAttentionIdentity {
+  return { kind: 'mention', sourceId: commentId, occurrence: 0 };
 }
 
 export function factoryAttentionKey(factoryProjectId: string, identity: FactoryAttentionIdentity): string {
@@ -424,6 +428,10 @@ export interface WorkItemRow {
    * work they already asked for, so runs on an armed item skip the gate.
    */
   autonomyArmedAt: Date | null;
+  /** Denormalized feed counters, maintained by the comments domain via recount. */
+  commentCount: number;
+  /** Bumps on every feed mutation (create/edit/delete) — the clients' change hint. */
+  feedActivityAt: Date | null;
   revision: number;
   createdBy: string;
   createdAt: Date;
@@ -474,6 +482,8 @@ export const WORK_ITEMS_SCHEMA: CollectionSchema = {
     metadata: { type: 'json', nullable: true },
     triage_type: { type: 'text', nullable: true },
     autonomy_armed_at: { type: 'timestamp', nullable: true },
+    comment_count: { type: 'integer', default: 0 },
+    feed_activity_at: { type: 'timestamp', nullable: true },
     revision: { type: 'integer', default: 1 },
     created_by: { type: 'text' },
     created_at: { type: 'timestamp' },
@@ -511,6 +521,8 @@ interface WorkItemDbRow extends Record<string, unknown> {
   metadata: Record<string, unknown> | null;
   triage_type: FactoryTriageType | null;
   autonomy_armed_at: Date | null;
+  comment_count: number;
+  feed_activity_at: Date | null;
   revision: number;
   created_by: string;
   created_at: Date;
@@ -535,6 +547,8 @@ function toWorkItem(row: WorkItemDbRow): WorkItemRow {
     metadata: row.metadata,
     triageType: row.triage_type ?? null,
     autonomyArmedAt: row.autonomy_armed_at ?? null,
+    commentCount: row.comment_count ?? 0,
+    feedActivityAt: row.feed_activity_at ?? null,
     revision: row.revision,
     createdBy: row.created_by,
     createdAt: row.created_at,
@@ -930,7 +944,7 @@ function toDeferredDecision(row: GovernanceDbRow): FactoryDeferredDecisionRecord
   };
 }
 function attentionReceiptKind(value: unknown): FactoryAttentionKind {
-  if (value === 'automation-failed') return value;
+  if (value === 'automation-failed' || value === 'mention') return value;
   throw new Error(`Unsupported attention receipt kind '${String(value)}'.`);
 }
 
@@ -995,7 +1009,14 @@ export class WorkItemsStorage extends FactoryStorageDomain {
   }
 
   async init(): Promise<void> {
-    await this.ensureCollections([WORK_ITEMS_SCHEMA, ...FACTORY_GOVERNANCE_SCHEMAS]);
+    // The comment schemas are co-registered so the delete cascade below can
+    // purge feed rows regardless of domain init order.
+    await this.ensureCollections([
+      WORK_ITEMS_SCHEMA,
+      ...FACTORY_GOVERNANCE_SCHEMAS,
+      WORK_ITEM_COMMENTS_SCHEMA,
+      WORK_ITEM_COMMENT_MENTIONS_SCHEMA,
+    ]);
     await this.repairLegacyAttentionState();
   }
 
@@ -1673,18 +1694,20 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     orgId,
     factoryProjectId,
     userId,
+    kind,
     state,
   }: {
     orgId: string;
     factoryProjectId: string;
     userId: string;
+    kind: FactoryAttentionKind;
     state?: FactoryAttentionReceiptState;
   }): Promise<number> {
     return this.#countRows('factory_attention_receipts', {
       org_id: orgId,
       factory_project_id: factoryProjectId,
       user_id: userId,
-      kind: 'automation-failed',
+      kind,
       ...(state ? { state } : {}),
     });
   }
@@ -1692,10 +1715,13 @@ export class WorkItemsStorage extends FactoryStorageDomain {
   async deleteAttentionReceipts({
     orgId,
     factoryProjectId,
+    userId,
     identities,
   }: {
     orgId: string;
     factoryProjectId: string;
+    /** Restrict to one user's receipts (a removed mention must keep other users' read state). */
+    userId?: string;
     identities: FactoryAttentionIdentity[];
   }): Promise<void> {
     const unique = [
@@ -1709,6 +1735,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
           this.#db.deleteMany('factory_attention_receipts', {
             org_id: orgId,
             factory_project_id: factoryProjectId,
+            ...(userId ? { user_id: userId } : {}),
             kind: identity.kind,
             source_id: identity.sourceId,
             occurrence: identity.occurrence,
@@ -1733,22 +1760,57 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     }
   }
 
+  /**
+   * Per-kind currency predicate: a receipt may only target a source that still
+   * projects an attention item FOR THIS USER — otherwise the route answers
+   * 409. Without the mention-row check, any member could write receipts
+   * against arbitrary comment ids and permanently skew their own badge math.
+   */
+  async #attentionSourceIsCurrent(
+    ops: FactoryStorageOps,
+    {
+      orgId,
+      factoryProjectId,
+      userId,
+      identity,
+    }: { orgId: string; factoryProjectId: string; userId: string; identity: FactoryAttentionIdentity },
+  ): Promise<boolean> {
+    if (identity.kind === 'automation-failed') {
+      let currentOccurrence = false;
+      const decision = await ops.updateAtomic<GovernanceDbRow>(
+        'factory_deferred_decisions',
+        { id: identity.sourceId, org_id: orgId, factory_project_id: factoryProjectId },
+        current => {
+          currentOccurrence =
+            current.status === 'failed' && Number(current.failure_occurrence ?? 0) === identity.occurrence;
+          return null;
+        },
+      );
+      return Boolean(decision) && currentOccurrence;
+    }
+    if (identity.occurrence !== 0) return false;
+    const mention = await ops.findOne('work_item_comment_mentions', {
+      comment_id: identity.sourceId,
+      org_id: orgId,
+      factory_project_id: factoryProjectId,
+      mentioned_kind: 'user',
+      mentioned_id: userId,
+    });
+    if (!mention) return false;
+    const comment = await ops.findOne('work_item_comments', {
+      id: identity.sourceId,
+      org_id: orgId,
+      factory_project_id: factoryProjectId,
+      deleted_at: null,
+    });
+    return comment !== null;
+  }
+
   async #setAttentionReceiptWithOps(
     ops: FactoryStorageOps,
-    { orgId, factoryProjectId, userId, decisionId, failureOccurrence, action, now }: SetAttentionReceiptInput,
+    { orgId, factoryProjectId, userId, identity, action, now }: SetAttentionReceiptInput,
   ): Promise<FactoryAttentionReceiptRecord | null> {
-    const identity = factoryDecisionAttentionIdentity(decisionId, failureOccurrence);
-    let currentOccurrence = false;
-    const decision = await ops.updateAtomic<GovernanceDbRow>(
-      'factory_deferred_decisions',
-      { id: decisionId, org_id: orgId, factory_project_id: factoryProjectId },
-      current => {
-        currentOccurrence =
-          current.status === 'failed' && Number(current.failure_occurrence ?? 0) === failureOccurrence;
-        return null;
-      },
-    );
-    if (!decision || !currentOccurrence) return null;
+    if (!(await this.#attentionSourceIsCurrent(ops, { orgId, factoryProjectId, userId, identity }))) return null;
 
     const where = {
       org_id: orgId,
@@ -1792,30 +1854,30 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     orgId,
     factoryProjectId,
     userId,
-    occurrences,
+    identities,
     now,
   }: {
     orgId: string;
     factoryProjectId: string;
     userId: string;
-    occurrences: Array<{ decisionId: string; failureOccurrence: number }>;
+    identities: FactoryAttentionIdentity[];
     now: Date;
   }): Promise<void> {
-    const uniqueOccurrences = [
+    const uniqueIdentities = [
       ...new Map(
-        occurrences.map(occurrence => [`${occurrence.decisionId}:${occurrence.failureOccurrence}`, occurrence]),
+        identities.map(identity => [`${identity.kind}\0${identity.sourceId}\0${identity.occurrence}`, identity]),
       ).values(),
     ];
-    for (let index = 0; index < uniqueOccurrences.length; index += ATTENTION_RECEIPT_WRITE_BATCH_SIZE) {
-      const batch = uniqueOccurrences.slice(index, index + ATTENTION_RECEIPT_WRITE_BATCH_SIZE);
+    for (let index = 0; index < uniqueIdentities.length; index += ATTENTION_RECEIPT_WRITE_BATCH_SIZE) {
+      const batch = uniqueIdentities.slice(index, index + ATTENTION_RECEIPT_WRITE_BATCH_SIZE);
       await this.#retryAttentionReceiptWrite(() =>
         this.storage.withTransaction(async ops => {
-          for (const occurrence of batch) {
+          for (const identity of batch) {
             await this.#setAttentionReceiptWithOps(ops, {
               orgId,
               factoryProjectId,
               userId,
-              ...occurrence,
+              identity,
               action: 'read',
               now,
             });
@@ -2715,6 +2777,35 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     }
   }
 
+  /**
+   * Feed rows die with their work item: orphan mention rows would keep
+   * projecting attention items that deep-link to a card that no longer exists.
+   */
+  async #purgeFeedState(
+    ops: FactoryStorageOps,
+    { orgId, factoryProjectId, workItemId }: { orgId: string; factoryProjectId: string; workItemId: string },
+  ): Promise<void> {
+    // Paged harvest: this runs inside the delete transaction and a long-lived
+    // item can carry thousands of comments — never materialize them all.
+    const where = { org_id: orgId, factory_project_id: factoryProjectId, work_item_id: workItemId };
+    while (true) {
+      const comments = await ops.findMany<{ id: string } & Record<string, unknown>>('work_item_comments', where, {
+        limit: ATTENTION_RECEIPT_QUERY_BATCH_SIZE,
+      });
+      if (comments.length === 0) break;
+      const commentIds = comments.map(comment => comment.id);
+      await ops.deleteMany('factory_attention_receipts', {
+        org_id: orgId,
+        factory_project_id: factoryProjectId,
+        kind: 'mention',
+        source_id: { in: commentIds },
+      });
+      await ops.deleteMany('work_item_comments', { ...where, id: { in: commentIds } });
+      if (comments.length < ATTENTION_RECEIPT_QUERY_BATCH_SIZE) break;
+    }
+    await ops.deleteMany('work_item_comment_mentions', where);
+  }
+
   async delete({ orgId, id }: { orgId: string; id: string }): Promise<WorkItemRow | null> {
     const candidate = await this.#db.findOne<WorkItemDbRow>('work_items', { org_id: orgId, id });
     if (!candidate) return null;
@@ -2724,6 +2815,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
       if (!existing) return null;
       const deleted = await ops.deleteMany('work_items', { org_id: orgId, id });
       if (deleted === 0) return null;
+      await this.#purgeFeedState(ops, { orgId, factoryProjectId: existing.factory_project_id, workItemId: id });
       if (existing.source_key) {
         await this.#purgeRuleState(ops, {
           orgId,

--- a/mastracode/factory/src/storage/test-utils.ts
+++ b/mastracode/factory/src/storage/test-utils.ts
@@ -9,6 +9,7 @@ import { onTestFinished } from 'vitest';
 
 import { AuditStorage } from './domains/audit/base.js';
 import { ChannelIdentityStorage } from './domains/channel-identity/base.js';
+import { WorkItemCommentsStorage } from './domains/comments/base.js';
 import { ModelCredentialsStorage } from './domains/credentials/base.js';
 import { CustomProvidersStorage } from './domains/custom-providers/base.js';
 import { IntakeStorage } from './domains/intake/base.js';
@@ -34,6 +35,7 @@ export interface FactoryStorageTestSeed {
   customProviders: CustomProvidersStorage;
   queueHealth: QueueHealthStorage;
   channelIdentity: ChannelIdentityStorage;
+  comments: WorkItemCommentsStorage;
 }
 
 /**
@@ -55,6 +57,7 @@ export async function createFactoryStorageForTests(): Promise<FactoryStorageTest
   const customProviders = storage.registerDomain(new CustomProvidersStorage());
   const queueHealth = storage.registerDomain(new QueueHealthStorage());
   const channelIdentity = storage.registerDomain(new ChannelIdentityStorage());
+  const comments = storage.registerDomain(new WorkItemCommentsStorage());
   await storage.init();
   onTestFinished(() => storage.close());
   return {
@@ -71,5 +74,6 @@ export async function createFactoryStorageForTests(): Promise<FactoryStorageTest
     customProviders,
     queueHealth,
     channelIdentity,
+    comments,
   };
 }


### PR DESCRIPTION
TLDR: work items get a comment thread — storage, routes, and the attention record a
mention leaves behind. No UI in this PR. COR-1170.

---

Two people cannot address each other anywhere in the Factory today: discussion happens
in Slack or Linear and never reaches the item the agent works on. This is the data and
the API that the rest of In-Item Collaboration plugs into.

### What changes

| situation | before | after |
| --- | --- | --- |
| a caller wants the discussion on a work item | no such thing | `GET/POST/PATCH/DELETE …/work-items/:id/comments`, newest-first with a cursor |
| the same post is retried | duplicate comment | one comment: `clientToken` is idempotent, 409 only when it resolves to another item or author |
| two people edit the same comment | silent last-write-wins | the edit carries `expectedRevision`, stale edits get 409 |
| a comment is deleted | — | tombstone: the row stays, so ordering and replies hold |
| a comment names a teammate | — | a mention row plus an attention record, deep-linkable to the comment |
| the inbox serves attention | one hardcoded kind | per-kind providers over one bounded scan, cursor is a per-kind map |

### Judgment calls

Attention becoming per-kind providers is a wire break. Its only consumer is factory-ui,
updated in the PR directly on top of this one — they should land together.

Receipts are only accepted when the source still names the caller. Without that check any
member could POST receipts for occurrences they were never part of and skew their own badge.

Authz stays org-wide like every other factory route, and there is no rate limiting — no
factory precedent for it. Caps, idempotent create tokens and tenant checks are the defense.

Comment rows are source-keyed (`external_source` → `source_key`, partial unique) so local
retries and a future Slack mirror share one idempotency story. The Slack seam ships as
interfaces and a publisher slot only — no Slack code, and nothing exercises it yet beyond
the fake-publisher tests.

### Cost

The attention GET roughly doubles per polling client: a second provider's bounded index
reads on the same 5s poll. First place to look if attention shows up in traces.

### On deploy

Additive DDL only, no migration. Existing work items start at zero comments, which is true.

```
source        +2586  -279
tests         +1197   -17
changeset       +10     0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Work items can now have comments. People can reply, mention others, and receive alerts. The system prevents duplicate submissions and conflicting edits.

## Changes

- Added comment storage with cursor pagination, `around` cursors, client-token idempotency, revision-checked edits, soft-delete tombstones, quoted replies, and mention tracking.
- Added authenticated API routes to list, create, edit, and delete comments.
- Added mention-roster retrieval from organization members, recent authors, and linked channel accounts.
- Added mention-based attention records with deep links.
- Refactored attention handling into per-kind providers for mentions and automation failures.
- Added per-kind cursors, merged pagination, counts, latest-item handling, read-all support, and kind-aware receipts.
- Added support for legacy attention cursors during deployment.
- Added `commentCount` and `feedActivityAt` fields to work items.
- Derived feed activity from the newest comment and prevented stale refresh snapshots from overwriting newer values.
- Added additive database schemas and cleanup for comments, mentions, and related attention receipts.
- Added platform-agnostic comment ingest and publishing interfaces for future integrations.
- Added organization-scoped account-link listing and comment source-key recovery.
- Kept platform join keys out of comment API payloads.
- Omitted unset `editedAt` and `deletedAt` fields from the comment wire format.
- Added comprehensive storage and route tests.
- Added a minor release changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->