### PR TITLE
fix(factory): parking a card takes back autonomy

### DIFF
--- a/.changeset/park-disarms-autonomy.md
+++ b/.changeset/park-disarms-autonomy.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Parking a card now revokes the standing permission your earlier drag gave the Factory.
+
+Any drag used to arm autonomy — including the drag that parked the card. So with auto-start off, parking a reviewed pull request meant its next push restarted the review on its own, overriding the park. A drag now speaks in the direction it points: into a working lane it hands the Factory the work, out to Intake, Done or Canceled it takes it back. Events on a parked card suggest; they no longer restart it.

--- a/mastracode/factory/src/rules/transition-service.test.ts
+++ b/mastracode/factory/src/rules/transition-service.test.ts
@@ -398,6 +398,46 @@ describe('FactoryTransitionService', () => {
     expect((await storage.get({ orgId: 'org-1', id: item.id }))?.autonomyArmedAt).toBeInstanceOf(Date);
   });
 
+  it('disarms autonomy when a person parks the card, so later events suggest instead of restarting it', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage, { stages: ['intake'] });
+    const service = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+    const dragged = await service.transition({ ...request(item, { stage: 'triage' }), cause: 'board_drag' });
+    assert(dragged.status === 'accepted');
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.autonomyArmedAt).toBeInstanceOf(Date);
+
+    const parked = await service.transition({
+      ...request(item, { stage: 'intake', expectedRevision: dragged.revision, identity: 'request-2' }),
+      cause: 'board_drag',
+    });
+
+    expect(parked.status).toBe('accepted');
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.autonomyArmedAt).toBeNull();
+  });
+
+  it('keeps autonomy armed when something other than a person moves the card to rest', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage, { stages: ['intake'] });
+    const service = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+    const dragged = await service.transition({ ...request(item, { stage: 'triage' }), cause: 'board_drag' });
+    assert(dragged.status === 'accepted');
+
+    const rested = await service.transition({
+      ...request(item, { stage: 'done', expectedRevision: dragged.revision, identity: 'request-2' }),
+      actor: { type: 'system', id: 'reconciler' },
+      ingress: { type: 'rule', identity: 'rule-1' },
+    });
+
+    expect(rested.status).toBe('accepted');
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.autonomyArmedAt).toBeInstanceOf(Date);
+  });
+
   it('leaves autonomy unarmed when the mover is not a person', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const item = await createItem(storage, { stages: ['intake'] });

--- a/mastracode/factory/src/rules/transition-service.ts
+++ b/mastracode/factory/src/rules/transition-service.ts
@@ -343,12 +343,14 @@ export class FactoryTransitionService {
           : ruleFailure(error);
       evaluation = { outcome: 'rejected', ...failed };
     }
-    // Moving a card by hand is itself the request to do the work. Arm the item
-    // inside the same revision-checked update that commits the transition, so
-    // the decisions it emits run instead of parking as proposals — and so a
-    // stale or rejected commit does not leave the item spuriously armed.
+    // A person's drag speaks in the direction it points: into a working lane
+    // it hands the factory the work, out to a resting lane it takes it back —
+    // later events may suggest, never restart. Flipped inside the same
+    // revision-checked update that commits the transition, so a stale or
+    // rejected commit leaves consent untouched.
+    const dragConsent = isWorkingStage(request.stage) ? ('arm' as const) : ('disarm' as const);
     return this.#commit(request, transitionId, evaluation, {
-      armAutonomy: evaluation.outcome === 'accepted' && humanBoardDrag,
+      autonomy: evaluation.outcome === 'accepted' && humanBoardDrag ? dragConsent : undefined,
     });
   }
 
