### PR TITLE
feat(memory): add asynchronous reminder questions

### DIFF
--- a/.changeset/remind-ask-native-signals.md
+++ b/.changeset/remind-ask-native-signals.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Improve experimental Subconscious reminder interactions.

--- a/.changeset/remind-ask-native-signals.md
+++ b/.changeset/remind-ask-native-signals.md
@@ -2,4 +2,4 @@
 '@mastra/memory': patch
 ---
 
-Improve experimental Subconscious reminder interactions.
+Route experimental Subconscious reminder questions through continuing native agent conversations and clean up their owned conversation data with the parent session.

--- a/packages/memory/integration-tests/src/subconscious-libsql.test.ts
+++ b/packages/memory/integration-tests/src/subconscious-libsql.test.ts
@@ -307,10 +307,9 @@ describe('Subconscious LibSQL integration', () => {
 
     expect(result.observed).toBe(true);
     expect(getModel).not.toHaveBeenCalled();
-    // The observation pass streams; the reminder lane calls `agent.generate()`, so it must not add a
-    // second stream call. Routing reminders through the streaming transport lands in a later PR.
-    expect(streamCall).toBe(1);
-    expect(generateCall).toBe(1);
+    // The observation pass and native reminder conversation each stream through the configured model.
+    expect(streamCall).toBe(2);
+    expect(generateCall).toBe(0);
     expect(sendSignal).toHaveBeenCalledOnce();
     expect(sendSignal).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'reactive', tagName: 'remembered', contents: expect.stringContaining(reminder) }),
