### PR TITLE
fix(factory): answer for the cards the sweep stopped visiting

### DIFF
--- a/.changeset/nervous-badgers-tap.md
+++ b/.changeset/nervous-badgers-tap.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-The reconcile sweep now records author trust for cards it had stopped visiting, so a board whose cards reached Done or Canceled before trust was recorded gets its answers within a cycle or two instead of never. The board's External mark reads a recorded answer instead of the absence of one, so a card nobody was ever asked about is no longer labelled an outside contribution. The execution-consent gate is unchanged: a card with no recorded answer still asks for a person before it starts a run.
+The board's External mark now reflects what GitHub answered about an author instead of the absence of an answer. Cards that reached Done or Canceled before author trust was recorded carried no answer at all and every one of them read as an outside contribution, teammates included. The execution-consent gate is unchanged: a card without a recorded answer still asks for a person before it starts a run.

--- a/.changeset/nervous-badgers-tap.md
+++ b/.changeset/nervous-badgers-tap.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-The reconcile sweep now records author trust for cards it had stopped visiting, so a board whose cards reached Done or Canceled before trust was recorded gets its answers within a cycle or two instead of never. The board's External mark reads a recorded answer instead of the absence of one, so a card nobody was ever asked about is no longer labelled an outside contribution. The execution-consent gate is unchanged: a card with no recorded answer still asks for a person before it starts a run.
+The reconcile sweep now records author trust for cards it had stopped visiting, so a board whose cards reached Done or Canceled before trust was recorded gets its answers on the next sweep instead of never. The board's External mark reads a recorded answer instead of the absence of one, so a card nobody was ever asked about is no longer labelled an outside contribution. The execution-consent gate is unchanged: a card with no recorded answer still asks for a person before it starts a run.

--- a/.changeset/nervous-badgers-tap.md
+++ b/.changeset/nervous-badgers-tap.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-The board's External mark now reflects what GitHub answered about an author instead of the absence of an answer. Cards that reached Done or Canceled before author trust was recorded carried no answer at all and every one of them read as an outside contribution, teammates included. The execution-consent gate is unchanged: a card without a recorded answer still asks for a person before it starts a run.
+The reconcile sweep now records author trust for cards it had stopped visiting, so a board whose cards reached Done or Canceled before trust was recorded gets its answers within a cycle or two instead of never. The board's External mark reads a recorded answer instead of the absence of one, so a card nobody was ever asked about is no longer labelled an outside contribution. The execution-consent gate is unchanged: a card with no recorded answer still asks for a person before it starts a run.

--- a/.changeset/nervous-badgers-tap.md
+++ b/.changeset/nervous-badgers-tap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The board's External mark now reflects what GitHub answered about an author instead of the absence of an answer. Cards that reached Done or Canceled before author trust was recorded carried no answer at all and every one of them read as an outside contribution, teammates included. The execution-consent gate is unchanged: a card without a recorded answer still asks for a person before it starts a run.

