### PR TITLE
fix(memory): persist reminder conversations across turns

### DIFF
--- a/.changeset/remind-continuity-thread.md
+++ b/.changeset/remind-continuity-thread.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Improve experimental Subconscious reminder continuity.

--- a/packages/memory/integration-tests/src/subconscious-libsql.test.ts
+++ b/packages/memory/integration-tests/src/subconscious-libsql.test.ts
@@ -303,7 +303,7 @@ describe('Subconscious LibSQL integration', () => {
 
     expect(result.observed).toBe(true);
     expect(getModel).not.toHaveBeenCalled();
-    expect(streamCall).toBe(1);
+    expect(streamCall).toBe(2);
     expect(sendSignal).toHaveBeenCalledOnce();
     expect(sendSignal).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'reactive', tagName: 'remembered', contents: expect.stringContaining(reminder) }),
@@ -322,19 +322,25 @@ describe('Subconscious LibSQL integration', () => {
     const observations = threadIds
       .map(threadId => `<thread id="${threadId}">\n- Project Atlas planning is active.\n</thread>`)
       .join('\n');
+    let streamCall = 0;
+    const reminder = 'Project Atlas launches January 15. Source KnowledgeRecord: record-atlas-resource-launch.';
     const model = new MockLanguageModelV2({
-      doStream: async () => ({
-        stream: convertArrayToReadableStream([
-          { type: 'stream-start', warnings: [] },
-          { type: 'response-metadata', id: 'resource-observation', modelId: 'aimock', timestamp: new Date() },
-          { type: 'text-start', id: 'resource-text' },
-          { type: 'text-delta', id: 'resource-text', delta: `<observations>${observations}</observations>` },
-          { type: 'text-end', id: 'resource-text' },
-          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 } },
-        ]),
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        warnings: [],
-      }),
+      doStream: async () => {
+        streamCall += 1;
+        const text = streamCall === 1 ? `<observations>${observations}</observations>` : reminder;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: `resource-${streamCall}`, modelId: 'aimock', timestamp: new Date() },
+            { type: 'text-start', id: `resource-text-${streamCall}` },
+            { type: 'text-delta', id: `resource-text-${streamCall}`, delta: text },
+            { type: 'text-end', id: `resource-text-${streamCall}` },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
       doGenerate: async () => ({
         rawCall: { rawPrompt: null, rawSettings: {} },
         finishReason: 'stop' as const,

--- a/packages/memory/integration-tests/src/subconscious-libsql.test.ts
+++ b/packages/memory/integration-tests/src/subconscious-libsql.test.ts
@@ -231,6 +231,7 @@ describe('Subconscious LibSQL integration', () => {
     await storage.init();
 
     let streamCall = 0;
+    let generateCall = 0;
     const reminder = 'Project Atlas launches January 15. Source KnowledgeRecord: record-atlas-launch.';
     const model = new MockLanguageModelV2({
       doStream: async () => {
@@ -250,13 +251,16 @@ describe('Subconscious LibSQL integration', () => {
           warnings: [],
         };
       },
-      doGenerate: async () => ({
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        finishReason: 'stop' as const,
-        usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 },
-        warnings: [],
-        content: [{ type: 'text' as const, text: reminder }],
-      }),
+      doGenerate: async () => {
+        generateCall += 1;
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 },
+          warnings: [],
+          content: [{ type: 'text' as const, text: reminder }],
+        };
+      },
     });
     const memory = new Memory({
       storage,
@@ -303,7 +307,10 @@ describe('Subconscious LibSQL integration', () => {
 
     expect(result.observed).toBe(true);
     expect(getModel).not.toHaveBeenCalled();
-    expect(streamCall).toBe(2);
+    // The observation pass streams; the reminder lane calls `agent.generate()`, so it must not add a
+    // second stream call. Routing reminders through the streaming transport lands in a later PR.
+    expect(streamCall).toBe(1);
+    expect(generateCall).toBe(1);
     expect(sendSignal).toHaveBeenCalledOnce();
     expect(sendSignal).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'reactive', tagName: 'remembered', contents: expect.stringContaining(reminder) }),
@@ -322,25 +329,19 @@ describe('Subconscious LibSQL integration', () => {
     const observations = threadIds
       .map(threadId => `<thread id="${threadId}">\n- Project Atlas planning is active.\n</thread>`)
       .join('\n');
-    let streamCall = 0;
-    const reminder = 'Project Atlas launches January 15. Source KnowledgeRecord: record-atlas-resource-launch.';
     const model = new MockLanguageModelV2({
-      doStream: async () => {
-        streamCall += 1;
-        const text = streamCall === 1 ? `<observations>${observations}</observations>` : reminder;
-        return {
-          stream: convertArrayToReadableStream([
-            { type: 'stream-start', warnings: [] },
-            { type: 'response-metadata', id: `resource-${streamCall}`, modelId: 'aimock', timestamp: new Date() },
-            { type: 'text-start', id: `resource-text-${streamCall}` },
-            { type: 'text-delta', id: `resource-text-${streamCall}`, delta: text },
-            { type: 'text-end', id: `resource-text-${streamCall}` },
-            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 } },
-          ]),
-          rawCall: { rawPrompt: null, rawSettings: {} },
-          warnings: [],
-        };
-      },
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'resource-observation', modelId: 'aimock', timestamp: new Date() },
+          { type: 'text-start', id: 'resource-text' },
+          { type: 'text-delta', id: 'resource-text', delta: `<observations>${observations}</observations>` },
+          { type: 'text-end', id: 'resource-text' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 } },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
       doGenerate: async () => ({
         rawCall: { rawPrompt: null, rawSettings: {} },
         finishReason: 'stop' as const,

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -58,6 +58,7 @@ import {
   composeReflectionAgentHandlers,
   createLearnerHandler,
 } from './processors/observational-memory/subconscious/learn';
+import { remindThreadKey } from './processors/observational-memory/subconscious/remind';
 import { summarizeConversation, SUMMARIZE_THREAD_DEFAULTS } from './processors/observational-memory/summarize';
 import type {
   SummarizeConversationOptions,
@@ -387,8 +388,9 @@ export class Memory extends MastraMemory {
     const observation = (omConfig.observation ?? {}) as NonNullable<ObservationalMemoryConfig['observation']>;
     const extract = observation.extract ?? [];
     const existingSlugs = new Set(extract.map(extractor => extractor.slug));
+    const omModel = observation.model ?? omConfig.model;
     const subconsciousExtractors = omConfig.experimental_subconscious
-      .createObservationExtractors(observation.model ?? omConfig.model)
+      .createObservationExtractors(omModel, { createRemindMemory: () => this.getSubconsciousRemindMemory(omModel) })
       .filter(extractor => !existingSlugs.has(extractor.slug));
 
     return {
@@ -405,6 +407,30 @@ export class Memory extends MastraMemory {
 
   /** Threads with a curation currently in flight in this process; guards same-process double-fire only. */
   private _curationsInFlight = new Set<string>();
+
+  /**
+   * The Memory backing the reminder agent's own conversation, one thread per main-agent session
+   * (`subconscious:<threadId>:remind`). Built fresh per call so each session's effective model
+   * applies — a cached instance froze the first session's model forever. Continuity is unaffected:
+   * observational memory keys its record and its locks by thread, never by instance.
+   *
+   * Deliberately unlike the curate and learn memories, which pass `observationalMemory: false`:
+   * that kills compression and reflection to stop a regress only Subconscious could cause. Omitting
+   * `experimental_subconscious` is the narrower guard — with the key absent, the extractor injection
+   * and the reflection handlers above never run for this Memory, so its thread gets a real
+   * observational memory and spawns no nested subconscious agents.
+   */
+  private getSubconsciousRemindMemory(omModel?: ObservationalMemoryConfig['model']): Memory {
+    const remindMemory = new Memory({
+      storage: this.storage,
+      options: { observationalMemory: { model: omModel } },
+    });
+    // Without the app instance the child engine cannot resolve a model that only exists in the
+    // app's registry, which would leave the remind thread with observational memory configured and
+    // unable to run. Curate and learn never hit this: their engine is off.
+    if (this._mastraInstance) remindMemory.__registerMastra(this._mastraInstance);
+    return remindMemory;
+  }
 
   /**
    * Run the subconscious curator directly over the pending fact worklist, without a reflection.
@@ -916,6 +942,16 @@ export class Memory extends MastraMemory {
   async deleteThread(threadId: string): Promise<void> {
     const memoryStore = await this.getMemoryStore();
     const thread = await memoryStore.getThreadById({ threadId });
+    // The session's derived reminder conversation lives and dies with the session. Delete it first,
+    // through this same path, so a failure leaves the parent thread intact and the whole deletion
+    // retryable instead of orphaning the derived thread. Only cascade when both threads have the
+    // same resource owner; a caller must not delete an unrelated thread that happens to use the
+    // deterministic derived id.
+    const derivedRemindThreadId = remindThreadKey(threadId);
+    const derivedRemindThread = await memoryStore.getThreadById({ threadId: derivedRemindThreadId });
+    if (thread?.resourceId && derivedRemindThread?.resourceId === thread.resourceId) {
+      await this.deleteThread(derivedRemindThreadId);
+    }
     await memoryStore.deleteThread({ threadId });
     if (thread?.resourceId && memoryStore.supportsObservationalMemory) {
       await memoryStore.clearObservationalMemory(threadId, thread.resourceId);

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -58,7 +58,10 @@ import {
   composeReflectionAgentHandlers,
   createLearnerHandler,
 } from './processors/observational-memory/subconscious/learn';
-import { remindThreadKey } from './processors/observational-memory/subconscious/remind';
+import {
+  REMIND_PARENT_THREAD_METADATA_KEY,
+  remindThreadKey,
+} from './processors/observational-memory/subconscious/remind';
 import { summarizeConversation, SUMMARIZE_THREAD_DEFAULTS } from './processors/observational-memory/summarize';
 import type {
   SummarizeConversationOptions,
@@ -949,7 +952,11 @@ export class Memory extends MastraMemory {
     // deterministic derived id.
     const derivedRemindThreadId = remindThreadKey(threadId);
     const derivedRemindThread = await memoryStore.getThreadById({ threadId: derivedRemindThreadId });
-    if (thread?.resourceId && derivedRemindThread?.resourceId === thread.resourceId) {
+    if (
+      thread?.resourceId &&
+      derivedRemindThread?.resourceId === thread.resourceId &&
+      derivedRemindThread.metadata?.[REMIND_PARENT_THREAD_METADATA_KEY] === threadId
+    ) {
       await this.deleteThread(derivedRemindThreadId);
     }
     await memoryStore.deleteThread({ threadId });

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-config.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-config.test.ts
@@ -168,6 +168,55 @@ describe('Subconscious configuration', () => {
     expect(getExtractors(memory)).toEqual([]);
   });
 
+  it('builds the reminder memory with observational memory on and Subconscious omitted', () => {
+    const memory = new Memory({
+      storage: new InMemoryStore(),
+      ...semanticInfrastructure,
+      options: {
+        observationalMemory: { model, experimental_subconscious: new Subconscious() },
+      },
+    });
+
+    const remindMemory = (memory as any).getSubconsciousRemindMemory(model) as Memory;
+    const remindOm = remindMemory.getMergedThreadConfig().observationalMemory as Record<string, unknown>;
+
+    // Not the `observationalMemory: false` sledgehammer the curate and learn memories use: the
+    // reminder thread gets real compression and reflection.
+    expect(remindOm).toBeTruthy();
+    expect(remindOm).not.toBe(false);
+    expect(remindOm.model).toBe(model);
+    // Omitting the key is the entire recursion guard — no nested subconscious on this thread.
+    expect('experimental_subconscious' in remindOm).toBe(false);
+    expect(getExtractors(remindMemory)).toEqual([]);
+  });
+
+  it('resolves the reminder memory model per invocation instead of freezing the first session model', () => {
+    const memory = new Memory({
+      storage: new InMemoryStore(),
+      ...semanticInfrastructure,
+      options: {
+        observationalMemory: { model, experimental_subconscious: new Subconscious() },
+      },
+    });
+
+    // Two sessions with different effective models: the second must not inherit the first.
+    const firstOm = ((memory as any).getSubconsciousRemindMemory('openai/gpt-5') as Memory).getMergedThreadConfig()
+      .observationalMemory as Record<string, unknown>;
+    const secondOm = (
+      (memory as any).getSubconsciousRemindMemory('anthropic/claude-sonnet-4-5') as Memory
+    ).getMergedThreadConfig().observationalMemory as Record<string, unknown>;
+
+    expect(firstOm.model).toBe('openai/gpt-5');
+    expect(secondOm.model).toBe('anthropic/claude-sonnet-4-5');
+
+    // The child engine resolves its model through the app instance, so the parent has to hand it
+    // over — otherwise a model that only exists in the app registry never resolves on this thread.
+    const mastra = { getAgentById: vi.fn() } as any;
+    memory.__registerMastra(mastra);
+    const remindMemory = (memory as any).getSubconsciousRemindMemory(model) as Memory;
+    expect((remindMemory as any)._mastraInstance).toBe(mastra);
+  });
+
   it('does not alter observational memory when Subconscious is absent', () => {
     const memory = new Memory({
       storage: new InMemoryStore(),

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -1,6 +1,7 @@
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
+import type { MemoryStorage } from '@mastra/core/storage';
 import { describe, expect, it, vi } from 'vitest';
 
 import { applyExtractorHooks } from '../extracted-values';
@@ -388,6 +389,390 @@ describe('Subconscious remind', () => {
 
     expect(result.failures).toBeUndefined();
     expect(context.sendSignal).not.toHaveBeenCalled();
+  });
+
+  describe('continuity: the reminder agent keeps one conversation per session', () => {
+    async function seedRelevantItem(context: ReturnType<typeof createContext>) {
+      const store = await context.memory.storage.getStore('knowledge');
+      const node = await store.createNode({
+        name: 'Project Atlas',
+        kind: 'project',
+        scope: ['org:acme', 'resource:user-42'],
+      });
+      return store.appendKnowledge({
+        node,
+        text: 'Project Atlas launches January 15.',
+        scope: ['org:acme', 'resource:user-42'],
+        sourceThreadId: 'beta',
+        resolutionScope: ['org:acme', 'resource:user-42', 'thread:beta'],
+        defaultScope: ['org:acme', 'resource:user-42'],
+      });
+    }
+
+    /** Runs the hook with `generate` stubbed, so the assertions are about wiring, not model output. */
+    async function runWithGenerateSpy(options: {
+      createRemindMemory?: () => any;
+      threadId?: string;
+      resourceId?: string | null;
+      response?: string;
+    }) {
+      const { Agent } = await import('@mastra/core/agent');
+      const generateSpy = vi
+        .spyOn(Agent.prototype, 'generate' as any)
+        .mockResolvedValue({ text: options.response ?? '<no-reminder />' } as any);
+      try {
+        const extractor = new SubconsciousRemindExtractor({ name: 'remind', maxSteps: 3, builtIn: true }, undefined, {
+          createRemindMemory: options.createRemindMemory,
+        });
+        const context = createContext('unused');
+        if (options.threadId) context.threadId = options.threadId;
+        if (options.resourceId === null) {
+          context.resourceId = undefined as any;
+          context.requestContext.set('knowledgeResourceId', 'user-42');
+        } else if (options.resourceId) {
+          context.resourceId = options.resourceId;
+        }
+        await seedRelevantItem(context);
+
+        const result = await applyExtractorHooks({
+          source: 'observer',
+          extractors: [extractor],
+          rawObservations: 'The user is scheduling Project Atlas.',
+          ...context,
+        });
+
+        // Snapshot the recorded calls before restoring — mockRestore clears them.
+        return {
+          result,
+          context,
+          calls: [...generateSpy.mock.calls] as any[][],
+          agents: [...((generateSpy.mock as any).contexts ?? [])],
+        };
+      } finally {
+        generateSpy.mockRestore();
+      }
+    }
+
+    it('generates against the shared remind thread derived from the parent thread id', async () => {
+      const remindMemory = { id: 'remind-memory' } as any;
+      const { result, calls } = await runWithGenerateSpy({ createRemindMemory: () => remindMemory });
+
+      expect(result.failures).toBeUndefined();
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.[1]).toMatchObject({
+        memory: { thread: 'subconscious:alpha:remind', resource: 'user-42' },
+      });
+    });
+
+    it('runs stateless when the observation path lacks the session resource owner', async () => {
+      const createRemindMemory = vi.fn(() => ({ id: 'remind-memory' }) as any);
+      const { result, calls } = await runWithGenerateSpy({ createRemindMemory, resourceId: null });
+
+      expect(result.failures).toBeUndefined();
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.[1]).not.toHaveProperty('memory');
+      expect(createRemindMemory).not.toHaveBeenCalled();
+    });
+
+    it('keys the thread off the parent thread id, never off the agent id', async () => {
+      const { calls } = await runWithGenerateSpy({
+        createRemindMemory: () => ({}) as any,
+        threadId: 'gamma',
+      });
+
+      const thread = (calls[0]?.[1] as any).memory.thread;
+      expect(thread).toBe('subconscious:gamma:remind');
+      // The agent id convention is `subconscious-remind-<threadId>`; confusing the two produces a
+      // thread that looks plausible and groups wrongly.
+      expect(thread).not.toContain('subconscious-remind-');
+    });
+
+    it('hands the reminder agent the memory its owner built', async () => {
+      const remindMemory = { id: 'remind-memory' } as any;
+      const createRemindMemory = vi.fn(() => remindMemory);
+      const { agents } = await runWithGenerateSpy({ createRemindMemory });
+
+      expect(createRemindMemory).toHaveBeenCalledOnce();
+      const agent = agents[0] as any;
+      expect(await agent.getMemory()).toBe(remindMemory);
+    });
+
+    it('passes the same thread on every run, so passive reminders and questions share one conversation', async () => {
+      const first = await runWithGenerateSpy({ createRemindMemory: () => ({}) as any });
+      const second = await runWithGenerateSpy({ createRemindMemory: () => ({}) as any });
+
+      expect((first.calls[0]?.[1] as any).memory.thread).toBe((second.calls[0]?.[1] as any).memory.thread);
+    });
+
+    it('omits the memory option entirely when no remind memory is available', async () => {
+      const { result, calls } = await runWithGenerateSpy({});
+
+      expect(result.failures).toBeUndefined();
+      expect(calls[0]?.[1]).not.toHaveProperty('memory');
+    });
+
+    it('still drops the thread\u2019s own fresh items when a remind memory is attached', async () => {
+      const extractor = new SubconsciousRemindExtractor({ name: 'remind', maxSteps: 3, builtIn: true }, undefined, {
+        createRemindMemory: () => ({}) as any,
+      });
+      const context = createContext('The launch happens January 15.');
+      const store = await context.memory.storage.getStore('knowledge');
+      const node = await store.createNode({
+        name: 'Zeta initiative',
+        kind: 'program',
+        scope: ['org:acme', 'resource:user-42'],
+      });
+      await store.appendKnowledge({
+        node,
+        text: 'The launch happens January 15.',
+        scope: ['org:acme', 'resource:user-42'],
+        sourceThreadId: 'alpha',
+        resolutionScope: ['org:acme', 'resource:user-42', 'thread:alpha'],
+        defaultScope: ['org:acme', 'resource:user-42'],
+      });
+
+      const result = await applyExtractorHooks({
+        source: 'observer',
+        extractors: [extractor],
+        rawObservations: 'The user is scheduling the launch.',
+        ...context,
+      });
+
+      // Continuity fixes repetition; freshness is a different failure and its guard must survive.
+      expect(result.failures).toBeUndefined();
+      expect(context.sendSignal).not.toHaveBeenCalled();
+    });
+
+    it('keeps the no-reminder contract when a remind memory is attached', async () => {
+      const { result, context } = await runWithGenerateSpy({ createRemindMemory: () => ({}) as any });
+
+      expect(result.failures).toBeUndefined();
+      expect(context.sendSignal).not.toHaveBeenCalled();
+    });
+
+    it('persists the reminder exchange so a later run, even on a reconstructed Memory, sees it', async () => {
+      const { Memory } = await import('../../../index');
+      // One storage shared by both runs; each run gets its own Memory instance over it, the same
+      // way a process restart reconstructs Memory around surviving storage.
+      const sharedStorage = new InMemoryStore();
+      const prompts: unknown[] = [];
+      const recordingModel = (response: string) =>
+        new MockLanguageModelV2({
+          doGenerate: async options => {
+            prompts.push(options.prompt);
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'stop' as const,
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              warnings: [],
+              content: [{ type: 'text' as const, text: response }],
+            };
+          },
+          doStream: async options => {
+            prompts.push(options.prompt);
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                { type: 'response-metadata', id: 'remind-1', modelId: 'remind-model', timestamp: new Date() },
+                { type: 'text-start', id: 'text-1' },
+                { type: 'text-delta', id: 'text-1', delta: response },
+                { type: 'text-end', id: 'text-1' },
+                { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+              ]),
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              warnings: [],
+            };
+          },
+        });
+
+      const runOnce = async (response: string) => {
+        const extractor = new SubconsciousRemindExtractor({ name: 'remind', maxSteps: 3, builtIn: true }, undefined, {
+          createRemindMemory: () => new Memory({ storage: sharedStorage }),
+        });
+        const context = createContext('unused');
+        const item = await seedRelevantItem(context);
+        context.mainAgent.getModel = vi.fn(async () => recordingModel(response.replace('{itemId}', item.id))) as any;
+        const result = await applyExtractorHooks({
+          source: 'observer',
+          extractors: [extractor],
+          rawObservations: 'The user is scheduling Project Atlas.',
+          ...context,
+        });
+        return { result, context };
+      };
+
+      // First run: a grounded reminder fires once and is written to the remind conversation.
+      const first = await runOnce('marker-first-reminder Project Atlas launches January 15. Source: {itemId}');
+      expect(first.result.failures).toBeUndefined();
+      expect(first.context.sendSignal).toHaveBeenCalledOnce();
+
+      // Second run: fresh Memory over the same storage. The persisted first exchange must reach
+      // the model's prompt (that history is what lets it decline to repeat itself), and its
+      // no-reminder decision must stay silent.
+      prompts.length = 0;
+      const second = await runOnce('<no-reminder />');
+      expect(second.result.failures).toBeUndefined();
+      expect(second.context.sendSignal).not.toHaveBeenCalled();
+      expect(JSON.stringify(prompts)).toContain('marker-first-reminder');
+    });
+
+    it('deletes the derived reminder conversation when the session thread is deleted', async () => {
+      const { Memory } = await import('../../../index');
+      const storage = new InMemoryStore();
+      const memory = new Memory({ storage });
+      const now = new Date();
+      const thread = (id: string) => ({
+        id,
+        resourceId: 'user-42',
+        title: id,
+        createdAt: now,
+        updatedAt: now,
+        metadata: {},
+      });
+      await memory.saveThread({ thread: thread('alpha') });
+      await memory.saveThread({ thread: thread('subconscious:alpha:remind') });
+      const memoryStore = await (memory as unknown as { getMemoryStore(): Promise<MemoryStorage> }).getMemoryStore();
+      await memoryStore.saveMessages({
+        messages: [
+          {
+            id: 'remind-msg-1',
+            threadId: 'subconscious:alpha:remind',
+            resourceId: 'user-42',
+            role: 'assistant' as const,
+            content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'a persisted reminder' }] },
+            type: 'text',
+            createdAt: now,
+          },
+        ],
+      });
+
+      await memory.deleteThread('alpha');
+
+      // The session owns its derived reminder conversation: both die together, messages included.
+      expect(await memory.getThreadById({ threadId: 'alpha' })).toBeNull();
+      expect(await memory.getThreadById({ threadId: 'subconscious:alpha:remind' })).toBeNull();
+      const remaining = await memoryStore.listMessages({ threadId: 'subconscious:alpha:remind' });
+      expect(remaining.messages).toHaveLength(0);
+    });
+
+    it('does not delete a derived-id thread owned by another resource', async () => {
+      const { Memory } = await import('../../../index');
+      const storage = new InMemoryStore();
+      const memory = new Memory({ storage });
+      const now = new Date();
+      await memory.saveThread({
+        thread: { id: 'alpha', resourceId: 'user-42', title: 'alpha', createdAt: now, updatedAt: now, metadata: {} },
+      });
+      await memory.saveThread({
+        thread: {
+          id: 'subconscious:alpha:remind',
+          resourceId: 'user-99',
+          title: 'unrelated',
+          createdAt: now,
+          updatedAt: now,
+          metadata: {},
+        },
+      });
+
+      await memory.deleteThread('alpha');
+
+      expect(await memory.getThreadById({ threadId: 'alpha' })).toBeNull();
+      expect(await memory.getThreadById({ threadId: 'subconscious:alpha:remind' })).not.toBeNull();
+    });
+
+    it('does not delete a colliding reminder thread owned by another resource', async () => {
+      const { Memory } = await import('../../../index');
+      const storage = new InMemoryStore();
+      const memory = new Memory({ storage });
+      const now = new Date();
+      await memory.saveThread({
+        thread: { id: 'alpha', resourceId: 'user-42', title: 'alpha', createdAt: now, updatedAt: now, metadata: {} },
+      });
+      await memory.saveThread({
+        thread: {
+          id: 'subconscious:alpha:remind',
+          resourceId: 'other-user',
+          title: 'collision',
+          createdAt: now,
+          updatedAt: now,
+          metadata: {},
+        },
+      });
+
+      await memory.deleteThread('alpha');
+
+      expect(await memory.getThreadById({ threadId: 'alpha' })).toBeNull();
+      expect(await memory.getThreadById({ threadId: 'subconscious:alpha:remind' })).not.toBeNull();
+    });
+
+    it('does not cascade from a missing parent into a colliding reminder thread', async () => {
+      const { Memory } = await import('../../../index');
+      const storage = new InMemoryStore();
+      const memory = new Memory({ storage });
+      const now = new Date();
+      await memory.saveThread({
+        thread: {
+          id: 'subconscious:missing:remind',
+          resourceId: 'missing',
+          title: 'collision',
+          createdAt: now,
+          updatedAt: now,
+          metadata: {},
+        },
+      });
+
+      await memory.deleteThread('missing');
+
+      expect(await memory.getThreadById({ threadId: 'subconscious:missing:remind' })).not.toBeNull();
+    });
+
+    it('leaves other sessions reminder conversations alone when a thread is deleted', async () => {
+      const { Memory } = await import('../../../index');
+      const storage = new InMemoryStore();
+      const memory = new Memory({ storage });
+      const now = new Date();
+      const thread = (id: string) => ({
+        id,
+        resourceId: 'user-42',
+        title: id,
+        createdAt: now,
+        updatedAt: now,
+        metadata: {},
+      });
+      await memory.saveThread({ thread: thread('alpha') });
+      await memory.saveThread({ thread: thread('beta') });
+      await memory.saveThread({ thread: thread('subconscious:beta:remind') });
+
+      await memory.deleteThread('alpha');
+
+      expect(await memory.getThreadById({ threadId: 'subconscious:beta:remind' })).not.toBeNull();
+    });
+
+    it('routes a remind memory construction failure into the extractor failure path', async () => {
+      const extractor = new SubconsciousRemindExtractor({ name: 'remind', maxSteps: 3, builtIn: true }, undefined, {
+        createRemindMemory: () => {
+          throw new Error('remind memory unavailable');
+        },
+      });
+      const context = createContext('Project Atlas launches January 15.');
+      await seedRelevantItem(context);
+
+      const result = await applyExtractorHooks({
+        source: 'observer',
+        extractors: [extractor],
+        rawObservations: 'The user is scheduling Project Atlas.',
+        ...context,
+      });
+
+      expect(result.failures).toEqual([{ slug: 'remind', error: 'remind memory unavailable' }]);
+      expect(context.sendSignal).not.toHaveBeenCalled();
+      expect(context.sendStateSignal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'subconscious-activity',
+          value: expect.objectContaining({ errors: ['remind: remind memory unavailable'] }),
+        }),
+      );
+    });
   });
 
   it('isolates reminder failures from the observation lifecycle', async () => {

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -460,7 +460,13 @@ describe('Subconscious remind', () => {
       expect(result.failures).toBeUndefined();
       expect(calls).toHaveLength(1);
       expect(calls[0]?.[1]).toMatchObject({
-        memory: { thread: 'subconscious:alpha:remind', resource: 'user-42' },
+        memory: {
+          thread: {
+            id: 'subconscious:alpha:remind',
+            metadata: { subconsciousRemindParentThreadId: 'alpha' },
+          },
+          resource: 'user-42',
+        },
       });
     });
 
@@ -481,7 +487,10 @@ describe('Subconscious remind', () => {
       });
 
       const thread = (calls[0]?.[1] as any).memory.thread;
-      expect(thread).toBe('subconscious:gamma:remind');
+      expect(thread).toEqual({
+        id: 'subconscious:gamma:remind',
+        metadata: { subconsciousRemindParentThreadId: 'gamma' },
+      });
       // The agent id convention is `subconscious-remind-<threadId>`; confusing the two produces a
       // thread that looks plausible and groups wrongly.
       expect(thread).not.toContain('subconscious-remind-');
@@ -501,7 +510,7 @@ describe('Subconscious remind', () => {
       const first = await runWithGenerateSpy({ createRemindMemory: () => ({}) as any });
       const second = await runWithGenerateSpy({ createRemindMemory: () => ({}) as any });
 
-      expect((first.calls[0]?.[1] as any).memory.thread).toBe((second.calls[0]?.[1] as any).memory.thread);
+      expect((first.calls[0]?.[1] as any).memory.thread).toEqual((second.calls[0]?.[1] as any).memory.thread);
     });
 
     it('omits the memory option entirely when no remind memory is available', async () => {
@@ -630,7 +639,12 @@ describe('Subconscious remind', () => {
         metadata: {},
       });
       await memory.saveThread({ thread: thread('alpha') });
-      await memory.saveThread({ thread: thread('subconscious:alpha:remind') });
+      await memory.saveThread({
+        thread: {
+          ...thread('subconscious:alpha:remind'),
+          metadata: { subconsciousRemindParentThreadId: 'alpha' },
+        },
+      });
       const memoryStore = await (memory as unknown as { getMemoryStore(): Promise<MemoryStorage> }).getMemoryStore();
       await memoryStore.saveMessages({
         messages: [
@@ -653,6 +667,31 @@ describe('Subconscious remind', () => {
       expect(await memory.getThreadById({ threadId: 'subconscious:alpha:remind' })).toBeNull();
       const remaining = await memoryStore.listMessages({ threadId: 'subconscious:alpha:remind' });
       expect(remaining.messages).toHaveLength(0);
+    });
+
+    it('does not delete an unmarked same-resource thread with a colliding derived id', async () => {
+      const { Memory } = await import('../../../index');
+      const storage = new InMemoryStore();
+      const memory = new Memory({ storage });
+      const now = new Date();
+      await memory.saveThread({
+        thread: { id: 'alpha', resourceId: 'user-42', title: 'alpha', createdAt: now, updatedAt: now, metadata: {} },
+      });
+      await memory.saveThread({
+        thread: {
+          id: 'subconscious:alpha:remind',
+          resourceId: 'user-42',
+          title: 'unrelated same-resource thread',
+          createdAt: now,
+          updatedAt: now,
+          metadata: {},
+        },
+      });
+
+      await memory.deleteThread('alpha');
+
+      expect(await memory.getThreadById({ threadId: 'alpha' })).toBeNull();
+      expect(await memory.getThreadById({ threadId: 'subconscious:alpha:remind' })).not.toBeNull();
     });
 
     it('does not delete a derived-id thread owned by another resource', async () => {

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -653,7 +653,10 @@ describe('Subconscious remind', () => {
             threadId: 'subconscious:alpha:remind',
             resourceId: 'user-42',
             role: 'assistant' as const,
-            content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'a persisted reminder' }] },
+            content: {
+              format: 2 as const,
+              parts: [{ type: 'text' as const, text: 'a persisted reminder', createdAt: now.getTime() }],
+            },
             type: 'text',
             createdAt: now,
           },

--- a/packages/memory/src/processors/observational-memory/subconscious/index.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/index.ts
@@ -3,6 +3,7 @@ import type { ObservationalMemoryModel } from '../types';
 import { SubconsciousCaptureExtractor } from './capture';
 import { DEFAULT_MAX_PINS, DEFAULT_PINNED_MAX_CHARACTERS, MAX_PINNED_MAX_CHARACTERS } from './pinned';
 import { SubconsciousRemindExtractor } from './remind';
+import type { SubconsciousRemindOptions } from './remind';
 import type {
   ResolvedSubconsciousAgent,
   ResolvedSubconsciousConfig,
@@ -154,7 +155,10 @@ export class Subconscious {
     });
   }
 
-  createObservationExtractors(omModel?: ObservationalMemoryModel): Extractor<any>[] {
+  createObservationExtractors(
+    omModel?: ObservationalMemoryModel,
+    options?: SubconsciousRemindOptions,
+  ): Extractor<any>[] {
     const extractors: Extractor<any>[] = [];
     for (const entry of this.config.observation ?? []) {
       const name = entryName(entry);
@@ -171,7 +175,7 @@ export class Subconscious {
         );
       } else if (name === 'remind') {
         const resolved = this.resolved.observation.find(agent => agent.name === name);
-        if (resolved) extractors.push(new SubconsciousRemindExtractor(resolved, omModel));
+        if (resolved) extractors.push(new SubconsciousRemindExtractor(resolved, omModel, options));
       } else if (!BUILT_IN_OBSERVATION.has(name)) {
         const custom = entry as SubconsciousCustomObservationConfig;
         extractors.push(

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -2,6 +2,7 @@ import { Agent } from '@mastra/core/agent';
 import type { KnowledgeScope, KnowledgeStorage, SearchKnowledgeResult } from '@mastra/core/storage';
 import { canonicalizeKnowledgeScope } from '@mastra/core/storage';
 
+import type { Memory } from '../../..';
 import { Extractor } from '../extractor';
 import type { ObservationalMemoryModel } from '../types';
 import { publishSubconsciousActivity } from './activity';
@@ -102,8 +103,31 @@ async function dropFreshOwnRecords(
   return sources.filter((_, index) => checks[index]);
 }
 
+/**
+ * The id of the reminder agent's own conversation thread, derived from the parent session's thread
+ * id. The derived thread is owned by the session: it is created on demand when the session first
+ * reminds, and `Memory.deleteThread()` cascades to it when the session's thread is deleted.
+ */
+export function remindThreadKey(parentThreadId: string): string {
+  return `subconscious:${parentThreadId}:remind`;
+}
+
+export interface SubconsciousRemindOptions {
+  /**
+   * Returns the Memory that backs the reminder agent's own conversation. Called on demand so a
+   * session that never reminds never builds one, and built fresh per call so each session's
+   * effective model applies. Per-session identity is carried by the thread key alone, never by
+   * the instance.
+   */
+  createRemindMemory?: () => Memory;
+}
+
 export class SubconsciousRemindExtractor extends Extractor<string> {
-  constructor(config: ResolvedSubconsciousAgent, omModel?: ObservationalMemoryModel) {
+  constructor(
+    config: ResolvedSubconsciousAgent,
+    omModel?: ObservationalMemoryModel,
+    options?: SubconsciousRemindOptions,
+  ) {
     super({
       name: 'Remind',
       mode: 'hook',
@@ -132,11 +156,17 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
             requestContext: context.requestContext,
           });
           if (!model) return;
+          // One reminder conversation per main-agent session. The thread key is derived from the
+          // PARENT thread id, not from the agent id above, and matches the curate/learn convention.
+          // Without the session's resource owner, run stateless rather than create an orphaned
+          // derived thread that Memory.deleteThread() cannot safely prove it owns.
+          const remindMemory = context.resourceId ? options?.createRemindMemory?.() : undefined;
           const agent = new Agent({
             id: `subconscious-remind-${context.threadId}`,
             name: 'Subconscious Remind',
             instructions: [DEFAULT_INSTRUCTIONS, config.instructions?.trim()].filter(Boolean).join('\n\n'),
             model,
+            ...(remindMemory ? { memory: remindMemory } : {}),
             tools: createKnowledgeTools(context.memory, scope),
           });
           const recentMessagesSection = context.recentMessages?.trim()
@@ -148,6 +178,14 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
               requestContext: context.requestContext,
               abortSignal: context.abortSignal,
               maxSteps: config.maxSteps,
+              ...(remindMemory
+                ? {
+                    memory: {
+                      thread: remindThreadKey(context.threadId),
+                      resource: context.resourceId,
+                    },
+                  }
+                : {}),
             },
           );
           const reminder = result.text.trim();

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -104,6 +104,13 @@ async function dropFreshOwnRecords(
 }
 
 /**
+ * Thread-metadata key stamping the parent session thread that owns a derived reminder thread. The
+ * deletion cascade requires it, so an unrelated thread that happens to occupy the derived id under
+ * the same resource is never deleted.
+ */
+export const REMIND_PARENT_THREAD_METADATA_KEY = 'subconsciousRemindParentThreadId';
+
+/**
  * The id of the reminder agent's own conversation thread, derived from the parent session's thread
  * id. The derived thread is owned by the session: it is created on demand when the session first
  * reminds, and `Memory.deleteThread()` cascades to it when the session's thread is deleted.
@@ -181,7 +188,10 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
               ...(remindMemory
                 ? {
                     memory: {
-                      thread: remindThreadKey(context.threadId),
+                      thread: {
+                        id: remindThreadKey(context.threadId),
+                        metadata: { [REMIND_PARENT_THREAD_METADATA_KEY]: context.threadId },
+                      },
                       resource: context.resourceId,
                     },
                   }


### PR DESCRIPTION
## Summary

Give the experimental Subconscious reminder agent one persistent conversation per owned session using the derived thread `subconscious:<parentThreadId>:remind`. The reminder `Memory` is created per invocation so each session resolves its current model rather than reusing a process-cached instance.

## Root cause

The reminder agent previously started without its own prior conversation on every evaluation. It could repeat reminders after relevant context left the visible observation window, and the original implementation could create a derived reminder thread without a resource owner.

## What changed

- Persist reminder work in one deterministic derived thread per parent session.
- Construct the reminder `Memory` per invocation while preserving reminder-thread observation and reflection.
- Stamp the derived reminder thread with parent-thread provenance metadata (`subconsciousRemindParentThreadId`).
- Cascade deletion of the derived reminder thread only when the resource owner matches the parent thread **and** the provenance metadata names that parent.
- Preserve derived-looking threads when the parent is missing, the resource owner differs, or provenance is absent.
- Run resource-less passive reminder evaluations statelessly instead of creating an orphaned persistent thread.

## Model-call shape (please read before reviewing the test diff)

This PR does **not** add an LLM call. The reminder lane runs through `agent.generate()` (`packages/memory/src/processors/observational-memory/subconscious/remind.ts`), so only the observation pass streams.

An earlier revision of this branch asserted `expect(streamCall).toBe(2)` in the LibSQL integration test and CI failed with `expected 1 to be 2`. That two-call shape is the behavior of the stacked follow-up #22481, which routes reminders through the streaming transport — not of this PR.

The local suite had passed only because `packages/memory/integration-tests/node_modules` is a symlink into a second worktree checked out on #22481's branch, so `@mastra/memory`, `@mastra/core` and `@mastra/libsql` all resolved to #22481's code. The local run never exercised this PR. Re-running with `@mastra/memory` aliased to this branch's own build reproduces CI's `expected 1 to be 2` exactly.

The test now pins the real contract for this PR: one stream call for the observation pass and one generate call for the reminder lane, so the boundary with #22481 cannot drift silently again. Unrelated mock churn in the resource-scoped test — which never asserted the counter — has been reverted.

## Notes for reviewers

This PR owns continuity and lifecycle only. Serialized question and passive-reminder transport is added by the stacked #22481.

The cleanup check is deliberately conservative: a missing parent, a resource mismatch, or missing provenance metadata all preserve the derived-looking thread rather than risk deleting unrelated data. Note the back-compat consequence — derived reminder threads created before this change carry no provenance metadata, so they are preserved rather than cascaded on parent deletion.

Resource-less evaluations retain one-shot reminder behavior but do not persist continuity.

The derived reminder `Memory` is configured with `observationalMemory: { model }`. Nested subconscious agents are not attached, but the ordinary observer can still extract knowledge from the reminder agent's own output into the shared store. Flagging this write-back path explicitly for reviewer judgement; it is unchanged in behavior by this PR.

## Test plan

Reviewed locally at `9b003d48a0ea15de101abe6e5954c52664636394`.

From `packages/memory`:

```bash
pnpm exec vitest run
pnpm lint
```

From `packages/memory/integration-tests`, with `@mastra/memory` aliased to this branch's own build (see note above — the default symlink resolves to another worktree):

```bash
pnpm vitest run src/subconscious-libsql.test.ts
```

Results:

- `@mastra/memory` full unit suite: 63 files, 1542 passed, 1 todo
- Focused `subconscious-remind.test.ts`: 28 passed
- LibSQL Subconscious integration, aliased to this branch's build: 5 passed
- Falsification check: restoring `toBe(2)` under the same alias fails with exactly `AssertionError: expected 1 to be 2`, matching CI
- Lint: 0 warnings and 0 errors across 195 files
- `git diff --check`: clean

Known limitation: `pnpm build:lib`'s tsc/dts step fails in this worktree with `TS2307` on `@mastra/core/*` and `@internal/*` because those workspace dependencies are not linked here. The bundler still emits `dist/index.js`, which is what the aliased integration run used. This is worktree environment breakage, not a defect in this diff, and this body does not claim a passing `pnpm check`.

Independent multi-model review tooling was unavailable in the session that prepared this revision; the analysis above is self-review with the reproduction steps stated explicitly so a human reviewer can re-run them.

The PR includes a patch changeset for `@mastra/memory`. It is intentionally minimal because Subconscious remains experimental.