### PR TITLE
feat(platform-workspace): default sandboxes to E2B

### DIFF
--- a/.changeset/fast-zebras-burn.md
+++ b/.changeset/fast-zebras-burn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/platform-workspace': minor
+---
+
+Changed Platform sandboxes to use E2B by default. Set sandboxProvider or SANDBOX_PROVIDER to railway to opt into Railway.

--- a/workspaces/platform-workspace/README.md
+++ b/workspaces/platform-workspace/README.md
@@ -21,7 +21,7 @@ All options can be passed to the constructor or read from environment variables:
 | `sandboxProvider` | `SANDBOX_PROVIDER`             | No (sandbox)     |
 | `bucketName`      | `MASTRA_PLATFORM_BUCKET_NAME`  | Yes (filesystem) |
 
-The sandbox provider resolves from the explicit `sandboxProvider` option, then `SANDBOX_PROVIDER`, then defaults to `railway`. The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` env var (useful for staging).
+The sandbox provider resolves from the explicit `sandboxProvider` option, then `SANDBOX_PROVIDER`, then defaults to `e2b`. Set either option to `railway` to use Railway sandboxes. The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` env var (useful for staging).
 
 Requests to the proxy are authenticated with `Authorization: Bearer <accessToken>`. For sandbox requests authenticated with a project access token, set `actingUserId` to the stable opaque user subject from your authentication system. It is sent as `x-acting-user-id` for token partitioning and attribution; it is not an authorization claim.
 

--- a/workspaces/platform-workspace/src/client.test.ts
+++ b/workspaces/platform-workspace/src/client.test.ts
@@ -34,7 +34,7 @@ describe('PlatformClient', () => {
     expect(init.method).toBe('POST');
   });
 
