### PR TITLE
fix(playground): secure preview Hono dependency

### DIFF
--- a/packages/playground/vercel-preview/package.json
+++ b/packages/playground/vercel-preview/package.json
@@ -16,7 +16,7 @@
     "@mastra/deployer-vercel": "link:../../../deployers/vercel",
     "@mastra/editor": "link:../../../packages/editor",
     "@mastra/memory": "link:../../../packages/memory",
-    "hono": "^4.12.8",
+    "hono": "^4.12.34",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/playground/vercel-preview/pnpm-lock.yaml
+++ b/packages/playground/vercel-preview/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: link:../../../packages/memory
         version: link:../../memory
       hono:
-        specifier: ^4.12.8
-        version: 4.12.31
+        specifier: ^4.12.34
+        version: 4.13.5
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -75,8 +75,8 @@ packages:
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
     engines: {node: '>=16.9.0'}
 
   turbo@2.10.5:
@@ -118,7 +118,7 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  hono@4.12.31: {}
+  hono@4.13.5: {}
 
   turbo@2.10.5:
     optionalDependencies:

--- a/packages/playground/vercel-preview/pnpm-workspace.yaml
+++ b/packages/playground/vercel-preview/pnpm-workspace.yaml
@@ -1,5 +1,9 @@
 packages:
   - '.'
 
+pnpm:
+  overrides:
+    hono@<4.12.34: 4.12.34
+
 # a dependency install script this project never needed must not fail a preview deploy
 strictDepBuilds: false


### PR DESCRIPTION
Raises the Vercel preview's direct Hono requirement from `^4.12.8` to `^4.12.34` and adds a matching standalone pnpm override. The regenerated lockfile now resolves Hono 4.13.5 instead of the vulnerable 4.12.31 release, addressing four Dependabot alerts.\n\nFrozen installation, typechecking, and dependency audit pass. The production build reaches Vercel packaging but cannot install the current unpublished `@mastra/core@1.63.1-alpha.2` workspace version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Vercel preview now requires a safer Hono version. The lockfile and workspace override prevent installation of a vulnerable version.

## Changes

- Raised the direct `hono` dependency from `^4.12.8` to `^4.12.34`.
- Added a pnpm override for Hono versions below `4.12.34`.
- Regenerated the lockfile to resolve Hono `4.13.5`.
- Addressed four Dependabot alerts.

## Validation

- Frozen installation passed.
- Typechecking passed.
- Dependency audit passed.
- The production build reached Vercel packaging but could not install unpublished `@mastra/core@1.63.1-alpha.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->