### PR TITLE
fix(schema-compat): type-stamp required-only union branches for Gemini

### DIFF
--- a/.changeset/soft-candies-nail.md
+++ b/.changeset/soft-candies-nail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed Gemini schema compatibility for tools that use required-only union constraints (e.g. "provide at least one of `name` or `kind`"). Made the Google API stop rejecting such schemas with a 400 (`required` only allowed for OBJECT type) by type-stamping those `anyOf` branches as objects while preserving their constraints. Follow-up to #22337, which worked around the same issue at the tool level.

--- a/packages/schema-compat/src/provider-compats/google.test.ts
+++ b/packages/schema-compat/src/provider-compats/google.test.ts
@@ -373,5 +373,82 @@ describe('GoogleSchemaCompatLayer', () => {
       expect(resumeData.anyOf.map((v: any) => v.type)).toEqual(['string', 'number', 'integer', 'boolean', 'object']);
       expect((result as any).required).toContain('resumeData');
     });
+
+    it('type-stamps required-only union branches so Gemini accepts `required` (issue #22337 follow-up)', () => {
+      // Google's API rejects `required` inside non-OBJECT anyOf branches ("required only
+      // allowed for OBJECT type"), and the layer previously left required-only branches
+      // (`{ required: ['name'] }`) typeless, which Gemini then refused. Type-stamp them
+      // as `object` while preserving the "at least one of" constraint they express.
+      const result = applyCompatLayer({
+        schema: {
+          type: 'object',
+          properties: {
+            node: { type: 'string', minLength: 1 },
+            expectedVersion: { type: 'number' },
+            name: { type: 'string', minLength: 1 },
+            kind: { type: 'string', minLength: 1 },
+          },
+          required: ['node', 'expectedVersion'],
+          anyOf: [{ required: ['name'] }, { required: ['kind'] }],
+          additionalProperties: false,
+        } as any,
+        compatLayers: [layer],
+        mode: 'jsonSchema',
+      });
+
+      const branches = (result as any).anyOf;
+      expect(branches).toEqual([
+        { required: ['name'], type: 'object' },
+        { required: ['kind'], type: 'object' },
+      ]);
+      // Root-level shape preserved on both passes.
+      expect((result as any).type).toBe('object');
+      expect((result as any).required).toEqual(['node', 'expectedVersion']);
+    });
+
+    it('type-stamps nested required-only union branches on an object property', () => {
+      const result = applyCompatLayer({
+        schema: {
+          type: 'object',
+          properties: {
+            target: { anyOf: [{ required: ['name'] }, { required: ['kind'] }] },
+          },
+        } as any,
+        compatLayers: [layer],
+        mode: 'jsonSchema',
+      });
+
+      const branches = (result as any).properties.target.anyOf;
+      expect(branches).toEqual([
+        { required: ['name'], type: 'object' },
+        { required: ['kind'], type: 'object' },
+      ]);
+    });
+
+    it('does not type-stamp empty required arrays or primitive union alternatives', () => {
+      // `required: []` is a Draft 7 no-op, and `required` is ignored for non-object
+      // instances — so an empty required array and a primitive union branch must NOT be
+      // narrowed to `type: 'object'`, or a valid primitive alternative would be rejected
+      // after conversion. Only branches that actually name required properties are
+      // type-stamped.
+      const result = applyCompatLayer({
+        schema: {
+          type: 'object',
+          properties: {
+            target: { anyOf: [{ required: [] }, { required: ['name'] }, { type: 'string' }] },
+          },
+        } as any,
+        compatLayers: [layer],
+        mode: 'jsonSchema',
+      });
+
+      const branches = (result as any).properties.target.anyOf;
+      // branch with a named required property is type-stamped object.
+      expect(branches).toContainEqual({ required: ['name'], type: 'object' });
+      // the primitive alternative is preserved (not turned into an object).
+      expect(branches).toContainEqual({ type: 'string' });
+      // the empty-required branch is not given a strict `type: 'object'` leaf.
+      expect(branches.some((b: any) => b.required?.length === 0 && b.type === 'object')).toBe(false);
+    });
   });
 });

