### PR TITLE
fix(core): keep image-url tool results intact for spec-v3+ models

### DIFF
--- a/.changeset/lucky-pears-listen.md
+++ b/.changeset/lucky-pears-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix DurableAgent rewriting `image-url` tool-result parts into the Base64-only `media.data` shape. Stored `toModelOutput` content now keeps `image-url` parts (including their `providerOptions`) intact; spec-`v3` prompts consume them natively, spec-`v4` prompts map them to url-tagged `file` parts, and spec-`v2` prompts get the legacy best-effort `media` downgrade.

--- a/packages/core/src/agent/durable/__tests__/normalize-model-output.test.ts
+++ b/packages/core/src/agent/durable/__tests__/normalize-model-output.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeModelOutput, downgradeImageUrlPartsForV2 } from '../workflows/steps/normalize-model-output';
+
+describe('normalizeModelOutput', () => {
+  it('keeps image-url parts as-is, preserving providerOptions', () => {
+    const output = {
+      type: 'content',
+      value: [
+        { type: 'text', text: 'radar image' },
+        {
+          type: 'image-url',
+          url: 'https://example.com/radar.png',
+          providerOptions: { repro: { traceId: 'preserve-me' } },
+        },
+      ],
+    };
+
+    expect(normalizeModelOutput(output)).toEqual(output);
+  });
+
+  it('still normalizes image-data parts into the media shape', () => {
+    const output = {
+      type: 'content',
+      value: [{ type: 'image-data', data: 'abc123', mediaType: 'image/png' }],
+    };
+
+    expect(normalizeModelOutput(output)).toEqual({
+      type: 'content',
+      value: [{ type: 'media', data: 'abc123', mediaType: 'image/png' }],
+    });
+  });
+
+  it('still normalizes file-data parts into the media shape', () => {
+    const output = {
+      type: 'content',
+      value: [{ type: 'file-data', data: 'Zm9v' }],
+    };
+
+    expect(normalizeModelOutput(output)).toEqual({
+      type: 'content',
+      value: [{ type: 'media', data: 'Zm9v', mediaType: 'application/octet-stream' }],
+    });
+  });
+
+  it('returns non-content outputs untouched', () => {
+    expect(normalizeModelOutput({ foo: 'bar' })).toEqual({ foo: 'bar' });
+    expect(normalizeModelOutput(null)).toBeNull();
+    expect(normalizeModelOutput('text')).toBe('text');
+  });
+});
+
+describe('downgradeImageUrlPartsForV2', () => {
+  it('downgrades image-url parts to the V2 media shape', () => {
+    const output = {
+      type: 'content',
+      value: [
+        { type: 'text', text: 'radar image' },
+        { type: 'image-url', url: 'https://example.com/radar.png', mediaType: 'image/png' },
+      ],
+    };
+
+    expect(downgradeImageUrlPartsForV2(output)).toEqual({
+      type: 'content',
+      value: [
+        { type: 'text', text: 'radar image' },
+        { type: 'media', data: 'https://example.com/radar.png', mediaType: 'image/png' },
+      ],
+    });
+  });
+
+  it('defaults mediaType to image/jpeg and infers it from data: URLs', () => {
+    const output = {
+      type: 'content',
+      value: [
+        { type: 'image-url', url: 'https://example.com/a.png' },
+        { type: 'image-url', url: 'data:image/webp;base64,abc' },
+      ],
+    };
+
+    expect(downgradeImageUrlPartsForV2(output)).toEqual({
+      type: 'content',
+      value: [
+        { type: 'media', data: 'https://example.com/a.png', mediaType: 'image/jpeg' },
+        { type: 'media', data: 'data:image/webp;base64,abc', mediaType: 'image/webp' },
+      ],
+    });
+  });
+
+  it('leaves media parts and non-content outputs untouched', () => {
+    const output = {
+      type: 'content',
+      value: [{ type: 'media', data: 'abc', mediaType: 'image/png' }],
+    };
+    expect(downgradeImageUrlPartsForV2(output)).toEqual(output);
+    expect(downgradeImageUrlPartsForV2('raw')).toBe('raw');
+  });
+});

