### PR TITLE
fix(inngest): route durable agent control events through realtime

### DIFF
--- a/.changeset/calm-otters-abort.md
+++ b/.changeset/calm-otters-abort.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Route DurableAgent `agent.control.<runId>` events through Inngest Realtime so cross-process abort requests reach the worker executing the run.

--- a/workflows/inngest/src/pubsub.test.ts
+++ b/workflows/inngest/src/pubsub.test.ts
@@ -1,0 +1,135 @@
+import type { Inngest } from 'inngest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { subscribeMock } = vi.hoisted(() => ({
+  subscribeMock: vi.fn(),
+}));
+
+vi.mock('inngest/realtime', () => ({
+  subscribe: subscribeMock,
+}));
+
+import { InngestPubSub } from './pubsub';
+
+describe('InngestPubSub', () => {
+  beforeEach(() => {
+    subscribeMock.mockReset();
+  });
+
+  it('round-trips agent.control events through the agent-control realtime topic', async () => {
+    let onMessage: ((message: { data: unknown }) => void) | undefined;
+    subscribeMock.mockImplementation(async options => {
+      onMessage = options.onMessage;
+      return { close: vi.fn() };
+    });
+
+    const realtimePublish = vi.fn(async (_ref: unknown, data: unknown) => {
+      onMessage?.({ data });
+    });
+    const inngest = {
+      realtime: { publish: realtimePublish },
+    } as unknown as Inngest;
+
+    const pubsub = new InngestPubSub(inngest, 'workflow-id');
+    const runId = 'run-control';
+    const event = {
+      type: 'abort-request',
+      runId,
+      data: {},
+    };
+    const received: Array<{ type?: string; runId?: string; data?: unknown }> = [];
+
+    await pubsub.subscribe(`agent.control.${runId}`, receivedEvent => {
+      received.push(receivedEvent);
+    });
+    await pubsub.publish(`agent.control.${runId}`, event);
+
+    expect(subscribeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: `agent:${runId}`,
+        topics: ['agent-control'],
+        app: inngest,
+      }),
+    );
+    expect(realtimePublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: `agent:${runId}`,
+        topic: 'agent-control',
+      }),
+      event,
+    );
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject(event);
+  });
+
+  it('keeps agent.stream events on the agent-stream realtime topic', async () => {
+    const realtimePublish = vi.fn(async () => undefined);
+    const inngest = {
+      realtime: { publish: realtimePublish },
+    } as unknown as Inngest;
+
+    const pubsub = new InngestPubSub(inngest, 'workflow-id');
+    const runId = 'run-stream';
+    const event = {
+      type: 'chunk',
+      runId,
+      data: { text: 'hello' },
+    };
+
+    await pubsub.publish(`agent.stream.${runId}`, event);
+
+    expect(realtimePublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: `agent:${runId}`,
+        topic: 'agent-stream',
+      }),
+      event,
+    );
+  });
+
+  it('keeps workflow events on the watch realtime topic with their existing data payload', async () => {
+    const realtimePublish = vi.fn(async () => undefined);
+    const inngest = {
+      realtime: { publish: realtimePublish },
+    } as unknown as Inngest;
+
+    const pubsub = new InngestPubSub(inngest, 'workflow-id');
+    const runId = 'run-workflow';
+    const data = { status: 'finished' };
+
+    await pubsub.publish(`workflow.events.v2.${runId}`, {
+      type: 'finish',
+      runId,
+      data,
+    });
+
+    expect(realtimePublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: `workflow:workflow-id:${runId}`,
+        topic: 'watch',
+      }),
+      data,
+    );
+  });
+
+  it('surfaces agent.control publish failures to the caller', async () => {
+    const failure = new Error('realtime publish failed');
+    const inngest = {
+      realtime: {
+        publish: vi.fn(async () => {
+          throw failure;
+        }),
+      },
+    } as unknown as Inngest;
+
+    const pubsub = new InngestPubSub(inngest, 'workflow-id');
+
+    await expect(
+      pubsub.publish('agent.control.run-failure', {
+        type: 'abort-request',
+        runId: 'run-failure',
+        data: {},
+      }),
+    ).rejects.toBe(failure);
+  });
+});

