### PR TITLE
fix(observability): don't let undefined explicit metadata shadow requestContextKeys (#22597)

### DIFF
--- a/.changeset/lucky-pandas-remember.md
+++ b/.changeset/lucky-pandas-remember.md
@@ -2,4 +2,4 @@
 '@mastra/observability': patch
 ---
 
-Don't let a span's `undefined` explicit metadata shadow a `requestContextKeys` value. An agent-run span names `threadId` (`threadFromArgs?.id`), which is `undefined` when no memory is configured; that own property used to win the merge and drop the value extracted from the RequestContext. A key the span actually provides still takes precedence.
+Fixed span metadata precedence so `RequestContext` values are preserved when explicit metadata is `undefined`. Defined explicit metadata still takes precedence.

--- a/.changeset/lucky-pandas-remember.md
+++ b/.changeset/lucky-pandas-remember.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Don't let a span's `undefined` explicit metadata shadow a `requestContextKeys` value. An agent-run span names `threadId` (`threadFromArgs?.id`), which is `undefined` when no memory is configured; that own property used to win the merge and drop the value extracted from the RequestContext. A key the span actually provides still takes precedence.

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -671,32 +671,41 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     // Merging that `undefined` over the RequestContext value silently drops the
     // key the caller asked for via `requestContextKeys` (#22597), so drop the
     // undefined-valued own properties first instead of shadowing with them.
-    const definedExplicit = stripUndefined(explicitMetadata);
+    const definedExplicit = this.stripUndefined(explicitMetadata);
 
     return mergeMetadata(extracted, definedExplicit);
   }
 
   /**
-   * Returns a copy of `metadata` without own properties whose value is `undefined`,
-   * or the original value when it is not a plain record. Preserves descriptors so
-   * getters are not invoked here — the merge downstream handles that.
+   * Returns a copy of `metadata` without own data properties whose value is
+   * `undefined`, or the original value when it is not a plain record. Accessor
+   * properties are inspected via their descriptor and never invoked, so a getter
+   * cannot run during span creation; the merge downstream handles that.
    */
   protected stripUndefined(metadata: Record<string, any> | undefined): Record<string, any> | undefined {
     if (!metadata || !isPlainRecord(metadata)) {
       return metadata;
     }
 
-    const hasUndefined = Object.getOwnPropertyNames(metadata).some((key) => metadata[key] === undefined);
+    const hasUndefined = Object.getOwnPropertyNames(metadata).some((key) => {
+      const descriptor = Object.getOwnPropertyDescriptor(metadata, key);
+      return descriptor !== undefined && 'value' in descriptor && descriptor.value === undefined;
+    });
     if (!hasUndefined) {
       return metadata;
     }
 
     const result: Record<string, any> = {};
     for (const key of Object.getOwnPropertyNames(metadata)) {
-      if (metadata[key] === undefined) {
+      const descriptor = Object.getOwnPropertyDescriptor(metadata, key);
+      if (descriptor === undefined) {
         continue;
       }
-      Object.defineProperty(result, key, Object.getOwnPropertyDescriptor(metadata, key)!);
+      // data property whose value is undefined: drop it (never reads accessors)
+      if ('value' in descriptor && descriptor.value === undefined) {
+        continue;
+      }
+      Object.defineProperty(result, key, descriptor);
     }
     return result;
   }

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -665,8 +665,40 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
       return undefined;
     }
 
