### PR TITLE
fix: validate core imports against peer dependency floors

### DIFF
--- a/.changeset/bright-suns-count.md
+++ b/.changeset/bright-suns-count.md
@@ -1,0 +1,5 @@
+---
+'@mastra/clickhouse': patch
+---
+
+Corrected the minimum supported @mastra/core version to match the APIs used by this store.

--- a/.changeset/calm-bears-grab.md
+++ b/.changeset/calm-bears-grab.md
@@ -1,0 +1,5 @@
+---
+'@mastra/cloudflare-d1': patch
+---
+
+Corrected the minimum supported @mastra/core version to match the APIs used by this store.

--- a/.changeset/dry-comics-act.md
+++ b/.changeset/dry-comics-act.md
@@ -1,0 +1,5 @@
+---
+'@mastra/dsql': patch
+---
+
+Corrected the minimum supported @mastra/core version to match the APIs used by this store.

--- a/.changeset/free-cameras-smell.md
+++ b/.changeset/free-cameras-smell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/duckdb': patch
+---
+
+Corrected the minimum supported @mastra/core version to match the APIs used by this store.

--- a/.changeset/gold-showers-yell.md
+++ b/.changeset/gold-showers-yell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/dynamodb': patch
+---
+
+Corrected the minimum supported @mastra/core version to match the APIs used by this store.

--- a/.changeset/grumpy-snakes-smell.md
+++ b/.changeset/grumpy-snakes-smell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/elasticsearch': patch
+---
+
+Corrected the minimum supported @mastra/core version to match the APIs used by this store.

--- a/.changeset/hot-eels-dress.md
+++ b/.changeset/hot-eels-dress.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mssql': patch
+---
+
+Corrected the minimum supported @mastra/core version to match the APIs used by this store.

--- a/.changeset/late-toys-kneel.md
+++ b/.changeset/late-toys-kneel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/oracledb': patch
+---
+
+Corrected the minimum supported @mastra/core version to match the APIs used by this store.

--- a/.changeset/lemon-geckos-kneel.md
+++ b/.changeset/lemon-geckos-kneel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/redis': patch
+---
+
+Corrected the minimum supported @mastra/core version to match the APIs used by this store.

--- a/.changeset/mighty-pants-warn.md
+++ b/.changeset/mighty-pants-warn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/spanner': patch
+---
+
+Corrected the minimum supported @mastra/core version to match the APIs used by this store.

--- a/.changeset/shaky-years-study.md
+++ b/.changeset/shaky-years-study.md
@@ -1,0 +1,5 @@
+---
+'@mastra/upstash': patch
+---
+
+Corrected the minimum supported @mastra/core version to match this store's runtime dependencies.

--- a/.changeset/strong-items-read.md
+++ b/.changeset/strong-items-read.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Improved peer dependency checks to catch unsupported @mastra/core imports across published packages.

--- a/.changeset/strong-items-read.md
+++ b/.changeset/strong-items-read.md
@@ -1,5 +1,0 @@
----
-'@mastra/server': patch
----
-
-Improved peer dependency checks to catch unsupported @mastra/core imports across the server package, server adapters, and stores.

--- a/.changeset/strong-items-read.md
+++ b/.changeset/strong-items-read.md
@@ -2,4 +2,4 @@
 '@mastra/server': patch
 ---
 
-Improved peer dependency checks to catch unsupported @mastra/core imports across published packages.
+Improved peer dependency checks to catch unsupported @mastra/core imports across the server package, server adapters, and stores.

--- a/.changeset/tame-rice-drive.md
+++ b/.changeset/tame-rice-drive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/valkey': patch
+---
+
+Corrected the minimum supported @mastra/core version to match the APIs used by this store.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -211,7 +211,7 @@ jobs:
         run: node ./scripts/validate-peerdeps.mjs
 
       - name: Check @mastra/core import floor