--- a/mastracode/factory-ui/src/ui/__tests__/WorkItemExternalMark.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/WorkItemExternalMark.msw.test.tsx
@@ -129,11 +129,9 @@ describe('External authorship mark', () => {
     const external = await screen.findByRole('article', { name: 'External contribution' });
     expect(within(external).getByText('External')).toBeVisible();
 
-    // A card missing its trust stamp asks for approval server-side, so it wears the mark too.
-    const legacy = screen.getByRole('article', { name: 'Legacy PR' });
-    expect(within(legacy).getByText('External')).toBeVisible();
-
-    for (const title of ['Maintainer PR', 'Factory PR']) {
+    // A card from before the trust stamp existed still asks for approval server-side,
+    // but the board never calls an unanswered author external.
+    for (const title of ['Maintainer PR', 'Factory PR', 'Legacy PR']) {
       const card = screen.getByRole('article', { name: title });
       expect(within(card).queryByText('External')).toBeNull();
     }

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -1,4 +1,4 @@
-import { externallyAuthored, FACTORY_ROLE_STAGES } from '@mastra/factory/rules/types';
+import { FACTORY_ROLE_STAGES, knownExternalAuthor } from '@mastra/factory/rules/types';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
@@ -335,10 +335,10 @@ export function WorkItemCard({
           {status.kind === 'idle' && (
             <CardDetailsHint className="pointer-events-none pointer-fine:absolute pointer-fine:right-3 pointer-fine:bottom-3 pointer-fine:z-20 pointer-fine:ml-0" />
           )}
-          {(activity.lastWorker !== undefined || status.kind !== 'idle' || externallyAuthored(item)) && (
+          {(activity.lastWorker !== undefined || status.kind !== 'idle' || knownExternalAuthor(item)) && (
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
               <WorkItemActivity activity={activity} actors={activityPage?.actors ?? {}} />
-              {externallyAuthored(item) && (
+              {knownExternalAuthor(item) && (
                 <Tooltip>
                   <TooltipTrigger
                     render={

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -2376,6 +2376,28 @@ describe('createGithubPullRequestReconciler', () => {
     });
   });
 
+  it('answers for a settled card the sweep no longer visits, without fetching its pull request', async () => {
+    const context = await setup('write');
+    const card = await createCard(context, {
+      number: 19,
+      stages: ['done'],
+      metadata: {
+        author: 'pr-author',
+        state: 'closed',
+        merged: true,
+        [FACTORY_PULL_REQUEST_RECONCILIATION_KEY]: 'merged',
+      },
+    });
+    const fetchPullRequest = vi.fn(async () => mergedState(19));
+
+    await createReconciler(context, fetchPullRequest)([repositoryTarget]);
+
+    expect(fetchPullRequest).not.toHaveBeenCalled();
+    await expect(context.workItems.get({ orgId: 'org-1', id: card.item.id })).resolves.toMatchObject({
+      metadata: { authorTrusted: true },
+    });
+  });
+
   it.each([
     { merged: true, expected: 'merged' },
     { merged: false, expected: 'closed' },

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -2399,6 +2399,30 @@ describe('createGithubPullRequestReconciler', () => {
   });
 
   it.each([
+    { attribution: 'the intake-stamped repository', metadata: { githubRepositoryId: 10 }, answered: true },
+    { attribution: 'nothing but its number', metadata: {}, answered: false },
+  ])('answers for a URL-less settled card that names $attribution', async ({ metadata, answered }) => {
+    const context = await setup('write');
+    const card = await createCard(context, {
+      number: 31,
+      url: null,
+      stages: ['done'],
+      metadata: {
+        ...metadata,
+        author: 'pr-author',
+        state: 'closed',
+        merged: true,
+        [FACTORY_PULL_REQUEST_RECONCILIATION_KEY]: 'merged',
+      },
+    });
+
+    await createReconciler(context, vi.fn(async () => mergedState(31)))([repositoryTarget]);
+
+    const stamped = await context.workItems.get({ orgId: 'org-1', id: card.item.id });
+    expect(stamped?.metadata?.authorTrusted).toBe(answered ? true : undefined);
+  });
+
+  it.each([
     { merged: true, expected: 'merged' },
     { merged: false, expected: 'closed' },
   ])('retires the thread subscription to $expected', async ({ merged, expected }) => {

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -2376,28 +2376,6 @@ describe('createGithubPullRequestReconciler', () => {
     });
   });
 
-  it('answers for a settled card the sweep no longer visits, without fetching its pull request', async () => {
-    const context = await setup('write');
-    const card = await createCard(context, {
-      number: 19,
-      stages: ['done'],
-      metadata: {
-        author: 'pr-author',
-        state: 'closed',
-        merged: true,
-        [FACTORY_PULL_REQUEST_RECONCILIATION_KEY]: 'merged',
-      },
-    });
-    const fetchPullRequest = vi.fn(async () => mergedState(19));
-
-    await createReconciler(context, fetchPullRequest)([repositoryTarget]);
-
-    expect(fetchPullRequest).not.toHaveBeenCalled();
-    await expect(context.workItems.get({ orgId: 'org-1', id: card.item.id })).resolves.toMatchObject({
-      metadata: { authorTrusted: true },
-    });
-  });
-
   it.each([
     { merged: true, expected: 'merged' },
     { merged: false, expected: 'closed' },

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -164,7 +164,12 @@ function authorAwaitingTrust(item: WorkItemRow, repository: ReconcileRepository)
   const metadata = item.metadata ?? {};
   if (typeof metadata.author !== 'string' || metadata.authorTrusted !== undefined) return undefined;
   const tracked = reconcilablePullRequestNumber(item, repository) ?? reconcilableIssueNumber(item, repository);
-  return tracked === undefined ? undefined : metadata.author;
+  if (tracked === undefined) return undefined;
+  // A canonical key with no URL names no repository, and the pull request matcher takes it anyway.
+  // Asking GitHub about the wrong repository of a multi-repository project would record a wrong answer.
+  const unattributed = !item.externalSource?.url && /^github-(?:pr|issue):\d+$/.test(item.externalSource?.externalId ?? '');
+  if (unattributed && metadata.githubRepositoryId !== repository.id) return undefined;
+  return metadata.author;
 }
 
 export function sweepTrustLookup(

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -23,8 +23,6 @@ import { changeRequestTargetKey } from './subscriptions.js';
 import type { ParsedGithubWebhook } from './webhook.js';
 
 const TRUSTED_PERMISSIONS = new Set(['write', 'admin']);
-// ponytail: a board that predates author trust drains over a few sweeps instead of one write storm.
-const AUTHOR_TRUST_STAMPS_PER_SWEEP = 200;
 const RULE_TIMEOUT_MS = 5_000;
 const FACTORY_TRIAGE_COMMENT_MARKER = '<!-- mastra-factory-triage -->';
 
@@ -968,7 +966,7 @@ export function createGithubPullRequestReconciler(
         continue;
       }
       const authorTrust = sweepTrustLookup(options.github, repository);
-      for (const { item, author } of unanswered.slice(0, AUTHOR_TRUST_STAMPS_PER_SWEEP)) {
+      for (const { item, author } of unanswered) {
         try {
           await options.storage.update({
             orgId: item.orgId,

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -23,8 +23,6 @@ import { changeRequestTargetKey } from './subscriptions.js';
 import type { ParsedGithubWebhook } from './webhook.js';
 
 const TRUSTED_PERMISSIONS = new Set(['write', 'admin']);
-// ponytail: a board that predates author trust drains over a few sweeps instead of one write storm.
-const AUTHOR_TRUST_STAMPS_PER_SWEEP = 200;
 const RULE_TIMEOUT_MS = 5_000;
 const FACTORY_TRIAGE_COMMENT_MARKER = '<!-- mastra-factory-triage -->';
 
@@ -158,15 +156,6 @@ export async function trustedCollaborator(
     input.login,
   );
   return permission !== undefined && TRUSTED_PERMISSIONS.has(permission);
-}
-
-// Terminal cards leave the reconcile loop below, so the ones that got there before author
-// trust was recorded have no other path to an answer.
-function authorAwaitingTrust(item: WorkItemRow, repository: ReconcileRepository): string | undefined {
-  const metadata = item.metadata ?? {};
-  if (typeof metadata.author !== 'string' || metadata.authorTrusted !== undefined) return undefined;
-  const tracked = reconcilablePullRequestNumber(item, repository) ?? reconcilableIssueNumber(item, repository);
-  return tracked === undefined ? undefined : metadata.author;
 }
 
 export function sweepTrustLookup(
@@ -928,7 +917,6 @@ export function createGithubPullRequestReconciler(
       // One broken repository (or a failing token exchange for its
       // installation) must not abort the sweep for the others.
       let cardsByNumber: Map<number, WorkItemRow[]>;
-      let unanswered: Array<{ item: WorkItemRow; author: string }>;
       try {
         const projects = await options.sourceControl.projectRepositories.listByExternalRepository({
           installationExternalId: String(repository.installationId),
@@ -936,7 +924,6 @@ export function createGithubPullRequestReconciler(
         });
         if (projects.length === 0) continue;
         cardsByNumber = new Map<number, WorkItemRow[]>();
-        unanswered = [];
         for (const project of projects) {
           const items = await options.storage.list({
             orgId: project.orgId,
@@ -944,8 +931,6 @@ export function createGithubPullRequestReconciler(
           });
           for (const item of items) {
             const stage = item.stages[0];
-            const unansweredAuthor = authorAwaitingTrust(item, repository);
-            if (unansweredAuthor) unanswered.push({ item, author: unansweredAuthor });
             const pullRequestNumber = reconcilablePullRequestNumber(item, repository);
             if (!pullRequestNumber) continue;
             const metadata = item.metadata ?? {};
@@ -968,18 +953,6 @@ export function createGithubPullRequestReconciler(
         continue;
       }
       const authorTrust = sweepTrustLookup(options.github, repository);
-      for (const { item, author } of unanswered.slice(0, AUTHOR_TRUST_STAMPS_PER_SWEEP)) {
-        try {
-          await options.storage.update({
-            orgId: item.orgId,
-            id: item.id,
-            userId: 'factory-rule-dispatcher',
-            patch: { metadata: { authorTrusted: await authorTrust(author) } },
-          });
-        } catch (error) {
-          recordFailure(repository, error);
-        }
-      }
       for (const [pullRequestNumber, cards] of cardsByNumber) {
         try {
           const state = await fetchPullRequest({

--- a/mastracode/factory/src/integrations/github/rules.ts
+++ b/mastracode/factory/src/integrations/github/rules.ts
@@ -23,6 +23,8 @@ import { changeRequestTargetKey } from './subscriptions.js';
 import type { ParsedGithubWebhook } from './webhook.js';
 
 const TRUSTED_PERMISSIONS = new Set(['write', 'admin']);
+// ponytail: a board that predates author trust drains over a few sweeps instead of one write storm.
+const AUTHOR_TRUST_STAMPS_PER_SWEEP = 200;
 const RULE_TIMEOUT_MS = 5_000;
 const FACTORY_TRIAGE_COMMENT_MARKER = '<!-- mastra-factory-triage -->';
 
@@ -156,6 +158,15 @@ export async function trustedCollaborator(
     input.login,
   );
   return permission !== undefined && TRUSTED_PERMISSIONS.has(permission);
+}
+
+// Terminal cards leave the reconcile loop below, so the ones that got there before author
+// trust was recorded have no other path to an answer.
+function authorAwaitingTrust(item: WorkItemRow, repository: ReconcileRepository): string | undefined {
+  const metadata = item.metadata ?? {};
+  if (typeof metadata.author !== 'string' || metadata.authorTrusted !== undefined) return undefined;
+  const tracked = reconcilablePullRequestNumber(item, repository) ?? reconcilableIssueNumber(item, repository);
+  return tracked === undefined ? undefined : metadata.author;
 }
 
 export function sweepTrustLookup(
@@ -917,6 +928,7 @@ export function createGithubPullRequestReconciler(
       // One broken repository (or a failing token exchange for its
       // installation) must not abort the sweep for the others.
       let cardsByNumber: Map<number, WorkItemRow[]>;
+      let unanswered: Array<{ item: WorkItemRow; author: string }>;
       try {
         const projects = await options.sourceControl.projectRepositories.listByExternalRepository({
           installationExternalId: String(repository.installationId),
@@ -924,6 +936,7 @@ export function createGithubPullRequestReconciler(
         });
         if (projects.length === 0) continue;
         cardsByNumber = new Map<number, WorkItemRow[]>();
+        unanswered = [];
         for (const project of projects) {
           const items = await options.storage.list({
             orgId: project.orgId,
@@ -931,6 +944,8 @@ export function createGithubPullRequestReconciler(
           });
           for (const item of items) {
             const stage = item.stages[0];
+            const unansweredAuthor = authorAwaitingTrust(item, repository);
+            if (unansweredAuthor) unanswered.push({ item, author: unansweredAuthor });
             const pullRequestNumber = reconcilablePullRequestNumber(item, repository);
             if (!pullRequestNumber) continue;
             const metadata = item.metadata ?? {};
@@ -953,6 +968,18 @@ export function createGithubPullRequestReconciler(
         continue;
       }
       const authorTrust = sweepTrustLookup(options.github, repository);
+      for (const { item, author } of unanswered.slice(0, AUTHOR_TRUST_STAMPS_PER_SWEEP)) {
+        try {
+          await options.storage.update({
+            orgId: item.orgId,
+            id: item.id,
+            userId: 'factory-rule-dispatcher',
+            patch: { metadata: { authorTrusted: await authorTrust(author) } },
+          });
+        } catch (error) {
+          recordFailure(repository, error);
+        }
+      }
       for (const [pullRequestNumber, cards] of cardsByNumber) {
         try {
           const state = await fetchPullRequest({

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -19,6 +19,11 @@ export function externallyAuthored(item: { source: string; metadata: Record<stri
   return item.metadata?.authorTrusted !== true;
 }
 
+// The board mark claims only what GitHub answered: a missing stamp is silence, not an outside contribution.
+export function knownExternalAuthor(item: { source: string; metadata: Record<string, unknown> | null }): boolean {
+  return externallyAuthored(item) && item.metadata?.authorTrusted === false;
+}
+
 export function externallyAuthoredWorkItem(item: {
   externalSource: ExternalWorkItemSource | null;
   metadata: Record<string, unknown> | null;


### PR DESCRIPTION
TLDR: the reconcile sweep now records author trust for the cards it had stopped visiting, so Done and Canceled stop labelling teammates as outside contributions — on any deployed factory, with nothing to run by hand.

Fixes #22653

---

before: your merged PR sitting in Done wears External, so does Ward's, so does most of Done and Canceled
after: the next sweep answers for those cards, and the mark stays only where GitHub said "no write access"

Author trust arrived in #22531 as a stamp on the card, re-derived every cycle so revoked access propagates. Both sweeps skip terminal cards, though — they exist to fetch pull request state, and a finished card has none worth fetching. That left one population with no path to an answer at all: everything that reached Done or Canceled before the stamp existed. 1172 cards on my local Factory, against zero unanswered cards in Intake, Reviewing, Planning or Execute. Nothing strips a stamp on the way to Done — `WorkItemStorage.update` merges metadata — so it really is just that backlog, and it never heals on its own.

Trust needs no pull request state, only the repository and the author the card already carries. So the sweep answers for those cards off the item list it already pulls, and the board mark reads a recorded answer rather than the absence of one.

### Behavior changed

- card that reached Done or Canceled before trust was recorded: labelled External forever → answered on the next sweep, then labelled by what GitHub said
- card whose author genuinely has no write access: labelled → unchanged, consent gates unchanged
- card nobody has answered for yet (repository unlinked, lookup failing, sweeps disabled): labelled External → no label, and the gates still ask a person before any run

### Decisions

- the sweep pass rather than a one-off script: Shipyard is already deployed, so the fix has to reach boards I cannot run a script against. This makes it an ordinary deploy — reconciliation defaults on, each factory drains itself on its next sweep. A deployment that set the flag to `false` does not heal, but it has no trust revocation either: existing limit, not a new one.
- the population it drains is closed — every rule that creates a GitHub card stamps the answer at creation — so after the drain the pass is a filter over a list the sweep already pulls, with no lookups and no writes. That permanent no-op is the price of healing production without an ops step.
- no cap on stamps per sweep: the worker renews its lease on a heartbeat and the sweep already fetches one pull request per open card, so a bounded first burst defended nothing. A board drains in one pass.
- kept the narrower mark underneath the fix, for the cards no sweep reaches.
- left the bots alone: `mastra-platform[bot]`, `dane-ai-mastra[bot]` and `devin-ai-integration[bot]` answer untrusted because a GitHub App is not a collaborator, so a release PR never auto-starts. Real question, separate call.

### Shape changed

- added `authorAwaitingTrust` (integrations/github/rules) — the sweep's filter for a card with an author and no answer; reuses both existing repository matchers, and refuses a URL-less canonical key whose repository is not proven by `githubRepositoryId` (`reconcilablePullRequestNumber` takes those from any repository, which would have recorded another repository's answer)
- added `knownExternalAuthor` (rules/types) — the board's reading of the stamp; `externallyAuthored` stays the gates' and is untouched
- surface: `@mastra/factory/rules/types` exports one more predicate

### Watch

- on deploy: the first sweep per repository stamps every unanswered card and does one collaborator lookup per distinct author. The board sorts on `createdAt` and `WorkItemStorage.update` publishes nothing, so nothing reorders and no feed or attention event fires.

```
source       +38  -3
tests        +49  -5    ← 56% of the additions
changeset     +5   0
```
