### PR TITLE
fix(mastracode): secure web dependencies

### DIFF
--- a/mastracode/web/package.json
+++ b/mastracode/web/package.json
@@ -38,7 +38,7 @@
     "@mastra/client-js": "link:../../client-sdks/client-js",
     "@mastra/hono": "link:../../server-adapters/hono",
     "@types/node": "22.20.1",
-    "hono": "^4.12.8",
+    "hono": "^4.12.34",
     "mastra": "link:../../packages/cli",
     "typescript": "^7.0.2",
     "varlock": "^1.9.0",

--- a/mastracode/web/pnpm-lock.yaml
+++ b/mastracode/web/pnpm-lock.yaml
@@ -5,7 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  hono@<4.12.34: 4.12.34
+  nanoid@>=3.0.0 <3.3.18: 3.3.18
   postcss@<8.5.23: 8.5.23
+  undici@<6.28.0: 6.28.0
 
 importers:
 
@@ -52,8 +55,8 @@ importers:
         specifier: 22.20.1
         version: 22.20.1
       hono:
-        specifier: ^4.12.8
-        version: 4.12.31
+        specifier: ^4.12.34
+        version: 4.13.5
       mastra:
         specifier: link:../../packages/cli
         version: link:../../packages/cli
@@ -443,10 +446,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@inquirer/ansi@2.0.7':
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
@@ -945,8 +944,8 @@ packages:
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -1088,8 +1087,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1249,9 +1248,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
 
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
@@ -1424,7 +1423,7 @@ snapshots:
       '@ai-sdk/provider': 3.0.14
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
-      undici: 5.29.0
+      undici: 6.28.0
       zod: 4.4.3
 
   '@ai-sdk/provider@3.0.14':
@@ -1624,8 +1623,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
-
-  '@fastify/busboy@2.1.1': {}
 
   '@inquirer/ansi@2.0.7':
     optional: true
@@ -2057,7 +2054,7 @@ snapshots:
       set-cookie-parser: 3.1.2
     optional: true
 
-  hono@4.12.31: {}
+  hono@4.13.5: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -2216,7 +2213,7 @@ snapshots:
   mute-stream@3.0.0:
     optional: true
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nwsapi@2.2.24:
     optional: true
@@ -2242,7 +2239,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2414,9 +2411,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
+  undici@6.28.0: {}
 
   until-async@3.0.2:
     optional: true

--- a/mastracode/web/pnpm-workspace.yaml
+++ b/mastracode/web/pnpm-workspace.yaml
@@ -6,7 +6,10 @@
 packages:
   - '.'
 overrides:
+  hono@<4.12.34: 4.12.34
+  nanoid@>=3.0.0 <3.3.18: 3.3.18
   postcss@<8.5.23: 8.5.23
+  undici@<6.28.0: 6.28.0
 # Share pnpm's machine-global virtual store (same setting as the monorepo
 # root). With identical versions this makes react/react-dom resolve to the
 # exact same physical module as the `link:`ed monorepo packages use, so the


### PR DESCRIPTION
Raises the direct Hono floor and adds patched transitive floors for nanoid and undici in the standalone Mastra Code web project. The regenerated lockfile now resolves Hono 4.13.5, nanoid 3.3.18, and undici 6.28.0.

The frozen install, TypeScript check, and dependency audit pass with no known vulnerabilities. The web test run passed 85 tests; its two failures are unchanged baseline issues in the Markdown test import and workspace readiness scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates the web project to use safer versions of several dependencies. It also refreshes the lockfile so installs use the patched versions.

## Changes

- Raised the direct `hono` dependency floor.
- Added dependency overrides for:
  - `hono` `4.13.5`
  - `nanoid` `3.3.18`
  - `undici` `6.28.0`
- Retained the existing `postcss` override.
- Regenerated the lockfile.

## Validation

- Frozen install passed.
- TypeScript checks passed.
- Dependency audit passed with no known vulnerabilities.
- Web tests passed 85 tests.
- Two baseline test failures remain:
  - Markdown test imports.
  - Workspace readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->