### PR TITLE
fix(core): parent durable stream processor spans under the agent run

### DIFF
--- a/.changeset/legal-symbols-fry.md
+++ b/.changeset/legal-symbols-fry.md
@@ -2,4 +2,11 @@
 '@mastra/core': patch
 ---
 
-Fixed durable agent traces being polluted by output-stream processor spans. The durable per-chunk processor pipeline ran without a tracing context, so every `output stream processor` span exported with no parent — creating orphan trace roots that could rename the whole trace in span stores (the trace list then showed a processor id instead of the agent). These spans now nest under the run's `agent run` span, including tool-call chunks and resumed runs, and the tool-call pipeline ends its processor spans as soon as its chunk is processed. A processor span whose ancestors cannot reach exporters is no longer created at all, so context-less callers can never mint orphan trace roots. Fixes #22602
+Fixed durable agent traces being polluted by output-stream processor spans. The durable per-chunk processor pipeline ran without a tracing context, so every `output stream processor` span exported with no parent. Span stores that label a trace by its newest root row then showed a processor id instead of the agent.
+
+- Output-stream processor spans now nest under the run's `agent run` span.
+- Tool-call chunks and resumed runs parent their processor spans the same way.
+- The tool-call pipeline ends its processor spans right after each chunk, so none stay open.
+- Callers without a tracing context no longer create processor spans, so orphan trace roots can never appear.
+
+Fixes #22602

--- a/.changeset/legal-symbols-fry.md
+++ b/.changeset/legal-symbols-fry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed durable agent traces being polluted by output-stream processor spans. The durable per-chunk processor pipeline ran without a tracing context, so every `output stream processor` span exported with no parent — creating orphan trace roots that could rename the whole trace in span stores (the trace list then showed a processor id instead of the agent). These spans now nest under the run's `agent run` span, including tool-call chunks and resumed runs, and the tool-call pipeline ends its processor spans as soon as its chunk is processed. A processor span whose ancestors cannot reach exporters is no longer created at all, so context-less callers can never mint orphan trace roots. Fixes #22602

--- a/observability/mastra/src/durable-agent-tracing.integration.test.ts
+++ b/observability/mastra/src/durable-agent-tracing.integration.test.ts
@@ -13,7 +13,9 @@ import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-
 import { Agent } from '@mastra/core/agent';
 import { createDurableAgent, createEventedAgent } from '@mastra/core/agent/durable';
 import { Mastra } from '@mastra/core/mastra';
+import type { Processor, ProcessOutputStreamArgs } from '@mastra/core/processors';
 import { MockStore } from '@mastra/core/storage';
+import type { ChunkType } from '@mastra/core/stream';
 import { createTool } from '@mastra/core/tools';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { z } from 'zod';
@@ -92,6 +94,21 @@ function errorModel() {
       warnings: [],
     }),
   });