-  it('uses the legacy Railway routes when SANDBOX_PROVIDER is unset', async () => {
+  it('uses E2B provider routes when SANDBOX_PROVIDER is unset', async () => {
     vi.stubEnv('SANDBOX_PROVIDER', undefined);
     vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
     const fetchMock = vi.fn().mockResolvedValue(response('{}', { status: 200 }));
@@ -46,8 +46,8 @@ describe('PlatformClient', () => {
 
     await client.request('/sandbox');
 
-    expect(client.sandboxProvider).toBe('railway');
-    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox');
+    expect(client.sandboxProvider).toBe('e2b');
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/e2b/projects/proj_123/sandbox');
   });
 
   it('uses E2B provider routes when SANDBOX_PROVIDER is e2b', async () => {
@@ -82,7 +82,7 @@ describe('PlatformClient', () => {
     expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/e2b/projects/proj_123/sandbox');
   });
 
-  it('can force provider-prefixed routes while preserving legacy sandbox routing', async () => {
+  it('uses the default E2B provider for sandbox and template requests', async () => {
     vi.stubEnv('SANDBOX_PROVIDER', undefined);
     vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
     const fetchMock = vi.fn().mockResolvedValue(response('{}', { status: 200 }));
@@ -91,10 +91,8 @@ describe('PlatformClient', () => {
     await client.request('/sandbox');
     await client.requestProvider('/templates/builds');
 
-    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox');
-    expect(String(fetchMock.mock.calls[1]![0])).toBe(
-      'https://proxy.test/v1/railway/projects/proj_123/templates/builds',
-    );
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/e2b/projects/proj_123/sandbox');
+    expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/e2b/projects/proj_123/templates/builds');
   });
 
   it('rejects unsupported SANDBOX_PROVIDER values', () => {

--- a/workspaces/platform-workspace/src/client.ts
+++ b/workspaces/platform-workspace/src/client.ts
@@ -40,7 +40,7 @@ export function requireOption(value: string | undefined, name: string): string {
 }
 
 function resolveSandboxProvider(value: string | undefined): SandboxProvider {
-  const provider = value?.trim() || 'railway';
+  const provider = value?.trim() || 'e2b';
   if (provider !== 'railway' && provider !== 'e2b') {
     throw new Error('SANDBOX_PROVIDER must be either "railway" or "e2b"');
   }
@@ -57,7 +57,6 @@ export function resolvePlatformOptions(options: PlatformClientOptions) {
     actingUserId: options.actingUserId?.trim() || undefined,
     proxyUrl: (process.env.MASTRA_WORKSPACE_PROXY_URL ?? DEFAULT_PROXY_URL).replace(/\/$/, ''),
     sandboxProvider: resolveSandboxProvider(configuredSandboxProvider),
-    useLegacyRoutes: !options.sandboxProvider && !environmentSandboxProvider,
     sessionId: options.sessionId,
     threadId: options.threadId,
     fetch: options.fetch ?? fetch,
@@ -118,7 +117,6 @@ export class PlatformClient {
   readonly actingUserId: string | undefined;
   readonly proxyUrl: string;
   readonly sandboxProvider: SandboxProvider;
-  private readonly useLegacyRoutes: boolean;
   /** Advisory session correlation id — see {@link PlatformClientOptions.sessionId}. */
   readonly sessionId: string | undefined;
   /** Advisory thread correlation id — see {@link PlatformClientOptions.threadId}. */
@@ -132,15 +130,13 @@ export class PlatformClient {
     this.actingUserId = resolved.actingUserId;
     this.proxyUrl = resolved.proxyUrl;
     this.sandboxProvider = resolved.sandboxProvider;
-    this.useLegacyRoutes = resolved.useLegacyRoutes;
     this.sessionId = resolved.sessionId;
     this.threadId = resolved.threadId;
     this.fetch = resolved.fetch;
   }
 
   async request(path: string, options: PlatformRequestOptions = {}): Promise<Response> {
-    const providerPath = this.useLegacyRoutes ? '' : `/${this.sandboxProvider}`;
-    return this.requestAtPath(providerPath, path, options);
+    return this.requestAtPath(`/${this.sandboxProvider}`, path, options);
   }
 
   async requestProvider(path: string, options: PlatformRequestOptions = {}): Promise<Response> {

--- a/workspaces/platform-workspace/src/provider.test.ts
+++ b/workspaces/platform-workspace/src/provider.test.ts
@@ -6,7 +6,7 @@ describe('platformSandboxProvider', () => {
     const schema = platformSandboxProvider.configSchema!;
     const properties = schema.properties as Record<string, Record<string, unknown>>;
 
-    expect(properties.sandboxProvider).toMatchObject({ enum: ['railway', 'e2b'] });
+    expect(properties.sandboxProvider).toMatchObject({ enum: ['railway', 'e2b'], default: 'e2b' });
     expect(properties).not.toHaveProperty('template');
   });
 });

--- a/workspaces/platform-workspace/src/provider.ts
+++ b/workspaces/platform-workspace/src/provider.ts
@@ -19,8 +19,9 @@ export const platformSandboxProvider: SandboxProvider<PlatformSandboxOptions> = 
       actingUserId: { type: 'string', description: 'Opaque user subject attributed to sandbox requests' },
       sandboxProvider: {
         type: 'string',
-        description: 'Sandbox provider (falls back to SANDBOX_PROVIDER, then railway)',
+        description: 'Sandbox provider (falls back to SANDBOX_PROVIDER, then e2b)',
         enum: ['railway', 'e2b'],
+        default: 'e2b',
       },
       environmentId: { type: 'string', description: 'Platform environment ID (falls back to MASTRA_ENVIRONMENT_ID)' },
       sandboxId: { type: 'string', description: 'Reattach to an existing Platform sandbox by ID' },

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -234,7 +234,7 @@ describe('PlatformSandbox', () => {
     expect(JSON.stringify(definition)).not.toContain('ghs_build_only');
   });
 
-  it('uses provider-prefixed Railway routes for a template-backed sandbox when SANDBOX_PROVIDER is unset', async () => {
+  it('uses provider-prefixed E2B routes for a template-backed sandbox when SANDBOX_PROVIDER is unset', async () => {
     // Stub to empty rather than unstubbing: `vi.unstubAllEnvs()` restores the
     // host environment, and CI runners can carry their own (unrelated)
     // SANDBOX_PROVIDER value. Empty trims to falsy — same as unset.
@@ -255,8 +255,8 @@ describe('PlatformSandbox', () => {
     await sandbox._start();
     await sandbox.getInfo();
 
-    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/railway/projects/proj_123/sandbox');
-    expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/railway/projects/proj_123/sandbox/sbx_1');
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/e2b/projects/proj_123/sandbox');
+    expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/e2b/projects/proj_123/sandbox/sbx_1');
   });
 
   it('resolves a lazy template and surfaces templatePending when the platform boots on a fallback', async () => {
@@ -2710,10 +2710,8 @@ describe('PlatformSandbox', () => {
       await child.getInfo();
 
       expect(resolveTemplate).toHaveBeenCalledTimes(1);
-      expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/railway/projects/proj_123/sandbox');
-      expect(String(fetchMock.mock.calls[1]![0])).toBe(
-        'https://proxy.test/v1/railway/projects/proj_123/sandbox/sbx_child',
-      );
+      expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/e2b/projects/proj_123/sandbox');
+      expect(String(fetchMock.mock.calls[1]![0])).toBe('https://proxy.test/v1/e2b/projects/proj_123/sandbox/sbx_child');
     });
 
     it('inherits template defaults when no overrides are passed', async () => {


### PR DESCRIPTION
Stacks on #22065.

`PlatformSandbox` now uses E2B when neither `sandboxProvider` nor `SANDBOX_PROVIDER` is set, and all default requests use provider-prefixed E2B routes. Railway remains available as an explicit override:

```ts
new PlatformSandbox({ sandboxProvider: 'railway' })
```

The provider schema, package README, regression tests, and changeset reflect the new default. Verified with the full `@mastra/platform-workspace` unit suite, type tests, build, and lint.
