### PR TITLE
fix(playground): allow deleting stored prompt blocks from Studio UI

### DIFF
--- a/packages/playground/src/domains/prompt-blocks/components/__tests__/delete-prompt-block-action.test.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/__tests__/delete-prompt-block-action.test.tsx
@@ -1,26 +1,14 @@
-import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DeletePromptBlockButton } from '../delete-prompt-block-action';
+import { LinkComponentProvider } from '@/lib/framework';
+import { StubLink, stubLinkPaths } from '@/test/link-provider';
 import { server } from '@/test/msw-server';
-
-const navigate = vi.fn();
-
-vi.mock('@/lib/framework', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/framework')>('@/lib/framework');
-  return {
-    ...actual,
-    useLinkComponent: () => ({
-      ...actual.useLinkComponent(),
-      navigate,
-      paths: { ...actual.useLinkComponent().paths, promptBlocksLink: () => '/prompts' },
-    }),
-  };
-});
 
 vi.mock('@mastra/playground-ui/store/playground-store', () => ({
   usePlaygroundStore: () => ({ requestContext: undefined }),
@@ -33,6 +21,8 @@ vi.mock('@mastra/playground-ui/utils/toast', () => ({
 const { toast } = await import('@mastra/playground-ui/utils/toast');
 
 const BASE_URL = 'http://localhost:4111';
+
+const navigate = vi.fn();
 
 const installRadixDomShims = () => {
   if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
@@ -55,7 +45,9 @@ const Wrapper = ({ children }: { children: ReactNode }) => {
   return (
     <MastraReactProvider baseUrl={BASE_URL}>
       <QueryClientProvider client={queryClient}>
-        <TooltipProvider>{children}</TooltipProvider>
+        <LinkComponentProvider Link={StubLink} navigate={navigate} paths={stubLinkPaths}>
+          <MemoryRouter>{children}</MemoryRouter>
+        </LinkComponentProvider>
       </QueryClientProvider>
     </MastraReactProvider>
   );
@@ -142,7 +134,7 @@ describe('DeletePromptBlockButton', () => {
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith('Prompt block deleted');
     });
-    expect(navigate).toHaveBeenCalledWith('/prompts');
+    expect(navigate).toHaveBeenCalledWith(stubLinkPaths.promptBlocksLink());
   });
 
   it('toasts an error and keeps the dialog open when the DELETE fails', async () => {

--- a/packages/playground/src/domains/prompt-blocks/components/__tests__/delete-prompt-block-action.test.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/__tests__/delete-prompt-block-action.test.tsx
@@ -1,0 +1,171 @@
+import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeletePromptBlockButton } from '../delete-prompt-block-action';
+import { server } from '@/test/msw-server';
+
+const navigate = vi.fn();
+
+vi.mock('@/lib/framework', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/framework')>('@/lib/framework');
+  return {
+    ...actual,
+    useLinkComponent: () => ({
+      ...actual.useLinkComponent(),
+      navigate,
+      paths: { ...actual.useLinkComponent().paths, promptBlocksLink: () => '/prompts' },
+    }),
+  };
+});
+
+vi.mock('@mastra/playground-ui/store/playground-store', () => ({
+  usePlaygroundStore: () => ({ requestContext: undefined }),
+}));
+
+vi.mock('@mastra/playground-ui/utils/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const { toast } = await import('@mastra/playground-ui/utils/toast');
+
+const BASE_URL = 'http://localhost:4111';
+
+const installRadixDomShims = () => {
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+  if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+  if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    class StubResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+  }
+};
+
+const Wrapper = ({ children }: { children: ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>{children}</TooltipProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+describe('DeletePromptBlockButton', () => {
+  beforeAll(() => {
+    installRadixDomShims();
+  });
+
+  beforeEach(() => {
+    navigate.mockReset();
+    (toast.success as ReturnType<typeof vi.fn>).mockReset();
+    (toast.error as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens the confirmation dialog with the block name when clicked', async () => {
+    render(
+      <Wrapper>
+        <DeletePromptBlockButton blockId="block-123" blockName="My Prompt Block" />
+      </Wrapper>,
+    );
+
+    const button = screen.getByTestId('delete-prompt-block');
+    expect(button.textContent).toContain('Delete');
+
+    fireEvent.click(button);
+
+    const dialog = await screen.findByTestId('delete-prompt-block-dialog');
+    expect(dialog.textContent).toContain('My Prompt Block');
+  });
+
+  it('does not fire a DELETE request when the user cancels', async () => {
+    let deleteCalled = false;
+    server.use(
+      http.delete(`${BASE_URL}/api/stored/prompt-blocks/block-123`, () => {
+        deleteCalled = true;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <DeletePromptBlockButton blockId="block-123" blockName="My Prompt Block" />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId('delete-prompt-block'));
+    fireEvent.click(screen.getByTestId('delete-prompt-block-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('delete-prompt-block-dialog')).toBeNull();
+    });
+    expect(deleteCalled).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('calls DELETE, toasts success, and navigates after the request resolves', async () => {
+    let deleteCalled = false;
+    server.use(
+      http.delete(`${BASE_URL}/api/stored/prompt-blocks/block-123`, () => {
+        deleteCalled = true;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <DeletePromptBlockButton blockId="block-123" blockName="My Prompt Block" />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId('delete-prompt-block'));
+    const confirmBtn = await screen.findByTestId('delete-prompt-block-confirm');
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(deleteCalled).toBe(true);
+    });
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Prompt block deleted');
+    });
+    expect(navigate).toHaveBeenCalledWith('/prompts');
+  });
+
+  it('toasts an error and keeps the dialog open when the DELETE fails', async () => {
+    server.use(
+      http.delete(`${BASE_URL}/api/stored/prompt-blocks/block-123`, () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 }),
+      ),
+    );
+
+    render(
+      <Wrapper>
+        <DeletePromptBlockButton blockId="block-123" blockName="My Prompt Block" />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId('delete-prompt-block'));
+    const confirmBtn = await screen.findByTestId('delete-prompt-block-confirm');
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+    expect(navigate).not.toHaveBeenCalled();
+    expect(await screen.findByTestId('delete-prompt-block-dialog')).toBeTruthy();
+  });
+});

--- a/packages/playground/src/domains/prompt-blocks/components/delete-prompt-block-action.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/delete-prompt-block-action.tsx
@@ -1,0 +1,113 @@
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
+import { Button } from '@mastra/playground-ui/components/Button';
+import { toast } from '@mastra/playground-ui/utils/toast';
+import { Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useStoredPromptBlockMutations } from '../hooks/use-stored-prompt-blocks';
+import { useLinkComponent } from '@/lib/framework';
+
+interface UseDeletePromptBlockActionParams {
+  blockId: string;
+}
+
+const useDeletePromptBlockAction = ({ blockId }: UseDeletePromptBlockActionParams) => {
+  const [open, setOpen] = useState(false);
+  const { navigate, paths } = useLinkComponent();
+  const { deleteStoredPromptBlock } = useStoredPromptBlockMutations(blockId);
+
+  const confirm = async () => {
+    try {
+      await deleteStoredPromptBlock.mutateAsync();
+      toast.success('Prompt block deleted');
+      setOpen(false);
+      void navigate(paths.promptBlocksLink());
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete prompt block');
+    }
+  };
+
+  return {
+    open,
+    setOpen,
+    isPending: deleteStoredPromptBlock.isPending,
+    confirm,
+  };
+};
+
+interface DeletePromptBlockDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  blockName: string;
+  isPending: boolean;
+  onConfirm: () => void;
+}
+
+const DeletePromptBlockDialog = ({
+  open,
+  onOpenChange,
+  blockName,
+  isPending,
+  onConfirm,
+}: DeletePromptBlockDialogProps) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialog.Content data-testid="delete-prompt-block-dialog">
+        <AlertDialog.Header>
+          <AlertDialog.Title>Delete prompt block?</AlertDialog.Title>
+          <AlertDialog.Description>
+            This permanently deletes &quot;{blockName}&quot;. This cannot be undone.
+          </AlertDialog.Description>
+        </AlertDialog.Header>
+        <AlertDialog.Footer>
+          <AlertDialog.Cancel data-testid="delete-prompt-block-cancel" disabled={isPending}>
+            Cancel
+          </AlertDialog.Cancel>
+          <Button
+            variant="primary"
+            data-testid="delete-prompt-block-confirm"
+            disabled={isPending}
+            onClick={() => {
+              // Use a plain button (not AlertDialog.Close) so the dialog stays
+              // open while the request is in flight and on error.
+              onConfirm();
+            }}
+          >
+            {isPending ? 'Deleting…' : 'Delete prompt block'}
+          </Button>
+        </AlertDialog.Footer>
+      </AlertDialog.Content>
+    </AlertDialog>
+  );
+};
+
+interface DeletePromptBlockButtonProps {
+  blockId: string;
+  blockName: string;
+  disabled?: boolean;
+}
+
+export const DeletePromptBlockButton = ({ blockId, blockName, disabled = false }: DeletePromptBlockButtonProps) => {
+  const { open, setOpen, isPending, confirm } = useDeletePromptBlockAction({ blockId });
+
+  return (
+    <>
+      <Button
+        onClick={() => setOpen(true)}
+        disabled={disabled || isPending}
+        data-testid="delete-prompt-block"
+        variant="ghost"
+        size="sm"
+      >
+        <Trash2 />
+        Delete
+      </Button>
+      <DeletePromptBlockDialog
+        open={open}
+        onOpenChange={setOpen}
+        blockName={blockName}
+        isPending={isPending}
+        onConfirm={confirm}
+      />
+    </>
+  );
+};

--- a/packages/playground/src/domains/prompt-blocks/index.ts
+++ b/packages/playground/src/domains/prompt-blocks/index.ts
@@ -17,6 +17,7 @@ export {
 
 export { PromptsList, type PromptsListProps } from './components/prompts-list/prompts-list';
 export { NoPromptBlocksInfo } from './components/prompts-list/no-prompt-blocks-info';
+export { DeletePromptBlockButton } from './components/delete-prompt-block-action';
 
 // Hooks
 export {

--- a/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
+++ b/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
@@ -20,6 +20,7 @@ import {
   PromptBlockEditSidebar,
   PromptBlockVersionCombobox,
   usePromptBlockEditForm,
+  DeletePromptBlockButton,
 } from '@/domains/prompt-blocks';
 import { useLinkComponent } from '@/lib/framework';
 import { RouteHeaderActions } from '@/lib/route-header';
@@ -281,6 +282,7 @@ function CmsPromptBlocksEditPage() {
             variant="ghost"
             activeVersionId={activeVersionId}
           />
+          <DeletePromptBlockButton blockId={blockId} blockName={block.name} />
         </div>
       </RouteHeaderActions>
       <CmsPromptBlocksEditForm


### PR DESCRIPTION
## What

Closes #22356. Stored prompt blocks could be created in Studio but not deleted — the `deleteStoredPromptBlock` mutation (with query invalidation) already existed in `use-stored-prompt-blocks.ts`, but no component consumed it. The only workaround was `curl`.

## How

Adds a `DeletePromptBlockButton` (confirm dialog + toast + redirect to the list) wired into the prompt block edit page header actions, following the existing `delete-agent-action.tsx` pattern (`AlertDialog` + `toast` + `useLinkComponent`). No changes below the component layer — the server handler, client SDK method, and playground hook mutation were all already in place.

## Testing

Added `delete-prompt-block-action.test.tsx` (4 cases via MSW):
- opens the confirm dialog with the block name
- cancels without firing a DELETE request
- deletes → success toast → navigates back to the list
- DELETE fails → keeps the dialog open with an error toast

All green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Users can delete stored prompt blocks from the Studio UI. The UI asks for confirmation, reports the result, and returns to the prompt block list after a successful deletion.

## Changes

- Added `DeletePromptBlockButton` to the prompt block edit page header.
- Reused the existing `deleteStoredPromptBlock` mutation and query invalidation.
- Added confirmation and cancellation behavior.
- Added success and error toast notifications.
- Kept the dialog open during deletion and after failures.
- Added tests for confirmation, cancellation, success, navigation, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->