### PR TITLE
fix(observability): read MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT in MastraPlatformExporter

### DIFF
--- a/.changeset/tasty-knives-greet.md
+++ b/.changeset/tasty-knives-greet.md
@@ -2,4 +2,14 @@
 '@mastra/observability': patch
 ---
 
-Fixed MastraPlatformExporter ignoring the documented MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT environment variable. The exporter now reads it as an observability endpoint override (a base origin like https://observability.eu.mastra.ai or a full traces publish URL), so projects in non-default regions can route traces, logs, metrics, scores, and feedback to the right collector. The legacy MASTRA_CLOUD_TRACES_ENDPOINT variable still works and takes precedence when both are set.
+Fixed `MastraPlatformExporter` ignoring the documented `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` environment variable. The exporter now reads it as an observability endpoint override, so projects in non-default regions can route traces, logs, metrics, scores, and feedback to the right collector.
+
+```dotenv
+# Base origin (other signal endpoints are derived from it)
+MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT=https://observability.eu.mastra.ai
+
+# Or a full traces publish URL
+MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT=https://observability.eu.mastra.ai/spans/publish
+```
+
+The legacy `MASTRA_CLOUD_TRACES_ENDPOINT` variable still works and takes precedence when both are set.

--- a/.changeset/tasty-knives-greet.md
+++ b/.changeset/tasty-knives-greet.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed MastraPlatformExporter ignoring the documented MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT environment variable. The exporter now reads it as an observability endpoint override (a base origin like https://observability.eu.mastra.ai or a full traces publish URL), so projects in non-default regions can route traces, logs, metrics, scores, and feedback to the right collector. The legacy MASTRA_CLOUD_TRACES_ENDPOINT variable still works and takes precedence when both are set.

--- a/docs/src/content/en/docs/mastra-platform/configuration.mdx
+++ b/docs/src/content/en/docs/mastra-platform/configuration.mdx
@@ -55,7 +55,7 @@ The following environment variables configure the Observability product on the M
 | - | - |
 | `MASTRA_PLATFORM_ACCESS_TOKEN` | Org-scoped access token. The CLI writes this during observability provisioning and uses it for platform authentication. |
 | `MASTRA_PROJECT_ID` | UUID of the platform project. `MastraPlatformExporter` uses it to link observability data to the platform project. Studio and Server deploys read the project ID from `.mastra-project.json`. |
-| `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` | Optional observability endpoint override for `MastraPlatformExporter` and Studio. Set it to your region's collector, for example `https://observability.eu.mastra.ai`, when your project is not in the default US region. Defaults to `https://observability.mastra.ai`. |
+| `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` | Optional observability endpoint override for `MastraPlatformExporter` and Studio. Set it to your region's collector, for example `https://observability.eu.mastra.ai`, when your project isn't in the default US region. Defaults to `https://observability.mastra.ai`. |
 | `MASTRA_ORG_ID` | Overrides the active organization for CLI commands. You can also set it with the `--org` flag on supported commands. |
 
 `MastraPlatformExporter` reads `MASTRA_PLATFORM_ACCESS_TOKEN` to authenticate platform export.

--- a/docs/src/content/en/docs/mastra-platform/configuration.mdx
+++ b/docs/src/content/en/docs/mastra-platform/configuration.mdx
@@ -55,7 +55,7 @@ The following environment variables configure the Observability product on the M
 | - | - |
 | `MASTRA_PLATFORM_ACCESS_TOKEN` | Org-scoped access token. The CLI writes this during observability provisioning and uses it for platform authentication. |
 | `MASTRA_PROJECT_ID` | UUID of the platform project. `MastraPlatformExporter` uses it to link observability data to the platform project. Studio and Server deploys read the project ID from `.mastra-project.json`. |
-| `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` | Optional observability endpoint override. This is only set automatically for local platform development. Defaults to `https://observability.mastra.ai`. |
+| `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` | Optional observability endpoint override for `MastraPlatformExporter` and Studio. Set it to your region's collector, for example `https://observability.eu.mastra.ai`, when your project is not in the default US region. Defaults to `https://observability.mastra.ai`. |
 | `MASTRA_ORG_ID` | Overrides the active organization for CLI commands. You can also set it with the `--org` flag on supported commands. |
 
 `MastraPlatformExporter` reads `MASTRA_PLATFORM_ACCESS_TOKEN` to authenticate platform export.

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -84,9 +84,11 @@ Extends `BaseExporterConfig`, which includes:
 
 The exporter reads these environment variables if not provided in config:
 
-- `MASTRA_PLATFORM_ACCESS_TOKEN` - Authentication token for `CloudExporter` requests
+- `MASTRA_CLOUD_ACCESS_TOKEN` - Authentication token for `CloudExporter` requests
 - `MASTRA_PROJECT_ID` - Project ID to use when deriving project-scoped collector routes such as `/projects/:projectId/ai/spans/publish`
-- `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` - Observability endpoint override. Pass either a base origin or a full traces publish URL. Defaults to `https://observability.mastra.ai` in `@mastra/observability@1.9.2` and later
+- `MASTRA_CLOUD_TRACES_ENDPOINT` - Traces endpoint override. Pass either a base origin or a full traces publish URL ending in `/spans/publish`; the other signal endpoints are derived from it. Defaults to `https://observability.mastra.ai`
+
+`CloudExporter` does not read `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT`. Use [`MastraPlatformExporter`](/reference/observability/tracing/exporters/mastra-platform-exporter) for that variable.
 
 ## Properties
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -86,9 +86,9 @@ The exporter reads these environment variables if not provided in config:
 
 - `MASTRA_CLOUD_ACCESS_TOKEN` - Authentication token for `CloudExporter` requests
 - `MASTRA_PROJECT_ID` - Project ID to use when deriving project-scoped collector routes such as `/projects/:projectId/ai/spans/publish`
-- `MASTRA_CLOUD_TRACES_ENDPOINT` - Traces endpoint override. Pass either a base origin or a full traces publish URL ending in `/spans/publish`; the other signal endpoints are derived from it. Defaults to `https://observability.mastra.ai`
+- `MASTRA_CLOUD_TRACES_ENDPOINT` - Traces endpoint override. Pass either a base origin or a full traces publish URL ending in `/spans/publish`. The other signal endpoints are derived from it. Defaults to `https://observability.mastra.ai`
 
-`CloudExporter` does not read `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT`. Use [`MastraPlatformExporter`](/reference/observability/tracing/exporters/mastra-platform-exporter) for that variable.
+`CloudExporter` doesn't read `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT`. Use [`MastraPlatformExporter`](/reference/observability/tracing/exporters/mastra-platform-exporter) for that variable.
 
 ## Properties
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/mastra-platform-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/mastra-platform-exporter.mdx
@@ -86,7 +86,8 @@ The exporter reads these environment variables if not provided in config:
 
 - `MASTRA_PLATFORM_ACCESS_TOKEN` - Authentication token for `MastraPlatformExporter` requests
 - `MASTRA_PROJECT_ID` - Project ID to use when deriving project-scoped collector routes such as `/projects/:projectId/ai/spans/publish`
-- `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` - Observability endpoint override. Pass either a base origin or a full traces publish URL. Defaults to `https://observability.mastra.ai` in `@mastra/observability@1.9.2` and later
+- `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` - Observability endpoint override, read by the exporter in `@mastra/observability@1.17.4` and later. Pass either a base origin such as `https://observability.eu.mastra.ai` or a full traces publish URL ending in `/spans/publish`; the other signal endpoints are derived from it. Defaults to `https://observability.mastra.ai`
+- `MASTRA_CLOUD_TRACES_ENDPOINT` - Legacy traces endpoint override. Takes precedence over `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` when both are set
 
 ## Properties
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/mastra-platform-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/mastra-platform-exporter.mdx
@@ -86,7 +86,7 @@ The exporter reads these environment variables if not provided in config:
 
 - `MASTRA_PLATFORM_ACCESS_TOKEN` - Authentication token for `MastraPlatformExporter` requests
 - `MASTRA_PROJECT_ID` - Project ID to use when deriving project-scoped collector routes such as `/projects/:projectId/ai/spans/publish`
-- `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` - Observability endpoint override, read by the exporter in `@mastra/observability@1.17.4` and later. Pass either a base origin such as `https://observability.eu.mastra.ai` or a full traces publish URL ending in `/spans/publish`; the other signal endpoints are derived from it. Defaults to `https://observability.mastra.ai`
+- `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` - Observability endpoint override, read by the exporter in `@mastra/observability@1.17.4` and later. Pass either a base origin such as `https://observability.eu.mastra.ai` or a full traces publish URL ending in `/spans/publish`. The other signal endpoints are derived from it. Defaults to `https://observability.mastra.ai`
 - `MASTRA_CLOUD_TRACES_ENDPOINT` - Legacy traces endpoint override. Takes precedence over `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` when both are set
 
 ## Properties

--- a/observability/mastra/src/exporters/mastra-platform.test.ts
+++ b/observability/mastra/src/exporters/mastra-platform.test.ts
@@ -1359,6 +1359,175 @@ describe('MastraPlatformExporter', () => {
       }
     });
 
+    it('should resolve signal endpoints from a MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT base origin', async () => {
+      vi.stubEnv('MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT', 'https://observability.eu.mastra.ai');
+
+      const derivedExporter = new MastraPlatformExporter({
+        accessToken: 'sk_org_api_key',
+        projectId: 'project-workos',
+      });
+
+      try {
+        await derivedExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await derivedExporter.onScoreEvent(getMockScoreEvent());
+        await derivedExporter.flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+          'https://observability.eu.mastra.ai/projects/project-workos/ai/spans/publish',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.any(String),
+          }),
+          3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
+        );
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+          'https://observability.eu.mastra.ai/projects/project-workos/ai/scores/publish',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.any(String),
+          }),
+          3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
+        );
+      } finally {
+        await derivedExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should prefer MASTRA_CLOUD_TRACES_ENDPOINT over MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT', async () => {
+      vi.stubEnv('MASTRA_CLOUD_TRACES_ENDPOINT', 'https://legacy.example.com/env/spans/publish');
+      vi.stubEnv('MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT', 'https://observability.eu.mastra.ai');
+
+      const derivedExporter = new MastraPlatformExporter({
+        accessToken: testJWT,
+      });
+
+      try {
+        await derivedExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await derivedExporter.flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+          'https://legacy.example.com/env/spans/publish',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.any(String),
+          }),
+          3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
+        );
+      } finally {
+        await derivedExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should prefer config tracesEndpoint over MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT', async () => {
+      vi.stubEnv('MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT', 'https://observability.eu.mastra.ai');
+
+      const derivedExporter = new MastraPlatformExporter({
+        accessToken: testJWT,
+        tracesEndpoint: 'https://config.example.com/custom/spans/publish',
+      });
+
+      try {
+        await derivedExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await derivedExporter.flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+          'https://config.example.com/custom/spans/publish',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.any(String),
+          }),
+          3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
+        );
+      } finally {
+        await derivedExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should derive sibling signal endpoints from a full MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT publish URL', async () => {
+      // The CLI writes this form: <origin>/projects/:projectId/ai/spans/publish
+      vi.stubEnv('MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT', 'http://localhost:8080/projects/proj_x/ai/spans/publish');
+
+      const derivedExporter = new MastraPlatformExporter({
+        accessToken: testJWT,
+      });
+
+      try {
+        await derivedExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await derivedExporter.onScoreEvent(getMockScoreEvent());
+        await derivedExporter.flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+          'http://localhost:8080/projects/proj_x/ai/spans/publish',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.any(String),
+          }),
+          3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
+        );
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+          'http://localhost:8080/projects/proj_x/ai/scores/publish',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.any(String),
+          }),
+          3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
+        );
+      } finally {
+        await derivedExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should treat an empty MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT as unset', async () => {
+      vi.stubEnv('MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT', '');
+
+      const derivedExporter = new MastraPlatformExporter({
+        accessToken: testJWT,
+      });
+
+      try {
+        await derivedExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await derivedExporter.flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+          'https://observability.mastra.ai/ai/spans/publish',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.any(String),
+          }),
+          3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
+        );
+      } finally {
+        await derivedExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
     it('should derive project-scoped signal endpoints from MASTRA_PROJECT_ID', async () => {
       vi.stubEnv('MASTRA_PROJECT_ID', 'project-from-env');
 

--- a/observability/mastra/src/exporters/mastra-platform.ts
+++ b/observability/mastra/src/exporters/mastra-platform.ts
@@ -292,7 +292,12 @@ export class MastraPlatformExporter extends BaseExporter {
       this.setDisabled('MASTRA_PLATFORM_ACCESS_TOKEN environment variable not set.', 'debug');
     }
 
-    const tracesEndpointOverride = config.tracesEndpoint ?? process.env.MASTRA_CLOUD_TRACES_ENDPOINT;
+    // MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT is the documented override (also
+    // consumed by Studio); MASTRA_CLOUD_TRACES_ENDPOINT is the legacy name.
+    // `||` lets an empty legacy value fall through to the platform variable.
+    const tracesEndpointOverride =
+      config.tracesEndpoint ??
+      (process.env.MASTRA_CLOUD_TRACES_ENDPOINT || process.env.MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT || undefined);
     let baseEndpoint: string | undefined;
     let tracesEndpoint: string;
 


### PR DESCRIPTION
The reference docs advertise `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` as the endpoint override for `MastraPlatformExporter`, but the exporter only ever read the legacy `MASTRA_CLOUD_TRACES_ENDPOINT` variable. Anyone on a non-default region (like EU) following the docs silently exported traces, logs, metrics, scores, and feedback to the US collector.

Before, only the legacy variable worked:

```dotenv
MASTRA_CLOUD_TRACES_ENDPOINT=https://observability.eu.mastra.ai
```

Now the documented variable works too (legacy still wins when both are set):

```dotenv
MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT=https://observability.eu.mastra.ai
```

Accepts a base origin or a full `/spans/publish` URL — the other signal endpoints are derived from it, same as the legacy variable. This also makes the value `mastra init` writes for local/staging platform setups actually reach the exporter.

The deprecated `CloudExporter` is intentionally left untouched (it's frozen for backward compatibility). Its reference page is corrected to reflect what it really reads, including the access-token variable it documents (`MASTRA_CLOUD_ACCESS_TOKEN`, not `MASTRA_PLATFORM_ACCESS_TOKEN`).

Test plan: new unit tests cover base-origin expansion, full publish-URL form, config-over-env and legacy-over-new precedence, and empty-value handling (`pnpm vitest run src/exporters/mastra-platform.test.ts` — 96 passing), plus `tsc --noEmit` and docs format/remark checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This update lets the platform exporter use the documented observability endpoint. It keeps the older endpoint setting as the higher-priority option and adds tests and documentation for the supported endpoint formats.

## Changes

- Added `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT` support to `MastraPlatformExporter`.
- Preserved precedence for configured endpoints and `MASTRA_CLOUD_TRACES_ENDPOINT`.
- Added support for base origins and full `/spans/publish` URLs.
- Derived related signal endpoints from the configured traces endpoint.
- Added tests for endpoint expansion, precedence, project scoping, and empty values.
- Updated platform and CloudExporter documentation.
- Documented `MASTRA_CLOUD_ACCESS_TOKEN` for `CloudExporter`.
- Added a patch changeset for `@mastra/observability`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->