### PR TITLE
Show why a span matches a trace search in Studio

### DIFF
--- a/.changeset/fair-impalas-tie.md
+++ b/.changeset/fair-impalas-tie.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved trace search in Studio: when a span matches your search only through its metadata, attributes or error payload, its name in the timeline is now painted in a distinct color so you can see why the row is there without opening it. Spans matching by name keep the usual highlight.

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -129,6 +129,26 @@ describe('TraceDataPanelView — search highlighting', () => {
     expect(harness.highlights.set).not.toHaveBeenCalled();
   });
 
+  it('paints the whole name of a span matched only by its metadata', async () => {
+    render(<TraceDataPanelView {...baseProps} spans={deepTraceFixture} />);
+
+    // 'pgvector' lives in the memory span's metadata and in no span name.
+    search('pgvector');
+
+    // The rows are marked once the filtered tree commits, one frame after the query.
+    await waitFor(() => expect(harness.highlightedText('search-result-indirect')).toEqual(['memory lookup']));
+    expect(harness.highlightedText()).toEqual([]);
+  });
+
+  it('leaves a span matched by its name on the normal highlight', async () => {
+    render(<TraceDataPanelView {...baseProps} spans={deepTraceFixture} />);
+
+    search('memory');
+
+    await waitFor(() => expect(harness.highlightedText()).toEqual(['memory']));
+    expect(harness.highlightedText('search-result-indirect')).toEqual([]);
+  });
+
   it('removes the highlight when the search field is cleared', () => {
     renderWithSpanPanel();
     search('agent');

--- a/packages/playground-ui/src/domains/traces/components/format-hierarchical-spans.ts
+++ b/packages/playground-ui/src/domains/traces/components/format-hierarchical-spans.ts
@@ -8,6 +8,7 @@ type TimelineSpan = {
   startedAt: Date | string;
   endedAt?: Date | string | null;
   parentSpanId?: string | null;
+  matchedInPayloadOnly?: boolean;
 };
 
 /**
@@ -45,6 +46,7 @@ export const formatHierarchicalSpans = (spans: TimelineSpan[], anchorSpanId?: st
       endTime: endDate ? endDate.toISOString() : undefined,
       spans: [],
       parentSpanId: spanRecord.parentSpanId,
+      matchedInPayloadOnly: spanRecord.matchedInPayloadOnly,
     };
 
     spanMap.set(spanRecord.spanId, uiSpan);

--- a/packages/playground-ui/src/domains/traces/components/timeline-name-col.tsx
+++ b/packages/playground-ui/src/domains/traces/components/timeline-name-col.tsx
@@ -63,8 +63,15 @@ export function TimelineNameCol({
             style={{ backgroundColor: spanUI.color }}
           />
         )}
-        {/* Searchable: the span name is what the timeline search matches on. */}
-        <span data-highlight className="min-w-0 truncate">
+        {/* Searchable: the span name is what the timeline search matches on. When the match
+            is in the span's payload instead, the whole name is painted in the indirect color
+            so the row explains its own presence. */}
+        <span
+          data-highlight={span.matchedInPayloadOnly ? undefined : ''}
+          data-highlight-indirect={span.matchedInPayloadOnly ? '' : undefined}
+          title={span.matchedInPayloadOnly ? 'Matches your search in this span’s details' : undefined}
+          className="min-w-0 truncate"
+        >
           {span.name}
         </span>
       </button>

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -163,9 +163,18 @@ export function TraceDataPanelView({
   }, [initialSpanId, spans, isLoading]);
 
   const searchFieldName = useId();
-  const { query, setQuery, results } = useTraceSearch(spans ?? []);
+  const { query, setQuery, results, payloadOnlyMatchIds } = useTraceSearch(spans ?? []);
 
-  const hierarchicalSpans = useMemo(() => formatHierarchicalSpans(results, anchorSpanId), [results, anchorSpanId]);
+  const hierarchicalSpans = useMemo(
+    () =>
+      formatHierarchicalSpans(
+        // Carried on the span rather than drilled as a prop: the tree is rebuilt here and
+        // rendered several components deeper.
+        results.map(span => ({ ...span, matchedInPayloadOnly: payloadOnlyMatchIds.has(span.spanId) })),
+        anchorSpanId,
+      ),
+    [results, payloadOnlyMatchIds, anchorSpanId],
+  );
 
   const [expandedSpanIds, setExpandedSpanIds] = useState<string[]>([]);
 

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-search.test.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-trace-search.test.tsx
@@ -204,6 +204,45 @@ describe('useTraceSearch', () => {
     });
   });
 
