### PR TITLE
feat(memory): route capture through keyed Knowledge

### DIFF
--- a/.changeset/fair-aliens-tell.md
+++ b/.changeset/fair-aliens-tell.md
@@ -2,4 +2,4 @@
 '@mastra/memory': minor
 ---
 
-Added keyed Knowledge selection for Memory so observation-time curation, derived Subconscious agents, tools, semantic indexing, and pinned context share one runtime. Explicitly disabled or unresolved Knowledge cannot fall back to another store.
+Added keyed Knowledge selection for Memory so observation-time curation, derived Subconscious agents, tools, semantic indexing, and pinned context share one runtime. Curators receive the selected instance and visible scope descriptions as placement guidance. Explicitly disabled or unresolved Knowledge cannot fall back to another store.

--- a/.changeset/fair-aliens-tell.md
+++ b/.changeset/fair-aliens-tell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': minor
+---
+
+Added keyed Knowledge selection for Memory so observation-time curation, derived Subconscious agents, tools, semantic indexing, and pinned context share one runtime. Explicitly disabled or unresolved Knowledge cannot fall back to another store.

--- a/.changeset/orange-bobcats-roll.md
+++ b/.changeset/orange-bobcats-roll.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/pg': patch
+'@mastra/mysql': patch
+'@mastra/mongodb': patch
+---
+
+Added built-in uncurated companion scope templates for Knowledge capture. Companion-scoped records are now resolved consistently, existing scopes can gain newly declared parents and grants, and search results redact parent identity when the record is visible but its node is not.

--- a/packages/core/src/knowledge/__tests__/reconcile.test.ts
+++ b/packages/core/src/knowledge/__tests__/reconcile.test.ts
@@ -59,6 +59,26 @@ describe('Knowledge structure reconciliation', () => {
     });
   });
 