-        run: pnpm --filter ./packages/server check:core-imports
+        run: pnpm check:core-imports
 
       - name: Check for git changes
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,6 @@ For schema-backed execution, put deterministic input/output constraints (shape, 
 Use literal model names/IDs from `docs/src/plugins/remark-model-tokens/models.ts` in changesets/comments; placeholders are not replaced.
 
 Use the narrowest package build/test/lint/typecheck; run unit/integration before E2E. Prefer targeted `pnpm --filter` or `pnpm turbo build --filter` commands; avoid root setup/build scripts unless needed. Fresh clone: `pnpm install`, then build relevant dependencies. Unresolved workspace imports usually mean dependencies need building; some integration tests need `pnpm i --ignore-workspace`.
-Run `pnpm check:core-imports` to validate `packages/server` and all published stores against their `@mastra/core` peer floors; pass repo-relative package directories to scope the check.
 
 Features/new packages need docs. For docs, follow `docs/AGENTS.md` and styleguides. After code changes, read `@.mastracode/commands/changeset.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ For schema-backed execution, put deterministic input/output constraints (shape, 
 Use literal model names/IDs from `docs/src/plugins/remark-model-tokens/models.ts` in changesets/comments; placeholders are not replaced.
 
 Use the narrowest package build/test/lint/typecheck; run unit/integration before E2E. Prefer targeted `pnpm --filter` or `pnpm turbo build --filter` commands; avoid root setup/build scripts unless needed. Fresh clone: `pnpm install`, then build relevant dependencies. Unresolved workspace imports usually mean dependencies need building; some integration tests need `pnpm i --ignore-workspace`.
+Run `pnpm check:core-imports` to validate `packages/server` and all published stores against their `@mastra/core` peer floors; pass repo-relative package directories to scope the check.
 
 Features/new packages need docs. For docs, follow `docs/AGENTS.md` and styleguides. After code changes, read `@.mastracode/commands/changeset.md`.
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "changeset": "pnpm --filter @internal/changeset-cli start",
     "changeset-cli": "changeset",
+    "check:core-imports": "tsx scripts/check-core-imports.ts",
     "ci:publish": "pnpm publish -r",
     "build": "pnpm turbo build --filter \"!./examples/*\" --filter \"!./examples/**/*\"",
     "build:server-adapters": "pnpm turbo build --filter \"./server-adapters/*\"",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.1",
     "@types/node": "22.20.1",
+    "@types/semver": "^7.7.1",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
     "changesets-changelog-github-local": "^1.0.1",

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -1,7 +1,7 @@
 Build from root: pnpm build:server
 Test from root: pnpm test:server
 If you change permissions, also run pnpm --filter ./packages/server generate:permissions and pnpm --filter ./packages/server check:permissions
-If you add new @mastra/core imports, also run pnpm --filter ./packages/server check:core-imports
+Run pnpm --filter ./packages/server check:core-imports to validate every published package's @mastra/core value imports against its peer floor; pass repo-relative package directories as arguments to scope the check
 
 Most validation is package-scoped tests plus build output
 Permission and handler-contract changes need extra verification

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -1,7 +1,7 @@
 Build from root: pnpm build:server
 Test from root: pnpm test:server
 If you change permissions, also run pnpm --filter ./packages/server generate:permissions and pnpm --filter ./packages/server check:permissions
-Run pnpm --filter ./packages/server check:core-imports to validate every published package's @mastra/core value imports against its peer floor; pass repo-relative package directories as arguments to scope the check
+Run pnpm --filter ./packages/server check:core-imports to validate the server package, published server adapters, and stores against their @mastra/core peer floors; pass repo-relative package directories as arguments to scope the check
 
 Most validation is package-scoped tests plus build output
 Permission and handler-contract changes need extra verification

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -1,7 +1,6 @@
 Build from root: pnpm build:server
 Test from root: pnpm test:server
 If you change permissions, also run pnpm --filter ./packages/server generate:permissions and pnpm --filter ./packages/server check:permissions
-Run pnpm --filter ./packages/server check:core-imports to validate the server package, published server adapters, and stores against their @mastra/core peer floors; pass repo-relative package directories as arguments to scope the check
 
 Most validation is package-scoped tests plus build output
 Permission and handler-contract changes need extra verification

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -102,7 +102,6 @@
     "generate:api-cli-route-metadata": "tsx scripts/generate-api-cli-route-metadata.ts",
     "generate:route-types": "tsx scripts/generate-route-types.ts",
     "check:permissions": "tsx scripts/check-permissions.ts",
-    "check:core-imports": "tsx scripts/check-core-imports.ts",
     "test": "vitest run",
     "lint": "oxlint . && eslint .",
     "lint:fix": "oxlint --fix . && eslint --fix ."

--- a/packages/server/scripts/check-core-imports.ts
+++ b/packages/server/scripts/check-core-imports.ts
@@ -5,22 +5,78 @@ import { fileURLToPath } from 'node:url';
 import ts from 'typescript-classic';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const packageRoot = resolve(__dirname, '..');
-const repoRoot = resolve(packageRoot, '../..');
+const repoRoot = resolve(__dirname, '../../..');
 const corePackageRoot = join(repoRoot, 'packages', 'core');
-const packageJsonPath = join(packageRoot, 'package.json');
-const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
-  peerDependencies?: Record<string, string>;
-};
 const corePackageJsonPath = join(corePackageRoot, 'package.json');
 const corePackageJson = JSON.parse(readFileSync(corePackageJsonPath, 'utf-8')) as {
   version?: string;
 };
+const skippedDirectories = new Set([
+  '.git',
+  '.pnpm',
+  'build',
+  'dist',
+  'docs',
+  'e2e-tests',
+  'examples',
+  'explorations',
+  'node_modules',
+]);
+// TODO(#22555): Remove packages from this rollout baseline as their existing @mastra/core peer floors are corrected.
+// Explicit CLI targets are still checked, including packages listed here.
+const temporarilyExcludedPackages = new Set([
+  '@mastra/agent-browser',
+  '@mastra/agent-builder',
+  '@mastra/agentcore',
+  '@mastra/ai-sdk',
+  '@mastra/apple-container',
+  '@mastra/azure',
+  '@mastra/blaxel',
+  '@mastra/browser-firecrawl',
+  '@mastra/browser-viewer',
+  '@mastra/clickhouse',
+  '@mastra/cloudflare-d1',
+  '@mastra/dsql',
+  '@mastra/duckdb',
+  '@mastra/dynamodb',
+  '@mastra/e2b',
+  '@mastra/editor',
+  '@mastra/elasticsearch',
+  '@mastra/google-drive',
+  '@mastra/loggers',
+  '@mastra/mcp',
+  '@mastra/memory',
+  '@mastra/mesa',
+  '@mastra/modal',
+  '@mastra/mssql',
+  '@mastra/observability',
+  '@mastra/oracledb',
+  '@mastra/platform-workspace',
+  '@mastra/playground-ui',
+  '@mastra/rag',
+  '@mastra/railway',
+  '@mastra/redis',
+  '@mastra/s3',
+  '@mastra/spanner',
+  '@mastra/stagehand',
+  '@mastra/telegram',
+  '@mastra/valkey',
+  '@mastra/vercel',
+]);
 
 type CoreValueImport = {
   file: string;
   moduleName: string;
   names: string[];
+};
+
+type PackageInfo = {
+  coreRange: string;
+  coreFloorVersion: string;
+  corePackVersion: string;
+  name: string;
+  packageJsonPath: string;
+  root: string;
 };
 
 const formatHost: ts.FormatDiagnosticsHost = {
@@ -29,13 +85,98 @@ const formatHost: ts.FormatDiagnosticsHost = {
   getNewLine: () => ts.sys.newLine,
 };
 
-const coreRange = packageJson.peerDependencies?.['@mastra/core'];
-const coreFloorVersion = coreRange?.match(/>=\s*(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)/)?.[1];
-const corePackVersion = coreFloorVersion?.endsWith('-0') ? coreFloorVersion.slice(0, -2) : coreFloorVersion;
+function findPackageRoots(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const roots = existsSync(join(dir, 'package.json')) ? [dir] : [];
 
-if (!coreRange || !coreFloorVersion || !corePackVersion) {
-  console.error('✗ Could not determine @mastra/core peer dependency floor from package.json');
-  process.exit(1);
+  for (const entry of entries) {
+    if (!entry.isDirectory() || skippedDirectories.has(entry.name)) continue;
+    roots.push(...findPackageRoots(join(dir, entry.name)));
+  }
+
+  return roots;
+}
+
+function getPackageInfo(packageRoot: string): PackageInfo | undefined {
+  const packageJsonPath = join(packageRoot, 'package.json');
+
+  if (
+    !existsSync(packageJsonPath) ||
+    !existsSync(join(packageRoot, 'src')) ||
+    !existsSync(join(packageRoot, 'tsconfig.json'))
+  ) {
+    return undefined;
+  }
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+    name?: string;
+    peerDependencies?: Record<string, string>;
+    private?: boolean;
+  };
+  const coreRange = packageJson.peerDependencies?.['@mastra/core'];
+
+  if (!coreRange) {
+    return undefined;
+  }
+
+  const coreFloorVersion = coreRange.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/)?.[0];
+  const corePackVersion = coreFloorVersion?.endsWith('-0') ? coreFloorVersion.slice(0, -2) : coreFloorVersion;
+
+  if (!coreFloorVersion || !corePackVersion) {
+    throw new Error(
+      `Could not determine @mastra/core peer dependency floor from ${relative(repoRoot, packageJsonPath)}`,
+    );
+  }
+
+  return {
+    coreRange,
+    coreFloorVersion,
+    corePackVersion,
+    name: packageJson.name ?? relative(repoRoot, packageRoot),
+    packageJsonPath,
+    root: packageRoot,
+  };
+}
+
+function getPackagesToCheck() {
+  if (process.argv.length > 2) {
+    const packages = process.argv.slice(2).map(packagePath => {
+      const packageRoot = resolve(repoRoot, packagePath);
+      const packageInfo = getPackageInfo(packageRoot);
+
+      if (!packageInfo) {
+        throw new Error(
+          `${packagePath} must contain package.json, src/, tsconfig.json, and an @mastra/core peer dependency`,
+        );
+      }
+
+      return packageInfo;
+    });
+
+    return { excluded: [], packages };
+  }
+
+  const excluded: PackageInfo[] = [];
+  const packages: PackageInfo[] = [];
+
+  for (const packageRoot of findPackageRoots(repoRoot)) {
+    const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8')) as { private?: boolean };
+    if (packageJson.private) continue;
+
+    const packageInfo = getPackageInfo(packageRoot);
+    if (!packageInfo) continue;
+
+    if (temporarilyExcludedPackages.has(packageInfo.name)) {
+      excluded.push(packageInfo);
+    } else {
+      packages.push(packageInfo);
+    }
+  }
+
+  return {
+    excluded: excluded.sort((a, b) => a.name.localeCompare(b.name)),
+    packages: packages.sort((a, b) => a.name.localeCompare(b.name)),
+  };
 }
 
 function findTypeScriptFiles(dir: string): string[] {
@@ -57,7 +198,7 @@ function getModuleName(moduleSpecifier: ts.Expression) {
   return moduleSpecifier.text;
 }
 
-function collectCoreValueImports() {
+function collectCoreValueImports(packageRoot: string) {
   const imports: CoreValueImport[] = [];
 
   for (const file of findTypeScriptFiles(join(packageRoot, 'src'))) {
@@ -202,6 +343,7 @@ function resolveExportTypesPath(coreRoot: string, moduleName: string) {
     if (!exportKey.includes('*')) continue;
 
     const [prefix, suffix] = exportKey.split('*') as [string, string];
+
     if (!exportSubpath.startsWith(prefix) || !exportSubpath.endsWith(suffix)) continue;
 
     const matchedSubpath = exportSubpath.slice(prefix.length, exportSubpath.length - suffix.length);
@@ -235,7 +377,7 @@ function createCorePaths(coreRoot: string, moduleNames: string[]) {
   return { paths, availablePaths };
 }
 
-function writeImportCheck(imports: CoreValueImport[], destination: string) {
+function writeImportCheck(imports: CoreValueImport[], destination: string, packageRoot: string) {
   const lines = imports.flatMap(({ file, moduleName, names }, index) => {
     const uniqueNames = [...new Set(names)].sort();
     const importNames = uniqueNames.map(name => `${name} as import_${index}_${name}`).join(', ');
@@ -276,27 +418,25 @@ function runTypeCheck(tsconfigPath: string) {
   return 0;
 }
 
-const tempDir = mkdtempSync(join(corePackageRoot, '.core-import-check-'));
-let exitCode = 1;
-
-try {
-  const imports = collectCoreValueImports();
+function checkPackage(packageInfo: PackageInfo, floorCoreRoot: string, tempRoot: string) {
+  const imports = collectCoreValueImports(packageInfo.root);
   const moduleNames = [...new Set(imports.map(item => item.moduleName))].sort();
-  const floorCoreRoot = extractCorePackage(corePackVersion, tempDir);
   const { paths, availablePaths } = createCorePaths(floorCoreRoot, moduleNames);
-  const checkFilePath = join(tempDir, 'core-import-check.ts');
-  const tsconfigPath = join(tempDir, 'tsconfig.json');
+  const packageTempDir = mkdtempSync(join(tempRoot, 'check-'));
+  const checkFilePath = join(packageTempDir, 'core-import-check.ts');
+  const tsconfigPath = join(packageTempDir, 'tsconfig.json');
 
-  writeImportCheck(imports, checkFilePath);
+  writeImportCheck(imports, checkFilePath, packageInfo.root);
 
   writeFileSync(
     tsconfigPath,
     JSON.stringify(
       {
-        extends: join(packageRoot, 'tsconfig.json'),
+        extends: join(packageInfo.root, 'tsconfig.json'),
         compilerOptions: {
           moduleResolution: 'bundler',
           paths,
+          rootDir: packageTempDir,
           typeRoots: [join(repoRoot, 'node_modules', '@types')],
         },
         include: [checkFilePath],
@@ -306,7 +446,9 @@ try {
     ),
   );
 
-  console.info(`Checking @mastra/server value imports against @mastra/core@${corePackVersion} (${coreRange})`);
+  console.info(
+    `\nChecking ${packageInfo.name} value imports against @mastra/core@${packageInfo.corePackVersion} (${packageInfo.coreRange})`,
+  );
   console.info(
     `Resolved ${availablePaths}/${moduleNames.length} @mastra/core import paths from the peer dependency floor`,
   );
@@ -315,17 +457,60 @@ try {
   const status = runTypeCheck(tsconfigPath);
 
   if (status === 0) {
-    console.info('✓ @mastra/core value imports are compatible with the peer dependency floor');
+    console.info(`✓ ${packageInfo.name} @mastra/core value imports are compatible with the peer dependency floor`);
   } else {
-    console.error('✗ @mastra/core value imports are not compatible with the peer dependency floor');
+    console.error(`✗ ${packageInfo.name} @mastra/core value imports are not compatible with the peer dependency floor`);
     console.error(
-      `  Either avoid newer @mastra/core value imports or bump the peer dependency floor in ${relative(repoRoot, packageJsonPath)}`,
+      `  Either avoid newer @mastra/core value imports or bump the peer dependency floor in ${relative(repoRoot, packageInfo.packageJsonPath)}`,
     );
   }
 
-  exitCode = status;
+  return status;
+}
+
+const tempRoot = mkdtempSync(join(corePackageRoot, '.core-import-check-'));
+let exitCode = 0;
+
+try {
+  const { excluded, packages } = getPackagesToCheck();
+  const floorCoreRoots = new Map<string, string>();
+
+  console.info(
+    `Found ${packages.length} package${packages.length === 1 ? '' : 's'} with an @mastra/core peer dependency`,
+  );
+  if (excluded.length > 0) {
+    console.info(
+      `Temporarily excluding ${excluded.length} package${excluded.length === 1 ? '' : 's'} with known pre-existing floor violations:`,
+    );
+    console.info(`  ${excluded.map(packageInfo => packageInfo.name).join(', ')}`);
+  }
+
+  for (const packageInfo of packages) {
+    try {
+      let floorCoreRoot = floorCoreRoots.get(packageInfo.corePackVersion);
+
+      if (!floorCoreRoot) {
+        const versionTempDir = mkdtempSync(
+          join(tempRoot, `core-${packageInfo.corePackVersion.replace(/[^0-9A-Za-z.-]/g, '-')}-`),
+        );
+        floorCoreRoot = extractCorePackage(packageInfo.corePackVersion, versionTempDir);
+        floorCoreRoots.set(packageInfo.corePackVersion, floorCoreRoot);
+      }
+
+      if (checkPackage(packageInfo, floorCoreRoot, tempRoot) !== 0) {
+        exitCode = 1;
+      }
+    } catch (error) {
+      console.error(`\n✗ Failed to check ${packageInfo.name}`);
+      console.error(error instanceof Error ? error.message : error);
+      exitCode = 1;
+    }
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  exitCode = 1;
 } finally {
-  rmSync(tempDir, { recursive: true, force: true });
+  rmSync(tempRoot, { recursive: true, force: true });
 }
 
 process.exit(exitCode);

--- a/packages/server/scripts/check-core-imports.ts
+++ b/packages/server/scripts/check-core-imports.ts
@@ -25,43 +25,17 @@ const skippedDirectories = new Set([
 // TODO(#22555): Remove packages from this rollout baseline as their existing @mastra/core peer floors are corrected.
 // Explicit CLI targets are still checked, including packages listed here.
 const temporarilyExcludedPackages = new Set([
-  '@mastra/agent-browser',
-  '@mastra/agent-builder',
-  '@mastra/agentcore',
-  '@mastra/ai-sdk',
-  '@mastra/apple-container',
-  '@mastra/azure',
-  '@mastra/blaxel',
-  '@mastra/browser-firecrawl',
-  '@mastra/browser-viewer',
   '@mastra/clickhouse',
   '@mastra/cloudflare-d1',
   '@mastra/dsql',
   '@mastra/duckdb',
   '@mastra/dynamodb',
-  '@mastra/e2b',
-  '@mastra/editor',
   '@mastra/elasticsearch',
-  '@mastra/google-drive',
-  '@mastra/loggers',
-  '@mastra/mcp',
-  '@mastra/memory',
-  '@mastra/mesa',
-  '@mastra/modal',
   '@mastra/mssql',
-  '@mastra/observability',
   '@mastra/oracledb',
-  '@mastra/platform-workspace',
-  '@mastra/playground-ui',
-  '@mastra/rag',
-  '@mastra/railway',
   '@mastra/redis',
-  '@mastra/s3',
   '@mastra/spanner',
-  '@mastra/stagehand',
-  '@mastra/telegram',
   '@mastra/valkey',
-  '@mastra/vercel',
 ]);
 
 type CoreValueImport = {
@@ -158,8 +132,13 @@ function getPackagesToCheck() {
 
   const excluded: PackageInfo[] = [];
   const packages: PackageInfo[] = [];
+  const defaultPackageRoots = [
+    join(repoRoot, 'packages', 'server'),
+    ...findPackageRoots(join(repoRoot, 'server-adapters')),
+    ...findPackageRoots(join(repoRoot, 'stores')),
+  ];
 
-  for (const packageRoot of findPackageRoots(repoRoot)) {
+  for (const packageRoot of defaultPackageRoots) {
     const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8')) as { private?: boolean };
     if (packageJson.private) continue;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)

--- a/scripts/check-core-imports.ts
+++ b/scripts/check-core-imports.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import semver from 'semver';
 import ts from 'typescript-classic';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -9,7 +10,7 @@ const repoRoot = resolve(__dirname, '..');
 const corePackageRoot = join(repoRoot, 'packages', 'core');
 const corePackageJsonPath = join(corePackageRoot, 'package.json');
 const corePackageJson = JSON.parse(readFileSync(corePackageJsonPath, 'utf-8')) as {
-  version?: string;
+  version: string;
 };
 const skippedDirectories = new Set([
   '.git',
@@ -30,8 +31,9 @@ type CoreValueImport = {
 
 type PackageInfo = {
   coreRange: string;
-  coreFloorVersion: string;
-  corePackVersion: string;
+  coreFloorVersion?: string;
+  corePackVersion?: string;
+  coreRangeError?: string;
   name: string;
   packageJsonPath: string;
   root: string;
@@ -53,6 +55,20 @@ function findPackageRoots(dir: string): string[] {
   }
 
   return roots;
+}
+
+function resolveCoreSemverRange(coreRange: string) {
+  if (!coreRange.startsWith('workspace:')) {
+    return coreRange;
+  }
+
+  const workspaceRange = coreRange.slice('workspace:'.length);
+
+  if (workspaceRange === '*' || workspaceRange === '^' || workspaceRange === '~') {
+    return workspaceRange === '*' ? corePackageJson.version : `${workspaceRange}${corePackageJson.version}`;
+  }
+
+  return workspaceRange;
 }
 
 function getPackageInfo(packageRoot: string): PackageInfo | undefined {
@@ -77,23 +93,35 @@ function getPackageInfo(packageRoot: string): PackageInfo | undefined {
     return undefined;
   }
 
-  const coreFloorVersion = coreRange.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/)?.[0];
-  const corePackVersion = coreFloorVersion?.endsWith('-0') ? coreFloorVersion.slice(0, -2) : coreFloorVersion;
-
-  if (!coreFloorVersion || !corePackVersion) {
-    throw new Error(
-      `Could not determine @mastra/core peer dependency floor from ${relative(repoRoot, packageJsonPath)}`,
-    );
-  }
-
-  return {
+  const packageInfo = {
     coreRange,
-    coreFloorVersion,
-    corePackVersion,
     name: packageJson.name ?? relative(repoRoot, packageRoot),
     packageJsonPath,
     root: packageRoot,
   };
+
+  try {
+    const coreFloorVersion = semver.minVersion(resolveCoreSemverRange(coreRange), { includePrerelease: true })?.version;
+    const corePackVersion = coreFloorVersion?.endsWith('-0') ? coreFloorVersion.slice(0, -2) : coreFloorVersion;
+
+    if (!coreFloorVersion || !corePackVersion) {
+      return {
+        ...packageInfo,
+        coreRangeError: `Could not determine @mastra/core peer dependency floor from range "${coreRange}"`,
+      };
+    }
+
+    return {
+      ...packageInfo,
+      coreFloorVersion,
+      corePackVersion,
+    };
+  } catch {
+    return {
+      ...packageInfo,
+      coreRangeError: `Could not determine @mastra/core peer dependency floor from range "${coreRange}"`,
+    };
+  }
 }
 
 function getPackagesToCheck() {
@@ -429,15 +457,24 @@ try {
   );
 
   for (const packageInfo of packages) {
+    const corePackVersion = packageInfo.corePackVersion;
+
+    if (packageInfo.coreRangeError || !corePackVersion) {
+      console.error(`\n✗ Failed to check ${packageInfo.name}`);
+      console.error(
+        `${packageInfo.coreRangeError ?? 'Could not determine @mastra/core peer dependency floor'} in ${relative(repoRoot, packageInfo.packageJsonPath)}`,
+      );
+      exitCode = 1;
+      continue;
+    }
+
     try {
-      let floorCoreRoot = floorCoreRoots.get(packageInfo.corePackVersion);
+      let floorCoreRoot = floorCoreRoots.get(corePackVersion);
 
       if (!floorCoreRoot) {
-        const versionTempDir = mkdtempSync(
-          join(tempRoot, `core-${packageInfo.corePackVersion.replace(/[^0-9A-Za-z.-]/g, '-')}-`),
-        );
-        floorCoreRoot = extractCorePackage(packageInfo.corePackVersion, versionTempDir);
-        floorCoreRoots.set(packageInfo.corePackVersion, floorCoreRoot);
+        const versionTempDir = mkdtempSync(join(tempRoot, `core-${corePackVersion.replace(/[^0-9A-Za-z.-]/g, '-')}-`));
+        floorCoreRoot = extractCorePackage(corePackVersion, versionTempDir);
+        floorCoreRoots.set(corePackVersion, floorCoreRoot);
       }
 
       if (checkPackage(packageInfo, floorCoreRoot, tempRoot) !== 0) {

--- a/scripts/check-core-imports.ts
+++ b/scripts/check-core-imports.ts
@@ -89,7 +89,7 @@ function getPackageInfo(packageRoot: string): PackageInfo | undefined {
   };
   const coreRange = packageJson.peerDependencies?.['@mastra/core'];
 
-  if (!coreRange) {
+  if (packageJson.private || !coreRange) {
     return undefined;
   }
 
@@ -146,9 +146,6 @@ function getPackagesToCheck() {
   const defaultPackageRoots = [join(repoRoot, 'packages', 'server'), ...findPackageRoots(join(repoRoot, 'stores'))];
 
   for (const packageRoot of defaultPackageRoots) {
-    const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8')) as { private?: boolean };
-    if (packageJson.private) continue;
-
     const packageInfo = getPackageInfo(packageRoot);
     if (packageInfo) packages.push(packageInfo);
   }

--- a/scripts/check-core-imports.ts
+++ b/scripts/check-core-imports.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import ts from 'typescript-classic';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const repoRoot = resolve(__dirname, '../../..');
+const repoRoot = resolve(__dirname, '..');
 const corePackageRoot = join(repoRoot, 'packages', 'core');
 const corePackageJsonPath = join(corePackageRoot, 'package.json');
 const corePackageJson = JSON.parse(readFileSync(corePackageJsonPath, 'utf-8')) as {
@@ -22,22 +22,6 @@ const skippedDirectories = new Set([
   'explorations',
   'node_modules',
 ]);
-// TODO(#22555): Remove packages from this rollout baseline as their existing @mastra/core peer floors are corrected.
-// Explicit CLI targets are still checked, including packages listed here.
-const temporarilyExcludedPackages = new Set([
-  '@mastra/clickhouse',
-  '@mastra/cloudflare-d1',
-  '@mastra/dsql',
-  '@mastra/duckdb',
-  '@mastra/dynamodb',
-  '@mastra/elasticsearch',
-  '@mastra/mssql',
-  '@mastra/oracledb',
-  '@mastra/redis',
-  '@mastra/spanner',
-  '@mastra/valkey',
-]);
-
 type CoreValueImport = {
   file: string;
   moduleName: string;
@@ -127,35 +111,21 @@ function getPackagesToCheck() {
       return packageInfo;
     });
 
-    return { excluded: [], packages };
+    return packages;
   }
 
-  const excluded: PackageInfo[] = [];
   const packages: PackageInfo[] = [];
-  const defaultPackageRoots = [
-    join(repoRoot, 'packages', 'server'),
-    ...findPackageRoots(join(repoRoot, 'server-adapters')),
-    ...findPackageRoots(join(repoRoot, 'stores')),
-  ];
+  const defaultPackageRoots = [join(repoRoot, 'packages', 'server'), ...findPackageRoots(join(repoRoot, 'stores'))];
 
   for (const packageRoot of defaultPackageRoots) {
     const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8')) as { private?: boolean };
     if (packageJson.private) continue;
 
     const packageInfo = getPackageInfo(packageRoot);
-    if (!packageInfo) continue;
-
-    if (temporarilyExcludedPackages.has(packageInfo.name)) {
-      excluded.push(packageInfo);
-    } else {
-      packages.push(packageInfo);
-    }
+    if (packageInfo) packages.push(packageInfo);
   }
 
-  return {
-    excluded: excluded.sort((a, b) => a.name.localeCompare(b.name)),
-    packages: packages.sort((a, b) => a.name.localeCompare(b.name)),
-  };
+  return packages.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 function findTypeScriptFiles(dir: string): string[] {
@@ -451,18 +421,12 @@ const tempRoot = mkdtempSync(join(corePackageRoot, '.core-import-check-'));
 let exitCode = 0;
 
 try {
-  const { excluded, packages } = getPackagesToCheck();
+  const packages = getPackagesToCheck();
   const floorCoreRoots = new Map<string, string>();
 
   console.info(
     `Found ${packages.length} package${packages.length === 1 ? '' : 's'} with an @mastra/core peer dependency`,
   );
-  if (excluded.length > 0) {
-    console.info(
-      `Temporarily excluding ${excluded.length} package${excluded.length === 1 ? '' : 's'} with known pre-existing floor violations:`,
-    );
-    console.info(`  ${excluded.map(packageInfo => packageInfo.name).join(', ')}`);
-  }
 
   for (const packageInfo of packages) {
     try {

--- a/stores/clickhouse/package.json
+++ b/stores/clickhouse/package.json
@@ -51,7 +51,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.57.0-0 <2.0.0-0",
+    "@mastra/core": ">=1.60.0-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "files": [

--- a/stores/cloudflare-d1/package.json
+++ b/stores/cloudflare-d1/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/core": ">=1.54.0-0 <2.0.0-0",
     "@cloudflare/workers-types": "^4.20240919.0"
   },
   "homepage": "https://mastra.ai",

--- a/stores/dsql/package.json
+++ b/stores/dsql/package.json
@@ -49,7 +49,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.61.0-0 <2.0.0-0"
   },
   "files": [
     "dist"

--- a/stores/duckdb/package.json
+++ b/stores/duckdb/package.json
@@ -47,7 +47,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.57.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.58.0-0 <2.0.0-0"
   },
   "files": [
     "dist"

--- a/stores/dynamodb/package.json
+++ b/stores/dynamodb/package.json
@@ -42,7 +42,7 @@
     "electrodb": "^3.9.1"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.61.0-0 <2.0.0-0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/stores/elasticsearch/package.json
+++ b/stores/elasticsearch/package.json
@@ -49,7 +49,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.61.0-0 <2.0.0-0"
   },
   "files": [
     "dist"

--- a/stores/mssql/package.json
+++ b/stores/mssql/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.61.0-0 <2.0.0-0"
   },
   "files": [
     "dist"

--- a/stores/oracledb/package.json
+++ b/stores/oracledb/package.json
@@ -51,7 +51,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.34.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.61.0-0 <2.0.0-0"
   },
   "files": [
     "dist"

--- a/stores/redis/package.json
+++ b/stores/redis/package.json
@@ -51,7 +51,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.61.0-0 <2.0.0-0"
   },
   "files": [
     "dist"

--- a/stores/spanner/package.json
+++ b/stores/spanner/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.51.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.61.0-0 <2.0.0-0"
   },
   "files": [
     "dist"

--- a/stores/upstash/package.json
+++ b/stores/upstash/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.61.0-0 <2.0.0-0"
   },
   "files": [
     "dist"

--- a/stores/valkey/package.json
+++ b/stores/valkey/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.53.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.61.0-0 <2.0.0-0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
The repository previously validated `@mastra/core` imports only for `@mastra/server`, allowing stores to import values that were unavailable at the minimum core versions declared by their peer dependencies.

This PR adds a repository-level `pnpm check:core-imports` command that:

- checks `packages/server` and every published package under `stores/`
- downloads each distinct `@mastra/core` floor version once
- type-checks every named value import against that floor
- supports explicit package paths for targeted checks
- runs alongside the existing peer dependency validator in CI

It also corrects the minimum core versions for ClickHouse, Cloudflare D1, DSQL, DuckDB, DynamoDB, Elasticsearch, MSSQL, OracleDB, Redis, Spanner, Upstash, and Valkey. Upstash is aligned with the newer floor required by its Redis runtime dependency.

There are no temporary store exclusions: the default command checks `@mastra/server` plus all 29 published stores.

## Verification

- `pnpm check:core-imports` — 30 packages passed
- `node scripts/validate-peerdeps.mjs` — 119 valid, 0 invalid; no transitive errors
- Lint passed for all 12 changed stores
- `scripts/check-core-imports.ts` passed Oxlint and standalone TypeScript checking
- Formatting and `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR checks that the server and published stores use compatible `@mastra/core` versions. It also fixes outdated minimum version requirements so packages do not claim support they do not have.

## Changes

- Added the root `pnpm check:core-imports` command.
- Validated named `@mastra/core` imports in `packages/server` and all 29 published stores.
- Added explicit package selection and per-package error reporting.
- Parsed semver lower bounds and normalized workspace ranges.
- Cached each distinct downloaded `@mastra/core` version.
- Continued compatibility checks after reporting malformed peer ranges.
- Corrected minimum `@mastra/core` peer versions for 12 stores.
- Added patch changesets for the affected stores.
- Updated CI and repository guidance to use the root-level check.
- Removed temporary store exclusions.

## Verification

- 30 packages passed validation.
- 119 peer dependencies passed with no transitive errors.
- Linting, Oxlint, standalone TypeScript checks, formatting, and `git diff --check` passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->