### PR TITLE
feat(factory): a parked card resumes through its own agent's transition

### DIFF
--- a/.changeset/message-resumes-parked-card.md
+++ b/.changeset/message-resumes-parked-card.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Asking a parked card's agent to resume now moves the card back into its lane.
+
+Messaging the thread of a card parked in Intake previously changed nothing on the board: the agent either kept chatting with the card at rest, or its transition request dispatched a second run racing the conversation. The bound agent's session is now told when its card rests in Intake — answer questions freely, request the governed transition before resuming work — and a transition requested by the seat's own agent no longer starts a duplicate run for that seat; the conversation the user is already in carries the resumed work.

--- a/mastracode/factory/src/rules/processor.test.ts
+++ b/mastracode/factory/src/rules/processor.test.ts
@@ -355,6 +355,35 @@ describe('FactoryPhaseStateProcessor', () => {
     expect(signal?.contents).toContain('Factory work phase: Building (execute)');
   });
 
+  it('tells a parked card`s agent to transition back before resuming, and only then', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const prepared = await prepare(storage);
+    const rules = defaultFactoryRules({ version: 'rules-v1' });
+    const service = new FactoryTransitionService({ rules, storage });
+    const processor = new FactoryPhaseStateProcessor({ rules, storage });
+
+    const working = await processor.computeStateSignal(stateArgs(requestContext()));
+    expect(working?.contents).not.toContain('rests in Intake');
+
+    const parked = await service.transition({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: prepared.item.id,
+      board: 'work',
+      stage: 'intake',
+      expectedRevision: prepared.item.revision,
+      actor: { type: 'human', id: 'user-1' },
+      ingress: { type: 'human', identity: 'park-1' },
+      cause: 'board_drag',
+    });
+    expect(parked.status).toBe('accepted');
+
+    const resting = await processor.computeStateSignal(stateArgs(requestContext()));
+    expect(resting?.contents).toContain('Factory work phase: Intake (intake)');
+    expect(resting?.contents).toContain('rests in Intake');
+    expect(resting?.contents).toContain('request the transition into the working stage first');
+  });
+
   it('does nothing for sessions that were never Factory-bound', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const rules = defaultFactoryRules({ version: 'rules-v1' });

--- a/mastracode/factory/src/rules/processor.ts
+++ b/mastracode/factory/src/rules/processor.ts
@@ -325,6 +325,9 @@ export class FactoryPhaseStateProcessor implements Processor<'factory-phase'> {
       (value.board === 'review'
         ? `Runtime: model=${escapeText(value.modelId)}, reasoning-setting=${escapeText(value.thinkingLevel)}\n`
         : '') +
+      (stage === 'intake'
+        ? 'This card rests in Intake: its work is paused. Answer questions without moving it; when the user asks to resume, request the transition into the working stage first, then continue the work in this session.\n'
+        : '') +
       `Use factory_transition_work_item with expectedRevision ${item.revision} to request a phase change.${escapeText(linkedText)}`;
     const isDelta = hasBase && prior?.status === 'active';
     return {

--- a/mastracode/factory/src/rules/transition-service.test.ts
+++ b/mastracode/factory/src/rules/transition-service.test.ts
@@ -611,6 +611,44 @@ describe('FactoryTransitionService', () => {
     expect(await storage.listDeferredDecisions('org-1', PROJECT_ID)).toEqual([]);
   });
 
+  it('lets the bound agent walk its parked card back into its lane without racing a second run', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage, { source: 'github-pr', stages: ['intake'] });
+    const service = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+
+    const result = await service.transition({
+      ...request(item, { board: 'review', stage: 'review' }),
+      actor: { type: 'agent', bindingId: 'binding-1', role: 'review' },
+      ingress: { type: 'agent', identity: 'request-1' },
+      cause: 'user asked to resume the review',
+    });
+
+    expect(result).toMatchObject({ status: 'accepted', stage: 'review', decisions: [] });
+    expect(await storage.listDeferredDecisions('org-1', PROJECT_ID)).toEqual([]);
+  });
+
+  it('still hands the next seat its run when an agent moves the card past its own stage', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage, { stages: ['planning'] });
+    const service = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+
+    const result = await service.transition({
+      ...request(item, { stage: 'execute' }),
+      actor: { type: 'agent', bindingId: 'binding-1', role: 'plan' },
+      ingress: { type: 'agent', identity: 'request-1' },
+      cause: 'plan approved',
+    });
+
+    assert(result.status === 'accepted');
+    expect(result.decisions).toMatchObject([{ type: 'invokeSkill', role: 'work' }]);
+  });
+
   it('still runs the left lane onExit when a run start skips the entered lane', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const item = await createItem(storage, { stages: ['triage'] });

--- a/mastracode/factory/src/rules/transition-service.ts
+++ b/mastracode/factory/src/rules/transition-service.ts
@@ -123,8 +123,20 @@ function isWorkingStage(stage: FactoryRuleStage): boolean {
   return stage !== 'intake' && !TERMINAL_STAGES.has(stage);
 }
 
-function startsRun(decision: FactoryCommitDecision): boolean {
+type RunStartDecision = Extract<FactoryCommitDecision, { type: 'invokeSkill' | 'sendMessage' }>;
+
+function startsRun(decision: FactoryCommitDecision): decision is RunStartDecision {
   return decision.type === 'invokeSkill' || (decision.type === 'sendMessage' && decision.prepareBinding === true);
+}
+
+/**
+ * A run for the decision's role is already going: the request records a run
+ * start, or comes from that role's own bound agent mid-run. Answering either
+ * with a run would start a second one beside it.
+ */
+function runAlreadyUnderway(request: FactoryTransitionRequest, decision: RunStartDecision): boolean {
+  if (request.cause === 'run_start') return true;
+  return request.actor.type === 'agent' && request.actor.role === decision.role;
 }
 
 function stageTransitionMessage(fromStage: FactoryRuleStage, toStage: FactoryRuleStage): string {
@@ -311,9 +323,7 @@ export class FactoryTransitionService {
             if (decision.type === 'reject') {
               return { outcome: 'rejected' as const, code: decision.code, reason: decision.reason };
             }
-            // A run start records a run already dispatched; the rules still get
-            // to reject it, but answering it with a run would start a second.
-            if (request.cause === 'run_start' && startsRun(decision)) continue;
+            if (startsRun(decision) && runAlreadyUnderway(request, decision)) continue;
             decisions.push(decision);
           }
           const validated = validateFactoryRuleDecisions(decisions);


### PR DESCRIPTION
Folded into #22531 — the stack collapsed into one PR; this lands there as its own commit.

---

TLDR: asking a parked card's agent to resume now moves the card back into its lane, and the conversation you are already in carries the work.

---

```
before   message "please continue the review" on a parked card's thread   agent chats, board never moves; if it did transition, a second run raced the conversation
after    same message                                                     agent requests the governed transition, card re-enters its lane, review continues in this thread
question "what did you find?" on a parked card                            unchanged: answered in place, card stays parked
```

The card cannot move on the message itself, because only the agent can tell "resume" from a question about the parked work — a server hook keying on any user message would yank the card back out of Intake exactly when someone parked it to ask why. So the seam is the agent, and two server changes make its path work:

- The factory-phase snapshot tells a bound session when its card rests in Intake: answer freely, request the transition before resuming, then continue here.
- A rule decision that would start a run for the requesting agent's own role is dropped — that seat's session is the run. This extends the existing `run_start` skip; a decision for another role (plan finishing into Building dispatches the work seat) still fires.

### Judgment call

An agent-mediated resume does not arm autonomy — arming stays a board-drag gesture only, so a chat resume leaves the next external event as a proposal. One condition away if you want chat consent to arm too.

### Not verified

"Transition before resuming" is prompt-enforced: the snapshot instructs the agent, nothing makes the transition a precondition of the run continuing. An agent that ignores the instruction chats on with the card still parked — the board just doesn't move, no worse than today.

```
tests        +67   0
source       +17  -4
changeset     +7   0
```


