### PR TITLE
fix(core): skip locked threads when auto-selecting a thread to resume

### DIFF
--- a/.changeset/light-frogs-listen.md
+++ b/.changeset/light-frogs-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Thread lock files are now created exclusively and supersede stale locks by generation, so two simultaneous launches cannot both claim the same thread and a stale lock can no longer be deleted out from under a live owner. (#21243)

--- a/.changeset/quiet-moons-compete.md
+++ b/.changeset/quiet-moons-compete.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Automatic thread selection now skips threads locked by another live process and resumes the next unlocked one (or creates a fresh thread), instead of failing startup. Explicitly targeting a locked thread still throws. (#21243)

--- a/.changeset/quiet-moons-compete.md
+++ b/.changeset/quiet-moons-compete.md
@@ -3,3 +3,14 @@
 ---
 
 Automatic thread selection now skips threads locked by another live process and resumes the next unlocked one (or creates a fresh thread), instead of failing startup. Explicitly targeting a locked thread still throws. (#21243)
+
+```ts
+const controller = new AgentController({
+  // ...
+  threadLock: {
+    acquire: threadId => lock.acquire(threadId), // throws when held elsewhere
+    tryAcquire: threadId => lock.tryAcquire(threadId), // false when held elsewhere
+    release: threadId => lock.release(threadId),
+  },
+});
+```

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -382,6 +382,7 @@ vi.mock('../utils/storage-factory.js', () => ({
 
 vi.mock('../utils/thread-lock.js', () => ({
   acquireThreadLock: vi.fn(),
+  tryAcquireThreadLock: vi.fn(() => true),
   releaseThreadLock: vi.fn(),
 }));
 
@@ -828,10 +829,12 @@ describe('createMastraCode', () => {
     await createMastraCode({ pubsub, unixSocketPubSub: true });
 
     const agentControllerConfig = controllerConstructorMock.mock.calls.at(-1)?.[0] as
-      | { pubsub?: unknown; threadLock?: unknown }
+      | { pubsub?: unknown; threadLock?: { tryAcquire?: (threadId: string) => boolean } }
       | undefined;
     expect(agentControllerConfig?.pubsub).toBe(pubsub);
     expect(agentControllerConfig?.threadLock).toBeDefined();
+    expect(agentControllerConfig?.threadLock?.tryAcquire).toEqual(expect.any(Function));
+    expect(agentControllerConfig?.threadLock?.tryAcquire?.('thread-id')).toBe(true);
   });
 
   it('skips thread locks for configured PubSub when cross-process mode is explicit', async () => {

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -822,34 +822,6 @@ describe('createMastraCode', () => {
     );
   });
 
-  it('keeps thread locks enabled for configured PubSub unless cross-process mode is explicit', async () => {
-    const pubsub = {} as any;
-    const { createMastraCode } = await import('../index.js');
-
-    await createMastraCode({ pubsub, unixSocketPubSub: true });
-
-    const agentControllerConfig = controllerConstructorMock.mock.calls.at(-1)?.[0] as
-      | { pubsub?: unknown; threadLock?: { tryAcquire?: (threadId: string) => boolean } }
-      | undefined;
-    expect(agentControllerConfig?.pubsub).toBe(pubsub);
-    expect(agentControllerConfig?.threadLock).toBeDefined();
-    expect(agentControllerConfig?.threadLock?.tryAcquire).toEqual(expect.any(Function));
-    expect(agentControllerConfig?.threadLock?.tryAcquire?.('thread-id')).toBe(true);
-  });
-
-  it('skips thread locks for configured PubSub when cross-process mode is explicit', async () => {
-    const pubsub = {} as any;
-    const { createMastraCode } = await import('../index.js');
-
-    await createMastraCode({ pubsub, crossProcessPubSub: true });
-
-    const agentControllerConfig = controllerConstructorMock.mock.calls.at(-1)?.[0] as
-      | { pubsub?: unknown; threadLock?: unknown }
-      | undefined;
-    expect(agentControllerConfig?.pubsub).toBe(pubsub);
-    expect(agentControllerConfig?.threadLock).toBeUndefined();
-  });
-
   it('restores the current thread caveman observation setting at startup', async () => {
     controllerGetCurrentThreadIdMock.mockReturnValue('thread-1');
     controllerListThreadsMock.mockResolvedValue([{ id: 'thread-1', metadata: { cavemanObservations: true } }]);

--- a/mastracode/sdk/src/index.test.ts
+++ b/mastracode/sdk/src/index.test.ts
@@ -7,6 +7,9 @@ const createSessionCalls = vi.hoisted<Array<{ id?: string; ownerId?: string; res
 // Captures the AgentController constructor initialState so tests can assert on
 // which settings.json values were seeded into session state.
 const controllerInitialStates = vi.hoisted<Array<Record<string, unknown>>>(() => []);
+// Captures full AgentController constructor configs so tests can assert on
+// wiring (e.g. pubsub/threadLock).
+const controllerConstructorConfigs = vi.hoisted<Array<Record<string, unknown>>>(() => []);
 const authCredentials = vi.hoisted(() => new Map<string, Record<string, unknown>>());
 
 vi.mock('@mastra/core/llm', () => ({
@@ -31,7 +34,10 @@ vi.mock('@mastra/core/agent-controller', () => ({
       resourceId?: string;
       initialState?: Record<string, unknown>;
       intervalHandlers?: Array<{ immediate?: boolean; handler: () => unknown }>;
+      pubsub?: unknown;
+      threadLock?: unknown;
     }) {
+      controllerConstructorConfigs.push(config as Record<string, unknown>);
       controllerInitialStates.push(config.initialState ?? {});
       for (const interval of config.intervalHandlers ?? []) {
         if (interval.immediate !== false) void interval.handler();
@@ -381,6 +387,38 @@ describe('settings.json OM seeding', () => {
       vi.mocked(resolveOmRoleModel).mockReturnValue('');
       vi.mocked(loadSettings).mockReturnValue(baseSettings);
     }
+  });
+});
+
+describe('createMastraCode thread lock wiring', () => {
+  beforeEach(() => {
+    controllerConstructorConfigs.length = 0;
+  });
+
+  it('keeps thread locks enabled for configured PubSub unless cross-process mode is explicit', async () => {
+    const pubsub = {} as Record<string, never>;
+    const { createMastraCode } = await import('./index.js');
+
+    await createMastraCode({ pubsub: pubsub as never, unixSocketPubSub: true });
+
+    const agentControllerConfig = controllerConstructorConfigs.at(-1) as
+      | { pubsub?: unknown; threadLock?: { tryAcquire?: (threadId: string) => boolean } }
+      | undefined;
+    expect(agentControllerConfig?.pubsub).toBe(pubsub);
+    expect(agentControllerConfig?.threadLock).toBeDefined();
+    expect(agentControllerConfig?.threadLock?.tryAcquire).toEqual(expect.any(Function));
+    expect(agentControllerConfig?.threadLock?.tryAcquire?.('thread-id')).toBe(true);
+  });
+
+  it('skips thread locks for configured PubSub when cross-process mode is explicit', async () => {
+    const pubsub = {} as Record<string, never>;
+    const { createMastraCode } = await import('./index.js');
+
+    await createMastraCode({ pubsub: pubsub as never, crossProcessPubSub: true });
+
+    const agentControllerConfig = controllerConstructorConfigs.at(-1);
+    expect(agentControllerConfig?.pubsub).toBe(pubsub);
+    expect(agentControllerConfig?.threadLock).toBeUndefined();
   });
 });
 

--- a/mastracode/sdk/src/index.test.ts
+++ b/mastracode/sdk/src/index.test.ts
@@ -198,6 +198,7 @@ vi.mock('./utils/storage-factory.js', () => ({
 
 vi.mock('./utils/thread-lock.js', () => ({
   acquireThreadLock: vi.fn(),
+  tryAcquireThreadLock: vi.fn(() => true),
   releaseThreadLock: vi.fn(),
 }));
 

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -114,7 +114,7 @@ import { createStorage, createVectorStore } from './utils/storage-factory.js';
 import type { StorageResult } from './utils/storage-factory.js';
 import { createStorageMaintenance, DEFAULT_RETENTION, resolveLocalDbFiles } from './utils/storage-maintenance.js';
 import type { StorageMaintenance } from './utils/storage-maintenance.js';
-import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
+import { acquireThreadLock, releaseThreadLock, tryAcquireThreadLock } from './utils/thread-lock.js';
 import { registerWorkflowBuilderPrimitives } from './workflows/register-primitives.js';
 
 const CODE_AGENT_ID = 'code-agent';
@@ -1158,6 +1158,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
       ? undefined
       : {
           acquire: acquireThreadLock,
+          tryAcquire: tryAcquireThreadLock,
           release: releaseThreadLock,
         },
   });

--- a/mastracode/sdk/src/utils/thread-lock.test.ts
+++ b/mastracode/sdk/src/utils/thread-lock.test.ts
@@ -1,0 +1,195 @@
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  acquireThreadLock,
+  getThreadLockOwner,
+  releaseThreadLock,
+  ThreadLockError,
+  tryAcquireThreadLock,
+} from './thread-lock.js';
+
+// No real process can ever have this PID.
+const DEAD_PID = 2_147_483_647;
+
+// One-shot seams for driving interleavings inside a single acquire() call.
+// `beforeExclusiveCreate` fires immediately before an exclusive ('wx') create;
+// `beforeSupersededScan` arms a hook that fires before the *second* directory
+// listing, which is where acquire() scans for live owners below the
+// generation it just claimed (the first listing picks the generation).
+const interleave = vi.hoisted(() => ({
+  beforeExclusiveCreate: undefined as (() => void) | undefined,
+  beforeSupersededScan: undefined as (() => void) | undefined,
+  armedReaddirCount: 0,
+}));
+
+function fireOnce(key: 'beforeExclusiveCreate' | 'beforeSupersededScan'): void {
+  const hook = interleave[key];
+  if (!hook) return;
+  interleave[key] = undefined;
+  hook();
+}
+
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    openSync: (...args: Parameters<typeof actual.openSync>) => {
+      if (args[1] === 'wx') fireOnce('beforeExclusiveCreate');
+      return actual.openSync(...args);
+    },
+    readdirSync: ((...args: unknown[]) => {
+      if (interleave.beforeSupersededScan) {
+        interleave.armedReaddirCount++;
+        if (interleave.armedReaddirCount === 2) fireOnce('beforeSupersededScan');
+      }
+      return (actual.readdirSync as (...args: unknown[]) => string[])(...args);
+    }) as typeof actual.readdirSync,
+  };
+});
+
+describe('thread locks', () => {
+  let appDataDir: string;
+
+  beforeEach(() => {
+    appDataDir = mkdtempSync(join(tmpdir(), 'mastracode-thread-lock-'));
+    vi.stubEnv('MASTRA_APP_DATA_DIR', appDataDir);
+  });
+
+  afterEach(() => {
+    interleave.beforeExclusiveCreate = undefined;
+    interleave.beforeSupersededScan = undefined;
+    interleave.armedReaddirCount = 0;
+    vi.unstubAllEnvs();
+    rmSync(appDataDir, { recursive: true, force: true });
+  });
+
+  function locksDir(): string {
+    const dir = join(appDataDir, 'locks');
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  function lockPathFor(threadId: string, generation?: number): string {
+    const suffix = generation === undefined ? '' : `.${generation}`;
+    return join(locksDir(), `${threadId}${suffix}.lock`);
+  }
+
+  function writeOwner(threadId: string, pid: number, generation?: number): string {
+    const filePath = lockPathFor(threadId, generation);
+    writeFileSync(filePath, String(pid));
+    return filePath;
+  }
+
+  function lockFilesFor(threadId: string): string[] {
+    return readdirSync(locksDir())
+      .filter(file => file.startsWith(`${threadId}.`) && file.endsWith('.lock'))
+      .sort();
+  }
+
+  function currentOwnerPid(threadId: string): number | undefined {
+    const files = lockFilesFor(threadId);
+    const newest = files
+      .map(file => ({ file, generation: Number(file.slice(threadId.length + 1, -'.lock'.length) || 0) }))
+      .sort((a, b) => b.generation - a.generation)[0];
+    return newest ? Number(readFileSync(join(locksDir(), newest.file), 'utf-8')) : undefined;
+  }
+
+  /** Runs fn as if this process had `pid`, so two claimants can be driven in-process. */
+  function asPid<T>(pid: number, fn: () => T): T {
+    const descriptor = Object.getOwnPropertyDescriptor(process, 'pid')!;
+    Object.defineProperty(process, 'pid', { ...descriptor, value: pid });
+    try {
+      return fn();
+    } finally {
+      Object.defineProperty(process, 'pid', descriptor);
+    }
+  }
+
+  it('reports contention without touching a live process lock', () => {
+    const livePath = writeOwner('thread-live', process.ppid);
+
+    expect(tryAcquireThreadLock('thread-live')).toBe(false);
+    expect(() => acquireThreadLock('thread-live')).toThrow(ThreadLockError);
+    expect(getThreadLockOwner('thread-live')).toBe(process.ppid);
+    expect(readFileSync(livePath, 'utf-8')).toBe(String(process.ppid));
+  });
+
+  it('supersedes a stale lock and cleans the superseded generation', () => {
+    writeOwner('thread-stale', DEAD_PID, 3);
+
+    expect(tryAcquireThreadLock('thread-stale')).toBe(true);
+    expect(currentOwnerPid('thread-stale')).toBe(process.pid);
+    expect(lockFilesFor('thread-stale')).toEqual(['thread-stale.4.lock']);
+  });
+
+  it('honours pre-generation lock files and supersedes them when stale', () => {
+    const legacyPath = writeOwner('thread-legacy', process.ppid);
+
+    expect(tryAcquireThreadLock('thread-legacy')).toBe(false);
+    expect(readFileSync(legacyPath, 'utf-8')).toBe(String(process.ppid));
+
+    writeFileSync(legacyPath, String(DEAD_PID));
+    expect(tryAcquireThreadLock('thread-legacy')).toBe(true);
+    expect(lockFilesFor('thread-legacy')).toEqual(['thread-legacy.1.lock']);
+  });
+
+  it('treats a lock already held by this process as acquired', () => {
+    writeOwner('thread-own', process.pid);
+
+    expect(tryAcquireThreadLock('thread-own')).toBe(true);
+    expect(currentOwnerPid('thread-own')).toBe(process.pid);
+  });
+
+  it('reports a stale lock as unlocked without deleting it', () => {
+    const stalePath = writeOwner('thread-stale-query', DEAD_PID);
+
+    expect(getThreadLockOwner('thread-stale-query')).toBeNull();
+    expect(readFileSync(stalePath, 'utf-8')).toBe(String(DEAD_PID));
+  });
+
+  it('releases only its own lock files', () => {
+    writeOwner('thread-release', process.pid);
+    const foreignPath = writeOwner('thread-release', process.ppid, 0);
+
+    releaseThreadLock('thread-release');
+
+    expect(lockFilesFor('thread-release')).toEqual([basename(foreignPath)]);
+    expect(getThreadLockOwner('thread-release')).toBe(process.ppid);
+  });
+
+  it('grants a stale lock to a single claimant when a competitor wins the exclusive create first', () => {
+    const otherPid = process.ppid;
+    writeOwner('thread-race-create', DEAD_PID);
+
+    let competitorAcquired = false;
+    interleave.beforeExclusiveCreate = () => {
+      competitorAcquired = asPid(otherPid, () => tryAcquireThreadLock('thread-race-create'));
+    };
+
+    const selfAcquired = tryAcquireThreadLock('thread-race-create');
+
+    expect([selfAcquired, competitorAcquired].filter(Boolean)).toHaveLength(1);
+    expect(currentOwnerPid('thread-race-create')).toBe(selfAcquired ? process.pid : otherPid);
+  });
+
+  it('backs off when a live owner appears below the generation it just claimed', () => {
+    writeOwner('thread-race-reset', DEAD_PID);
+
+    // Between our exclusive create and the superseded scan, a legacy lock file
+    // owned by a live process shows up below our generation — the lock
+    // directory changed behind our snapshot and the live owner keeps the thread.
+    interleave.beforeSupersededScan = () => {
+      writeOwner('thread-race-reset', process.ppid, 0);
+    };
+
+    expect(() => acquireThreadLock('thread-race-reset')).toThrow(ThreadLockError);
+    expect(currentOwnerPid('thread-race-reset')).toBe(process.ppid);
+    // The live legacy owner keeps the thread; the inert stale file it displaced
+    // stays behind for the next claimant to supersede.
+    expect(lockFilesFor('thread-race-reset')).toEqual(['thread-race-reset.0.lock', 'thread-race-reset.lock']);
+    expect(tryAcquireThreadLock('thread-race-reset')).toBe(false);
+  });
+});

--- a/mastracode/sdk/src/utils/thread-lock.test.ts
+++ b/mastracode/sdk/src/utils/thread-lock.test.ts
@@ -16,16 +16,17 @@ const DEAD_PID = 2_147_483_647;
 
 // One-shot seams for driving interleavings inside a single acquire() call.
 // `beforeExclusiveCreate` fires immediately before an exclusive ('wx') create;
-// `beforeSupersededScan` arms a hook that fires before the *second* directory
-// listing, which is where acquire() scans for live owners below the
-// generation it just claimed (the first listing picks the generation).
+// the superseded-scan seams arm hooks around the *second* directory listing,
+// where acquire() scans for live owners below the generation it just claimed
+// (the first listing picks the generation).
 const interleave = vi.hoisted(() => ({
   beforeExclusiveCreate: undefined as (() => void) | undefined,
   beforeSupersededScan: undefined as (() => void) | undefined,
+  afterSupersededScan: undefined as (() => void) | undefined,
   armedReaddirCount: 0,
 }));
 
-function fireOnce(key: 'beforeExclusiveCreate' | 'beforeSupersededScan'): void {
+function fireOnce(key: 'beforeExclusiveCreate' | 'beforeSupersededScan' | 'afterSupersededScan'): void {
   const hook = interleave[key];
   if (!hook) return;
   interleave[key] = undefined;
@@ -41,9 +42,14 @@ vi.mock('node:fs', async importOriginal => {
       return actual.openSync(...args);
     },
     readdirSync: ((...args: unknown[]) => {
-      if (interleave.beforeSupersededScan) {
+      if (interleave.beforeSupersededScan || interleave.afterSupersededScan) {
         interleave.armedReaddirCount++;
-        if (interleave.armedReaddirCount === 2) fireOnce('beforeSupersededScan');
+        if (interleave.armedReaddirCount === 2) {
+          fireOnce('beforeSupersededScan');
+          const result = (actual.readdirSync as (...args: unknown[]) => string[])(...args);
+          fireOnce('afterSupersededScan');
+          return result;
+        }
       }
       return (actual.readdirSync as (...args: unknown[]) => string[])(...args);
     }) as typeof actual.readdirSync,
@@ -61,6 +67,7 @@ describe('thread locks', () => {
   afterEach(() => {
     interleave.beforeExclusiveCreate = undefined;
     interleave.beforeSupersededScan = undefined;
+    interleave.afterSupersededScan = undefined;
     interleave.armedReaddirCount = 0;
     vi.unstubAllEnvs();
     rmSync(appDataDir, { recursive: true, force: true });
@@ -117,12 +124,14 @@ describe('thread locks', () => {
     expect(readFileSync(livePath, 'utf-8')).toBe(String(process.ppid));
   });
 
-  it('supersedes a stale lock and cleans the superseded generation', () => {
+  it('supersedes a stale lock and leaves the superseded file in place', () => {
     writeOwner('thread-stale', DEAD_PID, 3);
 
     expect(tryAcquireThreadLock('thread-stale')).toBe(true);
     expect(currentOwnerPid('thread-stale')).toBe(process.pid);
-    expect(lockFilesFor('thread-stale')).toEqual(['thread-stale.4.lock']);
+    // Superseded files are inert garbage: readers only consider the highest
+    // generation, so they are left for the owner's own release to clean up.
+    expect(lockFilesFor('thread-stale')).toEqual(['thread-stale.3.lock', 'thread-stale.4.lock']);
   });
 
   it('honours pre-generation lock files and supersedes them when stale', () => {
@@ -133,7 +142,7 @@ describe('thread locks', () => {
 
     writeFileSync(legacyPath, String(DEAD_PID));
     expect(tryAcquireThreadLock('thread-legacy')).toBe(true);
-    expect(lockFilesFor('thread-legacy')).toEqual(['thread-legacy.1.lock']);
+    expect(lockFilesFor('thread-legacy')).toEqual(['thread-legacy.1.lock', 'thread-legacy.lock']);
   });
 
   it('treats a lock already held by this process as acquired', () => {
@@ -191,5 +200,22 @@ describe('thread locks', () => {
     // stays behind for the next claimant to supersede.
     expect(lockFilesFor('thread-race-reset')).toEqual(['thread-race-reset.0.lock', 'thread-race-reset.lock']);
     expect(tryAcquireThreadLock('thread-race-reset')).toBe(false);
+  });
+
+  it('yields to, and never deletes, a lower-generation lock that turns live after the scan', () => {
+    const stalePath = writeOwner('thread-late-live', DEAD_PID);
+
+    // A legacy writer reclaims the same path with a live PID right after the
+    // superseded scan listed it. The re-read inside the scan detects the new
+    // owner: the claim backs off, and the now-live file is never unlinked.
+    interleave.afterSupersededScan = () => {
+      writeFileSync(stalePath, String(process.ppid));
+    };
+
+    expect(tryAcquireThreadLock('thread-late-live')).toBe(false);
+    expect(readFileSync(stalePath, 'utf-8')).toBe(String(process.ppid));
+    expect(lockFilesFor('thread-late-live')).toEqual(['thread-late-live.lock']);
+    // The displaced live lock keeps working as a lock.
+    expect(getThreadLockOwner('thread-late-live')).toBe(process.ppid);
   });
 });

--- a/mastracode/sdk/src/utils/thread-lock.ts
+++ b/mastracode/sdk/src/utils/thread-lock.ts
@@ -1,13 +1,19 @@
 /**
  * Thread lock — ensures only one process writes to a thread at a time.
  *
- * Uses filesystem lock files: <appDataDir>/locks/<threadId>.lock
- * Each lock file contains the PID of the owning process.
- * Stale locks (from crashed processes) are detected and reclaimed.
+ * Lock files live at <appDataDir>/locks/<threadId>.<generation>.lock and each
+ * contains the PID of the owning process. The current owner is the highest
+ * generation present, and claiming is an exclusive ('wx') create one
+ * generation above it, so a stale lock is superseded rather than overwritten:
+ * no process ever removes a file that a live process may have created. Lock
+ * files without a generation suffix, written by older versions, count as
+ * generation 0.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { getAppDataDir } from './project.js';
+
+const LOCK_SUFFIX = '.lock';
 
 export class ThreadLockError extends Error {
   constructor(
@@ -27,10 +33,36 @@ function getLocksDir(): string {
   return dir;
 }
 
-function getLockPath(threadId: string): string {
+function getSafeThreadId(threadId: string): string {
   // Sanitize thread ID for filesystem safety
-  const safeId = threadId.replace(/[^a-zA-Z0-9_-]/g, '_');
-  return path.join(getLocksDir(), `${safeId}.lock`);
+  return threadId.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+/** `<safeId>.lock` (pre-generation layout) parses as generation 0. */
+function parseGeneration(fileName: string, safeThreadId: string): number | undefined {
+  const prefix = `${safeThreadId}.`;
+  if (!fileName.startsWith(prefix) || !fileName.endsWith(LOCK_SUFFIX)) return undefined;
+  const generation = fileName.slice(prefix.length, -LOCK_SUFFIX.length);
+  if (generation === '') return 0;
+  return /^\d+$/.test(generation) ? Number(generation) : undefined;
+}
+
+type LockFile = { generation: number; filePath: string };
+
+/** Lock files for a thread, highest generation first. */
+function listLockFiles(threadId: string): LockFile[] {
+  const locksDir = getLocksDir();
+  const safeThreadId = getSafeThreadId(threadId);
+  const files: LockFile[] = [];
+
+  for (const fileName of fs.readdirSync(locksDir)) {
+    const generation = parseGeneration(fileName, safeThreadId);
+    if (generation === undefined) continue;
+    files.push({ generation, filePath: path.join(locksDir, fileName) });
+  }
+
+  files.sort((a, b) => b.generation - a.generation);
+  return files;
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -42,51 +74,108 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+function getErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return undefined;
+  return typeof error.code === 'string' ? error.code : undefined;
+}
+
+/** PID stored in a lock file; undefined for unreadable or malformed content. */
+function readOwnerPid(filePath: string): number | undefined {
+  try {
+    const ownerPid = parseInt(fs.readFileSync(filePath, 'utf-8').trim(), 10);
+    return isNaN(ownerPid) ? undefined : ownerPid;
+  } catch {
+    return undefined;
+  }
+}
+
+function removeLockFile(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    // Best-effort — a superseded lock left behind is ignored by every reader
+  }
+}
+
+/** Exclusively create a lock file; throws EEXIST if the path is taken. */
+function claimLockFile(filePath: string, pid: number): void {
+  const fd = fs.openSync(filePath, 'wx', 0o644);
+  try {
+    fs.writeSync(fd, String(pid));
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 /**
  * Attempt to acquire a lock for the given thread.
  * Throws ThreadLockError if another live process holds the lock.
- * Reclaims stale locks from dead processes.
+ * Supersedes stale locks from dead processes.
  */
 export function acquireThreadLock(threadId: string): void {
-  const lockPath = getLockPath(threadId);
   const myPid = process.pid;
 
-  // Check for existing lock
-  if (fs.existsSync(lockPath)) {
-    try {
-      const content = fs.readFileSync(lockPath, 'utf-8').trim();
-      const ownerPid = parseInt(content, 10);
+  while (true) {
+    const current = listLockFiles(threadId)[0];
 
-      if (!isNaN(ownerPid) && ownerPid !== myPid && isProcessAlive(ownerPid)) {
+    if (current) {
+      const ownerPid = readOwnerPid(current.filePath);
+      if (ownerPid === myPid) return; // already ours
+      // A dead owner stays dead, so this observation cannot go stale under us.
+      if (ownerPid !== undefined && isProcessAlive(ownerPid)) {
         throw new ThreadLockError(threadId, ownerPid);
       }
-      // Stale lock (dead process) or our own lock — reclaim it
-    } catch (error) {
-      if (error instanceof ThreadLockError) throw error;
-      // File read error — try to overwrite
     }
-  }
 
-  // Write our PID to the lock file
-  fs.writeFileSync(lockPath, String(myPid), { mode: 0o644 });
+    const generation = (current?.generation ?? 0) + 1;
+    const lockPath = path.join(getLocksDir(), `${getSafeThreadId(threadId)}.${generation}${LOCK_SUFFIX}`);
+    try {
+      claimLockFile(lockPath, myPid);
+    } catch (error) {
+      // Someone claimed this generation first — rescan and reconsider.
+      if (getErrorCode(error) === 'EEXIST') continue;
+      throw error;
+    }
+
+    // We hold `generation`. A live owner below us means the lock directory
+    // changed behind our snapshot (e.g. recreated from legacy files): back off
+    // and let them keep the thread.
+    const superseded = listLockFiles(threadId).filter(file => file.generation < generation);
+    for (const file of superseded) {
+      const ownerPid = readOwnerPid(file.filePath);
+      if (ownerPid !== undefined && ownerPid !== myPid && isProcessAlive(ownerPid)) {
+        removeLockFile(lockPath);
+        throw new ThreadLockError(threadId, ownerPid);
+      }
+    }
+    for (const file of superseded) removeLockFile(file.filePath);
+    return;
+  }
+}
+
+/**
+ * Try to acquire a lock without treating contention as an error.
+ * Returns false when another live process holds the lock.
+ */
+export function tryAcquireThreadLock(threadId: string): boolean {
+  try {
+    acquireThreadLock(threadId);
+    return true;
+  } catch (error) {
+    if (error instanceof ThreadLockError) return false;
+    throw error;
+  }
 }
 
 /**
  * Release the lock for the given thread (only if we own it).
  */
 export function releaseThreadLock(threadId: string): void {
-  const lockPath = getLockPath(threadId);
   const myPid = process.pid;
 
   try {
-    if (!fs.existsSync(lockPath)) return;
-
-    const content = fs.readFileSync(lockPath, 'utf-8').trim();
-    const ownerPid = parseInt(content, 10);
-
-    // Only remove if we own it
-    if (ownerPid === myPid) {
-      fs.unlinkSync(lockPath);
+    for (const file of listLockFiles(threadId)) {
+      if (readOwnerPid(file.filePath) === myPid) removeLockFile(file.filePath);
     }
   } catch {
     // Best-effort cleanup — ignore errors
@@ -95,28 +184,18 @@ export function releaseThreadLock(threadId: string): void {
 
 /**
  * Check if a thread is locked by another process.
- * Returns the PID of the owner if locked, null otherwise.
+ * Returns the PID of the owner if locked, null otherwise. Stale locks are
+ * reported as unlocked and left for the next claimant to supersede.
  */
 export function getThreadLockOwner(threadId: string): number | null {
-  const lockPath = getLockPath(threadId);
-
   try {
-    if (!fs.existsSync(lockPath)) return null;
+    const current = listLockFiles(threadId)[0];
+    if (!current) return null;
 
-    const content = fs.readFileSync(lockPath, 'utf-8').trim();
-    const ownerPid = parseInt(content, 10);
+    const ownerPid = readOwnerPid(current.filePath);
+    if (ownerPid === undefined || ownerPid === process.pid) return null;
 
-    if (isNaN(ownerPid)) return null;
-    if (ownerPid === process.pid) return null; // Our own lock
-    if (!isProcessAlive(ownerPid)) {
-      // Stale lock — clean it up
-      try {
-        fs.unlinkSync(lockPath);
-      } catch {}
-      return null;
-    }
-
-    return ownerPid;
+    return isProcessAlive(ownerPid) ? ownerPid : null;
   } catch {
     return null;
   }
@@ -130,19 +209,12 @@ export function releaseAllThreadLocks(): void {
   try {
     const locksDir = getLocksDir();
     const files = fs.readdirSync(locksDir);
-    const myPid = String(process.pid);
+    const myPid = process.pid;
 
     for (const file of files) {
-      if (!file.endsWith('.lock')) continue;
+      if (!file.endsWith(LOCK_SUFFIX)) continue;
       const lockPath = path.join(locksDir, file);
-      try {
-        const content = fs.readFileSync(lockPath, 'utf-8').trim();
-        if (content === myPid) {
-          fs.unlinkSync(lockPath);
-        }
-      } catch {
-        // Best-effort
-      }
+      if (readOwnerPid(lockPath) === myPid) removeLockFile(lockPath);
     }
   } catch {
     // Best-effort

--- a/mastracode/sdk/src/utils/thread-lock.ts
+++ b/mastracode/sdk/src/utils/thread-lock.ts
@@ -4,10 +4,12 @@
  * Lock files live at <appDataDir>/locks/<threadId>.<generation>.lock and each
  * contains the PID of the owning process. The current owner is the highest
  * generation present, and claiming is an exclusive ('wx') create one
- * generation above it, so a stale lock is superseded rather than overwritten:
- * no process ever removes a file that a live process may have created. Lock
- * files without a generation suffix, written by older versions, count as
- * generation 0.
+ * generation above it, so a stale lock is superseded rather than overwritten.
+ * Superseded files are left in place as inert garbage — a lock file is only
+ * ever removed by its own owner (release paths), because a liveness check on
+ * a lower generation can go stale under a legacy writer that reuses the same
+ * path. Lock files without a generation suffix, written by older versions,
+ * count as generation 0.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -139,7 +141,9 @@ export function acquireThreadLock(threadId: string): void {
 
     // We hold `generation`. A live owner below us means the lock directory
     // changed behind our snapshot (e.g. recreated from legacy files): back off
-    // and let them keep the thread.
+    // and let them keep the thread. Superseded files are otherwise left in
+    // place — deleting them after a non-atomic liveness check could destroy a
+    // lock that a legacy writer just reclaimed.
     const superseded = listLockFiles(threadId).filter(file => file.generation < generation);
     for (const file of superseded) {
       const ownerPid = readOwnerPid(file.filePath);
@@ -148,7 +152,6 @@ export function acquireThreadLock(threadId: string): void {
         throw new ThreadLockError(threadId, ownerPid);
       }
     }
-    for (const file of superseded) removeLockFile(file.filePath);
     return;
   }
 }

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -714,14 +714,34 @@ export class AgentController<TState = {}> {
         return scopeEntries.every(([key, value]) => metadata[key] === value);
       });
 
-      if (candidates.length === 0) {
-        await session.thread.create();
-      } else {
-        const mostRecent = [...candidates].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0]!;
-        await this.config.threadLock?.acquire(mostRecent.id);
-        session.thread.set({ threadId: mostRecent.id });
+      // Automatic selection walks candidates newest to oldest and skips the
+      // ones another live process owns, creating a fresh thread when they are
+      // all active elsewhere. Explicitly targeting an owned thread (above)
+      // still surfaces the contention error.
+      const byRecency = [...candidates].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+      const threadLock = this.config.threadLock;
+
+      let selected: (typeof byRecency)[number] | undefined;
+      if (threadLock?.tryAcquire) {
+        for (const candidate of byRecency) {
+          if (await threadLock.tryAcquire(candidate.id)) {
+            selected = candidate;
+            break;
+          }
+        }
+      } else if (byRecency[0]) {
+        // no non-throwing probe available — contention stays fatal, as before
+        // tryAcquire existed
+        await threadLock?.acquire(byRecency[0].id);
+        selected = byRecency[0];
+      }
+
+      if (selected) {
+        session.thread.set({ threadId: selected.id });
         await session.thread.loadMetadata();
         await session.thread.ensureCurrentSubscription();
+      } else {
+        await session.thread.create();
       }
     }
 

--- a/packages/core/src/agent-controller/thread-locking.test.ts
+++ b/packages/core/src/agent-controller/thread-locking.test.ts
@@ -183,7 +183,7 @@ describe('AgentController thread locking', () => {
   });
 
   describe('createSession thread selection', () => {
-    function freshController(store: InMemoryStore) {
+    function freshController(store: InMemoryStore, tryAcquire?: (id: string) => boolean) {
       const agent = new Agent({
         name: 'test-agent',
         instructions: 'You are a test agent.',
@@ -194,7 +194,7 @@ describe('AgentController thread locking', () => {
         id: 'test-controller',
         storage: store,
         modes: [{ id: 'default', name: 'Default', default: true, agent }],
-        threadLock: { acquire, release },
+        threadLock: { acquire, tryAcquire, release },
       });
     }
 
@@ -226,6 +226,92 @@ describe('AgentController thread locking', () => {
 
       expect(sessionB.thread.getId()).toBe(existing);
       expect(acquire).toHaveBeenCalledWith(existing);
+    });
+
+    it('skips locked threads and resumes the next unlocked one', async () => {
+      const store = new InMemoryStore();
+
+      const controllerA = freshController(store);
+      await controllerA.init();
+      const sessionA = await controllerA.createSession({
+        id: 'session-a',
+        ownerId: 'test-owner',
+        resourceId: 'user-1',
+      });
+      const olderThreadId = sessionA.thread.getId();
+
+      // Create a newer thread with a strictly newer updatedAt so recency
+      // ordering is deterministic.
+      const now = Date.now();
+      vi.useFakeTimers();
+      vi.setSystemTime(now + 1000);
+      const newestThread = await sessionA.thread.create();
+      vi.useRealTimers();
+
+      acquire.mockClear();
+      const tryAcquire = vi.fn((id: string) => id !== newestThread.id);
+      const controllerB = freshController(store, tryAcquire);
+      await controllerB.init();
+      const sessionB = await controllerB.createSession({
+        id: 'session-b',
+        ownerId: 'test-owner',
+        resourceId: 'user-1',
+      });
+
+      expect(tryAcquire).toHaveBeenNthCalledWith(1, newestThread.id);
+      expect(tryAcquire).toHaveBeenNthCalledWith(2, olderThreadId);
+      expect(sessionB.thread.getId()).toBe(olderThreadId);
+    });
+
+    it('creates a fresh thread when every existing thread is locked', async () => {
+      const store = new InMemoryStore();
+
+      const controllerA = freshController(store);
+      await controllerA.init();
+      const sessionA = await controllerA.createSession({
+        id: 'session-a',
+        ownerId: 'test-owner',
+        resourceId: 'user-1',
+      });
+      const lockedThreadId = sessionA.thread.getId();
+
+      acquire.mockClear();
+      const tryAcquire = vi.fn(() => false);
+      const controllerB = freshController(store, tryAcquire);
+      await controllerB.init();
+      const sessionB = await controllerB.createSession({
+        id: 'session-b',
+        ownerId: 'test-owner',
+        resourceId: 'user-1',
+      });
+
+      expect(tryAcquire).toHaveBeenCalledWith(lockedThreadId);
+      expect(sessionB.thread.getId()).not.toBe(lockedThreadId);
+      expect(acquire).toHaveBeenCalledWith(sessionB.thread.getId());
+    });
+
+    it('keeps contention fatal for the most recent thread when no tryAcquire is provided', async () => {
+      const store = new InMemoryStore();
+
+      const controllerA = freshController(store);
+      await controllerA.init();
+      const sessionA = await controllerA.createSession({
+        id: 'session-a',
+        ownerId: 'test-owner',
+        resourceId: 'user-1',
+      });
+      const lockedThreadId = sessionA.thread.getId()!;
+
+      acquire.mockClear();
+      acquire.mockImplementation((id: string) => {
+        if (id === lockedThreadId) throw new Error('locked by another process');
+      });
+      const controllerB = freshController(store);
+      await controllerB.init();
+
+      await expect(
+        controllerB.createSession({ id: 'session-b', ownerId: 'test-owner', resourceId: 'user-1' }),
+      ).rejects.toThrow('locked by another process');
     });
 
     it('creates a fresh thread for a different resourceId', async () => {

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -383,6 +383,13 @@ export interface AgentControllerConfig<TState = {}> {
    */
   threadLock?: {
     acquire: (threadId: string) => void | Promise<void>;
+    /**
+     * Non-throwing variant used when auto-selecting a thread to resume:
+     * returns false instead of throwing when another live process holds the
+     * lock. When omitted, auto-selection falls back to `acquire` on the most
+     * recent thread and contention stays fatal.
+     */
+    tryAcquire?: (threadId: string) => boolean | Promise<boolean>;
     release: (threadId: string) => void | Promise<void>;
   };
 


### PR DESCRIPTION
Fixes #21243

## Summary
- `createSession()` auto-selection now walks scope-matched threads newest→oldest through an optional `threadLock.tryAcquire`, skips threads owned by another live process, and creates a fresh thread when all are busy. Explicitly targeting a locked thread still throws.
- Thread lock files are claimed exclusively (`openSync(..., 'wx')`) at `<threadId>.<generation>.lock`; stale locks are superseded by a higher generation instead of overwritten, and a claim that finds a live owner below its generation backs off. No process ever removes a lock file a live process may have created.
- Follows the fix sketched in the issue; builds on the earlier attempts in #20350 and #21437 (thanks @damien-schneider and @lawrence-millard).

## Test plan
- [x] `pnpm --filter ./packages/core exec vitest run src/agent-controller/thread-locking.test.ts` — 25 passed
- [x] `pnpm --filter ./mastracode/sdk exec vitest run src/utils/thread-lock.test.ts src/index.test.ts src/__tests__/index.test.ts` — 8 + 10 + 39 passed

Windows caveat from the issue: `wx` exclusive create and `process.kill(pid, 0)` liveness checks behave differently there; happy to follow up on whatever CI surfaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When another process uses the newest thread, MastraCode now tries older threads instead of failing. If all threads are busy, it creates a new thread.

## Changes

- Added automatic thread selection with optional `threadLock.tryAcquire`.
- Checked eligible threads from newest to oldest.
- Kept explicit selection of a locked thread as an error.
- Added generation-based lock files with exclusive creation using `openSync(..., 'wx')`.
- Improved stale-lock handling to avoid deleting locks reclaimed by another process.
- Added SDK integration for `tryAcquireThreadLock`.
- Added tests for lock contention, stale locks, concurrent claims, release behavior, and session selection.
- Added patch changesets for `@mastra/core` and `@mastra/code-sdk`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->