### PR TITLE
fix(daytona): require explicit computer use opt-in

### DIFF
--- a/.changeset/deep-showers-check.md
+++ b/.changeset/deep-showers-check.md
@@ -1,0 +1,5 @@
+---
+'@mastra/daytona': patch
+---
+
+Fixed Daytona computer use to remain disabled unless `computerUse` is explicitly enabled, preventing unexpected computer tools from being added after upgrading.

--- a/docs/src/content/en/integrations/sandboxes/daytona.mdx
+++ b/docs/src/content/en/integrations/sandboxes/daytona.mdx
@@ -290,12 +290,12 @@ Inside the sandbox, the environment variable holds an opaque placeholder. Dayton
 
 ### Computer use (desktop)
 
-`DaytonaSandbox` exposes the [computer capability](/docs/sandbox/overview#computer-use-tools): screenshot, mouse, and keyboard control of a desktop environment inside the sandbox. When the sandbox is used in a workspace, agents automatically get the `mastra_workspace_computer_*` tools.
+Enable the [computer capability](/docs/sandbox/overview#computer-use-tools) with `computerUse`. This adds screenshot, mouse, and keyboard control to the sandbox. When the sandbox is used in a workspace, agents automatically get the `mastra_workspace_computer_*` tools.
 
-The desktop processes (Xvfb, xfce4, x11vnc, noVNC) are started lazily on the first computer operation:
+Computer use is disabled by default. Set `computerUse: true` to start the desktop processes (Xvfb, xfce4, x11vnc, noVNC) lazily on the first computer operation:
 
 ```typescript
-const sandbox = new DaytonaSandbox()
+const sandbox = new DaytonaSandbox({ computerUse: true })
 await sandbox.start()
 
 await sandbox.computer.leftClick(100, 200)
@@ -306,14 +306,15 @@ const { data } = await sandbox.computer.screenshot() // PNG bytes
 const url = await sandbox.computer.streamUrl()
 ```
 
-Disable the capability, or manage the desktop processes yourself, with the `computerUse` option:
+Pass an options object to configure the capability. For example, disable automatic desktop startup when you manage the Daytona process directly:
 
 ```typescript
-// No computer capability, no computer tools
-new DaytonaSandbox({ computerUse: false })
+const sandbox = new DaytonaSandbox({
+  computerUse: { autoStart: false },
+})
 
-// Capability stays on, but you call sandbox.daytona.computerUse.start() yourself
-new DaytonaSandbox({ computerUse: { autoStart: false } })
+await sandbox.start()
+await sandbox.daytona.computerUse.start()
 ```
 
 For Daytona-specific desktop APIs (regions, compressed screenshots, screen recording, accessibility tree), use the [direct SDK access](#direct-sdk-access) escape hatch: `sandbox.daytona.computerUse`.
@@ -481,9 +482,9 @@ For Daytona-specific desktop APIs (regions, compressed screenshots, screen recor
     name: 'computerUse',
     type: 'boolean | { autoStart?: boolean; noVncPort?: number }',
     description:
-      'Computer-use (desktop) capability configuration. Set to false to disable the capability. Set autoStart to false to manage the desktop processes yourself. noVncPort sets the noVNC viewer port used by computer.streamUrl().',
+      'Computer-use (desktop) capability configuration. Set to true or provide an options object to enable the capability. Set autoStart to false to manage the desktop processes yourself. noVncPort sets the noVNC viewer port used by computer.streamUrl().',
     isOptional: true,
-    defaultValue: 'true',
+    defaultValue: 'false',
   },
 ]}
 />
@@ -528,7 +529,7 @@ For Daytona-specific desktop APIs (regions, compressed screenshots, screen recor
     name: 'computer',
     type: 'SandboxComputer | undefined',
     description:
-      'Computer-use capability: screenshot, mouse, keyboard, and stream URL. Undefined when constructed with computerUse: false. See [SandboxComputer reference](/reference/workspace/sandbox#computer-capability).',
+      'Computer-use capability: screenshot, mouse, keyboard, and stream URL. Available only when computerUse is explicitly enabled. See [SandboxComputer reference](/reference/workspace/sandbox#computer-capability).',
   },
 ]}
 />

--- a/workspaces/daytona/src/sandbox/index.integration.test.ts
+++ b/workspaces/daytona/src/sandbox/index.integration.test.ts
@@ -848,6 +848,7 @@ describe.skipIf(!process.env.DAYTONA_API_KEY)('DaytonaSandbox Computer Use', () 
     sandbox = new DaytonaSandbox({
       id: `test-computer-${Date.now()}`,
       timeout: 60000,
+      computerUse: true,
     });
   });
 