@@ -367,10 +369,10 @@ export class FactoryTransitionService {
     evaluation:
       | { outcome: 'accepted'; decisions: Record<string, unknown>[] }
       | { outcome: 'rejected'; code: string; reason: string },
-    options: { armAutonomy?: boolean } = {},
+    options: { autonomy?: 'arm' | 'disarm' } = {},
   ): Promise<FactoryTransitionResult> {
     const committed = await this.#storage.commitTransition({
-      armAutonomy: options.armAutonomy === true,
+      autonomy: options.autonomy,
       orgId: request.orgId,
       factoryProjectId: request.factoryProjectId,
       workItemId: request.workItemId,

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -376,8 +376,8 @@ export interface CommitFactoryTransitionInput {
   evaluation:
     | { outcome: 'accepted'; decisions: Record<string, unknown>[] }
     | { outcome: 'rejected'; code: string; reason: string };
-  /** Arm autonomy in the same revision-checked update that commits the transition. */
-  armAutonomy?: boolean;
+  /** Arm or disarm autonomy in the same revision-checked update that commits the transition. */
+  autonomy?: 'arm' | 'disarm';
   /** Triage classification reported by an authenticated triage binding. */
   triageType?: FactoryTriageType;
 }
@@ -576,9 +576,7 @@ function patchColumns(changes: Partial<WorkItemRow>): Partial<WorkItemDbRow> {
     ...(changes.sessions !== undefined ? { sessions: changes.sessions } : {}),
     ...(changes.metadata !== undefined ? { metadata: changes.metadata } : {}),
     ...(changes.triageType !== undefined ? { triage_type: changes.triageType } : {}),
-    ...(changes.autonomyArmedAt !== undefined && changes.autonomyArmedAt !== null
-      ? { autonomy_armed_at: changes.autonomyArmedAt }
-      : {}),
+    ...(changes.autonomyArmedAt !== undefined ? { autonomy_armed_at: changes.autonomyArmedAt } : {}),
     ...(changes.revision !== undefined ? { revision: changes.revision } : {}),
     ...(changes.updatedAt !== undefined ? { updated_at: changes.updatedAt } : {}),
   };
@@ -1326,15 +1324,17 @@ export class WorkItemsStorage extends FactoryStorageDomain {
               reason = input.evaluation.reason;
               return null;
             }
-            const arm = input.armAutonomy === true && !existing.autonomyArmedAt;
+            const arm = input.autonomy === 'arm' && !existing.autonomyArmedAt;
+            const disarm = input.autonomy === 'disarm' && existing.autonomyArmedAt !== null;
             const triageType = existing.triageType ?? input.triageType ?? null;
             const classified = triageType !== existing.triageType;
             if (existing.stages.length === 1 && existing.stages[0] === input.destinationStage) {
               // Classification is part of a triage terminal handoff, so unlike
-              // arming alone it is a revisioned work-item change.
-              return arm || classified
+              // an autonomy flip alone it is a revisioned work-item change.
+              return arm || disarm || classified
                 ? patchColumns({
                     ...(arm ? { autonomyArmedAt: now } : {}),
+                    ...(disarm ? { autonomyArmedAt: null } : {}),
                     ...(classified ? { triageType } : {}),
                     ...(classified ? { revision: existing.revision + 1, updatedAt: now } : {}),
                   })
@@ -1342,6 +1342,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
             }
             return patchColumns({
               ...(arm ? { autonomyArmedAt: now } : {}),
+              ...(disarm ? { autonomyArmedAt: null } : {}),
               ...(classified ? { triageType } : {}),
               stages: [input.destinationStage],
               stageHistory: applyStageTransition(


### PR DESCRIPTION
Folded into #22531 — the stack collapsed into one PR; this lands there as its own commit.

---

TLDR: dragging a card out to a resting lane now takes the work back — later events suggest a run instead of restarting it unasked.

---

```
before   card parked in Intake, its PR gets a push → run auto-restarts (the old drag armed it forever)
after    same push → the run is proposed on the card and waits for a person
```

Any human drag armed autonomy and nothing ever disarmed it, so a card someone had deliberately pulled back to Intake would restart itself on the next event. A drag now speaks in the direction it points: into a working lane it arms, out to Intake/Done/Canceled it disarms. Both flips happen inside the same revision-checked update that commits the transition, so a stale or rejected commit leaves consent untouched.

### Judgment call

Only a person's drag flips consent. A rule or reconciler moving a card to Done keeps whatever arming the person gave it — the factory finishing work is not the person taking it back. It is one condition away if you disagree.

```
tests        +40   0
source       +18  -15
changeset     +7   0
```