--- a/packages/core/src/agent/durable/workflows/steps/normalize-model-output.ts
+++ b/packages/core/src/agent/durable/workflows/steps/normalize-model-output.ts
@@ -1,12 +1,44 @@
 /**
- * Normalize modelOutput from toModelOutput() into the AI SDK's
- * LanguageModelV2ToolResultOutput shape.
+ * Normalize modelOutput from toModelOutput() for storage in
+ * providerMetadata.mastra.modelOutput.
  *
- * The AI SDK's content array only accepts type 'text' or 'media'.
- * Mastra's createTool docs expose image-url as a convenience shorthand,
- * so normalize it here into type 'media' with the correct structure.
+ * `image-data` / `file-data` parts carry raw Base64 and are stored in the
+ * V2-compatible `media` shape that the prompt builders convert per target
+ * model spec. `image-url` parts are stored as-is (including their
+ * `providerOptions`): the AI SDK `v3` spec consumes `image-url` directly, and
+ * consumers targeting other specs downgrade it when building the prompt —
+ * collapsing it here would corrupt the stored form (a URL is not Base64
+ * `media.data`) and drop the part's providerOptions.
  */
 export function normalizeModelOutput(output: unknown): unknown {
+  if (output == null || typeof output !== 'object') return output;
+
+  const obj = output as Record<string, unknown>;
+  if (obj.type !== 'content' || !Array.isArray(obj.value)) return output;
+
+  return {
+    ...obj,
+    value: (obj.value as unknown[]).map(item => {
+      if (item == null || typeof item !== 'object') return item;
+      const part = item as Record<string, unknown>;
+      if (part.type === 'image-data' && typeof part.data === 'string') {
+        return { type: 'media', data: part.data, mediaType: part.mediaType ?? 'image/jpeg' };
+      }
+      if (part.type === 'file-data' && typeof part.data === 'string') {
+        return { type: 'media', data: part.data, mediaType: part.mediaType ?? 'application/octet-stream' };
+      }
+      return part;
+    }),
+  };
+}
+
+/**
+ * Downgrade `image-url` tool-result parts to the V2 `media` shape for prompts
+ * targeting spec-`v2` models, whose tool-result output has no URL form. The
+ * data field carries the URL as a best effort (legacy behavior — some
+ * providers accept it); spec-`v3`+ consumers receive `image-url` unchanged.
+ */
+export function downgradeImageUrlPartsForV2(output: unknown): unknown {
   if (output == null || typeof output !== 'object') return output;
 
   const obj = output as Record<string, unknown>;
@@ -25,12 +57,6 @@ export function normalizeModelOutput(output: unknown): unknown {
               ? part.url.slice(5, part.url.indexOf(';')) || 'image/jpeg'
               : 'image/jpeg';
         return { type: 'media', data: part.url, mediaType };
-      }
-      if (part.type === 'image-data' && typeof part.data === 'string') {
-        return { type: 'media', data: part.data, mediaType: part.mediaType ?? 'image/jpeg' };
-      }
-      if (part.type === 'file-data' && typeof part.data === 'string') {
-        return { type: 'media', data: part.data, mediaType: part.mediaType ?? 'application/octet-stream' };
       }
       return part;
     }),

