### PR TITLE
fix(dsql): write memory timestamps as UTC

### DIFF
--- a/.changeset/dsql-utc-timestamps.md
+++ b/.changeset/dsql-utc-timestamps.md
@@ -1,0 +1,5 @@
+---
+'@mastra/dsql': patch
+---
+
+Fixed DSQL memory timestamps to stay aligned across server timezones.

--- a/stores/dsql/src/storage/domains/memory/index.ts
+++ b/stores/dsql/src/storage/domains/memory/index.ts
@@ -48,6 +48,14 @@ type MessageRowFromDB = {
 function inPlaceholders(count: number, startIndex = 1): string {
   return Array.from({ length: count }, (_, i) => `$${i + startIndex}`).join(', ');
 }
+/**
+ * Bind dates as UTC strings because node-postgres serializes Date parameters
+ * for TIMESTAMP columns using the process's local timezone.
+ */
+function toUtcISOString(date: Date): string {
+  return date.toISOString();
+}
+
 export class MemoryDSQL extends MemoryStorage {
   override readonly supportsPartialThreadUpdate = true;
   #db: DsqlDB;
@@ -313,6 +321,8 @@ export class MemoryDSQL extends MemoryStorage {
 
   async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
     const tableName = getTableName({ indexName: TABLE_THREADS, schemaName: getSchemaName(this.#schema) });
+    const createdAt = toUtcISOString(thread.createdAt);
+    const updatedAt = toUtcISOString(thread.updatedAt);
 
     await withRetry(
       async () => {
@@ -340,10 +350,10 @@ export class MemoryDSQL extends MemoryStorage {
             thread.resourceId,
             thread.title,
             thread.metadata ? JSON.stringify(thread.metadata) : null,
-            thread.createdAt,
-            thread.createdAt,
-            thread.updatedAt,
-            thread.updatedAt,
+            createdAt,
+            createdAt,
+            updatedAt,
+            updatedAt,
           ],
         );
       },

--- a/stores/dsql/src/storage/domains/memory/save-thread.test.ts
+++ b/stores/dsql/src/storage/domains/memory/save-thread.test.ts
@@ -1,0 +1,78 @@
+import type { StorageThreadType } from '@mastra/core/memory';
+import { describe, expect, it } from 'vitest';
+import { MemoryDSQL } from './index';
+
+type QueryValues = any[] | undefined;
+
+interface RecordedQuery {
+  query: string;
+  values: QueryValues;
+}
+
+/**
+ * node-postgres renders a Date parameter in the process's local timezone, so a raw Date bound to a
+ * TIMESTAMP column stores the local wall clock rather than the instant. Recording the bound values
+ * is enough to pin that; it does not need a live database.
+ */
+class RecordingDbClient {
+  readonly queries: RecordedQuery[] = [];
+
+  async none(query: string, values?: QueryValues): Promise<null> {
+    this.queries.push({ query, values });
+    return null;
+  }
+
+  async manyOrNone<T = any>(): Promise<T[]> {
+    return [] as T[];
+  }
+
+  async oneOrNone<T = any>(): Promise<T | null> {
+    return null;
+  }
+
+  async tx<T>(cb: (t: RecordingDbClient) => Promise<T>): Promise<T> {
+    return cb(this);
+  }
+}
+
+function makeThread(createdAt: Date, updatedAt: Date): StorageThreadType {
+  return {
+    id: 'thread-1',
+    resourceId: 'resource-1',
+    title: 'Test thread',
+    metadata: {},
+    createdAt,
+    updatedAt,
+  };
+}
+
+describe('MemoryDSQL.saveThread', () => {
+  it('binds UTC strings for both timestamp column variants', async () => {
+    const client = new RecordingDbClient();
+    const memory = new MemoryDSQL({ client } as any);
+    const createdAt = new Date('2026-07-01T12:34:56.789Z');
+    const updatedAt = new Date('2026-07-02T01:02:03.456Z');
+
+    await memory.saveThread({ thread: makeThread(createdAt, updatedAt) });
+
+    const insert = client.queries.find(q => q.query.includes('INSERT INTO'));
+    expect(insert).toBeDefined();
+    expect(insert!.values![4]).toBe(createdAt.toISOString());
+    expect(insert!.values![5]).toBe(createdAt.toISOString());
+    expect(insert!.values![6]).toBe(updatedAt.toISOString());
+    expect(insert!.values![7]).toBe(updatedAt.toISOString());
+  });
+
+  it('keeps the instant when the server runs behind UTC', async () => {
+    const client = new RecordingDbClient();
+    const memory = new MemoryDSQL({ client } as any);
+    // 00:30Z renders as the previous calendar day west of UTC.
+    const createdAt = new Date('2026-08-29T00:30:00.000Z');
+
+    await memory.saveThread({ thread: makeThread(createdAt, createdAt) });
+
+    const insert = client.queries.find(q => q.query.includes('INSERT INTO'));
+    expect(insert!.values![4]).toBe('2026-08-29T00:30:00.000Z');
+    expect(String(insert!.values![4])).toMatch(/Z$/);
+  });
+});


### PR DESCRIPTION
## Description

`MemoryDSQL.saveThread` bound `thread.createdAt` and `thread.updatedAt` as raw `Date` objects. node-postgres renders a `Date` parameter using the process's local timezone, so the `TIMESTAMP` columns received the server's local wall clock rather than the instant.

`stores/pg` fixed this in #20831. `stores/dsql` uses the same `pg` driver and was not part of that change, so this ports the `toUtcISOString` helper across.

The insert binds the same value to both column variants. `createdAtZ` is `timestamptz`, so the offset is honoured and the instant survives; `createdAt` is `timestamp` without time zone, so the offset is dropped and the local wall clock is stored. The two columns disagreed, and reads that fall back through `row.createdAtZ || row.createdAt` returned the shifted value.

Observable straight from the driver, no database needed:

```
TZ=Asia/Kolkata      raw Date -> 2026-08-29T06:00:00.000+05:30
TZ=America/New_York  raw Date -> 2026-08-28T20:30:00.000-04:00
                     toISOString() -> 2026-08-29T00:30:00.000Z
```

For an instant at `00:30Z`, a host in Asia/Kolkata stored `06:00`, and one in America/New_York stored the **previous calendar day**, so anything grouping by day bucketed the thread wrongly. The shift is silent and depends on where the process happens to run.

Fixes #22589

## Scope

Four bindings in `saveThread`. I checked the other dsql domains and none of them binds a raw `Date`.

`stores/mysql` also binds dates without conversion, but through `mysql2`, whose serialization rules are its own. I have not verified that one and deliberately left it out rather than widen this PR on an assumption.

## Testing

`src/storage/domains/memory/save-thread.test.ts`, mirroring the recording-client approach `stores/pg` used in #20831: capture the values bound to the insert and assert they are UTC strings. No live database required.

Both tests fail on `main` and pass here; reverting the source change turns exactly those two red and nothing else.

```
vitest run src/storage/domains/memory/save-thread.test.ts   ->  2 passed
vitest run --exclude '**/*.integration.test.ts'             ->  47 passed, 5 files
pnpm run lint                                               ->  clean
```

One unrelated file fails to collect in my environment, `packages/memory/.../token-counter.ts`, because `probe-image-size` is not installed. It fails identically with this branch stashed, so it is not from this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR stores thread timestamps in a standard UTC format. This prevents server location settings from changing the recorded time.

## Changes

- Convert all `createdAt` and `updatedAt` values in `MemoryDSQL.saveThread` to UTC ISO strings.
- Apply the conversion to both timestamp column variants.
- Add tests that verify UTC bindings without a live database.
- Add a patch changeset for `@mastra/dsql`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->