### PR TITLE
feat(workflows): add id, description, metadata to control-flow entries

### DIFF
--- a/.changeset/easy-shrimps-glow.md
+++ b/.changeset/easy-shrimps-glow.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': minor
+---
+
+Added optional `id`, `description`, and `metadata` to workflow control-flow entries: `.parallel()`, `.branch()`, `.dowhile()`, `.dountil()`, `.foreach()`, `.sleep()`, `.sleepUntil()`, and `.map()`. Executable steps already supported these fields; the entries between them now follow the same model, so visual editors and review tools can label a parallel block or a sleep and address it with a stable id instead of a generated one or a position in the graph.
+
+```typescript
+workflow
+  .parallel([validateStep, enrichStep], {
+    id: 'independent-enrichment',
+    description: 'Run independent enrichment tasks concurrently',
+    metadata: { title: 'Independent enrichment' },
+  })
+  .sleep(5000, { id: 'wait-before-retry', metadata: { title: 'Wait before retry' } });
+```
+
+The fields appear in `serializedStepGraph`, survive storage and rehydration of dynamic workflow definitions, and have no effect on execution. For `.map()`, `.sleep()`, and `.sleepUntil()`, a supplied `id` replaces the generated entry id.

--- a/.changeset/great-terms-remain.md
+++ b/.changeset/great-terms-remain.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Accepted and preserved the new `id`, `description`, and `metadata` fields on control-flow entries (`parallel`, `conditional`, `loop`, `foreach`, `sleep`, `sleepUntil`, `mapping`) in the dynamic workflow API schemas. Definitions posted over HTTP keep these fields instead of having them silently stripped.

--- a/.changeset/great-terms-remain.md
+++ b/.changeset/great-terms-remain.md
@@ -3,3 +3,13 @@
 ---
 
 Accepted and preserved the new `id`, `description`, and `metadata` fields on control-flow entries (`parallel`, `conditional`, `loop`, `foreach`, `sleep`, `sleepUntil`, `mapping`) in the dynamic workflow API schemas. Definitions posted over HTTP keep these fields instead of having them silently stripped.
+
+```json
+{
+  "type": "sleep",
+  "id": "wait-before-retry",
+  "description": "Pause before retrying the external operation",
+  "metadata": { "title": "Wait before retry" },
+  "duration": 5000
+}
+```

--- a/.changeset/stale-wolves-post.md
+++ b/.changeset/stale-wolves-post.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Regenerated route types: workflow step-graph entries now expose optional `id`, `description`, and `metadata` fields.

--- a/.changeset/stale-wolves-post.md
+++ b/.changeset/stale-wolves-post.md
@@ -3,3 +3,11 @@
 ---
 
 Regenerated route types: workflow step-graph entries now expose optional `id`, `description`, and `metadata` fields.
+
+```typescript
+const workflow = await client.getWorkflow("my-workflow").details();
+for (const entry of workflow.stepGraph) {
+  // id, description, and metadata are now typed on every entry
+  console.log(entry.id, entry.description, entry.metadata);
+}
+```

--- a/.changeset/yummy-dancers-add.md
+++ b/.changeset/yummy-dancers-add.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Sleep, sleepUntil, and mapping nodes in the workflow graph now receive their entry's `description` and `metadata`, matching regular step nodes.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -17,7 +17,7 @@ type Shared_Auxiliary_298 =
       [key: string]: Shared_Auxiliary_298;
     };
 
-type Shared_Auxiliary_1097 =
+type Shared_Auxiliary_1090 =
   | {
       op: 'eq' | 'ne' | 'lt' | 'lte' | 'gt' | 'gte';
       left:
@@ -62,19 +62,19 @@ type Shared_Auxiliary_1097 =
     }
   | {
       op: 'and' | 'or';
-      args: Shared_Auxiliary_1097[];
+      args: Shared_Auxiliary_1090[];
     }
   | {
       op: 'not';
-      arg: Shared_Auxiliary_1097;
+      arg: Shared_Auxiliary_1090;
     };
 