-    // Explicit metadata always wins.
-    return mergeMetadata(extracted, explicitMetadata);
+    // Explicit metadata wins — but only for keys it actually provides.
+    // A span can name a key it did not resolve (e.g. an agent-run span sets
+    // `threadId: threadFromArgs?.id`, which is `undefined` without memory).
+    // Merging that `undefined` over the RequestContext value silently drops the
+    // key the caller asked for via `requestContextKeys` (#22597), so drop the
+    // undefined-valued own properties first instead of shadowing with them.
+    const definedExplicit = stripUndefined(explicitMetadata);
+
+    return mergeMetadata(extracted, definedExplicit);
+  }
+
+  /**
+   * Returns a copy of `metadata` without own properties whose value is `undefined`,
+   * or the original value when it is not a plain record. Preserves descriptors so
+   * getters are not invoked here — the merge downstream handles that.
+   */
+  protected stripUndefined(metadata: Record<string, any> | undefined): Record<string, any> | undefined {
+    if (!metadata || !isPlainRecord(metadata)) {
+      return metadata;
+    }
+
+    const hasUndefined = Object.getOwnPropertyNames(metadata).some((key) => metadata[key] === undefined);
+    if (!hasUndefined) {
+      return metadata;
+    }
+
+    const result: Record<string, any> = {};
+    for (const key of Object.getOwnPropertyNames(metadata)) {
+      if (metadata[key] === undefined) {
+        continue;
+      }
+      Object.defineProperty(result, key, Object.getOwnPropertyDescriptor(metadata, key)!);
+    }
+    return result;
   }
 
   /**

--- a/observability/mastra/src/tracing.test.ts
+++ b/observability/mastra/src/tracing.test.ts
@@ -1969,6 +1969,61 @@ describe('Tracing', () => {
       span.end();
     });
 
+    it('does not let an undefined explicit value shadow an extracted key (#22597)', () => {
+      const observability = new DefaultObservabilityInstance({
+        serviceName: 'test-service',
+        name: 'test',
+        requestContextKeys: ['threadId', 'userId'],
+        exporters: [testExporter],
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('threadId', 'thread-abc');
+      requestContext.set('userId', 'user-123');
+
+      // An agent-run span names `threadId` in its own metadata but may not have
+      // resolved it (no memory configured) — the `undefined` must not win.
+      const span = observability.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'test-agent',
+        attributes: { agentId: 'agent-1' },
+        metadata: { runId: 'run-1', threadId: undefined },
+        requestContext,
+      });
+
+      expect(span.metadata).toEqual({
+        threadId: 'thread-abc',
+        userId: 'user-123',
+        runId: 'run-1',
+      });
+
+      span.end();
+    });
+
+    it('still lets a defined explicit value win over the extracted key', () => {
+      const observability = new DefaultObservabilityInstance({
+        serviceName: 'test-service',
+        name: 'test',
+        requestContextKeys: ['threadId'],
+        exporters: [testExporter],
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('threadId', 'thread-from-context');
+
+      const span = observability.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'test-agent',
+        attributes: { agentId: 'agent-1' },
+        metadata: { threadId: 'thread-explicit' },
+        requestContext,
+      });
+
+      expect(span.metadata).toEqual({ threadId: 'thread-explicit' });
+
+      span.end();
+    });
+
     it('should merge configured keys with per-request keys', () => {
       const observability = new DefaultObservabilityInstance({
         serviceName: 'test-service',


### PR DESCRIPTION
## Summary

Fixes #22597 — `requestContextKeys` silently drops any key the span's own metadata also names.

With `requestContextKeys: ['threadId', 'userId']` and a `RequestContext` carrying both, `threadId` never reached the exported span while `userId` (set on the same context, in the same request) did.

**Cause:** the agent-run span is created with explicit metadata that names `threadId` (`{ runId, resourceId, threadId: threadFromArgs?.id }`). Without memory configured that resolves to `undefined` — but it is still an own property. `extractMetadataFromRequestContext` merges explicit metadata over the RequestContext-extracted values, and `mergeMetadata` copies property descriptors, so the `undefined` wins and the extracted value is discarded.

**Fix:** strip `undefined`-valued own properties from the explicit metadata before the merge. This keeps the documented precedence — a key the span actually provides still wins — while a key it merely *names* falls back to the RequestContext value instead of being erased.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Reproduced the merge behaviour in isolation:

```
extracted = { threadId: 'THREAD-1', userId: 'USER-XYZ' }
explicit  = { runId: 'RUN-1', resourceId: null, threadId: undefined }

before: { userId, runId, resourceId }        // threadId dropped
after:  { threadId, userId, runId, resourceId }
```

Two regression tests added to `tracing.test.ts`:
1. an `undefined` explicit value no longer shadows the extracted key (#22597)
2. a defined explicit value still takes precedence (guards the fix from over-correcting)

## Checklist

- [x] My code follows the style guidelines of this project (prettier: 2-space, single quotes, printWidth 120)
- [x] I have performed a self-review of my own code
- [x] I have commented my code where the reasoning is non-obvious
- [x] I have added tests that prove my fix is effective
- [ ] I have run the full test suite (requires the repo's dev deps)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When explicit span metadata has no value, it no longer erases a valid value from `RequestContext`. Defined explicit metadata still takes priority.

## Changes

- Remove own data properties with `undefined` values before merging metadata.
- Preserve defined explicit metadata precedence.
- Avoid invoking accessor getters during cleanup.
- Add regression tests for fallback and override behavior.
- Add a patch changeset for `@mastra/observability`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->