### PR TITLE
fix(mcp): validate tool structuredContent against its outputSchema

### DIFF
--- a/.changeset/silent-memes-stare.md
+++ b/.changeset/silent-memes-stare.md
@@ -4,3 +4,7 @@
 ---
 
 Fixed MCP tools handing malformed structured output to the model. When a tool advertises an `outputSchema`, its `structuredContent` is now validated against that schema before it reaches the model, matching how tools created with `createTool` already behave. On a mismatch the model receives a structured validation error it can recover from, instead of acting on the invalid payload. This also covers tools rebuilt from a cached definition (toolsets loaded without a live `tools/list` call), which previously had no output validation at all.
+
+Validation is skipped for an `outputSchema` that cannot be compiled (for example an unresolvable remote `$ref`), so those tools keep returning their results unchanged rather than failing every call.
+
+For consumers using `onToolError: 'return'`: an errored result (`isError: true`) that also carries `structuredContent` now returns the full `CallToolResult` envelope (`isError`, `content`, `_meta`) instead of the bare structured value.

--- a/.changeset/silent-memes-stare.md
+++ b/.changeset/silent-memes-stare.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/mcp': patch
+---
+
+Fixed MCP tools handing malformed structured output to the model. When a tool advertises an `outputSchema`, its `structuredContent` is now validated against that schema before it reaches the model, matching how tools created with `createTool` already behave. On a mismatch the model receives a structured validation error it can recover from, instead of acting on the invalid payload. This also covers tools rebuilt from a cached definition (toolsets loaded without a live `tools/list` call), which previously had no output validation at all.

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -4,7 +4,7 @@ export * from './ui-types';
 export { getTransformedToolPayload, hasTransformedToolPayload } from './payload-transform';
 export { isProviderDefinedTool, isProviderTool, isVercelTool } from './toolchecks';
 export { ToolStream } from './stream';
-export { type ValidationError, isValidationError } from './validation';
+export { type ValidationError, isValidationError, validateToolOutput } from './validation';
 export * from './code-mode';
 export { askUserTool, formatQuestionAnswer } from './builtin/ask-user';
 export type { AskUserAnswer, AskUserOption, AskUserSelectionMode, AskUserSuspendPayload } from './builtin/ask-user';

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1440,6 +1440,38 @@ describe('MastraMCPClient - structuredContent is validated against outputSchema'
     expect(result).toMatchObject({ error: true });
     expect(result.message).toContain('output validation failed');
   });
