### PR TITLE
feat(factory-ui): resume a parked card from its primary action

### DIFF
--- a/.changeset/resume-parked-cards.md
+++ b/.changeset/resume-parked-cards.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+A card parked in Intake now offers Resume as its primary action.
+
+Once a seat's run had ever started, its action disappeared from the card — a parked card kept only "Open session", so the one way back into Reviewing was dragging it there. Resume restarts the deepest used seat's run, continuing in the same thread and branch, and the card re-enters that seat's lane exactly like a fresh Start. A parked suggestion still wins the primary slot.

--- a/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ItemRunSpec, RunAction } from './boardRunSpecs';
+import { cardPrimaryAction, resumeRunAction } from './cardPrimaryAction';
+import type { FactoryDecisionSummary } from './services/decisions';
+import type { WorkItem, WorkItemSessionRef } from './services/workItems';
+
+const review: RunAction = {
+  label: 'Review',
+  role: 'review',
+  stage: 'review',
+  invocation: { type: 'skill', skillName: 'factory-review', arguments: 'PR #1' },
+};
+
+const investigate: RunAction = {
+  label: 'Investigate',
+  role: 'plan',
+  stage: 'planning',
+  invocation: { type: 'skill', skillName: 'factory-triage', arguments: 'issue #1' },
+};
+
+const build: RunAction = {
+  label: 'Build',
+  role: 'work',
+  stage: 'execute',
+  invocation: { type: 'prompt', prompt: 'Implement a fix for issue #1' },
+};
+
+function spec(...actions: RunAction[]): ItemRunSpec {
+  return { branch: 'factory/pr-1', threadTitle: 'PR: one', actions };
+}
+
+function sessionRef(role: string): WorkItemSessionRef {
+  return { sessionId: `session-${role}`, branch: 'factory/pr-1', threadId: `thread-${role}`, startedBy: 'user-1' };
+}
+
+function item(sessions: Record<string, WorkItemSessionRef>): WorkItem {
+  return {
+    id: 'item-1',
+    orgId: 'org-1',
+    createdBy: 'user-1',
+    githubProjectId: 'project-1',
+    source: 'github-pr',
+    sourceKey: 'github-pr:1',
+    parentWorkItemId: null,
+    title: 'one',
+    url: null,
+    stages: ['intake'],
+    stageHistory: [],
+    sessions,
+    metadata: {},
+    commentCount: 0,
+    feedActivityAt: null,
+    revision: 1,
+    createdAt: '2026-08-30T00:00:00.000Z',
+    updatedAt: '2026-08-30T00:00:00.000Z',
+  };
+}
+
+function proposalSummary(): FactoryDecisionSummary {
+  return {
+    id: 'decision-1',
+    evaluationId: 'evaluation-1',
+    workItemId: 'item-1',
+    type: 'invokeSkill',
+    role: 'review',
+    status: 'proposed',
+    attempts: 0,
+    failureOccurrence: 0,
+    failureCode: null,
+    canRetry: false,
+    lastError: null,
+    createdAt: '2026-08-30T00:00:00.000Z',
+    updatedAt: '2026-08-30T00:00:00.000Z',
+    completedAt: null,
+  };
+}
+
+describe('resumeRunAction', () => {
+  it('offers the deepest used seat of a card parked in Intake', () => {
+    const sessions = { plan: sessionRef('plan'), work: sessionRef('work') };
+    expect(resumeRunAction('intake', spec(investigate, build), sessions)).toBe(build);
+  });
+
+  it('offers nothing for a fresh arrival or outside Intake', () => {
+    expect(resumeRunAction('intake', spec(review), {})).toBeUndefined();
+    expect(resumeRunAction('done', spec(review), { review: sessionRef('review') })).toBeUndefined();
+  });
+});
+
+describe('cardPrimaryAction', () => {
+  it('resumes a parked card instead of leaving Open session as the only way back', () => {
+    const runSpec = spec(review);
+    const onRestartRun = vi.fn();
+    const action = cardPrimaryAction({
+      item: item({ review: sessionRef('review') }),
+      runSpec,
+      resumeAction: review,
+      hasSession: true,
+      onApproveProposal: vi.fn(),
+      onStartRun: vi.fn(),
+      onRestartRun,
+      onCreateSession: vi.fn(),
+    });
+
+    expect(action?.label).toBe('Resume');
+    action?.start();
+    expect(onRestartRun).toHaveBeenCalledWith(runSpec, review);
+  });
+
+  it('still releases a proposed run first: the suggestion beats resuming beside it', () => {
+    const onApproveProposal = vi.fn();
+    const action = cardPrimaryAction({
+      item: item({ review: sessionRef('review') }),
+      runSpec: spec(review),
+      resumeAction: review,
+      proposal: proposalSummary(),
+      hasSession: true,
+      onApproveProposal,
+      onStartRun: vi.fn(),
+      onRestartRun: vi.fn(),
+      onCreateSession: vi.fn(),
+    });
+
+    expect(action?.label).toBe('Review');
+    action?.start();
+    expect(onApproveProposal).toHaveBeenCalledWith('decision-1');
+  });
+
+  it('keeps Start for a fresh arrival with no seat used', () => {
+    const runSpec = spec(review);
+    const onStartRun = vi.fn();
+    const action = cardPrimaryAction({
+      item: item({}),
+      runSpec,
+      runAction: review,
+      hasSession: false,
+      onApproveProposal: vi.fn(),
+      onStartRun,
+      onRestartRun: vi.fn(),
+      onCreateSession: vi.fn(),
+    });
+
+    expect(action?.label).toBe('Review');
+    action?.start();
+    expect(onStartRun).toHaveBeenCalledWith(runSpec, review);
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.ts
@@ -1,37 +1,58 @@
 import { itemSessionSpec } from './boardRunSpecs';
 import type { ItemRunSpec, RunAction } from './boardRunSpecs';
 import type { FactoryDecisionSummary } from './services/decisions';
-import type { WorkItem } from './services/workItems';
+import type { WorkItem, WorkItemSessionRef } from './services/workItems';
+import type { BoardStageId } from './stages';
 
 export interface CardPrimaryAction {
   label: string;
   start: () => void;
 }
 
-/** A proposed run wins the primary slot: releasing it beats starting a rival run beside it. */
+/** A card parked in Intake resumes its deepest used seat — the run it was pulled out of. */
+export function resumeRunAction(
+  columnStage: BoardStageId,
+  runSpec: ItemRunSpec | undefined,
+  sessions: Record<string, WorkItemSessionRef>,
+): RunAction | undefined {
+  if (columnStage !== 'intake') return undefined;
+  return runSpec?.actions.findLast(action => action.role in sessions);
+}
+
+/** A proposed run wins the primary slot: releasing it beats starting a rival run beside it. Resuming parked work comes next, for the same reason. */
 export function cardPrimaryAction({
   item,
   runSpec,
   runAction,
+  resumeAction,
   proposal,
   hasSession,
   onApproveProposal,
   onStartRun,
+  onRestartRun,
   onCreateSession,
 }: {
   item: WorkItem;
   runSpec?: ItemRunSpec;
   runAction?: RunAction;
+  resumeAction?: RunAction;
   proposal?: FactoryDecisionSummary;
   hasSession: boolean;
   onApproveProposal: (decisionId: string) => void;
   onStartRun: (spec: ItemRunSpec, action: RunAction) => void;
+  onRestartRun: (spec: ItemRunSpec, action: RunAction) => void;
   onCreateSession: (spec: { branch: string; threadTitle: string }) => void;
 }): CardPrimaryAction | undefined {
   if (proposal !== undefined) {
     const proposed = runSpec?.actions.find(action => action.role === proposal.role) ?? runAction;
     const label = proposed?.label ?? 'Start run';
     return { label, start: () => onApproveProposal(proposal.id) };
+  }
+  if (runSpec !== undefined && resumeAction !== undefined) {
+    return {
+      label: 'Resume',
+      start: () => onRestartRun(runSpec, resumeAction),
+    };
   }
   if (runSpec !== undefined && runAction !== undefined) {
     return {

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -20,7 +20,7 @@ import {
 import { itemRunSpec } from '../boardRunSpecs';
 import type { ItemRunSpec, RunAction } from '../boardRunSpecs';
 import { itemStageLabel } from '../boardStages';
-import { cardPrimaryAction } from '../cardPrimaryAction';
+import { cardPrimaryAction, resumeRunAction } from '../cardPrimaryAction';
 import { useCardMorph } from '../hooks/useCardMorph';
 import type { AuditEventPage } from '../services/audit';
 import type { FactoryDecisionSummary } from '../services/decisions';
@@ -140,10 +140,12 @@ export function WorkItemCard({
     item,
     runSpec,
     runAction: defaultRunAction,
+    resumeAction: resumeRunAction(columnStage, runSpec, sessions),
     proposal,
     hasSession: threadSession !== undefined,
     onApproveProposal,
     onStartRun,
+    onRestartRun,
     onCreateSession,
   });
   const proposedRunLabel =


### PR DESCRIPTION
Folded into #22531 — the stack collapsed into one PR; this lands there as its own commit.

---

TLDR: a card parked in Intake now offers Resume as its primary action, continuing the run it was pulled out of in the same thread.

---

```
before   card parked back in Intake       only "Open session" — no way to restart the work from the board
after    same card                        "Resume" continues the deepest used seat's run in its existing thread
fresh arrival in Intake, no seat used     unchanged: its normal start action
```

Parking a card kept its session refs, so the board filtered every run action out ("slot already used") and the card became a dead end: you could open the thread, but nothing on the board said "take this up again". Resume picks the deepest seat the card already used (build over investigate) and restarts that role's run with `openExisting: false`, which reuses the item's branch and thread — a follow-up in the same conversation, not a rival run.

A proposed run still wins the primary slot over Resume: releasing the factory's own suggestion beats starting beside it.

```
tests       +147   0
source       +26  -3
changeset     +7   0
```