--- a/packages/core/src/agent/message-list/conversion/to-prompt.ts
+++ b/packages/core/src/agent/message-list/conversion/to-prompt.ts
@@ -320,6 +320,7 @@ export function aiV5ModelMessageToV2PromptMessage(modelMessage: AIV5Type.ModelMe
 function convertToolResultContent(
   prompt: LanguageModelV2Prompt,
   convertMediaPart: (contentPart: Record<string, unknown>, mediaType: string) => unknown,
+  convertImageUrlPart?: (contentPart: Record<string, unknown>, mediaType: string) => unknown,
 ): LanguageModelV2Prompt {
   return prompt.map(message => {
     if (message.role !== `tool`) return message;
@@ -334,10 +335,17 @@ function convertToolResultContent(
       const value = (output.value as unknown[]).map(item => {
         if (item == null || typeof item !== `object`) return item;
         const contentPart = item as Record<string, unknown>;
-        if (contentPart.type !== `media` || typeof contentPart.data !== `string`) return item;
-        outputModified = true;
-        const mediaType = typeof contentPart.mediaType === `string` ? contentPart.mediaType : ``;
-        return convertMediaPart(contentPart, mediaType);
+        if (contentPart.type === `media` && typeof contentPart.data === `string`) {
+          outputModified = true;
+          const mediaType = typeof contentPart.mediaType === `string` ? contentPart.mediaType : ``;
+          return convertMediaPart(contentPart, mediaType);
+        }
+        if (convertImageUrlPart && contentPart.type === `image-url` && typeof contentPart.url === `string`) {
+          outputModified = true;
+          const mediaType = typeof contentPart.mediaType === `string` ? contentPart.mediaType : ``;
+          return convertImageUrlPart(contentPart, mediaType);
+        }
+        return item;
       });
 
       if (!outputModified) return part;
@@ -352,7 +360,8 @@ function convertToolResultContent(
 /**
  * Convert v5-authored media tool results to the `image-data`/`file-data` shape
  * expected only by AI SDK v6 (`v3`) providers. V5 providers accept `media`, and
- * V7 providers expect `file` parts with tagged data instead.
+ * V7 providers expect `file` parts with tagged data instead. `image-url` parts
+ * pass through unchanged: the `v3` spec consumes them natively.
  *
  * See: https://github.com/mastra-ai/mastra/issues/17876
  */
@@ -365,9 +374,19 @@ export function aiV5PromptToAIV6Prompt(prompt: LanguageModelV2Prompt): LanguageM
 }
 
 export function aiV5PromptToAIV7Prompt(prompt: LanguageModelV2Prompt): LanguageModelV2Prompt {
-  return convertToolResultContent(prompt, (contentPart, mediaType) => ({
-    type: `file`,
-    data: { type: `data`, data: contentPart.data },
-    mediaType,
-  }));
+  return convertToolResultContent(
+    prompt,
+    (contentPart, mediaType) => ({
+      type: `file`,
+      data: { type: `data`, data: contentPart.data },
+      mediaType,
+    }),
+    // The `v4` spec has no `image-url` tool-result part; its `file` part carries
+    // URLs as tagged data instead.
+    (contentPart, mediaType) => ({
+      type: `file`,
+      data: { type: `url`, url: contentPart.url },
+      mediaType: mediaType || `image/jpeg`,
+    }),
+  );
 }

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -7,6 +7,7 @@ import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import type { IMastraLogger } from '../../logger';
 import { getTransformedToolPayload, hasTransformedToolPayload } from '../../tools/payload-transform';
 import type { IdGeneratorContext } from '../../types';
+import { downgradeImageUrlPartsForV2 } from '../durable/workflows/steps/normalize-model-output';
 import { createSignal, isCreatedAgentSignal, isTransientSignalMessage, mastraDBMessageToSignal } from '../signals';
 import type { CreatedAgentSignal } from '../signals';
 import { AIV4Adapter, AIV5Adapter, AIV6Adapter } from './adapters';
@@ -618,6 +619,12 @@ export class MessageList {
            * @see https://github.com/mastra-ai/mastra/issues/23082
            */
           targetProvider?: string;
+          /**
+           * Downgrade stored `image-url` tool-result parts to the V2 `media`
+           * shape. Defaults to true (spec-v2 consumers); the aiV6/aiV7 prompt
+           * builders pass false and map the parts to their target spec instead.
+           */
+          downgradeImageUrlParts?: boolean;
         } = {
           downloadConcurrency: 10,
           downloadRetries: 3,
@@ -654,15 +661,20 @@ export class MessageList {
         }
 
         if (storedModelOutputs.size > 0) {
+          const downgrade = options.downgradeImageUrlParts !== false;
           for (const modelMsg of modelMessages) {
             if (modelMsg.role !== 'tool' || !Array.isArray(modelMsg.content)) continue;
 
             for (let i = 0; i < modelMsg.content.length; i++) {
               const part = modelMsg.content[i]!;
               if (part.type === 'tool-result' && storedModelOutputs.has(part.toolCallId)) {
+                const storedOutput = storedModelOutputs.get(part.toolCallId);
                 modelMsg.content[i] = {
                   ...part,
-                  output: storedModelOutputs.get(part.toolCallId) as any,
+                  // V2 prompts have no URL image form, so spec-v2 consumers get the
+                  // legacy best-effort `media` downgrade; spec-v3+ consumers receive
+                  // `image-url` parts unchanged and map them to their target spec.
+                  output: (downgrade ? downgradeImageUrlPartsForV2(storedOutput) : storedOutput) as any,
                 };
               }
             }
@@ -759,7 +771,8 @@ export class MessageList {
         downloadRetries?: number;
         supportedUrls?: Record<string, RegExp[]>;
         targetProvider?: string;
-      }): Promise<LanguageModelV2Prompt> => aiV5PromptToAIV6Prompt(await this.all.aiV5.llmPrompt(options)),
+      }): Promise<LanguageModelV2Prompt> =>
+        aiV5PromptToAIV6Prompt(await this.all.aiV5.llmPrompt({ ...options, downgradeImageUrlParts: false })),
     },
     aiV7: {
       ui: () => this.toAIV6UIMessages(this.all.db()),
@@ -771,7 +784,8 @@ export class MessageList {
         downloadRetries?: number;
         supportedUrls?: Record<string, RegExp[]>;
         targetProvider?: string;
-      }): Promise<LanguageModelV2Prompt> => aiV5PromptToAIV7Prompt(await this.all.aiV5.llmPrompt(options)),
+      }): Promise<LanguageModelV2Prompt> =>
+        aiV5PromptToAIV7Prompt(await this.all.aiV5.llmPrompt({ ...options, downgradeImageUrlParts: false })),
     },
 
     /* @deprecated use list.get.all.aiV4.prompt() instead */

--- a/packages/core/src/agent/message-list/tests/message-list-v5.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-v5.test.ts
@@ -1976,6 +1976,151 @@ describe('MessageList V5 Support', () => {
       });
     });
 
