### PR TITLE
fix(playground): paginate evaluation overview scores past the first page

### DIFF
--- a/.changeset/eighty-doors-open.md
+++ b/.changeset/eighty-doors-open.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed the Evaluation overview in Studio truncating each scorer's history to its newest 100 scores. The Scores chart and summary now page through the full score list, so multi-week history and averages are complete for scorers with more than 100 scores. Fixes [#22540](https://github.com/mastra-ai/mastra/issues/22540).

--- a/packages/playground/src/domains/scores/hooks/__tests__/fixtures/score-metrics.ts
+++ b/packages/playground/src/domains/scores/hooks/__tests__/fixtures/score-metrics.ts
@@ -19,3 +19,19 @@ export const scoreMetricsScorers: GetScoresScorers_Response = {
 export const emptyScoreMetrics: GetObservabilityScores_Response = {
   scores: [],
 };
+
+const qualityScore = (timestamp: string, score: number): GetObservabilityScores_Response['scores'][number] => ({
+  scorerId: 'quality',
+  score,
+  timestamp: new Date(timestamp),
+});
+
+export const scoreMetricsFirstPage: GetObservabilityScores_Response = {
+  scores: [qualityScore('2026-07-02T10:00:00.000Z', 0.8), qualityScore('2026-07-02T09:00:00.000Z', 0.8)],
+  pagination: { total: 3, page: 0, perPage: 100, hasMore: true },
+};
+
+export const scoreMetricsLastPage: GetObservabilityScores_Response = {
+  scores: [qualityScore('2026-06-22T10:00:00.000Z', 0.2)],
+  pagination: { total: 3, page: 1, perPage: 100, hasMore: false },
+};

--- a/packages/playground/src/domains/scores/hooks/__tests__/use-score-metrics.msw.test.tsx
+++ b/packages/playground/src/domains/scores/hooks/__tests__/use-score-metrics.msw.test.tsx
@@ -3,7 +3,12 @@ import { http, HttpResponse } from 'msw';
 import { describe, expect, it, vi } from 'vitest';
 import { useScoreMetrics } from '../use-score-metrics';
 import type { ScoreMetricsDateRange } from '../use-score-metrics';
-import { emptyScoreMetrics, scoreMetricsScorers } from './fixtures/score-metrics';
+import {
+  emptyScoreMetrics,
+  scoreMetricsFirstPage,
+  scoreMetricsLastPage,
+  scoreMetricsScorers,
+} from './fixtures/score-metrics';
 import { server } from '@/test/msw-server';
 import { renderHookWithProviders } from '@/test/render';
 
@@ -50,6 +55,53 @@ describe('useScoreMetrics', () => {
       await waitFor(() => expect(onScoresRequest).toHaveBeenCalledTimes(2));
       expect(onScoresRequest.mock.calls).toEqual([[serializeRange(firstRange)], [serializeRange(secondRange)]]);
       expect(queryClient.getQueryCache().findAll({ queryKey: ['score-metrics'] })).toHaveLength(2);
+    });
+  });
+
+  describe('when a scorer has more than one page of scores', () => {
+    type ScoresRequestParams = { page: string | null; field: string | null; direction: string | null };
+
+    const usePaginatedScoresHandlers = (onScoresRequest: (params: ScoresRequestParams) => void) => {
+      server.use(
+        http.get(`${BASE_URL}/api/scores/scorers`, () => HttpResponse.json(scoreMetricsScorers)),
+        http.get(`${BASE_URL}/api/observability/scores`, ({ request }) => {
+          const params = new URL(request.url).searchParams;
+          onScoresRequest({ page: params.get('page'), field: params.get('field'), direction: params.get('direction') });
+          return HttpResponse.json(params.get('page') === '0' ? scoreMetricsFirstPage : scoreMetricsLastPage);
+        }),
+      );
+    };
+
+    it('requests pages until hasMore is false', async () => {
+      const onScoresRequest = vi.fn<(params: ScoresRequestParams) => void>();
+      usePaginatedScoresHandlers(onScoresRequest);
+
+      const { result } = renderHookWithProviders(() => useScoreMetrics());
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(onScoresRequest.mock.calls.map(([{ page }]) => page)).toEqual(['0', '1']);
+    });
+
+    it('requests every page ordered by timestamp descending', async () => {
+      const onScoresRequest = vi.fn<(params: ScoresRequestParams) => void>();
+      usePaginatedScoresHandlers(onScoresRequest);
+
+      const { result } = renderHookWithProviders(() => useScoreMetrics());
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      for (const [{ field, direction }] of onScoresRequest.mock.calls) {
+        expect({ field, direction }).toEqual({ field: 'timestamp', direction: 'DESC' });
+      }
+    });
+
+    it('aggregates scores from every page', async () => {
+      const onScoresRequest = vi.fn<(page: string | null) => void>();
+      usePaginatedScoresHandlers(onScoresRequest);
+
+      const { result } = renderHookWithProviders(() => useScoreMetrics());
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data?.summaryData).toEqual([{ scorer: 'quality', avg: 0.6, min: 0.2, max: 0.8, count: 3 }]);
     });
   });
 