--- a/workflows/inngest/src/pubsub.ts
+++ b/workflows/inngest/src/pubsub.ts
@@ -101,7 +101,8 @@ export class InngestPubSub extends PubSub {
     // Agent stream/control events share the run-scoped channel but use separate
     // realtime topics so control traffic never reaches stream consumers.
     const isAgentTopic = topicType === 'agent' || topicType === 'control';
-    const inngestTopic = topicType === 'agent' ? 'agent-stream' : topicType === 'control' ? 'agent-control' : 'watch';
+    const inngestTopic =
+      topicType === 'agent' ? 'agent-stream' : topicType === 'control' ? 'agent-control' : 'watch';
     const channel = isAgentTopic ? `agent:${runId}` : `workflow:${this.workflowId}:${runId}`;
 
     try {
@@ -112,7 +113,10 @@ export class InngestPubSub extends PubSub {
     } catch (err: any) {
       // Losing a control request means a remote durable run cannot be stopped,
       // so surface it to the caller. Terminal stream events have the same rule.
-      if (topicType === 'control' || (topicType === 'agent' && (event.type === 'finish' || event.type === 'error'))) {
+      if (
+        topicType === 'control' ||
+        (topicType === 'agent' && (event.type === 'finish' || event.type === 'error'))
+      ) {
         throw err;
       }
       // Non-terminal events: log but don't throw
@@ -129,6 +133,8 @@ export class InngestPubSub extends PubSub {
    * - "agent.stream.{runId}" - agent stream events
    *   -> channel: "agent:{runId}", topic: "agent-stream"
    *   (Note: agent stream uses runId-only channel so nested workflows can publish to same channel)
+   * - "agent.control.{runId}" - agent control events
+   *   -> channel: "agent:{runId}", topic: "agent-control"
    */
   async subscribe(topic: string, cb: (event: Event, ack?: () => Promise<void>) => void): Promise<void> {
     const parsed = parseTopic(topic);

--- a/workflows/inngest/src/pubsub.ts
+++ b/workflows/inngest/src/pubsub.ts
@@ -18,10 +18,11 @@ function buildTopicRef(channel: string, topic: string) {
  * Supported formats:
  * - "workflow.events.v2.{runId}" - workflow events
  * - "agent.stream.{runId}" - agent stream events
+ * - "agent.control.{runId}" - agent control events
  *
  * @returns { runId, topicType } or null if not a recognized format
  */
-function parseTopic(topic: string): { runId: string; topicType: 'workflow' | 'agent' } | null {
+function parseTopic(topic: string): { runId: string; topicType: 'workflow' | 'agent' | 'control' } | null {
   // Try workflow format first
   const workflowMatch = topic.match(/^workflow\.events\.v2\.(.+)$/);
   if (workflowMatch && workflowMatch[1]) {
@@ -32,6 +33,12 @@ function parseTopic(topic: string): { runId: string; topicType: 'workflow' | 'ag
   const agentMatch = topic.match(/^agent\.stream\.(.+)$/);
   if (agentMatch && agentMatch[1]) {
     return { runId: agentMatch[1], topicType: 'agent' };
+  }
+
+  // Try agent control format
+  const controlMatch = topic.match(/^agent\.control\.(.+)$/);
+  if (controlMatch && controlMatch[1]) {
+    return { runId: controlMatch[1], topicType: 'control' };
   }
 
   return null;
@@ -51,6 +58,8 @@ function parseTopic(topic: string): { runId: string; topicType: 'workflow' | 'ag
  *   -> Inngest channel: "workflow:{workflowId}:{runId}", topic: "watch"
  * - "agent.stream.{runId}" - agent stream events (for InngestAgent)
  *   -> Inngest channel: "agent:{runId}", topic: "agent-stream"
+ * - "agent.control.{runId}" - agent control events (for cross-process abort)
+ *   -> Inngest channel: "agent:{runId}", topic: "agent-control"
  */
 export class InngestPubSub extends PubSub {
   private inngest: Inngest;
@@ -78,6 +87,8 @@ export class InngestPubSub extends PubSub {
    * - "agent.stream.{runId}" - agent stream events
    *   -> channel: "agent:{runId}", topic: "agent-stream"
    *   (Note: agent stream uses runId-only channel so nested workflows can publish to same channel)
+   * - "agent.control.{runId}" - agent control events
+   *   -> channel: "agent:{runId}", topic: "agent-control"
    */
   async publish(topic: string, event: Omit<Event, 'id' | 'createdAt'>): Promise<void> {
     const parsed = parseTopic(topic);
@@ -87,20 +98,21 @@ export class InngestPubSub extends PubSub {
 
     const { runId, topicType } = parsed;
 
-    // Use different Inngest topics and channels for different event types
-    // Agent stream events use a runId-only channel so nested workflows publish to the same channel
-    const inngestTopic = topicType === 'agent' ? 'agent-stream' : 'watch';
-    const channel = topicType === 'agent' ? `agent:${runId}` : `workflow:${this.workflowId}:${runId}`;
+    // Agent stream/control events share the run-scoped channel but use separate
+    // realtime topics so control traffic never reaches stream consumers.
+    const isAgentTopic = topicType === 'agent' || topicType === 'control';
+    const inngestTopic = topicType === 'agent' ? 'agent-stream' : topicType === 'control' ? 'agent-control' : 'watch';
+    const channel = isAgentTopic ? `agent:${runId}` : `workflow:${this.workflowId}:${runId}`;
 
     try {
-      // For agent stream events, send the full event structure so subscribers can access type/runId/data
-      // For workflow events, send just the data (existing behavior)
-      const dataToSend = topicType === 'agent' ? event : event.data;
+      // Agent stream/control events need the full event structure so subscribers
+      // can inspect type/runId/data. Workflow events keep their existing payload.
+      const dataToSend = isAgentTopic ? event : event.data;
       await this.inngest.realtime.publish(buildTopicRef(channel, inngestTopic), dataToSend);
     } catch (err: any) {
-      // For agent stream terminal events, rethrow — losing a finish/error event
-      // causes the client stream to hang indefinitely
-      if (topicType === 'agent' && (event.type === 'finish' || event.type === 'error')) {
+      // Losing a control request means a remote durable run cannot be stopped,
+      // so surface it to the caller. Terminal stream events have the same rule.
+      if (topicType === 'control' || (topicType === 'agent' && (event.type === 'finish' || event.type === 'error'))) {
         throw err;
       }
       // Non-terminal events: log but don't throw
@@ -134,10 +146,11 @@ export class InngestPubSub extends PubSub {
 
     const callbacks = new Set<(event: Event, ack?: () => Promise<void>) => void>([cb]);
 
-    // Use different Inngest topics and channels for different event types
-    // Agent stream events use a runId-only channel so nested workflows publish to the same channel
-    const inngestTopic = topicType === 'agent' ? 'agent-stream' : 'watch';
-    const channel = topicType === 'agent' ? `agent:${runId}` : `workflow:${this.workflowId}:${runId}`;
+    // Agent stream/control events share the run-scoped channel but use separate
+    // realtime topics so control traffic never reaches stream consumers.
+    const isAgentTopic = topicType === 'agent' || topicType === 'control';
+    const inngestTopic = topicType === 'agent' ? 'agent-stream' : topicType === 'control' ? 'agent-control' : 'watch';
+    const channel = isAgentTopic ? `agent:${runId}` : `workflow:${this.workflowId}:${runId}`;
 
     // Await the subscribe call to ensure the WebSocket connection is established
     // before we consider the subscription "ready". This prevents race conditions
@@ -147,14 +160,14 @@ export class InngestPubSub extends PubSub {
       topics: [inngestTopic],
       app: this.inngest,
       onMessage: (message: any) => {
-        // For agent stream events, message.data is the full AgentStreamEvent structure (type, runId, data)
-        // For workflow events, wrap message.data in a PubSub Event format
+        // Agent stream/control messages carry the full event structure
+        // (type, runId, data). Workflow events carry only their data payload.
         // IMPORTANT: Always generate a unique `id` and `createdAt` for every event.
         // CachingPubSub deduplicates events by `id` — without a unique id, all events
         // after the first would be filtered out (since undefined === undefined in the seen set).
         let event: Event;
-        if (topicType === 'agent' && message.data?.type && message.data?.runId) {
-          // Agent stream event - spread the AgentStreamEvent data and add required Event fields
+        if (isAgentTopic && message.data?.type && message.data?.runId) {
+          // Agent stream/control event - preserve its shape and add required Event fields
           event = {
             id: crypto.randomUUID(),
             createdAt: new Date(),


### PR DESCRIPTION
## Description

Fixes #22543.

`@mastra/inngest` now transports the `agent.control.<runId>` topic used by Mastra's cross-process DurableAgent abort protocol.

Mastra core already publishes remote abort requests through:

```text
agent.control.<runId>
```

so the process actually executing a durable step can receive the request and abort its worker-local `AbortController`.

`InngestPubSub`, however, only recognized:

```text
workflow.events.v2.<runId>
agent.stream.<runId>
```

and silently ignored any other topic.

That meant a DurableAgent abort could be successfully dispatched by core while never reaching the Inngest worker executing the model call.

Before:

```text
observe(runId).abort()
  ↓
publishAbortRequest()
  ↓
agent.control.<runId>
  ↓
InngestPubSub.parseTopic()
  ↓
null
  ↓
dropped
  ↓
worker continues to natural completion
```

After:

```text
observe(runId).abort()
  ↓
publishAbortRequest()
  ↓
agent.control.<runId>
  ↓
Inngest Realtime
  ↓
agent:<runId> / agent-control
  ↓
executing worker
  ↓
AbortController.abort()
  ↓
finishReason = "abort"
```

## Changes

### Route DurableAgent control topics

`InngestPubSub.parseTopic()` now recognizes:

```text
agent.control.<runId>
```

as a separate control topic type.

### Keep control traffic separate from stream traffic

The mappings are now:

```text
workflow.events.v2.<runId>
  → workflow:<workflowId>:<runId>
  → watch

agent.stream.<runId>
  → agent:<runId>
  → agent-stream

agent.control.<runId>
  → agent:<runId>
  → agent-control
```

The control topic deliberately shares the run-scoped agent channel while using a separate realtime topic, so abort requests never leak into normal stream consumers.

### Preserve the complete control event

Agent control events are published as the full Mastra event envelope:

```ts
{
  type: 'abort-request',
  runId,
  data: {},
}
```

and restored as the same logical event on subscribe.

This is required because core's `subscribeToAbortRequests()` matches the top-level event type.

### Surface control transport failures

Control-event publish failures are rethrown from `InngestPubSub`.

`createInngestAgent()` already treats remote abort publishing as best-effort and catches/logs failures in `requestRemoteAbort()`, so surfacing the transport failure lets that layer report it instead of silently swallowing a failed cancellation request.

No DurableAgent core cancellation behavior is changed.

## Why this belongs in the Inngest transport

Cross-process graceful abort is already the DurableAgent protocol implemented by core.

The executing worker installs `ensureRemoteAbortListener()`, grows its own `AbortController` when necessary, and propagates that signal into active model/tool execution.

The missing piece was only:

```text
agent.control.<runId>
        ↓
@mastra/inngest transport
        ↓
executing worker
```

This PR fills that transport gap rather than adding another cancellation mechanism or hard-cancelling the underlying Inngest workflow.

## Related issue(s)

Fixes #22543

Related context:

- #19869
- #21009
- #22202
- #22255

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue above
- [x] I have added regression coverage for the fix
- [x] Existing `agent.stream.*` routing is unchanged
- [x] Existing `workflow.events.v2.*` routing is unchanged
- [x] Control messages remain isolated from stream messages
- [x] I verified the complete Inngest DurableAgent abort path

## Test plan

### Transport regression

The new `InngestPubSub` regression test exercises a full publish → subscribe round-trip and verifies:

```text
agent.control.<runId>
→ channel: agent:<runId>
→ topic: agent-control
→ subscriber receives full event
→ event.type === "abort-request"
→ event.runId is preserved
```

### Existing routing regression

Verified:

```text
agent.stream.<runId>
→ agent:<runId> / agent-stream
```

and:

```text
workflow.events.v2.<runId>
→ workflow:<workflowId>:<runId> / watch
```

continue to behave unchanged.

### Failure behavior

The regression suite verifies that an `agent.control` realtime publish failure is surfaced rather than silently swallowed.

### Inngest E2E

A real `createInngestAgent()` durable execution with a separate Inngest worker was allowed to begin model streaming before cancellation.

Before this fix:

```text
abort dispatch succeeds
→ worker keeps generating
→ run finishes naturally
```

With this fix:

```text
abort dispatch succeeds
→ worker receives abort-request
→ active generation stops
→ durable run unwinds normally
→ terminal finishReason = "abort"
```

This verifies the complete caller → Inngest Realtime → worker → AbortSignal → durable terminal-event path.

## Implementation notes

The change intentionally does not use Inngest workflow hard cancellation.

Mastra's durable abort transport is designed to stop the active execution through the worker-local `AbortController`, allowing normal durable finalization and terminal stream emission.

The PR only makes `@mastra/inngest` capable of carrying the control topic that core already uses for that protocol.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Durable agents can now receive stop requests through Inngest when they run in another process. The worker stops gracefully and reports `finishReason = "abort"`.

## Changes

- Added `agent.control.<runId>` routing through Inngest Realtime.
- Maps control events to:
  - Channel: `agent:<runId>`
  - Topic: `agent-control`
- Preserves the full control-event envelope.
- Keeps control events separate from `agent-stream` events.
- Propagates control-event publish failures.
- Preserves existing workflow and agent stream routing.
- Added regression tests for routing, event preservation, and error propagation.
- Added end-to-end coverage for remote DurableAgent aborts.
- Added a patch changeset for `@mastra/inngest`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->