### PR TITLE
feat(factory): rest means rest — resting a card disarms it, whoever rests it

### DIFF
--- a/.changeset/rest-means-rest.md
+++ b/.changeset/rest-means-rest.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': patch
+---
+
+Resting a card now takes the factory's hand off it, whoever rested it.
+
+Any accepted move into Intake, Done or Canceled clears the card's autonomy consent — previously only a human drag out of a working lane did, so an external event landing a card in Done left it armed to restart later. The close-out run that same transition queued still fires: the commit stamps it as pre-authorized, and rule output claiming that stamp for itself is rejected. Two more doors close with it: a transition pushed by an external actor into a working lane now parks for approval when the card is unarmed and auto-run is off, and a card whose author lacks write access never starts a run on its own, even with auto-run on.

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -18,6 +18,7 @@ import type {
   FactoryStartRequest,
 } from '../rules/start-coordinator.js';
 import { FactoryStartTransitionError } from '../rules/start-coordinator.js';
+import { roleForStage } from '../rules/transition-service.js';
 import type { FactoryTransitionRequest, FactoryTransitionService } from '../rules/transition-service.js';
 import type { FactoryRuleBoard } from '../rules/types.js';
 import { FACTORY_RULE_BOARDS, isFactoryRuleStage } from '../rules/types.js';
@@ -398,13 +399,23 @@ function parseDecisionCursor(raw: string | undefined): { createdAt: Date; id: st
   }
 }
 
