### PR TITLE
fix(playground): avoid duplicate production builds

### DIFF
--- a/packages/playground/turbo.json
+++ b/packages/playground/turbo.json
@@ -8,7 +8,7 @@
       "inputs": ["$TURBO_DEFAULT$", "./vite.config.ts"]
     },
     "build": {
-      "dependsOn": ["^build", "build:lib", "typecheck"],
+      "dependsOn": ["^build", "typecheck"],
       "outputs": ["dist/**"]
     }
   }


### PR DESCRIPTION
The Playground build now runs its Vite production bundle once after typechecking instead of running build:lib first. This removes redundant work from Turbo's build graph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Playground build now creates its production bundle only once. This removes duplicate build work and makes builds faster.

## Changes

- Removed the `build:lib` dependency from the Playground `build` task in `packages/playground/turbo.json`.
- Kept the existing dependencies on upstream `build` tasks and `typecheck`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->