### PR TITLE
fix(deployer): compile transitive workspace subpath imports inline under externals

### DIFF
--- a/.changeset/ninety-donkeys-listen.md
+++ b/.changeset/ninety-donkeys-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix `mastra build` under `bundler: { externals: true }` emitting a transitive workspace subpath import (e.g. `@scope/b/feature` imported by another workspace package) as an unresolved bare specifier. Such imports now resolve through the workspace package's `exports` map and compile inline, so the output no longer fails at runtime with `ERR_MODULE_NOT_FOUND` or `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`.

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -1,9 +1,11 @@
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
+import * as resolveExports from 'resolve.exports';
 import { rollup } from 'rollup';
 import type { InputOptions, OutputOptions, Plugin } from 'rollup';
 import { minify as esbuildMinify } from 'rollup-plugin-esbuild';
@@ -17,8 +19,52 @@ import { removeDeployer } from './plugins/remove-deployer';
 import { subpathExternalsResolver } from './plugins/subpath-externals-resolver';
 import { tsConfigPaths } from './plugins/tsconfig-paths';
 import type { ExternalDependencyInfo } from './types';
-import { getNodeResolveOptions, slash } from './utils';
+import { getNodeResolveOptions, getPackageName, slash } from './utils';
 import type { BundlerPlatform } from './utils';