+}
+
+/** Pass-through output processor that runs per-chunk via processOutputStream. */
+class PassThroughStreamProcessor implements Processor {
+  readonly id: string;
+  readonly name: string;
+
+  constructor(id: string) {
+    this.id = id;
+    this.name = `Stream: ${id}`;
+  }
+
+  async processOutputStream(args: ProcessOutputStreamArgs): Promise<ChunkType | null | undefined> {
+    return args.part;
+  }
 }
 
 const weatherTool = createTool({
@@ -201,6 +218,71 @@ describe('durable-agent observability — full span tree (real exporter)', () =>
     expect(testExporter.getSpansByType('agent_run' as any)).toHaveLength(1);
     // Regression guard for the durable-specific gap: MODEL_STEP + MODEL_INFERENCE
     // must close on error (reportGenerationError closes its open children).
+    expect(testExporter.getIncompleteSpans()).toHaveLength(0);
+  });
+
+  it('DurableAgent output stream processors: PROCESSOR_RUN spans parent under AGENT_RUN, never orphan roots', async () => {
+    const agent = new Agent({
+      id: 'a',
+      name: 'a',
+      instructions: 'x',
+      model: textModel('Hello') as any,
+      outputProcessors: [new PassThroughStreamProcessor('stream-a'), new PassThroughStreamProcessor('stream-b')],
+    });
+    const { wrapped } = buildMastra(testExporter, agent, 'durable');
+    await runToCompletion(wrapped, 'hi', testExporter);
+
+    // one trace, and the agent_run is the only span without a parentSpanId —
+    // processor spans must not export as extra root rows (stores label the
+    // trace by its latest parentless row)
+    expect(testExporter.getTraceIds()).toHaveLength(1);
+    const agentRuns = testExporter.getSpansByType('agent_run' as any);
+    expect(agentRuns).toHaveLength(1);
+    const parentless = testExporter.getAllSpans().filter((s: any) => !s.parentSpanId);
+    expect(parentless.map(idOf)).toEqual([idOf(agentRuns[0])]);
+
+    const processorSpans = testExporter
+      .getAllSpans()
+      .filter((s: any) => typeof s.name === 'string' && s.name.startsWith('output stream processor:'));
+    expect(processorSpans.map((s: any) => s.name).sort()).toEqual([
+      'output stream processor: stream-a',
+      'output stream processor: stream-b',
+    ]);
+    for (const span of processorSpans) {
+      expect(parentOf(span)).toBe(idOf(agentRuns[0]));
+      expect((span as any).traceId).toBe((agentRuns[0] as any).traceId);
+    }
+    expect(testExporter.getIncompleteSpans()).toHaveLength(0);
+  });
+
+  it('DurableAgent tool call with output stream processors: every PROCESSOR_RUN span has a parent on the agent trace', async () => {
+    const agent = new Agent({
+      id: 'a',
+      name: 'a',
+      instructions: 'use the tool',
+      model: toolThenTextModel('get_weather', { city: 'Paris' }, 'It is 21C in Paris.') as any,
+      tools: { get_weather: weatherTool },
+      outputProcessors: [new PassThroughStreamProcessor('stream-a')],
+    });
+    const { wrapped } = buildMastra(testExporter, agent, 'durable');
+    await runToCompletion(wrapped, 'weather in paris?', testExporter);
+
+    expect(testExporter.getTraceIds()).toHaveLength(1);
+    const agentRuns = testExporter.getSpansByType('agent_run' as any);
+    expect(agentRuns).toHaveLength(1);
+    const parentless = testExporter.getAllSpans().filter((s: any) => !s.parentSpanId);
+    expect(parentless.map(idOf)).toEqual([idOf(agentRuns[0])]);
+
+    // the tool-call step runs the same processors through its own state map, so
+    // more than one span per processor may exist — all must be parented on this trace
+    const processorSpans = testExporter
+      .getAllSpans()
+      .filter((s: any) => typeof s.name === 'string' && s.name.startsWith('output stream processor:'));
+    expect(processorSpans.length).toBeGreaterThanOrEqual(1);
+    for (const span of processorSpans) {
+      expect(parentOf(span)).toBe(idOf(agentRuns[0]));
+      expect((span as any).traceId).toBe((agentRuns[0] as any).traceId);
+    }
     expect(testExporter.getIncompleteSpans()).toHaveLength(0);
   });
 

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -1849,6 +1849,7 @@ export class DurableAgent<
       structuredOutput: registryEntry.structuredOutput as any,
       outputProcessors: registryEntry.outputProcessors,
       requestContext: registryEntry.requestContext,
+      tracingContext: registryEntry.agentSpan ? { currentSpan: registryEntry.agentSpan } : undefined,
       messageList,
     });
 
@@ -2136,6 +2137,60 @@ export class DurableAgent<
     // (resumeGenerate) would immediately close on the replayed SUSPENDED.
     const resumeOffset = await this.#getPubsubOffset(runId);
 