-type Shared_Auxiliary_1238 = {
+type Shared_Auxiliary_1230 = {
   id?: string | undefined;
   name: string;
   type: 'file' | 'folder';
   content?: string | undefined;
-  children?: Shared_Auxiliary_1238[] | undefined;
+  children?: Shared_Auxiliary_1230[] | undefined;
 };
 
 type Shared_Type_0 = {
@@ -1254,6 +1254,29 @@ type Shared_Type_57 = {
 };
 
 type Shared_Type_58 = {
+  type:
+    | 'step'
+    | 'agent'
+    | 'tool'
+    | 'mapping'
+    | 'sleep'
+    | 'sleepUntil'
+    | 'waitForEvent'
+    | 'parallel'
+    | 'conditional'
+    | 'loop'
+    | 'foreach'
+    | 'workflow';
+  id?: string | undefined;
+  description?: string | undefined;
+  metadata?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
+};
+
+type Shared_Type_59 = {
   steps: {
     [key: string]: Shared_Type_57;
   };
@@ -1267,21 +1290,7 @@ type Shared_Type_58 = {
         [key: string]: unknown;
       }
     | undefined;
-  stepGraph: {
-    type:
-      | 'step'
-      | 'agent'
-      | 'tool'
-      | 'mapping'
-      | 'sleep'
-      | 'sleepUntil'
-      | 'waitForEvent'
-      | 'parallel'
-      | 'conditional'
-      | 'loop'
-      | 'foreach'
-      | 'workflow';
-  }[];
+  stepGraph: Shared_Type_58[];
   inputSchema?: string | undefined;
   outputSchema?: string | undefined;
   stateSchema?: string | undefined;
@@ -1290,7 +1299,7 @@ type Shared_Type_58 = {
   origin?: ('code' | 'dynamic') | undefined;
 };
 
-type Shared_Type_59 = {
+type Shared_Type_60 = {
   id: string;
   role: 'user' | 'assistant' | 'system' | 'tool' | 'signal';
   createdAt?: Date | undefined;
@@ -1305,7 +1314,7 @@ type Shared_Type_59 = {
   [x: string]: unknown;
 };
 
-type Shared_Type_60 = {
+type Shared_Type_61 = {
   type: 'json_schema';
   name: string;
   description?: string | undefined;
@@ -1315,7 +1324,7 @@ type Shared_Type_60 = {
   strict?: boolean | undefined;
 };
 
-type Shared_Type_61 = {
+type Shared_Type_62 = {
   /** OpenAI provider options such as previousResponseId, conversation, or responseId */
   openai?:
     | {
@@ -1331,7 +1340,7 @@ type Shared_Type_61 = {
   [x: string]: unknown;
 };
 
-type Shared_Type_62 = {
+type Shared_Type_63 = {
   id: string;
   type: 'function_call';
   call_id: string;
@@ -1340,7 +1349,7 @@ type Shared_Type_62 = {
   status?: ('in_progress' | 'completed' | 'incomplete') | undefined;
 };
 
-type Shared_Type_63 = {
+type Shared_Type_64 = {
   id: string;
   title?: string | undefined;
   resourceId: string;
@@ -1353,7 +1362,7 @@ type Shared_Type_63 = {
     | undefined;
 };
 
-type Shared_Type_64 = {
+type Shared_Type_65 = {
   id?: string | undefined;
   cycleId: string;
   observations: string;
@@ -1378,14 +1387,14 @@ type Shared_Type_64 = {
     | undefined;
 };
 
-type Shared_Type_65 = {
+type Shared_Type_66 = {
   id: string;
   scope: 'thread' | 'resource';
   resourceId: string;
   threadId: string | null;
   activeObservations: string;
   bufferedObservations?: string | undefined;
-  bufferedObservationChunks?: Shared_Type_64[] | undefined;
+  bufferedObservationChunks?: Shared_Type_65[] | undefined;
   bufferedReflection?: string | undefined;
   originType: 'initial' | 'observation' | 'reflection';
   generationCount: number;
@@ -1407,7 +1416,7 @@ type Shared_Type_65 = {
   updatedAt: Date;
 };
 
-type Shared_Type_66 = {
+type Shared_Type_67 = {
   dateRange?:
     | {
         start?: Date | undefined;
@@ -1424,7 +1433,7 @@ type Shared_Type_66 = {
     | undefined;
 };
 
-type Shared_Type_67 = {
+type Shared_Type_68 = {
   config: {
     id: string;
     name?: string | undefined;
@@ -1434,8 +1443,8 @@ type Shared_Type_67 = {
   };
 };
 
-type Shared_Type_68 = {
-  scorer: Shared_Type_67;
+type Shared_Type_69 = {
+  scorer: Shared_Type_68;
   sampling?: {} | undefined;
   agentIds: string[];
   agentNames: string[];
@@ -1444,7 +1453,7 @@ type Shared_Type_68 = {
   source: 'code' | 'stored' | 'fs';
 };
 
-type Shared_Type_69 = {
+type Shared_Type_70 = {
   /** Start of date range (inclusive by default) */
   start?: Date | undefined;
   /** End of date range (inclusive by default) */
@@ -1455,7 +1464,7 @@ type Shared_Type_69 = {
   endExclusive?: boolean | undefined;
 };
 
-type Shared_Type_70 =
+type Shared_Type_71 =
   | 'agent_run'
   | 'scorer_run'
   | 'scorer_step'
@@ -1487,7 +1496,7 @@ type Shared_Type_70 =
   | 'mapping'
   | 'skill_resolution';
 
-type Shared_Type_71 =
+type Shared_Type_72 =
   | 'agent'
   | 'scorer'
   | 'rag_ingestion'
@@ -1502,7 +1511,7 @@ type Shared_Type_71 =
   | 'workflow_run'
   | 'memory';
 
-type Shared_Type_72 = {
+type Shared_Type_73 = {
   /** Total number of items available */
   total: number;
   /** Current page */
@@ -1513,14 +1522,14 @@ type Shared_Type_72 = {
   hasMore: boolean;
 };
 
-type Shared_Type_73 = {
+type Shared_Type_74 = {
   /** Maximum number of updates requested for this delta poll */
   limit: number;
   /** True when more matching updates remain after this response */
   hasMore: boolean;
 };
 
-type Shared_Type_74 = {
+type Shared_Type_75 = {
   /** Unique trace identifier */
   traceId: string;
   /** Unique span identifier within a trace */
@@ -1528,19 +1537,19 @@ type Shared_Type_74 = {
   /** Human-readable span name */
   name: string;
   /** Span type (e.g., WORKFLOW_RUN, AGENT_RUN, TOOL_CALL, etc.) */
-  spanType: Shared_Type_70;
+  spanType: Shared_Type_71;
   /** Whether this is an event (point-in-time) vs a span (duration) */
   isEvent: boolean;
   /** When the span started */
   startedAt: Date;
   parentSpanId?: (string | null) | undefined;
-  entityType?: (Shared_Type_71 | null) | undefined;
+  entityType?: (Shared_Type_72 | null) | undefined;
   entityId?: (string | null) | undefined;
   entityName?: (string | null) | undefined;
-  parentEntityType?: (Shared_Type_71 | null) | undefined;
+  parentEntityType?: (Shared_Type_72 | null) | undefined;
   parentEntityId?: (string | null) | undefined;
   parentEntityName?: (string | null) | undefined;
-  rootEntityType?: (Shared_Type_71 | null) | undefined;
+  rootEntityType?: (Shared_Type_72 | null) | undefined;
   rootEntityId?: (string | null) | undefined;
   rootEntityName?: (string | null) | undefined;
   userId?: (string | null) | undefined;
@@ -1593,7 +1602,7 @@ type Shared_Type_74 = {
   status: 'success' | 'error' | 'running';
 };
 
-type Shared_Type_75 = {
+type Shared_Type_76 = {
   /** Unique trace identifier */
   traceId: string;
   /** Unique span identifier within a trace */
@@ -1601,7 +1610,7 @@ type Shared_Type_75 = {
   /** Human-readable span name */
   name: string;
   /** Span type (e.g., WORKFLOW_RUN, AGENT_RUN, TOOL_CALL, etc.) */
-  spanType: Shared_Type_70;
+  spanType: Shared_Type_71;
   /** Whether this is an event (point-in-time) vs a span (duration) */
   isEvent: boolean;
   /** When the span started */
@@ -1610,7 +1619,7 @@ type Shared_Type_75 = {
   endedAt?: (Date | null) | undefined;
   error?: (unknown | null) | undefined;
   status?: (('success' | 'error' | 'running') | null) | undefined;
-  entityType?: (Shared_Type_71 | null) | undefined;
+  entityType?: (Shared_Type_72 | null) | undefined;
   entityId?: (string | null) | undefined;
   entityName?: (string | null) | undefined;
   metadata?:
@@ -1625,7 +1634,7 @@ type Shared_Type_75 = {
   updatedAt: Date | null;
 };
 
-type Shared_Type_76 = {
+type Shared_Type_77 = {
   /** Unique trace identifier */
   traceId: string;
   /** Unique span identifier within a trace */
@@ -1633,19 +1642,19 @@ type Shared_Type_76 = {
   /** Human-readable span name */
   name: string;
   /** Span type (e.g., WORKFLOW_RUN, AGENT_RUN, TOOL_CALL, etc.) */
-  spanType: Shared_Type_70;
+  spanType: Shared_Type_71;
   /** Whether this is an event (point-in-time) vs a span (duration) */
   isEvent: boolean;
   /** When the span started */
   startedAt: Date;
   parentSpanId?: (string | null) | undefined;
-  entityType?: (Shared_Type_71 | null) | undefined;
+  entityType?: (Shared_Type_72 | null) | undefined;
   entityId?: (string | null) | undefined;
   entityName?: (string | null) | undefined;
-  parentEntityType?: (Shared_Type_71 | null) | undefined;
+  parentEntityType?: (Shared_Type_72 | null) | undefined;
   parentEntityId?: (string | null) | undefined;
   parentEntityName?: (string | null) | undefined;
-  rootEntityType?: (Shared_Type_71 | null) | undefined;
+  rootEntityType?: (Shared_Type_72 | null) | undefined;
   rootEntityId?: (string | null) | undefined;
   rootEntityName?: (string | null) | undefined;
   userId?: (string | null) | undefined;
@@ -1696,7 +1705,7 @@ type Shared_Type_76 = {
   updatedAt: Date | null;
 };
 
-type Shared_Type_77 = {
+type Shared_Type_78 = {
   /** Unique id for this score event */
   scoreId?: (string | null) | undefined;
   /** When the score was recorded */
@@ -1714,13 +1723,13 @@ type Shared_Type_77 = {
   /** Score value (range defined by scorer) */
   score: number;
   reason?: (string | null) | undefined;
-  entityType?: (Shared_Type_71 | null) | undefined;
+  entityType?: (Shared_Type_72 | null) | undefined;
   entityId?: (string | null) | undefined;
   entityName?: (string | null) | undefined;
-  parentEntityType?: (Shared_Type_71 | null) | undefined;
+  parentEntityType?: (Shared_Type_72 | null) | undefined;
   parentEntityId?: (string | null) | undefined;
   parentEntityName?: (string | null) | undefined;
-  rootEntityType?: (Shared_Type_71 | null) | undefined;
+  rootEntityType?: (Shared_Type_72 | null) | undefined;
   rootEntityId?: (string | null) | undefined;
   rootEntityName?: (string | null) | undefined;
   userId?: (string | null) | undefined;
@@ -1753,15 +1762,15 @@ type Shared_Type_77 = {
     | undefined;
 };
 
-type Shared_Type_78 = {
+type Shared_Type_79 = {
   /** Filter by timestamp range */
-  timestamp?: Shared_Type_69 | undefined;
+  timestamp?: Shared_Type_70 | undefined;
   /** Filter by trace ID */
   traceId?: string | undefined;
   /** Filter by span ID */
   spanId?: string | undefined;
   /** Entity type (e.g., 'agent' | 'processor' | 'tool' | 'workflow') */
-  entityType?: Shared_Type_71 | undefined;
+  entityType?: Shared_Type_72 | undefined;
   /** Name of the entity */
   entityName?: string | undefined;
   /** Version ID of the entity that produced this signal (e.g., agent version, workflow version) */
@@ -1781,11 +1790,11 @@ type Shared_Type_78 = {
   /** Environment (e.g., "production" | "staging" | "development") */
   environment?: string | undefined;
   /** Entity type of the parent entity */
-  parentEntityType?: Shared_Type_71 | undefined;
+  parentEntityType?: Shared_Type_72 | undefined;
   /** Name of the parent entity */
   parentEntityName?: string | undefined;
   /** Entity type of the root entity */
-  rootEntityType?: Shared_Type_71 | undefined;
+  rootEntityType?: Shared_Type_72 | undefined;
   /** Name of the root entity */
   rootEntityName?: string | undefined;
   /** Broader resource context (Mastra memory compatibility) */
@@ -1816,7 +1825,7 @@ type Shared_Type_78 = {
   source?: string | undefined;
 };
 
-type Shared_Type_79 = {
+type Shared_Type_80 = {
   /** Unique id for this feedback event */
   feedbackId?: (string | null) | undefined;
   /** When the feedback was recorded */
@@ -1833,13 +1842,13 @@ type Shared_Type_79 = {
   value: number | string;
   comment?: (string | null) | undefined;
   feedbackUserId?: (string | null) | undefined;
-  entityType?: (Shared_Type_71 | null) | undefined;
+  entityType?: (Shared_Type_72 | null) | undefined;
   entityId?: (string | null) | undefined;
   entityName?: (string | null) | undefined;
-  parentEntityType?: (Shared_Type_71 | null) | undefined;
+  parentEntityType?: (Shared_Type_72 | null) | undefined;
   parentEntityId?: (string | null) | undefined;
   parentEntityName?: (string | null) | undefined;
-  rootEntityType?: (Shared_Type_71 | null) | undefined;
+  rootEntityType?: (Shared_Type_72 | null) | undefined;
   rootEntityId?: (string | null) | undefined;
   rootEntityName?: (string | null) | undefined;
   userId?: (string | null) | undefined;
@@ -1874,15 +1883,15 @@ type Shared_Type_79 = {
   reviewStatus: 'needs-review' | 'reviewed';
 };
 
-type Shared_Type_80 = {
+type Shared_Type_81 = {
   /** Filter by timestamp range */
-  timestamp?: Shared_Type_69 | undefined;
+  timestamp?: Shared_Type_70 | undefined;
   /** Filter by trace ID */
   traceId?: string | undefined;
   /** Filter by span ID */
   spanId?: string | undefined;
   /** Entity type (e.g., 'agent' | 'processor' | 'tool' | 'workflow') */
-  entityType?: Shared_Type_71 | undefined;
+  entityType?: Shared_Type_72 | undefined;
   /** Name of the entity */
   entityName?: string | undefined;
   /** Version ID of the entity that produced this signal (e.g., agent version, workflow version) */
@@ -1902,11 +1911,11 @@ type Shared_Type_80 = {
   /** Environment (e.g., "production" | "staging" | "development") */
   environment?: string | undefined;
   /** Entity type of the parent entity */
-  parentEntityType?: Shared_Type_71 | undefined;
+  parentEntityType?: Shared_Type_72 | undefined;
   /** Name of the parent entity */
   parentEntityName?: string | undefined;
   /** Entity type of the root entity */
-  rootEntityType?: Shared_Type_71 | undefined;
+  rootEntityType?: Shared_Type_72 | undefined;
   /** Name of the root entity */
   rootEntityName?: string | undefined;
   /** Broader resource context (Mastra memory compatibility) */
@@ -1934,7 +1943,7 @@ type Shared_Type_80 = {
   reviewStatus?: ('needs-review' | 'reviewed') | undefined;
 };
 
-type Shared_Type_81 =
+type Shared_Type_82 =
   | 'entityType'
   | 'entityName'
   | 'parentEntityType'
@@ -1950,15 +1959,15 @@ type Shared_Type_81 =
   | 'threadId'
   | 'resourceId';
 
-type Shared_Type_82 = {
+type Shared_Type_83 = {
   /** Filter by timestamp range */
-  timestamp?: Shared_Type_69 | undefined;
+  timestamp?: Shared_Type_70 | undefined;
   /** Filter by trace ID */
   traceId?: string | undefined;
   /** Filter by span ID */
   spanId?: string | undefined;
   /** Entity type (e.g., 'agent' | 'processor' | 'tool' | 'workflow') */
-  entityType?: Shared_Type_71 | undefined;
+  entityType?: Shared_Type_72 | undefined;
   /** Name of the entity */
   entityName?: string | undefined;
   /** Version ID of the entity that produced this signal (e.g., agent version, workflow version) */
@@ -1978,11 +1987,11 @@ type Shared_Type_82 = {
   /** Environment (e.g., "production" | "staging" | "development") */
   environment?: string | undefined;
   /** Entity type of the parent entity */
-  parentEntityType?: Shared_Type_71 | undefined;
+  parentEntityType?: Shared_Type_72 | undefined;
   /** Name of the parent entity */
   parentEntityName?: string | undefined;
   /** Entity type of the root entity */
-  rootEntityType?: Shared_Type_71 | undefined;
+  rootEntityType?: Shared_Type_72 | undefined;
   /** Name of the root entity */
   rootEntityName?: string | undefined;
   /** Broader resource context (Mastra memory compatibility) */
@@ -2019,7 +2028,7 @@ type Shared_Type_82 = {
     | undefined;
 };
 
-type Shared_Type_83 = {
+type Shared_Type_84 = {
   /** Part type - text for TextParts */
   kind: 'text';
   /** Text content */
@@ -2032,7 +2041,7 @@ type Shared_Type_83 = {
     | undefined;
 };
 
-type Shared_Type_84 = {
+type Shared_Type_85 = {
   /** base64 encoded content of the file */
   bytes: string;
   /** Optional mimeType for the file */
@@ -2041,7 +2050,7 @@ type Shared_Type_84 = {
   name?: string | undefined;
 };
 
-type Shared_Type_85 = {
+type Shared_Type_86 = {
   /** URL for the File content */
   uri: string;
   /** Optional mimeType for the file */
@@ -2050,11 +2059,11 @@ type Shared_Type_85 = {
   name?: string | undefined;
 };
 
-type Shared_Type_86 = {
+type Shared_Type_87 = {
   /** Part type - file for FileParts */
   kind: 'file';
   /** File content either as url or bytes */
-  file: Shared_Type_84 | Shared_Type_85;
+  file: Shared_Type_85 | Shared_Type_86;
   /** Optional metadata associated with the part */
   metadata?:
     | {
@@ -2063,7 +2072,7 @@ type Shared_Type_86 = {
     | undefined;
 };
 
-type Shared_Type_87 = {
+type Shared_Type_88 = {
   /** Part type - data for DataParts */
   kind: 'data';
   /** Structured data content */
@@ -2078,7 +2087,7 @@ type Shared_Type_87 = {
     | undefined;
 };
 
-type Shared_Type_88 = {
+type Shared_Type_89 = {
   text?: string | undefined;
   raw?: string | undefined;
   url?: string | undefined;
@@ -2092,7 +2101,7 @@ type Shared_Type_88 = {
     | undefined;
 };
 
-type Shared_Type_89 = {
+type Shared_Type_90 = {
   /** Event type */
   kind?: 'message' | undefined;
   /** Identifier created by the message creator */
@@ -2100,7 +2109,7 @@ type Shared_Type_89 = {
   /** Message sender's role */
   role: 'user' | 'agent' | 'ROLE_USER' | 'ROLE_AGENT';
   /** Message content */
-  parts: ((Shared_Type_83 | Shared_Type_86 | Shared_Type_87) | Shared_Type_88)[];
+  parts: ((Shared_Type_84 | Shared_Type_87 | Shared_Type_88) | Shared_Type_89)[];
   /** The context the message is associated with */
   contextId?: string | undefined;
   /** Identifier of task the message is related to */
@@ -2117,24 +2126,24 @@ type Shared_Type_89 = {
     | undefined;
 };
 
-type Shared_Type_90 = {
+type Shared_Type_91 = {
   /** Supported authentication schemes - e.g. Basic, Bearer */
   schemes: string[];
   /** Optional credentials */
   credentials?: string | undefined;
 };
 
-type Shared_Type_91 = {
+type Shared_Type_92 = {
   /** URL for sending the push notifications */
   url: string;
   /** Push Notification ID - created by server to support multiple callbacks */
   id?: string | undefined;
   /** Token unique to this task/session */
   token?: string | undefined;
-  authentication?: Shared_Type_90 | undefined;
+  authentication?: Shared_Type_91 | undefined;
 };
 
-type Shared_Type_92 = {
+type Shared_Type_93 = {
   /** Accepted output modalities by the client */
   acceptedOutputModes?: string[] | undefined;
   /** If the server should treat the client as a blocking request */
@@ -2143,13 +2152,13 @@ type Shared_Type_92 = {
   returnImmediately?: boolean | undefined;
   /** Number of recent messages to be retrieved */
   historyLength?: number | undefined;
-  pushNotificationConfig?: Shared_Type_91 | undefined;
-  taskPushNotificationConfig?: Shared_Type_91 | undefined;
+  pushNotificationConfig?: Shared_Type_92 | undefined;
+  taskPushNotificationConfig?: Shared_Type_92 | undefined;
 };
 
-type Shared_Type_93 = {
-  message: Shared_Type_89;
-  configuration?: Shared_Type_92 | undefined;
+type Shared_Type_94 = {
+  message: Shared_Type_90;
+  configuration?: Shared_Type_93 | undefined;
   /** Extension metadata */
   metadata?:
     | {
@@ -2158,7 +2167,7 @@ type Shared_Type_93 = {
     | undefined;
 };
 
-type Shared_Type_94 = {
+type Shared_Type_95 = {
   name: string;
   description?: string | undefined;
   inputSchema: unknown;
@@ -2171,7 +2180,7 @@ type Shared_Type_94 = {
     | undefined;
 };
 
-type Shared_Type_95 =
+type Shared_Type_96 =
   | (
       | (
           | {
@@ -2186,7 +2195,7 @@ type Shared_Type_95 =
     )
   | undefined;
 
-type Shared_Type_96 =
+type Shared_Type_97 =
   | (
       | (
           | Shared_Type_4
@@ -2200,7 +2209,7 @@ type Shared_Type_96 =
     )
   | undefined;
 
-type Shared_Type_97 =
+type Shared_Type_98 =
   | (
       | (
           | {
@@ -2217,7 +2226,7 @@ type Shared_Type_97 =
     )
   | undefined;
 
-type Shared_Type_98 =
+type Shared_Type_99 =
   | (
       | (
           | {
@@ -2234,7 +2243,7 @@ type Shared_Type_98 =
     )
   | undefined;
 
-type Shared_Type_99 =
+type Shared_Type_100 =
   | (
       | (
           | {
@@ -2251,7 +2260,7 @@ type Shared_Type_99 =
     )
   | undefined;
 
-type Shared_Type_100 =
+type Shared_Type_101 =
   | (
       | (
           | (
@@ -2271,7 +2280,7 @@ type Shared_Type_100 =
     )
   | undefined;
 
-type Shared_Type_101 = {
+type Shared_Type_102 = {
   /** Unique identifier for the version (UUID) */
   id: string;
   /** ID of the agent this version belongs to */
@@ -2408,7 +2417,7 @@ type Shared_Type_101 = {
   createdAt: Date;
 };
 
-type Shared_Type_102 = {
+type Shared_Type_103 = {
   /** The field path that changed */
   field: string;
   /** The value in the "from" version */
@@ -2417,7 +2426,7 @@ type Shared_Type_102 = {
   currentValue: unknown;
 };
 
-type Shared_Type_103 = {
+type Shared_Type_104 = {
   id: string;
   description?: string | undefined;
   metadata?:
@@ -2437,7 +2446,7 @@ type Shared_Type_103 = {
   updatedAt: Date | string;
 };
 
-type Shared_Type_104 = {
+type Shared_Type_105 = {
   type: 'agent';
   id: string;
   agentId: string;
@@ -2459,7 +2468,7 @@ type Shared_Type_104 = {
     | undefined;
 };
 
-type Shared_Type_105 = {
+type Shared_Type_106 = {
   type: 'tool';
   id: string;
   toolId: string;
@@ -2476,26 +2485,54 @@ type Shared_Type_105 = {
     | undefined;
 };
 
-type Shared_Type_106 =
-  | Shared_Type_104
+type Shared_Type_107 = {
+  type: 'mapping';
+  id: string;
+  description?: string | undefined;
+  metadata?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
+  mapConfig: string;
+};
+
+type Shared_Type_108 = (
   | Shared_Type_105
-  | {
-      type: 'mapping';
-      id: string;
-      mapConfig: string;
-    }
+  | Shared_Type_106
+  | Shared_Type_107
   | {
       type: 'workflow';
       id: string;
       workflowId: string;
       description?: string | undefined;
-    };
+    }
+)[];
 
-type Shared_Type_107 = {
+type Shared_Type_109 = {
+  type: 'parallel';
+  id?: string | undefined;
+  description?: string | undefined;
+  metadata?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
+  steps: Shared_Type_108;
+};
+
+type Shared_Type_110 = {
   type: 'foreach';
+  id?: string | undefined;
+  description?: string | undefined;
+  metadata?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
   step:
-    | Shared_Type_104
     | Shared_Type_105
+    | Shared_Type_106
     | {
         type: 'workflow';
         id: string;
@@ -2509,48 +2546,84 @@ type Shared_Type_107 = {
     | undefined;
 };
 
-type Shared_Type_108 =
-  | Shared_Type_104
+type Shared_Type_111 = {
+  type: 'sleep';
+  id: string;
+  description?: string | undefined;
+  metadata?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
+  duration: number;
+};
+
+type Shared_Type_112 = {
+  type: 'sleepUntil';
+  id: string;
+  description?: string | undefined;
+  metadata?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
+  date: string;
+};
+
+type Shared_Type_113 = {
+  type: 'conditional';
+  id?: string | undefined;
+  description?: string | undefined;
+  metadata?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
+  steps: Shared_Type_108;
+  predicates: Shared_Auxiliary_1090[];
+};
+
+type Shared_Type_114 = {
+  type: 'loop';
+  id?: string | undefined;
+  description?: string | undefined;
+  metadata?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
+  step:
+    | Shared_Type_105
+    | Shared_Type_106
+    | Shared_Type_107
+    | {
+        type: 'workflow';
+        id: string;
+        workflowId: string;
+        description?: string | undefined;
+      };
+  loopType: 'dowhile' | 'dountil';
+  predicate: Shared_Auxiliary_1090;
+};
+
+type Shared_Type_115 =
   | Shared_Type_105
-  | {
-      type: 'mapping';
-      id: string;
-      mapConfig: string;
-    }
+  | Shared_Type_106
+  | Shared_Type_107
   | {
       type: 'workflow';
       id: string;
       workflowId: string;
       description?: string | undefined;
     }
-  | {
-      type: 'parallel';
-      steps: Shared_Type_106[];
-    }
-  | Shared_Type_107
-  | {
-      type: 'sleep';
-      id: string;
-      duration: number;
-    }
-  | {
-      type: 'sleepUntil';
-      id: string;
-      date: string;
-    }
-  | {
-      type: 'conditional';
-      steps: Shared_Type_106[];
-      predicates: Shared_Auxiliary_1097[];
-    }
-  | {
-      type: 'loop';
-      step: Shared_Type_106;
-      loopType: 'dowhile' | 'dountil';
-      predicate: Shared_Auxiliary_1097;
-    };
+  | Shared_Type_109
+  | Shared_Type_110
+  | Shared_Type_111
+  | Shared_Type_112
+  | Shared_Type_113
+  | Shared_Type_114;
 
-type Shared_Type_109 = {
+type Shared_Type_116 = {
   /** Transport type: stdio for local processes, http for remote servers */
   type: 'stdio' | 'http';
   /** Command to run (stdio only) */
@@ -2569,7 +2642,7 @@ type Shared_Type_109 = {
   timeout?: number | undefined;
 };
 
-type Shared_Type_110 = {
+type Shared_Type_117 = {
   id: string;
   /** MCP client status: draft, published, or archived */
   status: string;
@@ -2588,11 +2661,11 @@ type Shared_Type_110 = {
   description?: string | undefined;
   /** Map of server name to server configuration */
   servers: {
-    [key: string]: Shared_Type_109;
+    [key: string]: Shared_Type_116;
   };
 };
 
-type Shared_Type_111 = {
+type Shared_Type_118 = {
   type: 'stdio' | 'http';
   command?: string | undefined;
   args?: string[] | undefined;
@@ -2605,7 +2678,7 @@ type Shared_Type_111 = {
   timeout?: number | undefined;
 };
 
-type Shared_Type_112 = {
+type Shared_Type_119 = {
   /** Unique identifier for the version (UUID) */
   id: string;
   /** ID of the MCP client this version belongs to */
@@ -2617,7 +2690,7 @@ type Shared_Type_112 = {
   /** Description of the MCP client */
   description?: string | undefined;
   servers: {
-    [key: string]: Shared_Type_111;
+    [key: string]: Shared_Type_118;
   };
   /** Array of field names that changed from the previous version */
   changedFields?: string[] | undefined;
@@ -2627,7 +2700,7 @@ type Shared_Type_112 = {
   createdAt: Date;
 };
 
-type Shared_Type_113 = {
+type Shared_Type_120 = {
   id: string;
   /** Prompt block status: draft, published, or archived */
   status: string;
@@ -2658,7 +2731,7 @@ type Shared_Type_113 = {
     | undefined;
 };
 
-type Shared_Type_114 = {
+type Shared_Type_121 = {
   /** Unique identifier for the version (UUID) */
   id: string;
   /** ID of the prompt block this version belongs to */
@@ -2687,7 +2760,7 @@ type Shared_Type_114 = {
   createdAt: Date;
 };
 
-type Shared_Type_115 =
+type Shared_Type_122 =
   | 'llm-judge'
   | 'answer-relevancy'
   | 'answer-similarity'
@@ -2701,7 +2774,7 @@ type Shared_Type_115 =
   | 'tool-call-accuracy'
   | 'toxicity';
 
-type Shared_Type_116 = {
+type Shared_Type_123 = {
   id: string;
   /** Scorer status: draft, published, or archived */
   status: string;
@@ -2719,7 +2792,7 @@ type Shared_Type_116 = {
   /** Description of the scorer */
   description?: string | undefined;
   /** Scorer type: llm-judge for custom, or a preset type name */
-  type: Shared_Type_115;
+  type: Shared_Type_122;
   model?: Shared_Type_11 | undefined;
   /** System instructions for the judge LLM */
   instructions?: string | undefined;
@@ -2747,7 +2820,7 @@ type Shared_Type_116 = {
     | undefined;
 };
 
-type Shared_Type_117 =
+type Shared_Type_124 =
   | {
       /** Minimum score value (default: 0) */
       min?: number | undefined;
@@ -2756,7 +2829,7 @@ type Shared_Type_117 =
     }
   | undefined;
 
-type Shared_Type_118 = {
+type Shared_Type_125 = {
   /** Unique identifier for the version (UUID) */
   id: string;
   /** ID of the scorer this version belongs to */
@@ -2767,7 +2840,7 @@ type Shared_Type_118 = {
   name: string;
   /** Description of the scorer */
   description?: string | undefined;
-  type: Shared_Type_115;
+  type: Shared_Type_122;
   model?: Shared_Type_11 | undefined;
   instructions?: string | undefined;
   scoreRange?:
@@ -2800,7 +2873,7 @@ type Shared_Type_118 = {
   createdAt: Date;
 };
 
-type Shared_Type_119 = {
+type Shared_Type_126 = {
   id: string;
   /** Workspace status: draft, published, or archived */
   status: string;
@@ -2835,7 +2908,7 @@ type Shared_Type_119 = {
   operationTimeout?: number | undefined;
 };
 
-type Shared_Type_120 =
+type Shared_Type_127 =
   | {
       type: 'external';
       /** Package path for external source */
@@ -2852,7 +2925,7 @@ type Shared_Type_120 =
       mastraPath: string;
     };
 
-type Shared_Type_121 = {
+type Shared_Type_128 = {
   id: string;
   /** Skill status: draft, published, or archived */
   status: string;
@@ -2876,7 +2949,7 @@ type Shared_Type_121 = {
   /** Compatibility requirements */
   compatibility?: unknown | undefined;
   /** Source location of the skill */
-  source?: Shared_Type_120 | undefined;
+  source?: Shared_Type_127 | undefined;
   /** List of reference file paths */
   references?: string[] | undefined;
   /** List of script file paths */
@@ -2884,7 +2957,7 @@ type Shared_Type_121 = {
   /** List of asset file paths */
   assets?: string[] | undefined;
   /** Full file tree structure for the skill */
-  files?: Shared_Auxiliary_1238[] | undefined;
+  files?: Shared_Auxiliary_1230[] | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | {
@@ -2893,7 +2966,7 @@ type Shared_Type_121 = {
     | undefined;
 };
 
-type Shared_Type_122 = {
+type Shared_Type_129 = {
   id: string;
   name: string;
   description?: (string | undefined) | null;
@@ -2929,7 +3002,7 @@ type Shared_Type_122 = {
   updatedAt: Date;
 };
 
-type Shared_Type_123 = {
+type Shared_Type_130 = {
   /** Name of the tool this mock applies to */
   toolName: string;
   /** Arguments to match against the tool call */
@@ -2942,14 +3015,14 @@ type Shared_Type_123 = {
   matchArgs?: ('strict' | 'ignore') | undefined;
 };
 
-type Shared_Type_124 = {
+type Shared_Type_131 = {
   /** How this item was created */
   type: 'csv' | 'json' | 'trace' | 'llm' | 'experiment-result' | 'candidate-screener';
   /** Reference identifier (e.g., trace id, csv filename) */
   referenceId?: string | undefined;
 };
 
-type Shared_Type_125 = {
+type Shared_Type_132 = {
   id: string;
   datasetId: string;
   datasetVersion: number;
@@ -2958,7 +3031,7 @@ type Shared_Type_125 = {
   groundTruth?: unknown | undefined;
   expectedTrajectory?: unknown | undefined;
   /** Ordered item-level static tool mocks served in place of executing the real tool */
-  toolMocks?: Shared_Type_123[] | undefined;
+  toolMocks?: Shared_Type_130[] | undefined;
   /** Policy for undeclared tool calls. 'allow' runs them live; 'deny' fails the experiment item */
   unmockedToolPolicy?: ('allow' | 'deny') | undefined;
   scorerIds?: string[] | undefined;
@@ -2973,12 +3046,12 @@ type Shared_Type_125 = {
       }
     | undefined;
   /** Source/provenance of this dataset item */
-  source?: Shared_Type_124 | undefined;
+  source?: Shared_Type_131 | undefined;
   createdAt: Date;
   updatedAt: Date;
 };
 
-type Shared_Type_126 = {
+type Shared_Type_133 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3003,7 +3076,7 @@ type Shared_Type_126 = {
   success?: boolean | undefined;
 };
 
-type Shared_Type_127 = {
+type Shared_Type_134 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3029,7 +3102,7 @@ type Shared_Type_127 = {
   success?: boolean | undefined;
 };
 
-type Shared_Type_128 = {
+type Shared_Type_135 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3047,7 +3120,7 @@ type Shared_Type_128 = {
   finishReason?: string | undefined;
 };
 
-type Shared_Type_129 = {
+type Shared_Type_136 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3062,7 +3135,7 @@ type Shared_Type_129 = {
   agentId?: string | undefined;
 };
 
-type Shared_Type_130 = {
+type Shared_Type_137 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3083,7 +3156,7 @@ type Shared_Type_130 = {
     | undefined;
 };
 
-type Shared_Type_131 = {
+type Shared_Type_138 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3099,7 +3172,7 @@ type Shared_Type_131 = {
   status?: string | undefined;
 };
 
-type Shared_Type_132 = {
+type Shared_Type_139 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3115,7 +3188,7 @@ type Shared_Type_132 = {
   selectedSteps?: string[] | undefined;
 };
 
-type Shared_Type_133 = {
+type Shared_Type_140 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3131,7 +3204,7 @@ type Shared_Type_133 = {
   parallelSteps?: string[] | undefined;
 };
 
-type Shared_Type_134 = {
+type Shared_Type_141 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3147,7 +3220,7 @@ type Shared_Type_134 = {
   totalIterations?: number | undefined;
 };
 
-type Shared_Type_135 = {
+type Shared_Type_142 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3163,7 +3236,7 @@ type Shared_Type_135 = {
   sleepType?: string | undefined;
 };
 
-type Shared_Type_136 = {
+type Shared_Type_143 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3179,7 +3252,7 @@ type Shared_Type_136 = {
   eventReceived?: boolean | undefined;
 };
 
-type Shared_Type_137 = {
+type Shared_Type_144 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3194,21 +3267,21 @@ type Shared_Type_137 = {
   processorId?: string | undefined;
 };
 
-type Shared_Type_138 =
-  | Shared_Type_126
-  | Shared_Type_127
-  | Shared_Type_128
-  | Shared_Type_129
-  | Shared_Type_130
-  | Shared_Type_131
-  | Shared_Type_132
+type Shared_Type_145 =
   | Shared_Type_133
   | Shared_Type_134
   | Shared_Type_135
   | Shared_Type_136
-  | Shared_Type_137;
+  | Shared_Type_137
+  | Shared_Type_138
+  | Shared_Type_139
+  | Shared_Type_140
+  | Shared_Type_141
+  | Shared_Type_142
+  | Shared_Type_143
+  | Shared_Type_144;
 
-type Shared_Type_139 = {
+type Shared_Type_146 = {
   /** Step name to match */
   name: string;
   durationMs?: number | undefined;
@@ -3222,9 +3295,9 @@ type Shared_Type_139 = {
   stepType?: undefined | undefined;
 };
 
-type Shared_Type_140 = {
+type Shared_Type_147 = {
   /** Expected steps for accuracy checking */
-  steps?: (Shared_Type_138 | Shared_Type_139)[] | undefined;
+  steps?: (Shared_Type_145 | Shared_Type_146)[] | undefined;
   /** How to compare step ordering (default: relaxed) */
   ordering?: ('strict' | 'relaxed' | 'unordered') | undefined;
   /** Whether to allow repeated steps (default: true) */
@@ -3245,7 +3318,7 @@ type Shared_Type_140 = {
   maxRetriesPerTool?: number | undefined;
 };
 
-type Shared_Type_141 = {
+type Shared_Type_148 = {
   source?: string | undefined;
   sourceId?: string | undefined;
   sourceVersion?: string | undefined;
@@ -3256,7 +3329,7 @@ type Shared_Type_141 = {
     | undefined;
 };
 
-type Shared_Type_142 = {
+type Shared_Type_149 = {
   id: string;
   datasetId: string | null;
   datasetVersion: number | null;
@@ -3271,7 +3344,7 @@ type Shared_Type_142 = {
         [key: string]: unknown;
       }
     | undefined;
-  provenance?: (Shared_Type_141 | null) | undefined;
+  provenance?: (Shared_Type_148 | null) | undefined;
   runnerAttestation?:
     | ({
         runnerId: string;
@@ -3294,7 +3367,7 @@ type Shared_Type_142 = {
   updatedAt: Date;
 };
 
-type Shared_Type_143 = {
+type Shared_Type_150 = {
   served: {
     mockIndex: number;
     toolName: string;
@@ -3318,7 +3391,7 @@ type Shared_Type_143 = {
     | undefined;
 };
 
-type Shared_Type_144 = {
+type Shared_Type_151 = {
   id: string;
   experimentId: string;
   itemId: string;
@@ -3349,11 +3422,11 @@ type Shared_Type_144 = {
   tags?: (string[] | null) | undefined;
   comment?: (string | null) | undefined;
   /** Diagnostic receipt for item-level tool mocks */
-  toolMockReport?: (Shared_Type_143 | undefined) | null;
+  toolMockReport?: (Shared_Type_150 | undefined) | null;
   createdAt: Date;
 };
 
-type Shared_Type_145 = {
+type Shared_Type_152 = {
   id: string;
   status: 'pending' | 'running' | 'suspended' | 'completed' | 'failed' | 'cancelled' | 'timed_out';
   toolName: string;
@@ -3381,7 +3454,7 @@ type Shared_Type_145 = {
   suspendPayload?: unknown | undefined;
 };
 
-type Shared_Type_146 =
+type Shared_Type_153 =
   | {
       kind: 'custom';
       provider: string;
@@ -3392,7 +3465,7 @@ type Shared_Type_146 =
       modelId?: string | undefined;
     };
 
-type Shared_Type_147 =
+type Shared_Type_154 =
   | {
       kind: 'custom';
       provider: string;
@@ -3403,7 +3476,7 @@ type Shared_Type_147 =
       modelId: string;
     };
 
-type Shared_Type_148 = {
+type Shared_Type_155 = {
   behavior?: ('deliver' | 'persist' | 'discard') | undefined;
   attributes?:
     | {
@@ -3412,7 +3485,7 @@ type Shared_Type_148 = {
     | undefined;
 };
 
-type Shared_Type_149 = {
+type Shared_Type_156 = {
   behavior?: ('wake' | 'persist' | 'discard') | undefined;
   attributes?:
     | {
@@ -3430,7 +3503,7 @@ type Shared_Type_149 = {
     | undefined;
 };
 
-type Shared_Type_150 = {
+type Shared_Type_157 = {
   id: string;
   agentId: string;
   workflowId?: undefined | undefined;
@@ -3452,8 +3525,8 @@ type Shared_Type_150 = {
         [key: string]: (string | number | boolean | null) | undefined;
       }
     | undefined;
-  ifActive?: Shared_Type_148 | undefined;
-  ifIdle?: Shared_Type_149 | undefined;
+  ifActive?: Shared_Type_155 | undefined;
+  ifIdle?: Shared_Type_156 | undefined;
   providerOptions?:
     | {
         [key: string]: unknown;
@@ -3468,7 +3541,7 @@ type Shared_Type_150 = {
   updatedAt: number;
 };
 
-type Shared_Type_151 = {
+type Shared_Type_158 = {
   status:
     | 'running'
     | 'success'
@@ -3487,7 +3560,7 @@ type Shared_Type_151 = {
   error?: string | undefined;
 };
 
-type Shared_Type_152 = {
+type Shared_Type_159 = {
   id: string;
   workflowId: string;
   agentId?: undefined | undefined;
@@ -3497,7 +3570,7 @@ type Shared_Type_152 = {
   nextFireAt: number;
   lastFireAt?: number | undefined;
   lastRunId?: string | undefined;
-  lastRun?: Shared_Type_151 | undefined;
+  lastRun?: Shared_Type_158 | undefined;
   inputData?: unknown | undefined;
   initialState?: unknown | undefined;
   requestContext?:
@@ -5660,7 +5733,7 @@ export interface GetAuthPermissionPatterns_RouteContract {
 export type GetWorkflows_QueryParams = GetAgents_QueryParams;
 
 export type GetWorkflows_Response = {
-  [key: string]: Shared_Type_58;
+  [key: string]: Shared_Type_59;
 };
 
 export type GetWorkflows_Request = Simplify<
@@ -5715,7 +5788,7 @@ export type GetWorkflowsWorkflowId_PathParams = {
   workflowId: string;
 };
 
-export type GetWorkflowsWorkflowId_Response = Shared_Type_58;
+export type GetWorkflowsWorkflowId_Response = Shared_Type_59;
 
 export type GetWorkflowsWorkflowId_Request = Simplify<
   (GetWorkflowsWorkflowId_PathParams extends never ? {} : { params: GetWorkflowsWorkflowId_PathParams }) &
@@ -5850,23 +5923,7 @@ export type GetWorkflowsWorkflowIdRunsRunId_Response = {
         [key: string]: number[];
       }
     | undefined;
-  serializedStepGraph?:
-    | {
-        type:
-          | 'step'
-          | 'agent'
-          | 'tool'
-          | 'mapping'
-          | 'sleep'
-          | 'sleepUntil'
-          | 'waitForEvent'
-          | 'parallel'
-          | 'conditional'
-          | 'loop'
-          | 'foreach'
-          | 'workflow';
-      }[]
-    | undefined;
+  serializedStepGraph?: Shared_Type_58[] | undefined;
 };
 
 export type GetWorkflowsWorkflowIdRunsRunId_Request = Simplify<
@@ -6101,23 +6158,7 @@ export type PostWorkflowsWorkflowIdStartAsync_Response = {
         [key: string]: number[];
       }
     | undefined;
-  serializedStepGraph?:
-    | {
-        type:
-          | 'step'
-          | 'agent'
-          | 'tool'
-          | 'mapping'
-          | 'sleep'
-          | 'sleepUntil'
-          | 'waitForEvent'
-          | 'parallel'
-          | 'conditional'
-          | 'loop'
-          | 'foreach'
-          | 'workflow';
-      }[]
-    | undefined;
+  serializedStepGraph?: Shared_Type_58[] | undefined;
 };
 
 export type PostWorkflowsWorkflowIdStartAsync_Request = Simplify<
@@ -6847,7 +6888,7 @@ export type PostProcessorsProcessorIdExecute_PathParams = GetProcessorsProcessor
 
 export type PostProcessorsProcessorIdExecute_Body = {
   phase: 'input' | 'inputStep' | 'outputStream' | 'outputResult' | 'outputStep' | 'toolResult';
-  messages: Shared_Type_59[];
+  messages: Shared_Type_60[];
   agentId?: string | undefined;
   requestContext?:
     | {
@@ -6859,10 +6900,10 @@ export type PostProcessorsProcessorIdExecute_Body = {
 export type PostProcessorsProcessorIdExecute_Response = {
   success: boolean;
   phase: string;
-  messages?: Shared_Type_59[] | undefined;
+  messages?: Shared_Type_60[] | undefined;
   messageList?:
     | {
-        messages: Shared_Type_59[];
+        messages: Shared_Type_60[];
       }
     | undefined;
   tripwire?:
@@ -6924,13 +6965,13 @@ export type PostV1Responses_Body = {
               /** Requests JSON object output compatibility for the response */
               type: 'json_object';
             }
-          | Shared_Type_60;
+          | Shared_Type_61;
       }
     | undefined;
   /** Optional conversation ID. In Mastra this is the raw threadId. */
   conversation_id?: string | undefined;
   /** Optional provider-specific options passed through to the underlying model call */
-  providerOptions?: Shared_Type_61 | undefined;
+  providerOptions?: Shared_Type_62 | undefined;
   stream: boolean | undefined;
   store: boolean | undefined;
   previous_response_id?: string | undefined;
@@ -6957,7 +6998,7 @@ export type PostV1Responses_Response = {
           logprobs?: unknown[] | undefined;
         }[];
       }
-    | Shared_Type_62
+    | Shared_Type_63
     | {
         id: string;
         type: 'function_call_output';
@@ -6990,12 +7031,12 @@ export type PostV1Responses_Response = {
               /** Requests JSON object output compatibility for the response */
               type: 'json_object';
             }
-          | Shared_Type_60;
+          | Shared_Type_61;
       } | null)
     | undefined;
   previous_response_id?: (string | null) | undefined;
   conversation_id?: (string | null) | undefined;
-  providerOptions?: Shared_Type_61 | undefined;
+  providerOptions?: Shared_Type_62 | undefined;
   tools?:
     | {
         type: 'function';
@@ -7098,7 +7139,7 @@ export type PostV1Conversations_Body = {
 export type PostV1Conversations_Response = {
   id: string;
   object: 'conversation';
-  thread: Shared_Type_63;
+  thread: Shared_Type_64;
 };
 
 export type PostV1Conversations_Request = Simplify<
@@ -7173,7 +7214,7 @@ export type GetV1ConversationsConversationIdItems_Response = {
             }
         )[];
       }
-    | Shared_Type_62
+    | Shared_Type_63
     | {
         id: string;
         type: 'function_call_output';
@@ -7373,8 +7414,8 @@ export type GetMemoryObservationalMemory_QueryParams = {
 };
 
 export type GetMemoryObservationalMemory_Response = {
-  record: Shared_Type_65 | null;
-  history?: Shared_Type_65[] | undefined;
+  record: Shared_Type_66 | null;
+  history?: Shared_Type_66[] | undefined;
 };
 
 export type GetMemoryObservationalMemory_Request = Simplify<
@@ -7402,7 +7443,7 @@ export interface GetMemoryObservationalMemory_RouteContract {
 export type PostMemoryObservationalMemoryBufferStatus_Body = GetMemoryStatus_QueryParams;
 
 export type PostMemoryObservationalMemoryBufferStatus_Response = {
-  record: Shared_Type_65 | null;
+  record: Shared_Type_66 | null;
 };
 
 export type PostMemoryObservationalMemoryBufferStatus_Request = Simplify<
@@ -7453,7 +7494,7 @@ export type GetMemoryThreads_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  threads: Shared_Type_63[];
+  threads: Shared_Type_64[];
 };
 
 export type GetMemoryThreads_Request = Simplify<
@@ -7488,7 +7529,7 @@ export type GetMemoryThreadsThreadId_QueryParams = {
   resourceId?: string | undefined;
 };
 
-export type GetMemoryThreadsThreadId_Response = Shared_Type_63;
+export type GetMemoryThreadsThreadId_Response = Shared_Type_64;
 
 export type GetMemoryThreadsThreadId_Request = Simplify<
   (GetMemoryThreadsThreadId_PathParams extends never ? {} : { params: GetMemoryThreadsThreadId_PathParams }) &
@@ -7536,7 +7577,7 @@ export type GetMemoryThreadsThreadIdMessages_QueryParams = {
         withNextMessages?: number | undefined;
       }[]
     | undefined;
-  filter?: Shared_Type_66 | undefined;
+  filter?: Shared_Type_67 | undefined;
   includeSystemReminders?: boolean | undefined;
 };
 
@@ -7790,7 +7831,7 @@ export type PostMemoryThreadsThreadIdClone_Body = {
 };
 
 export type PostMemoryThreadsThreadIdClone_Response = {
-  thread: Shared_Type_63;
+  thread: Shared_Type_64;
   clonedMessages: unknown[];
 };
 
@@ -8060,7 +8101,7 @@ export type GetMemoryNetworkThreadsThreadIdMessages_QueryParams = {
         withNextMessages?: number | undefined;
       }[]
     | undefined;
-  filter?: Shared_Type_66 | undefined;
+  filter?: Shared_Type_67 | undefined;
 };
 
 export type GetMemoryNetworkThreadsThreadIdMessages_Response = GetMemoryThreadsThreadIdMessages_Response;
@@ -8252,7 +8293,7 @@ export interface PostMemoryNetworkMessagesDelete_RouteContract {
 // Route: GET /scores/scorers
 // ============================================================================
 export type GetScoresScorers_Response = {
-  [key: string]: Shared_Type_68;
+  [key: string]: Shared_Type_69;
 };
 
 export type GetScoresScorers_Request = Simplify<
@@ -8278,7 +8319,7 @@ export type GetScoresScorersScorerId_PathParams = {
   scorerId: string;
 };
 
-export type GetScoresScorersScorerId_Response = Shared_Type_68 | null;
+export type GetScoresScorersScorerId_Response = Shared_Type_69 | null;
 
 export type GetScoresScorersScorerId_Request = Simplify<
   (GetScoresScorersScorerId_PathParams extends never ? {} : { params: GetScoresScorersScorerId_PathParams }) &
@@ -8434,18 +8475,18 @@ export interface PostScores_RouteContract {
 // Route: GET /observability/traces
 // ============================================================================
 export type GetObservabilityTraces_QueryParams = {
-  startedAt?: ((Shared_Type_69 | undefined) | undefined) | unknown;
-  endedAt?: ((Shared_Type_69 | undefined) | undefined) | unknown;
-  spanType?: (Shared_Type_70 | undefined) | undefined;
+  startedAt?: ((Shared_Type_70 | undefined) | undefined) | unknown;
+  endedAt?: ((Shared_Type_70 | undefined) | undefined) | unknown;
+  spanType?: (Shared_Type_71 | undefined) | undefined;
   /** Filter by trace ID (matches root span) */
   traceId?: (string | undefined) | undefined;
-  entityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  entityType?: ((Shared_Type_72 | null) | undefined) | undefined;
   entityId?: ((string | null) | undefined) | undefined;
   entityName?: ((string | null) | undefined) | undefined;
-  parentEntityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  parentEntityType?: ((Shared_Type_72 | null) | undefined) | undefined;
   parentEntityId?: ((string | null) | undefined) | undefined;
   parentEntityName?: ((string | null) | undefined) | undefined;
-  rootEntityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  rootEntityType?: ((Shared_Type_72 | null) | undefined) | undefined;
   rootEntityId?: ((string | null) | undefined) | undefined;
   rootEntityName?: ((string | null) | undefined) | undefined;
   userId?: ((string | null) | undefined) | undefined;
@@ -8487,7 +8528,7 @@ export type GetObservabilityTraces_QueryParams = {
   tags?: (((string[] | null) | undefined) | undefined) | unknown;
   status?: (('success' | 'error' | 'running') | undefined) | undefined;
   hasChildError?: (boolean | undefined) | undefined;
-  dateRange?: ((Shared_Type_69 | undefined) | undefined) | unknown;
+  dateRange?: ((Shared_Type_70 | undefined) | undefined) | unknown;
   name?: (string | undefined) | undefined;
   page?: (number | undefined) | undefined;
   perPage?: (number | undefined) | undefined;
@@ -8502,12 +8543,12 @@ export type GetObservabilityTraces_QueryParams = {
 };
 
 export type GetObservabilityTraces_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_73 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_74 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
-  spans: Shared_Type_74[];
+  spans: Shared_Type_75[];
 };
 
 export type GetObservabilityTraces_Request = Simplify<
@@ -8535,12 +8576,12 @@ export interface GetObservabilityTraces_RouteContract {
 export type GetObservabilityTracesLight_QueryParams = GetObservabilityTraces_QueryParams;
 
 export type GetObservabilityTracesLight_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_73 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_74 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
-  spans: Shared_Type_75[];
+  spans: Shared_Type_76[];
 };
 
 export type GetObservabilityTracesLight_Request = Simplify<
@@ -8566,18 +8607,18 @@ export interface GetObservabilityTracesLight_RouteContract {
 // Route: GET /observability/branches
 // ============================================================================
 export type GetObservabilityBranches_QueryParams = {
-  startedAt?: ((Shared_Type_69 | undefined) | undefined) | unknown;
-  endedAt?: ((Shared_Type_69 | undefined) | undefined) | unknown;
-  spanType?: (Shared_Type_70 | undefined) | undefined;
+  startedAt?: ((Shared_Type_70 | undefined) | undefined) | unknown;
+  endedAt?: ((Shared_Type_70 | undefined) | undefined) | unknown;
+  spanType?: (Shared_Type_71 | undefined) | undefined;
   /** Filter by parent trace ID */
   traceId?: (string | undefined) | undefined;
-  entityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  entityType?: ((Shared_Type_72 | null) | undefined) | undefined;
   entityId?: ((string | null) | undefined) | undefined;
   entityName?: ((string | null) | undefined) | undefined;
-  parentEntityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  parentEntityType?: ((Shared_Type_72 | null) | undefined) | undefined;
   parentEntityId?: ((string | null) | undefined) | undefined;
   parentEntityName?: ((string | null) | undefined) | undefined;
-  rootEntityType?: ((Shared_Type_71 | null) | undefined) | undefined;
+  rootEntityType?: ((Shared_Type_72 | null) | undefined) | undefined;
   rootEntityId?: ((string | null) | undefined) | undefined;
   rootEntityName?: ((string | null) | undefined) | undefined;
   userId?: ((string | null) | undefined) | undefined;
@@ -8631,12 +8672,12 @@ export type GetObservabilityBranches_QueryParams = {
 };
 
 export type GetObservabilityBranches_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_73 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_74 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
-  branches: Shared_Type_74[];
+  branches: Shared_Type_75[];
 };
 
 export type GetObservabilityBranches_Request = Simplify<
@@ -8676,7 +8717,7 @@ export type GetObservabilityTracesTraceIdBranchesSpanId_QueryParams = {
 export type GetObservabilityTracesTraceIdBranchesSpanId_Response = {
   /** Unique trace identifier */
   traceId: string;
-  spans: Shared_Type_76[];
+  spans: Shared_Type_77[];
 };
 
 export type GetObservabilityTracesTraceIdBranchesSpanId_Request = Simplify<
@@ -8711,7 +8752,7 @@ export type GetObservabilityTracesTraceId_PathParams = {
 export type GetObservabilityTracesTraceId_Response = {
   /** Unique trace identifier */
   traceId: string;
-  spans: Shared_Type_74[];
+  spans: Shared_Type_75[];
 };
 
 export type GetObservabilityTracesTraceId_Request = Simplify<
@@ -8737,7 +8778,7 @@ export type GetObservabilityTracesTraceIdLight_PathParams = GetObservabilityTrac
 export type GetObservabilityTracesTraceIdLight_Response = {
   /** Unique trace identifier */
   traceId: string;
-  spans: Shared_Type_75[];
+  spans: Shared_Type_76[];
 };
 
 export type GetObservabilityTracesTraceIdLight_Request = Simplify<
@@ -8765,7 +8806,7 @@ export type GetObservabilityTracesTraceIdSpansSpanId_PathParams =
 
 export type GetObservabilityTracesTraceIdSpansSpanId_Response = {
   /** Span record data */
-  span: Shared_Type_76;
+  span: Shared_Type_77;
 };
 
 export type GetObservabilityTracesTraceIdSpansSpanId_Request = Simplify<
@@ -8866,7 +8907,7 @@ export type GetObservabilityTracesTraceIdSpanIdScores_QueryParams = {
 };
 
 export type GetObservabilityTracesTraceIdSpanIdScores_Response = {
-  pagination: Shared_Type_72;
+  pagination: Shared_Type_73;
   scores: {
     id: string;
     scorerId: string;
@@ -9000,12 +9041,12 @@ export interface GetObservabilityTracesTraceIdSpanIdScores_RouteContract {
 // Route: GET /observability/metrics
 // ============================================================================
 export type GetObservabilityMetrics_QueryParams = {
-  timestamp?: ((Shared_Type_69 | undefined) | undefined) | unknown;
+  timestamp?: ((Shared_Type_70 | undefined) | undefined) | unknown;
   /** Filter by trace ID */
   traceId?: (string | undefined) | undefined;
   /** Filter by span ID */
   spanId?: (string | undefined) | undefined;
-  entityType?: (Shared_Type_71 | undefined) | undefined;
+  entityType?: (Shared_Type_72 | undefined) | undefined;
   entityName?: (string | undefined) | undefined;
   entityVersionId?: (string | undefined) | undefined;
   parentEntityVersionId?: (string | undefined) | undefined;
@@ -9015,9 +9056,9 @@ export type GetObservabilityMetrics_QueryParams = {
   experimentId?: (string | undefined) | undefined;
   serviceName?: (string | undefined) | undefined;
   environment?: (string | undefined) | undefined;
-  parentEntityType?: (Shared_Type_71 | undefined) | undefined;
+  parentEntityType?: (Shared_Type_72 | undefined) | undefined;
   parentEntityName?: (string | undefined) | undefined;
-  rootEntityType?: (Shared_Type_71 | undefined) | undefined;
+  rootEntityType?: (Shared_Type_72 | undefined) | undefined;
   rootEntityName?: (string | undefined) | undefined;
   resourceId?: (string | undefined) | undefined;
   runId?: (string | undefined) | undefined;
@@ -9057,9 +9098,9 @@ export type GetObservabilityMetrics_QueryParams = {
 };
 
 export type GetObservabilityMetrics_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_73 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_74 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
   metrics: {
@@ -9073,13 +9114,13 @@ export type GetObservabilityMetrics_Response = {
     value: number;
     traceId?: (string | null) | undefined;
     spanId?: (string | null) | undefined;
-    entityType?: (Shared_Type_71 | null) | undefined;
+    entityType?: (Shared_Type_72 | null) | undefined;
     entityId?: (string | null) | undefined;
     entityName?: (string | null) | undefined;
-    parentEntityType?: (Shared_Type_71 | null) | undefined;
+    parentEntityType?: (Shared_Type_72 | null) | undefined;
     parentEntityId?: (string | null) | undefined;
     parentEntityName?: (string | null) | undefined;
-    rootEntityType?: (Shared_Type_71 | null) | undefined;
+    rootEntityType?: (Shared_Type_72 | null) | undefined;
     rootEntityId?: (string | null) | undefined;
     rootEntityName?: (string | null) | undefined;
     userId?: (string | null) | undefined;
@@ -9154,12 +9195,12 @@ export interface GetObservabilityMetrics_RouteContract {
 // Route: GET /observability/logs
 // ============================================================================
 export type GetObservabilityLogs_QueryParams = {
-  timestamp?: ((Shared_Type_69 | undefined) | undefined) | unknown;
+  timestamp?: ((Shared_Type_70 | undefined) | undefined) | unknown;
   /** Filter by trace ID */
   traceId?: (string | undefined) | undefined;
   /** Filter by span ID */
   spanId?: (string | undefined) | undefined;
-  entityType?: (Shared_Type_71 | undefined) | undefined;
+  entityType?: (Shared_Type_72 | undefined) | undefined;
   entityName?: (string | undefined) | undefined;
   entityVersionId?: (string | undefined) | undefined;
   parentEntityVersionId?: (string | undefined) | undefined;
@@ -9169,9 +9210,9 @@ export type GetObservabilityLogs_QueryParams = {
   experimentId?: (string | undefined) | undefined;
   serviceName?: (string | undefined) | undefined;
   environment?: (string | undefined) | undefined;
-  parentEntityType?: (Shared_Type_71 | undefined) | undefined;
+  parentEntityType?: (Shared_Type_72 | undefined) | undefined;
   parentEntityName?: (string | undefined) | undefined;
-  rootEntityType?: (Shared_Type_71 | undefined) | undefined;
+  rootEntityType?: (Shared_Type_72 | undefined) | undefined;
   rootEntityName?: (string | undefined) | undefined;
   resourceId?: (string | undefined) | undefined;
   runId?: (string | undefined) | undefined;
@@ -9202,9 +9243,9 @@ export type GetObservabilityLogs_QueryParams = {
 };
 
 export type GetObservabilityLogs_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_73 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_74 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
   logs: {
@@ -9223,13 +9264,13 @@ export type GetObservabilityLogs_Response = {
       | undefined;
     traceId?: (string | null) | undefined;
     spanId?: (string | null) | undefined;
-    entityType?: (Shared_Type_71 | null) | undefined;
+    entityType?: (Shared_Type_72 | null) | undefined;
     entityId?: (string | null) | undefined;
     entityName?: (string | null) | undefined;
-    parentEntityType?: (Shared_Type_71 | null) | undefined;
+    parentEntityType?: (Shared_Type_72 | null) | undefined;
     parentEntityId?: (string | null) | undefined;
     parentEntityName?: (string | null) | undefined;
-    rootEntityType?: (Shared_Type_71 | null) | undefined;
+    rootEntityType?: (Shared_Type_72 | null) | undefined;
     rootEntityId?: (string | null) | undefined;
     rootEntityName?: (string | null) | undefined;
     userId?: (string | null) | undefined;
@@ -9285,12 +9326,12 @@ export interface GetObservabilityLogs_RouteContract {
 // Route: GET /observability/scores
 // ============================================================================
 export type GetObservabilityScores_QueryParams = {
-  timestamp?: ((Shared_Type_69 | undefined) | undefined) | unknown;
+  timestamp?: ((Shared_Type_70 | undefined) | undefined) | unknown;
   /** Filter by trace ID */
   traceId?: (string | undefined) | undefined;
   /** Filter by span ID */
   spanId?: (string | undefined) | undefined;
-  entityType?: (Shared_Type_71 | undefined) | undefined;
+  entityType?: (Shared_Type_72 | undefined) | undefined;
   entityName?: (string | undefined) | undefined;
   entityVersionId?: (string | undefined) | undefined;
   parentEntityVersionId?: (string | undefined) | undefined;
@@ -9300,9 +9341,9 @@ export type GetObservabilityScores_QueryParams = {
   experimentId?: (string | undefined) | undefined;
   serviceName?: (string | undefined) | undefined;
   environment?: (string | undefined) | undefined;
-  parentEntityType?: (Shared_Type_71 | undefined) | undefined;
+  parentEntityType?: (Shared_Type_72 | undefined) | undefined;
   parentEntityName?: (string | undefined) | undefined;
-  rootEntityType?: (Shared_Type_71 | undefined) | undefined;
+  rootEntityType?: (Shared_Type_72 | undefined) | undefined;
   rootEntityName?: (string | undefined) | undefined;
   resourceId?: (string | undefined) | undefined;
   runId?: (string | undefined) | undefined;
@@ -9341,12 +9382,12 @@ export type GetObservabilityScores_QueryParams = {
 };
 
 export type GetObservabilityScores_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_73 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_74 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
-  scores: Shared_Type_77[];
+  scores: Shared_Type_78[];
 };
 
 export type GetObservabilityScores_Request = Simplify<
@@ -9388,13 +9429,13 @@ export type PostObservabilityScores_Body = {
     /** Score value (range defined by scorer) */
     score: number;
     reason?: (string | null) | undefined;
-    entityType?: (Shared_Type_71 | null) | undefined;
+    entityType?: (Shared_Type_72 | null) | undefined;
     entityId?: (string | null) | undefined;
     entityName?: (string | null) | undefined;
-    parentEntityType?: (Shared_Type_71 | null) | undefined;
+    parentEntityType?: (Shared_Type_72 | null) | undefined;
     parentEntityId?: (string | null) | undefined;
     parentEntityName?: (string | null) | undefined;
-    rootEntityType?: (Shared_Type_71 | null) | undefined;
+    rootEntityType?: (Shared_Type_72 | null) | undefined;
     rootEntityId?: (string | null) | undefined;
     rootEntityName?: (string | null) | undefined;
     userId?: (string | null) | undefined;
@@ -9458,7 +9499,7 @@ export type GetObservabilityScoresScoreId_PathParams = {
 
 export type GetObservabilityScoresScoreId_Response = {
   /** Score record as stored in the database */
-  score: Shared_Type_77 | null;
+  score: Shared_Type_78 | null;
 };
 
 export type GetObservabilityScoresScoreId_Request = Simplify<
@@ -9487,7 +9528,7 @@ export type PostObservabilityScoresAggregate_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying scores */
-  filters?: Shared_Type_78 | undefined;
+  filters?: Shared_Type_79 | undefined;
   /** Comparison period for aggregate queries */
   comparePeriod?: ('previous_period' | 'previous_day' | 'previous_week') | undefined;
 };
@@ -9533,7 +9574,7 @@ export type PostObservabilityScoresBreakdown_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying scores */
-  filters?: Shared_Type_78 | undefined;
+  filters?: Shared_Type_79 | undefined;
 };
 
 export type PostObservabilityScoresBreakdown_Response = {
@@ -9579,7 +9620,7 @@ export type PostObservabilityScoresTimeseries_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying scores */
-  filters?: Shared_Type_78 | undefined;
+  filters?: Shared_Type_79 | undefined;
   /** Fields to group by */
   groupBy?: string[] | undefined;
 };
@@ -9629,7 +9670,7 @@ export type PostObservabilityScoresPercentiles_Body = {
   /** Time bucket interval */
   interval: '1m' | '5m' | '15m' | '1h' | '1d';
   /** Filters for querying scores */
-  filters?: Shared_Type_78 | undefined;
+  filters?: Shared_Type_79 | undefined;
 };
 
 export type PostObservabilityScoresPercentiles_Response = {
@@ -9668,12 +9709,12 @@ export interface PostObservabilityScoresPercentiles_RouteContract {
 // Route: GET /observability/feedback
 // ============================================================================
 export type GetObservabilityFeedback_QueryParams = {
-  timestamp?: ((Shared_Type_69 | undefined) | undefined) | unknown;
+  timestamp?: ((Shared_Type_70 | undefined) | undefined) | unknown;
   /** Filter by trace ID */
   traceId?: (string | undefined) | undefined;
   /** Filter by span ID */
   spanId?: (string | undefined) | undefined;
-  entityType?: (Shared_Type_71 | undefined) | undefined;
+  entityType?: (Shared_Type_72 | undefined) | undefined;
   entityName?: (string | undefined) | undefined;
   entityVersionId?: (string | undefined) | undefined;
   parentEntityVersionId?: (string | undefined) | undefined;
@@ -9683,9 +9724,9 @@ export type GetObservabilityFeedback_QueryParams = {
   experimentId?: (string | undefined) | undefined;
   serviceName?: (string | undefined) | undefined;
   environment?: (string | undefined) | undefined;
-  parentEntityType?: (Shared_Type_71 | undefined) | undefined;
+  parentEntityType?: (Shared_Type_72 | undefined) | undefined;
   parentEntityName?: (string | undefined) | undefined;
-  rootEntityType?: (Shared_Type_71 | undefined) | undefined;
+  rootEntityType?: (Shared_Type_72 | undefined) | undefined;
   rootEntityName?: (string | undefined) | undefined;
   resourceId?: (string | undefined) | undefined;
   runId?: (string | undefined) | undefined;
@@ -9713,12 +9754,12 @@ export type GetObservabilityFeedback_QueryParams = {
 };
 
 export type GetObservabilityFeedback_Response = {
-  pagination?: Shared_Type_72 | undefined;
+  pagination?: Shared_Type_73 | undefined;
   /** Incremental polling metadata */
-  delta?: Shared_Type_73 | undefined;
+  delta?: Shared_Type_74 | undefined;
   /** Opaque cursor value for incremental polling */
   deltaCursor?: string | undefined;
-  feedback: Shared_Type_79[];
+  feedback: Shared_Type_80[];
 };
 
 export type GetObservabilityFeedback_Request = Simplify<
@@ -9759,13 +9800,13 @@ export type PostObservabilityFeedback_Body = {
     value: number | string;
     comment?: (string | null) | undefined;
     feedbackUserId?: (string | null) | undefined;
-    entityType?: (Shared_Type_71 | null) | undefined;
+    entityType?: (Shared_Type_72 | null) | undefined;
     entityId?: (string | null) | undefined;
     entityName?: (string | null) | undefined;
-    parentEntityType?: (Shared_Type_71 | null) | undefined;
+    parentEntityType?: (Shared_Type_72 | null) | undefined;
     parentEntityId?: (string | null) | undefined;
     parentEntityName?: (string | null) | undefined;
-    rootEntityType?: (Shared_Type_71 | null) | undefined;
+    rootEntityType?: (Shared_Type_72 | null) | undefined;
     rootEntityId?: (string | null) | undefined;
     rootEntityName?: (string | null) | undefined;
     userId?: (string | null) | undefined;
@@ -9833,7 +9874,7 @@ export type PatchObservabilityFeedbackFeedbackIdReviewStatus_Body = {
   reviewStatus: 'needs-review' | 'reviewed';
 };
 
-export type PatchObservabilityFeedbackFeedbackIdReviewStatus_Response = Shared_Type_79;
+export type PatchObservabilityFeedbackFeedbackIdReviewStatus_Response = Shared_Type_80;
 
 export type PatchObservabilityFeedbackFeedbackIdReviewStatus_Request = Simplify<
   (PatchObservabilityFeedbackFeedbackIdReviewStatus_PathParams extends never
@@ -9867,7 +9908,7 @@ export type PostObservabilityFeedbackAggregate_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying feedback */
-  filters?: Shared_Type_80 | undefined;
+  filters?: Shared_Type_81 | undefined;
   /** Comparison period for aggregate queries */
   comparePeriod?: ('previous_period' | 'previous_day' | 'previous_week') | undefined;
 };
@@ -9906,7 +9947,7 @@ export type PostObservabilityFeedbackBreakdown_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying feedback */
-  filters?: Shared_Type_80 | undefined;
+  filters?: Shared_Type_81 | undefined;
 };
 
 export type PostObservabilityFeedbackBreakdown_Response = PostObservabilityScoresBreakdown_Response;
@@ -9943,7 +9984,7 @@ export type PostObservabilityFeedbackTimeseries_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Filters for querying feedback */
-  filters?: Shared_Type_80 | undefined;
+  filters?: Shared_Type_81 | undefined;
   /** Fields to group by */
   groupBy?: string[] | undefined;
 };
@@ -9993,7 +10034,7 @@ export type PostObservabilityFeedbackPercentiles_Body = {
   /** Time bucket interval */
   interval: '1m' | '5m' | '15m' | '1h' | '1d';
   /** Filters for querying feedback */
-  filters?: Shared_Type_80 | undefined;
+  filters?: Shared_Type_81 | undefined;
 };
 
 export type PostObservabilityFeedbackPercentiles_Response = PostObservabilityScoresPercentiles_Response;
@@ -10026,9 +10067,9 @@ export type PostObservabilityMetricsAggregate_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Column to apply count_distinct over (required when aggregation is 'count_distinct'). Restricted to allowlisted metric dimensions. */
-  distinctColumn?: Shared_Type_81 | undefined;
+  distinctColumn?: Shared_Type_82 | undefined;
   /** Filters for querying metrics */
-  filters?: Shared_Type_82 | undefined;
+  filters?: Shared_Type_83 | undefined;
   /** Comparison period for aggregate queries */
   comparePeriod?: ('previous_period' | 'previous_day' | 'previous_week') | undefined;
 };
@@ -10080,9 +10121,9 @@ export type PostObservabilityMetricsBreakdown_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Column to apply count_distinct over (required when aggregation is 'count_distinct'). Restricted to allowlisted metric dimensions. */
-  distinctColumn?: Shared_Type_81 | undefined;
+  distinctColumn?: Shared_Type_82 | undefined;
   /** Filters for querying metrics */
-  filters?: Shared_Type_82 | undefined;
+  filters?: Shared_Type_83 | undefined;
   /** Maximum number of groups to return (server-side TopK). Required for high-cardinality groupBy. */
   limit?: number | undefined;
   /** Sort direction for the aggregated value (defaults to 'DESC' at the storage layer; pairs with limit for top/bottom-N). */
@@ -10134,9 +10175,9 @@ export type PostObservabilityMetricsTimeseries_Body = {
   /** Aggregation function */
   aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   /** Column to apply count_distinct over (required when aggregation is 'count_distinct'). Restricted to allowlisted metric dimensions. */
-  distinctColumn?: Shared_Type_81 | undefined;
+  distinctColumn?: Shared_Type_82 | undefined;
   /** Filters for querying metrics */
-  filters?: Shared_Type_82 | undefined;
+  filters?: Shared_Type_83 | undefined;
   /** Fields to group by */
   groupBy?: string[] | undefined;
 };
@@ -10188,7 +10229,7 @@ export type PostObservabilityMetricsPercentiles_Body = {
   /** Time bucket interval */
   interval: '1m' | '5m' | '15m' | '1h' | '1d';
   /** Filters for querying metrics */
-  filters?: Shared_Type_82 | undefined;
+  filters?: Shared_Type_83 | undefined;
 };
 
 export type PostObservabilityMetricsPercentiles_Response = PostObservabilityScoresPercentiles_Response;
@@ -10321,7 +10362,7 @@ export interface GetObservabilityDiscoveryMetricLabelValues_RouteContract {
 // ============================================================================
 export type GetObservabilityDiscoveryEntityTypes_Response = {
   /** Distinct entity types */
-  entityTypes: Shared_Type_71[];
+  entityTypes: Shared_Type_72[];
 };
 
 export type GetObservabilityDiscoveryEntityTypes_Request = Simplify<
@@ -10344,7 +10385,7 @@ export interface GetObservabilityDiscoveryEntityTypes_RouteContract {
 // ============================================================================
 export type GetObservabilityDiscoveryEntityNames_QueryParams = {
   /** Optional entity type filter */
-  entityType?: (Shared_Type_71 | undefined) | undefined;
+  entityType?: (Shared_Type_72 | undefined) | undefined;
 };
 
 export type GetObservabilityDiscoveryEntityNames_Response = {
@@ -10881,13 +10922,13 @@ export type PostA2aAgentId_Body =
       jsonrpc: '2.0';
       id: string | number;
       method: 'message/send';
-      params: Shared_Type_93;
+      params: Shared_Type_94;
     }
   | {
       jsonrpc: '2.0';
       id: string | number;
       method: 'message/stream';
-      params: Shared_Type_93;
+      params: Shared_Type_94;
     }
   | {
       jsonrpc: '2.0';
@@ -10955,7 +10996,7 @@ export type PostA2aAgentId_Body =
       params: {
         /** Task id */
         taskId: string;
-        pushNotificationConfig: Shared_Type_91;
+        pushNotificationConfig: Shared_Type_92;
       };
     }
   | {
@@ -12298,7 +12339,7 @@ export type GetMcpServerIdTools_PathParams = {
 };
 
 export type GetMcpServerIdTools_Response = {
-  tools: Shared_Type_94[];
+  tools: Shared_Type_95[];
 };
 
 export type GetMcpServerIdTools_Request = Simplify<
@@ -12326,7 +12367,7 @@ export type GetMcpServerIdToolsToolId_PathParams = {
   toolId: string;
 };
 
-export type GetMcpServerIdToolsToolId_Response = Shared_Type_94;
+export type GetMcpServerIdToolsToolId_Response = Shared_Type_95;
 
 export type GetMcpServerIdToolsToolId_Request = Simplify<
   (GetMcpServerIdToolsToolId_PathParams extends never ? {} : { params: GetMcpServerIdToolsToolId_PathParams }) &
@@ -12659,19 +12700,19 @@ export type PostStoredAgentsStoredAgentIdExport_Body = {
       )
     | undefined;
   /** Tool keys mapped to per-tool config — static or conditional */
-  tools?: Shared_Type_95;
+  tools?: Shared_Type_96;
   /** Default options for generate/stream calls — static or conditional */
-  defaultOptions?: Shared_Type_96;
+  defaultOptions?: Shared_Type_97;
   /** Workflow keys with optional per-workflow config — static or conditional */
-  workflows?: Shared_Type_95;
+  workflows?: Shared_Type_96;
   /** Agent keys with optional per-agent config — static or conditional */
-  agents?: Shared_Type_95;
+  agents?: Shared_Type_96;
   /** Map of tool provider IDs to their tool configurations — static or conditional */
-  integrationTools?: Shared_Type_97;
+  integrationTools?: Shared_Type_98;
   /** Tool provider connections and per-tool config (provider-agnostic). Coexists with the deprecated `integrationTools` field. */
-  toolProviders?: Shared_Type_98;
+  toolProviders?: Shared_Type_99;
   /** Map of stored MCP client IDs to their tool configurations — static or conditional */
-  mcpClients?: Shared_Type_97;
+  mcpClients?: Shared_Type_98;
   /** Input processor graph — static or conditional */
   inputProcessors?: (Shared_Type_20 | undefined) | undefined;
   /** Output processor graph — static or conditional */
@@ -12693,7 +12734,7 @@ export type PostStoredAgentsStoredAgentIdExport_Body = {
       )
     | undefined;
   /** Scorer keys with optional sampling config — static or conditional */
-  scorers?: Shared_Type_99;
+  scorers?: Shared_Type_100;
   /** Skill IDs mapped to per-skill config — static or conditional */
   skills?:
     | (
@@ -12708,7 +12749,7 @@ export type PostStoredAgentsStoredAgentIdExport_Body = {
       )
     | undefined;
   /** Workspace reference (stored ID or inline config) — static or conditional */
-  workspace?: Shared_Type_100;
+  workspace?: Shared_Type_101;
   /** Browser configuration — object config, true (apply default), false/null (disable) */
   browser?: ((Shared_Type_41 | boolean | null) | undefined) | undefined;
   /** JSON Schema defining valid request context variables for conditional rule evaluation */
@@ -12788,19 +12829,19 @@ export type PostStoredAgentsStoredAgentIdChangeRequest_Body = {
       )
     | undefined;
   /** Tool keys mapped to per-tool config — static or conditional */
-  tools?: Shared_Type_95;
+  tools?: Shared_Type_96;
   /** Default options for generate/stream calls — static or conditional */
-  defaultOptions?: Shared_Type_96;
+  defaultOptions?: Shared_Type_97;
   /** Workflow keys with optional per-workflow config — static or conditional */
-  workflows?: Shared_Type_95;
+  workflows?: Shared_Type_96;
   /** Agent keys with optional per-agent config — static or conditional */
-  agents?: Shared_Type_95;
+  agents?: Shared_Type_96;
   /** Map of tool provider IDs to their tool configurations — static or conditional */
-  integrationTools?: Shared_Type_97;
+  integrationTools?: Shared_Type_98;
   /** Tool provider connections and per-tool config (provider-agnostic). Coexists with the deprecated `integrationTools` field. */
-  toolProviders?: Shared_Type_98;
+  toolProviders?: Shared_Type_99;
   /** Map of stored MCP client IDs to their tool configurations — static or conditional */
-  mcpClients?: Shared_Type_97;
+  mcpClients?: Shared_Type_98;
   /** Input processor graph — static or conditional */
   inputProcessors?: (Shared_Type_20 | undefined) | undefined;
   /** Output processor graph — static or conditional */
@@ -12822,7 +12863,7 @@ export type PostStoredAgentsStoredAgentIdChangeRequest_Body = {
       )
     | undefined;
   /** Scorer keys with optional sampling config — static or conditional */
-  scorers?: Shared_Type_99;
+  scorers?: Shared_Type_100;
   /** Skill IDs mapped to per-skill config — static or conditional */
   skills?:
     | (
@@ -12837,7 +12878,7 @@ export type PostStoredAgentsStoredAgentIdChangeRequest_Body = {
       )
     | undefined;
   /** Workspace reference (stored ID or inline config) — static or conditional */
-  workspace?: Shared_Type_100;
+  workspace?: Shared_Type_101;
   /** Browser configuration — object config, true (apply default), false/null (disable) */
   browser?: ((Shared_Type_41 | boolean | null) | undefined) | undefined;
   /** JSON Schema defining valid request context variables for conditional rule evaluation */
@@ -13475,7 +13516,7 @@ export type GetStoredAgentsAgentIdVersions_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  versions: Shared_Type_101[];
+  versions: Shared_Type_102[];
 };
 
 export type GetStoredAgentsAgentIdVersions_Request = Simplify<
@@ -13711,7 +13752,7 @@ export type GetStoredAgentsAgentIdVersionsCompare_QueryParams = {
 
 export type GetStoredAgentsAgentIdVersionsCompare_Response = {
   /** List of differences between versions */
-  diffs: Shared_Type_102[];
+  diffs: Shared_Type_103[];
   /** The source version */
   fromVersion: {
     /** Unique identifier for the version (UUID) */
@@ -14019,7 +14060,7 @@ export type GetStoredAgentsAgentIdVersionsVersionId_PathParams = {
   versionId: string;
 };
 
-export type GetStoredAgentsAgentIdVersionsVersionId_Response = Shared_Type_101;
+export type GetStoredAgentsAgentIdVersionsVersionId_Response = Shared_Type_102;
 
 export type GetStoredAgentsAgentIdVersionsVersionId_Request = Simplify<
   (GetStoredAgentsAgentIdVersionsVersionId_PathParams extends never
@@ -14315,7 +14356,7 @@ export type GetStoredWorkflows_QueryParams = {
 };
 
 export type GetStoredWorkflows_Response = {
-  workflows: Shared_Type_103[];
+  workflows: Shared_Type_104[];
   total: number;
 };
 
@@ -14369,7 +14410,7 @@ export type PostStoredWorkflows_Body = {
       }
     | undefined;
   /** Static workflow graph — ordered array of serialized step entries with all refs as ids. */
-  graph: Shared_Type_108[];
+  graph: Shared_Type_115[];
   /** Helper workflow definitions this workflow nests. Saved with it as one unit — the whole set is validated together, hydrated in derived dependency order, and rejected together, so a failed save never leaves orphaned helpers behind. Each helper becomes an ordinary dynamic workflow in its own right. */
   dependencies?:
     | {
@@ -14400,7 +14441,7 @@ export type PostStoredWorkflows_Body = {
             }
           | undefined;
         /** Static workflow graph — ordered array of serialized step entries with all refs as ids. */
-        graph: Shared_Type_108[];
+        graph: Shared_Type_115[];
       }[]
     | undefined;
 };
@@ -14439,7 +14480,7 @@ export type GetStoredWorkflowsDynamicWorkflowId_PathParams = {
   dynamicWorkflowId: string;
 };
 
-export type GetStoredWorkflowsDynamicWorkflowId_Response = Shared_Type_103;
+export type GetStoredWorkflowsDynamicWorkflowId_Response = Shared_Type_104;
 
 export type GetStoredWorkflowsDynamicWorkflowId_Request = Simplify<
   (GetStoredWorkflowsDynamicWorkflowId_PathParams extends never
@@ -14514,7 +14555,7 @@ export type GetStoredMcpClients_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  mcpClients: Shared_Type_110[];
+  mcpClients: Shared_Type_117[];
 };
 
 export type GetStoredMcpClients_Request = Simplify<
@@ -14546,7 +14587,7 @@ export type GetStoredMcpClientsStoredMCPClientId_PathParams = {
 
 export type GetStoredMcpClientsStoredMCPClientId_QueryParams = GetStoredAgentsStoredAgentId_QueryParams;
 
-export type GetStoredMcpClientsStoredMCPClientId_Response = Shared_Type_110;
+export type GetStoredMcpClientsStoredMCPClientId_Response = Shared_Type_117;
 
 export type GetStoredMcpClientsStoredMCPClientId_Request = Simplify<
   (GetStoredMcpClientsStoredMCPClientId_PathParams extends never
@@ -14589,7 +14630,7 @@ export type PostStoredMcpClients_Body = {
   description?: string | undefined;
   /** Map of server name to server configuration */
   servers: {
-    [key: string]: Shared_Type_109;
+    [key: string]: Shared_Type_116;
   };
 };
 
@@ -14636,7 +14677,7 @@ export type PatchStoredMcpClientsStoredMCPClientId_Body = {
   /** Map of server name to server configuration */
   servers?:
     | {
-        [key: string]: Shared_Type_109;
+        [key: string]: Shared_Type_116;
       }
     | undefined;
 };
@@ -14655,7 +14696,7 @@ export type PatchStoredMcpClientsStoredMCPClientId_Response =
       createdAt: Date;
       updatedAt: Date;
     }
-  | Shared_Type_110;
+  | Shared_Type_117;
 
 export type PatchStoredMcpClientsStoredMCPClientId_Request = Simplify<
   (PatchStoredMcpClientsStoredMCPClientId_PathParams extends never
@@ -14717,7 +14758,7 @@ export type GetStoredMcpClientsMcpClientIdVersions_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  versions: Shared_Type_112[];
+  versions: Shared_Type_119[];
 };
 
 export type GetStoredMcpClientsMcpClientIdVersions_Request = Simplify<
@@ -14758,7 +14799,7 @@ export type PostStoredMcpClientsMcpClientIdVersions_Response = {
   description?: (string | undefined) | undefined;
   servers?:
     | {
-        [key: string]: Shared_Type_111;
+        [key: string]: Shared_Type_118;
       }
     | undefined;
   /** Array of field names that changed from the previous version */
@@ -14800,7 +14841,7 @@ export type GetStoredMcpClientsMcpClientIdVersionsCompare_QueryParams =
 
 export type GetStoredMcpClientsMcpClientIdVersionsCompare_Response = {
   /** List of differences between versions */
-  diffs: Shared_Type_102[];
+  diffs: Shared_Type_103[];
   /** The source version */
   fromVersion: {
     /** Unique identifier for the version (UUID) */
@@ -14814,7 +14855,7 @@ export type GetStoredMcpClientsMcpClientIdVersionsCompare_Response = {
     /** Description of the MCP client */
     description?: string | undefined;
     servers: {
-      [key: string]: Shared_Type_111;
+      [key: string]: Shared_Type_118;
     };
     /** Array of field names that changed from the previous version */
     changedFields?: string[] | undefined;
@@ -14836,7 +14877,7 @@ export type GetStoredMcpClientsMcpClientIdVersionsCompare_Response = {
     /** Description of the MCP client */
     description?: string | undefined;
     servers: {
-      [key: string]: Shared_Type_111;
+      [key: string]: Shared_Type_118;
     };
     /** Array of field names that changed from the previous version */
     changedFields?: string[] | undefined;
@@ -14878,7 +14919,7 @@ export type GetStoredMcpClientsMcpClientIdVersionsVersionId_PathParams = {
   versionId: string;
 };
 
-export type GetStoredMcpClientsMcpClientIdVersionsVersionId_Response = Shared_Type_112;
+export type GetStoredMcpClientsMcpClientIdVersionsVersionId_Response = Shared_Type_119;
 
 export type GetStoredMcpClientsMcpClientIdVersionsVersionId_Request = Simplify<
   (GetStoredMcpClientsMcpClientIdVersionsVersionId_PathParams extends never
@@ -15003,7 +15044,7 @@ export type GetStoredPromptBlocks_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  promptBlocks: Shared_Type_113[];
+  promptBlocks: Shared_Type_120[];
 };
 
 export type GetStoredPromptBlocks_Request = Simplify<
@@ -15035,7 +15076,7 @@ export type GetStoredPromptBlocksStoredPromptBlockId_PathParams = {
 
 export type GetStoredPromptBlocksStoredPromptBlockId_QueryParams = GetStoredAgentsStoredAgentId_QueryParams;
 
-export type GetStoredPromptBlocksStoredPromptBlockId_Response = Shared_Type_113;
+export type GetStoredPromptBlocksStoredPromptBlockId_Response = Shared_Type_120;
 
 export type GetStoredPromptBlocksStoredPromptBlockId_Request = Simplify<
   (GetStoredPromptBlocksStoredPromptBlockId_PathParams extends never
@@ -15154,7 +15195,7 @@ export type PatchStoredPromptBlocksStoredPromptBlockId_Response =
       createdAt: Date;
       updatedAt: Date;
     }
-  | Shared_Type_113;
+  | Shared_Type_120;
 
 export type PatchStoredPromptBlocksStoredPromptBlockId_Request = Simplify<
   (PatchStoredPromptBlocksStoredPromptBlockId_PathParams extends never
@@ -15217,7 +15258,7 @@ export type GetStoredPromptBlocksPromptBlockIdVersions_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  versions: Shared_Type_114[];
+  versions: Shared_Type_121[];
 };
 
 export type GetStoredPromptBlocksPromptBlockIdVersions_Request = Simplify<
@@ -15309,7 +15350,7 @@ export type GetStoredPromptBlocksPromptBlockIdVersionsCompare_QueryParams =
 
 export type GetStoredPromptBlocksPromptBlockIdVersionsCompare_Response = {
   /** List of differences between versions */
-  diffs: Shared_Type_102[];
+  diffs: Shared_Type_103[];
   /** The source version */
   fromVersion: {
     /** Unique identifier for the version (UUID) */
@@ -15401,7 +15442,7 @@ export type GetStoredPromptBlocksPromptBlockIdVersionsVersionId_PathParams = {
   versionId: string;
 };
 
-export type GetStoredPromptBlocksPromptBlockIdVersionsVersionId_Response = Shared_Type_114;
+export type GetStoredPromptBlocksPromptBlockIdVersionsVersionId_Response = Shared_Type_121;
 
 export type GetStoredPromptBlocksPromptBlockIdVersionsVersionId_Request = Simplify<
   (GetStoredPromptBlocksPromptBlockIdVersionsVersionId_PathParams extends never
@@ -15526,7 +15567,7 @@ export type GetStoredScorers_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  scorerDefinitions: Shared_Type_116[];
+  scorerDefinitions: Shared_Type_123[];
 };
 
 export type GetStoredScorers_Request = Simplify<
@@ -15558,7 +15599,7 @@ export type GetStoredScorersStoredScorerId_PathParams = {
 
 export type GetStoredScorersStoredScorerId_QueryParams = GetStoredAgentsStoredAgentId_QueryParams;
 
-export type GetStoredScorersStoredScorerId_Response = Shared_Type_116;
+export type GetStoredScorersStoredScorerId_Response = Shared_Type_123;
 
 export type GetStoredScorersStoredScorerId_Request = Simplify<
   (GetStoredScorersStoredScorerId_PathParams extends never
@@ -15600,13 +15641,13 @@ export type PostStoredScorers_Body = {
   /** Description of the scorer */
   description?: string | undefined;
   /** Scorer type: llm-judge for custom, or a preset type name */
-  type: Shared_Type_115;
+  type: Shared_Type_122;
   /** Model configuration for LLM judge */
   model?: Shared_Type_11 | undefined;
   /** System instructions for the judge LLM (used when type is llm-judge) */
   instructions?: string | undefined;
   /** Score range configuration (used when type is llm-judge) */
-  scoreRange?: Shared_Type_117;
+  scoreRange?: Shared_Type_124;
   /** Serializable config options for preset scorers */
   presetConfig?:
     | {
@@ -15668,13 +15709,13 @@ export type PatchStoredScorersStoredScorerId_Body = {
   /** Description of the scorer */
   description?: (string | undefined) | undefined;
   /** Scorer type: llm-judge for custom, or a preset type name */
-  type?: Shared_Type_115 | undefined;
+  type?: Shared_Type_122 | undefined;
   /** Model configuration for LLM judge */
   model?: (Shared_Type_11 | undefined) | undefined;
   /** System instructions for the judge LLM (used when type is llm-judge) */
   instructions?: (string | undefined) | undefined;
   /** Score range configuration (used when type is llm-judge) */
-  scoreRange?: Shared_Type_117 | undefined;
+  scoreRange?: Shared_Type_124 | undefined;
   /** Serializable config options for preset scorers */
   presetConfig?:
     | (
@@ -15715,7 +15756,7 @@ export type PatchStoredScorersStoredScorerId_Response =
       createdAt: Date;
       updatedAt: Date;
     }
-  | Shared_Type_116;
+  | Shared_Type_123;
 
 export type PatchStoredScorersStoredScorerId_Request = Simplify<
   (PatchStoredScorersStoredScorerId_PathParams extends never
@@ -15777,7 +15818,7 @@ export type GetStoredScorersScorerIdVersions_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  versions: Shared_Type_118[];
+  versions: Shared_Type_125[];
 };
 
 export type GetStoredScorersScorerIdVersions_Request = Simplify<
@@ -15816,7 +15857,7 @@ export type PostStoredScorersScorerIdVersions_Response = {
   name?: string | undefined;
   /** Description of the scorer */
   description?: (string | undefined) | undefined;
-  type?: Shared_Type_115 | undefined;
+  type?: Shared_Type_122 | undefined;
   model?: (Shared_Type_11 | undefined) | undefined;
   instructions?: (string | undefined) | undefined;
   scoreRange?:
@@ -15887,7 +15928,7 @@ export type GetStoredScorersScorerIdVersionsCompare_QueryParams = GetStoredAgent
 
 export type GetStoredScorersScorerIdVersionsCompare_Response = {
   /** List of differences between versions */
-  diffs: Shared_Type_102[];
+  diffs: Shared_Type_103[];
   /** The source version */
   fromVersion: {
     /** Unique identifier for the version (UUID) */
@@ -15900,7 +15941,7 @@ export type GetStoredScorersScorerIdVersionsCompare_Response = {
     name: string;
     /** Description of the scorer */
     description?: string | undefined;
-    type: Shared_Type_115;
+    type: Shared_Type_122;
     model?: Shared_Type_11 | undefined;
     instructions?: string | undefined;
     scoreRange?:
@@ -15944,7 +15985,7 @@ export type GetStoredScorersScorerIdVersionsCompare_Response = {
     name: string;
     /** Description of the scorer */
     description?: string | undefined;
-    type: Shared_Type_115;
+    type: Shared_Type_122;
     model?: Shared_Type_11 | undefined;
     instructions?: string | undefined;
     scoreRange?:
@@ -16009,7 +16050,7 @@ export type GetStoredScorersScorerIdVersionsVersionId_PathParams = {
   versionId: string;
 };
 
-export type GetStoredScorersScorerIdVersionsVersionId_Response = Shared_Type_118;
+export type GetStoredScorersScorerIdVersionsVersionId_Response = Shared_Type_125;
 
 export type GetStoredScorersScorerIdVersionsVersionId_Request = Simplify<
   (GetStoredScorersScorerIdVersionsVersionId_PathParams extends never
@@ -16197,7 +16238,7 @@ export type GetStoredWorkspacesStoredWorkspaceId_PathParams = {
   storedWorkspaceId: string;
 };
 
-export type GetStoredWorkspacesStoredWorkspaceId_Response = Shared_Type_119;
+export type GetStoredWorkspacesStoredWorkspaceId_Response = Shared_Type_126;
 
 export type GetStoredWorkspacesStoredWorkspaceId_Request = Simplify<
   (GetStoredWorkspacesStoredWorkspaceId_PathParams extends never
@@ -16323,7 +16364,7 @@ export type PatchStoredWorkspacesStoredWorkspaceId_Response =
       createdAt: Date;
       updatedAt: Date;
     }
-  | Shared_Type_119;
+  | Shared_Type_126;
 
 export type PatchStoredWorkspacesStoredWorkspaceId_Request = Simplify<
   (PatchStoredWorkspacesStoredWorkspaceId_PathParams extends never
@@ -16405,7 +16446,7 @@ export type GetStoredSkills_Response = {
   page: number;
   perPage: number | false;
   hasMore: boolean;
-  skills: Shared_Type_121[];
+  skills: Shared_Type_128[];
 };
 
 export type GetStoredSkills_Request = Simplify<
@@ -16435,7 +16476,7 @@ export type GetStoredSkillsStoredSkillId_PathParams = {
   storedSkillId: string;
 };
 
-export type GetStoredSkillsStoredSkillId_Response = Shared_Type_121;
+export type GetStoredSkillsStoredSkillId_Response = Shared_Type_128;
 
 export type GetStoredSkillsStoredSkillId_Request = Simplify<
   (GetStoredSkillsStoredSkillId_PathParams extends never ? {} : { params: GetStoredSkillsStoredSkillId_PathParams }) &
@@ -16473,7 +16514,7 @@ export type PostStoredSkills_Body = {
   /** Compatibility requirements */
   compatibility?: unknown | undefined;
   /** Source location of the skill */
-  source?: Shared_Type_120 | undefined;
+  source?: Shared_Type_127 | undefined;
   /** List of reference file paths */
   references?: string[] | undefined;
   /** List of script file paths */
@@ -16481,7 +16522,7 @@ export type PostStoredSkills_Body = {
   /** List of asset file paths */
   assets?: string[] | undefined;
   /** Full file tree structure for the skill */
-  files?: Shared_Auxiliary_1238[] | undefined;
+  files?: Shared_Auxiliary_1230[] | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | {
@@ -16531,7 +16572,7 @@ export type PatchStoredSkillsStoredSkillId_Body = {
   /** Compatibility requirements */
   compatibility?: (unknown | undefined) | undefined;
   /** Source location of the skill */
-  source?: (Shared_Type_120 | undefined) | undefined;
+  source?: (Shared_Type_127 | undefined) | undefined;
   /** List of reference file paths */
   references?: (string[] | undefined) | undefined;
   /** List of script file paths */
@@ -16539,7 +16580,7 @@ export type PatchStoredSkillsStoredSkillId_Body = {
   /** List of asset file paths */
   assets?: (string[] | undefined) | undefined;
   /** Full file tree structure for the skill */
-  files?: (Shared_Auxiliary_1238[] | undefined) | undefined;
+  files?: (Shared_Auxiliary_1230[] | undefined) | undefined;
   /** Additional metadata for the skill */
   metadata?:
     | (
@@ -16561,7 +16602,7 @@ export type PatchStoredSkillsStoredSkillId_Response =
       createdAt: Date;
       updatedAt: Date;
     }
-  | Shared_Type_121;
+  | Shared_Type_128;
 
 export type PatchStoredSkillsStoredSkillId_Request = Simplify<
   (PatchStoredSkillsStoredSkillId_PathParams extends never
@@ -17417,7 +17458,7 @@ export interface GetSystemApiSchema_RouteContract {
 export type GetDatasets_QueryParams = GetScoresRunRunId_QueryParams;
 
 export type GetDatasets_Response = {
-  datasets: Shared_Type_122[];
+  datasets: Shared_Type_129[];
   pagination: {
     total: number;
     page: number;
@@ -17485,7 +17526,7 @@ export type PostDatasets_Body = {
   scorerIds?: string[] | undefined;
 };
 
-export type PostDatasets_Response = Shared_Type_122;
+export type PostDatasets_Response = Shared_Type_129;
 
 export type PostDatasets_Request = Simplify<
   (never extends never ? {} : { params: never }) &
@@ -17521,7 +17562,7 @@ export type GetDatasetsDatasetId_QueryParams = {
   projectId?: string | undefined;
 };
 
-export type GetDatasetsDatasetId_Response = Shared_Type_122 | null;
+export type GetDatasetsDatasetId_Response = Shared_Type_129 | null;
 
 export type GetDatasetsDatasetId_Request = Simplify<
   (GetDatasetsDatasetId_PathParams extends never ? {} : { params: GetDatasetsDatasetId_PathParams }) &
@@ -17654,7 +17695,7 @@ export type GetDatasetsDatasetIdItems_QueryParams = {
 };
 
 export type GetDatasetsDatasetIdItems_Response = {
-  items: Shared_Type_125[];
+  items: Shared_Type_132[];
   pagination: {
     total: number;
     page: number;
@@ -17695,9 +17736,9 @@ export type PostDatasetsDatasetIdItems_Body = {
   /** Expected output for comparison */
   groundTruth?: unknown | undefined;
   /** Expected trajectory configuration for trajectory scoring */
-  expectedTrajectory?: (Shared_Type_140 | undefined) | null;
+  expectedTrajectory?: (Shared_Type_147 | undefined) | null;
   /** Ordered item-level static tool mocks served in place of executing the real tool */
-  toolMocks?: Shared_Type_123[] | undefined;
+  toolMocks?: Shared_Type_130[] | undefined;
   /** Policy for undeclared tool calls. 'allow' runs them live; 'deny' fails the experiment item */
   unmockedToolPolicy?: ('allow' | 'deny') | undefined;
   /** IDs of scorers selected for this item */
@@ -17715,10 +17756,10 @@ export type PostDatasetsDatasetIdItems_Body = {
       }
     | undefined;
   /** Source/provenance of this dataset item */
-  source?: Shared_Type_124 | undefined;
+  source?: Shared_Type_131 | undefined;
 };
 
-export type PostDatasetsDatasetIdItems_Response = Shared_Type_125;
+export type PostDatasetsDatasetIdItems_Response = Shared_Type_132;
 
 export type PostDatasetsDatasetIdItems_Request = Simplify<
   (PostDatasetsDatasetIdItems_PathParams extends never ? {} : { params: PostDatasetsDatasetIdItems_PathParams }) &
@@ -17750,9 +17791,9 @@ export type PostDatasetsDatasetIdItemsBatch_Body = {
     input: unknown;
     groundTruth?: unknown | undefined;
     /** Expected trajectory configuration for trajectory scoring */
-    expectedTrajectory?: (Shared_Type_140 | undefined) | null;
+    expectedTrajectory?: (Shared_Type_147 | undefined) | null;
     /** Ordered item-level static tool mocks served in place of executing the real tool */
-    toolMocks?: Shared_Type_123[] | undefined;
+    toolMocks?: Shared_Type_130[] | undefined;
     /** Policy for undeclared tool calls. 'allow' runs them live; 'deny' fails the experiment item */
     unmockedToolPolicy?: ('allow' | 'deny') | undefined;
     scorerIds?: string[] | undefined;
@@ -17767,12 +17808,12 @@ export type PostDatasetsDatasetIdItemsBatch_Body = {
         }
       | undefined;
     /** Source/provenance of this dataset item */
-    source?: Shared_Type_124 | undefined;
+    source?: Shared_Type_131 | undefined;
   }[];
 };
 
 export type PostDatasetsDatasetIdItemsBatch_Response = {
-  items: Shared_Type_125[];
+  items: Shared_Type_132[];
   count: number;
 };
 
@@ -17842,7 +17883,7 @@ export type GetDatasetsDatasetIdItemsItemId_PathParams = {
   itemId: string;
 };
 
-export type GetDatasetsDatasetIdItemsItemId_Response = Shared_Type_125 | null;
+export type GetDatasetsDatasetIdItemsItemId_Response = Shared_Type_132 | null;
 
 export type GetDatasetsDatasetIdItemsItemId_Request = Simplify<
   (GetDatasetsDatasetIdItemsItemId_PathParams extends never
@@ -17872,9 +17913,9 @@ export type PatchDatasetsDatasetIdItemsItemId_Body = {
   /** Expected output for comparison */
   groundTruth?: unknown | undefined;
   /** Expected trajectory configuration for trajectory scoring */
-  expectedTrajectory?: (Shared_Type_140 | undefined) | null;
+  expectedTrajectory?: (Shared_Type_147 | undefined) | null;
   /** Ordered item-level static tool mocks served in place of executing the real tool */
-  toolMocks?: Shared_Type_123[] | undefined;
+  toolMocks?: Shared_Type_130[] | undefined;
   /** Policy for undeclared tool calls. 'allow' runs them live; 'deny' fails the experiment item */
   unmockedToolPolicy?: ('allow' | 'deny') | undefined;
   /** IDs of scorers selected for this item */
@@ -17892,7 +17933,7 @@ export type PatchDatasetsDatasetIdItemsItemId_Body = {
       }
     | undefined;
   /** Source/provenance of this dataset item */
-  source?: Shared_Type_124 | undefined;
+  source?: Shared_Type_131 | undefined;
 };
 
 export type PatchDatasetsDatasetIdItemsItemId_Response = PostDatasetsDatasetIdItems_Response;
@@ -17997,7 +18038,7 @@ export type GetDatasetsDatasetIdItemsItemIdHistory_Response = {
     groundTruth?: unknown | undefined;
     expectedTrajectory?: unknown | undefined;
     /** Ordered item-level static tool mocks served in place of executing the real tool */
-    toolMocks?: Shared_Type_123[] | undefined;
+    toolMocks?: Shared_Type_130[] | undefined;
     /** Policy for undeclared tool calls. 'allow' runs them live; 'deny' fails the experiment item */
     unmockedToolPolicy?: ('allow' | 'deny') | undefined;
     scorerIds?: string[] | undefined;
@@ -18074,7 +18115,7 @@ export type GetExperiments_QueryParams = {
 };
 
 export type GetExperiments_Response = {
-  experiments: Shared_Type_142[];
+  experiments: Shared_Type_149[];
   pagination: {
     total: number;
     page: number;
@@ -18268,7 +18309,7 @@ export type PostDatasetsDatasetIdExperiments_Response = {
     completedAt: Date;
     retryCount: number;
     /** Diagnostic receipt for item-level tool mocks */
-    toolMockReport?: (Shared_Type_143 | undefined) | null;
+    toolMockReport?: (Shared_Type_150 | undefined) | null;
     scores: {
       scorerId: string;
       scorerName: string;
@@ -18324,7 +18365,7 @@ export type PostDatasetsDatasetIdExperimentsExperimentIdItemsItemIdRun_Body = {
 };
 
 export type PostDatasetsDatasetIdExperimentsExperimentIdItemsItemIdRun_Response = {
-  result: Shared_Type_144;
+  result: Shared_Type_151;
   scores: {
     scorerId: string;
     scorerName: string;
@@ -18407,7 +18448,7 @@ export type PostDatasetsDatasetIdExperimentsExperimentIdResults_Body = {
     | undefined;
 };
 
-export type PostDatasetsDatasetIdExperimentsExperimentIdResults_Response = Shared_Type_144;
+export type PostDatasetsDatasetIdExperimentsExperimentIdResults_Response = Shared_Type_151;
 
 export type PostDatasetsDatasetIdExperimentsExperimentIdResults_Request = Simplify<
   (PostDatasetsDatasetIdExperimentsExperimentIdResults_PathParams extends never
@@ -18436,7 +18477,7 @@ export interface PostDatasetsDatasetIdExperimentsExperimentIdResults_RouteContra
 export type PostDatasetsDatasetIdExperimentsExperimentIdFinalize_PathParams =
   PostDatasetsDatasetIdExperimentsExperimentIdResults_PathParams;
 
-export type PostDatasetsDatasetIdExperimentsExperimentIdFinalize_Response = Shared_Type_142;
+export type PostDatasetsDatasetIdExperimentsExperimentIdFinalize_Response = Shared_Type_149;
 
 export type PostDatasetsDatasetIdExperimentsExperimentIdFinalize_Request = Simplify<
   (PostDatasetsDatasetIdExperimentsExperimentIdFinalize_PathParams extends never
@@ -18461,7 +18502,7 @@ export interface PostDatasetsDatasetIdExperimentsExperimentIdFinalize_RouteContr
 export type GetDatasetsDatasetIdExperimentsExperimentId_PathParams =
   PostDatasetsDatasetIdExperimentsExperimentIdResults_PathParams;
 
-export type GetDatasetsDatasetIdExperimentsExperimentId_Response = Shared_Type_142 | null;
+export type GetDatasetsDatasetIdExperimentsExperimentId_Response = Shared_Type_149 | null;
 
 export type GetDatasetsDatasetIdExperimentsExperimentId_Request = Simplify<
   (GetDatasetsDatasetIdExperimentsExperimentId_PathParams extends never
@@ -18532,7 +18573,7 @@ export type GetDatasetsDatasetIdExperimentsExperimentIdResults_PathParams =
 export type GetDatasetsDatasetIdExperimentsExperimentIdResults_QueryParams = GetScoresRunRunId_QueryParams;
 
 export type GetDatasetsDatasetIdExperimentsExperimentIdResults_Response = {
-  results: Shared_Type_144[];
+  results: Shared_Type_151[];
   pagination: {
     total: number;
     page: number;
@@ -18821,7 +18862,7 @@ export type GetBackgroundTasks_QueryParams = {
 };
 
 export type GetBackgroundTasks_Response = {
-  tasks: Shared_Type_145[];
+  tasks: Shared_Type_152[];
   total: number;
 };
 
@@ -18851,7 +18892,7 @@ export type GetBackgroundTasksBackgroundTaskId_PathParams = {
   backgroundTaskId: string;
 };
 
-export type GetBackgroundTasksBackgroundTaskId_Response = Shared_Type_145;
+export type GetBackgroundTasksBackgroundTaskId_Response = Shared_Type_152;
 
 export type GetBackgroundTasksBackgroundTaskId_Request = Simplify<
   (GetBackgroundTasksBackgroundTaskId_PathParams extends never
@@ -18900,8 +18941,8 @@ export type GetEditorBuilderSettings_Response = {
           | {
               models?:
                 | {
-                    allowed?: Shared_Type_146[] | undefined;
-                    default?: Shared_Type_147 | undefined;
+                    allowed?: Shared_Type_153[] | undefined;
+                    default?: Shared_Type_154 | undefined;
                   }
                 | undefined;
               tools?:
@@ -18928,8 +18969,8 @@ export type GetEditorBuilderSettings_Response = {
     | {
         active: boolean;
         pickerVisible?: boolean | undefined;
-        allowed?: Shared_Type_146[] | undefined;
-        default?: Shared_Type_147 | undefined;
+        allowed?: Shared_Type_153[] | undefined;
+        default?: Shared_Type_154 | undefined;
       }
     | undefined;
   picker?:
@@ -19746,7 +19787,7 @@ export type GetSchedules_QueryParams = {
 };
 
 export type GetSchedules_Response = {
-  schedules: (Shared_Type_150 | Shared_Type_152)[];
+  schedules: (Shared_Type_157 | Shared_Type_159)[];
 };
 
 export type GetSchedules_Request = Simplify<
@@ -19775,7 +19816,7 @@ export type GetSchedulesScheduleId_PathParams = {
   scheduleId: string;
 };
 
-export type GetSchedulesScheduleId_Response = Shared_Type_150 | Shared_Type_152;
+export type GetSchedulesScheduleId_Response = Shared_Type_157 | Shared_Type_159;
 
 export type GetSchedulesScheduleId_Request = Simplify<
   (GetSchedulesScheduleId_PathParams extends never ? {} : { params: GetSchedulesScheduleId_PathParams }) &
@@ -19812,8 +19853,8 @@ export type PostSchedules_Body =
             [key: string]: (string | number | boolean | null) | undefined;
           }
         | undefined;
-      ifActive?: Shared_Type_148 | undefined;
-      ifIdle?: Shared_Type_149 | undefined;
+      ifActive?: Shared_Type_155 | undefined;
+      ifIdle?: Shared_Type_156 | undefined;
       providerOptions?:
         | {
             [key: string]: unknown;
@@ -19888,8 +19929,8 @@ export type PatchSchedulesScheduleId_Body = {
         [key: string]: (string | number | boolean | null) | undefined;
       }
     | undefined;
-  ifActive?: Shared_Type_148 | undefined;
-  ifIdle?: Shared_Type_149 | undefined;
+  ifActive?: Shared_Type_155 | undefined;
+  ifIdle?: Shared_Type_156 | undefined;
   providerOptions?:
     | {
         [key: string]: unknown;
@@ -19989,7 +20030,7 @@ export type GetSchedulesScheduleIdTriggers_Response = {
           [key: string]: unknown;
         }
       | undefined;
-    run?: Shared_Type_151 | undefined;
+    run?: Shared_Type_158 | undefined;
   }[];
 };
 

--- a/docs/src/content/en/docs/workflows/control-flow.mdx
+++ b/docs/src/content/en/docs/workflows/control-flow.mdx
@@ -805,6 +805,22 @@ export const batchProcessWorkflow = createWorkflow({
 1. The nested workflow's final output becomes one element in the result array
 1. After all nested workflows complete, the next step in the parent receives the full array
 
+## Labeling control-flow entries
+
+Every control-flow method accepts an optional final argument with a stable `id`, a `description`, and JSON-serializable `metadata`. These fields identify and describe the graph entry itself, separate from the steps inside it. They survive serialization and storage, appear in `serializedStepGraph`, and have no effect on execution.
+
+```typescript
+workflow
+  .parallel([validateStep, enrichStep], {
+    id: 'independent-enrichment',
+    description: 'Run independent enrichment tasks concurrently',
+    metadata: { title: 'Independent enrichment' },
+  })
+  .sleep(5000, { id: 'wait-before-retry', description: 'Pause before retrying' })
+```
+
+Visual editors and review tools can key layout and selection state by `id` and render `metadata.title` as a display label. For `.foreach()`, pass the fields in the same options object as `concurrency`. For `.map()`, `.sleep()`, and `.sleepUntil()`, a supplied `id` replaces the generated entry id.
+
 ## Choosing the right pattern
 
 Use this section as a reference for selecting the appropriate control flow method.

--- a/docs/src/content/en/docs/workflows/control-flow.mdx
+++ b/docs/src/content/en/docs/workflows/control-flow.mdx
@@ -807,7 +807,7 @@ export const batchProcessWorkflow = createWorkflow({
 
 ## Labeling control-flow entries
 
-Every control-flow method accepts an optional final argument with a stable `id`, a `description`, and JSON-serializable `metadata`. These fields identify and describe the graph entry itself, separate from the steps inside it. They survive serialization and storage, appear in `serializedStepGraph`, and have no effect on execution.
+Every control-flow method accepts an optional final argument with a stable `id`, a `description`, and JSON-serializable `metadata`. These fields identify and describe the graph entry itself, separate from the steps inside it. They survive serialization and storage and appear in `serializedStepGraph`. They have no effect on execution.
 
 ```typescript
 workflow

--- a/docs/src/content/en/reference/workflows/dynamic-workflow-definition.mdx
+++ b/docs/src/content/en/reference/workflows/dynamic-workflow-definition.mdx
@@ -75,6 +75,31 @@ Entries in the `graph` run in order. Each entry receives the previous entry's ou
 
 Code-defined workflows that use [`.agent()`](/reference/workflows/workflow-methods/agent) and [`.tool()`](/reference/workflows/workflow-methods/tool) produce the same declarative entries when serialized.
 
+### Identity and display fields
+
+Control-flow entries accept optional fields that identify and describe the entry without affecting execution:
+
+| Field | Type | Description |
+| - | - | - |
+| `id` | `string` | Stable identity for addressing the entry across edits and serialization. Optional on `parallel`, `conditional`, `foreach`, and `loop`; required on `mapping`, `sleep`, and `sleepUntil`. |
+| `description` | `string` | Human-readable intent of the control-flow operation |
+| `metadata` | `Record<string, unknown>` | Arbitrary JSON metadata preserved through storage, for example a display title for visual editors |
+
+```json
+{
+  "type": "parallel",
+  "id": "independent-enrichment",
+  "description": "Run independent document enrichment tasks concurrently",
+  "metadata": { "title": "Independent enrichment" },
+  "steps": [
+    { "type": "tool", "id": "extract-entities", "toolId": "entity-tool" },
+    { "type": "tool", "id": "classify", "toolId": "classify-tool" }
+  ]
+}
+```
+
+All three fields survive storage and rehydration, and they appear in `serializedStepGraph` for API and Studio consumers. Agent and tool steps carry the equivalent information on their own `description` and `options.metadata` fields.
+
 ### Agent steps
 
 An `agent` entry invokes a registered agent by ID. Agent steps accept `{ prompt: string }` as input and return `{ text: string }` by default.

--- a/docs/src/content/en/reference/workflows/workflow-methods/branch.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/branch.mdx
@@ -29,6 +29,33 @@ workflow.branch([
       'An array of tuples, each containing a condition function and a step to execute if the condition is true',
     isOptional: false,
   },
+  {
+    name: 'options',
+    type: 'StepFlowEntryOptions',
+    description:
+      'Optional identity and display metadata for this graph entry. Preserved through serialization and storage; has no effect on execution.',
+    isOptional: true,
+    properties: [
+      {
+        name: 'id',
+        type: 'string',
+        description: 'Stable entry id that editors and tools can use to address this entry across edits',
+        isOptional: true,
+      },
+      {
+        name: 'description',
+        type: 'string',
+        description: 'Human-readable description of this control-flow operation',
+        isOptional: true,
+      },
+      {
+        name: 'metadata',
+        type: 'Record<string, unknown>',
+        description: 'JSON-serializable metadata, for example a display title for visual editors',
+        isOptional: true,
+      },
+    ],
+  },
 ]}
 />
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/dountil.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/dountil.mdx
@@ -32,6 +32,33 @@ workflow.dountil(step1, async ({ inputData }) => true)
       'A function that returns a boolean indicating whether to continue the loop. The function receives the execution parameters and the iteration count.',
     isOptional: false,
   },
+  {
+    name: 'options',
+    type: 'StepFlowEntryOptions',
+    description:
+      'Optional identity and display metadata for this graph entry. Preserved through serialization and storage; has no effect on execution.',
+    isOptional: true,
+    properties: [
+      {
+        name: 'id',
+        type: 'string',
+        description: 'Stable entry id that editors and tools can use to address this entry across edits',
+        isOptional: true,
+      },
+      {
+        name: 'description',
+        type: 'string',
+        description: 'Human-readable description of this control-flow operation',
+        isOptional: true,
+      },
+      {
+        name: 'metadata',
+        type: 'Record<string, unknown>',
+        description: 'JSON-serializable metadata, for example a display title for visual editors',
+        isOptional: true,
+      },
+    ],
+  },
 ]}
 />
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/dowhile.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/dowhile.mdx
@@ -32,6 +32,33 @@ workflow.dowhile(step1, async ({ inputData }) => true)
       'A function that returns a boolean indicating whether to continue the loop. The function receives the execution parameters and the iteration count.',
     isOptional: false,
   },
+  {
+    name: 'options',
+    type: 'StepFlowEntryOptions',
+    description:
+      'Optional identity and display metadata for this graph entry. Preserved through serialization and storage; has no effect on execution.',
+    isOptional: true,
+    properties: [
+      {
+        name: 'id',
+        type: 'string',
+        description: 'Stable entry id that editors and tools can use to address this entry across edits',
+        isOptional: true,
+      },
+      {
+        name: 'description',
+        type: 'string',
+        description: 'Human-readable description of this control-flow operation',
+        isOptional: true,
+      },
+      {
+        name: 'metadata',
+        type: 'Record<string, unknown>',
+        description: 'JSON-serializable metadata, for example a display title for visual editors',
+        isOptional: true,
+      },
+    ],
+  },
 ]}
 />
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/foreach.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/foreach.mdx
@@ -29,13 +29,31 @@ workflow.foreach(step1, { concurrency: 2 })
     name: 'opts',
     type: 'object',
     description:
-      'Optional configuration for the loop. The concurrency option controls how many iterations can run in parallel (default: 1)',
+      'Optional configuration for the loop. The concurrency option controls how many iterations can run in parallel (default: 1). The identity and display fields are preserved through serialization and storage and have no effect on execution.',
     isOptional: true,
     properties: [
       {
         name: 'concurrency',
         type: 'number',
         description: 'The number of concurrent iterations allowed (default: 1)',
+        isOptional: true,
+      },
+      {
+        name: 'id',
+        type: 'string',
+        description: 'Stable entry id that editors and tools can use to address this entry across edits',
+        isOptional: true,
+      },
+      {
+        name: 'description',
+        type: 'string',
+        description: 'Human-readable description of this control-flow operation',
+        isOptional: true,
+      },
+      {
+        name: 'metadata',
+        type: 'Record<string, unknown>',
+        description: 'JSON-serializable metadata, for example a display title for visual editors',
         isOptional: true,
       },
     ],

--- a/docs/src/content/en/reference/workflows/workflow-methods/map.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/map.mdx
@@ -25,6 +25,33 @@ workflow.map(async ({ inputData }) => `${inputData.value} - map`)
     description: 'Function that transforms input data and returns the mapped result',
     isOptional: false,
   },
+  {
+    name: 'stepOptions',
+    type: 'object',
+    description:
+      'Optional identity and display metadata for the mapping entry. Preserved through serialization and storage; has no effect on execution.',
+    isOptional: true,
+    properties: [
+      {
+        name: 'id',
+        type: 'string',
+        description: 'Stable entry id. Overrides the generated mapping id.',
+        isOptional: true,
+      },
+      {
+        name: 'description',
+        type: 'string',
+        description: 'Human-readable description of the mapping',
+        isOptional: true,
+      },
+      {
+        name: 'metadata',
+        type: 'Record<string, unknown>',
+        description: 'JSON-serializable metadata, for example a display title for visual editors',
+        isOptional: true,
+      },
+    ],
+  },
 ]}
 />
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/parallel.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/parallel.mdx
@@ -25,6 +25,33 @@ workflow.parallel([step1, step2])
     description: 'The step instances to execute in parallel',
     isOptional: false,
   },
+  {
+    name: 'options',
+    type: 'StepFlowEntryOptions',
+    description:
+      'Optional identity and display metadata for this graph entry. Preserved through serialization and storage; has no effect on execution.',
+    isOptional: true,
+    properties: [
+      {
+        name: 'id',
+        type: 'string',
+        description: 'Stable entry id that editors and tools can use to address this entry across edits',
+        isOptional: true,
+      },
+      {
+        name: 'description',
+        type: 'string',
+        description: 'Human-readable description of this control-flow operation',
+        isOptional: true,
+      },
+      {
+        name: 'metadata',
+        type: 'Record<string, unknown>',
+        description: 'JSON-serializable metadata, for example a display title for visual editors',
+        isOptional: true,
+      },
+    ],
+  },
 ]}
 />
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/sleep.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/sleep.mdx
@@ -25,6 +25,33 @@ workflow.sleep(5000)
     description: 'The number of milliseconds to pause execution, or a callback that returns the delay',
     isOptional: false,
   },
+  {
+    name: 'options',
+    type: 'StepFlowEntryOptions',
+    description:
+      'Optional identity and display metadata for this graph entry. Preserved through serialization and storage; has no effect on execution.',
+    isOptional: true,
+    properties: [
+      {
+        name: 'id',
+        type: 'string',
+        description: 'Stable entry id. Overrides the generated sleep step id.',
+        isOptional: true,
+      },
+      {
+        name: 'description',
+        type: 'string',
+        description: 'Human-readable description of this control-flow operation',
+        isOptional: true,
+      },
+      {
+        name: 'metadata',
+        type: 'Record<string, unknown>',
+        description: 'JSON-serializable metadata, for example a display title for visual editors',
+        isOptional: true,
+      },
+    ],
+  },
 ]}
 />
 

--- a/docs/src/content/en/reference/workflows/workflow-methods/sleepUntil.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/sleepUntil.mdx
@@ -26,6 +26,33 @@ workflow.sleepUntil(new Date(Date.now() + 5000))
       'Either a Date object or a callback function that returns a Date. The callback receives execution context and can compute the target time dynamically based on input data.',
     isOptional: false,
   },
+  {
+    name: 'options',
+    type: 'StepFlowEntryOptions',
+    description:
+      'Optional identity and display metadata for this graph entry. Preserved through serialization and storage; has no effect on execution.',
+    isOptional: true,
+    properties: [
+      {
+        name: 'id',
+        type: 'string',
+        description: 'Stable entry id. Overrides the generated sleep step id.',
+        isOptional: true,
+      },
+      {
+        name: 'description',
+        type: 'string',
+        description: 'Human-readable description of this control-flow operation',
+        isOptional: true,
+      },
+      {
+        name: 'metadata',
+        type: 'Record<string, unknown>',
+        description: 'JSON-serializable metadata, for example a display title for visual editors',
+        isOptional: true,
+      },
+    ],
+  },
 ]}
 />
 

--- a/packages/core/src/workflows/__tests__/dynamic-round-trip.test.ts
+++ b/packages/core/src/workflows/__tests__/dynamic-round-trip.test.ts
@@ -1910,6 +1910,10 @@ describe('control-flow entry identity and display metadata', () => {
       .foreach(plusOneStep, { id: 'annotated-foreach', metadata: { title: 'Annotated foreach' } })
       .commit();
 
+    // The live entry gets the engine default so its opts match the declared
+    // `ForeachOptions` shape, and the caller's object is left untouched.
+    expect(wf.stepGraph[0]).toMatchObject({ type: 'foreach', opts: { concurrency: 1 } });
+
     const stored = JSON.parse(JSON.stringify(toStorableGraph(wf.stepGraph)));
     expect(stored[0]).toMatchObject({
       type: 'foreach',

--- a/packages/core/src/workflows/__tests__/dynamic-round-trip.test.ts
+++ b/packages/core/src/workflows/__tests__/dynamic-round-trip.test.ts
@@ -1891,6 +1891,9 @@ describe('control-flow entry identity and display metadata', () => {
     expect(live[2]).toMatchObject(displayed.loop);
     expect(live[4]).toMatchObject(displayed.sleep);
 
+    // … including the synthesized sleep placeholder in the steps map.
+    expect(workflow.steps['wait-before-retry']?.description).toBe(displayed.sleep.description);
+
     // … and the full save → load → save loop is drift-free.
     const restored = JSON.parse(JSON.stringify(toStorableGraph(workflow.stepGraph)));
     expect(restored).toEqual(stored);

--- a/packages/core/src/workflows/__tests__/dynamic-round-trip.test.ts
+++ b/packages/core/src/workflows/__tests__/dynamic-round-trip.test.ts
@@ -1786,3 +1786,141 @@ describe('dynamic workflow schedules (#22756)', () => {
     await mastra.stopWorkers?.();
   });
 });
+
+describe('control-flow entry identity and display metadata', () => {
+  const displayed = {
+    parallel: { id: 'fan-out', description: 'Run both tone tools', metadata: { title: 'Fan out' } },
+    conditional: { id: 'route-by-value', description: 'Route on value', metadata: { title: 'Route' } },
+    loop: { id: 'bump-until-5', description: 'Increment to 5', metadata: { title: 'Bump' } },
+    foreach: { id: 'bump-each', description: 'Increment each item', metadata: { title: 'Bump each' } },
+    sleep: { id: 'wait-before-retry', description: 'Pause before retrying', metadata: { title: 'Wait' } },
+    sleepUntil: { id: 'wait-until-y2099', description: 'Hold until 2099', metadata: { title: 'Hold' } },
+    mapping: { id: 'normalize-results', description: 'Reshape output', metadata: { title: 'Normalize' } },
+  } as const;
+
+  function buildAnnotatedWorkflow() {
+    // Chained outputs deliberately don't type-flow into each other — these
+    // tests exercise the serialize/rehydrate pipeline, not execution.
+    return (
+      createWorkflow({
+        id: 'cf-fields-wf',
+        inputSchema: z.object({ value: z.number() }),
+        outputSchema: z.object({ value: z.number() }),
+      }) as any
+    )
+      .parallel([shoutStep, whisperStep], displayed.parallel)
+      .branch(
+        [
+          [{ predicate: { op: 'gt', left: { path: 'inputData.value' }, right: { literal: 10 } } }, shoutStep],
+          [{ predicate: { op: 'lte', left: { path: 'inputData.value' }, right: { literal: 10 } } }, whisperStep],
+        ],
+        displayed.conditional,
+      )
+      .dountil(
+        plusOneStep,
+        { predicate: { op: 'gte', left: { path: 'inputData.value' }, right: { literal: 5 } } },
+        displayed.loop,
+      )
+      .foreach(plusOneStep, { concurrency: 2, ...displayed.foreach })
+      .sleep(500, displayed.sleep)
+      .sleepUntil(new Date(Date.UTC(2099, 0, 1)), displayed.sleepUntil)
+      .map({ note: { template: 'v=${inputData.value}' } } as any, displayed.mapping)
+      .commit();
+  }
+
+  it('the fluent builder writes id/description/metadata onto serialized control-flow entries', () => {
+    const wf = buildAnnotatedWorkflow();
+    const graph = wf.serializedStepGraph as Array<Record<string, any>>;
+
+    expect(graph.map(e => e.type)).toEqual([
+      'parallel',
+      'conditional',
+      'loop',
+      'foreach',
+      'sleep',
+      'sleepUntil',
+      'mapping',
+    ]);
+    expect(graph[0]).toMatchObject(displayed.parallel);
+    expect(graph[1]).toMatchObject(displayed.conditional);
+    expect(graph[2]).toMatchObject(displayed.loop);
+    expect(graph[3]).toMatchObject(displayed.foreach);
+    expect(graph[4]).toMatchObject(displayed.sleep);
+    expect(graph[5]).toMatchObject(displayed.sleepUntil);
+    expect(graph[6]).toMatchObject(displayed.mapping);
+
+    // foreach identity fields live on the entry, not inside execution opts.
+    expect(graph[3]!.opts).toEqual({ concurrency: 2 });
+
+    // A caller-supplied sleep/mapping id also keys the synthesized step.
+    expect(wf.steps['wait-before-retry']).toBeDefined();
+    expect(wf.steps['wait-before-retry'].description).toBe(displayed.sleep.description);
+    expect(wf.steps['normalize-results']).toBeDefined();
+  });
+
+  it('identity fields survive store → rehydrate → re-store without drift', async () => {
+    const wf = buildAnnotatedWorkflow();
+    const stored = JSON.parse(JSON.stringify(toStorableGraph(wf.stepGraph)));
+
+    expect(stored[0]).toMatchObject(displayed.parallel);
+    expect(stored[6]).toMatchObject(displayed.mapping);
+
+    const mastra = new Mastra({
+      logger: false,
+      tools: {
+        'shout-tool': shoutTool,
+        'whisper-tool': whisperTool,
+        'plus-one': plusOneTool,
+      } as any,
+      storage: new InMemoryStore({ id: 'cf-fields' }),
+    });
+
+    const { workflow } = await rehydrateWorkflow(
+      {
+        id: 'cf-fields-wf',
+        inputSchema: { type: 'object', properties: { value: { type: 'number' } }, required: ['value'] },
+        outputSchema: { type: 'object', properties: { value: { type: 'number' } }, required: ['value'] },
+        graph: stored,
+      },
+      mastra,
+    );
+
+    // Fields land on the live entries (what a later re-serialize reads) …
+    const live = workflow.stepGraph as Array<Record<string, any>>;
+    expect(live[0]).toMatchObject(displayed.parallel);
+    expect(live[2]).toMatchObject(displayed.loop);
+    expect(live[4]).toMatchObject(displayed.sleep);
+
+    // … and the full save → load → save loop is drift-free.
+    const restored = JSON.parse(JSON.stringify(toStorableGraph(workflow.stepGraph)));
+    expect(restored).toEqual(stored);
+  });
+
+  it('display metadata has no effect on execution results', async () => {
+    const wf = createWorkflow({
+      id: 'cf-exec-wf',
+      inputSchema: z.object({ value: z.number() }),
+      outputSchema: z.object({ message: z.string() }),
+    })
+      .tool(doubleTool)
+      .sleep(1, { id: 'tiny-pause', description: 'breathe', metadata: { title: 'Pause' } })
+      .map(
+        { message: { template: 'Doubled value is ${stepResults.double-tool.doubled}' } },
+        { id: 'render-message', description: 'format the reply', metadata: { title: 'Render' } },
+      )
+      .commit();
+
+    const mastra = new Mastra({
+      logger: false,
+      tools: { 'double-tool': doubleTool } as any,
+      workflows: { 'cf-exec-wf': wf } as any,
+      storage: new InMemoryStore({ id: 'cf-exec' }),
+    });
+    wf.__registerMastra(mastra);
+
+    const run = await mastra.getWorkflow('cf-exec-wf').createRun();
+    const result = await run.start({ inputData: { value: 21 } });
+    expect(result.status).toBe('success');
+    expect((result as any).result).toEqual({ message: 'Doubled value is 42' });
+  });
+});

--- a/packages/core/src/workflows/__tests__/dynamic-round-trip.test.ts
+++ b/packages/core/src/workflows/__tests__/dynamic-round-trip.test.ts
@@ -1899,6 +1899,43 @@ describe('control-flow entry identity and display metadata', () => {
     expect(restored).toEqual(stored);
   });
 
+  it('a foreach annotated without concurrency still stores a valid default and round-trips drift-free', async () => {
+    const wf = (
+      createWorkflow({
+        id: 'foreach-default-wf',
+        inputSchema: z.object({ value: z.number() }),
+        outputSchema: z.object({ value: z.number() }),
+      }) as any
+    )
+      .foreach(plusOneStep, { id: 'annotated-foreach', metadata: { title: 'Annotated foreach' } })
+      .commit();
+
+    const stored = JSON.parse(JSON.stringify(toStorableGraph(wf.stepGraph)));
+    expect(stored[0]).toMatchObject({
+      type: 'foreach',
+      id: 'annotated-foreach',
+      metadata: { title: 'Annotated foreach' },
+      opts: { concurrency: 1 },
+    });
+
+    const mastra = new Mastra({
+      logger: false,
+      tools: { 'plus-one': plusOneTool } as any,
+      storage: new InMemoryStore({ id: 'foreach-default' }),
+    });
+    const { workflow } = await rehydrateWorkflow(
+      {
+        id: 'foreach-default-wf',
+        inputSchema: { type: 'object', properties: { value: { type: 'number' } }, required: ['value'] },
+        outputSchema: { type: 'object', properties: { value: { type: 'number' } }, required: ['value'] },
+        graph: stored,
+      },
+      mastra,
+    );
+    const restored = JSON.parse(JSON.stringify(toStorableGraph(workflow.stepGraph)));
+    expect(restored).toEqual(stored);
+  });
+
   it('display metadata has no effect on execution results', async () => {
     const wf = createWorkflow({
       id: 'cf-exec-wf',

--- a/packages/core/src/workflows/builder/authoring-schema.test.ts
+++ b/packages/core/src/workflows/builder/authoring-schema.test.ts
@@ -250,13 +250,28 @@ describe('shared workflow builder authoring schema', () => {
     it.each([
       ['an invented foreach input selector', { type: 'foreach', input: { step: 'lookup', path: 'customers' } }],
       ['an invented foreach items selector', { type: 'foreach', items: { initData: true, path: 'customers' } }],
-      ['a container id', { type: 'foreach', id: 'lookup-each' }],
     ])('rejects %s', (_label, extra) => {
       const result = workflowBuilderDefinitionInputSchema.safeParse({
         ...authoringDefinition,
         graph: [{ step: { type: 'tool', id: 'lookup', toolId: 'lookupCustomer' }, ...extra }],
       });
       expect(result.success).toBe(false);
+    });
+
+    it('accepts the identity/display fields (id, description, metadata) on a container entry', () => {
+      const result = workflowBuilderDefinitionInputSchema.safeParse({
+        ...authoringDefinition,
+        graph: [
+          {
+            type: 'foreach',
+            id: 'lookup-each',
+            description: 'Look up every customer',
+            metadata: { title: 'Lookup each' },
+            step: { type: 'tool', id: 'lookup', toolId: 'lookupCustomer' },
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
     });
 
     it('rejects a bogus inputMapping descriptor on a container child', () => {

--- a/packages/core/src/workflows/builder/authoring-schema.ts
+++ b/packages/core/src/workflows/builder/authoring-schema.ts
@@ -57,6 +57,33 @@ const stepOptionsInputSchema = z
   .nullish()
   .describe(STEP_OPTIONS_DESCRIPTION);
 
+const ENTRY_ID_DESCRIPTION =
+  'Optional stable entry id — kebab-case, unique within the workflow. Lets editors and tools address this control-flow entry across edits and serialization.';
+const ENTRY_DESCRIPTION_DESCRIPTION = 'Optional human-readable description of why this control-flow operation exists.';
+const ENTRY_METADATA_DESCRIPTION =
+  'Arbitrary JSON-safe metadata attached to this entry (e.g. a display title for visual editors). Does not affect execution.';
+
+// Identity/display fields shared by every control-flow entry (parallel,
+// conditional, foreach, loop, sleep, sleepUntil, mapping). Container entries
+// additionally take an optional `id`; sleep/sleepUntil/mapping already carry a
+// required one.
+const entryDisplayFields = {
+  description: z.string().optional().describe(ENTRY_DESCRIPTION_DESCRIPTION),
+  metadata: jsonSchema.optional().describe(ENTRY_METADATA_DESCRIPTION),
+};
+const entryDisplayInputFields = {
+  description: z.string().nullish().describe(ENTRY_DESCRIPTION_DESCRIPTION),
+  metadata: z.unknown().nullish().describe(ENTRY_METADATA_DESCRIPTION),
+};
+const containerIdentityFields = {
+  id: z.string().min(1).optional().describe(ENTRY_ID_DESCRIPTION),
+  ...entryDisplayFields,
+};
+const containerIdentityInputFields = {
+  id: z.string().min(1).nullish().describe(ENTRY_ID_DESCRIPTION),
+  ...entryDisplayInputFields,
+};
+
 const agentOutputSchemaDescription =
   "OPTIONAL JSON Schema (Draft 2020-12) describing the structured output the agent must produce for this step. When set, the agent runs with structured output and the step's output IS that shape (not `{ text: string }`). Use this when a downstream step needs a machine-readable field — for example, an agent that reads a listing and emits `{ files: string[] }`, which a subsequent `foreach` iterates over.";
 
@@ -134,6 +161,7 @@ export const workflowBuilderMappingEntrySchema = z
   .strictObject({
     type: z.literal('mapping'),
     id: z.string().min(1).describe('Step id — kebab-case, unique within the workflow.'),
+    ...entryDisplayFields,
     mapConfig: z.string().min(1).describe(`A JSON-ENCODED STRING of ${WORKFLOW_BUILDER_MAPPING_CONFIG_DESCRIPTION}`),
   })
   .describe('Mapping step. Its output is an object whose top-level keys are exactly the keys of mapConfig.');
@@ -142,6 +170,7 @@ export const workflowBuilderMappingEntryInputSchema = z
   .strictObject({
     type: z.literal('mapping'),
     id: z.string().min(1).describe('Step id — kebab-case, unique within the workflow.'),
+    ...entryDisplayInputFields,
     mapConfig: z
       .union([workflowBuilderMappingConfigSchema, z.string().min(1)])
       .describe(WORKFLOW_BUILDER_MAPPING_CONFIG_DESCRIPTION),
@@ -229,12 +258,17 @@ const LOOP_DESCRIPTION =
   '`dowhile` keeps looping while the predicate is TRUE; `dountil` keeps looping until the predicate is TRUE (exit condition). The inner step runs at least once and receives its own previous output on later iterations.';
 
 export const workflowBuilderParallelEntrySchema = z
-  .strictObject({ type: z.literal('parallel'), steps: z.array(executableInnerStepSchema).min(1) })
+  .strictObject({
+    type: z.literal('parallel'),
+    ...containerIdentityFields,
+    steps: z.array(executableInnerStepSchema).min(1),
+  })
   .describe(PARALLEL_DESCRIPTION);
 
 export const workflowBuilderForeachEntrySchema = z
   .strictObject({
     type: z.literal('foreach'),
+    ...containerIdentityFields,
     step: executableInnerStepSchema,
     opts: z
       .object({ concurrency: z.number().int().positive() })
@@ -246,17 +280,20 @@ export const workflowBuilderForeachEntrySchema = z
 export const workflowBuilderSleepEntrySchema = z.strictObject({
   type: z.literal('sleep'),
   id: z.string().min(1),
+  ...entryDisplayFields,
   duration: z.number().nonnegative().describe('Milliseconds to wait. Static number only.'),
 });
 export const workflowBuilderSleepUntilEntrySchema = z.strictObject({
   type: z.literal('sleepUntil'),
   id: z.string().min(1),
+  ...entryDisplayFields,
   date: z.string().min(1).describe('ISO 8601 wall-clock date to wait until. Static string only.'),
 });
 
 export const workflowBuilderConditionalEntrySchema = z
   .strictObject({
     type: z.literal('conditional'),
+    ...containerIdentityFields,
     steps: z.array(executableInnerStepSchema).min(1),
     predicates: z
       .array(workflowBuilderPredicateSchema)
@@ -268,6 +305,7 @@ export const workflowBuilderConditionalEntrySchema = z
 export const workflowBuilderLoopEntrySchema = z
   .strictObject({
     type: z.literal('loop'),
+    ...containerIdentityFields,
     step: executableInnerStepSchema,
     loopType: z.enum(['dowhile', 'dountil']),
     predicate: workflowBuilderPredicateSchema.describe('Declarative predicate — no JS closures.'),
@@ -275,14 +313,20 @@ export const workflowBuilderLoopEntrySchema = z
   .describe(LOOP_DESCRIPTION);
 
 // Container input twins: children use the null-tolerant executable input steps,
-// and foreach's optional opts accept null from strict providers.
+// optional identity/display fields accept null, and foreach's optional opts
+// accept null from strict providers.
 export const workflowBuilderParallelEntryInputSchema = z
-  .strictObject({ type: z.literal('parallel'), steps: z.array(executableInnerStepInputSchema).min(1) })
+  .strictObject({
+    type: z.literal('parallel'),
+    ...containerIdentityInputFields,
+    steps: z.array(executableInnerStepInputSchema).min(1),
+  })
   .describe(PARALLEL_DESCRIPTION);
 
 export const workflowBuilderForeachEntryInputSchema = z
   .strictObject({
     type: z.literal('foreach'),
+    ...containerIdentityInputFields,
     step: executableInnerStepInputSchema,
     opts: z
       .object({ concurrency: z.number().int().positive().nullish() })
@@ -291,9 +335,23 @@ export const workflowBuilderForeachEntryInputSchema = z
   })
   .describe(FOREACH_DESCRIPTION);
 
+export const workflowBuilderSleepEntryInputSchema = z.strictObject({
+  type: z.literal('sleep'),
+  id: z.string().min(1),
+  ...entryDisplayInputFields,
+  duration: z.number().nonnegative().describe('Milliseconds to wait. Static number only.'),
+});
+export const workflowBuilderSleepUntilEntryInputSchema = z.strictObject({
+  type: z.literal('sleepUntil'),
+  id: z.string().min(1),
+  ...entryDisplayInputFields,
+  date: z.string().min(1).describe('ISO 8601 wall-clock date to wait until. Static string only.'),
+});
+
 export const workflowBuilderConditionalEntryInputSchema = z
   .strictObject({
     type: z.literal('conditional'),
+    ...containerIdentityInputFields,
     steps: z.array(executableInnerStepInputSchema).min(1),
     predicates: z
       .array(workflowBuilderPredicateSchema)
@@ -305,6 +363,7 @@ export const workflowBuilderConditionalEntryInputSchema = z
 export const workflowBuilderLoopEntryInputSchema = z
   .strictObject({
     type: z.literal('loop'),
+    ...containerIdentityInputFields,
     step: executableInnerStepInputSchema,
     loopType: z.enum(['dowhile', 'dountil']),
     predicate: workflowBuilderPredicateSchema.describe('Declarative predicate — no JS closures.'),
@@ -331,8 +390,8 @@ export const workflowBuilderGraphEntryInputSchema = z.discriminatedUnion('type',
   workflowBuilderNestedWorkflowEntryInputSchema,
   workflowBuilderParallelEntryInputSchema,
   workflowBuilderForeachEntryInputSchema,
-  workflowBuilderSleepEntrySchema,
-  workflowBuilderSleepUntilEntrySchema,
+  workflowBuilderSleepEntryInputSchema,
+  workflowBuilderSleepUntilEntryInputSchema,
   workflowBuilderConditionalEntryInputSchema,
   workflowBuilderLoopEntryInputSchema,
 ]);

--- a/packages/core/src/workflows/builder/index.ts
+++ b/packages/core/src/workflows/builder/index.ts
@@ -38,37 +38,50 @@ export type WorkflowBuilderExecutableInnerEntry = Exclude<WorkflowBuilderSingleS
  * The static assertions at the bottom of this file prove each narrowing stays
  * inside the canonical union — drift is a compile error.
  */
-export interface WorkflowBuilderParallelEntry {
+/**
+ * Optional identity/display fields shared by every control-flow entry.
+ * Mirrors `StepFlowEntryOptions` on the canonical union.
+ */
+interface WorkflowBuilderEntryDisplayFields {
+  description?: string;
+  metadata?: Record<string, any>;
+}
+
+export interface WorkflowBuilderParallelEntry extends WorkflowBuilderEntryDisplayFields {
   type: 'parallel';
+  id?: string;
   steps: WorkflowBuilderExecutableInnerEntry[];
 }
 
-export interface WorkflowBuilderForeachEntry {
+export interface WorkflowBuilderForeachEntry extends WorkflowBuilderEntryDisplayFields {
   type: 'foreach';
+  id?: string;
   step: WorkflowBuilderExecutableInnerEntry;
   opts?: { concurrency: number };
 }
 
-export interface WorkflowBuilderSleepEntry {
+export interface WorkflowBuilderSleepEntry extends WorkflowBuilderEntryDisplayFields {
   type: 'sleep';
   id: string;
   duration: number;
 }
 
-export interface WorkflowBuilderSleepUntilEntry {
+export interface WorkflowBuilderSleepUntilEntry extends WorkflowBuilderEntryDisplayFields {
   type: 'sleepUntil';
   id: string;
   date: string;
 }
 
-export interface WorkflowBuilderConditionalEntry {
+export interface WorkflowBuilderConditionalEntry extends WorkflowBuilderEntryDisplayFields {
   type: 'conditional';
+  id?: string;
   steps: WorkflowBuilderExecutableInnerEntry[];
   predicates: Predicate[];
 }
 
-export interface WorkflowBuilderLoopEntry {
+export interface WorkflowBuilderLoopEntry extends WorkflowBuilderEntryDisplayFields {
   type: 'loop';
+  id?: string;
   step: WorkflowBuilderExecutableInnerEntry;
   loopType: 'dowhile' | 'dountil';
   predicate: Predicate;
@@ -160,7 +173,11 @@ function normalizeJsonValue(value: unknown, path: string, seen: Set<object>): Wo
 // would otherwise omit. Strip null at exactly the optional structural slots the
 // canonical schema declares — never blanket-strip, because a mapping constant
 // source `{ "value": null }` is a legitimate null.
-const OPTIONAL_ENTRY_KEYS = ['description', 'outputSchema', 'options', 'opts'] as const;
+const OPTIONAL_ENTRY_KEYS = ['description', 'metadata', 'outputSchema', 'options', 'opts'] as const;
+// `id` is optional only on container entries (parallel/conditional/foreach/loop);
+// on sleep/sleepUntil/mapping it is required, so a null id there must survive to
+// fail validation instead of being silently dropped.
+const OPTIONAL_ID_ENTRY_TYPES = new Set(['parallel', 'conditional', 'foreach', 'loop']);
 const OPTIONAL_STEP_OPTION_KEYS = ['retries', 'metadata'] as const;
 const OPTIONAL_FOREACH_OPT_KEYS = ['concurrency'] as const;
 
@@ -173,6 +190,9 @@ function dropNullKeys(target: WorkflowBuilderJsonObject, keys: readonly string[]
 function normalizeEntry(entry: Record<string, unknown>): WorkflowBuilderGraphEntry {
   const normalized = normalizeJsonValue(entry, 'graph entry', new Set()) as WorkflowBuilderJsonObject;
   dropNullKeys(normalized, OPTIONAL_ENTRY_KEYS);
+  if (typeof normalized.type === 'string' && OPTIONAL_ID_ENTRY_TYPES.has(normalized.type)) {
+    dropNullKeys(normalized, ['id']);
+  }
   if (normalized.options && typeof normalized.options === 'object' && !Array.isArray(normalized.options)) {
     dropNullKeys(normalized.options as WorkflowBuilderJsonObject, OPTIONAL_STEP_OPTION_KEYS);
     if (Object.keys(normalized.options).length === 0) delete normalized.options;

--- a/packages/core/src/workflows/dynamic/rehydrate.ts
+++ b/packages/core/src/workflows/dynamic/rehydrate.ts
@@ -16,6 +16,7 @@ import { mapVariable, predicateToCondition } from '../workflow';
 import { jsonSchemaToZod } from './json-schema-to-zod';
 import type { JsonSchema, JsonSchemaToZodOptions } from './json-schema-to-zod';
 import { parseMapConfig } from './mapping-config';
+import { entryOptionFields } from './serialize';
 import type { ValidatableStepFlowEntry } from './validate/types';
 
 /**
@@ -119,7 +120,7 @@ function applyGraphEntry(
     case 'mapping': {
       const cfg = parseMapConfig(entry.mapConfig, entry.id);
       const live = rehydrateMapConfig(cfg, mastra);
-      wf.map(live, { id: entry.id });
+      wf.map(live, { id: entry.id, description: entry.description, metadata: entry.metadata });
       return;
     }
     case 'sleep': {
@@ -128,7 +129,12 @@ function applyGraphEntry(
       }
       // Push directly (not wf.sleep()) so the stored step id survives the
       // round-trip — the builder generates a fresh random id per call.
-      const live: StepFlowEntry = { type: 'sleep', id: entry.id, duration: entry.duration };
+      const live: StepFlowEntry = {
+        type: 'sleep',
+        ...entryOptionFields(entry),
+        id: entry.id,
+        duration: entry.duration,
+      };
       wf.__pushStepFlowEntry(live, live);
       return;
     }
@@ -140,13 +146,14 @@ function applyGraphEntry(
       if (Number.isNaN(date.getTime())) {
         throw new Error(`Stored sleepUntil "${entry.id}" has an unparseable date: ${String(entry.date)}`);
       }
-      const live: StepFlowEntry = { type: 'sleepUntil', id: entry.id, date };
-      wf.__pushStepFlowEntry(live, { type: 'sleepUntil', id: entry.id, date });
+      const live: StepFlowEntry = { type: 'sleepUntil', ...entryOptionFields(entry), id: entry.id, date };
+      wf.__pushStepFlowEntry(live, { type: 'sleepUntil', ...entryOptionFields(entry), id: entry.id, date });
       return;
     }
     case 'parallel': {
       const live: StepFlowEntry = {
         type: 'parallel',
+        ...entryOptionFields(entry),
         steps: entry.steps.map(s => rehydrateSingleEntry(s, mastra, schemaOpts)),
       };
       wf.__pushStepFlowEntry(live, entry);
@@ -160,6 +167,7 @@ function applyGraphEntry(
       }
       const live: StepFlowEntry = {
         type: 'foreach',
+        ...entryOptionFields(entry),
         step: rehydrateSingleEntry(entry.step, mastra, schemaOpts),
         opts: { concurrency: entry.opts?.concurrency ?? 1 },
       };
@@ -196,6 +204,7 @@ function applyGraphEntry(
         steps.map((s, i) => ({ id: `${getSingleStepEntryId(s)}-condition`, fn: derivePredicateLabel(predicates[i]!) }));
       const live: StepFlowEntry = {
         type: 'conditional',
+        ...entryOptionFields(entry),
         steps,
         conditions: predicates.map(p => predicateToCondition(p!)),
         serializedConditions,
@@ -218,6 +227,7 @@ function applyGraphEntry(
       };
       const live: StepFlowEntry = {
         type: 'loop',
+        ...entryOptionFields(entry),
         step,
         condition: predicateToCondition(predicate),
         loopType,

--- a/packages/core/src/workflows/dynamic/serialize.ts
+++ b/packages/core/src/workflows/dynamic/serialize.ts
@@ -87,7 +87,10 @@ function serializeEntry(entry: StepFlowEntry): SerializedStepFlowEntry {
         opts:
           typeof entry.opts.concurrency === 'function'
             ? { fn: entry.opts.concurrency.toString() }
-            : { concurrency: entry.opts.concurrency },
+            : // The live entry keeps the caller's options object by reference, and
+              // `.foreach(step, { id })` is valid without a concurrency — default it
+              // here so stored graphs never carry an empty (schema-invalid) opts.
+              { concurrency: entry.opts.concurrency ?? 1 },
       };
     case 'conditional': {
       const predicates = entry.predicates;

--- a/packages/core/src/workflows/dynamic/serialize.ts
+++ b/packages/core/src/workflows/dynamic/serialize.ts
@@ -24,8 +24,27 @@ import type {
   SerializedStepOptions,
   SingleStepEntry,
   StepFlowEntry,
+  StepFlowEntryOptions,
 } from '../types';
 import { getSingleStepEntryId } from '../utils';
+
+/**
+ * The optional identity/display fields (`id` / `description` / `metadata`) of a
+ * control-flow entry, as a spreadable object. Both halves of the round-trip
+ * rebuild entries from a whitelist (`serializeEntry` here, `applyGraphEntry` in
+ * `./rehydrate`), so these must be picked explicitly or they'd be dropped.
+ */
+export function entryOptionFields(entry: {
+  id?: string;
+  description?: string;
+  metadata?: Record<string, any>;
+}): StepFlowEntryOptions {
+  const out: StepFlowEntryOptions = {};
+  if (entry.id !== undefined) out.id = entry.id;
+  if (entry.description !== undefined) out.description = entry.description;
+  if (entry.metadata !== undefined) out.metadata = entry.metadata;
+  return out;
+}
 
 /**
  * Walk a live `stepFlow` and emit a JSON-safe `SerializedStepFlowEntry[]` with
@@ -47,14 +66,14 @@ function serializeEntry(entry: StepFlowEntry): SerializedStepFlowEntry {
       if (typeof entry.duration !== 'number') {
         throw new Error(`Sleep step "${entry.id}" cannot be stored: dynamic duration (function) is not supported.`);
       }
-      return { type: 'sleep', id: entry.id, duration: entry.duration };
+      return { type: 'sleep', ...entryOptionFields(entry), id: entry.id, duration: entry.duration };
     case 'sleepUntil':
       if (!(entry.date instanceof Date)) {
         throw new Error(`SleepUntil step "${entry.id}" cannot be stored: dynamic date (function) is not supported.`);
       }
-      return { type: 'sleepUntil', id: entry.id, date: entry.date };
+      return { type: 'sleepUntil', ...entryOptionFields(entry), id: entry.id, date: entry.date };
     case 'parallel':
-      return { type: 'parallel', steps: entry.steps.map(s => serializeSingleEntry(s)) };
+      return { type: 'parallel', ...entryOptionFields(entry), steps: entry.steps.map(s => serializeSingleEntry(s)) };
     case 'foreach':
       if (entry.step.type === 'mapping') {
         throw new Error(
@@ -63,6 +82,7 @@ function serializeEntry(entry: StepFlowEntry): SerializedStepFlowEntry {
       }
       return {
         type: 'foreach',
+        ...entryOptionFields(entry),
         step: serializeSingleEntry(entry.step),
         opts:
           typeof entry.opts.concurrency === 'function'
@@ -78,6 +98,7 @@ function serializeEntry(entry: StepFlowEntry): SerializedStepFlowEntry {
       }
       return {
         type: 'conditional',
+        ...entryOptionFields(entry),
         steps: entry.steps.map(s => serializeSingleEntry(s)),
         serializedConditions: entry.serializedConditions,
         predicates,
@@ -92,6 +113,7 @@ function serializeEntry(entry: StepFlowEntry): SerializedStepFlowEntry {
       }
       return {
         type: 'loop',
+        ...entryOptionFields(entry),
         step: serializeSingleEntry(entry.step),
         serializedCondition: entry.serializedCondition,
         loopType: entry.loopType,
@@ -157,7 +179,7 @@ function serializeSingleEntry(entry: SingleStepEntry): SerializedSingleStepEntry
         serialized[key] = m;
       }
     }
-    return { type: 'mapping', id: entry.id, mapConfig: JSON.stringify(serialized) };
+    return { type: 'mapping', ...entryOptionFields(entry), id: entry.id, mapConfig: JSON.stringify(serialized) };
   }
   // A nested Workflow reached the generic `.then(step)` fallback (its
   // component discriminator is 'WORKFLOW'). Emit a declarative `workflow`

--- a/packages/core/src/workflows/dynamic/validate/index.test.ts
+++ b/packages/core/src/workflows/dynamic/validate/index.test.ts
@@ -41,6 +41,46 @@ describe('validateDynamicWorkflow', () => {
       );
     });
 
+    it('flags duplicated container entry ids, including collisions with leaf ids', () => {
+      const issues = validateDynamicWorkflow(
+        def({
+          graph: [
+            { type: 'parallel', id: 'duplicate', steps: [{ type: 'tool', id: 'left', toolId: 'a' }] },
+            { type: 'parallel', id: 'duplicate', steps: [{ type: 'tool', id: 'right', toolId: 'b' }] },
+            {
+              type: 'foreach',
+              id: 'left',
+              step: { type: 'tool', id: 'body', toolId: 'c' },
+              opts: { concurrency: 1 },
+            },
+          ],
+        }),
+      );
+      expect(issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: 'duplicate-step-id', path: 'graph.1.id' }),
+          expect.objectContaining({ code: 'duplicate-step-id', path: 'graph.2.id' }),
+        ]),
+      );
+    });
+
+    it('accepts unique container entry ids', () => {
+      const issues = validateDynamicWorkflow(
+        def({
+          graph: [
+            { type: 'parallel', id: 'fan-out', steps: [{ type: 'tool', id: 'left', toolId: 'a' }] },
+            {
+              type: 'foreach',
+              id: 'each-item',
+              step: { type: 'tool', id: 'body', toolId: 'b' },
+              opts: { concurrency: 1 },
+            },
+          ],
+        }),
+      );
+      expect(issues.filter(issue => issue.code === 'duplicate-step-id')).toEqual([]);
+    });
+
     it('rejects a mapping inside a container with exactly one issue', () => {
       const issues = validateDynamicWorkflow(
         def({

--- a/packages/core/src/workflows/dynamic/validate/index.test.ts
+++ b/packages/core/src/workflows/dynamic/validate/index.test.ts
@@ -64,6 +64,43 @@ describe('validateDynamicWorkflow', () => {
       );
     });
 
+    it('rejects a supplied-but-empty container entry id', () => {
+      const issues = validateDynamicWorkflow(
+        def({
+          graph: [{ type: 'parallel', id: '', steps: [{ type: 'tool', id: 'left', toolId: 'a' }] }],
+        }),
+      );
+      expect(issues).toEqual(
+        expect.arrayContaining([expect.objectContaining({ code: 'missing-step-id', path: 'graph.0.id' })]),
+      );
+    });
+
+    it('flags a container id colliding with a sleep id regardless of graph order', () => {
+      const issues = validateDynamicWorkflow(
+        def({
+          graph: [
+            { type: 'parallel', id: 'same', steps: [{ type: 'tool', id: 'left', toolId: 'a' }] },
+            { type: 'sleep', id: 'same', duration: 5 },
+          ],
+        }),
+      );
+      expect(issues).toEqual(
+        expect.arrayContaining([expect.objectContaining({ code: 'duplicate-step-id', path: 'graph.0.id' })]),
+      );
+    });
+
+    it('still accepts pre-existing sleep-to-sleep duplicate ids (backward compatibility)', () => {
+      const issues = validateDynamicWorkflow(
+        def({
+          graph: [
+            { type: 'sleep', id: 'wait', duration: 5 },
+            { type: 'sleep', id: 'wait', duration: 10 },
+          ],
+        }),
+      );
+      expect(issues.filter(issue => issue.code === 'duplicate-step-id')).toEqual([]);
+    });
+
     it('accepts unique container entry ids', () => {
       const issues = validateDynamicWorkflow(
         def({

--- a/packages/core/src/workflows/dynamic/validate/index.test.ts
+++ b/packages/core/src/workflows/dynamic/validate/index.test.ts
@@ -89,6 +89,20 @@ describe('validateDynamicWorkflow', () => {
       );
     });
 
+    it('flags the container id when the sleep comes first in the graph', () => {
+      const issues = validateDynamicWorkflow(
+        def({
+          graph: [
+            { type: 'sleep', id: 'same', duration: 5 },
+            { type: 'parallel', id: 'same', steps: [{ type: 'tool', id: 'left', toolId: 'a' }] },
+          ],
+        }),
+      );
+      expect(issues).toEqual(
+        expect.arrayContaining([expect.objectContaining({ code: 'duplicate-step-id', path: 'graph.1.id' })]),
+      );
+    });
+
     it('still accepts pre-existing sleep-to-sleep duplicate ids (backward compatibility)', () => {
       const issues = validateDynamicWorkflow(
         def({

--- a/packages/core/src/workflows/dynamic/validate/structure.ts
+++ b/packages/core/src/workflows/dynamic/validate/structure.ts
@@ -46,6 +46,29 @@ export function validateWorkflowStructure(def: WorkflowValidationInput): Workflo
 
   def.graph.forEach((entry, index) => {
     const path = `graph.${index}`;
+    // Container ids are optional stable addresses; when supplied they must be
+    // unique against every other id in the workflow (leaf ids included — the
+    // leaf pass above has already populated `seenIds`). Sleep/sleepUntil ids
+    // stay outside this check: stored definitions carried author-supplied
+    // sleep ids long before duplicates were validated, so tightening them
+    // would reject previously-valid rows at boot.
+    if (
+      (entry.type === 'parallel' ||
+        entry.type === 'conditional' ||
+        entry.type === 'foreach' ||
+        entry.type === 'loop') &&
+      entry.id
+    ) {
+      if (seenIds.has(entry.id)) {
+        issues.push({
+          code: 'duplicate-step-id',
+          path: `${path}.id`,
+          message: `Entry id "${entry.id}" is duplicated.`,
+        });
+      } else {
+        seenIds.add(entry.id);
+      }
+    }
     switch (entry.type) {
       case 'parallel':
       case 'conditional': {

--- a/packages/core/src/workflows/dynamic/validate/structure.ts
+++ b/packages/core/src/workflows/dynamic/validate/structure.ts
@@ -44,22 +44,37 @@ export function validateWorkflowStructure(def: WorkflowValidationInput): Workflo
     }
   });
 
+  // Reserve sleep/sleepUntil ids before checking container ids, WITHOUT
+  // emitting issues for the sleeps themselves: stored definitions carried
+  // author-supplied sleep ids long before duplicates were validated, so
+  // flagging sleep-to-sleep (or sleep-to-leaf) collisions would reject
+  // previously-valid rows at boot. Reserving them still stops a NEW container
+  // id from squatting on a sleep id, regardless of graph order.
+  for (const entry of def.graph) {
+    if ((entry.type === 'sleep' || entry.type === 'sleepUntil') && entry.id) {
+      seenIds.add(entry.id);
+    }
+  }
+
   def.graph.forEach((entry, index) => {
     const path = `graph.${index}`;
     // Container ids are optional stable addresses; when supplied they must be
-    // unique against every other id in the workflow (leaf ids included — the
-    // leaf pass above has already populated `seenIds`). Sleep/sleepUntil ids
-    // stay outside this check: stored definitions carried author-supplied
-    // sleep ids long before duplicates were validated, so tightening them
-    // would reject previously-valid rows at boot.
+    // non-empty and unique against every other id in the workflow (leaf and
+    // sleep ids included — both passes above have populated `seenIds`).
     if (
       (entry.type === 'parallel' ||
         entry.type === 'conditional' ||
         entry.type === 'foreach' ||
         entry.type === 'loop') &&
-      entry.id
+      entry.id !== undefined
     ) {
-      if (seenIds.has(entry.id)) {
+      if (!entry.id) {
+        issues.push({
+          code: 'missing-step-id',
+          path: `${path}.id`,
+          message: 'Entry id must not be empty when supplied.',
+        });
+      } else if (seenIds.has(entry.id)) {
         issues.push({
           code: 'duplicate-step-id',
           path: `${path}.id`,

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -599,6 +599,22 @@ export type DefaultEngineType = {};
 export type MappingConfig = Record<string, any>;
 
 /**
+ * Optional identity and display metadata accepted by the control-flow builder
+ * methods (`.parallel()`, `.branch()`, `.dowhile()`, `.dountil()`, `.foreach()`,
+ * `.sleep()`, `.sleepUntil()`, `.map()`). Mirrors the `id` / `description` /
+ * `metadata` model that executable steps already have: `id` is a stable machine
+ * identity for addressing the entry across edits and serialization,
+ * `description` explains the intent of the control-flow operation, and
+ * `metadata` carries arbitrary JSON-serializable data (e.g. a display title
+ * for visual editors). None of these affect execution.
+ */
+export type StepFlowEntryOptions = {
+  id?: string;
+  description?: string;
+  metadata?: StepMetadata;
+};
+
+/**
  * The "single step-like" graph entries: a plain user step plus the declarative
  * variants that Mastra interprets at execution time (agent / tool / mapping).
  *
@@ -612,7 +628,13 @@ export type SingleStepEntry<TEngineType = DefaultEngineType> =
   | { type: 'step'; step: Step }
   | { type: 'agent'; id: string; agentId: string; agent?: any; options?: any }
   | { type: 'tool'; id: string; toolId: string; tool?: any; options?: any }
-  | { type: 'mapping'; id: string; mapConfig: MappingConfig | ExecuteFunction<any, any, any, any, any, TEngineType> };
+  | {
+      type: 'mapping';
+      id: string;
+      description?: string;
+      metadata?: StepMetadata;
+      mapConfig: MappingConfig | ExecuteFunction<any, any, any, any, any, TEngineType>;
+    };
 
 /** The `{ type: 'step' }` variant of {@link SingleStepEntry}: a plain live step. */
 export type StepEntry = Extract<SingleStepEntry, { type: 'step' }>;
@@ -628,14 +650,34 @@ export type MappingStepEntry<TEngineType = DefaultEngineType> = Extract<
 
 export type StepFlowEntry<TEngineType = DefaultEngineType> =
   | SingleStepEntry<TEngineType>
-  | { type: 'sleep'; id: string; duration?: number; fn?: ExecuteFunction<any, any, any, any, any, TEngineType> }
-  | { type: 'sleepUntil'; id: string; date?: Date; fn?: ExecuteFunction<any, any, any, any, any, TEngineType> }
+  | {
+      type: 'sleep';
+      id: string;
+      description?: string;
+      metadata?: StepMetadata;
+      duration?: number;
+      fn?: ExecuteFunction<any, any, any, any, any, TEngineType>;
+    }
+  | {
+      type: 'sleepUntil';
+      id: string;
+      description?: string;
+      metadata?: StepMetadata;
+      date?: Date;
+      fn?: ExecuteFunction<any, any, any, any, any, TEngineType>;
+    }
   | {
       type: 'parallel';
+      id?: string;
+      description?: string;
+      metadata?: StepMetadata;
       steps: SingleStepEntry<TEngineType>[];
     }
   | {
       type: 'conditional';
+      id?: string;
+      description?: string;
+      metadata?: StepMetadata;
       steps: SingleStepEntry<TEngineType>[];
       conditions: ConditionFunction<any, any, any, any, any, TEngineType>[];
       serializedConditions: { id: string; fn: string }[];
@@ -653,6 +695,9 @@ export type StepFlowEntry<TEngineType = DefaultEngineType> =
       // storable). The live step shape is aligned with `parallel` / `foreach`
       // so the builder can accept an Agent / Tool directly.
       type: 'loop';
+      id?: string;
+      description?: string;
+      metadata?: StepMetadata;
       step: SingleStepEntry<TEngineType>;
       condition: LoopConditionFunction<any, any, any, any, any, TEngineType>;
       serializedCondition: { id: string; fn: string };
@@ -666,6 +711,9 @@ export type StepFlowEntry<TEngineType = DefaultEngineType> =
     }
   | {
       type: 'foreach';
+      id?: string;
+      description?: string;
+      metadata?: StepMetadata;
       step: SingleStepEntry<TEngineType>;
       opts: ForeachOptions;
     };
@@ -746,7 +794,7 @@ export type SerializedSingleStepEntry =
       // looked up from the live Mastra instance at rehydration time.
       options?: SerializedStepOptions;
     }
-  | { type: 'mapping'; id: string; mapConfig: string }
+  | { type: 'mapping'; id: string; description?: string; metadata?: StepMetadata; mapConfig: string }
   /**
    * A nested workflow referenced by its registered id (code-defined or
    * another dynamic workflow). The referenced workflow must resolve on the
@@ -771,21 +819,31 @@ export type SerializedStepFlowEntry =
   | {
       type: 'sleep';
       id: string;
+      description?: string;
+      metadata?: StepMetadata;
       duration?: number;
       fn?: string;
     }
   | {
       type: 'sleepUntil';
       id: string;
+      description?: string;
+      metadata?: StepMetadata;
       date?: Date;
       fn?: string;
     }
   | {
       type: 'parallel';
+      id?: string;
+      description?: string;
+      metadata?: StepMetadata;
       steps: SerializedSingleStepEntry[];
     }
   | {
       type: 'conditional';
+      id?: string;
+      description?: string;
+      metadata?: StepMetadata;
       steps: SerializedSingleStepEntry[];
       serializedConditions: { id: string; fn: string }[];
       /**
@@ -801,6 +859,9 @@ export type SerializedStepFlowEntry =
     }
   | {
       type: 'loop';
+      id?: string;
+      description?: string;
+      metadata?: StepMetadata;
       step: SerializedSingleStepEntry;
       serializedCondition: { id: string; fn: string };
       loopType: 'dowhile' | 'dountil';
@@ -813,6 +874,9 @@ export type SerializedStepFlowEntry =
     }
   | {
       type: 'foreach';
+      id?: string;
+      description?: string;
+      metadata?: StepMetadata;
       step: SerializedSingleStepEntry;
       /**
        * Optional. When omitted, the engine defaults to `concurrency: 1`. Present

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -105,6 +105,7 @@ import type {
   StepMetadata,
   WorkflowRunStartOptions,
   ForeachOptions,
+  StepFlowEntryOptions,
 } from './types';
 import {
   cleanStepResult,
@@ -608,6 +609,19 @@ function toSerializedSingleStepEntry(step: StepWithRefMetadata): SerializedSingl
       canSuspend: Boolean(step.suspendSchema || step.resumeSchema),
     },
   };
+}
+
+/**
+ * The identity/display fields of a control-flow entry as a spreadable object,
+ * omitting absent fields so live and serialized graphs stay free of
+ * `undefined`-valued keys (serialized graphs are persisted as JSON).
+ */
+function toEntryOptionFields(options?: StepFlowEntryOptions): StepFlowEntryOptions {
+  const out: StepFlowEntryOptions = {};
+  if (options?.id !== undefined) out.id = options.id;
+  if (options?.description !== undefined) out.description = options.description;
+  if (options?.metadata !== undefined) out.metadata = options.metadata;
+  return out;
 }
 
 function createStepFromProcessor<TProcessorId extends string>(
@@ -1997,24 +2011,33 @@ export class Workflow<
   /**
    * Adds a sleep step to the workflow
    * @param duration The duration to sleep for
+   * @param options Optional stable `id`, `description`, and `metadata` for the entry
    * @returns The workflow instance for chaining
    */
-  sleep(duration: number | ExecuteFunction<TState, TPrevSchema, number, any, any, TEngineType>) {
-    const id = `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep' }) || randomUUID()}`;
+  sleep(
+    duration: number | ExecuteFunction<TState, TPrevSchema, number, any, any, TEngineType>,
+    options?: StepFlowEntryOptions,
+  ) {
+    const id =
+      options?.id ||
+      `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep' }) || randomUUID()}`;
+    const displayFields = toEntryOptionFields(options);
 
     const opts: StepFlowEntry<TEngineType> =
       typeof duration === 'function'
-        ? { type: 'sleep', id, fn: duration }
-        : { type: 'sleep', id, duration: duration as number };
+        ? { type: 'sleep', id, ...displayFields, fn: duration }
+        : { type: 'sleep', id, ...displayFields, duration: duration as number };
     const serializedOpts: SerializedStepFlowEntry =
       typeof duration === 'function'
-        ? { type: 'sleep', id, fn: duration.toString() }
-        : { type: 'sleep', id, duration: duration as number };
+        ? { type: 'sleep', id, ...displayFields, fn: duration.toString() }
+        : { type: 'sleep', id, ...displayFields, duration: duration as number };
 
     this.stepFlow.push(opts);
     this.serializedStepFlow.push(serializedOpts);
     this.steps[id] = createStep({
       id,
+      description: options?.description,
+      metadata: options?.metadata,
       inputSchema: z.object({}),
       outputSchema: z.object({}),
       execute: async () => {
@@ -2036,23 +2059,32 @@ export class Workflow<
   /**
    * Adds a sleep until step to the workflow
    * @param date The date to sleep until
+   * @param options Optional stable `id`, `description`, and `metadata` for the entry
    * @returns The workflow instance for chaining
    */
-  sleepUntil(date: Date | ExecuteFunction<TState, TPrevSchema, Date, any, any, TEngineType>) {
-    const id = `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep-until' }) || randomUUID()}`;
+  sleepUntil(
+    date: Date | ExecuteFunction<TState, TPrevSchema, Date, any, any, TEngineType>,
+    options?: StepFlowEntryOptions,
+  ) {
+    const id =
+      options?.id ||
+      `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep-until' }) || randomUUID()}`;
+    const displayFields = toEntryOptionFields(options);
     const opts: StepFlowEntry<TEngineType> =
       typeof date === 'function'
-        ? { type: 'sleepUntil', id, fn: date }
-        : { type: 'sleepUntil', id, date: date as Date };
+        ? { type: 'sleepUntil', id, ...displayFields, fn: date }
+        : { type: 'sleepUntil', id, ...displayFields, date: date as Date };
     const serializedOpts: SerializedStepFlowEntry =
       typeof date === 'function'
-        ? { type: 'sleepUntil', id, fn: date.toString() }
-        : { type: 'sleepUntil', id, date: date as Date };
+        ? { type: 'sleepUntil', id, ...displayFields, fn: date.toString() }
+        : { type: 'sleepUntil', id, ...displayFields, date: date as Date };
 
     this.stepFlow.push(opts);
     this.serializedStepFlow.push(serializedOpts);
     this.steps[id] = createStep({
       id,
+      description: options?.description,
+      metadata: options?.metadata,
       inputSchema: z.object({}),
       outputSchema: z.object({}),
       execute: async () => {
@@ -2122,7 +2154,7 @@ export class Workflow<
             | DynamicMapping<TPrevSchema, any>;
         }
       | ExecuteFunction<TState, TPrevSchema, any, any, any, TEngineType>,
-    stepOptions?: { id?: string | null },
+    stepOptions?: { id?: string | null; description?: string; metadata?: StepMetadata },
   ): Workflow<TEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, any, TRequestContext> {
     // Build a declarative `{ type: 'mapping' }` graph entry; the mapping logic is
     // interpreted at execution time by `createMappingStep`, not baked in here.
@@ -2159,11 +2191,17 @@ export class Workflow<
       }
     }
 
+    const mappingDisplayFields = toEntryOptionFields({
+      description: stepOptions?.description,
+      metadata: stepOptions?.metadata,
+    });
+
     if (typeof mappingConfig === 'function') {
-      this.stepFlow.push({ type: 'mapping', id: mappingId, mapConfig: mappingConfig as any });
+      this.stepFlow.push({ type: 'mapping', id: mappingId, ...mappingDisplayFields, mapConfig: mappingConfig as any });
       this.serializedStepFlow.push({
         type: 'mapping',
         id: mappingId,
+        ...mappingDisplayFields,
         mapConfig: truncate(mappingConfig.toString()),
       });
       this.steps[mappingId] = createMappingStep(mappingId, mappingConfig as any) as any;
@@ -2228,10 +2266,16 @@ export class Workflow<
 
     type MappedOutputSchema = any;
 
-    this.stepFlow.push({ type: 'mapping', id: mappingId, mapConfig: mappingConfig as MappingConfig });
+    this.stepFlow.push({
+      type: 'mapping',
+      id: mappingId,
+      ...mappingDisplayFields,
+      mapConfig: mappingConfig as MappingConfig,
+    });
     this.serializedStepFlow.push({
       type: 'mapping',
       id: mappingId,
+      ...mappingDisplayFields,
       mapConfig: truncate(JSON.stringify(newMappingConfig, null, 2)),
     });
     this.steps[mappingId] = createMappingStep(mappingId, mappingConfig as MappingConfig) as any;
@@ -2274,13 +2318,17 @@ export class Workflow<
           >
         : `Error: Expected Step with state schema that is a subset of workflow state`;
     },
+    options?: StepFlowEntryOptions,
   ) {
+    const entryOptionFields = toEntryOptionFields(options);
     this.stepFlow.push({
       type: 'parallel',
+      ...entryOptionFields,
       steps: steps.map(step => toSingleStepEntry(step as StepWithRefMetadata)),
     });
     this.serializedStepFlow.push({
       type: 'parallel',
+      ...entryOptionFields,
       steps: steps.map(step => toSerializedSingleStepEntry(step as StepWithRefMetadata)),
     });
     steps.forEach(step => {
@@ -2311,7 +2359,8 @@ export class Workflow<
         Step<string, any, TPrevSchema, any, any, any, TEngineType, any>,
       ]
     >,
-  >(steps: TBranchSteps) {
+  >(steps: TBranchSteps, options?: StepFlowEntryOptions) {
+    const entryOptionFields = toEntryOptionFields(options);
     const resolved = steps.map(([condOrPred, step]) => {
       const isDeclarative = isDeclarativePredicateArg(condOrPred);
       const predicate = isDeclarative ? (condOrPred as { predicate: Predicate }).predicate : undefined;
@@ -2323,6 +2372,7 @@ export class Workflow<
     });
     this.stepFlow.push({
       type: 'conditional',
+      ...entryOptionFields,
       steps: resolved.map(({ step }) => toSingleStepEntry(step as StepWithRefMetadata)),
       conditions: resolved.map(({ condition }) => condition),
       serializedConditions: resolved.map(({ step, label }) => ({ id: `${step.id}-condition`, fn: label })),
@@ -2332,6 +2382,7 @@ export class Workflow<
     } as StepFlowEntry<TEngineType>);
     this.serializedStepFlow.push({
       type: 'conditional',
+      ...entryOptionFields,
       steps: resolved.map(({ step }) => toSerializedSingleStepEntry(step as StepWithRefMetadata)),
       serializedConditions: resolved.map(({ step, label }) => ({ id: `${step.id}-condition`, fn: label })),
       ...(resolved.some(({ predicate }) => predicate)
@@ -2379,7 +2430,9 @@ export class Workflow<
       unknown extends TStepRC ? unknown : TRequestContext
     >,
     condition: LoopConditionFunction<TState, TSchemaOut, any, any, any, TEngineType> | { predicate: Predicate },
+    options?: StepFlowEntryOptions,
   ) {
+    const entryOptionFields = toEntryOptionFields(options);
     const isDeclarative = isDeclarativePredicateArg(condition);
     const predicate = isDeclarative ? (condition as { predicate: Predicate }).predicate : undefined;
     const runtimeCondition = isDeclarative
@@ -2388,6 +2441,7 @@ export class Workflow<
     const label = predicate ? derivePredicateLabel(predicate) : runtimeCondition.toString();
     this.stepFlow.push({
       type: 'loop',
+      ...entryOptionFields,
       step: toSingleStepEntry(step),
       condition: runtimeCondition,
       loopType: 'dowhile',
@@ -2396,6 +2450,7 @@ export class Workflow<
     } as StepFlowEntry<TEngineType>);
     this.serializedStepFlow.push({
       type: 'loop',
+      ...entryOptionFields,
       step: toSerializedSingleStepEntry(step as StepWithRefMetadata),
       serializedCondition: { id: `${step.id}-condition`, fn: label },
       loopType: 'dowhile',
@@ -2428,7 +2483,9 @@ export class Workflow<
       unknown extends TStepRC ? unknown : TRequestContext
     >,
     condition: LoopConditionFunction<TState, TSchemaOut, any, any, any, TEngineType> | { predicate: Predicate },
+    options?: StepFlowEntryOptions,
   ) {
+    const entryOptionFields = toEntryOptionFields(options);
     const isDeclarative = isDeclarativePredicateArg(condition);
     const predicate = isDeclarative ? (condition as { predicate: Predicate }).predicate : undefined;
     const runtimeCondition = isDeclarative
@@ -2437,6 +2494,7 @@ export class Workflow<
     const label = predicate ? derivePredicateLabel(predicate) : runtimeCondition.toString();
     this.stepFlow.push({
       type: 'loop',
+      ...entryOptionFields,
       step: toSingleStepEntry(step),
       condition: runtimeCondition,
       loopType: 'dountil',
@@ -2445,6 +2503,7 @@ export class Workflow<
     } as StepFlowEntry<TEngineType>);
     this.serializedStepFlow.push({
       type: 'loop',
+      ...entryOptionFields,
       step: toSerializedSingleStepEntry(step as StepWithRefMetadata),
       serializedCondition: { id: `${step.id}-condition`, fn: label },
       loopType: 'dountil',
@@ -2485,18 +2544,21 @@ export class Workflow<
           unknown extends TStepRC ? unknown : TRequestContext
         >
       : 'Previous step must return an array type',
-    opts?: ForeachOptions,
+    opts?: Partial<ForeachOptions> & StepFlowEntryOptions,
   ) {
     const concurrency = opts?.concurrency ?? 1;
     const serializedOpts = typeof concurrency === 'function' ? { fn: concurrency.toString() } : { concurrency };
+    const entryOptionFields = toEntryOptionFields(opts);
     const foreachStep = step as StepWithRefMetadata;
     this.stepFlow.push({
       type: 'foreach',
+      ...entryOptionFields,
       step: toSingleStepEntry(foreachStep),
-      opts: opts ?? { concurrency: 1 },
+      opts: { concurrency },
     });
     this.serializedStepFlow.push({
       type: 'foreach',
+      ...entryOptionFields,
       step: toSerializedSingleStepEntry(foreachStep),
       opts: serializedOpts,
     });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2561,11 +2561,14 @@ export class Workflow<
       type: 'foreach',
       ...entryOptionFields,
       step: toSingleStepEntry(foreachStep),
-      // Keep the caller's options object BY REFERENCE: the agentic execution
-      // workflow mutates `concurrency` on it between build and execution
-      // (see createAgenticExecutionWorkflow's map-tool-calls step). Snapshotting
-      // here would freeze tool-call parallelism at its conservative initial value.
-      opts: (opts as ForeachOptions | undefined) ?? { concurrency: 1 },
+      // Keep the caller's options object BY REFERENCE when it carries a
+      // concurrency: the agentic execution workflow mutates `concurrency` on it
+      // between build and execution (see createAgenticExecutionWorkflow's
+      // map-tool-calls step), and snapshotting would freeze tool-call
+      // parallelism at its conservative initial value. `.foreach(step, { id })`
+      // has no concurrency to mutate, so give that live entry the engine
+      // default instead of an opts object that lies about the type.
+      opts: opts?.concurrency === undefined ? { ...opts, concurrency: 1 } : (opts as ForeachOptions),
     });
     this.serializedStepFlow.push({
       type: 'foreach',

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2024,7 +2024,9 @@ export class Workflow<
     const id =
       options?.id ||
       `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep' }) || randomUUID()}`;
-    const displayFields = toEntryOptionFields(options);
+    // Only the display fields: `id` is spelled explicitly from the normalized
+    // value above, so a falsy caller id can never override the generated one.
+    const displayFields = toEntryOptionFields({ description: options?.description, metadata: options?.metadata });
 
     const opts: StepFlowEntry<TEngineType> =
       typeof duration === 'function'
@@ -2072,7 +2074,9 @@ export class Workflow<
     const id =
       options?.id ||
       `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep-until' }) || randomUUID()}`;
-    const displayFields = toEntryOptionFields(options);
+    // Only the display fields: `id` is spelled explicitly from the normalized
+    // value above, so a falsy caller id can never override the generated one.
+    const displayFields = toEntryOptionFields({ description: options?.description, metadata: options?.metadata });
     const opts: StepFlowEntry<TEngineType> =
       typeof date === 'function'
         ? { type: 'sleepUntil', id, ...displayFields, fn: date }
@@ -2557,7 +2561,11 @@ export class Workflow<
       type: 'foreach',
       ...entryOptionFields,
       step: toSingleStepEntry(foreachStep),
-      opts: { concurrency },
+      // Keep the caller's options object BY REFERENCE: the agentic execution
+      // workflow mutates `concurrency` on it between build and execution
+      // (see createAgenticExecutionWorkflow's map-tool-calls step). Snapshotting
+      // here would freeze tool-call parallelism at its conservative initial value.
+      opts: (opts as ForeachOptions | undefined) ?? { concurrency: 1 },
     });
     this.serializedStepFlow.push({
       type: 'foreach',

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1849,9 +1849,12 @@ export class Workflow<
         return;
       case 'sleep':
       case 'sleepUntil':
-        // Same no-op placeholder the sleep/sleepUntil builder methods register.
+        // Same no-op placeholder the sleep/sleepUntil builder methods register,
+        // including the entry's display fields so steps/allSteps stay in sync.
         this.steps[live.id] = createStep({
           id: live.id,
+          description: live.description,
+          metadata: live.metadata,
           inputSchema: z.object({}),
           outputSchema: z.object({}),
           execute: async () => ({}),

--- a/packages/playground/src/domains/workflows/workflow/utils.ts
+++ b/packages/playground/src/domains/workflows/workflow/utils.ts
@@ -181,7 +181,9 @@ export type WStep = {
 
 /** Resolves the id of a single step-like serialized entry (step / agent / tool / mapping). */
 const getSingleStepFlowId = (flow: SerializedStepFlowEntry): string => {
-  if ('id' in flow) return flow.id;
+  // Container entries also carry an optional `id` now, so guard for presence,
+  // not just for the key existing on the variant.
+  if ('id' in flow && flow.id !== undefined) return flow.id;
   if ('step' in flow) {
     const inner = flow.step;
     if ('id' in inner) return inner.id;
@@ -342,7 +344,7 @@ const getStepNodeAndEdge = ({
     const stepId = stepFlow.id;
     const rawNodeId = allPrevNodeIds.has(getWorkflowNodeId(stepId)) ? `${stepId}-${yIndex}` : stepId;
     const nodeId = getWorkflowNodeId(rawNodeId);
-    const description = stepFlow.type === 'mapping' ? undefined : stepFlow.description;
+    const description = stepFlow.description;
     const label = stepFlow.type === 'mapping' ? formatMappingLabel(stepId, prevStepIds, nextStepIds) : stepId;
     const conditionNodes: WorkflowStepNode[] = condition
       ? [
@@ -375,6 +377,7 @@ const getStepNodeAndEdge = ({
           workflowStep: resolveWorkflowGraphStep(stepFlow),
           stepId,
           description,
+          metadata: stepFlow.type === 'mapping' ? stepFlow.metadata : undefined,
           withoutTopHandle: condition ? false : !prevNodeIds.length,
           withoutBottomHandle: !nextNodeIds.length,
           mapConfig: stepFlow.type === 'mapping' ? stepFlow.mapConfig : undefined,
@@ -455,6 +458,8 @@ const getStepNodeAndEdge = ({
           label: stepFlow.id,
           workflowStep: resolveWorkflowGraphStep(stepFlow),
           stepId: stepFlow.id,
+          description: stepFlow.description,
+          metadata: stepFlow.metadata,
           withoutTopHandle: condition ? false : !prevNodeIds.length,
           withoutBottomHandle: !nextNodeIds.length,
           ...(stepFlow.type === 'sleepUntil' ? { date: stepFlow.date } : { duration: stepFlow.duration }),

--- a/packages/server/src/server/schemas/dynamic-workflows.test.ts
+++ b/packages/server/src/server/schemas/dynamic-workflows.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { dynamicWorkflowDefinitionBodySchema } from './dynamic-workflows';
+
+const baseDefinition = {
+  id: 'wire-wf',
+  inputSchema: { type: 'object' },
+  outputSchema: { type: 'object' },
+};
+
+describe('dynamic workflow wire schema — control-flow entry identity fields', () => {
+  it('preserves id/description/metadata on every control-flow entry instead of stripping them', () => {
+    const graph = [
+      {
+        type: 'parallel',
+        id: 'fan-out',
+        description: 'Run both',
+        metadata: { title: 'Fan out' },
+        steps: [{ type: 'tool', id: 'echo', toolId: 'echo-tool' }],
+      },
+      {
+        type: 'conditional',
+        id: 'route',
+        description: 'Route on value',
+        metadata: { title: 'Route' },
+        steps: [{ type: 'tool', id: 'echo-2', toolId: 'echo-tool' }],
+        predicates: [{ op: 'truthy', value: { path: 'inputData.value' } }],
+      },
+      {
+        type: 'loop',
+        id: 'bump',
+        description: 'Loop it',
+        metadata: { title: 'Bump' },
+        step: { type: 'tool', id: 'echo-3', toolId: 'echo-tool' },
+        loopType: 'dountil',
+        predicate: { op: 'truthy', value: { path: 'inputData.done' } },
+      },
+      {
+        type: 'foreach',
+        id: 'each',
+        description: 'Per item',
+        metadata: { title: 'Each' },
+        step: { type: 'tool', id: 'echo-4', toolId: 'echo-tool' },
+        opts: { concurrency: 2 },
+      },
+      { type: 'sleep', id: 'wait', description: 'Pause', metadata: { title: 'Wait' }, duration: 5 },
+      { type: 'sleepUntil', id: 'hold', description: 'Hold', metadata: { title: 'Hold' }, date: '2099-01-01' },
+      { type: 'mapping', id: 'shape', description: 'Reshape', metadata: { title: 'Shape' }, mapConfig: '{}' },
+    ];
+
+    const result = dynamicWorkflowDefinitionBodySchema.safeParse({ ...baseDefinition, graph });
+
+    expect(result.success).toBe(true);
+    for (const [index, entry] of graph.entries()) {
+      expect(result.data!.graph[index]).toMatchObject({
+        id: entry.id,
+        description: entry.description,
+        metadata: entry.metadata,
+      });
+    }
+  });
+
+  it('still accepts control-flow entries without the optional identity fields', () => {
+    const result = dynamicWorkflowDefinitionBodySchema.safeParse({
+      ...baseDefinition,
+      graph: [
+        { type: 'parallel', steps: [{ type: 'tool', id: 'echo', toolId: 'echo-tool' }] },
+        { type: 'sleep', id: 'wait', duration: 5 },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data!.graph[0]).not.toHaveProperty('description');
+  });
+});

--- a/packages/server/src/server/schemas/dynamic-workflows.ts
+++ b/packages/server/src/server/schemas/dynamic-workflows.ts
@@ -17,6 +17,19 @@ const stepOptionsSchema = z
   })
   .optional();
 
+// Optional identity/display fields on control-flow entries (mirrors core's
+// `StepFlowEntryOptions`). Declared explicitly because zod's default object
+// mode strips unknown keys — without these, posted fields would vanish
+// silently before reaching core.
+const entryDisplayFields = {
+  description: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+};
+const containerIdentityFields = {
+  id: z.string().optional(),
+  ...entryDisplayFields,
+};
+
 // ----------------------------------------------------------------------------
 // Predicate DSL — declarative condition for `conditional` / `loop` entries.
 // Mirrors `Predicate` in `@mastra/core/workflows/predicate`; duplicated
@@ -70,6 +83,7 @@ const toolEntrySchema = z.object({
 const mappingEntrySchema = z.object({
   type: z.literal('mapping'),
   id: z.string(),
+  ...entryDisplayFields,
   mapConfig: z.string(),
 });
 
@@ -96,21 +110,25 @@ const graphEntrySchema = z.discriminatedUnion('type', [
   workflowEntrySchema,
   z.object({
     type: z.literal('parallel'),
+    ...containerIdentityFields,
     steps: z.array(singleStepEntrySchema),
   }),
   z.object({
     type: z.literal('foreach'),
+    ...containerIdentityFields,
     step: foreachInnerStepSchema,
     opts: z.object({ concurrency: z.number().int().positive() }).optional(),
   }),
   z.object({
     type: z.literal('sleep'),
     id: z.string(),
+    ...entryDisplayFields,
     duration: z.number(),
   }),
   z.object({
     type: z.literal('sleepUntil'),
     id: z.string(),
+    ...entryDisplayFields,
     date: z.string(),
   }),
   z
@@ -120,6 +138,7 @@ const graphEntrySchema = z.discriminatedUnion('type', [
       // accepted over the wire (they'd be arbitrary JS strings we can't
       // safely rehydrate).
       type: z.literal('conditional'),
+      ...containerIdentityFields,
       steps: z.array(singleStepEntrySchema),
       predicates: z.array(predicateSchema),
     })
@@ -131,6 +150,7 @@ const graphEntrySchema = z.discriminatedUnion('type', [
   z.object({
     // Declarative-only loop. Same rationale as `conditional`.
     type: z.literal('loop'),
+    ...containerIdentityFields,
     step: singleStepEntrySchema,
     loopType: z.enum(['dowhile', 'dountil']),
     predicate: predicateSchema,

--- a/packages/server/src/server/schemas/workflows.ts
+++ b/packages/server/src/server/schemas/workflows.ts
@@ -61,6 +61,12 @@ const serializedStepFlowEntrySchema = z.object({
     'foreach',
     'workflow',
   ]),
+  // Identity/display fields shared by declarative and control-flow entries.
+  // This schema documents responses (OpenAPI/generated clients); it is not
+  // parsed at runtime, so per-type fields beyond these stay untyped.
+  id: z.string().optional(),
+  description: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 /**


### PR DESCRIPTION
## Description

Adds optional `id`, `description`, and `metadata` to workflow control-flow entries (`.parallel()`, `.branch()`, `.dowhile()`, `.dountil()`, `.foreach()`, `.sleep()`, `.sleepUntil()`, `.map()`), matching the identity model executable steps already have. Visual editors can label these entries and address them with a stable id instead of a graph position.

- New `StepFlowEntryOptions` accepted as a trailing options argument on all control-flow builder methods; for `.foreach()` the fields ride in the existing `opts` object
- Fields survive the full round trip: `serializedStepGraph`, `toStorableGraph`, storage, `rehydrateWorkflow`, and boot-time rehydration (save → load → save is drift-free, covered by tests)
- Server wire schemas for dynamic workflows now accept and preserve the fields instead of silently stripping unknown keys; response schema documents them and client route types are regenerated
- Studio passes `description`/`metadata` into sleep, sleepUntil, and mapping graph nodes, same scope as #12508 did for step nodes
- A supplied `id` on `.sleep()`, `.sleepUntil()`, or `.map()` replaces the generated entry id; all fields are optional and have no effect on execution

## Related Issue(s)

Fixes #22616

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Workflow control-flow entries can now have stable IDs, descriptions, and extra metadata. These details remain available when workflows are saved, loaded, or displayed in visual tools, without changing execution.

## Summary

- Added optional `id`, `description`, and JSON-compatible `metadata` support to workflow control-flow builders.
- Preserved these fields through serialization, storage, rehydration, Dynamic Workflow validation, and HTTP schemas.
- Retained supplied IDs for `.map()`, `.sleep()`, and `.sleepUntil()`.
- Added validation for container IDs, including duplicate and empty IDs.
- Updated Studio nodes, Dynamic Workflow schemas, documentation, client route types, and package changesets.
- Added round-trip, validation, and schema tests.
- Kept execution, input schemas, and output schemas unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->