### PR TITLE
Search a trace and see where the matches are in Studio

### DIFF
--- a/.changeset/lucky-otters-repeat.md
+++ b/.changeset/lucky-otters-repeat.md
@@ -1,0 +1,8 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Load the full trace when a trace is opened in Studio. The trace list keeps using the lightweight
+projection, but the trace detail panel, the logs page featured trace and the topics trace panel now
+read `getTrace`, so span input, output, attributes, tags and links are available to the timeline,
+the span panel and trace search instead of being silently missing.

--- a/.changeset/shaggy-icons-count.md
+++ b/.changeset/shaggy-icons-count.md
@@ -1,0 +1,9 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Search terms typed into the trace search field are now highlighted where the matches actually are: on the span names in the timeline tree, and throughout the span side panel, so a match is easy to spot inside a large payload.
+
+Regions opt in to highlighting rather than opting out, so the chrome around a trace — the panel header, the trace metadata, the tab labels, the span type legend — is never painted, and nothing added later has to remember to exclude itself. Highlighting starts from the second character: a single letter matches almost everywhere and paints noise rather than results.
+
+It uses the CSS Custom Highlight API, so no wrapper element is injected: the text stays exactly as rendered, and selection and copy/paste are unaffected. Browsers without the API simply show no highlight.

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -4,11 +4,13 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { http } from 'msw';
 import { setupServer } from 'msw/node';
 import type { ReactNode } from 'react';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TraceDataPanelView } from '../trace-data-panel-view';
 import type { TraceDataPanelViewProps } from '../trace-data-panel-view';
 import { deepTraceFixture, nestedSpanFixture, rootSpanFixture } from './fixtures/trace-data-panel-view';
+import { installHighlightApi } from '@/test/highlight-api';
+import type { HighlightApiHarness } from '@/test/highlight-api';
 
 const baseProps: TraceDataPanelViewProps = {
   traceId: 'trace-1',
@@ -42,6 +44,100 @@ describe('TraceDataPanelView — span panel slot', () => {
   it('renders no split when the slot is omitted', () => {
     render(<TraceDataPanelView {...baseProps} />);
     expect(screen.queryByTestId('span-detail')).toBeNull();
+  });
+});
+
+describe('TraceDataPanelView — search highlighting', () => {
+  let harness: HighlightApiHarness;
+
+  beforeEach(() => {
+    harness = installHighlightApi();
+  });
+
+  afterEach(() => {
+    // Unmount first: the hook clears its registry entry on teardown.
+    cleanup();
+    harness.restore();
+  });
+
+  const renderWithSpanPanel = () =>
+    render(
+      <TraceDataPanelView
+        {...baseProps}
+        spanPanelSlot={
+          <div data-testid="span-detail">
+            <p>agent run details</p>
+            <p>tool call</p>
+          </div>
+        }
+      />,
+    );
+
+  const search = (value: string) => {
+    fireEvent.change(screen.getByPlaceholderText('Search spans...'), { target: { value } });
+  };
+
+  it('highlights matching span names in the timeline tree', () => {
+    render(<TraceDataPanelView {...baseProps} spans={nestedSpanFixture} />);
+
+    search('weather');
+
+    expect(harness.highlightedText()).toEqual(['weather']);
+  });
+
+  it('highlights matches in the timeline tree and the span panel at once', () => {
+    renderWithSpanPanel();
+
+    search('agent');
+
+    // The tree row "agent run" plus "agent run details" in the span detail.
+    expect(harness.highlightedText()).toEqual(['agent', 'agent']);
+  });
+
+  it('does not highlight the span type legend', () => {
+    render(<TraceDataPanelView {...baseProps} spans={nestedSpanFixture} />);
+
+    search('tool');
+
+    // "weather tool" matches; the "Tool" legend label is chrome, not trace content.
+    expect(harness.highlightedText()).toEqual(['tool']);
+  });
+
+  it('does not highlight the trace name in the panel header', () => {
+    renderWithSpanPanel();
+
+    search('agent');
+
+    const heading = screen.getByRole('heading');
+    expect(harness.highlightedIn().some(element => heading.contains(element))).toBe(false);
+  });
+
+  it('does not highlight the trace metadata above the timeline', () => {
+    renderWithSpanPanel();
+
+    // "Started at" is a metadata label, not span content.
+    search('started');
+
+    expect(harness.highlightedText()).toEqual([]);
+  });
+
+  it('waits for a second character before highlighting', () => {
+    renderWithSpanPanel();
+
+    search('a');
+
+    expect(harness.highlights.set).not.toHaveBeenCalled();
+  });
+
+  it('removes the highlight when the search field is cleared', () => {
+    renderWithSpanPanel();
+    search('agent');
+    harness.highlights.set.mockClear();
+
+    search('');
+
+    expect(harness.highlights.set).not.toHaveBeenCalled();
+    expect(harness.highlights.delete).toHaveBeenCalledWith('search-result');
   });
 });
 

--- a/packages/playground-ui/src/domains/traces/components/timeline-name-col.tsx
+++ b/packages/playground-ui/src/domains/traces/components/timeline-name-col.tsx
@@ -63,7 +63,10 @@ export function TimelineNameCol({
             style={{ backgroundColor: spanUI.color }}
           />
         )}
-        <span className="min-w-0 truncate">{span.name}</span>
+        {/* Searchable: the span name is what the timeline search matches on. */}
+        <span data-highlight className="min-w-0 truncate">
+          {span.name}
+        </span>
       </button>
     </div>
   );

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -25,6 +25,7 @@ import { SearchFieldBlock } from '@/ds/components/FormFieldBlocks';
 import { Notice } from '@/ds/components/Notice';
 import { Tab, TabContent, TabList, Tabs } from '@/ds/components/Tabs';
 import type { LinkComponent } from '@/ds/types/link-component';