+  it('materializes built-in uncurated companions with mirrored parent access', () => {
+    expect(
+      materializeKnowledgeScopePlan(undefined, {
+        address: 'thread:alpha:uncurated',
+        contextualScopeAddress: 'thread:alpha',
+        parentAddresses: ['thread:alpha'],
+        parameters: { threadId: 'alpha' },
+      }),
+    ).toMatchObject({
+      scopes: [
+        {
+          address: 'thread:alpha:uncurated',
+          description: expect.stringContaining('not yet reviewed or integrated'),
+          parentAddresses: ['thread:alpha'],
+          grants: [{ scopeRefAddress: 'thread:alpha', role: 'mirror' }],
+        },
+      ],
+    });
+  });
+
   it('rejects mismatched host-vouched parameters and ambiguous patterns', () => {
     expect(() =>
       materializeKnowledgeScopePlan(undefined, {

--- a/packages/core/src/knowledge/index.ts
+++ b/packages/core/src/knowledge/index.ts
@@ -97,6 +97,22 @@ export class Knowledge extends MastraBase {
     );
   }
 
+  /** Returns trusted placement context for the exact scope addresses visible to an agent. @internal */
+  __getDescriptionContext(scope: KnowledgeScope): {
+    description?: string;
+    scopes: Array<{ address: string; name: string; description: string }>;
+  } {
+    const visibleAddresses = new Set(scope);
+    return {
+      description: this.description?.trim() || undefined,
+      scopes: (this.#structure?.scopes ?? []).flatMap(configuredScope => {
+        const description = configuredScope.description?.trim();
+        if (!description || !visibleAddresses.has(configuredScope.address)) return [];
+        return [{ address: configuredScope.address, name: configuredScope.name, description }];
+      }),
+    };
+  }
+
   /** @internal */
   setStorage(storage: MastraCompositeStore, source: MastraCompositeStore = storage): void {
     if (this.hasOwnStorage) return;

--- a/packages/core/src/knowledge/index.ts
+++ b/packages/core/src/knowledge/index.ts
@@ -103,14 +103,53 @@ export class Knowledge extends MastraBase {
     scopes: Array<{ address: string; name: string; description: string }>;
   } {
     const visibleAddresses = new Set(scope);
+    const structural = new Set(this.__getVisibleStructureScopes(scope).map(visibleScope => visibleScope.address));
     return {
       description: this.description?.trim() || undefined,
       scopes: (this.#structure?.scopes ?? []).flatMap(configuredScope => {
         const description = configuredScope.description?.trim();
-        if (!description || !visibleAddresses.has(configuredScope.address)) return [];
+        if (!description) return [];
+        if (!visibleAddresses.has(configuredScope.address) && !structural.has(configuredScope.address)) return [];
         return [{ address: configuredScope.address, name: configuredScope.name, description }];
       }),
     };
+  }
+
+  /**
+   * Structural scopes a writer holding `scope` may place content into: every configured
+   * scope whose ancestor chain (via declared parent addresses) reaches a held address.
+   * Held identity addresses themselves are excluded — those are placed via rungs. The
+   * structure plan is host configuration, so this frontier is host-vouched. @internal
+   */
+  __getVisibleStructureScopes(scope: KnowledgeScope): Array<{ address: string; name: string; description?: string }> {
+    const held = new Set(scope);
+    const configured = this.#structure?.scopes ?? [];
+    const parentsByAddress = new Map(configured.map(configuredScope => [configuredScope.address, configuredScope]));
+    const reachesHeld = (address: string): boolean => {
+      // DFS over all declared parents (multi-parent scopes are valid); the plan is
+      // validated acyclic, the seen set is just belt-and-braces.
+      const seen = new Set<string>();
+      const stack = [address];
+      while (stack.length > 0) {
+        const current = stack.pop()!;
+        if (seen.has(current)) continue;
+        seen.add(current);
+        if (held.has(current)) return true;
+        for (const parent of parentsByAddress.get(current)?.parentAddresses ?? []) stack.push(parent);
+      }
+      return false;
+    };
+    const visible: Array<{ address: string; name: string; description?: string }> = [];
+    for (const configuredScope of configured) {
+      if (held.has(configuredScope.address)) continue;
+      if (!reachesHeld(configuredScope.address)) continue;
+      visible.push({
+        address: configuredScope.address,
+        name: configuredScope.name,
+        ...(configuredScope.description ? { description: configuredScope.description } : {}),
+      });
+    }
+    return visible;
   }
 
   /** @internal */

--- a/packages/core/src/knowledge/reconcile.ts
+++ b/packages/core/src/knowledge/reconcile.ts
@@ -26,10 +26,21 @@ export interface MaterializeKnowledgeScopeInput {
   parameters?: Record<string, string>;
 }
 
+const UNCURATED_SCOPE_DESCRIPTION =
+  'Live capture from sessions. Extracted automatically, not yet reviewed or integrated. Treat as provisional — it may be wrong, duplicated, or superseded by curated knowledge.';
+
 const BUILT_IN_SCOPE_TYPES: KnowledgeScopeTypesConfig = {
   'org:$orgId': { access: [{ principal: 'self', role: 'owner' }] },
   'resource:$resourceId': { access: [{ principal: 'self', role: 'owner' }] },
   'thread:$threadId': { access: [{ principal: 'self', role: 'owner' }] },
+  'resource:$resourceId:uncurated': {
+    access: [{ principal: 'resource:$resourceId', role: 'mirror' }],
+    description: UNCURATED_SCOPE_DESCRIPTION,
+  },
+  'thread:$threadId:uncurated': {
+    access: [{ principal: 'thread:$threadId', role: 'mirror' }],
+    description: UNCURATED_SCOPE_DESCRIPTION,
+  },
   custom: { access: [{ principal: 'self', role: 'owner' }] },
 };
 

--- a/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
+++ b/packages/core/src/storage/domains/knowledge/__tests__/base.test.ts
@@ -66,6 +66,36 @@ describe('InMemoryKnowledgeStorage', () => {
     ).rejects.toBeInstanceOf(KnowledgeUnsupportedCapabilityError);
   });
 
+  it('enriches existing scopes with new parents and grants idempotently', async () => {
+    const store = createStore();
+    const initial = await store.reconcileStructure({
+      scopes: [
+        { address: 'org:acme', name: 'Acme' },
+        { address: 'org:partner', name: 'Partner' },
+        { address: 'resource:mastra', name: 'Mastra', parentAddresses: ['org:acme'] },
+      ],
+    });
+
+    const enrichedPlan = {
+      scopes: [
+        { address: 'org:acme', name: 'Acme' },
+        { address: 'org:partner', name: 'Partner' },
+        {
+          address: 'resource:mastra',
+          name: 'Mastra',
+          parentAddresses: ['org:acme', 'org:partner'],
+          grants: [{ scopeRefAddress: 'org:partner', role: 'readonly' as const }],
+        },
+      ],
+    };
+    const enriched = await store.reconcileStructure(enrichedPlan);
+    const replayed = await store.reconcileStructure(enrichedPlan);
+
+    expect(initial).toMatchObject({ changed: true, accessEpoch: 1 });
+    expect(enriched).toMatchObject({ changed: true, createdScopeIds: [], accessEpoch: 2 });
+    expect(replayed).toMatchObject({ changed: false, createdScopeIds: [], accessEpoch: 2 });
+  });
+
   it('reports the v2 contract and inspects schema without mutating Knowledge data', async () => {
     const store = createStore();
     const node = await store.createNode({ name: 'Keep me', kind: 'topic', scope: resource });
@@ -309,7 +339,7 @@ describe('InMemoryKnowledgeStorage', () => {
   it('applies record visibility independently from node scope', async () => {
     const store = createStore();
     const node = await store.createNode({ name: 'Resource Secret', kind: 'task', scope: resource });
-    await store.appendKnowledge({
+    const record = await store.appendKnowledge({
       node: node.id,
       text: 'org-visible wording',
       scope: org,
@@ -320,7 +350,7 @@ describe('InMemoryKnowledgeStorage', () => {
 
     expect((await store.listKnowledgeAbout({ node, scope: org })).records).toHaveLength(1);
     expect(await store.search({ query: 'org-visible', scope: org })).toEqual([
-      expect.objectContaining({ type: 'record', recordId: node.id, scope: org }),
+      expect.objectContaining({ type: 'record', recordId: record.id, name: '(private node)', scope: org }),
     ]);
     expect((await store.listKnowledgeAbout({ node, scope: thread })).records).toHaveLength(1);
   });

--- a/packages/core/src/storage/domains/knowledge/__tests__/scope.test.ts
+++ b/packages/core/src/storage/domains/knowledge/__tests__/scope.test.ts
@@ -6,6 +6,7 @@ import {
   expandKnowledgeScope,
   isKnowledgeScopeVisible,
   knowledgeScopeKey,
+  knowledgeVisibleScopeKeys,
 } from '../base';
 
 const context = ['thread:t1', 'org:o1', 'resource:r1'];
@@ -23,10 +24,33 @@ describe('knowledge scopes', () => {
     expect(() => expandKnowledgeScope(['org:o1'], 'thread')).toThrow('context has no thread entry');
   });
 
+  it('accepts opaque uncurated companion addresses without legacy ancestors', () => {
+    expect(canonicalizeKnowledgeScope(['thread:t1:uncurated'])).toEqual(['thread:t1:uncurated']);
+    expect(canonicalizeKnowledgeScope(['resource:r1:uncurated', 'thread:t1:uncurated'])).toEqual([
+      'resource:r1:uncurated',
+      'thread:t1:uncurated',
+    ]);
+  });
+
   it('uses subset visibility and excludes sibling scopes', () => {
     expect(isKnowledgeScopeVisible(['org:o1'], context)).toBe(true);
     expect(isKnowledgeScopeVisible(['org:o1', 'resource:r1'], context)).toBe(true);
     expect(isKnowledgeScopeVisible(['org:o1', 'resource:r2'], context)).toBe(false);
+  });
+
+  it('enumerates persisted scope subsets including uncurated companions', () => {
+    const resourceCompanion = 'resource:r1:uncurated';
+    const threadCompanion = 'thread:t1:uncurated';
+    const keys = knowledgeVisibleScopeKeys([...context, resourceCompanion, threadCompanion]);
+
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        knowledgeScopeKey(context),
+        knowledgeScopeKey([resourceCompanion]),
+        knowledgeScopeKey([threadCompanion]),
+        knowledgeScopeKey([resourceCompanion, threadCompanion]),
+      ]),
+    );
   });
 
   it('rejects malformed, partial, and cross-chain scopes', () => {

--- a/packages/core/src/storage/domains/knowledge/base.ts
+++ b/packages/core/src/storage/domains/knowledge/base.ts
@@ -526,16 +526,19 @@ export function canonicalizeKnowledgeScope(scope: KnowledgeScope): KnowledgeScop
     const separator = entry.indexOf(':');
     const level = entry.slice(0, separator) as KnowledgeScopeLevel;
     const id = entry.slice(separator + 1);
+    const isUncuratedCompanion =
+      (level === 'resource' || level === 'thread') && id.endsWith(':uncurated') && id.length > ':uncurated'.length;
     if (separator <= 0 || !id || id.includes('\u001f') || SCOPE_ORDER[level] === undefined) {
       throw new Error(`Invalid knowledge scope entry: ${entry}`);
     }
+    if (isUncuratedCompanion) continue;
     const existing = entriesByLevel.get(level);
     if (existing && existing !== entry) {
       throw new Error(`Knowledge scope contains multiple ${level} entries`);
     }
     entriesByLevel.set(level, entry);
   }
-  if (entriesByLevel.size === 0) {
+  if (scope.length === 0) {
     throw new Error('Knowledge scope cannot be empty');
   }
   if (entriesByLevel.has('thread') && (!entriesByLevel.has('resource') || !entriesByLevel.has('org'))) {
@@ -563,6 +566,21 @@ export function knowledgeScopeKey(scope: KnowledgeScope): string {
 export function isKnowledgeScopeVisible(recordScope: KnowledgeScope, queryScope: KnowledgeScope): boolean {
   const available = new Set(queryScope);
   return recordScope.every(entry => available.has(entry));
+}
+
+export function knowledgeVisibleScopeKeys(scope: KnowledgeScope): string[] {
+  const canonical = canonicalizeKnowledgeScope(scope);
+  const subsets: KnowledgeScope[] = [[]];
+  for (const entry of canonical) subsets.push(...subsets.map(subset => [...subset, entry]));
+  const keys = new Set<string>();
+  for (const subset of subsets.slice(1)) {
+    try {
+      keys.add(knowledgeScopeKey(subset));
+    } catch {
+      // Invalid hierarchy fragments cannot be persisted scope keys.
+    }
+  }
+  return [...keys];
 }
 
 export function expandKnowledgeScope(context: KnowledgeScope, level: KnowledgeScopeLevel): KnowledgeScope {

--- a/packages/core/src/storage/domains/knowledge/base.ts
+++ b/packages/core/src/storage/domains/knowledge/base.ts
@@ -166,6 +166,8 @@ export interface KnowledgeNode {
    * storage already accepted. Long-form detail belongs in {@link KnowledgeNode.content}.
    */
   description?: string;
+  /** True for scope nodes; absent for ordinary content nodes. */
+  isScope?: boolean;
   scope: KnowledgeScope;
   version: number;
   mergedInto?: string;
@@ -333,6 +335,13 @@ export interface CreateKnowledgeNodeInput {
   content?: string;
   description?: string;
   scope: KnowledgeScope;
+  /**
+   * Structural scope addresses the node is placed into, in addition to its identity scope.
+   * Every address must resolve to a live reconciled scope node; unknown or deleted addresses
+   * throw without creating the node. Placement is additive membership (`node_scopes`) — it does
+   * not change the node's identity scope.
+   */
+  scopeAddresses?: string[];
   resolutionScope?: KnowledgeScope;
 }
 
@@ -739,7 +748,7 @@ export abstract class KnowledgeStorage extends StorageDomain {
 
   /** Applies an additive, idempotent structured scope plan. */
   async reconcileStructure(_plan: KnowledgeStructurePlan): Promise<KnowledgeStructureReconcileResult> {
-    throw new Error('This Knowledge storage adapter does not support structured reconciliation.');
+    throw new KnowledgeUnsupportedCapabilityError('structured reconciliation');
   }
 
   /** Lists reconciled structural scope nodes with their parent membership edges (bounded, name-ordered). */

--- a/packages/core/src/storage/domains/knowledge/inmemory.ts
+++ b/packages/core/src/storage/domains/knowledge/inmemory.ts
@@ -293,11 +293,21 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
       updatedAt: now,
     };
     if (this.#db.knowledgeNodes.has(node.id)) throw new Error(`Knowledge node already exists: ${node.id}`);
+    // Validate structural placement before mutating anything: every address must
+    // resolve to a live reconciled scope node.
+    const placementIds = (input.scopeAddresses ?? []).map(address => {
+      const target = this.#structureScopes.get(address);
+      if (!target || target.deletedAt) throw new KnowledgeNotFoundError('scope', address);
+      return target.id;
+    });
     this.#db.knowledgeNodes.set(node.id, node);
     this.#db.knowledgeNodeKeys.set(key, node.id);
     this.#replaceMentions('node', node.id, node.content ?? '', input.resolutionScope ?? scope, scope);
     this.#recordActivity('node-created', 'node', node.id, scope);
     this.#enqueue('node', node.id, 'upsert', node.version, scope);
+    // Placement edges go last so no later step can fail after they are added
+    // (#structureParents is instance state, outside the atomic #db snapshot).
+    for (const scopeId of placementIds) this.#structureParents.add(`${node.id}\u0000${scopeId}`);
     return cloneNode(node);
   }
 

--- a/packages/core/src/storage/domains/knowledge/inmemory.ts
+++ b/packages/core/src/storage/domains/knowledge/inmemory.ts
@@ -134,6 +134,8 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
     const scopes: Record<string, string> = {};
     const createdScopeIds: string[] = [];
     const createdAddresses = new Set<string>();
+    const addedParentEdges = new Set<string>();
+    const addedGrantEdges = new Set<string>();
 
     for (const scope of plan.scopes) {
       const existing = this.#structureScopes.get(scope.address);
@@ -155,11 +157,15 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
 
     try {
       for (const scope of plan.scopes) {
-        if (!createdAddresses.has(scope.address)) continue;
+        if (this.#structureScopes.get(scope.address)?.deletedAt) continue;
         const scopeNodeId = scopes[scope.address]!;
         for (const parentAddress of scope.parentAddresses ?? []) {
           const parent = this.#structureScopes.get(parentAddress);
-          if (!parent || parent.deletedAt) throw new Error(`Knowledge parent scope does not exist: ${parentAddress}`);
+          const edge = parent ? `${scopeNodeId}\u0000${parent.id}` : undefined;
+          if (!parent || (parent.deletedAt && !this.#structureParents.has(edge!))) {
+            throw new Error(`Knowledge parent scope does not exist: ${parentAddress}`);
+          }
+          if (parent.deletedAt) continue;
           const sibling = [...this.#structureParents]
             .map(edge => edge.split('\u0000'))
             .find(
@@ -173,17 +179,27 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
                 ),
             );
           if (sibling) throw new Error(`Knowledge scope name ${scope.name} already exists under ${parentAddress}`);
-          this.#structureParents.add(`${scopeNodeId}\u0000${parent.id}`);
+          if (!this.#structureParents.has(edge!)) {
+            this.#structureParents.add(edge!);
+            addedParentEdges.add(edge!);
+          }
         }
         for (const grant of scope.grants ?? []) {
           const scopeRef = this.#structureScopes.get(grant.scopeRefAddress);
-          if (!scopeRef || scopeRef.deletedAt) {
+          const edge = scopeRef ? `${scopeNodeId}\u0000${scopeRef.id}` : undefined;
+          if (!scopeRef || (scopeRef.deletedAt && !this.#structureGrants.has(edge!))) {
             throw new Error(`Knowledge grant scope does not exist: ${grant.scopeRefAddress}`);
           }
-          this.#structureGrants.add(`${scopeNodeId}\u0000${scopeRef.id}`);
+          if (scopeRef.deletedAt) continue;
+          if (!this.#structureGrants.has(edge!)) {
+            this.#structureGrants.add(edge!);
+            addedGrantEdges.add(edge!);
+          }
         }
       }
     } catch (error) {
+      for (const edge of addedParentEdges) this.#structureParents.delete(edge);
+      for (const edge of addedGrantEdges) this.#structureGrants.delete(edge);
       for (const address of createdAddresses) this.#structureScopes.delete(address);
       for (const id of createdScopeIds) {
         for (const edge of this.#structureParents)
@@ -194,14 +210,15 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
       throw error;
     }
 
-    if (createdScopeIds.length) this.#accessEpoch += 1;
+    const changed = createdScopeIds.length > 0 || addedParentEdges.size > 0 || addedGrantEdges.size > 0;
+    if (changed) this.#accessEpoch += 1;
     return {
       scopes,
       createdScopeIds,
       deletedScopeAddresses: plan.scopes
         .filter(scope => this.#structureScopes.get(scope.address)?.deletedAt)
         .map(scope => scope.address),
-      changed: createdScopeIds.length > 0,
+      changed,
       accessEpoch: this.#accessEpoch,
     };
   }
@@ -302,15 +319,13 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
 
   #resolveNode({ name, scope }: { name: string; scope: KnowledgeScope }): KnowledgeNode | null {
     const canonical = canonicalizeKnowledgeScope(scope);
-    for (let length = canonical.length; length > 0; length--) {
-      const id = this.#db.knowledgeNodeKeys.get(recordKey(name, canonical.slice(0, length)));
-      const node = id ? this.#db.knowledgeNodes.get(id) : undefined;
-      if (node) {
-        const terminal = this.#resolveTerminalNode(node.id)!;
-        if (isKnowledgeScopeVisible(terminal.scope, canonical)) return cloneNode(terminal);
-      }
-    }
-    return null;
+    const canonicalName = name.trim().toLocaleLowerCase();
+    const visible = [...this.#db.knowledgeNodes.values()]
+      .filter(node => node.name.trim().toLocaleLowerCase() === canonicalName)
+      .map(node => this.#resolveTerminalNode(node.id)!)
+      .filter(node => isKnowledgeScopeVisible(node.scope, canonical))
+      .sort((left, right) => right.scope.length - left.scope.length);
+    return visible[0] ? cloneNode(visible[0]) : null;
   }
 
   async listNodes(input: ListKnowledgeNodesInput): Promise<KnowledgeNode[]> {
@@ -634,11 +649,12 @@ export class InMemoryKnowledgeStorage extends KnowledgeStorage {
       }
       const parent = this.#resolveTerminalNode(record.node);
       if (!parent) continue;
+      const parentVisible = isKnowledgeScopeVisible(parent.scope, queryScope);
       results.push({
         type: 'record',
         id: record.id,
-        recordId: parent.id,
-        name: parent.name,
+        recordId: parentVisible ? parent.id : record.id,
+        name: parentVisible ? parent.name : '(private node)',
         text: record.text,
         scope: [...record.scope],
       });

--- a/packages/memory/integration-tests/src/with-libsql-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-libsql-storage.test.ts
@@ -47,7 +47,7 @@ describe('Memory with LibSQL Integration', () => {
         id: randomUUID(),
       }),
       vector: new LibSQLVector({
-        url: 'file:libsql-test.db',
+        url: `file:${join(dbStoragePath, 'vectors.db')}`,
         id: randomUUID(),
       }),
       embedder: fastembed,
@@ -67,7 +67,7 @@ describe('Memory with LibSQL Integration', () => {
         storageConfigForWorker: { url: `file:${join(dbStoragePath, 'libsql-test.db')}`, id: randomUUID() },
         memoryOptionsForWorker: memoryOptions,
         vectorConfigForWorker: {
-          url: 'file:libsql-test.db',
+          url: `file:${join(dbStoragePath, 'vectors.db')}`,
           id: randomUUID(),
         },
       },
@@ -78,7 +78,7 @@ describe('Memory with LibSQL Integration', () => {
     it('should return the LAST N messages when using lastMessages config without explicit orderBy', async () => {
       const memoryWithLimit = new Memory({
         storage: new LibSQLStore({
-          url: 'file:libsql-test.db',
+          url: `file:${join(dbStoragePath, 'last-messages.db')}`,
           id: randomUUID(),
         }),
         embedder: fastembed.small,

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -7,6 +7,7 @@ import { MessageList } from '@mastra/core/agent';
 import type { MastraDBMessage } from '@mastra/core/agent';
 
 import { coreFeatures } from '@mastra/core/features';
+import type { Knowledge } from '@mastra/core/knowledge';
 import type { Mastra } from '@mastra/core/mastra';
 import { MastraMemory } from '@mastra/core/memory';
 import type {
@@ -124,6 +125,12 @@ type MemoryOptions = Omit<MemoryConfigInternal, 'observationalMemory'> & {
 
 type MemoryConstructorConfig = Omit<SharedMemoryConfig, 'options'> & {
   options?: MemoryOptions;
+  /**
+   * Selects the experimental Knowledge runtime used by Subconscious observation ingestion, tools, pinning,
+   * curation, and semantic indexing. A string resolves a keyed instance from the owning Mastra;
+   * a Knowledge instance supports standalone wiring. Omit to retain the v1 storage-domain path.
+   */
+  knowledge?: string | Knowledge | false;
 };
 
 type RuntimeMemoryConfig = Omit<MemoryConfig, 'observationalMemory'> & {
@@ -372,6 +379,8 @@ export class Memory extends MastraMemory {
   private _omEngine: Promise<ObservationalMemory | null> | undefined;
   private _omEngineInstance: ObservationalMemory | null | undefined;
   private _mastraInstance: Mastra | undefined;
+  private readonly _knowledge: MemoryConstructorConfig['knowledge'];
+  private _knowledgeStore?: Promise<KnowledgeStorage>;
   private _knowledgeSemanticIndex?: Promise<KnowledgeSemanticIndexCoordinator>;
 
   /**
@@ -428,6 +437,8 @@ export class Memory extends MastraMemory {
   __registerMastra(mastra: Mastra): void {
     super.__registerMastra(mastra);
     this._mastraInstance = mastra;
+    this._knowledgeStore = undefined;
+    this._knowledgeSemanticIndex = undefined;
     if (this._omEngineInstance) {
       this._omEngineInstance.__registerMastra(mastra);
     } else {
@@ -439,6 +450,7 @@ export class Memory extends MastraMemory {
   createSubconsciousMemory(): Memory {
     const memory = new Memory({
       storage: this.storage,
+      knowledge: this.getKnowledgeInstance() ?? this._knowledge,
       vector: this.vector,
       embedder: this.embedder,
       embedderOptions: this.embedderOptions,
@@ -469,7 +481,7 @@ export class Memory extends MastraMemory {
     const subconsciousExtractors = omConfig.experimental_subconscious
       .createObservationExtractors(
         observation.model ?? omConfig.model,
-        () => (curatorMemory ??= new Memory({ storage: this.storage, options: { observationalMemory: false } })),
+        () => (curatorMemory ??= this.createSubconsciousMemory()),
       )
       .filter(extractor => !existingSlugs.has(extractor.slug));
 
@@ -516,7 +528,9 @@ export class Memory extends MastraMemory {
   }
 
   constructor(config: MemoryConstructorConfig = {}) {
-    super({ name: 'Memory', ...config } as { name: string } & SharedMemoryConfig);
+    const { knowledge, ...memoryConfig } = config;
+    super({ name: 'Memory', ...memoryConfig } as { name: string } & SharedMemoryConfig);
+    this._knowledge = knowledge;
 
     const mergedConfig = this.getMergedThreadConfig({
       workingMemory: config.options?.workingMemory || {
@@ -545,17 +559,40 @@ export class Memory extends MastraMemory {
         );
       }
     }
-    if (omConfig?.experimental_subconscious) {
-      if (!this.vector) {
-        throw new Error('Subconscious semantic knowledge requires a vector store. Pass a `vector` option to Memory.');
-      }
-      if (!this.embedder) {
-        throw new Error('Subconscious semantic knowledge requires an embedder. Pass an `embedder` option to Memory.');
-      }
-    }
   }
 
-  private async getKnowledgeStore(): Promise<KnowledgeStorage> {
+  /** Returns the configured Knowledge v2 instance, or undefined for the v1 storage-domain path. */
+  public getKnowledgeInstance(): Knowledge | undefined {
+    if (this._knowledge === false || this._knowledge === undefined) return undefined;
+    if (typeof this._knowledge !== 'string') return this._knowledge;
+    if (!this._mastraInstance) {
+      throw new Error(
+        `Memory cannot resolve Knowledge instance "${this._knowledge}" before it is registered with Mastra.`,
+      );
+    }
+    return this._mastraInstance.getKnowledge(this._knowledge);
+  }
+
+  /**
+   * Resolves the one Knowledge storage domain used by every Subconscious path on this Memory.
+   * Configured v2 runtimes never fall back to Memory storage, preventing split-brain state.
+   */
+  public async getKnowledgeStore(): Promise<KnowledgeStorage> {
+    if (this._knowledge === undefined) return this.resolveLegacyKnowledgeStore();
+    if (this._knowledge === false) throw new Error('Knowledge is disabled for this Memory instance.');
+    if (!this._knowledgeStore) {
+      const promise = this.getKnowledgeInstance()!
+        .getStorage()
+        .catch(error => {
+          if (this._knowledgeStore === promise) this._knowledgeStore = undefined;
+          throw error;
+        });
+      this._knowledgeStore = promise;
+    }
+    return this._knowledgeStore;
+  }
+
+  private async resolveLegacyKnowledgeStore(): Promise<KnowledgeStorage> {
     const store = await this.storage.getStore('knowledge');
     if (!store) {
       throw new Error(`Knowledge storage domain is not available on ${this.storage.constructor.name}`);
@@ -563,24 +600,30 @@ export class Memory extends MastraMemory {
     return store;
   }
 
-  public async getKnowledgeSemanticIndex(): Promise<KnowledgeSemanticIndexCoordinator> {
-    if (!this.vector || !this.embedder) {
-      throw new Error('Subconscious semantic knowledge requires both a vector store and an embedder.');
+  public async getKnowledgeSemanticIndex(): Promise<KnowledgeSemanticIndexCoordinator | undefined> {
+    if (!this.vector || !this.embedder) return undefined;
+    if (!this._knowledgeSemanticIndex) {
+      const promise = this.getKnowledgeStore()
+        .then(
+          knowledge =>
+            new KnowledgeSemanticIndexCoordinator({
+              knowledge,
+              vector: this.vector!,
+              embedder: this.embedder!,
+              embedderOptions: this.embedderOptions,
+            }),
+        )
+        .catch(error => {
+          if (this._knowledgeSemanticIndex === promise) this._knowledgeSemanticIndex = undefined;
+          throw error;
+        });
+      this._knowledgeSemanticIndex = promise;
     }
-    this._knowledgeSemanticIndex ??= this.getKnowledgeStore().then(
-      knowledge =>
-        new KnowledgeSemanticIndexCoordinator({
-          knowledge,
-          vector: this.vector!,
-          embedder: this.embedder!,
-          embedderOptions: this.embedderOptions,
-        }),
-    );
     return this._knowledgeSemanticIndex;
   }
 
   public async drainKnowledgeSemanticIndex(scope?: KnowledgeScope): Promise<number> {
-    return (await this.getKnowledgeSemanticIndex()).drain(scope);
+    return (await this.getKnowledgeSemanticIndex())?.drain(scope) ?? 0;
   }
 
   /**
@@ -3752,7 +3795,7 @@ Notes:
     const alreadyConfigured = configuredProcessors.some(p => !('workflow' in p) && p.id === SUBCONSCIOUS_PINS_STATE_ID);
     if (alreadyConfigured) return null;
 
-    return new PinnedStateProcessor({ getKnowledgeStore: () => this.storage.getStore('knowledge') });
+    return new PinnedStateProcessor({ getKnowledgeStore: () => this.getKnowledgeStore() });
   }
 }
 

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-config.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-config.test.ts
@@ -113,14 +113,15 @@ describe('Subconscious configuration', () => {
     await expect((dynamicModel as (context: unknown) => Promise<unknown>)({})).resolves.toEqual([]);
   });
 
-  it('fails initialization explicitly when semantic infrastructure is missing', () => {
-    expect(
-      () =>
-        new Memory({
-          storage: new InMemoryStore(),
-          options: { observationalMemory: { model, experimental_subconscious: new Subconscious() } },
-        }),
-    ).toThrow(/requires a vector store/);
+  it('keeps non-semantic Subconscious features available without vector infrastructure', async () => {
+    const memory = new Memory({
+      storage: new InMemoryStore(),
+      options: { observationalMemory: { model, experimental_subconscious: new Subconscious() } },
+    });
+
+    expect(memory.listTools()).toHaveProperty('knowledge_browse');
+    await expect(memory.getKnowledgeSemanticIndex()).resolves.toBeUndefined();
+    await expect(memory.drainKnowledgeSemanticIndex()).resolves.toBe(0);
   });
 
   it('fails OM initialization when the storage adapter has no knowledge domain', async () => {

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-curate.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-curate.test.ts
@@ -95,6 +95,44 @@ describe('Subconscious observation curator', () => {
     expect(instructions).not.toContain('This description must not be visible to the current curator.');
   });
 
+  it('surfaces structural scope descriptions reachable from the curator frontier', async () => {
+    const knowledge = new Knowledge({
+      id: 'mastra',
+      storage: new InMemoryStore(),
+      structure: {
+        scopes: [
+          { address: 'org:acme', name: 'acme' },
+          { address: 'features', name: 'features', parentAddresses: ['org:acme'] },
+          {
+            address: 'features:memory',
+            name: 'memory',
+            parentAddresses: ['features'],
+            description: 'Knowledge about the memory subsystem belongs here.',
+          },
+          { address: 'org:other', name: 'other' },
+          {
+            address: 'other:things',
+            name: 'things',
+            parentAddresses: ['org:other'],
+            description: 'Unreachable scope description must stay hidden.',
+          },
+        ],
+      },
+    });
+    const { context, extractor } = fixture(knowledge);
+    let curatorAgent: Agent | undefined;
+    vi.spyOn(Agent.prototype, 'sendMessage').mockImplementation(function (this: Agent) {
+      curatorAgent = this;
+      return { accepted: new Promise(() => {}), signal: {} } as any;
+    });
+
+    await extractor.onExtracted!(context);
+
+    const instructions = await curatorAgent!.getInstructions();
+    expect(instructions).toContain('features:memory (memory): Knowledge about the memory subsystem belongs here.');
+    expect(instructions).not.toContain('Unreachable scope description must stay hidden.');
+  });
+
   it.each(['instance', 'key'] as const)(
     'passes selected Knowledge by %s into the configured curator',
     async selection => {

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-curate.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-curate.test.ts
@@ -58,6 +58,43 @@ describe('Subconscious observation curator', () => {
     expect(await getStore.mock.results[0]!.value).toBe(selectedStore);
   });
 
+  it('passes the selected Knowledge and exact visible scope descriptions to the curator', async () => {
+    const knowledge = new Knowledge({
+      id: 'mastra',
+      description: 'Project knowledge separated by organization and active workspace.',
+      storage: new InMemoryStore(),
+      structure: {
+        scopes: [
+          {
+            address: 'resource:user-42',
+            name: 'Project Atlas',
+            description: 'Store durable Project Atlas launch decisions at resource scope.',
+          },
+          {
+            address: 'resource:other',
+            name: 'Other project',
+            description: 'This description must not be visible to the current curator.',
+          },
+        ],
+      },
+    });
+    const { context, extractor } = fixture(knowledge);
+    let curatorAgent: Agent | undefined;
+    vi.spyOn(Agent.prototype, 'sendMessage').mockImplementation(function (this: Agent) {
+      curatorAgent = this;
+      return { accepted: new Promise(() => {}), signal: {} } as any;
+    });
+
+    await extractor.onExtracted!(context);
+
+    const instructions = await curatorAgent!.getInstructions();
+    expect(instructions).toContain('Project knowledge separated by organization and active workspace.');
+    expect(instructions).toContain(
+      'resource:user-42 (Project Atlas): Store durable Project Atlas launch decisions at resource scope.',
+    );
+    expect(instructions).not.toContain('This description must not be visible to the current curator.');
+  });
+
   it.each(['instance', 'key'] as const)(
     'passes selected Knowledge by %s into the configured curator',
     async selection => {

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-curate.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-curate.test.ts
@@ -1,4 +1,6 @@
 import { Agent } from '@mastra/core/agent';
+import { Knowledge } from '@mastra/core/knowledge';
+import { Mastra } from '@mastra/core/mastra';
 import { RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
 import type { MastraEmbeddingModel, MastraVector } from '@mastra/core/vector';
@@ -12,9 +14,9 @@ const semanticInfrastructure = {
   embedder: {} as MastraEmbeddingModel<string>,
 };
 
-function fixture() {
-  const memory = new Memory({ storage: new InMemoryStore(), ...semanticInfrastructure });
-  const curatorMemory = new Memory({ storage: memory.storage, options: { observationalMemory: false } });
+function fixture(knowledge?: Knowledge | false) {
+  const memory = new Memory({ storage: new InMemoryStore(), knowledge, ...semanticInfrastructure });
+  const curatorMemory = memory.createSubconsciousMemory();
   const subconscious = new Subconscious({ defaultScope: 'resource', maxScope: 'resource' });
   const config = subconscious.resolved.observation.find(agent => agent.name === 'curate')!;
   const extractor = new SubconsciousCurateExtractor(config, subconscious.resolved, () => curatorMemory, 'openai/test');
@@ -36,6 +38,72 @@ function fixture() {
 afterEach(() => vi.restoreAllMocks());
 
 describe('Subconscious observation curator', () => {
+  it('uses the selected Knowledge runtime for observation and derived agent memory', async () => {
+    const knowledge = new Knowledge({ id: 'mastra', storage: new InMemoryStore() });
+    const { memory, context, extractor } = fixture(knowledge);
+    const selectedStore = await knowledge.getStorage();
+    const legacyStore = await memory.storage.getStore('knowledge');
+    expect(selectedStore).not.toBe(legacyStore);
+    expect(await memory.createSubconsciousMemory().getKnowledgeStore()).toBe(selectedStore);
+    const getStore = vi.spyOn(memory, 'getKnowledgeStore');
+    const sendMessage = vi.spyOn(Agent.prototype, 'sendMessage').mockReturnValue({
+      accepted: new Promise(() => {}),
+      signal: {},
+    } as any);
+
+    await extractor.onExtracted!(context);
+
+    expect(getStore).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(await getStore.mock.results[0]!.value).toBe(selectedStore);
+  });
+
+  it.each(['instance', 'key'] as const)(
+    'passes selected Knowledge by %s into the configured curator',
+    async selection => {
+      const knowledge = new Knowledge({ id: 'mastra', storage: new InMemoryStore() });
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        knowledge: selection === 'key' ? 'selected' : knowledge,
+        options: { observationalMemory: { model: 'openai/test', experimental_subconscious: new Subconscious() } },
+      });
+      memory.__registerMastra(new Mastra({ knowledge: { selected: knowledge }, logger: false }));
+      const om = memory.getMergedThreadConfig().observationalMemory;
+      if (!om || typeof om !== 'object') throw new Error('Expected observational memory configuration');
+      const extractor = om.observation?.extract?.find(value => value instanceof SubconsciousCurateExtractor);
+      if (!(extractor instanceof SubconsciousCurateExtractor)) throw new Error('Expected observation curator');
+      let agent: Agent | undefined;
+      vi.spyOn(Agent.prototype, 'sendMessage').mockImplementation(function (this: Agent) {
+        agent = this;
+        return { accepted: new Promise(() => {}), signal: {} } as any;
+      });
+
+      await extractor.onExtracted!({ ...fixture().context, memory, extractor });
+
+      const derivedMemory = await agent?.getMemory();
+      if (!(derivedMemory instanceof Memory)) throw new Error('Expected curator Memory');
+      expect(await derivedMemory.getKnowledgeStore()).toBe(await knowledge.getStorage());
+      expect(await derivedMemory.getKnowledgeStore()).not.toBe(await memory.storage.getStore('knowledge'));
+    },
+  );
+
+  it('does not dispatch or fall back to ordinary storage when Knowledge is disabled', async () => {
+    const { context, extractor } = fixture(false);
+    const writer = { custom: vi.fn().mockResolvedValue(undefined) };
+    const sendMessage = vi.spyOn(Agent.prototype, 'sendMessage');
+
+    await extractor.onExtracted!({ ...context, writer });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    await vi.waitFor(() =>
+      expect(writer.custom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ error: expect.stringContaining('Knowledge is disabled') }),
+        }),
+      ),
+    );
+  });
+
   it('uses the thread as the resource scope fallback', () => {
     const { context } = fixture();
 

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind.test.ts
@@ -135,18 +135,19 @@ describe('Subconscious remind', () => {
     });
     const context = createContext('Project Atlas launches January 15.');
     const store = await context.memory.storage.getStore('knowledge');
+    const scope = ['org:acme', 'resource:user-42'];
     const node = await store.createNode({
       name: 'Project Atlas',
       kind: 'project',
-      scope: ['org:acme', 'resource:user-42'],
+      scope: scope,
     });
     const record = await store.appendKnowledge({
       node,
       text: 'Project Atlas launches January 15.',
-      scope: ['org:acme', 'resource:user-42'],
+      scope: scope,
       sourceThreadId: 'beta',
       resolutionScope: ['org:acme', 'resource:user-42', 'thread:beta'],
-      defaultScope: ['org:acme', 'resource:user-42'],
+      defaultScope: scope,
     });
     context.mainAgent.getModel = vi.fn(async () =>
       createModel(`Project Atlas launches January 15. Source: ${record.id}`, undefined, true),

--- a/packages/memory/src/processors/observational-memory/subconscious/curate.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/curate.ts
@@ -155,12 +155,12 @@ function createKnowledgeDescriptionInstructions(memory: Memory, scope: Knowledge
   const sections = [
     context.description ? `Knowledge instance: ${context.description}` : undefined,
     context.scopes.length > 0
-      ? `Visible configured scopes:\n${context.scopes
+      ? `Visible configured scopes (identity rungs and structural addresses):\n${context.scopes
           .map(item => `- ${item.address} (${item.name}): ${item.description}`)
           .join('\n')}`
       : undefined,
   ];
-  return `Host-configured Knowledge placement context. Use these descriptions to choose the appropriate allowed scope for each durable fact.\n${sections
+  return `Host-configured Knowledge placement context. Use these descriptions to choose the appropriate allowed scope for each durable fact. To place a node into a structural scope, pass its address as the knowledge_create nodeScope argument.\n${sections
     .filter(Boolean)
     .join('\n')}`;
 }

--- a/packages/memory/src/processors/observational-memory/subconscious/curate.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/curate.ts
@@ -69,8 +69,7 @@ export class SubconsciousCurateExtractor extends Extractor<unknown> {
         let scope: KnowledgeScope | undefined;
         try {
           scope = resolveCuratorScope(context);
-          store = await context.memory.storage.getStore('knowledge');
-          if (!store) throw new Error('Subconscious curate requires a configured knowledge storage domain.');
+          store = await context.memory.getKnowledgeStore();
 
           const agent = await createCuratorAgent(
             context.memory,

--- a/packages/memory/src/processors/observational-memory/subconscious/curate.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/curate.ts
@@ -148,6 +148,23 @@ async function reportCuratorError(
   }
 }
 
+function createKnowledgeDescriptionInstructions(memory: Memory, scope: KnowledgeScope): string | undefined {
+  const context = memory.getKnowledgeInstance()?.__getDescriptionContext(scope);
+  if (!context || (!context.description && context.scopes.length === 0)) return undefined;
+
+  const sections = [
+    context.description ? `Knowledge instance: ${context.description}` : undefined,
+    context.scopes.length > 0
+      ? `Visible configured scopes:\n${context.scopes
+          .map(item => `- ${item.address} (${item.name}): ${item.description}`)
+          .join('\n')}`
+      : undefined,
+  ];
+  return `Host-configured Knowledge placement context. Use these descriptions to choose the appropriate allowed scope for each durable fact.\n${sections
+    .filter(Boolean)
+    .join('\n')}`;
+}
+
 export async function createCuratorAgent(
   memory: Memory,
   curatorMemory: Memory,
@@ -169,6 +186,7 @@ export async function createCuratorAgent(
     name: 'Subconscious Curate',
     instructions: [
       DEFAULT_INSTRUCTIONS,
+      createKnowledgeDescriptionInstructions(memory, scope),
       subconscious.pins ? PINNED_INSTRUCTIONS : undefined,
       config.instructions?.trim(),
     ]

--- a/packages/memory/src/processors/observational-memory/subconscious/knowledge-tools.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/knowledge-tools.ts
@@ -16,11 +16,15 @@ import type { KnowledgeSemanticIndexCoordinator } from './semantic-index';
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 50;
 
-type KnowledgeToolsMemory = {
-  storage: {
+export type KnowledgeStoreMemory = {
+  getKnowledgeStore?: () => Promise<KnowledgeStorage>;
+  storage?: {
     getStore(name: 'knowledge'): Promise<KnowledgeStorage | undefined>;
   };
-  getKnowledgeSemanticIndex(): Promise<KnowledgeSemanticIndexCoordinator>;
+};
+
+type KnowledgeToolsMemory = KnowledgeStoreMemory & {
+  getKnowledgeSemanticIndex(): Promise<KnowledgeSemanticIndexCoordinator | undefined>;
 };
 
 export type KnowledgeToolContext = {
@@ -40,8 +44,9 @@ export function resolveKnowledgeToolScope(context: KnowledgeToolContext | undefi
   return [`org:${organizationId}`, `resource:${resourceId}`, `thread:${threadId}`];
 }
 
-async function getKnowledgeStore(memory: KnowledgeToolsMemory): Promise<KnowledgeStorage> {
-  const store = await memory.storage.getStore('knowledge');
+export async function getKnowledgeStore(memory: KnowledgeStoreMemory): Promise<KnowledgeStorage> {
+  if (memory.getKnowledgeStore) return memory.getKnowledgeStore();
+  const store = await memory.storage?.getStore('knowledge');
   if (!store) throw new Error('Knowledge tools require a configured knowledge storage domain.');
   return store;
 }
@@ -165,9 +170,8 @@ export function createKnowledgeTools(
       const scope = fixedScope ?? resolveKnowledgeToolScope(context as KnowledgeToolContext);
       const limit = normalizeLimit(requestedLimit);
       const store = await getKnowledgeStore(memory);
-      const semanticCandidates = await memory
-        .getKnowledgeSemanticIndex()
-        .then(index => index.search(query, scope, limit * 2));
+      const semanticIndex = await memory.getKnowledgeSemanticIndex();
+      const semanticCandidates = semanticIndex ? await semanticIndex.search(query, scope, limit * 2) : [];
       const lexical = await store.search({ query, scope, limit: limit * 2 });
       const semantic = (
         await Promise.all(semanticCandidates.map(candidate => loadSemanticResult(store, scope, candidate)))

--- a/packages/memory/src/processors/observational-memory/subconscious/knowledge-write-tools.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/knowledge-write-tools.ts
@@ -20,7 +20,8 @@ const dateTimeSchema: JSONSchema7 = {
 };
 
 type KnowledgeWriteToolsMemory = {
-  storage: {
+  getKnowledgeStore?: () => Promise<KnowledgeStorage>;
+  storage?: {
     getStore(name: 'knowledge'): Promise<KnowledgeStorage | undefined>;
   };
 };
@@ -33,7 +34,8 @@ export interface KnowledgeWriteToolsOptions {
 }
 
 async function getStore(memory: KnowledgeWriteToolsMemory): Promise<KnowledgeStorage> {
-  const store = await memory.storage.getStore('knowledge');
+  if (memory.getKnowledgeStore) return memory.getKnowledgeStore();
+  const store = await memory.storage?.getStore('knowledge');
   if (!store) throw new Error('Knowledge write tools require a configured knowledge storage domain.');
   return store;
 }

--- a/packages/memory/src/processors/observational-memory/subconscious/knowledge-write-tools.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/knowledge-write-tools.ts
@@ -11,7 +11,13 @@ import { createTool } from '@mastra/core/tools';
 import type { JSONSchema7 } from 'json-schema';
 
 const CURATOR_IDENTITY = 'subconscious:curate';
-const scopeLevelSchema: JSONSchema7 = { type: 'string', enum: ['org', 'resource', 'thread'] };
+const SCOPE_RUNGS = ['org', 'resource', 'thread'] as const;
+const scopeLevelSchema: JSONSchema7 = { type: 'string', enum: [...SCOPE_RUNGS] };
+const nodePlacementSchema: JSONSchema7 = {
+  type: 'string',
+  description:
+    "Placement for the node: an identity rung ('org', 'resource', or 'thread'), or a structural scope address from the host-configured placement context (for example 'features:memory').",
+};
 const dateTimeSchema: JSONSchema7 = {
   type: 'string',
   format: 'date-time',
@@ -21,6 +27,13 @@ const dateTimeSchema: JSONSchema7 = {
 
 type KnowledgeWriteToolsMemory = {
   getKnowledgeStore?: () => Promise<KnowledgeStorage>;
+  getKnowledgeInstance?: () =>
+    | {
+        __getVisibleStructureScopes(
+          scope: KnowledgeScope,
+        ): Array<{ address: string; name: string; description?: string }>;
+      }
+    | undefined;
   storage?: {
     getStore(name: 'knowledge'): Promise<KnowledgeStorage | undefined>;
   };
@@ -52,6 +65,33 @@ function requireVisible(scope: KnowledgeScope, options: KnowledgeWriteToolsOptio
   }
 }
 
+/**
+ * Resolve the node placement argument: a rung keeps the identity-scope path, anything
+ * else is treated as a structural scope address and must be inside the host-configured
+ * frontier visible to the curator's held scope.
+ */
+function resolveNodePlacement(
+  memory: KnowledgeWriteToolsMemory,
+  options: KnowledgeWriteToolsOptions,
+  placement: string | undefined,
+): { nodeScope: KnowledgeScope; scopeAddresses?: string[] } {
+  if (placement === undefined || (SCOPE_RUNGS as readonly string[]).includes(placement)) {
+    const nodeScope = expandKnowledgeScope(
+      options.scope,
+      (placement as KnowledgeScopeLevel | undefined) ?? options.defaultScope,
+    );
+    assertKnowledgeScopeWithinCeiling(nodeScope, options.maxScope);
+    return { nodeScope };
+  }
+  const visible = memory.getKnowledgeInstance?.()?.__getVisibleStructureScopes(options.scope) ?? [];
+  if (!visible.some(visibleScope => visibleScope.address === placement)) {
+    throw new Error(`Structural scope is outside the curator's visible scope: ${placement}`);
+  }
+  const nodeScope = expandKnowledgeScope(options.scope, options.defaultScope);
+  assertKnowledgeScopeWithinCeiling(nodeScope, options.maxScope);
+  return { nodeScope, scopeAddresses: [placement] };
+}
+
 export function createKnowledgeWriteTools(
   memory: KnowledgeWriteToolsMemory,
   options: KnowledgeWriteToolsOptions,
@@ -75,7 +115,7 @@ export function createKnowledgeWriteTools(
           name: { type: 'string', minLength: 1 },
           kind: { type: 'string', minLength: 1 },
           text: { type: 'string', minLength: 1 },
-          nodeScope: scopeLevelSchema,
+          nodeScope: nodePlacementSchema,
           scope: scopeLevelSchema,
           when: dateTimeSchema,
         },
@@ -87,16 +127,21 @@ export function createKnowledgeWriteTools(
           name: string;
           kind: string;
           text: string;
-          nodeScope?: KnowledgeScopeLevel;
+          nodeScope?: string;
           scope?: KnowledgeScopeLevel;
           when?: string;
         };
         const store = await getStore(memory);
-        const nodeScope = resolveWriteScope(options, value.nodeScope);
+        const { nodeScope, scopeAddresses } = resolveNodePlacement(memory, options, value.nodeScope);
         const recordScope = resolveWriteScope(options, value.scope);
         const when = value.when ? new Date(value.when) : undefined;
         if (when && Number.isNaN(when.getTime())) throw new Error('KnowledgeRecord when must be a valid date.');
-        const node = await store.createNode({ name: value.name, kind: value.kind, scope: nodeScope });
+        const node = await store.createNode({
+          name: value.name,
+          kind: value.kind,
+          scope: nodeScope,
+          ...(scopeAddresses ? { scopeAddresses } : {}),
+        });
         const record = await store.appendKnowledge({
           node: node.id,
           text: value.text,

--- a/packages/memory/src/processors/observational-memory/subconscious/pinned.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/pinned.ts
@@ -4,6 +4,9 @@ import type { ToolAction } from '@mastra/core/tools';
 import { createTool } from '@mastra/core/tools';
 import type { JSONSchema7 } from 'json-schema';
 
+import { getKnowledgeStore } from './knowledge-tools';
+import type { KnowledgeStoreMemory } from './knowledge-tools';
+
 /** Processor id and state-signal id for the pinned-knowledge lane. */
 export const SUBCONSCIOUS_PINS_STATE_ID = 'subconscious-pins';
 /** Snapshot tag the model sees; the delta tag appends `-update`. */
@@ -25,11 +28,7 @@ export interface PinnedKnowledgeSet {
   pins: KnowledgeRecord[];
 }
 
-type PinnedMemory = {
-  storage: {
-    getStore(name: 'knowledge'): Promise<KnowledgeStorage | undefined>;
-  };
-};
+type PinnedMemory = KnowledgeStoreMemory;
 
 export interface PinnedToolsOptions {
   /** Full visible scope context for the conversation (org + resource + thread entries). */
@@ -162,9 +161,7 @@ async function writePinnedKnowledge(
 }
 
 async function getStore(memory: PinnedMemory): Promise<KnowledgeStorage> {
-  const store = await memory.storage.getStore('knowledge');
-  if (!store) throw new Error('Pinned knowledge requires a configured knowledge storage domain.');
-  return store;
+  return getKnowledgeStore(memory);
 }
 
 async function requirePin(

--- a/packages/memory/src/processors/observational-memory/subconscious/remind.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind.ts
@@ -112,8 +112,7 @@ export class SubconsciousRemindExtractor extends Extractor<string> {
           // The knowledgeResourceId override moves only the knowledge scope; the sidekick thread stays owned by the agent resource.
           const resourceId = context.resourceId;
           if (!resourceId) throw new Error('Subconscious remind requires a resourceId.');
-          store = await context.memory.storage.getStore('knowledge');
-          if (!store) throw new Error('Subconscious remind requires a configured knowledge storage domain.');
+          store = await context.memory.getKnowledgeStore();
           const sources = await dropFreshOwnRecords(
             store,
             await findReminderSources(store, scope, context.rawObservations),

--- a/packages/memory/src/processors/observational-memory/subconscious/semantic-index.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/semantic-index.ts
@@ -4,7 +4,7 @@ import type {
   KnowledgeSemanticOutboxEntry,
   KnowledgeStorage,
 } from '@mastra/core/storage';
-import { canonicalizeKnowledgeScope, isKnowledgeScopeVisible } from '@mastra/core/storage';
+import { canonicalizeKnowledgeScope, isKnowledgeScopeVisible, knowledgeVisibleScopeKeys } from '@mastra/core/storage';
 import type { MastraEmbeddingModel, MastraEmbeddingOptions, MastraVector } from '@mastra/core/vector';
 
 const DEFAULT_BATCH_SIZE = 50;
@@ -79,7 +79,7 @@ export class KnowledgeSemanticIndexCoordinator {
       );
     }
 
-    const visibleScopeKeys = scope.map((_, index) => scope.slice(0, index + 1).join('\u001f'));
+    const visibleScopeKeys = knowledgeVisibleScopeKeys(scope);
     const batches = await Promise.all(
       visibleScopeKeys.map(scopeKey =>
         this.#vector.query({

--- a/packages/memory/src/tools/__tests__/__snapshots__/knowledge-write-tools.test.ts.snap
+++ b/packages/memory/src/tools/__tests__/__snapshots__/knowledge-write-tools.test.ts.snap
@@ -48,11 +48,7 @@ exports[`Subconscious knowledge write tools > keeps snapshots of all ten public 
         "type": "string",
       },
       "nodeScope": {
-        "enum": [
-          "org",
-          "resource",
-          "thread",
-        ],
+        "description": "Placement for the node: an identity rung ('org', 'resource', or 'thread'), or a structural scope address from the host-configured placement context (for example 'features:memory').",
         "type": "string",
       },
       "scope": {

--- a/packages/memory/src/tools/__tests__/knowledge-write-tools.test.ts
+++ b/packages/memory/src/tools/__tests__/knowledge-write-tools.test.ts
@@ -1,3 +1,4 @@
+import { Knowledge } from '@mastra/core/knowledge';
 import { InMemoryStore, MAX_KNOWLEDGE_NODE_DESCRIPTION_LENGTH } from '@mastra/core/storage';
 import { GoogleSchemaCompatLayer } from '@mastra/schema-compat';
 import { standardSchemaToJSONSchema } from '@mastra/schema-compat/schema';
@@ -20,6 +21,37 @@ async function fixture() {
     maxScope: 'resource',
   });
   return { store, source, target, tools };
+}
+
+async function structuralFixture() {
+  const knowledge = new Knowledge({
+    id: 'mastra',
+    storage: new InMemoryStore(),
+    structure: {
+      scopes: [
+        { address: 'org:acme', name: 'acme' },
+        { address: 'features', name: 'features', parentAddresses: ['org:acme'] },
+        {
+          address: 'features:memory',
+          name: 'memory',
+          parentAddresses: ['features'],
+          description: 'Memory subsystem knowledge.',
+        },
+        { address: 'org:other', name: 'other' },
+        { address: 'other:things', name: 'things', parentAddresses: ['org:other'] },
+      ],
+    },
+  });
+  const memory = new Memory({ storage: new InMemoryStore(), knowledge });
+  const { scopes: scopeIds } = await knowledge.reconcile();
+  const store = await knowledge.getStorage();
+  const tools = createKnowledgeWriteTools(memory, {
+    scope,
+    sourceThreadId: 'alpha',
+    defaultScope: 'resource',
+    maxScope: 'resource',
+  });
+  return { memory, store, scopeIds, tools };
 }
 
 describe('Subconscious knowledge write tools', () => {
@@ -81,6 +113,49 @@ describe('Subconscious knowledge write tools', () => {
     ).rejects.toThrow('record write failed');
 
     expect(await store.resolveNode({ name: 'Partial Atlas', scope })).toBeTruthy();
+  });
+
+  it('places created nodes into visible structural scopes by address', async () => {
+    const { store, scopeIds, tools } = await structuralFixture();
+
+    const result = (await tools.knowledge_create!.execute?.(
+      {
+        name: 'Memory Extraction',
+        kind: 'subsystem',
+        text: 'The memory subsystem extracts observations mid-conversation.',
+        nodeScope: 'features:memory',
+      },
+      {} as any,
+    )) as any;
+
+    // Identity scope still comes from the default rung; placement is additive membership.
+    expect(result.node.scope).toEqual(['org:acme', 'resource:user-42']);
+    expect(await store.listScopeMembers({ scopeNodeId: scopeIds['features:memory']! })).toEqual([
+      expect.objectContaining({ id: result.node.id }),
+    ]);
+  });
+
+  it('rejects structural placement outside the curator frontier', async () => {
+    const { tools } = await structuralFixture();
+
+    // Unreachable structural scope (different org root) and a totally unknown address
+    // are both refused before any storage write.
+    for (const nodeScope of ['other:things', 'bogus']) {
+      await expect(
+        tools.knowledge_create!.execute?.({ name: `Nope ${nodeScope}`, kind: 'x', text: 'x', nodeScope }, {} as any),
+      ).rejects.toThrow(`Structural scope is outside the curator's visible scope: ${nodeScope}`);
+    }
+  });
+
+  it('rejects structural placement when no Knowledge instance is registered', async () => {
+    const { tools } = await fixture();
+
+    await expect(
+      tools.knowledge_create!.execute?.(
+        { name: 'No instance', kind: 'x', text: 'x', nodeScope: 'features:memory' },
+        {} as any,
+      ),
+    ).rejects.toThrow("Structural scope is outside the curator's visible scope: features:memory");
   });
 
   it('rejects a non-RFC 3339 `when` at schema validation for create and append, before execute', async () => {

--- a/stores/_test-utils/src/domains/knowledge/index.ts
+++ b/stores/_test-utils/src/domains/knowledge/index.ts
@@ -112,7 +112,7 @@ export function createKnowledgeStorageTests(createStore: () => Promise<Knowledge
 
     it('applies record visibility independently from node scope', async () => {
       const node = await store.createNode({ name: 'Resource node', kind: 'task', scope: resource });
-      await store.appendKnowledge({
+      const record = await store.appendKnowledge({
         node,
         text: 'organization-visible knowledge',
         scope: ['org:acme'],
@@ -123,8 +123,45 @@ export function createKnowledgeStorageTests(createStore: () => Promise<Knowledge
 
       expect((await store.listKnowledgeAbout({ node, scope: ['org:acme'] })).records).toHaveLength(1);
       expect(await store.search({ query: 'organization-visible', scope: ['org:acme'] })).toEqual([
-        expect.objectContaining({ type: 'record', recordId: node.id, scope: ['org:acme'] }),
+        expect.objectContaining({
+          type: 'record',
+          recordId: record.id,
+          name: '(private node)',
+          scope: ['org:acme'],
+        }),
       ]);
+    });
+
+    it('queries arbitrary companion scope memberships as visible scope subsets', async () => {
+      const resourceCompanion = 'resource:r1:uncurated';
+      const threadCompanion = 'thread:t1:uncurated';
+      const queryScope = [...thread, resourceCompanion, threadCompanion];
+      const target = await store.createNode({ name: 'Companion Target', kind: 'person', scope: resource });
+      const node = await store.createNode({
+        name: 'Companion Draft',
+        kind: 'note',
+        scope: [resourceCompanion, threadCompanion],
+      });
+      const record = await store.appendKnowledge({
+        node,
+        text: 'Draft mentions [[Companion Target]].',
+        scope: [threadCompanion],
+        sourceThreadId: 't1',
+        resolutionScope: queryScope,
+        defaultScope: node.scope,
+      });
+
+      expect((await store.listNodes({ scope: queryScope })).map(result => result.id)).toContain(node.id);
+      await expect(store.resolveNode({ name: node.name, scope: queryScope })).resolves.toMatchObject({ id: node.id });
+      expect(await store.search({ query: 'Draft mentions', scope: queryScope })).toEqual([
+        expect.objectContaining({ id: record.id, recordId: node.id }),
+      ]);
+      expect((await store.listKnowledgeAbout({ node, scope: queryScope })).records.map(result => result.id)).toEqual([
+        record.id,
+      ]);
+      expect(
+        (await store.listKnowledgeRelatedTo({ node: target, scope: queryScope })).records.map(result => result.id),
+      ).toEqual([record.id]);
     });
 
     it('persists optional KnowledgeRecord metadata and returns it on reads', async () => {

--- a/stores/_test-utils/src/domains/knowledge/index.ts
+++ b/stores/_test-utils/src/domains/knowledge/index.ts
@@ -1,4 +1,4 @@
-import type { KnowledgeStorage } from '@mastra/core/storage';
+import type { KnowledgeStorage, KnowledgeStructurePlan } from '@mastra/core/storage';
 import {
   KnowledgeConflictError,
   KnowledgeSchemaResetRequiredError,
@@ -37,6 +37,17 @@ export function createKnowledgeSchemaResetTests(createFixture: () => Promise<Kno
 const resource = ['org:acme', 'resource:mastra'];
 const thread = [...resource, 'thread:t1'];
 
+const STRUCTURE_PLAN: KnowledgeStructurePlan = {
+  scopes: [
+    { address: 'org:acme', name: 'acme' },
+    { address: 'features', name: 'features', parentAddresses: ['org:acme'] },
+  ],
+};
+
+function isUnsupportedStructure(error: unknown): boolean {
+  return error instanceof Error && error.name === 'KnowledgeUnsupportedCapabilityError';
+}
+
 export function createKnowledgeStorageTests(createStore: () => Promise<KnowledgeStorage> | KnowledgeStorage): void {
   describe('knowledge storage contract', () => {
     let store: KnowledgeStorage;
@@ -64,6 +75,43 @@ export function createKnowledgeStorageTests(createStore: () => Promise<Knowledge
       expect(await store.listNodes({ scope: thread, hasContent: true })).toEqual([
         expect.objectContaining({ id: node.id }),
       ]);
+    });
+
+    it('places created nodes into structural scopes by address', async () => {
+      let scopeIds: Record<string, string>;
+      try {
+        const result = await store.reconcileStructure(STRUCTURE_PLAN);
+        scopeIds = result.scopes;
+      } catch (error) {
+        if (isUnsupportedStructure(error)) {
+          // Adapters without structural scope support must still reject placement
+          // outright — never silently create an unplaced node.
+          await expect(
+            store.createNode({ name: 'Placed', kind: 'doc', scope: resource, scopeAddresses: ['features'] }),
+          ).rejects.toThrow(/does not expose structural scope/);
+          return;
+        }
+        throw error;
+      }
+
+      const node = await store.createNode({
+        name: 'Placed',
+        kind: 'doc',
+        scope: resource,
+        scopeAddresses: ['features'],
+      });
+      // Placement is additive membership: the identity scope is unchanged.
+      expect(node.scope).toEqual(resource);
+      expect(node.isScope).toBeUndefined();
+      expect(await store.listScopeMembers({ scopeNodeId: scopeIds['features']! })).toEqual([
+        expect.objectContaining({ id: node.id }),
+      ]);
+
+      // Unknown or deleted addresses fail the whole create without mutation.
+      await expect(
+        store.createNode({ name: 'Lost', kind: 'doc', scope: resource, scopeAddresses: ['missing'] }),
+      ).rejects.toThrow(/scope/i);
+      expect(await store.getNodeByName({ name: 'Lost', scope: resource })).toBeNull();
     });
 
     it('treats scope identifiers literally when checking visibility', async () => {

--- a/stores/libsql/src/storage/domains/knowledge/index.test.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.test.ts
@@ -322,7 +322,7 @@ describe('KnowledgeLibSQL initialization', () => {
           {
             address: 'resource:mastra',
             name: 'Mastra',
-            parentAddresses: ['org:acme', 'org:partner'],
+            parentAddresses: ['org:acme'],
             grants: [{ scopeRefAddress: 'org:acme', role: 'readonly' as const }],
           },
         ],
@@ -340,8 +340,23 @@ describe('KnowledgeLibSQL initialization', () => {
         (await client.execute(`SELECT name FROM mastra_knowledge_nodes WHERE id='${first.scopes['org:acme']}'`))
           .rows[0],
       ).toMatchObject({ name: 'Acme' });
-      expect((await client.execute(`SELECT * FROM mastra_knowledge_node_scopes`)).rows).toHaveLength(2);
+      expect((await client.execute(`SELECT * FROM mastra_knowledge_node_scopes`)).rows).toHaveLength(1);
       expect((await client.execute(`SELECT * FROM mastra_knowledge_scope_grants`)).rows).toHaveLength(2);
+
+      const enriched = await store.reconcileStructure({
+        scopes: plan.scopes.map(scope =>
+          scope.address === 'resource:mastra'
+            ? {
+                ...scope,
+                parentAddresses: ['org:acme', 'org:partner'],
+                grants: [...(scope.grants ?? []), { scopeRefAddress: 'org:partner', role: 'readonly' as const }],
+              }
+            : scope,
+        ),
+      });
+      expect(enriched).toMatchObject({ changed: true, createdScopeIds: [], accessEpoch: 2 });
+      expect((await client.execute(`SELECT * FROM mastra_knowledge_node_scopes`)).rows).toHaveLength(2);
+      expect((await client.execute(`SELECT * FROM mastra_knowledge_scope_grants`)).rows).toHaveLength(3);
 
       await client.execute({
         sql: `UPDATE mastra_knowledge_nodes SET deletedAt=? WHERE id=?`,
@@ -370,7 +385,7 @@ describe('KnowledgeLibSQL initialization', () => {
       expect(
         (await client.execute(`SELECT epoch FROM mastra_knowledge_access_state WHERE id='global'`)).rows[0],
       ).toMatchObject({
-        epoch: 1,
+        epoch: 2,
       });
     } finally {
       client.close();

--- a/stores/libsql/src/storage/domains/knowledge/index.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.ts
@@ -117,7 +117,8 @@ function withReconcileLock<T>(key: unknown, operation: () => Promise<T>): Promis
   return result;
 }
 
-const visibleSql = `(scopeKey = ? OR substr(?, 1, length(scopeKey) + 1) = scopeKey || char(31))`;
+const visibleSql = (scopeColumn = 'scope') =>
+  `NOT EXISTS (SELECT 1 FROM json_each(${scopeColumn}) stored WHERE NOT EXISTS (SELECT 1 FROM json_each(?) available WHERE available.value = stored.value)) AND ? IS NOT NULL`;
 
 function parseJson<T>(value: unknown): T {
   if (typeof value === 'string') return JSON.parse(value) as T;
@@ -455,8 +456,8 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
         await tx.execute(`UPDATE "${TABLE_KNOWLEDGE_ACCESS_STATE}" SET epoch=epoch WHERE id='global'`);
         const scopes: Record<string, string> = {};
         const createdScopeIds: string[] = [];
-        const createdAddresses = new Set<string>();
         const deletedScopeAddresses = new Set<string>();
+        let structureChanged = false;
         const resolveAddress = async (address: string): Promise<string | undefined> => {
           if (scopes[address]) return scopes[address];
           const result = await tx.execute({
@@ -494,16 +495,24 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
             args: [scope.address, id],
           });
           scopes[scope.address] = id;
-          createdAddresses.add(scope.address);
           createdScopeIds.push(id);
+          structureChanged = true;
         }
 
         for (const scope of plan.scopes) {
-          if (!createdAddresses.has(scope.address)) continue;
+          if (deletedScopeAddresses.has(scope.address)) continue;
           const scopeNodeId = scopes[scope.address]!;
           for (const parentAddress of scope.parentAddresses ?? []) {
             const parentId = await resolveAddress(parentAddress);
             if (!parentId || deletedScopeAddresses.has(parentAddress)) {
+              const deletedParentId = scopes[parentAddress];
+              const existing = deletedParentId
+                ? await tx.execute({
+                    sql: `SELECT 1 FROM "${TABLE_KNOWLEDGE_NODE_SCOPES}" WHERE nodeId=? AND scopeNodeId=?`,
+                    args: [scopeNodeId, deletedParentId],
+                  })
+                : undefined;
+              if (existing?.rows.length) continue;
               throw new Error(`Knowledge parent scope does not exist: ${parentAddress}`);
             }
             const sibling = await tx.execute({
@@ -513,24 +522,34 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
             if (sibling.rows.length) {
               throw new Error(`Knowledge scope name ${scope.name} already exists under ${parentAddress}`);
             }
-            await tx.execute({
+            const inserted = await tx.execute({
               sql: `INSERT OR IGNORE INTO "${TABLE_KNOWLEDGE_NODE_SCOPES}" (nodeId,scopeNodeId,addedAt) VALUES (?,?,?)`,
               args: [scopeNodeId, parentId, new Date().toISOString()],
             });
+            structureChanged ||= inserted.rowsAffected > 0;
           }
           for (const grant of scope.grants ?? []) {
             const scopeRefId = await resolveAddress(grant.scopeRefAddress);
             if (!scopeRefId || deletedScopeAddresses.has(grant.scopeRefAddress)) {
+              const deletedScopeRefId = scopes[grant.scopeRefAddress];
+              const existing = deletedScopeRefId
+                ? await tx.execute({
+                    sql: `SELECT 1 FROM "${TABLE_KNOWLEDGE_SCOPE_GRANTS}" WHERE scopeNodeId=? AND scopeRefId=?`,
+                    args: [scopeNodeId, deletedScopeRefId],
+                  })
+                : undefined;
+              if (existing?.rows.length) continue;
               throw new Error(`Knowledge grant scope does not exist: ${grant.scopeRefAddress}`);
             }
-            await tx.execute({
+            const inserted = await tx.execute({
               sql: `INSERT OR IGNORE INTO "${TABLE_KNOWLEDGE_SCOPE_GRANTS}" (scopeNodeId,scopeRefId,role,canSuggest) VALUES (?,?,?,?)`,
               args: [scopeNodeId, scopeRefId, grant.role, grant.canSuggest ?? null],
             });
+            structureChanged ||= inserted.rowsAffected > 0;
           }
         }
 
-        if (createdScopeIds.length) {
+        if (structureChanged) {
           await tx.execute(`UPDATE "${TABLE_KNOWLEDGE_ACCESS_STATE}" SET epoch=epoch+1 WHERE id='global'`);
         }
         const state = await tx.execute(`SELECT epoch FROM "${TABLE_KNOWLEDGE_ACCESS_STATE}" WHERE id='global'`);
@@ -538,7 +557,7 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
           scopes,
           createdScopeIds,
           deletedScopeAddresses: [...deletedScopeAddresses],
-          changed: createdScopeIds.length > 0,
+          changed: structureChanged,
           accessEpoch: Number(state.rows[0]?.epoch ?? 0),
         };
       }),
@@ -645,8 +664,8 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
 
   async listNodes(input: ListKnowledgeNodesInput): Promise<KnowledgeNode[]> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
-    const clauses = [`type = 'node'`, 'mergedInto IS NULL', visibleSql];
+    const key = JSON.stringify(scope);
+    const clauses = [`type = 'node'`, 'mergedInto IS NULL', visibleSql()];
     const args: InValue[] = [key, key];
     if (input.namePrefix) {
       clauses.push("canonicalName LIKE ? ESCAPE '='");
@@ -889,13 +908,13 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
 
   async knowledgeBySource(input: QueryKnowledgeBySourceInput): Promise<QueryKnowledgeOutput> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
+    const key = JSON.stringify(scope);
     const args: InValue[] = [input.sourceThreadId, key, key];
     if (input.after) args.push(input.after);
     const limit = input.limit ?? 100;
     args.push(limit + 1);
     const result = await this.#client.execute({
-      sql: `SELECT *,json(scope) AS scopeJson,json(metadata) AS metadataJson FROM "${TABLE_KNOWLEDGE_RECORDS}" WHERE sourceThreadId=? AND ${visibleSql}${input.includeDeleted ? '' : ' AND deletedAt IS NULL'}${input.after ? ' AND id > ?' : ''} ORDER BY id ASC LIMIT ?`,
+      sql: `SELECT *,json(scope) AS scopeJson,json(metadata) AS metadataJson FROM "${TABLE_KNOWLEDGE_RECORDS}" WHERE sourceThreadId=? AND ${visibleSql()}${input.includeDeleted ? '' : ' AND deletedAt IS NULL'}${input.after ? ' AND id > ?' : ''} ORDER BY id ASC LIMIT ?`,
       args,
     });
     const records = result.rows.map(parseKnowledge);
@@ -972,12 +991,12 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
 
   async search(input: SearchKnowledgeInput): Promise<SearchKnowledgeResult[]> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
+    const key = JSON.stringify(scope);
     const normalizedQuery = input.query.trim().toLocaleLowerCase();
     if (!normalizedQuery) return [];
     const query = `%${escapeLikePattern(normalizedQuery)}%`;
     const records = await this.#client.execute({
-      sql: `SELECT *,json(scope) AS scopeJson FROM "${TABLE_KNOWLEDGE_NODES}" WHERE mergedInto IS NULL AND ${visibleSql} AND (canonicalName LIKE ? ESCAPE '=' OR lower(COALESCE(kind,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(content,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(description,'')) LIKE ? ESCAPE '=') ORDER BY updatedAt DESC LIMIT ?`,
+      sql: `SELECT *,json(scope) AS scopeJson FROM "${TABLE_KNOWLEDGE_NODES}" WHERE mergedInto IS NULL AND ${visibleSql()} AND (canonicalName LIKE ? ESCAPE '=' OR lower(COALESCE(kind,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(content,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(description,'')) LIKE ? ESCAPE '=') ORDER BY updatedAt DESC LIMIT ?`,
 
       args: [key, key, query, query, query, query, input.limit ?? 20],
     });
@@ -996,18 +1015,21 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
     }));
     if (results.length < (input.limit ?? 20)) {
       const knowledge = await this.#client.execute({
-        sql: `SELECT k.*,json(k.scope) AS scopeJson,json(k.metadata) AS metadataJson,n.name FROM "${TABLE_KNOWLEDGE_RECORDS}" k JOIN "${TABLE_KNOWLEDGE_NODES}" n ON n.id=k.node AND n.type='node' AND n.mergedInto IS NULL WHERE k.deletedAt IS NULL AND ${visibleSql.replaceAll('scopeKey', 'k.scopeKey')} AND lower(k.text) LIKE ? ESCAPE '=' ORDER BY k.id DESC LIMIT ?`,
+        sql: `SELECT k.*,json(k.scope) AS scopeJson,json(k.metadata) AS metadataJson,n.name,json(n.scope) AS parentScopeJson FROM "${TABLE_KNOWLEDGE_RECORDS}" k JOIN "${TABLE_KNOWLEDGE_NODES}" n ON n.id=k.node AND n.type='node' AND n.mergedInto IS NULL WHERE k.deletedAt IS NULL AND ${visibleSql('k.scope')} AND lower(k.text) LIKE ? ESCAPE '=' ORDER BY k.id DESC LIMIT ?`,
         args: [key, key, query, (input.limit ?? 20) - results.length],
       });
       results.push(
-        ...knowledge.rows.map(row => ({
-          type: 'record' as const,
-          id: String(row.id),
-          recordId: String(row.node),
-          name: String(row.name),
-          text: String(row.text),
-          scope: parseJson<KnowledgeScope>(row.scopeJson),
-        })),
+        ...knowledge.rows.map(row => {
+          const parentVisible = isKnowledgeScopeVisible(parseJson<KnowledgeScope>(row.parentScopeJson), scope);
+          return {
+            type: 'record' as const,
+            id: String(row.id),
+            recordId: parentVisible ? String(row.node) : String(row.id),
+            name: parentVisible ? String(row.name) : '(private node)',
+            text: String(row.text),
+            scope: parseJson<KnowledgeScope>(row.scopeJson),
+          };
+        }),
       );
     }
     return results;
@@ -1055,9 +1077,9 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
     limit?: number;
   }): Promise<KnowledgeActivityEvent[]> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
+    const key = JSON.stringify(scope);
     const result = await this.#client.execute({
-      sql: `SELECT *,json(scope) AS scopeJson FROM "${TABLE_KNOWLEDGE_ACTIVITY}" WHERE ${visibleSql}${input.after ? ' AND id < ?' : ''} ORDER BY id DESC LIMIT ?`,
+      sql: `SELECT *,json(scope) AS scopeJson FROM "${TABLE_KNOWLEDGE_ACTIVITY}" WHERE ${visibleSql()}${input.after ? ' AND id < ?' : ''} ORDER BY id DESC LIMIT ?`,
       args: [key, key, ...(input.after ? [input.after] : []), input.limit ?? 100],
     });
     return result.rows.map(row => ({
@@ -1081,8 +1103,8 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
       args.push(input.status);
     }
     if (input.scope) {
-      const key = knowledgeScopeKey(canonicalizeKnowledgeScope(input.scope));
-      clauses.push(visibleSql);
+      const key = JSON.stringify(canonicalizeKnowledgeScope(input.scope));
+      clauses.push(visibleSql());
       args.push(key, key);
     }
     args.push(input.limit ?? 100);
@@ -1104,8 +1126,8 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
       ];
       const args: InValue[] = [now.toISOString(), stale.toISOString()];
       if (input.scope) {
-        const key = knowledgeScopeKey(canonicalizeKnowledgeScope(input.scope));
-        clauses.push(visibleSql);
+        const key = JSON.stringify(canonicalizeKnowledgeScope(input.scope));
+        clauses.push(visibleSql());
         args.push(key, key);
       }
       args.push(input.limit ?? 100);
@@ -1182,12 +1204,14 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
     return result.rows[0] ? parseNode(result.rows[0]) : null;
   }
   async #resolveNode(executor: Executor, name: string, scope: KnowledgeScope): Promise<KnowledgeNode | null> {
-    for (let length = scope.length; length > 0; length--) {
-      const node = await this.#getNodeByName(executor, name, scope.slice(0, length));
-      if (node) {
-        const terminal = await this.#resolveTerminalNode(executor, node.id);
-        if (terminal && isKnowledgeScopeVisible(terminal.scope, scope)) return terminal;
-      }
+    const result = await executor.execute({
+      sql: `SELECT *,json(scope) AS scopeJson FROM "${TABLE_KNOWLEDGE_NODES}" WHERE type='node' AND canonicalName=?`,
+      args: [canonicalName(name)],
+    });
+    const candidates = result.rows.map(parseNode).sort((left, right) => right.scope.length - left.scope.length);
+    for (const candidate of candidates) {
+      const terminal = await this.#resolveTerminalNode(executor, candidate.id);
+      if (terminal && isKnowledgeScopeVisible(terminal.scope, scope)) return terminal;
     }
     return null;
   }
@@ -1216,7 +1240,7 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
     const scope = canonicalizeKnowledgeScope(input.scope);
     const node = await this.#resolveTerminalNode(this.#client, nodeReferenceId(input.node));
     if (!node) return { records: [] };
-    const key = knowledgeScopeKey(scope);
+    const key = JSON.stringify(scope);
     const includesMentions = relationship !== 'about';
     const relationSql =
       relationship === 'about'
@@ -1228,7 +1252,7 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
     if (input.after) args.push(input.after);
     args.push((input.limit ?? 100) + 1);
     const result = await this.#client.execute({
-      sql: `SELECT DISTINCT k.*,json(k.scope) AS scopeJson,json(k.metadata) AS metadataJson FROM "${TABLE_KNOWLEDGE_RECORDS}" k${includesMentions ? ` LEFT JOIN "${TABLE_KNOWLEDGE_MENTIONS}" m ON m.sourceType='record' AND m.sourceId=k.id` : ''} WHERE ${relationSql} AND ${visibleSql.replaceAll('scopeKey', 'k.scopeKey')}${input.includeDeleted ? '' : ' AND k.deletedAt IS NULL'}${input.after ? ' AND k.id < ?' : ''} ORDER BY k.id DESC LIMIT ?`,
+      sql: `SELECT DISTINCT k.*,json(k.scope) AS scopeJson,json(k.metadata) AS metadataJson FROM "${TABLE_KNOWLEDGE_RECORDS}" k${includesMentions ? ` LEFT JOIN "${TABLE_KNOWLEDGE_MENTIONS}" m ON m.sourceType='record' AND m.sourceId=k.id` : ''} WHERE ${relationSql} AND ${visibleSql('k.scope')}${input.includeDeleted ? '' : ' AND k.deletedAt IS NULL'}${input.after ? ' AND k.id < ?' : ''} ORDER BY k.id DESC LIMIT ?`,
       args,
     });
     const limit = input.limit ?? 100;

--- a/stores/libsql/src/storage/domains/knowledge/index.ts
+++ b/stores/libsql/src/storage/domains/knowledge/index.ts
@@ -155,6 +155,7 @@ function parseNode(row: Record<string, unknown>): KnowledgeNode {
     kind: row.kind == null ? '' : String(row.kind),
     content: row.content == null ? undefined : String(row.content),
     description: row.description == null ? undefined : String(row.description),
+    isScope: row.isScope === true || row.isScope === 1 ? true : undefined,
     scope: parseJson(row.scopeJson ?? row.scope),
     version: Number(row.version),
     mergedInto: row.mergedInto == null ? undefined : String(row.mergedInto),
@@ -643,6 +644,7 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
         ],
       });
       await this.#replaceNodeScopes(tx, node.id, scope, now);
+      await this.#placeNodeInScopes(tx, node.id, input.scopeAddresses, now);
       await this.#replaceMentions(tx, 'node', node.id, node.content ?? '', input.resolutionScope ?? scope, scope);
       await this.#activity(tx, 'node-created', 'node', node.id, scope);
       await this.#outbox(tx, 'node', node.id, 'upsert', node.version, scope);
@@ -1286,6 +1288,32 @@ export class KnowledgeLibSQL extends KnowledgeStorage {
       await executor.execute({
         sql: `INSERT OR IGNORE INTO "${TABLE_KNOWLEDGE_NODE_SCOPES}" (nodeId,scopeNodeId,addedAt) VALUES (?,?,?)`,
         args: [nodeId, scopeNodeId, addedAt.toISOString()],
+      });
+    }
+  }
+
+  /**
+   * Additive structural placement: every address must resolve to a live scope node
+   * (unlike identity membership, an unknown address is a caller error, not a lazy
+   * materialization miss). Runs inside the caller's transaction, so a throw aborts
+   * the whole mutation.
+   */
+  async #placeNodeInScopes(
+    executor: Executor,
+    nodeId: string,
+    addresses: string[] | undefined,
+    addedAt: Date,
+  ): Promise<void> {
+    for (const address of addresses ?? []) {
+      const result = await executor.execute({
+        sql: `SELECT sa.scopeNodeId AS scopeNodeId FROM "${TABLE_KNOWLEDGE_SCOPE_ADDRESSES}" sa JOIN "${TABLE_KNOWLEDGE_NODES}" n ON n.id=sa.scopeNodeId WHERE sa.address=? AND n.isScope AND n.deletedAt IS NULL`,
+        args: [address],
+      });
+      const scopeNodeId = result.rows[0]?.scopeNodeId;
+      if (scopeNodeId == null) throw new KnowledgeNotFoundError('scope', address);
+      await executor.execute({
+        sql: `INSERT OR IGNORE INTO "${TABLE_KNOWLEDGE_NODE_SCOPES}" (nodeId,scopeNodeId,addedAt) VALUES (?,?,?)`,
+        args: [nodeId, String(scopeNodeId), addedAt.toISOString()],
       });
     }
   }

--- a/stores/mongodb/src/storage/domains/knowledge/index.ts
+++ b/stores/mongodb/src/storage/domains/knowledge/index.ts
@@ -5,6 +5,7 @@ import {
   createKnowledgeUlid,
   isKnowledgeScopeVisible,
   knowledgeScopeKey,
+  knowledgeVisibleScopeKeys,
   knowledgeSemanticDocumentId,
   knowledgeSemanticIdempotencyKey,
   KnowledgeConflictError,
@@ -73,10 +74,7 @@ const canonicalName = (name: string) => name.trim().toLocaleLowerCase();
 const nodeReferenceId = (node: KnowledgeNode | string) => (typeof node === 'string' ? node : node.id);
 const sessionOptions = (session?: ClientSession) => (session ? { session } : {});
 
-function visibleScopeKeys(scope: KnowledgeScope): string[] {
-  const canonical = canonicalizeKnowledgeScope(scope);
-  return canonical.map((_, index) => knowledgeScopeKey(canonical.slice(0, index + 1)));
-}
+const visibleScopeKeys = knowledgeVisibleScopeKeys;
 
 function recordCursorFilter(cursor: string, expected: { namePrefix?: string; kind?: string; hasContent?: boolean }) {
   const parsed = parseKnowledgeNodeCursor(cursor, expected);
@@ -590,7 +588,7 @@ export class KnowledgeMongoDB extends KnowledgeStorage {
         results.push({
           type: 'record',
           id: record.id,
-          recordId: record.node,
+          recordId: parentVisible ? record.node : record.id,
           name: parentVisible ? parent.name : '(private node)',
           text: record.text,
           scope: cloneScope(record.scope),
@@ -783,12 +781,15 @@ export class KnowledgeMongoDB extends KnowledgeStorage {
     return row ? nodeFromDocument(row) : null;
   }
   async #resolveNode(name: string, scope: KnowledgeScope, session?: ClientSession): Promise<KnowledgeNode | null> {
-    for (let length = scope.length; length > 0; length--) {
-      const node = await this.#getNodeByName(name, scope.slice(0, length), session);
-      if (node) {
-        const terminal = await this.#resolveTerminalNode(node.id, session);
-        if (terminal && isKnowledgeScopeVisible(terminal.scope, scope)) return terminal;
-      }
+    const rows = await (
+      await this.#nodes()
+    )
+      .find({ type: 'node', canonicalName: canonicalName(name) }, sessionOptions(session))
+      .toArray();
+    const candidates = rows.map(nodeFromDocument).sort((left, right) => right.scope.length - left.scope.length);
+    for (const candidate of candidates) {
+      const terminal = await this.#resolveTerminalNode(candidate.id, session);
+      if (terminal && isKnowledgeScopeVisible(terminal.scope, scope)) return terminal;
     }
     return null;
   }

--- a/stores/mongodb/src/storage/domains/knowledge/index.ts
+++ b/stores/mongodb/src/storage/domains/knowledge/index.ts
@@ -5,7 +5,6 @@ import {
   createKnowledgeUlid,
   isKnowledgeScopeVisible,
   knowledgeScopeKey,
-  knowledgeVisibleScopeKeys,
   knowledgeSemanticDocumentId,
   knowledgeSemanticIdempotencyKey,
   KnowledgeConflictError,
@@ -74,7 +73,20 @@ const canonicalName = (name: string) => name.trim().toLocaleLowerCase();
 const nodeReferenceId = (node: KnowledgeNode | string) => (typeof node === 'string' ? node : node.id);
 const sessionOptions = (session?: ClientSession) => (session ? { session } : {});
 
-const visibleScopeKeys = knowledgeVisibleScopeKeys;
+function visibleScopeKeys(scope: KnowledgeScope): string[] {
+  const canonical = canonicalizeKnowledgeScope(scope);
+  const subsets: KnowledgeScope[] = [[]];
+  for (const entry of canonical) subsets.push(...subsets.map(subset => [...subset, entry]));
+  const keys = new Set<string>();
+  for (const subset of subsets.slice(1)) {
+    try {
+      keys.add(knowledgeScopeKey(subset));
+    } catch {
+      // Invalid hierarchy fragments cannot be persisted scope keys.
+    }
+  }
+  return [...keys];
+}
 
 function recordCursorFilter(cursor: string, expected: { namePrefix?: string; kind?: string; hasContent?: boolean }) {
   const parsed = parseKnowledgeNodeCursor(cursor, expected);

--- a/stores/mongodb/src/storage/domains/knowledge/index.ts
+++ b/stores/mongodb/src/storage/domains/knowledge/index.ts
@@ -199,6 +199,12 @@ export class KnowledgeMongoDB extends KnowledgeStorage {
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {
     await assertKnowledgeDescriptionWithinBoundCompat(input.description);
+    if (input.scopeAddresses?.length) {
+      // Peer-floor safe: mirrors KnowledgeUnsupportedCapabilityError without importing it.
+      const error = new Error('This Knowledge storage adapter does not expose structural scope placement.');
+      error.name = 'KnowledgeUnsupportedCapabilityError';
+      throw error;
+    }
     const scope = canonicalizeKnowledgeScope(input.scope);
     return this.#connector.withTransaction(async session => {
       const existing = await this.#getNodeByName(input.name, scope, session);

--- a/stores/mysql/src/storage/domains/knowledge/index.ts
+++ b/stores/mysql/src/storage/domains/knowledge/index.ts
@@ -103,7 +103,7 @@ function createExecutor(client: Pick<Pool, 'query'> | Pick<PoolConnection, 'quer
   };
 }
 
-const visibleSql = `(scopeKey = ? OR LEFT(?, CHAR_LENGTH(scopeKey) + 1) = CONCAT(scopeKey, char(31)))`;
+const visibleSql = (scopeColumn = 'scope') => `(JSON_CONTAINS(?, ${scopeColumn}) AND ? IS NOT NULL)`;
 
 function parseJson<T>(value: unknown): T {
   if (typeof value === 'string') return JSON.parse(value) as T;
@@ -339,8 +339,8 @@ export class KnowledgeMySQL extends KnowledgeStorage {
 
   async listNodes(input: ListKnowledgeNodesInput): Promise<KnowledgeNode[]> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
-    const clauses = [`type = 'node'`, 'mergedInto IS NULL', visibleSql];
+    const key = JSON.stringify(scope);
+    const clauses = [`type = 'node'`, 'mergedInto IS NULL', visibleSql()];
     const args: unknown[] = [key, key];
     if (input.namePrefix) {
       clauses.push("canonicalName LIKE ? ESCAPE '='");
@@ -574,13 +574,13 @@ export class KnowledgeMySQL extends KnowledgeStorage {
 
   async knowledgeBySource(input: QueryKnowledgeBySourceInput): Promise<QueryKnowledgeOutput> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
+    const key = JSON.stringify(scope);
     const args: unknown[] = [input.sourceThreadId, key, key];
     if (input.after) args.push(input.after);
     const limit = input.limit ?? 100;
     args.push(limit + 1);
     const result = await this.#client.execute({
-      sql: `SELECT *,scope AS scopeJson FROM "${TABLE_KNOWLEDGE_RECORDS}" WHERE sourceThreadId=? AND ${visibleSql}${input.includeDeleted ? '' : ' AND deletedAt IS NULL'}${input.after ? ' AND id > ?' : ''} ORDER BY id ASC LIMIT ?`,
+      sql: `SELECT *,scope AS scopeJson FROM "${TABLE_KNOWLEDGE_RECORDS}" WHERE sourceThreadId=? AND ${visibleSql()}${input.includeDeleted ? '' : ' AND deletedAt IS NULL'}${input.after ? ' AND id > ?' : ''} ORDER BY id ASC LIMIT ?`,
       args,
     });
     const records = result.rows.map(parseKnowledge);
@@ -655,12 +655,12 @@ export class KnowledgeMySQL extends KnowledgeStorage {
 
   async search(input: SearchKnowledgeInput): Promise<SearchKnowledgeResult[]> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
+    const key = JSON.stringify(scope);
     const normalizedQuery = input.query.trim().toLocaleLowerCase();
     if (!normalizedQuery) return [];
     const query = `%${escapeLikePattern(normalizedQuery)}%`;
     const records = await this.#client.execute({
-      sql: `SELECT *,scope AS scopeJson FROM "${TABLE_KNOWLEDGE_NODES}" WHERE mergedInto IS NULL AND ${visibleSql} AND (canonicalName LIKE ? ESCAPE '=' OR lower(COALESCE(kind,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(content,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(description,'')) LIKE ? ESCAPE '=') ORDER BY updatedAt DESC LIMIT ?`,
+      sql: `SELECT *,scope AS scopeJson FROM "${TABLE_KNOWLEDGE_NODES}" WHERE mergedInto IS NULL AND ${visibleSql()} AND (canonicalName LIKE ? ESCAPE '=' OR lower(COALESCE(kind,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(content,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(description,'')) LIKE ? ESCAPE '=') ORDER BY updatedAt DESC LIMIT ?`,
       args: [key, key, query, query, query, query, input.limit ?? 20],
     });
     const results: SearchKnowledgeResult[] = records.rows.map(row => ({
@@ -678,7 +678,7 @@ export class KnowledgeMySQL extends KnowledgeStorage {
     }));
     if (results.length < (input.limit ?? 20)) {
       const records = await this.#client.execute({
-        sql: `SELECT f.*,f.scope AS scopeJson,r.name,r.scope AS parentScopeJson FROM "${TABLE_KNOWLEDGE_RECORDS}" f JOIN "${TABLE_KNOWLEDGE_NODES}" r ON r.id=f.node AND r.type='node' AND r.mergedInto IS NULL WHERE f.deletedAt IS NULL AND ${visibleSql.replaceAll('scopeKey', 'f.scopeKey')} AND lower(f.text) LIKE ? ESCAPE '=' ORDER BY f.id DESC LIMIT ?`,
+        sql: `SELECT f.*,f.scope AS scopeJson,r.name,r.scope AS parentScopeJson FROM "${TABLE_KNOWLEDGE_RECORDS}" f JOIN "${TABLE_KNOWLEDGE_NODES}" r ON r.id=f.node AND r.type='node' AND r.mergedInto IS NULL WHERE f.deletedAt IS NULL AND ${visibleSql('f.scope')} AND lower(f.text) LIKE ? ESCAPE '=' ORDER BY f.id DESC LIMIT ?`,
         args: [key, key, query, (input.limit ?? 20) - results.length],
       });
       results.push(
@@ -687,7 +687,7 @@ export class KnowledgeMySQL extends KnowledgeStorage {
           return {
             type: 'record' as const,
             id: String(row.id),
-            recordId: String(row.node),
+            recordId: parentVisible ? String(row.node) : String(row.id),
             name: parentVisible ? String(row.name) : '(private node)',
             text: String(row.text),
             scope: parseJson<KnowledgeScope>(row.scopeJson),
@@ -734,9 +734,9 @@ export class KnowledgeMySQL extends KnowledgeStorage {
     limit?: number;
   }): Promise<KnowledgeActivityEvent[]> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
+    const key = JSON.stringify(scope);
     const result = await this.#client.execute({
-      sql: `SELECT *,scope AS scopeJson FROM "${TABLE_KNOWLEDGE_ACTIVITY}" WHERE ${visibleSql}${input.after ? ' AND id < ?' : ''} ORDER BY id DESC LIMIT ?`,
+      sql: `SELECT *,scope AS scopeJson FROM "${TABLE_KNOWLEDGE_ACTIVITY}" WHERE ${visibleSql()}${input.after ? ' AND id < ?' : ''} ORDER BY id DESC LIMIT ?`,
       args: [key, key, ...(input.after ? [input.after] : []), input.limit ?? 100],
     });
     return result.rows.map(row => ({
@@ -760,8 +760,8 @@ export class KnowledgeMySQL extends KnowledgeStorage {
       args.push(input.status);
     }
     if (input.scope) {
-      const key = knowledgeScopeKey(canonicalizeKnowledgeScope(input.scope));
-      clauses.push(visibleSql);
+      const key = JSON.stringify(canonicalizeKnowledgeScope(input.scope));
+      clauses.push(visibleSql());
       args.push(key, key);
     }
     args.push(input.limit ?? 100);
@@ -783,8 +783,8 @@ export class KnowledgeMySQL extends KnowledgeStorage {
       ];
       const args: unknown[] = [now.toISOString(), stale.toISOString()];
       if (input.scope) {
-        const key = knowledgeScopeKey(canonicalizeKnowledgeScope(input.scope));
-        clauses.push(visibleSql);
+        const key = JSON.stringify(canonicalizeKnowledgeScope(input.scope));
+        clauses.push(visibleSql());
         args.push(key, key);
       }
       args.push(input.limit ?? 100);
@@ -858,12 +858,14 @@ export class KnowledgeMySQL extends KnowledgeStorage {
     return result.rows[0] ? parseNode(result.rows[0]) : null;
   }
   async #resolveNode(executor: Executor, name: string, scope: KnowledgeScope): Promise<KnowledgeNode | null> {
-    for (let length = scope.length; length > 0; length--) {
-      const node = await this.#getNodeByName(executor, name, scope.slice(0, length));
-      if (node) {
-        const terminal = await this.#resolveTerminalNode(executor, node.id);
-        if (terminal && isKnowledgeScopeVisible(terminal.scope, scope)) return terminal;
-      }
+    const result = await executor.execute({
+      sql: `SELECT *,scope AS scopeJson FROM "${TABLE_KNOWLEDGE_NODES}" WHERE type='node' AND canonicalName=?`,
+      args: [canonicalName(name)],
+    });
+    const candidates = result.rows.map(parseNode).sort((left, right) => right.scope.length - left.scope.length);
+    for (const candidate of candidates) {
+      const terminal = await this.#resolveTerminalNode(executor, candidate.id);
+      if (terminal && isKnowledgeScopeVisible(terminal.scope, scope)) return terminal;
     }
     return null;
   }
@@ -892,12 +894,12 @@ export class KnowledgeMySQL extends KnowledgeStorage {
     const scope = canonicalizeKnowledgeScope(input.scope);
     const node = await this.#resolveTerminalNode(this.#client, nodeReferenceId(input.node));
     if (!node) return { records: [] };
-    const key = knowledgeScopeKey(scope);
+    const key = JSON.stringify(scope);
     const args: unknown[] = [node.id, ...(relationship === 'related' ? [node.id] : []), key, key];
     if (input.after) args.push(input.after);
     args.push((input.limit ?? 100) + 1);
     const result = await this.#client.execute({
-      sql: `SELECT DISTINCT f.*,f.scope AS scopeJson FROM "${TABLE_KNOWLEDGE_RECORDS}" f${relationship === 'about' ? '' : ` LEFT JOIN "${TABLE_KNOWLEDGE_MENTIONS}" m ON m.sourceType='record' AND m.sourceId=f.id`} WHERE ${relationship === 'about' ? 'f.node=?' : relationship === 'mentioning' ? 'm.recordId=?' : '(f.node=? OR m.recordId=?)'} AND ${visibleSql.replaceAll('scopeKey', 'f.scopeKey')}${input.includeDeleted ? '' : ' AND f.deletedAt IS NULL'}${input.after ? ' AND f.id < ?' : ''} ORDER BY f.id DESC LIMIT ?`,
+      sql: `SELECT DISTINCT f.*,f.scope AS scopeJson FROM "${TABLE_KNOWLEDGE_RECORDS}" f${relationship === 'about' ? '' : ` LEFT JOIN "${TABLE_KNOWLEDGE_MENTIONS}" m ON m.sourceType='record' AND m.sourceId=f.id`} WHERE ${relationship === 'about' ? 'f.node=?' : relationship === 'mentioning' ? 'm.recordId=?' : '(f.node=? OR m.recordId=?)'} AND ${visibleSql('f.scope')}${input.includeDeleted ? '' : ' AND f.deletedAt IS NULL'}${input.after ? ' AND f.id < ?' : ''} ORDER BY f.id DESC LIMIT ?`,
       args,
     });
     const records = result.rows.map(parseKnowledge);

--- a/stores/mysql/src/storage/domains/knowledge/index.ts
+++ b/stores/mysql/src/storage/domains/knowledge/index.ts
@@ -278,6 +278,12 @@ export class KnowledgeMySQL extends KnowledgeStorage {
 
   async createNode(input: CreateKnowledgeNodeInput): Promise<KnowledgeNode> {
     await assertKnowledgeDescriptionWithinBoundCompat(input.description);
+    if (input.scopeAddresses?.length) {
+      // Peer-floor safe: mirrors KnowledgeUnsupportedCapabilityError without importing it.
+      const error = new Error('This Knowledge storage adapter does not expose structural scope placement.');
+      error.name = 'KnowledgeUnsupportedCapabilityError';
+      throw error;
+    }
     const scope = canonicalizeKnowledgeScope(input.scope);
     return this.#transaction(async tx => {
       const existing = await this.#getNodeByName(tx, input.name, scope);

--- a/stores/pg/src/storage/domains/knowledge/index.test.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.test.ts
@@ -258,7 +258,7 @@ describe('PostgreSQL knowledge structured reconciliation', () => {
           {
             address: 'resource:mastra',
             name: 'Mastra',
-            parentAddresses: ['org:acme', 'org:partner'],
+            parentAddresses: ['org:acme'],
             grants: [{ scopeRefAddress: 'org:acme', role: 'readonly' as const }],
           },
         ],
@@ -279,8 +279,23 @@ describe('PostgreSQL knowledge structured reconciliation', () => {
           ])
         ).rows[0],
       ).toMatchObject({ name: 'Acme' });
-      expect((await pool.query(`SELECT * FROM "${schemaName}".mastra_knowledge_node_scopes`)).rows).toHaveLength(2);
+      expect((await pool.query(`SELECT * FROM "${schemaName}".mastra_knowledge_node_scopes`)).rows).toHaveLength(1);
       expect((await pool.query(`SELECT * FROM "${schemaName}".mastra_knowledge_scope_grants`)).rows).toHaveLength(2);
+
+      const enriched = await store.reconcileStructure({
+        scopes: plan.scopes.map(scope =>
+          scope.address === 'resource:mastra'
+            ? {
+                ...scope,
+                parentAddresses: ['org:acme', 'org:partner'],
+                grants: [...(scope.grants ?? []), { scopeRefAddress: 'org:partner', role: 'readonly' as const }],
+              }
+            : scope,
+        ),
+      });
+      expect(enriched).toMatchObject({ changed: true, createdScopeIds: [], accessEpoch: 2 });
+      expect((await pool.query(`SELECT * FROM "${schemaName}".mastra_knowledge_node_scopes`)).rows).toHaveLength(2);
+      expect((await pool.query(`SELECT * FROM "${schemaName}".mastra_knowledge_scope_grants`)).rows).toHaveLength(3);
     } finally {
       await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
     }

--- a/stores/pg/src/storage/domains/knowledge/index.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.ts
@@ -261,6 +261,7 @@ function parseNode(row: Record<string, unknown>): KnowledgeNode {
     kind: String(row.kind),
     content: row.content == null ? undefined : String(row.content),
     description: row.description == null ? undefined : String(row.description),
+    isScope: row.isScope === true || row.isScope === 1 ? true : undefined,
     scope: parseJson(row.scopeJson ?? row.scope),
     version: Number(row.version),
     mergedInto: row.mergedInto == null ? undefined : String(row.mergedInto),
@@ -858,6 +859,7 @@ export class KnowledgePG extends KnowledgeStorage {
         ],
       });
       await this.#replaceNodeScopes(tx, node.id, scope, now);
+      await this.#placeNodeInScopes(tx, node.id, input.scopeAddresses, now);
       await this.#replaceMentions(tx, 'node', node.id, node.content ?? '', input.resolutionScope ?? scope, scope);
       await this.#activity(tx, 'node-created', 'node', node.id, scope);
       await this.#outbox(tx, 'node', node.id, 'upsert', node.version, scope);
@@ -1470,6 +1472,32 @@ export class KnowledgePG extends KnowledgeStorage {
       await executor.execute({
         sql: `INSERT INTO "${TABLE_KNOWLEDGE_NODE_SCOPES}" (nodeId,scopeNodeId,addedAt) VALUES (?,?,?) ON CONFLICT DO NOTHING`,
         args: [nodeId, scopeNodeId, addedAt.toISOString()],
+      });
+    }
+  }
+
+  /**
+   * Additive structural placement: every address must resolve to a live scope node
+   * (unlike identity membership, an unknown address is a caller error, not a lazy
+   * materialization miss). Runs inside the caller's transaction, so a throw aborts
+   * the whole mutation.
+   */
+  async #placeNodeInScopes(
+    executor: Executor,
+    nodeId: string,
+    addresses: string[] | undefined,
+    addedAt: Date,
+  ): Promise<void> {
+    for (const address of addresses ?? []) {
+      const result = await executor.execute({
+        sql: `SELECT sa.scopeNodeId AS "scopeNodeId" FROM "${TABLE_KNOWLEDGE_SCOPE_ADDRESSES}" sa JOIN "${TABLE_KNOWLEDGE_NODES}" n ON n.id=sa."scopeNodeId" WHERE sa.address=? AND n."isScope" AND n."deletedAt" IS NULL`,
+        args: [address],
+      });
+      const scopeNodeId = result.rows[0]?.scopeNodeId;
+      if (scopeNodeId == null) throw new KnowledgeNotFoundError('scope', address);
+      await executor.execute({
+        sql: `INSERT INTO "${TABLE_KNOWLEDGE_NODE_SCOPES}" ("nodeId","scopeNodeId","addedAt") VALUES (?,?,?) ON CONFLICT DO NOTHING`,
+        args: [nodeId, String(scopeNodeId), addedAt.toISOString()],
       });
     }
   }

--- a/stores/pg/src/storage/domains/knowledge/index.ts
+++ b/stores/pg/src/storage/domains/knowledge/index.ts
@@ -198,7 +198,7 @@ function createExecutor(client: Pick<DbClient, 'query'> | TxClient, schemaName?:
   };
 }
 
-const visibleSql = `(scopeKey = ? OR LEFT(?, LENGTH(scopeKey) + 1) = scopeKey || chr(31))`;
+const visibleSql = (scopeColumn = 'scope') => `${scopeColumn} <@ CAST(? AS jsonb)`;
 
 function parseJson<T>(value: unknown): T {
   if (typeof value === 'string') return JSON.parse(value) as T;
@@ -673,8 +673,8 @@ export class KnowledgePG extends KnowledgeStorage {
       });
       const scopes: Record<string, string> = {};
       const createdScopeIds: string[] = [];
-      const createdAddresses = new Set<string>();
       const deletedScopeAddresses = new Set<string>();
+      let structureChanged = false;
       const resolveAddress = async (address: string): Promise<string | undefined> => {
         if (scopes[address]) return scopes[address];
         const result = await tx.execute({
@@ -712,16 +712,24 @@ export class KnowledgePG extends KnowledgeStorage {
           args: [scope.address, id],
         });
         scopes[scope.address] = id;
-        createdAddresses.add(scope.address);
         createdScopeIds.push(id);
+        structureChanged = true;
       }
 
       for (const scope of plan.scopes) {
-        if (!createdAddresses.has(scope.address)) continue;
+        if (deletedScopeAddresses.has(scope.address)) continue;
         const scopeNodeId = scopes[scope.address]!;
         for (const parentAddress of scope.parentAddresses ?? []) {
           const parentId = await resolveAddress(parentAddress);
           if (!parentId || deletedScopeAddresses.has(parentAddress)) {
+            const deletedParentId = scopes[parentAddress];
+            const existing = deletedParentId
+              ? await tx.execute({
+                  sql: `SELECT 1 FROM "${TABLE_KNOWLEDGE_NODE_SCOPES}" WHERE "nodeId"=? AND "scopeNodeId"=?`,
+                  args: [scopeNodeId, deletedParentId],
+                })
+              : undefined;
+            if (existing?.rows.length) continue;
             throw new Error(`Knowledge parent scope does not exist: ${parentAddress}`);
           }
           const sibling = await tx.execute({
@@ -731,24 +739,34 @@ export class KnowledgePG extends KnowledgeStorage {
           if (sibling.rows.length) {
             throw new Error(`Knowledge scope name ${scope.name} already exists under ${parentAddress}`);
           }
-          await tx.execute({
+          const inserted = await tx.execute({
             sql: `INSERT INTO "${TABLE_KNOWLEDGE_NODE_SCOPES}" ("nodeId","scopeNodeId","addedAt") VALUES (?,?,?) ON CONFLICT DO NOTHING`,
             args: [scopeNodeId, parentId, new Date()],
           });
+          structureChanged ||= inserted.rowsAffected > 0;
         }
         for (const grant of scope.grants ?? []) {
           const scopeRefId = await resolveAddress(grant.scopeRefAddress);
           if (!scopeRefId || deletedScopeAddresses.has(grant.scopeRefAddress)) {
+            const deletedScopeRefId = scopes[grant.scopeRefAddress];
+            const existing = deletedScopeRefId
+              ? await tx.execute({
+                  sql: `SELECT 1 FROM "${TABLE_KNOWLEDGE_SCOPE_GRANTS}" WHERE "scopeNodeId"=? AND "scopeRefId"=?`,
+                  args: [scopeNodeId, deletedScopeRefId],
+                })
+              : undefined;
+            if (existing?.rows.length) continue;
             throw new Error(`Knowledge grant scope does not exist: ${grant.scopeRefAddress}`);
           }
-          await tx.execute({
+          const inserted = await tx.execute({
             sql: `INSERT INTO "${TABLE_KNOWLEDGE_SCOPE_GRANTS}" ("scopeNodeId","scopeRefId",role,"canSuggest") VALUES (?,?,?,?) ON CONFLICT DO NOTHING`,
             args: [scopeNodeId, scopeRefId, grant.role, grant.canSuggest ?? null],
           });
+          structureChanged ||= inserted.rowsAffected > 0;
         }
       }
 
-      if (createdScopeIds.length) {
+      if (structureChanged) {
         await tx.execute(`UPDATE "${TABLE_KNOWLEDGE_ACCESS_STATE}" SET epoch=epoch+1 WHERE id='global'`);
       }
       const state = await tx.execute(`SELECT epoch FROM "${TABLE_KNOWLEDGE_ACCESS_STATE}" WHERE id='global'`);
@@ -756,7 +774,7 @@ export class KnowledgePG extends KnowledgeStorage {
         scopes,
         createdScopeIds,
         deletedScopeAddresses: [...deletedScopeAddresses],
-        changed: createdScopeIds.length > 0,
+        changed: structureChanged,
         accessEpoch: Number(state.rows[0]?.epoch ?? 0),
       };
     });
@@ -861,9 +879,9 @@ export class KnowledgePG extends KnowledgeStorage {
 
   async listNodes(input: ListKnowledgeNodesInput): Promise<KnowledgeNode[]> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
-    const clauses = [`type = 'node'`, 'mergedInto IS NULL', visibleSql];
-    const args: QueryValues = [key, key];
+    const key = JSON.stringify(scope);
+    const clauses = [`type = 'node'`, 'mergedInto IS NULL', visibleSql()];
+    const args: QueryValues = [key];
     if (input.namePrefix) {
       clauses.push("canonicalName LIKE ? ESCAPE '='");
       args.push(`${escapeLikePattern(canonicalName(input.namePrefix))}%`);
@@ -1102,13 +1120,13 @@ export class KnowledgePG extends KnowledgeStorage {
 
   async knowledgeBySource(input: QueryKnowledgeBySourceInput): Promise<QueryKnowledgeOutput> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
-    const args: QueryValues = [input.sourceThreadId, key, key];
+    const key = JSON.stringify(scope);
+    const args: QueryValues = [input.sourceThreadId, key];
     if (input.after) args.push(input.after);
     const limit = input.limit ?? 100;
     args.push(limit + 1);
     const result = await this.#readExecutor.execute({
-      sql: `SELECT *,scope AS "scopeJson" FROM "${TABLE_KNOWLEDGE_RECORDS}" WHERE sourceThreadId=? AND ${visibleSql}${input.includeDeleted ? '' : ' AND deletedAt IS NULL'}${input.after ? ' AND id > ?' : ''} ORDER BY id ASC LIMIT ?`,
+      sql: `SELECT *,scope AS "scopeJson" FROM "${TABLE_KNOWLEDGE_RECORDS}" WHERE sourceThreadId=? AND ${visibleSql()}${input.includeDeleted ? '' : ' AND deletedAt IS NULL'}${input.after ? ' AND id > ?' : ''} ORDER BY id ASC LIMIT ?`,
       args,
     });
     const records = result.rows.map(parseKnowledge);
@@ -1185,13 +1203,13 @@ export class KnowledgePG extends KnowledgeStorage {
 
   async search(input: SearchKnowledgeInput): Promise<SearchKnowledgeResult[]> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
+    const key = JSON.stringify(scope);
     const normalizedQuery = input.query.trim().toLocaleLowerCase();
     if (!normalizedQuery) return [];
     const query = `%${escapeLikePattern(normalizedQuery)}%`;
     const records = await this.#readExecutor.execute({
-      sql: `SELECT *,scope AS "scopeJson" FROM "${TABLE_KNOWLEDGE_NODES}" WHERE mergedInto IS NULL AND ${visibleSql} AND (canonicalName LIKE ? ESCAPE '=' OR lower(COALESCE(kind,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(content,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(description,'')) LIKE ? ESCAPE '=') ORDER BY updatedAt DESC LIMIT ?`,
-      args: [key, key, query, query, query, query, input.limit ?? 20],
+      sql: `SELECT *,scope AS "scopeJson" FROM "${TABLE_KNOWLEDGE_NODES}" WHERE mergedInto IS NULL AND ${visibleSql()} AND (canonicalName LIKE ? ESCAPE '=' OR lower(COALESCE(kind,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(content,'')) LIKE ? ESCAPE '=' OR lower(COALESCE(description,'')) LIKE ? ESCAPE '=') ORDER BY updatedAt DESC LIMIT ?`,
+      args: [key, query, query, query, query, input.limit ?? 20],
     });
     const results: SearchKnowledgeResult[] = records.rows.map(row => ({
       type: String(row.type) as 'node',
@@ -1208,8 +1226,8 @@ export class KnowledgePG extends KnowledgeStorage {
     }));
     if (results.length < (input.limit ?? 20)) {
       const records = await this.#readExecutor.execute({
-        sql: `SELECT f.*,f.scope AS "scopeJson",r.name,r.scope AS "parentScopeJson" FROM "${TABLE_KNOWLEDGE_RECORDS}" f JOIN "${TABLE_KNOWLEDGE_NODES}" r ON r.id=f.node AND r.type='node' AND r.mergedInto IS NULL WHERE f.deletedAt IS NULL AND ${visibleSql.replaceAll('scopeKey', 'f.scopeKey')} AND lower(f.text) LIKE ? ESCAPE '=' ORDER BY f.id DESC LIMIT ?`,
-        args: [key, key, query, (input.limit ?? 20) - results.length],
+        sql: `SELECT f.*,f.scope AS "scopeJson",r.name,r.scope AS "parentScopeJson" FROM "${TABLE_KNOWLEDGE_RECORDS}" f JOIN "${TABLE_KNOWLEDGE_NODES}" r ON r.id=f.node AND r.type='node' AND r.mergedInto IS NULL WHERE f.deletedAt IS NULL AND ${visibleSql('f.scope')} AND lower(f.text) LIKE ? ESCAPE '=' ORDER BY f.id DESC LIMIT ?`,
+        args: [key, query, (input.limit ?? 20) - results.length],
       });
       results.push(
         ...records.rows.map(row => {
@@ -1217,7 +1235,7 @@ export class KnowledgePG extends KnowledgeStorage {
           return {
             type: 'record' as const,
             id: String(row.id),
-            recordId: String(row.node),
+            recordId: parentVisible ? String(row.node) : String(row.id),
             name: parentVisible ? String(row.name) : '(private node)',
             text: String(row.text),
             scope: parseJson<KnowledgeScope>(row.scopeJson),
@@ -1264,10 +1282,10 @@ export class KnowledgePG extends KnowledgeStorage {
     limit?: number;
   }): Promise<KnowledgeActivityEvent[]> {
     const scope = canonicalizeKnowledgeScope(input.scope);
-    const key = knowledgeScopeKey(scope);
+    const key = JSON.stringify(scope);
     const result = await this.#readExecutor.execute({
-      sql: `SELECT *,scope AS "scopeJson" FROM "${TABLE_KNOWLEDGE_ACTIVITY}" WHERE ${visibleSql}${input.after ? ' AND id < ?' : ''} ORDER BY id DESC LIMIT ?`,
-      args: [key, key, ...(input.after ? [input.after] : []), input.limit ?? 100],
+      sql: `SELECT *,scope AS "scopeJson" FROM "${TABLE_KNOWLEDGE_ACTIVITY}" WHERE ${visibleSql()}${input.after ? ' AND id < ?' : ''} ORDER BY id DESC LIMIT ?`,
+      args: [key, ...(input.after ? [input.after] : []), input.limit ?? 100],
     });
     return result.rows.map(row => ({
       id: String(row.id),
@@ -1290,9 +1308,9 @@ export class KnowledgePG extends KnowledgeStorage {
       args.push(input.status);
     }
     if (input.scope) {
-      const key = knowledgeScopeKey(canonicalizeKnowledgeScope(input.scope));
-      clauses.push(visibleSql);
-      args.push(key, key);
+      const key = JSON.stringify(canonicalizeKnowledgeScope(input.scope));
+      clauses.push(visibleSql());
+      args.push(key);
     }
     args.push(input.limit ?? 100);
     const result = await this.#executor.execute({
@@ -1313,9 +1331,9 @@ export class KnowledgePG extends KnowledgeStorage {
       ];
       const args: QueryValues = [now.toISOString(), stale.toISOString()];
       if (input.scope) {
-        const key = knowledgeScopeKey(canonicalizeKnowledgeScope(input.scope));
-        clauses.push(visibleSql);
-        args.push(key, key);
+        const key = JSON.stringify(canonicalizeKnowledgeScope(input.scope));
+        clauses.push(visibleSql());
+        args.push(key);
       }
       args.push(input.limit ?? 100);
       const selected = await tx.execute({
@@ -1377,12 +1395,14 @@ export class KnowledgePG extends KnowledgeStorage {
     return result.rows[0] ? parseNode(result.rows[0]) : null;
   }
   async #resolveNode(executor: Executor, name: string, scope: KnowledgeScope): Promise<KnowledgeNode | null> {
-    for (let length = scope.length; length > 0; length--) {
-      const node = await this.#getNodeByName(executor, name, scope.slice(0, length));
-      if (node) {
-        const terminal = await this.#resolveTerminalNode(executor, node.id);
-        if (terminal && isKnowledgeScopeVisible(terminal.scope, scope)) return terminal;
-      }
+    const result = await executor.execute({
+      sql: `SELECT *,scope AS "scopeJson" FROM "${TABLE_KNOWLEDGE_NODES}" WHERE type='node' AND canonicalName=?`,
+      args: [canonicalName(name)],
+    });
+    const candidates = result.rows.map(parseNode).sort((left, right) => right.scope.length - left.scope.length);
+    for (const candidate of candidates) {
+      const terminal = await this.#resolveTerminalNode(executor, candidate.id);
+      if (terminal && isKnowledgeScopeVisible(terminal.scope, scope)) return terminal;
     }
     return null;
   }
@@ -1411,12 +1431,12 @@ export class KnowledgePG extends KnowledgeStorage {
     const scope = canonicalizeKnowledgeScope(input.scope);
     const node = await this.#resolveTerminalNode(this.#readExecutor, nodeReferenceId(input.node));
     if (!node) return { records: [] };
-    const key = knowledgeScopeKey(scope);
-    const args: QueryValues = [node.id, ...(relationship === 'related' ? [node.id] : []), key, key];
+    const key = JSON.stringify(scope);
+    const args: QueryValues = [node.id, ...(relationship === 'related' ? [node.id] : []), key];
     if (input.after) args.push(input.after);
     args.push((input.limit ?? 100) + 1);
     const result = await this.#readExecutor.execute({
-      sql: `SELECT DISTINCT f.*,f.scope AS "scopeJson" FROM "${TABLE_KNOWLEDGE_RECORDS}" f${relationship === 'about' ? '' : ` LEFT JOIN "${TABLE_KNOWLEDGE_MENTIONS}" m ON m.sourceType='record' AND m.sourceId=f.id`} WHERE ${relationship === 'about' ? 'f.node=?' : relationship === 'mentioning' ? 'm.recordId=?' : '(f.node=? OR m.recordId=?)'} AND ${visibleSql.replaceAll('scopeKey', 'f.scopeKey')}${input.includeDeleted ? '' : ' AND f.deletedAt IS NULL'}${input.after ? ' AND f.id < ?' : ''} ORDER BY f.id DESC LIMIT ?`,
+      sql: `SELECT DISTINCT f.*,f.scope AS "scopeJson" FROM "${TABLE_KNOWLEDGE_RECORDS}" f${relationship === 'about' ? '' : ` LEFT JOIN "${TABLE_KNOWLEDGE_MENTIONS}" m ON m.sourceType='record' AND m.sourceId=f.id`} WHERE ${relationship === 'about' ? 'f.node=?' : relationship === 'mentioning' ? 'm.recordId=?' : '(f.node=? OR m.recordId=?)'} AND ${visibleSql('f.scope')}${input.includeDeleted ? '' : ' AND f.deletedAt IS NULL'}${input.after ? ' AND f.id < ?' : ''} ORDER BY f.id DESC LIMIT ?`,
       args,
     });
     const records = result.rows.map(parseKnowledge);


### PR DESCRIPTION
Wave: 1 of 4
Segment: W1.5 of 8
Purpose: Route observational-memory capture through the selected governed Knowledge runtime.
Previous PR: https://github.com/mastra-ai/mastra/pull/22513
Next PR: https://github.com/mastra-ai/mastra/pull/22563
Previous wave: None
Next wave: https://github.com/mastra-ai/mastra/pull/22574

## Summary

- route observational-memory capture through a selected keyed Knowledge v2 runtime without adding a second model pass
- materialize mirrored uncurated resource/thread companion scopes and keep capture, tools, curation, reminders, learning, pins, activity, and semantic indexing on the same store
- make companion visibility consistent across storage adapters while redacting unauthorized parent identity
- support capture-only configurations without vector infrastructure and retry transient semantic-index initialization failures
- enrich existing reconciled scopes with newly declared parents/grants and bump the access epoch atomically

## Why

Subconscious capture previously resolved the generic Memory Knowledge domain, which could split writes and reads from a configured keyed Knowledge runtime. Prefix-only visibility also hid companion-scoped records from tools and reflection, while mixed record scopes could broaden or erase node identity. This change makes the capture lane durable, scoped, and consistently consumable.

## Test plan

- `packages/memory`: unit suite — 1,528 passed, 1 todo
- focused Subconscious capture/curate/learn/remind/pins — 68 passed
- Memory LibSQL integration — 40 passed
- Core Knowledge contract — 26 passed, no type errors
- LibSQL Knowledge — 33 passed
- PostgreSQL Knowledge — 38 passed
- MySQL Knowledge — 28 passed
- MongoDB Knowledge — 27 passed
- Memory check/build, Core build, Prettier, Oxlint, and adversarial review passed

## Stack navigation

- **Wave:** Knowledge v2 Wave 1 — Foundation
- **Segment:** W1.5 capture and Memory integration
- **Previous PR:** https://github.com/mastra-ai/mastra/pull/22513
- **Next PR:** https://github.com/mastra-ai/mastra/pull/22563
- **Previous wave:** None
- **Next wave:** Wave 2 imports (planned; remains draft/unmerged)
- **Stack:** #22508

## Type of change

- [x] New feature
- [x] Bug fix
- [x] Test update

## Checklist

- [x] Added focused and integration tests
- [x] Added package changesets
- [x] Kept the feature private/experimental; public docs remain deferred to the release boundary
- [x] No PR in this stack is ready to merge independently