+    // Open a fresh AGENT_RUN + MODEL_GENERATION for the resumed segment on the same
+    // traceId — the originals were ended as `suspended` and can't be reopened. Post-resume
+    // steps + terminal end() target these via the registry override. (Linking = follow-up.)
+    // Opened before the stream adapter so its per-chunk processor spans can parent
+    // under the resumed root.
+    const origTraceId = entry.agentSpan?.traceId;
+    const origSpanId = entry.agentSpan?.id;
+    if (origTraceId && this.#mastra?.observability) {
+      try {
+        const ag = this.#wrappedAgent as Agent<string, any, any>;
+        // Match non-durable Agent.stream() resume-span shape: same name suffix
+        // `(resumed)`, forward agent-level tracingPolicy, link to the original
+        // span via `resumedFromSpanId` metadata, and carry the resolvedVersionId.
+        const rawConfig = typeof (ag as any).toRawConfig === 'function' ? (ag as any).toRawConfig() : undefined;
+        const resolvedVersionId = rawConfig?.resolvedVersionId as string | undefined;
+        const agentTracingPolicy = typeof ag.getTracingPolicy === 'function' ? ag.getTracingPolicy() : undefined;
+        const resumeAgentSpan = getOrCreateSpan({
+          type: SpanType.AGENT_RUN,
+          name: `agent run: '${ag.id}' (resumed)`,
+          entityType: EntityType.AGENT,
+          entityId: ag.id,
+          entityName: ag.name,
+          metadata: {
+            runId,
+            resumed: true,
+            ...(origSpanId ? { resumedFromSpanId: origSpanId } : {}),
+            ...(resolvedVersionId ? { entityVersionId: resolvedVersionId } : {}),
+          },
+          tracingPolicy: agentTracingPolicy,
+          tracingOptions: { traceId: origTraceId },
+          requestContext: resolvedOptions.requestContext,
+          mastra: this.#mastra,
+        });
+        const resumeModelSpan = resumeAgentSpan?.createChildSpan({
+          type: SpanType.MODEL_GENERATION,
+          name: `llm: '${resumeModel?.modelId ?? ''}'`,
+          attributes: { model: resumeModel?.modelId, provider: resumeModel?.provider, streaming: true },
+          metadata: { runId, resumed: true },
+          requestContext: resolvedOptions.requestContext,
+        });
+        for (const reg of [entry, globalRunRegistry.get(runId)]) {
+          if (!reg) continue;
+          reg.resumeAgentSpan = resumeAgentSpan;
+          reg.resumeModelSpan = resumeModelSpan;
+          reg.resumeAgentSpanData = resumeAgentSpan?.exportSpan();
+          reg.resumeModelSpanData = resumeModelSpan?.exportSpan();
+        }
+      } catch (error) {
+        // Span bookkeeping must never block resume.
+        this.#mastra?.getLogger?.()?.warn?.(`[DurableAgent] Failed to open resume spans: ${error}`);
+      }
+    }
+    const resumeSegmentSpan = entry.resumeAgentSpan ?? entry.agentSpan;
+
     const {
       output,
       cleanup: streamCleanup,
@@ -2166,63 +2221,13 @@ export class DurableAgent<
       structuredOutput: entry.structuredOutput as any,
       outputProcessors: entry.outputProcessors,
       requestContext: resolvedOptions.requestContext,
+      tracingContext: resumeSegmentSpan ? { currentSpan: resumeSegmentSpan } : undefined,
       messageList: globalEntry?.messageList ?? this.#runRegistry.getMessageList(runId),
     });
 
     // Wait for subscription to be ready, then resume workflow
     const workflow = this.getWorkflow();
     const requestContext = resolvedOptions.requestContext;
