### PR TITLE
feat(factory): stamp the review verdict on the card it rests in Done

### DIFF
--- a/.changeset/review-verdict-stamp.md
+++ b/.changeset/review-verdict-stamp.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+A Done card now says when its review asked for changes.
+
+Both verdicts rest the card in Done — the review pass is over either way — so an approved PR and one waiting on its author looked identical. The review seat's terminal transition now requires a `verdict` (`approve` or `request_changes`), stamped on the card in the same commit that rests it; a card whose review requested changes wears a **Changes requested** mark in Done. Unmarked Done stays the normal good outcome, and the next review pass rewrites the stamp.

--- a/mastracode/factory-ui/src/ui/domains/factory/boardItems.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardItems.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { reviewVerdictForItem } from './boardItems';
+
+describe('reviewVerdictForItem', () => {
+  it('reads the stamped verdict and rejects values the factory never wrote', () => {
+    expect(reviewVerdictForItem({ metadata: { reviewVerdict: 'request_changes' } })).toBe('request_changes');
+    expect(reviewVerdictForItem({ metadata: { reviewVerdict: 'approve' } })).toBe('approve');
+    expect(reviewVerdictForItem({ metadata: { reviewVerdict: 'lgtm' } })).toBeUndefined();
+    expect(reviewVerdictForItem({ metadata: {} })).toBeUndefined();
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
@@ -1,3 +1,5 @@
+import { isFactoryReviewVerdict } from '@mastra/factory/rules/types';
+import type { FactoryReviewVerdict } from '@mastra/factory/rules/types';
 import { relativeTime } from '../../../lib/date/relativeTime';
 import type { WorkItem, WorkItemSessionRef, WorkItemSource } from './services/workItems';
 
@@ -63,6 +65,11 @@ export function isExternalPullRequest(item: Pick<WorkItem, 'source' | 'metadata'
   if (item.source !== 'github-pr') return false;
   if (item.metadata.factoryAuthored === true) return false;
   return item.metadata.authorTrusted === false;
+}
+
+/** The last review pass's verdict, stamped when the review seat rested the card in Done. */
+export function reviewVerdictForItem(item: Pick<WorkItem, 'metadata'>): FactoryReviewVerdict | undefined {
+  return isFactoryReviewVerdict(item.metadata.reviewVerdict) ? item.metadata.reviewVerdict : undefined;
 }
 
 export function candidateSourceKeyForItem(item: WorkItem): string | undefined {

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -15,6 +15,7 @@ import {
   itemThreadSession,
   metadataLabels,
   pullRequestStatusForItem,
+  reviewVerdictForItem,
   workItemMeta,
 } from '../boardItems';
 import { itemRunSpec } from '../boardRunSpecs';
@@ -332,6 +333,20 @@ export function WorkItemCard({
                   />
                   <TooltipContent side="bottom" className="max-w-64">
                     From someone without write access — never starts a run on its own, even with auto-start runs on.
+                  </TooltipContent>
+                </Tooltip>
+              )}
+              {columnStage === 'done' && reviewVerdictForItem(item) === 'request_changes' && (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Badge size="xs" tabIndex={0} className="relative z-10">
+                        Changes requested
+                      </Badge>
+                    }
+                  />
+                  <TooltipContent side="bottom" className="max-w-64">
+                    The review asked for changes — a new push brings the card back to Reviewing.
                   </TooltipContent>
                 </Tooltip>
               )}

--- a/mastracode/factory/factory-skills/factory-review/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-review/SKILL.md
@@ -149,6 +149,8 @@ Keep it strictly non-blocking and low-risk. A fix that demands design judgment, 
 
 Then make your terminal `factory_transition_work_item` call. Take the current stage and `expectedRevision` from the `factory-phase` signal. Request `stage: "done"` (review board) **for both verdicts** — the transition marks the review pass complete; what to do about requested changes is the human's call from the handoff.
 
+`verdict` — `"approve"` or `"request_changes"`, matching the verdict you published. Required with `stage: "done"`; the board shows it on the resting card.
+
 `rationale` (max 1000 chars) — one or two sentences: review complete, verdict, and the headline reason.
 
 The transition is governed by the server's rules. If it is rejected, read the stated reason, address it (re-check the revision from the latest `factory-phase` signal, re-examine contested findings, re-review if the PR changed), and retry once corrected. Once the transition succeeds, post the handoff as your final conversation message — including how the verdict was published — and stop.

--- a/mastracode/factory/src/rules/tools.test.ts
+++ b/mastracode/factory/src/rules/tools.test.ts
@@ -163,6 +163,41 @@ describe('factory_transition_work_item', () => {
     ).toBe(true);
   });
 
+  it('requires a verdict exactly when a review binding rests its card in Done', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    await prepareBoundItem(storage, 'github-pr', 'review');
+    const tools = await createFactoryTransitionTools({
+      requestContext: requestContext(),
+      storage,
+      transitionService: new FactoryTransitionService({ storage, rules: defaultFactoryRules({ version: 'rules-v1' }) }),
+    });
+    const reviewTool = tools.factory_transition_work_item as ExecutableTool;
+    const request = { stage: 'done', expectedRevision: 1, rationale: 'Review pass complete.' };
+    expect(reviewTool.inputSchema.safeParse(request).success).toBe(false);
+    expect(reviewTool.inputSchema.safeParse({ ...request, verdict: 'request_changes' }).success).toBe(true);
+    expect(reviewTool.inputSchema.safeParse({ ...request, stage: 'canceled' }).success).toBe(true);
+  });
+
+  it('stamps the review verdict on the card it rests in Done', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const prepared = await prepareBoundItem(storage, 'github-pr', 'review');
+    const context = requestContext();
+    const tools = await createFactoryTransitionTools({
+      requestContext: context,
+      storage,
+      transitionService: new FactoryTransitionService({ storage, rules: defaultFactoryRules({ version: 'rules-v1' }) }),
+    });
+    await execute(tools.factory_transition_work_item as ExecutableTool, context, {
+      stage: 'done',
+      expectedRevision: prepared.item.revision,
+      rationale: 'Review pass complete, changes requested on the PR.',
+      verdict: 'request_changes',
+    });
+    const item = await storage.get({ orgId: 'org-1', id: prepared.item.id });
+    expect(item?.stages).toEqual(['done']);
+    expect(item?.metadata?.reviewVerdict).toBe('request_changes');
+  });
+
   it('propagates a triage binding classification to the transition service', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const prepared = await prepareBoundItem(storage, 'github-issue', 'triage');

--- a/mastracode/factory/src/rules/tools.ts
+++ b/mastracode/factory/src/rules/tools.ts
@@ -8,7 +8,13 @@ import type { FactorySessionSourceLookup } from './binding-context.js';
 import { resolveFactorySessionAddress } from './binding-context.js';
 import type { FactoryTransitionService } from './transition-service.js';
 import { currentStage } from './transition-service.js';
-import { FACTORY_RULE_STAGES, FACTORY_TRIAGE_TYPES, isFactoryTriageType } from './types.js';
+import {
+  FACTORY_REVIEW_VERDICTS,
+  FACTORY_RULE_STAGES,
+  FACTORY_TRIAGE_TYPES,
+  isFactoryReviewVerdict,
+  isFactoryTriageType,
+} from './types.js';
 import type { FactoryRuleBoard } from './types.js';
 
 const MAX_RATIONALE_LENGTH = 1_000;
@@ -33,8 +39,23 @@ const triageTransitionInputSchema = transitionInputSchema.extend({
   triageType: z.enum(FACTORY_TRIAGE_TYPES),
 });
 
+// Done from the review seat means "verdict delivered" — the stamp is what keeps
+// a changes-requested card readable next to an approved one in the Done lane.
+const reviewTransitionInputSchema = transitionInputSchema
+  .extend({ verdict: z.enum(FACTORY_REVIEW_VERDICTS).optional() })
+  .refine(value => value.stage !== 'done' || value.verdict !== undefined, {
+    message: 'A review pass resting its card in Done must state its verdict.',
+    path: ['verdict'],
+  });
+
 function boardForSource(type: string | undefined): FactoryRuleBoard {
   return type === 'pull-request' ? 'review' : 'work';
+}
+
+function transitionSchemaForRole(role: string) {
+  if (role === 'triage') return triageTransitionInputSchema;
+  if (role === 'review') return reviewTransitionInputSchema;
+  return transitionInputSchema;
 }
 
 export async function createFactoryTransitionTools(options: {
@@ -59,7 +80,7 @@ export async function createFactoryTransitionTools(options: {
       description: isTriage
         ? 'Report the triage classification and request a governed stage transition for the Factory work item exactly bound to this thread. Only bugs may request Planning autonomously; closure outcomes may request a terminal stage. Feature requests and other non-bug classifications that remain open must stay in their current Intake or Triage stage for maintainer approval.'
         : 'Request a governed stage transition for the Factory work item exactly bound to this thread. Use the current revision from the factory-phase signal and explain why the transition is appropriate.',
-      inputSchema: isTriage ? triageTransitionInputSchema : transitionInputSchema,
+      inputSchema: transitionSchemaForRole(availableBinding.role),
       requireApproval: true,
       execute: async ({ stage, expectedRevision, rationale, ...input }, execution) => {
         const currentResolution = await resolveFactorySessionAddress({
@@ -86,6 +107,7 @@ export async function createFactoryTransitionTools(options: {
         if (!item) throw new Error('Bound Factory work item not found.');
         const triageType =
           'triageType' in input && isFactoryTriageType(input.triageType) ? input.triageType : undefined;
+        const reviewVerdict = 'verdict' in input && isFactoryReviewVerdict(input.verdict) ? input.verdict : undefined;
 
         const result = await options.transitionService.transition({
           orgId: binding.orgId,
@@ -98,6 +120,7 @@ export async function createFactoryTransitionTools(options: {
           ingress: { type: 'agent', identity: `${binding.id}:${toolCallId}` },
           cause: rationale,
           ...(triageType ? { triageType } : {}),
+          ...(reviewVerdict ? { reviewVerdict } : {}),
         });
 
         // A phase EXIT is the natural moment to ask what was worth keeping:

--- a/mastracode/factory/src/rules/transition-service.ts
+++ b/mastracode/factory/src/rules/transition-service.ts
@@ -7,6 +7,7 @@ import type {
   FactoryRuleActor,
   FactoryRuleBoard,
   FactoryRuleCausalEntry,
+  FactoryReviewVerdict,
   FactoryRuleRejectionCode,
   FactoryRuleStage,
   FactoryTriageType,
@@ -47,6 +48,8 @@ export interface FactoryTransitionRequest {
   reenter?: boolean;
   /** Structured verdict required from a bound triage-agent terminal request. */
   triageType?: FactoryTriageType;
+  /** Structured verdict required from a bound review-agent Done request; stamped on the card's metadata. */
+  reviewVerdict?: FactoryReviewVerdict;
 }
 
 export interface FactoryTransitionServiceOptions {
@@ -130,6 +133,10 @@ function stageTransitionMessage(fromStage: FactoryRuleStage, toStage: FactoryRul
 
 function isTriageAgent(actor: FactoryRuleActor): actor is Extract<FactoryRuleActor, { type: 'agent' }> {
   return actor.type === 'agent' && actor.role === 'triage';
+}
+
+function isReviewAgent(actor: FactoryRuleActor): boolean {
+  return actor.type === 'agent' && actor.role === 'review';
 }
 
 function isHumanTransition(request: FactoryTransitionRequest): boolean {
@@ -384,6 +391,7 @@ export class FactoryTransitionService {
       causalChain: [...(request.causalChain ?? [])],
       evaluation,
       ...(isTriageAgent(request.actor) && request.triageType ? { triageType: request.triageType } : {}),
+      ...(isReviewAgent(request.actor) && request.reviewVerdict ? { reviewVerdict: request.reviewVerdict } : {}),
     });
     if (committed.status === 'missing') {
       return rejection(transitionId, request.workItemId, 'invalid_transition', 'Work item not found.');

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -22,6 +22,13 @@ export function isFactoryTriageType(value: unknown): value is FactoryTriageType 
   return typeof value === 'string' && FACTORY_TRIAGE_TYPES.some(type => type === value);
 }
 
+export const FACTORY_REVIEW_VERDICTS = ['approve', 'request_changes'] as const;
+export type FactoryReviewVerdict = (typeof FACTORY_REVIEW_VERDICTS)[number];
+
+export function isFactoryReviewVerdict(value: unknown): value is FactoryReviewVerdict {
+  return typeof value === 'string' && FACTORY_REVIEW_VERDICTS.some(verdict => verdict === value);
+}
+
 export function isFactoryRuleStage(value: unknown): value is FactoryRuleStage {
   return typeof value === 'string' && FACTORY_RULE_STAGES.some(stage => stage === value);
 }

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -13,7 +13,7 @@ import { createHash } from 'node:crypto';
 import { FactoryStorageDomain, UniqueViolationError } from '@mastra/core/storage';
 import type { CollectionSchema, CollectionWhere, FactoryStorageOps } from '@mastra/core/storage';
 import { isTerminalFactoryRuleStage } from '../../../rules/types.js';
-import type { FactoryTriageType } from '../../../rules/types.js';
+import type { FactoryReviewVerdict, FactoryTriageType } from '../../../rules/types.js';
 import {
   WORK_ITEM_ACTIVITY_SCHEMA,
   WORK_ITEM_COMMENT_MENTIONS_SCHEMA,
@@ -380,6 +380,8 @@ export interface CommitFactoryTransitionInput {
   autonomy?: 'arm' | 'disarm';
   /** Triage classification reported by an authenticated triage binding. */
   triageType?: FactoryTriageType;
+  /** Review verdict reported by an authenticated review binding, stamped on the card's metadata. */
+  reviewVerdict?: FactoryReviewVerdict;
 }
 
 export type CommitFactoryTransitionResult =
@@ -1328,15 +1330,22 @@ export class WorkItemsStorage extends FactoryStorageDomain {
             const disarm = input.autonomy === 'disarm' && existing.autonomyArmedAt !== null;
             const triageType = existing.triageType ?? input.triageType ?? null;
             const classified = triageType !== existing.triageType;
+            const verdictStamped =
+              input.reviewVerdict !== undefined && existing.metadata?.reviewVerdict !== input.reviewVerdict;
+            const stampedMetadata = verdictStamped
+              ? { metadata: { ...existing.metadata, reviewVerdict: input.reviewVerdict } }
+              : {};
             if (existing.stages.length === 1 && existing.stages[0] === input.destinationStage) {
-              // Classification is part of a triage terminal handoff, so unlike
-              // an autonomy flip alone it is a revisioned work-item change.
-              return arm || disarm || classified
+              // Classification and the review verdict are part of a terminal
+              // handoff, so unlike an autonomy flip alone they are revisioned
+              // work-item changes.
+              return arm || disarm || classified || verdictStamped
                 ? patchColumns({
                     ...(arm ? { autonomyArmedAt: now } : {}),
                     ...(disarm ? { autonomyArmedAt: null } : {}),
                     ...(classified ? { triageType } : {}),
-                    ...(classified ? { revision: existing.revision + 1, updatedAt: now } : {}),
+                    ...stampedMetadata,
+                    ...(classified || verdictStamped ? { revision: existing.revision + 1, updatedAt: now } : {}),
                   })
                 : null;
             }
@@ -1344,6 +1353,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
               ...(arm ? { autonomyArmedAt: now } : {}),
               ...(disarm ? { autonomyArmedAt: null } : {}),
               ...(classified ? { triageType } : {}),
+              ...stampedMetadata,
               stages: [input.destinationStage],
               stageHistory: applyStageTransition(
                 existing.stageHistory,


### PR DESCRIPTION
Folded into #22531 — the stack collapsed into one PR; this lands there as its own commit.

---

TLDR: a Done card now says when its review asked for changes, so it stops looking identical to an approved one.

---

Both verdicts rest the card in Done — the review pass is over either way — but the lane could not tell them apart, and "requested changes" silently read as "approved".

### What changes

| situation | before | after |
| --- | --- | --- |
| review requests changes, card rests in Done | indistinguishable from approved | wears a **Changes requested** mark |
| review approves | plain Done card | unchanged — the normal outcome stays unmarked |
| next review pass on a new push | — | rewrites the stamp with its own verdict |
| review seat requests Done without a verdict | accepted | schema-rejected: the tool now requires `verdict` with `stage: "done"` |

The verdict travels the governed path: required by the review seat's transition tool schema, carried on the transition request, stamped into the card's metadata in the same revision-checked commit that rests it. The UI reads it through the exported `isFactoryReviewVerdict` guard, so the wire value has one definition.

### Judgment call

Only the exception is marked. An unmarked Done card stays the good outcome — labeling approvals too would make every card wear a badge and the signal would vanish.

```
tests        +46   0
source       +77  -7
skill         +2   0
changeset     +7   0
```

