### PR TITLE
fix(ci): compare changed tests from the PR merge base

### DIFF
--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -41,8 +41,12 @@ jobs:
 
           # Fetch the complete PR ancestry so the merge base is available. A direct
           # base-to-head diff reports base-only changes as PR deletions when the
-          # branch is behind the base branch.
-          git fetch --no-tags "${HEAD_REPO}" "${HEAD_SHA}"
+          # branch is behind the base branch. Keep the PR head as a blobless
+          # promisor remote so checkout can lazily retrieve PR-only test blobs.
+          git remote add pr-head "${HEAD_REPO}"
+          git config remote.pr-head.promisor true
+          git config remote.pr-head.partialclonefilter blob:none
+          git fetch --no-tags --filter=blob:none pr-head "${HEAD_SHA}"
           merge_base="$(git merge-base "${BASE_SHA}" FETCH_HEAD)"
           git diff --name-only --diff-filter=ACMRT "${merge_base}" FETCH_HEAD \
             | sort > /tmp/changed-files

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -39,10 +39,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch "${HEAD_REPO}" "${HEAD_SHA}" --depth=1
-          git diff --name-only --diff-filter=ACMRT "${BASE_SHA}" FETCH_HEAD \
+          # Fetch the complete PR ancestry so the merge base is available. A direct
+          # base-to-head diff reports base-only changes as PR deletions when the
+          # branch is behind the base branch.
+          git fetch --no-tags "${HEAD_REPO}" "${HEAD_SHA}"
+          merge_base="$(git merge-base "${BASE_SHA}" FETCH_HEAD)"
+          git diff --name-only --diff-filter=ACMRT "${merge_base}" FETCH_HEAD \
             | sort > /tmp/changed-files
-          git diff --no-renames --name-only --diff-filter=ACMRTD "${BASE_SHA}" FETCH_HEAD \
+          git diff --no-renames --name-only --diff-filter=ACMRTD "${merge_base}" FETCH_HEAD \
             | sort > /tmp/changed-coverage-files
 
           # Deployer changes must include monorepo E2E coverage. This rule runs


### PR DESCRIPTION
This makes the changed-test gate compare from the PR merge base, so branches behind main do not report base-only changes as deletions.\n\nBefore, a behind branch could appear to modify packages/deployer and require an unrelated monorepo E2E test. The gate now evaluates only files introduced by the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The test gate now checks only files changed by the PR. This prevents older branches from triggering tests for unrelated files already in `main`.

## Changes

- Configures a blobless promisor remote for the PR head.
- Fetches the complete PR head ancestry.
- Finds the merge base between the PR branch and its base branch.
- Compares changes from the merge base to the PR head.
- Applies coverage requirements only to files introduced by the PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->