### PR TITLE
docs: document DurableAgent abort and listActiveRuns

### DIFF
--- a/docs/src/content/en/reference/agents/durable-agent.mdx
+++ b/docs/src/content/en/reference/agents/durable-agent.mdx
@@ -325,11 +325,112 @@ interface PrepareResult {
 }
 ```
 
+### Cancellation
+
+#### `abortRunStream(runId)`
+
+Stops a run by ID from any process that shares the agent's [PubSub](/docs/server/pubsub). Only the `runId` from `stream()` or `prepare()` is needed, so a later request can stop a run it didn't start. The run ends the same way as `abort()` on the stream result: the `finish` event carries reason `abort`, `onAbort` fires, and `observe()` consumers see the stream end.
+
+```typescript
+const { runId } = await durableAgent.stream('Summarize the document')
+
+// later, from a different request handler
+durableAgent.abortRunStream(runId)
+```
+
+The abort request is published over PubSub, so a multi-process deployment needs a shared backend such as [`RedisStreamsPubSub`](/reference/pubsub/redis-streams). The default `EventEmitterPubSub` only reaches runs in the same process. `InngestAgent` doesn't implement this method. Cancel an Inngest run with the `abort()` returned by its `stream()`.
+
+Stopping a durable run through `abortRunStream()` or `abortThreadStream()` requires `@mastra/core@1.62.0` or later. Earlier versions record the abort without stopping the run.
+
+Returns: `boolean`. `true` when this process aborted the run locally or can see it executing. The abort request is published either way.
+
+#### `abortThreadStream({ threadId, resourceId? })`
+
+Aborts the active run on a memory thread with the same abort request as `abortRunStream()`. The run is resolved from this process's thread runtime, so it must have been started here or observed through `subscribeToThread()` on this process. The server route `POST /agents/:agentId/threads/abort` uses this method.
+
+```typescript
+durableAgent.abortThreadStream({ resourceId: 'user-1', threadId: 'thread-1' })
+```
+
+Returns: `boolean`. `false` when this process has no active run recorded for the thread. No abort request is sent in that case.
+
 ### Recovery
+
+#### `listActiveRuns(options?)`
+
+Lists this agent's runs whose persisted snapshot is in `running` status: runs whose agentic loop was mid-execution when the workflow engine last saved state. On a live process they transition to `suspended` or a terminal status. After a crash or restart they stay `running` with nothing driving them, which is what `recoverActiveRuns()` re-drives. Runs started by other durable agents on the same storage aren't included.
+
+```typescript
+const { runs, total } = await durableAgent.listActiveRuns({ resourceId: 'user-1' })
+
+for (const run of runs) {
+  await durableAgent.recoverActiveRuns({ runId: run.runId })
+}
+```
+
+Reads workflow snapshot storage on the Mastra instance the agent is registered with, and throws if the agent isn't registered with one. Use persistent storage: the default in-memory store loses these rows on the restart that orphans them.
+
+Only runs in `running` status are returned. Suspended runs keep their snapshots but aren't included, and finished runs aren't retained. Filter by `resourceId` to scope the list to one user.
+
+Returns:
+
+```typescript
+interface DurableAgentListActiveRunsResult {
+  runs: Array<{
+    runId: string
+    status: 'running'
+    threadId?: string
+    resourceId?: string
+    updatedAt: Date
+  }>
+  total: number
+}
+```
+
+<PropertiesTable
+  content={[
+  {
+    name: 'options.threadId',
+    type: 'string',
+    isOptional: true,
+    description: 'Only return runs that belong to this memory thread.',
+  },
+  {
+    name: 'options.resourceId',
+    type: 'string',
+    isOptional: true,
+    description: 'Only return runs that belong to this memory resource.',
+  },
+  {
+    name: 'options.fromDate',
+    type: 'Date',
+    isOptional: true,
+    description: 'Only return runs created at or after this date.',
+  },
+  {
+    name: 'options.toDate',
+    type: 'Date',
+    isOptional: true,
+    description: 'Only return runs created at or before this date.',
+  },
+  {
+    name: 'options.perPage',
+    type: 'number',
+    isOptional: true,
+    description: 'Runs per page. Applies only when `page` is also set. Must be a positive integer.',
+  },
+  {
+    name: 'options.page',
+    type: 'number',
+    isOptional: true,
+    description: 'Zero-indexed page number. Applies only when `perPage` is also set. Must be a non-negative integer.',
+  },
+]}
+/>
 
 #### `recoverActiveRuns(options?)`
 
-Discovers runs stuck in `running` status for this agent and re-drives them from the last persisted snapshot. Recovers up to `options.limit` runs (default: 100). Returns a summary of what was recovered.
+Discovers runs stuck in `running` status for this agent and re-drives them from the last persisted snapshot. Accepts the same filters and pagination as `listActiveRuns()`, plus `runId`. Returns a summary of what was recovered.
 
 ```typescript
 const result = await durableAgent.recoverActiveRuns()