+
+  it('passes structuredContent through when the outputSchema cannot be compiled', async () => {
+    const sdkClient = (client as any).client as Client;
+
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent: { result: 2 },
+      content: [{ type: 'text', text: 'done' }],
+      isError: false,
+    });
+
+    // An unresolvable remote $ref makes Ajv throw at compile time, which the
+    // schema adapter surfaces as a validation issue rather than a throw. The
+    // tool must still return its result, exactly as it does on main, instead of
+    // every call coming back as a validation error.
+    const tool = client.toolFromDefinition({
+      definition: {
+        name: 'calculate',
+        description: 'Calculates a math expression',
+        inputSchema: { type: 'object' as const, properties: { expression: { type: 'string' } } },
+        outputSchema: {
+          type: 'object' as const,
+          properties: { result: { $ref: 'https://example.com/does-not-exist.json' } },
+          required: ['result'],
+        },
+        server: { name: 'structured-validation-client' },
+      },
+    });
+
+    const result = await tool.execute?.({ expression: '1 + 1' });
+
+    expect(result).toEqual({ result: 2 });
+  });
 });
 
 describe('MastraMCPClient - tools without outputSchema preserve envelope', () => {

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -669,6 +669,41 @@ describe('MastraMCPClient - isError handling', () => {
 
     await client.disconnect().catch(() => {});
   });
+
+  it('returns the raw envelope for an errored result that also carries structuredContent (onToolError "return")', async () => {
+    const client = new InternalMastraMCPClient({
+      name: 'iserror-return-structured-client',
+      server: { url: testServer.baseUrl, onToolError: 'return' },
+    });
+    await client.connect();
+
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'fetch',
+          description: 'Fetches data',
+          inputSchema: { type: 'object' as const },
+          outputSchema: { type: 'object' as const, properties: { result: { type: 'number' } } },
+        },
+      ],
+    });
+    const erroredWithStructured = {
+      content: [{ type: 'text', text: 'upstream 500' }],
+      structuredContent: { result: 1 },
+      isError: true,
+    };
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue(erroredWithStructured);
+
+    const tools = await client.tools();
+    const result = await tools['fetch'].execute?.({});
+
+    // The failure must not be masked as a successful structured result.
+    expect(result).toEqual(erroredWithStructured);
+    expect((result as any).isError).toBe(true);
+
+    await client.disconnect().catch(() => {});
+  });
 });
 
 describe('MastraMCPClient - tool-execution errors vs reconnection', () => {
@@ -1288,6 +1323,122 @@ describe('MastraMCPClient - outputSchema with structuredContent', () => {
 
     expect(tool.toModelOutput?.(second)).toEqual({ type: 'json', value: 0 });
     expect(tool.toModelOutput?.(first)).toEqual({ type: 'json', value: 0 });
+  });
+});
+
+describe('MastraMCPClient - structuredContent is validated against outputSchema', () => {
+  // A tool that advertises an outputSchema must not pass structuredContent that
+  // violates that schema straight through to the model. This mirrors how
+  // non-MCP tools built with createTool() validate their output: a mismatch is
+  // returned as a structured validation error so the model can self-correct,
+  // rather than the malformed value flowing on unchecked.
+  let testServer: {
+    httpServer: HttpServer;
+    mcpServer: McpServer;
+    serverTransport: NodeStreamableHTTPServerTransport;
+    baseUrl: URL;
+  };
+  let client: InternalMastraMCPClient;
+
+  const outputSchema = {
+    type: 'object' as const,
+    properties: { result: { type: 'number' } },
+    required: ['result'],
+  };
+
+  beforeEach(async () => {
+    testServer = await setupTestServer(false);
+    client = new InternalMastraMCPClient({
+      name: 'structured-validation-client',
+      server: { url: testServer.baseUrl },
+    });
+    await client.connect();
+  });
+
+  afterEach(async () => {
+    await client?.disconnect().catch(() => {});
+    await testServer?.mcpServer.close().catch(() => {});
+    await testServer?.serverTransport?.close().catch(() => {});
+    testServer?.httpServer.close();
+  });
+
+  it('returns a validation error instead of structuredContent that violates the schema', async () => {
+    const sdkClient = (client as any).client as Client;
+
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'calculate',
+          description: 'Calculates a math expression',
+          inputSchema: { type: 'object' as const, properties: { expression: { type: 'string' } } },
+          outputSchema,
+        },
+      ],
+    });
+
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent: { result: 'not-a-number' },
+      content: [{ type: 'text', text: 'done' }],
+      isError: false,
+    });
+
+    const tools = await client.tools();
+    const result = (await tools['calculate'].execute?.({ expression: '1 + 1' })) as any;
+
+    expect(result).toMatchObject({ error: true });
+    expect(result.message).toContain('output validation failed');
+    expect(result).not.toMatchObject({ result: 'not-a-number' });
+  });
+
+  it('passes structuredContent through unchanged when it matches the schema', async () => {
+    const sdkClient = (client as any).client as Client;
+
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'calculate',
+          description: 'Calculates a math expression',
+          inputSchema: { type: 'object' as const, properties: { expression: { type: 'string' } } },
+          outputSchema,
+        },
+      ],
+    });
+
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent: { result: 2 },
+      content: [{ type: 'text', text: 'done' }],
+      isError: false,
+    });
+
+    const tools = await client.tools();
+    const result = await tools['calculate'].execute?.({ expression: '1 + 1' });
+
+    expect(result).toEqual({ result: 2 });
+  });
+
+  it('validates structuredContent for tools rebuilt from a cached definition', async () => {
+    const sdkClient = (client as any).client as Client;
+
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent: { result: 'still-not-a-number' },
+      content: [{ type: 'text', text: 'done' }],
+      isError: false,
+    });
+
+    const tool = client.toolFromDefinition({
+      definition: {
+        name: 'calculate',
+        description: 'Calculates a math expression',
+        inputSchema: { type: 'object' as const, properties: { expression: { type: 'string' } } },
+        outputSchema,
+        server: { name: 'structured-validation-client' },
+      },
+    });
+
+    const result = (await tool.execute?.({ expression: '1 + 1' })) as any;
+
+    expect(result).toMatchObject({ error: true });
+    expect(result.message).toContain('output validation failed');
   });
 });
 

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -4,7 +4,7 @@ import type { Stream } from 'node:stream';
 import { MastraBase } from '@mastra/core/base';
 import type { RequestContext } from '@mastra/core/di';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createTool } from '@mastra/core/tools';
+import { createTool, validateToolOutput } from '@mastra/core/tools';
 import type { NeedsApprovalFn, Tool } from '@mastra/core/tools';
 import { toStandardSchema } from '@mastra/schema-compat';
 import type { JSONSchema7, StandardSchemaWithJSON } from '@mastra/schema-compat';
