### PR TITLE
feat(memory): add partial reminder replies and wait checkpoints

### DIFF
--- a/.changeset/silly-wrens-research.md
+++ b/.changeset/silly-wrens-research.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Improve experimental Subconscious reminder research behavior.

--- a/packages/memory/src/processors/observational-memory/__tests__/remind-async-ux.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/remind-async-ux.test.ts
@@ -1,0 +1,290 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, expect, it, vi } from 'vitest';
+
+import { createRemindWaitTool } from '../subconscious/remind';
+import { ReminderResearchBudgetProcessor } from '../subconscious/remind-budget';
+import { RemindRequestRegistry } from '../subconscious/remind-request-state';
+
+const subconsciousDir = fileURLToPath(new URL('../subconscious/', import.meta.url));
+const remindSource = readFileSync(`${subconsciousDir}/remind.ts`, 'utf8');
+const requestStateSource = readFileSync(`${subconsciousDir}/remind-request-state.ts`, 'utf8');
+const budgetPath = `${subconsciousDir}/remind-budget.ts`;
+const budgetSource = existsSync(budgetPath) ? readFileSync(budgetPath, 'utf8') : '';
+
+function expectUx(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+it('async UX: reply schema exposes explicit more_coming partial state', () => {
+  expectUx(
+    /more_coming|moreComing/.test(remindSource) && /partial/.test(remindSource),
+    'missing partial protocol: reply_to_memory_question has no explicit more_coming partial schema',
+  );
+});
+
+it('async UX: lifecycle atomically reserves partial delivery before returning to pending', () => {
+  expectUx(
+    requestStateSource.includes('partial_sending') && requestStateSource.includes('reservePartial'),
+    'missing partial protocol: lifecycle has no atomic partial_sending reservation',
+  );
+});
+
+it('async UX: partial replies use deterministic monotonically sequenced signal ids', () => {
+  expectUx(
+    requestStateSource.includes('`remind-answer:${correlationId}:partial:${sequence}`'),
+    'missing partial protocol: deterministic partial sequence signal identity is absent',
+  );
+});
+
+it('async UX: partials persist without waking and terminal replies wake after them', () => {
+  expectUx(
+    /partial[\s\S]*behavior:\s*'persist'/.test(remindSource) && /terminal[\s\S]*behavior:\s*'wake'/.test(remindSource),
+    'missing partial protocol: persisted partial-before-terminal wake ordering is absent',
+  );
+});
+
+const conversation = { remindThreadId: 'remind:alpha', resourceId: 'remind-resource' };
+let budgetRegistry: RemindRequestRegistry | undefined;
+
+afterEach(() => {
+  budgetRegistry?.dispose();
+  budgetRegistry = undefined;
+  vi.useRealTimers();
+});
+
+function budgetFixture() {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  const registry = new RemindRequestRegistry();
+  budgetRegistry = registry;
+  registry.create({
+    correlationId: 'remind-ask-oldest',
+    conversation,
+    sourceAgentId: 'main',
+    sourceThreadId: 'alpha',
+    sourceResourceId: 'user-42',
+    now: 0,
+  });
+  const processor = new ReminderResearchBudgetProcessor(registry, conversation);
+  const state: Record<string, unknown> = {};
+  const messages = [{ metadata: { kind: 'remind-ask', correlationId: 'remind-ask-oldest' } }];
+  const inputArgs = { state, messages } as any;
+  const requestArgs = { state, prompt: [], stepNumber: 0, steps: [] } as any;
+  return { registry, processor, state, messages, inputArgs, requestArgs };
+}
+
+it('async UX: reminder Agent installs a question-aware research budget processor', () => {
+  expectUx(
+    budgetSource.length > 0 && /ReminderResearchBudgetProcessor/.test(remindSource),
+    'missing research budget: no question-aware budget processor is installed',
+  );
+});
+
+it('async UX: research budget nudges are transient and never persisted', () => {
+  const { processor, messages, inputArgs, requestArgs } = budgetFixture();
+  vi.setSystemTime(20_000);
+
+  processor.processInputStep(inputArgs);
+  const result = processor.processLLMRequest(requestArgs);
+
+  expect(messages).toEqual([{ metadata: { kind: 'remind-ask', correlationId: 'remind-ask-oldest' } }]);
+  expect(result?.prompt).toEqual([
+    expect.objectContaining({ role: 'system', content: expect.stringContaining('more_coming=true') }),
+  ]);
+  expectUx(/transient:\s*true/.test(budgetSource), 'missing research budget: budget nudges are not transient');
+});
+
+it('async UX: research budget escalates at twenty-second intervals', () => {
+  const { registry, processor, state, messages, inputArgs, requestArgs } = budgetFixture();
+
+  const levels: string[] = [];
+  for (const elapsed of [20_000, 40_000, 60_000]) {
+    vi.setSystemTime(elapsed);
+    processor.processInputStep(inputArgs);
+    const result = processor.processLLMRequest(requestArgs);
+    levels.push((result?.prompt?.at(-1)?.content as string) ?? '');
+  }
+
+  expect(levels[0]).toContain('partial delta');
+  expect(levels[1]).toContain('Synthesize');
+  expect(levels[2]).toContain('final delta');
+
+  processor.processInputStep(inputArgs);
+  expect(processor.processLLMRequest(requestArgs)).toBeUndefined();
+
+  registry.fail('remind-ask-oldest', 'aborted', 'cancelled');
+  const younger = registry.create({
+    correlationId: 'remind-ask-younger',
+    conversation,
+    sourceAgentId: 'main',
+    sourceThreadId: 'alpha',
+    sourceResourceId: 'user-42',
+    now: 60_000,
+  });
+  vi.setSystemTime(80_000);
+  processor.processInputStep({
+    ...inputArgs,
+    messages: [...messages, { metadata: { kind: 'remind-ask', correlationId: younger.correlationId } }],
+  });
+  expect(processor.processLLMRequest({ ...requestArgs, state })?.prompt?.at(-1)?.content).toContain('partial delta');
+});
+
+it('async UX: checkpoint returns at most twelve sanitized activity records without answer payloads', () => {
+  expectUx(
+    /recentActivity|toolActivity/.test(requestStateSource) &&
+      /slice\(-12\)|maxActivityEntries/.test(requestStateSource),
+    'missing wait checkpoint: lifecycle exposes no bounded sanitized recent activity projection',
+  );
+  expect(requestStateSource).not.toMatch(/^\s*answer\??\s*:/m);
+});
+
+const checkpointSource = { agentId: 'main', threadId: 'alpha', resourceId: 'user-42' };
+
+function checkpointFixture() {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  const registry = new RemindRequestRegistry();
+  budgetRegistry = registry;
+  const create = (correlationId: string) =>
+    registry.create({
+      correlationId,
+      conversation,
+      sourceAgentId: checkpointSource.agentId,
+      sourceThreadId: checkpointSource.threadId,
+      sourceResourceId: checkpointSource.resourceId,
+      now: 0,
+    });
+  const tool = createRemindWaitTool(registry);
+  const context = { agent: checkpointSource } as any;
+  const wait = (correlationIds: string[], timeoutMs = 0, contextOverride = context) =>
+    tool.execute!({ correlationIds, timeoutMs } as any, contextOverride);
+  return { registry, create, wait, context };
+}
+
+it('wait checkpoint: returns a pending request as checkpoint-only timeout after fifteen seconds', async () => {
+  const { create, wait } = checkpointFixture();
+  create('remind-ask-pending');
+
+  const result = wait(['remind-ask-pending'], 15_000);
+  await vi.advanceTimersByTimeAsync(15_000);
+
+  await expect(result).resolves.toMatchObject({
+    ok: true,
+    outstanding: true,
+    outstandingCorrelationIds: ['remind-ask-pending'],
+    requests: [{ correlationId: 'remind-ask-pending', status: 'timeout' }],
+  });
+});
+
+it('wait checkpoint: returns immediately when a request is terminal', async () => {
+  const { registry, create, wait } = checkpointFixture();
+  create('remind-ask-complete');
+  registry.reserveTerminal('remind-ask-complete', conversation);
+  registry.markReplied('remind-ask-complete');
+
+  await expect(wait(['remind-ask-complete'], 15_000)).resolves.toMatchObject({
+    outstanding: false,
+    outstandingCorrelationIds: [],
+    requests: [{ correlationId: 'remind-ask-complete', status: 'completed' }],
+  });
+});
+
+it('wait checkpoint: supports repeated pending then terminal checkpoints', async () => {
+  const { registry, create, wait } = checkpointFixture();
+  create('remind-ask-repeat');
+
+  await expect(wait(['remind-ask-repeat'])).resolves.toMatchObject({
+    requests: [{ status: 'timeout' }],
+  });
+  registry.reserveTerminal('remind-ask-repeat', conversation);
+  registry.markReplied('remind-ask-repeat');
+  await expect(wait(['remind-ask-repeat'])).resolves.toMatchObject({
+    requests: [{ status: 'completed' }],
+  });
+});
+
+it('wait checkpoint: exposes aborted lifecycle state without fabricating an answer', async () => {
+  const { registry, create, wait } = checkpointFixture();
+  create('remind-ask-aborted');
+  registry.fail('remind-ask-aborted', 'aborted', 'caller cancelled');
+
+  await expect(wait(['remind-ask-aborted'])).resolves.toMatchObject({
+    requests: [{ correlationId: 'remind-ask-aborted', status: 'aborted' }],
+  });
+});
+
+it('wait checkpoint: classifies unavailable correlations as unknown', async () => {
+  const { wait } = checkpointFixture();
+
+  await expect(wait(['remind-ask-missing'])).resolves.toMatchObject({
+    outstanding: false,
+    outstandingCorrelationIds: [],
+    requests: [{ correlationId: 'remind-ask-missing', status: 'unknown', recentActivity: [] }],
+  });
+});
+
+it('wait checkpoint: preserves independent mixed correlation outcomes', async () => {
+  const { registry, create, wait } = checkpointFixture();
+  create('remind-ask-pending');
+  create('remind-ask-complete');
+  create('remind-ask-failed');
+  registry.reserveTerminal('remind-ask-complete', conversation);
+  registry.markReplied('remind-ask-complete');
+  registry.fail('remind-ask-failed', 'model_failed', 'provider failed');
+
+  await expect(
+    wait(['remind-ask-pending', 'remind-ask-complete', 'remind-ask-failed', 'remind-ask-unknown']),
+  ).resolves.toMatchObject({
+    outstanding: true,
+    outstandingCorrelationIds: ['remind-ask-pending'],
+    requests: [
+      { correlationId: 'remind-ask-pending', status: 'timeout' },
+      { correlationId: 'remind-ask-complete', status: 'completed' },
+      { correlationId: 'remind-ask-failed', status: 'failed' },
+      { correlationId: 'remind-ask-unknown', status: 'unknown' },
+    ],
+  });
+});
+
+it('wait checkpoint: truncates sanitized activity to the latest twelve records in order', async () => {
+  const { registry, create, wait } = checkpointFixture();
+  create('remind-ask-activity');
+  for (let index = 0; index < 14; index += 1) {
+    registry.recordActivity('remind-ask-activity', {
+      timestamp: index,
+      toolName: `tool-${index}`,
+      action: 'execute',
+      status: 'completed',
+    });
+  }
+
+  const result = (await wait(['remind-ask-activity'])) as any;
+  expect(result.requests[0].recentActivity).toHaveLength(12);
+  expect(result.requests[0].recentActivity.map((entry: any) => entry.toolName)).toEqual(
+    Array.from({ length: 12 }, (_, index) => `tool-${index + 2}`),
+  );
+});
+
+it('wait checkpoint: excludes answer bodies and tool arguments from its read model', async () => {
+  const { registry, create, wait } = checkpointFixture();
+  create('remind-ask-sanitized');
+  registry.recordActivity('remind-ask-sanitized', {
+    toolName: 'knowledge_search',
+    action: 'execute',
+    status: 'completed',
+  });
+
+  const result = (await wait(['remind-ask-sanitized'])) as any;
+  const activity = result.requests[0].recentActivity[0];
+  expect(activity).toEqual({
+    toolName: 'knowledge_search',
+    action: 'execute',
+    status: 'completed',
+    timestamp: 0,
+  });
+  expect(activity).not.toHaveProperty('answer');
+  expect(activity).not.toHaveProperty('arguments');
+  expect(JSON.stringify(activity)).not.toContain('secret query');
+});

--- a/packages/memory/src/processors/observational-memory/__tests__/remind-request-state.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/remind-request-state.test.ts
@@ -88,6 +88,21 @@ describe('RemindRequestRegistry', () => {
     });
   });
 
