### PR TITLE
fix: clarify licensing and include core package license

### DIFF
--- a/.changeset/tired-bugs-agree.md
+++ b/.changeset/tired-bugs-agree.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Include LICENSE.md file in the published package.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,10 +1,12 @@
 Portions of this software are licensed as follows:
 
-- All content that resides under any directory named "ee/" within this
+- All content that resides under any directory named `ee/` within this
   repository, including but not limited to:
-  - `packages/core/src/auth/ee/`
-  - `packages/server/src/server/auth/ee/`
-    is licensed under the license defined in `ee/LICENSE`.
+  - `@mastra/core/auth/ee`
+  - `@mastra/core/agent-builder/ee`
+  - `@mastra/editor/ee`
+
+  is licensed under the license defined in [`ee/LICENSE`](https://github.com/mastra-ai/mastra/blob/main/ee/LICENSE).
 
 - All third-party components incorporated into the Mastra Software are
   licensed under the original license provided by the owner of the

--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ Purpose-built for TypeScript and designed around established AI patterns, Mastra
 
 Some highlights include:
 
-- [**Model routing**](https://mastra.ai/models) - Connect to 40+ providers through one standard interface. Use models from OpenAI, Anthropic, Gemini, and more.
+- [**Model routing**](https://mastra.ai/models): Connect to 40+ providers through one standard interface. Use models from OpenAI, Anthropic, Gemini, and more.
 
-- [**Agents**](https://mastra.ai/docs/agents/overview) - Build autonomous agents that use LLMs and tools to solve open-ended tasks. Agents reason about goals, decide which tools to use, and iterate internally until the model emits a final answer or an optional stopping condition is met.
+- [**Agents**](https://mastra.ai/docs/agents/overview): Build autonomous agents that use LLMs and tools to solve open-ended tasks. Agents reason about goals, decide which tools to use, and iterate internally until the model emits a final answer or an optional stopping condition is met.
 
-- [**Workflows**](https://mastra.ai/docs/workflows/overview) - When you need explicit control over execution, use Mastra's graph-based workflow engine to orchestrate complex multi-step processes. Mastra workflows use an intuitive syntax for control flow (`.then()`, `.branch()`, `.parallel()`).
+- [**Workflows**](https://mastra.ai/docs/workflows/overview): When you need explicit control over execution, use Mastra's graph-based workflow engine to orchestrate complex multi-step processes. Mastra workflows use an intuitive syntax for control flow (`.then()`, `.branch()`, `.parallel()`).
 
-- [**Human-in-the-loop**](https://mastra.ai/docs/workflows/suspend-and-resume) - Suspend an agent or workflow and await user input or approval before resuming. Mastra uses [storage](https://mastra.ai/docs/server-db/storage) to remember execution state, so you can pause indefinitely and resume where you left off.
+- [**Human-in-the-loop**](https://mastra.ai/docs/workflows/suspend-and-resume): Suspend an agent or workflow and await user input or approval before resuming. Mastra uses [storage](https://mastra.ai/docs/server-db/storage) to remember execution state, so you can pause indefinitely and resume where you left off.
 
-- **Context management** - Give your agents the right context at the right time. Provide [conversation history](https://mastra.ai/docs/memory/conversation-history), [retrieve](https://mastra.ai/docs/rag/overview) data from your sources (APIs, databases, files), and add human-like memory with [Observational Memory](https://mastra.ai/docs/memory/observational-memory) so your agents behave coherently.
+- **Context management**: Give your agents the right context at the right time. Provide [conversation history](https://mastra.ai/docs/memory/conversation-history), [retrieve](https://mastra.ai/docs/rag/overview) data from your sources (APIs, databases, files), and add human-like memory with [Observational Memory](https://mastra.ai/docs/memory/observational-memory) so your agents behave coherently.
 
-- **Integrations** - Bundle agents and workflows into existing React, Next.js, or Node.js apps, or ship them as standalone endpoints. When building UIs, integrate with agentic libraries like Vercel's AI SDK UI and CopilotKit to bring your AI assistant to life on the web.
+- **Integrations**: Bundle agents and workflows into existing React, Next.js, or Node.js apps, or ship them as standalone endpoints. When building UIs, integrate with agentic libraries like Vercel's AI SDK UI and CopilotKit to bring your AI assistant to life on the web.
 
-- [**MCP servers**](https://mastra.ai/docs/tools-mcp/mcp-overview) - Author Model Context Protocol servers, exposing agents, tools, and other structured resources via the MCP interface. These can then be accessed by any system or agent that supports the protocol.
+- [**MCP servers**](https://mastra.ai/docs/tools-mcp/mcp-overview): Author Model Context Protocol servers, exposing agents, tools, and other structured resources via the MCP interface. These can then be accessed by any system or agent that supports the protocol.
 
-- **Production essentials** - Shipping reliable agents takes ongoing insight, evaluation, and iteration. With built-in [evals](https://mastra.ai/docs/evals/overview) and [observability](https://mastra.ai/docs/observability/overview), Mastra gives you the tools to observe, measure, and refine continuously.
+- **Production essentials**: Shipping reliable agents takes ongoing insight, evaluation, and iteration. With built-in [evals](https://mastra.ai/docs/evals/overview) and [observability](https://mastra.ai/docs/observability/overview), Mastra gives you the tools to observe, measure, and refine continuously.
 
 ## Get started
 
@@ -53,18 +53,18 @@ If you're new to AI agents, check out our [templates](https://mastra.ai/docs/get
 ```md
 Create a new Mastra project. Mastra is a framework for AI applications and agents on a modern TypeScript stack. Before running the command, ask these questions one at a time and wait for each answer unless it was already provided:
 
-Project name? (default: "my-mastra-app")
-Provider? (required; options: "openai", "anthropic", "google", "xai")
+1. Project name? (default: "my-mastra-app")
+2. Provider? (required; options: "openai", "anthropic", "google", "xai")
 
 If the provider isn't supported, ask again and list the supported values.
 
-Run: npm create mastra@latest <project-name> -- --llm <provider>
+Run: `npm create mastra@latest <project-name> -- --llm <provider>`
 
 The command creates a default Mastra project, installs Mastra skills for detected coding assistants, and initializes Git when appropriate.
 
-After creation, enter the project directory and start the dev server: npx bgproc start -n <project-name> -w -- npm run dev
+After creation, enter the project directory and start the dev server: `npx bgproc start -n <project-name> -w -- npm run dev`
 
-Open Mastra Studio at http://localhost:4111. Studio is the interface for building, testing, and managing agents, workflows, and tools.
+Open Mastra Studio at `http://localhost:4111`. Studio is the interface for building, testing, and managing agents, workflows, and tools.
 
 Also mention that the Mastra model router provides access to thousands of models: https://mastra.ai/models
 ```
@@ -97,8 +97,8 @@ It's also super helpful if you leave the project a star here, at the [top of the
 
 This repository uses a dual-license model:
 
-- **Apache License 2.0** — The core framework and the vast majority of this codebase is open source under Apache-2.0.
-- **Mastra Enterprise License** — Code in any directory named `ee/` (e.g., `packages/core/src/auth/ee/`) is source-available under the Mastra Enterprise License. These features require a valid enterprise license for production use but can be freely used for development and testing.
+- **Apache License 2.0**: The core framework and the vast majority of this codebase is open source under Apache-2.0.
+- **Mastra Enterprise License**: Code in any directory named `ee/` (e.g., `packages/core/src/auth/ee/`) is source-available under the Mastra Enterprise License. These features require a valid enterprise license for production use but can be freely used for development and testing.
 
 See [LICENSE.md](./LICENSE.md) for the full license mapping and [ee/LICENSE](./ee/LICENSE) for the enterprise license terms.
 

--- a/docs/src/content/en/docs/license.mdx
+++ b/docs/src/content/en/docs/license.mdx
@@ -1,69 +1,46 @@
 ---
-title: "License | Community"
-description: "Mastra License"
+title: "License"
+description: "Mastra uses a dual-license model with Apache License 2.0 and Mastra Enterprise License"
 ---
 
 # License
 
-Mastra is licensed under the Apache License 2.0, a permissive open-source license that provides users with broad rights to use, modify, and distribute the software.
+Mastra uses a dual-license model with the Apache License 2.0 for the majority of the codebase and the Mastra Enterprise License for enterprise-specific features.
 
-## What's Apache License 2.0?
+- All content that resides under any directory called `ee/` within Mastra's repository, including but not limited to:
 
-The Apache License 2.0 is a permissive open-source license that grants users extensive rights to use, modify, and distribute the software. It allows:
+  - `@mastra/core/auth/ee`
+  - `@mastra/core/agent-builder/ee`
+  - `@mastra/editor/ee`
 
-- Free use for any purpose, including commercial use
-- Viewing, modifying, and redistributing the source code
-- Creating and distributing derivative works
-- Commercial use without restrictions
-- Patent protection from contributors
+  is licensed under the license defined in [`ee/LICENSE`](https://github.com/mastra-ai/mastra/blob/main/ee/LICENSE).
 
-The Apache License 2.0 is one of the most permissive and business-friendly open-source licenses available.
+- All third-party components incorporated into the Mastra Software are licensed under the original license provided by the owner of the applicable component.
 
-## Why We Chose Apache License 2.0
+- Content outside of the above-mentioned directories or restrictions is available under the "Apache License 2.0".
 
-We selected the Apache License 2.0 for several important reasons:
+## Apache License 2.0
 
-1. **True Open Source**: It's a recognized open-source license that aligns with open-source principles and community expectations.
+```md
+Copyright (c) 2025 Kepler Software, Inc.
 
-1. **Business Friendly**: It allows for unrestricted commercial use and distribution, making it ideal for businesses of all sizes.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-1. **Patent Protection**: It includes explicit patent protection for users, providing additional legal security.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-1. **Community Focus**: It encourages community contributions and collaboration without restrictions.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
 
-1. **Widely Adopted**: It's one of the most popular and well-understood open-source licenses in the industry.
+## Mastra Enterprise License
 
-## Building Your Business with Mastra
+Code in any directory called `ee/` (e.g., `@mastra/core/auth/ee`) is source-available under the Mastra Enterprise License. These features require a valid enterprise license for production use but can be freely used for development and testing. [Contact sales](https://mastra.ai/contact) for more information.
 
-The Apache License 2.0 provides maximum flexibility for building businesses with Mastra:
+## Questions?
 
-### Allowed Business Models
-
-- **Building Applications**: Create and sell applications built with Mastra
-- **Offering Consulting Services**: Provide expertise, implementation, and customization services
-- **Developing Custom Solutions**: Build bespoke AI solutions for clients using Mastra
-- **Creating Add-ons and Extensions**: Develop and sell complementary tools that extend Mastra's functionality
-- **Training and Education**: Offer courses and educational materials about using Mastra effectively
-- **Hosted Services**: Offer Mastra as a hosted or managed service
-- **SaaS Platforms**: Build SaaS platforms powered by Mastra
-
-### Examples of Compliant Usage
-
-- A company builds an AI-powered customer service application using Mastra and sells it to clients
-- A consulting firm offers implementation and customization services for Mastra
-- A developer creates specialized agents and tools with Mastra and licenses them to other businesses
-- A startup builds a vertical-specific solution (e.g., healthcare AI assistant) powered by Mastra
-- A company offers Mastra as a hosted service to their customers
-- A SaaS platform integrates Mastra as their AI backend
-
-### Compliance Requirements
-
-The Apache License 2.0 has minimal requirements:
-
-- **Attribution**: Maintain copyright notices and license information (including NOTICE file)
-- **State Changes**: If you modify the software, state that you have made changes
-- **Include License**: Include a copy of the Apache License 2.0 when distributing
-
-## Questions About Licensing?
-
-If you have specific questions about how the Apache License 2.0 applies to your use case, please [contact us](https://discord.gg/BTYqqHKUrf) on Discord for clarification. We're committed to supporting all legitimate use cases while maintaining the open-source nature of the project.
+For questions about how Mastra's dual-license approach applies to your use case, [contact Mastra](https://mastra.ai/contact).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@ This is the `@mastra/core` package, which includes the main functionality of Mas
 
 ## Installation
 
-`@mastra/core` is an essential building block for a Mastra application and you most likely don't want to use it as a standalone package. Therefore we recommend following the [installation guide](https://mastra.ai/docs/getting-started/installation) to get started with Mastra.
+`@mastra/core` is an essential building block for a Mastra application and you most likely don't want to use it as a standalone package. Therefore we recommend following the [installation guide](https://mastra.ai/docs) to get started with Mastra.
 
 You can install the package like so:
 
@@ -18,45 +18,46 @@ npm install @mastra/core
 
 ## Core Components
 
-- **Mastra** (`/mastra`) - Central orchestration class that initializes and coordinates all Mastra components. Provides dependency injection for agents, workflows, tools,
-  memory, storage, and other services through a unified configuration interface. [Learn more about Mastra](https://mastra.ai/docs/getting-started/installation)
+- **Mastra** (`/mastra`): Central orchestration class that initializes and coordinates all Mastra components. Provides dependency injection for agents, workflows, tools,
+  memory, storage, and other services through a unified configuration interface. [Learn more about Mastra](https://mastra.ai/docs)
 
-- **Agents** (`/agent`) - Autonomous AI entities that understand instructions, use tools, and complete tasks. Encapsulate LLM interactions with conversation history, tool
+- **Agents** (`/agent`): Autonomous AI entities that understand instructions, use tools, and complete tasks. Encapsulate LLM interactions with conversation history, tool
   execution, memory integration, and behavioral guidelines. [Learn more about Agents](https://mastra.ai/docs/agents/overview)
 
-- **Workflows** (`/workflows`) - Graph-based execution engine for chaining, branching, and parallelizing LLM calls. Orchestrates complex AI tasks with state management,
+- **Workflows** (`/workflows`): Graph-based execution engine for chaining, branching, and parallelizing LLM calls. Orchestrates complex AI tasks with state management,
   error recovery, and conditional logic. [Learn more about Workflows](https://mastra.ai/docs/workflows/overview)
 
-- **Tools** (`/tools`) - Functions that agents can invoke to interact with external systems. Each tool has a schema and description enabling AI to understand and use them
-  effectively. Supports custom tools, toolsets, and runtime context. [Learn more about Tools](https://mastra.ai/docs/tools-mcp/overview)
+- **Tools** (`/tools`): Functions that agents can invoke to interact with external systems. Each tool has a schema and description enabling AI to understand and use them
+  effectively. Supports custom tools, toolsets, and runtime context. [Learn more about Tools](https://mastra.ai/docs/agents/tools)
 
-- **Memory** (`/memory`) - Thread-based conversation persistence with semantic recall and working memory capabilities. Stores conversation history, retrieves contextually
+- **Memory** (`/memory`): Thread-based conversation persistence with semantic recall and working memory capabilities. Stores conversation history, retrieves contextually
   relevant information, and maintains agent state across interactions. [Learn more about Memory](https://mastra.ai/docs/memory/overview)
 
-- **MCP** (`/mcp`) - Model Context Protocol integration enabling external tool sources. Supports SSE, HTTP, and Hono-based MCP servers with automatic tool conversion and
-  registration. [Learn more about MCP](https://mastra.ai/docs/tools-mcp/mcp-overview)
+- **MCP** (`/mcp`): Model Context Protocol integration enabling external tool sources. Supports SSE, HTTP, and Hono-based MCP servers with automatic tool conversion and
+  registration. [Learn more about MCP](https://mastra.ai/docs/connections/mcp)
 
-- **Observability** - Type-safe observability system tracking AI operations through spans. Provides flexible tracing with event-driven exports, configurable sampling, and pluggable processors and exporters for real-time monitoring. Full observability features are available in the `@mastra/observability` package. [Learn more about Observability](https://mastra.ai/docs/observability/tracing/overview)
+- **Observability**: Type-safe observability system tracking AI operations through spans. Provides flexible tracing with event-driven exports, configurable sampling, and pluggable processors and exporters for real-time monitoring. Full observability features are available in the `@mastra/observability` package. [Learn more about Observability](https://mastra.ai/docs/observability/tracing/overview)
 
-- **Storage** (`/storage`) - Pluggable storage layer with standardized interfaces for multiple backends. Supports PostgreSQL, LibSQL, MongoDB, and other databases for
-  persisting agent data, memory, and workflow state. [Learn more about Storage](https://mastra.ai/docs/server-db/storage)
+- **Storage** (`/storage`): Pluggable storage layer with standardized interfaces for multiple backends. Supports PostgreSQL, LibSQL, MongoDB, and other databases for
+  persisting agent data, memory, and workflow state. [Learn more about Storage](https://mastra.ai/docs/storage)
 
-- **Vector** (`/vector`) - Vector operations and embedding management for semantic search. Provides unified interface for vector stores with filtering capabilities and
-  similarity search. [Learn more about Vector](https://mastra.ai/docs/rag/vector-databases)
+- **Vector** (`/vector`): Vector operations and embedding management for semantic search. Provides unified interface for vector stores with filtering capabilities and
+  similarity search. [Learn more about Vector](https://mastra.ai/reference/rag/vector-databases)
 
-- **Server** (`/server`) - HTTP server implementation built on Hono with OpenAPI support. Provides custom API routes, middleware, authentication, and runtime context for
-  deploying Mastra as a standalone service. [Learn more about Server](https://mastra.ai/docs/server-db/production-server)
+- **Server** (`/server`): HTTP server implementation built on Hono with OpenAPI support. Provides custom API routes, middleware, authentication, and runtime context for
+  deploying Mastra as a standalone service. [Learn more about Server](https://mastra.ai/docs/server/overview)
 
-- **Voice** (`/voice`) - Voice interaction capabilities with text-to-speech and speech-to-text integration. Supports multiple voice providers and real-time voice
-  communication for agents. [Learn more about Voice](https://mastra.ai/docs/voice/overview)
+- **Voice** (`/voice`): Voice interaction capabilities with text-to-speech and speech-to-text integration. Supports multiple voice providers and real-time voice
+  communication for agents. [Learn more about Voice](https://mastra.ai/reference/voice/overview)
 
-- **Browser** (`/browser`) - Base classes and utilities for browser automation. Provides the `MastraBrowser` abstract class, thread management, and screencast streaming
-  for building browser providers. Use with `@mastra/agent-browser` or `@mastra/stagehand` for complete browser automation. [Learn more about Browser](https://mastra.ai/docs/browser/overview)
+- **Browser** (`/browser`): Base classes and utilities for browser automation. Provides the `MastraBrowser` abstract class, thread management, and screencast streaming
+  for building browser providers. Use with `@mastra/agent-browser` or `@mastra/stagehand` for complete browser automation. [Learn more about Browser](https://mastra.ai/docs/browser)
 
-## Additional Resources
+## License
 
-- [Getting Started Guide](https://mastra.ai/docs/getting-started/installation)
-- [API Reference](https://mastra.ai/reference)
-- [Examples](https://mastra.ai/docs/examples)
-- [Deployment Guide](https://mastra.ai/docs/deployment/overview)
-- [Community Discord](https://discord.gg/mastra-ai)
+This package uses a dual-license model:
+
+- **Apache License 2.0**: The vast majority of this codebase is open source under Apache-2.0.
+- **Mastra Enterprise License**: Code in any directory named `ee/` (e.g., `@mastra/core/auth/ee`) is source-available under the Mastra Enterprise License. These features require a valid enterprise license for production use but can be freely used for development and testing.
+
+See [LICENSE.md](https://github.com/mastra-ai/mastra/blob/main/LICENSE.md) for the full license mapping and [ee/LICENSE](https://github.com/mastra-ai/mastra/blob/main/ee/LICENSE) for the enterprise license terms.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
   "files": [
     "dist",
     "CHANGELOG.md",
+    "LICENSE.md",
     "./**/*.d.ts"
   ],
   "exports": {
@@ -871,7 +872,8 @@
     "lint:fix": "oxlint --fix . && eslint --fix .",
     "build:lib": "tsdown --silent --config tsdown.config.ts --no-dts",
     "build:patch-commonjs": "node ../../scripts/commonjs-tsc-fixer.js",
-    "prepack": "tsx ../../scripts/generate-package-docs.ts",
+    "prepack": "tsx ../../scripts/generate-package-docs.ts && node -e \"require('node:fs').copyFileSync('../../LICENSE.md', 'LICENSE.md')\"",
+    "postpack": "node -e \"require('node:fs').rmSync('LICENSE.md', { force: true })\"",
     "build:watch": "pnpm build:lib --watch",
     "generate:providers": "tsx scripts/generate-providers.ts",
     "generate:model-router": "tsx scripts/generate-providers.ts && tsx scripts/generate-model-docs.ts && cd ../.. && pnpm oxfmt:changed",


### PR DESCRIPTION
## Description

Clarifies Mastra's dual-license boundaries in the repository license, root README, public license documentation, and `@mastra/core` README.

The published `@mastra/core` package now includes a root-level `LICENSE.md`. The package copies the current repository license during packing and removes the generated copy afterward, keeping the published license synchronized with the repository source.

Verified with a real `pnpm pack` run. The tarball contained `package/LICENSE.md`, its contents were byte-identical to the repository-root license, and postpack cleanup removed the generated package-local file. The updated MDX also passes formatting, Remark, Vale, and frontmatter validation.

## Related issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/22113

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR explains which Mastra code uses the Apache-2.0 license and which code uses the Enterprise license. It also ensures that `@mastra/core` packages the applicable license document.

## Changes

- Clarified the Apache-2.0 and Enterprise Edition boundaries in:
  - `LICENSE.md`
  - Root `README.md`
  - Public license documentation
  - `packages/core/README.md`
- Updated the license scope to cover content under `ee/` directories.
- Added license guidance for third-party code and self-hosted applications.
- Added a `License` section to `@mastra/core` documentation.
- Updated `@mastra/core` packaging:
  - Copies the repository `LICENSE.md` during `prepack`.
  - Includes `LICENSE.md` in the published package.
  - Removes the temporary file during `postpack`.
- Added a changeset for the package license update.
- Verified that `pnpm pack` creates a byte-identical `package/LICENSE.md` and that cleanup removes the generated file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->