### PR TITLE
docs: correct Signals XML name guidance

### DIFF
--- a/docs/src/content/en/docs/harness/signals.mdx
+++ b/docs/src/content/en/docs/harness/signals.mdx
@@ -157,7 +157,7 @@ The model receives the signal as context like this:
 <notification source="github" pr="123">PR #123 has a new review comment from User X about the API surface.</notification>
 ```
 
-Use XML-safe `tagName` and attribute names. They can contain letters, numbers, shows, periods, and hyphens. They must start with a letter or underscore.
+Use XML-safe `tagName` and attribute names. They can contain letters, numbers, periods, hyphens, and the underscore character (`_`). They must start with a letter or underscore.
 
 #### Storage support
 


### PR DESCRIPTION
Fixes #22533.

The Signals docs currently list `shows` as a valid XML name character. This replaces that typo with the literal underscore character (`_`), matching the runtime validator.

Before: `letters, numbers, shows, periods, and hyphens`

After: `letters, numbers, periods, hyphens, and the underscore character (_)`

Validated with focused Remark and Vale checks plus `git diff --check`. The configured `oxfmt-mdx` check could not be run because the current checkout does not provide that executable; the one-line prose edit does not alter MDX structure or formatting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Signals documentation now says that `_` is valid in XML names. This matches the runtime validator and removes the incorrect word “shows.”

## Changes

- Updated the “Send notification context” guidance in `signals.mdx`.
- Preserved the existing guidance for letters, numbers, periods, and hyphens.
- Validated the change with focused Remark, Vale, and `git diff --check` checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->