### PR TITLE
feat(core): define Knowledge v2 storage contract

### DIFF
--- a/.changeset/busy-tools-arrive.md
+++ b/.changeset/busy-tools-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added an experimental Knowledge v2 storage contract with capability inspection and explicit Knowledge-only reset support.

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -67,6 +67,34 @@ export const TABLE_KNOWLEDGE_MENTIONS = 'mastra_knowledge_mentions';
 export const TABLE_KNOWLEDGE_CURSORS = 'mastra_knowledge_cursors';
 export const TABLE_KNOWLEDGE_ACTIVITY = 'mastra_knowledge_activity';
 export const TABLE_KNOWLEDGE_SEMANTIC_OUTBOX = 'mastra_knowledge_semantic_outbox';
+export const TABLE_KNOWLEDGE_NODE_SCOPES = 'mastra_knowledge_node_scopes';
+export const TABLE_KNOWLEDGE_RECORD_SCOPES = 'mastra_knowledge_record_scopes';
+export const TABLE_KNOWLEDGE_SCOPE_GRANTS = 'mastra_knowledge_scope_grants';
+export const TABLE_KNOWLEDGE_ACCESS_STATE = 'mastra_knowledge_access_state';
+export const TABLE_KNOWLEDGE_SCOPE_ADDRESSES = 'mastra_knowledge_scope_addresses';
+export const TABLE_KNOWLEDGE_NODE_ADDRESSES = 'mastra_knowledge_node_addresses';
+export const TABLE_KNOWLEDGE_IMPORT_STATE = 'mastra_knowledge_import_state';
+export const TABLE_KNOWLEDGE_IMPORT_RUNS = 'mastra_knowledge_import_runs';
+export const TABLE_KNOWLEDGE_PROPOSALS = 'mastra_knowledge_proposals';
+
+/** Physical tables owned by one Knowledge domain. Explicit reset may target only this list. */
+export const KNOWLEDGE_TABLE_NAMES = [
+  TABLE_KNOWLEDGE_NODES,
+  TABLE_KNOWLEDGE_RECORDS,
+  TABLE_KNOWLEDGE_MENTIONS,
+  TABLE_KNOWLEDGE_CURSORS,
+  TABLE_KNOWLEDGE_ACTIVITY,
+  TABLE_KNOWLEDGE_SEMANTIC_OUTBOX,
+  TABLE_KNOWLEDGE_NODE_SCOPES,
+  TABLE_KNOWLEDGE_RECORD_SCOPES,
+  TABLE_KNOWLEDGE_SCOPE_GRANTS,
+  TABLE_KNOWLEDGE_ACCESS_STATE,
+  TABLE_KNOWLEDGE_SCOPE_ADDRESSES,
+  TABLE_KNOWLEDGE_NODE_ADDRESSES,
+  TABLE_KNOWLEDGE_IMPORT_STATE,
+  TABLE_KNOWLEDGE_IMPORT_RUNS,
+  TABLE_KNOWLEDGE_PROPOSALS,
+] as const;
 
 /** Union of all core table name constants. */
 export type TABLE_NAMES =

--- a/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
+++ b/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
@@ -72,6 +72,18 @@ describe('InMemoryKnowledgeStorage', () => {
       status: 'uninitialized',
       schemaVersion: null,
     });
+    expect(
+      inspectKnowledgeSchema({
+        available: true,
+        tableNames: ['mastra_knowledge_nodes'],
+        schemaVersion: KNOWLEDGE_STORAGE_SCHEMA_VERSION,
+      }),
+    ).toEqual({ status: 'compatible', schemaVersion: KNOWLEDGE_STORAGE_SCHEMA_VERSION });
+    expect(inspectKnowledgeSchema({ available: false, tableNames: [], reason: 'adapter offline' })).toEqual({
+      status: 'unavailable',
+      schemaVersion: null,
+      reason: 'adapter offline',
+    });
     expect(() => assertKnowledgeSchemaCompatible({ status: 'uninitialized', schemaVersion: null })).not.toThrow();
   });
 

--- a/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
+++ b/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
 import { InMemoryDB } from '../../inmemory-db';
-import { createKnowledgeUlid, KnowledgeConflictError } from '../base';
+import {
+  assertKnowledgeSchemaCompatible,
+  createKnowledgeUlid,
+  KnowledgeConflictError,
+  KnowledgeSchemaResetRequiredError,
+  KNOWLEDGE_STORAGE_CONTRACT_VERSION,
+  KNOWLEDGE_STORAGE_SCHEMA_VERSION,
+} from '../base';
 import { InMemoryKnowledgeStorage } from '../inmemory';
 
 const org = ['org:acme'];