--- a/workspaces/daytona/src/sandbox/index.test.ts
+++ b/workspaces/daytona/src/sandbox/index.test.ts
@@ -1265,8 +1265,15 @@ describe('DaytonaSandbox', () => {
   });
 
   describe('Computer Use', () => {
-    it('exposes the computer capability by default', () => {
+    it('does not expose the computer capability by default', () => {
       const sandbox = new DaytonaSandbox();
+
+      expect(sandbox.computer).toBeUndefined();
+      expect(supportsComputer(sandbox)).toBe(false);
+    });
+
+    it('computerUse: true enables the capability', () => {
+      const sandbox = new DaytonaSandbox({ computerUse: true });
 
       expect(sandbox.computer).toBeDefined();
       expect(supportsComputer(sandbox)).toBe(true);
@@ -1280,7 +1287,7 @@ describe('DaytonaSandbox', () => {
     });
 
     it('starts desktop processes lazily on the first operation and memoizes', async () => {
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
       expect(mockSandbox.computerUse.start).not.toHaveBeenCalled();
 
@@ -1301,7 +1308,7 @@ describe('DaytonaSandbox', () => {
     });
 
     it('restarts desktop processes after the sandbox is stopped', async () => {
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
       await sandbox.computer!.leftClick(1, 1);
       expect(mockSandbox.computerUse.start).toHaveBeenCalledTimes(1);
@@ -1314,7 +1321,7 @@ describe('DaytonaSandbox', () => {
 
     it('retries lazy start after a startup failure', async () => {
       mockSandbox.computerUse.start.mockRejectedValueOnce(new Error('no desktop'));
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       await expect(sandbox.computer!.leftClick(1, 1)).rejects.toThrow('no desktop');
@@ -1325,7 +1332,7 @@ describe('DaytonaSandbox', () => {
     });
 
     it('screenshot decodes the base64 response to PNG bytes', async () => {
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       const shot = await sandbox.computer!.screenshot();
@@ -1337,14 +1344,14 @@ describe('DaytonaSandbox', () => {
 
     it('screenshot throws on an empty response', async () => {
       mockSandbox.computerUse.screenshot.takeFullScreen.mockResolvedValueOnce({});
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       await expect(sandbox.computer!.screenshot()).rejects.toThrow(/empty screenshot/);
     });
 
     it('maps clicks to mouse.click with the right button semantics', async () => {
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       await sandbox.computer!.leftClick(10, 20);
@@ -1357,7 +1364,7 @@ describe('DaytonaSandbox', () => {
     });
 
     it('maps moveMouse and drag', async () => {
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       await sandbox.computer!.moveMouse(5, 6);
@@ -1369,7 +1376,7 @@ describe('DaytonaSandbox', () => {
 
     it('scroll uses the current cursor position', async () => {
       mockSandbox.computerUse.mouse.getPosition.mockResolvedValue({ x: 640, y: 360 });
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       await sandbox.computer!.scroll('down', 3);
@@ -1378,7 +1385,7 @@ describe('DaytonaSandbox', () => {
     });
 
     it('maps type, single key press, and hotkey chords', async () => {
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       await sandbox.computer!.type('hello world');
@@ -1397,7 +1404,7 @@ describe('DaytonaSandbox', () => {
           { id: 1, x: 800, y: 0, width: 1920, height: 1080, isActive: true },
         ],
       });
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       const size = await sandbox.computer!.getScreenSize();
@@ -1407,7 +1414,7 @@ describe('DaytonaSandbox', () => {
 
     it('getScreenSize throws when no display info is returned', async () => {
       mockSandbox.computerUse.display.getInfo.mockResolvedValueOnce({ displays: [] });
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       await expect(sandbox.computer!.getScreenSize()).rejects.toThrow(/display information/);
@@ -1415,7 +1422,7 @@ describe('DaytonaSandbox', () => {
 
     it('getCursorPosition returns the mouse position', async () => {
       mockSandbox.computerUse.mouse.getPosition.mockResolvedValue({ x: 12, y: 34 });
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       const position = await sandbox.computer!.getCursorPosition();
@@ -1425,7 +1432,7 @@ describe('DaytonaSandbox', () => {
 
     it('streamUrl resolves the noVNC preview link (default port 6080)', async () => {
       mockSandbox.getPreviewLink.mockResolvedValue({ url: 'https://6080-mock.proxy.daytona.work', token: 't' });
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       const url = await sandbox.computer!.streamUrl!();
@@ -1446,7 +1453,7 @@ describe('DaytonaSandbox', () => {
 
     it('streamUrl returns null when the preview link fails', async () => {
       mockSandbox.getPreviewLink.mockRejectedValueOnce(new Error('preview unavailable'));
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       await sandbox._start();
 
       const url = await sandbox.computer!.streamUrl!();
@@ -1455,7 +1462,7 @@ describe('DaytonaSandbox', () => {
     });
 
     it('operations start the sandbox automatically when not running', async () => {
-      const sandbox = new DaytonaSandbox();
+      const sandbox = new DaytonaSandbox({ computerUse: true });
 
       await sandbox.computer!.leftClick(1, 2);
 
@@ -1463,8 +1470,19 @@ describe('DaytonaSandbox', () => {
       expect(mockSandbox.computerUse.mouse.click).toHaveBeenCalledWith(1, 2, 'left');
     });
 
-    it('emits exactly the workspace computer tool set', async () => {
+    it('does not emit workspace computer tools by default', async () => {
       const sandbox = new DaytonaSandbox();
+      const workspace = new Workspace({ sandbox });
+
+      const tools = await createWorkspaceTools(workspace);
+
+      const computerToolNames = Object.keys(tools).filter(name => name.startsWith('mastra_workspace_computer_'));
+      expect(computerToolNames).toEqual([]);
+      expect(tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]).toBeDefined();
+    });
+
+    it('emits exactly the workspace computer tool set when enabled', async () => {
+      const sandbox = new DaytonaSandbox({ computerUse: true });
       const workspace = new Workspace({ sandbox });
 
       const tools = await createWorkspaceTools(workspace);
@@ -1955,6 +1973,14 @@ describe('DaytonaSandbox.clone', () => {
     expect(child).not.toBe(template);
     expect(child.id).toBe('mc-project-1');
     expect(child.status).toBe('pending');
+  });
+
+  it('preserves explicit computer use configuration', () => {
+    const disabledChild = new DaytonaSandbox().clone();
+    const enabledChild = new DaytonaSandbox({ computerUse: true }).clone();
+
+    expect(disabledChild.computer).toBeUndefined();
+    expect(enabledChild.computer).toBeDefined();
   });
 
   it('inherits template config and applies env override', () => {

--- a/workspaces/daytona/src/sandbox/index.ts
+++ b/workspaces/daytona/src/sandbox/index.ts
@@ -188,12 +188,12 @@ export interface DaytonaSandboxOptions extends Omit<MastraSandboxOptions, 'proce
   /**
    * Computer-use (desktop) capability configuration.
    *
-   * When enabled (the default), the sandbox exposes the `computer` capability
-   * and workspaces emit the `mastra_workspace_computer_*` tools. The desktop
-   * processes (Xvfb, xfce4, x11vnc, noVNC) are started lazily on the first
-   * computer operation.
+   * Set to `true` or provide an options object to expose the `computer`
+   * capability and emit the `mastra_workspace_computer_*` workspace tools.
+   * The desktop processes (Xvfb, xfce4, x11vnc, noVNC) are started lazily on
+   * the first computer operation.
    *
-   * Set to `false` to disable the capability entirely.
+   * @default false
    */
   computerUse?:
     | boolean
@@ -287,9 +287,9 @@ export class DaytonaSandbox extends MastraSandbox {
    * Computer-use (desktop) capability: screenshot, mouse, and keyboard control
    * of the sandbox's desktop environment via Daytona's computer use API.
    *
-   * `undefined` when the sandbox was constructed with `computerUse: false`.
-   * Desktop processes are started lazily on the first operation (unless
-   * `computerUse.autoStart` is `false`).
+   * Available when the sandbox is constructed with `computerUse: true` or an
+   * options object. Desktop processes are started lazily on the first operation
+   * unless `computerUse.autoStart` is `false`.
    */
   declare readonly computer?: SandboxComputer;
 
@@ -363,11 +363,11 @@ export class DaytonaSandbox extends MastraSandbox {
     };
     this._constructorOptions = { ...options };
 
-    const computerUseOption = options.computerUse ?? true;
+    const computerUseOption = options.computerUse;
     this.computerUseAutoStart = typeof computerUseOption === 'object' ? (computerUseOption.autoStart ?? true) : true;
     this.noVncPort =
       typeof computerUseOption === 'object' ? (computerUseOption.noVncPort ?? DEFAULT_NOVNC_PORT) : DEFAULT_NOVNC_PORT;
-    if (computerUseOption !== false) {
+    if (computerUseOption === true || typeof computerUseOption === 'object') {
       this.computer = this.createComputer();
     }
   }


### PR DESCRIPTION
## Summary

- keep Daytona computer use disabled unless `computerUse` is explicitly enabled
- preserve desktop behavior for `computerUse: true` and options-object configurations
- add regression coverage for default workspace tool registration, explicit opt-in, cloning, and integration setup
- update the Daytona integration guide and add a patch changeset

## Why

Upgrading `@mastra/daytona` caused ordinary Daytona-backed agents to receive all 11 computer-use tools even when desktop control was never requested. Computer use is an optional capability and should require explicit configuration.

## Test plan

- `pnpm test:unit` in `workspaces/daytona` — 154 passed, 13 skipped
- `pnpm test` in `workspaces/daytona` — 130 credential-gated tests skipped without `DAYTONA_API_KEY`
- `pnpm build` in `workspaces/daytona`
- `pnpm lint` in `workspaces/daytona`
- `pnpm exec tsc --noEmit -p tsconfig.json` in `workspaces/daytona`
- focused MDX formatting, Remark, and Vale checks for the Daytona integration guide
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Daytona computer-use tools are now off by default. They become available only when `computerUse: true` or a `computerUse` options object is provided.

## Changes

- Updated `@mastra/daytona` to require explicit computer-use enablement.
- Preserved desktop behavior for `computerUse: true` and options-object configurations.
- Updated clone behavior to preserve computer-use settings.
- Added regression tests for:
  - Default tool registration.
  - Explicit computer-use opt-in.
  - Cloning.
  - Integration setup.
- Updated the Daytona integration guide.
- Added a patch changeset for `@mastra/daytona`.
- Ran unit, integration, build, lint, type-check, documentation formatting, and diff validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->