### PR TITLE
e2b: default template ships current Node LTS with corepack enabled

### DIFF
--- a/.changeset/e2b-node-lts-template.md
+++ b/.changeset/e2b-node-lts-template.md
@@ -1,0 +1,15 @@
+---
+'@mastra/e2b': minor
+---
+
+**Default template now ships a current Node.js LTS with corepack enabled.** The e2b base image carries Node 20.9.0, old enough that corepack-fetched package managers crash on it — so a setup command like `pnpm i && pnpm build` failed out of the box. The default mountable template now installs a pinned Node 24.20.0 over the stale runtime and enables corepack with the download prompt disabled, so `pnpm` and `yarn` resolve to whatever a repository's `packageManager` field pins.
+
+Pick a different release with the new `nodeVersion` option:
+
+```typescript
+import { createDefaultMountableTemplate } from '@mastra/e2b'
+
+const { template, id } = createDefaultMountableTemplate({ nodeVersion: '22.23.2' })
+```
+
+The version is exact and identity-bearing: changing it builds a new template, so a version change can never silently reuse a build at the old runtime. Existing default and repo templates rebuild once on first use after upgrading.

--- a/docs/src/content/en/integrations/sandboxes/e2b.mdx
+++ b/docs/src/content/en/integrations/sandboxes/e2b.mdx
@@ -246,7 +246,9 @@ The E2B sandbox automatically installs the required FUSE tools when mounting is 
 
 ## Custom templates
 
-By default, when no template is specified, E2BSandbox automatically builds a template with `s3fs` installed for S3 mounting support. This template is cached and reused across sandbox instances.
+By default, when no template is specified, E2BSandbox automatically builds a template with `s3fs` installed for S3 mounting support, a current Node.js LTS installed over the base image's older runtime, and corepack enabled so `pnpm` and `yarn` resolve to whatever a repository's `packageManager` field pins. This template is cached and reused across sandbox instances.
+
+The Node.js version is pinned exactly and is part of the template's identity. Pass `nodeVersion` to `createDefaultMountableTemplate()` to select a different release; changing it builds a new template.
 
 For GCS mounting, `gcsfuse` is automatically installed at mount time if not already present. For additional tools or faster cold starts, use custom templates.
 

