### PR TITLE
fix(core): resume plan runs through their owner

### DIFF
--- a/.changeset/many-candies-taste.md
+++ b/.changeset/many-candies-taste.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed plan approvals so mode changes resume the original agent run.

--- a/.changeset/salty-seals-live.md
+++ b/.changeset/salty-seals-live.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed approval resumes when Agent Controller uses in-memory storage.

--- a/packages/core/src/agent-controller/__tests__/agent-controller-notifications.test.ts
+++ b/packages/core/src/agent-controller/__tests__/agent-controller-notifications.test.ts
@@ -12,9 +12,18 @@ function createSubscription() {
 }
 
 function createAgentMock() {
+  let mastra: unknown;
   return {
     id: 'agent-1',
-    getMastraInstance: vi.fn(() => undefined),
+    getMastraInstance: vi.fn(() => mastra),
+    __setLogger: vi.fn(),
+    __registerMastra: vi.fn((nextMastra: unknown) => {
+      mastra = nextMastra;
+    }),
+    __registerPrimitives: vi.fn(),
+    getConfiguredProcessorWorkflows: vi.fn(async () => []),
+    listScorers: vi.fn(async () => []),
+    getChannels: vi.fn(() => null),
     subscribeToThread: vi.fn(async () => createSubscription()),
     sendNotificationSignal: vi.fn(async (_input, target) => ({
       record: { id: 'notification-1', threadId: target.threadId, source: 'mastracode' },

--- a/packages/core/src/agent-controller/__tests__/signal-messages.test.ts
+++ b/packages/core/src/agent-controller/__tests__/signal-messages.test.ts
@@ -12,9 +12,18 @@ function createSubscription(activeRunId: () => string | null) {
 }
 
 function createAgentMock(activeRunId: () => string | null) {
+  let mastra: unknown;
   return {
     id: 'agent-1',
-    getMastraInstance: vi.fn(() => undefined),
+    getMastraInstance: vi.fn(() => mastra),
+    __setLogger: vi.fn(),
+    __registerMastra: vi.fn((nextMastra: unknown) => {
+      mastra = nextMastra;
+    }),
+    __registerPrimitives: vi.fn(),
+    getConfiguredProcessorWorkflows: vi.fn(async () => []),
+    listScorers: vi.fn(async () => []),
+    getChannels: vi.fn(() => null),
     subscribeToThread: vi.fn(async () => createSubscription(activeRunId)),
     sendSignal: vi.fn((signal: any, _options?: any) => ({
       accepted: Promise.resolve({ action: 'deliver' as const, runId: 'run-1' }),

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -407,6 +407,7 @@ export class AgentController<TState = {}> {
     session.thread.connect(this.createThreadDataStore(session), session as Session);
     session.setMachinery({
       getAgent: () => this.getCurrentAgent(session),
+      getRunScope: runId => this.getMastra()?.__getRunScope(runId),
       subscribeToThread: ({ resourceId, threadId }) =>
         this.getCurrentAgent(session).subscribeToThread({ resourceId, threadId }),
       buildStreamOptions: input => this.buildAgentMessageStreamOptions({ session, ...input }),

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -931,14 +931,14 @@ export class AgentController<TState = {}> {
   #storageInitPromise?: Promise<void>;
 
   private async runStorageInit(): Promise<void> {
-    // Create an internal Mastra instance so agents have access to storage
-    // (required for tool approval snapshot persistence/resume).
+    // Create an internal Mastra instance so mode agents share the run state
+    // needed to persist and resume tool approvals, even without configured storage.
     // We init storage through Mastra's proxied storage so augmentWithInit
     // tracks it and won't double-init.
     //
     // Skip this when registered on a parent Mastra: that Mastra already owns
     // storage/agents/gateways, and getMastra() resolves to it.
-    if (this.config.storage && !this.#externalMastra) {
+    if (!this.#externalMastra) {
       const enabledGateways = this.config.gateways?.filter(gateway => gateway.shouldEnable?.() ?? true);
       const gateways = enabledGateways?.length
         ? Object.fromEntries(enabledGateways.map(gateway => [gateway.id, gateway]))
@@ -946,7 +946,7 @@ export class AgentController<TState = {}> {
 
       this.#internalMastra = new Mastra({
         logger: false,
-        storage: this.config.storage,
+        ...(this.config.storage ? { storage: this.config.storage } : {}),
         ...(this.config.pubsub ? { pubsub: this.config.pubsub } : {}),
         ...(this.config.observability ? { observability: this.config.observability } : {}),
         ...(gateways ? { gateways } : {}),

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -408,8 +408,8 @@ export class AgentController<TState = {}> {
     session.setMachinery({
       getAgent: () => this.getCurrentAgent(session),
       getRunScope: runId => this.getMastra()?.__getRunScope(runId),
-      subscribeToThread: ({ resourceId, threadId }) =>
-        this.getCurrentAgent(session).subscribeToThread({ resourceId, threadId }),
+      subscribeToThread: ({ agent, resourceId, threadId }) =>
+        (agent ?? this.getCurrentAgent(session)).subscribeToThread({ resourceId, threadId }),
       buildStreamOptions: input => this.buildAgentMessageStreamOptions({ session, ...input }),
       buildSharedRunOptions: () => this.buildSharedRunOptions(session),
       buildToolsets: requestContext => this.buildToolsets(session, requestContext),

--- a/packages/core/src/agent-controller/mode-model-persistence.test.ts
+++ b/packages/core/src/agent-controller/mode-model-persistence.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { AgentController } from './agent-controller';
@@ -9,14 +9,19 @@ type AgentControllerTestState = { currentModelId?: string };
 
 const agent = () =>
   new Agent({
+    id: 'test-agent',
     name: 'test-agent',
     instructions: 'You are a test agent.',
     model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
   });
 
-async function buildController(
-  storage: InMemoryStore,
-): Promise<{ controller: AgentController<AgentControllerTestState>; session: Session<AgentControllerTestState> }> {
+async function buildController(storage: InMemoryStore): Promise<{
+  controller: AgentController<AgentControllerTestState>;
+  session: Session<AgentControllerTestState>;
+  agents: { build: Agent; plan: Agent };
+}> {
+  const buildAgent = agent();
+  const planAgent = agent();
   const controller = new AgentController<AgentControllerTestState>({
     workspace: createMockWorkspace(),
     id: 'test-controller',
@@ -28,13 +33,13 @@ async function buildController(
         name: 'Build',
         default: true,
         defaultModelId: 'openai/gpt-5.5',
-        agent: agent(),
+        agent: buildAgent,
       },
       {
         id: 'plan',
         name: 'Plan',
         defaultModelId: 'openai/gpt-5.2-codex',
-        agent: agent(),
+        agent: planAgent,
       },
       {
         id: 'fast',
@@ -46,7 +51,7 @@ async function buildController(
   });
   await controller.init();
   const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
-  return { controller, session };
+  return { controller, session, agents: { build: buildAgent, plan: planAgent } };
 }
 
 describe('AgentController mode-model persistence across restarts', () => {
@@ -134,19 +139,32 @@ describe('AgentController mode-model persistence across restarts', () => {
     expect(restoreEvent?.previousModeId).toBe('build');
   });
 
-  it('approving a submit_plan suspension switches to the default mode and clears the suspension', async () => {
-    const { session } = await buildController(storage);
+  it('resumes a submit_plan suspension through its plan-mode agent after switching to build', async () => {
+    const { session, agents } = await buildController(storage);
     await session.thread.create();
     await session.mode.switch({ modeId: 'plan' });
 
+    const planResume = vi.spyOn(agents.plan, 'sendStreamResume').mockImplementation(async () => {
+      session.emit({ type: 'agent_end', reason: 'complete' });
+      return undefined as never;
+    });
+    const buildResume = vi.spyOn(agents.build, 'sendStreamResume');
+
     // Simulate a submit_plan tool that suspended during a plan-mode run.
-    session.suspensions.register({ toolCallId: 'plan-call-1', runId: 'run-1', toolName: 'submit_plan' });
+    session.suspensions.register({
+      toolCallId: 'plan-call-1',
+      runId: 'run-1',
+      agent: agents.plan,
+      toolName: 'submit_plan',
+    });
 
     await session.respondToToolSuspension({ toolCallId: 'plan-call-1', resumeData: { action: 'approved' } });
 
-    // Approval resumes the parked submit_plan suspension after switching to the
-    // default execution mode. It must not abort the plan run before the approved
-    // tool result is persisted.
+    // The approval switches to build before resuming, but the in-memory run is
+    // still owned by the plan-mode agent. Resuming through build would fail to
+    // find it in that agent's run registry.
+    expect(planResume).toHaveBeenCalledWith(expect.objectContaining({ runId: 'run-1', toolCallId: 'plan-call-1' }));
+    expect(buildResume).not.toHaveBeenCalled();
     expect(session.suspensions.has({ toolCallId: 'plan-call-1' })).toBe(false);
     expect(session.mode.get()).toBe('build');
   });

--- a/packages/core/src/agent-controller/mode-model-persistence.test.ts
+++ b/packages/core/src/agent-controller/mode-model-persistence.test.ts
@@ -183,74 +183,77 @@ describe('AgentController mode-model persistence across restarts', () => {
     expect(restoreEvent?.previousModeId).toBe('build');
   });
 
-  it('resumes a submit_plan run through its plan-mode agent after switching to build', async () => {
-    let planCalls = 0;
-    let buildCalls = 0;
-    const planAgent = new Agent({
-      id: 'plan-agent',
-      name: 'plan-agent',
-      instructions: 'You plan work.',
-      model: new MastraLanguageModelV2Mock({
-        doStream: async () => {
-          planCalls += 1;
-          return {
-            stream:
-              planCalls === 1
-                ? createToolCallStream({
-                    toolCallId: 'plan-call-1',
-                    toolName: 'submit_plan',
-                    input: '{"path":"plan.md"}',
-                  })
-                : createTextStream('Plan approved.'),
-          };
-        },
-      }),
-      tools: { submit_plan: submitPlanTool },
-    });
-    const buildAgent = new Agent({
-      id: 'build-agent',
-      name: 'build-agent',
-      instructions: 'You implement work.',
-      model: new MastraLanguageModelV2Mock({
-        doStream: async () => {
-          buildCalls += 1;
-          return { stream: createTextStream('Implementation complete.') };
-        },
-      }),
-    });
-    const controller = new AgentController<AgentControllerTestState>({
-      workspace: createMockWorkspace(),
-      id: 'test-controller',
-      storage,
-      initialState: { yolo: true } as any,
-      modes: [
-        { id: 'plan', name: 'Plan', default: true, transitionsTo: 'build', agent: planAgent },
-        { id: 'build', name: 'Build', agent: buildAgent },
-      ],
-    });
-    await controller.init();
-    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
-    await session.thread.create();
+  it.each([true, false])(
+    'resumes a submit_plan run through its plan-mode agent after switching to build (controller storage: %s)',
+    async hasStorage => {
+      let planCalls = 0;
+      let buildCalls = 0;
+      const planAgent = new Agent({
+        id: 'plan-agent',
+        name: 'plan-agent',
+        instructions: 'You plan work.',
+        model: new MastraLanguageModelV2Mock({
+          doStream: async () => {
+            planCalls += 1;
+            return {
+              stream:
+                planCalls === 1
+                  ? createToolCallStream({
+                      toolCallId: 'plan-call-1',
+                      toolName: 'submit_plan',
+                      input: '{"path":"plan.md"}',
+                    })
+                  : createTextStream('Plan approved.'),
+            };
+          },
+        }),
+        tools: { submit_plan: submitPlanTool },
+      });
+      const buildAgent = new Agent({
+        id: 'build-agent',
+        name: 'build-agent',
+        instructions: 'You implement work.',
+        model: new MastraLanguageModelV2Mock({
+          doStream: async () => {
+            buildCalls += 1;
+            return { stream: createTextStream('Implementation complete.') };
+          },
+        }),
+      });
+      const controller = new AgentController<AgentControllerTestState>({
+        workspace: createMockWorkspace(),
+        id: 'test-controller',
+        ...(hasStorage ? { storage } : {}),
+        initialState: { yolo: true } as any,
+        modes: [
+          { id: 'plan', name: 'Plan', default: true, transitionsTo: 'build', agent: planAgent },
+          { id: 'build', name: 'Build', agent: buildAgent },
+        ],
+      });
+      await controller.init();
+      const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+      await session.thread.create();
 
-    const events: any[] = [];
-    session.subscribe(event => {
-      events.push(event);
-    });
-    await session.sendMessage({ content: 'Create a plan' });
-    const suspended = events.find(event => event.type === 'tool_suspended');
-    expect(suspended?.toolCallId).toBe('plan-call-1');
+      const events: any[] = [];
+      session.subscribe(event => {
+        events.push(event);
+      });
+      await session.sendMessage({ content: 'Create a plan' });
+      const suspended = events.find(event => event.type === 'tool_suspended');
+      expect(suspended?.toolCallId).toBe('plan-call-1');
 
-    events.length = 0;
-    await session.respondToToolSuspension({ toolCallId: suspended.toolCallId, resumeData: { action: 'approved' } });
+      events.length = 0;
+      await session.respondToToolSuspension({ toolCallId: suspended.toolCallId, resumeData: { action: 'approved' } });
 
-    expect(planCalls).toBe(2);
-    expect(buildCalls).toBe(0);
-    expect(events.some(event => event.type === 'agent_end')).toBe(true);
-    expect(session.mode.get()).toBe('build');
+      expect(planCalls).toBe(2);
+      expect(buildCalls).toBe(0);
+      expect(events.some(event => event.type === 'agent_end')).toBe(true);
+      expect(session.mode.get()).toBe('build');
 
-    events.length = 0;
-    await session.sendMessage({ content: 'Implement the approved plan' });
-    await vi.waitFor(() => expect(events.some(event => event.type === 'agent_end')).toBe(true));
-    expect(buildCalls).toBe(1);
-  });
+      events.length = 0;
+      await session.sendMessage({ content: 'Implement the approved plan' });
+      await vi.waitFor(() => expect(events.some(event => event.type === 'agent_end')).toBe(true));
+      expect(buildCalls).toBe(1);
+    },
+  );
 });

--- a/packages/core/src/agent-controller/mode-model-persistence.test.ts
+++ b/packages/core/src/agent-controller/mode-model-persistence.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
+import { MastraLanguageModelV2Mock } from '../test-utils/llm-mock';
+import { submitPlanTool } from '../tools/builtin/submit-plan';
 import { AgentController } from './agent-controller';
 import type { Session } from './session';
 import { createMockWorkspace } from './test-utils';
@@ -14,6 +16,48 @@ const agent = () =>
     instructions: 'You are a test agent.',
     model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
   });
+
+function createToolCallStream({
+  toolCallId,
+  toolName,
+  input,
+}: {
+  toolCallId: string;
+  toolName: string;
+  input: string;
+}) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+      controller.enqueue({ type: 'response-metadata', id: 'id-0', modelId: 'mock', timestamp: new Date(0) });
+      controller.enqueue({ type: 'tool-call', toolCallId, toolName, input, providerExecuted: false });
+      controller.enqueue({
+        type: 'finish',
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      });
+      controller.close();
+    },
+  });
+}
+
+function createTextStream(text: string) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+      controller.enqueue({ type: 'response-metadata', id: 'id-1', modelId: 'mock', timestamp: new Date(0) });
+      controller.enqueue({ type: 'text-start', id: 'text-1' });
+      controller.enqueue({ type: 'text-delta', id: 'text-1', delta: text });
+      controller.enqueue({ type: 'text-end', id: 'text-1' });
+      controller.enqueue({
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      });
+      controller.close();
+    },
+  });
+}
 
 async function buildController(storage: InMemoryStore): Promise<{
   controller: AgentController<AgentControllerTestState>;
@@ -139,33 +183,74 @@ describe('AgentController mode-model persistence across restarts', () => {
     expect(restoreEvent?.previousModeId).toBe('build');
   });
 
-  it('resumes a submit_plan suspension through its plan-mode agent after switching to build', async () => {
-    const { session, agents } = await buildController(storage);
+  it('resumes a submit_plan run through its plan-mode agent after switching to build', async () => {
+    let planCalls = 0;
+    let buildCalls = 0;
+    const planAgent = new Agent({
+      id: 'plan-agent',
+      name: 'plan-agent',
+      instructions: 'You plan work.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => {
+          planCalls += 1;
+          return {
+            stream:
+              planCalls === 1
+                ? createToolCallStream({
+                    toolCallId: 'plan-call-1',
+                    toolName: 'submit_plan',
+                    input: '{"path":"plan.md"}',
+                  })
+                : createTextStream('Plan approved.'),
+          };
+        },
+      }),
+      tools: { submit_plan: submitPlanTool },
+    });
+    const buildAgent = new Agent({
+      id: 'build-agent',
+      name: 'build-agent',
+      instructions: 'You implement work.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => {
+          buildCalls += 1;
+          return { stream: createTextStream('Implementation complete.') };
+        },
+      }),
+    });
+    const controller = new AgentController<AgentControllerTestState>({
+      workspace: createMockWorkspace(),
+      id: 'test-controller',
+      storage,
+      initialState: { yolo: true } as any,
+      modes: [
+        { id: 'plan', name: 'Plan', default: true, transitionsTo: 'build', agent: planAgent },
+        { id: 'build', name: 'Build', agent: buildAgent },
+      ],
+    });
+    await controller.init();
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
     await session.thread.create();
-    await session.mode.switch({ modeId: 'plan' });
 
-    const planResume = vi.spyOn(agents.plan, 'sendStreamResume').mockImplementation(async () => {
-      session.emit({ type: 'agent_end', reason: 'complete' });
-      return undefined as never;
+    const events: any[] = [];
+    session.subscribe(event => {
+      events.push(event);
     });
-    const buildResume = vi.spyOn(agents.build, 'sendStreamResume');
+    await session.sendMessage({ content: 'Create a plan' });
+    const suspended = events.find(event => event.type === 'tool_suspended');
+    expect(suspended?.toolCallId).toBe('plan-call-1');
 
-    // Simulate a submit_plan tool that suspended during a plan-mode run.
-    session.suspensions.register({
-      toolCallId: 'plan-call-1',
-      runId: 'run-1',
-      agent: agents.plan,
-      toolName: 'submit_plan',
-    });
+    events.length = 0;
+    await session.respondToToolSuspension({ toolCallId: suspended.toolCallId, resumeData: { action: 'approved' } });
 
-    await session.respondToToolSuspension({ toolCallId: 'plan-call-1', resumeData: { action: 'approved' } });
-
-    // The approval switches to build before resuming, but the in-memory run is
-    // still owned by the plan-mode agent. Resuming through build would fail to
-    // find it in that agent's run registry.
-    expect(planResume).toHaveBeenCalledWith(expect.objectContaining({ runId: 'run-1', toolCallId: 'plan-call-1' }));
-    expect(buildResume).not.toHaveBeenCalled();
-    expect(session.suspensions.has({ toolCallId: 'plan-call-1' })).toBe(false);
+    expect(planCalls).toBe(2);
+    expect(buildCalls).toBe(0);
+    expect(events.some(event => event.type === 'agent_end')).toBe(true);
     expect(session.mode.get()).toBe('build');
+
+    events.length = 0;
+    await session.sendMessage({ content: 'Implement the approved plan' });
+    await vi.waitFor(() => expect(events.some(event => event.type === 'agent_end')).toBe(true));
+    expect(buildCalls).toBe(1);
   });
 });

--- a/packages/core/src/agent-controller/mode-model-persistence.test.ts
+++ b/packages/core/src/agent-controller/mode-model-persistence.test.ts
@@ -184,7 +184,7 @@ describe('AgentController mode-model persistence across restarts', () => {
   });
 
   it.each([true, false])(
-    'resumes a submit_plan run through its plan-mode agent after switching to build (controller storage: %s)',
+    'keeps using the plan-mode agent when a resumed submit_plan run suspends again after switching to build (controller storage: %s)',
     async hasStorage => {
       let planCalls = 0;
       let buildCalls = 0;
@@ -197,9 +197,9 @@ describe('AgentController mode-model persistence across restarts', () => {
             planCalls += 1;
             return {
               stream:
-                planCalls === 1
+                planCalls <= 2
                   ? createToolCallStream({
-                      toolCallId: 'plan-call-1',
+                      toolCallId: `plan-call-${planCalls}`,
                       toolName: 'submit_plan',
                       input: '{"path":"plan.md"}',
                     })
@@ -220,6 +220,8 @@ describe('AgentController mode-model persistence across restarts', () => {
           },
         }),
       });
+      const planResume = vi.spyOn(planAgent, 'sendStreamResume');
+      const buildResume = vi.spyOn(buildAgent, 'sendStreamResume');
       const controller = new AgentController<AgentControllerTestState>({
         workspace: createMockWorkspace(),
         id: 'test-controller',
@@ -245,15 +247,20 @@ describe('AgentController mode-model persistence across restarts', () => {
       events.length = 0;
       await session.respondToToolSuspension({ toolCallId: suspended.toolCallId, resumeData: { action: 'approved' } });
 
+      const resuspended = events.find(event => event.type === 'tool_suspended');
+      expect(resuspended?.toolCallId).toBe('plan-call-2');
       expect(planCalls).toBe(2);
-      expect(buildCalls).toBe(0);
-      expect(events.some(event => event.type === 'agent_end')).toBe(true);
+      expect(planResume).toHaveBeenCalledTimes(1);
+      expect(buildResume).not.toHaveBeenCalled();
       expect(session.mode.get()).toBe('build');
 
       events.length = 0;
-      await session.sendMessage({ content: 'Implement the approved plan' });
-      await vi.waitFor(() => expect(events.some(event => event.type === 'agent_end')).toBe(true));
-      expect(buildCalls).toBe(1);
+      await session.respondToToolSuspension({ toolCallId: resuspended.toolCallId, resumeData: { action: 'approved' } });
+
+      expect(planCalls).toBe(2);
+      expect(planResume).toHaveBeenCalledTimes(2);
+      expect(buildResume).not.toHaveBeenCalled();
+      expect(events.some(event => event.type === 'error')).toBe(false);
     },
   );
 });

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -741,6 +741,7 @@ export class SessionRunEngine {
           this.#session.suspensions.register({
             toolCallId: suspToolCallId,
             runId: suspRunId,
+            agent: this.#machinery.getAgent(),
             toolName: suspToolName,
           });
         }

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -10,7 +10,7 @@ import type { RequestContext } from '../request-context';
 import type { GoalEvaluationPayload } from '../stream/types';
 import { getTransformedToolPayload, hasTransformedToolPayload } from '../tools/payload-transform';
 import type { Session, SessionMachinery } from './session';
-import { ABORTED_BY_USER_REASON } from './session';
+import { ABORTED_BY_USER_REASON, SUSPENDED_RUN_AGENT_KEY } from './session';
 import {
   addOptionalUsageField,
   describeNonSuccessFinishReason,
@@ -738,10 +738,10 @@ export class SessionRunEngine {
 
         const suspRunId = this.#session.run.getRunId();
         if (suspRunId) {
+          this.#machinery.getRunScope(suspRunId)?.set(SUSPENDED_RUN_AGENT_KEY, this.#machinery.getAgent());
           this.#session.suspensions.register({
             toolCallId: suspToolCallId,
             runId: suspRunId,
-            agent: this.#machinery.getAgent(),
             toolName: suspToolName,
           });
         }

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -1,3 +1,4 @@
+import type { Agent } from '../agent';
 import type {
   MastraDBMessage,
   MastraMessagePart,
@@ -486,6 +487,7 @@ export class SessionRunEngine {
     state: StreamState,
     chunk: StreamChunk,
     requestContext: RequestContext,
+    agent: Agent = this.#machinery.getAgent(),
   ): Promise<{ message: MastraDBMessage; suspended?: boolean } | undefined> {
     if ('runId' in chunk && chunk.runId) {
       this.#session.run.setRunId({ runId: chunk.runId });
@@ -738,7 +740,13 @@ export class SessionRunEngine {
 
         const suspRunId = this.#session.run.getRunId();
         if (suspRunId) {
-          this.#machinery.getRunScope(suspRunId)?.set(SUSPENDED_RUN_AGENT_KEY, this.#machinery.getAgent());
+          const runScope = this.#machinery.getRunScope(suspRunId);
+          // A subscription restored for the current mode can replay this
+          // suspension after a plan→build transition. Keep the agent that first
+          // owned the run so a later resume reaches its original snapshot.
+          if (!runScope?.get(SUSPENDED_RUN_AGENT_KEY)) {
+            runScope?.set(SUSPENDED_RUN_AGENT_KEY, agent);
+          }
           this.#session.suspensions.register({
             toolCallId: suspToolCallId,
             runId: suspRunId,
@@ -1231,6 +1239,7 @@ export class SessionRunEngine {
   }
 
   async processSubscribedThreadStream(subscription: AgentThreadSubscription<StreamChunk>): Promise<void> {
+    const agent = this.#session.stream.getAgent({ subscription }) ?? this.#machinery.getAgent();
     let currentRun: StreamState | undefined;
     let requestContext!: RequestContext;
     let bailed = false;
@@ -1259,7 +1268,7 @@ export class SessionRunEngine {
         }
 
         try {
-          const streamResult = await this.processStreamChunk(currentRun, chunk, requestContext);
+          const streamResult = await this.processStreamChunk(currentRun, chunk, requestContext, agent);
           if (
             streamResult ||
             chunk.type === 'finish' ||

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -1060,6 +1060,8 @@ export class SessionStream {
 export interface PendingSuspension {
   /** The run id to resume when this tool call is answered. */
   runId: string;
+  /** The agent that owns the in-memory suspended run. */
+  agent?: Agent;
   /** The suspended tool's name (e.g. `ask_user`, `submit_plan`). */
   toolName: string;
 }
@@ -1081,8 +1083,18 @@ export class SessionSuspensions {
   readonly #pending = new Map<string, PendingSuspension>();
 
   /** Park `toolCallId` as awaiting a resume on `runId` for `toolName`. */
-  register({ toolCallId, runId, toolName }: { toolCallId: string; runId: string; toolName: string }): void {
-    this.#pending.set(toolCallId, { runId, toolName });
+  register({
+    toolCallId,
+    runId,
+    agent,
+    toolName,
+  }: {
+    toolCallId: string;
+    runId: string;
+    agent?: Agent;
+    toolName: string;
+  }): void {
+    this.#pending.set(toolCallId, { runId, agent, toolName });
   }
 
   /** The parked suspension for `toolCallId`, or undefined when none. */
@@ -3857,7 +3869,11 @@ export class Session<TState = unknown> {
       throw new Error('No active suspension to resume');
     }
 
-    const agent = this.machinery.getAgent();
+    // Resume through the agent that suspended the run. A `submit_plan` approval
+    // switches modes before resuming, but suspended snapshots are owned by their
+    // originating agent so another mode's agent cannot reclaim one by run id.
+    // An explicit, authorized run-handoff would be required to transfer ownership.
+    const agent = suspension.agent ?? this.machinery.getAgent();
 
     // Remove before resuming so a re-suspend during the resumed run can
     // re-register the same toolCallId without being clobbered by this cleanup.

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -271,7 +271,11 @@ export interface SessionMachinery {
   /** Get the ephemeral state associated with an active or suspended run. */
   getRunScope(runId: string): RunScope | undefined;
   /** Open a fresh subscription to a thread's agent event stream. */
-  subscribeToThread(input: { resourceId: string; threadId: string }): Promise<AgentThreadSubscription<any>>;
+  subscribeToThread(input: {
+    agent?: Agent;
+    resourceId: string;
+    threadId: string;
+  }): Promise<AgentThreadSubscription<any>>;
   /** Build the per-call stream options (instructions, memory, toolsets, abort signal, tracing). */
   buildStreamOptions(input: {
     requestContext?: RequestContext;
@@ -544,15 +548,14 @@ export class SessionThread {
    * Ensure the session is subscribed to the given agent/thread stream, opening a
    * fresh subscription (and driving its run loop) when the binding changed.
    */
-  async ensureSubscription(threadId: string): Promise<void> {
+  async ensureSubscription(threadId: string, agent = this.#owner.machinery.getAgent()): Promise<void> {
     const session = this.#owner;
-    const agent = session.machinery.getAgent();
     const resourceId = this.#getResourceId();
     const key = SessionStream.keyFor({ agent, resourceId, threadId });
     if (session.stream.matches({ key })) return;
 
     this.cleanupSubscription();
-    const subscription = await session.machinery.subscribeToThread({ resourceId, threadId });
+    const subscription = await session.machinery.subscribeToThread({ agent, resourceId, threadId });
     session.stream.attach({ subscription, key });
     void session.processSubscribedThreadStream(subscription);
   }
@@ -3883,7 +3886,7 @@ export class Session<TState = unknown> {
       throw new Error('Cannot resume a suspended tool without a current thread');
     }
 
-    await this.thread.ensureSubscription(threadId);
+    await this.thread.ensureSubscription(threadId, agent);
     const resumedSubscriptionBoundary = this.createSubscribedResumeBoundaryWaiter(
       suspension.toolName === 'submit_plan' ? toolCallId : undefined,
     );
@@ -3916,6 +3919,7 @@ export class Session<TState = unknown> {
       await resumedSubscriptionBoundary.promise;
     } finally {
       resumedSubscriptionBoundary.cancel();
+      await this.thread.ensureSubscription(threadId);
     }
   }
 

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -19,6 +19,8 @@ import { getErrorFromUnknown } from '../error';
 import type { MastraModelGatewayInterface } from '../llm/model/gateways';
 import { ModelRouterLanguageModel } from '../llm/model/router';
 import type { MastraModelConfig } from '../llm/model/shared.types';
+import { createRunScopeKey } from '../mastra/run-scope';
+import type { RunScope } from '../mastra/run-scope';
 import type { SendNotificationSignalInput } from '../notifications';
 import type { TracingContext, TracingOptions } from '../observability';
 import type { RequestContext } from '../request-context';
@@ -46,6 +48,8 @@ import type {
   TokenUsage,
   ToolCategory,
 } from './types';
+
+export const SUSPENDED_RUN_AGENT_KEY = createRunScopeKey<Agent>('agent-controller.suspendedRunAgent');
 
 /**
  * Minimal persistence surface the Session uses to read and write per-thread
@@ -264,6 +268,8 @@ export interface ThreadDataStore {
 export interface SessionMachinery {
   /** Resolve the agent that should answer for the session's current mode/model. */
   getAgent(): Agent;
+  /** Get the ephemeral state associated with an active or suspended run. */
+  getRunScope(runId: string): RunScope | undefined;
   /** Open a fresh subscription to a thread's agent event stream. */
   subscribeToThread(input: { resourceId: string; threadId: string }): Promise<AgentThreadSubscription<any>>;
   /** Build the per-call stream options (instructions, memory, toolsets, abort signal, tracing). */
@@ -1060,8 +1066,6 @@ export class SessionStream {
 export interface PendingSuspension {
   /** The run id to resume when this tool call is answered. */
   runId: string;
-  /** The agent that owns the in-memory suspended run. */
-  agent?: Agent;
   /** The suspended tool's name (e.g. `ask_user`, `submit_plan`). */
   toolName: string;
 }
@@ -1083,18 +1087,8 @@ export class SessionSuspensions {
   readonly #pending = new Map<string, PendingSuspension>();
 
   /** Park `toolCallId` as awaiting a resume on `runId` for `toolName`. */
-  register({
-    toolCallId,
-    runId,
-    agent,
-    toolName,
-  }: {
-    toolCallId: string;
-    runId: string;
-    agent?: Agent;
-    toolName: string;
-  }): void {
-    this.#pending.set(toolCallId, { runId, agent, toolName });
+  register({ toolCallId, runId, toolName }: { toolCallId: string; runId: string; toolName: string }): void {
+    this.#pending.set(toolCallId, { runId, toolName });
   }
 
   /** The parked suspension for `toolCallId`, or undefined when none. */
@@ -3873,7 +3867,8 @@ export class Session<TState = unknown> {
     // switches modes before resuming, but suspended snapshots are owned by their
     // originating agent so another mode's agent cannot reclaim one by run id.
     // An explicit, authorized run-handoff would be required to transfer ownership.
-    const agent = suspension.agent ?? this.machinery.getAgent();
+    const agent =
+      this.machinery.getRunScope(suspension.runId)?.get(SUSPENDED_RUN_AGENT_KEY) ?? this.machinery.getAgent();
 
     // Remove before resuming so a re-suspend during the resumed run can
     // re-register the same toolCallId without being clobbered by this cleanup.

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3821,16 +3821,11 @@ export class Session<TState = unknown> {
     });
   }
 
-  private createSubscribedResumeBoundaryWaiter(toolCallId?: string): { promise: Promise<void>; cancel: () => void } {
+  private createSubscribedResumeBoundaryWaiter(): { promise: Promise<void>; cancel: () => void } {
     let unsubscribe: (() => void) | undefined;
     const promise = new Promise<void>(resolve => {
       unsubscribe = this.subscribe(event => {
-        if (
-          event.type === 'tool_suspended' ||
-          event.type === 'agent_end' ||
-          event.type === 'error' ||
-          (event.type === 'tool_end' && toolCallId && event.toolCallId === toolCallId)
-        ) {
+        if (event.type === 'tool_suspended' || event.type === 'agent_end' || event.type === 'error') {
           unsubscribe?.();
           resolve();
         }
@@ -3887,9 +3882,7 @@ export class Session<TState = unknown> {
     }
 
     await this.thread.ensureSubscription(threadId, agent);
-    const resumedSubscriptionBoundary = this.createSubscribedResumeBoundaryWaiter(
-      suspension.toolName === 'submit_plan' ? toolCallId : undefined,
-    );
+    const resumedSubscriptionBoundary = this.createSubscribedResumeBoundaryWaiter();
 
     try {
       const resourceId = this.identity.getResourceId();

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -556,7 +556,7 @@ export class SessionThread {
 
     this.cleanupSubscription();
     const subscription = await session.machinery.subscribeToThread({ agent, resourceId, threadId });
-    session.stream.attach({ subscription, key });
+    session.stream.attach({ subscription, agent, key });
     void session.processSubscribedThreadStream(subscription);
   }
 
@@ -978,6 +978,8 @@ export class SessionThread {
 export class SessionStream {
   /** The live subscription to the active thread, or null when none is open. */
   #subscription: AgentThreadSubscription<any> | null = null;
+  /** Agent that created the live subscription, or null when none is open. */
+  #agent: Agent | null = null;
   /** Dedup key (`agentId:resourceId:threadId`) for the open subscription, or null. */
   #key: string | null = null;
   readonly #teardownWaiters = new Set<() => void>();
@@ -1014,10 +1016,24 @@ export class SessionStream {
     return this.#key === key && this.#subscription !== null;
   }
 
-  /** Adopt `subscription` as the live one, recording its dedup `key`. */
-  attach({ subscription, key }: { subscription: AgentThreadSubscription<any>; key: string }): void {
+  /** Adopt `subscription` as the live one, recording its owning agent and dedup `key`. */
+  attach({
+    subscription,
+    agent,
+    key,
+  }: {
+    subscription: AgentThreadSubscription<any>;
+    agent?: Agent;
+    key: string;
+  }): void {
     this.#subscription = subscription;
+    this.#agent = agent ?? null;
     this.#key = key;
+  }
+
+  /** Agent that owns `subscription`, when it is the live subscription. */
+  getAgent({ subscription }: { subscription: AgentThreadSubscription<any> }): Agent | null {
+    return this.#subscription === subscription ? this.#agent : null;
   }
 
   /** Whether a subscription is currently open. */
@@ -1051,6 +1067,7 @@ export class SessionStream {
   detach(): void {
     this.#subscription?.unsubscribe();
     this.#subscription = null;
+    this.#agent = null;
     this.#key = null;
     this.#notifyTeardown();
   }
@@ -1060,6 +1077,7 @@ export class SessionStream {
     this.#subscription?.abort();
     this.#subscription?.unsubscribe();
     this.#subscription = null;
+    this.#agent = null;
     this.#key = null;
     this.#notifyTeardown();
   }

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3729,7 +3729,14 @@ export class Session<TState = unknown> {
     requestContext?: RequestContext;
   }): Promise<void> {
     if (response.action === 'rejected') {
-      await this.resumeToolCall({ resumeData: response, toolCallId, requestContext });
+      // The caller aborts once the rejected tool result is persisted. Waiting for
+      // the run to terminate here would prevent that abort from ever being sent.
+      await this.resumeToolCall({
+        resumeData: response,
+        toolCallId,
+        requestContext,
+        resolveOnToolEnd: true,
+      });
       return;
     }
 
@@ -3821,11 +3828,19 @@ export class Session<TState = unknown> {
     });
   }
 
-  private createSubscribedResumeBoundaryWaiter(): { promise: Promise<void>; cancel: () => void } {
+  private createSubscribedResumeBoundaryWaiter({
+    toolCallId,
+    resolveOnToolEnd = false,
+  }: {
+    toolCallId: string;
+    resolveOnToolEnd?: boolean;
+  }): { promise: Promise<void>; cancel: () => void } {
     let unsubscribe: (() => void) | undefined;
     const promise = new Promise<void>(resolve => {
       unsubscribe = this.subscribe(event => {
-        if (event.type === 'tool_suspended' || event.type === 'agent_end' || event.type === 'error') {
+        const isTerminal = event.type === 'tool_suspended' || event.type === 'agent_end' || event.type === 'error';
+        const completedResumedTool = resolveOnToolEnd && event.type === 'tool_end' && event.toolCallId === toolCallId;
+        if (isTerminal || completedResumedTool) {
           unsubscribe?.();
           resolve();
         }
@@ -3851,10 +3866,12 @@ export class Session<TState = unknown> {
     resumeData,
     toolCallId,
     requestContext: requestContextInput,
+    resolveOnToolEnd = false,
   }: {
     resumeData: any;
     toolCallId: string;
     requestContext?: RequestContext;
+    resolveOnToolEnd?: boolean;
   }): Promise<void> {
     const suspension = this.suspensions.get({ toolCallId });
     if (!suspension) {
@@ -3882,7 +3899,7 @@ export class Session<TState = unknown> {
     }
 
     await this.thread.ensureSubscription(threadId, agent);
-    const resumedSubscriptionBoundary = this.createSubscribedResumeBoundaryWaiter();
+    const resumedSubscriptionBoundary = this.createSubscribedResumeBoundaryWaiter({ toolCallId, resolveOnToolEnd });
 
     try {
       const resourceId = this.identity.getResourceId();


### PR DESCRIPTION
Plan approvals switch the session to build mode before the suspended run resumes. The run remains owned by the agent that created it, so resuming through the build agent could not find the stored suspension.

Before: the newly selected mode tried to resume the plan run.
After: the suspension resumes through its owner while the session retains the build-mode transition.

Added a regression test covering the plan-to-build transition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a plan pauses for approval, it resumes with the same agent that started it. After approval, the session changes to build mode and uses the build agent for later messages.

## Changes

- Store the owning agent in the suspended run scope.
- Resume suspended runs through the owning agent.
- Restore the current mode subscription after the run ends.
- Support rejected plan resumes at the tool-completion boundary.
- Expose run scopes through `SessionMachinery`.
- Allow thread subscriptions to use an explicit agent.
- Initialize internal Mastra support for standalone controllers without storage.
- Add an end-to-end regression test for the plan-to-build transition.
- Add patch changesets for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->