### PR TITLE
feat(factory): sandboxStart option to boot a session's sandbox eagerly

### DIFF
--- a/.changeset/factory-eager-sandbox-start.md
+++ b/.changeset/factory-eager-sandbox-start.md
@@ -1,0 +1,12 @@
+---
+'@mastra/factory': minor
+---
+
+Added `sandboxStart: 'eager' | 'lazy'` to `MastraFactoryConfig`. `'eager'` starts a session's sandbox as soon as its workspace is first resolved instead of on the agent's first command. Defaults to `'lazy'`.
+
+```ts
+new MastraFactory({
+  sandbox: ctx => new PlatformSandbox({ id: ctx.sessionId }),
+  sandboxStart: 'eager',
+});
+```

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -101,6 +101,7 @@ import { WorkItemsStorage } from './storage/domains/work-items/base.js';
 import type { WorkItemRow } from './storage/domains/work-items/base.js';
 import { timedPhase } from './timing.js';
 import { createWorkspaceFactory, FactoryWorkspaceRegistry } from './workspace.js';
+import type { FactorySandboxStart } from './workspace.js';
 
 type BuildApiRoutesDeps = Pick<FactoryApiRoutesDeps, 'controller' | 'authStorage'>;
 
@@ -161,6 +162,12 @@ export interface MastraFactoryConfig {
   allowedOrigins?: string[];
   /** Sandbox configuration. Omitted → repository sandboxes are disabled. */
   sandbox?: MastraFactorySandboxConfig;
+  /**
+   * When a session's sandbox boots: on the agent's first command (`'lazy'`,
+   * the default) or as soon as the session's workspace is first resolved
+   * (`'eager'`), so the boot overlaps the model's own latency.
+   */
+  sandboxStart?: FactorySandboxStart;
   /** Background Factory dispatcher configuration. */
   dispatcher?: MastraFactoryDispatcherConfig;
   /**
@@ -203,6 +210,7 @@ export interface MastraFactoryConfig {
 }
 
 export type { MastraFactorySandboxConfig } from './sandbox/session-sandbox.js';
+export type { FactorySandboxStart } from './workspace.js';
 
 /**
  * Per-process cap on concurrent background Factory dispatches. Omitted means
@@ -657,6 +665,7 @@ export class MastraFactory {
         controllerId: CONTROLLER_ID,
         workspace: createWorkspaceFactory({
           ...(sandboxConfig ? { sandbox: sandboxConfig } : {}),
+          ...(this.#config.sandboxStart ? { sandboxStart: this.#config.sandboxStart } : {}),
           ...(githubIntegration ? { github: githubIntegration } : {}),
           ...(workItemsStorage ? { workItems: workItemsStorage } : {}),
           workspaceRegistry,

--- a/mastracode/factory/src/index.ts
+++ b/mastracode/factory/src/index.ts
@@ -1,5 +1,5 @@
 export { MastraFactory } from './factory.js';
-export type { MastraArgs, MastraFactoryConfig, MastraFactorySandboxConfig } from './factory.js';
+export type { MastraArgs, MastraFactoryConfig, MastraFactorySandboxConfig, FactorySandboxStart } from './factory.js';
 export type { FactorySandboxContext, SessionSetupGate, SessionSetupRun } from './sandbox/session-sandbox.js';
 export { ChannelIdentityStorage } from './storage/domains/channel-identity/base.js';
 export type {

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -1897,12 +1897,27 @@ describe('GitHub session workspace preparation', () => {
         setState: (u: Record<string, unknown>) => Promise<void>;
       };
       const pinned = controller.setState;
+      let releasePin!: () => void;
+      let pinEntered!: () => void;
+      const pinEnteredPromise = new Promise<void>(resolve => {
+        pinEntered = resolve;
+      });
       controller.setState = async updates => {
-        await new Promise(resolve => setTimeout(resolve, 30));
+        pinEntered();
+        await new Promise<void>(resolve => {
+          releasePin = resolve;
+        });
         await pinned(updates);
       };
 
-      const workspace = await resolver({ requestContext });
+      const resolving = resolver({ requestContext });
+      await pinEnteredPromise;
+      await settle();
+      // The sandbox is constructed by now, but must not have started.
+      expect(constructedSandbox().start).not.toHaveBeenCalled();
+
+      releasePin();
+      const workspace = await resolving;
 
       expect(workspace?.id).toContain('project-1-session-1');
       await vi.waitFor(() => expect(constructedSandbox().start).toHaveBeenCalledTimes(1));

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -1844,6 +1844,106 @@ describe('GitHub session workspace preparation', () => {
     expect(result).toBeUndefined();
   });
 
+  describe('sandboxStart', () => {
+    async function createFactory(sandboxStart?: 'lazy' | 'eager') {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'mastracode-web-sandbox-start-'));
+      tempDirs.push(root);
+      mocks.localRoot = root;
+      return createWorkspaceFactory({
+        sandbox: mocks.createSandbox as any,
+        github: fakeGithubIntegration() as any,
+        workItems: { findRunBindingBySession: mocks.findRunBindingBySession } as any,
+        ...(sandboxStart !== undefined ? { sandboxStart } : {}),
+      });
+    }
+
+    const constructedSandbox = () => mocks.createSandbox.mock.results[0]!.value as { start: ReturnType<typeof vi.fn> };
+
+    /** The eager path is fire-and-forget; give its microtasks a chance to run. */
+    const settle = () => new Promise(resolve => setTimeout(resolve, 20));
+
+    it("starts the sandbox right after resolution when set to 'eager'", async () => {
+      const resolver = await createFactory('eager');
+      addProject();
+      addSession({ id: 'session-1' });
+
+      const workspace = await resolver({ requestContext: createGithubRequestContext('project-1', 'session-1') });
+
+      expect(workspace?.id).toContain('project-1-session-1');
+      await vi.waitFor(() => expect(constructedSandbox().start).toHaveBeenCalledTimes(1));
+      // The eager start ran the full session setup, so the first command
+      // finds a prepared checkout, not just a booted VM.
+      await vi.waitFor(() => expect(mocks.materializeRepo).toHaveBeenCalledTimes(1));
+    });
+
+    it.each([undefined, 'lazy'] as const)('leaves the sandbox lazy when sandboxStart is %s', async sandboxStart => {
+      const resolver = await createFactory(sandboxStart);
+      addProject();
+      addSession({ id: 'session-1' });
+
+      await resolver({ requestContext: createGithubRequestContext('project-1', 'session-1') });
+      await settle();
+
+      expect(constructedSandbox().start).not.toHaveBeenCalled();
+      expect(mocks.materializeRepo).not.toHaveBeenCalled();
+    });
+
+    it('starts only after the resolver finished, even when pinning state is slow', async () => {
+      const resolver = await createFactory('eager');
+      addProject();
+      addSession({ id: 'session-1' });
+      const requestContext = createGithubRequestContext('project-1', 'session-1');
+      const controller = requestContext.get('controller') as {
+        setState: (u: Record<string, unknown>) => Promise<void>;
+      };
+      const pinned = controller.setState;
+      controller.setState = async updates => {
+        await new Promise(resolve => setTimeout(resolve, 30));
+        await pinned(updates);
+      };
+
+      const workspace = await resolver({ requestContext });
+
+      expect(workspace?.id).toContain('project-1-session-1');
+      await vi.waitFor(() => expect(constructedSandbox().start).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(mocks.materializeRepo).toHaveBeenCalledTimes(1));
+    });
+
+    it('starts once per constructed instance, not per resolution', async () => {
+      const resolver = await createFactory('eager');
+      addProject();
+      addSession({ id: 'session-1' });
+
+      await resolver({ requestContext: createGithubRequestContext('project-1', 'session-1') });
+      await resolver({ requestContext: createGithubRequestContext('project-1', 'session-1') });
+      await settle();
+
+      expect(constructedSandbox().start).toHaveBeenCalledTimes(1);
+    });
+
+    it('surfaces a failed eager start as a warning while the lazy path stays intact', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        // First start (the eager one) fails inside setup; the record it leaves
+        // must not stop a later lazy start from retrying materialization.
+        mocks.materializeRepo.mockRejectedValueOnce(new MaterializeError('exec', 'clone flaked'));
+        const resolver = await createFactory('eager');
+        addProject();
+        addSession({ id: 'session-1' });
+
+        const workspace = await resolver({ requestContext: createGithubRequestContext('project-1', 'session-1') });
+        await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+
+        expect(workspace?.id).toContain('project-1-session-1');
+        // The lazy path retries in full and succeeds.
+        await (workspace as any).sandbox.getInfo();
+        expect(mocks.materializeRepo).toHaveBeenCalledTimes(2);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
   // The factory used to construct a Workspace and return it without ever
   // adding it to the Mastra registry, so any HTTP handler that resolved the
   // workspace synchronously via `mastra.getWorkspaceById(id)` (file tree,

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -218,9 +218,18 @@ const factorySkillExtension: WorkspaceSkillExtension = {
 
 type DynamicWorkspaceContext = Parameters<typeof getDynamicWorkspace>[0];
 
+/**
+ * When a session's sandbox boots: on the agent's first command (`'lazy'`, the
+ * default) or as soon as the session's workspace is first resolved (`'eager'`).
+ * An eager start is fire-and-forget; if it fails, the lazy path still runs.
+ */
+export type FactorySandboxStart = 'lazy' | 'eager';
+
 export interface CreateWorkspaceFactoryOptions {
   /** Factory sandbox runtime config (session sandbox callback). */
   sandbox?: MastraFactorySandboxConfig;
+  /** Defaults to `'lazy'`. */
+  sandboxStart?: FactorySandboxStart;
   /** GitHub integration used to resolve Factory sessions and mint repo tokens. */
   github?: GithubIntegration;
   /** Work-items storage used to resolve the session's run-binding role, so
@@ -271,6 +280,7 @@ export class FactoryWorkspaceRegistry {
 
 export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = {}) {
   const { sandbox: sandboxConfig, github, workItems } = options;
+  const eagerSandboxStart = options.sandboxStart === 'eager';
   const workspaceRegistry = options.workspaceRegistry ?? new FactoryWorkspaceRegistry();
   type GithubTokenRegistration = {
     inject: (token: string) => void;
@@ -433,8 +443,20 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
           await setupHook(args);
           await previous?.(args);
         });
+        // Only a freshly constructed instance starts eagerly; the start itself
+        // waits for this resolver to finish because the start hook reads
+        // bindings declared further down.
+        startEagerly = eagerSandboxStart;
         return sandbox;
       });
+    let startEagerly = false;
+    const fireEagerStart = () => {
+      if (!startEagerly) return;
+      startEagerly = false;
+      sessionEntry.sandbox.start?.().catch(error => {
+        console.warn(`[factory] Eager sandbox start for session ${session.id} failed:`, error);
+      });
+    };
     const sessionEntry = constructSessionEntry();
     const workdir = sessionEntry.workdir;
     const isLocalSandbox = sessionEntry.sandbox.provider === 'local';
@@ -730,10 +752,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       throw new Error(`Factory session ${session.sessionId} was retired during workspace materialization`);
     }
 
-    // Fully lazy: nothing provisions until the first real sandbox operation
-    // (`ensureRunning()` inside the provider). A background warm-up at session
-    // start was considered and dropped — it speculatively created a VM for
-    // every session, including ones whose agent never touches the workspace.
+    fireEagerStart();
     return workspace;
   };
 }


### PR DESCRIPTION
## What

Adds `sandboxStart: 'eager' | 'lazy'` to `MastraFactoryConfig` (default `'lazy'`).

Session sandboxes start lazily on the agent's first command, which puts VM boot, clone and setup on that command's wall clock. With `'eager'` the factory fires `start()` as soon as the session's workspace is first resolved, so the boot overlaps the model's own latency.

```ts
new MastraFactory({
  sandbox: ctx => new PlatformSandbox({ id: ctx.sessionId }),
  sandboxStart: 'eager',
});
```

## Notes

- The start is fire-and-forget: the resolving request never waits on it, a failure is logged, and the lazy first-command path still starts (or surfaces the failure) as before. A quick first command coalesces with the eager start on the provider's single-flighted `start()`.
- Fires once per constructed sandbox instance, after the resolver has finished building the closure the start hook depends on.

## Tests

`workspace.test.ts`: eager start boots and runs full session setup; `'lazy'`/omitted stay lazy; start happens after a slow state pin; once per instance across repeated resolutions; a failed eager start warns while the lazy path retries in full.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This change lets the factory start a sandbox early or wait until the first command. Early startup can reduce waiting time while other work runs.

## Changes

- Added `MastraFactoryConfig.sandboxStart`.
- Supported values are `'eager'` and `'lazy'`.
- Default behavior remains `'lazy'`.
- Exported the `FactorySandboxStart` type.
- Eager startup:
  - Starts after workspace resolution completes.
  - Runs without blocking workspace creation.
  - Coalesces repeated starts.
  - Logs startup failures.
  - Allows the normal lazy path to retry and report failures.
- Added a changeset for `@mastra/factory`.

## Tests

Added coverage for eager startup, lazy and default behavior, delayed state pinning, repeated resolutions, full session setup, and retry after startup failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->