### PR TITLE
feat(factory): one source for role lanes and the reporter credit

### DIFF
--- a/.changeset/role-lane-ssot.md
+++ b/.changeset/role-lane-ssot.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+A Build run started from the board now credits the issue reporter the way the factory's own build dispatch always has.
+
+The role→stage pairing and the reporter-credit instruction each lived twice — once in the rules, once re-typed in the board UI — and the UI copy of the credit had silently drifted to nothing. `FACTORY_ROLE_STAGES` and `reporterCredit` are now exported once from `@mastra/factory`; the board derives a run's landing lane from its role and appends the same `Co-Authored-By` instruction to board-started Build runs.

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCandidates.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCandidates.ts
@@ -64,7 +64,9 @@ export function issueCandidate(issue: GithubIssue): BoardCandidate {
     url: issue.url,
     meta: `#${issue.number}${issue.author ? ` · ${issue.author}` : ''} · ${relativeTime(issue.createdAt)}`,
     column: autoTriaged ? 'triage' : 'intake',
-    runActions: needsApproval ? [approvalRunAction(ref, issue.number)] : issueRunActions(ref, { triage: true }),
+    runActions: needsApproval
+      ? [approvalRunAction(ref, issue.number)]
+      : issueRunActions(ref, { triage: true, author: issue.author }),
     branch: `factory/issue-${issue.number}`,
     threadTitle: needsApproval ? `Triage #${issue.number}: ${issue.title}` : `Issue #${issue.number}: ${issue.title}`,
     customPrompt: instructions => guidedPrompt(needsApproval ? approvalBase : investigateBase, instructions),

--- a/mastracode/factory-ui/src/ui/domains/factory/boardRunSpecs.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardRunSpecs.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert';
+import { describe, expect, it } from 'vitest';
+import { issueRunActions, itemRunSpec } from './boardRunSpecs';
+import type { WorkItem } from './services/workItems';
+
+function issueItem(author?: string): WorkItem {
+  return {
+    id: 'item-1',
+    orgId: 'org-1',
+    createdBy: 'user-1',
+    githubProjectId: 'project-1',
+    source: 'github-issue',
+    sourceKey: 'github-issue:7',
+    parentWorkItemId: null,
+    title: 'Fix the settings page',
+    url: 'https://github.com/acme/repo/issues/7',
+    stages: ['intake'],
+    stageHistory: [],
+    sessions: {},
+    metadata: { number: 7, ...(author ? { author } : {}) },
+    commentCount: 0,
+    feedActivityAt: null,
+    revision: 1,
+    createdAt: '2026-08-30T00:00:00.000Z',
+    updatedAt: '2026-08-30T00:00:00.000Z',
+  };
+}
+
+function buildPrompt(actions: ReturnType<typeof issueRunActions>): string {
+  const build = actions.find(action => action.label === 'Build');
+  assert(build && build.invocation.type === 'prompt');
+  return build.invocation.prompt;
+}
+
+describe('the Build run credits the reporter like the factory-dispatched build', () => {
+  it('carries the Co-Authored-By trailer for the issue author', () => {
+    const spec = itemRunSpec(issueItem('octocat'));
+    assert(spec);
+    expect(buildPrompt(spec.actions)).toContain('Co-Authored-By: octocat <ID+octocat@users.noreply.github.com>');
+  });
+
+  it('credits nobody when the author is missing, a bot, or not a GitHub login', () => {
+    const spec = itemRunSpec(issueItem());
+    assert(spec);
+    expect(buildPrompt(spec.actions)).not.toContain('Co-Authored-By');
+    expect(buildPrompt(issueRunActions('issue #7', { author: 'mastra-platform[bot]' }))).not.toContain(
+      'Co-Authored-By',
+    );
+    expect(buildPrompt(issueRunActions('issue #7', { author: '__unknown__' }))).not.toContain('Co-Authored-By');
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/factory/boardRunSpecs.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardRunSpecs.ts
@@ -1,8 +1,9 @@
+import { reporterCredit } from '@mastra/factory/reporter-credit';
+import type { FactoryRole } from '@mastra/factory/rules/types';
 import { workItemBranch } from '@mastra/factory/work-item-branch';
 import type { FactoryRunInvocation, FactoryRunPhase } from '../../../hooks/useStartFactoryRun';
 import { NEEDS_APPROVAL_LABEL, githubNumberForItem, hasLabel, metadataLabels } from './boardItems';
 import type { WorkItem } from './services/workItems';
-import type { BoardStageId } from './stages';
 
 export const RUN_PHASE_LABELS: Record<FactoryRunPhase, string> = {
   workspace: 'preparing workspace…',
@@ -11,18 +12,17 @@ export const RUN_PHASE_LABELS: Record<FactoryRunPhase, string> = {
 };
 
 /**
- * One agent run a card or candidate can start, and the lane it lands the card
- * in. Cards offer several: e.g. an issue can be investigated (understand it →
- * Planning) or built right away (implement it → Building). All of an item's
- * runs share one branch/worktree, so a later run continues the same
- * conversation as a follow-up.
+ * One agent run a card or candidate can start. Cards offer several: e.g. an
+ * issue can be investigated (understand it → Planning) or built right away
+ * (implement it → Building). The lane a run lands the card in is the role's
+ * stage (`FACTORY_ROLE_STAGES`). All of an item's runs share one
+ * branch/worktree, so a later run continues the same conversation as a
+ * follow-up.
  */
 export interface RunAction {
   label: 'Investigate' | 'Build' | 'Prepare approval' | 'Review';
   /** Session slot the run fills on the card, e.g. `plan` or `work`. */
-  role: 'triage' | 'plan' | 'work' | 'review';
-  /** Lane the card lands in once the run is underway. */
-  stage: BoardStageId;
+  role: FactoryRole;
   invocation: FactoryRunInvocation;
   threadTags?: Record<string, string>;
 }
@@ -48,15 +48,15 @@ export function guidedPrompt(base: string, instructions: string): string {
 }
 
 /** Investigate an issue, then Build it when needed. */
-export function issueRunActions(ref: string, extra?: { context?: string; triage?: boolean }): RunAction[] {
+export function issueRunActions(
+  ref: string,
+  extra?: { context?: string; triage?: boolean; author?: unknown },
+): RunAction[] {
   const context = extra?.context ? `\n\n${extra.context}` : '';
-  const role = extra?.triage ? 'triage' : 'plan';
-  const stage = extra?.triage ? 'triage' : 'planning';
   return [
     {
       label: 'Investigate',
-      role,
-      stage,
+      role: extra?.triage ? 'triage' : 'plan',
       invocation: {
         type: 'skill',
         skillName: 'factory-triage',
@@ -66,10 +66,9 @@ export function issueRunActions(ref: string, extra?: { context?: string; triage?
     {
       label: 'Build',
       role: 'work',
-      stage: 'execute',
       invocation: {
         type: 'prompt',
-        prompt: `Implement a fix for ${ref}: investigate the root cause, make the change with tests, and open a pull request.${extra?.context ? ` ${extra.context}` : ''}`,
+        prompt: `Implement a fix for ${ref}: investigate the root cause, make the change with tests, and open a pull request.${extra?.context ? ` ${extra.context}` : ''}${reporterCredit(extra?.author)}`,
       },
     },
   ];
@@ -79,7 +78,6 @@ export function approvalRunAction(ref: string, issueNumber: number): RunAction {
   return {
     label: 'Prepare approval',
     role: 'triage',
-    stage: 'triage',
     invocation: {
       type: 'prompt',
       prompt: `Prepare approval for ${ref}. Review the existing triage comment and summarize the decision needed before implementation or closure.`,
@@ -92,7 +90,6 @@ export function reviewRunAction(ref: string, checkout: string): RunAction {
   return {
     label: 'Review',
     role: 'review',
-    stage: 'review',
     invocation: {
       type: 'skill',
       skillName: 'factory-review',
@@ -118,7 +115,9 @@ export function itemRunSpec(item: WorkItem): ItemRunSpec | undefined {
     return {
       branch: workItemBranch(item),
       threadTitle: needsApproval ? `Triage #${githubNumber}: ${item.title}` : `Issue #${githubNumber}: ${item.title}`,
-      actions: needsApproval ? [approvalRunAction(ref, githubNumber)] : issueRunActions(ref, { triage: true }),
+      actions: needsApproval
+        ? [approvalRunAction(ref, githubNumber)]
+        : issueRunActions(ref, { triage: true, author: meta.author }),
     };
   }
   if (item.source === 'linear-issue' && typeof meta.identifier === 'string') {

--- a/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
@@ -7,21 +7,18 @@ import type { WorkItem, WorkItemSessionRef } from './services/workItems';
 const review: RunAction = {
   label: 'Review',
   role: 'review',
-  stage: 'review',
   invocation: { type: 'skill', skillName: 'factory-review', arguments: 'PR #1' },
 };
 
 const investigate: RunAction = {
   label: 'Investigate',
   role: 'plan',
-  stage: 'planning',
   invocation: { type: 'skill', skillName: 'factory-triage', arguments: 'issue #1' },
 };
 
 const build: RunAction = {
   label: 'Build',
   role: 'work',
-  stage: 'execute',
   invocation: { type: 'prompt', prompt: 'Implement a fix for issue #1' },
 };
 

--- a/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ItemRunSpec, RunAction } from './boardRunSpecs';
-import { cardPrimaryAction, resumeRunAction } from './cardPrimaryAction';
+import { cardPrimaryAction, resumeTarget } from './cardPrimaryAction';
 import type { FactoryDecisionSummary } from './services/decisions';
 import type { WorkItem, WorkItemSessionRef } from './services/workItems';
 
@@ -13,6 +13,12 @@ const review: RunAction = {
 const investigate: RunAction = {
   label: 'Investigate',
   role: 'plan',
+  invocation: { type: 'skill', skillName: 'factory-triage', arguments: 'issue #1' },
+};
+
+const investigateTriage: RunAction = {
+  label: 'Investigate',
+  role: 'triage',
   invocation: { type: 'skill', skillName: 'factory-triage', arguments: 'issue #1' },
 };
 
@@ -72,15 +78,30 @@ function proposalSummary(): FactoryDecisionSummary {
   };
 }
 
-describe('resumeRunAction', () => {
-  it('offers the deepest used seat of a card parked in Intake', () => {
+describe('resumeTarget', () => {
+  it('resumes the deepest used seat of a card parked in Intake', () => {
     const sessions = { plan: sessionRef('plan'), work: sessionRef('work') };
-    expect(resumeRunAction('intake', spec(investigate, build), sessions)).toBe(build);
+    expect(resumeTarget('intake', spec(investigate, build), sessions)).toEqual({ kind: 'run', action: build });
+  });
+
+  it('re-enters the lane of a used seat the board cannot start directly', () => {
+    // A GitHub issue offers Investigate (triage) and Build (work); plan is rule-only,
+    // so a card parked mid-Planning must go back to Planning, not restart the triage run.
+    const sessions = { triage: sessionRef('triage'), plan: sessionRef('plan') };
+    expect(resumeTarget('intake', spec(investigateTriage, build), sessions)).toEqual({
+      kind: 'move',
+      stage: 'planning',
+    });
+  });
+
+  it('re-enters the lane even when the card offers no runs at all', () => {
+    const sessions = { plan: sessionRef('plan') };
+    expect(resumeTarget('intake', undefined, sessions)).toEqual({ kind: 'move', stage: 'planning' });
   });
 
   it('offers nothing for a fresh arrival or outside Intake', () => {
-    expect(resumeRunAction('intake', spec(review), {})).toBeUndefined();
-    expect(resumeRunAction('done', spec(review), { review: sessionRef('review') })).toBeUndefined();
+    expect(resumeTarget('intake', spec(review), {})).toBeUndefined();
+    expect(resumeTarget('done', spec(review), { review: sessionRef('review') })).toBeUndefined();
   });
 });
 
@@ -91,12 +112,13 @@ describe('cardPrimaryAction', () => {
     const action = cardPrimaryAction({
       item: item({ review: sessionRef('review') }),
       runSpec,
-      resumeAction: review,
+      resume: { kind: 'run', action: review },
       hasSession: true,
       onApproveProposal: vi.fn(),
       onStartRun: vi.fn(),
       onRestartRun,
       onCreateSession: vi.fn(),
+      onMove: vi.fn(),
     });
 
     expect(action?.label).toBe('Resume');
@@ -104,18 +126,38 @@ describe('cardPrimaryAction', () => {
     expect(onRestartRun).toHaveBeenCalledWith(runSpec, review);
   });
 
+  it('resumes a rule-only seat by re-entering its lane', () => {
+    const onMove = vi.fn();
+    const action = cardPrimaryAction({
+      item: item({ plan: sessionRef('plan') }),
+      runSpec: spec(build),
+      resume: { kind: 'move', stage: 'planning' },
+      hasSession: true,
+      onApproveProposal: vi.fn(),
+      onStartRun: vi.fn(),
+      onRestartRun: vi.fn(),
+      onCreateSession: vi.fn(),
+      onMove,
+    });
+
+    expect(action?.label).toBe('Resume');
+    action?.start();
+    expect(onMove).toHaveBeenCalledWith('planning');
+  });
+
   it('still releases a proposed run first: the suggestion beats resuming beside it', () => {
     const onApproveProposal = vi.fn();
     const action = cardPrimaryAction({
       item: item({ review: sessionRef('review') }),
       runSpec: spec(review),
-      resumeAction: review,
+      resume: { kind: 'run', action: review },
       proposal: proposalSummary(),
       hasSession: true,
       onApproveProposal,
       onStartRun: vi.fn(),
       onRestartRun: vi.fn(),
       onCreateSession: vi.fn(),
+      onMove: vi.fn(),
     });
 
     expect(action?.label).toBe('Review');
@@ -135,6 +177,7 @@ describe('cardPrimaryAction', () => {
       onStartRun,
       onRestartRun: vi.fn(),
       onCreateSession: vi.fn(),
+      onMove: vi.fn(),
     });
 
     expect(action?.label).toBe('Review');

--- a/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.ts
@@ -1,3 +1,5 @@
+import { FACTORY_ROLE_STAGES, FACTORY_RULE_STAGES, isFactoryRole } from '@mastra/factory/rules/types';
+import type { FactoryRuleStage } from '@mastra/factory/rules/types';
 import { itemSessionSpec } from './boardRunSpecs';
 import type { ItemRunSpec, RunAction } from './boardRunSpecs';
 import type { FactoryDecisionSummary } from './services/decisions';
@@ -9,14 +11,31 @@ export interface CardPrimaryAction {
   start: () => void;
 }
 
-/** A card parked in Intake resumes its deepest used seat — the run it was pulled out of. */
-export function resumeRunAction(
+export type ResumeTarget = { kind: 'run'; action: RunAction } | { kind: 'move'; stage: FactoryRuleStage };
+
+function seatDepth(role: string): number {
+  return isFactoryRole(role) ? FACTORY_RULE_STAGES.indexOf(FACTORY_ROLE_STAGES[role]) : -1;
+}
+
+/**
+ * A card parked in Intake resumes its deepest used seat — the work it was
+ * pulled out of. A seat the board can start directly restarts its run; a
+ * rule-only seat (plan) re-enters its lane instead, where the entry rule
+ * dispatches the run.
+ */
+export function resumeTarget(
   columnStage: BoardStageId,
   runSpec: ItemRunSpec | undefined,
   sessions: Record<string, WorkItemSessionRef>,
-): RunAction | undefined {
+): ResumeTarget | undefined {
   if (columnStage !== 'intake') return undefined;
-  return runSpec?.actions.findLast(action => action.role in sessions);
+  const deepest = Object.keys(sessions)
+    .filter(isFactoryRole)
+    .sort((left, right) => seatDepth(left) - seatDepth(right))
+    .at(-1);
+  if (deepest === undefined) return undefined;
+  const action = runSpec?.actions.find(candidate => candidate.role === deepest);
+  return action !== undefined ? { kind: 'run', action } : { kind: 'move', stage: FACTORY_ROLE_STAGES[deepest] };
 }
 
 /** A proposed run wins the primary slot: releasing it beats starting a rival run beside it. Resuming parked work comes next, for the same reason. */
@@ -24,34 +43,41 @@ export function cardPrimaryAction({
   item,
   runSpec,
   runAction,
-  resumeAction,
+  resume,
   proposal,
   hasSession,
   onApproveProposal,
   onStartRun,
   onRestartRun,
   onCreateSession,
+  onMove,
 }: {
   item: WorkItem;
   runSpec?: ItemRunSpec;
   runAction?: RunAction;
-  resumeAction?: RunAction;
+  resume?: ResumeTarget;
   proposal?: FactoryDecisionSummary;
   hasSession: boolean;
   onApproveProposal: (decisionId: string) => void;
   onStartRun: (spec: ItemRunSpec, action: RunAction) => void;
   onRestartRun: (spec: ItemRunSpec, action: RunAction) => void;
   onCreateSession: (spec: { branch: string; threadTitle: string }) => void;
+  onMove: (toStage: string) => void;
 }): CardPrimaryAction | undefined {
   if (proposal !== undefined) {
     const proposed = runSpec?.actions.find(action => action.role === proposal.role) ?? runAction;
     const label = proposed?.label ?? 'Start run';
     return { label, start: () => onApproveProposal(proposal.id) };
   }
-  if (runSpec !== undefined && resumeAction !== undefined) {
+  if (resume?.kind === 'move') {
+    const stage = resume.stage;
+    return { label: 'Resume', start: () => onMove(stage) };
+  }
+  if (resume?.kind === 'run' && runSpec !== undefined) {
+    const action = resume.action;
     return {
       label: 'Resume',
-      start: () => onRestartRun(runSpec, resumeAction),
+      start: () => onRestartRun(runSpec, action),
     };
   }
   if (runSpec !== undefined && runAction !== undefined) {

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -1,3 +1,4 @@
+import { FACTORY_ROLE_STAGES } from '@mastra/factory/rules/types';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
@@ -134,7 +135,7 @@ export function WorkItemCard({
   // run from the menu so the card is never a dead end.
   const laneAction =
     runSpec !== undefined && reReviewAction === undefined
-      ? runSpec.actions.find(action => action.stage === columnStage && action.role in sessions)
+      ? runSpec.actions.find(action => FACTORY_ROLE_STAGES[action.role] === columnStage && action.role in sessions)
       : undefined;
   const threadSession = itemThreadSession(sessions);
   const primaryAction = cardPrimaryAction({

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -22,7 +22,7 @@ import {
 import { itemRunSpec } from '../boardRunSpecs';
 import type { ItemRunSpec, RunAction } from '../boardRunSpecs';
 import { itemStageLabel } from '../boardStages';
-import { cardPrimaryAction, resumeRunAction } from '../cardPrimaryAction';
+import { cardPrimaryAction, resumeTarget } from '../cardPrimaryAction';
 import { useCardMorph } from '../hooks/useCardMorph';
 import type { AuditEventPage } from '../services/audit';
 import type { FactoryDecisionSummary } from '../services/decisions';
@@ -142,13 +142,14 @@ export function WorkItemCard({
     item,
     runSpec,
     runAction: defaultRunAction,
-    resumeAction: resumeRunAction(columnStage, runSpec, sessions),
+    resume: resumeTarget(columnStage, runSpec, sessions),
     proposal,
     hasSession: threadSession !== undefined,
     onApproveProposal,
     onStartRun,
     onRestartRun,
     onCreateSession,
+    onMove,
   });
   const proposedRunLabel =
     proposal === undefined

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardRuns.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useBoardRuns.ts
@@ -1,3 +1,4 @@
+import { FACTORY_ROLE_STAGES } from '@mastra/factory/rules/types';
 import { toast } from '@mastra/playground-ui/components/Toaster';
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -153,7 +154,7 @@ export function useBoardRuns({
         id: refreshed.id,
         role: action.role,
         existingRoles: Object.keys(refreshed.sessions),
-        stages: [action.stage],
+        stages: [FACTORY_ROLE_STAGES[action.role]],
         source: refreshed.source,
         sourceKey: refreshed.sourceKey,
         title: refreshed.title,
@@ -172,7 +173,7 @@ export function useBoardRuns({
           prompt === undefined ? action.invocation : { type: 'prompt', prompt: candidate.customPrompt(prompt) },
         workItem: {
           role: action.role,
-          stages: [action.stage],
+          stages: [FACTORY_ROLE_STAGES[action.role]],
           source: candidate.source,
           sourceKey: candidate.sourceKey,
           parentWorkItemId:

--- a/mastracode/factory/src/reporter-credit.ts
+++ b/mastracode/factory/src/reporter-credit.ts
@@ -1,0 +1,23 @@
+// A GitHub login is alphanumeric with interior hyphens — no underscores, no
+// spaces. Checking the grammar rejects the placeholder the issue poller stamps
+// when the reporter's account is gone (`__unknown__`), which would otherwise
+// become a trailer crediting an account that does not exist.
+const GITHUB_LOGIN = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
+
+/**
+ * The reporter earns a `Co-Authored-By` trailer on the work their report
+ * caused, whether the run was dispatched by a rule or clicked from the board.
+ * Only a GitHub login qualifies — Linear stamps a display name and a manual
+ * card stamps nothing — and Factory's own bot reports are skipped. The trailer
+ * needs the reporter's numeric id, which intake does not stamp, so the agent
+ * resolves it from the same issue it is already reading.
+ */
+export function reporterCredit(author: unknown): string {
+  if (typeof author !== 'string' || !author) return '';
+  if (author.endsWith('[bot]') || !GITHUB_LOGIN.test(author)) return '';
+  return (
+    ` The work was reported by @${author}: credit them on every commit with a ` +
+    `\`Co-Authored-By: ${author} <ID+${author}@users.noreply.github.com>\` trailer, ` +
+    `resolving ID with \`gh api users/${author} --jq .id\`.`
+  );
+}

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -1,3 +1,4 @@
+import { reporterCredit } from '../reporter-credit.js';
 import type {
   FactoryBoardRuleLeaf,
   FactoryBoardRules,
@@ -15,7 +16,6 @@ import type {
   FactoryToolResultRuleContext,
   FactoryToolRuleLeaf,
 } from './types.js';
-import { reporterCredit } from '../reporter-credit.js';
 import { assertFactoryRules, FactoryRuleValidationError } from './validation.js';
 
 export const DEFAULT_FACTORY_RULE_VERSION = 'factory-default-v1';

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -15,6 +15,7 @@ import type {
   FactoryToolResultRuleContext,
   FactoryToolRuleLeaf,
 } from './types.js';
+import { reporterCredit } from '../reporter-credit.js';
 import { assertFactoryRules, FactoryRuleValidationError } from './validation.js';
 
 export const DEFAULT_FACTORY_RULE_VERSION = 'factory-default-v1';
@@ -92,26 +93,6 @@ function planWorkItem(context: FactoryStageRuleContext) {
   } as const;
 }
 
-// A GitHub login is alphanumeric with interior hyphens — no underscores, no
-// spaces. Checking the grammar rejects the placeholder the issue poller stamps
-// when the reporter's account is gone (`__unknown__`), which would otherwise
-// become a trailer crediting an account that does not exist.
-const GITHUB_LOGIN = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
-
-/**
- * The reporter earns a `Co-Authored-By` trailer on the work their report caused.
- * Only a GitHub issue qualifies: Linear stamps a display name and a manual card
- * stamps nothing, and neither resolves to the GitHub identity a trailer needs.
- * Factory's own reports are skipped — crediting ourselves is noise.
- */
-function reporterCoAuthor(context: FactoryStageRuleContext) {
-  if (context.source !== 'issue') return undefined;
-  const author = context.item.metadata?.author;
-  if (typeof author !== 'string' || !author) return undefined;
-  if (author.endsWith('[bot]') || !GITHUB_LOGIN.test(author)) return undefined;
-  return author;
-}
-
 /**
  * Building carries a prompt rather than a skill. The approved plan is already
  * the specification, so there is nothing for a skill document to add, and the
@@ -120,14 +101,9 @@ function reporterCoAuthor(context: FactoryStageRuleContext) {
  */
 function buildWorkItem(context: FactoryStageRuleContext) {
   const subject = context.item.url ? `the approved plan for ${context.item.url}` : 'the approved plan';
-  const reporter = reporterCoAuthor(context);
-  // The trailer needs the reporter's numeric id, which intake does not stamp, so
-  // the agent resolves it from the same issue it is already reading.
-  const credit = reporter
-    ? ` The work was reported by @${reporter}: credit them on every commit with a ` +
-      `\`Co-Authored-By: ${reporter} <ID+${reporter}@users.noreply.github.com>\` trailer, ` +
-      `resolving ID with \`gh api users/${reporter} --jq .id\`.`
-    : '';
+  // Only a GitHub issue's author is credited: Linear stamps a display name and
+  // a manual card stamps nothing, neither the login a trailer needs.
+  const credit = context.source === 'issue' ? reporterCredit(context.item.metadata?.author) : '';
   return {
     type: 'invokeSkill',
     idempotencyKey: `${context.ingress.id}:build`,

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -12,6 +12,10 @@ export const FACTORY_ROLE_STAGES = {
 } as const satisfies Record<string, FactoryRuleStage>;
 export type FactoryRole = keyof typeof FACTORY_ROLE_STAGES;
 
+export function isFactoryRole(value: string): value is FactoryRole {
+  return value in FACTORY_ROLE_STAGES;
+}
+
 export const FACTORY_TRIAGE_TYPES = [
   'bug',
   'feature request',
@@ -52,13 +56,6 @@ export function isTerminalFactoryRuleStage(stages: readonly string[]): boolean {
   return stage === 'done' || stage === 'canceled';
 }
 
-const FACTORY_ROLE_LANES = new Map<string, FactoryRuleStage>([
-  ['triage', 'triage'],
-  ['plan', 'planning'],
-  ['work', 'execute'],
-  ['review', 'review'],
-]);
-
 /**
  * The lane a run entering from Intake lands its card in, keyed by the session
  * role the run fills. Consulted only for that Intake exit — a card already in
@@ -66,7 +63,7 @@ const FACTORY_ROLE_LANES = new Map<string, FactoryRuleStage>([
  * roles don't own lanes (the Done close-out runs in the triage seat).
  */
 export function factoryLaneForRole(role: string): FactoryRuleStage | undefined {
-  return FACTORY_ROLE_LANES.get(role);
+  return isFactoryRole(role) ? FACTORY_ROLE_STAGES[role] : undefined;
 }
 
 export const FACTORY_RULE_BOARDS = ['work', 'review'] as const;

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -3,6 +3,15 @@ export type WorkItemSource = 'github-issue' | 'github-pr' | 'linear-issue' | 'ma
 export const FACTORY_RULE_STAGES = ['intake', 'triage', 'planning', 'execute', 'review', 'done', 'canceled'] as const;
 export type FactoryRuleStage = (typeof FACTORY_RULE_STAGES)[number];
 
+/** Each agent role and the working stage its run holds the card in. */
+export const FACTORY_ROLE_STAGES = {
+  triage: 'triage',
+  plan: 'planning',
+  work: 'execute',
+  review: 'review',
+} as const satisfies Record<string, FactoryRuleStage>;
+export type FactoryRole = keyof typeof FACTORY_ROLE_STAGES;
+
 export const FACTORY_TRIAGE_TYPES = [
   'bug',
   'feature request',


### PR DESCRIPTION
Folded into #22531 — the stack collapsed into one PR; this lands there as its own commits.

---

TLDR: board-started Build runs now credit the issue reporter the way the factory's own build dispatch always has, and the role→lane pairing exists once — including the Intake exit and the card's Resume button.

---

```
before   Build clicked on an issue card    commits never carry the reporter's Co-Authored-By trailer
after    same click                        same credit instruction as the rule-dispatched build
board RunAction                           re-typed its landing lane 4× beside its role
after                                     lane derived from FACTORY_ROLE_STAGES[role]
```

Two facts each lived twice — the role→stage pairing (rules + every UI RunAction literal) and the reporter-credit instruction (rules only; the UI copy had drifted to nothing). `FACTORY_ROLE_STAGES` and `reporterCredit` are now exported once from `@mastra/factory`; the board's `RunAction` loses its `stage` field entirely, and both dispatch paths compose the same credit sentence, including the bot/`__unknown__` rejection.

### What changes

| situation | before | after |
| --- | --- | --- |
| run starts from Intake | landing lane from a second map in `surface.ts` | same `FACTORY_ROLE_STAGES` lookup; unknown role now throws instead of silently staying in Intake |
| Resume on a parked card that reached Plan | re-ran the first seat's action (re-triage) | re-enters the deepest seat used; a seat with no board action (plan) moves the card so its entry rule takes over |

### Judgment call

Server-side `roleForStage` keeps its explicit chain instead of inverting the map: it is seat-addressing policy, not the role→stage fact — it knows the review board has one seat and where resting stages fall back, which the map deliberately does not carry. Inverting it changed real behavior in tests (work-board Reviewing notices went to a review seat that does not exist there), so the chain stays.

### Side effects to check

The Intake exit previously ignored a role it did not recognize; it now throws. Nothing produces an unknown role today — every caller goes through the typed `FactoryRole` — but a bad stored value that used to no-op would now fail the run start loudly.

```
source       +104  -69    ← net +35
tests        +102  -11
changeset      +7    0
```