@@ -19,6 +26,51 @@ describe('InMemoryKnowledgeStorage', () => {
     const second = createKnowledgeUlid(1);
 
     expect(second > first).toBe(true);
+  });
+
+  it('reports the v2 contract and inspects schema without mutating Knowledge data', async () => {
+    const store = createStore();
+    const node = await store.createNode({ name: 'Keep me', kind: 'topic', scope: resource });
+
+    expect(store.getCapabilities()).toEqual({
+      contractVersion: KNOWLEDGE_STORAGE_CONTRACT_VERSION,
+      schemaVersion: KNOWLEDGE_STORAGE_SCHEMA_VERSION,
+      supportsV2: true,
+      supportsSchemaInspection: true,
+      supportsExplicitReset: true,
+    });
+    expect(await store.inspectSchema()).toEqual({
+      status: 'compatible',
+      schemaVersion: KNOWLEDGE_STORAGE_SCHEMA_VERSION,
+    });
+    expect(await store.getNode(node.id)).toEqual(node);
+  });
+
+  it('fails incompatible schema inspection with an actionable reset requirement', () => {
+    const inspection = {
+      status: 'incompatible-reset-required',
+      schemaVersion: 1,
+      reason: 'experimental v1 columns detected',
+    } as const;
+
+    expect(() => assertKnowledgeSchemaCompatible(inspection)).toThrow(KnowledgeSchemaResetRequiredError);
+    expect(() => assertKnowledgeSchemaCompatible(inspection)).toThrow(
+      'Knowledge schema reset required: experimental v1 columns detected',
+    );
+    expect(() => assertKnowledgeSchemaCompatible({ status: 'uninitialized', schemaVersion: null })).not.toThrow();
+  });
+
+  it('resets only Knowledge-owned state', async () => {
+    const db = new InMemoryDB();
+    const store = new InMemoryKnowledgeStorage({ db });
+    const now = new Date();
+    db.threads.set('thread-1', { id: 'thread-1', resourceId: 'resource-1', createdAt: now, updatedAt: now });
+    const node = await store.createNode({ name: 'Reset me', kind: 'topic', scope: resource });
+
+    await store.dangerouslyReset();
+
+    expect(await store.getNode(node.id)).toBeNull();
+    expect(db.threads.has('thread-1')).toBe(true);
   });
 
   it('stores identity and optional content on one node type', async () => {

--- a/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
+++ b/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
@@ -4,6 +4,7 @@ import { InMemoryDB } from '../../inmemory-db';
 import {
   assertKnowledgeSchemaCompatible,
   createKnowledgeUlid,
+  inspectKnowledgeSchema,
   KnowledgeConflictError,
   KnowledgeSchemaResetRequiredError,
   KNOWLEDGE_STORAGE_CONTRACT_VERSION,
@@ -46,17 +47,31 @@ describe('InMemoryKnowledgeStorage', () => {
     expect(await store.getNode(node.id)).toEqual(node);
   });
 
-  it('fails incompatible schema inspection with an actionable reset requirement', () => {
-    const inspection = {
+  it('classifies incompatible schema snapshots without mutating probe results', () => {
+    const tableNames = Object.freeze(['mastra_knowledge_nodes', 'mastra_knowledge_records']);
+    const snapshot = Object.freeze({
+      available: true,
+      tableNames,
+      schemaVersion: 1,
+      reason: 'experimental v1 columns detected',
+    });
+
+    const inspection = inspectKnowledgeSchema(snapshot);
+
+    expect(inspection).toEqual({
       status: 'incompatible-reset-required',
       schemaVersion: 1,
       reason: 'experimental v1 columns detected',
-    } as const;
-
+    });
+    expect(snapshot.tableNames).toBe(tableNames);
     expect(() => assertKnowledgeSchemaCompatible(inspection)).toThrow(KnowledgeSchemaResetRequiredError);
     expect(() => assertKnowledgeSchemaCompatible(inspection)).toThrow(
       'Knowledge schema reset required: experimental v1 columns detected',
     );
+    expect(inspectKnowledgeSchema({ available: true, tableNames: [] })).toEqual({
+      status: 'uninitialized',
+      schemaVersion: null,
+    });
     expect(() => assertKnowledgeSchemaCompatible({ status: 'uninitialized', schemaVersion: null })).not.toThrow();
   });
 
@@ -70,6 +85,13 @@ describe('InMemoryKnowledgeStorage', () => {
     await store.dangerouslyReset();
 
     expect(await store.getNode(node.id)).toBeNull();
+    expect(db.knowledgeNodeKeys.size).toBe(0);
+    expect(db.knowledgeRecords.size).toBe(0);
+    expect(db.knowledgeMentions.size).toBe(0);
+    expect(db.knowledgeCursors.size).toBe(0);
+    expect(db.knowledgeActivity).toHaveLength(0);
+    expect(db.knowledgeSemanticOutbox.size).toBe(0);
+    expect(db.knowledgeSemanticIdempotency.size).toBe(0);
     expect(db.threads.has('thread-1')).toBe(true);
   });
 

--- a/packages/core/src/storage/domains/knowledge/base.ts
+++ b/packages/core/src/storage/domains/knowledge/base.ts
@@ -32,6 +32,39 @@ export type KnowledgeSchemaInspection =
   | { status: 'unavailable'; schemaVersion: null; reason: string };
 
 /** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeSchemaSnapshot {
+  available: boolean;
+  tableNames: readonly string[];
+  schemaVersion?: number;
+  reason?: string;
+}
+
+/**
+ * Classifies an adapter-provided, read-only schema snapshot. Adapters own the physical probe; this
+ * helper owns version negotiation and never mutates the snapshot or backing store.
+ *
+ * @experimental Knowledge APIs are experimental and may change without notice.
+ */
+export function inspectKnowledgeSchema(snapshot: KnowledgeSchemaSnapshot): KnowledgeSchemaInspection {
+  if (!snapshot.available) {
+    return {
+      status: 'unavailable',
+      schemaVersion: null,
+      reason: snapshot.reason ?? 'The Knowledge storage adapter is unavailable.',
+    };
+  }
+  if (snapshot.tableNames.length === 0) return { status: 'uninitialized', schemaVersion: null };
+  if (snapshot.schemaVersion === KNOWLEDGE_STORAGE_SCHEMA_VERSION) {
+    return { status: 'compatible', schemaVersion: KNOWLEDGE_STORAGE_SCHEMA_VERSION };
+  }
+  return {
+    status: 'incompatible-reset-required',
+    schemaVersion: snapshot.schemaVersion ?? null,
+    reason: snapshot.reason ?? 'Existing experimental Knowledge tables are not compatible with schema version 2.',
+  };
+}
+
+/** @experimental Knowledge APIs are experimental and may change without notice. */
 export type KnowledgeConcreteRole = 'readonly' | 'append' | 'edit' | 'owner';
 /** @experimental Knowledge APIs are experimental and may change without notice. */
 export type KnowledgeGrantRole = KnowledgeConcreteRole | 'mirror';

--- a/packages/core/src/storage/domains/knowledge/base.ts
+++ b/packages/core/src/storage/domains/knowledge/base.ts
@@ -11,6 +11,105 @@ export type KnowledgeSemanticDocumentType = 'node' | 'record';
 /** @experimental Knowledge APIs are experimental and may change without notice. */
 export type KnowledgeSemanticOperation = 'upsert' | 'delete';
 /** @experimental Knowledge APIs are experimental and may change without notice. */
+export const KNOWLEDGE_STORAGE_CONTRACT_VERSION = 2 as const;
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export const KNOWLEDGE_STORAGE_SCHEMA_VERSION = 2 as const;
+
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeStorageCapabilities {
+  contractVersion: typeof KNOWLEDGE_STORAGE_CONTRACT_VERSION;
+  schemaVersion: 1 | typeof KNOWLEDGE_STORAGE_SCHEMA_VERSION;
+  supportsV2: boolean;
+  supportsSchemaInspection: boolean;
+  supportsExplicitReset: boolean;
+}
+
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export type KnowledgeSchemaInspection =
+  | { status: 'compatible'; schemaVersion: typeof KNOWLEDGE_STORAGE_SCHEMA_VERSION }
+  | { status: 'uninitialized'; schemaVersion: null }
+  | { status: 'incompatible-reset-required'; schemaVersion: number | null; reason: string }
+  | { status: 'unavailable'; schemaVersion: null; reason: string };
+
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export type KnowledgeConcreteRole = 'readonly' | 'append' | 'edit' | 'owner';
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export type KnowledgeGrantRole = KnowledgeConcreteRole | 'mirror';
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeScopeGrant {
+  scopeNodeId: string;
+  scopeRefId: string;
+  role: KnowledgeGrantRole;
+  canSuggest?: boolean;
+}
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeNodeScope {
+  nodeId: string;
+  scopeNodeId: string;
+  addedAt: Date;
+}
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeRecordScope {
+  recordId: string;
+  scopeNodeId: string;
+  addedAt: Date;
+}
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeScopeAddress {
+  address: string;
+  scopeNodeId: string;
+}
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeNodeAddress {
+  source: string;
+  address: string;
+  nodeId: string;
+}
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeImportState {
+  importerId: string;
+  binding: string;
+  key: string;
+  value: string;
+}
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export type KnowledgeImportKind = 'static' | 'agentic';
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export type KnowledgeImportTriggerKind = 'cron' | 'webhook' | 'programmatic';
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export type KnowledgeImportRunStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'skipped' | 'interrupted';
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeImportRun {
+  id: string;
+  importerId: string;
+  binding: string;
+  importKind: KnowledgeImportKind;
+  triggerKind: KnowledgeImportTriggerKind;
+  status: KnowledgeImportRunStatus;
+  error?: string;
+  transcriptThreadId?: string;
+  traceId?: string;
+  queuedAt: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+}
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export type KnowledgeProposalStatus = 'pending' | 'approved' | 'rejected' | 'conflicted';
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeProposal {
+  id: string;
+  targetType: 'node' | 'record';
+  targetId: string;
+  expectedVersion: number;
+  operation: string;
+  payload: Record<string, unknown>;
+  scopes: string[];
+  status: KnowledgeProposalStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** @experimental Knowledge APIs are experimental and may change without notice. */
 export type KnowledgeActivityAction =
   | 'node-created'
   | 'node-updated'
@@ -41,6 +140,27 @@ export interface KnowledgeNode {
   updatedAt: Date;
 }
 
+/**
+ * The normalized v2 node shape. `KnowledgeNode` remains the shipped v1 compatibility shape until
+ * every adapter is v2-capable.
+ *
+ * @experimental Knowledge APIs are experimental and may change without notice.
+ */
+export interface KnowledgeV2Node {
+  id: string;
+  type: 'node';
+  name: string;
+  kind?: string;
+  isScope: boolean;
+  metadata?: Record<string, unknown>;
+  scopes: string[];
+  version: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date;
+  deletedBy?: string;
+}
+
 /** @experimental Knowledge APIs are experimental and may change without notice. */
 export type KnowledgeNodeReference = KnowledgeNode | string;
 
@@ -56,6 +176,26 @@ export interface KnowledgeRecord {
   maxScope?: KnowledgeScopeLevel;
   /** Free-form provenance, e.g. the capture agent's reasoning for keeping or pinning the item. */
   metadata?: Record<string, unknown>;
+  deletedAt?: Date;
+  deletedBy?: string;
+}
+
+/**
+ * The normalized v2 record shape. Scope declarations are part of the record API and are backed by
+ * `mastra_knowledge_record_scopes` in relational adapters.
+ *
+ * @experimental Knowledge APIs are experimental and may change without notice.
+ */
+export interface KnowledgeV2Record {
+  id: string;
+  node: string;
+  text: string;
+  metadata?: Record<string, unknown>;
+  source?: string;
+  scopes: string[];
+  version: number;
+  createdAt: Date;
+  updatedAt: Date;
   deletedAt?: Date;
   deletedBy?: string;
 }
@@ -83,6 +223,7 @@ export interface KnowledgeActivityEvent {
   recordId: string;
   scope: KnowledgeScope;
   sourceThreadId?: string;
+  importRunId?: string;
   createdAt: Date;
 }
 
@@ -268,6 +409,24 @@ export class KnowledgeNotFoundError extends Error {
   }
 }
 
+export class KnowledgeSchemaResetRequiredError extends Error {
+  readonly inspection: Extract<KnowledgeSchemaInspection, { status: 'incompatible-reset-required' }>;
+
+  constructor(inspection: Extract<KnowledgeSchemaInspection, { status: 'incompatible-reset-required' }>) {
+    super(`Knowledge schema reset required: ${inspection.reason}`);
+    this.name = 'KnowledgeSchemaResetRequiredError';
+    this.inspection = inspection;
+  }
+}
+
+export function assertKnowledgeSchemaCompatible(inspection: KnowledgeSchemaInspection): void {
+  if (inspection.status === 'compatible' || inspection.status === 'uninitialized') return;
+  if (inspection.status === 'incompatible-reset-required') {
+    throw new KnowledgeSchemaResetRequiredError(inspection);
+  }
+  throw new Error(`Knowledge schema inspection unavailable: ${inspection.reason}`);
+}
+
 const SCOPE_ORDER: Record<KnowledgeScopeLevel, number> = { org: 0, resource: 1, thread: 2 };
 const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 let lastUlidTime = -1;
@@ -440,6 +599,28 @@ export function knowledgeSemanticIdempotencyKey(
 export abstract class KnowledgeStorage extends StorageDomain {
   constructor() {
     super({ component: 'STORAGE', name: 'KNOWLEDGE' });
+  }
+
+  getCapabilities(): KnowledgeStorageCapabilities {
+    return {
+      contractVersion: KNOWLEDGE_STORAGE_CONTRACT_VERSION,
+      schemaVersion: 1,
+      supportsV2: false,
+      supportsSchemaInspection: false,
+      supportsExplicitReset: false,
+    };
+  }
+
+  async inspectSchema(): Promise<KnowledgeSchemaInspection> {
+    return {
+      status: 'unavailable',
+      schemaVersion: null,
+      reason: 'This Knowledge storage adapter does not support v2 schema inspection.',
+    };
+  }
+
+  async dangerouslyReset(): Promise<void> {
+    throw new Error('This Knowledge storage adapter does not support an explicit Knowledge-only reset.');
   }
 
   abstract createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode>;

--- a/packages/core/src/storage/domains/knowledge/inmemory.ts
+++ b/packages/core/src/storage/domains/knowledge/inmemory.ts
@@ -12,6 +12,8 @@ import {
   KnowledgeConflictError,
   KnowledgeNotFoundError,
   KnowledgeStorage,
+  KNOWLEDGE_STORAGE_CONTRACT_VERSION,
+  KNOWLEDGE_STORAGE_SCHEMA_VERSION,
   parseKnowledgeNodeCursor,
   parseKnowledgeWikilinks,
 } from './base';
@@ -82,6 +84,24 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
   constructor({ db }: { db: InMemoryDB }) {
     super();
     this.#db = db;
+  }
+
+  override getCapabilities() {
+    return {
+      contractVersion: KNOWLEDGE_STORAGE_CONTRACT_VERSION,
+      schemaVersion: KNOWLEDGE_STORAGE_SCHEMA_VERSION,
+      supportsV2: true,
+      supportsSchemaInspection: true,
+      supportsExplicitReset: true,
+    } as const;
+  }
+
+  override async inspectSchema() {
+    return { status: 'compatible', schemaVersion: KNOWLEDGE_STORAGE_SCHEMA_VERSION } as const;
+  }
+
+  override async dangerouslyReset(): Promise<void> {
+    await this.dangerouslyClearAll();
   }
 
   async dangerouslyClearAll(): Promise<void> {

--- a/scripts/check-core-imports.ts
+++ b/scripts/check-core-imports.ts
@@ -231,8 +231,14 @@ function packLocalCore(version: string, tempDir: string) {
   }
 
   console.info(
-    `@mastra/core@${version} is not available from npm; packing local ${relative(repoRoot, corePackageRoot)} because its version matches`,
+    `@mastra/core@${version} is not available from npm; building and packing local ${relative(repoRoot, corePackageRoot)} because its version matches`,
   );
+
+  const build = runCommand('pnpm', ['build:core'], repoRoot);
+
+  if (build.status !== 0) {
+    throw new Error(`Failed to build local @mastra/core@${version}${formatCommandFailure(build)}`);
+  }
 
   const pack = runCommand('npm', ['pack', corePackageRoot, '--pack-destination', tempDir, '--silent'], repoRoot);
 


### PR DESCRIPTION
Wave: 1 of 4
Segment: W1.1 of 8
Purpose: Define the experimental Knowledge v2 Core storage contract, non-mutating schema negotiation, and explicit Knowledge-only reset boundary.
Previous PR: None
Next PR: https://github.com/mastra-ai/mastra/pull/22507
Previous wave: None
Next wave: feat/knowledge-v2-w2-contract (planned)

## Summary

- adds normalized v2 node, record, scope, grant, importer, proposal, and capability types while preserving shipped v1 adapter interfaces
- classifies read-only schema snapshots as compatible, uninitialized, reset-required, or unavailable
- exposes an explicit Knowledge-domain reset contract and freezes all Knowledge-owned physical table names
- proves in-memory reset clears only Knowledge state and preserves unrelated storage

## Test plan

- `pnpm build:core`
- `pnpm --filter ./packages/core exec vitest run src/storage/domains/knowledge/__tests__/base.test.ts --reporter=dot --bail 1`
- `pnpm --filter ./packages/core check`
- `git diff --check origin/main...HEAD`