@@ -1243,8 +1243,11 @@ export class InternalMastraMCPClient extends MastraBase {
   }
 
   /**
-   * Wraps the output schema with a validator that always succeeds. The MCP client validates
-   * structuredContent via AJV; the JSON schema is surfaced here for documentation only.
+   * Wraps the output schema with a validator that always succeeds. This is the schema
+   * attached to the executable tool: it keeps the JSON schema available for documentation
+   * and gates `toModelOutput`, but never rejects, so the raw CallToolResult envelope
+   * returned on the in-band-error and no-structuredContent paths is passed through untouched.
+   * Structured results are checked separately via {@link buildStructuredContentValidator}.
    */
   private convertOutputSchema(
     outputSchema: Awaited<ReturnType<Client['listTools']>>['tools'][0]['outputSchema'],
@@ -1258,6 +1261,30 @@ export class InternalMastraMCPClient extends MastraBase {
         validate: value => ({ value }),
       },
     };
+  }
+
+  /**
+   * Builds a real (issue-reporting) Standard Schema from an MCP tool's `outputSchema`,
+   * used to check `structuredContent` before it reaches the model. The MCP client's own
+   * AJV validation only runs when its cached `tools/list` holds an entry for the tool, so
+   * it is skipped entirely for tools rebuilt via {@link toolFromDefinition}. Validating
+   * here as well brings MCP tools in line with tools created via `createTool`, which always
+   * validate their output. Returns `undefined` when the tool has no `outputSchema` or the
+   * schema cannot be converted.
+   */
+  private buildStructuredContentValidator(
+    outputSchema: Awaited<ReturnType<Client['listTools']>>['tools'][0]['outputSchema'],
+  ): StandardSchemaWithJSON | undefined {
+    if (!outputSchema) return undefined;
+    try {
+      const schema = ('jsonSchema' in outputSchema ? outputSchema.jsonSchema : outputSchema) as JSONSchema7;
+      return toStandardSchema(schema);
+    } catch (e) {
+      this.log('warning', `Could not build an output-schema validator for an MCP tool`, {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return undefined;
+    }
   }
 
   /**
@@ -1413,8 +1440,10 @@ export class InternalMastraMCPClient extends MastraBase {
                 },
               }
             : {};
+        const toolId = `${this.name}_${tool.name}`;
+        const structuredContentValidator = this.buildStructuredContentValidator(tool.outputSchema);
         const mastraTool = createTool({
-          id: `${this.name}_${tool.name}`,
+          id: toolId,
           description: tool.description || '',
           inputSchema: this.convertInputSchema(tool.inputSchema),
           outputSchema: this.convertOutputSchema(tool.outputSchema),
@@ -1493,7 +1522,31 @@ export class InternalMastraMCPClient extends MastraBase {
 
                 this.log('debug', `Tool executed successfully: ${tool.name}`);
 
-                if (res.structuredContent !== undefined) {
+                if (res.structuredContent !== undefined && !res.isError) {
+                  // A tool that advertises an outputSchema must not hand the model
+                  // structuredContent that violates it. On a mismatch, return the same
+                  // structured validation error `createTool` would, so the model can
+                  // self-correct instead of acting on a malformed payload.
+                  if (structuredContentValidator) {
+                    let outputValidation;
+                    try {
+                      outputValidation = validateToolOutput(structuredContentValidator, res.structuredContent, toolId);
+                    } catch (validationError) {
+                      // A malformed or unsupported schema must not take down tool execution.
+                      this.log('warning', `Skipped output-schema validation for tool ${tool.name}`, {
+                        error: validationError instanceof Error ? validationError.message : String(validationError),
+                      });
+                    }
+                    if (outputValidation?.error) {
+                      this.log(
+                        'warning',
+                        `MCP tool ${tool.name} returned structuredContent that does not match its outputSchema`,
+                        { toolName: tool.name, serverName: this.name },
+                      );
+                      return outputValidation.error;
+                    }
+                  }
+
                   return attachMcpCallToolContent(
                     res.structuredContent,
                     res.content,
@@ -1501,6 +1554,9 @@ export class InternalMastraMCPClient extends MastraBase {
                   );
                 }
 
+                // In-band tool errors that weren't thrown (onToolError: 'return'), and
+                // results with no structuredContent, return the full CallToolResult
+                // envelope untouched so callers still see isError / content / _meta.
                 return res;
               };
 

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -1269,22 +1269,54 @@ export class InternalMastraMCPClient extends MastraBase {
    * AJV validation only runs when its cached `tools/list` holds an entry for the tool, so
    * it is skipped entirely for tools rebuilt via {@link toolFromDefinition}. Validating
    * here as well brings MCP tools in line with tools created via `createTool`, which always
-   * validate their output. Returns `undefined` when the tool has no `outputSchema` or the
-   * schema cannot be converted.
+   * validate their output. Returns `undefined` when the tool has no `outputSchema`, or the
+   * schema cannot be converted or compiled — in which case the raw `structuredContent`
+   * passes through unchecked, exactly as it did before this validation existed.
    */
   private buildStructuredContentValidator(
     outputSchema: Awaited<ReturnType<Client['listTools']>>['tools'][0]['outputSchema'],
   ): StandardSchemaWithJSON | undefined {
     if (!outputSchema) return undefined;
+
+    let validator: StandardSchemaWithJSON;
     try {
       const schema = ('jsonSchema' in outputSchema ? outputSchema.jsonSchema : outputSchema) as JSONSchema7;
-      return toStandardSchema(schema);
+      validator = toStandardSchema(schema);
     } catch (e) {
       this.log('warning', `Could not build an output-schema validator for an MCP tool`, {
+        serverName: this.name,
         error: e instanceof Error ? e.message : String(e),
       });
       return undefined;
     }
+
+    // The JSON-schema adapter compiles AJV lazily and reports a *compile* failure
+    // (an unresolvable remote `$ref`, an invalid `type`, a `$ref` into a `$defs`
+    // block the server omitted) as a validation issue rather than a throw. Probe
+    // it once here: if the schema can't compile, drop the validator so an
+    // otherwise-working tool keeps returning its result, instead of every call
+    // coming back as "Tool output validation failed".
+    try {
+      const probe = validator['~standard'].validate(undefined);
+      if (
+        !(probe instanceof Promise) &&
+        'issues' in probe &&
+        probe.issues?.some(issue => issue.message.startsWith('Schema validation error:'))
+      ) {
+        this.log('warning', `Ignoring an MCP tool's outputSchema that could not be compiled`, {
+          serverName: this.name,
+        });
+        return undefined;
+      }
+    } catch (e) {
+      this.log('warning', `Ignoring an MCP tool's outputSchema that could not be compiled`, {
+        serverName: this.name,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return undefined;
+    }
+
+    return validator;
   }
 
   /**
@@ -1541,7 +1573,7 @@ export class InternalMastraMCPClient extends MastraBase {
                       this.log(
                         'warning',
                         `MCP tool ${tool.name} returned structuredContent that does not match its outputSchema`,
-                        { toolName: tool.name, serverName: this.name },
+                        { toolName: tool.name, serverName: this.name, error: outputValidation.error.message },
                       );
                       return outputValidation.error;
                     }


### PR DESCRIPTION
Fixes the validation gap left open by #18850 (closed by #18854, which exposed the schema "for documentation" with a no-op validator) and distinct from #20168 (closed by #20176, which only changed which channel the model sees).

Before this PR, `structuredContent` returned by an MCP tool was never validated against the tool's declared `outputSchema` on the Mastra side. The MCP SDK's AJV validation only fires when its cached `tools/list` document holds the tool, so tools rebuilt from a cached catalog (`MCPClient.toolsFromDefinitions()` / `toolFromDefinition()`) had **no output validation at all**. A misbehaving or version-skewed MCP server could hand a malformed payload straight to the model.

After this PR, `structuredContent` is validated against `outputSchema` on both the live-discovery and cached-catalog paths. On mismatch, `execute()` returns the same structured `ValidationError` that `createTool` produces, so the model can self-correct. Valid `structuredContent` passes through unchanged, and the in-band-error / no-`structuredContent` paths still return the full
`CallToolResult` envelope (no reintroduction of the #18850 stripping regression).

**Tests** (`packages/mcp/src/client/client.test.ts`): rejects schema-violating `structuredContent`; passes valid `structuredContent` through unchanged; covers the `toolFromDefinition()` hydrated path that previously had zero validation.

A changeset is included (`@mastra/mcp` + `@mastra/core`, patch).

## Related issue(s)

Fixes #22549

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable) — n/a, brings MCP tools in line with existing `createTool` output-validation behavior
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

MCP tools now check that returned data matches the format they declared. Invalid data produces a clear validation error instead of reaching the model.

## Changes

- Validate `structuredContent` against `outputSchema` for live-discovered and cached MCP tools.
- Return structured validation errors from `execute()` when validation fails.
- Preserve valid results without changes.
- Preserve the complete `CallToolResult` envelope for in-band errors and results without `structuredContent`.
- Skip validation when an output schema cannot be compiled.
- Re-export `validateToolOutput` from `@mastra/core/tools`.
- Add tests for valid, invalid, cached-definition, uncompilable-schema, and error-envelope cases.
- Add patch changesets for `@mastra/core` and `@mastra/mcp`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->