### PR TITLE
fix(browser-viewer): return real URL and tab state from public getters

### DIFF
--- a/.changeset/shy-humans-double.md
+++ b/.changeset/shy-humans-double.md
@@ -1,0 +1,5 @@
+---
+'@mastra/browser-viewer': patch
+---
+
+Fixed the browser viewer reporting no URL and no tabs. `getCurrentUrl()` and `getBrowserState()` on `BrowserViewer` always returned `null` because they were never wired to the internal tab state. The viewer now returns the current URL and the list of open tabs. Fixes [#22539](https://github.com/mastra-ai/mastra/issues/22539).

--- a/browser/browser-viewer/src/__tests__/browser-viewer.test.ts
+++ b/browser/browser-viewer/src/__tests__/browser-viewer.test.ts
@@ -1,7 +1,47 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { BrowserViewer } from '../browser-viewer';
 
 describe('BrowserViewer', () => {
+  describe('browser state', () => {
+    it('getBrowserState returns null when no browser is running', async () => {
+      const viewer = new BrowserViewer({ cli: 'browser-use' });
+      expect(await viewer.getBrowserState()).toBeNull();
+    });
+
+    it('getCurrentUrl returns null when no browser is running', async () => {
+      const viewer = new BrowserViewer({ cli: 'browser-use' });
+      expect(await viewer.getCurrentUrl()).toBeNull();
+    });
+
+    it('getBrowserState delegates to the thread-aware state lookup', async () => {
+      const viewer = new BrowserViewer({ cli: 'browser-use' });
+      const state = {
+        tabs: [
+          { url: 'https://example.com', title: '', isActive: false },
+          { url: 'https://mastra.ai', title: '', isActive: true },
+        ],
+        activeTabIndex: 1,
+      };
+      const spy = vi.spyOn(viewer as any, 'getBrowserStateForThread').mockReturnValue(state);
+
+      expect(await viewer.getBrowserState('thread-1')).toEqual(state);
+      expect(spy).toHaveBeenCalledWith('thread-1');
+    });
+
+    it('getCurrentUrl returns the active tab URL', async () => {
+      const viewer = new BrowserViewer({ cli: 'browser-use' });
+      vi.spyOn(viewer as any, 'getBrowserStateForThread').mockReturnValue({
+        tabs: [
+          { url: 'https://example.com', title: '', isActive: false },
+          { url: 'https://mastra.ai', title: '', isActive: true },
+        ],
+        activeTabIndex: 1,
+      });
+
+      expect(await viewer.getCurrentUrl()).toBe('https://mastra.ai');
+    });
+  });
+
   describe('constructor', () => {
     it('defaults headless to true', () => {
       const viewer = new BrowserViewer({ cli: 'browser-use' });

--- a/browser/browser-viewer/src/browser-viewer.ts
+++ b/browser/browser-viewer/src/browser-viewer.ts
@@ -253,6 +253,25 @@ export class BrowserViewer extends MastraBrowser {
     };
   }
 
+  /**
+   * Get the current page URL without launching the browser.
+   * @param threadId - Optional thread ID for thread-isolated browsers
+   * @returns The current URL string, or null if browser is not running
+   */
+  override async getCurrentUrl(threadId?: string): Promise<string | null> {
+    const state = this.getBrowserStateForThread(threadId);
+    return state?.tabs[state.activeTabIndex]?.url ?? null;
+  }
+
+  /**
+   * Get the current browser state (all tabs and active tab index).
+   * @param threadId - Optional thread ID for thread-isolated sessions
+   * @returns The browser state, or null if browser is not running
+   */
+  override async getBrowserState(threadId?: string): Promise<BrowserState | null> {
+    return this.getBrowserStateForThread(threadId);
+  }
+
   // ---------------------------------------------------------------------------
   // Screencast Support
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`BrowserViewer` inherited the base-class stubs for `getCurrentUrl()` and `getBrowserState()`, which always return `null`. The viewer showed "No URL" and an empty tab list even while the screencast streamed correctly. This PR overrides both methods, delegating to the existing thread-aware `getBrowserStateForThread()`.

- `getBrowserState(threadId)` now returns the state from `getBrowserStateForThread(threadId)` instead of the base-class `null` stub
- `getCurrentUrl(threadId)` now returns the active tab's URL from that same state
- Both return `null` when no browser is running for the thread, matching the behavior of the other providers (`AgentBrowser`, `StagehandBrowser`)
- Adds unit tests for the null case, the delegation, and the active-tab URL selection

Note: tab titles remain empty for this provider — `getBrowserStateForThread()` hard-codes `title: ''` (getting titles would need an async call per page). URL and tab count now work.

## Related Issue(s)

Fixes #22539

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

`BrowserViewer` now shows the real browser URL and open tabs. It returns no browser data when the thread has no running browser.

## Changes

- Added `getBrowserState()` and `getCurrentUrl()` overrides.
- Delegated both methods to the thread-aware browser state.
- Added tests for missing browser state, delegation, and active-tab URL selection.
- Added a patch changeset for `@mastra/browser-viewer`.
- Tab titles remain empty because title retrieval requires an asynchronous per-page call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->