### PR TITLE
fix: secure remaining e2e dependencies

### DIFF
--- a/e2e-tests/_local-registry-setup/pnpm-lock.yaml
+++ b/e2e-tests/_local-registry-setup/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml@>=4.0.0 <4.2.0: 4.3.0
+  brace-expansion@>=2.0.0 <2.1.4: 2.1.4
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
   qs@>=6.11.1 <6.15.2: 6.15.2
   uuid@<11.1.1: 11.1.1
 
@@ -224,8 +225,8 @@ packages:
     resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -634,8 +635,8 @@ packages:
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -1252,7 +1253,7 @@ snapshots:
     dependencies:
       '@verdaccio/core': 8.1.2
       debug: 4.4.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
@@ -1480,7 +1481,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -1955,7 +1956,7 @@ snapshots:
 
   isstream@0.1.2: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2071,7 +2072,7 @@ snapshots:
 
   minimatch@7.4.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/e2e-tests/_local-registry-setup/pnpm-workspace.yaml
+++ b/e2e-tests/_local-registry-setup/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
 
 # Security floors for Dependabot alerts on transitive deps.
 overrides:
-  js-yaml@>=4.0.0 <4.2.0: 4.3.0
+  brace-expansion@>=2.0.0 <2.1.4: 2.1.4
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
   qs@>=6.11.1 <6.15.2: 6.15.2
   uuid@<11.1.1: 11.1.1

--- a/e2e-tests/experiment-worker/pnpm-lock.yaml
+++ b/e2e-tests/experiment-worker/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid@>=3.0.0 <3.3.18: 3.3.18
+
 importers:
 
   .:
@@ -1134,8 +1137,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2822,7 +2825,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
 
@@ -2907,7 +2910,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/e2e-tests/experiment-worker/pnpm-workspace.yaml
+++ b/e2e-tests/experiment-worker/pnpm-workspace.yaml
@@ -1,5 +1,8 @@
 packages:
   - '.'
 
+overrides:
+  nanoid@>=3.0.0 <3.3.18: 3.3.18
+
 allowBuilds:
   esbuild: true

--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -380,7 +380,7 @@ export const environmentRoute = registerApiRoute('/environment', {
 
       expect(outputFiles).not.toContain('nodemailer.mjs');
       expect(output).not.toContain('nodemailer/lib');
-      expect(packageJson.dependencies?.nodemailer).toBe('^7.0.0');
+      expect(packageJson.dependencies?.nodemailer).toBe('^9.0.1');
     });
 
     // This stays in the monorepo E2E suite because it builds the generated fixture and validates its output manifest.

--- a/e2e-tests/monorepo/template/apps/custom/package.json
+++ b/e2e-tests/monorepo/template/apps/custom/package.json
@@ -22,7 +22,7 @@
     "date-fns": "4.4.0",
     "lodash": "^4.18.1",
     "hono": "^4.12.29",
-    "nodemailer": "^7.0.0",
+    "nodemailer": "^9.0.1",
     "unicorn-magic": "0.4.0",
     "zod": "^4.0.0"
   },


### PR DESCRIPTION
Raises the vulnerable brace-expansion, js-yaml, and nanoid resolutions used by standalone E2E projects. It also upgrades the monorepo fixture from nodemailer ^7.0.0 to ^9.0.1 while retaining the test that verifies Nodemailer stays external to generated bundles.

Focused frozen installs and audits report no vulnerabilities, and both the monorepo and experiment-worker E2E suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates vulnerable packages used by the E2E test projects. It also updates the Nodemailer test dependency while confirming that generated bundles still keep Nodemailer external.

## Changes

- Added safe dependency overrides for:
  - `brace-expansion` `2.1.4`
  - `js-yaml` `4.3.1`
  - `nanoid` `3.3.18`
- Upgraded the monorepo fixture’s `nodemailer` dependency from `^7.0.0` to `^9.0.1`.
- Updated the build output test to expect the new Nodemailer version.
- Preserved coverage that verifies Nodemailer remains external to generated bundles.

## Validation

- Frozen installs report no vulnerabilities.
- Dependency audits report no vulnerabilities.
- The monorepo and experiment-worker E2E suites pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->