### PR TITLE
test(knowledge): prove Wave 1 linked-workspace integration

### DIFF
--- a/.changeset/moody-islands-sleep.md
+++ b/.changeset/moody-islands-sleep.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed `Memory.settled()` to wait for observation-time curation before storage is closed. Added actionable guidance for unknown Subconscious observation agents.

--- a/mastracode/factory-ui/e2e/knowledge/explore.spec.ts
+++ b/mastracode/factory-ui/e2e/knowledge/explore.spec.ts
@@ -88,6 +88,7 @@ test('explores scoped knowledge and activity', async ({ context, page }) => {
         },
       });
     }
+    if (url.pathname.endsWith('/feed-events')) return route.fulfill({ body: '', contentType: 'text/event-stream' });
     if (url.pathname.endsWith('/active-runs')) return route.fulfill({ json: { runs: [] } });
     if (url.pathname.endsWith('/decisions')) return route.fulfill({ json: { decisions: [] } });
     if (url.pathname.endsWith('/work-records')) return route.fulfill({ json: { workRecords: [] } });

--- a/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ModelPacksSection.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/settings/components/__tests__/ModelPacksSection.msw.test.tsx
@@ -37,6 +37,7 @@ async function pickOption(user: ReturnType<typeof userEvent.setup>, trigger: HTM
 }
 
 async function enterCustomModel(user: ReturnType<typeof userEvent.setup>, trigger: HTMLElement, modelId: string) {
+  await waitFor(() => expect(screen.queryByPlaceholderText('Search models…')).not.toBeInTheDocument());
   await user.click(trigger);
   await user.type(await screen.findByPlaceholderText('Search models…'), modelId);
   const option = await screen.findByRole('option', { name: `Use “${modelId}”` });

--- a/packages/core/src/workspace/lsp/servers.test.ts
+++ b/packages/core/src/workspace/lsp/servers.test.ts
@@ -519,7 +519,12 @@ describe('BUILTIN_SERVERS command()', () => {
     });
 
     it('returns undefined when binary not found', () => {
-      expect(eslintCommand(tempDir)).toBeUndefined();
+      vi.stubEnv('PATH', tempDir);
+      try {
+        expect(eslintCommand(tempDir)).toBeUndefined();
+      } finally {
+        vi.unstubAllEnvs();
+      }
     });
   });
 

