### PR TITLE
feat(core): add keyed isolated Knowledge runtimes

### DIFF
--- a/.changeset/funny-zoos-divide.md
+++ b/.changeset/funny-zoos-divide.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': minor
+'@mastra/libsql': patch
+'@mastra/pg': patch
+---
+
+Added keyed Knowledge instances with lazy initialization and physical storage isolation checks.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -321,6 +321,16 @@
         "default": "./dist/llm/index.cjs"
       }
     },
+    "./knowledge": {
+      "import": {
+        "types": "./dist/knowledge/index.d.ts",
+        "default": "./dist/knowledge/index.js"
+      },
+      "require": {
+        "types": "./dist/knowledge/index.d.ts",
+        "default": "./dist/knowledge/index.cjs"
+      }
+    },
     "./logger": {
       "import": {
         "types": "./dist/logger/index.d.ts",

--- a/packages/core/src/knowledge/__tests__/knowledge.test.ts
+++ b/packages/core/src/knowledge/__tests__/knowledge.test.ts
@@ -52,6 +52,20 @@ describe('Knowledge', () => {
     expect(mastra.getKnowledge('inherited')).toBe(inherited);
   });
 
+  it('initializes registries before editor registration can replace storage', () => {
+    const replacement = new InMemoryStore({ id: 'editor-storage' });
+    const editor = {
+      registerWithMastra(mastra: Mastra) {
+        mastra.setStorage(replacement);
+      },
+    } as unknown as NonNullable<ConstructorParameters<typeof Mastra>[0]>['editor'];
+
+    const mastra = new Mastra({ editor, logger: false });
+
+    expect(mastra.getStorage()?.id).toBe('editor-storage');
+    expect(mastra.listKnowledge()).toEqual({});
+  });
+
   it('fails explicitly for missing and duplicate registration keys', () => {
     const mastra = new Mastra({ logger: false });
     const first = new Knowledge({ id: 'first', storage: new InMemoryStore() });

--- a/packages/core/src/knowledge/__tests__/knowledge.test.ts
+++ b/packages/core/src/knowledge/__tests__/knowledge.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Mastra } from '../../mastra';
+import { InMemoryStore, MastraCompositeStore } from '../../storage';
+import { Knowledge } from '../index';
+
+const scope = ['org:acme', 'resource:mastra'];
+
+describe('Knowledge', () => {
+  it('registers default and named instances without eagerly initializing storage', async () => {
+    const defaultStorage = new InMemoryStore({ id: 'default-knowledge' });
+    const analyticsStorage = new InMemoryStore({ id: 'analytics-knowledge' });
+    const defaultInit = vi.spyOn(defaultStorage, 'init');
+    const analyticsInit = vi.spyOn(analyticsStorage, 'init');
+    const defaultKnowledge = new Knowledge({ id: 'default-instance', storage: defaultStorage });
+    const analytics = new Knowledge({ id: 'analytics-instance', storage: analyticsStorage });
+
+    const mastra = new Mastra({
+      knowledge: { default: defaultKnowledge, analytics },
+      logger: false,
+    });
+
+    expect(mastra.getKnowledge('default')).toBe(defaultKnowledge);
+    expect(mastra.getKnowledge('analytics')).toBe(analytics);
+    expect(mastra.listKnowledge()).toEqual({ default: defaultKnowledge, analytics });
+    expect(defaultInit).not.toHaveBeenCalled();
+    expect(analyticsInit).not.toHaveBeenCalled();
+
+    await Promise.all([defaultKnowledge.getStorage(), defaultKnowledge.getStorage()]);
+    expect(defaultInit).toHaveBeenCalledTimes(1);
+    expect(analyticsInit).not.toHaveBeenCalled();
+  });
+
+  it('keeps instances with separate storage backends isolated', async () => {
+    const first = new Knowledge({ storage: new InMemoryStore({ id: 'first' }) });
+    const second = new Knowledge({ storage: new InMemoryStore({ id: 'second' }) });
+
+    const node = await first.createNode({ id: 'shared-id', name: 'First', kind: 'topic', scope });
+
+    expect(node.id).toBe('shared-id');
+    await expect(second.getNode('shared-id')).resolves.toBeNull();
+  });
+
+  it('inherits Mastra storage only when the instance has no storage', async () => {
+    const storage = new InMemoryStore({ id: 'shared' });
+    const inherited = new Knowledge({ id: 'inherited' });
+    const ownedStorage = new InMemoryStore({ id: 'owned' });
+    const owned = new Knowledge({ id: 'owned', storage: ownedStorage });
+    const mastra = new Mastra({ storage, knowledge: { inherited, owned }, logger: false });
+
+    expect(await inherited.getStorage()).toBe(await storage.getStore('knowledge'));
+    expect(await owned.getStorage()).toBe(await ownedStorage.getStore('knowledge'));
+    expect(mastra.getKnowledge('inherited')).toBe(inherited);
+  });
+
+  it('fails explicitly for missing and duplicate registration keys', () => {
+    const mastra = new Mastra({ logger: false });
+    const first = new Knowledge({ id: 'first', storage: new InMemoryStore() });
+
+    expect(() => mastra.getKnowledge('missing')).toThrow('Knowledge with key missing not found');
+    mastra.addKnowledge(first, 'shared');
+    expect(() => mastra.addKnowledge(new Knowledge({ id: 'second', storage: new InMemoryStore() }), 'shared')).toThrow(
+      'Knowledge with key shared is already registered',
+    );
+  });
+
+  it('rejects multiple instances inheriting one Mastra storage backend', () => {
+    expect(
+      () =>
+        new Mastra({
+          knowledge: {
+            default: new Knowledge({ id: 'default' }),
+            analytics: new Knowledge({ id: 'analytics' }),
+          },
+          logger: false,
+        }),
+    ).toThrow('Knowledge instances cannot share a storage backend');
+  });
+
+  it('rejects multiple instances configured with the same storage object', () => {
+    const storage = new InMemoryStore();
+
+    expect(
+      () =>
+        new Mastra({
+          knowledge: {
+            default: new Knowledge({ id: 'default', storage }),
+            analytics: new Knowledge({ id: 'analytics', storage }),
+          },
+          logger: false,
+        }),
+    ).toThrow('Knowledge instances cannot share a storage backend');
+  });
+
+  it('rejects different composite stores that resolve to the same Knowledge domain', () => {
+    const storage = new InMemoryStore();
+    const first = new MastraCompositeStore({ id: 'first-wrapper', default: storage });
+    const second = new MastraCompositeStore({ id: 'second-wrapper', default: storage });
+
+    expect(
+      () =>
+        new Mastra({
+          knowledge: {
+            default: new Knowledge({ id: 'default', storage: first }),
+            analytics: new Knowledge({ id: 'analytics', storage: second }),
+          },
+          logger: false,
+        }),
+    ).toThrow('Knowledge instances cannot share a storage backend');
+  });
+
+  it('rejects distinct domain objects that identify the same physical backend', () => {
+    const firstStorage = new InMemoryStore();
+    const secondStorage = new InMemoryStore();
+    vi.spyOn(firstStorage.stores.knowledge!, 'getStorageIsolationKey').mockReturnValue('shared-backend');
+    vi.spyOn(secondStorage.stores.knowledge!, 'getStorageIsolationKey').mockReturnValue('shared-backend');
+    const first = new MastraCompositeStore({
+      id: 'first-wrapper',
+      domains: { knowledge: firstStorage.stores.knowledge },
+    });
+    const second = new MastraCompositeStore({
+      id: 'second-wrapper',
+      domains: { knowledge: secondStorage.stores.knowledge },
+    });
+
+    expect(
+      () =>
+        new Mastra({
+          knowledge: {
+            default: new Knowledge({ id: 'default', storage: first }),
+            analytics: new Knowledge({ id: 'analytics', storage: second }),
+          },
+          logger: false,
+        }),
+    ).toThrow('Knowledge instances cannot share a storage backend');
+  });
+
+  it.each(['inherited-first', 'owned-first'])(
+    'rejects own and inherited instances sharing Mastra storage (%s)',
+    order => {
+      const storage = new InMemoryStore();
+      const inherited = new Knowledge({ id: 'inherited' });
+      const owned = new Knowledge({ id: 'owned', storage });
+      const knowledge = order === 'inherited-first' ? { inherited, owned } : { owned, inherited };
+
+      expect(() => new Mastra({ storage, knowledge, logger: false })).toThrow(
+        'Knowledge instances cannot share a storage backend',
+      );
+    },
+  );
+
+  it('rejects sharing through the augmented Mastra storage accessor', () => {
+    const mastra = new Mastra({
+      storage: new InMemoryStore(),
+      knowledge: { default: new Knowledge({ id: 'default' }) },
+      logger: false,
+    });
+
+    expect(() =>
+      mastra.addKnowledge(new Knowledge({ id: 'analytics', storage: mastra.getStorage()! }), 'analytics'),
+    ).toThrow('Knowledge instances cannot share a storage backend');
+  });
+
+  it('updates inherited Knowledge when Mastra storage changes', async () => {
+    const original = new InMemoryStore({ id: 'original' });
+    const replacement = new InMemoryStore({ id: 'replacement' });
+    const knowledge = new Knowledge({ id: 'default' });
+    const mastra = new Mastra({ storage: original, knowledge: { default: knowledge }, logger: false });
+
+    expect(await knowledge.getStorage()).toBe(await original.getStore('knowledge'));
+    mastra.setStorage(replacement);
+    expect(await knowledge.getStorage()).toBe(await replacement.getStore('knowledge'));
+  });
+
+  it('rejects a Mastra storage update that would merge Knowledge instances', () => {
+    const replacement = new InMemoryStore({ id: 'replacement' });
+    const mastra = new Mastra({
+      knowledge: {
+        default: new Knowledge({ id: 'default' }),
+        analytics: new Knowledge({ id: 'analytics', storage: replacement }),
+      },
+      logger: false,
+    });
+
+    expect(() => mastra.setStorage(replacement)).toThrow(
+      'Cannot set Mastra storage because a named Knowledge instance already uses that backend',
+    );
+  });
+
+  it('rejects a Mastra storage wrapper that resolves to an owned Knowledge domain', () => {
+    const storage = new InMemoryStore();
+    const ownedWrapper = new MastraCompositeStore({ id: 'owned-wrapper', default: storage });
+    const replacementWrapper = new MastraCompositeStore({ id: 'replacement-wrapper', default: storage });
+    const mastra = new Mastra({
+      knowledge: {
+        default: new Knowledge({ id: 'default' }),
+        analytics: new Knowledge({ id: 'analytics', storage: ownedWrapper }),
+      },
+      logger: false,
+    });
+
+    expect(() => mastra.setStorage(replacementWrapper)).toThrow(
+      'Cannot set Mastra storage because a named Knowledge instance already uses that backend',
+    );
+  });
+
+  it('retries initialization after failure and coalesces concurrent callers', async () => {
+    const storage = new InMemoryStore();
+    const originalInit = storage.init.bind(storage);
+    const init = vi
+      .spyOn(storage, 'init')
+      .mockRejectedValueOnce(new Error('temporary init failure'))
+      .mockImplementation(originalInit);
+    const knowledge = new Knowledge({ storage });
+
+    const first = knowledge.getStorage();
+    const concurrent = knowledge.getStorage();
+    await expect(first).rejects.toThrow('temporary init failure');
+    await expect(concurrent).rejects.toThrow('temporary init failure');
+    expect(init).toHaveBeenCalledTimes(1);
+
+    await expect(knowledge.getStorage()).resolves.toBeDefined();
+    expect(init).toHaveBeenCalledTimes(2);
+  });
+
+  it('respects disableInit and reports adapters without v2 capability', async () => {
+    const disabledStorage = new InMemoryStore();
+    disabledStorage.disableInit = true;
+    const disabledInit = vi.spyOn(disabledStorage, 'init');
+    await new Knowledge({ storage: disabledStorage }).getStorage();
+    expect(disabledInit).not.toHaveBeenCalled();
+
+    const unsupportedStorage = new InMemoryStore();
+    const domain = unsupportedStorage.stores.knowledge!;
+    vi.spyOn(domain, 'getCapabilities').mockReturnValue({
+      contractVersion: 2,
+      schemaVersion: 1,
+      supportsV2: false,
+      supportsSchemaInspection: false,
+      supportsExplicitReset: false,
+    });
+
+    await expect(new Knowledge({ storage: unsupportedStorage }).getStorage()).rejects.toThrow(
+      'supports schema version 1, but Knowledge requires schema version 2',
+    );
+  });
+});

--- a/packages/core/src/knowledge/index.ts
+++ b/packages/core/src/knowledge/index.ts
@@ -1,0 +1,225 @@
+import { randomUUID } from 'node:crypto';
+import { MastraBase } from '../base';
+import type { Mastra } from '../mastra';
+import type { MastraCompositeStore } from '../storage';
+import type {
+  AppendKnowledgeInput,
+  ClaimKnowledgeSemanticOutboxInput,
+  CreateKnowledgeNodeInput,
+  KnowledgeScope,
+  KnowledgeScopeLevel,
+  KnowledgeSemanticOutboxEntry,
+  KnowledgeStorage,
+  ListKnowledgeNodesInput,
+  QueryKnowledgeBySourceInput,
+  QueryKnowledgeInput,
+  SearchKnowledgeInput,
+  UpdateKnowledgeNodeInput,
+} from '../storage/domains/knowledge';
+import { augmentWithInit, getStorageSource } from '../storage/storageWithInit';
+
+export interface KnowledgeConfig {
+  id?: string;
+  name?: string;
+  storage?: MastraCompositeStore;
+}
+
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export class Knowledge extends MastraBase {
+  readonly id: string;
+  readonly hasOwnStorage: boolean;
+
+  #storage?: MastraCompositeStore;
+  #storageSource?: MastraCompositeStore;
+  #storagePromise?: Promise<KnowledgeStorage>;
+
+  constructor(config: KnowledgeConfig = {}) {
+    super({ component: 'STORAGE', name: config.name ?? config.id ?? 'Knowledge' });
+    this.id = config.id ?? randomUUID();
+    this.hasOwnStorage = config.storage !== undefined;
+    if (config.storage) {
+      this.#storageSource = getStorageSource(config.storage);
+      this.#storage = augmentWithInit(config.storage);
+    }
+  }
+
+  /** @internal */
+  __registerMastra(_mastra: Mastra): void {}
+
+  /** @internal */
+  __sharesStorageWith(other: Knowledge): boolean {
+    if (!this.#storageSource || !other.#storageSource) return false;
+    if (this.#storageSource === other.#storageSource) return true;
+
+    const domain = this.#storageSource.stores?.knowledge;
+    const otherDomain = other.#storageSource.stores?.knowledge;
+    return (
+      domain !== undefined &&
+      otherDomain !== undefined &&
+      domain.getStorageIsolationKey() === otherDomain.getStorageIsolationKey()
+    );
+  }
+
+  /** @internal */
+  __usesStorage(storage: MastraCompositeStore): boolean {
+    const source = getStorageSource(storage);
+    if (this.#storageSource === source) return true;
+
+    const domain = this.#storageSource?.stores?.knowledge;
+    const sourceDomain = source.stores?.knowledge;
+    return (
+      domain !== undefined &&
+      sourceDomain !== undefined &&
+      domain.getStorageIsolationKey() === sourceDomain.getStorageIsolationKey()
+    );
+  }
+
+  /** @internal */
+  setStorage(storage: MastraCompositeStore, source: MastraCompositeStore = storage): void {
+    if (this.hasOwnStorage) return;
+    this.#storageSource = getStorageSource(source);
+    this.#storage = augmentWithInit(storage);
+    this.#storagePromise = undefined;
+  }
+
+  async getStorage(): Promise<KnowledgeStorage> {
+    if (!this.#storagePromise) {
+      const promise = this.#resolveStorage().catch(error => {
+        if (this.#storagePromise === promise) {
+          this.#storagePromise = undefined;
+        }
+        throw error;
+      });
+      this.#storagePromise = promise;
+    }
+    return this.#storagePromise;
+  }
+
+  async #resolveStorage(): Promise<KnowledgeStorage> {
+    if (!this.#storage) {
+      throw new Error(
+        'Knowledge requires a storage provider. Configure storage on the Knowledge instance or on the owning Mastra instance.',
+      );
+    }
+
+    const storage = await this.#storage.getStore('knowledge');
+    if (!storage) {
+      throw new Error('The configured storage provider does not provide a Knowledge storage domain.');
+    }
+
+    const capabilities = storage.getCapabilities();
+    if (!capabilities.supportsV2) {
+      throw new Error(
+        `The configured Knowledge storage adapter supports schema version ${capabilities.schemaVersion}, but Knowledge requires schema version 2.`,
+      );
+    }
+
+    return storage;
+  }
+
+  async createNode(input: CreateKnowledgeNodeInput) {
+    return (await this.getStorage()).createNode(input);
+  }
+
+  async getNode(id: string) {
+    return (await this.getStorage()).getNode(id);
+  }
+
+  async getNodeByName(input: { name: string; scope: KnowledgeScope }) {
+    return (await this.getStorage()).getNodeByName(input);
+  }
+
+  async resolveNode(input: { name: string; scope: KnowledgeScope }) {
+    return (await this.getStorage()).resolveNode(input);
+  }
+
+  async listNodes(input: ListKnowledgeNodesInput) {
+    return (await this.getStorage()).listNodes(input);
+  }
+
+  async updateNode(input: UpdateKnowledgeNodeInput) {
+    return (await this.getStorage()).updateNode(input);
+  }
+
+  async mergeNodes(input: { sourceId: string; targetId: string; sourceVersion: number }) {
+    return (await this.getStorage()).mergeNodes(input);
+  }
+
+  async appendKnowledge(input: AppendKnowledgeInput) {
+    return (await this.getStorage()).appendKnowledge(input);
+  }
+
+  async getKnowledge(input: { id: string; includeDeleted?: boolean }) {
+    return (await this.getStorage()).getKnowledge(input);
+  }
+
+  async listKnowledgeAbout(input: QueryKnowledgeInput) {
+    return (await this.getStorage()).listKnowledgeAbout(input);
+  }
+
+  async listKnowledgeMentioning(input: QueryKnowledgeInput) {
+    return (await this.getStorage()).listKnowledgeMentioning(input);
+  }
+
+  async listKnowledgeRelatedTo(input: QueryKnowledgeInput) {
+    return (await this.getStorage()).listKnowledgeRelatedTo(input);
+  }
+
+  async knowledgeBySource(input: QueryKnowledgeBySourceInput) {
+    return (await this.getStorage()).knowledgeBySource(input);
+  }
+
+  async removeKnowledge(input: { id: string; deletedBy: string }) {
+    return (await this.getStorage()).removeKnowledge(input);
+  }
+
+  async restoreKnowledge(input: { id: string }) {
+    return (await this.getStorage()).restoreKnowledge(input);
+  }
+
+  async rescopeKnowledge(input: { id: string; scope: KnowledgeScope }) {
+    return (await this.getStorage()).rescopeKnowledge(input);
+  }
+
+  async raiseKnowledgeCeiling(input: { id: string; maxScope?: KnowledgeScopeLevel }) {
+    return (await this.getStorage()).raiseKnowledgeCeiling(input);
+  }
+
+  async search(input: SearchKnowledgeInput) {
+    return (await this.getStorage()).search(input);
+  }
+
+  async getCurationCursor(input: { sourceThreadId: string; agent: string }) {
+    return (await this.getStorage()).getCurationCursor(input);
+  }
+
+  async advanceCurationCursor(input: { sourceThreadId: string; agent: string; lastKnowledgeId: string }) {
+    return (await this.getStorage()).advanceCurationCursor(input);
+  }
+
+  async listActivity(input: { scope: KnowledgeScope; after?: string; limit?: number }) {
+    return (await this.getStorage()).listActivity(input);
+  }
+
+  async listSemanticOutbox(input?: {
+    status?: KnowledgeSemanticOutboxEntry['status'];
+    scope?: KnowledgeScope;
+    limit?: number;
+  }) {
+    return (await this.getStorage()).listSemanticOutbox(input);
+  }
+
+  async claimSemanticOutbox(input: ClaimKnowledgeSemanticOutboxInput) {
+    return (await this.getStorage()).claimSemanticOutbox(input);
+  }
+
+  async completeSemanticOutbox(input: { ids: string[]; workerId: string }) {
+    return (await this.getStorage()).completeSemanticOutbox(input);
+  }
+
+  async releaseSemanticOutbox(input: { ids: string[]; workerId: string; retryAt?: Date }) {
+    return (await this.getStorage()).releaseSemanticOutbox(input);
+  }
+}
+
+export * from '../storage/domains/knowledge';

--- a/packages/core/src/knowledge/types.test-d.ts
+++ b/packages/core/src/knowledge/types.test-d.ts
@@ -1,0 +1,19 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { Mastra } from '../mastra';
+import { InMemoryStore } from '../storage';
+import { Knowledge } from './index';
+
+describe('Knowledge public types', () => {
+  it('preserves keyed instance types through Mastra accessors', () => {
+    const primary = new Knowledge({ id: 'primary', storage: new InMemoryStore() });
+    const analytics = new Knowledge({ id: 'analytics', storage: new InMemoryStore() });
+    const mastra = new Mastra({ knowledge: { default: primary, analytics } });
+
+    expectTypeOf(mastra.getKnowledge('default')).toEqualTypeOf<Knowledge>();
+    expectTypeOf(mastra.getKnowledge('analytics')).toEqualTypeOf<Knowledge>();
+    expectTypeOf(mastra.listKnowledge()).toEqualTypeOf<{
+      default: Knowledge;
+      analytics: Knowledge;
+    }>();
+  });
+});

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1642,6 +1642,21 @@ export class Mastra<
     };
     this.#logger = this.#wireLoggerObservability(this.#logger);
 
+    // Initialize primitive registries before registering storage or editor integrations.
+    // Those integrations can call back into Mastra during construction (for example,
+    // an editor can replace storage), so registry-dependent methods must already be safe.
+    this.#vectors = {} as TVectors;
+    this.#mcpServers = {} as TMCPServers;
+    this.#tts = {} as TTTS;
+    this.#agents = {} as TAgents;
+    this.#scorers = {} as TScorers;
+    this.#tools = {} as TTools;
+    this.#processors = {} as TProcessors;
+    this.#memory = {} as TMemory;
+    this.#knowledge = {} as TKnowledge;
+    this.#workflows = {} as TWorkflows;
+    this.#gateways = {} as Record<string, MastraModelGatewayInterface>;
+
     this.#storage = storage;
 
     // Give storage adapters a back-pointer to this Mastra instance so they
@@ -1681,19 +1696,6 @@ export class Mastra<
     this.#schedulerConfig = config?.scheduler;
     this.#notificationDispatchConfig = config?.notifications?.dispatch;
     this.#schedulesConfig = config?.schedules;
-
-    // Initialize all primitive storage objects first, we need to do this before adding primitives to avoid circular dependencies
-    this.#vectors = {} as TVectors;
-    this.#mcpServers = {} as TMCPServers;
-    this.#tts = {} as TTTS;
-    this.#agents = {} as TAgents;
-    this.#scorers = {} as TScorers;
-    this.#tools = {} as TTools;
-    this.#processors = {} as TProcessors;
-    this.#memory = {} as TMemory;
-    this.#knowledge = {} as TKnowledge;
-    this.#workflows = {} as TWorkflows;
-    this.#gateways = {} as Record<string, MastraModelGatewayInterface>;
 
     // Now add primitives - order matters for auto-registration
     // Tools and processors should be added before agents and MCP servers that might use them

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -24,6 +24,7 @@ import { isRunLocalTopic } from '../events/topics';
 import type { Event, EventCallback } from '../events/types';
 import type { Harness } from '../harness';
 import { AvailableHooks, deregisterHook, registerHook } from '../hooks';
+import { Knowledge } from '../knowledge';
 import { LicenseClient } from '../license';
 import type { MastraModelGatewayInterface } from '../llm/model/gateways';
 import { getGatewayId } from '../llm/model/gateways';
@@ -72,7 +73,7 @@ import { BackgroundTasksInMemory } from '../storage/domains/background-tasks/inm
 import { InMemoryDB } from '../storage/domains/inmemory-db';
 import type { Schedule, ScheduleUpdate, SchedulesStorage } from '../storage/domains/schedules/base';
 import { WorkflowsInMemory } from '../storage/domains/workflows/inmemory';
-import { augmentWithInit } from '../storage/storageWithInit';
+import { augmentWithInit, getStorageSource } from '../storage/storageWithInit';
 import type { StorageResolvedPromptBlockType } from '../storage/types';
 import { trackFeatureUsage } from '../telemetry/feature-telemetry';
 import type { ToolLoopAgentLike } from '../tool-loop-agent';
@@ -128,6 +129,7 @@ function createUndefinedPrimitiveError(
     | 'mcp-server'
     | 'gateway'
     | 'memory'
+    | 'knowledge'
     | 'workspace',
   value: null | undefined,
   key?: string,
@@ -268,6 +270,7 @@ export interface Config<
   TProcessors extends Record<string, Processor<any>> = Record<string, Processor<any>>,
   TMemory extends Record<string, MastraMemory> = Record<string, MastraMemory>,
   TChannels extends Record<string, ChannelProvider> = Record<string, ChannelProvider>,
+  TKnowledge extends Record<string, Knowledge> = Record<string, Knowledge>,
 > {
   /**
    * Agents are autonomous systems that can make decisions and take actions.
@@ -463,6 +466,11 @@ export interface Config<
    * Keys are used to look up memory instances when resolving stored agent configurations.
    */
   memory?: TMemory;
+
+  /**
+   * Knowledge instances registered by stable application key.
+   */
+  knowledge?: TKnowledge;
 
   /**
    * Global workspace for file storage, skills, and code execution.
@@ -765,6 +773,7 @@ export class Mastra<
   TProcessors extends Record<string, Processor<any>> = Record<string, Processor<any>>,
   TMemory extends Record<string, MastraMemory> = Record<string, MastraMemory>,
   TChannels extends Record<string, ChannelProvider> = Record<string, ChannelProvider>,
+  TKnowledge extends Record<string, Knowledge> = Record<string, Knowledge>,
 > {
   #vectors?: TVectors;
   #agents: TAgents;
@@ -787,6 +796,7 @@ export class Mastra<
   }> = [];
 
   #storage?: MastraCompositeStore;
+  #storageSource?: MastraCompositeStore;
   #storageExplicit = false;
   #storageFallbackWarningPending = false;
   #recoveryConfig: MastraRecoveryConfig = { durableAgents: 'off' };
@@ -796,6 +806,7 @@ export class Mastra<
   #processorConfigurations: Map<string, Array<{ processor: Processor; agentId: string; type: 'input' | 'output' }>> =
     new Map();
   #memory?: TMemory;
+  #knowledge: TKnowledge;
   #workspace?: Workspace;
   #workspaces: Record<string, RegisteredWorkspace> = {};
   #server?: ServerConfig;
@@ -1423,7 +1434,8 @@ export class Mastra<
       TTools,
       TProcessors,
       TMemory,
-      TChannels
+      TChannels,
+      TKnowledge
     >,
   ) {
     // Register AsyncLocalStorage-backed context resolvers so that DualLogger
@@ -1578,6 +1590,7 @@ export class Mastra<
         );
       });
     }
+    this.#storageSource = getStorageSource(storage);
     storage = augmentWithInit(storage);
 
     // The evented workflow engine (used internally by the agentic loop) requires
@@ -1678,6 +1691,7 @@ export class Mastra<
     this.#tools = {} as TTools;
     this.#processors = {} as TProcessors;
     this.#memory = {} as TMemory;
+    this.#knowledge = {} as TKnowledge;
     this.#workflows = {} as TWorkflows;
     this.#gateways = {} as Record<string, MastraModelGatewayInterface>;
 
@@ -1705,6 +1719,14 @@ export class Mastra<
       Object.entries(config.memory).forEach(([key, memory]) => {
         if (memory != null) {
           this.addMemory(memory, key);
+        }
+      });
+    }
+
+    if (config?.knowledge) {
+      Object.entries(config.knowledge).forEach(([key, knowledge]) => {
+        if (knowledge != null) {
+          this.addKnowledge(knowledge, key);
         }
       });
     }
@@ -4731,6 +4753,75 @@ export class Mastra<
     return this.#processorConfigurations;
   }
 
+  /** Retrieves a registered Knowledge instance by its application key. */
+  public getKnowledge<TKnowledgeKey extends keyof TKnowledge>(key: TKnowledgeKey): TKnowledge[TKnowledgeKey] {
+    const knowledge = this.#knowledge[key];
+    if (!knowledge) {
+      const error = new MastraError({
+        id: 'MASTRA_GET_KNOWLEDGE_BY_KEY_NOT_FOUND',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: `Knowledge with key ${String(key)} not found`,
+        details: {
+          status: 404,
+          knowledgeKey: String(key),
+          availableKeys: Object.keys(this.#knowledge).join(', '),
+        },
+      });
+      this.#logger?.trackException(error);
+      throw error;
+    }
+    return knowledge;
+  }
+
+  /** Returns all registered Knowledge instances keyed by application key. */
+  public listKnowledge(): TKnowledge {
+    return this.#knowledge;
+  }
+
+  /** Registers a Knowledge instance without initializing its storage. */
+  public addKnowledge<K extends Knowledge>(knowledge: K, key?: string): void {
+    if (!knowledge) {
+      throw createUndefinedPrimitiveError('knowledge', knowledge, key);
+    }
+
+    const knowledgeKey = key ?? knowledge.id;
+    const registry = this.#knowledge as Record<string, Knowledge>;
+    if (registry[knowledgeKey]) {
+      throw new MastraError({
+        id: 'MASTRA_ADD_KNOWLEDGE_DUPLICATE_KEY',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: `Knowledge with key ${knowledgeKey} is already registered`,
+        details: { status: 409, knowledgeKey },
+      });
+    }
+    if (
+      Object.values(registry).some(
+        instance =>
+          (!knowledge.hasOwnStorage && !instance.hasOwnStorage) ||
+          knowledge.__sharesStorageWith(instance) ||
+          (!knowledge.hasOwnStorage &&
+            this.#storageSource !== undefined &&
+            instance.__usesStorage(this.#storageSource)),
+      )
+    ) {
+      throw new MastraError({
+        id: 'MASTRA_ADD_KNOWLEDGE_SHARED_STORAGE',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: 'Knowledge instances cannot share a storage backend. Configure separate storage on named instances to preserve isolation.',
+        details: { status: 409, knowledgeKey },
+      });
+    }
+
+    knowledge.__registerMastra(this);
+    if (!knowledge.hasOwnStorage && this.#storage) {
+      knowledge.setStorage(this.#storage, this.#storageSource);
+    }
+    registry[knowledgeKey] = knowledge;
+  }
+
   /**
    * Retrieves a registered memory instance by its registration key.
    *
@@ -5611,9 +5702,29 @@ export class Mastra<
    * ```
    */
   public setStorage(storage: MastraCompositeStore) {
+    const knowledgeInstances = Object.values(this.#knowledge);
+    if (
+      knowledgeInstances.some(instance => !instance.hasOwnStorage) &&
+      knowledgeInstances.some(instance => instance.hasOwnStorage && instance.__usesStorage(storage))
+    ) {
+      throw new MastraError({
+        id: 'MASTRA_SET_STORAGE_KNOWLEDGE_CONFLICT',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: 'Cannot set Mastra storage because a named Knowledge instance already uses that backend.',
+        details: { status: 409 },
+      });
+    }
+
     this.#storageFallbackWarningPending = false;
+    this.#storageSource = getStorageSource(storage);
     this.#storage = augmentWithInit(storage);
     this.#storage?.__registerMastra?.(this as unknown as Parameters<NonNullable<typeof storage.__registerMastra>>[0]);
+    for (const knowledge of Object.values(this.#knowledge)) {
+      if (!knowledge.hasOwnStorage) {
+        knowledge.setStorage(this.#storage, this.#storageSource);
+      }
+    }
     this.#ensureBackgroundTaskManager();
     // If storage was attached after construction, the SchedulerWorker
     // will pick it up when startWorkers() is called.

--- a/packages/core/src/storage/domains/knowledge/base.ts
+++ b/packages/core/src/storage/domains/knowledge/base.ts
@@ -630,8 +630,16 @@ export function knowledgeSemanticIdempotencyKey(
 
 /** @experimental Knowledge APIs are experimental and may change without notice. */
 export abstract class KnowledgeStorage extends StorageDomain {
-  constructor() {
+  readonly #storageIsolationKey: unknown;
+
+  constructor(config: { storageIsolationKey?: unknown } = {}) {
     super({ component: 'STORAGE', name: 'KNOWLEDGE' });
+    this.#storageIsolationKey = config.storageIsolationKey ?? this;
+  }
+
+  /** Identifies the physical Knowledge backend and namespace used by this domain. */
+  getStorageIsolationKey(): unknown {
+    return this.#storageIsolationKey;
   }
 
   getCapabilities(): KnowledgeStorageCapabilities {

--- a/packages/core/src/storage/storageWithInit.test.ts
+++ b/packages/core/src/storage/storageWithInit.test.ts
@@ -3,7 +3,7 @@ import { MastraCompositeStore } from './base';
 import type { MastraStorage } from './base';
 import { InMemoryDB } from './domains/inmemory-db';
 import { InMemoryKnowledgeStorage } from './domains/knowledge';
-import { augmentWithInit } from './storageWithInit';
+import { augmentWithInit, getStorageSource } from './storageWithInit';
 
 describe('augmentWithInit', () => {
   it('should augment the storage with init', async () => {
@@ -28,6 +28,14 @@ describe('augmentWithInit', () => {
 
     expect(initializedKnowledge).toBe(knowledge);
     expect(knowledgeInitSpy).toHaveBeenCalledOnce();
+  });
+
+  it('retains the original storage identity across augmentation', () => {
+    const storage = new MastraCompositeStore({ id: 'source' });
+    const augmented = augmentWithInit(storage);
+
+    expect(getStorageSource(storage)).toBe(storage);
+    expect(getStorageSource(augmented)).toBe(storage);
   });
 
   it("shouln't double augment the storage", async () => {

--- a/packages/core/src/storage/storageWithInit.ts
+++ b/packages/core/src/storage/storageWithInit.ts
@@ -2,6 +2,12 @@ import type { IMastraLogger } from '../logger';
 import type { MastraCompositeStore } from './base';
 
 const isAugmentedSymbol = Symbol('isAugmented');
+const storageSources = new WeakMap<MastraCompositeStore, MastraCompositeStore>();
+
+export function getStorageSource(storage: MastraCompositeStore): MastraCompositeStore {
+  return storageSources.get(storage) ?? storage;
+}
+
 const initIndependentMethods = new Set<PropertyKey>([
   '__registerMastra',
   '__setLogger',
@@ -107,5 +113,6 @@ export function augmentWithInit(storage: MastraCompositeStore): MastraCompositeS
     },
   });
 
+  storageSources.set(proxy, getStorageSource(storage));
   return proxy;
 }

--- a/stores/libsql/src/storage/db/index.ts
+++ b/stores/libsql/src/storage/db/index.ts
@@ -24,6 +24,8 @@ import { withClientWriteLock } from './write-lock';
  * Base configuration options shared across LibSQL domain configurations
  */
 export type LibSQLDomainBaseConfig = {
+  /** @internal Identifies the physical backend and namespace for keyed Knowledge isolation. */
+  storageIsolationKey?: unknown;
   /**
    * Maximum number of retries for write operations if an SQLITE_BUSY error occurs.
    * @default 5

--- a/stores/libsql/src/storage/domains/knowledge/index.test.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.test.ts
@@ -16,7 +16,7 @@ import * as coreStorage from '@mastra/core/storage';
 import { describe, expect, it, vi } from 'vitest';
 
 import { withClientWriteLock } from '../../db/write-lock';
-import { KnowledgeLibSQL } from '.';
+import { getLibSQLKnowledgeIsolationKey, KnowledgeLibSQL } from '.';
 
 const COMPAT_CONSTANTS = [
   'KNOWLEDGE_ACCESS_STATE_SCHEMA',
@@ -95,6 +95,23 @@ async function seedPublishedKnowledgeV1(client: ReturnType<typeof createClient>)
     'write',
   );
 }
+
+describe('KnowledgeLibSQL storage isolation', () => {
+  it('identifies domains configured for the same URL as one physical backend', () => {
+    expect(new KnowledgeLibSQL({ url: 'file:shared.db' }).getStorageIsolationKey()).toBe(
+      new KnowledgeLibSQL({ url: 'file:./shared.db' }).getStorageIsolationKey(),
+    );
+    expect(getLibSQLKnowledgeIsolationKey({ url: 'file:///tmp/shared.db' })).toBe(
+      getLibSQLKnowledgeIsolationKey({ url: 'file://localhost/tmp/shared.db' }),
+    );
+    expect(getLibSQLKnowledgeIsolationKey({ url: 'libsql://EXAMPLE.com/db?mode=ro' })).toBe(
+      getLibSQLKnowledgeIsolationKey({ url: 'libsql://example.com:443/db' }),
+    );
+    expect(new KnowledgeLibSQL({ url: 'file:first.db' }).getStorageIsolationKey()).not.toBe(
+      new KnowledgeLibSQL({ url: 'file:second.db' }).getStorageIsolationKey(),
+    );
+  });
+});
 
 createKnowledgeSchemaResetTests(async () => {
   const client = createClient({ url: ':memory:' });

--- a/stores/libsql/src/storage/domains/knowledge/index.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import {
   KNOWLEDGE_ACCESS_STATE_SCHEMA,
   KNOWLEDGE_IMPORT_RUNS_SCHEMA,
@@ -192,13 +194,42 @@ const knowledgeV2TableSchemas = new Map([
   [TABLE_KNOWLEDGE_PROPOSALS, KNOWLEDGE_PROPOSALS_SCHEMA],
 ]);
 
+function canonicalizeLibSQLUrl(url: string): string | undefined {
+  if (url.includes(':memory:')) return undefined;
+  if (url.startsWith('file:')) {
+    const [path] = url.slice('file:'.length).split('?');
+    if (url.startsWith('file://')) {
+      const parsed = new URL(url);
+      const host = parsed.hostname.toLocaleLowerCase();
+      const filePath = host && host !== 'localhost' ? `//${host}${parsed.pathname}` : parsed.pathname;
+      return `file:${resolve(decodeURIComponent(filePath))}`;
+    }
+    return `file:${resolve(decodeURIComponent(path!))}`;
+  }
+
+  try {
+    const parsed = new URL(url);
+    const port = parsed.port || (parsed.protocol === 'libsql:' || parsed.protocol === 'https:' ? '443' : '80');
+    return `${parsed.protocol}//${parsed.hostname.toLocaleLowerCase()}:${port}${parsed.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
+export function getLibSQLKnowledgeIsolationKey(config: { url?: string; client?: Client }, client?: Client): unknown {
+  const urlKey = config.url ? canonicalizeLibSQLUrl(config.url) : undefined;
+  return urlKey ? `libsql:${urlKey}` : (client ?? config.client ?? config);
+}
+
 export class KnowledgeLibSQL extends KnowledgeStorage {
   readonly #client: Client;
   readonly #db: LibSQLDB;
 
   constructor(config: LibSQLDomainConfig) {
-    super();
-    this.#client = resolveClient(config);
+    const client = resolveClient(config);
+    const storageIsolationKey = config.storageIsolationKey ?? getLibSQLKnowledgeIsolationKey(config, client);
+    super({ storageIsolationKey });
+    this.#client = client;
     this.#db = new LibSQLDB({
       client: this.#client,
       maxRetries: config.maxRetries,

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -13,7 +13,7 @@ import { DatasetsLibSQL } from './domains/datasets';
 import { ExperimentsLibSQL } from './domains/experiments';
 import { FavoritesLibSQL } from './domains/favorites';
 import { HarnessLibSQL } from './domains/harness';
-import { KnowledgeLibSQL } from './domains/knowledge';
+import { getLibSQLKnowledgeIsolationKey, KnowledgeLibSQL } from './domains/knowledge';
 import { MCPClientsLibSQL } from './domains/mcp-clients';
 import { MCPServersLibSQL } from './domains/mcp-servers';
 import { MemoryLibSQL } from './domains/memory';
@@ -246,7 +246,10 @@ export class LibSQLStore extends MastraCompositeStore {
     const workflows = new WorkflowsLibSQL(domainConfig);
     const workflowDefinitions = new WorkflowDefinitionsLibSQL(domainConfig);
     const memory = new MemoryLibSQL(domainConfig);
-    const knowledge = new KnowledgeLibSQL(domainConfig);
+    const knowledge = new KnowledgeLibSQL({
+      ...domainConfig,
+      storageIsolationKey: getLibSQLKnowledgeIsolationKey(config, this.client),
+    });
     const observability = new ObservabilityLibSQL(domainConfig);
     const agents = new AgentsLibSQL(domainConfig);
     const channels = new ChannelsLibSQL(domainConfig);

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -35,7 +35,10 @@ export type { DbClient } from '../client';
  * 1. An existing database client (Pool or PoolAdapter)
  * 2. Config to create a new pool internally
  */
-export type PgDomainConfig = PgDomainClientConfig | PgDomainPoolConfig | PgDomainRestConfig;
+export type PgDomainConfig = (PgDomainClientConfig | PgDomainPoolConfig | PgDomainRestConfig) & {
+  /** @internal Identifies the physical backend and namespace for keyed Knowledge isolation. */
+  storageIsolationKey?: unknown;
+};
 
 /**
  * Pass an existing database client (DbClient)

--- a/stores/pg/src/storage/domains/knowledge/index.test.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.test.ts
@@ -18,9 +18,10 @@ import {
 import { Pool } from 'pg';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 
+import { PoolAdapter } from '../../client';
 import { generateTableSQL } from '../../db';
 import { connectionString } from '../../test-utils';
-import { KnowledgePG, postgresSql } from '.';
+import { getPgKnowledgeIsolationKey, KnowledgePG, postgresSql } from '.';
 
 vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
 
@@ -38,6 +39,40 @@ describe('PostgreSQL knowledge SQL normalization', () => {
 });
 
 const pool = new Pool({ connectionString });
+
+describe('KnowledgePG storage isolation', () => {
+  it('identifies domains using the same pool and schema as one physical backend', () => {
+    expect(new KnowledgePG({ pool, schemaName: 'shared' }).getStorageIsolationKey()).toBe(
+      new KnowledgePG({ pool, schemaName: 'shared' }).getStorageIsolationKey(),
+    );
+    expect(new KnowledgePG({ pool, schemaName: 'first' }).getStorageIsolationKey()).not.toBe(
+      new KnowledgePG({ pool, schemaName: 'second' }).getStorageIsolationKey(),
+    );
+  });
+
+  it('canonicalizes equivalent connection forms', () => {
+    expect(
+      getPgKnowledgeIsolationKey({
+        connectionString: 'postgresql://first:secret@EXAMPLE.com/knowledge?sslmode=require',
+        schemaName: 'shared',
+      }),
+    ).toBe(
+      getPgKnowledgeIsolationKey({
+        host: 'example.com',
+        port: 5432,
+        database: 'knowledge',
+        schemaName: 'shared',
+      }),
+    );
+  });
+
+  it('resolves separate client wrappers around the same pool', () => {
+    expect(new KnowledgePG({ client: new PoolAdapter(pool), schemaName: 'shared' }).getStorageIsolationKey()).toBe(
+      new KnowledgePG({ client: new PoolAdapter(pool), schemaName: 'shared' }).getStorageIsolationKey(),
+    );
+  });
+});
+
 const createStore = (schemaName?: string) => new KnowledgePG({ pool, schemaName });
 createKnowledgeStorageTests(createStore);
 

--- a/stores/pg/src/storage/domains/knowledge/index.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.ts
@@ -416,6 +416,72 @@ const knowledgeTableDefinitions: Array<{
   { tableName: TABLE_KNOWLEDGE_SEMANTIC_OUTBOX, schema: KNOWLEDGE_SEMANTIC_OUTBOX_SCHEMA },
 ];
 
+const pgKnowledgeIsolationKeys = new WeakMap<object, Map<string, object>>();
+
+type PgKnowledgeIsolationConfig = {
+  schemaName?: string;
+  client?: DbClient;
+  pool?: object;
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  database?: string;
+};
+
+function canonicalPgTarget(config: PgKnowledgeIsolationConfig): string | undefined {
+  if (config.connectionString) {
+    try {
+      const parsed = new URL(config.connectionString);
+      const host = decodeURIComponent(parsed.hostname).toLocaleLowerCase();
+      const port = parsed.port || '5432';
+      const database = decodeURIComponent(parsed.pathname.slice(1));
+      return `${host}:${port}/${database}`;
+    } catch {
+      return config.connectionString;
+    }
+  }
+
+  if (config.host && config.database) {
+    const host = config.host.startsWith('/') ? config.host : config.host.toLocaleLowerCase();
+    return `${host}:${config.port ?? 5432}/${config.database}`;
+  }
+
+  return undefined;
+}
+
+function pgSourceConfig(source: object | undefined): PgKnowledgeIsolationConfig | undefined {
+  if (!source || !('options' in source)) return undefined;
+  return (source as { options?: PgKnowledgeIsolationConfig }).options;
+}
+
+function pgClientPool(client: DbClient | undefined): object | undefined {
+  if (!client || !('$pool' in client)) return undefined;
+  return (client as DbClient & { $pool?: object }).$pool;
+}
+
+export function getPgKnowledgeIsolationKey(config: PgKnowledgeIsolationConfig): unknown {
+  const schema = config.schemaName ?? 'public';
+  const pool = config.pool ?? pgClientPool(config.client);
+  const target = canonicalPgTarget(config) ?? canonicalPgTarget(pgSourceConfig(pool) ?? {});
+  if (target) return `pg:${target}:schema:${schema}`;
+
+  const source = pool ?? config.client;
+  if (source) {
+    let schemaKeys = pgKnowledgeIsolationKeys.get(source);
+    if (!schemaKeys) {
+      schemaKeys = new Map();
+      pgKnowledgeIsolationKeys.set(source, schemaKeys);
+    }
+    let key = schemaKeys.get(schema);
+    if (!key) {
+      key = {};
+      schemaKeys.set(schema, key);
+    }
+    return key;
+  }
+  return config;
+}
+
 export class KnowledgePG extends KnowledgeStorage {
   static readonly MANAGED_TABLES = KNOWLEDGE_TABLE_NAMES;
 
@@ -440,7 +506,7 @@ export class KnowledgePG extends KnowledgeStorage {
   readonly #schemaName?: string;
 
   constructor(config: PgDomainConfig) {
-    super();
+    super({ storageIsolationKey: config.storageIsolationKey ?? getPgKnowledgeIsolationKey(config) });
     const { client, readClient, schemaName, skipDefaultIndexes } = resolvePgConfig(config);
     this.#client = client;
     this.#schemaName = schemaName;

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -26,7 +26,7 @@ import { ChannelsPG } from './domains/channels';
 import { DatasetsPG } from './domains/datasets';
 import { ExperimentsPG } from './domains/experiments';
 import { FavoritesPG } from './domains/favorites';
-import { KnowledgePG } from './domains/knowledge';
+import { getPgKnowledgeIsolationKey, KnowledgePG } from './domains/knowledge';
 import { MCPClientsPG } from './domains/mcp-clients';
 import { MCPServersPG } from './domains/mcp-servers';
 import { MemoryPG } from './domains/memory';
@@ -250,7 +250,7 @@ export class PostgresStore extends MastraCompositeStore {
         workflows: new WorkflowsPG(domainConfig),
         workflowDefinitions: new WorkflowDefinitionsPG(domainConfig),
         memory: new MemoryPG(domainConfig),
-        knowledge: new KnowledgePG(domainConfig),
+        knowledge: new KnowledgePG({ ...domainConfig, storageIsolationKey: getPgKnowledgeIsolationKey(config) }),
         notifications: new NotificationsPG(domainConfig),
         observability: new ObservabilityPG(domainConfig),
         agents: new AgentsPG(domainConfig),


### PR DESCRIPTION
Wave: 1 of 4
Segment: W1.3 of 8
Purpose: Add first-class keyed Knowledge runtimes with lazy initialization and fail-closed physical storage isolation.
Previous PR: https://github.com/mastra-ai/mastra/pull/22507
Next PR: https://github.com/mastra-ai/mastra/pull/22513
Previous wave: None
Next wave: feat/knowledge-v2-w2-contract (planned)

## Summary

- adds `Knowledge` as a Core runtime and publishes it through `@mastra/core/knowledge`
- registers default and named Knowledge instances on `Mastra` with typed lookup/list APIs and explicit duplicate/missing-key errors
- lazily initializes each runtime, coalesces concurrent initialization, retries transient failures, and reports unsupported-v2 capability errors without fallback
- rebinds inherited storage when Mastra storage changes while preserving explicitly owned storage
- rejects multiple Knowledge runtimes that target the same physical backend, including equivalent LibSQL URLs and equivalent PostgreSQL endpoint/database/schema configurations

## Test plan

- `pnpm --filter ./packages/core exec vitest run src/knowledge/__tests__/knowledge.test.ts src/storage/storageWithInit.test.ts --reporter=dot --bail=1` (34 passed, no type errors)
- `pnpm --filter ./packages/core check`
- `pnpm build:core`
- `pnpm --filter ./stores/libsql exec vitest run src/storage/domains/knowledge/index.test.ts --reporter=dot --bail=1` (30 passed)
- `pnpm --filter ./stores/libsql build:lib`
- `pnpm --filter ./stores/pg exec vitest run src/storage/domains/knowledge/index.test.ts --reporter=dot --bail=1` (36 passed)
- `pnpm --filter ./stores/pg build:lib`
- LibSQL, PostgreSQL, MySQL, and MongoDB adapter builds
- Prettier, Oxlint, and `git diff --check`
- built package export/declaration probes for `@mastra/core/knowledge`