+/** A proposed transition names the seat its lane addresses, so the card can label what approving starts. */
+function summaryRole(decision: Record<string, unknown>): string | null {
+  if (typeof decision.role === 'string') return decision.role.slice(0, 32);
+  if (decision.type !== 'transition') return null;
+  const board = decision.board;
+  const stage = decision.stage;
+  if ((board !== 'work' && board !== 'review') || !isFactoryRuleStage(stage)) return null;
+  return roleForStage(board, stage);
+}
+
 function decisionSummary(decision: FactoryDeferredDecisionRecord) {
   return {
     id: decision.id,
     evaluationId: decision.evaluationId,
     workItemId: decision.workItemId,
     type: factoryDecisionType(decision),
-    role: typeof decision.decision.role === 'string' ? decision.decision.role.slice(0, 32) : null,
+    role: summaryRole(decision.decision),
     status: decision.status,
     attempts: decision.attempts,
     failureOccurrence: decision.failureOccurrence,

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -303,24 +303,6 @@ describe('defaultFactoryRules', () => {
     },
   );
 
-  it('does not duplicate investigation when a new GitHub issue is materialized into Triage', async () => {
-    const rule = defaultFactoryRules({ version: 'deployment-7' }).work.triage?.issue?.onEnter;
-    const context = {
-      ...stageContext({ type: 'github', login: 'author', trusted: true, factoryAuthored: false }, 'work'),
-      cause: 'linked_item_materialized',
-      stage: 'triage',
-      fromStage: 'intake',
-      toStage: 'triage',
-    } as FactoryStageRuleContext;
-
-    expect(await rule?.(context)).toBeUndefined();
-    expect(await rule?.({ ...context, fromStage: 'planning' })).toMatchObject({
-      type: 'invokeSkill',
-      role: 'triage',
-      skillName: 'factory-triage',
-    });
-  });
-
   it('starts investigation when a board drag or reconciliation moves an issue into Triage', async () => {
     const rule = defaultFactoryRules({ version: 'deployment-7' }).work.triage?.issue?.onEnter;
     const context = {

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -38,13 +38,6 @@ function invokeIssueInvestigation(context: FactoryStageRuleContext) {
   } as const;
 }
 
-function investigateTriagedIssue(context: FactoryStageRuleContext) {
-  if (context.cause === 'linked_item_materialized' && context.fromStage === 'intake' && context.toStage === 'triage') {
-    return;
-  }
-  return invokeIssueInvestigation(context);
-}
-
 function retriageGithubIssue(context: FactoryGithubRuleContext) {
   if (!context.item || context.item.source !== 'github-issue' || !context.item.url) return;
   if (context.actor.type === 'github' && context.actor.factoryAuthored) return;
@@ -508,7 +501,7 @@ const BUILT_IN_DEFAULTS: FactoryRulesOverrides = {
   work: {
     intake: { issue: { onEnter: onArrival(invokeIssueInvestigation) } },
     triage: {
-      issue: { onEnter: investigateTriagedIssue },
+      issue: { onEnter: invokeIssueInvestigation },
       linearIssue: { onEnter: investigateTriagedLinearIssue },
     },
     planning: {

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -1610,6 +1610,237 @@ describe('FactoryDecisionDispatcher', () => {
     expect((await storage.listDeferredDecisions('org-1', PROJECT_ID))[0]?.status).toBe('succeeded');
   });
 
+  async function createPullRequestItem(storage: WorkItemsStorage) {
+    return (
+      await storage.upsert({
+        orgId: 'org-1',
+        userId: 'user-1',
+        factoryProjectId: PROJECT_ID,
+        input: {
+          externalSource: { integrationId: 'github', type: 'pull-request', externalId: 'github-pr:7' },
+          title: 'Fix change',
+          stages: ['intake'],
+          sessions: {},
+          metadata: {},
+        },
+      })
+    ).item;
+  }
+
+  it('parks an external push that would pull a rested card back into a working lane', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createPullRequestItem(storage);
+    const transitionService = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+    await storage.commitRuleEvaluation({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      ingress: { identity: 'push-1', triggerType: 'github' },
+      ruleSetVersion: 'rules-v1',
+      expectedRevision: item.revision,
+      actor: { type: 'github', login: 'author', trusted: true, factoryAuthored: false },
+      outcome: { status: 'accepted' },
+      decisions: [{ type: 'transition', board: 'review', stage: 'review', idempotencyKey: 're-review-1' }],
+      causalChain: [],
+      now: new Date('2030-01-01T00:00:00Z'),
+    });
+    const { controller, session } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+      isAutoRunEnabled: async () => false,
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:01:00Z'));
+
+    const [parked] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(parked).toMatchObject({ status: 'proposed' });
+    expect(session.sendSignal).not.toHaveBeenCalled();
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['intake']);
+  });
+
+  it('lets an external push move a card a person already handed over', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createPullRequestItem(storage);
+    await storage.armAutonomy({ orgId: 'org-1', id: item.id, now: new Date('2030-01-01T00:00:00Z') });
+    const armed = await storage.get({ orgId: 'org-1', id: item.id });
+    const transitionService = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+    await storage.commitRuleEvaluation({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      ingress: { identity: 'push-2', triggerType: 'github' },
+      ruleSetVersion: 'rules-v1',
+      expectedRevision: armed?.revision ?? item.revision,
+      actor: { type: 'github', login: 'author', trusted: true, factoryAuthored: false },
+      outcome: { status: 'accepted' },
+      decisions: [{ type: 'transition', board: 'review', stage: 'review', idempotencyKey: 're-review-2' }],
+      causalChain: [],
+      now: new Date('2030-01-01T00:00:30Z'),
+    });
+    const { controller } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+      isAutoRunEnabled: async () => false,
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:01:00Z'));
+
+    const rows = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(rows.find(row => row.idempotencyKey === 're-review-2')?.status).toBe('succeeded');
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['review']);
+  });
+
+  it('still mirrors an external close onto a resting lane without asking', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const transitionService = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+    await storage.commitRuleEvaluation({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      ingress: { identity: 'closed-1', triggerType: 'github' },
+      ruleSetVersion: 'rules-v1',
+      expectedRevision: item.revision,
+      actor: { type: 'github', login: 'author', trusted: true, factoryAuthored: false },
+      outcome: { status: 'accepted' },
+      decisions: [{ type: 'transition', board: 'work', stage: 'canceled', idempotencyKey: 'closed-1' }],
+      causalChain: [],
+      now: new Date('2030-01-01T00:00:00Z'),
+    });
+    const { controller } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+      isAutoRunEnabled: async () => false,
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:01:00Z'));
+
+    expect((await storage.listDeferredDecisions('org-1', PROJECT_ID))[0]?.status).toBe('succeeded');
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['canceled']);
+  });
+
+  it('keeps auto-run from starting runs on an externally authored card', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = (
+      await storage.upsert({
+        orgId: 'org-1',
+        userId: 'user-1',
+        factoryProjectId: PROJECT_ID,
+        input: {
+          externalSource: { integrationId: 'github', type: 'pull-request', externalId: 'github-pr:7' },
+          title: 'External change',
+          stages: ['intake'],
+          sessions: {},
+          metadata: { authorTrusted: false },
+        },
+      })
+    ).item;
+    const transitionService = new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    });
+    await storage.commitRuleEvaluation({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      ingress: { identity: 'external-run-1', triggerType: 'github' },
+      ruleSetVersion: 'rules-v1',
+      expectedRevision: item.revision,
+      actor: { type: 'github', login: 'stranger', trusted: false, factoryAuthored: false },
+      outcome: { status: 'accepted' },
+      decisions: [
+        { type: 'invokeSkill', role: 'review', skillName: 'factory-review', idempotencyKey: 'external-run-1' },
+      ],
+      causalChain: [],
+      now: new Date('2030-01-01T00:00:00Z'),
+    });
+    const { controller, session } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+      isAutoRunEnabled: async () => true,
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:01:00Z'));
+
+    expect((await storage.listDeferredDecisions('org-1', PROJECT_ID))[0]?.status).toBe('proposed');
+    expect(session.sendSignal).not.toHaveBeenCalled();
+  });
+
+  it('still runs the close-out a resting verdict queued, while the disarm parks later events', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const rules = defaultFactoryRules({
+      version: 'rules-v1',
+      overrides: {
+        work: {
+          done: {
+            issue: {
+              onEnter: () => ({
+                type: 'invokeSkill',
+                role: 'work',
+                skillName: 'factory-complete-issue',
+                idempotencyKey: 'close-out-1',
+              }),
+            },
+          },
+        },
+      },
+    });
+    const transitionService = new FactoryTransitionService({ storage, rules });
+    const item = await createItem(storage);
+    await storage.armAutonomy({ orgId: 'org-1', id: item.id, now: new Date('2030-01-01T00:00:00Z') });
+    await bindWorkRun(storage, item.id);
+    const bound = await storage.get({ orgId: 'org-1', id: item.id });
+    const rested = await transitionService.transition({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      board: 'work',
+      stage: 'done',
+      expectedRevision: bound?.revision ?? item.revision,
+      actor: { type: 'agent', bindingId: 'binding-1', role: 'review' },
+      ingress: { type: 'agent', identity: 'verdict-1' },
+      cause: 'review verdict',
+    });
+    expect(rested.status).toBe('accepted');
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.autonomyArmedAt).toBeNull();
+    const [queued] = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(queued?.decision).toMatchObject({ type: 'invokeSkill', preauthorized: true });
+
+    const { controller, session } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+      isAutoRunEnabled: async () => false,
+    });
+    await dispatcher.runOnce(new Date('2030-01-01T00:01:00Z'));
+
+    expect((await storage.listDeferredDecisions('org-1', PROJECT_ID))[0]?.status).toBe('succeeded');
+    expect(session.sendSignal).toHaveBeenCalledTimes(1);
+  });
+
   it('arms an item once, so the first commitment is the one that counts', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const { item } = await queueDecision(storage, {

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -19,8 +19,8 @@ import { FACTORY_RULE_MATERIALIZATION_KEY } from '../storage/domains/work-items/
 import { FactoryDispatchError, factoryDispatchFailureCode } from './dispatch-errors.js';
 import type { FactoryTransitionService } from './transition-service.js';
 import type { FactoryCommitDecision, FactoryRuleActor, FactoryRuleCausalEntry } from './types.js';
-import { FACTORY_RULE_STAGES } from './types.js';
-import { MAX_FACTORY_RULE_CAUSAL_DEPTH, validateFactoryRuleDecision } from './validation.js';
+import { FACTORY_RULE_STAGES, isWorkingFactoryRuleStage } from './types.js';
+import { MAX_FACTORY_RULE_CAUSAL_DEPTH, validateStoredFactoryDecision } from './validation.js';
 
 const LEASE_MS = 30_000;
 const POLL_MS = 1_000;
@@ -160,6 +160,16 @@ function deferredActor(record: FactoryDeferredDecisionRecord): FactoryRuleActor 
     };
   }
   return { type: 'system', id: 'factory-rule-dispatcher' };
+}
+
+function externalActor(actor: FactoryDeferredDecisionRecord['actor']): boolean {
+  return actor !== null && actor.type !== 'human' && actor.type !== 'agent' && actor.type !== 'system';
+}
+
+/** A run start asks for consent unless its commit granted it; an external event asks before pulling a card back into a working lane. */
+function requestsConsent(record: FactoryDeferredDecisionRecord, decision: FactoryCommitDecision): boolean {
+  if (decision.type === 'invokeSkill') return decision.preauthorized !== true;
+  return decision.type === 'transition' && isWorkingFactoryRuleStage(decision.stage) && externalActor(record.actor);
 }
 
 function leaseIdentity(
@@ -389,7 +399,7 @@ export class FactoryDecisionDispatcher {
   async #dispatchDecision(record: FactoryDeferredDecisionRecord, now: Date): Promise<void> {
     let executionCompleted = false;
     try {
-      const decision = validateFactoryRuleDecision(record.decision, record.causalChain.length);
+      const decision = validateStoredFactoryDecision(record.decision, record.causalChain.length);
       if (decision.type === 'reject') throw new Error('Deferred Factory decisions cannot reject.');
       if (await this.#needsApproval(record, decision)) {
         const proposed = await this.#storage.proposeDeferredDecision(leaseIdentity(record, this.#ownerId), new Date());
@@ -442,15 +452,22 @@ export class FactoryDecisionDispatcher {
     }
   }
 
-  /** Starting an agent run spends the project's compute and executes its code — the one effect a human owns. */
+  /**
+   * Effects a person owns: starting a run — it spends the project's compute
+   * and executes its code — and an external event pulling a card back into a
+   * working lane.
+   */
   async #needsApproval(record: FactoryDeferredDecisionRecord, decision: FactoryCommitDecision): Promise<boolean> {
-    if (decision.type !== 'invokeSkill' || record.approvedAt !== null) return false;
-    if (await this.#isAutoRunEnabled({ orgId: record.orgId, factoryProjectId: record.factoryProjectId })) return false;
+    if (record.approvedAt !== null || !requestsConsent(record, decision)) return false;
     // Withholding auto-run decides what the Factory may pick up on its own, not
     // whether it may finish work a person already handed it. Once someone starts
     // an item, the runs that carry it to review are that same request continuing.
     const item = record.workItemId ? await this.#storage.get({ orgId: record.orgId, id: record.workItemId }) : null;
-    return item?.autonomyArmedAt == null;
+    if (item?.autonomyArmedAt != null) return false;
+    // Auto-run is the project's standing consent for its own work; code from an
+    // author without write access never rides it.
+    if (item?.metadata?.authorTrusted === false) return true;
+    return !(await this.#isAutoRunEnabled({ orgId: record.orgId, factoryProjectId: record.factoryProjectId }));
   }
 
   async #executeDecision(record: FactoryDeferredDecisionRecord, decision: FactoryCommitDecision): Promise<void> {

--- a/mastracode/factory/src/rules/transition-service.test.ts
+++ b/mastracode/factory/src/rules/transition-service.test.ts
@@ -418,7 +418,7 @@ describe('FactoryTransitionService', () => {
     expect((await storage.get({ orgId: 'org-1', id: item.id }))?.autonomyArmedAt).toBeNull();
   });
 
-  it('keeps autonomy armed when something other than a person moves the card to rest', async () => {
+  it('takes the factory hand off a card whoever rests it, so a push cannot restart finished work', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const item = await createItem(storage, { stages: ['intake'] });
     const service = new FactoryTransitionService({
@@ -435,7 +435,7 @@ describe('FactoryTransitionService', () => {
     });
 
     expect(rested.status).toBe('accepted');
-    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.autonomyArmedAt).toBeInstanceOf(Date);
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.autonomyArmedAt).toBeNull();
   });
 
   it('leaves autonomy unarmed when the mover is not a person', async () => {

--- a/mastracode/factory/src/rules/transition-service.ts
+++ b/mastracode/factory/src/rules/transition-service.ts
@@ -15,7 +15,7 @@ import type {
   FactoryStageRuleContext,
   FactoryTransitionResult,
 } from './types.js';
-import { factoryRuleSourceForWorkItem, isFactoryRuleStage } from './types.js';
+import { factoryRuleSourceForWorkItem, isFactoryRuleStage, isWorkingFactoryRuleStage } from './types.js';
 import {
   MAX_FACTORY_RULE_CAUSAL_DEPTH,
   validateFactoryRuleDecision,
@@ -112,15 +112,21 @@ export function workItemSource(source: ExternalWorkItemSource | null) {
   return source.type === 'pull-request' ? ('github-pr' as const) : ('github-issue' as const);
 }
 
-function roleForStage(board: FactoryRuleBoard, stage: FactoryRuleStage): string {
+export function roleForStage(board: FactoryRuleBoard, stage: FactoryRuleStage): string {
   if (board === 'review') return 'review';
   if (stage === 'triage') return 'triage';
   if (stage === 'planning') return 'plan';
   return 'work';
 }
 
-function isWorkingStage(stage: FactoryRuleStage): boolean {
-  return stage !== 'intake' && !TERMINAL_STAGES.has(stage);
+/**
+ * Entering a resting lane takes the factory's hand off the card no matter who
+ * rests it — a verdict, a mirrored close, a drag. Only a person's drag into a
+ * working lane hands it the work.
+ */
+function transitionConsent(stage: FactoryRuleStage, humanBoardDrag: boolean): 'arm' | 'disarm' | undefined {
+  if (!isWorkingFactoryRuleStage(stage)) return 'disarm';
+  return humanBoardDrag ? 'arm' : undefined;
 }
 
 type RunStartDecision = Extract<FactoryCommitDecision, { type: 'invokeSkill' | 'sendMessage' }>;
@@ -342,7 +348,7 @@ export class FactoryTransitionService {
                 idleBehavior: 'wake',
                 // Parking a card in Intake, Done or Canceled says stop working
                 // on it, so the notice reaches a live session or nobody.
-                prepareBinding: isWorkingStage(request.stage),
+                prepareBinding: isWorkingFactoryRuleStage(request.stage),
               });
             }
           }
@@ -360,14 +366,10 @@ export class FactoryTransitionService {
           : ruleFailure(error);
       evaluation = { outcome: 'rejected', ...failed };
     }
-    // A person's drag speaks in the direction it points: into a working lane
-    // it hands the factory the work, out to a resting lane it takes it back —
-    // later events may suggest, never restart. Flipped inside the same
-    // revision-checked update that commits the transition, so a stale or
-    // rejected commit leaves consent untouched.
-    const dragConsent = isWorkingStage(request.stage) ? ('arm' as const) : ('disarm' as const);
+    // Flipped inside the same revision-checked update that commits the
+    // transition, so a stale or rejected commit leaves consent untouched.
     return this.#commit(request, transitionId, evaluation, {
-      autonomy: evaluation.outcome === 'accepted' && humanBoardDrag ? dragConsent : undefined,
+      autonomy: evaluation.outcome === 'accepted' ? transitionConsent(request.stage, humanBoardDrag) : undefined,
     });
   }
 

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -56,6 +56,11 @@ export function isTerminalFactoryRuleStage(stages: readonly string[]): boolean {
   return stage === 'done' || stage === 'canceled';
 }
 
+/** Working lanes hold cards with a seat engaged; Intake, Done and Canceled rest them. */
+export function isWorkingFactoryRuleStage(stage: FactoryRuleStage): boolean {
+  return stage !== 'intake' && !isTerminalFactoryRuleStage([stage]);
+}
+
 /**
  * The lane a run entering from Intake lands its card in, keyed by the session
  * role the run fills. Consulted only for that Intake exit — a card already in
@@ -333,6 +338,12 @@ interface FactoryInvokeSkillDecisionBase extends FactoryCommitDecisionBase {
   arguments?: string;
   precedingMessage?: string;
   cancelInFlight?: boolean;
+  /**
+   * Commit-stamped, never rule-authored: this run is an outcome of the same
+   * consented transition that rested the card, so the disarm it carried does
+   * not park it.
+   */
+  preauthorized?: boolean;
 }
 
 /**

--- a/mastracode/factory/src/rules/validation.test.ts
+++ b/mastracode/factory/src/rules/validation.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_FACTORY_RULE_CAUSAL_DEPTH,
   validateFactoryRuleDecision,
   validateFactoryRuleDecisions,
+  validateStoredFactoryDecision,
 } from './validation.js';
 
 describe('Factory rule validation', () => {
@@ -212,6 +213,39 @@ describe('Factory rule validation', () => {
         cancelInFlight: 'yes',
       }),
     ).toThrow(/cancelInFlight must be a boolean/i);
+  });
+
+  it('rejects rule output that grants its own run consent', () => {
+    expect(() =>
+      validateFactoryRuleDecision({
+        type: 'invokeSkill',
+        idempotencyKey: 'self-consent',
+        role: 'work',
+        skillName: 'factory-review',
+        preauthorized: true,
+      }),
+    ).toThrow(FactoryRuleValidationError);
+  });
+
+  it('keeps the commit-stamped consent only on stored skill invocations', () => {
+    expect(
+      validateStoredFactoryDecision({
+        type: 'invokeSkill',
+        idempotencyKey: 'close-out',
+        role: 'work',
+        skillName: 'factory-complete-issue',
+        preauthorized: true,
+      }),
+    ).toMatchObject({ type: 'invokeSkill', preauthorized: true });
+    expect(
+      validateStoredFactoryDecision({
+        type: 'transition',
+        idempotencyKey: 'stray-stamp',
+        board: 'work',
+        stage: 'done',
+        preauthorized: true,
+      }),
+    ).not.toHaveProperty('preauthorized');
   });
 
   it('requires unique decision idempotency keys', () => {

--- a/mastracode/factory/src/rules/validation.ts
+++ b/mastracode/factory/src/rules/validation.ts
@@ -202,6 +202,18 @@ function commonCommitFields(value: Record<string, unknown>): { idempotencyKey: s
   };
 }
 
+/**
+ * Stored decisions may carry the commit-stamped `preauthorized` flag; rule
+ * output may not — a rule granting its own run consent would bypass the
+ * approval gate.
+ */
+export function validateStoredFactoryDecision(value: unknown, causalDepth = 0): FactoryRuleDecision {
+  if (!isPlainObject(value)) throw new FactoryRuleValidationError('Factory rule decision must be an object.');
+  const { preauthorized, ...rest } = value;
+  const decision = validateFactoryRuleDecision(rest, causalDepth);
+  return decision.type === 'invokeSkill' && preauthorized === true ? { ...decision, preauthorized: true } : decision;
+}
+
 export function validateFactoryRuleDecision(value: unknown, causalDepth = 0): FactoryRuleDecision {
   if (causalDepth > MAX_FACTORY_RULE_CAUSAL_DEPTH) {
     throw new FactoryRuleValidationError('Factory rule causal depth exceeded.');

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -1408,6 +1408,12 @@ export class WorkItemsStorage extends FactoryStorageDomain {
           });
           if (outcome === 'accepted' && input.evaluation.outcome === 'accepted') {
             for (const [index, decision] of input.evaluation.decisions.entries()) {
+              // A disarming transition's own runs carry the consent that
+              // committed it; the disarm parks later events, not these.
+              const stored =
+                input.autonomy === 'disarm' && decision.type === 'invokeSkill'
+                  ? { ...decision, preauthorized: true }
+                  : decision;
               await ops.insertOne<GovernanceDbRow>('factory_deferred_decisions', {
                 org_id: input.orgId,
                 factory_project_id: input.factoryProjectId,
@@ -1419,7 +1425,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
                 effect_hash: factoryDecisionHash(decision),
                 causal_chain: input.causalChain,
                 actor: null,
-                decision,
+                decision: stored,
                 status: 'pending',
                 attempts: 0,
                 delivery_generation: 0,


### PR DESCRIPTION
Folded into #22531 — the stack collapsed into one PR; this lands there as its own commit.

---

TLDR: resting a card now takes the factory's hand off it whoever rests it — and external events can no longer restart or re-enter rested work without a person's consent.

---

Stacked on #22615. The lane model says lanes are engagement and events on rested cards suggest, never restart. Three doors still leaked around that sentence; this closes them.

### What changes

| card at rest (Intake, Done, Canceled) | before | after |
| --- | --- | --- |
| a review verdict or mirrored close rests it | consent stayed armed — the next event could start a run unattended | any accepted entry into a resting lane disarms, same as a human drag out |
| that same resting transition queued a close-out run | the disarm would have parked the factory's own verdict follow-up | the commit stamps its own runs `preauthorized`; they still fire, later events park |
| a GitHub push proposes pulling it back into a working lane | executed silently — the card re-entered Review on its own | parks as a proposal unless the card is armed or auto-run covers it |
| card authored by someone without write access, auto-run on | run started anyway — the External badge tooltip was lying | never self-starts; the tooltip ("never starts a run on its own, even with auto-start runs on") is now true |

### Judgment call

`preauthorized` lives inside the stored decision JSON, not a new column. Rule output claiming the stamp for itself is rejected at validation — only the commit path can grant it, so a rule cannot buy its own consent. A column would say the same thing with a migration; it is one `ALTER TABLE` away if you disagree.

External means "not human, agent, or system" — exclusion, not inclusion — so a future Linear actor is external by default. Fail-safe direction: a new actor type asks for consent until someone decides otherwise.

Also in this diff: the `investigateTriagedIssue` dead guard is deleted (its `linked_item_materialized` branch is unreachable since materialization stopped landing in Triage), and proposed transitions now name the seat their lane addresses, so the board can label what approving starts.

### Side effects to check

`#needsApproval` now reads the work item before the auto-run flag instead of after, so auto-run-on projects pay one item read per deferred decision they previously skipped. Same table the dispatch reads anyway.

```
tests        +267  -20    ← 77% of the additions
source        +81  -29
changeset      +7    0
```