--- a/packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts
+++ b/packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts
@@ -1,0 +1,281 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import type { MastraDBMessage } from '@mastra/core/agent';
+import { Knowledge } from '@mastra/core/knowledge';
+import { Mastra } from '@mastra/core/mastra';
+import { RequestContext } from '@mastra/core/request-context';
+import type { MastraCompositeStore } from '@mastra/core/storage';
+import { LibSQLStore } from '@mastra/libsql';
+import { Memory, Subconscious } from '@mastra/memory';
+import { PostgresStore } from '@mastra/pg';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const adapter = process.env.KNOWLEDGE_ADAPTER === 'pg' ? 'pg' : 'libsql';
+const outputPath = process.env.KNOWLEDGE_PROOF_OUTPUT;
+const temporaryDirectories: string[] = [];
+const stores: MastraCompositeStore[] = [];
+const postgresSchemas: string[] = [];
+
+const structure = {
+  scopes: [
+    { address: 'org:acme', name: 'Acme' },
+    { address: 'resource:shipyard', name: 'Shipyard', parentAddresses: ['org:acme'] },
+    { address: 'subject:payments', name: 'Payments', parentAddresses: ['resource:shipyard'] },
+    { address: 'feature:refunds', name: 'Refunds', parentAddresses: ['subject:payments'] },
+    { address: 'area:runtime', name: 'Runtime', parentAddresses: ['feature:refunds'] },
+    { address: 'repository:mastra', name: 'Mastra', parentAddresses: ['feature:refunds'] },
+    { address: 'visibility:public', name: 'Public', parentAddresses: ['feature:refunds'] },
+    { address: 'visibility:internal', name: 'Internal', parentAddresses: ['feature:refunds'] },
+  ],
+};
+
+function message(threadId: string): MastraDBMessage {
+  return {
+    id: randomUUID(),
+    threadId,
+    resourceId: 'shipyard',
+    role: 'user',
+    createdAt: new Date('2026-08-28T00:00:00.000Z'),
+    content: { format: 2, parts: [{ type: 'text', text: 'Maya Chen owns the Atlas refund launch.' }] },
+  };
+}
+
+function deterministicCaptureModel() {
+  const doStream = vi.fn(async () => ({
+    stream: convertArrayToReadableStream([
+      { type: 'stream-start', warnings: [] },
+      { type: 'response-metadata', id: 'wave-1-observation', modelId: 'aimock', timestamp: new Date() },
+      { type: 'text-start', id: 'wave-1-text' },
+      {
+        type: 'text-delta',
+        id: 'wave-1-text',
+        delta: '<observations>Maya Chen owns the Atlas refund launch.</observations>',
+      },
+      { type: 'text-end', id: 'wave-1-text' },
+      { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 8, totalTokens: 28 } },
+    ]),
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    warnings: [],
+  }));
+  const doGenerate = vi.fn(async () => ({
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    finishReason: 'stop' as const,
+    usage: { inputTokens: 20, outputTokens: 20, totalTokens: 40 },
+    warnings: [],
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({
+          capture: {
+            nodes: [
+              {
+                name: 'Atlas refund launch',
+                kind: 'feature',
+                scope: 'resource',
+                records: [
+                  {
+                    text: '[[Maya Chen]] owns the [[Atlas refund launch]].',
+                    scope: 'resource',
+                    reason: 'Ownership is required to coordinate the refund launch.',
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      },
+    ],
+  }));
+  return {
+    model: new MockLanguageModelV2({ doStream: doStream as never, doGenerate: doGenerate as never }),
+    doGenerate,
+  };
+}
+
+async function createStorage(id: string): Promise<{ storage: MastraCompositeStore; location: string }> {
+  if (adapter === 'pg') {
+    const schemaName = `knowledge_w1_${randomUUID().replaceAll('-', '')}`;
+    postgresSchemas.push(schemaName);
+    const storage = new PostgresStore({
+      id,
+      host: process.env.POSTGRES_HOST || 'localhost',
+      port: Number(process.env.POSTGRES_PORT) || 5434,
+      database: process.env.POSTGRES_DB || 'postgres',
+      user: process.env.POSTGRES_USER || 'postgres',
+      password: process.env.POSTGRES_PASSWORD || 'postgres',
+      schemaName,
+    });
+    stores.push(storage);
+    return { storage, location: schemaName };
+  }
+
+  const directory = await mkdtemp(join(tmpdir(), 'knowledge-v2-wave-1-'));
+  temporaryDirectories.push(directory);
+  const location = join(directory, 'knowledge.db');
+  const storage = new LibSQLStore({ id, url: `file:${location}` });
+  stores.push(storage);
+  return { storage, location };
+}
+
+function createRuntime(storage: MastraCompositeStore) {
+  const knowledge = new Knowledge({ id: 'shipyard-knowledge', storage, structure });
+  const { model, doGenerate } = deterministicCaptureModel();
+  const memory = new Memory({
+    storage,
+    knowledge: 'default',
+    options: {
+      observationalMemory: {
+        enabled: true,
+        model,
+        experimental_subconscious: new Subconscious({ observation: ['capture'], reflection: [] }),
+        observation: { messageTokens: 1, bufferTokens: false, previousObserverTokens: 1_000 },
+      },
+    },
+  });
+  const mastra = new Mastra({ knowledge: { default: knowledge }, memory: { default: memory }, logger: false });
+  return { knowledge: mastra.getKnowledge('default'), memory, doGenerate };
+}
+
+function sanitizePackageUrl(url: string): string {
+  return new URL(url).pathname.match(/(?:packages|stores)\/.*$/)?.[0] ?? 'outside-worktree';
+}
+
+async function writeProofOutput(value: Record<string, unknown>) {
+  if (!outputPath) return;
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+afterEach(async () => {
+  for (const storage of stores.splice(0).reverse()) {
+    if (storage instanceof PostgresStore) {
+      const schemaName = postgresSchemas.pop();
+      if (schemaName) {
+        if (!schemaName.startsWith('knowledge_w1_')) throw new Error(`Refusing to drop non-proof schema ${schemaName}`);
+        await storage.db.none(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      }
+    }
+    await storage.close();
+  }
+  await Promise.all(temporaryDirectories.splice(0).map(path => rm(path, { recursive: true, force: true })));
+});
+
+describe(`Knowledge v2 Wave 1 linked-workspace proof (${adapter})`, () => {
+  it('reconciles, captures through OM, and survives a fresh runtime restart', async () => {
+    const resolvedPackages = {
+      core: import.meta.resolve('@mastra/core/knowledge'),
+      memory: import.meta.resolve('@mastra/memory'),
+      adapter: import.meta.resolve(adapter === 'pg' ? '@mastra/pg' : '@mastra/libsql'),
+    };
+    expect(resolvedPackages.core).toContain('/packages/core/dist/knowledge/');
+    expect(resolvedPackages.memory).toContain('/packages/memory/dist/');
+    expect(resolvedPackages.adapter).toContain(adapter === 'pg' ? '/stores/pg/dist/' : '/stores/libsql/dist/');
+
+    const { storage, location } = await createStorage(`wave-1-${adapter}`);
+    const first = createRuntime(storage);
+    const reconciled = await first.knowledge.reconcile();
+    expect(Object.keys(reconciled.scopes)).toEqual(
+      expect.arrayContaining(structure.scopes.map(scope => scope.address)),
+    );
+
+    const threadId = `proof-${randomUUID()}`;
+    await first.memory.createThread({ threadId, resourceId: 'shipyard', title: 'Wave 1 proof' });
+    await first.memory.saveMessages({ messages: [message(threadId)] });
+    const requestContext = new RequestContext();
+    requestContext.set('organizationId', 'acme');
+    const observed = await (await first.memory.omEngine)!.observe({
+      threadId,
+      resourceId: 'shipyard',
+      requestContext,
+      sendStateSignal: async () => ({ skipped: false }) as never,
+    });
+    expect(observed.observed).toBe(true);
+    expect(first.doGenerate).toHaveBeenCalledTimes(1);
+
+    const visibleScope = ['org:acme', 'resource:shipyard', 'resource:shipyard:uncurated'];
+    const captured = await first.knowledge.resolveNode({ name: 'Atlas refund launch', scope: visibleScope });
+    expect(captured).toMatchObject({ kind: 'feature', scope: ['resource:shipyard:uncurated'] });
+    const records = await first.knowledge.listKnowledgeAbout({ node: captured!.id, scope: visibleScope });
+    expect(records.records).toHaveLength(1);
+    expect(records.records[0]).toMatchObject({
+      text: '[[Maya Chen]] owns the [[Atlas refund launch]].',
+      sourceThreadId: threadId,
+      scope: ['resource:shipyard:uncurated'],
+      metadata: { reason: 'Ownership is required to coordinate the refund launch.' },
+    });
+    expect(records.records[0]?.capturedAt).toBeInstanceOf(Date);
+    expect(await first.knowledge.listActivity({ scope: visibleScope, limit: 100 })).not.toEqual([]);
+
+    await first.memory.settled();
+    await storage.close();
+    stores.splice(stores.indexOf(storage), 1);
+
+    const restartedStorage =
+      adapter === 'pg'
+        ? new PostgresStore({
+            id: `wave-1-${adapter}-restart`,
+            host: process.env.POSTGRES_HOST || 'localhost',
+            port: Number(process.env.POSTGRES_PORT) || 5434,
+            database: process.env.POSTGRES_DB || 'postgres',
+            user: process.env.POSTGRES_USER || 'postgres',
+            password: process.env.POSTGRES_PASSWORD || 'postgres',
+            schemaName: location,
+          })
+        : new LibSQLStore({ id: `wave-1-${adapter}-restart`, url: `file:${location}` });
+    stores.push(restartedStorage);
+    const restarted = createRuntime(restartedStorage);
+    const replay = await restarted.knowledge.reconcile();
+    expect(replay.createdScopeIds).toEqual([]);
+    const persisted = await restarted.knowledge.resolveNode({ name: 'Atlas refund launch', scope: visibleScope });
+    expect(persisted?.id).toBe(captured?.id);
+    expect(
+      (await restarted.knowledge.listKnowledgeAbout({ node: persisted!.id, scope: visibleScope })).records,
+    ).toHaveLength(1);
+
+    await writeProofOutput({
+      adapter,
+      resolvedPackages: Object.fromEntries(
+        Object.entries(resolvedPackages).map(([name, url]) => [name, sanitizePackageUrl(url)]),
+      ),
+      structureScopeCount: Object.keys(reconciled.scopes).length,
+      capture: { node: captured?.name, records: records.records.length, activity: 'present' },
+      restart: { sameNodeId: persisted?.id === captured?.id, duplicateScopes: replay.createdScopeIds.length },
+    });
+  });
+
+  it.skipIf(adapter !== 'libsql')(
+    'detects incompatibility without mutation and resets only disposable Knowledge data',
+    async () => {
+      const directory = await mkdtemp(join(tmpdir(), 'knowledge-v2-wave-1-reset-'));
+      temporaryDirectories.push(directory);
+      const databasePath = join(directory, 'reset.db');
+      const initialStorage = new LibSQLStore({ id: 'wave-1-reset-seed', url: `file:${databasePath}` });
+      stores.push(initialStorage);
+      const initialMemory = new Memory({ storage: initialStorage });
+      await initialMemory.createThread({ threadId: 'preserved-thread', resourceId: 'proof', title: 'Preserved' });
+      await initialStorage.close();
+      stores.splice(stores.indexOf(initialStorage), 1);
+
+      const database = new DatabaseSync(databasePath);
+      database.exec('DROP TABLE mastra_knowledge_proposals');
+      database.close();
+
+      const storage = new LibSQLStore({ id: 'wave-1-reset', url: `file:${databasePath}` });
+      stores.push(storage);
+      const domain = storage.stores.knowledge!;
+      expect(await domain.inspectSchema()).toMatchObject({ status: 'incompatible-reset-required' });
+
+      if (!databasePath.startsWith(tmpdir()))
+        throw new Error(`Refusing to reset non-temporary database ${databasePath}`);
+      await domain.dangerouslyReset();
+      expect(await domain.inspectSchema()).toEqual({ status: 'compatible', schemaVersion: 2 });
+      expect(await new Memory({ storage }).getThreadById({ threadId: 'preserved-thread' })).toMatchObject({
+        title: 'Preserved',
+      });
+    },
+  );
+});

--- a/packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts
+++ b/packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts
@@ -163,17 +163,31 @@ async function writeProofOutput(value: Record<string, unknown>) {
 }
 
 afterEach(async () => {
+  const cleanupErrors: unknown[] = [];
   for (const storage of stores.splice(0).reverse()) {
     if (storage instanceof PostgresStore) {
       const schemaName = postgresSchemas.pop();
       if (schemaName) {
-        if (!schemaName.startsWith('knowledge_w1_')) throw new Error(`Refusing to drop non-proof schema ${schemaName}`);
-        await storage.db.none(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+        try {
+          if (!schemaName.startsWith('knowledge_w1_'))
+            throw new Error(`Refusing to drop non-proof schema ${schemaName}`);
+          await storage.db.none(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
       }
     }
-    await storage.close();
+    try {
+      await storage.close();
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
   }
-  await Promise.all(temporaryDirectories.splice(0).map(path => rm(path, { recursive: true, force: true })));
+  const directoryResults = await Promise.allSettled(
+    temporaryDirectories.splice(0).map(path => rm(path, { recursive: true, force: true })),
+  );
+  cleanupErrors.push(...directoryResults.filter(result => result.status === 'rejected').map(result => result.reason));
+  if (cleanupErrors.length) throw cleanupErrors[0];
 });
 
 describe(`Knowledge v2 Wave 1 linked-workspace proof (${adapter})`, () => {

--- a/packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts
+++ b/packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts
@@ -3,7 +3,6 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
-import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import type { MastraDBMessage } from '@mastra/core/agent';
 import { Knowledge } from '@mastra/core/knowledge';
 import { Mastra } from '@mastra/core/mastra';
@@ -46,18 +45,25 @@ function message(threadId: string): MastraDBMessage {
 
 function deterministicCaptureModel() {
   const doStream = vi.fn(async () => ({
-    stream: convertArrayToReadableStream([
-      { type: 'stream-start', warnings: [] },
-      { type: 'response-metadata', id: 'wave-1-observation', modelId: 'aimock', timestamp: new Date() },
-      { type: 'text-start', id: 'wave-1-text' },
-      {
-        type: 'text-delta',
-        id: 'wave-1-text',
-        delta: '<observations>Maya Chen owns the Atlas refund launch.</observations>',
+    stream: new ReadableStream({
+      start(controller) {
+        for (const chunk of [
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'wave-1-observation', modelId: 'aimock', timestamp: new Date() },
+          { type: 'text-start', id: 'wave-1-text' },
+          {
+            type: 'text-delta',
+            id: 'wave-1-text',
+            delta: '<observations>Maya Chen owns the Atlas refund launch.</observations>',
+          },
+          { type: 'text-end', id: 'wave-1-text' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 8, totalTokens: 28 } },
+        ]) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
       },
-      { type: 'text-end', id: 'wave-1-text' },
-      { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 8, totalTokens: 28 } },
-    ]),
+    }),
     rawCall: { rawPrompt: null, rawSettings: {} },
     warnings: [],
   }));
@@ -91,7 +97,13 @@ function deterministicCaptureModel() {
     ],
   }));
   return {
-    model: new MockLanguageModelV2({ doStream: doStream as never, doGenerate: doGenerate as never }),
+    model: {
+      specificationVersion: 'v2' as const,
+      provider: 'aimock',
+      modelId: 'deterministic-wave-1',
+      doStream,
+      doGenerate,
+    },
     doGenerate,
   };
 }

--- a/packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts
+++ b/packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts
@@ -17,6 +17,7 @@ const adapter = process.env.KNOWLEDGE_ADAPTER === 'pg' ? 'pg' : 'libsql';
 const outputPath = process.env.KNOWLEDGE_PROOF_OUTPUT;
 const temporaryDirectories: string[] = [];
 const stores: MastraCompositeStore[] = [];
+const memories: Memory[] = [];
 const postgresSchemas: string[] = [];
 
 const structure = {
@@ -43,10 +44,33 @@ function message(threadId: string): MastraDBMessage {
   };
 }
 
-function deterministicCaptureModel() {
+function deterministicObservationModel(curate = false) {
+  let wrote = false;
   const doStream = vi.fn(async () => ({
     stream: new ReadableStream({
       start(controller) {
+        if (curate && !wrote) {
+          wrote = true;
+          controller.enqueue({
+            type: 'tool-call',
+            toolCallId: 'wave-1-create',
+            toolName: 'knowledge_create',
+            input: JSON.stringify({
+              name: 'Atlas refund launch',
+              kind: 'feature',
+              text: '[[Maya Chen]] owns the [[Atlas refund launch]].',
+              nodeScope: 'resource',
+              scope: 'resource',
+            }),
+          });
+          controller.enqueue({
+            type: 'finish',
+            finishReason: 'tool-calls',
+            usage: { inputTokens: 20, outputTokens: 8 },
+          });
+          controller.close();
+          return;
+        }
         for (const chunk of [
           { type: 'stream-start', warnings: [] },
           { type: 'response-metadata', id: 'wave-1-observation', modelId: 'aimock', timestamp: new Date() },
@@ -54,7 +78,7 @@ function deterministicCaptureModel() {
           {
             type: 'text-delta',
             id: 'wave-1-text',
-            delta: '<observations>Maya Chen owns the Atlas refund launch.</observations>',
+            delta: '<observations>\nMaya Chen owns the Atlas refund launch.\n</observations>',
           },
           { type: 'text-end', id: 'wave-1-text' },
           { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 8, totalTokens: 28 } },
@@ -67,35 +91,9 @@ function deterministicCaptureModel() {
     rawCall: { rawPrompt: null, rawSettings: {} },
     warnings: [],
   }));
-  const doGenerate = vi.fn(async () => ({
-    rawCall: { rawPrompt: null, rawSettings: {} },
-    finishReason: 'stop' as const,
-    usage: { inputTokens: 20, outputTokens: 20, totalTokens: 40 },
-    warnings: [],
-    content: [
-      {
-        type: 'text' as const,
-        text: JSON.stringify({
-          capture: {
-            nodes: [
-              {
-                name: 'Atlas refund launch',
-                kind: 'feature',
-                scope: 'resource',
-                records: [
-                  {
-                    text: '[[Maya Chen]] owns the [[Atlas refund launch]].',
-                    scope: 'resource',
-                    reason: 'Ownership is required to coordinate the refund launch.',
-                  },
-                ],
-              },
-            ],
-          },
-        }),
-      },
-    ],
-  }));
+  const doGenerate = vi.fn(async () => {
+    throw new Error('Wave 1 proof requires streaming observation-time curate, not structured capture extraction.');
+  });
   return {
     model: {
       specificationVersion: 'v2' as const,
@@ -105,6 +103,7 @@ function deterministicCaptureModel() {
       doGenerate,
     },
     doGenerate,
+    doStream,
   };
 }
 
@@ -135,21 +134,23 @@ async function createStorage(id: string): Promise<{ storage: MastraCompositeStor
 
 function createRuntime(storage: MastraCompositeStore) {
   const knowledge = new Knowledge({ id: 'shipyard-knowledge', storage, structure });
-  const { model, doGenerate } = deterministicCaptureModel();
+  const { model, doGenerate } = deterministicObservationModel();
+  const curator = deterministicObservationModel(true);
   const memory = new Memory({
     storage,
-    knowledge: 'default',
+    knowledge: 'mastra',
     options: {
       observationalMemory: {
         enabled: true,
         model,
-        experimental_subconscious: new Subconscious({ observation: ['capture'], reflection: [] }),
+        experimental_subconscious: new Subconscious({ observation: [{ name: 'curate', model: curator.model }] }),
         observation: { messageTokens: 1, bufferTokens: false, previousObserverTokens: 1_000 },
       },
     },
   });
-  const mastra = new Mastra({ knowledge: { default: knowledge }, memory: { default: memory }, logger: false });
-  return { knowledge: mastra.getKnowledge('default'), memory, doGenerate };
+  memories.push(memory);
+  const mastra = new Mastra({ knowledge: { mastra: knowledge }, memory: { default: memory }, logger: false });
+  return { knowledge: mastra.getKnowledge('mastra'), memory, doGenerate, curator };
 }
 
 function sanitizePackageUrl(url: string): string {
@@ -164,6 +165,13 @@ async function writeProofOutput(value: Record<string, unknown>) {
 
 afterEach(async () => {
   const cleanupErrors: unknown[] = [];
+  for (const memory of memories.splice(0)) {
+    try {
+      await memory.settled();
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
   for (const storage of stores.splice(0).reverse()) {
     if (storage instanceof PostgresStore) {
       const schemaName = postgresSchemas.pop();
@@ -191,7 +199,13 @@ afterEach(async () => {
 });
 
 describe(`Knowledge v2 Wave 1 linked-workspace proof (${adapter})`, () => {
-  it('reconciles, captures through OM, and survives a fresh runtime restart', async () => {
+  it('rejects obsolete observation-agent configuration with migration guidance', () => {
+    expect(() => new Subconscious(JSON.parse('{"observation":["capture"]}'))).toThrow(
+      'Unknown Subconscious observation agent: capture. Use "curate" for observation-time ingestion or "remind" for retrieval.',
+    );
+  });
+
+  it('reconciles, curates through OM, and survives a fresh runtime restart', async () => {
     const resolvedPackages = {
       core: import.meta.resolve('@mastra/core/knowledge'),
       memory: import.meta.resolve('@mastra/memory'),
@@ -220,23 +234,38 @@ describe(`Knowledge v2 Wave 1 linked-workspace proof (${adapter})`, () => {
       sendStateSignal: async () => ({ skipped: false }) as never,
     });
     expect(observed.observed).toBe(true);
-    expect(first.doGenerate).toHaveBeenCalledTimes(1);
-
-    const visibleScope = ['org:acme', 'resource:shipyard', 'resource:shipyard:uncurated'];
+    const visibleScope = ['org:acme', 'resource:shipyard'];
+    await first.memory.settled();
+    expect(await first.knowledge.resolveNode({ name: 'Atlas refund launch', scope: visibleScope })).toMatchObject({
+      kind: 'feature',
+      scope: ['org:acme', 'resource:shipyard'],
+    });
+    expect(first.doGenerate).not.toHaveBeenCalled();
+    expect(first.curator.doGenerate).not.toHaveBeenCalled();
+    expect(first.curator.doStream).toHaveBeenCalled();
     const captured = await first.knowledge.resolveNode({ name: 'Atlas refund launch', scope: visibleScope });
-    expect(captured).toMatchObject({ kind: 'feature', scope: ['resource:shipyard:uncurated'] });
     const records = await first.knowledge.listKnowledgeAbout({ node: captured!.id, scope: visibleScope });
     expect(records.records).toHaveLength(1);
     expect(records.records[0]).toMatchObject({
       text: '[[Maya Chen]] owns the [[Atlas refund launch]].',
       sourceThreadId: threadId,
-      scope: ['resource:shipyard:uncurated'],
-      metadata: { reason: 'Ownership is required to coordinate the refund launch.' },
+      scope: ['org:acme', 'resource:shipyard'],
     });
     expect(records.records[0]?.capturedAt).toBeInstanceOf(Date);
-    expect(await first.knowledge.listActivity({ scope: visibleScope, limit: 100 })).not.toEqual([]);
+    expect(await first.knowledge.listActivity({ scope: visibleScope, limit: 100 })).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ action: 'node-created', recordId: captured!.id, scope: visibleScope }),
+        expect.objectContaining({
+          action: 'record-created',
+          recordId: records.records[0]!.id,
+          sourceThreadId: threadId,
+          scope: visibleScope,
+        }),
+      ]),
+    );
 
     await first.memory.settled();
+    memories.splice(memories.indexOf(first.memory), 1);
     await storage.close();
     stores.splice(stores.indexOf(storage), 1);
 
@@ -268,7 +297,7 @@ describe(`Knowledge v2 Wave 1 linked-workspace proof (${adapter})`, () => {
         Object.entries(resolvedPackages).map(([name, url]) => [name, sanitizePackageUrl(url)]),
       ),
       structureScopeCount: Object.keys(reconciled.scopes).length,
-      capture: { node: captured?.name, records: records.records.length, activity: 'present' },
+      curation: { node: captured?.name, records: records.records.length, activity: 'present' },
       restart: { sameNodeId: persisted?.id === captured?.id, duplicateScopes: replay.createdScopeIds.length },
     });
   });

--- a/packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts
+++ b/packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts
@@ -22,14 +22,14 @@ const postgresSchemas: string[] = [];
 
 const structure = {
   scopes: [
-    { address: 'org:acme', name: 'Acme' },
+    { address: 'org:acme', name: 'mastra' },
+    { address: 'features', name: 'features', parentAddresses: ['org:acme'] },
+    { address: 'features:memory', name: 'memory', parentAddresses: ['features'] },
+    { address: 'features:memory:subconscious', name: 'subconscious', parentAddresses: ['features:memory'] },
+    { address: 'repo:mastra', name: 'repo:mastra', parentAddresses: ['org:acme'] },
+    { address: 'repo:mastra:issues', name: 'issues', parentAddresses: ['repo:mastra'] },
+    { address: 'repo:mastra:prs', name: 'prs', parentAddresses: ['repo:mastra'] },
     { address: 'resource:shipyard', name: 'Shipyard', parentAddresses: ['org:acme'] },
-    { address: 'subject:payments', name: 'Payments', parentAddresses: ['resource:shipyard'] },
-    { address: 'feature:refunds', name: 'Refunds', parentAddresses: ['subject:payments'] },
-    { address: 'area:runtime', name: 'Runtime', parentAddresses: ['feature:refunds'] },
-    { address: 'repository:mastra', name: 'Mastra', parentAddresses: ['feature:refunds'] },
-    { address: 'visibility:public', name: 'Public', parentAddresses: ['feature:refunds'] },
-    { address: 'visibility:internal', name: 'Internal', parentAddresses: ['feature:refunds'] },
   ],
 };
 
@@ -133,7 +133,13 @@ async function createStorage(id: string): Promise<{ storage: MastraCompositeStor
 }
 
 function createRuntime(storage: MastraCompositeStore) {
-  const knowledge = new Knowledge({ id: 'shipyard-knowledge', storage, structure });
+  const knowledge = new Knowledge({
+    id: 'mastra',
+    name: 'Mastra Knowledge',
+    description: 'Product architecture, repository work, and operational knowledge for Mastra.',
+    storage,
+    structure,
+  });
   const { model, doGenerate } = deterministicObservationModel();
   const curator = deterministicObservationModel(true);
   const memory = new Memory({
@@ -312,6 +318,7 @@ describe(`Knowledge v2 Wave 1 linked-workspace proof (${adapter})`, () => {
       stores.push(initialStorage);
       const initialMemory = new Memory({ storage: initialStorage });
       await initialMemory.createThread({ threadId: 'preserved-thread', resourceId: 'proof', title: 'Preserved' });
+      await initialStorage.getStore('knowledge');
       await initialStorage.close();
       stores.splice(stores.indexOf(initialStorage), 1);
 

--- a/packages/memory/integration-tests/src/knowledge-wave-1-real-curate.mts
+++ b/packages/memory/integration-tests/src/knowledge-wave-1-real-curate.mts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Knowledge } from '@mastra/core/knowledge';
+import { Mastra } from '@mastra/core/mastra';
+import { RequestContext } from '@mastra/core/request-context';
+import { LibSQLStore } from '@mastra/libsql';
+import { Memory, Subconscious } from '@mastra/memory';
+
+// Linked built-package consumer; never logs prompts, responses, credentials, or local database paths.
+assert(process.env.OPENAI_API_KEY, 'OPENAI_API_KEY is required for the real-provider proof');
+const directory = await mkdtemp(join(tmpdir(), 'knowledge-real-curate-'));
+const url = `file:${join(directory, 'proof.db')}`;
+const scope = ['org:acme', 'resource:shipyard'];
+const model = 'openai/gpt-5-mini';
+let storage = new LibSQLStore({ id: 'real-curate', url });
+let memory: Memory | undefined;
+let failure: unknown;
+try {
+  for (const [entry, expected] of [
+    ['@mastra/core/knowledge', '/packages/core/dist/knowledge/'],
+    ['@mastra/memory', '/packages/memory/dist/'],
+    ['@mastra/libsql', '/stores/libsql/dist/'],
+  ] as const) {
+    assert(import.meta.resolve(entry).includes(expected), 'Consumer must resolve linked built packages');
+  }
+  const knowledge = new Knowledge({
+    id: 'mastra',
+    storage,
+    structure: {
+      scopes: [
+        { address: 'org:acme', name: 'Acme' },
+        { address: 'resource:shipyard', name: 'Shipyard', parentAddresses: ['org:acme'] },
+      ],
+    },
+  });
+  memory = new Memory({
+    storage,
+    knowledge: 'mastra',
+    options: {
+      observationalMemory: {
+        enabled: true,
+        model,
+        observation: { messageTokens: 1, bufferTokens: false },
+        experimental_subconscious: new Subconscious({
+          observation: [
+            {
+              name: 'curate',
+              model,
+              instructions:
+                'For this bounded synthetic proof, create exactly one feature node named "Atlas refund launch" using knowledge_create, with one record: "[[Maya Chen]] owns the [[Atlas refund launch]]." Use resource scope. Do not create other nodes or records. Verify existing evidence first; do not duplicate it.',
+            },
+          ],
+        }),
+      },
+    },
+  });
+  const mastra = new Mastra({ knowledge: { mastra: knowledge }, memory: { default: memory }, logger: false });
+  assert.equal(mastra.getKnowledge('mastra'), knowledge);
+  await knowledge.reconcile();
+  const threadId = randomUUID();
+  await memory.createThread({ threadId, resourceId: 'shipyard', title: 'Synthetic curation proof' });
+  await memory.saveMessages({
+    messages: [
+      {
+        id: randomUUID(),
+        threadId,
+        resourceId: 'shipyard',
+        role: 'user',
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'text',
+              text: 'Confirmed durable project fact: Maya Chen owns the Atlas refund launch. Remember this ownership for future work.',
+            },
+          ],
+        },
+      },
+    ],
+  });
+  const requestContext = new RequestContext();
+  requestContext.set('organizationId', 'acme');
+  const observed = await (await memory.omEngine)!.observe({ threadId, resourceId: 'shipyard', requestContext });
+  assert(observed.observed, 'Observer must process the synthetic message');
+  await memory.settled();
+  const node = await knowledge.resolveNode({ name: 'Atlas refund launch', scope });
+  assert(node, 'Curator must create the expected feature');
+  assert.equal(node.kind, 'feature');
+  const records = (await knowledge.listKnowledgeAbout({ node: node.id, scope })).records;
+  assert.equal(records.length, 1);
+  assert.equal(records[0]!.text, '[[Maya Chen]] owns the [[Atlas refund launch]].');
+  assert.equal(records[0]!.sourceThreadId, threadId);
+  assert(records[0]!.capturedAt instanceof Date);
+  assert.deepEqual(records[0]!.scope, scope);
+  assert.deepEqual(node.scope, scope);
+  const activity = await knowledge.listActivity({ scope, limit: 100 });
+  assert(
+    activity.some(
+      event =>
+        event.action === 'node-created' &&
+        event.recordId === node.id &&
+        JSON.stringify(event.scope) === JSON.stringify(scope),
+    ),
+  );
+  assert(
+    activity.some(
+      event =>
+        event.action === 'record-created' &&
+        event.recordId === records[0]!.id &&
+        event.sourceThreadId === threadId &&
+        JSON.stringify(event.scope) === JSON.stringify(scope),
+    ),
+  );
+  memory = undefined;
+  await storage.close();
+  storage = new LibSQLStore({ id: 'real-curate-reopened', url });
+  const restartedKnowledge = new Knowledge({ id: 'mastra', storage });
+  memory = new Memory({ storage, knowledge: 'mastra', options: { observationalMemory: false } });
+  const restartedMastra = new Mastra({
+    knowledge: { mastra: restartedKnowledge },
+    memory: { default: memory },
+    logger: false,
+  });
+  const reopened = restartedMastra.getKnowledge('mastra');
+  assert.equal(await memory.getKnowledgeStore(), await reopened.getStorage());
+  assert.equal((await reopened.resolveNode({ name: 'Atlas refund launch', scope }))?.id, node.id);
+  assert.equal((await reopened.listKnowledgeAbout({ node: node.id, scope })).records[0]?.id, records[0]!.id);
+  console.log(
+    JSON.stringify({
+      model,
+      observationTimeCuration: true,
+      keyedRuntime: true,
+      records: 1,
+      provenance: true,
+      activity: true,
+      settledBeforeClose: true,
+      restart: true,
+    }),
+  );
+} catch (error) {
+  failure = error;
+} finally {
+  for (const cleanup of [
+    () => memory?.settled(),
+    () => storage.close(),
+    () => rm(directory, { recursive: true, force: true }),
+  ]) {
+    try {
+      await cleanup();
+    } catch (error) {
+      failure ??= error;
+    }
+  }
+}
+if (failure) throw failure;
+console.log('PROOF: GREEN — real-provider observation-time curation and durable restart');

--- a/packages/memory/integration-tests/src/with-pg-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-pg-storage.test.ts
@@ -11,9 +11,11 @@ if (!process.env.DB_URL) {
 
 const __dirname = fileURLToPath(import.meta.url);
 const connectionString = process.env.DB_URL || 'postgres://postgres:password@localhost:5434/mastra';
+const managesDocker = !process.env.DB_URL;
 
 describe('PostgreSQL Storage Tests', () => {
   beforeAll(async () => {
+    if (!managesDocker) return;
     await $({
       cwd: join(__dirname, '..'),
       stdio: 'inherit',
@@ -25,6 +27,7 @@ describe('PostgreSQL Storage Tests', () => {
   // This afterAll runs last (vitest runs them in reverse registration order)
   // so by this point all PG pools have been gracefully closed.
   afterAll(async () => {
+    if (!managesDocker) return;
     return $({
       cwd: join(__dirname, '..'),
     })`docker compose down --volumes postgres`;

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -397,10 +397,21 @@ export class Memory extends MastraMemory {
     this.pendingVectorCleanup = Promise.allSettled([this.pendingVectorCleanup, cleanup]).then(() => undefined);
   }
 
+  private pendingSubconsciousWork = new Set<Promise<void>>();
+
+  /** @internal Track observation-dispatched work without blocking the observation turn. */
+  trackSubconsciousWork(work: Promise<void>): void {
+    this.pendingSubconsciousWork.add(work);
+    void work.then(
+      () => this.pendingSubconsciousWork.delete(work),
+      () => this.pendingSubconsciousWork.delete(work),
+    );
+  }
+
   /**
    * Resolve once all background work this Memory started has finished: observational-memory
-   * cycles (buffered observation and reflection, including the nested agent runs they spawn)
-   * and vector cleanup from `deleteThread` / `deleteMessages`.
+   * cycles (buffered observation and reflection, including the nested agent runs they spawn),
+   * observation-dispatched Subconscious curator runs, and vector cleanup from `deleteThread` / `deleteMessages`.
    *
    * Callers that own the storage connection should await this before closing it, otherwise
    * background statements can race the close.
@@ -416,6 +427,9 @@ export class Memory extends MastraMemory {
     // Only join an engine that already exists — never instantiate one just to drain it.
     const engine = this._omEngine ? await this._omEngine : this._omEngineInstance;
     await engine?.settled();
+    while (this.pendingSubconsciousWork.size) {
+      await Promise.all([...this.pendingSubconsciousWork]);
+    }
     // Observational-memory cycles can start further vector cleanup; drain once more.
     await this.pendingVectorCleanup;
   }

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-curate.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-curate.test.ts
@@ -38,6 +38,25 @@ function fixture(knowledge?: Knowledge | false) {
 afterEach(() => vi.restoreAllMocks());
 
 describe('Subconscious observation curator', () => {
+  it('settles observation-dispatched work including work queued during completion', async () => {
+    const memory = new Memory({ storage: new InMemoryStore(), options: { observationalMemory: false } });
+    const first = Promise.withResolvers<void>();
+    const second = Promise.withResolvers<void>();
+    memory.trackSubconsciousWork(first.promise.then(() => memory.trackSubconsciousWork(second.promise)));
+    const completed = vi.fn();
+    const settling = memory.settled().then(completed);
+    await Promise.resolve();
+    expect(completed).not.toHaveBeenCalled();
+    first.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(completed).not.toHaveBeenCalled();
+    second.resolve();
+    await settling;
+    expect(completed).toHaveBeenCalledOnce();
+    await memory.settled();
+  });
+
   it('uses the selected Knowledge runtime for observation and derived agent memory', async () => {
     const knowledge = new Knowledge({ id: 'mastra', storage: new InMemoryStore() });
     const { memory, context, extractor } = fixture(knowledge);

--- a/packages/memory/src/processors/observational-memory/subconscious/curate.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/curate.ts
@@ -82,15 +82,19 @@ export class SubconsciousCurateExtractor extends Extractor<unknown> {
           );
           const result = dispatchCuratorObservation(agent, context, config, context.rawObservations);
 
-          void result.accepted
-            .then(async accepted => {
-              if (accepted.action === 'wake') await accepted.output.consumeStream();
-            })
-            .catch(error => reportCuratorError(error, context, subconscious, store, scope))
-            .catch(error => omError(`[Subconscious:curate] failed to report curator error: ${String(error)}`));
+          context.memory.trackSubconsciousWork(
+            result.accepted
+              .then(async accepted => {
+                if (accepted.action === 'wake') await accepted.output.consumeStream();
+              })
+              .catch(error => reportCuratorError(error, context, subconscious, store, scope))
+              .catch(error => omError(`[Subconscious:curate] failed to report curator error: ${String(error)}`)),
+          );
         } catch (error) {
-          void reportCuratorError(error, context, subconscious, store, scope).catch(reportingError =>
-            omError(`[Subconscious:curate] failed to report curator error: ${String(reportingError)}`),
+          context.memory.trackSubconsciousWork(
+            reportCuratorError(error, context, subconscious, store, scope).catch(reportingError =>
+              omError(`[Subconscious:curate] failed to report curator error: ${String(reportingError)}`),
+            ),
           );
         }
       },

--- a/packages/memory/src/processors/observational-memory/subconscious/index.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/index.ts
@@ -166,7 +166,11 @@ export class Subconscious {
   #validateObservationEntry(entry: SubconsciousObservationEntry): void {
     const name = entryName(entry);
     if (typeof entry === 'string') {
-      if (!BUILT_IN_OBSERVATION.has(name)) throw new Error(`Unknown Subconscious observation agent: ${name}`);
+      if (!BUILT_IN_OBSERVATION.has(name)) {
+        throw new Error(
+          `Unknown Subconscious observation agent: ${name}. Use "curate" for observation-time ingestion or "remind" for retrieval.`,
+        );
+      }
       return;
     }
     if (BUILT_IN_OBSERVATION.has(name)) return;


### PR DESCRIPTION
Wave: 1 of 4
Segment: W1.8 of 8
Purpose: Add the Shipyard-shaped linked-workspace proof harness for Wave 1, validating keyed Knowledge reconciliation, deterministic OM capture, LibSQL/PostgreSQL persistence, restart reuse, proof-output generation, and disposable Knowledge reset boundaries through public package entrypoints.
Previous PR: https://github.com/mastra-ai/mastra/pull/22567
Next PR: https://github.com/mastra-ai/mastra/pull/22574
Previous wave: None
Next wave: https://github.com/mastra-ai/mastra/pull/22574

## Summary

- Adds a Memory integration proof test that imports built public `@mastra/core/knowledge`, `@mastra/memory`, `@mastra/libsql`, and `@mastra/pg` packages from the linked workspace.
- Exercises Shipyard-shaped scope reconciliation, deterministic Subconscious/OM capture, keyed Knowledge reads/activity, restart persistence, and proof JSON output.
- Includes a LibSQL-only incompatible-schema/reset proof that preserves unrelated Memory data and operates only on disposable temporary databases.

## Test plan

- `pnpm build:core && pnpm --filter ./packages/memory build:lib && pnpm --filter ./stores/libsql build:lib && pnpm --filter ./stores/pg build:lib`
- `pnpm --filter ./packages/core check && pnpm --filter ./packages/memory check`
- From `packages/memory/integration-tests`: `KNOWLEDGE_ADAPTER=libsql KNOWLEDGE_PROOF_OUTPUT=../../../.mastracode/plans/knowledge-v2-wave-1-foundation.proof/consumer/libsql.json pnpm exec vitest run src/knowledge-v2-wave-1.test.ts --reporter=dot --bail 1`
- From `packages/memory/integration-tests`: `KNOWLEDGE_ADAPTER=pg KNOWLEDGE_PROOF_OUTPUT=../../../.mastracode/plans/knowledge-v2-wave-1-foundation.proof/consumer/postgres.json pnpm exec vitest run src/knowledge-v2-wave-1.test.ts --reporter=dot --bail 1`
- `MC_E2E_VITEST_SCENARIOS=knowledge-browser pnpm --filter ./mastracode/tui exec vitest run --config e2e/vitest.config.ts --reporter=dot`
- `pnpm --filter ./mastracode/factory-ui exec playwright test e2e/knowledge/explore.spec.ts --config e2e/playwright.config.ts`
- `pnpm exec prettier --check packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts && pnpm exec oxlint packages/memory/integration-tests/src/knowledge-v2-wave-1.test.ts && git diff --check`