@@ -329,19 +328,25 @@ describe('Subconscious LibSQL integration', () => {
     const observations = threadIds
       .map(threadId => `<thread id="${threadId}">\n- Project Atlas planning is active.\n</thread>`)
       .join('\n');
+    let streamCall = 0;
+    const reminder = 'Project Atlas launches January 15. Source KnowledgeRecord: record-atlas-resource-launch.';
     const model = new MockLanguageModelV2({
-      doStream: async () => ({
-        stream: convertArrayToReadableStream([
-          { type: 'stream-start', warnings: [] },
-          { type: 'response-metadata', id: 'resource-observation', modelId: 'aimock', timestamp: new Date() },
-          { type: 'text-start', id: 'resource-text' },
-          { type: 'text-delta', id: 'resource-text', delta: `<observations>${observations}</observations>` },
-          { type: 'text-end', id: 'resource-text' },
-          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 } },
-        ]),
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        warnings: [],
-      }),
+      doStream: async () => {
+        streamCall += 1;
+        const text = streamCall === 1 ? `<observations>${observations}</observations>` : reminder;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: `resource-${streamCall}`, modelId: 'aimock', timestamp: new Date() },
+            { type: 'text-start', id: `resource-text-${streamCall}` },
+            { type: 'text-delta', id: `resource-text-${streamCall}`, delta: text },
+            { type: 'text-end', id: `resource-text-${streamCall}` },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
       doGenerate: async () => ({
         rawCall: { rawPrompt: null, rawSettings: {} },
         finishReason: 'stop' as const,
@@ -391,40 +396,36 @@ describe('Subconscious LibSQL integration', () => {
     const requestContext = new RequestContext();
     requestContext.set('organizationId', 'acme');
     const mainAgent = new Agent({ id: 'resource-main-agent', name: 'Main Agent', instructions: 'Help.', model });
-    const targetedDeliveries: Array<{
-      resourceId?: string;
-      threadId?: string;
-      ifActive?: { behavior?: string };
-      ifIdle?: { behavior?: string };
-    }> = [];
     const getModel = vi.spyOn(mainAgent, 'getModel');
-    vi.spyOn(mainAgent, 'sendSignal').mockImplementation((signal, options) => {
-      targetedDeliveries.push(options);
-      return {
-        signal: createSignal(signal),
-        accepted: Promise.resolve({ action: 'persist' }),
-        persisted: Promise.resolve(),
-      } as any;
-    });
+    const agentSignal = vi.spyOn(mainAgent, 'sendSignal');
+    const sendSignal = vi.fn(async () => undefined) as any;
 
     const result = await (await memory.omEngine)!.observe({
       threadId: threadIds[0],
       resourceId,
       agent: mainAgent,
       requestContext,
-      sendSignal: vi.fn(async () => undefined) as any,
+      sendSignal,
     });
 
     expect(result.observed).toBe(true);
     expect(getModel).not.toHaveBeenCalled();
-    expect(targetedDeliveries).toEqual([
+    expect(streamCall).toBe(2);
+    expect(agentSignal).toHaveBeenCalledOnce();
+    expect(agentSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'reactive',
+        tagName: 'remembered',
+        contents: expect.stringContaining(reminder),
+        attributes: expect.objectContaining({ threadId: threadIds[0] }),
+      }),
       expect.objectContaining({
         resourceId,
         threadId: threadIds[0],
         ifActive: { behavior: 'deliver' },
         ifIdle: { behavior: 'persist' },
       }),
-    ]);
+    );
   });
 
   it('runs curate after reflection with cursor recovery, CAS, and application restore', async () => {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -60,8 +60,10 @@ import {
 } from './processors/observational-memory/subconscious/learn';
 import {
   REMIND_PARENT_THREAD_METADATA_KEY,
+  createRemindAskTool,
   remindThreadKey,
 } from './processors/observational-memory/subconscious/remind';
+import { RemindRequestRegistry } from './processors/observational-memory/subconscious/remind-request-state';
 import { summarizeConversation, SUMMARIZE_THREAD_DEFAULTS } from './processors/observational-memory/summarize';
 import type {
   SummarizeConversationOptions,
@@ -320,6 +322,13 @@ export class Memory extends MastraMemory {
   private pendingVectorCleanup: Promise<void> = Promise.resolve();
 
   /**
+   * Correlated reminder questions in flight for this Memory. Shared by the `ask_memory` tool and every
+   * reminder agent it creates, because the run that answers a question is not necessarily the run that
+   * received it. In-memory and process-local: pending questions do not survive a restart.
+   */
+  private remindRequests = new RemindRequestRegistry();
+
+  /**
    * Adds a background vector cleanup to the join handle.
    * The handle keeps the earlier cleanups, so it settles only after all of them end.
    */
@@ -393,7 +402,10 @@ export class Memory extends MastraMemory {
     const existingSlugs = new Set(extract.map(extractor => extractor.slug));
     const omModel = observation.model ?? omConfig.model;
     const subconsciousExtractors = omConfig.experimental_subconscious
-      .createObservationExtractors(omModel, { createRemindMemory: () => this.getSubconsciousRemindMemory(omModel) })
+      .createObservationExtractors(omModel, {
+        createRemindMemory: () => this.getSubconsciousRemindMemory(omModel),
+        registry: this.remindRequests,
+      })
       .filter(extractor => !existingSlugs.has(extractor.slug));
 
     return {
@@ -2668,6 +2680,25 @@ Notes:
       omConfig.experimental_subconscious.resolved.tools
     ) {
       Object.assign(tools, createKnowledgeTools(this));
+
+      // The ask lane rides the same `tools` flag: a client that turned the knowledge tools off did
+      // not ask for a new agent-facing tool either.
+      const remindConfig = omConfig.experimental_subconscious.resolved.observation.find(
+        agent => agent.name === 'remind',
+      );
+      if (remindConfig) {
+        const omModel = omConfig.observation?.model ?? omConfig.model;
+        Object.assign(
+          tools,
+          createRemindAskTool({
+            memory: this,
+            config: remindConfig,
+            omModel,
+            createRemindMemory: () => this.getSubconsciousRemindMemory(omModel),
+            registry: this.remindRequests,
+          }),
+        );
+      }
     }
 
     return tools;

--- a/packages/memory/src/processors/observational-memory/__tests__/remind-request-state.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/remind-request-state.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { RemindConversation, RemindRequestFailureStatus } from '../subconscious/remind-request-state';
+import { REMINDER_TURN_DEADLINE_MS, RemindRequestRegistry } from '../subconscious/remind-request-state';
+
+const conversation: RemindConversation = { remindThreadId: 'subconscious:alpha:remind', resourceId: 'user-42' };
+const otherConversation: RemindConversation = { remindThreadId: 'subconscious:beta:remind', resourceId: 'user-99' };
+
+function register(
+  registry: RemindRequestRegistry,
+  correlationId: string,
+  conversationOverride: RemindConversation = conversation,
+) {
+  return registry.create({
+    correlationId,
+    conversation: conversationOverride,
+    sourceAgentId: 'main-agent',
+    sourceThreadId: 'alpha',
+    sourceResourceId: 'user-42',
+  });
+}
+
+const registries: RemindRequestRegistry[] = [];
+function makeRegistry(options?: { deadlineMs?: number; maxTerminalEntries?: number }) {
+  const registry = new RemindRequestRegistry(options);
+  registries.push(registry);
+  return registry;
+}
+
+afterEach(() => {
+  while (registries.length) registries.pop()!.dispose();
+  vi.useRealTimers();
+});
+
+describe('RemindRequestRegistry', () => {
+  it('registers minimal pending lifecycle and routing state', () => {
+    const registry = makeRegistry();
+    const record = register(registry, 'remind-ask-1');
+
+    expect(record).toMatchObject({
+      correlationId: 'remind-ask-1',
+      status: 'pending',
+      conversation,
+      sourceAgentId: 'main-agent',
+      sourceThreadId: 'alpha',
+      sourceResourceId: 'user-42',
+    });
+    expect(record.deadlineAt - record.createdAt).toBe(REMINDER_TURN_DEADLINE_MS);
+    expect(record).not.toHaveProperty('answer');
+    expect(record).not.toHaveProperty('settled');
+  });
+
+  it('rejects a second registration of the same correlation id', () => {
+    const registry = makeRegistry();
+    register(registry, 'remind-ask-dup');
+    expect(() => register(registry, 'remind-ask-dup')).toThrow(/already exists/);
+  });
+
+  it('reserves deterministic terminal signal identity without storing an answer', () => {
+    const registry = makeRegistry();
+    register(registry, 'remind-ask-2');
+
+    const reservation = registry.reserveTerminal('remind-ask-2', conversation);
+
+    expect(reservation.outcome).toBe('reserved');
+    expect(registry.get('remind-ask-2')).toMatchObject({
+      status: 'terminal_sending',
+      terminalSequence: 1,
+      terminalSignalId: 'remind-answer:remind-ask-2:terminal',
+    });
+    expect(registry.get('remind-ask-2')).not.toHaveProperty('answer');
+  });
+
+  it('marks a reserved terminal reply as delivered', () => {
+    const registry = makeRegistry();
+    register(registry, 'remind-ask-3');
+    registry.reserveTerminal('remind-ask-3', conversation);
+
+    registry.markReplied('remind-ask-3');
+
+    expect(registry.get('remind-ask-3')).toMatchObject({ status: 'replied', terminalSequence: 1 });
+    expect(registry.get('remind-ask-3')?.terminalAt).toEqual(expect.any(Number));
+  });
+
+  it('treats a second terminal reservation as a duplicate', () => {
+    const registry = makeRegistry();
+    register(registry, 'remind-ask-4');
+    registry.reserveTerminal('remind-ask-4', conversation);
+
+    expect(registry.reserveTerminal('remind-ask-4', conversation).outcome).toBe('duplicate');
+    registry.markReplied('remind-ask-4');
+    expect(registry.reserveTerminal('remind-ask-4', conversation).outcome).toBe('duplicate');
+  });
+
+  it('rejects unknown and wrong-conversation terminal reservations', () => {
+    const registry = makeRegistry();
+    register(registry, 'remind-ask-5');
+
+    expect(registry.reserveTerminal('missing', conversation)).toEqual({ outcome: 'rejected', reason: 'unknown' });
+    expect(registry.reserveTerminal('remind-ask-5', otherConversation)).toMatchObject({
+      outcome: 'rejected',
+      reason: 'wrong_conversation',
+    });
+    expect(registry.get('remind-ask-5')?.status).toBe('pending');
+  });
+
+  const failureStatuses: RemindRequestFailureStatus[] = [
+    'timed_out',
+    'model_failed',
+    'aborted',
+    'delivery_failed',
+    'delivery_unknown',
+  ];
+
+  it.each(failureStatuses)('records an inspectable %s failure without fabricating an answer', status => {
+    const registry = makeRegistry();
+    register(registry, `remind-ask-${status}`);
+
+    registry.fail(`remind-ask-${status}`, status, `boom: ${status}`);
+
+    expect(registry.get(`remind-ask-${status}`)).toMatchObject({
+      status,
+      failure: { status, message: `boom: ${status}` },
+    });
+    expect(registry.get(`remind-ask-${status}`)).not.toHaveProperty('answer');
+  });
+
+  it('keeps the first terminal state when a later failure races delivery', () => {
+    const registry = makeRegistry();
+    register(registry, 'remind-ask-6');
+    registry.reserveTerminal('remind-ask-6', conversation);
+    registry.markReplied('remind-ask-6');
+
+    registry.fail('remind-ask-6', 'model_failed', 'late model failure');
+
+    expect(registry.get('remind-ask-6')?.status).toBe('replied');
+    expect(registry.get('remind-ask-6')?.failure).toBeUndefined();
+  });
+
+  it('times out a pending request at its deadline', async () => {
+    vi.useFakeTimers();
+    const registry = makeRegistry({ deadlineMs: 50 });
+    register(registry, 'remind-ask-timeout');
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(registry.get('remind-ask-timeout')).toMatchObject({
+      status: 'timed_out',
+      failure: { status: 'timed_out', message: 'Memory question timed out after 50ms' },
+    });
+  });
+
+  it('does not overwrite an in-flight terminal delivery with the question deadline', async () => {
+    vi.useFakeTimers();
+    const registry = makeRegistry({ deadlineMs: 50 });
+    register(registry, 'remind-ask-in-flight');
+    registry.reserveTerminal('remind-ask-in-flight', conversation);
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(registry.get('remind-ask-in-flight')).toMatchObject({ status: 'terminal_sending' });
+    registry.markReplied('remind-ask-in-flight');
+    expect(registry.get('remind-ask-in-flight')).toMatchObject({ status: 'replied' });
+  });
+
+  it('keeps terminal lifecycle state bounded', () => {
+    const registry = makeRegistry({ maxTerminalEntries: 2 });
+    for (const correlationId of ['first', 'second', 'third']) {
+      register(registry, correlationId);
+      registry.reserveTerminal(correlationId, conversation);
+      registry.markReplied(correlationId);
+    }
+
+    expect(registry.get('first')).toBeUndefined();
+    expect(registry.get('second')?.status).toBe('replied');
+    expect(registry.get('third')?.status).toBe('replied');
+  });
+
+  it('disposal releases all lifecycle records', () => {
+    const registry = makeRegistry();
+    register(registry, 'pending');
+    register(registry, 'sending');
+    register(registry, 'replied');
+    registry.reserveTerminal('sending', conversation);
+    registry.reserveTerminal('replied', conversation);
+    registry.markReplied('replied');
+
+    registry.dispose();
+
+    expect(registry.get('pending')).toBeUndefined();
+    expect(registry.get('sending')).toBeUndefined();
+    expect(registry.get('replied')).toBeUndefined();
+  });
+});

--- a/packages/memory/src/processors/observational-memory/__tests__/remind-request-state.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/remind-request-state.test.ts
@@ -71,6 +71,20 @@ describe('RemindRequestRegistry', () => {
     expect(registry.get('remind-ask-2')).not.toHaveProperty('answer');
   });
 
+  it('rejects a terminal reservation after its absolute deadline even before the timer callback runs', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-30T12:00:00Z'));
+    const registry = makeRegistry({ deadlineMs: 100 });
+    register(registry, 'remind-ask-expired');
+    vi.setSystemTime(new Date('2026-08-30T12:00:00.100Z'));
+
+    expect(registry.reserveTerminal('remind-ask-expired', conversation)).toMatchObject({
+      outcome: 'rejected',
+      reason: 'terminal',
+      record: { status: 'timed_out' },
+    });
+  });
+
   it('marks a reserved terminal reply as delivered', () => {
     const registry = makeRegistry();
     register(registry, 'remind-ask-3');

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-read-tools.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-read-tools.test.ts
@@ -67,6 +67,11 @@ describe('Subconscious knowledge read tools', () => {
     expect((await createMemory(false)).listTools()).not.toHaveProperty('knowledge_search');
   });
 
+  it('registers the ask tool behind the same tools gate', async () => {
+    expect((await createMemory()).listTools()).toHaveProperty('ask_memory');
+    expect((await createMemory(false)).listTools()).not.toHaveProperty('ask_memory');
+  });
+
   it('reads and browses visible records without exposing a sibling thread', async () => {
     const memory = await createMemory();
     const store = (await memory.storage.getStore('knowledge'))!;

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -1,12 +1,18 @@
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { Agent } from '@mastra/core/agent';
 import { RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
 import type { MemoryStorage } from '@mastra/core/storage';
 import { describe, expect, it, vi } from 'vitest';
 
+import { OBSERVATIONAL_MEMORY_DEFAULTS } from '../constants';
 import { applyExtractorHooks } from '../extracted-values';
 import { buildExtractorOutputSections, Extractor } from '../extractor';
+import { ModelByInputTokens } from '../model-by-input-tokens';
 import { SubconsciousRemindExtractor } from '../subconscious';
+import { resolveReminderConversationModel, resolveSubconsciousAgentModel } from '../subconscious/model';
+import { createRemindAskTool, createReplyToolProcessor } from '../subconscious/remind';
+import { REMINDER_TURN_DEADLINE_MS, RemindRequestRegistry } from '../subconscious/remind-request-state';
 
 function createModel(response: string) {
   return new MockLanguageModelV2({
@@ -334,8 +340,9 @@ describe('Subconscious remind', () => {
 
   it('shows the reminder agent the recent messages so it can skip what is already visible', async () => {
     const { Agent } = await import('@mastra/core/agent');
-    const generateSpy = vi.spyOn(Agent.prototype, 'generate' as any);
-    generateSpy.mockClear();
+    // The passive path enters the continuing reminder conversation through sendMessage.
+    const sendMessageSpy = vi.spyOn(Agent.prototype, 'sendMessage' as any);
+    sendMessageSpy.mockClear();
     try {
       const extractor = new SubconsciousRemindExtractor({
         name: 'remind',
@@ -366,12 +373,12 @@ describe('Subconscious remind', () => {
         ...context,
       });
 
-      expect(generateSpy).toHaveBeenCalledOnce();
-      const prompt = generateSpy.mock.calls[0]?.[0] as string;
+      expect(sendMessageSpy).toHaveBeenCalledOnce();
+      const prompt = sendMessageSpy.mock.calls[0]?.[0] as string;
       expect(prompt).toContain('user: what is the weather like on the moon?');
       expect(prompt).toContain('already visible');
     } finally {
-      generateSpy.mockRestore();
+      sendMessageSpy.mockRestore();
     }
   });
 
@@ -392,6 +399,18 @@ describe('Subconscious remind', () => {
   });
 
   describe('continuity: the reminder agent keeps one conversation per session', () => {
+    function createRemindMemoryStub(extra: Record<string, unknown> = {}) {
+      let thread: any;
+      return {
+        ...extra,
+        getThreadById: vi.fn(async () => thread),
+        saveThread: vi.fn(async ({ thread: nextThread }: any) => {
+          thread = nextThread;
+          return nextThread;
+        }),
+      } as any;
+    }
+
     async function seedRelevantItem(context: ReturnType<typeof createContext>) {
       const store = await context.memory.storage.getStore('knowledge');
       const node = await store.createNode({
@@ -409,7 +428,7 @@ describe('Subconscious remind', () => {
       });
     }
 
-    /** Runs the hook with `generate` stubbed, so the assertions are about wiring, not model output. */
+    /** Runs the hook with the conversation's `sendMessage` stubbed, so assertions cover wiring rather than model output. */
     async function runWithGenerateSpy(options: {
       createRemindMemory?: () => any;
       threadId?: string;
@@ -417,9 +436,17 @@ describe('Subconscious remind', () => {
       response?: string;
     }) {
       const { Agent } = await import('@mastra/core/agent');
-      const generateSpy = vi
-        .spyOn(Agent.prototype, 'generate' as any)
-        .mockResolvedValue({ text: options.response ?? '<no-reminder />' } as any);
+      const generateSpy = vi.spyOn(Agent.prototype, 'sendMessage' as any).mockImplementation(function () {
+        return {
+          accepted: Promise.resolve({
+            action: 'wake',
+            output: {
+              consumeStream: vi.fn().mockResolvedValue(undefined),
+              getFullOutput: vi.fn().mockResolvedValue({ text: options.response ?? '<no-reminder />' }),
+            },
+          }),
+        };
+      } as any);
       try {
         const extractor = new SubconsciousRemindExtractor({ name: 'remind', maxSteps: 3, builtIn: true }, undefined, {
           createRemindMemory: options.createRemindMemory,
@@ -454,19 +481,14 @@ describe('Subconscious remind', () => {
     }
 
     it('generates against the shared remind thread derived from the parent thread id', async () => {
-      const remindMemory = { id: 'remind-memory' } as any;
+      const remindMemory = createRemindMemoryStub({ id: 'remind-memory' });
       const { result, calls } = await runWithGenerateSpy({ createRemindMemory: () => remindMemory });
 
       expect(result.failures).toBeUndefined();
       expect(calls).toHaveLength(1);
       expect(calls[0]?.[1]).toMatchObject({
-        memory: {
-          thread: {
-            id: 'subconscious:alpha:remind',
-            metadata: { subconsciousRemindParentThreadId: 'alpha' },
-          },
-          resource: 'user-42',
-        },
+        threadId: 'subconscious:alpha:remind',
+        resourceId: 'user-42',
       });
     });
 
@@ -482,22 +504,19 @@ describe('Subconscious remind', () => {
 
     it('keys the thread off the parent thread id, never off the agent id', async () => {
       const { calls } = await runWithGenerateSpy({
-        createRemindMemory: () => ({}) as any,
+        createRemindMemory: () => createRemindMemoryStub(),
         threadId: 'gamma',
       });
 
-      const thread = (calls[0]?.[1] as any).memory.thread;
-      expect(thread).toEqual({
-        id: 'subconscious:gamma:remind',
-        metadata: { subconsciousRemindParentThreadId: 'gamma' },
-      });
+      const thread = (calls[0]?.[1] as any).threadId;
+      expect(thread).toBe('subconscious:gamma:remind');
       // The agent id convention is `subconscious-remind-<threadId>`; confusing the two produces a
       // thread that looks plausible and groups wrongly.
       expect(thread).not.toContain('subconscious-remind-');
     });
 
     it('hands the reminder agent the memory its owner built', async () => {
-      const remindMemory = { id: 'remind-memory' } as any;
+      const remindMemory = createRemindMemoryStub({ id: 'remind-memory' });
       const createRemindMemory = vi.fn(() => remindMemory);
       const { agents } = await runWithGenerateSpy({ createRemindMemory });
 
@@ -507,22 +526,24 @@ describe('Subconscious remind', () => {
     });
 
     it('passes the same thread on every run, so passive reminders and questions share one conversation', async () => {
-      const first = await runWithGenerateSpy({ createRemindMemory: () => ({}) as any });
-      const second = await runWithGenerateSpy({ createRemindMemory: () => ({}) as any });
+      const first = await runWithGenerateSpy({ createRemindMemory: () => createRemindMemoryStub() });
+      const second = await runWithGenerateSpy({ createRemindMemory: () => createRemindMemoryStub() });
 
-      expect((first.calls[0]?.[1] as any).memory.thread).toEqual((second.calls[0]?.[1] as any).memory.thread);
+      expect((first.calls[0]?.[1] as any).threadId).toBe((second.calls[0]?.[1] as any).threadId);
     });
 
-    it('omits the memory option entirely when no remind memory is available', async () => {
-      const { result, calls } = await runWithGenerateSpy({});
+    it('builds the reminder agent without memory when no remind memory is available', async () => {
+      const { result, calls, agents } = await runWithGenerateSpy({});
 
       expect(result.failures).toBeUndefined();
-      expect(calls[0]?.[1]).not.toHaveProperty('memory');
+      // The turn still enters the serialized conversation thread; only history persistence is absent.
+      expect((calls[0]?.[1] as any).threadId).toBe('subconscious:alpha:remind');
+      expect(await (agents[0] as any).getMemory()).toBeUndefined();
     });
 
     it('still drops the thread\u2019s own fresh items when a remind memory is attached', async () => {
       const extractor = new SubconsciousRemindExtractor({ name: 'remind', maxSteps: 3, builtIn: true }, undefined, {
-        createRemindMemory: () => ({}) as any,
+        createRemindMemory: () => createRemindMemoryStub(),
       });
       const context = createContext('The launch happens January 15.');
       const store = await context.memory.storage.getStore('knowledge');
@@ -553,7 +574,7 @@ describe('Subconscious remind', () => {
     });
 
     it('keeps the no-reminder contract when a remind memory is attached', async () => {
-      const { result, context } = await runWithGenerateSpy({ createRemindMemory: () => ({}) as any });
+      const { result, context } = await runWithGenerateSpy({ createRemindMemory: () => createRemindMemoryStub() });
 
       expect(result.failures).toBeUndefined();
       expect(context.sendSignal).not.toHaveBeenCalled();
@@ -858,4 +879,1329 @@ describe('Subconscious remind', () => {
       }),
     );
   });
+});
+
+describe('Subconscious remind ask conversation', () => {
+  function createAskTool(
+    options: {
+      response?: string;
+      omModel?: any;
+      createRemindMemory?: () => any;
+      generate?: (prompt: string, args: any) => Promise<{ text: string }>;
+    } = {},
+  ) {
+    const memory = { storage: new InMemoryStore(), getKnowledgeSemanticIndex: vi.fn() } as any;
+    // Asks are delivered with sendMessage. The stub exercises the real current-input processor,
+    // then answers with the reply tool that processor exposes for this correlated question.
+    const generateSpy = vi.spyOn(Agent.prototype, 'sendMessage' as any);
+    generateSpy.mockImplementation(function (this: Agent, input: any, opts: any) {
+      void (async () => {
+        const text = options.generate
+          ? (await options.generate(input?.contents as string, opts)).text
+          : (options.response ?? 'That happened on Tuesday.');
+        const processor = createReplyToolProcessor(registry, {
+          remindThreadId: opts?.threadId,
+          resourceId: opts?.resourceId,
+        });
+        const processed = await processor.processInputStep?.({ messages: [input], tools: {} } as any);
+        if (!processed || !('tools' in processed)) return;
+        const replyTool = processed.tools?.reply_to_memory_question as any;
+        if (!replyTool) return;
+        await replyTool.execute(
+          { correlationId: input?.metadata?.correlationId, answer: text },
+          {
+            requestContext: opts?.requestContext,
+            agent: { threadId: opts?.threadId, resourceId: opts?.resourceId },
+          },
+        );
+      })().catch(() => {});
+      return { accepted: Promise.resolve({ action: 'deliver', runId: 'run-stub' }) };
+    } as any);
+    const registry = new RemindRequestRegistry();
+    const tools = createRemindAskTool({
+      memory,
+      config: { name: 'remind', maxSteps: 3, builtIn: true },
+      omModel: 'omModel' in options ? options.omModel : createModel('unused'),
+      createRemindMemory: options.createRemindMemory,
+      registry,
+    });
+    return { tools, generateSpy, memory, registry };
+  }
+
+  function askContext(overrides: Record<string, unknown> = {}) {
+    const requestContext = new RequestContext();
+    requestContext.set('organizationId', 'acme');
+    const sourceAgent = {
+      sendSignal: vi.fn(() => ({ accepted: Promise.resolve({ action: 'deliver' }) })),
+    };
+    return {
+      agent: { agentId: 'main', threadId: 'alpha', resourceId: 'user-42' },
+      requestContext,
+      mastra: { getAgentById: vi.fn(async () => sourceAgent) },
+      ...overrides,
+    } as any;
+  }
+
+  function signalCapture() {
+    const sent: any[] = [];
+    const sender = {
+      sendSignal: vi.fn((signal: any) => {
+        sent.push(signal);
+        return { persisted: Promise.resolve() };
+      }),
+    };
+    return {
+      sent,
+      sender,
+      mastra: { getAgentById: vi.fn(async () => sender) },
+    };
+  }
+
+  async function settle() {
+    for (let i = 0; i < 5; i++) await new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  it.each([
+    ['routing acceptance', { accepted: new Promise(() => {}) }],
+    ['signal persistence', { accepted: Promise.resolve({ action: 'persist' }), persisted: new Promise(() => {}) }],
+  ])('fails terminal delivery when %s never settles', async (_label, signalResult) => {
+    vi.useFakeTimers();
+    const { tools, generateSpy, registry } = createAskTool({ response: 'A terminal answer.' });
+    const sourceAgent = { sendSignal: vi.fn(() => signalResult) };
+    try {
+      const result: any = await tools.ask_memory.execute!(
+        { question: 'what happened?' } as any,
+        askContext({ mastra: { getAgentById: vi.fn(async () => sourceAgent) } }),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(registry.get(result.correlationId)?.status).toBe('terminal_sending');
+
+      await vi.advanceTimersByTimeAsync(REMINDER_TURN_DEADLINE_MS);
+      expect(registry.get(result.correlationId)).toMatchObject({
+        status: 'delivery_unknown',
+        failure: {
+          status: 'delivery_unknown',
+          message: `Terminal answer delivery timed out after ${REMINDER_TURN_DEADLINE_MS}ms`,
+        },
+      });
+    } finally {
+      generateSpy.mockRestore();
+      registry.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('bounds reminder question routing acceptance by the request deadline', async () => {
+    vi.useFakeTimers();
+    const { tools, generateSpy, registry } = createAskTool();
+    generateSpy.mockReturnValue({ accepted: new Promise(() => {}) } as any);
+    try {
+      const pending = tools.ask_memory.execute!({ question: 'what happened?' } as any, askContext());
+      await vi.advanceTimersByTimeAsync(REMINDER_TURN_DEADLINE_MS);
+      await expect(pending).resolves.toMatchObject({ ok: false, status: 'timed_out' });
+    } finally {
+      generateSpy.mockRestore();
+      registry.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not submit a reminder question when the caller is already aborted', async () => {
+    const { tools, generateSpy, registry } = createAskTool();
+    const controller = new AbortController();
+    controller.abort();
+    try {
+      await expect(
+        tools.ask_memory.execute!(
+          { question: 'what happened?' } as any,
+          askContext({ abortSignal: controller.signal }),
+        ),
+      ).resolves.toMatchObject({ ok: false, status: 'delivery_failed' });
+      expect(generateSpy).not.toHaveBeenCalled();
+    } finally {
+      generateSpy.mockRestore();
+      registry.dispose();
+    }
+  });
+
+  it('bounds terminal delivery by the remaining request deadline', async () => {
+    vi.useFakeTimers();
+    const sourceAgent = { sendSignal: vi.fn(() => ({ accepted: new Promise(() => {}) })) };
+    const { tools, generateSpy, registry } = createAskTool({
+      generate: async () => {
+        await new Promise(resolve => setTimeout(resolve, REMINDER_TURN_DEADLINE_MS - 1_000));
+        return { text: 'A late terminal answer.' };
+      },
+    });
+    try {
+      const result: any = await tools.ask_memory.execute!(
+        { question: 'what happened?' } as any,
+        askContext({ mastra: { getAgentById: vi.fn(async () => sourceAgent) } }),
+      );
+      await vi.advanceTimersByTimeAsync(REMINDER_TURN_DEADLINE_MS - 1_000);
+      expect(registry.get(result.correlationId)?.status).toBe('terminal_sending');
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(registry.get(result.correlationId)).toMatchObject({
+        status: 'delivery_unknown',
+        failure: { status: 'delivery_unknown', message: 'Terminal answer delivery timed out after 1000ms' },
+      });
+    } finally {
+      generateSpy.mockRestore();
+      registry.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('accepts a question when the observational memory model is the default sentinel', async () => {
+    const { tools, generateSpy } = createAskTool({ omModel: 'default', response: 'Answered on the default model.' });
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'what happened?' } as any, askContext());
+      expect(result.ok).toBe(true);
+      expect(result.accepted).toBe(true);
+      expect(result.status).toBe('pending');
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('does not collapse a token-routed observational-memory model without runtime context', async () => {
+    const config = { name: 'remind', maxSteps: 3, builtIn: true } as any;
+    const tiered = new ModelByInputTokens({ upTo: { 1000: 'openai/gpt-5-nano', 100000: 'openai/gpt-5' } });
+    await expect(resolveReminderConversationModel({ config, omModel: tiered })).resolves.toBeUndefined();
+
+    const mainAgent = { getModel: vi.fn(async () => 'main-agent-model') } as any;
+    await expect(resolveReminderConversationModel({ config, omModel: tiered, mainAgent })).resolves.toBe(
+      'main-agent-model',
+    );
+  });
+
+  it('resolves default and token-routed models only as a last resort', async () => {
+    const config = { name: 'remind', maxSteps: 3, builtIn: true } as any;
+    // The default sentinel falls back to the observational memory default model.
+    await expect(resolveSubconsciousAgentModel({ config, omModel: 'default' })).resolves.toBe(
+      OBSERVATIONAL_MEMORY_DEFAULTS.observation.model,
+    );
+    // A token-routed model resolves at the smallest tier: an ask prompt is a question, not a transcript.
+    const tiered = new ModelByInputTokens({ upTo: { 1000: 'openai/gpt-5-nano', 100000: 'openai/gpt-5' } });
+    await expect(resolveSubconsciousAgentModel({ config, omModel: tiered })).resolves.toBe('openai/gpt-5-nano');
+    // The main agent still wins over the fallback so extractor precedence is unchanged.
+    const mainAgent = { getModel: vi.fn(async () => 'main-agent-model') } as any;
+    await expect(resolveSubconsciousAgentModel({ config, omModel: 'default', mainAgent })).resolves.toBe(
+      'main-agent-model',
+    );
+  });
+
+  it('prefers a configured reminder model over token-routed observational memory', async () => {
+    const tiered = new ModelByInputTokens({ upTo: { 1000: 'openai/gpt-5-nano', 100000: 'openai/gpt-5' } });
+    const reminderModel = (() => 'openai/gpt-5') as any;
+    const config = { name: 'remind', maxSteps: 3, builtIn: true, model: reminderModel } as any;
+    await expect(resolveReminderConversationModel({ config, omModel: tiered })).resolves.toBe(reminderModel);
+  });
+
+  it('passes failover arrays and dynamic model configs to the reminder agent unreduced', async () => {
+    const config = { name: 'remind', maxSteps: 3, builtIn: true } as any;
+    const failover = [{ model: 'openai/gpt-5' }, { model: 'openai/gpt-5-nano' }] as any;
+    await expect(resolveReminderConversationModel({ config: { ...config, model: failover } })).resolves.toBe(failover);
+    const dynamic = (() => 'openai/gpt-5') as any;
+    await expect(resolveReminderConversationModel({ config: { ...config, model: dynamic } })).resolves.toBe(dynamic);
+  });
+
+  it('rejects immediately when the conversation refuses the turn as blocked', async () => {
+    const { tools, generateSpy } = createAskTool({});
+    // A blocked disposition means the turn will never run: the waiter must fail now, not after
+    // the full conversation deadline.
+    generateSpy.mockImplementation((() => ({
+      accepted: Promise.resolve({ action: 'blocked', reason: 'thread-blocked' }),
+    })) as any);
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'when?' } as any, askContext());
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe('thread-blocked');
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('rejects a blocking ask immediately when the conversation run fails after starting', async () => {
+    const { tools, generateSpy } = createAskTool({});
+    // A post-start failure reports through onError, and it fires BEFORE `accepted` names the run —
+    // the failure has to wait for the run id and then land, rather than stranding the question until
+    // the deadline. The waiter must not burn the deadline.
+    generateSpy.mockImplementation(((_input: any, opts: any) => {
+      opts?.ifIdle?.streamOptions?.onError?.({ error: new Error('model exploded mid-stream') });
+      return { accepted: Promise.resolve({ action: 'wake', runId: 'run-failed' }) };
+    }) as any);
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'when?' } as any, askContext());
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/model exploded mid-stream/);
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('keeps an accepted question alive when the calling turn aborts', async () => {
+    const { tools, generateSpy } = createAskTool({});
+    generateSpy.mockImplementation((() => ({ accepted: Promise.resolve({ action: 'deliver' }) })) as any);
+    const controller = new AbortController();
+    try {
+      const result: any = await tools.ask_memory.execute!(
+        { question: 'when?' } as any,
+        askContext({ abortSignal: controller.signal }),
+      );
+      controller.abort();
+      expect(result.ok).toBe(true);
+      expect(result.accepted).toBe(true);
+      expect(result.status).toBe('pending');
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('acknowledges the question instead of returning the answer inline', async () => {
+    const { tools, generateSpy } = createAskTool({ response: 'The deploy happened on Tuesday.' });
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'when did that happen?' } as any, askContext());
+      expect(result.ok).toBe(true);
+      expect(result.accepted).toBe(true);
+      expect(result).not.toHaveProperty('answer');
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('asks on the shared remind thread, not a thread of its own', async () => {
+    const calls: any[] = [];
+    const { tools, generateSpy } = createAskTool({
+      createRemindMemory: () => createRemindMemoryStub(),
+      generate: async (_prompt, args) => {
+        calls.push(args);
+        return { text: 'Tuesday.' };
+      },
+    });
+    try {
+      await tools.ask_memory.execute!({ question: 'when?' } as any, askContext());
+      expect(calls[0]).toMatchObject({ threadId: 'subconscious:alpha:remind', resourceId: 'user-42' });
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('returns immediately when wait is false, before the answer settles', async () => {
+    let release: (value: { text: string }) => void = () => {};
+    const deferred = new Promise<{ text: string }>(resolve => (release = resolve));
+    const generateArgs: any[] = [];
+    const { tools, generateSpy } = createAskTool({
+      generate: async (_prompt, args) => {
+        generateArgs.push(args);
+        return deferred;
+      },
+      createRemindMemory: () => createRemindMemoryStub(),
+    });
+    const capture = signalCapture();
+    try {
+      const result: any = await tools.ask_memory.execute!(
+        { question: 'when?' } as any,
+        askContext({ mastra: capture.mastra }),
+      );
+      expect(result.accepted).toBe(true);
+      expect(capture.sent).toHaveLength(0);
+      // The answer outlives the asking turn, so it must not be tied to that turn's abort signal.
+      expect(generateArgs[0]).not.toHaveProperty('abortSignal');
+      release({ text: 'Tuesday.' });
+      await settle();
+      expect(capture.sent).toHaveLength(1);
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('reports a broken agent registry as a tool error instead of throwing', async () => {
+    const { tools, generateSpy } = createAskTool({ response: 'Tuesday.' });
+    try {
+      const result: any = await tools.ask_memory.execute!(
+        { question: 'when?' } as any,
+        askContext({
+          mastra: {
+            getAgentById: vi.fn(async () => {
+              throw new Error('agent registry unavailable');
+            }),
+          },
+        }),
+      );
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('agent registry unavailable');
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('delivers the non-blocking answer as a remembered signal', async () => {
+    const { tools, generateSpy } = createAskTool({ response: 'Tuesday.' });
+    const capture = signalCapture();
+    try {
+      await tools.ask_memory.execute!({ question: 'when?' } as any, askContext({ mastra: capture.mastra }));
+      await settle();
+      expect(capture.sent[0]).toEqual(
+        expect.objectContaining({
+          type: 'reactive',
+          tagName: 'remembered',
+          attributes: expect.objectContaining({
+            source: 'subconscious',
+            agent: 'remind',
+            sourceThreadId: 'alpha',
+            sourceResourceId: 'user-42',
+          }),
+        }),
+      );
+      expect(capture.sender.sendSignal).toHaveBeenCalledWith(expect.anything(), {
+        threadId: 'alpha',
+        resourceId: 'user-42',
+        ifIdle: expect.objectContaining({ behavior: 'wake' }),
+      });
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('round-trips the correlation id from the acknowledgement to the late signal', async () => {
+    const { tools, generateSpy } = createAskTool({ response: 'Tuesday.' });
+    const capture = signalCapture();
+    try {
+      const result: any = await tools.ask_memory.execute!(
+        { question: 'when?' } as any,
+        askContext({ mastra: capture.mastra }),
+      );
+      await settle();
+      expect(result.correlationId).toBeTruthy();
+      expect(capture.sent[0].attributes.correlationId).toBe(result.correlationId);
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('keeps the question and the answer in the shared thread', async () => {
+    const generated: any[] = [];
+    const { tools, generateSpy } = createAskTool({
+      createRemindMemory: () => createRemindMemoryStub(),
+      generate: async (prompt, args) => {
+        generated.push({ prompt, args });
+        return { text: 'Tuesday.' };
+      },
+    });
+    try {
+      await tools.ask_memory.execute!({ question: 'when did the deploy happen?' } as any, askContext());
+      expect(generated[0].prompt).toContain('when did the deploy happen?');
+      expect(generated[0].args).toMatchObject({ threadId: 'subconscious:alpha:remind', resourceId: 'user-42' });
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('acknowledges accepted delivery without waiting for the reminder model', async () => {
+    const { tools, generateSpy } = createAskTool({
+      generate: async () => {
+        throw new Error('reminder provider unavailable');
+      },
+    });
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'when?' } as any, askContext());
+      expect(result).toEqual(expect.objectContaining({ ok: true, accepted: true, status: 'pending' }));
+      await settle();
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('does not fabricate a terminal signal when the accepted reminder run later fails', async () => {
+    const { tools, generateSpy, registry } = createAskTool({
+      generate: async () => {
+        throw new Error('reminder provider unavailable');
+      },
+    });
+    const capture = signalCapture();
+    try {
+      const result: any = await tools.ask_memory.execute!(
+        { question: 'when?' } as any,
+        askContext({ mastra: capture.mastra }),
+      );
+      await settle();
+      expect(result).toEqual(expect.objectContaining({ ok: true, accepted: true, status: 'pending' }));
+      expect(capture.sent).toEqual([]);
+      expect(registry.get(result.correlationId)?.status).toBe('pending');
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('gives concurrent non-blocking questions distinct correlation ids', async () => {
+    const { tools, generateSpy } = createAskTool({
+      generate: async prompt => ({ text: prompt.includes('first') ? 'answer one' : 'answer two' }),
+    });
+    const capture = signalCapture();
+    try {
+      const context = askContext({ mastra: capture.mastra });
+      const [one, two]: any[] = await Promise.all([
+        tools.ask_memory.execute!({ question: 'the first one?' } as any, context),
+        tools.ask_memory.execute!({ question: 'the second one?' } as any, context),
+      ]);
+      await settle();
+      expect(one.correlationId).not.toBe(two.correlationId);
+      const byId = new Map(capture.sent.map(signal => [signal.attributes.correlationId, signal]));
+      expect(byId.get(one.correlationId)?.contents).toBe('answer one');
+      expect(byId.get(two.correlationId)?.contents).toBe('answer two');
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it('leaves the passive reminder path unregressed while a question shares its thread', async () => {
+    // Hold a question open across a full passive reminder run: the passive signal's shape and its
+    // source ids must be untouched by an ask sharing the session, and the ask must still resolve.
+    const extractor = new SubconsciousRemindExtractor({ name: 'remind', maxSteps: 3, builtIn: true });
+    const context = createContext('Project Atlas launches January 15.');
+    const store = await context.memory.storage.getStore('knowledge');
+    const node = await store.createNode({
+      name: 'Project Atlas',
+      kind: 'project',
+      scope: ['org:acme', 'resource:user-42'],
+    });
+    const item = await store.appendKnowledge({
+      node,
+      text: 'Project Atlas launches January 15.',
+      scope: ['org:acme', 'resource:user-42'],
+      sourceThreadId: 'beta',
+      resolutionScope: ['org:acme', 'resource:user-42', 'thread:beta'],
+      defaultScope: ['org:acme', 'resource:user-42'],
+    });
+
+    let releaseAsk: (value: { text: string }) => void = () => {};
+    const pendingAsk = new Promise<{ text: string }>(resolve => (releaseAsk = resolve));
+    const registry = new RemindRequestRegistry();
+    const tools = createRemindAskTool({
+      memory: context.memory,
+      config: { name: 'remind', maxSteps: 3, builtIn: true },
+      omModel: createModel('unused'),
+      createRemindMemory: () => createRemindMemoryStub(),
+      registry,
+    });
+    // The passive reply cites the item id: the grounded-citation guard suppresses
+    // reminders that reference no candidate, and this test is about signal shape.
+    // Both entry points use sendMessage on the shared reminder conversation. Passive work owns its
+    // output; question work is accepted immediately and can only answer through the bound reply tool.
+    const sendSpy = vi.spyOn(Agent.prototype, 'sendMessage' as any);
+    sendSpy.mockImplementation(function (_input: any, opts: any) {
+      const input = _input as { metadata?: Record<string, unknown> } | string;
+      if (typeof input === 'string') {
+        return {
+          accepted: Promise.resolve({
+            action: 'wake',
+            output: {
+              consumeStream: vi.fn(async () => {}),
+              getFullOutput: vi.fn(async () => ({ text: `Atlas ships mid January, worth checking. (${item.id})` })),
+            },
+          }),
+        };
+      }
+      void pendingAsk.then(async answer => {
+        const processor = createReplyToolProcessor(registry, {
+          remindThreadId: opts?.threadId,
+          resourceId: opts?.resourceId,
+        });
+        const processed = await processor.processInputStep?.({ messages: [input], tools: {} } as any);
+        if (!processed || !('tools' in processed)) return;
+        await (processed.tools?.reply_to_memory_question as any).execute(
+          { correlationId: input.metadata?.correlationId, answer: answer.text },
+          { agent: { threadId: opts?.threadId, resourceId: opts?.resourceId } },
+        );
+      });
+      return { accepted: Promise.resolve({ action: 'deliver', runId: 'run-ask' }) };
+    } as any);
+
+    try {
+      const askInFlight = tools.ask_memory.execute!({ question: 'when?' } as any, askContext());
+
+      const result = await applyExtractorHooks({
+        source: 'observer',
+        extractors: [extractor],
+        rawObservations: 'The user is scheduling Project Atlas.',
+        ...context,
+      });
+
+      expect(result.failures).toBeUndefined();
+      expect(context.sendSignal).toHaveBeenCalledOnce();
+      expect(context.sendSignal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'reactive',
+          tagName: 'remembered',
+          // Both halves of the signal body: the reminder the agent wrote and the source ids
+          // appended after it. Asserting only the id passes even if the reminder text is dropped.
+          contents: expect.stringContaining('Atlas ships mid January, worth checking.'),
+          attributes: expect.objectContaining({
+            source: 'subconscious',
+            sourceIds: expect.stringContaining(item.id),
+            agent: 'remind',
+            threadId: 'alpha',
+          }),
+        }),
+      );
+
+      const acknowledgement: any = await askInFlight;
+      expect(acknowledgement).toEqual(
+        expect.objectContaining({ ok: true, accepted: true, status: 'pending', correlationId: expect.any(String) }),
+      );
+      releaseAsk({ text: 'January 15.' });
+      await vi.waitFor(() => expect(registry.get(acknowledgement.correlationId)?.status).toBe('replied'));
+      const targets = sendSpy.mock.calls.map(([, target]: any[]) => target);
+      expect(targets).toHaveLength(2);
+      expect(targets.every(target => target.threadId === 'subconscious:alpha:remind')).toBe(true);
+    } finally {
+      sendSpy.mockRestore();
+    }
+  });
+
+  it('returns an explicit unavailable result when no model can be resolved', async () => {
+    const { tools, generateSpy } = createAskTool({ omModel: undefined });
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'when?' } as any, askContext());
+      expect(result.ok).toBe(false);
+      expect(result.unavailable).toBe(true);
+      expect(result.error).toMatch(/model/i);
+      expect(generateSpy).not.toHaveBeenCalled();
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+});
+
+describe('reminder conversation serialization (real runtime)', () => {
+  // Tyler's review repro: two concurrent asks against the shared remind conversation must not
+  // interleave. This test uses the REAL Agent + thread-stream runtime + Memory over shared
+  // storage — no queueMessage spies — so it proves the runtime contract, not a mock of it.
+  it('serializes concurrent asks into one causal transcript on the shared remind thread', async () => {
+    const { Memory } = await import('../../../index');
+    const sharedStorage = new InMemoryStore();
+    const remindMemory = new Memory({ storage: sharedStorage });
+
+    // The first model turn parks until we explicitly release it, guaranteeing the second ask
+    // is enqueued while the first run is still in flight — the exact race from the review.
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>(resolve => (releaseFirst = resolve));
+    let streamCalls = 0;
+    // The scripted model answers each question exactly once, the way a well-behaved reminder agent
+    // does: the id it has already replied to gets no second reply.
+    const repliedTo = new Set<string>();
+    const model = new MockLanguageModelV2({
+      doStream: async ({ prompt }: any) => {
+        const transcript = JSON.stringify(prompt);
+
+        // The open question is the last correlation id the model can see. Answering means calling
+        // the reply tool with it — the run's text alone would settle nothing.
+        const ids = [...transcript.matchAll(/correlationId: (remind-ask-[0-9a-f-]+)/g)].map(match => match[1]);
+        const correlationId = ids[ids.length - 1]!;
+        const answered = repliedTo.has(correlationId);
+        if (answered) {
+          // The follow-up turn after the tool result: nothing left to say.
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'conversation-done', modelId: 'remind-model', timestamp: new Date() },
+              { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+            ]),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          };
+        }
+        const index = streamCalls++;
+        if (index === 0) await firstGate;
+        repliedTo.add(correlationId);
+        // The conversation thread carries every earlier question too, so the answer is chosen from the
+        // question that owns the OPEN correlation id — not from whatever text is in scrollback.
+        const asked = new RegExp(`correlationId: ${correlationId}[^:]*: (first|second) question`).exec(transcript)?.[1];
+        const text = `answer-${asked}`;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: `conversation-${index}`, modelId: 'remind-model', timestamp: new Date() },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: text },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'tool-call',
+              toolCallId: `reply-${index}`,
+              toolName: 'reply_to_memory_question',
+              input: JSON.stringify({ correlationId, answer: text }),
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    const memory = { storage: new InMemoryStore(), getKnowledgeSemanticIndex: vi.fn() } as any;
+    const tools = createRemindAskTool({
+      memory,
+      config: { name: 'remind', maxSteps: 3, builtIn: true },
+      omModel: model as any,
+      createRemindMemory: () => remindMemory as any,
+    });
+    const sent: any[] = [];
+    const sourceAgent = {
+      sendSignal: vi.fn((signal: any) => {
+        sent.push(signal);
+        return { accepted: Promise.resolve({ action: 'deliver' }) };
+      }),
+    };
+    const context = () => {
+      const requestContext = new RequestContext();
+      requestContext.set('organizationId', 'acme');
+      return {
+        agent: { agentId: 'main', threadId: 'alpha', resourceId: 'user-42' },
+        requestContext,
+        mastra: { getAgentById: vi.fn(async () => sourceAgent) },
+      } as any;
+    };
+
+    const first = tools.ask_memory.execute!({ question: 'first question' } as any, context());
+    // Wait for the first run to actually reach the model (run active on the conversation thread).
+    await vi.waitFor(() => expect(streamCalls).toBeGreaterThan(0), { timeout: 10_000 });
+    const second = tools.ask_memory.execute!({ question: 'second question' } as any, context());
+    // Give the runtime a beat to route the second ask while the first is mid-stream, then
+    // release the first turn.
+    await new Promise(resolve => setTimeout(resolve, 25));
+    expect(streamCalls).toBe(1); // second must be queued, not running concurrently
+    releaseFirst();
+
+    const [firstResult, secondResult] = (await Promise.all([first, second])) as any[];
+    expect(firstResult).toEqual(expect.objectContaining({ ok: true, accepted: true, status: 'pending' }));
+    expect(secondResult).toEqual(expect.objectContaining({ ok: true, accepted: true, status: 'pending' }));
+    await vi.waitFor(() => expect(sent).toHaveLength(2), { timeout: 10_000 });
+    const answers = new Map(sent.map(signal => [signal.attributes.correlationId, signal.contents]));
+    expect(answers.get(firstResult.correlationId)).toBe('answer-first');
+    expect(answers.get(secondResult.correlationId)).toBe('answer-second');
+
+    // The persisted transcript is the contract: question, its answer, next question, its answer.
+    // Queued conversation entries persist with the runtime's signal role rather than user — the causal
+    // pairing, not the role label, is what the concurrency bug corrupted.
+    const memoryStore = await (
+      remindMemory as unknown as { getMemoryStore(): Promise<MemoryStorage> }
+    ).getMemoryStore();
+    // The reply tool settles the asker before the conversation run finishes writing its own turn, so the
+    // transcript lands slightly after the answers do — wait for the run's persistence, not a sleep.
+    const messages = await vi.waitFor(
+      async () => {
+        const listed = await memoryStore.listMessages({ threadId: 'subconscious:alpha:remind' });
+        expect(listed.messages.length).toBeGreaterThanOrEqual(4);
+        return listed.messages;
+      },
+      { timeout: 10000 },
+    );
+    const transcript = messages.map(message => {
+      const parts = (message.content as { parts?: Array<{ type: string; text?: string }> })?.parts ?? [];
+      const text = parts
+        .filter(part => part.type === 'text')
+        .map(part => part.text ?? '')
+        .join('');
+      return `${message.role}:${text.includes('first question') ? 'first' : text.includes('second question') ? 'second' : text}`;
+    });
+    expect(transcript).toEqual(['signal:first', 'assistant:answer-first', 'signal:second', 'assistant:answer-second']);
+  }, 30_000);
+});
+
+describe('correlated request lifecycle (real runtime)', () => {
+  // These cases drive the REAL Agent + thread-stream runtime over shared storage. The only scripted
+  // piece is the model, because the contract under test is request identity, not provider behaviour.
+  type ScriptedStream = (args: { prompt: unknown }) => Promise<any>;
+
+  const openIds = (transcript: string) =>
+    [...transcript.matchAll(/correlationId: (remind-ask-[0-9a-f-]+)/g)].map(m => m[1]!);
+
+  let conversationSeq = 0;
+
+  const silentTurn = (id: string) => ({
+    stream: convertArrayToReadableStream([
+      { type: 'stream-start', warnings: [] },
+      { type: 'response-metadata', id, modelId: 'remind-model', timestamp: new Date() },
+      { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+    ]),
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    warnings: [],
+  });
+
+  const replyTurn = (id: string, correlationId: string, answer: string) => ({
+    stream: convertArrayToReadableStream([
+      { type: 'stream-start', warnings: [] },
+      { type: 'response-metadata', id, modelId: 'remind-model', timestamp: new Date() },
+      { type: 'text-start', id: 'text-1' },
+      { type: 'text-delta', id: 'text-1', delta: answer },
+      { type: 'text-end', id: 'text-1' },
+      {
+        type: 'tool-call',
+        toolCallId: `reply-${id}`,
+        toolName: 'reply_to_memory_question',
+        input: JSON.stringify({ correlationId, answer }),
+      },
+      { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+    ]),
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    warnings: [],
+  });
+
+  async function currentInputTools(agent: Agent, input: any) {
+    let tools: Record<string, any> = {};
+    for (const processor of await agent.listConfiguredInputProcessors()) {
+      if (!('processInputStep' in processor) || !processor.processInputStep) continue;
+      const result = await processor.processInputStep({
+        messages: [{ metadata: input?.metadata, content: input?.contents ?? input?.content }],
+        tools,
+      } as any);
+      if (result && !Array.isArray(result) && 'tools' in result && result.tools)
+        tools = result.tools as Record<string, any>;
+    }
+    return tools;
+  }
+
+  async function reminderConversation(options: {
+    doStream: ScriptedStream;
+    registry?: RemindRequestRegistry;
+    maxSteps?: number;
+  }) {
+    const { Memory } = await import('../../../index');
+    // Each case gets its own parent thread: reminder agents are keyed by it, so sharing one would let
+    // a previous case's still-live conversation run answer this case's questions.
+    conversationSeq += 1;
+    const parentThreadId = `alpha-${conversationSeq}`;
+    const remindMemory = new Memory({ storage: new InMemoryStore() });
+    const tools = createRemindAskTool({
+      memory: { storage: new InMemoryStore(), getKnowledgeSemanticIndex: vi.fn() } as any,
+      config: { name: 'remind', maxSteps: options.maxSteps ?? 3, builtIn: true },
+      omModel: new MockLanguageModelV2({ doStream: options.doStream as any }) as any,
+      createRemindMemory: () => remindMemory as any,
+      ...(options.registry ? { registry: options.registry } : {}),
+    });
+    const sent: any[] = [];
+    const signalAgent = {
+      sendSignal: (signal: any) => {
+        sent.push(signal);
+        return { accepted: Promise.resolve({ action: 'deliver' }), persisted: Promise.resolve() };
+      },
+    };
+    const context = (extra: Record<string, unknown> = {}) => {
+      const requestContext = new RequestContext();
+      requestContext.set('organizationId', 'acme');
+      return {
+        agent: { agentId: 'main', threadId: parentThreadId, resourceId: 'user-42' },
+        requestContext,
+        mastra: { getAgentById: () => signalAgent },
+        ...extra,
+      } as any;
+    };
+    return {
+      tools,
+      context,
+      sent,
+      remindMemory,
+      parentThreadId,
+      remindThreadId: `subconscious:${parentThreadId}:remind`,
+    };
+  }
+
+  it('gives each question delivered to one active run the answer for its own correlation id', async () => {
+    // The invariant is co-residency: both questions open inside ONE run, answered out of order, so a
+    // registry leaning on arrival order or on the run's final text would cross the wires. A model
+    // step only ever sees the prompt it was handed, so waiting inside a step cannot make a later
+    // delivery appear in it — the run has to take another step before the second question is visible.
+    // Until both are visible this poking turn keeps the run alive without answering anything, and the
+    // count of what was open when the first answer went out is asserted below: a run that only ever
+    // saw one question at a time fails here instead of passing on the weaker property.
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => (release = resolve));
+    const replied = new Set<string>();
+    let reachedModel = false;
+    let openWhenAnswered = 0;
+    let pokes = 0;
+    let step = 0;
+    const { tools, context, sent } = await reminderConversation({
+      maxSteps: 12,
+      doStream: async ({ prompt }: any) => {
+        const open = openIds(JSON.stringify(prompt)).filter(id => !replied.has(id));
+        if (!reachedModel) {
+          reachedModel = true;
+          await gate;
+        }
+        if (open.length === 0) return silentTurn(`idle-${step++}`);
+        if (open.length === 1 && openWhenAnswered === 0 && pokes < 6) {
+          pokes += 1;
+          // A reply naming a question that does not exist is refused without settling anything, so it
+          // costs the protocol nothing and buys the run another step to receive the second question.
+          return replyTurn(`poke-${pokes}`, 'remind-ask-00000000-0000-4000-8000-000000000000', 'ignored');
+        }
+        if (open.length > 1) openWhenAnswered = open.length;
+        // Answer the LAST open question first once both are in hand.
+        const id = openWhenAnswered > 0 ? open[open.length - 1]! : open[0]!;
+        replied.add(id);
+        return replyTurn(`t-${step++}`, id, `answer-for-${id}`);
+      },
+    });
+
+    const first = tools.ask_memory.execute!({ question: 'first question' } as any, context());
+    await vi.waitFor(() => expect(reachedModel).toBe(true), { timeout: 10_000 });
+    const second = tools.ask_memory.execute!({ question: 'second question' } as any, context());
+    release();
+
+    const [a, b] = (await Promise.all([first, second])) as any[];
+    expect(a).toEqual(expect.objectContaining({ ok: true, accepted: true, status: 'pending' }));
+    expect(b).toEqual(expect.objectContaining({ ok: true, accepted: true, status: 'pending' }));
+    await vi.waitFor(() => expect(sent).toHaveLength(2), { timeout: 10_000 });
+    // Without this the rest of the assertions also hold when the two questions never met in one run.
+    expect(openWhenAnswered).toBe(2);
+    const answers = new Map(sent.map(signal => [signal.attributes.correlationId, signal.contents]));
+    expect(answers.get(a.correlationId)).toBe(`answer-for-${a.correlationId}`);
+    expect(answers.get(b.correlationId)).toBe(`answer-for-${b.correlationId}`);
+    expect(a.correlationId).not.toBe(b.correlationId);
+  }, 30_000);
+
+  it('settles delivery_failed instead of leaking a pending request when building the conversation agent throws', async () => {
+    // `createRemindMemory` touches real storage, so it can throw before anything is dispatched. The
+    // correlation id is minted first by design, which means a throw on the way to the transport must
+    // still land on that id — otherwise the caller gets an error while the registry holds a pending
+    // record nobody can answer until the deadline reaps it.
+    const registry = new RemindRequestRegistry();
+    // The id is captured at registration rather than read off the result: when the throw escapes the
+    // guard the caller gets a bare failure with no correlation id at all, and an assertion that leans
+    // on the result would fail on the missing id and never reach the record it is supposed to inspect.
+    const registered: string[] = [];
+    const create = registry.create.bind(registry);
+    vi.spyOn(registry, 'create').mockImplementation((args: any) => {
+      registered.push(args.correlationId);
+      return create(args);
+    });
+    const tools = createRemindAskTool({
+      memory: { storage: new InMemoryStore(), getKnowledgeSemanticIndex: vi.fn() } as any,
+      config: { name: 'remind', maxSteps: 3, builtIn: true },
+      omModel: new MockLanguageModelV2({ doStream: (async () => silentTurn('unused')) as any }) as any,
+      createRemindMemory: () => {
+        throw new Error('remind memory unavailable');
+      },
+      registry,
+    });
+    const requestContext = new RequestContext();
+    requestContext.set('organizationId', 'acme');
+
+    const result: any = await tools.ask_memory.execute!(
+      { question: 'anything' } as any,
+      {
+        agent: { agentId: 'main', threadId: 'leak-thread', resourceId: 'user-42' },
+        requestContext,
+        mastra: { getAgentById: () => ({ sendSignal: () => ({ persisted: Promise.resolve() }) }) },
+      } as any,
+    );
+
+    // The leak assertion comes first and stands on its own: the registered id reached a terminal
+    // state rather than sitting pending on a two-minute timer. (Settled records are retained briefly
+    // for idempotent retries, so the registry is legitimately non-empty here — pending is the bug.)
+    expect(registered).toHaveLength(1);
+    expect(registry.get(registered[0]!)?.status).toBe('delivery_failed');
+    // And the caller is told, on the same id.
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe('delivery_failed');
+    expect(result.correlationId).toBe(registered[0]);
+    expect(result.error).toContain('remind memory unavailable');
+  });
+
+  it('tells a detached caller the truth when dispatch already failed instead of acknowledging pending', async () => {
+    // Both modes share one dispatch, so a construction failure settles the request before the
+    // detached branch gets to acknowledge it. Reporting `pending` there would leave the caller
+    // holding an id that already died, waiting on a signal for an answer that is never coming.
+    const registry = new RemindRequestRegistry();
+    const tools = createRemindAskTool({
+      memory: { storage: new InMemoryStore(), getKnowledgeSemanticIndex: vi.fn() } as any,
+      config: { name: 'remind', maxSteps: 3, builtIn: true },
+      omModel: new MockLanguageModelV2({ doStream: (async () => silentTurn('unused')) as any }) as any,
+      createRemindMemory: () => {
+        throw new Error('remind memory unavailable');
+      },
+      registry,
+    });
+    const requestContext = new RequestContext();
+    requestContext.set('organizationId', 'acme');
+    const sent: any[] = [];
+
+    const result: any = await tools.ask_memory.execute!(
+      { question: 'anything' } as any,
+      {
+        agent: { agentId: 'main', threadId: 'detached-dead', resourceId: 'user-42' },
+        requestContext,
+        mastra: {
+          getAgentById: () => ({
+            sendSignal: (signal: any) => {
+              sent.push(signal);
+              return { persisted: Promise.resolve() };
+            },
+          }),
+        },
+      } as any,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe('delivery_failed');
+    expect(result.accepted).toBeUndefined();
+    expect(result.error).toContain('remind memory unavailable');
+    // Nothing is promised over the signal channel for a failure the caller was handed directly.
+    expect(sent).toHaveLength(0);
+  });
+
+  it('sends every accepted question down the same dispatch path', async () => {
+    const seen: string[] = [];
+    const { tools, context, sent, parentThreadId, remindThreadId } = await reminderConversation({
+      doStream: async ({ prompt }: any) => {
+        const transcript = JSON.stringify(prompt);
+        const ids = openIds(transcript);
+        const id = ids[ids.length - 1]!;
+        if (seen.includes(id)) return silentTurn(`idle-${id}`);
+        seen.push(id);
+        return replyTurn(`t-${seen.length}`, id, `answer-${seen.length}`);
+      },
+    });
+    const sendSpy = vi.spyOn(Agent.prototype, 'sendMessage');
+    try {
+      const first: any = await tools.ask_memory.execute!({ question: 'first' } as any, context());
+      const second: any = await tools.ask_memory.execute!({ question: 'second' } as any, context());
+
+      // Both modes went through sendMessage with the same shape: identity in the visible content AND
+      // the structured metadata, addressed to the shared conversation.
+      expect(sendSpy).toHaveBeenCalledTimes(2);
+      for (const [input, target] of sendSpy.mock.calls as any[]) {
+        expect(input.metadata).toEqual(expect.objectContaining({ kind: 'remind-ask', parentThreadId, remindThreadId }));
+        expect(input.contents).toContain(input.metadata.correlationId);
+        expect(target).toEqual(expect.objectContaining({ threadId: remindThreadId, resourceId: 'user-42' }));
+      }
+      expect(first).toEqual(
+        expect.objectContaining({ ok: true, accepted: true, status: 'pending', correlationId: expect.any(String) }),
+      );
+      expect(second).toEqual(
+        expect.objectContaining({ ok: true, accepted: true, status: 'pending', correlationId: expect.any(String) }),
+      );
+      // Both answers land later on their own ids — one delivery each, no fabricated answer up front.
+      await vi.waitFor(
+        () => {
+          expect(sent.filter(s => s.attributes?.correlationId === first.correlationId)).toHaveLength(1);
+          expect(sent.filter(s => s.attributes?.correlationId === second.correlationId)).toHaveLength(1);
+        },
+        { timeout: 10_000 },
+      );
+    } finally {
+      sendSpy.mockRestore();
+    }
+  }, 30_000);
+
+  it('keeps one terminal result when the model replies twice, and rejects unknown or completed ids', async () => {
+    const replies: Record<string, number> = {};
+    const { tools, context, sent } = await reminderConversation({
+      doStream: async ({ prompt }: any) => {
+        const transcript = JSON.stringify(prompt);
+        const id = openIds(transcript).pop()!;
+        replies[id] = (replies[id] ?? 0) + 1;
+        // Answer the SAME question a second time with the same answer: an exact retry must be
+        // idempotent rather than a second terminal event.
+        if (replies[id] <= 2) return replyTurn(`t-${id}-${replies[id]}`, id, 'the answer');
+        return silentTurn(`idle-${id}`);
+      },
+    });
+
+    const detached: any = await tools.ask_memory.execute!({ question: 'twice' } as any, context());
+    await vi.waitFor(
+      () => expect(sent.filter(s => s.attributes?.correlationId === detached.correlationId).length).toBeGreaterThan(0),
+      { timeout: 10_000 },
+    );
+
+    // Barrier: a full round trip through the same runtime AFTER the first delivery. A delayed second
+    // terminal event would have to land before this completes, so silence afterwards is real.
+    const barrier: any = await tools.ask_memory.execute!({ question: 'barrier' } as any, context());
+    expect(barrier.status).toBe('pending');
+    await vi.waitFor(
+      () => expect(sent.filter(s => s.attributes?.correlationId === barrier.correlationId)).toHaveLength(1),
+      { timeout: 10_000 },
+    );
+    expect(sent.filter(s => s.attributes?.correlationId === detached.correlationId)).toHaveLength(1);
+    expect(replies[detached.correlationId]).toBeGreaterThan(1); // the model really did try twice
+  }, 30_000);
+
+  it('times out a question the conversation never answers and refuses the late reply', async () => {
+    // Long enough for the conversation run to actually reach the model, short enough to expire in-test: the
+    // deadline must fire on a question the runtime really carried, not on one that never left.
+    const registry = new RemindRequestRegistry({ deadlineMs: 2_000 });
+    let sawQuestion = false;
+    const { tools, context } = await reminderConversation({
+      registry,
+      doStream: async ({ prompt }: any) => {
+        sawQuestion = openIds(JSON.stringify(prompt)).length > 0;
+        // A run that produces text but never calls the reply tool settles nothing.
+        return silentTurn('mute');
+      },
+    });
+
+    const result: any = await tools.ask_memory.execute!({ question: 'never answered' } as any, context());
+    await vi.waitFor(() => expect(sawQuestion).toBe(true), { timeout: 10_000 });
+    expect(result).toEqual(
+      expect.objectContaining({ ok: true, accepted: true, status: 'pending', correlationId: expect.any(String) }),
+    );
+    await vi.waitFor(() => expect(registry.get(result.correlationId)?.status).toBe('timed_out'), { timeout: 10_000 });
+
+    // The late reply arrives after the deadline: the recorded terminal result stands.
+    const record = registry.get(result.correlationId)!;
+    const late = registry.reserveTerminal(result.correlationId, record.conversation);
+    expect(late.outcome).toBe('rejected');
+    expect(registry.get(result.correlationId)?.status).toBe('timed_out');
+  }, 30_000);
+
+  it('records model failure after an accepted question without fabricating an answer', async () => {
+    const registry = new RemindRequestRegistry();
+    const { tools, context, sent } = await reminderConversation({
+      registry,
+      doStream: async () => {
+        throw new Error('model exploded');
+      },
+    });
+    const result: any = await tools.ask_memory.execute!({ question: 'boom' } as any, context());
+    expect(result).toEqual(
+      expect.objectContaining({ ok: true, accepted: true, status: 'pending', correlationId: expect.any(String) }),
+    );
+    await vi.waitFor(() => expect(registry.get(result.correlationId)?.status).toBe('model_failed'), {
+      timeout: 10_000,
+    });
+    expect(registry.get(result.correlationId)?.failure?.message).toContain('model exploded');
+    expect(sent).toHaveLength(0);
+  }, 30_000);
+
+  it('refuses a reply that comes from outside the reminder conversation that owns the question', async () => {
+    // Trusted identity is the execution context, not the model's input: the same well-formed answer
+    // is rejected under a foreign thread and accepted under the owning one.
+    const { tools, context, remindThreadId, sent } = await reminderConversation({
+      doStream: async () => silentTurn('never'),
+    });
+    let rejected: any;
+    const sendSpy = vi.spyOn(Agent.prototype, 'sendMessage' as any);
+    sendSpy.mockImplementation(function (this: any, input: any, opts: any) {
+      const accepted = (async () => {
+        const agentTools = await currentInputTools(this, input);
+        const correlationId = input?.metadata?.correlationId;
+        rejected = await agentTools.reply_to_memory_question.execute(
+          { correlationId, answer: 'from the wrong room' },
+          { agent: { threadId: 'subconscious:someone-else:remind', resourceId: 'user-99' } },
+        );
+        await agentTools.reply_to_memory_question.execute(
+          { correlationId, answer: 'from the right room' },
+          { agent: { threadId: opts?.threadId, resourceId: opts?.resourceId } },
+        );
+        return { action: 'wake', runId: 'run-stub' };
+      })();
+      return { accepted };
+    } as any);
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'whose question is this' } as any, context());
+      expect(result).toEqual(expect.objectContaining({ ok: true, accepted: true, status: 'pending' }));
+      expect(rejected).toEqual(expect.objectContaining({ ok: false }));
+      expect(rejected.error).toMatch(/another conversation/);
+      await vi.waitFor(() => expect(sent).toHaveLength(1), { timeout: 10_000 });
+      expect(sent[0]).toEqual(
+        expect.objectContaining({
+          contents: 'from the right room',
+          attributes: expect.objectContaining({ correlationId: result.correlationId, status: 'replied' }),
+        }),
+      );
+      expect(remindThreadId).toContain(':remind');
+    } finally {
+      sendSpy.mockRestore();
+    }
+  }, 30_000);
+
+  it('keeps accepted reminder work alive when the calling turn aborts', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => (release = resolve));
+    const replied = new Set<string>();
+    const { tools, context, sent } = await reminderConversation({
+      doStream: async ({ prompt }: any) => {
+        const open = openIds(JSON.stringify(prompt)).filter(id => !replied.has(id));
+        if (open.length === 0) return silentTurn('idle');
+        await gate;
+        const id = open[open.length - 1]!;
+        replied.add(id);
+        return replyTurn('t-1', id, `answer-for-${id}`);
+      },
+    });
+
+    const controller = new AbortController();
+    const accepted: any = await tools.ask_memory.execute!(
+      { question: 'abandoned question' } as any,
+      context({ abortSignal: controller.signal }),
+    );
+    expect(accepted).toEqual(expect.objectContaining({ ok: true, accepted: true, status: 'pending' }));
+    controller.abort();
+    release();
+    await vi.waitFor(
+      () => expect(sent.some(signal => signal.attributes?.correlationId === accepted.correlationId)).toBe(true),
+      { timeout: 10_000 },
+    );
+
+    // Aborting the source turn did not cancel the reminder runtime or its accepted work.
+    const next: any = await tools.ask_memory.execute!({ question: 'still working' } as any, context());
+    expect(next).toEqual(expect.objectContaining({ ok: true, accepted: true }));
+    expect(next.correlationId).not.toBe(accepted.correlationId);
+  }, 30_000);
+
+  it('fails the question when the run dies before sendMessage finishes handing back its run id', async () => {
+    // The failure beats `accepted` home. Without the stashed run token the request would sit pending
+    // until the deadline instead of reporting the failure that already happened.
+    const { tools, context } = await reminderConversation({ doStream: async () => silentTurn('never') });
+    const sendSpy = vi.spyOn(Agent.prototype, 'sendMessage' as any);
+    sendSpy.mockImplementation(function (this: any, _input: any, opts: any) {
+      opts?.ifIdle?.streamOptions?.onError?.({ error: new Error('died on the way out') });
+      return {
+        accepted: new Promise(resolve => setTimeout(() => resolve({ action: 'wake', runId: 'run-late' }), 20)),
+      };
+    } as any);
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'fast failure' } as any, context());
+      expect(result).toEqual(
+        expect.objectContaining({ ok: false, status: 'model_failed', correlationId: expect.any(String) }),
+      );
+    } finally {
+      sendSpy.mockRestore();
+    }
+  }, 30_000);
+
+  it('lets a detached request outlive an aborted caller turn', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => (release = resolve));
+    const replied = new Set<string>();
+    const { tools, context, sent } = await reminderConversation({
+      doStream: async ({ prompt }: any) => {
+        const open = openIds(JSON.stringify(prompt)).filter(id => !replied.has(id));
+        if (open.length === 0) return silentTurn('idle');
+        await gate;
+        const id = open[open.length - 1]!;
+        replied.add(id);
+        return replyTurn('t-1', id, 'answered after the caller left');
+      },
+    });
+
+    const controller = new AbortController();
+    const ack: any = await tools.ask_memory.execute!(
+      { question: 'detached and abandoned' } as any,
+      context({ abortSignal: controller.signal }),
+    );
+    expect(ack.status).toBe('pending');
+    // The asking turn ends. Detached work is supposed to survive that, unlike a blocking wait.
+    controller.abort();
+    release();
+
+    await vi.waitFor(
+      () => expect(sent.filter(s => s.attributes?.correlationId === ack.correlationId)).toHaveLength(1),
+      { timeout: 10_000 },
+    );
+    const delivered = sent.find(s => s.attributes?.correlationId === ack.correlationId);
+    expect(delivered?.attributes?.status).toBe('replied');
+  }, 30_000);
+
+  it('rejects unknown replies and deduplicates terminal retries without retaining answer payloads', async () => {
+    const outcomes: any[] = [];
+    const { tools, context, sent } = await reminderConversation({ doStream: async () => silentTurn('never') });
+    const sendSpy = vi.spyOn(Agent.prototype, 'sendMessage' as any);
+    sendSpy.mockImplementation(function (this: any, input: any, opts: any) {
+      const accepted = (async () => {
+        const agentTools = await currentInputTools(this, input);
+        const correlationId = input?.metadata?.correlationId;
+        const conversationContext = { agent: { threadId: opts?.threadId, resourceId: opts?.resourceId } };
+        outcomes.push([
+          'unknown',
+          await agentTools.reply_to_memory_question.execute(
+            { correlationId: 'remind-ask-00000000-0000-4000-8000-000000000000', answer: 'nobody asked' },
+            conversationContext,
+          ),
+        ]);
+        outcomes.push([
+          'first',
+          await agentTools.reply_to_memory_question.execute(
+            { correlationId, answer: 'the answer' },
+            conversationContext,
+          ),
+        ]);
+        outcomes.push([
+          'retry',
+          await agentTools.reply_to_memory_question.execute(
+            { correlationId, answer: 'a different answer' },
+            conversationContext,
+          ),
+        ]);
+        return { action: 'wake', runId: 'run-stub' };
+      })();
+      return { accepted };
+    } as any);
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'protocol errors' } as any, context());
+      expect(result).toEqual(expect.objectContaining({ ok: true, accepted: true, status: 'pending' }));
+      await vi.waitFor(() => expect(outcomes).toHaveLength(3), { timeout: 10_000 });
+      const byName = Object.fromEntries(outcomes);
+      expect(byName.unknown).toEqual(expect.objectContaining({ ok: false }));
+      expect(byName.unknown.error).toMatch(/not part of the current reminder input/);
+      expect(byName.first).toEqual(expect.objectContaining({ ok: true, delivered: true }));
+      expect(byName.retry).toEqual(expect.objectContaining({ ok: true, duplicate: true }));
+      expect(sent).toHaveLength(1);
+      expect(sent[0].contents).toBe('the answer');
+    } finally {
+      sendSpy.mockRestore();
+    }
+  }, 30_000);
+
+  it('reports delivery_failed when the conversation refuses the message outright', async () => {
+    const { tools, context } = await reminderConversation({ doStream: async () => silentTurn('never') });
+    const sendSpy = vi.spyOn(Agent.prototype, 'sendMessage').mockReturnValue({
+      accepted: Promise.resolve({ action: 'blocked', reason: 'thread-blocked' }),
+    } as any);
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'refused' } as any, context());
+      expect(result).toEqual(
+        expect.objectContaining({ ok: false, status: 'delivery_failed', correlationId: expect.any(String) }),
+      );
+    } finally {
+      sendSpy.mockRestore();
+    }
+  }, 30_000);
+
+  it('persists the correlation id in both the visible message and its metadata', async () => {
+    const answered = new Set<string>();
+    const { tools, context, remindMemory, remindThreadId } = await reminderConversation({
+      doStream: async ({ prompt }: any) => {
+        const id = openIds(JSON.stringify(prompt)).pop();
+        if (!id || answered.has(id)) return silentTurn('idle');
+        answered.add(id);
+        return replyTurn('t-1', id, 'persisted answer');
+      },
+    });
+    const result: any = await tools.ask_memory.execute!({ question: 'remember me' } as any, context());
+    expect(result).toEqual(expect.objectContaining({ ok: true, accepted: true, status: 'pending' }));
+
+    const store = await (remindMemory as unknown as { getMemoryStore(): Promise<MemoryStorage> }).getMemoryStore();
+    const listed = await vi.waitFor(
+      async () => {
+        const messages = await store.listMessages({ threadId: remindThreadId });
+        expect(messages.messages.length).toBeGreaterThan(0);
+        return messages.messages;
+      },
+      { timeout: 10_000 },
+    );
+    const question = listed.find(message => JSON.stringify(message.content).includes(result.correlationId));
+    expect(question).toBeDefined();
+    expect((question!.content as any)?.metadata?.signal?.metadata).toEqual(
+      expect.objectContaining({ correlationId: result.correlationId, kind: 'remind-ask' }),
+    );
+  }, 30_000);
 });

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -56,8 +56,8 @@ function createContext(response: string) {
   };
 }
 
-function createRemindMemoryStub(extra: Record<string, unknown> = {}) {
-  let thread: any;
+function createRemindMemoryStub(extra: Record<string, unknown> = {}, initialThread?: any) {
+  let thread = initialThread;
   return {
     ...extra,
     getThreadById: vi.fn(async () => thread),
@@ -503,6 +503,36 @@ describe('Subconscious remind', () => {
           metadata: { subconsciousRemindParentThreadId: 'alpha' },
         }),
       });
+    });
+
+    it('cascades a passive reminder conversation when its parent thread is deleted', async () => {
+      const { Memory } = await import('../../../index');
+      const remindMemory = new Memory({ storage: new InMemoryStore() });
+      const now = new Date();
+      await remindMemory.saveThread({
+        thread: { id: 'alpha', resourceId: 'user-42', title: 'alpha', createdAt: now, updatedAt: now, metadata: {} },
+      });
+
+      await runWithGenerateSpy({ createRemindMemory: () => remindMemory });
+      expect(await remindMemory.getThreadById({ threadId: 'subconscious:alpha:remind' })).not.toBeNull();
+
+      await remindMemory.deleteThread('alpha');
+      expect(await remindMemory.getThreadById({ threadId: 'subconscious:alpha:remind' })).toBeNull();
+    });
+
+    it('does not claim an unmarked colliding thread for a passive reminder', async () => {
+      const remindMemory = createRemindMemoryStub(
+        {},
+        {
+          id: 'subconscious:alpha:remind',
+          resourceId: 'user-42',
+          metadata: { purpose: 'unrelated' },
+        },
+      );
+      const { agents } = await runWithGenerateSpy({ createRemindMemory: () => remindMemory });
+
+      expect(remindMemory.saveThread).not.toHaveBeenCalled();
+      expect(await (agents[0] as any).getMemory()).toBeUndefined();
     });
 
     it('runs stateless when the observation path lacks the session resource owner', async () => {
@@ -987,6 +1017,47 @@ describe('Subconscious remind ask conversation', () => {
           metadata: { subconsciousRemindParentThreadId: 'alpha' },
         }),
       });
+    } finally {
+      generateSpy.mockRestore();
+      registry.dispose();
+    }
+  });
+
+  it('cascades an asked reminder conversation when its parent thread is deleted', async () => {
+    const { Memory } = await import('../../../index');
+    const remindMemory = new Memory({ storage: new InMemoryStore() });
+    const now = new Date();
+    await remindMemory.saveThread({
+      thread: { id: 'alpha', resourceId: 'user-42', title: 'alpha', createdAt: now, updatedAt: now, metadata: {} },
+    });
+    const { tools, generateSpy, registry } = createAskTool({ createRemindMemory: () => remindMemory });
+    try {
+      await tools.ask_memory.execute!({ question: 'what happened?' } as any, askContext());
+      expect(await remindMemory.getThreadById({ threadId: 'subconscious:alpha:remind' })).not.toBeNull();
+
+      await remindMemory.deleteThread('alpha');
+      expect(await remindMemory.getThreadById({ threadId: 'subconscious:alpha:remind' })).toBeNull();
+    } finally {
+      generateSpy.mockRestore();
+      registry.dispose();
+    }
+  });
+
+  it('does not use a reminder thread owned by another parent for an ask', async () => {
+    const remindMemory = createRemindMemoryStub(
+      {},
+      {
+        id: 'subconscious:alpha:remind',
+        resourceId: 'user-42',
+        metadata: { subconsciousRemindParentThreadId: 'different-parent' },
+      },
+    );
+    const { tools, generateSpy, registry } = createAskTool({ createRemindMemory: () => remindMemory });
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'what happened?' } as any, askContext());
+      expect(result.ok).toBe(true);
+      expect(remindMemory.saveThread).not.toHaveBeenCalled();
+      expect(await (generateSpy.mock.contexts[0] as any).getMemory()).toBeUndefined();
     } finally {
       generateSpy.mockRestore();
       registry.dispose();

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -554,6 +554,7 @@ describe('Subconscious remind', () => {
 
       expect(result.failures).toBeUndefined();
       expect(calls).toHaveLength(1);
+      expect(calls[0]?.[1]).toMatchObject({ resourceId: 'user-42' });
       expect(calls[0]?.[1]).not.toHaveProperty('memory');
       expect(createRemindMemory).not.toHaveBeenCalled();
     });
@@ -1132,7 +1133,7 @@ describe('Subconscious remind ask conversation', () => {
           { question: 'what happened?' } as any,
           askContext({ abortSignal: controller.signal }),
         ),
-      ).resolves.toMatchObject({ ok: false, status: 'delivery_failed' });
+      ).resolves.toMatchObject({ ok: false, status: 'aborted' });
       expect(generateSpy).not.toHaveBeenCalled();
     } finally {
       generateSpy.mockRestore();

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -433,6 +433,7 @@ describe('Subconscious remind', () => {
       createRemindMemory?: () => any;
       threadId?: string;
       resourceId?: string | null;
+      knowledgeResourceId?: string;
       response?: string;
     }) {
       const { Agent } = await import('@mastra/core/agent');
@@ -458,6 +459,9 @@ describe('Subconscious remind', () => {
           context.requestContext.set('knowledgeResourceId', 'user-42');
         } else if (options.resourceId) {
           context.resourceId = options.resourceId;
+        }
+        if (options.knowledgeResourceId) {
+          context.requestContext.set('knowledgeResourceId', options.knowledgeResourceId);
         }
         await seedRelevantItem(context);
 
@@ -557,6 +561,16 @@ describe('Subconscious remind', () => {
       expect(calls[0]?.[1]).toMatchObject({ resourceId: 'user-42' });
       expect(calls[0]?.[1]).not.toHaveProperty('memory');
       expect(createRemindMemory).not.toHaveBeenCalled();
+    });
+
+    it('uses the knowledge-resource override as the passive conversation lane', async () => {
+      const { calls } = await runWithGenerateSpy({
+        createRemindMemory: () => createRemindMemoryStub(),
+        resourceId: 'source-user',
+        knowledgeResourceId: 'user-42',
+      });
+
+      expect(calls[0]?.[1]).toMatchObject({ resourceId: 'user-42' });
     });
 
     it('keys the thread off the parent thread id, never off the agent id', async () => {
@@ -1135,6 +1149,21 @@ describe('Subconscious remind ask conversation', () => {
         ),
       ).resolves.toMatchObject({ ok: false, status: 'aborted' });
       expect(generateSpy).not.toHaveBeenCalled();
+    } finally {
+      generateSpy.mockRestore();
+      registry.dispose();
+    }
+  });
+
+  it('uses the knowledge-resource override as the ask conversation lane', async () => {
+    const { tools, generateSpy, registry } = createAskTool();
+    const context = askContext();
+    context.requestContext.set('knowledgeResourceId', 'knowledge-user');
+    try {
+      await tools.ask_memory.execute!({ question: 'what happened?' } as any, context);
+
+      expect(generateSpy).toHaveBeenCalledOnce();
+      expect(generateSpy.mock.calls[0]?.[1]).toMatchObject({ resourceId: 'knowledge-user' });
     } finally {
       generateSpy.mockRestore();
       registry.dispose();

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -56,6 +56,18 @@ function createContext(response: string) {
   };
 }
 
+function createRemindMemoryStub(extra: Record<string, unknown> = {}) {
+  let thread: any;
+  return {
+    ...extra,
+    getThreadById: vi.fn(async () => thread),
+    saveThread: vi.fn(async ({ thread: nextThread }: any) => {
+      thread = nextThread;
+      return nextThread;
+    }),
+  } as any;
+}
+
 describe('Subconscious remind', () => {
   it('runs hook extractors without adding prompt output or requiring a parsed value', async () => {
     const onExtracted = vi.fn();
@@ -399,18 +411,6 @@ describe('Subconscious remind', () => {
   });
 
   describe('continuity: the reminder agent keeps one conversation per session', () => {
-    function createRemindMemoryStub(extra: Record<string, unknown> = {}) {
-      let thread: any;
-      return {
-        ...extra,
-        getThreadById: vi.fn(async () => thread),
-        saveThread: vi.fn(async ({ thread: nextThread }: any) => {
-          thread = nextThread;
-          return nextThread;
-        }),
-      } as any;
-    }
-
     async function seedRelevantItem(context: ReturnType<typeof createContext>) {
       const store = await context.memory.storage.getStore('knowledge');
       const node = await store.createNode({
@@ -492,8 +492,21 @@ describe('Subconscious remind', () => {
       });
     });
 
+    it('stamps passive reminder conversations with their parent thread provenance', async () => {
+      const remindMemory = createRemindMemoryStub();
+      await runWithGenerateSpy({ createRemindMemory: () => remindMemory });
+
+      expect(remindMemory.saveThread).toHaveBeenCalledWith({
+        thread: expect.objectContaining({
+          id: 'subconscious:alpha:remind',
+          resourceId: 'user-42',
+          metadata: { subconsciousRemindParentThreadId: 'alpha' },
+        }),
+      });
+    });
+
     it('runs stateless when the observation path lacks the session resource owner', async () => {
-      const createRemindMemory = vi.fn(() => ({ id: 'remind-memory' }) as any);
+      const createRemindMemory = vi.fn(() => createRemindMemoryStub({ id: 'remind-memory' }));
       const { result, calls } = await runWithGenerateSpy({ createRemindMemory, resourceId: null });
 
       expect(result.failures).toBeUndefined();
@@ -960,6 +973,25 @@ describe('Subconscious remind ask conversation', () => {
   async function settle() {
     for (let i = 0; i < 5; i++) await new Promise(resolve => setTimeout(resolve, 0));
   }
+
+  it('stamps asked reminder conversations with their parent thread provenance', async () => {
+    const remindMemory = createRemindMemoryStub();
+    const { tools, generateSpy, registry } = createAskTool({ createRemindMemory: () => remindMemory });
+    try {
+      const result: any = await tools.ask_memory.execute!({ question: 'what happened?' } as any, askContext());
+      expect(result.ok).toBe(true);
+      expect(remindMemory.saveThread).toHaveBeenCalledWith({
+        thread: expect.objectContaining({
+          id: 'subconscious:alpha:remind',
+          resourceId: 'user-42',
+          metadata: { subconsciousRemindParentThreadId: 'alpha' },
+        }),
+      });
+    } finally {
+      generateSpy.mockRestore();
+      registry.dispose();
+    }
+  });
 
   it.each([
     ['routing acceptance', { accepted: new Promise(() => {}) }],

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -56,13 +56,13 @@ function createContext(response: string) {
   };
 }
 
-function createRemindMemoryStub(extra: Record<string, unknown> = {}, initialThread?: any) {
+function createRemindMemoryStub(extra: Record<string, unknown> = {}, initialThread?: any, threadAfterSave?: any) {
   let thread = initialThread;
   return {
     ...extra,
     getThreadById: vi.fn(async () => thread),
     saveThread: vi.fn(async ({ thread: nextThread }: any) => {
-      thread = nextThread;
+      thread = threadAfterSave ?? nextThread;
       return nextThread;
     }),
   } as any;
@@ -532,6 +532,19 @@ describe('Subconscious remind', () => {
       const { agents } = await runWithGenerateSpy({ createRemindMemory: () => remindMemory });
 
       expect(remindMemory.saveThread).not.toHaveBeenCalled();
+      expect(await (agents[0] as any).getMemory()).toBeUndefined();
+    });
+
+    it('fails closed when another owner wins reminder thread creation', async () => {
+      const remindMemory = createRemindMemoryStub({}, undefined, {
+        id: 'subconscious:alpha:remind',
+        resourceId: 'other-user',
+        metadata: { subconsciousRemindParentThreadId: 'other-parent' },
+      });
+      const { agents } = await runWithGenerateSpy({ createRemindMemory: () => remindMemory });
+
+      expect(remindMemory.saveThread).toHaveBeenCalledOnce();
+      expect(remindMemory.getThreadById).toHaveBeenCalledTimes(2);
       expect(await (agents[0] as any).getMemory()).toBeUndefined();
     });
 

--- a/packages/memory/src/processors/observational-memory/subconscious/model.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/model.ts
@@ -1,5 +1,6 @@
 import type { RequestContext } from '@mastra/core/request-context';
 
+import { OBSERVATIONAL_MEMORY_DEFAULTS } from '../constants';
 import { ModelByInputTokens } from '../model-by-input-tokens';
 import type { ObservationalMemoryModel, ReflectionCommittedContext } from '../types';
 import type { ResolvedSubconsciousAgent, SubconsciousModel } from './types';
@@ -25,6 +26,35 @@ export function usableObservationalMemoryModel(
 }
 
 /**
+ * Resolve the model the reminder conversation runs on, preserving configured failover. A
+ * configured reminder-agent model wins, followed by an Agent-compatible observational-memory
+ * model and the source Agent model. Token-routed observational-memory configuration is unavailable
+ * here because its complete persisted conversation and tool context are not available to resolve it.
+ */
+export async function resolveReminderConversationModel(options: {
+  config: ResolvedSubconsciousAgent;
+  omModel?: ObservationalMemoryModel;
+  mainAgent?: ReflectionCommittedContext['mainAgent'];
+  requestContext?: RequestContext;
+}): Promise<SubconsciousModel | undefined> {
+  const { config, omModel, mainAgent, requestContext } = options;
+  if (config.model) {
+    // A per-agent model is an AgentConfig['model'] form already — hand it to the Agent whole
+    // so arrays keep their failover order and dynamic functions resolve at run time.
+    return config.model;
+  }
+  if (omModel && omModel !== 'default' && !(omModel instanceof ModelByInputTokens)) {
+    return omModel as SubconsciousModel;
+  }
+  if (mainAgent) return (await mainAgent.getModel({ requestContext })) as SubconsciousModel;
+  if (omModel instanceof ModelByInputTokens) return undefined;
+  if (omModel === 'default') {
+    return OBSERVATIONAL_MEMORY_DEFAULTS.observation.model as SubconsciousModel;
+  }
+  return undefined;
+}
+
+/**
  * Resolve the model a subconscious agent runs on. Precedence: the per-agent config model,
  * then the observational memory model, then the main agent's model. Returns undefined when
  * no source is available so callers keep their existing throw/silent-return behavior.
@@ -45,5 +75,26 @@ export async function resolveSubconsciousAgentModel(options: {
   const fromOm = usableObservationalMemoryModel(omModel);
   if (fromOm) return fromOm;
   if (mainAgent) return (await mainAgent.getModel({ requestContext })) as SubconsciousModel;
+  return lastResortObservationalMemoryModel(omModel);
+}
+
+/**
+ * Resolve OM model forms for one-shot subconscious extractors when no better source exists.
+ * Reminder conversations do not use this fallback because their persisted transcript and tools
+ * make an immediate-text token estimate incomplete.
+ */
+function lastResortObservationalMemoryModel(
+  model: ObservationalMemoryModel | undefined,
+): SubconsciousModel | undefined {
+  if (model === 'default') {
+    return OBSERVATIONAL_MEMORY_DEFAULTS.observation.model as SubconsciousModel;
+  }
+  if (model instanceof ModelByInputTokens) {
+    const smallestTier = model.getThresholds()[0]!;
+    const resolved = model.resolve(smallestTier);
+    return Array.isArray(resolved)
+      ? (resolved[0]?.model as SubconsciousModel | undefined)
+      : (resolved as SubconsciousModel);
+  }
   return undefined;
 }

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-request-state.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-request-state.ts
@@ -1,0 +1,149 @@
+export const REMINDER_TURN_DEADLINE_MS = 120_000;
+
+export type RemindRequestFailureStatus =
+  | 'timed_out'
+  | 'model_failed'
+  | 'aborted'
+  | 'delivery_failed'
+  | 'delivery_unknown';
+export type RemindRequestStatus = 'pending' | 'terminal_sending' | 'replied' | RemindRequestFailureStatus;
+
+export type RemindConversation = {
+  remindThreadId: string;
+  resourceId: string;
+};
+
+export type RemindRequestRecord = {
+  correlationId: string;
+  conversation: RemindConversation;
+  sourceAgentId: string;
+  sourceThreadId: string;
+  sourceResourceId: string;
+  createdAt: number;
+  deadlineAt: number;
+  status: RemindRequestStatus;
+  terminalSequence?: number;
+  terminalSignalId?: string;
+  terminalAt?: number;
+  failure?: { status: RemindRequestFailureStatus; message: string };
+};
+
+export type RemindTerminalReservation =
+  | { outcome: 'reserved'; record: RemindRequestRecord }
+  | { outcome: 'duplicate'; record: RemindRequestRecord }
+  | { outcome: 'rejected'; reason: 'unknown' | 'wrong_conversation' | 'terminal'; record?: RemindRequestRecord };
+
+function sameConversation(a: RemindConversation, b: RemindConversation): boolean {
+  return a.remindThreadId === b.remindThreadId && a.resourceId === b.resourceId;
+}
+
+export class RemindRequestRegistry {
+  readonly #entries = new Map<string, RemindRequestRecord>();
+  readonly #deadlineTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  readonly #terminalOrder: string[] = [];
+  readonly #deadlineMs: number;
+  readonly #maxTerminalEntries: number;
+
+  constructor(options: { deadlineMs?: number; maxTerminalEntries?: number } = {}) {
+    this.#deadlineMs = options.deadlineMs ?? REMINDER_TURN_DEADLINE_MS;
+    this.#maxTerminalEntries = options.maxTerminalEntries ?? 1_000;
+  }
+
+  create(args: {
+    correlationId: string;
+    conversation: RemindConversation;
+    sourceAgentId: string;
+    sourceThreadId: string;
+    sourceResourceId: string;
+    deadlineMs?: number;
+    now?: number;
+  }): RemindRequestRecord {
+    if (this.#entries.has(args.correlationId)) {
+      throw new Error(`Remind request ${args.correlationId} already exists`);
+    }
+
+    const createdAt = args.now ?? Date.now();
+    const deadlineMs = args.deadlineMs ?? this.#deadlineMs;
+    const record: RemindRequestRecord = {
+      correlationId: args.correlationId,
+      conversation: { ...args.conversation },
+      sourceAgentId: args.sourceAgentId,
+      sourceThreadId: args.sourceThreadId,
+      sourceResourceId: args.sourceResourceId,
+      createdAt,
+      deadlineAt: createdAt + deadlineMs,
+      status: 'pending',
+    };
+    this.#entries.set(args.correlationId, record);
+
+    const timer = setTimeout(() => {
+      this.fail(args.correlationId, 'timed_out', `Memory question timed out after ${deadlineMs}ms`);
+    }, deadlineMs);
+    timer.unref?.();
+    this.#deadlineTimers.set(args.correlationId, timer);
+    return record;
+  }
+
+  get(correlationId: string): RemindRequestRecord | undefined {
+    return this.#entries.get(correlationId);
+  }
+
+  reserveTerminal(correlationId: string, conversation: RemindConversation): RemindTerminalReservation {
+    const record = this.#entries.get(correlationId);
+    if (!record) return { outcome: 'rejected', reason: 'unknown' };
+    if (!sameConversation(record.conversation, conversation)) {
+      return { outcome: 'rejected', reason: 'wrong_conversation', record };
+    }
+    if (record.status === 'terminal_sending' || record.status === 'replied') {
+      return { outcome: 'duplicate', record };
+    }
+    if (record.status !== 'pending') return { outcome: 'rejected', reason: 'terminal', record };
+
+    record.status = 'terminal_sending';
+    record.terminalSequence = 1;
+    record.terminalSignalId = `remind-answer:${correlationId}:terminal`;
+    this.#clearDeadline(correlationId);
+    return { outcome: 'reserved', record };
+  }
+
+  markReplied(correlationId: string): void {
+    const record = this.#entries.get(correlationId);
+    if (!record || record.status !== 'terminal_sending') return;
+    record.status = 'replied';
+    record.terminalAt = Date.now();
+    this.#clearDeadline(correlationId);
+    this.#retainTerminal(correlationId);
+  }
+
+  fail(correlationId: string, status: RemindRequestFailureStatus, message: string): void {
+    const record = this.#entries.get(correlationId);
+    if (!record || (record.status !== 'pending' && record.status !== 'terminal_sending')) return;
+    if (status === 'timed_out' && record.status === 'terminal_sending') return;
+    record.status = status;
+    record.terminalAt = Date.now();
+    record.failure = { status, message };
+    this.#clearDeadline(correlationId);
+    this.#retainTerminal(correlationId);
+  }
+
+  dispose(): void {
+    for (const timer of this.#deadlineTimers.values()) clearTimeout(timer);
+    this.#deadlineTimers.clear();
+    this.#terminalOrder.length = 0;
+    this.#entries.clear();
+  }
+
+  #retainTerminal(correlationId: string): void {
+    this.#terminalOrder.push(correlationId);
+    while (this.#terminalOrder.length > this.#maxTerminalEntries) {
+      const expiredCorrelationId = this.#terminalOrder.shift();
+      if (expiredCorrelationId) this.#entries.delete(expiredCorrelationId);
+    }
+  }
+
+  #clearDeadline(correlationId: string): void {
+    const timer = this.#deadlineTimers.get(correlationId);
+    if (timer) clearTimeout(timer);
+    this.#deadlineTimers.delete(correlationId);
+  }
+}

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-request-state.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-request-state.ts
@@ -98,6 +98,14 @@ export class RemindRequestRegistry {
       return { outcome: 'duplicate', record };
     }
     if (record.status !== 'pending') return { outcome: 'rejected', reason: 'terminal', record };
+    if (Date.now() >= record.deadlineAt) {
+      this.fail(
+        correlationId,
+        'timed_out',
+        `Memory question timed out after ${record.deadlineAt - record.createdAt}ms`,
+      );
+      return { outcome: 'rejected', reason: 'terminal', record };
+    }
 
     record.status = 'terminal_sending';
     record.terminalSequence = 1;

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -27,8 +27,8 @@ Never remind about knowledge that is already visible in the current observations
 If nothing is relevant, respond with exactly ${NO_REMINDER} and nothing else.
 If knowledge is relevant, return one concise reminder that explains why it matters and includes source node or item IDs. Do not invent knowledge and do not expose knowledge outside the tools' scoped results.`;
 
-/** Own-thread items younger than this are treated as still-in-context and excluded from reminder candidates. */
-const FRESH_OWN_ITEM_WINDOW_MS = 30 * 60 * 1000;
+/** Own-thread records younger than this are treated as still-in-context and excluded from reminder candidates. */
+const FRESH_OWN_RECORD_WINDOW_MS = 30 * 60 * 1000;
 
 function resolveScope(context: {
   requestContext?: { get(key: string): unknown };
@@ -86,11 +86,11 @@ async function findReminderSources(
 }
 
 /**
- * Drop the current thread's own freshly captured KnowledgeItems from the candidate list. They match the
+ * Drop the current thread's own freshly captured KnowledgeRecords from the candidate list. They match the
  * current observations almost perfectly (they were just distilled from them), so without this
  * guard the reminder agent mostly echoes the session's own words back at it.
  */
-async function dropFreshOwnItems(
+async function dropFreshOwnRecords(
   store: KnowledgeStorage,
   sources: SearchKnowledgeResult[],
   threadId: string,
@@ -98,13 +98,13 @@ async function dropFreshOwnItems(
   const checks = await Promise.all(
     sources.map(async source => {
       if (source.type !== 'record') return true;
-      const item = await store.getKnowledge({ id: source.id }).catch(() => null);
-      if (!item) return true;
-      // KnowledgeItems written by the thread's own subconscious sub-agents (curate, learn, capture)
+      const record = await store.getKnowledge({ id: source.id }).catch(() => null);
+      if (!record) return true;
+      // KnowledgeRecords written by the thread's own subconscious sub-agents (curate, learn, capture)
       // carry a `subconscious:<threadId>:<agent>` source — they are this thread's too.
       const isOwnThread =
-        item.sourceThreadId === threadId || item.sourceThreadId.startsWith(`subconscious:${threadId}:`);
-      const isFresh = Date.now() - new Date(item.capturedAt).getTime() < FRESH_OWN_ITEM_WINDOW_MS;
+        record.sourceThreadId === threadId || record.sourceThreadId.startsWith(`subconscious:${threadId}:`);
+      const isFresh = Date.now() - new Date(record.capturedAt).getTime() < FRESH_OWN_RECORD_WINDOW_MS;
       return !(isOwnThread && isFresh);
     }),
   );
@@ -819,7 +819,7 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
           scope = resolveScope(context);
           store = await context.memory.storage.getStore('knowledge');
           if (!store) throw new Error('Subconscious remind requires a configured knowledge storage domain.');
-          const sources = await dropFreshOwnItems(
+          const sources = await dropFreshOwnRecords(
             store,
             await findReminderSources(store, scope, context.rawObservations),
             context.threadId,

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -131,8 +131,8 @@ export function remindThreadKey(parentThreadId: string): string {
  * The resource id the reminder conversation runs under. The runtime serializes work by
  * `[resourceId, threadId]`, so EVERY entry point must derive the resource identically — asks and
  * passive evaluations resolving different resource ids for the same session would split one
- * memory thread into two execution streams. Both paths read the session's resource and fall back
- * to the parent thread id when the session has none.
+ * memory thread into two execution streams. Both paths resolve the optional knowledge-resource
+ * override first, then fall back to the parent thread id when the session has no resource.
  */
 function reminderResourceId(parentThreadId: string, resourceId?: string): string {
   return resourceId ?? parentThreadId;
@@ -632,7 +632,7 @@ export function createRemindAskTool(options: RemindAskToolOptions) {
 
     const conversation: RemindConversation = {
       remindThreadId: remindThreadKey(threadId),
-      resourceId: reminderResourceId(threadId, sourceResourceId),
+      resourceId: reminderResourceId(threadId, resolveKnowledgeResourceId(context.requestContext, sourceResourceId)),
     };
     const correlationId = `remind-ask-${crypto.randomUUID()}`;
     const record = registry.create({

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -153,23 +153,26 @@ async function ensureRemindThreadProvenance(args: {
   remindThreadId: string;
   resourceId: string;
   parentThreadId: string;
-}): Promise<void> {
+}): Promise<boolean> {
   const existing = await args.memory.getThreadById({ threadId: args.remindThreadId });
-  const stamped = existing?.metadata?.[REMIND_PARENT_THREAD_METADATA_KEY];
-  if (stamped !== undefined) return;
+  if (existing) {
+    return (
+      existing.resourceId === args.resourceId &&
+      existing.metadata?.[REMIND_PARENT_THREAD_METADATA_KEY] === args.parentThreadId
+    );
+  }
 
   await args.memory.saveThread({
     thread: {
-      ...(existing ?? {
-        id: args.remindThreadId,
-        resourceId: args.resourceId,
-        createdAt: new Date(),
-        title: 'Subconscious Remind',
-      }),
+      id: args.remindThreadId,
+      resourceId: args.resourceId,
+      createdAt: new Date(),
       updatedAt: new Date(),
-      metadata: { ...existing?.metadata, [REMIND_PARENT_THREAD_METADATA_KEY]: args.parentThreadId },
+      title: 'Subconscious Remind',
+      metadata: { [REMIND_PARENT_THREAD_METADATA_KEY]: args.parentThreadId },
     },
   });
+  return true;
 }
 
 export interface SubconsciousRemindOptions {
@@ -647,14 +650,17 @@ export function createRemindAskTool(options: RemindAskToolOptions) {
       if (context.abortSignal?.aborted) {
         throw new Error('The caller aborted before submitting the reminder question.');
       }
-      const remindMemory = options.createRemindMemory?.();
-      if (remindMemory) {
-        await ensureRemindThreadProvenance({
+      let remindMemory = options.createRemindMemory?.();
+      if (
+        remindMemory &&
+        !(await ensureRemindThreadProvenance({
           memory: remindMemory,
           remindThreadId: conversation.remindThreadId,
           resourceId: conversation.resourceId,
           parentThreadId: threadId,
-        });
+        }))
+      ) {
+        remindMemory = undefined;
       }
       const agent = createReminderAgent({
         parentThreadId: threadId,
@@ -846,14 +852,17 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
           // never interleaves with an in-flight question turn. Without the session's resource owner,
           // run stateless rather than persist an orphaned derived thread that deleteThread cannot own.
           const registry = options?.registry ?? fallbackRegistry();
-          const remindMemory = context.resourceId ? options?.createRemindMemory?.() : undefined;
-          if (remindMemory) {
-            await ensureRemindThreadProvenance({
+          let remindMemory = context.resourceId ? options?.createRemindMemory?.() : undefined;
+          if (
+            remindMemory &&
+            !(await ensureRemindThreadProvenance({
               memory: remindMemory,
               remindThreadId: remindThreadKey(context.threadId),
               resourceId: reminderResourceId(context.threadId, context.resourceId),
               parentThreadId: context.threadId,
-            });
+            }))
+          ) {
+            remindMemory = undefined;
           }
           const agent = createReminderAgent({
             parentThreadId: context.threadId,

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -14,7 +14,7 @@ import type { ObservationalMemoryModel } from '../types';
 import { publishSubconsciousActivity } from './activity';
 import { createKnowledgeTools } from './knowledge-tools';
 import { resolveReminderConversationModel } from './model';
-import type { RemindConversation, RemindRequestRecord } from './remind-request-state';
+import type { RemindConversation, RemindRequestFailureStatus, RemindRequestRecord } from './remind-request-state';
 import { REMINDER_TURN_DEADLINE_MS, RemindRequestRegistry } from './remind-request-state';
 import { resolveKnowledgeResourceId } from './scope';
 import type { ResolvedSubconsciousAgent } from './types';
@@ -146,8 +146,10 @@ function reminderResourceId(parentThreadId: string, resourceId?: string): string
  * Without it `Memory.deleteThread()` cannot prove the derived thread belongs to the session being
  * deleted, and conservatively retains it forever.
  *
- * Returns false when an existing or concurrently-created thread does not match both the expected
- * resource and parent provenance, so the caller can continue without persistent reminder memory.
+ * Returns false when an observed thread does not match both the expected resource and parent
+ * provenance, so the caller can continue without persistent reminder memory. The storage API has
+ * no conditional-create operation, so a cross-process writer can still race the initial save; the
+ * post-write read only catches a writer that supersedes this process.
  */
 async function ensureRemindThreadProvenance(args: {
   memory: Memory;
@@ -647,7 +649,7 @@ export function createRemindAskTool(options: RemindAskToolOptions) {
     expiryTimer.unref?.();
     replyCapabilities.set(correlationId, { sourceAgent, conversation, expiryTimer });
 
-    const fail = (status: 'delivery_failed' | 'model_failed', error: unknown) => {
+    const fail = (status: RemindRequestFailureStatus, error: unknown) => {
       registry.fail(correlationId, status, error instanceof Error ? error.message : String(error));
       deleteReplyCapability(replyCapabilities, correlationId);
     };
@@ -734,7 +736,7 @@ export function createRemindAskTool(options: RemindAskToolOptions) {
         void disposition.output.consumeStream().catch(error => fail('model_failed', error));
       }
     } catch (error) {
-      fail('delivery_failed', error);
+      fail(context.abortSignal?.aborted ? 'aborted' : 'delivery_failed', error);
     }
 
     return record;
@@ -858,13 +860,17 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
           // never interleaves with an in-flight question turn. Without the session's resource owner,
           // run stateless rather than persist an orphaned derived thread that deleteThread cannot own.
           const registry = options?.registry ?? fallbackRegistry();
+          const conversationResourceId = reminderResourceId(
+            context.threadId,
+            resolveKnowledgeResourceId(context.requestContext, context.resourceId),
+          );
           let remindMemory = context.resourceId ? options?.createRemindMemory?.() : undefined;
           if (
             remindMemory &&
             !(await ensureRemindThreadProvenance({
               memory: remindMemory,
               remindThreadId: remindThreadKey(context.threadId),
-              resourceId: reminderResourceId(context.threadId, context.resourceId),
+              resourceId: conversationResourceId,
               parentThreadId: context.threadId,
             }))
           ) {
@@ -874,7 +880,7 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
             parentThreadId: context.threadId,
             conversation: {
               remindThreadId: remindThreadKey(context.threadId),
-              resourceId: reminderResourceId(context.threadId, context.resourceId),
+              resourceId: conversationResourceId,
             },
             instructions,
             model,
@@ -889,7 +895,7 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
           const reminder = await runReminderConversationTurn({
             agent,
             parentThreadId: context.threadId,
-            resourceId: reminderResourceId(context.threadId, context.resourceId),
+            resourceId: conversationResourceId,
             prompt,
             requestContext: context.requestContext,
             maxSteps: config.maxSteps,

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -146,7 +146,8 @@ function reminderResourceId(parentThreadId: string, resourceId?: string): string
  * Without it `Memory.deleteThread()` cannot prove the derived thread belongs to the session being
  * deleted, and conservatively retains it forever.
  *
- * Idempotent, and never re-owns a thread already stamped for a different parent.
+ * Returns false when an existing or concurrently-created thread does not match both the expected
+ * resource and parent provenance, so the caller can continue without persistent reminder memory.
  */
 async function ensureRemindThreadProvenance(args: {
   memory: Memory;
@@ -172,7 +173,12 @@ async function ensureRemindThreadProvenance(args: {
       metadata: { [REMIND_PARENT_THREAD_METADATA_KEY]: args.parentThreadId },
     },
   });
-  return true;
+
+  const persisted = await args.memory.getThreadById({ threadId: args.remindThreadId });
+  return (
+    persisted?.resourceId === args.resourceId &&
+    persisted.metadata?.[REMIND_PARENT_THREAD_METADATA_KEY] === args.parentThreadId
+  );
 }
 
 export interface SubconsciousRemindOptions {

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -1,26 +1,34 @@
-import { Agent } from '@mastra/core/agent';
+import { Agent, createSignal } from '@mastra/core/agent';
+import type { SendAgentSignalAccepted, SendAgentSignalResult } from '@mastra/core/agent';
+import type { InputProcessor, ProcessInputStepArgs, ProcessInputStepResult } from '@mastra/core/processors';
+import type { RequestContext } from '@mastra/core/request-context';
 import type { KnowledgeScope, KnowledgeStorage, SearchKnowledgeResult } from '@mastra/core/storage';
 import { canonicalizeKnowledgeScope } from '@mastra/core/storage';
+import type { ToolAction } from '@mastra/core/tools';
+import { createTool } from '@mastra/core/tools';
+import type { JSONSchema7 } from 'json-schema';
 
 import type { Memory } from '../../..';
 import { Extractor } from '../extractor';
 import type { ObservationalMemoryModel } from '../types';
 import { publishSubconsciousActivity } from './activity';
 import { createKnowledgeTools } from './knowledge-tools';
-import { resolveSubconsciousAgentModel } from './model';
+import { resolveReminderConversationModel } from './model';
+import type { RemindConversation, RemindRequestRecord } from './remind-request-state';
+import { REMINDER_TURN_DEADLINE_MS, RemindRequestRegistry } from './remind-request-state';
 import { resolveKnowledgeResourceId } from './scope';
 import type { ResolvedSubconsciousAgent } from './types';
 
 const NO_REMINDER = '<no-reminder />';
 const DEFAULT_INSTRUCTIONS = `Review the current observations and use the knowledge tools to find prior knowledge that is directly relevant now.
 
-Be selective. Treat future-dated records as relevant when their time is imminent or useful to the current task. When the observations show whether an earlier reminder was used, tune your selectivity accordingly without storing hit/miss counters.
+Be selective. Treat future-dated items as relevant when their time is imminent or useful to the current task. When the observations show whether an earlier reminder was used, tune your selectivity accordingly without storing hit/miss counters.
 Never remind about knowledge that is already visible in the current observations or recent messages — a reminder is only valuable for knowledge the agent can no longer see. Echoing back what was just said or just captured is noise.
 If nothing is relevant, respond with exactly ${NO_REMINDER} and nothing else.
-If knowledge is relevant, return one concise reminder that explains why it matters and includes source node or record IDs. Do not invent knowledge and do not expose knowledge outside the tools' scoped results.`;
+If knowledge is relevant, return one concise reminder that explains why it matters and includes source node or item IDs. Do not invent knowledge and do not expose knowledge outside the tools' scoped results.`;
 
-/** Own-thread records younger than this are treated as still-in-context and excluded from reminder candidates. */
-const FRESH_OWN_RECORD_WINDOW_MS = 30 * 60 * 1000;
+/** Own-thread items younger than this are treated as still-in-context and excluded from reminder candidates. */
+const FRESH_OWN_ITEM_WINDOW_MS = 30 * 60 * 1000;
 
 function resolveScope(context: {
   requestContext?: { get(key: string): unknown };
@@ -78,11 +86,11 @@ async function findReminderSources(
 }
 
 /**
- * Drop the current thread's own freshly captured KnowledgeRecords from the candidate list. They match the
+ * Drop the current thread's own freshly captured KnowledgeItems from the candidate list. They match the
  * current observations almost perfectly (they were just distilled from them), so without this
  * guard the reminder agent mostly echoes the session's own words back at it.
  */
-async function dropFreshOwnRecords(
+async function dropFreshOwnItems(
   store: KnowledgeStorage,
   sources: SearchKnowledgeResult[],
   threadId: string,
@@ -90,13 +98,13 @@ async function dropFreshOwnRecords(
   const checks = await Promise.all(
     sources.map(async source => {
       if (source.type !== 'record') return true;
-      const record = await store.getKnowledge({ id: source.id }).catch(() => null);
-      if (!record) return true;
-      // KnowledgeRecords written by the thread's own subconscious sub-agents (curate, learn, capture)
+      const item = await store.getKnowledge({ id: source.id }).catch(() => null);
+      if (!item) return true;
+      // KnowledgeItems written by the thread's own subconscious sub-agents (curate, learn, capture)
       // carry a `subconscious:<threadId>:<agent>` source — they are this thread's too.
       const isOwnThread =
-        record.sourceThreadId === threadId || record.sourceThreadId.startsWith(`subconscious:${threadId}:`);
-      const isFresh = Date.now() - new Date(record.capturedAt).getTime() < FRESH_OWN_RECORD_WINDOW_MS;
+        item.sourceThreadId === threadId || item.sourceThreadId.startsWith(`subconscious:${threadId}:`);
+      const isFresh = Date.now() - new Date(item.capturedAt).getTime() < FRESH_OWN_ITEM_WINDOW_MS;
       return !(isOwnThread && isFresh);
     }),
   );
@@ -119,14 +127,675 @@ export function remindThreadKey(parentThreadId: string): string {
   return `subconscious:${parentThreadId}:remind`;
 }
 
+/**
+ * The resource id the reminder conversation runs under. The runtime serializes work by
+ * `[resourceId, threadId]`, so EVERY entry point must derive the resource identically — asks and
+ * passive evaluations resolving different resource ids for the same session would split one
+ * memory thread into two execution streams. Both paths read the session's resource and fall back
+ * to the parent thread id when the session has none.
+ */
+function reminderResourceId(parentThreadId: string, resourceId?: string): string {
+  return resourceId ?? parentThreadId;
+}
+
+/**
+ * Stamps the derived reminder thread with the parent thread that owns it.
+ *
+ * The reminder conversation is created by the thread-stream runtime through `sendMessage()`, which
+ * carries no thread-metadata channel, so provenance has to be written here before the first turn.
+ * Without it `Memory.deleteThread()` cannot prove the derived thread belongs to the session being
+ * deleted, and conservatively retains it forever.
+ *
+ * Idempotent, and never re-owns a thread already stamped for a different parent.
+ */
+async function ensureRemindThreadProvenance(args: {
+  memory: Memory;
+  remindThreadId: string;
+  resourceId: string;
+  parentThreadId: string;
+}): Promise<void> {
+  const existing = await args.memory.getThreadById({ threadId: args.remindThreadId });
+  const stamped = existing?.metadata?.[REMIND_PARENT_THREAD_METADATA_KEY];
+  if (stamped !== undefined) return;
+
+  await args.memory.saveThread({
+    thread: {
+      ...(existing ?? {
+        id: args.remindThreadId,
+        resourceId: args.resourceId,
+        createdAt: new Date(),
+        title: 'Subconscious Remind',
+      }),
+      updatedAt: new Date(),
+      metadata: { ...existing?.metadata, [REMIND_PARENT_THREAD_METADATA_KEY]: args.parentThreadId },
+    },
+  });
+}
+
 export interface SubconsciousRemindOptions {
   /**
    * Returns the Memory that backs the reminder agent's own conversation. Called on demand so a
-   * session that never reminds never builds one, and built fresh per call so each session's
-   * effective model applies. Per-session identity is carried by the thread key alone, never by
-   * the instance.
+   * session that never reminds never builds one, and called again for every reminder turn rather
+   * than cached: a cached instance would pin the model of whichever session reminded first. Persisted
+   * continuity is unaffected, because the observational record and its locks are keyed by the thread,
+   * not by the instance; only in-process caches are rebuilt with it.
    */
   createRemindMemory?: () => Memory;
+  /**
+   * Correlated lifecycle registry shared by every reminder agent this Memory creates. It records
+   * routing, status, deadlines, and terminal deduplication while answers travel directly through
+   * source-agent signals.
+   */
+  registry?: RemindRequestRegistry;
+}
+
+const ASK_INSTRUCTIONS = `The main agent is asking you direct questions. This is a conversation, not an observation run: answer the question.
+
+Every question arrives with a correlationId. Answer it by calling reply_to_memory_question exactly once with that exact correlationId and your answer — plain text in the response is not delivered to the asker. Several questions may arrive during one turn; answer each one with its own correlationId.
+
+Use everything you already remember from this conversation plus the knowledge tools. A follow-up may refer back to something discussed earlier in this thread, so resolve references against your own history before searching. Answer plainly and include source node or item IDs when the answer rests on stored knowledge. If you do not know, say so plainly instead of guessing, and never respond with ${NO_REMINDER} to a question.`;
+
+type AskToolAgentContext = {
+  agentId?: string;
+  threadId?: string;
+  resourceId?: string;
+};
+
+type AskToolContext = {
+  agent?: AskToolAgentContext;
+  requestContext?: RequestContext;
+  abortSignal?: AbortSignal;
+  writer?: { custom(chunk: { type: string; data: unknown }): Promise<unknown> | unknown };
+  mastra?: { getAgentById?(id: string): Promise<unknown> | unknown };
+};
+
+const NO_MODEL_MESSAGE =
+  'The reminder agent has no model available at tool call time. Configure a model on the Subconscious remind agent or on observational memory; the main agent model is only reachable from the observation hook.';
+
+type SignalSender = {
+  sendSignal(
+    signal: unknown,
+    target: {
+      threadId: string;
+      resourceId: string;
+      ifIdle?: { behavior?: 'wake'; streamOptions?: { requestContext?: RequestContext } };
+    },
+  ): SendAgentSignalResult;
+};
+
+type ReplyCapability = {
+  sourceAgent: SignalSender;
+  conversation: RemindConversation;
+  expiryTimer: ReturnType<typeof setTimeout>;
+};
+
+type ReplyCapabilityRegistry = Map<string, ReplyCapability>;
+
+const replyCapabilitiesByRegistry = new WeakMap<RemindRequestRegistry, ReplyCapabilityRegistry>();
+
+function resolveReplyCapabilities(registry: RemindRequestRegistry): ReplyCapabilityRegistry {
+  let capabilities = replyCapabilitiesByRegistry.get(registry);
+  if (!capabilities) {
+    capabilities = new Map();
+    replyCapabilitiesByRegistry.set(registry, capabilities);
+  }
+  return capabilities;
+}
+
+function deleteReplyCapability(capabilities: ReplyCapabilityRegistry, correlationId: string) {
+  const capability = capabilities.get(correlationId);
+  if (capability) clearTimeout(capability.expiryTimer);
+  capabilities.delete(correlationId);
+}
+
+async function acceptSignalDelivery(
+  result: SendAgentSignalResult,
+  deadlineAt: number,
+): Promise<SendAgentSignalAccepted> {
+  const remainingMs = Math.max(0, deadlineAt - Date.now());
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Terminal answer delivery timed out after ${remainingMs}ms`)),
+      remainingMs,
+    );
+    timer.unref?.();
+  });
+
+  try {
+    return await Promise.race([
+      (async () => {
+        const disposition = await result.accepted;
+        if (disposition.action === 'persist') await result.persisted;
+        return disposition;
+      })(),
+      timeout,
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export interface RemindAskToolOptions extends SubconsciousRemindOptions {
+  memory: Memory;
+  config: ResolvedSubconsciousAgent;
+  omModel?: ObservationalMemoryModel;
+}
+
+async function resolveSignalSender(context: AskToolContext): Promise<SignalSender | undefined> {
+  const agentId = context.agent?.agentId;
+  const getAgentById = context.mastra?.getAgentById;
+  if (!agentId || typeof getAgentById !== 'function') return undefined;
+  const agent = (await getAgentById.call(context.mastra, agentId)) as Partial<SignalSender> | undefined;
+  return typeof agent?.sendSignal === 'function' ? (agent as SignalSender) : undefined;
+}
+
+function createReplyTool(
+  registry: RemindRequestRegistry,
+  capabilities: ReplyCapabilityRegistry,
+  conversation: RemindConversation,
+  allowedCorrelationIds: ReadonlySet<string>,
+) {
+  return createTool({
+    id: 'reply_to_memory_question',
+    description:
+      'Deliver the terminal answer to a question the main agent asked. Call this exactly once with the correlationId that came with the current question.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        correlationId: { type: 'string', minLength: 1, description: 'The correlationId that came with the question.' },
+        answer: { type: 'string', minLength: 1, description: 'The answer, in natural language.' },
+      },
+      required: ['correlationId', 'answer'],
+      additionalProperties: false,
+    } satisfies JSONSchema7,
+    execute: async (input, rawContext) => {
+      const { correlationId, answer } = input as { correlationId: string; answer: string };
+      const context = rawContext as AskToolContext;
+      if (!allowedCorrelationIds.has(correlationId)) {
+        return {
+          ok: false,
+          correlationId,
+          error: `Question ${correlationId} is not part of the current reminder input.`,
+        };
+      }
+      if (
+        context.agent?.threadId !== conversation.remindThreadId ||
+        context.agent?.resourceId !== conversation.resourceId
+      ) {
+        return { ok: false, correlationId, error: `Question ${correlationId} belongs to another conversation.` };
+      }
+
+      const reservation = registry.reserveTerminal(correlationId, conversation);
+      if (reservation.outcome === 'duplicate') {
+        return {
+          ok: true,
+          correlationId,
+          delivered: reservation.record.status === 'replied',
+          duplicate: true,
+          status: reservation.record.status,
+        };
+      }
+      if (reservation.outcome === 'rejected') {
+        return {
+          ok: false,
+          correlationId,
+          error:
+            reservation.reason === 'unknown'
+              ? `No open question with correlationId ${correlationId}. It may have timed out already.`
+              : reservation.reason === 'wrong_conversation'
+                ? `Question ${correlationId} belongs to another conversation.`
+                : `Question ${correlationId} can no longer accept a terminal answer.`,
+        };
+      }
+
+      const capability = capabilities.get(correlationId);
+      if (!capability) {
+        registry.fail(
+          correlationId,
+          'delivery_unknown',
+          'The source delivery capability expired before terminal reply.',
+        );
+        return {
+          ok: false,
+          correlationId,
+          error: `Question ${correlationId} no longer has a source delivery capability.`,
+        };
+      }
+
+      const signal = createSignal({
+        id: reservation.record.terminalSignalId!,
+        type: 'reactive',
+        tagName: 'remembered',
+        contents: answer,
+        createdAt: new Date(),
+        transient: false,
+        metadata: { origin: 'subconscious' },
+        attributes: {
+          source: 'subconscious',
+          agent: 'remind',
+          correlationId,
+          sequence: reservation.record.terminalSequence,
+          status: 'replied',
+          sourceAgentId: reservation.record.sourceAgentId,
+          sourceThreadId: reservation.record.sourceThreadId,
+          sourceResourceId: reservation.record.sourceResourceId,
+          remindThreadId: conversation.remindThreadId,
+          remindResourceId: conversation.resourceId,
+        },
+      });
+
+      let accepted: SendAgentSignalAccepted;
+      try {
+        accepted = await acceptSignalDelivery(
+          capability.sourceAgent.sendSignal(signal, {
+            threadId: reservation.record.sourceThreadId,
+            resourceId: reservation.record.sourceResourceId,
+            ifIdle: { behavior: 'wake', streamOptions: { requestContext: context.requestContext } },
+          }),
+          reservation.record.deadlineAt,
+        );
+      } catch (error) {
+        registry.fail(correlationId, 'delivery_unknown', error instanceof Error ? error.message : String(error));
+        deleteReplyCapability(capabilities, correlationId);
+        return { ok: false, correlationId, error: 'Terminal answer delivery could not be confirmed.' };
+      }
+
+      if (accepted.action === 'blocked' || accepted.action === 'discard') {
+        const refusal = accepted.action === 'blocked' ? accepted.reason : accepted.action;
+        registry.fail(correlationId, 'delivery_failed', refusal);
+        deleteReplyCapability(capabilities, correlationId);
+        return {
+          ok: false,
+          correlationId,
+          error: `The source conversation refused the answer: ${refusal}.`,
+        };
+      }
+
+      registry.markReplied(correlationId);
+      deleteReplyCapability(capabilities, correlationId);
+      return { ok: true, correlationId, delivered: true };
+    },
+  });
+}
+
+export function createReplyToolProcessor(
+  registry: RemindRequestRegistry,
+  conversation: RemindConversation,
+  capabilities: ReplyCapabilityRegistry = resolveReplyCapabilities(registry),
+): InputProcessor {
+  return {
+    id: 'remind-current-question-tools',
+    processInputStep(args: ProcessInputStepArgs): ProcessInputStepResult | undefined {
+      const correlations = new Set<string>();
+      for (const message of args.messages as Array<{
+        metadata?: Record<string, unknown>;
+        content?: string | { parts?: Array<{ type?: string; text?: string }> };
+      }>) {
+        const metadata = message.metadata;
+        const content = message.content;
+        const text =
+          typeof content === 'string'
+            ? content
+            : (content?.parts ?? [])
+                .filter(part => part.type === 'text')
+                .map(part => part.text ?? '')
+                .join('\n');
+        const correlationId =
+          metadata?.kind === 'remind-ask' && typeof metadata.correlationId === 'string'
+            ? metadata.correlationId
+            : /Question \[correlationId: (remind-ask-[0-9a-f-]+)\]:/.exec(text)?.[1];
+        if (!correlationId) continue;
+        const record = registry.get(correlationId);
+        const candidate = capabilities.get(correlationId);
+        if (!record || record.status !== 'pending' || !candidate) continue;
+        if (
+          candidate.conversation.remindThreadId !== conversation.remindThreadId ||
+          candidate.conversation.resourceId !== conversation.resourceId
+        ) {
+          continue;
+        }
+        correlations.add(correlationId);
+      }
+      if (correlations.size === 0) return undefined;
+      return {
+        tools: {
+          ...args.tools,
+          reply_to_memory_question: createReplyTool(registry, capabilities, conversation, correlations),
+        },
+      };
+    },
+  };
+}
+
+function createReminderAgent(args: {
+  parentThreadId: string;
+  conversation: RemindConversation;
+  instructions: string;
+  model: NonNullable<Awaited<ReturnType<typeof resolveReminderConversationModel>>>;
+  memory: Memory;
+  scope: KnowledgeScope;
+  registry: RemindRequestRegistry;
+  replyCapabilities: ReplyCapabilityRegistry;
+  remindMemory?: Memory;
+}): Agent {
+  return new Agent({
+    id: `subconscious-remind-${args.parentThreadId}`,
+    name: 'Subconscious Remind',
+    instructions: args.instructions,
+    model: args.model,
+    ...(args.remindMemory ? { memory: args.remindMemory } : {}),
+    tools: createKnowledgeTools(args.memory, args.scope),
+    inputProcessors: [createReplyToolProcessor(args.registry, args.conversation, args.replyCapabilities)],
+  });
+}
+
+interface ReminderConversationTurnArgs {
+  agent: Agent;
+  /** The parent session thread id; the reminder thread key is derived from it. */
+  parentThreadId: string;
+  resourceId: string;
+  prompt: string;
+  requestContext?: RequestContext;
+  maxSteps?: number;
+  deadlineMs?: number;
+  /**
+   * Rejects this passive evaluation when aborted. The reminder turn itself is not cancelled, so its
+   * transcript can still persist in causal order.
+   */
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Run one serialized passive-evaluation turn in the continuing reminder conversation.
+ *
+ * Explicit questions bypass this helper: they are acknowledged after `sendMessage()` accepts them,
+ * and correlated answers return directly through source-agent signals. Passive evaluation needs the
+ * accepted wake run's final text, so it consumes that run's stream without attributing question
+ * answers to run completion.
+ *
+ * Both paths use the same resource and reminder thread. The core thread-stream runtime owns active,
+ * reserved, and idle routing, serializes turns, and persists conversation history in causal order.
+ */
+async function runReminderConversationTurn(args: ReminderConversationTurnArgs): Promise<string> {
+  const threadId = remindThreadKey(args.parentThreadId);
+  const deadlineMs = args.deadlineMs ?? REMINDER_TURN_DEADLINE_MS;
+  const deadlineAt = Date.now() + deadlineMs;
+  const abortMessage = 'The caller aborted while waiting for the reminder conversation turn.';
+
+  const waitWithinDeadline = async <T>(promise: Promise<T>, phase: 'accept' | 'complete'): Promise<T> => {
+    if (args.abortSignal?.aborted) throw new Error(abortMessage);
+
+    const remainingMs = Math.max(0, deadlineAt - Date.now());
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let onAbort: (() => void) | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  phase === 'accept'
+                    ? `The reminder conversation did not accept this turn within ${deadlineMs}ms.`
+                    : `The reminder conversation did not complete this turn within ${deadlineMs}ms.`,
+                ),
+              ),
+            remainingMs,
+          );
+          timer.unref?.();
+
+          if (args.abortSignal) {
+            onAbort = () => reject(new Error(abortMessage));
+            args.abortSignal.addEventListener('abort', onAbort, { once: true });
+          }
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+      if (onAbort && args.abortSignal) args.abortSignal.removeEventListener('abort', onAbort);
+    }
+  };
+
+  const result = args.agent.sendMessage(args.prompt, {
+    threadId,
+    resourceId: args.resourceId,
+    ifIdle: {
+      behavior: 'wake',
+      streamOptions: {
+        requestContext: args.requestContext,
+        maxSteps: args.maxSteps,
+      },
+    },
+  });
+  const accepted = await waitWithinDeadline(result.accepted, 'accept');
+
+  if (accepted.action === 'blocked' || accepted.action === 'discard') {
+    throw new Error(
+      accepted.action === 'blocked'
+        ? `The reminder conversation is blocked: ${accepted.reason}.`
+        : 'The reminder conversation discarded this turn.',
+    );
+  }
+  if (accepted.action !== 'wake') return NO_REMINDER;
+
+  const output = await waitWithinDeadline(
+    accepted.output.consumeStream().then(() => accepted.output.getFullOutput()),
+    'complete',
+  );
+  return output.text.trim();
+}
+
+/**
+ * The reminder agent as an agent-facing tool. The main agent receives an immediate routing
+ * acknowledgement; the answer returns later as a correlated source-agent signal. Questions and
+ * passive evaluations enter the same serialized reminder conversation.
+ */
+export function createRemindAskTool(options: RemindAskToolOptions) {
+  const { memory, config, omModel } = options;
+  // Same fallback the passive path uses. A per-call registry here would put the ask tool and the
+  // reminder agent that answers it on two different authorities whenever an owner wired none.
+  const registry = options.registry ?? fallbackRegistry();
+  const replyCapabilities = resolveReplyCapabilities(registry);
+
+  /** The single acceptance-only dispatch path for every explicit reminder question. */
+  const dispatch = async (
+    question: string,
+    context: AskToolContext,
+    threadId: string,
+    sourceAgent: SignalSender,
+  ): Promise<RemindRequestRecord> => {
+    const sourceResourceId = context.agent?.resourceId;
+    const sourceAgentId = context.agent?.agentId;
+    if (!sourceResourceId || !sourceAgentId) {
+      throw new ReminderUnavailableError('ask_memory requires an active source Agent, thread, and resource.');
+    }
+
+    const scope = resolveScope({ requestContext: context.requestContext, resourceId: sourceResourceId, threadId });
+    const instructions = [DEFAULT_INSTRUCTIONS, ASK_INSTRUCTIONS, config.instructions?.trim()]
+      .filter(Boolean)
+      .join('\n\n');
+    const model = await resolveReminderConversationModel({ config, omModel, requestContext: context.requestContext });
+    if (!model) throw new ReminderUnavailableError(NO_MODEL_MESSAGE);
+
+    const conversation: RemindConversation = {
+      remindThreadId: remindThreadKey(threadId),
+      resourceId: reminderResourceId(threadId, sourceResourceId),
+    };
+    const correlationId = `remind-ask-${crypto.randomUUID()}`;
+    const record = registry.create({
+      correlationId,
+      conversation,
+      sourceAgentId,
+      sourceThreadId: threadId,
+      sourceResourceId,
+    });
+    const expiryTimer = setTimeout(
+      () => deleteReplyCapability(replyCapabilities, correlationId),
+      Math.max(0, record.deadlineAt - Date.now()),
+    );
+    expiryTimer.unref?.();
+    replyCapabilities.set(correlationId, { sourceAgent, conversation, expiryTimer });
+
+    const fail = (status: 'delivery_failed' | 'model_failed', error: unknown) => {
+      registry.fail(correlationId, status, error instanceof Error ? error.message : String(error));
+      deleteReplyCapability(replyCapabilities, correlationId);
+    };
+
+    try {
+      if (context.abortSignal?.aborted) {
+        throw new Error('The caller aborted before submitting the reminder question.');
+      }
+      await ensureRemindThreadProvenance({
+        memory,
+        remindThreadId: conversation.remindThreadId,
+        resourceId: conversation.resourceId,
+        parentThreadId: threadId,
+      });
+      const agent = createReminderAgent({
+        parentThreadId: threadId,
+        conversation,
+        instructions,
+        model,
+        memory,
+        scope,
+        registry,
+        replyCapabilities,
+        remindMemory: options.createRemindMemory?.(),
+      });
+      const contents = `Current time: ${new Date().toISOString()}\n\nQuestion [correlationId: ${correlationId}]: ${question}\n\nAnswer this by calling reply_to_memory_question with correlationId "${correlationId}".`;
+      const result = agent.sendMessage(
+        {
+          contents,
+          metadata: {
+            correlationId,
+            kind: 'remind-ask',
+            sourceAgentId,
+            sourceThreadId: threadId,
+            sourceResourceId,
+            parentThreadId: threadId,
+            remindThreadId: conversation.remindThreadId,
+          },
+        },
+        {
+          threadId: conversation.remindThreadId,
+          resourceId: conversation.resourceId,
+          ifIdle: {
+            behavior: 'wake',
+            streamOptions: {
+              requestContext: context.requestContext,
+              maxSteps: config.maxSteps,
+              onError: ({ error }: { error: Error | string }) => fail('model_failed', error),
+            },
+          },
+        },
+      );
+      const remainingMs = Math.max(0, record.deadlineAt - Date.now());
+      let acceptanceTimer: ReturnType<typeof setTimeout> | undefined;
+      let onAbort: (() => void) | undefined;
+      const acceptanceDeadline = new Promise<never>((_, reject) => {
+        acceptanceTimer = setTimeout(
+          () => reject(new Error(`The reminder conversation did not accept this question within ${remainingMs}ms.`)),
+          remainingMs,
+        );
+        acceptanceTimer.unref?.();
+        if (context.abortSignal) {
+          onAbort = () => reject(new Error('The caller aborted while submitting the reminder question.'));
+          if (context.abortSignal.aborted) onAbort();
+          else context.abortSignal.addEventListener('abort', onAbort, { once: true });
+        }
+      });
+      let disposition: Awaited<typeof result.accepted>;
+      try {
+        disposition = await Promise.race([result.accepted, acceptanceDeadline]);
+      } finally {
+        if (acceptanceTimer) clearTimeout(acceptanceTimer);
+        if (onAbort && context.abortSignal) context.abortSignal.removeEventListener('abort', onAbort);
+      }
+      if (disposition.action === 'blocked' || disposition.action === 'discard') {
+        fail('delivery_failed', disposition.action === 'blocked' ? disposition.reason : disposition.action);
+      } else if (disposition.action === 'wake') {
+        void disposition.output.consumeStream().catch(error => fail('model_failed', error));
+      }
+    } catch (error) {
+      fail('delivery_failed', error);
+    }
+
+    return record;
+  };
+
+  const askMemory = createTool({
+    id: 'ask_memory',
+    description:
+      'Ask the reminder agent a question about what this session already knows or discussed. The question is accepted immediately; its terminal answer arrives later as a correlated reactive remembered signal.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        question: { type: 'string', minLength: 1, description: 'The question, in natural language.' },
+      },
+      required: ['question'],
+      additionalProperties: false,
+    } satisfies JSONSchema7,
+    execute: async (input, rawContext) => {
+      const { question } = input as { question: string };
+      const context = rawContext as AskToolContext;
+      const threadId = context.agent?.threadId;
+      if (!threadId) return { ok: false, error: 'ask_memory requires an active threadId.' };
+
+      let sourceAgent: SignalSender | undefined;
+      try {
+        sourceAgent = await resolveSignalSender(context);
+      } catch (error) {
+        return { ok: false, ...describeAskFailure(error) };
+      }
+      if (!sourceAgent || !context.agent?.resourceId) {
+        return { ok: false, error: 'ask_memory requires the source Agent signal channel.' };
+      }
+
+      let record: RemindRequestRecord;
+      try {
+        record = await dispatch(question, context, threadId, sourceAgent);
+      } catch (error) {
+        return { ok: false, ...describeAskFailure(error) };
+      }
+      if (record.failure) {
+        return {
+          ok: false,
+          correlationId: record.correlationId,
+          status: record.status,
+          error: record.failure.message,
+        };
+      }
+
+      return {
+        ok: true,
+        accepted: true,
+        correlationId: record.correlationId,
+        status: 'pending',
+        note: 'The answer will arrive as a correlated reactive remembered signal. This segment has no blocking checkpoint.',
+      };
+    },
+  });
+
+  return { ask_memory: askMemory } satisfies Record<string, ToolAction<any, any, any, any, any, any, any>>;
+}
+
+/**
+ * Registry used when the owner wired none. The current-input processor injects the reply tool only
+ * when a correlated question in this registry belongs to the active reminder conversation.
+ */
+let fallback: RemindRequestRegistry | undefined;
+function fallbackRegistry(): RemindRequestRegistry {
+  return (fallback ??= new RemindRequestRegistry());
+}
+
+/** A configuration gap rather than a failure — reported as an explicit unavailable result. */
+class ReminderUnavailableError extends Error {}
+
+function describeAskFailure(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return error instanceof ReminderUnavailableError ? { unavailable: true, error: message } : { error: message };
 }
 
 export class SubconsciousRemindExtractor extends Extractor<string> {
@@ -150,13 +819,18 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
           scope = resolveScope(context);
           store = await context.memory.storage.getStore('knowledge');
           if (!store) throw new Error('Subconscious remind requires a configured knowledge storage domain.');
-          const sources = await dropFreshOwnRecords(
+          const sources = await dropFreshOwnItems(
             store,
             await findReminderSources(store, scope, context.rawObservations),
             context.threadId,
           );
           if (sources.length === 0) return;
-          const model = await resolveSubconsciousAgentModel({
+          const instructions = [DEFAULT_INSTRUCTIONS, config.instructions?.trim()].filter(Boolean).join('\n\n');
+          const recentMessagesSection = context.recentMessages?.trim()
+            ? `\n\nRecent conversation messages (already visible to the agent — never remind about anything present here):\n${context.recentMessages}`
+            : '';
+          const prompt = `Current time: ${new Date().toISOString()}\n\nScoped source candidates:\n${JSON.stringify(sources)}\n\nCurrent observations:\n${context.rawObservations}${recentMessagesSection}`;
+          const model = await resolveReminderConversationModel({
             config,
             omModel,
             mainAgent: context.mainAgent,
@@ -165,40 +839,46 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
           if (!model) return;
           // One reminder conversation per main-agent session. The thread key is derived from the
           // PARENT thread id, not from the agent id above, and matches the curate/learn convention.
-          // Without the session's resource owner, run stateless rather than create an orphaned
-          // derived thread that Memory.deleteThread() cannot safely prove it owns.
+          // The evaluation enters the same serialized conversation as asks, so a passive reminder
+          // never interleaves with an in-flight question turn. Without the session's resource owner,
+          // run stateless rather than persist an orphaned derived thread that deleteThread cannot own.
+          const registry = options?.registry ?? fallbackRegistry();
           const remindMemory = context.resourceId ? options?.createRemindMemory?.() : undefined;
-          const agent = new Agent({
-            id: `subconscious-remind-${context.threadId}`,
-            name: 'Subconscious Remind',
-            instructions: [DEFAULT_INSTRUCTIONS, config.instructions?.trim()].filter(Boolean).join('\n\n'),
-            model,
-            ...(remindMemory ? { memory: remindMemory } : {}),
-            tools: createKnowledgeTools(context.memory, scope),
-          });
-          const recentMessagesSection = context.recentMessages?.trim()
-            ? `\n\nRecent conversation messages (already visible to the agent — never remind about anything present here):\n${context.recentMessages}`
-            : '';
-          const result = await agent.generate(
-            `Current time: ${new Date().toISOString()}\n\nScoped source candidates:\n${JSON.stringify(sources)}\n\nCurrent observations:\n${context.rawObservations}${recentMessagesSection}`,
-            {
-              requestContext: context.requestContext,
-              abortSignal: context.abortSignal,
-              maxSteps: config.maxSteps,
-              ...(remindMemory
-                ? {
-                    memory: {
-                      thread: {
-                        id: remindThreadKey(context.threadId),
-                        metadata: { [REMIND_PARENT_THREAD_METADATA_KEY]: context.threadId },
-                      },
-                      resource: context.resourceId,
-                    },
-                  }
-                : {}),
+          if (remindMemory) {
+            await ensureRemindThreadProvenance({
+              memory: remindMemory,
+              remindThreadId: remindThreadKey(context.threadId),
+              resourceId: reminderResourceId(context.threadId, context.resourceId),
+              parentThreadId: context.threadId,
+            });
+          }
+          const agent = createReminderAgent({
+            parentThreadId: context.threadId,
+            conversation: {
+              remindThreadId: remindThreadKey(context.threadId),
+              resourceId: reminderResourceId(context.threadId, context.resourceId),
             },
-          );
-          const reminder = result.text.trim();
+            instructions,
+            model,
+            memory: context.memory,
+            scope,
+            // A question can be delivered into this passive run, so it must carry the same reply
+            // authority an ask-woken run has.
+            registry,
+            replyCapabilities: resolveReplyCapabilities(registry),
+            remindMemory: context.resourceId ? options?.createRemindMemory?.() : undefined,
+          });
+          const reminder = await runReminderConversationTurn({
+            agent,
+            parentThreadId: context.threadId,
+            resourceId: reminderResourceId(context.threadId, context.resourceId),
+            prompt,
+            requestContext: context.requestContext,
+            maxSteps: config.maxSteps,
+            // The passive evaluation stops waiting when its calling turn aborts. The reminder turn
+            // itself may still complete and persist in causal order.
+            abortSignal: context.abortSignal,
+          });
           if (!reminder || /^<no-reminder\s*\/>$/i.test(reminder)) {
             return;
           }

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -647,12 +647,15 @@ export function createRemindAskTool(options: RemindAskToolOptions) {
       if (context.abortSignal?.aborted) {
         throw new Error('The caller aborted before submitting the reminder question.');
       }
-      await ensureRemindThreadProvenance({
-        memory,
-        remindThreadId: conversation.remindThreadId,
-        resourceId: conversation.resourceId,
-        parentThreadId: threadId,
-      });
+      const remindMemory = options.createRemindMemory?.();
+      if (remindMemory) {
+        await ensureRemindThreadProvenance({
+          memory: remindMemory,
+          remindThreadId: conversation.remindThreadId,
+          resourceId: conversation.resourceId,
+          parentThreadId: threadId,
+        });
+      }
       const agent = createReminderAgent({
         parentThreadId: threadId,
         conversation,
@@ -662,7 +665,7 @@ export function createRemindAskTool(options: RemindAskToolOptions) {
         scope,
         registry,
         replyCapabilities,
-        remindMemory: options.createRemindMemory?.(),
+        remindMemory,
       });
       const contents = `Current time: ${new Date().toISOString()}\n\nQuestion [correlationId: ${correlationId}]: ${question}\n\nAnswer this by calling reply_to_memory_question with correlationId "${correlationId}".`;
       const result = agent.sendMessage(
@@ -866,7 +869,7 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
             // authority an ask-woken run has.
             registry,
             replyCapabilities: resolveReplyCapabilities(registry),
-            remindMemory: context.resourceId ? options?.createRemindMemory?.() : undefined,
+            remindMemory,
           });
           const reminder = await runReminderConversationTurn({
             agent,


### PR DESCRIPTION
## Summary

Add an acceptance-only `ask_memory` tool that sends correlated questions into the session's continuing reminder conversation. Answers return later as deterministic reactive signals from the source Agent, not through a process-local waiter or the reminder run's final text.

## Root cause

The previous answer transport tied replies to process-local run state. It mixed lifecycle and answer payload ownership, could not safely continue across reminder turns, and did not share one serialized conversation with passive reminder work.

## What changed

- Route explicit questions and passive reminders through the same persistent reminder conversation with `Agent.sendMessage()`.
- Assign every question a correlation ID carried in structured message metadata.
- Inject `reply_to_memory_question` only for eligible correlations in the current input.
- Deliver terminal answers through the source Agent's `sendSignal()` using deterministic signal IDs.
- Keep the registry payload-free: routing identity, timestamps, lifecycle status, and bounded terminal metadata only.
- Bound wake acceptance, passive completion, and terminal signal acceptance to absolute request deadlines.
- Preserve delivery reservations after ambiguous failures so retries cannot duplicate a terminal answer.
- Stamp owned derived reminder threads with parent provenance before their first native turn so deleting the parent can safely clean up the reminder conversation.
- Refuse persistent reminder memory when the deterministic derived thread is already unmarked, owned by another parent or resource, or changes ownership after creation; those turns continue stateless instead of claiming foreign data.
- Keep resource-less passive evaluations stateless: they may run, but they do not create persistent reminder memory or an owned derived conversation.

## Design notes

`ask_memory` returns `{ accepted: true, correlationId, status: 'pending' }`. It confirms dispatch, not answer delivery. Post-dispatch lifecycle is inspected by the stacked #22515 checkpoint tool.

Terminal delivery waits only for routing acceptance, never durable signal persistence. A signal accepted at an exact deadline boundary remains scheduler-dependent. Resource-less passive evaluations still run, but without persistent reminder memory; the owned session continuity path is used only when a resource ID exists.

The portable `MemoryStorage` contract has no atomic create-if-absent operation. Pre-existing collisions and post-save ownership conflicts fail closed to stateless operation. A foreign writer landing specifically between the initial ownership read and the unconditional thread upsert can still have its row replaced; eliminating that narrow cross-process window requires a separate Memory-domain conditional-create capability across storage adapters.

## Lineage

This PR is rebuilt on the repaired #22479 continuity branch and should be reviewed after it. It supersedes the earlier process-local answer-bus design.

Closes #22447

## Test plan

From `packages/memory`:

```bash
pnpm exec vitest run src/processors/observational-memory/__tests__/subconscious-remind.test.ts src/processors/observational-memory/__tests__/remind-request-state.test.ts --reporter=dot --bail=1
pnpm test:unit
pnpm check
pnpm lint
```

From the repository root:

```bash
pnpm build:memory
```

Results on the reviewed and restacked head `caca9f952c14d12dee5cb0dde7ec40013b65637f`:

- Focused transport, provenance, and lifecycle suites: 91 passed
- Full `@mastra/memory` unit suite: 1,606 passed, 1 todo across 64 files
- TypeScript check: passed
- Lint: 0 warnings and 0 errors across 197 files
- Memory/core build: 15/15 tasks successful
- Three-model adversarial review: no remaining must-fix findings

The PR includes a patch changeset for `@mastra/memory`. Subconscious remains experimental, but the changeset now discloses native conversation continuity and owned conversation cleanup.