@@ -358,19 +459,7 @@ interface DurableAgentRecoverActiveRunsResult {
     name: 'options.runId',
     type: 'string',
     isOptional: true,
-    description: 'Recover a specific run by ID. When set, discovery filters are ignored.',
-  },
-  {
-    name: 'options.limit',
-    type: 'number',
-    isOptional: true,
-    description: 'Maximum number of active runs to discover. Defaults to 100.',
-  },
-  {
-    name: 'options.createdBefore',
-    type: 'Date',
-    isOptional: true,
-    description: 'Only recover runs created before this date.',
+    description: 'Recover a specific run by ID. When set, the discovery filters and pagination are ignored.',
   },
 ]}
 />
@@ -401,7 +490,7 @@ Returns: [`Promise<DurableAgentStreamResult>`](#durableagentstreamresult)
     name: 'runId',
     type: 'string',
     isOptional: true,
-    description: 'Unique identifier for this run. Use it later with `resume()` or `observe()`.',
+    description: 'Unique identifier for this run. Use it later with `resume()`, `observe()`, or `abortRunStream()`.',
   },
   {
     name: 'instructions',
@@ -617,7 +706,7 @@ Returns: [`Promise<DurableAgentStreamResult>`](#durableagentstreamresult)
     type: "AgentExecutionOptions['onAbort']",
     isOptional: true,
     description:
-      'Called when the run is aborted via `abortSignal` or `result.abort()`. Receives the steps completed before the abort and, in `text`, the assistant text streamed so far.',
+      'Called when the run is aborted via `abortSignal`, `result.abort()`, `abortRunStream()`, or `abortThreadStream()`. Receives the steps completed before the abort and, in `text`, the assistant text streamed so far.',
   },
   {
     name: 'onIterationComplete',


### PR DESCRIPTION
## Description

Adds `abortRunStream()`, `abortThreadStream()` and `listActiveRuns()` to the DurableAgent reference page. All three exist on the class but were not documented, which came up in a Discord thread about stopping an evented agent run by `runId` from a later request.

Also corrects the `recoverActiveRuns()` entry: it accepts the `listActiveRuns()` filters plus `runId`, not the `limit` and `createdBefore` options the table listed.

Docs-only change, no changeset. `oxfmt-mdx --check`, Vale (error level) and remark pass locally on the file.

## Related issue(s)

Fixes #22631

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates the `DurableAgent` reference page. It explains how to stop active runs, find stuck runs, and recover them. It also corrects the documented options for `recoverActiveRuns()`.

## Changes

- Documented `abortRunStream(runId)`.
- Documented `abortThreadStream({ threadId, resourceId? })`.
- Added behavior, return values, PubSub requirements, multi-process requirements, and version information.
- Documented `listActiveRuns(options?)`, including filters and pagination.
- Updated `recoverActiveRuns(options?)` to use the supported `listActiveRuns()` filters and pagination.
- Added the `recoverActiveRuns()` `runId` parameter.
- Removed the unsupported `limit` and `createdBefore` options from `recoverActiveRuns()`.
- Updated `runId` and `onAbort` descriptions to reference the abort methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->