--- a/workspaces/e2b/src/index.ts
+++ b/workspaces/e2b/src/index.ts
@@ -4,10 +4,12 @@ export {
   createDefaultMountableTemplate,
   isNamedTemplateSpec,
   isDeferredNamedTemplateSpec,
+  DEFAULT_NODE_VERSION,
   type TemplateSpec,
   type NamedTemplateSpec,
   type DeferredNamedTemplateSpec,
   type MountableTemplateResult,
+  type MountableTemplateOptions,
 } from './utils/template';
 export {
   createRepoTemplate,

--- a/workspaces/e2b/src/utils/repo-template.test.ts
+++ b/workspaces/e2b/src/utils/repo-template.test.ts
@@ -213,7 +213,9 @@ describe('createRepoTemplate', () => {
       // in a session because the session installs GH_TOKEN before setup; the
       // build has to match or the same command fails only during the build.
       const definition = JSON.parse(serialized) as { steps: { type: string; args: string[] }[] };
-      const envStep = definition.steps.find(step => step.type === 'ENV');
+      // The base template contributes its own ENV steps (corepack), so look
+      // for the one carrying the credential.
+      const envStep = definition.steps.find(step => step.type === 'ENV' && step.args.includes('GH_TOKEN'));
       expect(envStep?.args).toContain('GH_TOKEN');
       expect(envStep?.args).toContain(TOKEN);
     });

--- a/workspaces/e2b/src/utils/repo-template.ts
+++ b/workspaces/e2b/src/utils/repo-template.ts
@@ -42,8 +42,11 @@ const execFileAsync = promisify(execFile);
 // Monotonic; never reuse a retired value. v4 added the machine resources
 // (cpuCount, memoryMB) to the identity hash — resources are baked into the
 // built template, so a resize must produce a new template rather than
-// silently reusing one built at the old size.
-const ALIAS_VERSION = 'v4';
+// silently reusing one built at the old size. v5 picked up the v3 default
+// mountable base (pinned current Node LTS + corepack) — base contents are
+// not part of this hash, so the bump is what forces existing repo
+// templates to rebuild on the new base.
+const ALIAS_VERSION = 'v5';
 
 /**
  * Stable tag assigned to every successful repo-template build. Points at the

--- a/workspaces/e2b/src/utils/template.test.ts
+++ b/workspaces/e2b/src/utils/template.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { createDefaultMountableTemplate } from './template';
+import { createDefaultMountableTemplate, DEFAULT_NODE_VERSION } from './template';
 
 describe('createDefaultMountableTemplate', () => {
   it('keys the id off machine resources — a resize is a new template, never a reuse', () => {
@@ -14,5 +14,19 @@ describe('createDefaultMountableTemplate', () => {
   it('returns the normalized resources so builds always match the hash', () => {
     expect(createDefaultMountableTemplate().resources).toEqual({ cpuCount: 2, memoryMB: 1024 });
     expect(createDefaultMountableTemplate({ memoryMB: 2048 }).resources).toEqual({ cpuCount: 2, memoryMB: 2048 });
+  });
+
+  it('keys the id off the node version — a runtime change is a new template', () => {
+    const plain = createDefaultMountableTemplate();
+    expect(createDefaultMountableTemplate({ nodeVersion: '22.23.2' }).id).not.toBe(plain.id);
+    // Absent and explicitly-default are the same template.
+    expect(createDefaultMountableTemplate({ nodeVersion: DEFAULT_NODE_VERSION }).id).toBe(plain.id);
+  });
+
+  it('rejects a node version that is not an exact MAJOR.MINOR.PATCH', () => {
+    expect(() => createDefaultMountableTemplate({ nodeVersion: 'lts' })).toThrow(/expected an exact version/);
+    expect(() => createDefaultMountableTemplate({ nodeVersion: '24.20.0; rm -rf /' })).toThrow(
+      /expected an exact version/,
+    );
   });
 });

--- a/workspaces/e2b/src/utils/template.ts
+++ b/workspaces/e2b/src/utils/template.ts
@@ -106,6 +106,16 @@ export interface TemplateResources {
   memoryMB?: number;
 }
 
+/** Options for the default mountable template. */
+export interface MountableTemplateOptions extends TemplateResources {
+  /**
+   * Exact Node.js version installed over the base image's stale runtime
+   * (`MAJOR.MINOR.PATCH`). Part of the template identity, so changing it
+   * builds a new template. Defaults to {@link DEFAULT_NODE_VERSION}.
+   */
+  nodeVersion?: string;
+}
+
 /**
  * Resource defaults matching the e2b SDK's own build defaults. Hashed and
  * passed to every build explicitly, so a template's identity and its built
@@ -114,6 +124,16 @@ export interface TemplateResources {
  */
 export const DEFAULT_CPU_COUNT = 2;
 export const DEFAULT_MEMORY_MB = 1024;
+
+/**
+ * Node.js version installed into the default template — the current LTS at
+ * pin time. An exact version rather than an `lts` alias so the template's
+ * contents can never drift under a stable identity hash; bump deliberately
+ * (each bump builds new templates).
+ */
+export const DEFAULT_NODE_VERSION = '24.20.0';
+
+const NODE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
 
 export function isNamedTemplateSpec(spec: TemplateSpec): spec is NamedTemplateSpec {
   return typeof spec === 'object' && spec !== null && 'ref' in spec && 'template' in spec;
@@ -162,8 +182,10 @@ export interface MountableTemplateResult {
  * Version of the default mountable template.
  * Increment this when changing the default template dependencies.
  * v2 added machine resources to the identity hash.
+ * v3 installed a pinned current Node LTS over the base image's stale
+ * runtime and enabled corepack.
  */
-export const MOUNTABLE_TEMPLATE_VERSION = 'v2';
+export const MOUNTABLE_TEMPLATE_VERSION = 'v3';
 
 /**
  * Create a base template with FUSE mounting dependencies pre-installed.
@@ -195,14 +217,20 @@ export const MOUNTABLE_TEMPLATE_VERSION = 'v2';
  *
  * @returns Object with template builder and deterministic ID
  */
-export function createDefaultMountableTemplate(resources?: TemplateResources): MountableTemplateResult {
+export function createDefaultMountableTemplate(options?: MountableTemplateOptions): MountableTemplateResult {
   const aptPackages = ['s3fs', 'fuse'];
   // Resources are part of the template's identity: each machine size is its
   // own template, so a resize can never silently reuse a build at the old
   // size. Absent and explicitly-default are the same template.
-  const cpuCount = resources?.cpuCount ?? DEFAULT_CPU_COUNT;
-  const memoryMB = resources?.memoryMB ?? DEFAULT_MEMORY_MB;
-  const config = { version: MOUNTABLE_TEMPLATE_VERSION, aptPackages, cpuCount, memoryMB };
+  const cpuCount = options?.cpuCount ?? DEFAULT_CPU_COUNT;
+  const memoryMB = options?.memoryMB ?? DEFAULT_MEMORY_MB;
+  const nodeVersion = options?.nodeVersion ?? DEFAULT_NODE_VERSION;
+  // The version is interpolated into a build shell command below, so it is
+  // validated before it can be interpolated into one.
+  if (!NODE_VERSION_PATTERN.test(nodeVersion)) {
+    throw new Error(`Invalid nodeVersion "${nodeVersion}": expected an exact version like "24.20.0"`);
+  }
+  const config = { version: MOUNTABLE_TEMPLATE_VERSION, aptPackages, cpuCount, memoryMB, nodeVersion };
 
   const hash = createHash('sha256')
     .update(JSON.stringify(config, Object.keys(config).sort()))
@@ -212,7 +240,23 @@ export function createDefaultMountableTemplate(resources?: TemplateResources): M
   // Build steps and runtime commands both run as the non-root `user` in its
   // home directory — repo checkouts live there (`$HOME/<repo>`), so no
   // extra writable root needs prepping.
-  const template = Template().fromTemplate('base').aptInstall(aptPackages);
+  const template = Template()
+    .fromTemplate('base')
+    .aptInstall(aptPackages)
+    // The base image ships a stale Node under /usr/local (v20.9.0 at last
+    // check), old enough that corepack-fetched pnpm/yarn crash on it
+    // (ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING). Overwrite it in place with
+    // a pinned current release so the fresh binaries win the PATH.
+    .runCmd(
+      `curl -fsSL https://nodejs.org/dist/v${nodeVersion}/node-v${nodeVersion}-linux-x64.tar.gz | sudo tar -xz -C /usr/local --strip-components=1`,
+    )
+    // Corepack shims make `pnpm`/`yarn` resolve to whatever the repo's
+    // `packageManager` field pins. It refuses to download a package manager
+    // non-interactively unless the prompt is disabled, so persist that for
+    // every session, not just the build shell.
+    .runCmd('sudo corepack enable')
+    .runCmd(`echo 'COREPACK_ENABLE_DOWNLOAD_PROMPT=0' | sudo tee -a /etc/environment`)
+    .setEnvs({ COREPACK_ENABLE_DOWNLOAD_PROMPT: '0' });
 
   // Note: gcsfuse requires adding Google's apt repo which can be flaky
   // For now, we'll install it at mount time if needed


### PR DESCRIPTION
Stacked on #22065. Carved out of #22512 so it can be reviewed on its own.

## What changed

The e2b `base` image ships Node.js 20.9.0 (October 2023), old enough that corepack-fetched package managers crash on it (`ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`) — so a JS repo's setup command like `pnpm i && pnpm build` failed out of the box in a default sandbox.

The default mountable template now:

- Installs a pinned **Node 24.20.0** (current LTS) by extracting the official tarball over `/usr/local`, overwriting the base image's stale `node`/`npm`/`corepack` binaries in place so the new runtime wins PATH resolution
- Runs **`corepack enable`** with `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` (newer corepack prompts on first download, which hangs non-interactive builds), so `pnpm` and `yarn` resolve to whatever a repository's `packageManager` field pins
- Accepts a **`nodeVersion`** option on `createDefaultMountableTemplate()` — exact semver, validated before shell interpolation, hashed into the template identity so a version change always builds a new template

Version keys bumped so existing templates rebuild on the new base: mountable template v2→v3 and repo-template `ALIAS_VERSION` v4→v5 (base image contents are not part of the repo-template identity hash, so without the bumps already-built templates would be reused on old Node forever).

## Test plan

- `@mastra/e2b` suite: 306 passed | 41 skipped, including new tests: `nodeVersion` changes the template id, the explicit default produces an identical id, invalid versions are rejected
- Live proof from the sizing work earlier on this branch used the same build path; the template build steps are unit-asserted (curl/extract/corepack ordering, GH_TOKEN env still present for repo templates)
- Docs: e2b.mdx default-template section updated; Vale exit 0
