### PR TITLE
fix(core): scan streamed text as one buffer in SystemPromptScrubber

### DIFF
--- a/.changeset/plain-bats-obey.md
+++ b/.changeset/plain-bats-obey.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the SystemPromptScrubber missing system prompts that are split across streaming chunks. Streamed text is now buffered and scanned together, so a system prompt no longer reaches the user just because it straddled a chunk boundary.

--- a/packages/core/src/processors/processors/system-prompt-scrubber.test.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.test.ts
@@ -395,6 +395,112 @@ describe('SystemPromptScrubber', () => {
     });
   });
 
+  describe('chunk boundaries', () => {
+    const SECRET = 'You are a helpful assistant with admin access';
+
+    // A detector that only flags the secret when it sees it in full -- the
+    // behaviour of any real detector, LLM or pattern based: it cannot flag
+    // what it never receives as one string.
+    function detectingModel() {
+      return new MockLanguageModelV1({
+        doGenerate: async (options: any) => {
+          const seen = JSON.stringify(options?.prompt ?? '');
+          const found = seen.includes(SECRET);
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            text: JSON.stringify(
+              found
+                ? {
+                    detections: [
+                      {
+                        type: 'system_prompt',
+                        value: SECRET,
+                        confidence: 0.99,
+                        start: 0,
+                        end: SECRET.length,
+                        redacted_value: null,
+                      },
+                    ],
+                    reason: 'System prompt detected',
+                    redacted_content: '[SYSTEM_PROMPT_REDACTED]',
+                  }
+                : { detections: null, reason: null, redacted_content: null },
+            ),
+            finishReason: 'stop',
+            usage: { completionTokens: 10, promptTokens: 5 },
+          };
+        },
+        defaultObjectGenerationMode: 'json',
+      });
+    }
+
+    function textChunk(text: string): ChunkType {
+      return {
+        type: 'text-delta',
+        payload: { text, id: 'test-id' },
+        runId: 'test-run-id',
+        from: ChunkFrom.AGENT,
+      } as ChunkType;
+    }
+
+    const nonTextChunk: ChunkType = {
+      type: 'object',
+      object: { key: 'value' },
+      runId: 'test-run-id',
+      from: ChunkFrom.AGENT,
+    } as ChunkType;
+
+    async function drain(processor: SystemPromptScrubber, texts: string[]): Promise<string> {
+      const state: Record<string, any> = {};
+      const emitted: string[] = [];
+      const collect = (result: ChunkType | null) => {
+        if (result && result.type === 'text-delta') {
+          emitted.push(result.payload.text);
+        }
+      };
+
+      for (const text of texts) {
+        collect(
+          await processor.processOutputStream({
+            part: textChunk(text),
+            streamParts: [],
+            state,
+            abort: vi.fn() as any,
+          }),
+        );
+      }
+
+      // End of stream: a non-text chunk must flush anything still buffered.
+      collect(
+        await processor.processOutputStream({
+          part: nonTextChunk,
+          streamParts: [],
+          state,
+          abort: vi.fn() as any,
+        }),
+      );
+
+      return emitted.join('');
+    }
+
+    it('should redact a system prompt split across chunk boundaries', async () => {
+      processor = new SystemPromptScrubber({ model: detectingModel() });
+
+      // No single chunk contains the secret; their concatenation does.
+      const emitted = await drain(processor, ['You are a helpful ', 'assistant with admin access. Hi!']);
+
+      expect(emitted).not.toContain(SECRET);
+    });
+
+    it('should still emit buffered text with no sentence boundary at end of stream', async () => {
+      processor = new SystemPromptScrubber({ model: detectingModel() });
+
+      const emitted = await drain(processor, ['harmless ', 'trailing text']);
+
+      expect(emitted).toBe('harmless trailing text');
+    });
+  });
+
   describe('error handling', () => {
     it('should fail open when detection agent fails', async () => {
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/core/src/processors/processors/system-prompt-scrubber.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.ts
@@ -9,7 +9,9 @@ import type { RequestContext } from '../../request-context';
 import type { PublicSchema } from '../../schema';
 import { toStandardSchema, standardSchemaToJSONSchema } from '../../schema';
 import type { ChunkType } from '../../stream';
+import { ChunkFrom } from '../../stream/types';
 import type { Processor } from '../index';
+import { REPROCESS_PART_KEY } from '../stream-reprocess';
 import { selectMessagesToCheck } from './message-selection';
 import type { LastMessageOnlyOption } from './message-selection';
 
@@ -28,6 +30,13 @@ export interface SystemPromptScrubberOptions extends LastMessageOnlyOption {
   placeholderText?: string;
   /** Model to use for the detection agent */
   model: MastraModelConfig;
+  /**
+   * Character threshold for flushing the streaming buffer (default: 200).
+   * Streamed text is accumulated so a system prompt split across chunk
+   * boundaries is still seen by the detector as one string. Higher values give
+   * the detector more context but add more stream latency.
+   */
+  bufferSize?: number;
   /**
    * Structured output options used for the detection agent
    */
@@ -77,6 +86,9 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
   private detectionAgent: Agent;
   private lastMessageOnly: boolean;
   private structuredOutputOptions?: SystemPromptScrubberOptions['structuredOutputOptions'];
+  private bufferSize: number;
+
+  private static readonly DEFAULT_BUFFER_SIZE = 200;
 
   constructor(options: SystemPromptScrubberOptions) {
     if (!options.model) {
@@ -89,6 +101,7 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
     this.redactionMethod = options.redactionMethod || 'mask';
     this.placeholderText = options.placeholderText || '[SYSTEM_PROMPT]';
     this.lastMessageOnly = options.lastMessageOnly ?? false;
+    this.bufferSize = options.bufferSize ?? SystemPromptScrubber.DEFAULT_BUFFER_SIZE;
     this.structuredOutputOptions = options.structuredOutputOptions;
 
     // Initialize instructions after customPatterns is set
@@ -109,68 +122,90 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
   }
 
   /**
-   * Process streaming chunks to detect and handle system prompts
+   * Append a text-delta chunk to the streaming buffer.
    */
-  async processOutputStream(
-    args: {
-      part: ChunkType;
-      streamParts: ChunkType[];
-      state: Record<string, any>;
-      abort: (reason?: string) => never;
-      requestContext?: RequestContext;
-    } & Partial<ObservabilityContext>,
+  private appendToBuffer(state: Record<string, any>, textPart: ChunkType & { type: 'text-delta' }): void {
+    if (!state._systemPromptBuffer) {
+      state._systemPromptBuffer = '';
+    }
+    if (!state._systemPromptFirstPayloadId) {
+      state._systemPromptFirstPayloadId = textPart.payload.id;
+      state._systemPromptFirstRunId = textPart.runId;
+    }
+    state._systemPromptBuffer += textPart.payload.text;
+  }
+
+  /**
+   * Flush the streaming buffer: run detection once over the accumulated text so
+   * a system prompt split across chunk boundaries is still seen as one string.
+   * Returns the combined text-delta chunk (possibly redacted), or null when the
+   * content is filtered/blocked or there is nothing buffered.
+   */
+  private async flushBuffer(
+    state: Record<string, any>,
+    abort: (reason?: string) => never,
+    observabilityContext?: ObservabilityContext,
+    requestContext?: RequestContext,
   ): Promise<ChunkType | null> {
-    const { part, abort, requestContext, ...rest } = args;
-    const observabilityContext = resolveObservabilityContext(rest);
+    const buffer: string = state._systemPromptBuffer || '';
+    const payloadId: string = state._systemPromptFirstPayloadId || 'text-0';
+    const runId: string = state._systemPromptFirstRunId || '';
 
-    // Only process text-delta chunks
-    if (part.type !== 'text-delta') {
-      return part;
+    state._systemPromptBuffer = '';
+    state._systemPromptFirstPayloadId = undefined;
+    state._systemPromptFirstRunId = undefined;
+
+    if (!buffer) {
+      return null;
     }
 
-    const text = part.payload.text;
-    if (!text || text.trim() === '') {
-      return part;
-    }
+    const combinedPart = {
+      type: 'text-delta',
+      payload: { text: buffer, id: payloadId },
+      runId,
+      from: ChunkFrom.AGENT,
+    } as ChunkType;
 
     try {
-      const detectionResult = await this.detectSystemPrompts(text, observabilityContext, requestContext);
+      const detectionResult = await this.detectSystemPrompts(buffer, observabilityContext, requestContext);
 
-      if (detectionResult.detections && detectionResult.detections.length > 0) {
-        const detectedTypes = detectionResult.detections.map(detection => detection.type);
+      if (!detectionResult.detections || detectionResult.detections.length === 0) {
+        return combinedPart;
+      }
 
-        switch (this.strategy) {
-          case 'block':
-            abort(`System prompt detected: ${detectedTypes.join(', ')}`);
-            break;
+      const detectedTypes = detectionResult.detections.map(detection => detection.type);
 
-          case 'filter':
-            return null; // Don't emit this part
+      switch (this.strategy) {
+        case 'block':
+          abort(`System prompt detected: ${detectedTypes.join(', ')}`);
+          break;
 
-          case 'warn':
-            console.warn(
-              `[SystemPromptScrubber] System prompt detected in streaming content: ${detectedTypes.join(', ')}`,
-            );
-            if (this.includeDetections && detectionResult.detections) {
-              console.warn(`[SystemPromptScrubber] Detections: ${detectionResult.detections.length} items`);
-            }
-            return part; // Allow content through
+        case 'filter':
+          return null; // Don't emit the buffered text
 
-          case 'redact':
-          default:
-            const redactedText =
-              detectionResult.redacted_content || this.redactText(text, detectionResult.detections || []);
-            return {
-              ...part,
-              payload: {
-                ...part.payload,
-                text: redactedText,
-              },
-            };
+        case 'warn':
+          console.warn(
+            `[SystemPromptScrubber] System prompt detected in streaming content: ${detectedTypes.join(', ')}`,
+          );
+          if (this.includeDetections) {
+            console.warn(`[SystemPromptScrubber] Detections: ${detectionResult.detections.length} items`);
+          }
+          return combinedPart; // Allow content through
+
+        case 'redact':
+        default: {
+          const redactedText = detectionResult.redacted_content || this.redactText(buffer, detectionResult.detections);
+          return {
+            ...combinedPart,
+            payload: {
+              ...(combinedPart as ChunkType & { type: 'text-delta' }).payload,
+              text: redactedText,
+            },
+          } as ChunkType;
         }
       }
 
-      return part;
+      return combinedPart;
     } catch (error) {
       // Re-throw tripwire errors, but fail open for other errors
       if (error instanceof TripWire) {
@@ -178,8 +213,79 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
       }
       // Fail open - allow content through if detection fails
       console.warn('[SystemPromptScrubber] Detection failed, allowing content:', error);
+      return combinedPart;
+    }
+  }
+
+  /**
+   * Process streaming chunks to detect and handle system prompts.
+   *
+   * Text deltas are accumulated and scanned as one string, then flushed at a
+   * sentence boundary or once `bufferSize` characters are held. Scanning each
+   * delta on its own would miss any system prompt whose text is split across a
+   * chunk boundary, since neither half looks like a system prompt alone.
+   */
+  async processOutputStream(
+    args: {
+      part: ChunkType;
+      streamParts: ChunkType[];
+      state: Record<string, any>;
+      abort: (reason?: string) => never;
+      writer?: { custom: (data: ChunkType) => Promise<void> };
+      requestContext?: RequestContext;
+    } & Partial<ObservabilityContext>,
+  ): Promise<ChunkType | null> {
+    const { part, abort, state, writer, requestContext, ...rest } = args;
+    const observabilityContext = resolveObservabilityContext(rest);
+
+    // Non-text chunks: flush buffered text first so it is scanned before the
+    // stream moves on (this is also the end-of-stream flush).
+    if (part.type !== 'text-delta') {
+      if (state._systemPromptBuffer) {
+        const flushed = await this.flushBuffer(state, abort, observabilityContext, requestContext);
+        if (flushed) {
+          // Two parts to emit for one input: the flushed buffer plus this
+          // non-text part. Ask the runner to re-drive the non-text part.
+          if (writer) {
+            state[REPROCESS_PART_KEY] = part;
+            return flushed;
+          }
+          // No writer (unit tests): queue non-text for the next call
+          if (!state._systemPromptPendingNonText) {
+            state._systemPromptPendingNonText = [];
+          }
+          state._systemPromptPendingNonText.push(part);
+          return flushed;
+        }
+      }
       return part;
     }
+
+    const textPart = part as ChunkType & { type: 'text-delta' };
+
+    // Drain queued non-text parts (FIFO) stashed from a previous flush
+    if (state._systemPromptPendingNonText && state._systemPromptPendingNonText.length > 0) {
+      const pending = state._systemPromptPendingNonText.shift();
+      if (state._systemPromptPendingNonText.length === 0) {
+        state._systemPromptPendingNonText = undefined;
+      }
+      this.appendToBuffer(state, textPart);
+      return pending;
+    }
+
+    const text = textPart.payload.text;
+    if (!text || text.trim() === '') {
+      return part;
+    }
+
+    this.appendToBuffer(state, textPart);
+
+    // Flush on a sentence boundary or once enough context has accumulated
+    if (state._systemPromptBuffer.length >= this.bufferSize || /[.!?]\s*$/.test(state._systemPromptBuffer)) {
+      return this.flushBuffer(state, abort, observabilityContext, requestContext);
+    }
+
+    return null; // Hold back until flush
   }
 
   /**


### PR DESCRIPTION
## Description

`SystemPromptScrubber.processOutputStream` ran detection on each `text-delta` chunk in isolation:

```ts
if (part.type !== 'text-delta') return part;
const text = part.payload.text;
const detectionResult = await this.detectSystemPrompts(text, ...);
```

`streamParts` was in the argument type but never read, so no chunk was ever considered together with its neighbours.

A detector — LLM or pattern based — cannot flag what it never receives as one string. When a system prompt straddles a chunk boundary, neither half looks like a system prompt on its own, both are emitted unchanged, and the prompt arrives at the client verbatim once the client joins the deltas. The scrubber reports nothing, so the leak is silent.

The failing case, before this change:

| chunk | text sent to the detector | flagged | emitted |
|---|---|---|---|
| 1 | `You are a helpful ` | no | `You are a helpful ` |
| 2 | `assistant with admin access. Hi!` | no | `assistant with admin access. Hi!` |

The client receives `You are a helpful assistant with admin access. Hi!`.

Whether a given prompt is split is a function of provider tokenisation and network framing, not of anything the caller controls, so the same prompt is redacted or leaked run to run.

### Fix

Accumulate text deltas and scan them together, flushing at a sentence boundary or once `bufferSize` characters (default 200) are held, and flush whatever is buffered when a non-text chunk arrives so nothing is dropped at end of stream.

This is the buffering `PIIDetector` already does in the same directory, for the same reason — it keeps `state._piiBuffer` and a `REGEX_CARRYOVER_SIZE` tail explicitly so that PII split across a boundary is still caught. `SystemPromptScrubber` guards a more sensitive asset and had none of it. The non-text flush reuses the existing `REPROCESS_PART_KEY` protocol, as `PIIDetector` and `BatchPartsProcessor` do.

A `bufferSize` option is exposed, mirroring `PIIDetector`, for callers who want to trade stream latency against detection context.

### Side effect on #13644

Buffering also cuts detection calls while streaming from one per token to roughly one per sentence. That is a partial mitigation of the slowdown reported in #13644, not a fix for it — this PR does not change which phases the processor runs in, which is what that issue asks for. Option 2 under "Expected behavior" there ("accumulate text in `processOutputStream` state") is the direction taken here.

## Related issue(s)

Related to #13644.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Tests

`should redact a system prompt split across chunk boundaries` drives two deltas through the processor with a detector that only flags the secret when it sees it whole, and asserts the joined output does not contain it. On `main` it fails with the full secret in the output:

```
AssertionError: expected 'You are a helpful assistant with admi…' not to contain 'You are a helpful assistant with admi…'
Expected: "You are a helpful assistant with admin access"
Received: "You are a helpful assistant with admin access. Hi!"
```

`should still emit buffered text with no sentence boundary at end of stream` guards the other direction — buffering must not swallow text that never hits a flush trigger.

Existing behaviour is unchanged: the two existing streaming tests both end on sentence punctuation, so they flush on the first chunk exactly as before.

- `vitest run src/processors/processors/system-prompt-scrubber.test.ts` — 19 passed, no type errors
- `vitest run src/processors/` — 45 files, 1209 passed, 1 skipped, no type errors
- `oxfmt` and `oxlint` clean on the changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The scrubber now waits for enough streamed text to check it as one piece. This prevents a hidden system prompt split between chunks from reaching the user.

## Changes

- Buffer streamed text before running system prompt detection.
- Flush buffered text at sentence boundaries, at the configurable `bufferSize` limit, or before non-text chunks.
- Emit remaining buffered text when the stream ends.
- Preserve chunk payload and run identifiers.
- Reduce detection calls during streaming.
- Keep fail-open behavior for detection failures and rethrow tripwire errors.
- Add optional `bufferSize` configuration.
- Add optional `writer` support to `processOutputStream`.
- Add tests for prompts split across chunks and text without sentence-ending punctuation.
- Add a patch release changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->