### PR TITLE
feat(factory-ui): show mentions in the attention inbox

### DIFF
--- a/.changeset/attention-mentions-inbox.md
+++ b/.changeset/attention-mentions-inbox.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The Factory attention inbox now lists mentions alongside automation failures. A mention row opens the board card and scrolls to the comment that named you, and read, archive and restore behave the same on both kinds.

--- a/.changeset/attention-mentions-inbox.md
+++ b/.changeset/attention-mentions-inbox.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-The Factory attention inbox now lists mentions alongside automation failures. A mention row opens the board card and scrolls to the comment that named you, and read, archive and restore behave the same on both kinds.
+The Factory attention inbox now lists mentions alongside automation failures. A mention row opens the board card it was posted on, and read, archive and restore behave the same on both kinds.

--- a/mastracode/factory-ui/src/hooks/useFactoryAttention.ts
+++ b/mastracode/factory-ui/src/hooks/useFactoryAttention.ts
@@ -52,7 +52,7 @@ export function useFactoryAttentionReceiptAction(
   const { baseUrl } = useApiConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (item: Pick<FactoryAttentionItem, 'decisionId' | 'occurrence'>) => {
+    mutationFn: (item: FactoryAttentionItem) => {
       if (!factoryProjectId) throw new Error('Factory project is required');
       return updateFactoryAttentionReceipt(baseUrl, factoryProjectId, item, action);
     },

--- a/mastracode/factory-ui/src/ui/domains/factory/components/AttentionItemRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/AttentionItemRow.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { Archive, ArchiveRestore, MailOpen, RotateCw, TriangleAlert } from 'lucide-react';
+import { Archive, ArchiveRestore, MailOpen, MessageSquare, RotateCw, TriangleAlert } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Link } from 'react-router';
 
@@ -75,10 +75,18 @@ export function AttentionItemRow({
       />
       <span className="flex items-center justify-between gap-2">
         <span className="text-ui-xs text-icon3 flex min-w-0 items-center gap-1.5">
-          <TriangleAlert size={14} className="text-error shrink-0" aria-hidden />
+          {item.kind === 'mention' ? (
+            <MessageSquare size={14} className="text-accent1 shrink-0" aria-hidden />
+          ) : (
+            <TriangleAlert size={14} className="text-error shrink-0" aria-hidden />
+          )}
           <span className="sr-only">{item.read ? 'Read' : 'Unread'}</span>
           {!item.read ? <span className="bg-warning1 size-1.5 shrink-0 rounded-full" aria-hidden /> : null}
-          <span className="truncate">Automation failed · {relativeTime(item.occurredAt)}</span>
+          <span className="truncate">
+            {item.kind === 'mention'
+              ? `${item.authorName ?? 'Someone'} mentioned you · ${relativeTime(item.occurredAt)}`
+              : `Automation failed · ${relativeTime(item.occurredAt)}`}
+          </span>
         </span>
         <span className={cn('relative flex items-center gap-0.5', REVEAL_ON_CARD_HOVER)}>
           {onRetry ? (

--- a/mastracode/factory-ui/src/ui/domains/factory/components/SidebarAttention.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/SidebarAttention.tsx
@@ -9,11 +9,10 @@ import { useEffect, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router';
 
 import { useFactoryAuth } from '../../../../hooks/useFactoryAuth';
-import { useFactoryAttention, useFactoryAttentionReceiptAction } from '../../../../hooks/useFactoryAttention';
-import { useFactoryDecisionAction } from '../../../../hooks/useFactoryDecisions';
-import type { FactoryAttentionItem } from '../services/attention';
+import { useFactoryAttention } from '../../../../hooks/useFactoryAttention';
 import { playAttentionSoundOnce } from '../services/attentionSound';
 import { AttentionItemRow } from './AttentionItemRow';
+import { useAttentionItemActions } from './useAttentionItemActions';
 
 function triggerLabel(openCount: number, unreadCount: number, approvalCount: number): string {
   const counts = [
@@ -24,22 +23,11 @@ function triggerLabel(openCount: number, unreadCount: number, approvalCount: num
   return counts.length > 0 ? `Needs attention, ${counts.join(', ')}` : 'Needs attention';
 }
 
-function sameItem(a: Pick<FactoryAttentionItem, 'decisionId' | 'occurrence'> | undefined, b: FactoryAttentionItem) {
-  return a?.decisionId === b.decisionId && a.occurrence === b.occurrence;
-}
-
-function showReceiptError(error: unknown, fallback: string): void {
-  toast.error(error instanceof Error ? error.message : fallback);
-}
-
 export function SidebarAttention() {
   const { factoryId } = useParams<{ factoryId: string }>();
   const auth = useFactoryAuth();
   const attention = useFactoryAttention(factoryId, 'open', 5);
-  const retryDecision = useFactoryDecisionAction(factoryId, 'retry');
-  const readItem = useFactoryAttentionReceiptAction(factoryId, 'read');
-  const archiveItem = useFactoryAttentionReceiptAction(factoryId, 'archive');
-  const restoreItem = useFactoryAttentionReceiptAction(factoryId, 'restore');
+  const rowProps = useAttentionItemActions(factoryId);
   const [open, setOpen] = useState(false);
   const items = attention.data?.items ?? [];
   const openCount = attention.data?.openCount ?? 0;
@@ -136,41 +124,7 @@ export function SidebarAttention() {
               ) : null}
               {items.map(item => (
                 <li key={item.key}>
-                  <AttentionItemRow
-                    factoryId={factoryId}
-                    item={item}
-                    retrying={retryDecision.isPending && retryDecision.variables === item.decisionId}
-                    updatingReceipt={
-                      (readItem.isPending && sameItem(readItem.variables, item)) ||
-                      (archiveItem.isPending && sameItem(archiveItem.variables, item)) ||
-                      (restoreItem.isPending && sameItem(restoreItem.variables, item))
-                    }
-                    onOpen={() => setOpen(false)}
-                    onRetry={
-                      item.canRetry
-                        ? () =>
-                            retryDecision.mutate(item.decisionId, {
-                              onError: error =>
-                                toast.error(error instanceof Error ? error.message : 'Unable to retry automation'),
-                            })
-                        : undefined
-                    }
-                    onRead={() =>
-                      readItem.mutate(item, {
-                        onError: error => showReceiptError(error, 'Unable to mark attention item as read'),
-                      })
-                    }
-                    onArchive={() =>
-                      archiveItem.mutate(item, {
-                        onError: error => showReceiptError(error, 'Unable to archive attention item'),
-                      })
-                    }
-                    onRestore={() =>
-                      restoreItem.mutate(item, {
-                        onError: error => showReceiptError(error, 'Unable to restore attention item'),
-                      })
-                    }
-                  />
+                  <AttentionItemRow factoryId={factoryId} {...rowProps(item)} onOpen={() => setOpen(false)} />
                 </li>
               ))}
             </ul>

--- a/mastracode/factory-ui/src/ui/domains/factory/components/__tests__/SidebarAttention.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/__tests__/SidebarAttention.msw.test.tsx
@@ -8,7 +8,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { queryKeys } from '../../../../../api/keys';
 import { server } from '../../../../../../e2e/ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../../../../e2e/ui/render';
-import type { FactoryAttentionItem, FactoryAttentionView } from '../../services/attention';
+import {
+  attentionItemSourceId,
+  type FactoryAttentionItem,
+  type FactoryAttentionView,
+  type FactoryAutomationFailedAttentionItem,
+  type FactoryMentionAttentionItem,
+} from '../../services/attention';
 import { playAttentionSoundOnce } from '../../services/attentionSound';
 import { SidebarAttention } from '../SidebarAttention';
 
@@ -45,7 +51,7 @@ class AudioContextStub {
   }
 }
 
-function attentionItem(occurrence = 1): FactoryAttentionItem {
+function attentionItem(occurrence = 1): FactoryAutomationFailedAttentionItem {
   return {
     key: `factory:${FACTORY_ID}:attention:automation-failed:${DECISION_ID}:${occurrence}`,
     kind: 'automation-failed',
@@ -61,6 +67,24 @@ function attentionItem(occurrence = 1): FactoryAttentionItem {
     read: false,
     target: { kind: 'thread', sessionId: 'session-attention', threadId: 'thread-attention' },
     archived: false,
+  };
+}
+
+function mentionItem(): FactoryMentionAttentionItem {
+  return {
+    key: `factory:${FACTORY_ID}:attention:mention:comment-1:0`,
+    kind: 'mention',
+    commentId: 'comment-1',
+    occurrence: 0,
+    workItemId: 'item-1',
+    title: 'Fix the loader',
+    detail: 'Hey @you, can you check this?',
+    authorId: 'user-2',
+    authorName: 'Rita',
+    occurredAt: '2026-08-20T10:00:00.000Z',
+    read: false,
+    archived: false,
+    target: { kind: 'work-item', workItemId: 'item-1', board: 'work', commentId: 'comment-1' },
   };
 }
 
@@ -93,6 +117,7 @@ function stubAttention(initialItems: FactoryAttentionItem[], initialApprovalCoun
   let items = initialItems;
   let approvalCount = initialApprovalCount;
   const retried: string[] = [];
+  const receipts: string[] = [];
   server.use(
     http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/attention`, ({ request }) => {
       const url = new URL(request.url);
@@ -117,11 +142,17 @@ function stubAttention(initialItems: FactoryAttentionItem[], initialApprovalCoun
       });
     }),
     http.post(
-      `${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/attention/automation-failed/:decisionId/:occurrence/:action`,
+      `${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/attention/:kind/:sourceId/:occurrence/:action`,
       ({ params }) => {
+        receipts.push(`${params.kind}/${params.sourceId}/${params.occurrence}/${params.action}`);
         const occurrence = Number(params.occurrence);
         items = items.map(item => {
-          if (item.decisionId !== params.decisionId || item.occurrence !== occurrence) return item;
+          if (
+            item.kind !== params.kind ||
+            attentionItemSourceId(item) !== params.sourceId ||
+            item.occurrence !== occurrence
+          )
+            return item;
           if (params.action === 'archive') return { ...item, read: true, archived: true };
           if (params.action === 'restore') return { ...item, read: true, archived: false };
           return { ...item, read: true };
@@ -131,7 +162,7 @@ function stubAttention(initialItems: FactoryAttentionItem[], initialApprovalCoun
     ),
     http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/decisions/:decisionId/retry`, ({ params }) => {
       retried.push(String(params.decisionId));
-      items = items.filter(item => item.decisionId !== params.decisionId);
+      items = items.filter(item => item.kind !== 'automation-failed' || item.decisionId !== params.decisionId);
       return HttpResponse.json({ decision: { id: params.decisionId, status: 'retry' } });
     }),
   );
@@ -140,6 +171,7 @@ function stubAttention(initialItems: FactoryAttentionItem[], initialApprovalCoun
       items = nextItems;
     },
     retried,
+    receipts,
     setApprovalCount: (count: number) => {
       approvalCount = count;
     },
@@ -265,6 +297,27 @@ describe('Sidebar attention', () => {
 
     await waitFor(() => expect(localStorage.getItem(SOUND_STORAGE_KEY)).toContain(next.key));
     expect(oscillatorStart).toHaveBeenCalled();
+  });
+
+  it('shows a mention linking to the comment and reads it through the mention receipt path', async () => {
+    const api = stubAttention([mentionItem()]);
+    const user = userEvent.setup();
+    const { client } = renderAttention();
+
+    await user.click(await screen.findByRole('button', { name: 'Needs attention, 1 unread, 1 open' }));
+
+    expect(await screen.findByText(/Rita mentioned you/)).toBeVisible();
+    expect(screen.queryByRole('button', { name: /Retry/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View card for Fix the loader' })).toHaveAttribute(
+      'href',
+      `/factories/${FACTORY_ID}/work?item=item-1&comment=comment-1`,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Mark Fix the loader as read' }));
+    await waitForMutationsIdle(client);
+
+    expect(api.receipts).toEqual(['mention/comment-1/0/read']);
+    await screen.findByRole('button', { name: 'Needs attention, 1 open' });
   });
 
   it('does not offer Retry for a deterministic failure', async () => {

--- a/mastracode/factory-ui/src/ui/domains/factory/components/useAttentionItemActions.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/useAttentionItemActions.ts
@@ -1,0 +1,38 @@
+import { toast } from '@mastra/playground-ui/components/Toaster';
+
+import { useFactoryAttentionReceiptAction } from '../../../../hooks/useFactoryAttention';
+import { useFactoryDecisionAction } from '../../../../hooks/useFactoryDecisions';
+import type { FactoryAttentionItem } from '../services/attention';
+
+function isSameItem(a: FactoryAttentionItem | undefined, b: FactoryAttentionItem): boolean {
+  return a?.key === b.key;
+}
+
+function notifyFailure(fallback: string) {
+  return (error: unknown) => toast.error(error instanceof Error ? error.message : fallback);
+}
+
+/** Row wiring shared by the sidebar popover and the attention page. */
+export function useAttentionItemActions(factoryId: string | undefined) {
+  const retryDecision = useFactoryDecisionAction(factoryId, 'retry');
+  const readItem = useFactoryAttentionReceiptAction(factoryId, 'read');
+  const archiveItem = useFactoryAttentionReceiptAction(factoryId, 'archive');
+  const restoreItem = useFactoryAttentionReceiptAction(factoryId, 'restore');
+
+  return (item: FactoryAttentionItem) => ({
+    item,
+    retrying:
+      item.kind === 'automation-failed' && retryDecision.isPending && retryDecision.variables === item.decisionId,
+    updatingReceipt:
+      (readItem.isPending && isSameItem(readItem.variables, item)) ||
+      (archiveItem.isPending && isSameItem(archiveItem.variables, item)) ||
+      (restoreItem.isPending && isSameItem(restoreItem.variables, item)),
+    onRetry:
+      item.kind === 'automation-failed' && item.canRetry
+        ? () => retryDecision.mutate(item.decisionId, { onError: notifyFailure('Unable to retry automation') })
+        : undefined,
+    onRead: () => readItem.mutate(item, { onError: notifyFailure('Unable to mark attention item as read') }),
+    onArchive: () => archiveItem.mutate(item, { onError: notifyFailure('Unable to archive attention item') }),
+    onRestore: () => restoreItem.mutate(item, { onError: notifyFailure('Unable to restore attention item') }),
+  });
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/services/attention.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/attention.ts
@@ -6,24 +6,40 @@ export type FactoryAttentionView = 'open' | 'unread' | 'archived';
 export type FactoryAttentionReceiptAction = 'read' | 'archive' | 'restore';
 export type FactoryAttentionTarget =
   | { kind: 'thread'; sessionId: string; threadId: string }
-  | { kind: 'work-item'; workItemId: string; board: 'work' | 'review' }
+  | { kind: 'work-item'; workItemId: string; board: 'work' | 'review'; commentId?: string }
   | { kind: 'rules' };
 
-export interface FactoryAttentionItem {
+interface FactoryAttentionItemBase {
   key: string;
-  kind: 'automation-failed';
-  decisionId: string;
   occurrence: number;
   workItemId: string | null;
   title: string;
   detail: string;
-  decisionType: string;
-  failureCode: FactoryDispatchFailureCode | null;
-  canRetry: boolean;
   occurredAt: string;
   read: boolean;
   archived: boolean;
   target: FactoryAttentionTarget;
+}
+
+export interface FactoryAutomationFailedAttentionItem extends FactoryAttentionItemBase {
+  kind: 'automation-failed';
+  decisionId: string;
+  decisionType: string;
+  failureCode: FactoryDispatchFailureCode | null;
+  canRetry: boolean;
+}
+
+export interface FactoryMentionAttentionItem extends FactoryAttentionItemBase {
+  kind: 'mention';
+  commentId: string;
+  authorId: string;
+  authorName?: string;
+}
+
+export type FactoryAttentionItem = FactoryAutomationFailedAttentionItem | FactoryMentionAttentionItem;
+
+export function attentionItemSourceId(item: FactoryAttentionItem): string {
+  return item.kind === 'mention' ? item.commentId : item.decisionId;
 }
 
 export interface FactoryAttentionResponse {
@@ -44,7 +60,8 @@ export function factoryAttentionTargetPath(factoryId: string, target: FactoryAtt
     return `/factories/${factoryId}/workspaces/${encodeURIComponent(target.sessionId)}/threads/${encodeURIComponent(target.threadId)}`;
   }
   if (target.kind === 'work-item') {
-    return `/factories/${factoryId}/${target.board}?item=${encodeURIComponent(target.workItemId)}`;
+    const comment = target.commentId ? `&comment=${encodeURIComponent(target.commentId)}` : '';
+    return `/factories/${factoryId}/${target.board}?item=${encodeURIComponent(target.workItemId)}${comment}`;
   }
   return `/factories/${factoryId}/rules`;
 }
@@ -73,11 +90,11 @@ export function fetchFactoryAttention(
 export function updateFactoryAttentionReceipt(
   baseUrl: string,
   factoryProjectId: string,
-  item: Pick<FactoryAttentionItem, 'decisionId' | 'occurrence'>,
+  item: FactoryAttentionItem,
   action: FactoryAttentionReceiptAction,
 ): Promise<{ receipt: { key: string; state: 'read' | 'archived'; readAt: string; archivedAt: string | null } }> {
   return requestJson(
-    `${baseUrl}/web/factory/projects/${encodeURIComponent(factoryProjectId)}/attention/automation-failed/${encodeURIComponent(item.decisionId)}/${item.occurrence}/${action}`,
+    `${baseUrl}/web/factory/projects/${encodeURIComponent(factoryProjectId)}/attention/${item.kind}/${encodeURIComponent(attentionItemSourceId(item))}/${item.occurrence}/${action}`,
     { method: 'POST' },
   );
 }

--- a/mastracode/factory-ui/src/ui/pages/AttentionPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/AttentionPage.tsx
@@ -7,13 +7,9 @@ import { Archive, Inbox, Mail } from 'lucide-react';
 import { useDeferredValue, useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 
-import {
-  useFactoryAttentionHistory,
-  useFactoryAttentionReceiptAction,
-  useMarkAllFactoryAttentionRead,
-} from '../../hooks/useFactoryAttention';
-import { useFactoryDecisionAction } from '../../hooks/useFactoryDecisions';
+import { useFactoryAttentionHistory, useMarkAllFactoryAttentionRead } from '../../hooks/useFactoryAttention';
 import { AttentionItemRow } from '../domains/factory/components/AttentionItemRow';
+import { useAttentionItemActions } from '../domains/factory/components/useAttentionItemActions';
 import { DocumentFactoryPageShell } from '../domains/factory/components/FactoryPageShell';
 import type { FactoryAttentionItem, FactoryAttentionView } from '../domains/factory/services/attention';
 import { SkeletonRows } from '../ui/SkeletonRows';
@@ -28,14 +24,6 @@ function attentionView(value: string | null): FactoryAttentionView {
   return value === 'unread' || value === 'archived' ? value : 'open';
 }
 
-function sameItem(a: Pick<FactoryAttentionItem, 'decisionId' | 'occurrence'> | undefined, b: FactoryAttentionItem) {
-  return a?.decisionId === b.decisionId && a.occurrence === b.occurrence;
-}
-
-function showReceiptError(error: unknown, fallback: string): void {
-  toast.error(error instanceof Error ? error.message : fallback);
-}
-
 export function AttentionPage() {
   return <DocumentFactoryPageShell>{factory => <AttentionContent factoryId={factory.id} />}</DocumentFactoryPageShell>;
 }
@@ -46,10 +34,7 @@ export function AttentionContent({ factoryId }: { factoryId: string }) {
   const view = attentionView(searchParams.get('view'));
   const normalizedSearch = useDeferredValue(search.trim());
   const attention = useFactoryAttentionHistory(factoryId, view, normalizedSearch);
-  const retryDecision = useFactoryDecisionAction(factoryId, 'retry');
-  const readItem = useFactoryAttentionReceiptAction(factoryId, 'read');
-  const archiveItem = useFactoryAttentionReceiptAction(factoryId, 'archive');
-  const restoreItem = useFactoryAttentionReceiptAction(factoryId, 'restore');
+  const rowProps = useAttentionItemActions(factoryId);
   const markAllRead = useMarkAllFactoryAttentionRead(factoryId);
   const pages = attention.data?.pages ?? [];
   const summary = pages[0];
@@ -63,7 +48,7 @@ export function AttentionContent({ factoryId }: { factoryId: string }) {
           <h1 id="attention-heading" className="text-ui-lg text-icon6 m-0 font-semibold">
             Needs attention
           </h1>
-          <p className="text-ui-sm text-icon3 mt-1 mb-0">Factory work that needs a decision or recovery.</p>
+          <p className="text-ui-sm text-icon3 mt-1 mb-0">Mentions, failures, and work waiting on you.</p>
         </div>
         {!normalizedSearch && view !== 'archived' && summary && summary.unreadCount > 0 ? (
           <Button
@@ -145,40 +130,7 @@ export function AttentionContent({ factoryId }: { factoryId: string }) {
           ) : null}
           {items.map(item => (
             <li key={item.key}>
-              <AttentionItemRow
-                factoryId={factoryId}
-                item={item}
-                retrying={retryDecision.isPending && retryDecision.variables === item.decisionId}
-                updatingReceipt={
-                  (readItem.isPending && sameItem(readItem.variables, item)) ||
-                  (archiveItem.isPending && sameItem(archiveItem.variables, item)) ||
-                  (restoreItem.isPending && sameItem(restoreItem.variables, item))
-                }
-                onRetry={
-                  item.canRetry
-                    ? () =>
-                        retryDecision.mutate(item.decisionId, {
-                          onError: error =>
-                            toast.error(error instanceof Error ? error.message : 'Unable to retry automation'),
-                        })
-                    : undefined
-                }
-                onRead={() =>
-                  readItem.mutate(item, {
-                    onError: error => showReceiptError(error, 'Unable to mark attention item as read'),
-                  })
-                }
-                onArchive={() =>
-                  archiveItem.mutate(item, {
-                    onError: error => showReceiptError(error, 'Unable to archive attention item'),
-                  })
-                }
-                onRestore={() =>
-                  restoreItem.mutate(item, {
-                    onError: error => showReceiptError(error, 'Unable to restore attention item'),
-                  })
-                }
-              />
+              <AttentionItemRow factoryId={factoryId} {...rowProps(item)} />
             </li>
           ))}
         </ul>

--- a/mastracode/factory-ui/src/ui/pages/__tests__/AttentionPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/AttentionPage.msw.test.tsx
@@ -6,12 +6,16 @@ import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../../e2e/ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../../e2e/ui/render';
-import type { FactoryAttentionItem, FactoryAttentionView } from '../../domains/factory/services/attention';
+import type {
+  FactoryAutomationFailedAttentionItem,
+  FactoryAttentionView,
+  FactoryMentionAttentionItem,
+} from '../../domains/factory/services/attention';
 import { AttentionContent } from '../AttentionPage';
 
 const FACTORY_ID = 'factory-1';
 
-function item(id: string, title: string, read: boolean): FactoryAttentionItem {
+function item(id: string, title: string, read: boolean): FactoryAutomationFailedAttentionItem {
   return {
     key: `factory:${FACTORY_ID}:attention:automation-failed:${id}:1`,
     kind: 'automation-failed',
@@ -32,6 +36,24 @@ function item(id: string, title: string, read: boolean): FactoryAttentionItem {
 
 function attentionView(value: string | null): FactoryAttentionView {
   return value === 'unread' || value === 'archived' ? value : 'open';
+}
+
+function mentionItem(commentId: string, title: string): FactoryMentionAttentionItem {
+  return {
+    key: `factory:${FACTORY_ID}:attention:mention:${commentId}:0`,
+    kind: 'mention',
+    commentId,
+    authorId: 'user-2',
+    authorName: 'Ada',
+    occurrence: 0,
+    workItemId: 'item-9',
+    title,
+    detail: 'Can you look at this?',
+    occurredAt: '2026-08-21T10:00:00.000Z',
+    read: false,
+    archived: false,
+    target: { kind: 'work-item', workItemId: 'item-9', board: 'work', commentId },
+  };
 }
 
 describe('AttentionPage', () => {
@@ -133,6 +155,56 @@ describe('AttentionPage', () => {
     );
     expect(screen.queryByRole('button', { name: 'Mark all open as read' })).not.toBeInTheDocument();
   });
+  it('renders mentions beside failures, deep-links to the comment, and pages with the cursor', async () => {
+    const KIND_CURSOR = 'mention=2026-08-21T10:00:00.000Z_comment-1;automation-failed=2026-08-20T10:00:00.000Z_1';
+    const requestedCursors: (string | null)[] = [];
+    const receiptCalls: string[] = [];
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/attention`, ({ request }) => {
+        const before = new URL(request.url).searchParams.get('before');
+        requestedCursors.push(before);
+        const firstPage = [mentionItem('comment-1', 'Fix login bug'), item('decision-1', 'Fix the loader', false)];
+        const secondPage = [item('decision-2', 'Repair auth', false)];
+        return HttpResponse.json({
+          items: before === KIND_CURSOR ? secondPage : firstPage,
+          openCount: 3,
+          approvalCount: 0,
+          badgeCount: 3,
+          unreadCount: 3,
+          hasMore: before !== KIND_CURSOR,
+          ...(before !== KIND_CURSOR ? { nextCursor: KIND_CURSOR } : {}),
+        });
+      }),
+      http.post(
+        `${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/attention/:kind/:sourceId/:occurrence/:action`,
+        ({ params }) => {
+          receiptCalls.push(`${params.kind}/${params.sourceId}/${params.occurrence}/${params.action}`);
+          return HttpResponse.json({ receipt: { state: 'archived' } });
+        },
+      ),
+    );
+    const user = userEvent.setup();
+    const { client } = renderWithProviders(
+      <MemoryRouter initialEntries={[`/factories/${FACTORY_ID}/attention`]}>
+        <AttentionContent factoryId={FACTORY_ID} />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Ada mentioned you/)).toBeVisible();
+    expect(screen.getByRole('link', { name: /View card for Fix login bug/ })).toHaveAttribute(
+      'href',
+      `/factories/${FACTORY_ID}/work?item=item-9&comment=comment-1`,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Archive Fix login bug' }));
+    await waitForMutationsIdle(client);
+    expect(receiptCalls).toEqual(['mention/comment-1/0/archive']);
+
+    await user.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(await screen.findByText('Repair auth')).toBeVisible();
+    expect(requestedCursors.filter(cursor => cursor !== null)).toEqual([KIND_CURSOR]);
+  });
+
   it('searches the server before pagination', async () => {
     const allItems = Array.from({ length: 26 }, (_, index) =>
       item(`decision-${index}`, index === 25 ? 'Needle on page two' : `Routine failure ${index}`, false),


### PR DESCRIPTION
TLDR: the attention inbox lists mentions next to automation failures, and a mention row
opens the card and scrolls to the comment that named you.

---

Stacked on #22464, which makes attention per-kind on the server. That is a wire break, so
this should land with it: the list cursor becomes a per-kind map and every row carries its
kind.

### What changes

| situation | before | after |
| --- | --- | --- |
| you are @mentioned | nothing anywhere | a row in the sidebar popover and the attention page |
| you open a mention row | — | the board card opens and scrolls to the comment (`?item&comment`) |
| you read, archive or restore a row | failures only | the same on both kinds |

### Judgment calls

The sidebar popover and the attention page were wiring the same row with two copies of the
same props block — the same pending comparisons, the same error toasts, the same four
mutations. That is one hook now (`useAttentionItemActions`), which is why this PR deletes
more component code than it adds.

The badge still counts every open row, failures and mentions together. Splitting the inbox
into "needs you" and "activity you follow" is the next PR in this area, not this one.

```
source        +99  -124    ← net -25
tests        +117     0
changeset      +7     0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The attention inbox now shows both automation failures and mentions. When a user selects a mention, Factory opens the related card and jumps to the comment. Users can read, archive, and restore both types of items.

## Changes

- Added support for `mention` attention items across the sidebar and attention page.
- Added comment deep links through the `comment` query parameter.
- Updated cursors and receipt actions to support each attention item kind.
- Added shared `useAttentionItemActions` logic for retry, read, archive, and restore actions.
- Kept the badge count combined for all open attention items.
- Added tests for mixed failures and mentions, including pagination and receipts.
- Added a patch changeset for `@mastra/factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->