### PR TITLE
fix(factory): preserve signed-in credentials for Factory model calls

### DIFF
--- a/.changeset/factory-om-oauth-context.md
+++ b/.changeset/factory-om-oauth-context.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Factory-owned internal model calls can now recover the tenant credential scope from the trusted controller session when a child request context no longer carries the web-auth user entry. This keeps OpenAI Codex OAuth available to observational-memory observer and reflector runs without requiring an `OPENAI_API_KEY`, while incomplete or unresolved Factory identity continues to fail closed.

--- a/.changeset/factory-om-oauth-context.md
+++ b/.changeset/factory-om-oauth-context.md
@@ -1,5 +1,6 @@
 ---
 '@mastra/code-sdk': patch
+'@mastra/factory': patch
 ---
 
-Factory-owned internal model calls can now recover the tenant credential scope from the trusted controller session when a child request context no longer carries the web-auth user entry. This keeps OpenAI Codex OAuth available to observational-memory observer and reflector runs without requiring an `OPENAI_API_KEY`, while incomplete or unresolved Factory identity continues to fail closed.
+Factory-owned internal model calls can now recover tenant identity from the trusted controller session when a child request context no longer carries the web-auth user entry. Factory credential priming also hydrates both user-first and org-first snapshots when precedence is not explicitly selected, so signed-in OAuth remains visible to synchronous model routing after a restart without requiring an `OPENAI_API_KEY`. Incomplete or unresolved Factory identity continues to fail closed.

--- a/mastracode/factory/src/routes/tenant-credentials.test.ts
+++ b/mastracode/factory/src/routes/tenant-credentials.test.ts
@@ -28,6 +28,7 @@ import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
 import {
   TenantCredentialStore,
   createTenantCredentialPrimer,
+  primeTenantCredentials,
   registerTenantCredentialResolver,
   resetTenantCredentialResolverForTests,
 } from './tenant-credentials.js';