+
+/**
+ * Resolve a workspace package *subpath* specifier (e.g. `@scope/b/feature`,
+ * imported transitively by another workspace package) to the source file its
+ * package `exports` map points at. Used to compile such an import inline when
+ * it escaped analyze-time capture, instead of letting it leak out of the
+ * bundle as an unresolved bare specifier. Returns null for non-subpath ids,
+ * non-workspace packages, or when the exports lookup fails.
+ */
+export function resolveWorkspaceSubpathToSource(
+  id: string,
+  workspaceMap: Map<string, WorkspacePackageInfo>,
+): string | null {
+  const pkgName = getPackageName(id);
+  // Package roots are handled by the analyze dependency map; only subpaths
+  // can escape it.
+  if (!pkgName || id === pkgName) {
+    return null;
+  }
+  const info = workspaceMap.get(pkgName);
+  if (!info) {
+    return null;
+  }
+
+  let pkgJson: ReturnType<typeof JSON.parse>;
+  try {
+    pkgJson = JSON.parse(readFileSync(join(info.location, 'package.json'), 'utf-8'));
+  } catch {
+    return null;
+  }
+
+  // resolve.exports throws for a missing/invalid entry, so the lookup is guarded.
+  let rel: string | undefined;
+  try {
+    rel = resolveExports.exports(pkgJson, `.${id.slice(pkgName.length)}`)?.[0];
+  } catch {
+    rel = undefined;
+  }
+  if (!rel) {
+    return null;
+  }
+
+  return join(info.location, rel);
+}
 
 export function mastraInternalAliasPlugin(entryFile: string): Plugin {
   const normalizedEntryFile = slash(entryFile);
@@ -103,6 +149,20 @@ export async function getInputOptions(
         name: 'alias-optimized-deps',
         resolveId(id: string) {
           if (!analyzedBundleInfo.dependencies.has(id)) {
+            // A workspace subpath imported transitively (by another workspace
+            // package) can escape analyze capture and would otherwise leak
+            // out of the bundle as an unresolved bare specifier — either
+            // unregistered in the generated package.json (ERR_MODULE_NOT_
+            // FOUND) or installed as a workspace package whose subpath
+            // exports point at raw TypeScript
+            // (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING). Resolve it to
+            // its source so the bundler compiles it inline instead.
+            if (externalsPreset) {
+              const workspaceSource = resolveWorkspaceSubpathToSource(id, analyzedBundleInfo.workspaceMap);
+              if (workspaceSource) {
+                return { id: workspaceSource, external: false };
+              }
+            }
             return null;
           }
 

--- a/packages/deployer/src/build/bundler.workspace-subpath.test.ts
+++ b/packages/deployer/src/build/bundler.workspace-subpath.test.ts
@@ -1,0 +1,66 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ensureDir, remove, writeFile } from 'fs-extra';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { WorkspacePackageInfo } from '../bundler/workspaceDependencies';
+import { resolveWorkspaceSubpathToSource } from './bundler';
+
+describe('resolveWorkspaceSubpathToSource', () => {
+  let dir: string;
+  let counter = 0;
+
+  beforeEach(async () => {
+    dir = join(tmpdir(), `ws-subpath-${Date.now()}-${counter++}`);
+    await ensureDir(dir);
+  });
+
+  afterEach(async () => {
+    await remove(dir);
+  });
+
+  async function writePkg(exportsField: Record<string, string>) {
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: '@scope/leaf', version: '1.0.0', exports: exportsField }),
+    );
+    return new Map<string, WorkspacePackageInfo>([
+      ['@scope/leaf', { location: dir, dependencies: {}, version: '1.0.0' }],
+    ]);
+  }
+
+  it('resolves a transitive subpath to the source file its exports map points at', async () => {
+    const workspaceMap = await writePkg({ './feature': './src/feature.ts' });
+    expect(resolveWorkspaceSubpathToSource('@scope/leaf/feature', workspaceMap)).toBe(join(dir, 'src', 'feature.ts'));
+  });
+
+  it('resolves a wildcard subpath entry', async () => {
+    const workspaceMap = await writePkg({ './dist/*': './src/*.ts' });
+    expect(resolveWorkspaceSubpathToSource('@scope/leaf/dist/lexorder', workspaceMap)).toBe(
+      join(dir, 'src', 'lexorder.ts'),
+    );
+  });
+
+  it('returns null for a bare root specifier (roots are handled by the analyze dependency map)', async () => {
+    const workspaceMap = await writePkg({ './feature': './src/feature.ts' });
+    expect(resolveWorkspaceSubpathToSource('@scope/leaf', workspaceMap)).toBeNull();
+  });
+
+  it('returns null for a package outside the workspace map', async () => {
+    const workspaceMap = await writePkg({ './feature': './src/feature.ts' });
+    expect(resolveWorkspaceSubpathToSource('@other/pkg/feature', workspaceMap)).toBeNull();
+  });
+
+  it('swallows the resolve.exports throw for a missing entry and returns null', async () => {
+    const workspaceMap = await writePkg({ './feature': './src/feature.ts' });
+    expect(resolveWorkspaceSubpathToSource('@scope/leaf/does-not-exist', workspaceMap)).toBeNull();
+  });
+
+  it('returns null when the workspace package has no readable package.json', async () => {
+    const dir2 = join(dir, 'ghost');
+    await ensureDir(dir2); // package.json intentionally absent
+    const workspaceMap = new Map<string, WorkspacePackageInfo>([
+      ['@scope/ghost', { location: dir2, dependencies: {}, version: '1.0.0' }],
+    ]);
+    expect(resolveWorkspaceSubpathToSource('@scope/ghost/feature', workspaceMap)).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #19909

Under `bundler: { externals: true }`, a workspace subpath imported transitively (app → workspace A → `@scope/b/feature`) escapes analyze-time capture and leaks out of the bundle as a bare specifier — failing at runtime with `ERR_MODULE_NOT_FOUND`, or since #19808 with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` when the workspace package gets installed with raw `.ts` subpath exports.

The main-bundle resolver now resolves such an uncaptured subpath through the workspace package's `exports` map and returns it non-external, so the bundler compiles it inline. No new analysis pass is added — the manifest-based transitive-discovery invariant is preserved, and builds that already succeed are unchanged (the hook only fires for ids missing from the analyze dependency map under the externals preset).

Builds on the workspace-subpath resolver from #19913 (c2507a4), revived against current `main` following the reproducer's analysis in the issue.

**Verification**
- New `bundler.workspace-subpath.test.ts` (6 cases): exports-map lookup, wildcard entries, root / non-workspace / missing-entry / no-package.json guards.
- `vitest run src/build/` for the package: 479/480 — the single failure (`analyze.test.ts > protocol imports`) times out identically on unmodified `main` (verified by reverting this diff), a local environment issue unrelated to this change.
