### PR TITLE
fix(storage): avoid core compatibility load failure

### DIFF
--- a/.changeset/good-snakes-burn.md
+++ b/.changeset/good-snakes-burn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Fixed the store package failing to load when installed with `@mastra/core` older than 1.63.1, and corrected the minimum supported core version.

--- a/.changeset/hot-walls-matter.md
+++ b/.changeset/hot-walls-matter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed the store package failing to load when installed with `@mastra/core` older than 1.63.1, and corrected the minimum supported core version.

--- a/.changeset/sharp-baths-burn.md
+++ b/.changeset/sharp-baths-burn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mysql': patch
+---
+
+Fixed the store package failing to load when installed with `@mastra/core` older than 1.63.1, and corrected the minimum supported core version.

--- a/.changeset/silent-clowns-divide.md
+++ b/.changeset/silent-clowns-divide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mongodb': patch
+---
+
+Fixed the store package failing to load when installed with `@mastra/core` older than 1.63.1, and corrected the minimum supported core version.

--- a/.changeset/true-ties-end.md
+++ b/.changeset/true-ties-end.md
@@ -1,0 +1,5 @@
+---
+'@mastra/turso': patch
+---
+
+Fixed the minimum supported core version to match the LibSQL storage dependency.

--- a/stores/libsql/package.json
+++ b/stores/libsql/package.json
@@ -45,7 +45,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.51.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.63.1-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/libsql/src/storage/domains/knowledge/index.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.ts
@@ -1,6 +1,5 @@
 import {
   assertKnowledgeCeilingRaised,
-  assertKnowledgeDescriptionWithinBound,
   assertKnowledgeScopeWithinCeiling,
   canonicalizeKnowledgeScope,
   createKnowledgeUlid,
@@ -56,6 +55,26 @@ import type {
   SqliteTransaction as Transaction,
 } from '../../db/client';
 import { withClientWriteLock } from '../../db/write-lock';
+
+// #21830 shipped this helper in core 1.63.1; resolve it lazily so an older
+// installed core fails feature-detection instead of breaking module load.
+let assertDescriptionWithinBound: ((description: string | undefined) => void) | undefined;
+async function assertKnowledgeDescriptionWithinBoundCompat(description: string | undefined): Promise<void> {
+  let assertWithinBound = assertDescriptionWithinBound;
+  if (!assertWithinBound) {
+    const mod: Partial<typeof import('@mastra/core/storage')> = await import('@mastra/core/storage');
+    const resolvedAssert: (description: string | undefined) => void =
+      mod.assertKnowledgeDescriptionWithinBound ??
+      (value => {
+        if (value !== undefined && value.length > 400) {
+          throw new Error('Knowledge node description exceeds the 400 UTF-16 code unit limit');
+        }
+      });
+    assertDescriptionWithinBound = resolvedAssert;
+    assertWithinBound = resolvedAssert;
+  }
+  assertWithinBound(description);
+}
 
 interface Executor {
   execute(statement: string | { sql: string; args?: InValue[] }): Promise<ResultSet>;
@@ -236,7 +255,7 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
   }
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {
-    assertKnowledgeDescriptionWithinBound(input.description);
+    await assertKnowledgeDescriptionWithinBoundCompat(input.description);
     const scope = canonicalizeKnowledgeScope(input.scope);
     return this.#transaction(async tx => {
       const existing = await this.#getNodeByName(tx, input.name, scope);
@@ -331,7 +350,7 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
   }
 
   async updateNode(input: UpdateKnowledgeNodeInput): Promise<KnowledgeNode> {
-    assertKnowledgeDescriptionWithinBound(input.description);
+    await assertKnowledgeDescriptionWithinBoundCompat(input.description);
     return this.#transaction(async tx => {
       const existing = await this.#getNode(tx, input.id);
       if (!existing) throw new KnowledgeNotFoundError('node', input.id);

--- a/stores/mongodb/package.json
+++ b/stores/mongodb/package.json
@@ -51,7 +51,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.63.1-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/mongodb/src/storage/domains/knowledge/index.ts
+++ b/stores/mongodb/src/storage/domains/knowledge/index.ts
@@ -1,6 +1,5 @@
 import {
   assertKnowledgeCeilingRaised,
-  assertKnowledgeDescriptionWithinBound,
   assertKnowledgeScopeWithinCeiling,
   canonicalizeKnowledgeScope,
   createKnowledgeUlid,
@@ -46,6 +45,26 @@ import type { ClientSession, Collection, Filter } from 'mongodb';
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig } from '../../types';
+
+// #21830 shipped this helper in core 1.63.1; resolve it lazily so an older
+// installed core fails feature-detection instead of breaking module load.
+let assertDescriptionWithinBound: ((description: string | undefined) => void) | undefined;
+async function assertKnowledgeDescriptionWithinBoundCompat(description: string | undefined): Promise<void> {
+  let assertWithinBound = assertDescriptionWithinBound;
+  if (!assertWithinBound) {
+    const mod: Partial<typeof import('@mastra/core/storage')> = await import('@mastra/core/storage');
+    const resolvedAssert: (description: string | undefined) => void =
+      mod.assertKnowledgeDescriptionWithinBound ??
+      (value => {
+        if (value !== undefined && value.length > 400) {
+          throw new Error('Knowledge node description exceeds the 400 UTF-16 code unit limit');
+        }
+      });
+    assertDescriptionWithinBound = resolvedAssert;
+    assertWithinBound = resolvedAssert;
+  }
+  assertWithinBound(description);
+}
 
 type Document = Record<string, any>;
 
@@ -169,7 +188,7 @@ export class KnowledgeMongoDB extends KnowledgeStorage {
   }
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {
-    assertKnowledgeDescriptionWithinBound(input.description);
+    await assertKnowledgeDescriptionWithinBoundCompat(input.description);
     const scope = canonicalizeKnowledgeScope(input.scope);
     return this.#connector.withTransaction(async session => {
       const existing = await this.#getNodeByName(input.name, scope, session);
@@ -264,7 +283,7 @@ export class KnowledgeMongoDB extends KnowledgeStorage {
   }
 
   async updateNode(input: UpdateKnowledgeNodeInput): Promise<KnowledgeNode> {
-    assertKnowledgeDescriptionWithinBound(input.description);
+    await assertKnowledgeDescriptionWithinBoundCompat(input.description);
     return this.#connector.withTransaction(async session => {
       const existing = await this.#getNode(input.id, session);
       if (!existing) throw new KnowledgeNotFoundError('node', input.id);

--- a/stores/mysql/package.json
+++ b/stores/mysql/package.json
@@ -49,7 +49,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.51.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.63.1-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/mysql/src/storage/domains/knowledge/index.ts
+++ b/stores/mysql/src/storage/domains/knowledge/index.ts
@@ -1,6 +1,5 @@
 import {
   assertKnowledgeCeilingRaised,
-  assertKnowledgeDescriptionWithinBound,
   assertKnowledgeScopeWithinCeiling,
   canonicalizeKnowledgeScope,
   createKnowledgeUlid,
@@ -51,6 +50,26 @@ import type { Pool, PoolConnection, ResultSetHeader, RowDataPacket } from 'mysql
 
 import { generateTableSQL } from '../operations';
 import type { StoreOperationsMySQL } from '../operations';
+
+// #21830 shipped this helper in core 1.63.1; resolve it lazily so an older
+// installed core fails feature-detection instead of breaking module load.
+let assertDescriptionWithinBound: ((description: string | undefined) => void) | undefined;
+async function assertKnowledgeDescriptionWithinBoundCompat(description: string | undefined): Promise<void> {
+  let assertWithinBound = assertDescriptionWithinBound;
+  if (!assertWithinBound) {
+    const mod: Partial<typeof import('@mastra/core/storage')> = await import('@mastra/core/storage');
+    const resolvedAssert: (description: string | undefined) => void =
+      mod.assertKnowledgeDescriptionWithinBound ??
+      (value => {
+        if (value !== undefined && value.length > 400) {
+          throw new Error('Knowledge node description exceeds the 400 UTF-16 code unit limit');
+        }
+      });
+    assertDescriptionWithinBound = resolvedAssert;
+    assertWithinBound = resolvedAssert;
+  }
+  assertWithinBound(description);
+}
 
 interface QueryResult {
   rows: Record<string, unknown>[];
@@ -258,7 +277,7 @@ export class KnowledgeMySQL extends KnowledgeStorage {
   }
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {
-    assertKnowledgeDescriptionWithinBound(input.description);
+    await assertKnowledgeDescriptionWithinBoundCompat(input.description);
     const scope = canonicalizeKnowledgeScope(input.scope);
     return this.#transaction(async tx => {
       const existing = await this.#getNodeByName(tx, input.name, scope);
@@ -352,7 +371,7 @@ export class KnowledgeMySQL extends KnowledgeStorage {
   }
 
   async updateNode(input: UpdateKnowledgeNodeInput): Promise<KnowledgeNode> {
-    assertKnowledgeDescriptionWithinBound(input.description);
+    await assertKnowledgeDescriptionWithinBoundCompat(input.description);
     return this.#transaction(async tx => {
       const existing = await this.#getNode(tx, input.id);
       if (!existing) throw new KnowledgeNotFoundError('node', input.id);

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -64,7 +64,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.63.1-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/pg/src/storage/domains/knowledge/index.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.ts
@@ -1,6 +1,5 @@
 import {
   assertKnowledgeCeilingRaised,
-  assertKnowledgeDescriptionWithinBound,
   assertKnowledgeScopeWithinCeiling,
   canonicalizeKnowledgeScope,
   createKnowledgeUlid,
@@ -52,6 +51,26 @@ import { parseSqlIdentifier } from '@mastra/core/utils';
 import type { QueryValues, TxClient } from '../../client';
 import { generateTableSQL, PgDB, resolvePgConfig } from '../../db';
 import type { DbClient, PgDomainConfig } from '../../db';
+
+// #21830 shipped this helper in core 1.63.1; resolve it lazily so an older
+// installed core fails feature-detection instead of breaking module load.
+let assertDescriptionWithinBound: ((description: string | undefined) => void) | undefined;
+async function assertKnowledgeDescriptionWithinBoundCompat(description: string | undefined): Promise<void> {
+  let assertWithinBound = assertDescriptionWithinBound;
+  if (!assertWithinBound) {
+    const mod: Partial<typeof import('@mastra/core/storage')> = await import('@mastra/core/storage');
+    const resolvedAssert: (description: string | undefined) => void =
+      mod.assertKnowledgeDescriptionWithinBound ??
+      (value => {
+        if (value !== undefined && value.length > 400) {
+          throw new Error('Knowledge node description exceeds the 400 UTF-16 code unit limit');
+        }
+      });
+    assertDescriptionWithinBound = resolvedAssert;
+    assertWithinBound = resolvedAssert;
+  }
+  assertWithinBound(description);
+}
 
 interface QueryResult {
   rows: Record<string, unknown>[];
@@ -398,7 +417,7 @@ export class KnowledgePG extends KnowledgeStorage {
   }
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {
-    assertKnowledgeDescriptionWithinBound(input.description);
+    await assertKnowledgeDescriptionWithinBoundCompat(input.description);
     const scope = canonicalizeKnowledgeScope(input.scope);
     return this.#transaction(async tx => {
       const existing = await this.#getNodeByName(tx, input.name, scope);
@@ -492,7 +511,7 @@ export class KnowledgePG extends KnowledgeStorage {
   }
 
   async updateNode(input: UpdateKnowledgeNodeInput): Promise<KnowledgeNode> {
-    assertKnowledgeDescriptionWithinBound(input.description);
+    await assertKnowledgeDescriptionWithinBoundCompat(input.description);
     return this.#transaction(async tx => {
       const existing = await this.#getNode(tx, input.id);
       if (!existing) throw new KnowledgeNotFoundError('node', input.id);

--- a/stores/turso/package.json
+++ b/stores/turso/package.json
@@ -47,7 +47,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.51.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.63.1-0 <2.0.0-0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Storage adapters imported `assertKnowledgeDescriptionWithinBound` at module load time, so installing a newly released adapter with an older `@mastra/core` could prevent the entire package from loading.

Before:
```ts
import { assertKnowledgeDescriptionWithinBound } from '@mastra/core/storage';
```

After:
```ts
const coreStorage = await import('@mastra/core/storage');
const assertDescription = coreStorage.assertKnowledgeDescriptionWithinBound ?? localFallback;
```

The libsql, PostgreSQL, MySQL, and MongoDB adapters now resolve the helper lazily while preserving the 400-unit validation fallback. Their peer floors require the first compatible core release, and Turso's peer floor is aligned with libsql.

Verified with targeted adapter builds and linting, the libsql knowledge suite, Turso peer validation, typechecking, formatting, and `git diff --check`.