@@ -232,6 +233,64 @@ describe('createTenantCredentialPrimer', () => {
     ctx.set('user', { workosId: USER, organizationId: ORG });
     // Snapshot already hydrated by the primer — sync read works immediately.
     expect(resolveCredentialStore(ctx)!.getStoredApiKey('openai')).toBe('user-key');
+  });
+
+  it('primes the org-first Factory snapshot as well as the user-first snapshot', async () => {
+    const oauth = {
+      type: 'oauth' as const,
+      refresh: 'openai-refresh',
+      access: 'openai-access',
+      expires: Date.now() + 3_600_000,
+    };
+    await seed.credentials.setCredential(USER_TENANT, 'openai-codex', oauth);
+    registerTenantCredentialResolver(seed.credentials);
+
+    const res = await buildApp({ workosId: USER, organizationId: ORG }).request('/ok');
+    expect(res.status).toBe(200);
+
+    const ctx = new RequestContext();
+    ctx.set('user', { workosId: USER, organizationId: ORG });
+    const state = { factoryProjectId: 'project-1', factoryOrgId: ORG };
+    ctx.set('controller', {
+      state,
+      getState: () => state,
+      session: { ownerId: USER },
+    });
+
+    // Factory contexts resolve org-first in the SDK. The browser primer does
+    // not know that precedence ahead of time, so it must have hydrated this
+    // distinct cache entry as well as the ordinary user-first entry.
+    expect(resolveCredentialStore(ctx)!.get('openai-codex')).toEqual(oauth);
+  });
+
+  it('keeps explicit precedence priming narrow', async () => {
+    const oauth = {
+      type: 'oauth' as const,
+      refresh: 'openai-refresh',
+      access: 'openai-access',
+      expires: Date.now() + 3_600_000,
+    };
+    await seed.credentials.setCredential(USER_TENANT, 'openai-codex', oauth);
+    registerTenantCredentialResolver(seed.credentials);
+
+    await primeTenantCredentials({
+      tenant: { orgId: ORG, userId: USER, orgFirst: true },
+      credentials: seed.credentials,
+    });
+
+    const factoryCtx = new RequestContext();
+    factoryCtx.set('user', { workosId: USER, organizationId: ORG });
+    const state = { factoryProjectId: 'project-1', factoryOrgId: ORG };
+    factoryCtx.set('controller', {
+      state,
+      getState: () => state,
+      session: { ownerId: USER },
+    });
+    expect(resolveCredentialStore(factoryCtx)!.get('openai-codex')).toEqual(oauth);
+
+    const userCtx = new RequestContext();
+    userCtx.set('user', { workosId: USER, organizationId: ORG });
+    expect(resolveCredentialStore(userCtx)!.get('openai-codex')).toBeUndefined();
   });
 
   it('passes unauthenticated requests through untouched', async () => {

--- a/mastracode/factory/src/routes/tenant-credentials.ts
+++ b/mastracode/factory/src/routes/tenant-credentials.ts
@@ -217,7 +217,24 @@ export async function primeTenantCredentials({
   tenant: SdkCredentialTenant;
   credentials: ModelCredentialsStorage;
 }): Promise<void> {
-  await storeFor(tenant, credentials).ensureFresh();
+  const stores = [storeFor(tenant, credentials)];
+
+  // Factory controller runs always resolve org-first, but both the web auth
+  // primer and the background dispatcher naturally know only { orgId, userId }.
+  // The two precedence modes intentionally have separate cache entries, so
+  // priming just the default user-first entry leaves a freshly restarted
+  // Factory's org-first snapshot empty. Model selection is synchronous and
+  // interprets that empty snapshot as "no OAuth credential", which can fall
+  // through to an API-key provider before the async store has any chance to
+  // hydrate itself.
+  //
+  // When the caller has not explicitly selected precedence, hydrate both
+  // variants. Explicit callers still get exactly the store they requested.
+  if (tenant.orgFirst === undefined) {
+    stores.push(storeFor({ ...tenant, orgFirst: true }, credentials));
+  }
+
+  await Promise.all(stores.map(store => store.ensureFresh()));
 }
 
 export function createTenantCredentialPrimer({
@@ -231,7 +248,7 @@ export function createTenantCredentialPrimer({
     const tenant = auth.tenant(c);
     if (tenant) {
       try {
-        await storeFor(tenant, credentials).ensureFresh();
+        await primeTenantCredentials({ tenant, credentials });
       } catch {
         // Fail open: model calls fall back to env credentials.
       }

--- a/mastracode/sdk/src/agents/__tests__/model.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/model.test.ts
@@ -196,6 +196,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MODEL_TOKENS } from '../../../../../docs/src/plugins/remark-model-tokens/models.js';
 import { opencodeClaudeMaxProvider, buildAnthropicOAuthFetch } from '../../providers/claude-max.js';
 import { openaiCodexProvider, buildOpenAICodexOAuthFetch } from '../../providers/openai-codex.js';
+import { setCredentialStoreProvider } from '../credential-resolver.js';
 import {
   createMastraCodeGateway,
   resolveModel,
@@ -241,6 +242,7 @@ describe('resolveModel', () => {
   });
 
   afterEach(() => {
+    setCredentialStoreProvider(undefined);
     process.env = { ...originalEnv };
   });
 
@@ -448,6 +450,58 @@ describe('resolveModel', () => {
       const result = resolveModel('openai/gpt-4o') as Record<string, unknown>;
       expect(result.__provider).toBe('openai-codex');
       expect(openaiCodexProvider).toHaveBeenCalled();
+    });
+
+    it('uses Factory controller identity to recover tenant OpenAI OAuth when the web user entry is absent', () => {
+      const oauthStore = {
+        allowEnvironmentFallback: false,
+        reload: vi.fn(),
+        get: vi.fn((provider: string) =>
+          provider === 'openai-codex'
+            ? {
+                type: 'oauth' as const,
+                access: 'tenant-openai-access',
+                refresh: 'tenant-openai-refresh',
+                expires: Date.now() + 60_000,
+              }
+            : undefined,
+        ),
+        getStoredApiKey: vi.fn(() => undefined),
+        getApiKey: vi.fn(async () => undefined),
+      };
+      let seenTenant: unknown;
+      setCredentialStoreProvider(tenant => {
+        seenTenant = tenant;
+        return oauthStore;
+      });
+
+      const values = new Map<string, unknown>();
+      const requestContext = {
+        get: (key: string) => values.get(key),
+        set: (key: string, value: unknown) => values.set(key, value),
+      } as any;
+      const state = { factoryProjectId: 'project-1', factoryOrgId: 'org-1' };
+      requestContext.set('controller', {
+        state,
+        getState: () => state,
+        session: { ownerId: 'user-1' },
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+      });
+
+      const result = resolveModel('openai/gpt-5.6-terra', { requestContext }) as Record<string, unknown>;
+
+      expect(seenTenant).toEqual({ orgId: 'org-1', userId: 'user-1', orgFirst: true });
+      expect(result.__provider).toBe('openai-codex');
+      expect(openaiCodexProvider).toHaveBeenCalledWith('gpt-5.6-terra', {
+        thinkingLevel: undefined,
+        headers: {
+          'x-thread-id': 'thread-1',
+          'x-resource-id': 'resource-1',
+        },
+        authStorage: oauthStore,
+      });
+      expect(ModelRouterLanguageModel).not.toHaveBeenCalled();
     });
 
     it('uses direct OpenAI API key provider when stored API key credential exists', () => {

--- a/mastracode/sdk/src/agents/credential-resolver.test.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.test.ts
@@ -51,6 +51,49 @@ describe('credential store provider registry', () => {
     expect(seenTenant).toEqual({ orgId: 'org_1', userId: 'user_1' });
   });
 
+  it('recovers the tenant store from trusted Factory controller state when the web user entry is absent', () => {
+    const store = fakeStore({
+      'openai-codex': { type: 'oauth', refresh: 'r', access: 'a', expires: Date.now() + 60_000 },
+    });
+    let seenTenant: unknown;
+    setCredentialStoreProvider(tenant => {
+      seenTenant = tenant;
+      return store;
+    });
+
+    const ctx = new RequestContext();
+    const liveState = {
+      factoryProjectId: 'project-1',
+      factoryOrgId: 'org_1',
+    };
+    ctx.set('controller', {
+      state: { factoryProjectId: 'stale-project', factoryOrgId: 'stale-org' },
+      getState: () => liveState,
+      session: { ownerId: 'user_1' },
+    });
+
+    expect(resolveCredentialStore(ctx)).toBe(store);
+    expect(seenTenant).toEqual({ orgId: 'org_1', userId: 'user_1', orgFirst: true });
+  });
+
+  it.each([
+    ['missing factory org', { factoryProjectId: 'project-1' }, { ownerId: 'user_1' }],
+    ['missing session owner', { factoryProjectId: 'project-1', factoryOrgId: 'org_1' }, {}],
+    [
+      'explicitly unresolved factory org',
+      { factoryProjectId: 'project-1', factoryOrgId: 'org_1', factoryOrgUnresolved: true },
+      { ownerId: 'user_1' },
+    ],
+  ])('fails closed for controller-only Factory identity with %s', async (_label, state, session) => {
+    setCredentialStoreProvider(() => fakeStore({}));
+    const ctx = new RequestContext();
+    ctx.set('controller', { state, getState: () => state, session });
+
+    const resolved = resolveCredentialStore(ctx);
+    expect(resolved).toMatchObject({ allowEnvironmentFallback: false });
+    await expect(resolved?.getApiKey('openai-codex')).resolves.toBeUndefined();
+  });
+
   it('fails closed without an authenticated tenant on the request context', async () => {
     setCredentialStoreProvider(() => fakeStore({}));
     const withoutContext = resolveCredentialStore(undefined);

--- a/mastracode/sdk/src/agents/credential-resolver.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.ts
@@ -103,6 +103,53 @@ function isFactorySessionContext(requestContext?: RequestContext): boolean {
 }
 
 /**
+ * Recover the tenant identity for an internal run on a Factory-owned
+ * controller session when no web-auth `user` entry survives into the child
+ * request context.
+ *
+ * Factory seeds these values server-side when it creates the session. Requiring
+ * all three prevents a partial/stale controller context from turning into a
+ * credential lookup under a guessed tenant.
+ */
+function resolveFactorySessionTenant(requestContext?: RequestContext): CredentialTenant | undefined {
+  const controller = requestContext?.get('controller') as
+    | {
+        state?: {
+          factoryProjectId?: unknown;
+          factoryOrgId?: unknown;
+          factoryOrgUnresolved?: unknown;
+        };
+        getState?: () => unknown;
+        session?: { ownerId?: unknown };
+      }
+    | undefined;
+  if (!controller || typeof controller !== 'object') return undefined;
+
+  let state = controller.state;
+  if (typeof controller.getState === 'function') {
+    try {
+      const liveState = controller.getState();
+      if (liveState && typeof liveState === 'object') {
+        state = liveState as typeof state;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+
+  const factoryProjectId = state?.factoryProjectId;
+  const factoryOrgId = state?.factoryOrgId;
+  const ownerId = controller.session?.ownerId;
+
+  if (state?.factoryOrgUnresolved === true) return undefined;
+  if (typeof factoryProjectId !== 'string' || !factoryProjectId) return undefined;
+  if (typeof factoryOrgId !== 'string' || !factoryOrgId) return undefined;
+  if (typeof ownerId !== 'string' || !ownerId) return undefined;
+
+  return { orgId: factoryOrgId, userId: ownerId, orgFirst: true };
+}
+
+/**
  * Derive the calling tenant from a request context, if an authenticated web
  * user was stashed on it. Mirrors the web layer's stable-id resolution
  * (`workosId` falling back to the provider `id`).
@@ -115,7 +162,8 @@ function isFactorySessionContext(requestContext?: RequestContext): boolean {
  */
 export function resolveTenantFromRequestContext(requestContext?: RequestContext): CredentialTenant | undefined {
   const raw = requestContext?.get('user') as (RequestContextUser & RequestContextSession) | undefined;
-  if (!raw || typeof raw !== 'object') return undefined;
+  if (!raw) return resolveFactorySessionTenant(requestContext);
+  if (typeof raw !== 'object') return undefined;
 
   // Precedence matches `toFactoryAuthUser` in `@mastra/factory`: a wrapper's org
   // comes from the session half only, never from the inner user. The two parsers


### PR DESCRIPTION
Fixes #22654.

Factory work sessions can use signed-in provider credentials for their main model but can lose access to the same credential state on internal/resumed model paths. The observed OpenAI/Codex case falls through to the ordinary API-key router with:

```
Could not find API key process.env.OPENAI_API_KEY for model id openai/gpt-5.6-terra
```

Two independent seams are involved.

### 1. Recover Factory tenant identity when the web user entry is absent

The code-sdk credential resolver now permits a Factory-owned controller session to recover its tenant only from trusted server-seeded identity:

- non-empty `factoryProjectId`;
- non-empty authoritative `factoryOrgId`;
- non-empty `session.ownerId`;
- `factoryOrgUnresolved !== true`.

Recovered Factory credentials retain `orgFirst: true`. Incomplete/malformed/non-Factory contexts continue to fail closed.

### 2. Prime the credential snapshot Factory model routing actually reads

Factory deliberately has separate user-first and org-first credential-store snapshots. Factory controller runs resolve org-first, while browser and dispatcher primers naturally receive only `{ orgId, userId }`.

After a process restart, priming only the default user-first snapshot leaves the distinct org-first snapshot empty. Because provider selection is synchronous, the empty org-first snapshot makes stored OAuth appear absent and the model can fall through to an API-key route.

When precedence is unspecified, `primeTenantCredentials()` now hydrates both user-first and org-first variants. Explicit precedence still primes only the requested variant. The web primer routes through that shared helper, so interactive and dispatcher-triggered Factory work see the same hydrated credential state.

### Safety

- no credential is copied into `process.env`;
- no `OPENAI_API_KEY` is introduced;
- no paid/API fallback is added;
- org-first precedence remains unchanged;
- incomplete Factory identity remains fail-closed.

### Regression coverage

Coverage includes:
- controller-only Factory tenant recovery;
- fail-closed incomplete/unresolved Factory identity;
- OpenAI Codex OAuth model routing;
- web credential priming of both user-first and org-first snapshots;
- personal OAuth fallback in an org-first Factory store;
- explicit-precedence priming remaining narrow.

### Field evidence

The first resolver-only revision passed structural/runtime overlay checks but the real #703 Factory session still fell through to `OPENAI_API_KEY` after restart. That failure exposed the separate snapshot-priming seam above.

The amended head `9da656bf9cb9b0dfbf739d82a5ff3475da194229` then passed:
- exact runtime/source identity checks;
- user-first + org-first snapshot priming assertions;
- Factory personal OAuth fallback;
- fail-closed identity cases;
- loopback runtime health/listener/startup stability;
- live resolver and PgVector identity;
- the decisive real #703 behavioral check with Observer + Reflector on `openai/gpt-5.6-terra`.

The existing affected work session resumed successfully without the previous `process.env.OPENAI_API_KEY` fallback. No API key, credits, paid fallback, or provider workaround was introduced.

**Field status: PASS.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory’s background tasks sometimes forgot which signed-in account they belonged to. This PR restores that account safely, so Observer and Reflector can use the same OAuth credentials without requiring an API key.

## Changes

- Recover Factory tenant identity from trusted controller state when the web-auth `user` entry is missing.
- Require valid `factoryProjectId`, `factoryOrgId`, and `session.ownerId`.
- Use org-first precedence for recovered Factory credentials.
- Fail closed for incomplete, unresolved, or non-Factory contexts.
- Prime both user-first and org-first credential snapshots when precedence is unspecified.
- Preserve narrow behavior when precedence is explicit.
- Keep credential handling provider-neutral through the existing OAuth gateway.
- Avoid `OPENAI_API_KEY` requirements, environment credential copies, and paid/API fallbacks.
- Add regression coverage for tenant recovery, OAuth routing, fail-closed handling, credential priming, personal OAuth fallback, and precedence behavior.
- Add changesets for `@mastra/code-sdk` and `@mastra/factory`.

## Validation

- Resolver, credential priming, identity, health, and runtime checks passed.
- The affected Factory session resumed successfully with Observer and Reflector using `openai/gpt-5.6-terra` through signed-in OAuth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->