### PR TITLE
fix(playground): stop presenting experiment scores as pass/fail verdicts

### DIFF
--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
@@ -28,6 +28,7 @@ import type { AgentExperiment } from '../../hooks/use-agent-experiments';
 import { useAgentVersions } from '../../hooks/use-agent-versions';
 import { formatVersionLabel } from './format-version-label';
 import { useDatasetExperimentResults, useScoresByExperimentId } from '@/domains/datasets/hooks/use-dataset-experiments';
+import { STATUS_LABEL } from '@/domains/experiments/components/experiment-columns';
 import { useLinkComponent } from '@/lib/framework';
 
 function formatTimestamp(dateStr: string | Date): string {
@@ -42,32 +43,33 @@ function formatTimestamp(dateStr: string | Date): string {
 
 function ExperimentStatusBadge({ status }: { status: string }) {
   switch (status) {
+    // A finished run is not a good result — only a finished one, so it stays neutral.
     case 'completed':
       return (
-        <Badge variant="success" className="gap-1">
+        <Badge variant="default" className="gap-1">
           <CheckCircle className="h-3 w-3" />
-          completed
+          {STATUS_LABEL.completed}
         </Badge>
       );
     case 'failed':
       return (
         <Badge variant="error" className="gap-1">
           <XCircle className="h-3 w-3" />
-          failed
+          {STATUS_LABEL.failed}
         </Badge>
       );
     case 'running':
       return (
         <Badge variant="info" className="gap-1">
           <Loader2 className="h-3 w-3 animate-spin" />
-          running
+          {STATUS_LABEL.running}
         </Badge>
       );
     case 'pending':
       return (
         <Badge variant="default" className="gap-1">
           <Clock className="h-3 w-3" />
-          pending
+          {STATUS_LABEL.pending}
         </Badge>
       );
     default:

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
@@ -30,7 +30,7 @@ import { GenerateConfigDialog, GenerateReviewDialog } from '@/domains/datasets/c
 import { useGenerationTasks } from '@/domains/datasets/context/generation-context';
 import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
 import { useDatasets } from '@/domains/datasets/hooks/use-datasets';
-import { STATUS_VARIANT } from '@/domains/experiments/components/experiment-columns';
+import { STATUS_LABEL, STATUS_VARIANT } from '@/domains/experiments/components/experiment-columns';
 import { useScorers } from '@/domains/scores/hooks/use-scorers';
 
 type AgentEvalTab = 'experiments' | 'datasets' | 'scorers';
@@ -541,7 +541,7 @@ export function AgentPlaygroundEvaluate({
               </DataList.Cell>
               <DataList.Cell>
                 <StatusBadge variant={STATUS_VARIANT[status] ?? 'neutral'} withDot>
-                  {status}
+                  {STATUS_LABEL[status] ?? status}
                 </StatusBadge>
               </DataList.Cell>
               <DataList.Cell className="text-center">{total}</DataList.Cell>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
@@ -30,6 +30,7 @@ import { GenerateConfigDialog, GenerateReviewDialog } from '@/domains/datasets/c
 import { useGenerationTasks } from '@/domains/datasets/context/generation-context';
 import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
 import { useDatasets } from '@/domains/datasets/hooks/use-datasets';
+import { STATUS_VARIANT } from '@/domains/experiments/components/experiment-columns';
 import { useScorers } from '@/domains/scores/hooks/use-scorers';
 
 type AgentEvalTab = 'experiments' | 'datasets' | 'scorers';
@@ -76,13 +77,6 @@ function getExperimentStartedAtTime(startedAt: AgentExperiment['startedAt']): nu
   if (!startedAt) return 0;
   return startedAt instanceof Date ? startedAt.getTime() : new Date(startedAt).getTime();
 }
-
-const STATUS_VARIANT: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
-  completed: 'success',
-  running: 'warning',
-  failed: 'error',
-  pending: 'neutral',
-};
 
 export function AgentPlaygroundEvaluate({
   agentId,
@@ -521,8 +515,8 @@ export function AgentPlaygroundEvaluate({
           <DataList.TopCell>Dataset</DataList.TopCell>
           <DataList.TopCell>Status</DataList.TopCell>
           <DataList.TopCell className="text-center">Items</DataList.TopCell>
-          <DataList.TopCell className="text-center">Succeeded</DataList.TopCell>
-          <DataList.TopCell className="text-center">Failed</DataList.TopCell>
+          <DataList.TopCell className="text-center">Processed</DataList.TopCell>
+          <DataList.TopCell className="text-center">Errored</DataList.TopCell>
           <DataList.TopCell>Date</DataList.TopCell>
         </DataList.Top>
 
@@ -532,7 +526,6 @@ export function AgentPlaygroundEvaluate({
           const succeeded = exp.succeededCount ?? 0;
           const failed = exp.failedCount ?? 0;
           const total = exp.totalItems ?? 0;
-          const successPct = total > 0 ? Math.round((succeeded / total) * 100) : 0;
           const isFeatured = detailView?.type === 'experiment' && detailView.id === exp.id;
 
           return (
@@ -552,11 +545,7 @@ export function AgentPlaygroundEvaluate({
                 </StatusBadge>
               </DataList.Cell>
               <DataList.Cell className="text-center">{total}</DataList.Cell>
-              <DataList.Cell className="text-center">
-                <span className={succeeded > 0 ? 'text-accent1' : ''}>
-                  {succeeded} ({successPct}%)
-                </span>
-              </DataList.Cell>
+              <DataList.Cell className="text-center">{succeeded}</DataList.Cell>
               <DataList.Cell className="text-center">
                 <span className={failed > 0 ? 'text-accent2' : ''}>{failed}</span>
               </DataList.Cell>
@@ -1019,7 +1008,7 @@ export function AgentPlaygroundEvaluate({
 // --- Sub-components ---
 
 function ExperimentBadge({ experiment }: { experiment: AgentExperiment }) {
-  const { status, succeededCount, totalItems } = experiment;
+  const { status, failedCount, totalItems } = experiment;
 
   const versionTags = [
     experiment.datasetVersion != null ? formatVersionLabel('Dataset', experiment.datasetVersion) : null,
@@ -1055,13 +1044,11 @@ function ExperimentBadge({ experiment }: { experiment: AgentExperiment }) {
     );
   }
 
-  const passRate = succeededCount / totalItems;
-  const colorClass = passRate >= 0.8 ? 'text-positive1' : passRate >= 0.5 ? 'text-warning1' : 'text-negative1';
-
   return (
     <div className="flex flex-col">
-      <Txt variant="ui-xs" className={colorClass}>
-        {succeededCount}/{totalItems} passed
+      <Txt variant="ui-xs" className="text-neutral3">
+        {totalItems} items
+        {failedCount > 0 && <span className="text-error"> · {failedCount} errored</span>}
       </Txt>
       {versionLine}
     </div>

--- a/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -489,7 +489,8 @@ export function DatasetDetailView({
                           {exp.startedAt ? formatTimestamp(exp.startedAt) : 'Unknown'}
                         </Txt>
                         <Txt variant="ui-xs" className="text-neutral3">
-                          {exp.succeededCount}/{exp.totalItems} passed
+                          {exp.totalItems} items
+                          {exp.failedCount > 0 && ` · ${exp.failedCount} errored`}
                           {exp.datasetVersion != null && ` · ${formatVersionLabel('Dataset', exp.datasetVersion)}`}
                           {exp.agentVersion &&
                             (() => {

--- a/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
@@ -125,6 +125,16 @@ describe('experiment item sub-route', () => {
       expect(await screen.findByRole('button', { name: 'Flag 1 to review' })).toBeDefined();
       expect(screen.queryByText('1 selected')).toBeNull();
     });
+
+    it('only shows the selection actions once something is selected', async () => {
+      renderExperimentRoute();
+
+      await openResultsTab();
+      // Selecting is what reveals the actions, so no bulk-selection affordance is needed beforehand.
+      expect(await screen.findByRole('checkbox', { name: 'Select result item-1' })).toBeDefined();
+      expect(screen.queryByRole('button', { name: /Flag \d+ to review/ })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
+    });
   });
 
   describe('when visiting the item URL directly', () => {

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-flow-chain.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-flow-chain.test.tsx
@@ -1,0 +1,132 @@
+import type { DatasetExperiment, DatasetRecord, GetScorerResponse } from '@mastra/client-js';
+import { cleanup, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ExperimentFlowChain } from '../experiment-flow-chain';
+import { experiments, noAgents, noWorkflows } from './fixtures/experiments';
+import { TestLinkProvider } from '@/test/link-provider';
+import { server } from '@/test/msw-server';
+import { TEST_BASE_URL, renderWithProviders, waitForMutationsIdle } from '@/test/render';
+
+const scorer = (name: string): GetScorerResponse =>
+  ({
+    scorer: { config: { id: name, name, description: `${name} description` } },
+    source: 'code',
+    agentIds: [],
+    workflowIds: [],
+  }) as unknown as GetScorerResponse;
+
+const scorers: Record<string, GetScorerResponse> = {
+  'answer-relevancy': scorer('Answer relevancy'),
+  toxicity: scorer('Toxicity'),
+};
+
+const dataset: DatasetRecord = {
+  id: 'dataset-1',
+  name: 'Entity extraction dataset',
+  version: 3,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+};
+
+const agentExperiment: DatasetExperiment = {
+  ...experiments[0],
+  datasetVersion: 3,
+  scorerIds: ['answer-relevancy', 'toxicity'],
+};
+
+const renderChain = (experiment: DatasetExperiment) =>
+  renderWithProviders(
+    <TestLinkProvider>
+      <ExperimentFlowChain experiment={experiment} />
+    </TestLinkProvider>,
+  );
+
+describe('ExperimentFlowChain', () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    server.use(
+      http.get(`${TEST_BASE_URL}/api/datasets/dataset-1`, () => HttpResponse.json(dataset)),
+      http.get(`${TEST_BASE_URL}/api/agents`, () => HttpResponse.json(noAgents)),
+      http.get(`${TEST_BASE_URL}/api/workflows`, () => HttpResponse.json(noWorkflows)),
+      http.get(`${TEST_BASE_URL}/api/scores/scorers`, () => HttpResponse.json(scorers)),
+      http.get(`${TEST_BASE_URL}/api/scores/run/:experimentId`, () =>
+        HttpResponse.json({
+          scores: [{ entityId: 'item-1', scorerId: 'answer-relevancy', score: 0.5 }],
+          pagination: { total: 1, page: 0, perPage: 100, hasMore: false },
+        }),
+      ),
+    );
+  });
+
+  it('spells out the whole pipeline, from dataset to score', async () => {
+    const { queryClient } = renderChain(agentExperiment);
+
+    const datasetLink = await screen.findByRole('link', { name: /Entity extraction dataset/ });
+    expect(datasetLink.getAttribute('href')).toBe('/datasets/dataset-1');
+    expect(screen.getByText('each item')).toBeDefined();
+    expect(screen.getByRole('link', { name: /example-entity-extraction-agent/ })).toBeDefined();
+    expect(screen.getByText('output')).toBeDefined();
+    expect(screen.getByText('2 scorers')).toBeDefined();
+    expect(screen.getByText('comparing ground truth')).toBeDefined();
+    expect(screen.getByText('Score')).toBeDefined();
+
+    await waitForMutationsIdle(queryClient);
+  });
+
+  it('pins the dataset version next to the dataset', async () => {
+    const { queryClient } = renderChain(agentExperiment);
+
+    expect(await screen.findByText('(v3)')).toBeDefined();
+
+    await waitForMutationsIdle(queryClient);
+  });
+
+  it('names each node type on its icon, so the chain reads without a legend', async () => {
+    const { queryClient } = renderChain(agentExperiment);
+
+    expect(await screen.findByRole('img', { name: 'Dataset' })).toBeDefined();
+    expect(screen.getByRole('img', { name: 'Agent' })).toBeDefined();
+    expect(screen.getByRole('img', { name: 'Scorers' })).toBeDefined();
+
+    await waitForMutationsIdle(queryClient);
+  });
+
+  it('falls back to the scorers that actually scored when none are pinned', async () => {
+    // scorerIds is null whenever the scorers resolve from the dataset or the items.
+    const { queryClient } = renderChain({ ...agentExperiment, scorerIds: null });
+
+    expect(await screen.findByText('1 scorer')).toBeDefined();
+
+    await waitForMutationsIdle(queryClient);
+  });
+
+  it('keeps a target node without a link for a caller-run experiment', async () => {
+    const { queryClient } = renderChain({
+      ...agentExperiment,
+      targetType: null,
+      targetId: null,
+    });
+
+    expect(await screen.findByText('External (caller-run)')).toBeDefined();
+    expect(screen.queryByRole('link', { name: /External/ })).toBeNull();
+    expect(screen.getByRole('img', { name: 'Evaluation target' })).toBeDefined();
+
+    await waitForMutationsIdle(queryClient);
+  });
+
+  it('switches the node type when the target is a workflow', async () => {
+    const { queryClient } = renderChain({
+      ...agentExperiment,
+      targetType: 'workflow',
+      targetId: 'my-workflow',
+    });
+
+    const target = await screen.findByRole('link', { name: /my-workflow/ });
+    expect(target.getAttribute('href')).toContain('my-workflow');
+    expect(screen.getByRole('img', { name: 'Workflow' })).toBeDefined();
+
+    await waitForMutationsIdle(queryClient);
+  });
+});

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-meta-bar.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-meta-bar.test.tsx
@@ -59,26 +59,59 @@ describe('ExperimentMetaBar', () => {
     server.use(
       http.get(`${TEST_BASE_URL}/api/datasets/dataset-1`, () => HttpResponse.json(dataset)),
       http.get(`${TEST_BASE_URL}/api/scores/scorers`, () => HttpResponse.json(scorers)),
+      // avg of 0.5, 1 and 1 is 0.833.
+      http.get(`${TEST_BASE_URL}/api/scores/run/:experimentId`, () =>
+        HttpResponse.json({
+          scores: [
+            { entityId: 'item-1', scorerId: 'answer-relevancy', score: 0.5 },
+            { entityId: 'item-2', scorerId: 'answer-relevancy', score: 1 },
+            { entityId: 'item-2', scorerId: 'toxicity', score: 1 },
+          ],
+          pagination: { total: 3, page: 0, perPage: 100, hasMore: false },
+        }),
+      ),
     );
   });
 
   describe('for a completed experiment with a dataset and scorers', () => {
-    it('shows the four cell labels', async () => {
+    it('shows the four cell labels and no dataset cell', async () => {
       const { queryClient } = renderBar(completedExperiment);
 
-      expect(await screen.findByText('Results')).toBeDefined();
+      expect(await screen.findByText('Avg score')).toBeDefined();
+      expect(screen.getByText('Items')).toBeDefined();
       expect(screen.getByText('Started')).toBeDefined();
       expect(screen.getByText('Duration')).toBeDefined();
-      expect(screen.getByText('Dataset')).toBeDefined();
+      // The dataset now lives in the page title, not in the meta bar.
+      expect(screen.queryByText('Dataset')).toBeNull();
 
       await waitForMutationsIdle(queryClient);
     });
 
-    it('shows All passed when every item succeeds', async () => {
+    it('shows a neutral item count with no pass/fail verdict', async () => {
       const { queryClient } = renderBar(completedExperiment);
 
-      expect(await screen.findByText('All passed')).toBeDefined();
+      const total = completedExperiment.totalItems;
+      expect(await screen.findByText(`${total} item${total === 1 ? '' : 's'}`)).toBeDefined();
+      expect(screen.queryByText('All passed')).toBeNull();
       expect(screen.queryByText('failed')).toBeNull();
+
+      await waitForMutationsIdle(queryClient);
+    });
+
+    it('shows an errored suffix only when items errored', async () => {
+      const { queryClient } = renderBar({ ...completedExperiment, failedCount: 2 });
+
+      expect(await screen.findByText('· 2 errored')).toBeDefined();
+
+      await waitForMutationsIdle(queryClient);
+    });
+
+    it('shows the average of every score fetched for the run', async () => {
+      const { queryClient } = renderBar(completedExperiment);
+
+      expect(await screen.findByText('0.833')).toBeDefined();
+      // A completed run has nothing left to score, so no "so far" qualifier.
+      expect(screen.queryByText('· so far')).toBeNull();
 
       await waitForMutationsIdle(queryClient);
     });
@@ -99,24 +132,27 @@ describe('ExperimentMetaBar', () => {
       await waitForMutationsIdle(queryClient);
     });
 
-    it('links to the dataset by name with an item count', async () => {
+    it('does not link to the dataset', async () => {
       const { queryClient } = renderBar(completedExperiment);
 
-      const link = await screen.findByText('Entity extraction dataset');
-      expect(link.closest('a')?.getAttribute('href')).toBe('/datasets/dataset-1');
-      expect(screen.getByText('· 10 items')).toBeDefined();
+      expect(await screen.findByText('Duration')).toBeDefined();
+      expect(screen.queryByText('Entity extraction dataset')).toBeNull();
 
       await waitForMutationsIdle(queryClient);
     });
   });
 
   describe('for a running caller-driven experiment', () => {
-    it('shows Running… for the duration and a dash for the dataset', async () => {
+    it('shows Running… for the duration', async () => {
       const { queryClient } = renderBar(runningExperiment);
 
       expect(await screen.findByText('Running…')).toBeDefined();
-      // The Dataset cell falls back to a dash.
-      expect(screen.getAllByText('—')).toHaveLength(1);
+    });
+
+    it('qualifies the average as partial while items are still being scored', async () => {
+      const { queryClient } = renderBar(runningExperiment);
+
+      expect(await screen.findByText('· so far')).toBeDefined();
 
       await waitForMutationsIdle(queryClient);
     });

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-results-list.keyboard.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-results-list.keyboard.test.tsx
@@ -27,10 +27,7 @@ const makeResult = (id: string): DatasetExperimentResult => ({
 
 const results = [makeResult('r-1'), makeResult('r-2'), makeResult('r-3')];
 
-const columns = [
-  { name: 'id', label: 'Item', size: '1fr' },
-  { name: 'status', label: 'Status', size: 'auto' },
-];
+const columns = [{ name: 'id', label: 'Item', size: '1fr' }];
 
 const renderList = (props?: Partial<Parameters<typeof ExperimentResultsList>[0]>) =>
   renderWithProviders(

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-results-list.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-results-list.test.tsx
@@ -1,0 +1,60 @@
+import type { DatasetExperimentResult } from '@mastra/client-js';
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ExperimentResultsList } from '../experiment-results-list';
+import { renderWithProviders } from '@/test/render';
+
+const makeResult = (id: string, error: DatasetExperimentResult['error'] = null): DatasetExperimentResult => ({
+  id,
+  experimentId: 'exp-1',
+  itemId: `item-${id}`,
+  itemDatasetVersion: 1,
+  input: 'input',
+  output: 'output',
+  groundTruth: null,
+  error,
+  startedAt: '2026-08-25T10:00:00.000Z',
+  completedAt: '2026-08-25T10:00:01.000Z',
+  retryCount: 0,
+  traceId: null,
+  status: null,
+  tags: null,
+  scores: [],
+  createdAt: '2026-08-25T10:00:00.000Z',
+});
+
+const columns = [{ name: 'id', label: 'Item', size: '1fr' }];
+
+const renderList = (results: DatasetExperimentResult[]) =>
+  renderWithProviders(
+    <ExperimentResultsList
+      results={results}
+      isLoading={false}
+      featuredResultId={null}
+      onResultClick={() => {}}
+      columns={columns}
+    />,
+  );
+
+describe('ExperimentResultsList', () => {
+  afterEach(cleanup);
+
+  describe('for a result without an error', () => {
+    it('renders no success or status indicator', () => {
+      renderList([makeResult('r-1')]);
+
+      expect(screen.queryByRole('img', { name: 'Error' })).toBeNull();
+      expect(screen.queryByText('Success')).toBeNull();
+      expect(screen.queryByText('Status')).toBeNull();
+    });
+  });
+
+  describe('for a result with an error', () => {
+    it('renders an error marker', () => {
+      renderList([makeResult('r-1', { message: 'boom' } as DatasetExperimentResult['error'])]);
+
+      expect(screen.getByRole('img', { name: 'Error' })).toBeDefined();
+    });
+  });
+});

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-scorer-summary.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-scorer-summary.test.tsx
@@ -45,15 +45,20 @@ describe('ExperimentScorerSummary', () => {
   it('renders a metric card per scorer', async () => {
     const { queryClient } = renderSummary({ scoresByItemId });
 
-    // answer-relevancy: 1 of 2 items scored below 1 → failed, avg (0.5 + 1) / 2 = 0.750.
-    expect(screen.getByText('Avg score 0.750')).toBeDefined();
-    expect(screen.getByText('/2')).toBeDefined();
-    expect(screen.getAllByText('failed')).toHaveLength(2);
+    // answer-relevancy: avg (0.5 + 1) / 2 = 0.750 over 2 scored items.
+    expect(screen.getByText('0.750')).toBeDefined();
 
-    // toxicity: 0 of 1 failed, avg 1.000.
-    expect(screen.getByText('Avg score 1.000')).toBeDefined();
-    expect(screen.getByText('0').className).toContain('text-accent1');
-    expect(screen.getByText('/1')).toBeDefined();
+    // toxicity: avg 1.000 over a single scored item.
+    expect(screen.getByText('1.000')).toBeDefined();
+
+    // The scored-item count is not surfaced — the card only carries the score.
+    expect(screen.queryByText(/items? scored/)).toBeNull();
+
+    // The icon is labelled so hovering it explains what the link points at.
+    expect(screen.getAllByRole('img', { name: 'Scorer' })).toHaveLength(2);
+
+    // No invented pass/fail verdict.
+    expect(screen.queryByText('failed')).toBeNull();
 
     await waitForMutationsIdle(queryClient);
   });

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-top-area.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-top-area.test.tsx
@@ -37,17 +37,30 @@ describe('ExperimentTopArea', () => {
     );
   });
 
-  it('shows the eyebrow label and the target as the page title, linked to the entity', async () => {
+  it('shows the dataset as the page title, linked to the dataset', async () => {
     const { queryClient } = renderWithProviders(
       <TestLinkProvider>
         <ExperimentTopArea experiment={namedExperiment} />
       </TestLinkProvider>,
     );
 
-    expect(await screen.findByText('Evaluation target')).toBeDefined();
-    expect(await screen.findByText('Avg 0.833')).toBeDefined();
-    const title = await screen.findByRole('link', { name: /example-entity-extraction-agent/ });
-    expect(title.getAttribute('href')).toContain('example-entity-extraction-agent');
+    expect(await screen.findByText('Dataset')).toBeDefined();
+    const title = await screen.findByRole('link', { name: new RegExp(namedExperiment.datasetId!) });
+    expect(title.getAttribute('href')).toBe(`/datasets/${namedExperiment.datasetId}`);
+
+    await waitForMutationsIdle(queryClient);
+  });
+
+  it('describes the evaluation target below the title', async () => {
+    const { queryClient } = renderWithProviders(
+      <TestLinkProvider>
+        <ExperimentTopArea experiment={namedExperiment} />
+      </TestLinkProvider>,
+    );
+
+    expect(await screen.findByText('Evaluating')).toBeDefined();
+    const target = await screen.findByRole('link', { name: /example-entity-extraction-agent/ });
+    expect(target.getAttribute('href')).toContain('example-entity-extraction-agent');
 
     await waitForMutationsIdle(queryClient);
   });
@@ -59,7 +72,7 @@ describe('ExperimentTopArea', () => {
       </TestLinkProvider>,
     );
 
-    expect(await screen.findByText('Entity extraction evaluation using Model A')).toBeDefined();
+    expect(await screen.findByText(`· ${namedExperiment.description}`)).toBeDefined();
 
     await waitForMutationsIdle(queryClient);
   });
@@ -71,8 +84,8 @@ describe('ExperimentTopArea', () => {
       </TestLinkProvider>,
     );
 
-    expect(await screen.findByText('Evaluation target')).toBeDefined();
-    expect(screen.queryByText(namedExperiment.description!)).toBeNull();
+    expect(await screen.findByText('Dataset')).toBeDefined();
+    expect(screen.queryByText(`· ${namedExperiment.description}`)).toBeNull();
 
     await waitForMutationsIdle(queryClient);
   });

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-top-area.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-top-area.test.tsx
@@ -44,7 +44,8 @@ describe('ExperimentTopArea', () => {
       </TestLinkProvider>,
     );
 
-    expect(await screen.findByText('Dataset')).toBeDefined();
+    // The title is the dataset, so the eyebrow has to identify the run itself.
+    expect(await screen.findByText(`Experiment #${namedExperiment.id.slice(0, 8)}`)).toBeDefined();
     const title = await screen.findByRole('link', { name: new RegExp(namedExperiment.datasetId!) });
     expect(title.getAttribute('href')).toBe(`/datasets/${namedExperiment.datasetId}`);
 
@@ -84,7 +85,7 @@ describe('ExperimentTopArea', () => {
       </TestLinkProvider>,
     );
 
-    expect(await screen.findByText('Dataset')).toBeDefined();
+    expect(await screen.findByText(`Experiment #${unnamedExperiment.id.slice(0, 8)}`)).toBeDefined();
     expect(screen.queryByText(`· ${namedExperiment.description}`)).toBeNull();
 
     await waitForMutationsIdle(queryClient);

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-top-area.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-top-area.test.tsx
@@ -37,31 +37,36 @@ describe('ExperimentTopArea', () => {
     );
   });
 
-  it('shows the dataset as the page title, linked to the dataset', async () => {
+  it('titles the page with the run itself', async () => {
     const { queryClient } = renderWithProviders(
       <TestLinkProvider>
         <ExperimentTopArea experiment={namedExperiment} />
       </TestLinkProvider>,
     );
 
-    // The title is the dataset, so the eyebrow has to identify the run itself.
+    // The run is the subject of the page; the dataset it ran on lives in the flow chain.
     expect(await screen.findByText(`Experiment #${namedExperiment.id.slice(0, 8)}`)).toBeDefined();
-    const title = await screen.findByRole('link', { name: new RegExp(namedExperiment.datasetId!) });
-    expect(title.getAttribute('href')).toBe(`/datasets/${namedExperiment.datasetId}`);
 
     await waitForMutationsIdle(queryClient);
   });
 
-  it('describes the evaluation target below the title', async () => {
+  it('walks through the dataset, the target and the scorers', async () => {
     const { queryClient } = renderWithProviders(
       <TestLinkProvider>
         <ExperimentTopArea experiment={namedExperiment} />
       </TestLinkProvider>,
     );
 
-    expect(await screen.findByText('Evaluating')).toBeDefined();
+    const datasetLink = await screen.findByRole('link', { name: new RegExp(namedExperiment.datasetId!) });
+    expect(datasetLink.getAttribute('href')).toBe(`/datasets/${namedExperiment.datasetId}`);
+
     const target = await screen.findByRole('link', { name: /example-entity-extraction-agent/ });
     expect(target.getAttribute('href')).toContain('example-entity-extraction-agent');
+
+    // Two distinct scorers produced the mocked scores.
+    expect(await screen.findByText('2 scorers')).toBeDefined();
+    expect(screen.getByText('each item')).toBeDefined();
+    expect(screen.getByText('comparing ground truth')).toBeDefined();
 
     await waitForMutationsIdle(queryClient);
   });
@@ -73,7 +78,7 @@ describe('ExperimentTopArea', () => {
       </TestLinkProvider>,
     );
 
-    expect(await screen.findByText(`· ${namedExperiment.description}`)).toBeDefined();
+    expect(await screen.findByText(namedExperiment.description!)).toBeDefined();
 
     await waitForMutationsIdle(queryClient);
   });
@@ -86,7 +91,7 @@ describe('ExperimentTopArea', () => {
     );
 
     expect(await screen.findByText(`Experiment #${unnamedExperiment.id.slice(0, 8)}`)).toBeDefined();
-    expect(screen.queryByText(`· ${namedExperiment.description}`)).toBeNull();
+    expect(screen.queryByText(namedExperiment.description!)).toBeNull();
 
     await waitForMutationsIdle(queryClient);
   });

--- a/packages/playground/src/domains/experiments/components/__tests__/experiments-list.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiments-list.test.tsx
@@ -59,6 +59,15 @@ describe('ExperimentsList', () => {
     });
   });
 
+  describe('when an experiment has finished', () => {
+    it('qualifies the status as the run finishing, not the scores being good', () => {
+      renderList(<ExperimentsList experiments={experiments} isLoading={false} search="model-a" />);
+
+      expect(screen.getByText('Run completed')).toBeDefined();
+      expect(screen.queryByText('completed')).toBeNull();
+    });
+  });
+
   describe('when a search term matches an experiment name', () => {
     it('shows only the matching experiment', () => {
       renderList(<ExperimentsList experiments={experiments} isLoading={false} search="model-b" />);

--- a/packages/playground/src/domains/experiments/components/experiment-columns.ts
+++ b/packages/playground/src/domains/experiments/components/experiment-columns.ts
@@ -23,6 +23,14 @@ export const STATUS_VARIANT: Record<string, 'success' | 'warning' | 'error' | 'n
   pending: 'neutral',
 };
 
+// "Completed" alone reads as a verdict on the scores; "Run completed" says it's the run that finished.
+export const STATUS_LABEL: Record<string, string> = {
+  completed: 'Run completed',
+  running: 'Run in progress',
+  failed: 'Run failed',
+  pending: 'Run queued',
+};
+
 export function formatExperimentDate(dateStr: string | Date | undefined | null): string {
   if (!dateStr) return '—';
   const d = typeof dateStr === 'string' ? new Date(dateStr) : dateStr;

--- a/packages/playground/src/domains/experiments/components/experiment-columns.ts
+++ b/packages/playground/src/domains/experiments/components/experiment-columns.ts
@@ -9,10 +9,18 @@ export const experimentColumnLabels = {
   target: 'Target',
   status: 'Status',
   items: 'Items',
-  succeeded: 'Succeeded',
-  failed: 'Failed',
+  succeeded: 'Processed',
+  failed: 'Errored',
   review: 'Review',
   date: 'Date',
+};
+
+// A completed run is neutral, not a success: it says the run finished, not that the scores are good.
+export const STATUS_VARIANT: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
+  completed: 'neutral',
+  running: 'warning',
+  failed: 'error',
+  pending: 'neutral',
 };
 
 export function formatExperimentDate(dateStr: string | Date | undefined | null): string {

--- a/packages/playground/src/domains/experiments/components/experiment-flow-chain.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-flow-chain.tsx
@@ -1,0 +1,193 @@
+import type { DatasetExperiment } from '@mastra/client-js';
+import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
+import { AgentIcon } from '@mastra/playground-ui/icons/AgentIcon';
+import { DatasetsIcon } from '@mastra/playground-ui/icons/DatasetsIcon';
+import { ProcessorIcon } from '@mastra/playground-ui/icons/ProcessorIcon';
+import { ScorersIcon } from '@mastra/playground-ui/icons/ScorersIcon';
+import { WorkflowIcon } from '@mastra/playground-ui/icons/WorkflowIcon';
+import { cn } from '@mastra/playground-ui/utils/cn';
+import { ArrowRightIcon, ExternalLinkIcon } from 'lucide-react';
+import { type ReactNode, useMemo } from 'react';
+import { useAgents } from '@/domains/agents/hooks/use-agents';
+import { useScoresByExperimentId } from '@/domains/datasets/hooks/use-dataset-experiments';
+import { useDataset } from '@/domains/datasets/hooks/use-datasets';
+import { useScorers } from '@/domains/scores/hooks/use-scorers';
+import { useWorkflows } from '@/domains/workflows/hooks/use-workflows';
+import { useLinkComponent } from '@/lib/framework';
+
+export interface ExperimentFlowChainProps {
+  experiment: DatasetExperiment;
+  className?: string;
+}
+
+const TARGET_ICON = {
+  agent: AgentIcon,
+  workflow: WorkflowIcon,
+  scorer: ScorersIcon,
+  processor: ProcessorIcon,
+} as const;
+
+const TARGET_LABEL = {
+  agent: 'Agent',
+  workflow: 'Workflow',
+  scorer: 'Scorer',
+  processor: 'Processor',
+} as const;
+
+/** One step's subject: a typed icon (tooltip names the type) plus its label. */
+function Node({
+  icon,
+  typeLabel,
+  children,
+}: {
+  icon: ReactNode;
+  /** Named on the icon so the chain reads without a legend. */
+  typeLabel: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="text-ui-sm text-neutral5 flex flex-none items-center gap-1.5 [&_svg]:size-3.5 [&_svg]:shrink-0">
+      <Tooltip>
+        <TooltipTrigger render={<span className="text-neutral3 flex" role="img" aria-label={typeLabel} />}>
+          {icon}
+        </TooltipTrigger>
+        <TooltipContent>{typeLabel}</TooltipContent>
+      </Tooltip>
+      {children}
+    </div>
+  );
+}
+
+/** The labelled arrow between two nodes — the label is what makes the flow readable. */
+function Step({ label }: { label: string }) {
+  return (
+    <div className="text-neutral2 text-ui-xs flex flex-none items-center gap-1.5">
+      <span className="whitespace-nowrap">{label}</span>
+      <ArrowRightIcon className="size-3.5 shrink-0" aria-hidden />
+    </div>
+  );
+}
+
+const linkClass =
+  'text-neutral5 inline-flex items-center gap-1.5 hover:underline [&>svg]:text-neutral3 [&>svg]:size-3 [&>svg]:shrink-0';
+
+/**
+ * Reads the experiment as the pipeline it actually is: every dataset item is sent
+ * to the target, and its output is compared against the item's ground truth by the
+ * scorers. Purely explanatory — it carries no measurement, the meta bar does.
+ */
+export function ExperimentFlowChain({ experiment, className }: ExperimentFlowChainProps) {
+  const { Link: LinkComponent, paths } = useLinkComponent();
+  const { data: agents } = useAgents();
+  const { data: workflows } = useWorkflows();
+  const { data: scorers } = useScorers();
+  const { data: dataset, isLoading: isDatasetLoading } = useDataset(experiment.datasetId ?? '');
+  const { data: scoresByItemId } = useScoresByExperimentId(experiment.id, experiment.status);
+
+  // Scorers are pinned on the experiment at create time, but that field is null
+  // when they resolve from the dataset or the items, so fall back to whichever
+  // scorers actually produced a score.
+  const scorerIds = useMemo(() => {
+    if (experiment.scorerIds?.length) return experiment.scorerIds;
+    if (!scoresByItemId) return [];
+    const ids = new Set<string>();
+    for (const scores of Object.values(scoresByItemId)) {
+      for (const score of scores) ids.add(score.scorerId);
+    }
+    return [...ids].sort();
+  }, [experiment.scorerIds, scoresByItemId]);
+
+  const scorerNames = scorerIds.map(id => scorers?.[id]?.scorer?.config?.name ?? id);
+
+  const targetType = experiment.targetType;
+  const targetId = experiment.targetId;
+
+  const targetName = () => {
+    if (!targetId) return 'External (caller-run)';
+    switch (targetType) {
+      case 'agent':
+        return agents?.[targetId]?.name ?? targetId;
+      case 'workflow':
+        return workflows?.[targetId]?.name ?? targetId;
+      case 'scorer':
+        return scorers?.[targetId]?.scorer?.config?.name ?? targetId;
+      default:
+        return targetId;
+    }
+  };
+
+  const targetHref = () => {
+    if (!targetId) return null;
+    switch (targetType) {
+      case 'agent':
+        return paths.agentLink(targetId);
+      case 'workflow':
+        return paths.workflowLink(targetId);
+      case 'scorer':
+        return paths.scorerLink(targetId);
+      default:
+        return null;
+    }
+  };
+
+  const TargetIcon = (targetType && TARGET_ICON[targetType]) || AgentIcon;
+  const targetTypeLabel = (targetType && TARGET_LABEL[targetType]) || 'Evaluation target';
+  const href = targetHref();
+
+  return (
+    <div className={cn('flex items-center gap-3 overflow-x-auto', className)}>
+      <Node icon={<DatasetsIcon />} typeLabel="Dataset">
+        {experiment.datasetId ? (
+          <LinkComponent
+            href={paths.datasetLink(experiment.datasetId)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={linkClass}
+          >
+            {isDatasetLoading ? <Skeleton className="h-4 w-28" /> : (dataset?.name ?? experiment.datasetId)}
+            {experiment.datasetVersion != null && <span className="text-neutral3">(v{experiment.datasetVersion})</span>}
+            <ExternalLinkIcon />
+          </LinkComponent>
+        ) : (
+          <span className="text-neutral3">No dataset</span>
+        )}
+      </Node>
+
+      <Step label="each item" />
+
+      <Node icon={<TargetIcon />} typeLabel={targetTypeLabel}>
+        {href ? (
+          <LinkComponent href={href} target="_blank" rel="noopener noreferrer" className={linkClass}>
+            {targetName()}
+            <ExternalLinkIcon />
+          </LinkComponent>
+        ) : (
+          <span className="text-neutral3">{targetName()}</span>
+        )}
+      </Node>
+
+      <Step label="output" />
+
+      <Tooltip>
+        {/* Focusable so the scorer list is reachable without a pointer. */}
+        <TooltipTrigger
+          render={
+            <div tabIndex={0} className="flex outline-offset-4">
+              <Node icon={<ScorersIcon />} typeLabel="Scorers">
+                {scorerIds.length === 0 ? 'Scorers' : `${scorerIds.length} scorer${scorerIds.length === 1 ? '' : 's'}`}
+              </Node>
+            </div>
+          }
+        />
+        <TooltipContent>
+          {scorerNames.length > 0 ? scorerNames.join(', ') : 'No scorer has produced a score yet'}
+        </TooltipContent>
+      </Tooltip>
+
+      <Step label="comparing ground truth" />
+
+      <div className="text-ui-sm text-neutral5 flex-none whitespace-nowrap">Score</div>
+    </div>
+  );
+}

--- a/packages/playground/src/domains/experiments/components/experiment-meta-bar.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-meta-bar.tsx
@@ -1,11 +1,8 @@
 import type { DatasetExperiment } from '@mastra/client-js';
-import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { format, formatDistanceToNow } from 'date-fns';
-import { ExternalLinkIcon } from 'lucide-react';
-import type { ReactNode } from 'react';
-import { useDataset } from '@/domains/datasets/hooks/use-datasets';
-import { useLinkComponent } from '@/lib/framework';
+import { type ReactNode, useMemo } from 'react';
+import { useScoresByExperimentId } from '@/domains/datasets/hooks/use-dataset-experiments';
 
 export interface ExperimentMetaBarProps {
   experiment: DatasetExperiment;
@@ -33,12 +30,21 @@ function formatDuration(ms: number): string {
 }
 
 /**
- * Horizontal metadata strip for the experiment page — Results / Started /
- * Duration / Dataset cells separated by vertical borders.
+ * Horizontal metadata strip for the experiment page — Avg score / Items /
+ * Started / Duration cells separated by vertical borders. The dataset lives in
+ * the page title, so it is not repeated here.
  */
 export function ExperimentMetaBar({ experiment, className }: ExperimentMetaBarProps) {
-  const { Link: LinkComponent, paths } = useLinkComponent();
-  const { data: dataset, isLoading: isDatasetLoading } = useDataset(experiment.datasetId ?? '');
+  const { data: scoresByItemId } = useScoresByExperimentId(experiment.id, experiment.status);
+
+  // Averages every score fetched so far, so a running experiment reflects only
+  // the items scored up to now.
+  const overallAverage = useMemo(() => {
+    if (!scoresByItemId) return undefined;
+    const scores = Object.values(scoresByItemId).flat();
+    if (scores.length === 0) return undefined;
+    return scores.reduce((sum, score) => sum + score.score, 0) / scores.length;
+  }, [scoresByItemId]);
 
   const startedAt = experiment.startedAt ?? experiment.createdAt;
   const startedDate = startedAt ? new Date(startedAt) : null;
@@ -53,16 +59,32 @@ export function ExperimentMetaBar({ experiment, className }: ExperimentMetaBarPr
 
   return (
     <div className={cn('flex w-full items-stretch divide-x divide-border1 border-y border-border1', className)}>
-      <MetaCell label="Results">
-        {(experiment.failedCount ?? 0) === 0 && experiment.succeededCount === experiment.totalItems ? (
-          <span className="text-accent1">All passed</span>
+      <MetaCell label="Avg score">
+        {overallAverage === undefined ? (
+          <span className="text-neutral3">—</span>
         ) : (
           <>
-            <span className="font-mono">
-              <span className="text-error">{experiment.failedCount ?? 0}</span>
-              <span className="text-neutral3">/{experiment.totalItems}</span>
+            <span>{overallAverage.toFixed(3)}</span>
+            {(experiment.status === 'running' || experiment.status === 'pending') && (
+              <span className="text-neutral3">· so far</span>
+            )}
+          </>
+        )}
+      </MetaCell>
+
+      <MetaCell label="Items">
+        {experiment.status === 'running' || experiment.status === 'pending' ? (
+          <span className="text-neutral3">
+            {(experiment.succeededCount ?? 0) + (experiment.failedCount ?? 0)}/{experiment.totalItems} items processed
+          </span>
+        ) : (
+          <>
+            <span>
+              {experiment.totalItems} item{experiment.totalItems === 1 ? '' : 's'}
             </span>
-            <span>failed</span>
+            {(experiment.failedCount ?? 0) > 0 && (
+              <span className="text-error">· {experiment.failedCount} errored</span>
+            )}
           </>
         )}
       </MetaCell>
@@ -80,34 +102,6 @@ export function ExperimentMetaBar({ experiment, className }: ExperimentMetaBarPr
 
       <MetaCell label="Duration">
         <span>{durationValue}</span>
-      </MetaCell>
-
-      <MetaCell label="Dataset">
-        {experiment.datasetId ? (
-          isDatasetLoading ? (
-            <Skeleton className="h-4 w-40" />
-          ) : (
-            <>
-              <LinkComponent
-                href={paths.datasetLink(experiment.datasetId)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="[&>svg]:text-neutral3 flex min-w-0 items-center gap-1.5 hover:underline [&>svg]:size-3.5 [&>svg]:shrink-0"
-              >
-                <span className="truncate">{dataset?.name ?? experiment.datasetId}</span>
-                <ExternalLinkIcon />
-              </LinkComponent>
-              {experiment.datasetVersion != null && (
-                <span className="text-neutral3 shrink-0">v{experiment.datasetVersion}</span>
-              )}
-              <span className="text-neutral3 shrink-0">
-                · {experiment.totalItems} item{experiment.totalItems === 1 ? '' : 's'}
-              </span>
-            </>
-          )
-        ) : (
-          <span>—</span>
-        )}
       </MetaCell>
     </div>
   );

--- a/packages/playground/src/domains/experiments/components/experiment-page-tabs.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-page-tabs.tsx
@@ -7,8 +7,9 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { Tabs, Tab, TabList, TabContent } from '@mastra/playground-ui/components/Tabs';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
+import { cn } from '@mastra/playground-ui/utils/cn';
 import { toast } from '@mastra/playground-ui/utils/toast';
-import { ClipboardCheck, List, ListChecks } from 'lucide-react';
+import { ClipboardCheck, List } from 'lucide-react';
 import { useState, useMemo, useCallback } from 'react';
 import { useSearchParams } from 'react-router';
 
@@ -66,11 +67,6 @@ export function ExperimentPageTabs({
   }, []);
 
   const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
-
-  const selectLoadedFailed = useCallback(() => {
-    const failedIds = results.filter(r => Boolean(r.error)).map(r => r.id);
-    setSelectedIds(new Set(failedIds));
-  }, [results]);
 
   const flagForReview = useCallback(
     async (resultIds: string[]) => {
@@ -221,10 +217,17 @@ export function ExperimentPageTabs({
         />
       </TabContent>
 
-      <TabContent value="results" className="grid grid-rows-[auto_auto_1fr] gap-3 overflow-hidden pt-3">
+      {/* The action row only exists while something is selected, so it must not reserve a track otherwise. */}
+      <TabContent
+        value="results"
+        className={cn(
+          'grid gap-3 overflow-hidden pt-3',
+          selectedIds.size > 0 ? 'grid-rows-[auto_auto_1fr]' : 'grid-rows-[auto_1fr]',
+        )}
+      >
         <ExperimentScorerSummary scoresByItemId={scoresByExperimentId} experimentStatus={experimentStatus} />
 
-        {selectedIds.size > 0 ? (
+        {selectedIds.size > 0 && (
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" disabled={isFlagging} onClick={() => flagForReview([...selectedIds])}>
               <Icon size="sm">
@@ -236,17 +239,6 @@ export function ExperimentPageTabs({
               Clear
             </Button>
           </div>
-        ) : results.length > 0 && !isLoading ? (
-          <div className="flex items-center gap-2">
-            <Button size="sm" onClick={selectLoadedFailed}>
-              <Icon size="sm">
-                <ListChecks />
-              </Icon>
-              Select errored items
-            </Button>
-          </div>
-        ) : (
-          <div />
         )}
         <div className="min-h-0 overflow-y-auto">
           <ExperimentResultsList

--- a/packages/playground/src/domains/experiments/components/experiment-page-tabs.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-page-tabs.tsx
@@ -8,7 +8,7 @@ import { Tabs, Tab, TabList, TabContent } from '@mastra/playground-ui/components
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { toast } from '@mastra/playground-ui/utils/toast';
-import { ChartNoAxesColumn, ClipboardCheck, List, ListChecks } from 'lucide-react';
+import { ClipboardCheck, List, ListChecks } from 'lucide-react';
 import { useState, useMemo, useCallback } from 'react';
 import { useSearchParams } from 'react-router';
 
@@ -116,8 +116,8 @@ export function ExperimentPageTabs({
     [results, currentItemId],
   );
 
-  type TabValue = 'summary' | 'results' | 'reviews';
-  const [selectedTab, setSelectedTab] = useState<TabValue>('summary');
+  type TabValue = 'results' | 'reviews';
+  const [selectedTab, setSelectedTab] = useState<TabValue>('results');
   // Result id to auto-feature on the Reviews tab, driven by the `?review=` search
   // param (set when clicking "Review" in the item panel, and deep-linkable).
   const [searchParams, setSearchParams] = useSearchParams();
@@ -175,7 +175,6 @@ export function ExperimentPageTabs({
   const resultsListColumns = useMemo(
     () => [
       { name: 'itemId', label: 'Item ID', size: '7rem' },
-      { name: 'status', label: 'Status', size: '5rem' },
       { name: 'input', label: 'Input', size: 'minmax(15rem,1fr)' },
       ...scorerIds.map(id => ({ name: id, label: id, size: '12rem' })),
     ],
@@ -184,20 +183,12 @@ export function ExperimentPageTabs({
 
   return (
     <Tabs
-      defaultTab="summary"
+      defaultTab="results"
       value={activeTab}
       onValueChange={handleTabChange}
       className="grid h-full grid-rows-[auto_1fr] overflow-visible"
     >
       <TabList variant="pill-ghost">
-        <Tab value="summary" className="px-3 py-2.5">
-          <Icon size="sm">
-            <ChartNoAxesColumn />
-          </Icon>
-          <Txt variant="ui-sm" className="text-inherit">
-            Scorers summary
-          </Txt>
-        </Tab>
         <Tab value="results" className="px-3 py-2.5">
           <Icon size="sm">
             <List />
@@ -221,10 +212,6 @@ export function ExperimentPageTabs({
         </Tab>
       </TabList>
 
-      <TabContent value="summary" className="overflow-y-auto pt-3">
-        <ExperimentScorerSummary scoresByItemId={scoresByExperimentId} experimentStatus={experimentStatus} />
-      </TabContent>
-
       <TabContent value="reviews" className="h-full min-h-0 overflow-visible py-0">
         <DatasetReview
           datasetId={datasetId}
@@ -234,7 +221,9 @@ export function ExperimentPageTabs({
         />
       </TabContent>
 
-      <TabContent value="results" className="grid grid-rows-[auto_1fr] gap-3 overflow-hidden pt-3">
+      <TabContent value="results" className="grid grid-rows-[auto_auto_1fr] gap-3 overflow-hidden pt-3">
+        <ExperimentScorerSummary scoresByItemId={scoresByExperimentId} experimentStatus={experimentStatus} />
+
         {selectedIds.size > 0 ? (
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" disabled={isFlagging} onClick={() => flagForReview([...selectedIds])}>
@@ -253,7 +242,7 @@ export function ExperimentPageTabs({
               <Icon size="sm">
                 <ListChecks />
               </Icon>
-              Select all failures
+              Select errored items
             </Button>
           </div>
         ) : (

--- a/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
@@ -2,7 +2,7 @@ import type { ClientScoreRowData, DatasetExperimentResult } from '@mastra/client
 import { DataList, DataListSkeleton, useDataListKeyboard } from '@mastra/playground-ui/components/DataList';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { ScorersIcon } from '@mastra/playground-ui/icons/ScorersIcon';
-import { CircleCheckIcon, CircleXIcon, ExternalLinkIcon } from 'lucide-react';
+import { AlertCircleIcon, ExternalLinkIcon } from 'lucide-react';
 import { useLinkComponent } from '@/lib/framework';
 
 export type ExperimentResultsListProps = {
@@ -90,22 +90,16 @@ export function ExperimentResultsList({
 
             const rowCells = (
               <>
-                <DataList.IdCell id={result.itemId} />
-                <DataList.Cell>
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <div className="relative flex h-full w-10 items-center justify-center bg-transparent">
-                          {hasError ? (
-                            <CircleXIcon role="img" aria-label="Error" className="text-error size-4" />
-                          ) : (
-                            <CircleCheckIcon role="img" aria-label="Success" className="text-accent1 size-4" />
-                          )}
-                        </div>
-                      }
-                    />
-                    <TooltipContent>{hasError ? 'Error' : 'Success'}</TooltipContent>
-                  </Tooltip>
+                <DataList.Cell className="text-ui-smd text-neutral3 flex items-center gap-1.5 tracking-wide">
+                  <span>{result.itemId?.slice(0, 8) ?? ''}</span>
+                  {hasError && (
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={<AlertCircleIcon role="img" aria-label="Error" className="text-error size-3.5" />}
+                      />
+                      <TooltipContent>{result.error?.message || 'Error'}</TooltipContent>
+                    </Tooltip>
+                  )}
                 </DataList.Cell>
 
                 {hasInputColumn && (

--- a/packages/playground/src/domains/experiments/components/experiment-row-cells.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-row-cells.tsx
@@ -2,7 +2,7 @@ import type { DatasetExperiment } from '@mastra/client-js';
 import { Chip } from '@mastra/playground-ui/components/Chip';
 import { DataList as EntityList } from '@mastra/playground-ui/components/DataList';
 import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
-import { formatExperimentDate, STATUS_VARIANT } from './experiment-columns';
+import { formatExperimentDate, STATUS_LABEL, STATUS_VARIANT } from './experiment-columns';
 import { ExperimentNameLabel } from './experiment-name-label';
 
 export interface ExperimentReviewSummary {
@@ -37,7 +37,7 @@ export function ExperimentRowCells({ experiment: exp, datasetName, review }: Exp
       </EntityList.Cell>
       <EntityList.Cell>
         <StatusBadge variant={STATUS_VARIANT[status] ?? 'neutral'} withDot>
-          {status}
+          {STATUS_LABEL[status] ?? status}
         </StatusBadge>
       </EntityList.Cell>
       <EntityList.TextCell className="text-center">{total}</EntityList.TextCell>

--- a/packages/playground/src/domains/experiments/components/experiment-row-cells.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-row-cells.tsx
@@ -2,7 +2,7 @@ import type { DatasetExperiment } from '@mastra/client-js';
 import { Chip } from '@mastra/playground-ui/components/Chip';
 import { DataList as EntityList } from '@mastra/playground-ui/components/DataList';
 import { StatusBadge } from '@mastra/playground-ui/components/StatusBadge';
-import { formatExperimentDate } from './experiment-columns';
+import { formatExperimentDate, STATUS_VARIANT } from './experiment-columns';
 import { ExperimentNameLabel } from './experiment-name-label';
 
 export interface ExperimentReviewSummary {
@@ -10,13 +10,6 @@ export interface ExperimentReviewSummary {
   complete: number;
   total: number;
 }
-
-const STATUS_VARIANT: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
-  completed: 'success',
-  running: 'warning',
-  failed: 'error',
-  pending: 'neutral',
-};
 
 export interface ExperimentRowCellsProps {
   experiment: DatasetExperiment;
@@ -30,7 +23,6 @@ export function ExperimentRowCells({ experiment: exp, datasetName, review }: Exp
   const succeeded = exp.succeededCount ?? 0;
   const failed = exp.failedCount ?? 0;
   const total = exp.totalItems ?? 0;
-  const successPct = total > 0 ? Math.round((succeeded / total) * 100) : 0;
 
   return (
     <>
@@ -49,11 +41,7 @@ export function ExperimentRowCells({ experiment: exp, datasetName, review }: Exp
         </StatusBadge>
       </EntityList.Cell>
       <EntityList.TextCell className="text-center">{total}</EntityList.TextCell>
-      <EntityList.TextCell className="text-center">
-        <span className={succeeded > 0 ? 'text-accent1' : ''}>
-          {succeeded} ({successPct}%)
-        </span>
-      </EntityList.TextCell>
+      <EntityList.TextCell className="text-center">{succeeded}</EntityList.TextCell>
       <EntityList.TextCell className="text-center">
         <span className={failed > 0 ? 'text-accent2' : ''}>{failed}</span>
       </EntityList.TextCell>

--- a/packages/playground/src/domains/experiments/components/experiment-scorer-summary.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-scorer-summary.tsx
@@ -1,7 +1,7 @@
 import type { ClientScoreRowData } from '@mastra/client-js';
 import type { ExperimentStatus } from '@mastra/core/storage';
-import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { MetricsKpiCard } from '@mastra/playground-ui/components/MetricsKpiCard';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { ScorersIcon } from '@mastra/playground-ui/icons/ScorersIcon';
 import { ExternalLinkIcon, GaugeIcon } from 'lucide-react';
 import { useMemo } from 'react';
@@ -20,25 +20,22 @@ export function ExperimentScorerSummary({ scoresByItemId, experimentStatus }: Ex
   const scorerSummaries = useMemo(() => {
     if (!scoresByItemId) return [];
 
-    const scorerTotals: Record<string, { sum: number; count: number; failed: number }> = {};
+    const scorerTotals: Record<string, { sum: number; count: number }> = {};
 
     for (const scores of Object.values(scoresByItemId)) {
       for (const score of scores) {
         if (!scorerTotals[score.scorerId]) {
-          scorerTotals[score.scorerId] = { sum: 0, count: 0, failed: 0 };
+          scorerTotals[score.scorerId] = { sum: 0, count: 0 };
         }
         scorerTotals[score.scorerId].sum += score.score;
         scorerTotals[score.scorerId].count++;
-        if (score.score < 1) scorerTotals[score.scorerId].failed++;
       }
     }
 
     return Object.entries(scorerTotals)
-      .map(([scorerId, { sum, count, failed }]) => ({
+      .map(([scorerId, { sum, count }]) => ({
         scorerId,
         avg: sum / count,
-        count,
-        failed,
       }))
       .sort((a, b) => a.scorerId.localeCompare(b.scorerId));
   }, [scoresByItemId]);
@@ -62,41 +59,38 @@ export function ExperimentScorerSummary({ scoresByItemId, experimentStatus }: Ex
     }
 
     return (
-      <div className="flex h-full items-center justify-center py-12">
-        <EmptyState
-          iconSlot={<GaugeIcon className="text-neutral3 h-8 w-8" />}
-          titleSlot={title}
-          descriptionSlot={description}
-        />
+      <div className="text-ui-sm text-neutral3 flex items-center gap-2">
+        <GaugeIcon className="text-neutral3 size-4 shrink-0" />
+        <span className="text-neutral4">{title}</span>
+        <span className="truncate">{description}</span>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-wrap content-start gap-3">
-      {scorerSummaries.map(({ scorerId, avg, count, failed }) => {
+    <div className="flex items-stretch gap-2 overflow-x-auto pb-1">
+      {scorerSummaries.map(({ scorerId, avg }) => {
         const scorerName = scorers?.[scorerId]?.scorer?.config?.name ?? scorerId;
 
         return (
-          <MetricsKpiCard key={scorerId} className="max-w-96">
+          <MetricsKpiCard key={scorerId} className="w-52 min-w-0 flex-none p-3">
             <LinkComponent
               href={paths.scorerLink(scorerId)}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-ui-md text-neutral3 [&>svg]:text-neutral3 flex min-w-0 items-center gap-1.5 leading-relaxed hover:underline [&>svg]:size-3.5 [&>svg]:shrink-0"
+              className="text-ui-sm text-neutral3 [&>svg]:text-neutral3 flex min-w-0 items-center gap-1.5 hover:underline [&>svg]:size-3 [&>svg]:shrink-0"
             >
-              <ScorersIcon />
+              <Tooltip>
+                <TooltipTrigger render={<ScorersIcon role="img" aria-label="Scorer" />} />
+                <TooltipContent>Scorer</TooltipContent>
+              </Tooltip>
               <span className="truncate">{scorerName}</span>
               <ExternalLinkIcon />
             </LinkComponent>
-            <strong className="text-header-lg text-neutral4 font-semibold">
-              <span className={failed === 0 ? 'text-accent1' : 'text-error'}>{failed}</span>
-              <span className="text-neutral3">/{count}</span>
-              <span className="text-ui-md text-neutral3 ml-1.5 font-normal">failed</span>
+            <strong className="text-ui-lg text-neutral4 font-semibold">
+              {avg.toFixed(3)}
+              <span className="text-ui-sm text-neutral3 ml-1.5 font-normal">avg score</span>
             </strong>
-            <MetricsKpiCard.Label className="text-ui-sm text-neutral2">
-              {`Avg score ${avg.toFixed(3)}`}
-            </MetricsKpiCard.Label>
           </MetricsKpiCard>
         );
       })}

--- a/packages/playground/src/domains/experiments/components/experiment-stats.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-stats.tsx
@@ -14,7 +14,7 @@ type RunStatus = 'pending' | 'running' | 'completed' | 'failed';
 const statusIconMap: Record<RunStatus, { icon: React.ReactNode; label: string }> = {
   pending: { icon: <ClockIcon className="text-warning1 size-4" />, label: 'Pending' },
   running: { icon: <Spinner size="sm" />, label: 'Running' },
-  completed: { icon: <CircleCheckIcon className="text-accent1 size-4" />, label: 'Completed' },
+  completed: { icon: <CircleCheckIcon className="text-neutral3 size-4" />, label: 'Completed' },
   failed: { icon: <CircleXIcon className="text-error size-4" />, label: 'Failed' },
 };
 
@@ -59,10 +59,10 @@ export function ExperimentStats({ experiment, className }: ExperimentStatsProps)
           Total: <b>{experiment.totalItems}</b>
         </span>
         <span>
-          Succeeded: <b>{experiment.succeededCount}</b>
+          Processed: <b>{experiment.succeededCount}</b>
         </span>
         <span>
-          Failed: <b>{experiment.failedCount}</b>
+          Errored: <b>{experiment.failedCount}</b>
         </span>
         {(status === 'pending' || status === 'running') && (
           <span>

--- a/packages/playground/src/domains/experiments/components/experiment-status-card.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-status-card.tsx
@@ -1,10 +1,11 @@
 import type { DatasetExperiment, DatasetRecord } from '@mastra/client-js';
 import { HorizontalBars } from '@mastra/playground-ui/components/HorizontalBars';
 import { MetricsCard } from '@mastra/playground-ui/components/MetricsCard';
+import { Colors } from '@mastra/playground-ui/tokens';
 import { useMemo } from 'react';
 
 const STATUS_COLORS = {
-  completed: '#22c55e',
+  completed: Colors.neutral3,
   running: '#facc15',
   pending: '#fb923c',
   failed: '#f87171',

--- a/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
@@ -3,11 +3,11 @@ import { Badge } from '@mastra/playground-ui/components/Badge';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
 import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
 import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
+import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { ExternalLinkIcon } from 'lucide-react';
-import { useMemo } from 'react';
 import { useAgents } from '@/domains/agents/hooks/use-agents';
-import { useScoresByExperimentId } from '@/domains/datasets/hooks/use-dataset-experiments';
+import { useDataset } from '@/domains/datasets/hooks/use-datasets';
 import { ExperimentMetaBar } from '@/domains/experiments/components/experiment-meta-bar';
 import { ExperimentStatusIcon } from '@/domains/experiments/components/experiment-stats';
 import { useScorers } from '@/domains/scores/hooks/use-scorers';
@@ -28,16 +28,7 @@ export function ExperimentTopArea({ experiment }: ExperimentTopAreaProps) {
   const { data: agents } = useAgents();
   const { data: workflows } = useWorkflows();
   const { data: scorers } = useScorers();
-  const { data: scoresByItemId } = useScoresByExperimentId(experiment.id, experiment.status);
-
-  const overallAverage = useMemo(() => {
-    if (!scoresByItemId) return undefined;
-
-    const scores = Object.values(scoresByItemId).flat();
-    if (scores.length === 0) return undefined;
-
-    return scores.reduce((sum, score) => sum + score.score, 0) / scores.length;
-  }, [scoresByItemId]);
+  const { data: dataset, isLoading: isDatasetLoading } = useDataset(experiment.datasetId ?? '');
 
   const targetPath = () => {
     if (!experiment.targetId) return null;
@@ -81,30 +72,52 @@ export function ExperimentTopArea({ experiment }: ExperimentTopAreaProps) {
             {/* mt-4 skips the eyebrow line (1rem), h-7 matches the title line-height so the icon centers on the title. */}
             <ExperimentStatusIcon status={experiment.status} className="mt-4 h-7" />
             <PageHeader>
-              <p className="text-ui-xs text-neutral3 tracking-wider uppercase">Evaluation target</p>
+              <p className="text-ui-xs text-neutral3 tracking-wider uppercase">Dataset</p>
               <PageHeader.Title>
-                {(() => {
-                  const href = targetPath();
-                  return href ? (
-                    <LinkComponent
-                      href={href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={cn(
-                        'flex items-center gap-2 transition-colors',
-                        'hover:text-neutral4 [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-neutral3',
-                      )}
-                    >
-                      {targetName()}
-                      <ExternalLinkIcon />
-                    </LinkComponent>
-                  ) : (
-                    targetName()
-                  );
-                })()}
-                {overallAverage !== undefined && <Badge size="sm">Avg {overallAverage.toFixed(3)}</Badge>}
+                {experiment.datasetId ? (
+                  <LinkComponent
+                    href={paths.datasetLink(experiment.datasetId)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={cn(
+                      'flex items-center gap-2 transition-colors',
+                      'hover:text-neutral4 [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-neutral3',
+                    )}
+                  >
+                    {isDatasetLoading ? <Skeleton className="h-6 w-48" /> : (dataset?.name ?? experiment.datasetId)}
+                    <ExternalLinkIcon />
+                  </LinkComponent>
+                ) : (
+                  'No dataset'
+                )}
+                {experiment.datasetVersion != null && (
+                  <Badge size="sm" variant="default">
+                    v{experiment.datasetVersion}
+                  </Badge>
+                )}
               </PageHeader.Title>
-              {experiment.description && <PageHeader.Description>{experiment.description}</PageHeader.Description>}
+              <PageHeader.Description>
+                <span className="flex flex-wrap items-center gap-x-1.5">
+                  <span>Evaluating</span>
+                  {(() => {
+                    const href = targetPath();
+                    return href ? (
+                      <LinkComponent
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-neutral4 [&>svg]:text-neutral3 inline-flex items-center gap-1 hover:underline [&>svg]:size-3.5 [&>svg]:shrink-0"
+                      >
+                        {targetName()}
+                        <ExternalLinkIcon />
+                      </LinkComponent>
+                    ) : (
+                      <span className="text-neutral4">{targetName()}</span>
+                    );
+                  })()}
+                  {experiment.description && <span>· {experiment.description}</span>}
+                </span>
+              </PageHeader.Description>
             </PageHeader>
           </div>
         </PageLayout.Column>

--- a/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
@@ -1,17 +1,10 @@
 import type { DatasetExperiment } from '@mastra/client-js';
-import { Badge } from '@mastra/playground-ui/components/Badge';
 import { DataKeysAndValues } from '@mastra/playground-ui/components/DataKeysAndValues';
 import { PageHeader } from '@mastra/playground-ui/components/PageHeader';
 import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
-import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
-import { cn } from '@mastra/playground-ui/utils/cn';
-import { ExternalLinkIcon } from 'lucide-react';
-import { useAgents } from '@/domains/agents/hooks/use-agents';
-import { useDataset } from '@/domains/datasets/hooks/use-datasets';
+import { ExperimentFlowChain } from '@/domains/experiments/components/experiment-flow-chain';
 import { ExperimentMetaBar } from '@/domains/experiments/components/experiment-meta-bar';
 import { ExperimentStatusIcon } from '@/domains/experiments/components/experiment-stats';
-import { useScorers } from '@/domains/scores/hooks/use-scorers';
-import { useWorkflows } from '@/domains/workflows/hooks/use-workflows';
 import { useLinkComponent } from '@/lib/framework';
 
 export interface ExperimentTopAreaProps {
@@ -25,39 +18,6 @@ export interface ExperimentTopAreaProps {
  */
 export function ExperimentTopArea({ experiment }: ExperimentTopAreaProps) {
   const { Link: LinkComponent, paths } = useLinkComponent();
-  const { data: agents } = useAgents();
-  const { data: workflows } = useWorkflows();
-  const { data: scorers } = useScorers();
-  const { data: dataset, isLoading: isDatasetLoading } = useDataset(experiment.datasetId ?? '');
-
-  const targetPath = () => {
-    if (!experiment.targetId) return null;
-    switch (experiment.targetType) {
-      case 'agent':
-        return paths.agentLink(experiment.targetId);
-      case 'workflow':
-        return paths.workflowLink(experiment.targetId);
-      case 'scorer':
-        return paths.scorerLink(experiment.targetId);
-      default:
-        return '#';
-    }
-  };
-
-  const targetName = () => {
-    const targetId = experiment.targetId;
-    if (!targetId) return 'External (caller-run)';
-    switch (experiment.targetType) {
-      case 'agent':
-        return agents?.[targetId]?.name ?? targetId;
-      case 'workflow':
-        return workflows?.[targetId]?.name ?? targetId;
-      case 'scorer':
-        return scorers?.[targetId]?.scorer?.config?.name ?? targetId;
-      default:
-        return targetId;
-    }
-  };
 
   const versionLinkHref =
     experiment.agentVersion && experiment.targetType === 'agent' && experiment.targetId
@@ -69,58 +29,13 @@ export function ExperimentTopArea({ experiment }: ExperimentTopAreaProps) {
       <PageLayout.Row>
         <PageLayout.Column className="justify-items-start gap-3">
           <div className="flex items-start gap-3">
-            {/* mt-4 skips the eyebrow line (1rem), h-7 matches the title line-height so the icon centers on the title. */}
-            <ExperimentStatusIcon status={experiment.status} className="mt-4 h-7" />
+            {/* h-7 matches the title line-height so the icon centers on the title. */}
+            <ExperimentStatusIcon status={experiment.status} className="h-7" />
             <PageHeader>
-              {/* The title is the dataset, so the eyebrow has to say what this page actually is: one run. */}
-              <p className="text-ui-xs text-neutral3 tracking-wider uppercase">
-                Experiment #{experiment.id.slice(0, 8)}
-              </p>
-              <PageHeader.Title>
-                {experiment.datasetId ? (
-                  <LinkComponent
-                    href={paths.datasetLink(experiment.datasetId)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={cn(
-                      'flex items-center gap-2 transition-colors',
-                      'hover:text-neutral4 [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-neutral3',
-                    )}
-                  >
-                    {isDatasetLoading ? <Skeleton className="h-6 w-48" /> : (dataset?.name ?? experiment.datasetId)}
-                    <ExternalLinkIcon />
-                  </LinkComponent>
-                ) : (
-                  'No dataset'
-                )}
-                {experiment.datasetVersion != null && (
-                  <Badge size="sm" variant="default">
-                    v{experiment.datasetVersion}
-                  </Badge>
-                )}
-              </PageHeader.Title>
-              <PageHeader.Description>
-                <span className="flex flex-wrap items-center gap-x-1.5">
-                  <span>Evaluating</span>
-                  {(() => {
-                    const href = targetPath();
-                    return href ? (
-                      <LinkComponent
-                        href={href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-neutral4 [&>svg]:text-neutral3 inline-flex items-center gap-1 hover:underline [&>svg]:size-3.5 [&>svg]:shrink-0"
-                      >
-                        {targetName()}
-                        <ExternalLinkIcon />
-                      </LinkComponent>
-                    ) : (
-                      <span className="text-neutral4">{targetName()}</span>
-                    );
-                  })()}
-                  {experiment.description && <span>· {experiment.description}</span>}
-                </span>
-              </PageHeader.Description>
+              {/* The run is the subject of the page; what it ran on is spelled out by the chain below. */}
+              <PageHeader.Title>Experiment #{experiment.id.slice(0, 8)}</PageHeader.Title>
+              {experiment.description && <PageHeader.Description>{experiment.description}</PageHeader.Description>}
+              <ExperimentFlowChain experiment={experiment} className="mt-2" />
             </PageHeader>
           </div>
         </PageLayout.Column>

--- a/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-top-area.tsx
@@ -72,7 +72,10 @@ export function ExperimentTopArea({ experiment }: ExperimentTopAreaProps) {
             {/* mt-4 skips the eyebrow line (1rem), h-7 matches the title line-height so the icon centers on the title. */}
             <ExperimentStatusIcon status={experiment.status} className="mt-4 h-7" />
             <PageHeader>
-              <p className="text-ui-xs text-neutral3 tracking-wider uppercase">Dataset</p>
+              {/* The title is the dataset, so the eyebrow has to say what this page actually is: one run. */}
+              <p className="text-ui-xs text-neutral3 tracking-wider uppercase">
+                Experiment #{experiment.id.slice(0, 8)}
+              </p>
               <PageHeader.Title>
                 {experiment.datasetId ? (
                   <LinkComponent


### PR DESCRIPTION

<img width="3840" height="2160" alt="CleanShot 2026-08-31 at 10 07 39@2x" src="https://github.com/user-attachments/assets/943bb75f-8e96-48db-a623-8ddc829cef4c" />


The experiment pages in Studio were showing scores as if they were a pass/fail verdict, which isn't what they are. An experiment is a run — like a CI job — and `succeededCount`/`failedCount` count items whose *execution* errored. A scored item just has a score; core defines no threshold anywhere. The scorer summary was inventing one (`score < 1` counted as failed).

So the green success badges, the "All passed" line, the per-item Success/Error column and the invented failed count are gone. A completed run now just reads "Completed" in neutral styling, and items that genuinely errored during execution get a small inline error marker instead of a permanent two-state column. Scorer cards show the average score on its own.

While the vocabulary was being fixed I also tidied the experiment page: Summary is merged into Results with a compact horizontally scrollable scorer strip above the table, the header leads with the dataset name and the entity being evaluated, and the run's average score moved from a badge in the title into the metadata bar next to Items and Duration.

Before, per scorer: `2/10 failed · avg 0.82`. After: `0.820`.

Nothing changed in core, storage or the client types — `succeededCount`/`failedCount` keep their meaning, only the UI wording and emphasis change. The review workflow (needs-review/complete) is a real human verdict and is untouched.

Co-Authored-By: Mastra Code (anthropic/claude-opus-5) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Experiment pages now show scores and errors without treating them as pass/fail results. Users can see processed items, errored items, average scores, and reviews in one simpler view.

## Changes

- Replaced success/failure language with `Processed`, `Errored`, and neutral status labels.
- Removed the permanent Success/Error results column.
- Added inline error markers with tooltips for errored items.
- Displayed average scores without pass/fail thresholds.
- Added `· so far` for scores from running or pending experiments.
- Merged the scorer summary into the Results tab.
- Added horizontally scrollable scorer cards.
- Moved average score and item counts into the metadata bar.
- Added a dataset-to-target-to-scorer flow in the experiment header.
- Used the run number as the page title.
- Resolved scorer counts from configured scorers or scorers that produced scores.
- Applied neutral styling to completed experiment states.
- Updated experiment listings, dataset history, and agent playground badges to use processed and errored counts.
- Review actions now appear only after users select results.

## Tests

- Updated metadata, scorer summary, top area, experiment list, and keyboard navigation tests.
- Added coverage for the experiment flow, scorer fallback behavior, inline error markers, results without status indicators, and conditional review actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->