+import { useTextHighlight } from '@/hooks/use-text-highlight';
 import { truncateString } from '@/lib/truncate-string';
 
 export type TraceDataPanelPlacement = 'traces-list' | 'trace-page';
@@ -277,7 +278,7 @@ export function TraceDataPanelView({
       </DataPanel.Header>
 
       {!collapsed && (
-        <SplitWithSpanPanel spanPanelSlot={spanPanelSlot}>
+        <SplitWithSpanPanel spanPanelSlot={spanPanelSlot} highlightQuery={query}>
           {isLoading ? (
             <DataPanel.LoadingData>Loading trace...</DataPanel.LoadingData>
           ) : !spans?.length ? (
@@ -383,14 +384,38 @@ export function TraceDataPanelView({
 /**
  * Renders the trace content as-is, or — when a span panel is provided — as a
  * two-column split inside the same card, with the span detail on the right.
+ * Search matches — span names in the timeline tree as well as values in the span
+ * detail — are highlighted while a query is active.
  */
-function SplitWithSpanPanel({ spanPanelSlot, children }: { spanPanelSlot?: ReactNode; children: ReactNode }) {
-  if (!spanPanelSlot) return <>{children}</>;
+function SplitWithSpanPanel({
+  spanPanelSlot,
+  highlightQuery,
+  children,
+}: {
+  spanPanelSlot?: ReactNode;
+  highlightQuery: string;
+  children: ReactNode;
+}) {
+  // A single hook call on the common ancestor covers both the timeline tree and
+  // the span detail, so span names and payload values highlight together.
+  const { ref: highlightRef } = useTextHighlight<HTMLDivElement>(highlightQuery);
+
+  if (!spanPanelSlot) {
+    return (
+      <div ref={highlightRef} className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {children}
+      </div>
+    );
+  }
 
   return (
-    <div className="grid min-h-0 flex-1 grid-cols-[1fr_1fr]">
+    <div ref={highlightRef} className="grid min-h-0 flex-1 grid-cols-[1fr_1fr]">
       <div className="flex min-h-0 flex-col overflow-hidden">{children}</div>
-      <div className="animate-in border-border1 fade-in-0 flex min-h-0 flex-col overflow-hidden border-l duration-300">
+      {/* Searchable: the span detail is where a match hides inside a large payload. */}
+      <div
+        data-highlight
+        className="animate-in border-border1 fade-in-0 flex min-h-0 flex-col overflow-hidden border-l duration-300"
+      >
         {spanPanelSlot}
       </div>
     </div>

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-or-branch-spans.msw.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-or-branch-spans.msw.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { SpanType } from '@mastra/core/observability';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { server } from '../../../../test/msw-server';
+import { useTraceOrBranchSpans } from '../use-trace-or-branch-spans';
+
+const BASE_URL = 'http://localhost:4111';
+const TRACE_ID = 'trace-alpha';
+const FULL_URL = `${BASE_URL}/api/observability/traces/${TRACE_ID}`;
+const LIGHT_URL = `${FULL_URL}/light`;
+
+const timestamp = new Date('2026-06-10T00:00:00.000Z');
+
+/** A span as `getTrace` serves it: the heavy payload fields are present. */
+const fullSpan = {
+  traceId: TRACE_ID,
+  spanId: 'span-alpha',
+  parentSpanId: null,
+  name: 'weather agent run',
+  spanType: SpanType.AGENT_RUN,
+  isEvent: false,
+  startedAt: timestamp,
+  endedAt: timestamp,
+  input: { messages: [{ role: 'system', content: 'You are a weather assistant.' }] },
+  output: { text: 'It is raining in Lyon.' },
+  attributes: { model: 'gpt-4o-mini' },
+  createdAt: timestamp,
+  updatedAt: timestamp,
+};
+
+const queryClients: QueryClient[] = [];
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  queryClients.push(queryClient);
+  return ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+}
+
+const renderTraceSpans = () =>
+  renderHook(() => useTraceOrBranchSpans({ traceId: TRACE_ID, listMode: 'traces' }), { wrapper: makeWrapper() });
+
+afterEach(() => {
+  cleanup();
+  queryClients.splice(0).forEach(queryClient => queryClient.clear());
+});
+
+describe('useTraceOrBranchSpans in traces mode', () => {
+  it('reads the opened trace from the full-trace endpoint, not the light one', async () => {
+    const requested: string[] = [];
+    server.use(
+      http.get(FULL_URL, () => {
+        requested.push('full');
+        return HttpResponse.json({ traceId: TRACE_ID, spans: [fullSpan] });
+      }),
+      http.get(LIGHT_URL, () => {
+        requested.push('light');
+        return HttpResponse.json({ traceId: TRACE_ID, spans: [fullSpan] });
+      }),
+    );
+
+    const { result, unmount } = renderTraceSpans();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(requested).toEqual(['full']);
+    unmount();
+  });
+
+  it('makes the payload fields the light projection drops searchable', async () => {
+    server.use(http.get(FULL_URL, () => HttpResponse.json({ traceId: TRACE_ID, spans: [fullSpan] })));
+
+    const { result, unmount } = renderTraceSpans();
+    await waitFor(() => expect(result.current.spans).toBeDefined());
+
+    const searchText = result.current.spans?.[0]?.searchText ?? '';
+    expect(searchText).toContain('you are a weather assistant');
+    expect(searchText).toContain('it is raining in lyon');
+    expect(searchText).toContain('gpt-4o-mini');
+    unmount();
+  });
+});

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-or-branch-spans.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-or-branch-spans.ts
@@ -1,7 +1,7 @@
 import type { TraceListMode } from '../trace-filters';
 import type { SearchableSpan } from '../types';
 import { useBranch } from './use-branch';
-import { useTraceLightSpans } from './use-trace-light-spans';
+import { useTraceSpans } from './use-trace-spans';
 
 export interface UseTraceOrBranchSpansArgs {
   traceId: string | null | undefined;
@@ -26,6 +26,9 @@ export interface UseTraceOrBranchSpansResult {
  * Unified data source for the trace/span detail panel. Returns trace spans (full tree from the
  * root) in traces mode, or branch spans (subtree rooted at `anchorSpanId`) in branches mode.
  * Only the active query fires; the inactive one is disabled via its `enabled` flag.
+ *
+ * Both modes carry full span payloads: the panel renders and searches them, so a lightweight
+ * projection here would hide content from the reader looking straight at it.
  */
 export function useTraceOrBranchSpans({
   traceId,
@@ -35,7 +38,7 @@ export function useTraceOrBranchSpans({
 }: UseTraceOrBranchSpansArgs): UseTraceOrBranchSpansResult {
   const isBranches = listMode === 'branches';
 
-  const traceQuery = useTraceLightSpans(isBranches ? null : traceId);
+  const traceQuery = useTraceSpans(isBranches ? null : traceId);
   const branchQuery = useBranch({
     traceId: isBranches ? traceId : null,
     spanId: isBranches ? anchorSpanId : null,

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-spans.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-spans.ts
@@ -1,11 +1,23 @@
-import type { LightSpanRecord } from '@mastra/core/storage';
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import type { UseQueryResult } from '@tanstack/react-query';
+import type { SearchableSpan } from '../types';
+import { selectSearchableSpans } from '../utils';
 
+const IMMUTABLE_CACHE_TIME = 1000 * 60 * 60 * 24 * 30; // 30 days, massive cache, span data is immutable
+
+/**
+ * Every span of a single trace, with its full payload.
+ *
+ * The lightweight projection exists to keep blob columns off the read path of a
+ * *list*, where the cost is paid once per trace on screen. A trace that is open
+ * has already narrowed that to one, and the panel both renders and searches
+ * these spans -- `input`, `output` and `attributes` included -- so the
+ * projection would only hide content the reader is looking at.
+ */
 export function useTraceSpans(
   traceId: string | null | undefined,
-): UseQueryResult<{ traceId: string; spans: LightSpanRecord[] } | null> {
+): UseQueryResult<{ traceId: string; spans: SearchableSpan[] } | null> {
   const client = useMastraClient();
 
   return useQuery({
@@ -17,6 +29,13 @@ export function useTraceSpans(
       const res = await client.getTrace(traceId);
       return res;
     },
+    // Builds each span's search haystack once per fetch, cached with the query.
+    select: selectSearchableSpans,
     enabled: !!traceId,
+    staleTime: query => {
+      const data = query.state.data;
+      const isFinished = data?.spans.every(span => Boolean(span.endedAt));
+      return isFinished ? IMMUTABLE_CACHE_TIME : 0;
+    },
   });
 }

--- a/packages/playground-ui/src/ee/topics/components/topic-trace-details-panel.tsx
+++ b/packages/playground-ui/src/ee/topics/components/topic-trace-details-panel.tsx
@@ -1,8 +1,8 @@
 import { SpanDataPanelView } from '@/domains/traces/components/span-data-panel-view';
 import { TraceDetailsView } from '@/domains/traces/components/trace-details-view';
 import { useSpanDetail } from '@/domains/traces/hooks/use-span-detail';
-import { useTraceLightSpans } from '@/domains/traces/hooks/use-trace-light-spans';
 import { useTraceSpanNavigation } from '@/domains/traces/hooks/use-trace-span-navigation';
+import { useTraceSpans } from '@/domains/traces/hooks/use-trace-spans';
 import { cn } from '@/lib/utils';
 
 export interface TopicTraceDetailsPanelProps {
@@ -18,7 +18,7 @@ export function TopicTraceDetailsPanel({
   onSpanSelect,
   onClose,
 }: TopicTraceDetailsPanelProps) {
-  const traceSpans = useTraceLightSpans(traceId);
+  const traceSpans = useTraceSpans(traceId);
   const spanDetail = useSpanDetail(traceId, selectedSpanId);
   const { handlePreviousSpan, handleNextSpan } = useTraceSpanNavigation(
     traceSpans.data?.spans,

--- a/packages/playground-ui/src/hooks/use-text-highlight.css
+++ b/packages/playground-ui/src/hooks/use-text-highlight.css
@@ -1,7 +1,8 @@
-/* `accent3Dark` is the muted end of the accent ramp in both themes, so a match reads as
-   emphasis without drowning the text it sits on. Only color, background-color,
-   text-decoration and text-shadow are honoured by `::highlight()`. */
+/* `accent6` is the system orange (the hue behind `warning1`), used at full strength so a
+   match stays legible against dense JSON. Only color, background-color, text-decoration
+   and text-shadow are honoured by `::highlight()` — border, padding and border-radius are
+   ignored by the spec, so the highlight cannot have rounded corners. */
 ::highlight(search-result) {
-  background-color: var(--color-accent3Dark);
-  color: var(--color-neutral1);
+  background-color: var(--color-accent6);
+  color: var(--color-surface1);
 }

--- a/packages/playground-ui/src/hooks/use-text-highlight.css
+++ b/packages/playground-ui/src/hooks/use-text-highlight.css
@@ -1,0 +1,7 @@
+/* `accent3Dark` is the muted end of the accent ramp in both themes, so a match reads as
+   emphasis without drowning the text it sits on. Only color, background-color,
+   text-decoration and text-shadow are honoured by `::highlight()`. */
+::highlight(search-result) {
+  background-color: var(--color-accent3Dark);
+  color: var(--color-neutral1);
+}

--- a/packages/playground-ui/src/hooks/use-text-highlight.test.tsx
+++ b/packages/playground-ui/src/hooks/use-text-highlight.test.tsx
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+import { render, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { useTextHighlight } from './use-text-highlight';
+import { FakeHighlight, installHighlightApi } from '@/test/highlight-api';
+import type { HighlightApiHarness } from '@/test/highlight-api';
+
+const originalFrameApi = {
+  requestAnimationFrame: globalThis.requestAnimationFrame,
+  cancelAnimationFrame: globalThis.cancelAnimationFrame,
+};
+
+let harness: HighlightApiHarness;
+let highlights: HighlightApiHarness['highlights'];
+let lastHighlightedText: HighlightApiHarness['highlightedText'];
+let frames: Map<number, () => void>;
+let nextFrameId: number;
+
+/** The element the hook's ref is attached to. */
+const rootOf = (container: HTMLElement) => {
+  const root = container.firstElementChild;
+  if (!(root instanceof HTMLElement)) {
+    throw new Error('Expected the panel root to be rendered');
+  }
+  return root;
+};
+
+/** Lets queued MutationObserver callbacks (microtasks) run. */
+const flushMutations = () => act(async () => {});
+
+/** Runs every rAF callback queued so far, the way a browser paint would. */
+const flushFrames = () => {
+  const queued = [...frames.values()];
+  frames.clear();
+  act(() => {
+    queued.forEach(callback => callback());
+  });
+};
+
+beforeEach(() => {
+  harness = installHighlightApi();
+  highlights = harness.highlights;
+  lastHighlightedText = harness.highlightedText;
+  frames = new Map();
+  nextFrameId = 1;
+
+  Object.assign(globalThis, {
+    requestAnimationFrame: (callback: () => void) => {
+      const id = nextFrameId++;
+      frames.set(id, callback);
+      return id;
+    },
+    cancelAnimationFrame: (id: number) => {
+      frames.delete(id);
+    },
+  });
+});
+
+afterEach(() => {
+  harness.restore();
+  Object.assign(globalThis, originalFrameApi);
+});
+
+function Panel({ search, children }: { search: string; children?: React.ReactNode }) {
+  const { ref } = useTextHighlight(search);
+  return <div ref={ref}>{children ?? <p data-highlight>the agent called the agent tool</p>}</div>;
+}
+
+describe('useTextHighlight', () => {
+  it('registers a range for every occurrence of the search term', () => {
+    render(<Panel search="agent" />);
+
+    expect(lastHighlightedText()).toEqual(['agent', 'agent']);
+    expect(highlights.set).toHaveBeenCalledWith('search-result', expect.any(FakeHighlight));
+  });
+
+  it('matches regardless of case', () => {
+    render(<Panel search="AGENT" />);
+
+    expect(lastHighlightedText()).toEqual(['agent', 'agent']);
+  });
+
+  it('treats the search term as literal text, not a pattern', () => {
+    render(
+      <Panel search="a.ent">
+        <p data-highlight>axent a.ent</p>
+      </Panel>,
+    );
+
+    expect(lastHighlightedText()).toEqual(['a.ent']);
+  });
+
+  it('finds occurrences across sibling and nested text nodes', () => {
+    render(
+      <Panel search="span">
+        <div data-highlight>
+          <p>
+            outer span <em>nested span</em>
+          </p>
+          <p>sibling span</p>
+        </div>
+      </Panel>,
+    );
+
+    expect(lastHighlightedText()).toEqual(['span', 'span', 'span']);
+  });
+
+  it('only paints text inside a region that opted in', () => {
+    render(
+      <Panel search="agent">
+        <p>agent in surrounding chrome</p>
+        <p data-highlight>searchable agent</p>
+      </Panel>,
+    );
+
+    expect(lastHighlightedText()).toEqual(['agent']);
+  });
+
+  it('paints nothing when no region opted in', () => {
+    render(
+      <Panel search="agent">
+        <p>agent</p>
+      </Panel>,
+    );
+
+    expect(lastHighlightedText()).toEqual([]);
+  });
+
+  it('clears the highlight when the search term is blank', () => {
+    render(<Panel search="   " />);
+
+    expect(highlights.set).not.toHaveBeenCalled();
+    expect(highlights.delete).toHaveBeenCalledWith('search-result');
+  });
+
+  it('ignores a single-character search term', () => {
+    render(<Panel search="a" />);
+
+    expect(highlights.set).not.toHaveBeenCalled();
+    expect(highlights.delete).toHaveBeenCalledWith('search-result');
+  });
+
+  it('highlights from two characters on', () => {
+    render(<Panel search="ag" />);
+
+    expect(lastHighlightedText()).toEqual(['ag', 'ag']);
+  });
+
+  it('does nothing when the browser has no highlight registry', () => {
+    Object.assign(globalThis, { CSS: {} });
+
+    expect(() => render(<Panel search="agent" />)).not.toThrow();
+    expect(highlights.set).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the environment has no CSS object at all', () => {
+    Object.assign(globalThis, { CSS: undefined });
+
+    expect(() => render(<Panel search="agent" />)).not.toThrow();
+    expect(highlights.set).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the browser has no StaticRange', () => {
+    Object.assign(globalThis, { StaticRange: undefined });
+
+    render(<Panel search="agent" />);
+
+    expect(highlights.set).not.toHaveBeenCalled();
+    expect(highlights.delete).toHaveBeenCalledWith('search-result');
+  });
+
+  it('re-scans when the content changes', async () => {
+    const { container } = render(<Panel search="agent" />);
+    highlights.set.mockClear();
+
+    act(() => {
+      const paragraph = document.createElement('p');
+      paragraph.setAttribute('data-highlight', '');
+      paragraph.textContent = 'another agent';
+      rootOf(container).append(paragraph);
+    });
+    await flushMutations();
+    flushFrames();
+
+    expect(lastHighlightedText()).toEqual(['agent', 'agent', 'agent']);
+  });
+
+  it('coalesces a burst of content changes into a single re-scan', async () => {
+    const { container } = render(<Panel search="agent" />);
+    highlights.set.mockClear();
+    const root = rootOf(container);
+
+    act(() => {
+      root.append(document.createElement('p'));
+    });
+    await flushMutations();
+    act(() => {
+      root.append(document.createElement('p'));
+    });
+    await flushMutations();
+    flushFrames();
+
+    expect(highlights.set).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops highlighting once unmounted', async () => {
+    const { container, unmount } = render(<Panel search="agent" />);
+    const root = rootOf(container);
+
+    act(() => {
+      root.append(document.createElement('p'));
+    });
+    await flushMutations();
+    unmount();
+    highlights.set.mockClear();
+    flushFrames();
+
+    expect(highlights.delete).toHaveBeenCalledWith('search-result');
+    expect(highlights.set).not.toHaveBeenCalled();
+  });
+
+  it('clears the highlight when unmounted with no pending re-scan', () => {
+    const { unmount } = render(<Panel search="agent" />);
+
+    unmount();
+
+    expect(highlights.delete).toHaveBeenCalledWith('search-result');
+  });
+
+  it('highlights text nodes that are direct children of the opted-in element', async () => {
+    const { container } = render(<Panel search="agent" />);
+    highlights.set.mockClear();
+    const root = container.firstElementChild as HTMLElement;
+
+    act(() => {
+      root.setAttribute('data-highlight', '');
+      root.replaceChildren(document.createTextNode('agent'));
+    });
+    await flushMutations();
+    flushFrames();
+
+    expect(lastHighlightedText()).toEqual(['agent']);
+  });
+});

--- a/packages/playground-ui/src/hooks/use-text-highlight.ts
+++ b/packages/playground-ui/src/hooks/use-text-highlight.ts
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import type { RefCallback } from 'react';
+
+import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect';
+import './use-text-highlight.css';
+
+/** Single registry entry, so only one search surface can be highlighted at a time. */
+const HIGHLIGHT_NAME = 'search-result';
+
+/**
+ * A single character matches almost everywhere, which paints noise instead of results.
+ * Highlighting only starts once the term is discriminating enough.
+ */
+const MIN_SEARCH_LENGTH = 2;
+
+/**
+ * Opt-in marker: only text inside a `data-highlight` subtree can be painted. Highlighting
+ * is a claim about which text is searchable, so surfaces state it explicitly rather than
+ * having every piece of surrounding chrome remember to opt out.
+ */
+const INCLUDED_SELECTOR = '[data-highlight]';
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export interface UseTextHighlightResult<TElement extends HTMLElement> {
+  ref: RefCallback<TElement>;
+}
+
+/**
+ * Paints every occurrence of `search` inside the referenced subtree using the CSS Custom
+ * Highlight API. Only text under an element carrying `data-highlight` is painted, so a
+ * surface names its searchable regions and everything else — headers, labels, metadata —
+ * is left alone by default. The DOM is never mutated — no wrapper elements are injected — so text
+ * selection, copy/paste and virtualised renderers are unaffected. Styling lives in
+ * `use-text-highlight.css` (`::highlight(search-result)`).
+ *
+ * Terms shorter than two characters are ignored — they match too much to be useful.
+ * Matching is case-insensitive and literal (the term is escaped, not a pattern). The
+ * subtree is re-scanned on content changes, coalesced to one scan per frame. Browsers
+ * without the API simply render nothing highlighted.
+ */
+export function useTextHighlight<TElement extends HTMLElement = HTMLElement>(
+  search: string,
+): UseTextHighlightResult<TElement> {
+  const [root, setRoot] = useState<TElement | null>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    if (
+      !root ||
+      search.trim().length < MIN_SEARCH_LENGTH ||
+      typeof CSS === 'undefined' ||
+      !('highlights' in CSS) ||
+      typeof StaticRange === 'undefined'
+    ) {
+      CSS?.highlights?.delete(HIGHLIGHT_NAME);
+      return;
+    }
+
+    let animationFrame: number | null = null;
+
+    const updateHighlight = () => {
+      const ranges: StaticRange[] = [];
+      const regex = new RegExp(escapeRegExp(search), 'giu');
+
+      const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+        acceptNode(node) {
+          // Inside a rooted walker every text node has a parent element.
+          const parent = node.parentElement as HTMLElement;
+          return parent.closest(INCLUDED_SELECTOR) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+        },
+      });
+
+      while (walker.nextNode()) {
+        const textNode = walker.currentNode as Text;
+        regex.lastIndex = 0;
+
+        let match: RegExpExecArray | null;
+        while ((match = regex.exec(textNode.data)) !== null) {
+          ranges.push(
+            new StaticRange({
+              startContainer: textNode,
+              startOffset: match.index,
+              endContainer: textNode,
+              endOffset: match.index + match[0].length,
+            }),
+          );
+        }
+      }
+
+      CSS.highlights.set(HIGHLIGHT_NAME, new Highlight(...ranges));
+    };
+
+    const scheduleUpdate = () => {
+      if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+
+      animationFrame = requestAnimationFrame(() => {
+        animationFrame = null;
+        updateHighlight();
+      });
+    };
+
+    updateHighlight();
+
+    const observer = new MutationObserver(scheduleUpdate);
+    observer.observe(root, { subtree: true, childList: true, characterData: true });
+
+    return () => {
+      observer.disconnect();
+      if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+      CSS.highlights.delete(HIGHLIGHT_NAME);
+    };
+  }, [root, search]);
+
+  return { ref: setRoot };
+}

--- a/packages/playground-ui/src/test/highlight-api.ts
+++ b/packages/playground-ui/src/test/highlight-api.ts
@@ -1,0 +1,62 @@
+import { vi } from 'vitest';
+
+/**
+ * Minimal fakes for the CSS Custom Highlight API, which jsdom does not implement.
+ * Install with `installHighlightApi()` in `beforeEach` and undo with the returned
+ * `restore` in `afterEach`.
+ */
+export interface FakeStaticRange {
+  startContainer: Node;
+  startOffset: number;
+  endContainer: Node;
+  endOffset: number;
+}
+
+export class FakeHighlight {
+  readonly ranges: FakeStaticRange[];
+  constructor(...ranges: FakeStaticRange[]) {
+    this.ranges = ranges;
+  }
+}
+
+export interface HighlightApiHarness {
+  highlights: { set: ReturnType<typeof vi.fn>; delete: ReturnType<typeof vi.fn> };
+  /** The text covered by the ranges of the most recent registration. */
+  highlightedText: () => string[] | undefined;
+  /** The elements owning the highlighted text of the most recent registration. */
+  highlightedIn: () => (HTMLElement | null)[];
+  restore: () => void;
+}
+
+export function installHighlightApi(): HighlightApiHarness {
+  const originals = {
+    CSS: globalThis.CSS,
+    StaticRange: globalThis.StaticRange,
+    Highlight: (globalThis as Record<string, unknown>).Highlight,
+  };
+
+  const highlights = { set: vi.fn(), delete: vi.fn() };
+
+  Object.assign(globalThis, {
+    CSS: { highlights },
+    StaticRange: class {
+      constructor(init: FakeStaticRange) {
+        Object.assign(this, init);
+      }
+    },
+    Highlight: FakeHighlight,
+  });
+
+  const lastRanges = () => {
+    const call = highlights.set.mock.calls.at(-1);
+    return call ? (call[1] as FakeHighlight).ranges : undefined;
+  };
+
+  return {
+    highlights,
+    highlightedText: () =>
+      lastRanges()?.map(range => (range.startContainer as Text).data.slice(range.startOffset, range.endOffset)),
+    highlightedIn: () => lastRanges()?.map(range => (range.startContainer as Text).parentElement) ?? [],
+    restore: () => Object.assign(globalThis, originals),
+  };
+}

--- a/packages/playground/src/pages/logs/index.tsx
+++ b/packages/playground/src/pages/logs/index.tsx
@@ -24,7 +24,7 @@ import { useEnvironments } from '@mastra/playground-ui/domains/traces/hooks/use-
 import { useServiceNames } from '@mastra/playground-ui/domains/traces/hooks/use-service-names';
 import { useSpanDetail } from '@mastra/playground-ui/domains/traces/hooks/use-span-detail';
 import { useTags } from '@mastra/playground-ui/domains/traces/hooks/use-tags';
-import { useTraceLightSpans } from '@mastra/playground-ui/domains/traces/hooks/use-trace-light-spans';
+import { useTraceSpans } from '@mastra/playground-ui/domains/traces/hooks/use-trace-spans';
 import { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
 
@@ -97,7 +97,7 @@ export default function LogsPage() {
     url.featuredTraceId,
   );
 
-  const { data: lightSpansData, isLoading: isLoadingLightSpans } = useTraceLightSpans(url.featuredTraceId ?? null);
+  const { data: traceSpansData, isLoading: isLoadingTraceSpans } = useTraceSpans(url.featuredTraceId ?? null);
   const { data: spanDetailData, isLoading: isLoadingSpanDetail } = useSpanDetail(
     url.featuredTraceId ?? '',
     url.featuredSpanId ?? '',
@@ -220,8 +220,8 @@ export default function LogsPage() {
           url.featuredTraceId ? (
             <TraceDetailsView
               traceId={url.featuredTraceId}
-              spans={lightSpansData?.spans}
-              isLoading={isLoadingLightSpans}
+              spans={traceSpansData?.spans}
+              isLoading={isLoadingTraceSpans}
               onClose={handleTraceClose}
               onSpanSelect={handleSpanSelect}
               selectedSpanId={url.featuredSpanId}

--- a/packages/playground/src/pages/traces/__tests__/fixtures/traces.ts
+++ b/packages/playground/src/pages/traces/__tests__/fixtures/traces.ts
@@ -6,7 +6,7 @@ import { TraceStatus } from '@mastra/core/storage';
 type ListTracesResponse = Awaited<ReturnType<MastraClient['listTraces']>>;
 type ListBranchesResponse = Awaited<ReturnType<MastraClient['listBranches']>>;
 type MetricBreakdownResponse = Awaited<ReturnType<MastraClient['getMetricBreakdown']>>;
-type GetTraceLightResponse = Awaited<ReturnType<MastraClient['getTraceLight']>>;
+type GetTraceResponse = Awaited<ReturnType<MastraClient['getTrace']>>;
 type GetBranchResponse = Awaited<ReturnType<MastraClient['getBranch']>>;
 type ListFeedbackResponse = Awaited<ReturnType<MastraClient['listFeedback']>>;
 
@@ -73,7 +73,7 @@ export const traceUsageBreakdown: MetricBreakdownResponse = {
   ],
 };
 
-export const traceLightSpans: GetTraceLightResponse = {
+export const traceSpans: GetTraceResponse = {
   traceId: 'trace-a',
   spans: [{ ...trace, parentSpanId: null }],
 };

--- a/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
+++ b/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
@@ -17,7 +17,7 @@ import {
   rootBranchList,
   rootBranchSpans,
   subtraceBranchSpans,
-  traceLightSpans,
+  traceSpans,
   traceList,
   traceListWithTwoTraces,
   traceSpanScores,
@@ -60,6 +60,9 @@ const setTracePageHandlers = (systemPackages: GetSystemPackagesResponse) => {
     http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId/:spanId/scores`, () =>
       HttpResponse.json(emptyTraceSpanScores),
     ),
+    // Opening a trace reads the whole trace. Registered after the literal `traces/light`
+    // so the list's endpoint isn't swallowed by the `:traceId` segment.
+    http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId`, () => HttpResponse.json(traceSpans)),
     http.post(`${TEST_BASE_URL}/api/observability/metrics/breakdown`, () => {
       onBreakdownRequest();
       return HttpResponse.json(traceUsageBreakdown);
@@ -104,7 +107,7 @@ describe('Traces page usage columns', () => {
       server.use(
         http.get(`${TEST_BASE_URL}/api/observability/traces`, () => HttpResponse.json(traceListWithTwoTraces)),
         http.get(`${TEST_BASE_URL}/api/observability/traces/light`, () => HttpResponse.json(traceListWithTwoTraces)),
-        http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a/light`, () => HttpResponse.json(traceLightSpans)),
+        http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a`, () => HttpResponse.json(traceSpans)),
         http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
       );
 
@@ -142,7 +145,7 @@ describe('Traces page usage columns', () => {
         http.get(`${TEST_BASE_URL}/api/observability/traces/light`, () =>
           HttpResponse.json({ ...traceList, spans: [], pagination: { ...traceList.pagination, total: 0 } }),
         ),
-        http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a/light`, () => HttpResponse.json(traceLightSpans)),
+        http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a`, () => HttpResponse.json(traceSpans)),
         http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
       );
 
@@ -236,7 +239,7 @@ describe('Traces side panel header actions', () => {
   it('shows the trace actions in the panel header when a trace is selected', async () => {
     setTracePageHandlers(metricsCapableSystemPackages);
     server.use(
-      http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a/light`, () => HttpResponse.json(traceLightSpans)),
+      http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a`, () => HttpResponse.json(traceSpans)),
       http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
     );
 
@@ -254,7 +257,7 @@ describe('Traces side panel Scores tab', () => {
   const openScoresTab = async (scoresResponse = emptyTraceSpanScores) => {
     setTracePageHandlers(metricsCapableSystemPackages);
     server.use(
-      http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a/light`, () => HttpResponse.json(traceLightSpans)),
+      http.get(`${TEST_BASE_URL}/api/observability/traces/trace-a`, () => HttpResponse.json(traceSpans)),
       http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
       http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId/:spanId/scores`, () =>
         HttpResponse.json(scoresResponse),

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -103,11 +103,12 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
 
   // Trace + span detail fetched at the page level (was inside the old smart components).
   // In branches mode the data source is `getBranch` (subtree rooted at the selected span);
-  // in traces mode it's `getTraceLight` (full tree from the root).
+  // in traces mode it's `getTrace` (full tree from the root). Both carry full span payloads,
+  // which is what the panel renders and what its search reads.
   const {
-    spans: lightSpans,
+    spans: traceSpans,
     anchorSpanId,
-    isLoading: isLoadingLightSpans,
+    isLoading: isLoadingTraceSpans,
   } = useTraceOrBranchSpans({
     traceId: url.traceIdParam ?? null,
     // In branches mode the anchor lives in its own URL param so intra-panel span navigation
@@ -123,8 +124,8 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
   // Displayed root of the current view: branch anchor in branches mode, trace root otherwise.
   const anchorSpan = useMemo(
     () =>
-      anchorSpanId ? lightSpans?.find(s => s.spanId === anchorSpanId) : lightSpans?.find(s => s.parentSpanId == null),
-    [lightSpans, anchorSpanId],
+      anchorSpanId ? traceSpans?.find(s => s.spanId === anchorSpanId) : traceSpans?.find(s => s.parentSpanId == null),
+    [traceSpans, anchorSpanId],
   );
 
   // First page of the anchor span's scores: feeds the tab badge and the featured score lookup.
@@ -219,7 +220,7 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
       }
     : traceColumns.preferences;
   const selectedBranchAnchor =
-    url.listMode === 'branches' && anchorSpanId ? lightSpans?.find(span => span.spanId === anchorSpanId) : undefined;
+    url.listMode === 'branches' && anchorSpanId ? traceSpans?.find(span => span.spanId === anchorSpanId) : undefined;
   const canShowSelectedTraceUsage =
     url.listMode === 'traces' || (selectedBranchAnchor !== undefined && selectedBranchAnchor.parentSpanId == null);
   const listUsageEnabled =
@@ -261,7 +262,7 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
     if (url.listMode === 'branches') url.handleListModeChange('traces');
   }, [tracesError, branchesUnsupported, url]);
 
-  const { handlePreviousSpan, handleNextSpan } = useTraceSpanNavigation(lightSpans, url.spanIdParam ?? null, id =>
+  const { handlePreviousSpan, handleNextSpan } = useTraceSpanNavigation(traceSpans, url.spanIdParam ?? null, id =>
     url.handleSpanChange(id),
   );
 
@@ -474,14 +475,14 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
             <TraceDataPanel
               key={`${url.traceIdParam}:${url.anchorSpanIdParam ?? ''}`}
               traceId={url.traceIdParam}
-              spans={lightSpans}
+              spans={traceSpans}
               usage={
                 canShowSelectedTraceUsage
                   ? (selectedTraceUsageFromList ?? selectedTraceUsage.data?.get(url.traceIdParam))
                   : undefined
               }
               anchorSpanId={anchorSpanId}
-              isLoading={isLoadingLightSpans}
+              isLoading={isLoadingTraceSpans}
               onClose={url.handleTraceClose}
               onSpanSelect={id => url.handleSpanChange(id ?? null)}
               onSaveAsDatasetItem={args => setDatasetDialogTarget(args)}


### PR DESCRIPTION

<img width="3840" height="2160" alt="CleanShot 2026-08-27 at 15 30 38@2x" src="https://github.com/user-attachments/assets/e0c49455-9d46-44f7-8efb-5378be97f158" />


## What this changes

When you open a trace in Studio, the detail panel now loads the **full** trace, and any term typed into the trace search field is **highlighted** wherever it matches — on the span names in the timeline tree and throughout the span side panel.

## Why

Two problems, one cause.

The trace list uses a lightweight span projection: it deliberately leaves out `input`, `output`, `attributes`, `tags` and `links` so that blob columns stay off the read path of a list, where the cost is paid once per row on screen. The detail panel was reusing that same projection. But an open trace has already narrowed the list to one, and the panel both *renders* and *searches* those spans — so the projection was only hiding content from the reader looking straight at it. Searching for a word that was plainly visible in a span payload returned nothing.

Separately, once a search does match, finding the match inside a large JSON payload was still a manual scan.

## How

- The detail panel, the logs page featured trace and the topics trace panel read `getTrace` instead of `getTraceLight`. The trace **list** is untouched and keeps the lightweight projection.
- A `useTextHighlight` hook paints matches with the CSS Custom Highlight API (`CSS.highlights` + `::highlight()`), so nothing is injected into the DOM — copy/paste and the JSON viewers behave exactly as before.
- Regions **opt in** to highlighting via `data-highlight`, so the chrome around a trace (panel header, metadata, tab labels, legend) is never painted and nothing added later has to remember to exclude itself.
- Highlighting starts from the second character: a single letter matches almost everywhere and paints noise rather than results.

## Test plan

- `pnpm --filter ./packages/playground-ui test` — green, including a new MSW test asserting the panel data source hits the full-trace endpoint, and `use-text-highlight` unit tests at 100% coverage.
- `pnpm --filter ./packages/playground test src/pages/traces` — green.
- `tsc` clean on both packages; lint reports no new errors.
- Manually in Studio: open a trace, type a term present only in a span payload, confirm the trace list matches it and the occurrences are highlighted in both the tree and the panel; clear the field and the highlight goes away.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you open a trace, Studio now loads all its details instead of a shortened version. Trace search also highlights matching text in span names and details, while ignoring searches shorter than two characters.

## Changes

- Load full trace data with `getTrace` when users open traces.
- Keep lightweight trace data for the trace list.
- Use full span data in trace details, logs, and topic trace panels.
- Add `useTextHighlight` with CSS Custom Highlight API support.
- Highlight matches only inside elements marked with `data-highlight`.
- Support case-insensitive literal matching and dynamic content updates.
- Exclude unsupported browsers without affecting rendering.
- Add CSS styling for search highlights.
- Add tests for full-trace loading, searchable span fields, highlighting behavior, short queries, cleanup, and unsupported browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->