+  it('releases a failed partial reservation without consuming its sequence or terminal capability', () => {
+    const registry = makeRegistry();
+    register(registry, 'remind-ask-partial-retry');
+    registry.reservePartial('remind-ask-partial-retry', conversation);
+
+    registry.releasePartial('remind-ask-partial-retry');
+
+    expect(registry.get('remind-ask-partial-retry')).toMatchObject({ status: 'pending', partialSequence: 0 });
+    expect(registry.get('remind-ask-partial-retry')?.partialSignalId).toBeUndefined();
+    expect(registry.reserveTerminal('remind-ask-partial-retry', conversation)).toMatchObject({
+      outcome: 'reserved',
+      record: { terminalSequence: 1 },
+    });
+  });
+
   it('orders the terminal sequence after committed partials and rejects partials after terminal state', () => {
     const registry = makeRegistry();
     register(registry, 'remind-ask-ordered');

--- a/packages/memory/src/processors/observational-memory/__tests__/remind-request-state.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/remind-request-state.test.ts
@@ -56,6 +56,59 @@ describe('RemindRequestRegistry', () => {
     expect(() => register(registry, 'remind-ask-dup')).toThrow(/already exists/);
   });
 
+  it('reserves and commits monotonically sequenced partial deliveries without storing delta bodies', () => {
+    const registry = makeRegistry();
+    register(registry, 'remind-ask-partials');
+
+    const first = registry.reservePartial('remind-ask-partials', conversation);
+    expect(first).toMatchObject({
+      outcome: 'reserved',
+      sequence: 1,
+      signalId: 'remind-answer:remind-ask-partials:partial:1',
+    });
+    expect(registry.get('remind-ask-partials')).toMatchObject({
+      status: 'partial_sending',
+      partialSequence: 0,
+      partialSignalId: 'remind-answer:remind-ask-partials:partial:1',
+    });
+    expect(registry.reservePartial('remind-ask-partials', conversation)).toMatchObject({
+      outcome: 'rejected',
+      reason: 'in_progress',
+    });
+
+    registry.markPartialDelivered('remind-ask-partials', 1);
+    expect(registry.get('remind-ask-partials')).toMatchObject({ status: 'pending', partialSequence: 1 });
+    expect(registry.get('remind-ask-partials')).not.toHaveProperty('answer');
+
+    const second = registry.reservePartial('remind-ask-partials', conversation);
+    expect(second).toMatchObject({
+      outcome: 'reserved',
+      sequence: 2,
+      signalId: 'remind-answer:remind-ask-partials:partial:2',
+    });
+  });
+
+  it('orders the terminal sequence after committed partials and rejects partials after terminal state', () => {
+    const registry = makeRegistry();
+    register(registry, 'remind-ask-ordered');
+    registry.reservePartial('remind-ask-ordered', conversation);
+    registry.markPartialDelivered('remind-ask-ordered', 1);
+
+    expect(registry.reserveTerminal('remind-ask-ordered', conversation)).toMatchObject({
+      outcome: 'reserved',
+      record: { terminalSequence: 2 },
+    });
+    expect(registry.reservePartial('remind-ask-ordered', conversation)).toMatchObject({
+      outcome: 'rejected',
+      reason: 'in_progress',
+    });
+    registry.markReplied('remind-ask-ordered');
+    expect(registry.reservePartial('remind-ask-ordered', conversation)).toMatchObject({
+      outcome: 'rejected',
+      reason: 'terminal',
+    });
+  });
+
   it('reserves deterministic terminal signal identity without storing an answer', () => {
     const registry = makeRegistry();
     register(registry, 'remind-ask-2');
@@ -164,7 +217,7 @@ describe('RemindRequestRegistry', () => {
     });
   });
 
-  it('does not overwrite an in-flight terminal delivery with the question deadline', async () => {
+  it('keeps the original question deadline authoritative during terminal delivery', async () => {
     vi.useFakeTimers();
     const registry = makeRegistry({ deadlineMs: 50 });
     register(registry, 'remind-ask-in-flight');
@@ -172,9 +225,28 @@ describe('RemindRequestRegistry', () => {
 
     await vi.advanceTimersByTimeAsync(50);
 
-    expect(registry.get('remind-ask-in-flight')).toMatchObject({ status: 'terminal_sending' });
+    expect(registry.get('remind-ask-in-flight')).toMatchObject({
+      status: 'timed_out',
+      failure: { status: 'timed_out', message: 'Memory question timed out after 50ms' },
+    });
     registry.markReplied('remind-ask-in-flight');
-    expect(registry.get('remind-ask-in-flight')).toMatchObject({ status: 'replied' });
+    expect(registry.get('remind-ask-in-flight')?.status).toBe('timed_out');
+  });
+
+  it('keeps the original question deadline authoritative during partial delivery', async () => {
+    vi.useFakeTimers();
+    const registry = makeRegistry({ deadlineMs: 50 });
+    register(registry, 'remind-ask-partial-deadline');
+    registry.reservePartial('remind-ask-partial-deadline', conversation);
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(registry.get('remind-ask-partial-deadline')).toMatchObject({
+      status: 'timed_out',
+      failure: { status: 'timed_out', message: 'Memory question timed out after 50ms' },
+    });
+    registry.markPartialDelivered('remind-ask-partial-deadline', 1);
+    expect(registry.get('remind-ask-partial-deadline')?.status).toBe('timed_out');
   });
 
   it('keeps terminal lifecycle state bounded', () => {

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -1161,6 +1161,56 @@ describe('Subconscious remind ask conversation', () => {
     generateSpy.mockRestore();
   });
 
+  it('keeps terminal delivery available after a partial signal is refused', async () => {
+    const sent: any[] = [];
+    let calls = 0;
+    const sourceAgent = {
+      sendSignal: vi.fn((signal: any) => {
+        sent.push(signal);
+        calls++;
+        return calls === 1
+          ? { accepted: Promise.resolve({ action: 'blocked', reason: 'source busy' }) }
+          : { accepted: Promise.resolve({ action: 'wake', runId: 'source-run', output: {} }) };
+      }),
+    };
+    let partialResult: any;
+    let terminalResult: any;
+    const { tools, generateSpy, registry } = createAskTool({
+      response: 'unused',
+      reply: async (replyTool, input, opts) => {
+        const toolContext = {
+          requestContext: opts?.requestContext,
+          agent: { threadId: opts?.threadId, resourceId: opts?.resourceId },
+        };
+        partialResult = await replyTool.execute(
+          { correlationId: input.metadata.correlationId, answer: 'unavailable delta', more_coming: true },
+          toolContext,
+        );
+        terminalResult = await replyTool.execute(
+          { correlationId: input.metadata.correlationId, answer: 'final answer', more_coming: false },
+          toolContext,
+        );
+      },
+    });
+
+    const accepted: any = await tools.ask_memory.execute!(
+      { question: 'research this despite a failed partial' } as any,
+      askContext({ mastra: { getAgentById: vi.fn(async () => sourceAgent) } }),
+    );
+    await vi.waitFor(() => expect(sent).toHaveLength(2));
+
+    expect(partialResult).toEqual(expect.objectContaining({ ok: false, correlationId: accepted.correlationId }));
+    expect(terminalResult).toEqual(
+      expect.objectContaining({ ok: true, delivered: true, correlationId: accepted.correlationId, sequence: 1 }),
+    );
+    expect(registry.get(accepted.correlationId)).toMatchObject({
+      status: 'replied',
+      partialSequence: 0,
+      terminalSequence: 1,
+    });
+    generateSpy.mockRestore();
+  });
+
   it('times out terminal delivery when routing acceptance never settles', async () => {
     vi.useFakeTimers();
     const { tools, generateSpy, registry } = createAskTool({ response: 'A terminal answer.' });

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -1323,10 +1323,12 @@ describe('Subconscious remind ask conversation', () => {
       await vi.advanceTimersByTimeAsync(REMINDER_TURN_DEADLINE_MS - 1_000);
       expect(registry.get(result.correlationId)?.status).toBe('terminal_sending');
 
+      // Terminal delivery is bounded by whatever remains of the request deadline. When the answer
+      // lands with the budget already spent, the absolute deadline is what stops the wait.
       await vi.advanceTimersByTimeAsync(1_000);
       expect(registry.get(result.correlationId)).toMatchObject({
-        status: 'delivery_unknown',
-        failure: { status: 'delivery_unknown', message: 'Terminal answer delivery timed out after 1000ms' },
+        status: 'timed_out',
+        failure: { status: 'timed_out', message: `Memory question timed out after ${REMINDER_TURN_DEADLINE_MS}ms` },
       });
     } finally {
       generateSpy.mockRestore();

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -959,6 +959,7 @@ describe('Subconscious remind ask conversation', () => {
       omModel?: any;
       createRemindMemory?: () => any;
       generate?: (prompt: string, args: any) => Promise<{ text: string }>;
+      reply?: (replyTool: any, input: any, opts: any, text: string) => Promise<void>;
     } = {},
   ) {
     const memory = { storage: new InMemoryStore(), getKnowledgeSemanticIndex: vi.fn() } as any;
@@ -978,8 +979,12 @@ describe('Subconscious remind ask conversation', () => {
         if (!processed || !('tools' in processed)) return;
         const replyTool = processed.tools?.reply_to_memory_question as any;
         if (!replyTool) return;
+        if (options.reply) {
+          await options.reply(replyTool, input, opts, text);
+          return;
+        }
         await replyTool.execute(
-          { correlationId: input?.metadata?.correlationId, answer: text },
+          { correlationId: input?.metadata?.correlationId, answer: text, more_coming: false },
           {
             requestContext: opts?.requestContext,
             agent: { threadId: opts?.threadId, resourceId: opts?.resourceId },
@@ -1092,13 +1097,74 @@ describe('Subconscious remind ask conversation', () => {
     }
   });
 
-  it.each([
-    ['routing acceptance', { accepted: new Promise(() => {}) }],
-    ['signal persistence', { accepted: Promise.resolve({ action: 'persist' }), persisted: new Promise(() => {}) }],
-  ])('fails terminal delivery when %s never settles', async (_label, signalResult) => {
+  it('delivers persisted partial deltas before one terminal wake without retaining answer bodies', async () => {
+    const sent: Array<{ signal: any; options: any }> = [];
+    const sourceAgent = {
+      sendSignal: vi.fn((signal: any, options: any) => {
+        sent.push({ signal, options });
+        return options.ifIdle?.behavior === 'persist'
+          ? { accepted: Promise.resolve({ action: 'persist' }), persisted: Promise.resolve() }
+          : { accepted: Promise.resolve({ action: 'wake', runId: 'source-run', output: {} }) };
+      }),
+    };
+    const { tools, generateSpy, registry } = createAskTool({
+      response: 'unused',
+      reply: async (replyTool, input, opts) => {
+        const toolContext = {
+          requestContext: opts?.requestContext,
+          agent: { threadId: opts?.threadId, resourceId: opts?.resourceId },
+        };
+        await replyTool.execute(
+          { correlationId: input.metadata.correlationId, answer: 'first delta', more_coming: true },
+          toolContext,
+        );
+        await replyTool.execute(
+          { correlationId: input.metadata.correlationId, answer: 'final delta', more_coming: false },
+          toolContext,
+        );
+      },
+    });
+
+    const accepted: any = await tools.ask_memory.execute!(
+      { question: 'research this' } as any,
+      askContext({ mastra: { getAgentById: vi.fn(async () => sourceAgent) } }),
+    );
+    await vi.waitFor(() => expect(sent).toHaveLength(2));
+
+    expect(accepted).toEqual(expect.objectContaining({ ok: true, accepted: true, status: 'pending' }));
+    expect(sent.map(item => item.signal.contents)).toEqual(['first delta', 'final delta']);
+    expect(sent.map(item => item.signal.attributes)).toEqual([
+      expect.objectContaining({
+        correlationId: accepted.correlationId,
+        sequence: 1,
+        more_coming: true,
+        status: 'partial',
+      }),
+      expect.objectContaining({
+        correlationId: accepted.correlationId,
+        sequence: 2,
+        more_coming: false,
+        status: 'replied',
+      }),
+    ]);
+    expect(sent.map(item => item.signal.id)).toEqual([
+      `remind-answer:${accepted.correlationId}:partial:1`,
+      `remind-answer:${accepted.correlationId}:terminal`,
+    ]);
+    expect(sent.map(item => item.options.ifIdle.behavior)).toEqual(['persist', 'wake']);
+    expect(registry.get(accepted.correlationId)).toMatchObject({
+      status: 'replied',
+      partialSequence: 1,
+      terminalSequence: 2,
+    });
+    expect(registry.get(accepted.correlationId)).not.toHaveProperty('answer');
+    generateSpy.mockRestore();
+  });
+
+  it('times out terminal delivery when routing acceptance never settles', async () => {
     vi.useFakeTimers();
     const { tools, generateSpy, registry } = createAskTool({ response: 'A terminal answer.' });
-    const sourceAgent = { sendSignal: vi.fn(() => signalResult) };
+    const sourceAgent = { sendSignal: vi.fn(() => ({ accepted: new Promise(() => {}) })) };
     try {
       const result: any = await tools.ask_memory.execute!(
         { question: 'what happened?' } as any,
@@ -1109,10 +1175,10 @@ describe('Subconscious remind ask conversation', () => {
 
       await vi.advanceTimersByTimeAsync(REMINDER_TURN_DEADLINE_MS);
       expect(registry.get(result.correlationId)).toMatchObject({
-        status: 'delivery_unknown',
+        status: 'timed_out',
         failure: {
-          status: 'delivery_unknown',
-          message: `Terminal answer delivery timed out after ${REMINDER_TURN_DEADLINE_MS}ms`,
+          status: 'timed_out',
+          message: `Memory question timed out after ${REMINDER_TURN_DEADLINE_MS}ms`,
         },
       });
     } finally {
@@ -1164,6 +1230,26 @@ describe('Subconscious remind ask conversation', () => {
 
       expect(generateSpy).toHaveBeenCalledOnce();
       expect(generateSpy.mock.calls[0]?.[1]).toMatchObject({ resourceId: 'knowledge-user' });
+    } finally {
+      generateSpy.mockRestore();
+      registry.dispose();
+    }
+  });
+
+  it('completes terminal delivery on acceptance without waiting for persistence', async () => {
+    const { tools, generateSpy, registry } = createAskTool({ response: 'A terminal answer.' });
+    const sourceAgent = {
+      sendSignal: vi.fn(() => ({
+        accepted: Promise.resolve({ action: 'persist' }),
+        persisted: new Promise(() => {}),
+      })),
+    };
+    try {
+      const result: any = await tools.ask_memory.execute!(
+        { question: 'what happened?' } as any,
+        askContext({ mastra: { getAgentById: vi.fn(async () => sourceAgent) } }),
+      );
+      await vi.waitFor(() => expect(registry.get(result.correlationId)?.status).toBe('replied'));
     } finally {
       generateSpy.mockRestore();
       registry.dispose();
@@ -1558,7 +1644,7 @@ describe('Subconscious remind ask conversation', () => {
         const processed = await processor.processInputStep?.({ messages: [input], tools: {} } as any);
         if (!processed || !('tools' in processed)) return;
         await (processed.tools?.reply_to_memory_question as any).execute(
-          { correlationId: input.metadata?.correlationId, answer: answer.text },
+          { correlationId: input.metadata?.correlationId, answer: answer.text, more_coming: false },
           { agent: { threadId: opts?.threadId, resourceId: opts?.resourceId } },
         );
       });
@@ -1677,7 +1763,7 @@ describe('reminder conversation serialization (real runtime)', () => {
               type: 'tool-call',
               toolCallId: `reply-${index}`,
               toolName: 'reply_to_memory_question',
-              input: JSON.stringify({ correlationId, answer: text }),
+              input: JSON.stringify({ correlationId, answer: text, more_coming: false }),
             },
             {
               type: 'finish',
@@ -1792,7 +1878,7 @@ describe('correlated request lifecycle (real runtime)', () => {
         type: 'tool-call',
         toolCallId: `reply-${id}`,
         toolName: 'reply_to_memory_question',
-        input: JSON.stringify({ correlationId, answer }),
+        input: JSON.stringify({ correlationId, answer, more_coming: false }),
       },
       { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
     ]),
@@ -1802,11 +1888,13 @@ describe('correlated request lifecycle (real runtime)', () => {
 
   async function currentInputTools(agent: Agent, input: any) {
     let tools: Record<string, any> = {};
+    const state: Record<string, unknown> = {};
     for (const processor of await agent.listConfiguredInputProcessors()) {
       if (!('processInputStep' in processor) || !processor.processInputStep) continue;
       const result = await processor.processInputStep({
         messages: [{ metadata: input?.metadata, content: input?.contents ?? input?.content }],
         tools,
+        state,
       } as any);
       if (result && !Array.isArray(result) && 'tools' in result && result.tools)
         tools = result.tools as Record<string, any>;
@@ -2140,11 +2228,11 @@ describe('correlated request lifecycle (real runtime)', () => {
         const agentTools = await currentInputTools(this, input);
         const correlationId = input?.metadata?.correlationId;
         rejected = await agentTools.reply_to_memory_question.execute(
-          { correlationId, answer: 'from the wrong room' },
+          { correlationId, answer: 'from the wrong room', more_coming: false },
           { agent: { threadId: 'subconscious:someone-else:remind', resourceId: 'user-99' } },
         );
         await agentTools.reply_to_memory_question.execute(
-          { correlationId, answer: 'from the right room' },
+          { correlationId, answer: 'from the right room', more_coming: false },
           { agent: { threadId: opts?.threadId, resourceId: opts?.resourceId } },
         );
         return { action: 'wake', runId: 'run-stub' };
@@ -2269,21 +2357,25 @@ describe('correlated request lifecycle (real runtime)', () => {
         outcomes.push([
           'unknown',
           await agentTools.reply_to_memory_question.execute(
-            { correlationId: 'remind-ask-00000000-0000-4000-8000-000000000000', answer: 'nobody asked' },
+            {
+              correlationId: 'remind-ask-00000000-0000-4000-8000-000000000000',
+              answer: 'nobody asked',
+              more_coming: false,
+            },
             conversationContext,
           ),
         ]);
         outcomes.push([
           'first',
           await agentTools.reply_to_memory_question.execute(
-            { correlationId, answer: 'the answer' },
+            { correlationId, answer: 'the answer', more_coming: false },
             conversationContext,
           ),
         ]);
         outcomes.push([
           'retry',
           await agentTools.reply_to_memory_question.execute(
-            { correlationId, answer: 'a different answer' },
+            { correlationId, answer: 'a different answer', more_coming: false },
             conversationContext,
           ),
         ]);

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-budget.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-budget.ts
@@ -1,0 +1,97 @@
+import type { ProcessInputStepArgs, ProcessLLMRequestArgs, ProcessLLMRequestResult } from '@mastra/core/processors';
+
+import type { RemindConversation } from './remind-request-state';
+import { RemindRequestRegistry } from './remind-request-state';
+
+const NUDGE_INTERVAL_MS = 20_000;
+const MAX_LEVEL = 3;
+const BUDGET_STATE_KEY = 'subconsciousRemindBudget';
+
+type BudgetState = {
+  emittedLevels: Record<string, number>;
+  pendingNudge?: {
+    correlationId: string;
+    level: number;
+    transient: true;
+    contents: string;
+  };
+};
+
+function nudgeText(level: number, elapsedSeconds: number): string {
+  if (level === 1) {
+    return `The asker has waited ${elapsedSeconds}s. Send a useful partial delta now with more_coming=true, then continue researching.`;
+  }
+  if (level === 2) {
+    return `The asker has waited ${elapsedSeconds}s. Synthesize what you know and send another partial delta unless the final answer is immediately available.`;
+  }
+  return `The asker has waited ${elapsedSeconds}s. Reply this step with a final delta, or plainly report what remains blocked. Do not start another search.`;
+}
+
+function correlationIds(messages: ProcessInputStepArgs['messages']): string[] {
+  const ids = new Set<string>();
+  for (const message of messages as Array<{ metadata?: Record<string, unknown> }>) {
+    if (message.metadata?.kind !== 'remind-ask' || typeof message.metadata.correlationId !== 'string') continue;
+    ids.add(message.metadata.correlationId);
+  }
+  return [...ids];
+}
+
+function stateFor(state: Record<string, unknown>): BudgetState {
+  const existing = state[BUDGET_STATE_KEY];
+  if (existing && typeof existing === 'object') return existing as BudgetState;
+  const created: BudgetState = { emittedLevels: {} };
+  state[BUDGET_STATE_KEY] = created;
+  return created;
+}
+
+export class ReminderResearchBudgetProcessor {
+  readonly id = 'subconscious-remind-budget';
+
+  constructor(
+    private readonly registry: RemindRequestRegistry,
+    private readonly conversation: RemindConversation,
+  ) {}
+
+  processInputStep(args: ProcessInputStepArgs): void {
+    const budgetState = stateFor(args.state);
+    budgetState.pendingNudge = undefined;
+
+    const candidate = correlationIds(args.messages)
+      .map(correlationId => this.registry.get(correlationId))
+      .filter(
+        record =>
+          record?.status === 'pending' &&
+          record.conversation.remindThreadId === this.conversation.remindThreadId &&
+          record.conversation.resourceId === this.conversation.resourceId,
+      )
+      .sort((a, b) => a!.createdAt - b!.createdAt)
+      .find(record => {
+        const level = Math.min(MAX_LEVEL, Math.floor((Date.now() - record!.createdAt) / NUDGE_INTERVAL_MS));
+        return level > (budgetState.emittedLevels[record!.correlationId] ?? 0);
+      });
+
+    if (!candidate) return;
+    const level = Math.min(MAX_LEVEL, Math.floor((Date.now() - candidate.createdAt) / NUDGE_INTERVAL_MS));
+    budgetState.pendingNudge = {
+      correlationId: candidate.correlationId,
+      level,
+      transient: true,
+      contents: nudgeText(level, Math.floor((Date.now() - candidate.createdAt) / 1000)),
+    };
+  }
+
+  processLLMRequest(args: ProcessLLMRequestArgs): ProcessLLMRequestResult {
+    const budgetState = stateFor(args.state);
+    const nudge = budgetState.pendingNudge;
+    if (!nudge) return undefined;
+
+    const record = this.registry.get(nudge.correlationId);
+    budgetState.pendingNudge = undefined;
+    if (!record || record.status !== 'pending') return undefined;
+
+    budgetState.emittedLevels[nudge.correlationId] = nudge.level;
+    return {
+      prompt: [...args.prompt, { role: 'system', content: nudge.contents }],
+    };
+  }
+}

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-request-state.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-request-state.ts
@@ -223,6 +223,13 @@ export class RemindRequestRegistry {
     record.status = 'pending';
   }
 
+  releasePartial(correlationId: string): void {
+    const record = this.#entries.get(correlationId);
+    if (!record || record.status !== 'partial_sending') return;
+    record.partialSignalId = undefined;
+    record.status = 'pending';
+  }
+
   reserveTerminal(correlationId: string, conversation: RemindConversation): RemindTerminalReservation {
     const record = this.#entries.get(correlationId);
     if (!record) return { outcome: 'rejected', reason: 'unknown' };

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-request-state.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-request-state.ts
@@ -6,11 +6,23 @@ export type RemindRequestFailureStatus =
   | 'aborted'
   | 'delivery_failed'
   | 'delivery_unknown';
-export type RemindRequestStatus = 'pending' | 'terminal_sending' | 'replied' | RemindRequestFailureStatus;
+export type RemindRequestStatus =
+  | 'pending'
+  | 'partial_sending'
+  | 'terminal_sending'
+  | 'replied'
+  | RemindRequestFailureStatus;
 
 export type RemindConversation = {
   remindThreadId: string;
   resourceId: string;
+};
+
+export type RemindRequestActivity = {
+  timestamp: number;
+  toolName: string;
+  action: string;
+  status: 'started' | 'completed' | 'failed';
 };
 
 export type RemindRequestRecord = {
@@ -22,16 +34,43 @@ export type RemindRequestRecord = {
   createdAt: number;
   deadlineAt: number;
   status: RemindRequestStatus;
+  partialSequence: number;
+  recentActivity: RemindRequestActivity[];
+  partialSignalId?: string;
   terminalSequence?: number;
   terminalSignalId?: string;
   terminalAt?: number;
   failure?: { status: RemindRequestFailureStatus; message: string };
 };
 
+export type RemindCheckpointStatus = 'pending' | 'completed' | 'aborted' | 'failed' | 'timeout' | 'unknown';
+
+export type RemindRequestCheckpoint = {
+  correlationId: string;
+  status: RemindCheckpointStatus;
+  partialSequence: number;
+  createdAt?: number;
+  deadlineAt?: number;
+  terminalAt?: number;
+  recentActivity: RemindRequestActivity[];
+};
+
+export type RemindPartialReservation =
+  | { outcome: 'reserved'; record: RemindRequestRecord; sequence: number; signalId: string }
+  | {
+      outcome: 'rejected';
+      reason: 'unknown' | 'wrong_conversation' | 'in_progress' | 'terminal';
+      record?: RemindRequestRecord;
+    };
+
 export type RemindTerminalReservation =
   | { outcome: 'reserved'; record: RemindRequestRecord }
   | { outcome: 'duplicate'; record: RemindRequestRecord }
-  | { outcome: 'rejected'; reason: 'unknown' | 'wrong_conversation' | 'terminal'; record?: RemindRequestRecord };
+  | {
+      outcome: 'rejected';
+      reason: 'unknown' | 'wrong_conversation' | 'in_progress' | 'terminal';
+      record?: RemindRequestRecord;
+    };
 
 function sameConversation(a: RemindConversation, b: RemindConversation): boolean {
   return a.remindThreadId === b.remindThreadId && a.resourceId === b.resourceId;
@@ -43,10 +82,12 @@ export class RemindRequestRegistry {
   readonly #terminalOrder: string[] = [];
   readonly #deadlineMs: number;
   readonly #maxTerminalEntries: number;
+  readonly #maxActivityEntries: number;
 
-  constructor(options: { deadlineMs?: number; maxTerminalEntries?: number } = {}) {
+  constructor(options: { deadlineMs?: number; maxTerminalEntries?: number; maxActivityEntries?: number } = {}) {
     this.#deadlineMs = options.deadlineMs ?? REMINDER_TURN_DEADLINE_MS;
     this.#maxTerminalEntries = options.maxTerminalEntries ?? 1_000;
+    this.#maxActivityEntries = options.maxActivityEntries ?? 12;
   }
 
   create(args: {
@@ -73,19 +114,113 @@ export class RemindRequestRegistry {
       createdAt,
       deadlineAt: createdAt + deadlineMs,
       status: 'pending',
+      partialSequence: 0,
+      recentActivity: [],
     };
     this.#entries.set(args.correlationId, record);
-
-    const timer = setTimeout(() => {
-      this.fail(args.correlationId, 'timed_out', `Memory question timed out after ${deadlineMs}ms`);
-    }, deadlineMs);
-    timer.unref?.();
-    this.#deadlineTimers.set(args.correlationId, timer);
+    this.#armDeadline(record);
     return record;
   }
 
   get(correlationId: string): RemindRequestRecord | undefined {
     return this.#entries.get(correlationId);
+  }
+
+  openCorrelationIds(conversation: RemindConversation): string[] {
+    return [...this.#entries.values()]
+      .filter(
+        record =>
+          sameConversation(record.conversation, conversation) &&
+          (record.status === 'pending' || record.status === 'partial_sending' || record.status === 'terminal_sending'),
+      )
+      .map(record => record.correlationId);
+  }
+
+  recordActivity(
+    correlationId: string,
+    activity: Omit<RemindRequestActivity, 'timestamp'> & { timestamp?: number },
+  ): void {
+    const record = this.#entries.get(correlationId);
+    if (!record) return;
+    record.recentActivity.push({ ...activity, timestamp: activity.timestamp ?? Date.now() });
+    record.recentActivity = record.recentActivity.slice(-this.#maxActivityEntries);
+  }
+
+  checkpoint(
+    correlationIds: readonly string[],
+    timedOut = false,
+    source?: { agentId: string; threadId: string; resourceId: string },
+  ): {
+    requests: RemindRequestCheckpoint[];
+    outstanding: boolean;
+    outstandingCorrelationIds: string[];
+  } {
+    const requests: RemindRequestCheckpoint[] = correlationIds.map(correlationId => {
+      const record = this.#entries.get(correlationId);
+      if (
+        !record ||
+        (source &&
+          (record.sourceAgentId !== source.agentId ||
+            record.sourceThreadId !== source.threadId ||
+            record.sourceResourceId !== source.resourceId))
+      ) {
+        return { correlationId, status: 'unknown', partialSequence: 0, recentActivity: [] };
+      }
+      const pending =
+        record.status === 'pending' || record.status === 'partial_sending' || record.status === 'terminal_sending';
+      const status: RemindCheckpointStatus = pending
+        ? timedOut
+          ? 'timeout'
+          : 'pending'
+        : record.status === 'replied'
+          ? 'completed'
+          : record.status === 'aborted'
+            ? 'aborted'
+            : 'failed';
+      return {
+        correlationId,
+        status,
+        partialSequence: record.partialSequence,
+        createdAt: record.createdAt,
+        deadlineAt: record.deadlineAt,
+        terminalAt: record.terminalAt,
+        recentActivity: record.recentActivity.map(activity => ({ ...activity })),
+      };
+    });
+    const outstandingCorrelationIds = requests
+      .filter(request => request.status === 'pending' || request.status === 'timeout')
+      .map(request => request.correlationId);
+    return {
+      requests,
+      outstanding: outstandingCorrelationIds.length > 0,
+      outstandingCorrelationIds,
+    };
+  }
+
+  reservePartial(correlationId: string, conversation: RemindConversation): RemindPartialReservation {
+    const record = this.#entries.get(correlationId);
+    if (!record) return { outcome: 'rejected', reason: 'unknown' };
+    if (!sameConversation(record.conversation, conversation)) {
+      return { outcome: 'rejected', reason: 'wrong_conversation', record };
+    }
+    if (record.status === 'partial_sending' || record.status === 'terminal_sending') {
+      return { outcome: 'rejected', reason: 'in_progress', record };
+    }
+    if (record.status !== 'pending') return { outcome: 'rejected', reason: 'terminal', record };
+
+    const sequence = record.partialSequence + 1;
+    const signalId = `remind-answer:${correlationId}:partial:${sequence}`;
+    record.status = 'partial_sending';
+    record.partialSignalId = signalId;
+    return { outcome: 'reserved', record, sequence, signalId };
+  }
+
+  markPartialDelivered(correlationId: string, sequence: number): void {
+    const record = this.#entries.get(correlationId);
+    if (!record || record.status !== 'partial_sending' || record.partialSequence + 1 !== sequence) return;
+    record.partialSequence = sequence;
+    record.partialSignalId = undefined;
+    record.status = 'pending';
   }
 
   reserveTerminal(correlationId: string, conversation: RemindConversation): RemindTerminalReservation {
@@ -97,6 +232,7 @@ export class RemindRequestRegistry {
     if (record.status === 'terminal_sending' || record.status === 'replied') {
       return { outcome: 'duplicate', record };
     }
+    if (record.status === 'partial_sending') return { outcome: 'rejected', reason: 'in_progress', record };
     if (record.status !== 'pending') return { outcome: 'rejected', reason: 'terminal', record };
     if (Date.now() >= record.deadlineAt) {
       this.fail(
@@ -108,9 +244,8 @@ export class RemindRequestRegistry {
     }
 
     record.status = 'terminal_sending';
-    record.terminalSequence = 1;
+    record.terminalSequence = record.partialSequence + 1;
     record.terminalSignalId = `remind-answer:${correlationId}:terminal`;
-    this.#clearDeadline(correlationId);
     return { outcome: 'reserved', record };
   }
 
@@ -125,8 +260,12 @@ export class RemindRequestRegistry {
 
   fail(correlationId: string, status: RemindRequestFailureStatus, message: string): void {
     const record = this.#entries.get(correlationId);
-    if (!record || (record.status !== 'pending' && record.status !== 'terminal_sending')) return;
-    if (status === 'timed_out' && record.status === 'terminal_sending') return;
+    if (
+      !record ||
+      (record.status !== 'pending' && record.status !== 'partial_sending' && record.status !== 'terminal_sending')
+    ) {
+      return;
+    }
     record.status = status;
     record.terminalAt = Date.now();
     record.failure = { status, message };
@@ -147,6 +286,20 @@ export class RemindRequestRegistry {
       const expiredCorrelationId = this.#terminalOrder.shift();
       if (expiredCorrelationId) this.#entries.delete(expiredCorrelationId);
     }
+  }
+
+  #armDeadline(record: RemindRequestRecord): void {
+    this.#clearDeadline(record.correlationId);
+    const remainingMs = Math.max(0, record.deadlineAt - Date.now());
+    const timer = setTimeout(() => {
+      this.fail(
+        record.correlationId,
+        'timed_out',
+        `Memory question timed out after ${record.deadlineAt - record.createdAt}ms`,
+      );
+    }, remainingMs);
+    timer.unref?.();
+    this.#deadlineTimers.set(record.correlationId, timer);
   }
 
   #clearDeadline(correlationId: string): void {

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -14,6 +14,7 @@ import type { ObservationalMemoryModel } from '../types';
 import { publishSubconsciousActivity } from './activity';
 import { createKnowledgeTools } from './knowledge-tools';
 import { resolveReminderConversationModel } from './model';
+import { ReminderResearchBudgetProcessor } from './remind-budget';
 import type { RemindConversation, RemindRequestFailureStatus, RemindRequestRecord } from './remind-request-state';
 import { REMINDER_TURN_DEADLINE_MS, RemindRequestRegistry } from './remind-request-state';
 import { resolveKnowledgeResourceId } from './scope';
@@ -202,7 +203,7 @@ export interface SubconsciousRemindOptions {
 
 const ASK_INSTRUCTIONS = `The main agent is asking you direct questions. This is a conversation, not an observation run: answer the question.
 
-Every question arrives with a correlationId. Answer it by calling reply_to_memory_question exactly once with that exact correlationId and your answer — plain text in the response is not delivered to the asker. Several questions may arrive during one turn; answer each one with its own correlationId.
+Every question arrives with a correlationId. Answer it by calling reply_to_memory_question with that exact correlationId — plain text in the response is not delivered to the asker. Send delta-only partial answers with more_coming true while research continues, then one terminal delta with more_coming false. Several questions may arrive during one turn; keep each correlation's answer sequence independent.
 
 Use everything you already remember from this conversation plus the knowledge tools. A follow-up may refer back to something discussed earlier in this thread, so resolve references against your own history before searching. Answer plainly and include source node or item IDs when the answer rests on stored knowledge. If you do not know, say so plainly instead of guessing, and never respond with ${NO_REMINDER} to a question.`;
 
@@ -229,7 +230,7 @@ type SignalSender = {
     target: {
       threadId: string;
       resourceId: string;
-      ifIdle?: { behavior?: 'wake'; streamOptions?: { requestContext?: RequestContext } };
+      ifIdle?: { behavior?: 'wake' | 'persist'; streamOptions?: { requestContext?: RequestContext } };
     },
   ): SendAgentSignalResult;
 };
@@ -263,25 +264,15 @@ async function acceptSignalDelivery(
   result: SendAgentSignalResult,
   deadlineAt: number,
 ): Promise<SendAgentSignalAccepted> {
-  const remainingMs = Math.max(0, deadlineAt - Date.now());
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const remainingMs = Math.max(0, deadlineAt - Date.now());
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(
-      () => reject(new Error(`Terminal answer delivery timed out after ${remainingMs}ms`)),
-      remainingMs,
-    );
+    timer = setTimeout(() => reject(new Error('Answer delivery exceeded the question deadline.')), remainingMs);
     timer.unref?.();
   });
 
   try {
-    return await Promise.race([
-      (async () => {
-        const disposition = await result.accepted;
-        if (disposition.action === 'persist') await result.persisted;
-        return disposition;
-      })(),
-      timeout,
-    ]);
+    return await Promise.race([result.accepted, timeout]);
   } finally {
     if (timer) clearTimeout(timer);
   }
@@ -310,18 +301,26 @@ function createReplyTool(
   return createTool({
     id: 'reply_to_memory_question',
     description:
-      'Deliver the terminal answer to a question the main agent asked. Call this exactly once with the correlationId that came with the current question.',
+      'Deliver an answer delta to a question the main agent asked. Set more_coming true while research continues and false for the terminal delta.',
     inputSchema: {
       type: 'object',
       properties: {
         correlationId: { type: 'string', minLength: 1, description: 'The correlationId that came with the question.' },
-        answer: { type: 'string', minLength: 1, description: 'The answer, in natural language.' },
+        answer: { type: 'string', minLength: 1, description: 'The next answer delta, in natural language.' },
+        more_coming: {
+          type: 'boolean',
+          description: 'True when another answer delta will follow; false when this delta closes the question.',
+        },
       },
-      required: ['correlationId', 'answer'],
+      required: ['correlationId', 'answer', 'more_coming'],
       additionalProperties: false,
     } satisfies JSONSchema7,
     execute: async (input, rawContext) => {
-      const { correlationId, answer } = input as { correlationId: string; answer: string };
+      const { correlationId, answer, more_coming } = input as {
+        correlationId: string;
+        answer: string;
+        more_coming: boolean;
+      };
       const context = rawContext as AskToolContext;
       if (!allowedCorrelationIds.has(correlationId)) {
         return {
@@ -337,8 +336,11 @@ function createReplyTool(
         return { ok: false, correlationId, error: `Question ${correlationId} belongs to another conversation.` };
       }
 
-      const reservation = registry.reserveTerminal(correlationId, conversation);
-      if (reservation.outcome === 'duplicate') {
+      const action = more_coming ? 'deliver_partial' : 'deliver_terminal';
+      const reservation = more_coming
+        ? registry.reservePartial(correlationId, conversation)
+        : registry.reserveTerminal(correlationId, conversation);
+      if ('outcome' in reservation && reservation.outcome === 'duplicate') {
         return {
           ok: true,
           correlationId,
@@ -356,12 +358,16 @@ function createReplyTool(
               ? `No open question with correlationId ${correlationId}. It may have timed out already.`
               : reservation.reason === 'wrong_conversation'
                 ? `Question ${correlationId} belongs to another conversation.`
-                : `Question ${correlationId} can no longer accept a terminal answer.`,
+                : reservation.reason === 'in_progress'
+                  ? `Question ${correlationId} already has an answer delivery in progress.`
+                  : `Question ${correlationId} can no longer accept an answer.`,
         };
       }
 
+      registry.recordActivity(correlationId, { toolName: 'reply_to_memory_question', action, status: 'started' });
       const capability = capabilities.get(correlationId);
       if (!capability) {
+        registry.recordActivity(correlationId, { toolName: 'reply_to_memory_question', action, status: 'failed' });
         registry.fail(
           correlationId,
           'delivery_unknown',
@@ -374,8 +380,10 @@ function createReplyTool(
         };
       }
 
+      const sequence = more_coming ? reservation.record.partialSequence + 1 : reservation.record.terminalSequence!;
+      const signalId = more_coming ? reservation.record.partialSignalId! : reservation.record.terminalSignalId!;
       const signal = createSignal({
-        id: reservation.record.terminalSignalId!,
+        id: signalId,
         type: 'reactive',
         tagName: 'remembered',
         contents: answer,
@@ -386,8 +394,9 @@ function createReplyTool(
           source: 'subconscious',
           agent: 'remind',
           correlationId,
-          sequence: reservation.record.terminalSequence,
-          status: 'replied',
+          sequence,
+          more_coming,
+          status: more_coming ? 'partial' : 'replied',
           sourceAgentId: reservation.record.sourceAgentId,
           sourceThreadId: reservation.record.sourceThreadId,
           sourceResourceId: reservation.record.sourceResourceId,
@@ -402,18 +411,22 @@ function createReplyTool(
           capability.sourceAgent.sendSignal(signal, {
             threadId: reservation.record.sourceThreadId,
             resourceId: reservation.record.sourceResourceId,
-            ifIdle: { behavior: 'wake', streamOptions: { requestContext: context.requestContext } },
+            ifIdle: more_coming
+              ? { behavior: 'persist' }
+              : { behavior: 'wake', streamOptions: { requestContext: context.requestContext } },
           }),
           reservation.record.deadlineAt,
         );
       } catch (error) {
+        registry.recordActivity(correlationId, { toolName: 'reply_to_memory_question', action, status: 'failed' });
         registry.fail(correlationId, 'delivery_unknown', error instanceof Error ? error.message : String(error));
         deleteReplyCapability(capabilities, correlationId);
-        return { ok: false, correlationId, error: 'Terminal answer delivery could not be confirmed.' };
+        return { ok: false, correlationId, error: 'Answer delivery could not be confirmed.' };
       }
 
       if (accepted.action === 'blocked' || accepted.action === 'discard') {
         const refusal = accepted.action === 'blocked' ? accepted.reason : accepted.action;
+        registry.recordActivity(correlationId, { toolName: 'reply_to_memory_question', action, status: 'failed' });
         registry.fail(correlationId, 'delivery_failed', refusal);
         deleteReplyCapability(capabilities, correlationId);
         return {
@@ -423,9 +436,14 @@ function createReplyTool(
         };
       }
 
-      registry.markReplied(correlationId);
-      deleteReplyCapability(capabilities, correlationId);
-      return { ok: true, correlationId, delivered: true };
+      registry.recordActivity(correlationId, { toolName: 'reply_to_memory_question', action, status: 'completed' });
+      if (more_coming) {
+        registry.markPartialDelivered(correlationId, sequence);
+      } else {
+        registry.markReplied(correlationId);
+        deleteReplyCapability(capabilities, correlationId);
+      }
+      return { ok: true, correlationId, delivered: true, sequence, more_coming };
     },
   });
 }
@@ -479,6 +497,43 @@ export function createReplyToolProcessor(
   };
 }
 
+function withReminderActivity(
+  tools: Record<string, ToolAction<any, any, any>>,
+  registry: RemindRequestRegistry,
+  conversation: RemindConversation,
+): Record<string, ToolAction<any, any, any>> {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, tool]) => {
+      const execute = tool.execute;
+      if (!execute) return [name, tool];
+      return [
+        name,
+        {
+          ...tool,
+          execute: async (...args: Parameters<NonNullable<typeof execute>>) => {
+            const correlationIds = registry.openCorrelationIds(conversation);
+            for (const correlationId of correlationIds) {
+              registry.recordActivity(correlationId, { toolName: name, action: 'execute', status: 'started' });
+            }
+            try {
+              const result = await execute.call(tool, ...args);
+              for (const correlationId of correlationIds) {
+                registry.recordActivity(correlationId, { toolName: name, action: 'execute', status: 'completed' });
+              }
+              return result;
+            } catch (error) {
+              for (const correlationId of correlationIds) {
+                registry.recordActivity(correlationId, { toolName: name, action: 'execute', status: 'failed' });
+              }
+              throw error;
+            }
+          },
+        },
+      ];
+    }),
+  );
+}
+
 function createReminderAgent(args: {
   parentThreadId: string;
   conversation: RemindConversation;
@@ -496,8 +551,11 @@ function createReminderAgent(args: {
     instructions: args.instructions,
     model: args.model,
     ...(args.remindMemory ? { memory: args.remindMemory } : {}),
-    tools: createKnowledgeTools(args.memory, args.scope),
-    inputProcessors: [createReplyToolProcessor(args.registry, args.conversation, args.replyCapabilities)],
+    tools: withReminderActivity(createKnowledgeTools(args.memory, args.scope), args.registry, args.conversation),
+    inputProcessors: [
+      createReplyToolProcessor(args.registry, args.conversation, args.replyCapabilities),
+      new ReminderResearchBudgetProcessor(args.registry, args.conversation),
+    ],
   });
 }
 
@@ -531,43 +589,9 @@ interface ReminderConversationTurnArgs {
 async function runReminderConversationTurn(args: ReminderConversationTurnArgs): Promise<string> {
   const threadId = remindThreadKey(args.parentThreadId);
   const deadlineMs = args.deadlineMs ?? REMINDER_TURN_DEADLINE_MS;
-  const deadlineAt = Date.now() + deadlineMs;
-  const abortMessage = 'The caller aborted while waiting for the reminder conversation turn.';
-
-  const waitWithinDeadline = async <T>(promise: Promise<T>, phase: 'accept' | 'complete'): Promise<T> => {
-    if (args.abortSignal?.aborted) throw new Error(abortMessage);
-
-    const remainingMs = Math.max(0, deadlineAt - Date.now());
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    let onAbort: (() => void) | undefined;
-    try {
-      return await Promise.race([
-        promise,
-        new Promise<never>((_, reject) => {
-          timer = setTimeout(
-            () =>
-              reject(
-                new Error(
-                  phase === 'accept'
-                    ? `The reminder conversation did not accept this turn within ${deadlineMs}ms.`
-                    : `The reminder conversation did not complete this turn within ${deadlineMs}ms.`,
-                ),
-              ),
-            remainingMs,
-          );
-          timer.unref?.();
-
-          if (args.abortSignal) {
-            onAbort = () => reject(new Error(abortMessage));
-            args.abortSignal.addEventListener('abort', onAbort, { once: true });
-          }
-        }),
-      ]);
-    } finally {
-      if (timer) clearTimeout(timer);
-      if (onAbort && args.abortSignal) args.abortSignal.removeEventListener('abort', onAbort);
-    }
-  };
+  if (args.abortSignal?.aborted) {
+    throw new Error('The caller aborted while waiting for the reminder conversation turn.');
+  }
 
   const result = args.agent.sendMessage(args.prompt, {
     threadId,
@@ -580,7 +604,16 @@ async function runReminderConversationTurn(args: ReminderConversationTurnArgs): 
       },
     },
   });
-  const accepted = await waitWithinDeadline(result.accepted, 'accept');
+  const accepted = await Promise.race([
+    result.accepted,
+    new Promise<never>((_, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`The reminder conversation did not accept this turn within ${deadlineMs}ms.`)),
+        deadlineMs,
+      );
+      (timer as { unref?: () => void }).unref?.();
+    }),
+  ]);
 
   if (accepted.action === 'blocked' || accepted.action === 'discard') {
     throw new Error(
@@ -591,11 +624,11 @@ async function runReminderConversationTurn(args: ReminderConversationTurnArgs): 
   }
   if (accepted.action !== 'wake') return NO_REMINDER;
 
-  const output = await waitWithinDeadline(
-    accepted.output.consumeStream().then(() => accepted.output.getFullOutput()),
-    'complete',
-  );
-  return output.text.trim();
+  if (args.abortSignal?.aborted) {
+    throw new Error('The caller aborted while waiting for the reminder conversation turn.');
+  }
+  await accepted.output.consumeStream();
+  return (await accepted.output.getFullOutput()).text.trim();
 }
 
 /**
@@ -603,6 +636,69 @@ async function runReminderConversationTurn(args: ReminderConversationTurnArgs): 
  * acknowledgement; the answer returns later as a correlated source-agent signal. Questions and
  * passive evaluations enter the same serialized reminder conversation.
  */
+export function createRemindWaitTool(registry: RemindRequestRegistry) {
+  return createTool({
+    id: 'wait_for_memory_answers',
+    description:
+      'Wait briefly for one or more accepted memory questions to reach a terminal lifecycle state. Returns status and sanitized recent activity only; answers still arrive through reactive remembered signals.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        correlationIds: {
+          type: 'array',
+          minItems: 1,
+          uniqueItems: true,
+          items: { type: 'string', minLength: 1 },
+          description: 'Correlation IDs returned by ask_memory.',
+        },
+        timeoutMs: {
+          type: 'integer',
+          minimum: 0,
+          maximum: 15_000,
+          description: 'Maximum checkpoint wait in milliseconds. Defaults to 15000.',
+        },
+      },
+      required: ['correlationIds'],
+      additionalProperties: false,
+    } satisfies JSONSchema7,
+    execute: async (input, rawContext) => {
+      const { correlationIds, timeoutMs = 15_000 } = input as { correlationIds: string[]; timeoutMs?: number };
+      const boundedTimeoutMs = Math.min(15_000, Math.max(0, timeoutMs));
+      const context = rawContext as AskToolContext;
+      const source =
+        context.agent?.agentId && context.agent.threadId && context.agent.resourceId
+          ? {
+              agentId: context.agent.agentId,
+              threadId: context.agent.threadId,
+              resourceId: context.agent.resourceId,
+            }
+          : undefined;
+      if (!source) return { ok: false, error: 'wait_for_memory_answers requires an active source Agent.' };
+
+      const startedAt = Date.now();
+      let checkpoint = registry.checkpoint(correlationIds, false, source);
+      while (checkpoint.outstanding && Date.now() - startedAt < boundedTimeoutMs && !context.abortSignal?.aborted) {
+        await new Promise<void>(resolve => {
+          setTimeout(resolve, Math.min(25, boundedTimeoutMs - (Date.now() - startedAt)));
+        });
+        checkpoint = registry.checkpoint(correlationIds, false, source);
+      }
+
+      const timedOut = checkpoint.outstanding && !context.abortSignal?.aborted;
+      if (timedOut) checkpoint = registry.checkpoint(correlationIds, true, source);
+      return {
+        ok: true,
+        scope: 'current_process',
+        aborted: context.abortSignal?.aborted || undefined,
+        ...checkpoint,
+        note: checkpoint.outstanding
+          ? 'Some memory research is still outstanding. Continue now or call this checkpoint again later; reactive answers may still arrive.'
+          : 'Every requested memory question reached a terminal lifecycle state.',
+      };
+    },
+  });
+}
+
 export function createRemindAskTool(options: RemindAskToolOptions) {
   const { memory, config, omModel } = options;
   // Same fallback the passive path uses. A per-call registry here would put the ask tool and the
@@ -708,28 +804,7 @@ export function createRemindAskTool(options: RemindAskToolOptions) {
           },
         },
       );
-      const remainingMs = Math.max(0, record.deadlineAt - Date.now());
-      let acceptanceTimer: ReturnType<typeof setTimeout> | undefined;
-      let onAbort: (() => void) | undefined;
-      const acceptanceDeadline = new Promise<never>((_, reject) => {
-        acceptanceTimer = setTimeout(
-          () => reject(new Error(`The reminder conversation did not accept this question within ${remainingMs}ms.`)),
-          remainingMs,
-        );
-        acceptanceTimer.unref?.();
-        if (context.abortSignal) {
-          onAbort = () => reject(new Error('The caller aborted while submitting the reminder question.'));
-          if (context.abortSignal.aborted) onAbort();
-          else context.abortSignal.addEventListener('abort', onAbort, { once: true });
-        }
-      });
-      let disposition: Awaited<typeof result.accepted>;
-      try {
-        disposition = await Promise.race([result.accepted, acceptanceDeadline]);
-      } finally {
-        if (acceptanceTimer) clearTimeout(acceptanceTimer);
-        if (onAbort && context.abortSignal) context.abortSignal.removeEventListener('abort', onAbort);
-      }
+      const disposition = await result.accepted;
       if (disposition.action === 'blocked' || disposition.action === 'discard') {
         fail('delivery_failed', disposition.action === 'blocked' ? disposition.reason : disposition.action);
       } else if (disposition.action === 'wake') {
@@ -790,12 +865,15 @@ export function createRemindAskTool(options: RemindAskToolOptions) {
         accepted: true,
         correlationId: record.correlationId,
         status: 'pending',
-        note: 'The answer will arrive as a correlated reactive remembered signal. This segment has no blocking checkpoint.',
+        note: 'The answer will arrive as a correlated reactive remembered signal. Use wait_for_memory_answers only for a bounded status and activity checkpoint.',
       };
     },
   });
 
-  return { ask_memory: askMemory } satisfies Record<string, ToolAction<any, any, any, any, any, any, any>>;
+  return {
+    ask_memory: askMemory,
+    wait_for_memory_answers: createRemindWaitTool(registry),
+  } satisfies Record<string, ToolAction<any, any, any, any, any, any, any>>;
 }
 
 /**

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -501,7 +501,7 @@ export function createReplyToolProcessor(
       if (correlations.size === 0) return undefined;
       return {
         tools: {
-          ...args.tools,
+          ...withReminderActivity(args.tools as Record<string, ToolAction<any, any, any>>, registry, correlations),
           reply_to_memory_question: createReplyTool(registry, capabilities, conversation, correlations),
         },
       };
@@ -512,7 +512,7 @@ export function createReplyToolProcessor(
 function withReminderActivity(
   tools: Record<string, ToolAction<any, any, any>>,
   registry: RemindRequestRegistry,
-  conversation: RemindConversation,
+  correlationIds: ReadonlySet<string>,
 ): Record<string, ToolAction<any, any, any>> {
   return Object.fromEntries(
     Object.entries(tools).map(([name, tool]) => {
@@ -523,7 +523,6 @@ function withReminderActivity(
         {
           ...tool,
           execute: async (...args: Parameters<NonNullable<typeof execute>>) => {
-            const correlationIds = registry.openCorrelationIds(conversation);
             for (const correlationId of correlationIds) {
               registry.recordActivity(correlationId, { toolName: name, action: 'execute', status: 'started' });
             }
@@ -563,7 +562,7 @@ function createReminderAgent(args: {
     instructions: args.instructions,
     model: args.model,
     ...(args.remindMemory ? { memory: args.remindMemory } : {}),
-    tools: withReminderActivity(createKnowledgeTools(args.memory, args.scope), args.registry, args.conversation),
+    tools: createKnowledgeTools(args.memory, args.scope),
     inputProcessors: [
       createReplyToolProcessor(args.registry, args.conversation, args.replyCapabilities),
       new ReminderResearchBudgetProcessor(args.registry, args.conversation),

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -368,11 +368,15 @@ function createReplyTool(
       const capability = capabilities.get(correlationId);
       if (!capability) {
         registry.recordActivity(correlationId, { toolName: 'reply_to_memory_question', action, status: 'failed' });
-        registry.fail(
-          correlationId,
-          'delivery_unknown',
-          'The source delivery capability expired before terminal reply.',
-        );
+        if (more_coming) {
+          registry.releasePartial(correlationId);
+        } else {
+          registry.fail(
+            correlationId,
+            'delivery_unknown',
+            'The source delivery capability expired before terminal reply.',
+          );
+        }
         return {
           ok: false,
           correlationId,
@@ -419,16 +423,24 @@ function createReplyTool(
         );
       } catch (error) {
         registry.recordActivity(correlationId, { toolName: 'reply_to_memory_question', action, status: 'failed' });
-        registry.fail(correlationId, 'delivery_unknown', error instanceof Error ? error.message : String(error));
-        deleteReplyCapability(capabilities, correlationId);
+        if (more_coming) {
+          registry.releasePartial(correlationId);
+        } else {
+          registry.fail(correlationId, 'delivery_unknown', error instanceof Error ? error.message : String(error));
+          deleteReplyCapability(capabilities, correlationId);
+        }
         return { ok: false, correlationId, error: 'Answer delivery could not be confirmed.' };
       }
 
       if (accepted.action === 'blocked' || accepted.action === 'discard') {
         const refusal = accepted.action === 'blocked' ? accepted.reason : accepted.action;
         registry.recordActivity(correlationId, { toolName: 'reply_to_memory_question', action, status: 'failed' });
-        registry.fail(correlationId, 'delivery_failed', refusal);
-        deleteReplyCapability(capabilities, correlationId);
+        if (more_coming) {
+          registry.releasePartial(correlationId);
+        } else {
+          registry.fail(correlationId, 'delivery_failed', refusal);
+          deleteReplyCapability(capabilities, correlationId);
+        }
         return {
           ok: false,
           correlationId,

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -840,7 +840,28 @@ export function createRemindAskTool(options: RemindAskToolOptions) {
           },
         },
       );
-      const disposition = await result.accepted;
+      const remainingMs = Math.max(0, record.deadlineAt - Date.now());
+      let acceptanceTimer: ReturnType<typeof setTimeout> | undefined;
+      let onAbort: (() => void) | undefined;
+      const acceptanceDeadline = new Promise<never>((_, reject) => {
+        acceptanceTimer = setTimeout(
+          () => reject(new Error(`The reminder conversation did not accept this question within ${remainingMs}ms.`)),
+          remainingMs,
+        );
+        acceptanceTimer.unref?.();
+        if (context.abortSignal) {
+          onAbort = () => reject(new Error('The caller aborted while submitting the reminder question.'));
+          if (context.abortSignal.aborted) onAbort();
+          else context.abortSignal.addEventListener('abort', onAbort, { once: true });
+        }
+      });
+      let disposition: Awaited<typeof result.accepted>;
+      try {
+        disposition = await Promise.race([result.accepted, acceptanceDeadline]);
+      } finally {
+        if (acceptanceTimer) clearTimeout(acceptanceTimer);
+        if (onAbort && context.abortSignal) context.abortSignal.removeEventListener('abort', onAbort);
+      }
       if (disposition.action === 'blocked' || disposition.action === 'discard') {
         fail('delivery_failed', disposition.action === 'blocked' ? disposition.reason : disposition.action);
       } else if (disposition.action === 'wake') {

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -601,9 +601,43 @@ interface ReminderConversationTurnArgs {
 async function runReminderConversationTurn(args: ReminderConversationTurnArgs): Promise<string> {
   const threadId = remindThreadKey(args.parentThreadId);
   const deadlineMs = args.deadlineMs ?? REMINDER_TURN_DEADLINE_MS;
-  if (args.abortSignal?.aborted) {
-    throw new Error('The caller aborted while waiting for the reminder conversation turn.');
-  }
+  const deadlineAt = Date.now() + deadlineMs;
+  const abortMessage = 'The caller aborted while waiting for the reminder conversation turn.';
+
+  const waitWithinDeadline = async <T>(promise: Promise<T>, phase: 'accept' | 'complete'): Promise<T> => {
+    if (args.abortSignal?.aborted) throw new Error(abortMessage);
+
+    const remainingMs = Math.max(0, deadlineAt - Date.now());
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let onAbort: (() => void) | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  phase === 'accept'
+                    ? `The reminder conversation did not accept this turn within ${deadlineMs}ms.`
+                    : `The reminder conversation did not complete this turn within ${deadlineMs}ms.`,
+                ),
+              ),
+            remainingMs,
+          );
+          timer.unref?.();
+
+          if (args.abortSignal) {
+            onAbort = () => reject(new Error(abortMessage));
+            args.abortSignal.addEventListener('abort', onAbort, { once: true });
+          }
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+      if (onAbort && args.abortSignal) args.abortSignal.removeEventListener('abort', onAbort);
+    }
+  };
 
   const result = args.agent.sendMessage(args.prompt, {
     threadId,
@@ -616,16 +650,7 @@ async function runReminderConversationTurn(args: ReminderConversationTurnArgs): 
       },
     },
   });
-  const accepted = await Promise.race([
-    result.accepted,
-    new Promise<never>((_, reject) => {
-      const timer = setTimeout(
-        () => reject(new Error(`The reminder conversation did not accept this turn within ${deadlineMs}ms.`)),
-        deadlineMs,
-      );
-      (timer as { unref?: () => void }).unref?.();
-    }),
-  ]);
+  const accepted = await waitWithinDeadline(result.accepted, 'accept');
 
   if (accepted.action === 'blocked' || accepted.action === 'discard') {
     throw new Error(
@@ -636,11 +661,11 @@ async function runReminderConversationTurn(args: ReminderConversationTurnArgs): 
   }
   if (accepted.action !== 'wake') return NO_REMINDER;
 
-  if (args.abortSignal?.aborted) {
-    throw new Error('The caller aborted while waiting for the reminder conversation turn.');
-  }
-  await accepted.output.consumeStream();
-  return (await accepted.output.getFullOutput()).text.trim();
+  const output = await waitWithinDeadline(
+    accepted.output.consumeStream().then(() => accepted.output.getFullOutput()),
+    'complete',
+  );
+  return output.text.trim();
 }
 
 /**


### PR DESCRIPTION
## Summary

Extend the acceptance-only reminder ask protocol with ordered partial answer signals, transient research-budget guidance, and a bounded payload-free checkpoint tool.

## Root cause

A single terminal signal gave callers no progress visibility during longer reminder research. The lifecycle also needed deterministic ordering, one absolute deadline, and an explicit way to inspect status without reintroducing retained answer payloads or process-local resolvers.

## What changed

- Require `more_coming` on `reply_to_memory_question`.
- Send monotonic partial deltas with deterministic signal IDs and `ifIdle: persist`.
- Send exactly one terminal delta with `ifIdle: wake`.
- Preserve the original absolute request deadline across partial and terminal delivery.
- Reject overlapping partial and terminal sends while one delivery is in progress.
- Add `wait_for_memory_answers`, clamped to 15 seconds, returning lifecycle metadata and bounded sanitized activity without answer text.
- Add transient 20, 40, and 60 second provider-prompt nudges for the oldest eligible active correlation present in the current turn.
- Keep nudges out of persisted reminder history and passive-reminder inputs.
- Keep transport and lifecycle coverage behavioral; retained source-shape assertions are limited to narrow structural contracts.

## Design notes

Checkpoint timeout does not cancel the underlying reminder turn, so later signals may still arrive even after the registry records `timed_out`. A refused or ambiguous partial delivery releases only that in-flight partial reservation, preserves the original deadline and reply capability, and permits a later terminal answer; the partial itself is not retried because its acceptance is unknown. Partial delivery confirms routing acceptance, not durable signal persistence. The original question deadline remains authoritative during both partial and terminal delivery: if it expires while a delivery is in flight, the registry remains `timed_out` even if the signal is subsequently accepted. Activity attribution is bounded to correlations represented by the current question turn; when several questions share one reminder turn, a shared tool call may appear in each represented correlation's sanitized activity.

Budget threshold coverage uses deterministic fake clocks. A live-provider Factory run was attempted but is not claimed as proof because the environment lacked a usable provider credential.

## Lineage

This PR is rebuilt on the repaired #22481 ask lane and should be reviewed after #22479 and #22481.

## Test plan

From `packages/memory`:

```bash
pnpm exec vitest run src/processors/observational-memory/__tests__/remind-request-state.test.ts src/processors/observational-memory/__tests__/subconscious-remind.test.ts src/processors/observational-memory/__tests__/remind-async-ux.test.ts --reporter=dot --bail=1
pnpm check
pnpm lint
git diff --check
```

Results on the reviewed and restacked head `40d9cbf9758e23b58cb1bbe3aadd84052ae935a5`:

- Focused transport, lifecycle, and UX suites: 104 passed
- TypeScript check: passed
- Lint: 0 warnings and 0 errors across 199 files
- Diff check: passed

The PR includes a patch changeset for `@mastra/memory`. It is intentionally minimal because Subconscious remains experimental.
