### PR TITLE
feat(core): reconcile structured Knowledge plans

### DIFF
--- a/.changeset/clear-webs-walk.md
+++ b/.changeset/clear-webs-walk.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added structured Knowledge scope reconciliation with lazy, idempotent materialization.

--- a/.changeset/gentle-cooks-burn.md
+++ b/.changeset/gentle-cooks-burn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': minor
+---
+
+Added transactional Knowledge scope reconciliation for LibSQL storage.

--- a/.changeset/thin-tips-care.md
+++ b/.changeset/thin-tips-care.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': minor
+---
+
+Added transactional Knowledge scope reconciliation for PostgreSQL storage.

--- a/packages/_internal-core/src/knowledge-compat/index.ts
+++ b/packages/_internal-core/src/knowledge-compat/index.ts
@@ -11,6 +11,8 @@ export const MAX_KNOWLEDGE_SCOPE_NODES = 1000;
 export interface KnowledgeScopeNodeSummary {
   /** UUID of the `isScope` node. */
   id: string;
+  /** Canonical address the scope node was reconciled from (e.g. `features:memory`). */
+  address: string;
   name: string;
   kind?: string;
   description?: string;

--- a/packages/_internal-core/src/knowledge-compat/index.ts
+++ b/packages/_internal-core/src/knowledge-compat/index.ts
@@ -4,6 +4,20 @@ export const KNOWLEDGE_V2_MINIMUM_CORE_VERSION = '1.65.0-0';
 export const KNOWLEDGE_STORAGE_CONTRACT_VERSION = 2 as const;
 export const KNOWLEDGE_STORAGE_SCHEMA_VERSION = 2 as const;
 
+/** Hard cap on scope nodes returned by one `listScopeNodes` read. */
+export const MAX_KNOWLEDGE_SCOPE_NODES = 1000;
+
+/** A reconciled structural scope node with its containing scope nodes. */
+export interface KnowledgeScopeNodeSummary {
+  /** UUID of the `isScope` node. */
+  id: string;
+  name: string;
+  kind?: string;
+  description?: string;
+  /** UUIDs of the scope nodes that contain this scope (membership edges). */
+  parentIds: string[];
+}
+
 const TABLE_KNOWLEDGE_NODES = 'mastra_knowledge_nodes';
 const TABLE_KNOWLEDGE_RECORDS = 'mastra_knowledge_records';
 const TABLE_KNOWLEDGE_MENTIONS = 'mastra_knowledge_mentions';

--- a/packages/core/src/knowledge/__tests__/knowledge.test.ts
+++ b/packages/core/src/knowledge/__tests__/knowledge.test.ts
@@ -6,6 +6,70 @@ import { Knowledge } from '../index';
 const scope = ['org:acme', 'resource:mastra'];
 
 describe('Knowledge', () => {
+  it('reconciles configured structure in the background and coalesces explicit waits', async () => {
+    const storage = new InMemoryStore({ id: 'structured' });
+    const domain = storage.stores.knowledge!;
+    vi.spyOn(domain, 'getCapabilities').mockReturnValue({
+      contractVersion: 2,
+      schemaVersion: 2,
+      supportsV2: true,
+      supportsExplicitReset: true,
+    });
+    const result = { scopes: { 'org:acme': 'scope-id' }, createdScopeIds: ['scope-id'], changed: true, accessEpoch: 1 };
+    const reconcile = vi.spyOn(domain, 'reconcileStructure').mockResolvedValue(result);
+    const knowledge = new Knowledge({
+      storage,
+      structure: { scopes: [{ address: 'org:acme', name: 'Acme' }] },
+    });
+
+    new Mastra({ knowledge: { default: knowledge }, logger: false });
+
+    await expect(Promise.all([knowledge.reconcile(), knowledge.reconcile()])).resolves.toEqual([result, result]);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies structured plans with the v2 in-memory storage', async () => {
+    const knowledge = new Knowledge({
+      storage: new InMemoryStore({ id: 'in-memory-structure' }),
+      structure: { scopes: [{ address: 'org:acme', name: 'Acme' }] },
+    });
+
+    const first = await knowledge.reconcile();
+    const second = await knowledge.reconcile();
+    const lazy = await knowledge.materializeScope({
+      address: 'resource:mastra',
+      contextualScopeAddress: 'org:acme',
+      parameters: { resourceId: 'mastra' },
+    });
+
+    expect(first).toMatchObject({ changed: true, accessEpoch: 1 });
+    expect(second).toMatchObject({ changed: false, accessEpoch: 1, scopes: first.scopes });
+    expect(lazy).toMatchObject({ changed: true, accessEpoch: 2 });
+  });
+
+  it('coalesces concurrent lazy materialization for one concrete address', async () => {
+    const storage = new InMemoryStore({ id: 'lazy-structured' });
+    const domain = storage.stores.knowledge!;
+    vi.spyOn(domain, 'getCapabilities').mockReturnValue({
+      contractVersion: 2,
+      schemaVersion: 2,
+      supportsV2: true,
+      supportsExplicitReset: true,
+    });
+    const result = { scopes: { 'org:acme': 'scope-id' }, createdScopeIds: ['scope-id'], changed: true, accessEpoch: 1 };
+    const reconcile = vi.spyOn(domain, 'reconcileStructure').mockResolvedValue(result);
+    const knowledge = new Knowledge({ storage });
+    const input = { address: 'org:acme', contextualScopeAddress: 'org:acme', parameters: { orgId: 'acme' } };
+
+    const first = knowledge.materializeScope(input);
+    const second = knowledge.materializeScope(input);
+    const conflicting = knowledge.materializeScope({ ...input, name: 'Other Acme' });
+
+    await expect(conflicting).rejects.toThrow('Conflicting materialization is already in progress');
+    await expect(Promise.all([first, second])).resolves.toEqual([result, result]);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
   it('registers default and named instances without eagerly initializing storage', async () => {
     const defaultStorage = new InMemoryStore({ id: 'default-knowledge' });
     const analyticsStorage = new InMemoryStore({ id: 'analytics-knowledge' });

--- a/packages/core/src/knowledge/__tests__/reconcile.test.ts
+++ b/packages/core/src/knowledge/__tests__/reconcile.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { materializeKnowledgeScopePlan, validateKnowledgeStructurePlan } from '../reconcile';
+
+describe('Knowledge structure reconciliation', () => {
+  it('validates unique addresses and rejects hierarchy cycles', () => {
+    expect(() =>
+      validateKnowledgeStructurePlan({
+        scopes: [
+          { address: 'scope:a', name: 'A', parentAddresses: ['scope:b'] },
+          { address: 'scope:b', name: 'B', parentAddresses: ['scope:a'] },
+        ],
+      }),
+    ).toThrow('Knowledge scope hierarchy contains a cycle');
+
+    expect(() =>
+      validateKnowledgeStructurePlan({
+        scopes: [
+          { address: 'scope:a', name: 'A' },
+          { address: 'scope:a', name: 'Other A' },
+        ],
+      }),
+    ).toThrow('Duplicate Knowledge scope address: scope:a');
+  });
+
+  it('materializes a configured pattern from host-vouched parameters', () => {
+    expect(
+      materializeKnowledgeScopePlan(
+        {
+          'agent:$agentId:public': {
+            description: 'Public agent knowledge',
+            access: [
+              { principal: 'self', role: 'owner' },
+              { principal: 'team:$orgId', role: 'readonly', canSuggest: true },
+              { principal: 'parent', role: 'mirror' },
+            ],
+          },
+        },
+        {
+          address: 'agent:weather:public',
+          contextualScopeAddress: 'resource:weather',
+          parentAddresses: ['org:acme'],
+          parameters: { agentId: 'weather', orgId: 'acme' },
+        },
+      ),
+    ).toEqual({
+      scopes: [
+        {
+          address: 'agent:weather:public',
+          name: 'public',
+          description: 'Public agent knowledge',
+          parentAddresses: ['org:acme'],
+          grants: [
+            { scopeRefAddress: 'resource:weather', role: 'owner', canSuggest: undefined },
+            { scopeRefAddress: 'team:acme', role: 'readonly', canSuggest: true },
+            { scopeRefAddress: 'org:acme', role: 'mirror', canSuggest: undefined },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('rejects mismatched host-vouched parameters and ambiguous patterns', () => {
+    expect(() =>
+      materializeKnowledgeScopePlan(undefined, {
+        address: 'org:acme',
+        contextualScopeAddress: 'org:acme',
+        parameters: { orgId: 'other' },
+      }),
+    ).toThrow('Host-vouched Knowledge scope parameter orgId does not match address org:acme');
+
+    expect(() =>
+      materializeKnowledgeScopePlan(
+        {
+          'agent:$id': {},
+          '$kind:weather': {},
+        },
+        { address: 'agent:weather', contextualScopeAddress: 'org:acme' },
+      ),
+    ).toThrow('Knowledge scope patterns overlap');
+  });
+
+  it('uses the custom template for an opaque unmatched address', () => {
+    expect(
+      materializeKnowledgeScopePlan(
+        { custom: { access: [{ principal: 'self', role: 'owner' }] } },
+        { address: 'slack:workspace-123', contextualScopeAddress: 'org:acme' },
+      ),
+    ).toMatchObject({
+      scopes: [
+        {
+          address: 'slack:workspace-123',
+          name: 'workspace-123',
+          grants: [{ scopeRefAddress: 'org:acme', role: 'owner' }],
+        },
+      ],
+    });
+  });
+});

--- a/packages/core/src/knowledge/config.ts
+++ b/packages/core/src/knowledge/config.ts
@@ -1,0 +1,16 @@
+import type { MastraCompositeStore } from '../storage';
+import type { KnowledgeStructurePlan } from '../storage/domains/knowledge';
+import type { KnowledgeScopeTypesConfig } from './reconcile';
+
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeConfig {
+  id?: string;
+  name?: string;
+  /** Prose context for agents. Automatic description compilation lands in Knowledge v2 Wave 4. */
+  description?: string;
+  /** Hand-authored startup structure applied additively by `knowledge.reconcile()`. */
+  structure?: KnowledgeStructurePlan;
+  /** Lazy scope creation templates keyed by opaque address pattern. */
+  scopes?: KnowledgeScopeTypesConfig;
+  storage?: MastraCompositeStore;
+}

--- a/packages/core/src/knowledge/index.ts
+++ b/packages/core/src/knowledge/index.ts
@@ -9,6 +9,8 @@ import type {
   KnowledgeScope,
   KnowledgeScopeLevel,
   KnowledgeSemanticOutboxEntry,
+  KnowledgeStructurePlan,
+  KnowledgeStructureReconcileResult,
   KnowledgeStorage,
   ListKnowledgeNodesInput,
   QueryKnowledgeBySourceInput,
@@ -17,25 +19,39 @@ import type {
   UpdateKnowledgeNodeInput,
 } from '../storage/domains/knowledge';
 import { augmentWithInit, getStorageSource } from '../storage/storageWithInit';
-
-export interface KnowledgeConfig {
-  id?: string;
-  name?: string;
-  storage?: MastraCompositeStore;
-}
+import type { KnowledgeConfig } from './config';
+import {
+  materializeKnowledgeScopePlan,
+  validateKnowledgeScopeTypes,
+  validateKnowledgeStructurePlan,
+  type KnowledgeScopeTypesConfig,
+  type MaterializeKnowledgeScopeInput,
+} from './reconcile';
 
 /** @experimental Knowledge APIs are experimental and may change without notice. */
 export class Knowledge extends MastraBase {
   readonly id: string;
   readonly hasOwnStorage: boolean;
 
+  readonly description?: string;
+
   #storage?: MastraCompositeStore;
   #storageSource?: MastraCompositeStore;
   #storagePromise?: Promise<KnowledgeStorage>;
+  #structure?: KnowledgeStructurePlan;
+  #scopeTypes?: KnowledgeScopeTypesConfig;
+  #reconcilePromise?: Promise<KnowledgeStructureReconcileResult>;
+  #materializePromises = new Map<
+    string,
+    { plan: KnowledgeStructurePlan; promise: Promise<KnowledgeStructureReconcileResult> }
+  >();
 
   constructor(config: KnowledgeConfig = {}) {
     super({ component: 'STORAGE', name: config.name ?? config.id ?? 'Knowledge' });
     this.id = config.id ?? randomUUID();
+    this.description = config.description;
+    this.#structure = config.structure ? validateKnowledgeStructurePlan(structuredClone(config.structure)) : undefined;
+    this.#scopeTypes = validateKnowledgeScopeTypes(structuredClone(config.scopes));
     this.hasOwnStorage = config.storage !== undefined;
     if (config.storage) {
       this.#storageSource = getStorageSource(config.storage);
@@ -44,7 +60,14 @@ export class Knowledge extends MastraBase {
   }
 
   /** @internal */
-  __registerMastra(_mastra: Mastra): void {}
+  __registerMastra(_mastra: Mastra): void {
+    if (!this.#structure) return;
+    queueMicrotask(() => {
+      void this.reconcile().catch(error => {
+        this.logger.warn('Knowledge structure reconciliation failed; call reconcile() to retry', { error });
+      });
+    });
+  }
 
   /** @internal */
   __sharesStorageWith(other: Knowledge): boolean {
@@ -115,6 +138,49 @@ export class Knowledge extends MastraBase {
     }
 
     return storage;
+  }
+
+  async reconcile(): Promise<KnowledgeStructureReconcileResult> {
+    if (!this.#structure) {
+      return { scopes: {}, createdScopeIds: [], changed: false, accessEpoch: 0 };
+    }
+    if (!this.#reconcilePromise) {
+      const promise = this.getStorage()
+        .then(storage => storage.reconcileStructure(this.#structure!))
+        .finally(() => {
+          if (this.#reconcilePromise === promise) this.#reconcilePromise = undefined;
+        });
+      this.#reconcilePromise = promise;
+    }
+    return this.#reconcilePromise;
+  }
+
+  async materializeScope(input: MaterializeKnowledgeScopeInput): Promise<KnowledgeStructureReconcileResult> {
+    const snapshot = structuredClone(input);
+    const plan = materializeKnowledgeScopePlan(this.#scopeTypes, snapshot);
+    const existing = this.#materializePromises.get(snapshot.address);
+    if (existing) {
+      if (JSON.stringify(existing.plan) !== JSON.stringify(plan)) {
+        throw new Error(`Conflicting materialization is already in progress for Knowledge scope ${snapshot.address}`);
+      }
+      return existing.promise;
+    }
+
+    const promise = this.getStorage()
+      .then(storage => storage.reconcileStructure(plan))
+      .then(result => {
+        if (result.deletedScopeAddresses?.includes(snapshot.address)) {
+          throw new Error(`Knowledge scope ${snapshot.address} was explicitly deleted and cannot be recreated lazily`);
+        }
+        return result;
+      })
+      .finally(() => {
+        if (this.#materializePromises.get(snapshot.address)?.promise === promise) {
+          this.#materializePromises.delete(snapshot.address);
+        }
+      });
+    this.#materializePromises.set(snapshot.address, { plan, promise });
+    return promise;
   }
 
   async createNode(input: CreateKnowledgeNodeInput) {
@@ -223,3 +289,10 @@ export class Knowledge extends MastraBase {
 }
 
 export * from '../storage/domains/knowledge';
+export type { KnowledgeConfig } from './config';
+export type {
+  KnowledgeScopeAccessConfig,
+  KnowledgeScopeTypeConfig,
+  KnowledgeScopeTypesConfig,
+  MaterializeKnowledgeScopeInput,
+} from './reconcile';

--- a/packages/core/src/knowledge/reconcile.ts
+++ b/packages/core/src/knowledge/reconcile.ts
@@ -1,0 +1,217 @@
+import type {
+  KnowledgeGrantRole,
+  KnowledgeStructureGrant,
+  KnowledgeStructurePlan,
+  KnowledgeStructureScope,
+} from '../storage/domains/knowledge';
+
+export interface KnowledgeScopeAccessConfig {
+  principal: 'self' | 'parent' | string;
+  role: KnowledgeGrantRole;
+  canSuggest?: boolean;
+}
+
+export interface KnowledgeScopeTypeConfig {
+  access?: KnowledgeScopeAccessConfig[];
+  description?: string;
+}
+
+export type KnowledgeScopeTypesConfig = Record<string, KnowledgeScopeTypeConfig>;
+
+export interface MaterializeKnowledgeScopeInput {
+  address: string;
+  name?: string;
+  parentAddresses?: string[];
+  contextualScopeAddress: string;
+  parameters?: Record<string, string>;
+}
+
+const BUILT_IN_SCOPE_TYPES: KnowledgeScopeTypesConfig = {
+  'org:$orgId': { access: [{ principal: 'self', role: 'owner' }] },
+  'resource:$resourceId': { access: [{ principal: 'self', role: 'owner' }] },
+  'thread:$threadId': { access: [{ principal: 'self', role: 'owner' }] },
+  custom: { access: [{ principal: 'self', role: 'owner' }] },
+};
+
+export function validateKnowledgeScopeTypes(
+  scopeTypes: KnowledgeScopeTypesConfig | undefined,
+): KnowledgeScopeTypesConfig {
+  const types = { ...BUILT_IN_SCOPE_TYPES, ...scopeTypes };
+  const patterns = Object.keys(types).filter(pattern => pattern !== 'custom');
+  for (const [index, pattern] of patterns.entries()) {
+    assertPattern(pattern);
+    for (const other of patterns.slice(index + 1)) {
+      if (patternsOverlap(pattern, other)) {
+        throw new Error(`Knowledge scope patterns overlap: ${pattern} and ${other}`);
+      }
+    }
+    for (const access of types[pattern]?.access ?? []) {
+      if (access.role === 'mirror' && access.canSuggest !== undefined) {
+        throw new Error(`Knowledge mirror grant in ${pattern} cannot override suggest capability`);
+      }
+    }
+  }
+  return types;
+}
+
+export function validateKnowledgeStructurePlan(plan: KnowledgeStructurePlan): KnowledgeStructurePlan {
+  const addresses = new Set<string>();
+  for (const scope of plan.scopes) {
+    assertAddress(scope.address);
+    if (!scope.name.trim()) throw new Error(`Knowledge scope ${scope.address} must have a name`);
+    if (addresses.has(scope.address)) throw new Error(`Duplicate Knowledge scope address: ${scope.address}`);
+    addresses.add(scope.address);
+    const parents = new Set<string>();
+    for (const parent of scope.parentAddresses ?? []) {
+      assertAddress(parent);
+      if (parents.has(parent)) throw new Error(`Duplicate parent ${parent} for Knowledge scope ${scope.address}`);
+      parents.add(parent);
+    }
+    const grantRefs = new Set<string>();
+    for (const grant of scope.grants ?? []) {
+      assertAddress(grant.scopeRefAddress);
+      if (grantRefs.has(grant.scopeRefAddress)) {
+        throw new Error(`Duplicate grant scope ${grant.scopeRefAddress} for Knowledge scope ${scope.address}`);
+      }
+      grantRefs.add(grant.scopeRefAddress);
+      if (grant.role === 'mirror' && grant.canSuggest !== undefined) {
+        throw new Error(`Knowledge mirror grant for ${scope.address} cannot override suggest capability`);
+      }
+    }
+  }
+
+  const dependencies = new Map(plan.scopes.map(scope => [scope.address, scope.parentAddresses ?? []]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const visit = (address: string) => {
+    if (visiting.has(address)) throw new Error(`Knowledge scope hierarchy contains a cycle at ${address}`);
+    if (visited.has(address)) return;
+    visiting.add(address);
+    for (const parent of dependencies.get(address) ?? []) {
+      if (dependencies.has(parent)) visit(parent);
+    }
+    visiting.delete(address);
+    visited.add(address);
+  };
+  for (const address of dependencies.keys()) visit(address);
+
+  return plan;
+}
+
+export function materializeKnowledgeScopePlan(
+  scopeTypes: KnowledgeScopeTypesConfig | undefined,
+  input: MaterializeKnowledgeScopeInput,
+): KnowledgeStructurePlan {
+  assertAddress(input.address);
+  assertAddress(input.contextualScopeAddress);
+  const types = validateKnowledgeScopeTypes(scopeTypes);
+  const matches = Object.entries(types)
+    .filter(([pattern]) => pattern !== 'custom')
+    .map(([pattern, config]) => ({ pattern, config, parameters: matchPattern(pattern, input.address) }))
+    .filter(
+      (match): match is { pattern: string; config: KnowledgeScopeTypeConfig; parameters: Record<string, string> } =>
+        Boolean(match.parameters),
+    );
+  if (matches.length > 1) {
+    throw new Error(`Knowledge scope address ${input.address} matches multiple configured patterns`);
+  }
+
+  const match = matches[0];
+  const config = match?.config ?? types.custom ?? BUILT_IN_SCOPE_TYPES.custom!;
+  const parameters = { ...input.parameters, ...match?.parameters };
+  for (const [key, value] of Object.entries(match?.parameters ?? {})) {
+    if (input.parameters?.[key] !== undefined && input.parameters[key] !== value) {
+      throw new Error(`Host-vouched Knowledge scope parameter ${key} does not match address ${input.address}`);
+    }
+  }
+
+  const grants = (config.access ?? []).flatMap<KnowledgeStructureGrant>(access => {
+    const principal = resolvePrincipal(access.principal, input, parameters);
+    if (!principal) return [];
+    return [{ scopeRefAddress: principal, role: access.role, canSuggest: access.canSuggest }];
+  });
+
+  return validateKnowledgeStructurePlan({
+    scopes: [
+      {
+        address: input.address,
+        name: input.name?.trim() || input.address.split(':').at(-1)!,
+        description: config.description,
+        parentAddresses: input.parentAddresses,
+        grants,
+      },
+    ],
+  });
+}
+
+function matchPattern(pattern: string, address: string): Record<string, string> | null {
+  const patternSegments = pattern.split(':');
+  const addressSegments = address.split(':');
+  if (patternSegments.length !== addressSegments.length) return null;
+  const parameters: Record<string, string> = {};
+  for (let index = 0; index < patternSegments.length; index++) {
+    const expected = patternSegments[index]!;
+    const actual = addressSegments[index]!;
+    if (expected.startsWith('$')) {
+      if (!actual) return null;
+      parameters[expected.slice(1)] = actual;
+    } else if (expected !== actual) {
+      return null;
+    }
+  }
+  return parameters;
+}
+
+function resolvePrincipal(
+  principal: KnowledgeScopeAccessConfig['principal'],
+  input: MaterializeKnowledgeScopeInput,
+  parameters: Record<string, string>,
+): string | null {
+  if (principal === 'self') return input.contextualScopeAddress;
+  if (principal === 'parent') {
+    if (input.parentAddresses?.length !== 1) {
+      throw new Error(`Knowledge scope ${input.address} requires exactly one parent to resolve its parent grant`);
+    }
+    return input.parentAddresses[0]!;
+  }
+  return principal.replace(/\$([A-Za-z][A-Za-z0-9_]*)/g, (_match, name: string) => {
+    const value = parameters[name];
+    if (!value) throw new Error(`Missing host-vouched Knowledge scope parameter: ${name}`);
+    return value;
+  });
+}
+
+function assertPattern(pattern: string): void {
+  if (!pattern.trim() || pattern !== pattern.trim() || pattern.split(':').some(segment => !segment)) {
+    throw new Error(`Invalid Knowledge scope pattern: ${pattern}`);
+  }
+  const parameters = pattern
+    .split(':')
+    .filter(segment => segment.startsWith('$'))
+    .map(segment => segment.slice(1));
+  if (parameters.some(parameter => !/^[A-Za-z][A-Za-z0-9_]*$/.test(parameter))) {
+    throw new Error(`Invalid Knowledge scope pattern: ${pattern}`);
+  }
+  if (new Set(parameters).size !== parameters.length) {
+    throw new Error(`Knowledge scope pattern repeats a parameter: ${pattern}`);
+  }
+}
+
+function patternsOverlap(first: string, second: string): boolean {
+  const firstSegments = first.split(':');
+  const secondSegments = second.split(':');
+  return (
+    firstSegments.length === secondSegments.length &&
+    firstSegments.every(
+      (segment, index) =>
+        segment.startsWith('$') || secondSegments[index]!.startsWith('$') || segment === secondSegments[index],
+    )
+  );
+}
+
+function assertAddress(address: string): void {
+  if (!address.trim()) throw new Error('Knowledge scope addresses must not be empty');
+  if (address !== address.trim() || address.split(':').some(segment => !segment)) {
+    throw new Error(`Invalid Knowledge scope address: ${address}`);
+  }
+}

--- a/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
+++ b/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
@@ -47,9 +47,9 @@ describe('InMemoryKnowledgeStorage', () => {
     const features = nodes.find(node => node.name === 'features')!;
     const mastra = nodes.find(node => node.name === 'mastra')!;
     const memory = nodes.find(node => node.name === 'memory')!;
-    expect(features).toMatchObject({ kind: 'domain', parentIds: [mastra.id] });
-    expect(memory).toMatchObject({ description: 'Memory scope', parentIds: [features.id] });
-    expect(mastra.parentIds).toEqual([]);
+    expect(features).toMatchObject({ address: 'features', kind: 'domain', parentIds: [mastra.id] });
+    expect(memory).toMatchObject({ address: 'features:memory', description: 'Memory scope', parentIds: [features.id] });
+    expect(mastra).toMatchObject({ address: 'org:acme', parentIds: [] });
     expect(Object.values(scopes)).toEqual(expect.arrayContaining([features.id, mastra.id, memory.id]));
 
     await expect(store.listScopeMembers({ scopeNodeId: mastra.id })).resolves.toEqual([]);

--- a/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
+++ b/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
@@ -7,6 +7,8 @@ import {
   inspectKnowledgeSchema,
   KnowledgeConflictError,
   KnowledgeSchemaResetRequiredError,
+  KnowledgeStorage,
+  KnowledgeUnsupportedCapabilityError,
   KNOWLEDGE_STORAGE_CONTRACT_VERSION,
   KNOWLEDGE_STORAGE_SCHEMA_VERSION,
 } from '../base';
@@ -27,6 +29,41 @@ describe('InMemoryKnowledgeStorage', () => {
     const second = createKnowledgeUlid(1);
 
     expect(second > first).toBe(true);
+  });
+
+  it('lists reconciled scope nodes with parent membership edges', async () => {
+    const store = createStore();
+    const plan = {
+      scopes: [
+        { address: 'org:acme', name: 'mastra' },
+        { address: 'features', name: 'features', kind: 'domain', parentAddresses: ['org:acme'] },
+        { address: 'features:memory', name: 'memory', description: 'Memory scope', parentAddresses: ['features'] },
+      ],
+    };
+    const { scopes } = await store.reconcileStructure(plan);
+
+    const nodes = await store.listScopeNodes();
+    expect(nodes.map(node => node.name)).toEqual(['features', 'mastra', 'memory']);
+    const features = nodes.find(node => node.name === 'features')!;
+    const mastra = nodes.find(node => node.name === 'mastra')!;
+    const memory = nodes.find(node => node.name === 'memory')!;
+    expect(features).toMatchObject({ kind: 'domain', parentIds: [mastra.id] });
+    expect(memory).toMatchObject({ description: 'Memory scope', parentIds: [features.id] });
+    expect(mastra.parentIds).toEqual([]);
+    expect(Object.values(scopes)).toEqual(expect.arrayContaining([features.id, mastra.id, memory.id]));
+
+    await expect(store.listScopeMembers({ scopeNodeId: mastra.id })).resolves.toEqual([]);
+    await expect(store.listScopeMembers({ scopeNodeId: crypto.randomUUID() })).resolves.toEqual([]);
+  });
+
+  it('throws a typed capability error for adapters without the structural scope read', async () => {
+    const bare = {} as KnowledgeStorage;
+    await expect(KnowledgeStorage.prototype.listScopeNodes.call(bare)).rejects.toBeInstanceOf(
+      KnowledgeUnsupportedCapabilityError,
+    );
+    await expect(
+      KnowledgeStorage.prototype.listScopeMembers.call(bare, { scopeNodeId: crypto.randomUUID() }),
+    ).rejects.toBeInstanceOf(KnowledgeUnsupportedCapabilityError);
   });
 
   it('reports the v2 contract and inspects schema without mutating Knowledge data', async () => {

--- a/packages/core/src/storage/domains/knowledge/base.ts
+++ b/packages/core/src/storage/domains/knowledge/base.ts
@@ -234,6 +234,38 @@ export interface KnowledgeV2Record {
 }
 
 /** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeStructureGrant {
+  scopeRefAddress: string;
+  role: KnowledgeGrantRole;
+  canSuggest?: boolean;
+}
+
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeStructureScope {
+  address: string;
+  name: string;
+  kind?: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  parentAddresses?: string[];
+  grants?: KnowledgeStructureGrant[];
+}
+
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeStructurePlan {
+  scopes: KnowledgeStructureScope[];
+}
+
+/** @experimental Knowledge APIs are experimental and may change without notice. */
+export interface KnowledgeStructureReconcileResult {
+  scopes: Record<string, string>;
+  createdScopeIds: string[];
+  deletedScopeAddresses?: string[];
+  changed: boolean;
+  accessEpoch: number;
+}
+
+/** @experimental Knowledge APIs are experimental and may change without notice. */
 export interface KnowledgeMention {
   sourceType: 'record' | 'node';
   source: string;
@@ -662,6 +694,11 @@ export abstract class KnowledgeStorage extends StorageDomain {
 
   async dangerouslyReset(): Promise<void> {
     throw new Error('This Knowledge storage adapter does not support an explicit Knowledge-only reset.');
+  }
+
+  /** Applies an additive, idempotent structured scope plan. */
+  async reconcileStructure(_plan: KnowledgeStructurePlan): Promise<KnowledgeStructureReconcileResult> {
+    throw new Error('This Knowledge storage adapter does not support structured reconciliation.');
   }
 
   abstract createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode>;

--- a/packages/core/src/storage/domains/knowledge/base.ts
+++ b/packages/core/src/storage/domains/knowledge/base.ts
@@ -265,6 +265,20 @@ export interface KnowledgeStructureReconcileResult {
   accessEpoch: number;
 }
 
+/** A reconciled structural scope node with its containing scope nodes. @experimental */
+export interface KnowledgeScopeNodeSummary {
+  /** UUID of the `isScope` node. */
+  id: string;
+  name: string;
+  kind?: string;
+  description?: string;
+  /** UUIDs of the scope nodes that contain this scope (membership edges). */
+  parentIds: string[];
+}
+
+/** Hard cap on scope nodes returned by one `listScopeNodes` read. */
+export const MAX_KNOWLEDGE_SCOPE_NODES = 1000;
+
 /** @experimental Knowledge APIs are experimental and may change without notice. */
 export interface KnowledgeMention {
   sourceType: 'record' | 'node';
@@ -484,6 +498,13 @@ export class KnowledgeSchemaResetRequiredError extends Error {
   }
 }
 
+export class KnowledgeUnsupportedCapabilityError extends Error {
+  constructor(capability: string) {
+    super(`This Knowledge storage adapter does not expose ${capability}.`);
+    this.name = 'KnowledgeUnsupportedCapabilityError';
+  }
+}
+
 export function assertKnowledgeSchemaCompatible(inspection: KnowledgeSchemaInspection): void {
   if (inspection.status === 'compatible' || inspection.status === 'uninitialized') return;
   if (inspection.status === 'incompatible-reset-required') {
@@ -699,6 +720,16 @@ export abstract class KnowledgeStorage extends StorageDomain {
   /** Applies an additive, idempotent structured scope plan. */
   async reconcileStructure(_plan: KnowledgeStructurePlan): Promise<KnowledgeStructureReconcileResult> {
     throw new Error('This Knowledge storage adapter does not support structured reconciliation.');
+  }
+
+  /** Lists reconciled structural scope nodes with their parent membership edges (bounded, name-ordered). */
+  async listScopeNodes(): Promise<KnowledgeScopeNodeSummary[]> {
+    throw new KnowledgeUnsupportedCapabilityError('structural scope nodes');
+  }
+
+  /** Lists the nodes placed inside one structural scope, newest-first (bounded). */
+  async listScopeMembers(_input: { scopeNodeId: string; limit?: number }): Promise<KnowledgeNode[]> {
+    throw new KnowledgeUnsupportedCapabilityError('structural scope nodes');
   }
 
   abstract createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode>;

--- a/packages/core/src/storage/domains/knowledge/base.ts
+++ b/packages/core/src/storage/domains/knowledge/base.ts
@@ -269,6 +269,8 @@ export interface KnowledgeStructureReconcileResult {
 export interface KnowledgeScopeNodeSummary {
   /** UUID of the `isScope` node. */
   id: string;
+  /** Canonical structural address of the scope (for example `org:acme` or `features:memory`). */
+  address: string;
   name: string;
   kind?: string;
   description?: string;

--- a/packages/core/src/storage/domains/knowledge/inmemory.ts
+++ b/packages/core/src/storage/domains/knowledge/inmemory.ts
@@ -31,6 +31,8 @@ import type {
   KnowledgeSemanticDocumentType,
   KnowledgeSemanticOperation,
   KnowledgeSemanticOutboxEntry,
+  KnowledgeStructurePlan,
+  KnowledgeStructureReconcileResult,
   QueryKnowledgeBySourceInput,
   QueryKnowledgeInput,
   QueryKnowledgeOutput,
@@ -80,6 +82,10 @@ function recordKey(name: string, scope: KnowledgeScope): string {
 
 export class InMemoryKnowledgeStorage extends KnowledgeStorage {
   readonly #db: InMemoryDB;
+  readonly #structureScopes = new Map<string, { id: string; name: string; deletedAt?: Date }>();
+  readonly #structureParents = new Set<string>();
+  readonly #structureGrants = new Set<string>();
+  #accessEpoch = 0;
 
   constructor({ db }: { db: InMemoryDB }) {
     super();
@@ -113,6 +119,81 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
     this.#db.knowledgeActivity.length = 0;
     this.#db.knowledgeSemanticOutbox.clear();
     this.#db.knowledgeSemanticIdempotency.clear();
+    this.#structureScopes.clear();
+    this.#structureParents.clear();
+    this.#structureGrants.clear();
+    this.#accessEpoch = 0;
+  }
+
+  override async reconcileStructure(plan: KnowledgeStructurePlan): Promise<KnowledgeStructureReconcileResult> {
+    const scopes: Record<string, string> = {};
+    const createdScopeIds: string[] = [];
+    const createdAddresses = new Set<string>();
+
+    for (const scope of plan.scopes) {
+      const existing = this.#structureScopes.get(scope.address);
+      if (existing) {
+        scopes[scope.address] = existing.id;
+        continue;
+      }
+      const id = crypto.randomUUID();
+      this.#structureScopes.set(scope.address, { id, name: scope.name });
+      scopes[scope.address] = id;
+      createdAddresses.add(scope.address);
+      createdScopeIds.push(id);
+    }
+
+    try {
+      for (const scope of plan.scopes) {
+        if (!createdAddresses.has(scope.address)) continue;
+        const scopeNodeId = scopes[scope.address]!;
+        for (const parentAddress of scope.parentAddresses ?? []) {
+          const parent = this.#structureScopes.get(parentAddress);
+          if (!parent || parent.deletedAt) throw new Error(`Knowledge parent scope does not exist: ${parentAddress}`);
+          const sibling = [...this.#structureParents]
+            .map(edge => edge.split('\u0000'))
+            .find(
+              ([nodeId, parentId]) =>
+                parentId === parent.id &&
+                nodeId !== scopeNodeId &&
+                [...this.#structureScopes.values()].some(
+                  candidate =>
+                    candidate.id === nodeId &&
+                    candidate.name.trim().toLocaleLowerCase() === scope.name.trim().toLocaleLowerCase(),
+                ),
+            );
+          if (sibling) throw new Error(`Knowledge scope name ${scope.name} already exists under ${parentAddress}`);
+          this.#structureParents.add(`${scopeNodeId}\u0000${parent.id}`);
+        }
+        for (const grant of scope.grants ?? []) {
+          const scopeRef = this.#structureScopes.get(grant.scopeRefAddress);
+          if (!scopeRef || scopeRef.deletedAt) {
+            throw new Error(`Knowledge grant scope does not exist: ${grant.scopeRefAddress}`);
+          }
+          this.#structureGrants.add(`${scopeNodeId}\u0000${scopeRef.id}`);
+        }
+      }
+    } catch (error) {
+      for (const address of createdAddresses) this.#structureScopes.delete(address);
+      for (const id of createdScopeIds) {
+        for (const edge of this.#structureParents)
+          if (edge.startsWith(`${id}\u0000`)) this.#structureParents.delete(edge);
+        for (const grant of this.#structureGrants)
+          if (grant.startsWith(`${id}\u0000`)) this.#structureGrants.delete(grant);
+      }
+      throw error;
+    }
+
+    if (createdScopeIds.length) this.#accessEpoch += 1;
+    return {
+      scopes,
+      createdScopeIds,
+      deletedScopeAddresses: plan.scopes
+        .filter(scope => this.#structureScopes.get(scope.address)?.deletedAt)
+        .map(scope => scope.address),
+      changed: createdScopeIds.length > 0,
+      accessEpoch: this.#accessEpoch,
+    };
   }
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {

--- a/packages/core/src/storage/domains/knowledge/inmemory.ts
+++ b/packages/core/src/storage/domains/knowledge/inmemory.ts
@@ -14,6 +14,7 @@ import {
   KnowledgeStorage,
   KNOWLEDGE_STORAGE_CONTRACT_VERSION,
   KNOWLEDGE_STORAGE_SCHEMA_VERSION,
+  MAX_KNOWLEDGE_SCOPE_NODES,
   parseKnowledgeNodeCursor,
   parseKnowledgeWikilinks,
 } from './base';
@@ -28,6 +29,7 @@ import type {
   KnowledgeRecord,
   KnowledgeMention,
   KnowledgeScope,
+  KnowledgeScopeNodeSummary,
   KnowledgeSemanticDocumentType,
   KnowledgeSemanticOperation,
   KnowledgeSemanticOutboxEntry,
@@ -82,7 +84,10 @@ function recordKey(name: string, scope: KnowledgeScope): string {
 
 export class InMemoryKnowledgeStorage extends KnowledgeStorage {
   readonly #db: InMemoryDB;
-  readonly #structureScopes = new Map<string, { id: string; name: string; deletedAt?: Date }>();
+  readonly #structureScopes = new Map<
+    string,
+    { id: string; name: string; kind?: string; description?: string; deletedAt?: Date }
+  >();
   readonly #structureParents = new Set<string>();
   readonly #structureGrants = new Set<string>();
   #accessEpoch = 0;
@@ -137,7 +142,12 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
         continue;
       }
       const id = crypto.randomUUID();
-      this.#structureScopes.set(scope.address, { id, name: scope.name });
+      this.#structureScopes.set(scope.address, {
+        id,
+        name: scope.name,
+        ...(scope.kind ? { kind: scope.kind } : {}),
+        ...(scope.description ? { description: scope.description } : {}),
+      });
       scopes[scope.address] = id;
       createdAddresses.add(scope.address);
       createdScopeIds.push(id);
@@ -194,6 +204,44 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
       changed: createdScopeIds.length > 0,
       accessEpoch: this.#accessEpoch,
     };
+  }
+
+  override async listScopeNodes(): Promise<KnowledgeScopeNodeSummary[]> {
+    const parentsByScopeId = new Map<string, string[]>();
+    for (const edge of this.#structureParents) {
+      const [scopeId, parentId] = edge.split('\u0000');
+      if (!scopeId || !parentId) continue;
+      const parents = parentsByScopeId.get(scopeId);
+      if (parents) parents.push(parentId);
+      else parentsByScopeId.set(scopeId, [parentId]);
+    }
+    const summaries: KnowledgeScopeNodeSummary[] = [];
+    for (const scope of this.#structureScopes.values()) {
+      if (scope.deletedAt) continue;
+      summaries.push({
+        id: scope.id,
+        name: scope.name,
+        ...(scope.kind ? { kind: scope.kind } : {}),
+        ...(scope.description ? { description: scope.description } : {}),
+        parentIds: parentsByScopeId.get(scope.id) ?? [],
+      });
+    }
+    return summaries.sort((a, b) => a.name.localeCompare(b.name)).slice(0, MAX_KNOWLEDGE_SCOPE_NODES);
+  }
+
+  override async listScopeMembers(input: { scopeNodeId: string; limit?: number }): Promise<KnowledgeNode[]> {
+    const limit = Math.min(Math.max(input.limit ?? 500, 1), 500);
+    const memberIds = new Set<string>();
+    for (const edge of this.#structureParents) {
+      const [scopeId, parentId] = edge.split('\u0000');
+      if (scopeId && parentId === input.scopeNodeId) memberIds.add(scopeId);
+    }
+    const members: KnowledgeNode[] = [];
+    for (const id of memberIds) {
+      const node = await this.getNode(id);
+      if (node && !node.mergedInto) members.push(node);
+    }
+    return members.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()).slice(0, limit);
   }
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {

--- a/packages/core/src/storage/domains/knowledge/inmemory.ts
+++ b/packages/core/src/storage/domains/knowledge/inmemory.ts
@@ -216,10 +216,11 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
       else parentsByScopeId.set(scopeId, [parentId]);
     }
     const summaries: KnowledgeScopeNodeSummary[] = [];
-    for (const scope of this.#structureScopes.values()) {
+    for (const [address, scope] of this.#structureScopes) {
       if (scope.deletedAt) continue;
       summaries.push({
         id: scope.id,
+        address,
         name: scope.name,
         ...(scope.kind ? { kind: scope.kind } : {}),
         ...(scope.description ? { description: scope.description } : {}),

--- a/stores/libsql/src/storage/domains/knowledge/index.test.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.test.ts
@@ -397,8 +397,9 @@ describe('KnowledgeLibSQL initialization', () => {
       expect(nodes.map(node => node.name)).toEqual(['features', 'mastra', 'repo:mastra']);
       const mastra = nodes.find(node => node.name === 'mastra')!;
       const features = nodes.find(node => node.name === 'features')!;
-      expect(features).toMatchObject({ kind: 'domain', parentIds: [mastra.id] });
-      expect(mastra.parentIds).toEqual([]);
+      expect(features).toMatchObject({ address: 'features', kind: 'domain', parentIds: [mastra.id] });
+      expect(mastra).toMatchObject({ address: 'org:acme', parentIds: [] });
+      expect(nodes.find(node => node.name === 'repo:mastra')).toMatchObject({ address: 'repo:mastra' });
       expect(Object.values(scopes)).toEqual(expect.arrayContaining([mastra.id, features.id]));
 
       const members = await store.listScopeMembers({ scopeNodeId: mastra.id });

--- a/stores/libsql/src/storage/domains/knowledge/index.test.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.test.ts
@@ -378,6 +378,46 @@ describe('KnowledgeLibSQL initialization', () => {
     }
   });
 
+  it('reads structural scope nodes and members after reconciliation', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'knowledge-v2-scope-nodes-'));
+    const client = createClient({ url: `file:${join(directory, 'knowledge.db')}` });
+    try {
+      const store = new KnowledgeLibSQL({ client });
+      await store.init();
+      const plan = {
+        scopes: [
+          { address: 'org:acme', name: 'mastra' },
+          { address: 'features', name: 'features', kind: 'domain', parentAddresses: ['org:acme'] },
+          { address: 'repo:mastra', name: 'repo:mastra', parentAddresses: ['org:acme'] },
+        ],
+      };
+      const { scopes } = await store.reconcileStructure(plan);
+
+      const nodes = await store.listScopeNodes();
+      expect(nodes.map(node => node.name)).toEqual(['features', 'mastra', 'repo:mastra']);
+      const mastra = nodes.find(node => node.name === 'mastra')!;
+      const features = nodes.find(node => node.name === 'features')!;
+      expect(features).toMatchObject({ kind: 'domain', parentIds: [mastra.id] });
+      expect(mastra.parentIds).toEqual([]);
+      expect(Object.values(scopes)).toEqual(expect.arrayContaining([mastra.id, features.id]));
+
+      const members = await store.listScopeMembers({ scopeNodeId: mastra.id });
+      expect(members.map(node => node.id).sort()).toEqual([features.id, scopes['repo:mastra']!].sort());
+
+      // Content nodes never join structural scopes; deletion and unknown ids stay out of the read.
+      await client.execute(`UPDATE mastra_knowledge_nodes SET deletedAt=? WHERE id=?`, [
+        new Date().toISOString(),
+        features.id,
+      ]);
+      const afterDelete = await store.listScopeNodes();
+      expect(afterDelete.find(node => node.id === features.id)).toBeUndefined();
+      await expect(store.listScopeMembers({ scopeNodeId: crypto.randomUUID() })).resolves.toEqual([]);
+    } finally {
+      client.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it('serializes reconciliation across clients sharing one database', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'knowledge-v2-reconcile-concurrent-'));
     const url = `file:${join(directory, 'knowledge.db')}`;

--- a/stores/libsql/src/storage/domains/knowledge/index.test.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.test.ts
@@ -110,6 +110,20 @@ describe('KnowledgeLibSQL storage isolation', () => {
     expect(new KnowledgeLibSQL({ url: 'file:first.db' }).getStorageIsolationKey()).not.toBe(
       new KnowledgeLibSQL({ url: 'file:second.db' }).getStorageIsolationKey(),
     );
+
+    const firstClient = createClient({ url: 'file:first-client.db' });
+    const secondClient = createClient({ url: 'file:second-client.db' });
+    try {
+      expect(getLibSQLKnowledgeIsolationKey({ client: firstClient })).toBe(
+        getLibSQLKnowledgeIsolationKey({ client: secondClient }),
+      );
+      expect(getLibSQLKnowledgeIsolationKey({ client: firstClient, storageIsolationKey: 'first' })).not.toBe(
+        getLibSQLKnowledgeIsolationKey({ client: secondClient, storageIsolationKey: 'second' }),
+      );
+    } finally {
+      firstClient.close();
+      secondClient.close();
+    }
   });
 });
 
@@ -287,6 +301,103 @@ describe('KnowledgeLibSQL initialization', () => {
       expect(store.getCapabilities()).toMatchObject({ schemaVersion: 2, supportsV2: true });
     } finally {
       client.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('reconciles structured scope plans additively and idempotently', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'knowledge-v2-reconcile-'));
+    const client = createClient({ url: `file:${join(directory, 'knowledge.db')}` });
+    try {
+      const store = new KnowledgeLibSQL({ client });
+      await store.init();
+      const plan = {
+        scopes: [
+          {
+            address: 'org:acme',
+            name: 'Acme',
+            grants: [{ scopeRefAddress: 'org:acme', role: 'owner' as const }],
+          },
+          { address: 'org:partner', name: 'Partner' },
+          {
+            address: 'resource:mastra',
+            name: 'Mastra',
+            parentAddresses: ['org:acme', 'org:partner'],
+            grants: [{ scopeRefAddress: 'org:acme', role: 'readonly' as const }],
+          },
+        ],
+      };
+
+      const first = await store.reconcileStructure(plan);
+      const second = await store.reconcileStructure({
+        scopes: plan.scopes.map(scope => ({ ...scope, name: `Changed ${scope.name}` })),
+      });
+
+      expect(first).toMatchObject({ changed: true, accessEpoch: 1 });
+      expect(first.createdScopeIds).toHaveLength(3);
+      expect(second).toMatchObject({ changed: false, accessEpoch: 1, scopes: first.scopes });
+      expect(
+        (await client.execute(`SELECT name FROM mastra_knowledge_nodes WHERE id='${first.scopes['org:acme']}'`))
+          .rows[0],
+      ).toMatchObject({ name: 'Acme' });
+      expect((await client.execute(`SELECT * FROM mastra_knowledge_node_scopes`)).rows).toHaveLength(2);
+      expect((await client.execute(`SELECT * FROM mastra_knowledge_scope_grants`)).rows).toHaveLength(2);
+
+      await client.execute({
+        sql: `UPDATE mastra_knowledge_nodes SET deletedAt=? WHERE id=?`,
+        args: [new Date().toISOString(), first.scopes['org:acme']!],
+      });
+      await expect(store.reconcileStructure(plan)).resolves.toMatchObject({
+        changed: false,
+        deletedScopeAddresses: ['org:acme'],
+      });
+
+      await expect(
+        store.reconcileStructure({
+          scopes: [
+            {
+              address: 'resource:rolled-back',
+              name: 'Rolled Back',
+              grants: [{ scopeRefAddress: 'org:missing', role: 'readonly' }],
+            },
+          ],
+        }),
+      ).rejects.toThrow('Knowledge grant scope does not exist: org:missing');
+      expect(
+        (await client.execute(`SELECT * FROM mastra_knowledge_scope_addresses WHERE address='resource:rolled-back'`))
+          .rows,
+      ).toHaveLength(0);
+      expect(
+        (await client.execute(`SELECT epoch FROM mastra_knowledge_access_state WHERE id='global'`)).rows[0],
+      ).toMatchObject({
+        epoch: 1,
+      });
+    } finally {
+      client.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes reconciliation across clients sharing one database', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'knowledge-v2-reconcile-concurrent-'));
+    const url = `file:${join(directory, 'knowledge.db')}`;
+    const firstClient = createClient({ url });
+    const secondClient = createClient({ url });
+    try {
+      const first = new KnowledgeLibSQL({ client: firstClient });
+      const second = new KnowledgeLibSQL({ client: secondClient });
+      await first.init();
+      await second.init();
+      const plan = { scopes: [{ address: 'org:acme', name: 'Acme' }] };
+
+      const results = await Promise.all([first.reconcileStructure(plan), second.reconcileStructure(plan)]);
+
+      expect(results.map(result => result.changed).sort()).toEqual([false, true]);
+      expect(results[0]!.scopes).toEqual(results[1]!.scopes);
+      expect((await firstClient.execute(`SELECT * FROM mastra_knowledge_scope_addresses`)).rows).toHaveLength(1);
+    } finally {
+      firstClient.close();
+      secondClient.close();
       rmSync(directory, { recursive: true, force: true });
     }
   });

--- a/stores/libsql/src/storage/domains/knowledge/index.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.ts
@@ -547,7 +547,7 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
 
   override async listScopeNodes(): Promise<KnowledgeScopeNodeSummary[]> {
     const scopes = await this.#client.execute({
-      sql: `SELECT id,name,kind,description FROM "${TABLE_KNOWLEDGE_NODES}" WHERE isScope AND deletedAt IS NULL ORDER BY name LIMIT ?`,
+      sql: `SELECT n.id,n.name,n.kind,n.description,a.address FROM "${TABLE_KNOWLEDGE_NODES}" n LEFT JOIN "${TABLE_KNOWLEDGE_SCOPE_ADDRESSES}" a ON a.scopeNodeId=n.id WHERE n.isScope AND n.deletedAt IS NULL ORDER BY n.name LIMIT ?`,
       args: [MAX_KNOWLEDGE_SCOPE_NODES],
     });
     if (scopes.rows.length === 0) return [];
@@ -564,6 +564,7 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
     }
     return scopes.rows.map(row => ({
       id: String(row.id),
+      address: String(row.address),
       name: String(row.name),
       ...(row.kind == null ? {} : { kind: String(row.kind) }),
       ...(row.description == null ? {} : { description: String(row.description) }),

--- a/stores/libsql/src/storage/domains/knowledge/index.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 
 import {
@@ -63,6 +64,8 @@ import type {
   KnowledgeRecord,
   KnowledgeScope,
   KnowledgeSemanticDocumentType,
+  KnowledgeStructurePlan,
+  KnowledgeStructureReconcileResult,
   KnowledgeSemanticOperation,
   KnowledgeSemanticOutboxEntry,
   QueryKnowledgeBySourceInput,
@@ -92,6 +95,24 @@ async function assertKnowledgeDescriptionWithinBoundCompat(description: string |
 
 interface Executor {
   execute(statement: string | { sql: string; args?: InValue[] }): Promise<ResultSet>;
+}
+
+const reconcileChains = new Map<unknown, Promise<unknown>>();
+const unidentifiedClientReconcileKey = {};
+
+function withReconcileLock<T>(key: unknown, operation: () => Promise<T>): Promise<T> {
+  const lockKey = typeof key === 'string' ? key : unidentifiedClientReconcileKey;
+  const previous = reconcileChains.get(lockKey) ?? Promise.resolve();
+  const result = previous.then(operation, operation);
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  reconcileChains.set(lockKey, tail);
+  void tail.finally(() => {
+    if (reconcileChains.get(lockKey) === tail) reconcileChains.delete(lockKey);
+  });
+  return result;
 }
 
 const visibleSql = `(scopeKey = ? OR substr(?, 1, length(scopeKey) + 1) = scopeKey || char(31))`;
@@ -216,9 +237,15 @@ function canonicalizeLibSQLUrl(url: string): string | undefined {
   }
 }
 
-export function getLibSQLKnowledgeIsolationKey(config: { url?: string; client?: Client }, client?: Client): unknown {
+const unidentifiedClientIsolationKey = {};
+
+export function getLibSQLKnowledgeIsolationKey(
+  config: { url?: string; client?: Client; storageIsolationKey?: unknown },
+  _client?: Client,
+): unknown {
+  if (config.storageIsolationKey !== undefined) return config.storageIsolationKey;
   const urlKey = config.url ? canonicalizeLibSQLUrl(config.url) : undefined;
-  return urlKey ? `libsql:${urlKey}` : (client ?? config.client ?? config);
+  return urlKey ? `libsql:${urlKey}` : unidentifiedClientIsolationKey;
 }
 
 export class KnowledgeLibSQL extends KnowledgeStorage {
@@ -417,6 +444,103 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
       );
     });
     await this.init();
+  }
+
+  override async reconcileStructure(plan: KnowledgeStructurePlan): Promise<KnowledgeStructureReconcileResult> {
+    return withReconcileLock(this.getStorageIsolationKey(), () =>
+      this.#transaction(async tx => {
+        // Acquire the database write lock before any read so separate clients cannot both observe a missing address.
+        await tx.execute(`UPDATE "${TABLE_KNOWLEDGE_ACCESS_STATE}" SET epoch=epoch WHERE id='global'`);
+        const scopes: Record<string, string> = {};
+        const createdScopeIds: string[] = [];
+        const createdAddresses = new Set<string>();
+        const deletedScopeAddresses = new Set<string>();
+        const resolveAddress = async (address: string): Promise<string | undefined> => {
+          if (scopes[address]) return scopes[address];
+          const result = await tx.execute({
+            sql: `SELECT a.scopeNodeId,n.isScope,n.deletedAt FROM "${TABLE_KNOWLEDGE_SCOPE_ADDRESSES}" a JOIN "${TABLE_KNOWLEDGE_NODES}" n ON n.id=a.scopeNodeId WHERE a.address=?`,
+            args: [address],
+          });
+          const row = result.rows[0];
+          if (!row) return undefined;
+          if (!row.isScope) throw new Error(`Knowledge address ${address} does not reference a scope`);
+          if (row.deletedAt) deletedScopeAddresses.add(address);
+          scopes[address] = String(row.scopeNodeId);
+          return scopes[address];
+        };
+
+        for (const scope of plan.scopes) {
+          const existingId = await resolveAddress(scope.address);
+          if (existingId) continue;
+          const id = randomUUID();
+          const now = new Date().toISOString();
+          await tx.execute({
+            sql: `INSERT INTO "${TABLE_KNOWLEDGE_NODES}" (id,type,name,canonicalName,kind,description,isScope,metadata,version,createdAt,updatedAt) VALUES (?,'node',?,?,?,?,TRUE,jsonb(?),1,?,?)`,
+            args: [
+              id,
+              scope.name,
+              canonicalName(scope.name),
+              scope.kind ?? null,
+              scope.description ?? null,
+              scope.metadata ? JSON.stringify(scope.metadata) : null,
+              now,
+              now,
+            ],
+          });
+          await tx.execute({
+            sql: `INSERT INTO "${TABLE_KNOWLEDGE_SCOPE_ADDRESSES}" (address,scopeNodeId) VALUES (?,?)`,
+            args: [scope.address, id],
+          });
+          scopes[scope.address] = id;
+          createdAddresses.add(scope.address);
+          createdScopeIds.push(id);
+        }
+
+        for (const scope of plan.scopes) {
+          if (!createdAddresses.has(scope.address)) continue;
+          const scopeNodeId = scopes[scope.address]!;
+          for (const parentAddress of scope.parentAddresses ?? []) {
+            const parentId = await resolveAddress(parentAddress);
+            if (!parentId || deletedScopeAddresses.has(parentAddress)) {
+              throw new Error(`Knowledge parent scope does not exist: ${parentAddress}`);
+            }
+            const sibling = await tx.execute({
+              sql: `SELECT n.id FROM "${TABLE_KNOWLEDGE_NODE_SCOPES}" ns JOIN "${TABLE_KNOWLEDGE_NODES}" n ON n.id=ns.nodeId WHERE ns.scopeNodeId=? AND n.canonicalName=? AND n.deletedAt IS NULL AND n.id<>? LIMIT 1`,
+              args: [parentId, canonicalName(scope.name), scopeNodeId],
+            });
+            if (sibling.rows.length) {
+              throw new Error(`Knowledge scope name ${scope.name} already exists under ${parentAddress}`);
+            }
+            await tx.execute({
+              sql: `INSERT OR IGNORE INTO "${TABLE_KNOWLEDGE_NODE_SCOPES}" (nodeId,scopeNodeId,addedAt) VALUES (?,?,?)`,
+              args: [scopeNodeId, parentId, new Date().toISOString()],
+            });
+          }
+          for (const grant of scope.grants ?? []) {
+            const scopeRefId = await resolveAddress(grant.scopeRefAddress);
+            if (!scopeRefId || deletedScopeAddresses.has(grant.scopeRefAddress)) {
+              throw new Error(`Knowledge grant scope does not exist: ${grant.scopeRefAddress}`);
+            }
+            await tx.execute({
+              sql: `INSERT OR IGNORE INTO "${TABLE_KNOWLEDGE_SCOPE_GRANTS}" (scopeNodeId,scopeRefId,role,canSuggest) VALUES (?,?,?,?)`,
+              args: [scopeNodeId, scopeRefId, grant.role, grant.canSuggest ?? null],
+            });
+          }
+        }
+
+        if (createdScopeIds.length) {
+          await tx.execute(`UPDATE "${TABLE_KNOWLEDGE_ACCESS_STATE}" SET epoch=epoch+1 WHERE id='global'`);
+        }
+        const state = await tx.execute(`SELECT epoch FROM "${TABLE_KNOWLEDGE_ACCESS_STATE}" WHERE id='global'`);
+        return {
+          scopes,
+          createdScopeIds,
+          deletedScopeAddresses: [...deletedScopeAddresses],
+          changed: createdScopeIds.length > 0,
+          accessEpoch: Number(state.rows[0]?.epoch ?? 0),
+        };
+      }),
+    );
   }
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {

--- a/stores/libsql/src/storage/domains/knowledge/index.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 
+import type { KnowledgeScopeNodeSummary } from '@internal/core/knowledge-compat';
 import {
+  MAX_KNOWLEDGE_SCOPE_NODES,
   KNOWLEDGE_ACCESS_STATE_SCHEMA,
   KNOWLEDGE_IMPORT_RUNS_SCHEMA,
   KNOWLEDGE_IMPORT_STATE_SCHEMA,
@@ -541,6 +543,41 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
         };
       }),
     );
+  }
+
+  override async listScopeNodes(): Promise<KnowledgeScopeNodeSummary[]> {
+    const scopes = await this.#client.execute({
+      sql: `SELECT id,name,kind,description FROM "${TABLE_KNOWLEDGE_NODES}" WHERE isScope AND deletedAt IS NULL ORDER BY name LIMIT ?`,
+      args: [MAX_KNOWLEDGE_SCOPE_NODES],
+    });
+    if (scopes.rows.length === 0) return [];
+    const parents = await this.#client.execute({
+      sql: `SELECT ns.nodeId,ns.scopeNodeId FROM "${TABLE_KNOWLEDGE_NODE_SCOPES}" ns JOIN "${TABLE_KNOWLEDGE_NODES}" c ON c.id=ns.nodeId WHERE c.isScope AND c.deletedAt IS NULL`,
+    });
+    const parentsByScopeId = new Map<string, string[]>();
+    for (const row of parents.rows) {
+      const scopeId = String(row.nodeId);
+      const parentId = String(row.scopeNodeId);
+      const existing = parentsByScopeId.get(scopeId);
+      if (existing) existing.push(parentId);
+      else parentsByScopeId.set(scopeId, [parentId]);
+    }
+    return scopes.rows.map(row => ({
+      id: String(row.id),
+      name: String(row.name),
+      ...(row.kind == null ? {} : { kind: String(row.kind) }),
+      ...(row.description == null ? {} : { description: String(row.description) }),
+      parentIds: parentsByScopeId.get(String(row.id)) ?? [],
+    }));
+  }
+
+  override async listScopeMembers(input: { scopeNodeId: string; limit?: number }): Promise<KnowledgeNode[]> {
+    const limit = Math.min(Math.max(input.limit ?? 500, 1), 500);
+    const result = await this.#client.execute({
+      sql: `SELECT *, json(scope) AS scopeJson FROM "${TABLE_KNOWLEDGE_NODES}" n WHERE EXISTS (SELECT 1 FROM "${TABLE_KNOWLEDGE_NODE_SCOPES}" ns WHERE ns.nodeId=n.id AND ns.scopeNodeId=?) AND n.deletedAt IS NULL AND n.mergedInto IS NULL ORDER BY n.updatedAt DESC, n.name ASC, n.id ASC LIMIT ?`,
+      args: [input.scopeNodeId, limit],
+    });
+    return result.rows.map(parseNode);
   }
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {

--- a/stores/pg/src/storage/domains/knowledge/index.test.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.test.ts
@@ -305,8 +305,9 @@ describe('PostgreSQL knowledge structured reconciliation', () => {
       expect(nodes.map(node => node.name)).toEqual(['features', 'mastra', 'repo:mastra']);
       const mastra = nodes.find(node => node.name === 'mastra')!;
       const features = nodes.find(node => node.name === 'features')!;
-      expect(features).toMatchObject({ kind: 'domain', parentIds: [mastra.id] });
-      expect(mastra.parentIds).toEqual([]);
+      expect(features).toMatchObject({ address: 'features', kind: 'domain', parentIds: [mastra.id] });
+      expect(mastra).toMatchObject({ address: 'org:acme', parentIds: [] });
+      expect(nodes.find(node => node.name === 'repo:mastra')).toMatchObject({ address: 'repo:mastra' });
       expect(Object.values(scopes)).toEqual(expect.arrayContaining([mastra.id, features.id]));
 
       const members = await store.listScopeMembers({ scopeNodeId: mastra.id });

--- a/stores/pg/src/storage/domains/knowledge/index.test.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.test.ts
@@ -285,6 +285,37 @@ describe('PostgreSQL knowledge structured reconciliation', () => {
       await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
     }
   });
+
+  it('reads structural scope nodes and members after reconciliation', async () => {
+    const schemaName = `knowledge_scope_nodes_${Date.now()}`;
+    await pool.query(`CREATE SCHEMA "${schemaName}"`);
+    try {
+      const store = createStore(schemaName);
+      await store.init();
+      const plan = {
+        scopes: [
+          { address: 'org:acme', name: 'mastra' },
+          { address: 'features', name: 'features', kind: 'domain', parentAddresses: ['org:acme'] },
+          { address: 'repo:mastra', name: 'repo:mastra', parentAddresses: ['org:acme'] },
+        ],
+      };
+      const { scopes } = await store.reconcileStructure(plan);
+
+      const nodes = await store.listScopeNodes();
+      expect(nodes.map(node => node.name)).toEqual(['features', 'mastra', 'repo:mastra']);
+      const mastra = nodes.find(node => node.name === 'mastra')!;
+      const features = nodes.find(node => node.name === 'features')!;
+      expect(features).toMatchObject({ kind: 'domain', parentIds: [mastra.id] });
+      expect(mastra.parentIds).toEqual([]);
+      expect(Object.values(scopes)).toEqual(expect.arrayContaining([mastra.id, features.id]));
+
+      const members = await store.listScopeMembers({ scopeNodeId: mastra.id });
+      expect(members.map(node => node.id).sort()).toEqual([features.id, scopes['repo:mastra']!].sort());
+      await expect(store.listScopeMembers({ scopeNodeId: crypto.randomUUID() })).resolves.toEqual([]);
+    } finally {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    }
+  });
 });
 
 describe('PostgreSQL knowledge concurrency and indexes', () => {

--- a/stores/pg/src/storage/domains/knowledge/index.test.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.test.ts
@@ -240,6 +240,53 @@ describe('PostgreSQL knowledge legacy schema boundary', () => {
   });
 });
 
+describe('PostgreSQL knowledge structured reconciliation', () => {
+  it('creates a plan once and preserves existing scope fields on replay', async () => {
+    const schemaName = `knowledge_reconcile_${Date.now()}`;
+    await pool.query(`CREATE SCHEMA "${schemaName}"`);
+    try {
+      const store = createStore(schemaName);
+      await store.init();
+      const plan = {
+        scopes: [
+          {
+            address: 'org:acme',
+            name: 'Acme',
+            grants: [{ scopeRefAddress: 'org:acme', role: 'owner' as const }],
+          },
+          { address: 'org:partner', name: 'Partner' },
+          {
+            address: 'resource:mastra',
+            name: 'Mastra',
+            parentAddresses: ['org:acme', 'org:partner'],
+            grants: [{ scopeRefAddress: 'org:acme', role: 'readonly' as const }],
+          },
+        ],
+      };
+
+      const first = await store.reconcileStructure(plan);
+      const second = await store.reconcileStructure({
+        scopes: plan.scopes.map(scope => ({ ...scope, name: `Changed ${scope.name}` })),
+      });
+
+      expect(first).toMatchObject({ changed: true, accessEpoch: 1 });
+      expect(first.createdScopeIds).toHaveLength(3);
+      expect(second).toMatchObject({ changed: false, accessEpoch: 1, scopes: first.scopes });
+      expect(
+        (
+          await pool.query(`SELECT name FROM "${schemaName}".mastra_knowledge_nodes WHERE id=$1`, [
+            first.scopes['org:acme'],
+          ])
+        ).rows[0],
+      ).toMatchObject({ name: 'Acme' });
+      expect((await pool.query(`SELECT * FROM "${schemaName}".mastra_knowledge_node_scopes`)).rows).toHaveLength(2);
+      expect((await pool.query(`SELECT * FROM "${schemaName}".mastra_knowledge_scope_grants`)).rows).toHaveLength(2);
+    } finally {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    }
+  });
+});
+
 describe('PostgreSQL knowledge concurrency and indexes', () => {
   it('creates required indexes idempotently and exports its schema', async () => {
     const store = createStore();

--- a/stores/pg/src/storage/domains/knowledge/index.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.ts
@@ -764,7 +764,7 @@ export class KnowledgePG extends KnowledgeStorage {
 
   override async listScopeNodes(): Promise<KnowledgeScopeNodeSummary[]> {
     const scopes = await this.#readExecutor.execute({
-      sql: `SELECT id,name,kind,description FROM "${TABLE_KNOWLEDGE_NODES}" WHERE "isScope" AND "deletedAt" IS NULL ORDER BY name LIMIT ${MAX_KNOWLEDGE_SCOPE_NODES}`,
+      sql: `SELECT n.id,n.name,n.kind,n.description,a.address FROM "${TABLE_KNOWLEDGE_NODES}" n LEFT JOIN "${TABLE_KNOWLEDGE_SCOPE_ADDRESSES}" a ON a."scopeNodeId"=n.id WHERE n."isScope" AND n."deletedAt" IS NULL ORDER BY n.name LIMIT ${MAX_KNOWLEDGE_SCOPE_NODES}`,
     });
     if (scopes.rows.length === 0) return [];
     const parents = await this.#readExecutor.execute({
@@ -780,6 +780,7 @@ export class KnowledgePG extends KnowledgeStorage {
     }
     return (scopes.rows as Array<Record<string, unknown>>).map(row => ({
       id: String(row.id),
+      address: String(row.address),
       name: String(row.name),
       ...(row.kind == null ? {} : { kind: String(row.kind) }),
       ...(row.description == null ? {} : { description: String(row.description) }),

--- a/stores/pg/src/storage/domains/knowledge/index.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import {
   KNOWLEDGE_ACCESS_STATE_SCHEMA,
   KNOWLEDGE_IMPORT_RUNS_SCHEMA,
@@ -61,6 +63,8 @@ import type {
   KnowledgeRecord,
   KnowledgeScope,
   KnowledgeSemanticDocumentType,
+  KnowledgeStructurePlan,
+  KnowledgeStructureReconcileResult,
   KnowledgeSemanticOperation,
   KnowledgeSemanticOutboxEntry,
   QueryKnowledgeBySourceInput,
@@ -657,6 +661,103 @@ export class KnowledgePG extends KnowledgeStorage {
       .join(', ');
     await this.#executor.execute(`DROP TABLE IF EXISTS ${tables} CASCADE`);
     await this.init();
+  }
+
+  override async reconcileStructure(plan: KnowledgeStructurePlan): Promise<KnowledgeStructureReconcileResult> {
+    return this.#transaction(async tx => {
+      await tx.execute({
+        sql: `SELECT pg_advisory_xact_lock(hashtext(?))`,
+        args: [`mastra-knowledge-reconcile:${this.#schemaName}`],
+      });
+      const scopes: Record<string, string> = {};
+      const createdScopeIds: string[] = [];
+      const createdAddresses = new Set<string>();
+      const deletedScopeAddresses = new Set<string>();
+      const resolveAddress = async (address: string): Promise<string | undefined> => {
+        if (scopes[address]) return scopes[address];
+        const result = await tx.execute({
+          sql: `SELECT a."scopeNodeId",n."isScope",n."deletedAt" FROM "${TABLE_KNOWLEDGE_SCOPE_ADDRESSES}" a JOIN "${TABLE_KNOWLEDGE_NODES}" n ON n.id=a."scopeNodeId" WHERE a.address=?`,
+          args: [address],
+        });
+        const row = result.rows[0];
+        if (!row) return undefined;
+        if (!row.isScope) throw new Error(`Knowledge address ${address} does not reference a scope`);
+        if (row.deletedAt) deletedScopeAddresses.add(address);
+        scopes[address] = String(row.scopeNodeId);
+        return scopes[address];
+      };
+
+      for (const scope of plan.scopes) {
+        const existingId = await resolveAddress(scope.address);
+        if (existingId) continue;
+        const id = randomUUID();
+        const now = new Date();
+        await tx.execute({
+          sql: `INSERT INTO "${TABLE_KNOWLEDGE_NODES}" (id,type,name,"canonicalName",kind,description,"isScope",metadata,version,"createdAt","updatedAt") VALUES (?,'node',?,?,?,?,TRUE,?,1,?,?)`,
+          args: [
+            id,
+            scope.name,
+            canonicalName(scope.name),
+            scope.kind ?? null,
+            scope.description ?? null,
+            scope.metadata ?? null,
+            now,
+            now,
+          ],
+        });
+        await tx.execute({
+          sql: `INSERT INTO "${TABLE_KNOWLEDGE_SCOPE_ADDRESSES}" (address,"scopeNodeId") VALUES (?,?)`,
+          args: [scope.address, id],
+        });
+        scopes[scope.address] = id;
+        createdAddresses.add(scope.address);
+        createdScopeIds.push(id);
+      }
+
+      for (const scope of plan.scopes) {
+        if (!createdAddresses.has(scope.address)) continue;
+        const scopeNodeId = scopes[scope.address]!;
+        for (const parentAddress of scope.parentAddresses ?? []) {
+          const parentId = await resolveAddress(parentAddress);
+          if (!parentId || deletedScopeAddresses.has(parentAddress)) {
+            throw new Error(`Knowledge parent scope does not exist: ${parentAddress}`);
+          }
+          const sibling = await tx.execute({
+            sql: `SELECT n.id FROM "${TABLE_KNOWLEDGE_NODE_SCOPES}" ns JOIN "${TABLE_KNOWLEDGE_NODES}" n ON n.id=ns."nodeId" WHERE ns."scopeNodeId"=? AND n."canonicalName"=? AND n."deletedAt" IS NULL AND n.id<>? LIMIT 1`,
+            args: [parentId, canonicalName(scope.name), scopeNodeId],
+          });
+          if (sibling.rows.length) {
+            throw new Error(`Knowledge scope name ${scope.name} already exists under ${parentAddress}`);
+          }
+          await tx.execute({
+            sql: `INSERT INTO "${TABLE_KNOWLEDGE_NODE_SCOPES}" ("nodeId","scopeNodeId","addedAt") VALUES (?,?,?) ON CONFLICT DO NOTHING`,
+            args: [scopeNodeId, parentId, new Date()],
+          });
+        }
+        for (const grant of scope.grants ?? []) {
+          const scopeRefId = await resolveAddress(grant.scopeRefAddress);
+          if (!scopeRefId || deletedScopeAddresses.has(grant.scopeRefAddress)) {
+            throw new Error(`Knowledge grant scope does not exist: ${grant.scopeRefAddress}`);
+          }
+          await tx.execute({
+            sql: `INSERT INTO "${TABLE_KNOWLEDGE_SCOPE_GRANTS}" ("scopeNodeId","scopeRefId",role,"canSuggest") VALUES (?,?,?,?) ON CONFLICT DO NOTHING`,
+            args: [scopeNodeId, scopeRefId, grant.role, grant.canSuggest ?? null],
+          });
+        }
+      }
+
+      if (createdScopeIds.length) {
+        await tx.execute(`UPDATE "${TABLE_KNOWLEDGE_ACCESS_STATE}" SET epoch=epoch+1 WHERE id='global'`);
+      }
+      const state = await tx.execute(`SELECT epoch FROM "${TABLE_KNOWLEDGE_ACCESS_STATE}" WHERE id='global'`);
+      return {
+        scopes,
+        createdScopeIds,
+        deletedScopeAddresses: [...deletedScopeAddresses],
+        changed: createdScopeIds.length > 0,
+        accessEpoch: Number(state.rows[0]?.epoch ?? 0),
+      };
+    });
   }
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {

--- a/stores/pg/src/storage/domains/knowledge/index.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 
+import type { KnowledgeScopeNodeSummary } from '@internal/core/knowledge-compat';
 import {
+  MAX_KNOWLEDGE_SCOPE_NODES,
   KNOWLEDGE_ACCESS_STATE_SCHEMA,
   KNOWLEDGE_IMPORT_RUNS_SCHEMA,
   KNOWLEDGE_IMPORT_STATE_SCHEMA,
@@ -758,6 +760,40 @@ export class KnowledgePG extends KnowledgeStorage {
         accessEpoch: Number(state.rows[0]?.epoch ?? 0),
       };
     });
+  }
+
+  override async listScopeNodes(): Promise<KnowledgeScopeNodeSummary[]> {
+    const scopes = await this.#readExecutor.execute({
+      sql: `SELECT id,name,kind,description FROM "${TABLE_KNOWLEDGE_NODES}" WHERE "isScope" AND "deletedAt" IS NULL ORDER BY name LIMIT ${MAX_KNOWLEDGE_SCOPE_NODES}`,
+    });
+    if (scopes.rows.length === 0) return [];
+    const parents = await this.#readExecutor.execute({
+      sql: `SELECT ns."nodeId",ns."scopeNodeId" FROM "${TABLE_KNOWLEDGE_NODE_SCOPES}" ns JOIN "${TABLE_KNOWLEDGE_NODES}" c ON c.id=ns."nodeId" WHERE c."isScope" AND c."deletedAt" IS NULL`,
+    });
+    const parentsByScopeId = new Map<string, string[]>();
+    for (const row of parents.rows as Array<Record<string, unknown>>) {
+      const scopeId = String(row.nodeId);
+      const parentId = String(row.scopeNodeId);
+      const existing = parentsByScopeId.get(scopeId);
+      if (existing) existing.push(parentId);
+      else parentsByScopeId.set(scopeId, [parentId]);
+    }
+    return (scopes.rows as Array<Record<string, unknown>>).map(row => ({
+      id: String(row.id),
+      name: String(row.name),
+      ...(row.kind == null ? {} : { kind: String(row.kind) }),
+      ...(row.description == null ? {} : { description: String(row.description) }),
+      parentIds: parentsByScopeId.get(String(row.id)) ?? [],
+    }));
+  }
+
+  override async listScopeMembers(input: { scopeNodeId: string; limit?: number }): Promise<KnowledgeNode[]> {
+    const limit = Math.min(Math.max(input.limit ?? 500, 1), 500);
+    const result = await this.#readExecutor.execute({
+      sql: `SELECT *, scope AS "scopeJson" FROM "${TABLE_KNOWLEDGE_NODES}" n WHERE EXISTS (SELECT 1 FROM "${TABLE_KNOWLEDGE_NODE_SCOPES}" ns WHERE ns."nodeId"=n.id AND ns."scopeNodeId"=?) AND n."deletedAt" IS NULL AND n."mergedInto" IS NULL ORDER BY n."updatedAt" DESC, n.name ASC, n.id ASC LIMIT ?`,
+      args: [input.scopeNodeId, limit],
+    });
+    return (result.rows as Array<Record<string, unknown>>).map(parseNode);
   }
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {


### PR DESCRIPTION
Wave: 1 of 4
Segment: W1.4 of 8
Purpose: Add additive, transactional Knowledge structure reconciliation and lazy parameterized scope materialization.
Previous PR: https://github.com/mastra-ai/mastra/pull/22511
Next PR: https://github.com/mastra-ai/mastra/pull/22557
Previous wave: None
Next wave: https://github.com/mastra-ai/mastra/pull/22574

## Summary

Adds structured Knowledge v2 configuration reconciliation so applications can declare canonical scopes and lazily materialize parameterized scopes without mutating existing graph structure.

- validates hand-authored scope plans and host-vouched address parameters
- reconciles missing scopes, parent memberships, and scope grants additively and transactionally
- supports background startup reconciliation and explicit `await knowledge.reconcile()`
- coalesces identical lazy materialization requests and rejects conflicting concurrent plans
- implements the contract for InMemory, LibSQL, and PostgreSQL, including cross-client serialization and access-epoch updates

## Stack navigation

- **Wave:** Knowledge v2 Wave 1, Foundation
- **Stack:** #22508
- **Previous PR:** https://github.com/mastra-ai/mastra/pull/22511
- **This PR:** W1.4, structured reconciliation
- **Next PR:** https://github.com/mastra-ai/mastra/pull/22557
- **Previous wave:** None
- **Next wave:** Wave 2, imports

## Test plan

- `pnpm --filter ./packages/core exec vitest run src/knowledge/__tests__/knowledge.test.ts src/knowledge/__tests__/reconcile.test.ts --reporter=dot --bail=1 --typecheck.enabled` (23 passed)
- `pnpm --filter @mastra/core build:lib && pnpm --filter @mastra/core check`
- `pnpm --filter ./stores/libsql exec vitest run src/storage/domains/knowledge/index.test.ts --reporter=dot --bail=1 --typecheck.enabled` (32 passed)
- `pnpm --filter ./stores/libsql build:lib`
- `pnpm --filter ./stores/pg exec vitest run src/storage/domains/knowledge/index.test.ts --reporter=dot --bail=1 --typecheck.enabled` (37 passed)
- `pnpm --filter ./stores/pg build:lib`
- focused Core, LibSQL, and PostgreSQL Oxlint and ESLint checks

## Notes

Knowledge v2 remains private and experimental. Public configuration documentation is intentionally deferred to the release/documentation wave.


