### PR TITLE
fix(create-factory): generated Software Factory template is missing its @mastra/e2b dependency

### DIFF
--- a/.changeset/factory-template-e2b-dependency.md
+++ b/.changeset/factory-template-e2b-dependency.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Fix generated Software Factory projects failing to start with `Cannot find package '@mastra/e2b'`. The scaffold imports `@mastra/e2b` for its sandbox provider, but the template generator's runtime dependency list omitted it, so the generated `package.json` never installed it. The list is now covered by a test asserting the template declares every `@mastra/*` package its entrypoint imports.

--- a/.github/workflows/e2e-experiments.test.ts
+++ b/.github/workflows/e2e-experiments.test.ts
@@ -83,7 +83,11 @@ describe('experiments workflow contract', () => {
     ];
 
     for (const job of generalJobs) {
-      expect(mappingBlock(jobs, job)).toContain('if: inputs.e2e_changed');
+      const conditions = mappingBlock(jobs, job)
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line.startsWith('if:'));
+      expect(conditions).toEqual(['if: inputs.e2e_changed']);
     }
 
     for (const job of ['e2e-experiments', ...generalJobs]) {

--- a/.github/workflows/e2e-experiments.test.ts
+++ b/.github/workflows/e2e-experiments.test.ts
@@ -71,7 +71,7 @@ describe('experiments workflow contract', () => {
       'if: inputs.e2e_changed || inputs.softwarefactory_e2e_changed',
     );
 
-    for (const job of [
+    const generalJobs = [
       'e2e-monorepo',
       'e2e-no-bundling',
       'e2e-create-mastra',
@@ -80,8 +80,14 @@ describe('experiments workflow contract', () => {
       'e2e-type-check',
       'e2e-kitchen-sink',
       'e2e-client-js',
-    ]) {
+    ];
+
+    for (const job of generalJobs) {
       expect(mappingBlock(jobs, job)).toContain('if: inputs.e2e_changed');
+    }
+
+    for (const job of ['e2e-experiments', ...generalJobs]) {
+      expect(mappingBlock(jobs, job)).not.toContain('softwarefactory_e2e_changed');
     }
   });
 

--- a/.github/workflows/e2e-experiments.test.ts
+++ b/.github/workflows/e2e-experiments.test.ts
@@ -47,6 +47,42 @@ describe('experiments workflow contract', () => {
     expect(experimentsJob).toContain('if: inputs.experiment_worker_e2e_changed');
   });
 
+  test('routes Software Factory changes without enabling unrelated E2E jobs', async () => {
+    const prebuild = await readFile(resolve(workflowRoot, 'prebuild.yml'), 'utf8');
+    expect(prebuild).toContain("file.startsWith('mastracode/mastra-factory/')");
+    expect(prebuild).toContain("file.startsWith('mastracode/web/')");
+    expect(prebuild).toContain('output(`softwarefactory_e2e_changed=${softwarefactoryE2eChanged}\\n`)');
+
+    const generalE2eRouting = prebuild.slice(
+      prebuild.indexOf('const e2eChanged ='),
+      prebuild.indexOf('const softwarefactoryE2eChanged ='),
+    );
+    expect(generalE2eRouting).not.toContain('mastracode/mastra-factory/');
+    expect(generalE2eRouting).not.toContain('mastracode/web/');
+
+    const e2eCaller = mappingBlock(mappingBlock(prebuild, 'jobs'), 'e2e-tests');
+    expect(e2eCaller).toContain('softwarefactory_e2e_changed:');
+
+    const contents = await readFile(resolve(workflowRoot, 'e2e-tests.yml'), 'utf8');
+    const jobs = mappingBlock(contents, 'jobs');
+    expect(mappingBlock(jobs, 'e2e-softwarefactory')).toContain(
+      'if: inputs.e2e_changed || inputs.softwarefactory_e2e_changed',
+    );
+
+    for (const job of [
+      'e2e-monorepo',
+      'e2e-no-bundling',
+      'e2e-create-mastra',
+      'e2e-commonjs',
+      'e2e-deployers',
+      'e2e-type-check',
+      'e2e-kitchen-sink',
+      'e2e-client-js',
+    ]) {
+      expect(mappingBlock(jobs, job)).toContain('if: inputs.e2e_changed');
+    }
+  });
+
   test.each([
     {
       workflow: 'e2e-tests.yml',

--- a/.github/workflows/e2e-experiments.test.ts
+++ b/.github/workflows/e2e-experiments.test.ts
@@ -61,7 +61,9 @@ describe('experiments workflow contract', () => {
     expect(generalE2eRouting).not.toContain('mastracode/web/');
 
     const e2eCaller = mappingBlock(mappingBlock(prebuild, 'jobs'), 'e2e-tests');
-    expect(e2eCaller).toContain('softwarefactory_e2e_changed:');
+    expect(e2eCaller).toContain(
+      "softwarefactory_e2e_changed: ${{ needs.affected-tests.outputs.softwarefactory_e2e_changed == 'true' }}",
+    );
 
     const contents = await readFile(resolve(workflowRoot, 'e2e-tests.yml'), 'utf8');
     const jobs = mappingBlock(contents, 'jobs');

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,7 +6,15 @@ on:
       head_sha:
         required: true
         type: string
+      e2e_changed:
+        required: false
+        default: false
+        type: boolean
       experiment_worker_e2e_changed:
+        required: false
+        default: false
+        type: boolean
+      softwarefactory_e2e_changed:
         required: false
         default: false
         type: boolean
@@ -146,6 +154,7 @@ jobs:
 
   e2e-monorepo:
     needs: publish-e2e-registry
+    if: inputs.e2e_changed
     name: E2E monorepo
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 15
@@ -191,6 +200,7 @@ jobs:
 
   e2e-softwarefactory:
     needs: publish-e2e-registry
+    if: inputs.e2e_changed || inputs.softwarefactory_e2e_changed
     name: E2E softwarefactory template
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
@@ -238,6 +248,7 @@ jobs:
 
   e2e-no-bundling:
     needs: publish-e2e-registry
+    if: inputs.e2e_changed
     name: E2E no-bundling
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 15
@@ -283,6 +294,7 @@ jobs:
 
   e2e-create-mastra:
     needs: publish-e2e-registry
+    if: inputs.e2e_changed
     name: E2E create-mastra
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 15
@@ -328,6 +340,7 @@ jobs:
 
   e2e-commonjs:
     needs: publish-e2e-registry
+    if: inputs.e2e_changed
     name: E2E CommonJS
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 15
@@ -372,6 +385,7 @@ jobs:
 
   e2e-deployers:
     needs: publish-e2e-registry
+    if: inputs.e2e_changed
     name: E2E deployers
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 20
@@ -417,6 +431,7 @@ jobs:
 
   e2e-type-check:
     needs: publish-e2e-registry
+    if: inputs.e2e_changed
     name: E2E Type check
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 20
@@ -460,6 +475,7 @@ jobs:
           MASTRA_E2E_REGISTRY_PORT: '4873'
 
   e2e-kitchen-sink:
+    if: inputs.e2e_changed
     name: E2E kitchen-sink (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 15
@@ -506,6 +522,7 @@ jobs:
         run: pnpm exec playwright test -c e2e/playwright.config.ts --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
   e2e-client-js:
+    if: inputs.e2e_changed
     name: E2E client-js (optional)
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 15

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -225,6 +225,8 @@ jobs:
               !file.startsWith('e2e-tests/experiment-worker/') &&
               !file.startsWith('e2e-tests/_local-registry-setup/')) ||
             file.startsWith('packages/playground/e2e/') ||
+            file.startsWith('mastracode/mastra-factory/') ||
+            file.startsWith('mastracode/web/') ||
             file === '.github/workflows/e2e-tests.yml' ||
             file === 'pnpm-lock.yaml'
           );

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -113,6 +113,7 @@ jobs:
       e2e_changed: ${{ steps.compute.outputs.e2e_changed }}
       experiment_worker_e2e_changed: ${{ steps.compute.outputs.experiment_worker_e2e_changed }}
       mastracode_e2e_changed: ${{ steps.compute.outputs.mastracode_e2e_changed }}
+      softwarefactory_e2e_changed: ${{ steps.compute.outputs.softwarefactory_e2e_changed }}
       stores_changed: ${{ steps.compute.outputs.stores_changed }}
       workspaces_changed: ${{ steps.compute.outputs.workspaces_changed }}
       memory_changed: ${{ steps.compute.outputs.memory_changed }}
@@ -225,6 +226,10 @@ jobs:
               !file.startsWith('e2e-tests/experiment-worker/') &&
               !file.startsWith('e2e-tests/_local-registry-setup/')) ||
             file.startsWith('packages/playground/e2e/') ||
+            file === '.github/workflows/e2e-tests.yml' ||
+            file === 'pnpm-lock.yaml'
+          );
+          const softwarefactoryE2eChanged = changed(file =>
             file.startsWith('mastracode/mastra-factory/') ||
             file.startsWith('mastracode/web/') ||
             file === '.github/workflows/e2e-tests.yml' ||
@@ -263,6 +268,7 @@ jobs:
           output(`e2e_changed=${e2eChanged}\n`);
           output(`experiment_worker_e2e_changed=${experimentWorkerChanged}\n`);
           output(`mastracode_e2e_changed=${mastracodeE2eChanged}\n`);
+          output(`softwarefactory_e2e_changed=${softwarefactoryE2eChanged}\n`);
 
           console.error(`Affected: ${count}/${total} tests (${(ratio * 100).toFixed(1)}%)`);
           console.error(`Affected unit/type tests: ${unitTestFiles.length}`);
@@ -294,6 +300,7 @@ jobs:
           E2E_CHANGED: ${{ steps.compute.outputs.e2e_changed }}
           EXPERIMENT_WORKER_E2E_CHANGED: ${{ steps.compute.outputs.experiment_worker_e2e_changed }}
           MASTRACODE_E2E_CHANGED: ${{ steps.compute.outputs.mastracode_e2e_changed }}
+          SOFTWAREFACTORY_E2E_CHANGED: ${{ steps.compute.outputs.softwarefactory_e2e_changed }}
           STORES_CHANGED: ${{ steps.compute.outputs.stores_changed }}
           WORKSPACES_CHANGED: ${{ steps.compute.outputs.workspaces_changed }}
           MEMORY_CHANGED: ${{ steps.compute.outputs.memory_changed }}
@@ -308,6 +315,7 @@ jobs:
           echo "$E2E_CHANGED" > /tmp/affected-outputs/e2e_changed.txt
           echo "$EXPERIMENT_WORKER_E2E_CHANGED" > /tmp/affected-outputs/experiment_worker_e2e_changed.txt
           echo "$MASTRACODE_E2E_CHANGED" > /tmp/affected-outputs/mastracode_e2e_changed.txt
+          echo "$SOFTWAREFACTORY_E2E_CHANGED" > /tmp/affected-outputs/softwarefactory_e2e_changed.txt
           echo "$STORES_CHANGED" > /tmp/affected-outputs/stores_changed.txt
           echo "$WORKSPACES_CHANGED" > /tmp/affected-outputs/workspaces_changed.txt
           echo "$MEMORY_CHANGED" > /tmp/affected-outputs/memory_changed.txt
@@ -348,13 +356,15 @@ jobs:
   e2e-tests:
     name: E2E Tests
     needs: [changes, affected-tests, prebuild]
-    if: always() && github.repository == 'mastra-ai/mastra' && (needs.affected-tests.outputs.e2e_changed == 'true' || needs.affected-tests.outputs.experiment_worker_e2e_changed == 'true') && needs.prebuild.result == 'success'
+    if: always() && github.repository == 'mastra-ai/mastra' && (needs.affected-tests.outputs.e2e_changed == 'true' || needs.affected-tests.outputs.experiment_worker_e2e_changed == 'true' || needs.affected-tests.outputs.softwarefactory_e2e_changed == 'true') && needs.prebuild.result == 'success'
     uses: ./.github/workflows/e2e-tests.yml
     permissions:
       contents: read
     with:
       head_sha: ${{ github.event.pull_request.head.sha }}
+      e2e_changed: ${{ needs.affected-tests.outputs.e2e_changed == 'true' }}
       experiment_worker_e2e_changed: ${{ needs.affected-tests.outputs.experiment_worker_e2e_changed == 'true' }}
+      softwarefactory_e2e_changed: ${{ needs.affected-tests.outputs.softwarefactory_e2e_changed == 'true' }}
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -59,6 +59,7 @@ const RUNTIME_DEPENDENCIES = [
   '@mastra/auth-workos',
   '@mastra/code-sdk',
   '@mastra/core',
+  '@mastra/e2b',
   '@mastra/factory',
   '@mastra/libsql',
   '@mastra/pg',

--- a/mastracode/mastra-factory/src/sync-template.test.ts
+++ b/mastracode/mastra-factory/src/sync-template.test.ts
@@ -15,6 +15,7 @@ const TEMPLATE_LINKED_DEPENDENCIES = [
   '@mastra/auth-workos',
   '@mastra/code-sdk',
   '@mastra/core',
+  '@mastra/e2b',
   '@mastra/factory',
   '@mastra/libsql',
   '@mastra/pg',
@@ -159,6 +160,7 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
       '@mastra/auth-workos',
       '@mastra/code-sdk',
       '@mastra/core',
+      '@mastra/e2b',
       '@mastra/factory',
       '@mastra/libsql',
       '@mastra/memory',
@@ -196,5 +198,25 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     expect(readme).toContain('# Mastra Factory');
     expect(readme).toContain('npm create factory');
     expect(readme).not.toMatch(/\{\{[^}]+\}\}/);
+  });
+  // Regression guard: the runtime dependency list is hand-maintained, so a new
+  // import in the web scaffold (@mastra/e2b, added by #22065) can ship a
+  // template whose package.json cannot resolve its own entrypoint. That failure
+  // only surfaces at runtime, in the Software Factory E2E dev-server boot.
+  it('declares every @mastra package the generated entrypoint imports', () => {
+    const result = runSync(['--out', outDir]);
+    expect(result.status).toBe(0);
+
+    const entrypoint = fs.readFileSync(path.join(outDir, 'src/mastra/index.ts'), 'utf8');
+    const imported = new Set<string>();
+    for (const match of entrypoint.matchAll(/from\s+'(@mastra\/[^'/]+)(?:\/[^']*)?'/g)) {
+      imported.add(match[1]!);
+    }
+    expect(imported.size).toBeGreaterThan(0);
+
+    const pkg = JSON.parse(fs.readFileSync(path.join(outDir, 'package.json'), 'utf8'));
+    const declared = new Set(Object.keys(pkg.dependencies ?? {}));
+    const missing = [...imported].filter(name => !declared.has(name)).sort();
+    expect(missing, 'generated template imports packages it does not depend on').toEqual([]);
   });
 });


### PR DESCRIPTION
## What's broken

Every PR in the repo currently fails `E2E Tests / E2E softwarefactory template`. The generated Software Factory project cannot start:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@mastra/e2b'
  imported from /tmp/sf-e2e-.../factory/.mastra/output/index.mjs
Error: Dev server did not become ready on port 44387 (/ -> fetch failed, /api/tools -> fetch failed)
```

On several open PRs this is the only failing check, with everything else green, so the check rollup cannot go green for changes that have nothing to do with the Factory.

## Why

The template is generated from the `mastracode/web` scaffold by `mastracode/mastra-factory/scripts/sync-template.mjs`, which assembles the generated `package.json` from a hand-maintained `RUNTIME_DEPENDENCIES` array.

#22065 added `import { E2BSandbox, createRepoTemplate } from '@mastra/e2b'` to `mastracode/web/src/mastra/index.ts` and the matching link dependency to `mastracode/web/package.json`, but that array was not updated. The entrypoint is copied verbatim into the template, so every generated project imports a package its own manifest never installs.

Nothing catches this before runtime: the generated project is not typechecked against its generated manifest, and the existing test asserted a hardcoded expected dependency list maintained the same way the array is. The first signal is the dev server failing to boot — which is exactly where it showed up.

## What this changes

- Adds `@mastra/e2b` to `RUNTIME_DEPENDENCIES`.
- Adds a drift guard: parse the generated `src/mastra/index.ts` for `@mastra/*` import roots and assert every one is declared in the generated `dependencies`. This is the test that would have failed on #22065, and it removes the hand-maintenance hazard for the next scaffold import.
- Extends the test's stubbed-registry fixture list so the fake `npm view` can resolve the new package.
- Changeset: `create-factory` patch.

## Test plan

- **Red:** with `sync-template.mjs` reverted, `src/sync-template.test.ts` fails 2 tests — the new guard reports `missing: ["@mastra/e2b"]`, and the existing scaffold test fails because the generator cannot resolve the package through the stub.
- **Green:** with the fix, `src/sync-template.test.ts` passes 5/5.
- Full `create-factory` suite: 52/52 across 6 files.
- `tsc --noEmit` exit 0; oxlint 0 warnings/errors across 18 files.
- Generator run end to end against the real registry resolves `@mastra/e2b@0.11.0-alpha.0 (alpha)` alongside the other linked packages.
- The Software Factory E2E is now triggered by changes under `mastracode/mastra-factory/` and `mastracode/web/`; its result on the current head will provide the generated-project proof through the local registry.

## Scope and risk

Deliberately narrow: one dependency entry, a regression test, and CI routing so generator changes exercise the Software Factory E2E. It does not touch the sandbox implementation, the scaffold, or the publish roots — `@mastra/e2b` is already discovered for the local E2E registry through `mastracode/web/package.json`'s link dependencies, so no publishing change is needed.

Rollback is a straight revert of this commit; the only behavioral change to generated projects is one additional declared dependency, which they already import.

The alternative shape considered and rejected: deriving `RUNTIME_DEPENDENCIES` from the scaffold's imports at generation time. That removes the list entirely but changes what the generator guarantees (imports become the contract, and any transitional or type-only import would start shipping as a runtime dependency), which is a bigger decision than a red CI lane should force. The guard test gets the drift protection without that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The generated Software Factory project used a package that was missing from its dependency list. This PR adds the package, prevents similar omissions, and runs the correct E2E test when Factory files change.

## Changes

- Added `@mastra/e2b` to `RUNTIME_DEPENDENCIES`.
- Added a regression test for undeclared `@mastra/*` imports.
- Updated the registry fixture and expected dependency list.
- Routed Factory and web template changes to the dedicated Software Factory E2E job.
- Added workflow contract coverage.
- Added a patch changeset for `create-factory`.

## Validation

- `create-factory` test suite passes.
- TypeScript checks pass.
- Oxlint passes.
- Software Factory E2E routing is covered by workflow tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #22650