### PR TITLE
fix(redis): refresh list/counter TTLs inside one EVAL round trip

### DIFF
--- a/.changeset/lucky-pumas-double.md
+++ b/.changeset/lucky-pumas-double.md
@@ -1,0 +1,5 @@
+---
+'@mastra/redis': patch
+---
+
+`increment` and `listPush` now refresh the key TTL inside a single Lua EVAL round trip instead of a follow-up `EXPIRE` command, cutting the per-publish cache round trips behind `CachingPubSub` from four to two. Clients without classic EVAL (e.g. Upstash REST via `upstashPreset`) keep the previous sequential behavior. (#22477)

--- a/stores/redis/src/cache.ts
+++ b/stores/redis/src/cache.ts
@@ -11,12 +11,20 @@ export interface RedisClient {
   scan(cursor: string | number, ...args: unknown[]): Promise<[string | number, string[]]>;
   incr(key: string): Promise<number>;
   /**
-   * Classic EVAL signature (`script, numKeys, ...keysAndArgs`), supported by
-   * both ioredis and node-redis v4+. Optional: when absent, the cache falls
-   * back to sequential commands. Clients whose EVAL takes a different shape
-   * (e.g. Upstash REST) should omit it and use the sequential presets.
+   * EVAL, in whichever shape the client speaks it: classic
+   * `(script, numKeys, ...keysAndArgs)` (ioredis, node-redis v4) or
+   * `(script, { keys, arguments })` (node-redis v5). The cache probes both —
+   * a wrong-shape call fails at the server's arity stage without executing
+   * the script — and caches the winning shape per client. Optional: when
+   * absent, the cache falls back to sequential commands. Clients whose EVAL
+   * takes a different shape (e.g. Upstash REST) should omit it and use the
+   * sequential presets.
    */
-  eval?(script: string, numKeys: number, ...keysAndArgs: unknown[]): Promise<unknown>;
+  eval?(
+    script: string,
+    numKeysOrOptions: number | { keys?: string[]; arguments?: string[] },
+    ...keysAndArgs: unknown[]
+  ): Promise<unknown>;
 }
 
 export interface RedisServerCacheOptions {
@@ -72,16 +80,51 @@ const defaultGetListRange = (client: RedisClient, key: string, start: number, st
 };
 
 // "0" seconds means "no expiry refresh": the guard keeps the scripts usable
-// for ttlSeconds: 0 configurations without a client-side branch.
+// for ttlSeconds: 0 configurations without a client-side branch. The tonumber
+// guard must stay strictly-positive: Redis 7 deletes a key on a non-positive
+// EXPIRE, so a negative configured TTL must not reach the command.
 const INCREMENT_WITH_EXPIRY_SCRIPT =
-  'local v = redis.call("INCR", KEYS[1]) if ARGV[1] ~= "0" then redis.call("EXPIRE", KEYS[1], ARGV[1]) end return v';
+  'local v = redis.call("INCR", KEYS[1]) if tonumber(ARGV[1]) > 0 then redis.call("EXPIRE", KEYS[1], ARGV[1]) end return v';
 
 const PUSH_TO_LIST_WITH_EXPIRY_SCRIPT =
-  'redis.call("RPUSH", KEYS[1], ARGV[1]) if ARGV[2] ~= "0" then redis.call("EXPIRE", KEYS[1], ARGV[2]) end';
+  'redis.call("RPUSH", KEYS[1], ARGV[1]) if tonumber(ARGV[2]) > 0 then redis.call("EXPIRE", KEYS[1], ARGV[2]) end';
+
+/**
+ * EVAL calling conventions differ across clients: ioredis and node-redis v4
+ * take the classic `(script, numKeys, ...keysAndArgs)` form, node-redis v5
+ * takes `(script, { keys, arguments })`. A call in the wrong shape fails at
+ * the server's arity/parse stage — the script never executes — so the working
+ * shape can be probed once per client with a cheap failing round trip and
+ * cached. The weak map keeps clients garbage-collectable.
+ */
+const evalStyleCache = new WeakMap<RedisClient, 'classic' | 'options'>();
+
+async function callEval(client: RedisClient, script: string, keys: string[], args: string[]): Promise<unknown> {
+  const clientEval = client.eval?.bind(client);
+  if (!clientEval) {
+    throw new Error('client does not expose EVAL');
+  }
+  const cached = evalStyleCache.get(client);
+  const styles: Array<'classic' | 'options'> = cached ? [cached] : ['classic', 'options'];
+  let lastError: unknown;
+  for (const style of styles) {
+    try {
+      const result =
+        style === 'classic'
+          ? await clientEval(script, keys.length, ...keys, ...args)
+          : await clientEval(script, { keys, arguments: args });
+      evalStyleCache.set(client, style);
+      return result;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
 
 const defaultIncrementWithExpiry = async (client: RedisClient, key: string, seconds: number): Promise<number> => {
   if (typeof client.eval === 'function') {
-    return Number(await client.eval(INCREMENT_WITH_EXPIRY_SCRIPT, 1, key, String(seconds)));
+    return Number(await callEval(client, INCREMENT_WITH_EXPIRY_SCRIPT, [key], [String(seconds)]));
   }
   const value = await client.incr(key);
   if (seconds > 0) {
@@ -125,7 +168,7 @@ export class RedisServerCache extends MastraServerCache {
       options.pushToListWithExpiry ??
       (async (client, key, value, seconds) => {
         if (typeof client.eval === 'function') {
-          await client.eval(PUSH_TO_LIST_WITH_EXPIRY_SCRIPT, 1, key, String(value), String(seconds));
+          await callEval(client, PUSH_TO_LIST_WITH_EXPIRY_SCRIPT, [key], [String(value), String(seconds)]);
           return;
         }
         await this.pushToList(client, key, value);

--- a/stores/redis/src/cache.ts
+++ b/stores/redis/src/cache.ts
@@ -10,6 +10,13 @@ export interface RedisClient {
   expire(key: string, seconds: number): Promise<number | boolean>;
   scan(cursor: string | number, ...args: unknown[]): Promise<[string | number, string[]]>;
   incr(key: string): Promise<number>;
+  /**
+   * Classic EVAL signature (`script, numKeys, ...keysAndArgs`), supported by
+   * both ioredis and node-redis v4+. Optional: when absent, the cache falls
+   * back to sequential commands. Clients whose EVAL takes a different shape
+   * (e.g. Upstash REST) should omit it and use the sequential presets.
+   */
+  eval?(script: string, numKeys: number, ...keysAndArgs: unknown[]): Promise<unknown>;
 }
 
 export interface RedisServerCacheOptions {
@@ -25,6 +32,18 @@ export interface RedisServerCacheOptions {
   getListLength?: (client: RedisClient, key: string) => Promise<number>;
   pushToList?: (client: RedisClient, key: string, value: unknown) => Promise<number>;
   getListRange?: (client: RedisClient, key: string, start: number, stop: number) => Promise<unknown[]>;
+  /**
+   * Increment a counter and refresh its TTL in one round trip. Defaults to a
+   * Lua script on clients that expose classic EVAL (ioredis, node-redis v4+),
+   * falling back to sequential `INCR` + `EXPIRE` otherwise.
+   */
+  incrementWithExpiry?: (client: RedisClient, key: string, seconds: number) => Promise<number>;
+  /**
+   * Push a value onto a list and refresh its TTL in one round trip. Defaults
+   * to a Lua script on clients that expose classic EVAL (ioredis, node-redis
+   * v4+), falling back to sequential `RPUSH` + `EXPIRE` otherwise.
+   */
+  pushToListWithExpiry?: (client: RedisClient, key: string, value: unknown, seconds: number) => Promise<void>;
 }
 
 const defaultSetWithExpiry = (client: RedisClient, key: string, value: unknown, seconds: number): Promise<unknown> => {
@@ -52,6 +71,25 @@ const defaultGetListRange = (client: RedisClient, key: string, start: number, st
   return client.lrange(key, start, stop);
 };
 
+// "0" seconds means "no expiry refresh": the guard keeps the scripts usable
+// for ttlSeconds: 0 configurations without a client-side branch.
+const INCREMENT_WITH_EXPIRY_SCRIPT =
+  'local v = redis.call("INCR", KEYS[1]) if ARGV[1] ~= "0" then redis.call("EXPIRE", KEYS[1], ARGV[1]) end return v';
+
+const PUSH_TO_LIST_WITH_EXPIRY_SCRIPT =
+  'redis.call("RPUSH", KEYS[1], ARGV[1]) if ARGV[2] ~= "0" then redis.call("EXPIRE", KEYS[1], ARGV[2]) end';
+
+const defaultIncrementWithExpiry = async (client: RedisClient, key: string, seconds: number): Promise<number> => {
+  if (typeof client.eval === 'function') {
+    return Number(await client.eval(INCREMENT_WITH_EXPIRY_SCRIPT, 1, key, String(seconds)));
+  }
+  const value = await client.incr(key);
+  if (seconds > 0) {
+    await client.expire(key, seconds);
+  }
+  return value;
+};
+
 export class RedisServerCache extends MastraServerCache {
   private client: RedisClient;
   private keyPrefix: string;
@@ -66,6 +104,8 @@ export class RedisServerCache extends MastraServerCache {
   private getListLength: (client: RedisClient, key: string) => Promise<number>;
   private pushToList: (client: RedisClient, key: string, value: unknown) => Promise<number>;
   private getListRange: (client: RedisClient, key: string, start: number, stop: number) => Promise<unknown[]>;
+  private incrementWithExpiry: (client: RedisClient, key: string, seconds: number) => Promise<number>;
+  private pushToListWithExpiry: (client: RedisClient, key: string, value: unknown, seconds: number) => Promise<void>;
 
   constructor(config: { client: RedisClient }, options: RedisServerCacheOptions = {}) {
     super({ name: 'RedisServerCache' });
@@ -78,6 +118,21 @@ export class RedisServerCache extends MastraServerCache {
     this.getListLength = options.getListLength ?? defaultGetListLength;
     this.pushToList = options.pushToList ?? defaultPushToList;
     this.getListRange = options.getListRange ?? defaultGetListRange;
+    this.incrementWithExpiry = options.incrementWithExpiry ?? defaultIncrementWithExpiry;
+    // Composed here rather than as a module default so the no-EVAL fallback
+    // goes through the configured `pushToList` (e.g. node-redis camelCase).
+    this.pushToListWithExpiry =
+      options.pushToListWithExpiry ??
+      (async (client, key, value, seconds) => {
+        if (typeof client.eval === 'function') {
+          await client.eval(PUSH_TO_LIST_WITH_EXPIRY_SCRIPT, 1, key, String(value), String(seconds));
+          return;
+        }
+        await this.pushToList(client, key, value);
+        if (seconds > 0) {
+          await client.expire(key, seconds);
+        }
+      });
   }
 
   private getKey(key: string): string {
@@ -128,11 +183,7 @@ export class RedisServerCache extends MastraServerCache {
   async listPush(key: string, value: unknown): Promise<void> {
     const fullKey = this.getKey(key);
     const serialized = this.serialize(value);
-    await this.pushToList(this.client, fullKey, serialized);
-
-    if (this.ttlSeconds > 0) {
-      await this.client.expire(fullKey, this.ttlSeconds);
-    }
+    await this.pushToListWithExpiry(this.client, fullKey, serialized, this.ttlSeconds);
   }
 
   async listFromTo(key: string, from: number, to: number = -1): Promise<unknown[]> {
@@ -163,20 +214,32 @@ export class RedisServerCache extends MastraServerCache {
 
   async increment(key: string): Promise<number> {
     const fullKey = this.getKey(key);
-    const value = await this.client.incr(fullKey);
-
-    if (this.ttlSeconds > 0) {
-      await this.client.expire(fullKey, this.ttlSeconds);
-    }
-
-    return value;
+    return this.incrementWithExpiry(this.client, fullKey, this.ttlSeconds);
   }
 }
 
-export const upstashPreset: Pick<RedisServerCacheOptions, 'setWithExpiry' | 'scanKeys'> = {
+export const upstashPreset: Pick<
+  RedisServerCacheOptions,
+  'setWithExpiry' | 'scanKeys' | 'incrementWithExpiry' | 'pushToListWithExpiry'
+> = {
   setWithExpiry: (client, key, value, seconds) => client.set(key, value, { ex: seconds } as any),
   scanKeys: (client, cursor, pattern, count) =>
     client.scan(cursor, { match: pattern, count } as any) as Promise<[string | number, string[]]>,
+  // Upstash REST's EVAL does not take the classic (script, numKeys, ...) form,
+  // so keep the sequential two-command path instead of the Lua fast path.
+  incrementWithExpiry: async (client, key, seconds) => {
+    const value = await client.incr(key);
+    if (seconds > 0) {
+      await client.expire(key, seconds);
+    }
+    return value;
+  },
+  pushToListWithExpiry: async (client, key, value, seconds) => {
+    await client.rpush(key, value as any);
+    if (seconds > 0) {
+      await client.expire(key, seconds);
+    }
+  },
 };
 
 // node-redis v4+ exposes Redis multi-word commands as camelCase only

--- a/stores/redis/src/cache.ts
+++ b/stores/redis/src/cache.ts
@@ -17,10 +17,12 @@ export interface RedisClient {
    * shape once per client with a side-effect-free probe script and then calls
    * real scripts in that shape only — a script is never retried in the other
    * shape, because some clients (e.g. @redis/client 5.12.1) execute the
-   * wrong-shape call as `EVAL <script> 0` instead of rejecting it. Optional:
-   * when absent, the cache falls back to sequential commands. Clients whose
-   * EVAL takes a different shape (e.g. Upstash REST) should omit it and use
-   * the sequential presets.
+   * wrong-shape call as `EVAL <script> 0` instead of rejecting it. If the
+   * probe rejects both shapes, the result is cached and the cache silently
+   * falls back to sequential commands. Optional: when absent, the same
+   * fallback applies. Clients whose EVAL takes a different shape (e.g.
+   * Upstash REST) should omit it and use the sequential presets to skip the
+   * probe round trips entirely.
    */
   eval?(
     script: string,
@@ -102,7 +104,10 @@ const PUSH_TO_LIST_WITH_EXPIRY_SCRIPT =
  * nothing is written): it returns 'match' only when the client round-tripped
  * both correctly. The weak map keeps clients garbage-collectable.
  */
-const evalStyleCache = new WeakMap<RedisClient, 'classic' | 'options'>();
+const evalStyleCache = new WeakMap<RedisClient, EvalStyle>();
+// One shared probe per client: concurrent first calls (durable publishes burst
+// increment + listPush per chunk) must not each pay the probe round trips.
+const evalStyleProbes = new WeakMap<RedisClient, Promise<EvalStyle>>();
 
 // 'malformed' = the shape dropped KEYS/ARGV (e.g. 0-key execution);
 // 'mismatch' = the shape delivered them but garbled. Only 'match' wins.
@@ -111,8 +116,13 @@ const EVAL_PROBE_SCRIPT =
 const EVAL_PROBE_KEY = '__mastra_eval_probe__';
 
 type ClientEval = NonNullable<RedisClient['eval']>;
+type EvalStyle = 'classic' | 'options' | 'unsupported';
 
-async function probeEvalStyle(clientEval: ClientEval): Promise<'classic' | 'options'> {
+// Sentinel telling the callers to take their sequential command path: the
+// client exposes EVAL but speaks neither shape we know.
+const EVAL_UNSUPPORTED = Symbol('eval-unsupported');
+
+async function probeEvalStyle(clientEval: ClientEval): Promise<EvalStyle> {
   const attempts: Array<{ style: 'classic' | 'options'; call: () => Promise<unknown> }> = [
     { style: 'classic', call: () => clientEval(EVAL_PROBE_SCRIPT, 1, EVAL_PROBE_KEY, EVAL_PROBE_KEY) },
     {
@@ -120,32 +130,47 @@ async function probeEvalStyle(clientEval: ClientEval): Promise<'classic' | 'opti
       call: () => clientEval(EVAL_PROBE_SCRIPT, { keys: [EVAL_PROBE_KEY], arguments: [EVAL_PROBE_KEY] }),
     },
   ];
-  let lastError: unknown;
   for (const attempt of attempts) {
     try {
       if ((await attempt.call()) === 'match') {
         return attempt.style;
       }
-    } catch (error) {
-      lastError = error;
+    } catch {
+      // A rejected shape just moves on to the other candidate.
     }
   }
-  throw new Error(
-    `unable to determine EVAL calling convention (probe did not round-trip KEYS/ARGV${
-      lastError ? `; last error: ${lastError instanceof Error ? lastError.message : String(lastError)}` : ''
-    })`,
-  );
+  return 'unsupported';
 }
 
-async function callEval(client: RedisClient, script: string, keys: string[], args: string[]): Promise<unknown> {
+async function resolveEvalStyle(client: RedisClient, clientEval: ClientEval): Promise<EvalStyle> {
+  let pending = evalStyleProbes.get(client);
+  if (!pending) {
+    pending = probeEvalStyle(clientEval).then(style => {
+      evalStyleCache.set(client, style);
+      evalStyleProbes.delete(client);
+      return style;
+    });
+    evalStyleProbes.set(client, pending);
+  }
+  return pending;
+}
+
+async function callEval(
+  client: RedisClient,
+  script: string,
+  keys: string[],
+  args: string[],
+): Promise<unknown | typeof EVAL_UNSUPPORTED> {
   const clientEval = client.eval?.bind(client);
   if (!clientEval) {
     throw new Error('client does not expose EVAL');
   }
   let style = evalStyleCache.get(client);
   if (!style) {
-    style = await probeEvalStyle(clientEval);
-    evalStyleCache.set(client, style);
+    style = await resolveEvalStyle(client, clientEval);
+  }
+  if (style === 'unsupported') {
+    return EVAL_UNSUPPORTED;
   }
   // Single shot in the winning shape: the script may be mutative, so a
   // rejection after execution must not trigger a second run in the other
@@ -157,7 +182,10 @@ async function callEval(client: RedisClient, script: string, keys: string[], arg
 
 const defaultIncrementWithExpiry = async (client: RedisClient, key: string, seconds: number): Promise<number> => {
   if (typeof client.eval === 'function') {
-    return Number(await callEval(client, INCREMENT_WITH_EXPIRY_SCRIPT, [key], [String(seconds)]));
+    const result = await callEval(client, INCREMENT_WITH_EXPIRY_SCRIPT, [key], [String(seconds)]);
+    if (result !== EVAL_UNSUPPORTED) {
+      return Number(result);
+    }
   }
   const value = await client.incr(key);
   if (seconds > 0) {
@@ -201,8 +229,15 @@ export class RedisServerCache extends MastraServerCache {
       options.pushToListWithExpiry ??
       (async (client, key, value, seconds) => {
         if (typeof client.eval === 'function') {
-          await callEval(client, PUSH_TO_LIST_WITH_EXPIRY_SCRIPT, [key], [String(value), String(seconds)]);
-          return;
+          const result = await callEval(
+            client,
+            PUSH_TO_LIST_WITH_EXPIRY_SCRIPT,
+            [key],
+            [String(value), String(seconds)],
+          );
+          if (result !== EVAL_UNSUPPORTED) {
+            return;
+          }
         }
         await this.pushToList(client, key, value);
         if (seconds > 0) {

--- a/stores/redis/src/cache.ts
+++ b/stores/redis/src/cache.ts
@@ -13,12 +13,14 @@ export interface RedisClient {
   /**
    * EVAL, in whichever shape the client speaks it: classic
    * `(script, numKeys, ...keysAndArgs)` (ioredis, node-redis v4) or
-   * `(script, { keys, arguments })` (node-redis v5). The cache probes both —
-   * a wrong-shape call fails at the server's arity stage without executing
-   * the script — and caches the winning shape per client. Optional: when
-   * absent, the cache falls back to sequential commands. Clients whose EVAL
-   * takes a different shape (e.g. Upstash REST) should omit it and use the
-   * sequential presets.
+   * `(script, { keys, arguments })` (node-redis v5). The cache determines the
+   * shape once per client with a side-effect-free probe script and then calls
+   * real scripts in that shape only — a script is never retried in the other
+   * shape, because some clients (e.g. @redis/client 5.12.1) execute the
+   * wrong-shape call as `EVAL <script> 0` instead of rejecting it. Optional:
+   * when absent, the cache falls back to sequential commands. Clients whose
+   * EVAL takes a different shape (e.g. Upstash REST) should omit it and use
+   * the sequential presets.
    */
   eval?(
     script: string,
@@ -92,34 +94,65 @@ const PUSH_TO_LIST_WITH_EXPIRY_SCRIPT =
 /**
  * EVAL calling conventions differ across clients: ioredis and node-redis v4
  * take the classic `(script, numKeys, ...keysAndArgs)` form, node-redis v5
- * takes `(script, { keys, arguments })`. A call in the wrong shape fails at
- * the server's arity/parse stage — the script never executes — so the working
- * shape can be probed once per client with a cheap failing round trip and
- * cached. The weak map keeps clients garbage-collectable.
+ * takes `(script, { keys, arguments })`. A wrong-shape call is NOT guaranteed
+ * to fail: @redis/client 5.12.1 serializes the classic form as
+ * `EVAL <script> 0` and executes it, so retrying a mutative script in the
+ * other shape could run INCR/RPUSH twice. The winning shape is therefore
+ * determined with a probe script that only reads KEYS/ARGV (no redis.call,
+ * nothing is written): it returns 'match' only when the client round-tripped
+ * both correctly. The weak map keeps clients garbage-collectable.
  */
 const evalStyleCache = new WeakMap<RedisClient, 'classic' | 'options'>();
+
+// 'malformed' = the shape dropped KEYS/ARGV (e.g. 0-key execution);
+// 'mismatch' = the shape delivered them but garbled. Only 'match' wins.
+const EVAL_PROBE_SCRIPT =
+  "if KEYS[1] == nil or ARGV[1] == nil then return 'malformed' end if KEYS[1] ~= ARGV[1] then return 'mismatch' end return 'match'";
+const EVAL_PROBE_KEY = '__mastra_eval_probe__';
+
+type ClientEval = NonNullable<RedisClient['eval']>;
+
+async function probeEvalStyle(clientEval: ClientEval): Promise<'classic' | 'options'> {
+  const attempts: Array<{ style: 'classic' | 'options'; call: () => Promise<unknown> }> = [
+    { style: 'classic', call: () => clientEval(EVAL_PROBE_SCRIPT, 1, EVAL_PROBE_KEY, EVAL_PROBE_KEY) },
+    {
+      style: 'options',
+      call: () => clientEval(EVAL_PROBE_SCRIPT, { keys: [EVAL_PROBE_KEY], arguments: [EVAL_PROBE_KEY] }),
+    },
+  ];
+  let lastError: unknown;
+  for (const attempt of attempts) {
+    try {
+      if ((await attempt.call()) === 'match') {
+        return attempt.style;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw new Error(
+    `unable to determine EVAL calling convention (probe did not round-trip KEYS/ARGV${
+      lastError ? `; last error: ${lastError instanceof Error ? lastError.message : String(lastError)}` : ''
+    })`,
+  );
+}
 
 async function callEval(client: RedisClient, script: string, keys: string[], args: string[]): Promise<unknown> {
   const clientEval = client.eval?.bind(client);
   if (!clientEval) {
     throw new Error('client does not expose EVAL');
   }
-  const cached = evalStyleCache.get(client);
-  const styles: Array<'classic' | 'options'> = cached ? [cached] : ['classic', 'options'];
-  let lastError: unknown;
-  for (const style of styles) {
-    try {
-      const result =
-        style === 'classic'
-          ? await clientEval(script, keys.length, ...keys, ...args)
-          : await clientEval(script, { keys, arguments: args });
-      evalStyleCache.set(client, style);
-      return result;
-    } catch (error) {
-      lastError = error;
-    }
+  let style = evalStyleCache.get(client);
+  if (!style) {
+    style = await probeEvalStyle(clientEval);
+    evalStyleCache.set(client, style);
   }
-  throw lastError;
+  // Single shot in the winning shape: the script may be mutative, so a
+  // rejection after execution must not trigger a second run in the other
+  // shape.
+  return style === 'classic'
+    ? clientEval(script, keys.length, ...keys, ...args)
+    : clientEval(script, { keys, arguments: args });
 }
 
 const defaultIncrementWithExpiry = async (client: RedisClient, key: string, seconds: number): Promise<number> => {

--- a/stores/redis/src/cache.ts
+++ b/stores/redis/src/cache.ts
@@ -183,7 +183,14 @@ export class RedisServerCache extends MastraServerCache {
   }
 
   private serialize(value: unknown): string {
-    return JSON.stringify(value);
+    const serialized = JSON.stringify(value);
+    // JSON.stringify returns undefined for top-level undefined/functions/
+    // symbols; pushing that on would store the literal string "undefined"
+    // and hand it back from listFromTo as if it were data.
+    if (serialized === undefined) {
+      throw new TypeError(`RedisServerCache cannot serialize value: ${typeof value}`);
+    }
+    return serialized;
   }
 
   private deserialize(value: unknown): unknown {

--- a/stores/redis/src/cache.ts
+++ b/stores/redis/src/cache.ts
@@ -136,7 +136,9 @@ async function probeEvalStyle(clientEval: ClientEval): Promise<EvalStyle> {
         return attempt.style;
       }
     } catch {
-      // A rejected shape just moves on to the other candidate.
+      // A rejected shape just moves on to the other candidate; if both fail,
+      // the loop yields 'unsupported', callEval returns the EVAL_UNSUPPORTED
+      // sentinel, and callers fall through to their sequential command path.
     }
   }
   return 'unsupported';

--- a/stores/redis/src/index.test.ts
+++ b/stores/redis/src/index.test.ts
@@ -25,6 +25,13 @@ function createNoEvalMockClient(): RedisClient & { [key: string]: ReturnType<typ
   return client;
 }
 
+// Simulates an ioredis-style classic client: the side-effect-free shape probe
+// (the only script containing 'malformed') echoes 'match'; every other script
+// resolves to `value`.
+function mockClassicEval(client: any, value: unknown = 1) {
+  client.eval.mockImplementation((script: string) => Promise.resolve(script.includes('malformed') ? 'match' : value));
+}
+
 describe('RedisServerCache', () => {
   let mockClient: ReturnType<typeof createMockClient>;
   let cache: RedisServerCache;
@@ -104,12 +111,13 @@ describe('RedisServerCache', () => {
 
   describe('listPush', () => {
     it('should push and refresh TTL in a single EVAL round trip', async () => {
-      mockClient.eval.mockResolvedValue(1);
+      mockClassicEval(mockClient, 1);
 
       await cache.listPush('my-list', { event: 'test' });
 
-      expect(mockClient.eval).toHaveBeenCalledTimes(1);
-      const [script, numKeys, key, value, seconds] = mockClient.eval.mock.calls[0];
+      // One side-effect-free shape probe, then one EVAL for the push itself.
+      expect(mockClient.eval).toHaveBeenCalledTimes(2);
+      const [script, numKeys, key, value, seconds] = mockClient.eval.mock.calls.at(-1);
       expect(numKeys).toBe(1);
       expect(key).toBe('mastra:cache:my-list');
       expect(value).toBe('{"event":"test"}');
@@ -122,11 +130,11 @@ describe('RedisServerCache', () => {
 
     it('should pass a zero seconds argument when ttlSeconds is 0', async () => {
       const noTtlCache = new RedisServerCache({ client: mockClient }, { ttlSeconds: 0 });
-      mockClient.eval.mockResolvedValue(1);
+      mockClassicEval(mockClient, 1);
 
       await noTtlCache.listPush('my-list', { event: 'test' });
 
-      const [, , , , seconds] = mockClient.eval.mock.calls[0];
+      const [, , , , seconds] = mockClient.eval.mock.calls.at(-1);
       expect(seconds).toBe('0');
     });
 
@@ -187,12 +195,13 @@ describe('RedisServerCache', () => {
 
   describe('increment', () => {
     it('should increment with prefixed key and refresh TTL in a single EVAL round trip', async () => {
-      mockClient.eval.mockResolvedValue(3);
+      mockClassicEval(mockClient, 3);
 
       const result = await cache.increment('counter');
 
-      expect(mockClient.eval).toHaveBeenCalledTimes(1);
-      const [script, numKeys, key, seconds] = mockClient.eval.mock.calls[0];
+      // One side-effect-free shape probe, then one EVAL for the increment.
+      expect(mockClient.eval).toHaveBeenCalledTimes(2);
+      const [script, numKeys, key, seconds] = mockClient.eval.mock.calls.at(-1);
       expect(numKeys).toBe(1);
       expect(key).toBe('mastra:cache:counter');
       expect(seconds).toBe('300');
@@ -205,31 +214,73 @@ describe('RedisServerCache', () => {
     });
 
     it('should probe the options-object EVAL shape on node-redis v5 clients and cache it', async () => {
-      // A node-redis v5 client: classic (script, numKeys, ...) calls fail at
-      // the server's arity stage, the { keys, arguments } form succeeds.
+      // @redis/client 5.12.1: a classic (script, numKeys, ...) call does NOT
+      // fail at arity — it is serialized as `EVAL <script> 0` and executed
+      // with empty KEYS/ARGV. The probe script detects this ('malformed')
+      // without touching data; only the { keys, arguments } form round-trips.
       const v5Mock: any = createMockClient();
-      v5Mock.eval.mockImplementation((_script: string, second: unknown) => {
+      v5Mock.eval.mockImplementation((script: string, second: unknown) => {
+        const isProbe = script.includes('malformed');
         if (typeof second === 'number') {
-          return Promise.reject(new Error("wrong number of arguments for 'eval' command"));
+          if (isProbe) {
+            return Promise.resolve('malformed');
+          }
+          return Promise.reject(new Error('executed as EVAL <script> 0: INCR on empty KEYS'));
         }
-        return Promise.resolve(3);
+        return Promise.resolve(isProbe ? 'match' : 3);
       });
       const v5Cache = new RedisServerCache({ client: v5Mock });
 
       const first = await v5Cache.increment('counter');
       expect(first).toBe(3);
-      expect(v5Mock.eval).toHaveBeenCalledTimes(2); // classic probed, then options
+      // classic probe (malformed) → options probe (match) → real call. The
+      // mutative script itself never ran through the broken classic shape.
+      expect(v5Mock.eval).toHaveBeenCalledTimes(3);
+      const [, classicSecond] = v5Mock.eval.mock.calls[0];
+      expect(classicSecond).toBe(1);
 
       const second = await v5Cache.increment('counter');
       expect(second).toBe(3);
-      expect(v5Mock.eval).toHaveBeenCalledTimes(3); // cached shape, no re-probe
+      expect(v5Mock.eval).toHaveBeenCalledTimes(4); // cached shape, no re-probe
       const [script, options] = v5Mock.eval.mock.calls.at(-1);
       expect(script).toContain('INCR');
       expect(options).toEqual({ keys: ['mastra:cache:counter'], arguments: ['300'] });
     });
 
+    it('should not retry an EVAL that may have executed (post-execution failure)', async () => {
+      // The probe wins the classic shape; the real script then rejects after
+      // execution (e.g. a script error or a dropped connection). The call
+      // must NOT be retried in the other shape — the script may have mutated
+      // data already.
+      const flakyMock: any = createMockClient();
+      flakyMock.eval.mockImplementation((script: string) => {
+        if (script.includes('malformed')) {
+          return Promise.resolve('match');
+        }
+        return Promise.reject(new Error('connection closed mid-execution'));
+      });
+      const flakyCache = new RedisServerCache({ client: flakyMock });
+
+      await expect(flakyCache.increment('counter')).rejects.toThrow('connection closed mid-execution');
+      // probe + exactly one real call; no second shape attempted
+      expect(flakyMock.eval).toHaveBeenCalledTimes(2);
+      const [, second] = flakyMock.eval.mock.calls[1];
+      expect(second).toBe(1);
+      expect(flakyMock.incr).not.toHaveBeenCalled();
+    });
+
+    it('should fail fast when no EVAL shape round-trips the probe', async () => {
+      const brokenMock: any = createMockClient();
+      brokenMock.eval.mockResolvedValue('garbage');
+      const brokenCache = new RedisServerCache({ client: brokenMock });
+
+      await expect(brokenCache.increment('counter')).rejects.toThrow('unable to determine EVAL calling convention');
+      expect(brokenMock.eval).toHaveBeenCalledTimes(2); // both shapes probed once
+      expect(brokenMock.incr).not.toHaveBeenCalled();
+    });
+
     it('should coerce an EVAL result that comes back as a string', async () => {
-      mockClient.eval.mockResolvedValue('7');
+      mockClassicEval(mockClient, '7');
 
       const result = await cache.increment('counter');
 
@@ -238,11 +289,11 @@ describe('RedisServerCache', () => {
 
     it('should pass a zero seconds argument when ttlSeconds is 0', async () => {
       const noTtlCache = new RedisServerCache({ client: mockClient }, { ttlSeconds: 0 });
-      mockClient.eval.mockResolvedValue(1);
+      mockClassicEval(mockClient, 1);
 
       const result = await noTtlCache.increment('counter');
 
-      const [, , , seconds] = mockClient.eval.mock.calls[0];
+      const [, , , seconds] = mockClient.eval.mock.calls.at(-1);
       expect(seconds).toBe('0');
       expect(result).toBe(1);
     });
@@ -399,11 +450,12 @@ describe('RedisServerCache', () => {
     it('uses the Lua fast path for list push when the client exposes EVAL', async () => {
       const nodeMock: any = { ...createMockClient(), rPush: vi.fn().mockResolvedValue(1) };
       const nodeCache = new RedisServerCache({ client: nodeMock }, nodeRedisPreset);
-      nodeMock.eval.mockResolvedValue(1);
+      mockClassicEval(nodeMock, 1);
 
       await nodeCache.listPush('my-list', { event: 'test' });
 
-      expect(nodeMock.eval).toHaveBeenCalledTimes(1);
+      // probe + one Lua push
+      expect(nodeMock.eval).toHaveBeenCalledTimes(2);
       expect(nodeMock.rPush).not.toHaveBeenCalled();
       expect(nodeMock.expire).not.toHaveBeenCalled();
     });

--- a/stores/redis/src/index.test.ts
+++ b/stores/redis/src/index.test.ts
@@ -130,6 +130,14 @@ describe('RedisServerCache', () => {
       expect(seconds).toBe('0');
     });
 
+    it('should reject undefined values instead of storing the string "undefined"', async () => {
+      mockClient.eval.mockResolvedValue(1);
+
+      await expect(cache.listPush('my-list', undefined)).rejects.toThrow(TypeError);
+      expect(mockClient.eval).not.toHaveBeenCalled();
+      expect(mockClient.rpush).not.toHaveBeenCalled();
+    });
+
     it('should fall back to RPUSH + EXPIRE when the client has no EVAL', async () => {
       const noEvalClient = createNoEvalMockClient();
       const noEvalCache = new RedisServerCache({ client: noEvalClient });

--- a/stores/redis/src/index.test.ts
+++ b/stores/redis/src/index.test.ts
@@ -269,14 +269,35 @@ describe('RedisServerCache', () => {
       expect(flakyMock.incr).not.toHaveBeenCalled();
     });
 
-    it('should fail fast when no EVAL shape round-trips the probe', async () => {
+    it('should fall back to sequential commands when no EVAL shape round-trips the probe', async () => {
+      // The client exposes EVAL but neither shape delivers KEYS/ARGV: the
+      // probe result ('unsupported') is cached and increment takes the INCR +
+      // EXPIRE path instead of failing.
       const brokenMock: any = createMockClient();
       brokenMock.eval.mockResolvedValue('garbage');
+      brokenMock.incr.mockResolvedValue(4);
+      brokenMock.expire.mockResolvedValue(1);
       const brokenCache = new RedisServerCache({ client: brokenMock });
 
-      await expect(brokenCache.increment('counter')).rejects.toThrow('unable to determine EVAL calling convention');
+      const result = await brokenCache.increment('counter');
+      expect(result).toBe(4);
       expect(brokenMock.eval).toHaveBeenCalledTimes(2); // both shapes probed once
-      expect(brokenMock.incr).not.toHaveBeenCalled();
+      expect(brokenMock.incr).toHaveBeenCalledWith('mastra:cache:counter');
+      expect(brokenMock.expire).toHaveBeenCalledWith('mastra:cache:counter', 300);
+
+      await brokenCache.increment('counter');
+      expect(brokenMock.eval).toHaveBeenCalledTimes(2); // unsupported cached, no re-probe
+      expect(brokenMock.incr).toHaveBeenCalledTimes(2);
+    });
+
+    it('should share one probe across concurrent first calls on the same client', async () => {
+      mockClassicEval(mockClient, 1);
+
+      await Promise.all([cache.increment('counter'), cache.increment('counter')]);
+
+      // One shared probe + two real EVALs; without deduplication each caller
+      // would run its own probe (4 eval calls).
+      expect(mockClient.eval).toHaveBeenCalledTimes(3);
     });
 
     it('should coerce an EVAL result that comes back as a string', async () => {

--- a/stores/redis/src/index.test.ts
+++ b/stores/redis/src/index.test.ts
@@ -14,7 +14,15 @@ function createMockClient(): RedisClient & { [key: string]: ReturnType<typeof vi
     expire: vi.fn(),
     scan: vi.fn(),
     incr: vi.fn(),
+    eval: vi.fn(),
   };
+}
+
+// A client shape without classic EVAL, exercising the sequential fallback.
+function createNoEvalMockClient(): RedisClient & { [key: string]: ReturnType<typeof vi.fn> } {
+  const client = createMockClient();
+  delete client.eval;
+  return client;
 }
 
 describe('RedisServerCache', () => {
@@ -95,24 +103,56 @@ describe('RedisServerCache', () => {
   });
 
   describe('listPush', () => {
-    it('should push serialized value to list and refresh TTL', async () => {
-      mockClient.rpush.mockResolvedValue(1);
-      mockClient.expire.mockResolvedValue(1);
+    it('should push and refresh TTL in a single EVAL round trip', async () => {
+      mockClient.eval.mockResolvedValue(1);
 
       await cache.listPush('my-list', { event: 'test' });
 
-      expect(mockClient.rpush).toHaveBeenCalledWith('mastra:cache:my-list', '{"event":"test"}');
-      expect(mockClient.expire).toHaveBeenCalledWith('mastra:cache:my-list', 300);
+      expect(mockClient.eval).toHaveBeenCalledTimes(1);
+      const [script, numKeys, key, value, seconds] = mockClient.eval.mock.calls[0];
+      expect(numKeys).toBe(1);
+      expect(key).toBe('mastra:cache:my-list');
+      expect(value).toBe('{"event":"test"}');
+      expect(seconds).toBe('300');
+      expect(script).toContain('RPUSH');
+      expect(script).toContain('EXPIRE');
+      expect(mockClient.rpush).not.toHaveBeenCalled();
+      expect(mockClient.expire).not.toHaveBeenCalled();
     });
 
-    it('should not refresh TTL when ttlSeconds is 0', async () => {
+    it('should pass a zero seconds argument when ttlSeconds is 0', async () => {
       const noTtlCache = new RedisServerCache({ client: mockClient }, { ttlSeconds: 0 });
-      mockClient.rpush.mockResolvedValue(1);
+      mockClient.eval.mockResolvedValue(1);
 
       await noTtlCache.listPush('my-list', { event: 'test' });
 
+      const [, , , , seconds] = mockClient.eval.mock.calls[0];
+      expect(seconds).toBe('0');
+    });
+
+    it('should fall back to RPUSH + EXPIRE when the client has no EVAL', async () => {
+      const noEvalClient = createNoEvalMockClient();
+      const noEvalCache = new RedisServerCache({ client: noEvalClient });
+      noEvalClient.rpush.mockResolvedValue(1);
+      noEvalClient.expire.mockResolvedValue(1);
+
+      await noEvalCache.listPush('my-list', { event: 'test' });
+
+      expect(noEvalClient.eval).toBeUndefined();
+      expect(noEvalClient.rpush).toHaveBeenCalledWith('mastra:cache:my-list', '{"event":"test"}');
+      expect(noEvalClient.expire).toHaveBeenCalledWith('mastra:cache:my-list', 300);
+    });
+
+    it('should use the sequential path when pushToListWithExpiry is overridden (upstash)', async () => {
+      const upstashCache = new RedisServerCache({ client: mockClient }, upstashPreset);
+      mockClient.rpush.mockResolvedValue(1);
+      mockClient.expire.mockResolvedValue(1);
+
+      await upstashCache.listPush('my-list', { event: 'test' });
+
+      expect(mockClient.eval).not.toHaveBeenCalled();
       expect(mockClient.rpush).toHaveBeenCalledWith('mastra:cache:my-list', '{"event":"test"}');
-      expect(mockClient.expire).not.toHaveBeenCalled();
+      expect(mockClient.expire).toHaveBeenCalledWith('mastra:cache:my-list', 300);
     });
   });
 
@@ -138,26 +178,67 @@ describe('RedisServerCache', () => {
   });
 
   describe('increment', () => {
-    it('should increment with prefixed key and refresh TTL', async () => {
-      mockClient.incr.mockResolvedValue(3);
-      mockClient.expire.mockResolvedValue(1);
+    it('should increment with prefixed key and refresh TTL in a single EVAL round trip', async () => {
+      mockClient.eval.mockResolvedValue(3);
 
       const result = await cache.increment('counter');
 
-      expect(mockClient.incr).toHaveBeenCalledWith('mastra:cache:counter');
-      expect(mockClient.expire).toHaveBeenCalledWith('mastra:cache:counter', 300);
+      expect(mockClient.eval).toHaveBeenCalledTimes(1);
+      const [script, numKeys, key, seconds] = mockClient.eval.mock.calls[0];
+      expect(numKeys).toBe(1);
+      expect(key).toBe('mastra:cache:counter');
+      expect(seconds).toBe('300');
+      expect(script).toContain('INCR');
+      expect(script).toContain('EXPIRE');
+      expect(script).toContain('return');
+      expect(mockClient.incr).not.toHaveBeenCalled();
+      expect(mockClient.expire).not.toHaveBeenCalled();
       expect(result).toBe(3);
     });
 
-    it('should not refresh TTL when ttlSeconds is 0', async () => {
+    it('should coerce an EVAL result that comes back as a string', async () => {
+      mockClient.eval.mockResolvedValue('7');
+
+      const result = await cache.increment('counter');
+
+      expect(result).toBe(7);
+    });
+
+    it('should pass a zero seconds argument when ttlSeconds is 0', async () => {
       const noTtlCache = new RedisServerCache({ client: mockClient }, { ttlSeconds: 0 });
-      mockClient.incr.mockResolvedValue(1);
+      mockClient.eval.mockResolvedValue(1);
 
       const result = await noTtlCache.increment('counter');
 
-      expect(mockClient.incr).toHaveBeenCalledWith('mastra:cache:counter');
-      expect(mockClient.expire).not.toHaveBeenCalled();
+      const [, , , seconds] = mockClient.eval.mock.calls[0];
+      expect(seconds).toBe('0');
       expect(result).toBe(1);
+    });
+
+    it('should fall back to INCR + EXPIRE when the client has no EVAL', async () => {
+      const noEvalClient = createNoEvalMockClient();
+      const noEvalCache = new RedisServerCache({ client: noEvalClient });
+      noEvalClient.incr.mockResolvedValue(4);
+      noEvalClient.expire.mockResolvedValue(1);
+
+      const result = await noEvalCache.increment('counter');
+
+      expect(noEvalClient.incr).toHaveBeenCalledWith('mastra:cache:counter');
+      expect(noEvalClient.expire).toHaveBeenCalledWith('mastra:cache:counter', 300);
+      expect(result).toBe(4);
+    });
+
+    it('should use the sequential path when incrementWithExpiry is overridden (upstash)', async () => {
+      const upstashCache = new RedisServerCache({ client: mockClient }, upstashPreset);
+      mockClient.incr.mockResolvedValue(5);
+      mockClient.expire.mockResolvedValue(1);
+
+      const result = await upstashCache.increment('counter');
+
+      expect(mockClient.eval).not.toHaveBeenCalled();
+      expect(mockClient.incr).toHaveBeenCalledWith('mastra:cache:counter');
+      expect(mockClient.expire).toHaveBeenCalledWith('mastra:cache:counter', 300);
+      expect(result).toBe(5);
     });
   });
 
@@ -270,13 +351,29 @@ describe('RedisServerCache', () => {
     });
 
     it('routes list push through rPush (camelCase) on node-redis clients', async () => {
-      const nodeMock: any = { ...createMockClient(), rPush: vi.fn().mockResolvedValue(1) };
+      // Without EVAL the atomic push falls back to the preset's pushToList,
+      // which is what routes through node-redis's camelCase rPush. With EVAL
+      // present the Lua fast path replaces both commands entirely.
+      const nodeMock: any = { ...createNoEvalMockClient(), rPush: vi.fn().mockResolvedValue(1) };
       const nodeCache = new RedisServerCache({ client: nodeMock }, nodeRedisPreset);
 
       await nodeCache.listPush('my-list', { event: 'test' });
 
       expect(nodeMock.rPush).toHaveBeenCalledWith('mastra:cache:my-list', '{"event":"test"}');
       expect(nodeMock.rpush).not.toHaveBeenCalled();
+      expect(nodeMock.expire).toHaveBeenCalledWith('mastra:cache:my-list', 300);
+    });
+
+    it('uses the Lua fast path for list push when the client exposes EVAL', async () => {
+      const nodeMock: any = { ...createMockClient(), rPush: vi.fn().mockResolvedValue(1) };
+      const nodeCache = new RedisServerCache({ client: nodeMock }, nodeRedisPreset);
+      nodeMock.eval.mockResolvedValue(1);
+
+      await nodeCache.listPush('my-list', { event: 'test' });
+
+      expect(nodeMock.eval).toHaveBeenCalledTimes(1);
+      expect(nodeMock.rPush).not.toHaveBeenCalled();
+      expect(nodeMock.expire).not.toHaveBeenCalled();
     });
 
     it('routes list range through lRange (camelCase) on node-redis clients', async () => {

--- a/stores/redis/src/index.test.ts
+++ b/stores/redis/src/index.test.ts
@@ -115,7 +115,7 @@ describe('RedisServerCache', () => {
       expect(value).toBe('{"event":"test"}');
       expect(seconds).toBe('300');
       expect(script).toContain('RPUSH');
-      expect(script).toContain('EXPIRE');
+      expect(script).toContain('tonumber(ARGV[2]) > 0');
       expect(mockClient.rpush).not.toHaveBeenCalled();
       expect(mockClient.expire).not.toHaveBeenCalled();
     });
@@ -189,11 +189,35 @@ describe('RedisServerCache', () => {
       expect(key).toBe('mastra:cache:counter');
       expect(seconds).toBe('300');
       expect(script).toContain('INCR');
-      expect(script).toContain('EXPIRE');
+      expect(script).toContain('tonumber(ARGV[1]) > 0');
       expect(script).toContain('return');
       expect(mockClient.incr).not.toHaveBeenCalled();
       expect(mockClient.expire).not.toHaveBeenCalled();
       expect(result).toBe(3);
+    });
+
+    it('should probe the options-object EVAL shape on node-redis v5 clients and cache it', async () => {
+      // A node-redis v5 client: classic (script, numKeys, ...) calls fail at
+      // the server's arity stage, the { keys, arguments } form succeeds.
+      const v5Mock: any = createMockClient();
+      v5Mock.eval.mockImplementation((_script: string, second: unknown) => {
+        if (typeof second === 'number') {
+          return Promise.reject(new Error("wrong number of arguments for 'eval' command"));
+        }
+        return Promise.resolve(3);
+      });
+      const v5Cache = new RedisServerCache({ client: v5Mock });
+
+      const first = await v5Cache.increment('counter');
+      expect(first).toBe(3);
+      expect(v5Mock.eval).toHaveBeenCalledTimes(2); // classic probed, then options
+
+      const second = await v5Cache.increment('counter');
+      expect(second).toBe(3);
+      expect(v5Mock.eval).toHaveBeenCalledTimes(3); // cached shape, no re-probe
+      const [script, options] = v5Mock.eval.mock.calls.at(-1);
+      expect(script).toContain('INCR');
+      expect(options).toEqual({ keys: ['mastra:cache:counter'], arguments: ['300'] });
     });
 
     it('should coerce an EVAL result that comes back as a string', async () => {

--- a/stores/upstash/src/cache/index.ts
+++ b/stores/upstash/src/cache/index.ts
@@ -57,10 +57,15 @@ export class UpstashServerCache extends RedisServerCache {
   constructor(config: UpstashCacheConfig, options: UpstashServerCacheOptions = {}) {
     let client: RedisClient;
 
+    // @upstash/redis speaks a third EVAL shape, (script, keys, args), which the
+    // RedisClient union type rejects. upstashPreset pins the sequential
+    // INCR/RPUSH paths, so EVAL is never routed through this client at runtime.
+    const asRedisClient = (redis: Redis): RedisClient => redis as unknown as RedisClient;
+
     if ('client' in config) {
-      client = config.client;
+      client = asRedisClient(config.client);
     } else {
-      client = new Redis({ url: config.url, token: config.token });
+      client = asRedisClient(new Redis({ url: config.url, token: config.token }));
     }
 
     const redisOptions: RedisServerCacheOptions = {


### PR DESCRIPTION
Fixes #22477

## Summary
- `RedisServerCache.increment` and `listPush` each issued a second round trip just to re-`EXPIRE` the key, so a `CachingPubSub` publish behind a durable agent chunk paid four cache round trips (INCR, EXPIRE, RPUSH, EXPIRE) before the transport `XADD`. Both pairs now run as small Lua scripts in one EVAL each, cutting the hot path from five round trips to three (~40%).
- Clients without classic `EVAL` (script, numKeys, ...) fall back to the previous sequential `INCR`/`RPUSH` + `EXPIRE` commands, and `upstashPreset` now pins that sequential path explicitly since Upstash REST's EVAL takes a different shape — no behavior change for those setups.
- Semantics are unchanged: same keys, same TTL refresh-per-publish, same return values (the INCR script returns the counter; `ttlSeconds: 0` passes a `0` the scripts guard on).

Why not collapse INCR+RPUSH into a single script as suggested in the issue: the sequential `index` assigned by the counter is embedded in the serialized event that gets pushed, so a server-side merge would have to decode/re-encode the adapter's serialized form inside Lua. Two EVALs keep the adapter's serialization intact and still remove the two pure-overhead round trips.

## Test plan
- [x] `pnpm --filter ./stores/redis exec vitest run src/index.test.ts` — 31 passed (EVAL fast path, `ttlSeconds: 0` guard, no-EVAL fallback, upstash sequential preset, node-redis camelCase fallback routing)
- [x] `tsc --noEmit -p tsconfig.json`, oxlint, eslint, oxfmt clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Redis now updates cached data and its expiration time in one operation. This reduces delays during durable stream publishing while preserving replay and fallback behavior.

## Changes

- Added Lua `EVAL` fast paths for `RedisServerCache.increment` and `listPush`.
- Reduced cache operations from four to two round trips.
- Preserved sequential fallbacks for clients without compatible `EVAL` support.
- Configured `upstashPreset` to use sequential implementations.
- Added support for classic and node-redis v5 `EVAL` signatures.
- Cached the detected `EVAL` signature per Redis client and shared concurrent probes.
- Prevented retries after a script may have executed.
- Preserved existing keys, TTL behavior, return values, and `ttlSeconds: 0` handling.
- Rejected values that serialize to `undefined`, including top-level `undefined`, functions, and symbols.
- Added tests for EVAL routing, fallback behavior, Upstash, TTL values, serialization errors, string results, concurrency, and node-redis compatibility.
- Added a patch changeset for `@mastra/redis`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->