### PR TITLE
fix(cli): preserve literal file replacements

### DIFF
--- a/.changeset/literal-cli-file-replacements.md
+++ b/.changeset/literal-cli-file-replacements.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed CLI file replacements so dollar signs are preserved in generated files.

--- a/packages/cli/src/services/service.file.test.ts
+++ b/packages/cli/src/services/service.file.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { FileService } from './service.file';
+
+describe('FileService', () => {
+  let tempDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mastra-file-service-'));
+    filePath = path.join(tempDir, 'template.txt');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it.each(['$&-literal', '$$', '$`', "$'"])('writes the replacement value %s literally', replacement => {
+    fs.writeFileSync(filePath, 'before-TOKEN-after');
+
+    new FileService().replaceValuesInFile({
+      filePath,
+      replacements: [{ search: 'TOKEN', replace: replacement }],
+    });
+
+    expect(fs.readFileSync(filePath, 'utf8')).toBe(`before-${replacement}-after`);
+  });
+});

--- a/packages/cli/src/services/service.file.ts
+++ b/packages/cli/src/services/service.file.ts
@@ -58,7 +58,7 @@ export class FileService {
   }) {
     let fileContent = fs.readFileSync(filePath, 'utf8');
     replacements.forEach(({ search, replace }) => {
-      fileContent = fileContent.replaceAll(search, replace);
+      fileContent = fileContent.replaceAll(search, () => replace);
     });
 
     fs.writeFileSync(filePath, fileContent);


### PR DESCRIPTION
## Description

Use a replacement callback so JavaScript dollar substitution tokens are written literally. Add regression coverage for each special dollar replacement pattern.

## Related issue(s)

Fixes #22619

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
