### PR TITLE
feat(mastracode): name threads from the first message

### DIFF
--- a/.changeset/shiny-lands-poke.md
+++ b/.changeset/shiny-lands-poke.md
@@ -1,0 +1,6 @@
+---
+'mastracode': minor
+'@mastra/code-sdk': patch
+---
+
+Added automatic titles for Mastra Code threads.

--- a/.changeset/shiny-lands-poke.md
+++ b/.changeset/shiny-lands-poke.md
@@ -1,6 +1,6 @@
 ---
-'mastracode': minor
-'@mastra/code-sdk': patch
+'@mastra/code-sdk': minor
+'mastracode': patch
 ---
 
-Added automatic titles for Mastra Code threads.
+Enabled first-message thread title generation for all Mastra Code clients.

--- a/mastracode/sdk/src/agents/memory.test.ts
+++ b/mastracode/sdk/src/agents/memory.test.ts
@@ -39,6 +39,9 @@ type MemoryConfig = {
   vector: unknown;
   embedder?: unknown;
   options: {
+    generateTitle: {
+      model: (args: { requestContext: RequestContextStub }) => unknown;
+    };
     observationalMemory: {
       enabled: boolean;
       temporalMarkers: boolean;
@@ -131,6 +134,10 @@ describe('getDynamicMemory', () => {
     expect(config.storage).toEqual({ storage: true });
     expect(config.vector).toBe(false);
     expect(config.embedder).toBeUndefined();
+
+    expect(config.options.generateTitle.model({ requestContext })).toEqual({
+      modelId: 'google/gemini-3.5-flash',
+    });
 
     const om = config.options.observationalMemory;
     expect(om).toMatchObject({

--- a/mastracode/sdk/src/agents/memory.ts
+++ b/mastracode/sdk/src/agents/memory.ts
@@ -177,10 +177,9 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
       vector: vector || false,
       embedder: vector ? fastembed.small : undefined,
       options: {
-        // The factory sidebar shows a session the moment it exists, so it needs a
-        // name on the first turn. The TUI names its threads from OM's `threadTitle`
-        // as they grow and would only pay for an extra call here.
-        ...(isFactory ? { generateTitle: { model: getObserverModel } } : {}),
+        // Generate a durable title from the first user message. Every client uses
+        // the same title in its thread list and active-session chrome.
+        generateTitle: { model: getObserverModel },
         observationalMemory: {
           enabled: true,
           temporalMarkers: true,

--- a/mastracode/tui/e2e/fixtures/automated-chat.json
+++ b/mastracode/tui/e2e/fixtures/automated-chat.json
@@ -2,6 +2,17 @@
   "fixtures": [
     {
       "match": {
+        "userMessage": "User: Return the configured Mastra Code e2e smoke phrase.",
+        "systemMessage": "you will generate a short title",
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat"
+      },
+      "response": {
+        "content": "MC automated chat title"
+      }
+    },
+    {
+      "match": {
         "userMessage": "Return the configured Mastra Code e2e smoke phrase.",
         "model": "gpt-5.4-mini",
         "endpoint": "chat"

--- a/mastracode/tui/e2e/tui/automated-chat.ts
+++ b/mastracode/tui/e2e/tui/automated-chat.ts
@@ -1,3 +1,5 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { expect } from './expect.js';
 import type { McE2eScenario } from './types.js';
 
@@ -7,6 +9,12 @@ export const automatedChatScenario: McE2eScenario = {
   testName: 'submits an automated chat prompt to real Mastra Code',
   useOpenAIModel: true,
   aimockFixture: 'automated-chat.json',
+  prepare({ appDataDir }) {
+    const settingsPath = join(appDataDir, 'settings.json');
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, any>;
+    settings.models = { ...settings.models, observerModelOverride: 'openai/gpt-5.4-mini' };
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+  },
   async run({ terminal, runtime }) {
     runtime.startLiveOutput(terminal);
     runtime.printScreen('spawned', terminal);
@@ -18,7 +26,12 @@ export const automatedChatScenario: McE2eScenario = {
 
     terminal.submit('Return the configured Mastra Code e2e smoke phrase.');
     await runtime.waitForScreenText(/MC automated chat smoke response/i, terminal);
+    await runtime.waitForScreenText(/MC automated chat title/i, terminal, 10_000);
     runtime.printScreen('after automated prompt', terminal);
+    expect(terminal.serialize().view.match(/▐build▌/g) ?? []).toHaveLength(1);
+
+    terminal.submit('/thread');
+    await runtime.waitForScreenText(/Title: MC automated chat title/i, terminal);
 
     terminal.keyCtrlC();
     runtime.printScreen('after Ctrl-C', terminal);

--- a/mastracode/tui/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/tui/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -939,12 +939,15 @@ describe('syncInitialThreadState', () => {
         getGoal: vi.fn(() => null),
         loadFromThreadMetadata: vi.fn(),
       },
+      options: { appName: 'Mastra Code' },
+      ui: { terminal: { setTitle: vi.fn() } },
       currentThreadTitle: undefined,
     } as unknown as TUIState;
 
     await syncInitialThreadState(state);
 
     expect(state.currentThreadTitle).toBe('PR triage');
+    expect(state.ui.terminal.setTitle).toHaveBeenCalledWith('Mastra Code - PR triage');
     expect(state.goalManager.loadFromThread).toHaveBeenCalledWith(state);
     expect(state.goalManager.loadFromThreadMetadata).toHaveBeenCalledWith({ goal: persistedGoal });
     expect(state.session.sendMessage).not.toHaveBeenCalled();
@@ -980,6 +983,8 @@ describe('syncInitialThreadState', () => {
         getGoal: vi.fn(() => durableGoal),
         loadFromThreadMetadata: vi.fn(),
       },
+      options: { appName: 'Mastra Code' },
+      ui: { terminal: { setTitle: vi.fn() } },
       currentThreadTitle: undefined,
     } as unknown as TUIState;
 

--- a/mastracode/tui/src/tui/commands/__tests__/new.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/new.test.ts
@@ -18,6 +18,8 @@ function createMockState() {
     assistantRenderRegistry,
     assistantSegment,
     pendingNewThread: false,
+    currentThreadTitle: 'Current thread',
+    options: { appName: 'Mastra Code' },
     chatContainer: { clear: vi.fn() },
     pendingTools: { clear: vi.fn() },
     pendingTaskToolIds: { clear: vi.fn() },
@@ -41,7 +43,7 @@ function createMockState() {
       },
       setState: vi.fn(async () => {}),
     },
-    ui: { requestRender: vi.fn() },
+    ui: { requestRender: vi.fn(), terminal: { setTitle: vi.fn() } },
   } as any;
 }
 
@@ -102,6 +104,8 @@ describe('handleNewCommand', () => {
     });
     expect(state.taskProgress.updateTasks).toHaveBeenCalledWith([]);
     expect(state.taskToolInsertIndex).toBe(-1);
+    expect(state.currentThreadTitle).toBeUndefined();
+    expect(state.ui.terminal.setTitle).toHaveBeenCalledWith(`Mastra Code - ${process.cwd().split('/').pop()}`);
     expect(ctx.updateStatusLine).toHaveBeenCalled();
     expect(state.ui.requestRender).toHaveBeenCalled();
   });

--- a/mastracode/tui/src/tui/commands/__tests__/new.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/new.test.ts
@@ -1,3 +1,4 @@
+import { basename } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AssistantRenderRegistry, getAssistantSegmentKey } from '../../assistant-render-registry.js';
@@ -105,7 +106,7 @@ describe('handleNewCommand', () => {
     expect(state.taskProgress.updateTasks).toHaveBeenCalledWith([]);
     expect(state.taskToolInsertIndex).toBe(-1);
     expect(state.currentThreadTitle).toBeUndefined();
-    expect(state.ui.terminal.setTitle).toHaveBeenCalledWith(`Mastra Code - ${process.cwd().split('/').pop()}`);
+    expect(state.ui.terminal.setTitle).toHaveBeenCalledWith(`Mastra Code - ${basename(process.cwd())}`);
     expect(ctx.updateStatusLine).toHaveBeenCalled();
     expect(state.ui.requestRender).toHaveBeenCalled();
   });

--- a/mastracode/tui/src/tui/commands/new.ts
+++ b/mastracode/tui/src/tui/commands/new.ts
@@ -1,4 +1,5 @@
 import { disposeAssistantRenderState } from '../assistant-render-registry.js';
+import { setCurrentThreadTitle } from '../thread-title.js';
 import type { SlashCommandContext } from './types.js';
 
 export async function handleNewCommand(ctx: SlashCommandContext): Promise<void> {
@@ -11,6 +12,7 @@ export async function handleNewCommand(ctx: SlashCommandContext): Promise<void> 
   state.session.thread.detachFromCurrent();
 
   state.pendingNewThread = true;
+  setCurrentThreadTitle(state, undefined);
   disposeAssistantRenderState(state);
   state.chatContainer.clear();
   state.pendingTools.clear();

--- a/mastracode/tui/src/tui/event-dispatch.test.ts
+++ b/mastracode/tui/src/tui/event-dispatch.test.ts
@@ -109,6 +109,17 @@ describe('dispatchEvent thread lifecycle', () => {
     expect(state.ui.terminal.setTitle).not.toHaveBeenCalled();
   });
 
+  it('strips terminal control characters from generated titles', async () => {
+    await dispatchEvent(
+      { type: 'thread_title_updated', threadId: 'thread-1', title: 'Safe\x07\x1b]0;unsafe' } as any,
+      ectx,
+      state,
+    );
+
+    expect(state.currentThreadTitle).toBe('Safe  ]0;unsafe');
+    expect(state.ui.terminal.setTitle).toHaveBeenCalledWith('Mastra Code - Safe  ]0;unsafe');
+  });
+
   it('clears per-thread state on thread_changed', async () => {
     state.latestRequestPromptTokens = 90_000;
 

--- a/mastracode/tui/src/tui/event-dispatch.test.ts
+++ b/mastracode/tui/src/tui/event-dispatch.test.ts
@@ -109,15 +109,19 @@ describe('dispatchEvent thread lifecycle', () => {
     expect(state.ui.terminal.setTitle).not.toHaveBeenCalled();
   });
 
-  it('strips terminal control characters from generated titles', async () => {
+  it('strips terminal escape sequences and control characters from generated titles', async () => {
     await dispatchEvent(
-      { type: 'thread_title_updated', threadId: 'thread-1', title: 'Safe\x07\x1b]0;unsafe' } as any,
+      {
+        type: 'thread_title_updated',
+        threadId: 'thread-1',
+        title: 'Safe\x07\x1b]0;unsafe\x07Visible \x1b[31mRed\x1b[0m',
+      } as any,
       ectx,
       state,
     );
 
-    expect(state.currentThreadTitle).toBe('Safe  ]0;unsafe');
-    expect(state.ui.terminal.setTitle).toHaveBeenCalledWith('Mastra Code - Safe  ]0;unsafe');
+    expect(state.currentThreadTitle).toBe('Safe Visible Red');
+    expect(state.ui.terminal.setTitle).toHaveBeenCalledWith('Mastra Code - Safe Visible Red');
   });
 
   it('clears per-thread state on thread_changed', async () => {

--- a/mastracode/tui/src/tui/event-dispatch.test.ts
+++ b/mastracode/tui/src/tui/event-dispatch.test.ts
@@ -43,7 +43,8 @@ function createMockTUIState(controller: ReturnType<typeof createMockAgentControl
     allToolComponents: [],
     chatContainer: { children: [] },
     taskToolInsertIndex: 5,
-    ui: { requestRender: vi.fn() },
+    ui: { requestRender: vi.fn(), terminal: { setTitle: vi.fn() } },
+    options: { appName: 'Mastra Code' },
     projectInfo: { rootPath: '/tmp/test', gitBranch: 'main' },
     currentThreadTitle: 'Old thread',
     editor: { escapeEnabled: false },
@@ -83,6 +84,29 @@ describe('dispatchEvent thread lifecycle', () => {
     });
     state = createMockTUIState(controller);
     ectx = createMockEctx();
+  });
+
+  it('updates the active and terminal titles when a generated title arrives', async () => {
+    await dispatchEvent(
+      { type: 'thread_title_updated', threadId: 'thread-1', title: 'Generated demo title' } as any,
+      ectx,
+      state,
+    );
+
+    expect(state.currentThreadTitle).toBe('Generated demo title');
+    expect(state.ui.terminal.setTitle).toHaveBeenCalledWith('Mastra Code - Generated demo title');
+    expect(ectx.updateStatusLine).toHaveBeenCalledOnce();
+  });
+
+  it('ignores generated titles from another thread', async () => {
+    await dispatchEvent(
+      { type: 'thread_title_updated', threadId: 'thread-2', title: 'Wrong thread' } as any,
+      ectx,
+      state,
+    );
+
+    expect(state.currentThreadTitle).toBe('Old thread');
+    expect(state.ui.terminal.setTitle).not.toHaveBeenCalled();
   });
 
   it('clears per-thread state on thread_changed', async () => {

--- a/mastracode/tui/src/tui/event-dispatch.ts
+++ b/mastracode/tui/src/tui/event-dispatch.ts
@@ -48,6 +48,7 @@ import type { EventHandlerContext } from './handlers/types.js';
 import { flushRender } from './render-scheduler.js';
 import type { TUIState } from './state.js';
 import { getGithubPrSubscriptionsFromMetadata } from './state.js';
+import { setCurrentThreadTitle } from './thread-title.js';
 
 /**
  * Dispatch a AgentControllerEvent to the appropriate handler.
@@ -223,7 +224,7 @@ export async function dispatchEvent(
       const threads = await state.session.thread.list();
       const currentThread = threads.find((t: AgentControllerThread) => t.id === event.threadId);
       if (currentThread) {
-        state.currentThreadTitle = currentThread.title;
+        setCurrentThreadTitle(state, currentThread.title);
         const metadata = currentThread.metadata as Record<string, unknown> | undefined;
         state.activeGithubPrSubscriptions = getGithubPrSubscriptionsFromMetadata(metadata);
         state.githubPrPollingActive = false;
@@ -242,7 +243,7 @@ export async function dispatchEvent(
       ectx.showInfo(`Created thread: ${event.thread.id}`);
       state.latestRequestPromptTokens = undefined;
       // Update current thread title for status line display
-      state.currentThreadTitle = event.thread.title;
+      setCurrentThreadTitle(state, event.thread.title);
       state.activeGithubPrSubscriptions = getGithubPrSubscriptionsFromMetadata(
         event.thread.metadata as Record<string, unknown> | undefined,
       );
@@ -372,9 +373,15 @@ export async function dispatchEvent(
       break;
     }
 
+    case 'thread_title_updated':
+      if (event.threadId !== state.session.thread.getId()) break;
+      setCurrentThreadTitle(state, event.title);
+      ectx.updateStatusLine();
+      break;
+
     case 'om_thread_title_updated':
       if (event.threadId !== state.session.thread.getId()) break;
-      state.currentThreadTitle = event.newTitle;
+      setCurrentThreadTitle(state, event.newTitle);
       handleOMThreadTitleUpdated(ectx, event.newTitle, event.oldTitle);
       ectx.updateStatusLine();
       break;

--- a/mastracode/tui/src/tui/mastra-tui.ts
+++ b/mastracode/tui/src/tui/mastra-tui.ts
@@ -108,13 +108,14 @@ const CAFFEINATE_ARGS = ['-i', '-m'];
 
 export async function syncInitialThreadState(state: TUIState): Promise<void> {
   const initThreadId = state.session.thread.getId();
-  if (!initThreadId) return;
+  if (!initThreadId) {
+    setCurrentThreadTitle(state, undefined);
+    return;
+  }
 
   const initThreads = await state.session.thread.list();
   const initThread = initThreads.find(t => t.id === initThreadId);
-  if (initThread?.title) {
-    state.currentThreadTitle = initThread.title;
-  }
+  setCurrentThreadTitle(state, initThread?.title);
   const metadata = initThread?.metadata as Record<string, unknown> | undefined;
   state.activeGithubPrSubscriptions = getGithubPrSubscriptionsFromMetadata(metadata);
   // Prefer the durable ThreadState objective; fall back to the legacy
@@ -687,8 +688,6 @@ export class MastraTUI {
         });
     }
 
-    // Set terminal title
-    setCurrentThreadTitle(this.state, this.state.currentThreadTitle);
     // Render existing messages
     await this.renderExistingMessagesAndSeedIdleCounter();
     // Render existing tasks if any

--- a/mastracode/tui/src/tui/mastra-tui.ts
+++ b/mastracode/tui/src/tui/mastra-tui.ts
@@ -74,7 +74,6 @@ import {
   refreshSkillsAutocomplete,
   setupKeyHandlers,
   subscribeToAgentController,
-  updateTerminalTitle,
   promptForThreadSelection,
   renderExistingTasks,
 } from './setup.js';
@@ -82,6 +81,7 @@ import { handleShellPassthrough } from './shell.js';
 import type { MastraTUIOptions, TUIState } from './state.js';
 import { createTUIState, getGithubPrSubscriptionsFromMetadata } from './state.js';
 import { updateStatusLine } from './status-line.js';
+import { setCurrentThreadTitle } from './thread-title.js';
 
 // =============================================================================
 // Types
@@ -688,7 +688,7 @@ export class MastraTUI {
     }
 
     // Set terminal title
-    updateTerminalTitle(this.state);
+    setCurrentThreadTitle(this.state, this.state.currentThreadTitle);
     // Render existing messages
     await this.renderExistingMessagesAndSeedIdleCounter();
     // Render existing tasks if any

--- a/mastracode/tui/src/tui/setup.ts
+++ b/mastracode/tui/src/tui/setup.ts
@@ -680,16 +680,6 @@ export function subscribeToAgentController(state: TUIState, handleEvent: (event:
 }
 
 // =============================================================================
-// Terminal Title
-// =============================================================================
-
-export function updateTerminalTitle(state: TUIState): void {
-  const appName = state.options.appName || 'Mastra Code';
-  const cwd = process.cwd().split('/').pop() || '';
-  state.ui.terminal.setTitle(`${appName} - ${cwd}`);
-}
-
-// =============================================================================
 // Thread Selection
 // =============================================================================
 

--- a/mastracode/tui/src/tui/thread-title.ts
+++ b/mastracode/tui/src/tui/thread-title.ts
@@ -1,12 +1,14 @@
+import { basename } from 'node:path';
+import { stripVTControlCharacters } from 'node:util';
 import type { TUIState } from './state.js';
 
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/g;
 
 export function setCurrentThreadTitle(state: TUIState, title: string | undefined): void {
-  const safeTitle = title?.replace(CONTROL_CHARACTER_PATTERN, ' ').trim() || undefined;
+  const safeTitle = title ? stripVTControlCharacters(title).replace(CONTROL_CHARACTER_PATTERN, ' ').trim() : undefined;
   state.currentThreadTitle = safeTitle;
 
   const appName = state.options.appName || 'Mastra Code';
-  const cwd = process.cwd().split('/').pop() || '';
+  const cwd = basename(process.cwd());
   state.ui.terminal.setTitle(`${appName} - ${safeTitle || cwd}`.replace(CONTROL_CHARACTER_PATTERN, ' '));
 }

--- a/mastracode/tui/src/tui/thread-title.ts
+++ b/mastracode/tui/src/tui/thread-title.ts
@@ -1,9 +1,12 @@
 import type { TUIState } from './state.js';
 
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/g;
+
 export function setCurrentThreadTitle(state: TUIState, title: string | undefined): void {
-  state.currentThreadTitle = title;
+  const safeTitle = title?.replace(CONTROL_CHARACTER_PATTERN, ' ').trim() || undefined;
+  state.currentThreadTitle = safeTitle;
 
   const appName = state.options.appName || 'Mastra Code';
   const cwd = process.cwd().split('/').pop() || '';
-  state.ui.terminal.setTitle(`${appName} - ${title?.trim() || cwd}`);
+  state.ui.terminal.setTitle(`${appName} - ${safeTitle || cwd}`.replace(CONTROL_CHARACTER_PATTERN, ' '));
 }

--- a/mastracode/tui/src/tui/thread-title.ts
+++ b/mastracode/tui/src/tui/thread-title.ts
@@ -1,0 +1,9 @@
+import type { TUIState } from './state.js';
+
+export function setCurrentThreadTitle(state: TUIState, title: string | undefined): void {
+  state.currentThreadTitle = title;
+
+  const appName = state.options.appName || 'Mastra Code';
+  const cwd = process.cwd().split('/').pop() || '';
+  state.ui.terminal.setTitle(`${appName} - ${title?.trim() || cwd}`);
+}


### PR DESCRIPTION
New threads do not have a useful name, which makes thread history hard to scan.

Use the first user message as the initial thread title. Show that title in the terminal and status display. Strip terminal control characters before displaying generated titles.

Tested with the focused SDK and TUI unit suites, the TUI type check, and the `automated-chat` terminal scenario.

Model: gpt-5.6-sol
Harness: Codex CLI in Terminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The app now names each conversation using its first message. It shows the name in the terminal and removes unsafe characters before display.

## Changes

- Enabled first-message thread title generation for all Mastra Code clients.
- Updated terminal titles when threads load, change, or receive title updates.
- Sanitized titles by removing terminal control characters and trimming whitespace.
- Reset the title when users start a new conversation.
- Added SDK, TUI, and `automated-chat` test coverage.
- Added package version bumps for `@mastra/code-sdk` and `mastracode`.

## Testing

- Focused SDK unit tests.
- Focused TUI unit tests.
- TUI type checking.
- `automated-chat` terminal scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->