### PR TITLE
fix(release): fetch history for changesets

### DIFF
--- a/.changeset/green-birds-knock.md
+++ b/.changeset/green-birds-knock.md
@@ -1,7 +1,0 @@
----
-'@internal/llm-recorder': minor
----
-
-Added binary artifact support for non-JSON request/response payloads (for example audio) in the LLM recorder.
-
-Binary bytes are now written as hash-based sidecar files in `__recordings__/` and referenced from JSON recordings with metadata (`contentType`, `size`, and artifact `path`). Replay restores the original binary payload and content-type headers from artifacts, while keeping JSON fixtures small and readable.

--- a/.changeset/smooth-contextual-sidebars.md
+++ b/.changeset/smooth-contextual-sidebars.md
@@ -1,5 +1,0 @@
----
-'mastra-docs': patch
----
-
-Improved docs sidebar transitions when opening and closing contextual menus.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -214,6 +214,61 @@ jobs:
           fetch-tags: true
           persist-credentials: true
 
+      - name: Fetch enough history for Changesets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DEEPEN_BY=500
+
+          while true; do
+            missing=()
+
+            for f in .changeset/*.md; do
+              [ -e "$f" ] || continue
+
+              # Not an actual changeset
+              [[ "$f" == ".changeset/README.md" ]] && continue
+
+              result=$(
+                git log \
+                  --diff-filter=A \
+                  --follow \
+                  --max-count=1 \
+                  --pretty=format:'%H:%p' \
+                  -- "$f"
+              )
+
+              if [ -z "$result" ]; then
+                missing+=("$f")
+                continue
+              fi
+
+              commit="${result%%:*}"
+              parents="${result#*:}"
+
+              if [ -n "$commit" ] && [ -z "$parents" ]; then
+                missing+=("$f")
+              fi
+            done
+
+            if [ "${#missing[@]}" -eq 0 ]; then
+              echo "Enough history fetched for all changesets."
+              break
+            fi
+
+            echo "Need more history for ${#missing[@]} changeset(s):"
+            printf '  %s\n' "${missing[@]}"
+
+            if [ "$(git rev-parse --is-shallow-repository)" = "false" ]; then
+              echo "Repository is fully unshallow but some changesets still cannot be resolved."
+              exit 1
+            fi
+
+            echo "Deepening by $DEEPEN_BY commits..."
+            git fetch --deepen="$DEEPEN_BY"
+          done
+
       - name: Check for pre.json file existence
         id: check_files
         shell: bash


### PR DESCRIPTION
This makes stable publishing deepen its shallow checkout until Changesets can resolve each changeset's creation commit. It also removes the two changesets that have already shipped, so the next release only processes pending work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The release workflow now looks further back in Git history when it cannot find the changes that need to ship. This prevents pending changes from being skipped. It also removes two changesets that already shipped.

## Changes

- Updated `.github/workflows/npm-publish.yml` to progressively deepen shallow checkout history by 500 commits.
- Added validation for unresolved changeset creation commits.
- Added an error when the repository is fully unshallowed but required history remains unavailable.
- Removed shipped changesets for:
  - Binary artifact support in `@internal/llm-recorder`.
  - Documentation sidebar transitions for contextual menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->