+    it('keeps image-url tool-result parts unchanged for v6 (spec v3) models', async () => {
+      const list = new MessageList({ threadId, resourceId });
+
+      list.add('Fetch the radar image', 'input');
+
+      const continuationMessage: AIV5ModelMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-v6-url-1',
+            toolName: 'radarTool',
+            input: {},
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-v6-url-1',
+            toolName: 'radarTool',
+            output: { type: 'json', value: { ok: true } },
+            providerOptions: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'radar image' },
+                    {
+                      type: 'image-url',
+                      url: 'https://example.com/radar.png',
+                      providerOptions: { repro: { traceId: 'preserve-me' } },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      list.add(continuationMessage, 'input');
+
+      // The v3 spec consumes `image-url` tool results natively (including
+      // providerOptions); downgrading them to `media` would put a URL in the
+      // Base64-only `data` field and drop the part's providerOptions.
+      const prompt = await list.get.all.aiV6.llmPrompt();
+      const toolRole = prompt.find(m => m.role === 'tool');
+      const toolResultPart = (toolRole as any).content.find((p: any) => p.type === 'tool-result');
+      expect(toolResultPart.output).toEqual({
+        type: 'content',
+        value: [
+          { type: 'text', text: 'radar image' },
+          {
+            type: 'image-url',
+            url: 'https://example.com/radar.png',
+            providerOptions: { repro: { traceId: 'preserve-me' } },
+          },
+        ],
+      });
+    });
+
+    it('downgrades image-url tool-result parts to media for v5 (spec v2) models', async () => {
+      const list = new MessageList({ threadId, resourceId });
+
+      list.add('Fetch the radar image', 'input');
+
+      const continuationMessage: AIV5ModelMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-v5-url-1',
+            toolName: 'radarTool',
+            input: {},
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-v5-url-1',
+            toolName: 'radarTool',
+            output: { type: 'json', value: { ok: true } },
+            providerOptions: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [{ type: 'image-url', url: 'https://example.com/radar.png', mediaType: 'image/png' }],
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      list.add(continuationMessage, 'input');
+
+      // v2 prompts have no URL image form; the legacy best-effort mapping
+      // keeps working for spec-v2 models.
+      const prompt = await list.get.all.aiV5.llmPrompt();
+      const toolRole = prompt.find(m => m.role === 'tool');
+      const toolResultPart = (toolRole as any).content.find((p: any) => p.type === 'tool-result');
+      expect(toolResultPart.output).toEqual({
+        type: 'content',
+        value: [{ type: 'media', data: 'https://example.com/radar.png', mediaType: 'image/png' }],
+      });
+    });
+
+    it('converts image-url tool-result parts to url-tagged files for v7 (spec v4) models', async () => {
+      const list = new MessageList({ threadId, resourceId });
+
+      list.add('Fetch the radar image', 'input');
+
+      const continuationMessage: AIV5ModelMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-v7-url-1',
+            toolName: 'radarTool',
+            input: {},
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-v7-url-1',
+            toolName: 'radarTool',
+            output: { type: 'json', value: { ok: true } },
+            providerOptions: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [{ type: 'image-url', url: 'https://example.com/radar.png' }],
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      list.add(continuationMessage, 'input');
+
+      const prompt = await list.get.all.aiV7.llmPrompt();
+      const toolRole = prompt.find(m => m.role === 'tool');
+      const toolResultPart = (toolRole as any).content.find((p: any) => p.type === 'tool-result');
+      expect(toolResultPart.output).toEqual({
+        type: 'content',
+        value: [{ type: 'file', data: { type: 'url', url: 'https://example.com/radar.png' }, mediaType: 'image/jpeg' }],
+      });
+    });
+
     it('translates non-image tool-result media to file-data for v6 (spec v3) models', async () => {
       const list = new MessageList({ threadId, resourceId });
 


### PR DESCRIPTION
Fixes #22618

`DurableAgent` used to rewrite an `image-url` part returned by a tool's `toModelOutput()` into the V2 `media` shape at storage time — putting a remote URL into the Base64-only `data` field and dropping the part's `providerOptions`. Spec-`v3` models consume `image-url` natively, so the downgrade corrupted the part for exactly the models that support it best.

The stored `modelOutput` now keeps `image-url` parts intact (with `providerOptions`), and each prompt builder maps them for its target spec:

- **v6 (spec `v3`)**: `image-url` passes through unchanged (native form).
- **v7 (spec `v4`)**: mapped to a url-tagged `file` part (`data: { type: 'url', url }`), since the `v4` spec has no `image-url` tool-result part.
- **v5 (spec `v2`)**: the legacy best-effort `media` downgrade still applies (v2 has no URL image form), now happening at prompt-build time via an internal `llmPrompt` option instead of corrupting the stored form.

Related to #17876 / #18400 (the earlier media-shape fixes); this covers the remaining `image-url` path from the reproduction in #22618.

**Verification**
- New unit tests for the normalize layer: `image-url` stays as-is with `providerOptions`, `image-data`/`file-data` still normalize to `media`, and the V2 downgrade helper maps URLs/data-URLs with correct media types.
- New prompt-builder tests: spec-`v3` prompts receive `image-url` unchanged (providerOptions preserved), spec-`v2` prompts receive the legacy `media` shape, spec-`v4` prompts receive url-tagged `file` parts.
- Full regression: message-list suite + durable toModelOutput suite, 614/614 passing.
