### PR TITLE
fix(pg): respect effective schema in PgVector catalog lookups

### DIFF
--- a/.changeset/tidy-plums-search.md
+++ b/.changeset/tidy-plums-search.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Respect PostgreSQL's effective `current_schema()` in PgVector catalog lookups when `schemaName` is omitted, so vector tables created through the connection search path remain discoverable.

--- a/.changeset/tidy-plums-search.md
+++ b/.changeset/tidy-plums-search.md
@@ -2,4 +2,4 @@
 '@mastra/pg': patch
 ---
 
-Respect PostgreSQL's effective `current_schema()` in PgVector catalog lookups when `schemaName` is omitted, so vector tables created through the connection search path remain discoverable.
+Respect PostgreSQL search-path relation visibility in PgVector when `schemaName` is omitted, so vector tables created in visible non-`public` schemas remain discoverable across listing, metadata lookup, and namespace migration.

--- a/stores/pg/src/vector/index.schema-name.test.ts
+++ b/stores/pg/src/vector/index.schema-name.test.ts
@@ -484,7 +484,7 @@ describe('PgVector buildIndex uses correct operator class for halfvec', () => {
 });
 
 
-describe('PgVector default schema follows PostgreSQL current_schema()', () => {
+describe('PgVector default schema follows PostgreSQL search_path visibility', () => {
   const config: PgVectorConfig & { id: string } = {
     connectionString: 'postgresql://testflight:testflight@localhost:5432/mastra',
     id: 'pg-vector-effective-schema-test',
@@ -505,7 +505,7 @@ describe('PgVector default schema follows PostgreSQL current_schema()', () => {
         return { rows: returnIndexFromList ? [{ table_name: 'memory_observations_384' }] : [] };
       }
 
-      if (sql.includes('information_schema.columns') && sql.includes('udt_name')) {
+      if (sql.includes('FROM pg_attribute a') && sql.includes('JOIN pg_type typ')) {
         return { rows: [{ udt_name: 'vector' }] };
       }
 
@@ -519,6 +519,14 @@ describe('PgVector default schema follows PostgreSQL current_schema()', () => {
 
       if (sql.includes('COUNT(*)')) {
         return { rows: [{ count: '0' }] };
+      }
+
+      if (sql.includes("attname = 'vector_id'")) {
+        return { rows: [{}], rowCount: 1 };
+      }
+
+      if (sql.includes('FROM pg_constraint c')) {
+        return { rows: [] };
       }
 
       return { rows: [] };
@@ -536,7 +544,7 @@ describe('PgVector default schema follows PostgreSQL current_schema()', () => {
     mockClient.query.mockReset();
   });
 
-  it('uses current_schema() for catalog lookups when schemaName is omitted', async () => {
+  it('uses relation visibility for catalog lookups when schemaName is omitted', async () => {
     await expect(vectorStore.listIndexes()).resolves.toContain('memory_observations_384');
     await expect(vectorStore.describeIndex({ indexName: 'memory_observations_384' })).resolves.toMatchObject({
       dimension: 384,
@@ -544,17 +552,34 @@ describe('PgVector default schema follows PostgreSQL current_schema()', () => {
     });
 
     const listIndexesCall = queryHistory.find(call => call.text.includes('FROM information_schema.tables t'));
-    expect(listIndexesCall?.text ?? '').toContain('t.table_schema = COALESCE($1, current_schema())');
+    expect(listIndexesCall?.text ?? '').toContain('pg_table_is_visible');
     expect(listIndexesCall?.values).toEqual([null]);
 
     const tableLookupCall = queryHistory.find(
-      call => call.text.includes('FROM information_schema.columns') && call.text.includes('udt_name'),
+      call => call.text.includes('FROM pg_attribute a') && call.text.includes('JOIN pg_type typ'),
     );
-    expect(tableLookupCall?.text ?? '').toContain('table_schema = COALESCE($1, current_schema())');
-    expect(tableLookupCall?.values).toEqual([null, 'memory_observations_384']);
+    expect(tableLookupCall?.text ?? '').toContain('a.attrelid = to_regclass($1)');
+    expect(tableLookupCall?.values).toEqual(['"memory_observations_384"']);
 
     const indexLookupCall = queryHistory.find(call => call.text.includes('FROM pg_index'));
-    expect(indexLookupCall?.text ?? '').toContain('n.nspname = COALESCE($2, current_schema())');
-    expect(indexLookupCall?.values).toEqual(['memory_observations_384_vector_idx', null]);
+    expect(indexLookupCall?.text ?? '').toContain('i.indrelid = to_regclass($2)');
+    expect(indexLookupCall?.values).toEqual([
+      'memory_observations_384_vector_idx',
+      '"memory_observations_384"',
+    ]);
+  });
+
+  it('uses the resolved relation for namespace migration when schemaName is omitted', async () => {
+    queryHistory.length = 0;
+
+    await (vectorStore as any).ensureNamespaceSchema('memory_observations_384', mockClient);
+
+    const vectorIdLookup = queryHistory.find(call => call.text.includes("attname = 'vector_id'"));
+    expect(vectorIdLookup?.text ?? '').toContain('attrelid = to_regclass($1)');
+    expect(vectorIdLookup?.values).toEqual(['"memory_observations_384"']);
+
+    const constraintLookup = queryHistory.find(call => call.text.includes('FROM pg_constraint c'));
+    expect(constraintLookup?.text ?? '').toContain('c.conrelid = to_regclass($1)');
+    expect(constraintLookup?.values).toEqual(['"memory_observations_384"']);
   });
 });

--- a/stores/pg/src/vector/index.schema-name.test.ts
+++ b/stores/pg/src/vector/index.schema-name.test.ts
@@ -513,7 +513,6 @@ describe('PgVector buildIndex uses correct operator class for halfvec', () => {
   });
 });
 
-
 describe('PgVector default schema follows PostgreSQL search_path visibility', () => {
   const config: PgVectorConfig & { id: string } = {
     connectionString: 'postgresql://testflight:testflight@localhost:5432/mastra',
@@ -609,10 +608,7 @@ describe('PgVector default schema follows PostgreSQL search_path visibility', ()
 
     const indexLookupCall = queryHistory.find(call => call.text.includes('FROM pg_index'));
     expect(indexLookupCall?.text ?? '').toContain('i.indrelid = to_regclass($2)');
-    expect(indexLookupCall?.values).toEqual([
-      'memory_observations_384_vector_idx',
-      '"memory_observations_384"',
-    ]);
+    expect(indexLookupCall?.values).toEqual(['memory_observations_384_vector_idx', '"memory_observations_384"']);
   });
 
   it('uses the resolved relation for namespace migration when schemaName is omitted', async () => {

--- a/stores/pg/src/vector/index.schema-name.test.ts
+++ b/stores/pg/src/vector/index.schema-name.test.ts
@@ -226,8 +226,8 @@ describe('PgVector custom schema sets search_path before index creation and quer
         return { rows: [{ schema_name: 'myapp', version: '0.8.0' }] };
       }
 
-      // For describeIndex - simulate a vector table exists
-      if (sql.includes('information_schema.columns') && sql.includes('udt_name')) {
+      // For describeIndexMetadata - simulate a vector table exists through the current catalog query.
+      if (sql.includes('FROM pg_attribute a') && sql.includes('JOIN pg_type typ')) {
         return { rows: [{ udt_name: 'vector' }] };
       }
 
@@ -279,6 +279,12 @@ describe('PgVector custom schema sets search_path before index creation and quer
       indexConfig: { type: 'hnsw' },
     });
 
+    const metadataLookupCall = queryHistory.find(
+      call => call.text.includes('FROM pg_attribute a') && call.text.includes('JOIN pg_type typ'),
+    );
+    expect(metadataLookupCall?.text ?? '').toContain('a.attrelid = to_regclass($1)');
+    expect(metadataLookupCall?.values).toEqual(['"myapp"."testIndex"']);
+
     const createIndexIdx = queryHistory.findIndex(call => call.text.includes('CREATE INDEX'));
     expect(createIndexIdx).toBeGreaterThan(-1);
 
@@ -307,6 +313,11 @@ describe('PgVector custom schema sets search_path before index creation and quer
       indexName: 'queryTest',
       queryVector: new Array(1536).fill(0.1),
     });
+
+    const metadataLookupCall = queryHistory.find(
+      call => call.text.includes('FROM pg_attribute a') && call.text.includes('JOIN pg_type typ'),
+    );
+    expect(metadataLookupCall?.values).toEqual(['"myapp"."queryTest"']);
 
     const vectorQueryIdx = queryHistory.findIndex(call => call.text.includes('vector_scores'));
     expect(vectorQueryIdx).toBeGreaterThan(-1);
@@ -362,6 +373,11 @@ describe('PgVector custom schema sets search_path before index creation and quer
       metadata: [{ key: 'value' }],
     });
 
+    const metadataLookupCall = queryHistory.find(
+      call => call.text.includes('FROM pg_attribute a') && call.text.includes('JOIN pg_type typ'),
+    );
+    expect(metadataLookupCall?.values).toEqual(['"myapp"."upsertTest"']);
+
     const insertIdx = queryHistory.findIndex(call => call.text.includes('INSERT INTO'));
     expect(insertIdx).toBeGreaterThan(-1);
 
@@ -392,6 +408,11 @@ describe('PgVector custom schema sets search_path before index creation and quer
         vector: new Array(1536).fill(0.2),
       },
     });
+
+    const metadataLookupCall = queryHistory.find(
+      call => call.text.includes('FROM pg_attribute a') && call.text.includes('JOIN pg_type typ'),
+    );
+    expect(metadataLookupCall?.values).toEqual(['"myapp"."updateTest"']);
 
     const updateIdx = queryHistory.findIndex(call => call.text.includes('UPDATE'));
     expect(updateIdx).toBeGreaterThan(-1);
@@ -427,8 +448,8 @@ describe('PgVector buildIndex uses correct operator class for halfvec', () => {
         return { rows: [{ schema_name: 'public', version: '0.8.0' }] };
       }
 
-      // For describeIndex - simulate a halfvec table exists
-      if (sql.includes('information_schema.columns') && sql.includes('udt_name')) {
+      // For describeIndexMetadata - simulate a halfvec table exists through the current catalog query.
+      if (sql.includes('FROM pg_attribute a') && sql.includes('JOIN pg_type typ')) {
         return { rows: [{ udt_name: 'halfvec' }] };
       }
 
@@ -474,6 +495,12 @@ describe('PgVector buildIndex uses correct operator class for halfvec', () => {
       metric: 'cosine',
       indexConfig: { type: 'hnsw' },
     });
+
+    const metadataLookupCall = queryHistory.find(
+      call => call.text.includes('FROM pg_attribute a') && call.text.includes('JOIN pg_type typ'),
+    );
+    expect(metadataLookupCall?.text ?? '').toContain('a.attrelid = to_regclass($1)');
+    expect(metadataLookupCall?.values).toEqual(['"existingHalfvecTable"']);
 
     const createIndexCall = queryHistory.find(call => call.text.includes('CREATE INDEX'));
     expect(createIndexCall).toBeDefined();

--- a/stores/pg/src/vector/index.schema-name.test.ts
+++ b/stores/pg/src/vector/index.schema-name.test.ts
@@ -226,6 +226,14 @@ describe('PgVector custom schema sets search_path before index creation and quer
         return { rows: [{ schema_name: 'myapp', version: '0.8.0' }] };
       }
 
+      if (sql === 'SHOW search_path') {
+        return { rows: [{ search_path: '"$user", public' }] };
+      }
+
+      if (sql.includes("set_config('search_path'")) {
+        return { rows: [] };
+      }
+
       // For describeIndexMetadata - simulate a vector table exists through the current catalog query.
       if (sql.includes('FROM pg_attribute a') && sql.includes('JOIN pg_type typ')) {
         return { rows: [{ udt_name: 'vector' }] };
@@ -267,6 +275,19 @@ describe('PgVector custom schema sets search_path before index creation and quer
     mockClient.query.mockReset();
   });
 
+  const expectSearchPathPreservedAround = (operationIndex: number) => {
+    const extendSearchPathIdx = queryHistory.findIndex(call => call.text.includes('quote_ident($2)'));
+    expect(extendSearchPathIdx).toBeGreaterThan(-1);
+    expect(queryHistory[extendSearchPathIdx]?.values).toEqual(['"$user", public', 'myapp']);
+    expect(extendSearchPathIdx).toBeLessThan(operationIndex);
+
+    const restoreSearchPathIdx = queryHistory.findIndex(call =>
+      call.text.includes("set_config('search_path', $1, false)"),
+    );
+    expect(restoreSearchPathIdx).toBeGreaterThan(operationIndex);
+    expect(queryHistory[restoreSearchPathIdx]?.values).toEqual(['"$user", public']);
+  };
+
   it('should set search_path before index creation when extension is in custom schema', async () => {
     // When the vector extension is installed in a custom schema (myapp) and
     // the tables are also in myapp, operator classes like vector_cosine_ops
@@ -288,12 +309,9 @@ describe('PgVector custom schema sets search_path before index creation and quer
     const createIndexIdx = queryHistory.findIndex(call => call.text.includes('CREATE INDEX'));
     expect(createIndexIdx).toBeGreaterThan(-1);
 
-    // There must be a SET search_path call BEFORE the CREATE INDEX
-    const searchPathBeforeIndex = queryHistory
-      .slice(0, createIndexIdx)
-      .some(call => call.text.includes('search_path') && call.text.includes('myapp'));
-
-    expect(searchPathBeforeIndex).toBe(true);
+    // The extension schema must be appended without replacing the existing relation search path,
+    // and the original path must be restored before the client is released.
+    expectSearchPathPreservedAround(createIndexIdx);
   });
 
   it('should set search_path before vector similarity queries when extension is in custom schema', async () => {
@@ -322,12 +340,7 @@ describe('PgVector custom schema sets search_path before index creation and quer
     const vectorQueryIdx = queryHistory.findIndex(call => call.text.includes('vector_scores'));
     expect(vectorQueryIdx).toBeGreaterThan(-1);
 
-    // There must be a SET search_path call BEFORE the vector similarity query
-    const searchPathBeforeQuery = queryHistory
-      .slice(0, vectorQueryIdx)
-      .some(call => call.text.includes('search_path') && call.text.includes('myapp'));
-
-    expect(searchPathBeforeQuery).toBe(true);
+    expectSearchPathPreservedAround(vectorQueryIdx);
   });
 
   it('should NOT set search_path before CREATE TABLE in createIndex to avoid table placement regression', async () => {
@@ -345,11 +358,11 @@ describe('PgVector custom schema sets search_path before index creation and quer
     const createTableIdx = queryHistory.findIndex(call => call.text.includes('CREATE TABLE'));
     expect(createTableIdx).toBeGreaterThan(-1);
 
-    // There must NOT be a SET search_path call immediately before CREATE TABLE
-    // (search_path should only be set before index creation and queries, not table creation)
+    // There must NOT be a search_path mutation before CREATE TABLE
+    // (search_path should only be extended before index creation and vector operations).
     const searchPathBeforeTable = queryHistory
       .slice(0, createTableIdx)
-      .some(call => call.text.includes('SET search_path'));
+      .some(call => call.text === 'SHOW search_path' || call.text.includes("set_config('search_path'"));
 
     expect(searchPathBeforeTable).toBe(false);
   });
@@ -381,12 +394,7 @@ describe('PgVector custom schema sets search_path before index creation and quer
     const insertIdx = queryHistory.findIndex(call => call.text.includes('INSERT INTO'));
     expect(insertIdx).toBeGreaterThan(-1);
 
-    // There must be a SET search_path call BEFORE the INSERT
-    const searchPathBeforeInsert = queryHistory
-      .slice(0, insertIdx)
-      .some(call => call.text.includes('search_path') && call.text.includes('myapp'));
-
-    expect(searchPathBeforeInsert).toBe(true);
+    expectSearchPathPreservedAround(insertIdx);
   });
 
   it('should set search_path before updateVector when extension is in custom schema', async () => {
@@ -417,12 +425,7 @@ describe('PgVector custom schema sets search_path before index creation and quer
     const updateIdx = queryHistory.findIndex(call => call.text.includes('UPDATE'));
     expect(updateIdx).toBeGreaterThan(-1);
 
-    // There must be a SET search_path call BEFORE the UPDATE
-    const searchPathBeforeUpdate = queryHistory
-      .slice(0, updateIdx)
-      .some(call => call.text.includes('search_path') && call.text.includes('myapp'));
-
-    expect(searchPathBeforeUpdate).toBe(true);
+    expectSearchPathPreservedAround(updateIdx);
   });
 });
 
@@ -532,6 +535,18 @@ describe('PgVector default schema follows PostgreSQL search_path visibility', ()
         return { rows: returnIndexFromList ? [{ table_name: 'memory_observations_384' }] : [] };
       }
 
+      if (sql.includes('FROM pg_extension e')) {
+        return { rows: [{ schema_name: 'vector_ext', version: '0.8.0' }] };
+      }
+
+      if (sql === 'SHOW search_path') {
+        return { rows: [{ search_path: '"$user", public' }] };
+      }
+
+      if (sql.includes("set_config('search_path'")) {
+        return { rows: [] };
+      }
+
       if (sql.includes('FROM pg_attribute a') && sql.includes('JOIN pg_type typ')) {
         return { rows: [{ udt_name: 'vector' }] };
       }
@@ -546,6 +561,10 @@ describe('PgVector default schema follows PostgreSQL search_path visibility', ()
 
       if (sql.includes('COUNT(*)')) {
         return { rows: [{ count: '0' }] };
+      }
+
+      if (sql.includes('vector_scores')) {
+        return { rows: [] };
       }
 
       if (sql.includes("attname = 'vector_id'")) {
@@ -608,5 +627,30 @@ describe('PgVector default schema follows PostgreSQL search_path visibility', ()
     const constraintLookup = queryHistory.find(call => call.text.includes('FROM pg_constraint c'));
     expect(constraintLookup?.text ?? '').toContain('c.conrelid = to_regclass($1)');
     expect(constraintLookup?.values).toEqual(['"memory_observations_384"']);
+  });
+
+  it('preserves and restores the role search_path when pgvector is in another schema', async () => {
+    queryHistory.length = 0;
+
+    await expect(
+      vectorStore.query({
+        indexName: 'memory_observations_384',
+        queryVector: new Array(384).fill(0.1),
+      }),
+    ).resolves.toEqual([]);
+
+    const extendSearchPathIdx = queryHistory.findIndex(call => call.text.includes('quote_ident($2)'));
+    expect(extendSearchPathIdx).toBeGreaterThan(-1);
+    expect(queryHistory[extendSearchPathIdx]?.values).toEqual(['"$user", public', 'vector_ext']);
+
+    const vectorQueryIdx = queryHistory.findIndex(call => call.text.includes('vector_scores'));
+    expect(vectorQueryIdx).toBeGreaterThan(extendSearchPathIdx);
+    expect(queryHistory[vectorQueryIdx]?.text ?? '').toContain('FROM "memory_observations_384"');
+
+    const restoreSearchPathIdx = queryHistory.findIndex(call =>
+      call.text.includes("set_config('search_path', $1, false)"),
+    );
+    expect(restoreSearchPathIdx).toBeGreaterThan(vectorQueryIdx);
+    expect(queryHistory[restoreSearchPathIdx]?.values).toEqual(['"$user", public']);
   });
 });

--- a/stores/pg/src/vector/index.schema-name.test.ts
+++ b/stores/pg/src/vector/index.schema-name.test.ts
@@ -482,3 +482,79 @@ describe('PgVector buildIndex uses correct operator class for halfvec', () => {
     expect(createIndexCall?.text ?? '').not.toContain('vector_cosine_ops');
   });
 });
+
+
+describe('PgVector default schema follows PostgreSQL current_schema()', () => {
+  const config: PgVectorConfig & { id: string } = {
+    connectionString: 'postgresql://testflight:testflight@localhost:5432/mastra',
+    id: 'pg-vector-effective-schema-test',
+  };
+
+  let vectorStore: PgVector;
+  let returnIndexFromList = false;
+
+  beforeEach(async () => {
+    queryHistory.length = 0;
+    returnIndexFromList = false;
+
+    mockClient.query.mockImplementation(async (text: any, values?: any[]) => {
+      const sql = typeof text === 'string' ? text : text?.text || '';
+      queryHistory.push({ text: sql, values });
+
+      if (sql.includes('FROM information_schema.tables t')) {
+        return { rows: returnIndexFromList ? [{ table_name: 'memory_observations_384' }] : [] };
+      }
+
+      if (sql.includes('information_schema.columns') && sql.includes('udt_name')) {
+        return { rows: [{ udt_name: 'vector' }] };
+      }
+
+      if (sql.includes('pg_attribute') && sql.includes('atttypmod')) {
+        return { rows: [{ dimension: 384 }] };
+      }
+
+      if (sql.includes('pg_index') && sql.includes('pg_am')) {
+        return { rows: [] };
+      }
+
+      if (sql.includes('COUNT(*)')) {
+        return { rows: [{ count: '0' }] };
+      }
+
+      return { rows: [] };
+    });
+    mockClient.release.mockReset();
+
+    vectorStore = new PgVector(config);
+    await (vectorStore as any).cacheWarmupPromise;
+    queryHistory.length = 0;
+    returnIndexFromList = true;
+  });
+
+  afterEach(async () => {
+    await vectorStore.disconnect();
+    mockClient.query.mockReset();
+  });
+
+  it('uses current_schema() for catalog lookups when schemaName is omitted', async () => {
+    await expect(vectorStore.listIndexes()).resolves.toContain('memory_observations_384');
+    await expect(vectorStore.describeIndex({ indexName: 'memory_observations_384' })).resolves.toMatchObject({
+      dimension: 384,
+      count: 0,
+    });
+
+    const listIndexesCall = queryHistory.find(call => call.text.includes('FROM information_schema.tables t'));
+    expect(listIndexesCall?.text ?? '').toContain('t.table_schema = COALESCE($1, current_schema())');
+    expect(listIndexesCall?.values).toEqual([null]);
+
+    const tableLookupCall = queryHistory.find(
+      call => call.text.includes('FROM information_schema.columns') && call.text.includes('udt_name'),
+    );
+    expect(tableLookupCall?.text ?? '').toContain('table_schema = COALESCE($1, current_schema())');
+    expect(tableLookupCall?.values).toEqual([null, 'memory_observations_384']);
+
+    const indexLookupCall = queryHistory.find(call => call.text.includes('FROM pg_index'));
+    expect(indexLookupCall?.text ?? '').toContain('n.nspname = COALESCE($2, current_schema())');
+    expect(indexLookupCall?.values).toEqual(['memory_observations_384_vector_idx', null]);
+  });
+});

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -299,7 +299,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
    * PostgreSQL's default search_path is ("$user", public). If the extension lives in a custom schema
    * (e.g. "myapp"), operator classes and distance operators won't resolve without this.
    */
-  private async ensureSearchPath(client: pg.PoolClient) {
+  private async ensureSearchPath(client: pg.PoolClient): Promise<string | undefined> {
     // Lazily detect extension schema if not yet known
     if (!this.vectorExtensionSchema) {
       await this.detectVectorExtensionSchema(client);
@@ -310,12 +310,32 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       this.vectorExtensionSchema !== 'public' &&
       this.vectorExtensionSchema !== 'pg_catalog'
     ) {
-      const schemas = new Set<string>();
-      schemas.add(this.vectorExtensionSchema);
-      if (this.schema) schemas.add(this.schema);
-      schemas.add('public');
-      await client.query(`SET search_path TO ${[...schemas].map(s => `"${s}"`).join(', ')}`);
+      // Preserve the caller's existing relation-resolution order and append the extension
+      // schema only for pgvector types/operators. Prepending or replacing search_path can
+      // make an unqualified table that was visible through "$user" or another configured
+      // schema disappear (or resolve to a different same-named relation).
+      const currentSearchPath = await client.query<{ search_path: string }>('SHOW search_path');
+      const originalSearchPath = currentSearchPath.rows[0]?.search_path;
+      if (!originalSearchPath) {
+        return undefined;
+      }
+
+      await client.query(
+        `SELECT set_config('search_path', $1 || ', ' || quote_ident($2), false)`,
+        [originalSearchPath, this.vectorExtensionSchema],
+      );
+      return originalSearchPath;
     }
+
+    return undefined;
+  }
+
+  private async restoreSearchPath(client: pg.PoolClient, originalSearchPath?: string): Promise<void> {
+    if (!originalSearchPath) {
+      return;
+    }
+
+    await client.query(`SELECT set_config('search_path', $1, false)`, [originalSearchPath]);
   }
 
   /**
@@ -651,9 +671,11 @@ export class PgVector extends MastraVector<PGVectorFilter> {
 
     // Vector similarity query
     const client = await this.pool.connect();
+    let originalSearchPath: string | undefined;
     try {
-      // Set search path so vector operators (e.g. <=>) resolve correctly
-      await this.ensureSearchPath(client);
+      // Extend search_path so vector operators (e.g. <=>) resolve without changing
+      // the caller's existing relation-resolution order.
+      originalSearchPath = await this.ensureSearchPath(client);
       await client.query('BEGIN');
       const translatedFilter = this.transformFilter(filter);
       const { sql: filterQuery, values: filterValues } = buildFilterQuery(translatedFilter, minScore, topK);
@@ -757,6 +779,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       this.logger?.trackException(mastraError);
       throw mastraError;
     } finally {
+      await this.restoreSearchPath(client, originalSearchPath);
       client.release();
     }
   }
@@ -776,9 +799,10 @@ export class PgVector extends MastraVector<PGVectorFilter> {
 
     // Start a transaction
     const client = await this.pool.connect();
+    let originalSearchPath: string | undefined;
     try {
-      // Set search path so vector type casts (e.g. ::vector, ::halfvec) resolve correctly
-      await this.ensureSearchPath(client);
+      // Extend search_path so vector type casts resolve without changing relation precedence.
+      originalSearchPath = await this.ensureSearchPath(client);
 
       await client.query('BEGIN');
 
@@ -907,6 +931,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       this.logger?.trackException(mastraError);
       throw mastraError;
     } finally {
+      await this.restoreSearchPath(client, originalSearchPath);
       client.release();
     }
   }
@@ -1318,10 +1343,11 @@ export class PgVector extends MastraVector<PGVectorFilter> {
         return;
       }
 
-      // Set search path so vector operator classes (e.g. vector_cosine_ops) resolve correctly
-      await this.ensureSearchPath(client);
-
-      // Get the operator class based on vector type and metric
+      // Extend search_path so vector operator classes resolve while preserving the relation
+      // selected by the caller's existing path.
+      const originalSearchPath = await this.ensureSearchPath(client);
+      try {
+        // Get the operator class based on vector type and metric
       // pgvector uses different operator classes for vector vs halfvec
       // Use the detected vectorType from existing table if available, otherwise use the parameter
       const effectiveVectorType = existingIndexInfo?.vectorType ?? vectorType;
@@ -1357,7 +1383,10 @@ export class PgVector extends MastraVector<PGVectorFilter> {
         `;
       }
 
-      await client.query(indexSQL);
+        await client.query(indexSQL);
+      } finally {
+        await this.restoreSearchPath(client, originalSearchPath);
+      }
     });
   }
 
@@ -1776,6 +1805,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
     namespace = DEFAULT_NAMESPACE,
   }: PgUpdateVectorParams): Promise<void> {
     let client;
+    let originalSearchPath: string | undefined;
     try {
       if (!update.vector && !update.metadata) {
         throw new Error('No updates provided');
@@ -1803,8 +1833,8 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       }
 
       client = await this.pool.connect();
-      // Set search path so vector type casts (e.g. ::vector, ::halfvec) resolve correctly
-      await this.ensureSearchPath(client);
+      // Extend search_path so vector type casts resolve without changing relation precedence.
+      originalSearchPath = await this.ensureSearchPath(client);
 
       const { tableName } = this.getTableName(indexName);
 
@@ -1916,7 +1946,10 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       this.logger?.trackException(mastraError);
       throw mastraError;
     } finally {
-      client?.release();
+      if (client) {
+        await this.restoreSearchPath(client, originalSearchPath);
+        client.release();
+      }
     }
   }
 

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -320,10 +320,10 @@ export class PgVector extends MastraVector<PGVectorFilter> {
         return undefined;
       }
 
-      await client.query(
-        `SELECT set_config('search_path', $1 || ', ' || quote_ident($2), false)`,
-        [originalSearchPath, this.vectorExtensionSchema],
-      );
+      await client.query(`SELECT set_config('search_path', $1 || ', ' || quote_ident($2), false)`, [
+        originalSearchPath,
+        this.vectorExtensionSchema,
+      ]);
       return originalSearchPath;
     }
 

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -477,12 +477,15 @@ export class PgVector extends MastraVector<PGVectorFilter> {
 
   private async ensureNamespaceSchema(indexName: string, client: pg.PoolClient): Promise<void> {
     const { tableName, parsedIndexName } = this.getTableName(indexName);
-    const schemaName = this.schema ? parseSqlIdentifier(this.schema, 'schema name') : 'public';
+    // Resolve the exact relation the same way all unqualified PgVector SQL does:
+    // explicit schemaName stays qualified; otherwise PostgreSQL follows search_path.
     const vectorIdColumn = await client.query(
       `SELECT 1
-       FROM information_schema.columns
-       WHERE table_schema = $1 AND table_name = $2 AND column_name = 'vector_id'`,
-      [schemaName, parsedIndexName],
+       FROM pg_attribute
+       WHERE attrelid = to_regclass($1)
+         AND attname = 'vector_id'
+         AND NOT attisdropped`,
+      [tableName],
     );
     if (vectorIdColumn.rowCount === 0) {
       return;
@@ -495,13 +498,10 @@ export class PgVector extends MastraVector<PGVectorFilter> {
     const legacyConstraints = await client.query<{ conname: string }>(
       `SELECT c.conname
        FROM pg_constraint c
-       JOIN pg_class t ON t.oid = c.conrelid
-       JOIN pg_namespace n ON n.oid = t.relnamespace
-       WHERE n.nspname = $1
-         AND t.relname = $2
+       WHERE c.conrelid = to_regclass($1)
          AND c.contype = 'u'
          AND pg_get_constraintdef(c.oid) = 'UNIQUE (vector_id)'`,
-      [schemaName, parsedIndexName],
+      [tableName],
     );
 
     for (const { conname } of legacyConstraints.rows) {
@@ -1476,7 +1476,11 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       const mastraTablesQuery = `
         SELECT DISTINCT t.table_name
         FROM information_schema.tables t
-        WHERE t.table_schema = COALESCE($1, current_schema())
+        WHERE (
+          ($1::text IS NOT NULL AND t.table_schema = $1)
+          OR
+          ($1::text IS NULL AND pg_table_is_visible(to_regclass(format('%I.%I', t.table_schema, t.table_name))))
+        )
         AND EXISTS (
           SELECT 1
           FROM information_schema.columns c
@@ -1542,16 +1546,19 @@ export class PgVector extends MastraVector<PGVectorFilter> {
     try {
       const { tableName } = this.getTableName(indexName);
 
-      // Check if table exists with a vector-type column
+      // Resolve the table itself through regclass so implicit schema selection follows
+      // PostgreSQL search_path exactly, while explicit schemaName remains qualified in tableName.
       const tableExistsQuery = `
-        SELECT udt_name
-        FROM information_schema.columns
-        WHERE table_schema = COALESCE($1, current_schema())
-          AND table_name = $2
-          AND udt_name IN ('vector', 'halfvec', 'bit', 'sparsevec')
+        SELECT typ.typname AS udt_name
+        FROM pg_attribute a
+        JOIN pg_type typ ON typ.oid = a.atttypid
+        WHERE a.attrelid = to_regclass($1)
+          AND a.attname = 'embedding'
+          AND NOT a.attisdropped
+          AND typ.typname IN ('vector', 'halfvec', 'bit', 'sparsevec')
         LIMIT 1;
       `;
-      const tableExists = await client.query(tableExistsQuery, [this.schema ?? null, indexName]);
+      const tableExists = await client.query(tableExistsQuery, [tableName]);
 
       if (tableExists.rows.length === 0) {
         throw new Error(`Vector table ${tableName} does not exist`);
@@ -1586,13 +1593,12 @@ export class PgVector extends MastraVector<PGVectorFilter> {
             JOIN pg_class c ON i.indexrelid = c.oid
             JOIN pg_am am ON c.relam = am.oid
             JOIN pg_opclass opclass ON i.indclass[0] = opclass.oid
-            JOIN pg_namespace n ON c.relnamespace = n.oid
             WHERE c.relname = $1
-            AND n.nspname = COALESCE($2, current_schema());
+            AND i.indrelid = to_regclass($2);
             `;
 
       const dimResult = await client.query(dimensionQuery, [tableName]);
-      const indexResult = await client.query(indexQuery, [`${indexName}_vector_idx`, this.schema ?? null]);
+      const indexResult = await client.query(indexQuery, [`${indexName}_vector_idx`, tableName]);
 
       const { index_method, index_def, operator_class } = indexResult.rows[0] || {
         index_method: 'flat',

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -293,11 +293,11 @@ export class PgVector extends MastraVector<PGVectorFilter> {
   }
 
   /**
-   * Sets search_path on the client connection so that vector operators (e.g. <=>, vector_cosine_ops)
-   * are resolvable when the pgvector extension is installed in a non-default schema.
+   * Extends search_path on the client connection so vector operators (e.g. <=>, vector_cosine_ops)
+   * are resolvable when pgvector is installed in a non-default schema.
    *
-   * PostgreSQL's default search_path is ("$user", public). If the extension lives in a custom schema
-   * (e.g. "myapp"), operator classes and distance operators won't resolve without this.
+   * The existing path is kept first so unqualified application relations continue to resolve exactly
+   * as they did before this call. The returned value must be restored before releasing the client.
    */
   private async ensureSearchPath(client: pg.PoolClient): Promise<string | undefined> {
     // Lazily detect extension schema if not yet known
@@ -779,8 +779,11 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       this.logger?.trackException(mastraError);
       throw mastraError;
     } finally {
-      await this.restoreSearchPath(client, originalSearchPath);
-      client.release();
+      try {
+        await this.restoreSearchPath(client, originalSearchPath);
+      } finally {
+        client.release();
+      }
     }
   }
 
@@ -931,8 +934,11 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       this.logger?.trackException(mastraError);
       throw mastraError;
     } finally {
-      await this.restoreSearchPath(client, originalSearchPath);
-      client.release();
+      try {
+        await this.restoreSearchPath(client, originalSearchPath);
+      } finally {
+        client.release();
+      }
     }
   }
 
@@ -1347,41 +1353,40 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       // selected by the caller's existing path.
       const originalSearchPath = await this.ensureSearchPath(client);
       try {
-        // Get the operator class based on vector type and metric
-      // pgvector uses different operator classes for vector vs halfvec
-      // Use the detected vectorType from existing table if available, otherwise use the parameter
-      const effectiveVectorType = existingIndexInfo?.vectorType ?? vectorType;
-      const metricOp = this.getVectorOps(effectiveVectorType, metric).operatorClass;
+        // pgvector uses different operator classes for vector vs halfvec.
+        // Use the detected vectorType from the existing table if available, otherwise use the parameter.
+        const effectiveVectorType = existingIndexInfo?.vectorType ?? vectorType;
+        const metricOp = this.getVectorOps(effectiveVectorType, metric).operatorClass;
 
-      let indexSQL: string;
-      if (indexType === 'hnsw') {
-        const m = indexConfig.hnsw?.m ?? 8;
-        const efConstruction = indexConfig.hnsw?.efConstruction ?? 32;
+        let indexSQL: string;
+        if (indexType === 'hnsw') {
+          const m = indexConfig.hnsw?.m ?? 8;
+          const efConstruction = indexConfig.hnsw?.efConstruction ?? 32;
 
-        indexSQL = `
-          CREATE INDEX IF NOT EXISTS ${vectorIndexName}
-          ON ${tableName}
-          USING hnsw (embedding ${metricOp})
-          WITH (
-            m = ${m},
-            ef_construction = ${efConstruction}
-          )
-        `;
-      } else {
-        let lists: number;
-        if (indexConfig.ivf?.lists) {
-          lists = indexConfig.ivf.lists;
+          indexSQL = `
+            CREATE INDEX IF NOT EXISTS ${vectorIndexName}
+            ON ${tableName}
+            USING hnsw (embedding ${metricOp})
+            WITH (
+              m = ${m},
+              ef_construction = ${efConstruction}
+            )
+          `;
         } else {
-          const size = (await client.query(`SELECT COUNT(*) FROM ${tableName}`)).rows[0].count;
-          lists = Math.max(100, Math.min(4000, Math.floor(Math.sqrt(size) * 2)));
+          let lists: number;
+          if (indexConfig.ivf?.lists) {
+            lists = indexConfig.ivf.lists;
+          } else {
+            const size = (await client.query(`SELECT COUNT(*) FROM ${tableName}`)).rows[0].count;
+            lists = Math.max(100, Math.min(4000, Math.floor(Math.sqrt(size) * 2)));
+          }
+          indexSQL = `
+            CREATE INDEX IF NOT EXISTS ${vectorIndexName}
+            ON ${tableName}
+            USING ivfflat (embedding ${metricOp})
+            WITH (lists = ${lists});
+          `;
         }
-        indexSQL = `
-          CREATE INDEX IF NOT EXISTS ${vectorIndexName}
-          ON ${tableName}
-          USING ivfflat (embedding ${metricOp})
-          WITH (lists = ${lists});
-        `;
-      }
 
         await client.query(indexSQL);
       } finally {
@@ -1947,8 +1952,11 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       throw mastraError;
     } finally {
       if (client) {
-        await this.restoreSearchPath(client, originalSearchPath);
-        client.release();
+        try {
+          await this.restoreSearchPath(client, originalSearchPath);
+        } finally {
+          client.release();
+        }
       }
     }
   }

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -1476,7 +1476,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       const mastraTablesQuery = `
         SELECT DISTINCT t.table_name
         FROM information_schema.tables t
-        WHERE t.table_schema = $1
+        WHERE t.table_schema = COALESCE($1, current_schema())
         AND EXISTS (
           SELECT 1
           FROM information_schema.columns c
@@ -1502,7 +1502,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
           AND c.data_type = 'jsonb'
         );
       `;
-      const mastraTables = await client.query(mastraTablesQuery, [this.schema || 'public']);
+      const mastraTables = await client.query(mastraTablesQuery, [this.schema ?? null]);
       return mastraTables.rows.map(row => row.table_name);
     } catch (e) {
       const mastraError = new MastraError(
@@ -1546,12 +1546,12 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       const tableExistsQuery = `
         SELECT udt_name
         FROM information_schema.columns
-        WHERE table_schema = $1
+        WHERE table_schema = COALESCE($1, current_schema())
           AND table_name = $2
           AND udt_name IN ('vector', 'halfvec', 'bit', 'sparsevec')
         LIMIT 1;
       `;
-      const tableExists = await client.query(tableExistsQuery, [this.schema || 'public', indexName]);
+      const tableExists = await client.query(tableExistsQuery, [this.schema ?? null, indexName]);
 
       if (tableExists.rows.length === 0) {
         throw new Error(`Vector table ${tableName} does not exist`);
@@ -1588,11 +1588,11 @@ export class PgVector extends MastraVector<PGVectorFilter> {
             JOIN pg_opclass opclass ON i.indclass[0] = opclass.oid
             JOIN pg_namespace n ON c.relnamespace = n.oid
             WHERE c.relname = $1
-            AND n.nspname = $2;
+            AND n.nspname = COALESCE($2, current_schema());
             `;
 
       const dimResult = await client.query(dimensionQuery, [tableName]);
-      const indexResult = await client.query(indexQuery, [`${indexName}_vector_idx`, this.schema || 'public']);
+      const indexResult = await client.query(indexQuery, [`${indexName}_vector_idx`, this.schema ?? null]);
 
       const { index_method, index_def, operator_class } = indexResult.rows[0] || {
         index_method: 'flat',


### PR DESCRIPTION
## Description

Fixes #22545.

When `PgVector` is constructed without an explicit `schemaName`, PostgreSQL resolves unqualified relations through its normal `search_path` (for example `"$user", public`). PgVector previously mixed that behaviour with catalog paths that substituted `public`, so a vector table could be created and be visible to normal SQL while metadata lookup reported that it did not exist.

This change preserves explicit `schemaName` behaviour and makes the implicit-schema path follow PostgreSQL relation visibility consistently.

## Implementation

- `listIndexes()`
  - explicit schema: still filters by that schema;
  - implicit schema: uses `pg_table_is_visible(...)`, matching PostgreSQL search-path visibility instead of assuming `current_schema()` or `public`.
- `describeIndexMetadata()`
  - resolves the table itself with `to_regclass(tableName)`;
  - resolves index metadata by the resolved table relation via `i.indrelid = to_regclass(tableName)`.
- `ensureNamespaceSchema()`
  - resolves the same table relation with `to_regclass(tableName)` rather than defaulting omitted schema to `public`.

Using relation identity avoids recreating PostgreSQL's search-path rules manually and also handles the case where the visible relation is in a later search-path schema, not merely the first existing schema.

## Reproduction

Observed in a real Factory deployment with:

```
search_path="$user", public
current_schema=testflight
current_schemas=pg_catalog,testflight,public
public.memory_observations_384=absent
testflight.memory_observations_384=present
```

The unqualified relation resolves correctly, but PgVector reported:

```
Vector table "memory_observations_384" does not exist
```

because metadata lookup forced `public`.

## Tests

Regression coverage now proves that with no `schemaName` configured, PgVector:

- enumerates only relations visible through `search_path`;
- resolves table metadata through `regclass`;
- resolves index metadata through the resolved table relation;
- uses the same resolved relation for namespace migration.

The existing explicit custom-schema tests remain in place.

A patch changeset for `@mastra/pg` is included.

## Scope

This is intentionally separate from #14357 / #14526, which fixed explicit custom-`schemaName` handling. This PR covers the complementary case where `schemaName` is omitted and PostgreSQL's own search-path semantics should remain authoritative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

PgVector now finds vector tables in the schema that PostgreSQL actually uses, instead of always checking `public`. This prevents false “Vector table does not exist” errors when `schemaName` is not configured.

## Changes

- Use `pg_table_is_visible(...)` for implicit-schema lookups in `listIndexes()`.
- Resolve unqualified tables with `to_regclass(tableName)` in metadata and namespace operations.
- Resolve index metadata through the resolved table relation.
- Preserve and restore the caller’s `search_path` during vector operations.
- Preserve explicit custom-schema behavior.
- Add regression tests for visible relations, metadata resolution, namespace migration, role-specific search paths, and search-path restoration.
- Add a patch changeset for `@mastra/pg`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->