--- a/packages/schema-compat/src/provider-compats/google.ts
+++ b/packages/schema-compat/src/provider-compats/google.ts
@@ -189,6 +189,24 @@ export class GoogleSchemaCompatLayer extends SchemaCompatLayer {
     return 'jsonSchema7';
   }
 
+  protected override defaultObjectHandler(schema: JSONSchema7): JSONSchema7 {
+    // Ensure additionalProperties is set appropriately for strict mode
+    if (schema.properties && schema.additionalProperties === undefined) {
+      schema.additionalProperties = false;
+    }
+
+    // Preserve an explicitly-declared `required` even when the object has no
+    // `properties` — e.g. a required-only union branch like `{ required: ['name'] }`.
+    // The base handler empties `required` on any property-less object, which would
+    // silently drop the "at least one of" constraint such branches carry after they
+    // are type-stamped as `object` (Google rejects `required` on non-OBJECT types).
+    if (!Object.keys(schema.properties ?? {}).length && schema.required === undefined) {
+      schema.required = [];
+    }
+
+    return schema;
+  }
+
   shouldApply(): boolean {
     return (
       this.getModel().provider.includes('google') ||
@@ -365,6 +383,28 @@ export class GoogleSchemaCompatLayer extends SchemaCompatLayer {
         s['anyOf'] = nonNull;
         s['nullable'] = true;
       }
+    }
+
+    // A node that carries object constraints (`required`) but no explicit `type` — e.g.
+    // a required-only union branch like `{ required: ['name'] }` in an `anyOf` — is an
+    // object schema in JSON-Schema terms. Gemini's OpenAPI 3.0 subset rejects `required`
+    // unless the branch is typed OBJECT ("required only allowed for OBJECT type"), so
+    // type-stamp it here rather than letting the typeless fallback below attach
+    // `required` to a primitive `anyOf` the API refuses. Restrict this to non-empty
+    // `required` arrays: an empty `[]` is a Draft 7 no-op and must not narrow a schema
+    // or turn a primitive union alternative into `type: 'object'`.
+    if (
+      Array.isArray(s['required']) &&
+      s['required'].length > 0 &&
+      !s['type'] &&
+      !s['anyOf'] &&
+      !s['oneOf'] &&
+      !s['allOf'] &&
+      !s['$ref'] &&
+      !s['enum'] &&
+      !s['const']
+    ) {
+      s['type'] = 'object';
     }
 
     // Any node that still lacks a Gemini-recognised shape (`type`, `anyOf`, `oneOf`,


### PR DESCRIPTION
## Description

When a tool schema expresses an "at least one of X or Y" constraint using
required-only `anyOf` branches — e.g.

```json
{
  "anyOf": [{ "required": ["name"] }, { "required": ["kind"] }]
}
```

Google's API rejects it: `...parameters.any_of[0].required: only allowed for
OBJECT type`. The `GoogleSchemaCompatLayer` left these branches typeless, and the
typeless fallback then attached the orphaned `required` to a primitive `anyOf`
that Gemini refuses, surfacing as a 400 before your model ever ran.

This fixes it at the source for the whole class: a node that carries `required`
but no explicit `type`/composition keyword is now type-stamped as `object` in the
Google layer, and an explicitly-declared `required` on a property-less object
branch is preserved instead of being emptied. The "at least one of" constraint
survives and Gemini validates the schema.

Completes the follow-up proposed in #22337, which worked around the same issue
at the `knowledge_update_node` tool level. The change is scoped to the Google
compat layer only — other providers are untouched.

## Related issue(s)

Fixes #22489

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Linked related issue(s) (#22337 follow-up thread)
- [x] No documentation change required (internal compat-layer fix; no public API change)
- [x] Added tests that prove the fix: 2 regression cases (root + nested) that fail without the change
- [x] Addressed Coderabbit concerns (none open at staging time)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Some Google schemas required fields but did not identify themselves as objects. Google rejected these schemas. This change marks the affected `anyOf` branches as objects and preserves their constraints.

## Changes

- Update the Google schema compatibility layer to:
  - Assign `type: "object"` to required-only `anyOf` branches.
  - Preserve explicit `required` constraints on property-less object branches.
  - Preserve empty `required` arrays.
- Add root-level and nested regression tests.
- Add a patch changeset for `@mastra/schema-compat`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->