-
-    // Open a fresh AGENT_RUN + MODEL_GENERATION for the resumed segment on the same
-    // traceId — the originals were ended as `suspended` and can't be reopened. Post-resume
-    // steps + terminal end() target these via the registry override. (Linking = follow-up.)
-    const origTraceId = entry.agentSpan?.traceId;
-    const origSpanId = entry.agentSpan?.id;
-    if (origTraceId && this.#mastra?.observability) {
-      try {
-        const ag = this.#wrappedAgent as Agent<string, any, any>;
-        // Match non-durable Agent.stream() resume-span shape: same name suffix
-        // `(resumed)`, forward agent-level tracingPolicy, link to the original
-        // span via `resumedFromSpanId` metadata, and carry the resolvedVersionId.
-        const rawConfig = typeof (ag as any).toRawConfig === 'function' ? (ag as any).toRawConfig() : undefined;
-        const resolvedVersionId = rawConfig?.resolvedVersionId as string | undefined;
-        const agentTracingPolicy = typeof ag.getTracingPolicy === 'function' ? ag.getTracingPolicy() : undefined;
-        const resumeAgentSpan = getOrCreateSpan({
-          type: SpanType.AGENT_RUN,
-          name: `agent run: '${ag.id}' (resumed)`,
-          entityType: EntityType.AGENT,
-          entityId: ag.id,
-          entityName: ag.name,
-          metadata: {
-            runId,
-            resumed: true,
-            ...(origSpanId ? { resumedFromSpanId: origSpanId } : {}),
-            ...(resolvedVersionId ? { entityVersionId: resolvedVersionId } : {}),
-          },
-          tracingPolicy: agentTracingPolicy,
-          tracingOptions: { traceId: origTraceId },
-          requestContext,
-          mastra: this.#mastra,
-        });
-        const resumeModelSpan = resumeAgentSpan?.createChildSpan({
-          type: SpanType.MODEL_GENERATION,
-          name: `llm: '${resumeModel?.modelId ?? ''}'`,
-          attributes: { model: resumeModel?.modelId, provider: resumeModel?.provider, streaming: true },
-          metadata: { runId, resumed: true },
-          requestContext,
-        });
-        for (const reg of [entry, globalRunRegistry.get(runId)]) {
-          if (!reg) continue;
-          reg.resumeAgentSpan = resumeAgentSpan;
-          reg.resumeModelSpan = resumeModelSpan;
-          reg.resumeAgentSpanData = resumeAgentSpan?.exportSpan();
-          reg.resumeModelSpanData = resumeModelSpan?.exportSpan();
-        }
-      } catch (error) {
-        // Span bookkeeping must never block resume.
-        this.#mastra?.getLogger?.()?.warn?.(`[DurableAgent] Failed to open resume spans: ${error}`);
-      }
-    }
 
     // Capture the prior workflow execution BEFORE creating the new promise.
     // If we read it inside the `.then()` callback, the global registry will
@@ -2783,6 +2788,7 @@ export class DurableAgent<
       structuredOutput: registryEntry.structuredOutput as any,
       outputProcessors: registryEntry.outputProcessors,
       requestContext: registryEntry.requestContext,
+      tracingContext: registryEntry.agentSpan ? { currentSpan: registryEntry.agentSpan } : undefined,
       messageList,
     });
 
@@ -3206,6 +3212,11 @@ export class DurableAgent<
       }
     };
 
+    // Parent per-chunk processor spans under the run's live root when this
+    // process holds it (resumed segment wins over the original).
+    const observedEntry = globalRunRegistry.get(runId) ?? this.#runRegistry.get(runId);
+    const observedAgentSpan = observedEntry?.resumeAgentSpan ?? observedEntry?.agentSpan;
+
     const stream = createDurableAgentStream<TOutput>({
       pubsub: this.pubsub,
       runId,
@@ -3236,6 +3247,7 @@ export class DurableAgent<
       onSuspended: options?.onSuspended,
       structuredOutput: this.#runRegistry.get(runId)?.structuredOutput as any,
       outputProcessors: this.#runRegistry.get(runId)?.outputProcessors,
+      tracingContext: observedAgentSpan ? { currentSpan: observedAgentSpan } : undefined,
       messageList: globalRunRegistry.get(runId)?.messageList ?? this.#runRegistry.getMessageList(runId),
     });
     const { output, ready } = stream;

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -2140,8 +2140,7 @@ export class DurableAgent<
     // Open a fresh AGENT_RUN + MODEL_GENERATION for the resumed segment on the same
     // traceId — the originals were ended as `suspended` and can't be reopened. Post-resume
     // steps + terminal end() target these via the registry override. (Linking = follow-up.)
-    // Opened before the stream adapter so its per-chunk processor spans can parent
-    // under the resumed root.
+    // Opened before the stream adapter so per-chunk processor spans parent under it.
     const origTraceId = entry.agentSpan?.traceId;
     const origSpanId = entry.agentSpan?.id;
     if (origTraceId && this.#mastra?.observability) {
@@ -3212,8 +3211,6 @@ export class DurableAgent<
       }
     };
 
-    // Parent per-chunk processor spans under the run's live root when this
-    // process holds it (resumed segment wins over the original).
     const observedEntry = globalRunRegistry.get(runId) ?? this.#runRegistry.get(runId);
     const observedAgentSpan = observedEntry?.resumeAgentSpan ?? observedEntry?.agentSpan;
 