--- a/packages/playground/src/domains/scores/hooks/__tests__/use-score-metrics.msw.test.tsx
+++ b/packages/playground/src/domains/scores/hooks/__tests__/use-score-metrics.msw.test.tsx
@@ -95,7 +95,7 @@ describe('useScoreMetrics', () => {
     });
 
     it('aggregates scores from every page', async () => {
-      const onScoresRequest = vi.fn<(page: string | null) => void>();
+      const onScoresRequest = vi.fn<(params: ScoresRequestParams) => void>();
       usePaginatedScoresHandlers(onScoresRequest);
 
       const { result } = renderHookWithProviders(() => useScoreMetrics());
@@ -105,7 +105,7 @@ describe('useScoreMetrics', () => {
     });
 
     it('charts time buckets from every page', async () => {
-      const onScoresRequest = vi.fn<(page: string | null) => void>();
+      const onScoresRequest = vi.fn<(params: ScoresRequestParams) => void>();
       usePaginatedScoresHandlers(onScoresRequest);
 
       const { result } = renderHookWithProviders(() => useScoreMetrics());

--- a/packages/playground/src/domains/scores/hooks/__tests__/use-score-metrics.msw.test.tsx
+++ b/packages/playground/src/domains/scores/hooks/__tests__/use-score-metrics.msw.test.tsx
@@ -103,6 +103,19 @@ describe('useScoreMetrics', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data?.summaryData).toEqual([{ scorer: 'quality', avg: 0.6, min: 0.2, max: 0.8, count: 3 }]);
     });
+
+    it('charts time buckets from every page', async () => {
+      const onScoresRequest = vi.fn<(page: string | null) => void>();
+      usePaginatedScoresHandlers(onScoresRequest);
+
+      const { result } = renderHookWithProviders(() => useScoreMetrics());
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data?.overTimeData).toEqual([
+        expect.objectContaining({ quality: 0.2 }),
+        expect.objectContaining({ quality: 0.8 }),
+      ]);
+    });
   });
 
   describe('when no date range is supplied', () => {

--- a/packages/playground/src/domains/scores/hooks/use-score-metrics.ts
+++ b/packages/playground/src/domains/scores/hooks/use-score-metrics.ts
@@ -33,20 +33,28 @@ export function useScoreMetrics(dateRange?: ScoreMetricsDateRange) {
       }
 
       // Fetch scores from the new observability scores API.
-      // Fetch per-scorer to keep queries bounded.
+      // Fetch per-scorer to keep queries bounded, paginating through all
+      // pages so no scores are silently dropped.
       const allResults = await Promise.all(
-        scorerIds.map(scorerId =>
-          client.listScores({
-            filters: { scorerId, timestamp },
-            pagination: { page: 0, perPage: 100 },
-            orderBy: { field: 'timestamp', direction: 'DESC' },
-          }),
-        ),
+        scorerIds.map(async scorerId => {
+          const scores = [];
+          let page = 0;
+          while (true) {
+            const response = await client.listScores({
+              filters: { scorerId, timestamp },
+              pagination: { page, perPage: 100 },
+              orderBy: { field: 'timestamp', direction: 'DESC' },
+            });
+            scores.push(...response.scores);
+            if (!response.pagination?.hasMore) break;
+            page++;
+          }
+          return scores;
+        }),
       );
 
       const allScores: Array<{ scorerId: string; score: number; timestamp: string }> = [];
-      for (let i = 0; i < scorerIds.length; i++) {
-        const scores = allResults[i]?.scores ?? [];
+      for (const scores of allResults) {
         for (const s of scores) {
           allScores.push({
             scorerId: s.scorerId,


### PR DESCRIPTION
## Description

The Studio Evaluation overview (`/evaluation`) fetched each scorer's scores with a single `listScores` call (`page: 0, perPage: 100`) and never followed `pagination.hasMore`, so any scorer with more than 100 scores had its "Over Time" chart and Summary stats silently truncated to the newest 100 rows. With the default "All" range, weeks of history rendered as a single day and the averages were computed from the truncated slice.

## Before
<img width="1438" height="1003" alt="image" src="https://github.com/user-attachments/assets/96da2845-a8dd-450d-b2bc-96a389382018" />

## After
<img width="1422" height="1035" alt="image" src="https://github.com/user-attachments/assets/78abd5e6-6b2b-4bba-824a-343563bc86d9" />

Fixes #22540

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The Evaluation overview now loads all scores for each scorer instead of only the newest 100. Charts and summary statistics are now accurate for scorers with long histories.

## Changes

- Follow `pagination.hasMore` when fetching scores.
- Aggregate scores across all pages for each scorer.
- Preserve timestamp-descending ordering.
- Add MSW tests for pagination, aggregation, and cross-page time buckets.
- Add a changeset for `@internal/playground`.

## Validation

- Verified with 170 scores spanning 21 days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->