### PR TITLE
fix(core): strip foreign reasoning on provider switch

### DIFF
--- a/.changeset/short-files-double.md
+++ b/.changeset/short-files-double.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Anthropic tool continuations after switching providers by removing incompatible reasoning history.

--- a/packages/core/src/processors/provider-history-compat.test.ts
+++ b/packages/core/src/processors/provider-history-compat.test.ts
@@ -656,6 +656,42 @@ describe('trailing assistant message protection', () => {
     expect((result![3].content as any[]).map(p => p.type)).toEqual(['reasoning', 'reasoning', 'tool-call']);
   });
 
+  it('strips foreign reasoning from a trailing tool continuation after switching to Anthropic', () => {
+    const prompt: LanguageModelV2Prompt = [
+      { role: 'user', content: [{ type: 'text', text: 'do the thing' }] },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: '',
+            providerOptions: {
+              openai: {
+                itemId: 'rs_123',
+                reasoningEncryptedContent: 'encrypted-reasoning',
+              },
+            },
+          },
+          { type: 'tool-call', toolCallId: 'call-1', toolName: 'doThing', input: {} },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          { type: 'tool-result', toolCallId: 'call-1', toolName: 'doThing', output: { type: 'text', value: 'ok' } },
+        ],
+      },
+    ];
+
+    const result = anthropicStripForeignReasoningContent.applyToPrompt!({
+      prompt,
+      model: anthropicModel,
+    });
+
+    expect(result).toBeDefined();
+    expect((result![1].content as any[]).map(p => p.type)).toEqual(['tool-call']);
+  });
+
   it('empty-signed strip skips the trailing assistant of a tool continuation', () => {
     const prompt = toolContinuationPrompt();
     // Give the historical assistant an empty signed block so the rule has

--- a/packages/core/src/processors/provider-history-compat.ts
+++ b/packages/core/src/processors/provider-history-compat.ts
@@ -411,6 +411,16 @@ function isAnthropicReasoningPart(part: { providerOptions?: unknown; providerMet
   return false;
 }
 
+function getProtectedAnthropicAssistantIndex(prompt: LanguageModelV2Prompt): number {
+  const index = getProtectedAssistantIndex(prompt);
+  if (index === -1) return -1;
+
+  const message = prompt[index]!;
+  if (message.role !== 'assistant' || !Array.isArray(message.content)) return -1;
+
+  return message.content.some(part => part.type === 'reasoning' && isAnthropicReasoningPart(part)) ? index : -1;
+}
+
 function getProviderMetadataForProvider(metadata: unknown, provider: string): Record<string, unknown> | undefined {
   if (!metadata || typeof metadata !== 'object') return undefined;
   const value = (metadata as Record<string, unknown>)[provider];
@@ -494,7 +504,7 @@ export const anthropicStripForeignReasoningContent: CompatRule = {
     return stripReasoningFromPrompt(
       prompt,
       part => !isAnthropicReasoningPart(part),
-      getProtectedAssistantIndex(prompt),
+      getProtectedAnthropicAssistantIndex(prompt),
     );
   },
 };


### PR DESCRIPTION
When an active tool continuation was generated by another provider and then switched to Anthropic, provider history compatibility protected the entire latest assistant message. This allowed foreign reasoning metadata into the Anthropic request, which rejects it as a modified thinking block.

This change only protects the trailing assistant message when it contains Anthropic-native reasoning. Foreign reasoning is stripped while the tool call and result remain intact, and genuine Anthropic thinking continuations keep their existing byte-for-byte protection.

Tested with the provider history compatibility and Anthropic thinking round-trip suites (57 tests), plus the `@mastra/core` typecheck.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the system switches to Anthropic, it removes reasoning details from another provider that Anthropic cannot use. It keeps tool calls and Anthropic’s own reasoning data unchanged.

## Changes

- Strip foreign reasoning metadata from the trailing assistant message during provider switching to Anthropic.
- Preserve tool calls and tool results.
- Preserve Anthropic-native reasoning continuations byte-for-byte.
- Add regression coverage for OpenAI-to-Anthropic tool continuations.
- Add a patch changeset for `@mastra/core`.

## Validation

- Provider history compatibility and Anthropic thinking round-trip suites passed: 57 tests.
- `@mastra/core` typecheck passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->