--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -122,11 +122,7 @@ export interface DurableAgentStreamOptions<OUTPUT = undefined> {
   outputProcessors?: OutputProcessorOrWorkflow[];
   /** Run context passed to output processors for every streamed chunk. */
   requestContext?: RequestContext;
-  /**
-   * Tracing context whose current span is the run's AGENT_RUN span. Output
-   * processors run per-chunk in MastraModelOutput's pipeline; without this
-   * context their PROCESSOR_RUN spans export as orphan trace roots.
-   */
+  /** Tracing context whose current span is the run's AGENT_RUN span; parents per-chunk processor spans. */
   tracingContext?: TracingContext;
   /** Experimental transforms applied whenever the returned full stream is consumed. */
   experimentalTransform?: MastraStreamTransformOptions<OUTPUT>;
@@ -638,9 +634,6 @@ export function createDurableAgentStream<OUTPUT = undefined>(
       resolveFinalPromises: true,
       outputProcessors,
       requestContext,
-      // Parent per-chunk PROCESSOR_RUN spans under the run's AGENT_RUN span
-      // (the processor pipeline resolves its observability context from these
-      // options); without it they export as orphan trace roots.
       tracingContext,
       experimentalTransform,
     },

--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -2,6 +2,7 @@ import { ReadableStream } from 'node:stream/web';
 import type { PubSub } from '../../events/pubsub';
 import type { Event } from '../../events/types';
 import type { IMastraLogger } from '../../logger';
+import type { TracingContext } from '../../observability';
 import type { OutputProcessorOrWorkflow } from '../../processors';
 import type { RequestContext } from '../../request-context';
 import { safeClose, safeEnqueue } from '../../stream/base';
@@ -121,6 +122,12 @@ export interface DurableAgentStreamOptions<OUTPUT = undefined> {
   outputProcessors?: OutputProcessorOrWorkflow[];
   /** Run context passed to output processors for every streamed chunk. */
   requestContext?: RequestContext;
+  /**
+   * Tracing context whose current span is the run's AGENT_RUN span. Output
+   * processors run per-chunk in MastraModelOutput's pipeline; without this
+   * context their PROCESSOR_RUN spans export as orphan trace roots.
+   */
+  tracingContext?: TracingContext;
   /** Experimental transforms applied whenever the returned full stream is consumed. */
   experimentalTransform?: MastraStreamTransformOptions<OUTPUT>;
   /**
@@ -176,6 +183,7 @@ export function createDurableAgentStream<OUTPUT = undefined>(
     structuredOutput,
     outputProcessors,
     requestContext,
+    tracingContext,
     experimentalTransform,
     messageList: externalMessageList,
   } = options;
@@ -630,6 +638,10 @@ export function createDurableAgentStream<OUTPUT = undefined>(
       resolveFinalPromises: true,
       outputProcessors,
       requestContext,
+      // Parent per-chunk PROCESSOR_RUN spans under the run's AGENT_RUN span
+      // (the processor pipeline resolves its observability context from these
+      // options); without it they export as orphan trace roots.
+      tracingContext,
       experimentalTransform,
     },
   });

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -6,8 +6,8 @@ import type { PubSub } from '../../../../events/pubsub';
 import type { Mastra } from '../../../../mastra';
 import type { MastraMemory } from '../../../../memory/memory';
 import type { MemoryConfig } from '../../../../memory/types';
-import { EntityType, SpanType } from '../../../../observability';
-import type { ExportedSpan } from '../../../../observability';
+import { EntityType, SpanType, createObservabilityContext } from '../../../../observability';
+import type { ExportedSpan, ObservabilityContext } from '../../../../observability';
 import type { ProcessorState } from '../../../../processors';
 import { ProcessorRunner } from '../../../../processors/runner';
 import type { ChunkType } from '../../../../stream/types';
@@ -142,6 +142,7 @@ async function processChunkThroughOutputProcessors(
   agentName: string,
   logger: any,
   messageList?: MessageList,
+  observabilityContext?: ObservabilityContext,
 ): Promise<ChunkType | null> {
   if (!registryEntry?.outputProcessors?.length || !registryEntry.processorStates) {
     return chunk;
@@ -165,7 +166,7 @@ async function processChunkThroughOutputProcessors(
     } = await runner.processPart(
       chunk,
       registryEntry.processorStates as Map<string, ProcessorState>,
-      undefined, // observabilityContext
+      observabilityContext,
       registryEntry.requestContext,
       messageList,
       0,
@@ -177,6 +178,11 @@ async function processChunkThroughOutputProcessors(
           }
         : undefined,
     );
+
+    // This pipeline only ever sees single tool chunks — the `finish` chunk that
+    // normally ends stream-processor spans flows through the consumer-side
+    // pipeline, not this one — so end the spans opened for this chunk now.
+    runner.endStreamProcessorSpans(registryEntry.processorStates as Map<string, ProcessorState>);
 
     if (blocked) {
       // Emit a tripwire chunk so downstream knows about the block
@@ -326,6 +332,23 @@ export function createDurableToolCallStep() {
       // back to the Mastra-wide tool registry (exact name, provider-tool
       // name, then by id). Mirrors the non-durable tool-call step.
       const registryEntry = globalRunRegistry.get(runId);
+      const observability = (mastra as Mastra | undefined)?.observability?.getSelectedInstance({ requestContext });
+
+      // Parent per-chunk PROCESSOR_RUN spans under the run's AGENT_RUN span (live
+      // registry span in-process, rebuilt from the forwarded span data cross-process).
+      // Without a tracing context the processor workflow roots a detached internal
+      // tree and the public processor spans export as orphan trace roots.
+      const processorAgentSpanData = registryEntry?.resumeAgentSpanData ?? initData.agentSpanData;
+      const processorAgentSpan =
+        registryEntry?.resumeAgentSpan ??
+        registryEntry?.agentSpan ??
+        (processorAgentSpanData && observability
+          ? observability.rebuildSpan(processorAgentSpanData as ExportedSpan<SpanType.AGENT_RUN>)
+          : undefined);
+      const processorObservabilityContext = processorAgentSpan
+        ? createObservabilityContext({ currentSpan: processorAgentSpan })
+        : undefined;
+
       let tool = registryEntry?.tools?.[toolName];
       let mastraTools: Record<string, any> | undefined;
       // Tools rebuilt from the Mastra instance when the per-process registry is
@@ -737,6 +760,7 @@ export function createDurableToolCallStep() {
                 initData.agentId,
                 logger,
                 messageList,
+                processorObservabilityContext,
               );
               if (processed) {
                 await emitChunkEvent(pubsub, runId, processed);
@@ -828,7 +852,6 @@ export function createDurableToolCallStep() {
 
       // Rebuild the forwarded model_step span and pass it as the tool's tracing context so
       // the TOOL_CALL span nests under the LLM call (matches the non-durable path).
-      const observability = (mastra as Mastra | undefined)?.observability?.getSelectedInstance({ requestContext });
       const stepSpan =
         typedInput.stepSpanData && observability
           ? observability.rebuildSpan(typedInput.stepSpanData as ExportedSpan<SpanType.MODEL_STEP>)
@@ -1372,6 +1395,7 @@ export function createDurableToolCallStep() {
               initData.agentId,
               logger,
               messageList,
+              processorObservabilityContext,
             );
             if (processed) {
               await emitChunkEvent(pubsub, runId, processed);
@@ -1423,6 +1447,7 @@ export function createDurableToolCallStep() {
               initData.agentId,
               logger,
               messageList,
+              processorObservabilityContext,
             );
             if (processed) {
               await emitChunkEvent(pubsub, runId, processed);

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -148,15 +148,15 @@ async function processChunkThroughOutputProcessors(
     return chunk;
   }
 
-  try {
-    const runner = new ProcessorRunner({
-      inputProcessors: [],
-      outputProcessors: registryEntry.outputProcessors,
-      logger,
-      agentName,
-      processorStates: registryEntry.processorStates,
-    });
+  const runner = new ProcessorRunner({
+    inputProcessors: [],
+    outputProcessors: registryEntry.outputProcessors,
+    logger,
+    agentName,
+    processorStates: registryEntry.processorStates,
+  });
 
+  try {
     const {
       part: processed,
       blocked,
@@ -179,11 +179,6 @@ async function processChunkThroughOutputProcessors(
         : undefined,
     );
 
-    // This pipeline only ever sees single tool chunks — the `finish` chunk that
-    // normally ends stream-processor spans flows through the consumer-side
-    // pipeline, not this one — so end the spans opened for this chunk now.
-    runner.endStreamProcessorSpans(registryEntry.processorStates as Map<string, ProcessorState>);
-
     if (blocked) {
       // Emit a tripwire chunk so downstream knows about the block
       if (pubsub) {
@@ -205,6 +200,10 @@ async function processChunkThroughOutputProcessors(
     logger?.warn?.(`[DurableAgent] Output processor error for tool chunk: ${error}`);
     // Fall through: emit the original chunk if processor fails
     return chunk;
+  } finally {
+    // The finish chunk that normally ends stream-processor spans never reaches
+    // this pipeline, so end the spans opened for this chunk here.
+    runner.endStreamProcessorSpans(registryEntry.processorStates as Map<string, ProcessorState>);
   }
 }
 
@@ -334,10 +333,8 @@ export function createDurableToolCallStep() {
       const registryEntry = globalRunRegistry.get(runId);
       const observability = (mastra as Mastra | undefined)?.observability?.getSelectedInstance({ requestContext });
 
-      // Parent per-chunk PROCESSOR_RUN spans under the run's AGENT_RUN span (live
-      // registry span in-process, rebuilt from the forwarded span data cross-process).
-      // Without a tracing context the processor workflow roots a detached internal
-      // tree and the public processor spans export as orphan trace roots.
+      // Tracing context for per-chunk PROCESSOR_RUN spans: the run's AGENT_RUN span (live
+      // in-process, rebuilt cross-process). Without it they export as orphan trace roots.
       const processorAgentSpanData = registryEntry?.resumeAgentSpanData ?? initData.agentSpanData;
       const processorAgentSpan =
         registryEntry?.resumeAgentSpan ??

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1025,9 +1025,8 @@ function createStepFromProcessor<TProcessorId extends string>(
       // - For input/outputResult: find AGENT_RUN (processor runs once at start/end)
       // - For inputStep/outputStep/toolResult: find MODEL_STEP (processor runs per LLM call / tool round-trip)
       // When workflow is executed, currentSpan is WORKFLOW_STEP, so we walk up the parent chain
-      // Only fall back to currentSpan when its tree can reach exporters: a context-less
-      // caller leaves currentSpan on a detached internal workflow tree, and a public
-      // processor span parented there would export as an orphan trace root.
+      // Fall back to currentSpan only when its tree can reach exporters — otherwise
+      // the public processor span would export as an orphan trace root.
       const fallbackSpan = currentSpan && getRootExportSpan(currentSpan) ? currentSpan : undefined;
       const parentSpan =
         phase === 'inputStep' || phase === 'outputStep' || phase === 'toolResult'

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -23,6 +23,7 @@ import {
   SpanType,
   createObservabilityContext,
   getOrCreateSpan,
+  getRootExportSpan,
   resolveObservabilityContext,
 } from '../../observability';
 import type { ObservabilityContext, TracingContext, TracingPolicy } from '../../observability';
@@ -1024,10 +1025,14 @@ function createStepFromProcessor<TProcessorId extends string>(
       // - For input/outputResult: find AGENT_RUN (processor runs once at start/end)
       // - For inputStep/outputStep/toolResult: find MODEL_STEP (processor runs per LLM call / tool round-trip)
       // When workflow is executed, currentSpan is WORKFLOW_STEP, so we walk up the parent chain
+      // Only fall back to currentSpan when its tree can reach exporters: a context-less
+      // caller leaves currentSpan on a detached internal workflow tree, and a public
+      // processor span parented there would export as an orphan trace root.
+      const fallbackSpan = currentSpan && getRootExportSpan(currentSpan) ? currentSpan : undefined;
       const parentSpan =
         phase === 'inputStep' || phase === 'outputStep' || phase === 'toolResult'
-          ? currentSpan?.findParent(SpanType.MODEL_STEP) || currentSpan
-          : currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan;
+          ? currentSpan?.findParent(SpanType.MODEL_STEP) || fallbackSpan
+          : currentSpan?.findParent(SpanType.AGENT_RUN) || fallbackSpan;
 
       const processorSpan =
         phase !== 'outputStream'

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -27,6 +27,7 @@ import {
   SpanType,
   createObservabilityContext,
   getOrCreateSpan,
+  getRootExportSpan,
   resolveObservabilityContext,
 } from '../observability';
 import { executeWithContext } from '../observability/utils';
@@ -924,10 +925,14 @@ function createStepFromProcessor<TProcessorId extends string>(
       // - For input/outputResult: find AGENT_RUN (processor runs once at start/end)
       // - For inputStep/outputStep/toolResult: find MODEL_STEP (processor runs per LLM call / tool round-trip)
       // When workflow is executed, currentSpan is WORKFLOW_STEP, so we walk up the parent chain
+      // Only fall back to currentSpan when its tree can reach exporters: a context-less
+      // caller leaves currentSpan on a detached internal workflow tree, and a public
+      // processor span parented there would export as an orphan trace root.
+      const fallbackSpan = currentSpan && getRootExportSpan(currentSpan) ? currentSpan : undefined;
       const parentSpan =
         phase === 'inputStep' || phase === 'outputStep' || phase === 'toolResult'
-          ? currentSpan?.findParent(SpanType.MODEL_STEP) || currentSpan
-          : currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan;
+          ? currentSpan?.findParent(SpanType.MODEL_STEP) || fallbackSpan
+          : currentSpan?.findParent(SpanType.AGENT_RUN) || fallbackSpan;
 
       const processorSpan =
         phase !== 'outputStream'

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -925,9 +925,8 @@ function createStepFromProcessor<TProcessorId extends string>(
       // - For input/outputResult: find AGENT_RUN (processor runs once at start/end)
       // - For inputStep/outputStep/toolResult: find MODEL_STEP (processor runs per LLM call / tool round-trip)
       // When workflow is executed, currentSpan is WORKFLOW_STEP, so we walk up the parent chain
-      // Only fall back to currentSpan when its tree can reach exporters: a context-less
-      // caller leaves currentSpan on a detached internal workflow tree, and a public
-      // processor span parented there would export as an orphan trace root.
+      // Fall back to currentSpan only when its tree can reach exporters — otherwise
+      // the public processor span would export as an orphan trace root.
       const fallbackSpan = currentSpan && getRootExportSpan(currentSpan) ? currentSpan : undefined;
       const parentSpan =
         phase === 'inputStep' || phase === 'outputStep' || phase === 'toolResult'


### PR DESCRIPTION
## Description

Durable agents ran their per-chunk output processors with no tracing context, so every `output stream processor` `PROCESSOR_RUN` span exported with `parentSpanId: undefined` and landed in span storage as an orphan trace root. On stores that pick a trace's display root by "latest root row wins" (e.g. `@mastra/pg` VNext), the orphan written last renamed the whole trace after a processor id instead of the agent. This PR threads the run's `AGENT_RUN` tracing context into the durable per-chunk pipeline and hardens the processor-workflow parent resolution so context-less callers can never mint orphan roots.

## Before
<img width="1909" height="987" alt="image" src="https://github.com/user-attachments/assets/61b81c13-6af0-44c3-ae5e-1ca22b9cd3de" />

## After
<img width="1656" height="934" alt="image" src="https://github.com/user-attachments/assets/b582035f-fca0-4511-9e3f-71506e86432a" />

## Related Issue(s)

Fixes #22602

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Durable agent streams now keep processor tracing attached to the correct agent run. This prevents orphan traces and ensures processor spans close correctly after tool calls and resumed runs.

## Changes

- Passes the active `AGENT_RUN` tracing context through durable stream, generate, resume, observe, and tool-call paths.
- Uses the resumed segment’s root span for resumed runs.
- Ends tool-call processor spans after each chunk.
- Prevents detached internal workflow spans from becoming parents of public processor spans.
- Skips processor spans when no tracing context is available.
- Adds integration tests for simple and tool-calling durable runs.
- Adds a patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->