### PR TITLE
docs(observability): fix serialization option defaults in tracing docs

### DIFF
--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -664,8 +664,8 @@ export const mastra = new Mastra({
       default: {
         serviceName: 'my-service',
         serializationOptions: {
-          maxStringLength: 2048, // Maximum length for string values (default: 1024)
-          maxDepth: 10, // Maximum depth for nested objects (default: 6)
+          maxStringLength: 2048, // Maximum length for string values (default: 131072)
+          maxDepth: 10, // Maximum depth for nested objects (default: 8)
           maxArrayLength: 100, // Maximum number of items in arrays (default: 50)
           maxObjectKeys: 75, // Maximum number of keys in objects (default: 50)
         },
@@ -680,8 +680,8 @@ export const mastra = new Mastra({
 
 | Option | Default | Description |
 | - | - | - |
-| `maxStringLength` | 1024 | Maximum length for string values. Longer strings are truncated. |
-| `maxDepth` | 6 | Maximum depth for nested objects. Deeper levels are omitted. |
+| `maxStringLength` | 131072 (128 KB) | Maximum length for string values. Longer strings are truncated. |
+| `maxDepth` | 8 | Maximum depth for nested objects. Deeper levels are omitted. |
 | `maxArrayLength` | 50 | Maximum number of items in arrays. Additional items are omitted. |
 | `maxObjectKeys` | 50 | Maximum number of keys in objects. Additional keys are omitted. |
 
@@ -691,9 +691,9 @@ export const mastra = new Mastra({
 
 ```ts prettier:false
 serializationOptions: {
-  maxStringLength: 8192,  // Capture longer text content
-  maxDepth: 12,           // Handle deeply nested JSON responses
-  maxArrayLength: 200,    // Keep more items from large lists
+  maxStringLength: 262144, // Capture longer text content (256 KB)
+  maxDepth: 12,            // Handle deeply nested JSON responses
+  maxArrayLength: 200,     // Keep more items from large lists
 }
 ```
 

--- a/docs/src/content/en/reference/observability/tracing/configuration.mdx
+++ b/docs/src/content/en/reference/observability/tracing/configuration.mdx
@@ -138,13 +138,13 @@ interface ObservabilityInstanceConfig {
           {
             name: 'maxStringLength',
             type: 'number',
-            description: 'Maximum length for string values (default: 1024)',
+            description: 'Maximum length for string values (default: 131072)',
             isOptional: true,
           },
           {
             name: 'maxDepth',
             type: 'number',
-            description: 'Maximum depth for nested objects (default: 6)',
+            description: 'Maximum depth for nested objects (default: 8)',
             isOptional: true,
           },
           {


### PR DESCRIPTION
## Description

Corrects the documented defaults for tracing `serializationOptions` to match the actual values in `@mastra/observability`. The docs said `maxStringLength: 1024` and `maxDepth: 6`, but the code defaults are `131072` (128 KB) and `8` since #12579.

- Updated the defaults table and inline example comments in `docs/src/content/en/docs/observability/tracing/overview.mdx`
- Updated the `PropertiesTable` descriptions in `docs/src/content/en/reference/observability/tracing/configuration.mdx`
- Fixed the "Increasing limits for debugging" example, which suggested `maxStringLength: 8192` — below the real default, so it would shrink the limit instead of raising it

## Related Issue(s)

Fixes #22595

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The tracing documentation now shows the same limits used by `@mastra/observability`. This helps users understand when traced prompts and completions may be truncated.

## Changes

- Updated `maxStringLength` from `1,024` to `131,072`.
- Updated `maxDepth` from `6` to `8`.
- Kept `maxArrayLength` and `maxObjectKeys` at `50`.
- Updated defaults tables, configuration descriptions, inline comments, and the debugging example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->