+  describe('payloadOnlyMatchIds — the matches a name highlight cannot show', () => {
+    it('is empty while the query is', () => {
+      const spans = [makeSpan('a', null, { metadata: { city: 'Lyon' } })];
+      const { result } = renderHook(() => useTraceSearch(spans));
+
+      expect(result.current.payloadOnlyMatchIds.size).toBe(0);
+    });
+
+    it('holds a span matched only by its metadata', () => {
+      const spans = [makeSpan('a', null, { name: 'plain', metadata: { city: 'Lyon' } }), makeSpan('b', null)];
+      const { result } = renderHook(() => useTraceSearch(spans));
+
+      act(() => result.current.setQuery('lyon'));
+
+      expect([...result.current.payloadOnlyMatchIds]).toEqual(['a']);
+    });
+
+    it('leaves out a span whose name carries the term', () => {
+      const spans = [makeSpan('a', null, { name: 'Lyon lookup', metadata: { city: 'Lyon' } })];
+      const { result } = renderHook(() => useTraceSearch(spans));
+
+      act(() => result.current.setQuery('lyon'));
+
+      expect(result.current.payloadOnlyMatchIds.size).toBe(0);
+    });
+
+    it('leaves out ancestors kept only to hold the match', () => {
+      const spans = [
+        makeSpan('root', null, { name: 'root run' }),
+        makeSpan('leaf', 'root', { name: 'plain', metadata: { city: 'Lyon' } }),
+      ];
+      const { result } = renderHook(() => useTraceSearch(spans));
+
+      act(() => result.current.setQuery('lyon'));
+
+      expect([...result.current.payloadOnlyMatchIds]).toEqual(['leaf']);
+    });
+  });
+
   it('exposes the immediate query value and settles isPending', () => {
     const spans = [makeSpan('a', null, { name: 'Weather Agent' }), makeSpan('b', null, { name: 'travel' })];
     const { result } = renderHook(() => useTraceSearch(spans));

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-search.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-search.ts
@@ -8,6 +8,13 @@ export interface UseTraceSearchResult {
   setQuery: (query: string) => void;
   /** Rows matching the deferred query. An empty query returns the input array reference. */
   results: SearchableSpan[];
+  /**
+   * Spans that matched somewhere other than their name — in `metadata`, `attributes` or
+   * `error`. Their row shows no visible occurrence of the term, so the surface needs to say
+   * why it is there. Ancestors kept only to preserve the hierarchy are not in here: they did
+   * not match at all. Empty while the query is empty.
+   */
+  payloadOnlyMatchIds: Set<string>;
   /** True while the deferred value is behind `query` (the list is still catching up). */
   isPending: boolean;
 }
@@ -32,11 +39,21 @@ export function useTraceSearch(spans: SearchableSpan[]): UseTraceSearchResult {
   const [query, setQuery] = useState('');
   const deferredQuery = useDeferredValue(query);
 
-  const results = useMemo(() => {
+  const { results, payloadOnlyMatchIds } = useMemo(() => {
     const term = deferredQuery.trim().toLowerCase();
-    if (!term) return spans;
-    return filterSpansKeepingAncestors(spans, span => span.searchText.includes(term));
+    if (!term) return { results: spans, payloadOnlyMatchIds: new Set<string>() };
+
+    const payloadOnly = new Set<string>();
+    const filtered = filterSpansKeepingAncestors(spans, span => {
+      if (!span.searchText.includes(term)) return false;
+      // The name is the only part of a span the timeline paints, so a match it doesn't
+      // contain came from the payload.
+      if (!span.name.toLowerCase().includes(term)) payloadOnly.add(span.spanId);
+      return true;
+    });
+
+    return { results: filtered, payloadOnlyMatchIds: payloadOnly };
   }, [spans, deferredQuery]);
 
-  return { query, setQuery, results, isPending: query !== deferredQuery };
+  return { query, setQuery, results, payloadOnlyMatchIds, isPending: query !== deferredQuery };
 }

--- a/packages/playground-ui/src/domains/traces/types.ts
+++ b/packages/playground-ui/src/domains/traces/types.ts
@@ -27,6 +27,11 @@ export type UISpan = {
   endTime?: string;
   spans?: UISpan[];
   parentSpanId?: string | null;
+  /**
+   * Set when the span survived the active search because of its payload, not its name — the
+   * timeline paints such a row differently since the term is nowhere on it.
+   */
+  matchedInPayloadOnly?: boolean;
 };
 
 export type UISpanStyle = {

--- a/packages/playground-ui/src/hooks/use-text-highlight.css
+++ b/packages/playground-ui/src/hooks/use-text-highlight.css
@@ -6,3 +6,11 @@
   background-color: var(--color-accent6);
   color: var(--color-surface1);
 }
+
+/* The indirect match is a hint, not the answer: same hue, muted pairing (`accent6Dark`
+   background with `accent6` text, as `StatusBadge` uses for warnings) so it reads as related
+   to the direct highlight without competing with it. Both themes define the pair. */
+::highlight(search-result-indirect) {
+  background-color: var(--color-accent6Dark);
+  color: var(--color-accent6);
+}

--- a/packages/playground-ui/src/hooks/use-text-highlight.test.tsx
+++ b/packages/playground-ui/src/hooks/use-text-highlight.test.tsx
@@ -201,7 +201,7 @@ describe('useTextHighlight', () => {
     await flushMutations();
     flushFrames();
 
-    expect(highlights.set).toHaveBeenCalledTimes(1);
+    expect(harness.registrationCount()).toBe(1);
   });
 
   it('stops highlighting once unmounted', async () => {
@@ -226,6 +226,89 @@ describe('useTextHighlight', () => {
     unmount();
 
     expect(highlights.delete).toHaveBeenCalledWith('search-result');
+  });
+
+  describe('indirect regions', () => {
+    it('paints the whole text of an indirect region, term or not', () => {
+      render(
+        <Panel search="agent">
+          <p data-highlight-indirect>a span named nothing like it</p>
+        </Panel>,
+      );
+
+      expect(lastHighlightedText('search-result-indirect')).toEqual(['a span named nothing like it']);
+      expect(lastHighlightedText()).toEqual([]);
+    });
+
+    it('keeps direct regions matching on the term only', () => {
+      render(
+        <Panel search="agent">
+          <p data-highlight>searchable agent</p>
+          <p data-highlight-indirect>weather span</p>
+        </Panel>,
+      );
+
+      expect(lastHighlightedText()).toEqual(['agent']);
+      expect(lastHighlightedText('search-result-indirect')).toEqual(['weather span']);
+    });
+
+    it('paints an indirect region once when it also opted in directly', () => {
+      render(
+        <Panel search="agent">
+          <p data-highlight data-highlight-indirect>
+            agent span
+          </p>
+        </Panel>,
+      );
+
+      expect(lastHighlightedText()).toEqual([]);
+      expect(lastHighlightedText('search-result-indirect')).toEqual(['agent span']);
+    });
+
+    it('repaints a region that swaps which highlight it claims, text unchanged', async () => {
+      const Row = ({ indirect }: { indirect: boolean }) => (
+        <Panel search="agent">
+          <p data-highlight={indirect ? undefined : ''} data-highlight-indirect={indirect ? '' : undefined}>
+            agent run
+          </p>
+        </Panel>
+      );
+
+      const { rerender } = render(<Row indirect={false} />);
+      expect(lastHighlightedText()).toEqual(['agent']);
+
+      // Same text node, only the opt-in attribute moves — as when a row goes from a name
+      // match to a payload-only one while the term stays put.
+      rerender(<Row indirect />);
+      await flushMutations();
+      flushFrames();
+
+      expect(lastHighlightedText('search-result-indirect')).toEqual(['agent run']);
+      expect(lastHighlightedText()).toEqual([]);
+    });
+
+    it('clears the indirect highlight when the term gets too short', () => {
+      render(
+        <Panel search="a">
+          <p data-highlight-indirect>weather span</p>
+        </Panel>,
+      );
+
+      expect(highlights.set).not.toHaveBeenCalled();
+      expect(highlights.delete).toHaveBeenCalledWith('search-result-indirect');
+    });
+
+    it('clears the indirect highlight once unmounted', () => {
+      const { unmount } = render(
+        <Panel search="agent">
+          <p data-highlight-indirect>weather span</p>
+        </Panel>,
+      );
+
+      unmount();
+
+      expect(highlights.delete).toHaveBeenCalledWith('search-result-indirect');
+    });
   });
 
   it('highlights text nodes that are direct children of the opted-in element', async () => {

--- a/packages/playground-ui/src/hooks/use-text-highlight.ts
+++ b/packages/playground-ui/src/hooks/use-text-highlight.ts
@@ -8,6 +8,13 @@ import './use-text-highlight.css';
 const HIGHLIGHT_NAME = 'search-result';
 
 /**
+ * Second registry entry for text that carries no occurrence of the term itself, but stands
+ * for something elsewhere that does — a span name whose match hides in its metadata. Painted
+ * in its own color so the two claims stay distinguishable.
+ */
+const INDIRECT_HIGHLIGHT_NAME = 'search-result-indirect';
+
+/**
  * A single character matches almost everywhere, which paints noise instead of results.
  * Highlighting only starts once the term is discriminating enough.
  */
@@ -19,6 +26,13 @@ const MIN_SEARCH_LENGTH = 2;
  * having every piece of surrounding chrome remember to opt out.
  */
 const INCLUDED_SELECTOR = '[data-highlight]';
+
+/**
+ * Opt-in marker for the indirect highlight: the whole text of such a subtree is painted
+ * while a query is active, regardless of what the term is. Marking is the caller's decision
+ * — it knows why the row survived the filter, this hook only knows the term.
+ */
+const INDIRECT_SELECTOR = '[data-highlight-indirect]';
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -35,6 +49,11 @@ export interface UseTextHighlightResult<TElement extends HTMLElement> {
  * is left alone by default. The DOM is never mutated — no wrapper elements are injected — so text
  * selection, copy/paste and virtualised renderers are unaffected. Styling lives in
  * `use-text-highlight.css` (`::highlight(search-result)`).
+ *
+ * Text under `data-highlight-indirect` is painted in full, in a second color
+ * (`::highlight(search-result-indirect)`), whatever the term is. That is for labels standing
+ * in for a match that lives somewhere not on screen — a span name whose hit is in its
+ * metadata. It wins over `data-highlight` when both apply, so a text is never painted twice.
  *
  * Terms shorter than two characters are ignored — they match too much to be useful.
  * Matching is case-insensitive and literal (the term is escaped, not a pattern). The
@@ -55,6 +74,7 @@ export function useTextHighlight<TElement extends HTMLElement = HTMLElement>(
       typeof StaticRange === 'undefined'
     ) {
       CSS?.highlights?.delete(HIGHLIGHT_NAME);
+      CSS?.highlights?.delete(INDIRECT_HIGHLIGHT_NAME);
       return;
     }
 
@@ -62,18 +82,39 @@ export function useTextHighlight<TElement extends HTMLElement = HTMLElement>(
 
     const updateHighlight = () => {
       const ranges: StaticRange[] = [];
+      const indirectRanges: StaticRange[] = [];
       const regex = new RegExp(escapeRegExp(search), 'giu');
 
       const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
         acceptNode(node) {
           // Inside a rooted walker every text node has a parent element.
           const parent = node.parentElement as HTMLElement;
-          return parent.closest(INCLUDED_SELECTOR) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+          return parent.closest(`${INCLUDED_SELECTOR}, ${INDIRECT_SELECTOR}`)
+            ? NodeFilter.FILTER_ACCEPT
+            : NodeFilter.FILTER_REJECT;
         },
       });
 
       while (walker.nextNode()) {
         const textNode = walker.currentNode as Text;
+        const parent = textNode.parentElement as HTMLElement;
+
+        // The indirect claim is about the whole text, so there is nothing to search for
+        // inside it: the term lives in the payload this text stands for, not in the text.
+        if (parent.closest(INDIRECT_SELECTOR)) {
+          if (textNode.data.length > 0) {
+            indirectRanges.push(
+              new StaticRange({
+                startContainer: textNode,
+                startOffset: 0,
+                endContainer: textNode,
+                endOffset: textNode.data.length,
+              }),
+            );
+          }
+          continue;
+        }
+
         regex.lastIndex = 0;
 
         let match: RegExpExecArray | null;
@@ -90,6 +131,7 @@ export function useTextHighlight<TElement extends HTMLElement = HTMLElement>(
       }
 
       CSS.highlights.set(HIGHLIGHT_NAME, new Highlight(...ranges));
+      CSS.highlights.set(INDIRECT_HIGHLIGHT_NAME, new Highlight(...indirectRanges));
     };
 
     const scheduleUpdate = () => {
@@ -103,13 +145,22 @@ export function useTextHighlight<TElement extends HTMLElement = HTMLElement>(
 
     updateHighlight();
 
+    // The opt-in attributes are watched too: a region can change which highlight it claims
+    // while its text stays put, and that alone must repaint it.
     const observer = new MutationObserver(scheduleUpdate);
-    observer.observe(root, { subtree: true, childList: true, characterData: true });
+    observer.observe(root, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ['data-highlight', 'data-highlight-indirect'],
+    });
 
     return () => {
       observer.disconnect();
       if (animationFrame !== null) cancelAnimationFrame(animationFrame);
       CSS.highlights.delete(HIGHLIGHT_NAME);
+      CSS.highlights.delete(INDIRECT_HIGHLIGHT_NAME);
     };
   }, [root, search]);
 

--- a/packages/playground-ui/src/test/highlight-api.ts
+++ b/packages/playground-ui/src/test/highlight-api.ts
@@ -21,12 +21,16 @@ export class FakeHighlight {
 
 export interface HighlightApiHarness {
   highlights: { set: ReturnType<typeof vi.fn>; delete: ReturnType<typeof vi.fn> };
-  /** The text covered by the ranges of the most recent registration. */
-  highlightedText: () => string[] | undefined;
-  /** The elements owning the highlighted text of the most recent registration. */
-  highlightedIn: () => (HTMLElement | null)[];
+  /** The text covered by the most recent registration under `name` (the direct one by default). */
+  highlightedText: (name?: string) => string[] | undefined;
+  /** The elements owning that text. */
+  highlightedIn: (name?: string) => (HTMLElement | null)[];
+  /** How many times `name` was registered — one per scan of the surface. */
+  registrationCount: (name?: string) => number;
   restore: () => void;
 }
+
+const DIRECT_HIGHLIGHT_NAME = 'search-result';
 
 export function installHighlightApi(): HighlightApiHarness {
   const originals = {
@@ -47,16 +51,20 @@ export function installHighlightApi(): HighlightApiHarness {
     Highlight: FakeHighlight,
   });
 
-  const lastRanges = () => {
-    const call = highlights.set.mock.calls.at(-1);
+  const callsFor = (name: string) => highlights.set.mock.calls.filter(call => call[0] === name);
+
+  const lastRanges = (name: string) => {
+    const call = callsFor(name).at(-1);
     return call ? (call[1] as FakeHighlight).ranges : undefined;
   };
 
   return {
     highlights,
-    highlightedText: () =>
-      lastRanges()?.map(range => (range.startContainer as Text).data.slice(range.startOffset, range.endOffset)),
-    highlightedIn: () => lastRanges()?.map(range => (range.startContainer as Text).parentElement) ?? [],
+    highlightedText: (name = DIRECT_HIGHLIGHT_NAME) =>
+      lastRanges(name)?.map(range => (range.startContainer as Text).data.slice(range.startOffset, range.endOffset)),
+    highlightedIn: (name = DIRECT_HIGHLIGHT_NAME) =>
+      lastRanges(name)?.map(range => (range.startContainer as Text).parentElement) ?? [],
+    registrationCount: (name = DIRECT_HIGHLIGHT_NAME) => callsFor(name).length,
     restore: () => Object.assign(globalThis, originals),
   };
 }


### PR DESCRIPTION
 (see orange highlights on the span tree AND in the span details panel) 

<img width="3840" height="2160" alt="CleanShot 2026-08-31 at 09 07 19@2x" src="https://github.com/user-attachments/assets/9e17cdd6-435c-4c0c-8744-908358a8e6e9" />

## Summary

When searching traces in Studio, some spans appear in the results without any visible reason — the match happened inside metadata, attributes, or an error payload rather than in the span name, so the row looked identical to a non-matching one.

This change makes the reason for a match visible directly in the timeline. A span that matches only through its underlying data now renders its name in a distinct color, signalling "this row is here because of something you can't see yet". Spans that match by name keep the existing text highlight, so the two kinds of match stay visually distinguishable.

## Test plan

- Unit tests for the trace search hook covering name matches, data-only matches, and non-matches
- Component tests for the trace data panel view asserting the distinct treatment is applied to data-only matches
- Tests for the text highlight hook and its highlight API test helper
- `pnpm --filter @mastra/playground-ui lint` passes with 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Studio trace search now shows whether a span matched because of its name or because of hidden details. This makes search results easier to understand.

## Changes

- Track spans that match only in metadata, attributes, or error payloads.
- Display payload-only matches with a distinct muted highlight and tooltip.
- Preserve the existing highlight for direct span-name matches.
- Propagate payload-match state through hierarchical span formatting and `UISpan`.
- Extend text-highlight handling for indirect regions, precedence, updates, and cleanup.
- Add tests for search behavior, highlighting, non-matches, and test helper support.
- Add a patch changeset for `@mastra/playground-ui`.
- Lint passes with zero errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->