### PR TITLE
fix(server): acknowledge suspended tool responses immediately

### DIFF
--- a/.changeset/twenty-dingos-wash.md
+++ b/.changeset/twenty-dingos-wash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed suspended tool responses timing out while the resumed agent run continues. The endpoint now acknowledges immediately, preventing spurious 504 responses and delayed response-body errors for long-running continuations.

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -233,8 +233,8 @@ describe('agent-controller routes', () => {
     });
   });
 
-  // The messages/steer/follow-up routes ack immediately and let the session
-  // finish the turn in the background. Session methods can still reject (e.g.
+  // The messages/steer/follow-up/tool-suspension routes ack immediately and let
+  // the session finish the turn in the background. Session methods can still reject (e.g.
   // `sendMessage` rejects when signal submission fails before a stream starts),
   // and an unobserved rejection crashes the process on Node's default
   // `--unhandled-rejections=throw` (see mastra-ai/mastra#19734). The routes must
@@ -250,6 +250,11 @@ describe('agent-controller routes', () => {
       { name: 'sendMessage', method: 'sendMessage', route: SEND_AGENT_CONTROLLER_MESSAGE_ROUTE },
       { name: 'steer', method: 'steer', route: STEER_AGENT_CONTROLLER_SESSION_ROUTE },
       { name: 'followUp', method: 'followUp', route: FOLLOW_UP_AGENT_CONTROLLER_SESSION_ROUTE },
+      {
+        name: 'respondToToolSuspension',
+        method: 'respondToToolSuspension',
+        route: AGENT_CONTROLLER_TOOL_SUSPENSION_ROUTE,
+      },
     ] as const;
 
     for (const { name, method, route } of cases) {
@@ -425,6 +430,24 @@ describe('agent-controller routes', () => {
       } as any);
 
       expect(spy).toHaveBeenCalledWith({ toolCallId: 'call-2', resumeData: 'Yes', requestContext });
+    });
+
+    it('acks a tool suspension without waiting for the resumed run to finish', async () => {
+      const session = await getRouteSession('user-suspension-ack');
+      vi.spyOn(session, 'respondToToolSuspension').mockReturnValue(new Promise<void>(() => {}));
+
+      const result = await Promise.race([
+        AGENT_CONTROLLER_TOOL_SUSPENSION_ROUTE.handler({
+          mastra,
+          controllerId: 'code',
+          resourceId: 'user-suspension-ack',
+          toolCallId: 'call-3',
+          resumeData: 'Yes',
+        } as any),
+        new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 50)),
+      ]);
+
+      expect(result).toEqual({ ok: true });
     });
   });
 

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -680,7 +680,15 @@ export const AGENT_CONTROLLER_TOOL_SUSPENSION_ROUTE = createRoute({
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
       const session = await getSession(controller, resourceId, { scope: sessionScope }, requestContext);
-      await session.respondToToolSuspension({ toolCallId, resumeData, requestContext });
+      // A resumed tool drives the run to its next terminal or suspension boundary.
+      // Awaiting it holds this request open until the continuation finishes, which
+      // can trip the request timeout and leave CORS mutating an already-sent response.
+      ackBackgroundSessionWork({
+        work: session.respondToToolSuspension({ toolCallId, resumeData, requestContext }),
+        session,
+        mastra,
+        operation: 'respondToToolSuspension',
+      });
       return { ok: true };
     } catch (error) {
       return handleError(error, 'error responding to controller tool suspension');


### PR DESCRIPTION
Suspended tool responses now return immediately while the resumed run continues in the background. This prevents long plan approvals and other resumed interactions from receiving a spurious 504 after the request timeout.

Before: a plan approval request stayed open until the entire resumed run reached its next boundary.
After: the request returns `{ ok: true }` immediately; progress and errors continue over the session stream.

Tested with `pnpm --filter @mastra/server exec vitest run src/server/handlers/agent-controller.test.ts`.

The broader server suite has four unrelated Google-provider environment failures in `agents.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a tool pauses an agent run, the server now confirms the request immediately. The agent continues in the background, so long approvals do not time out.

## Changes

- Return `{ ok: true }` immediately for suspended tool responses.
- Continue resumed runs asynchronously.
- Report progress and errors through the session stream.
- Log background continuation failures.
- Add tests for immediate acknowledgment and background failures.
- Add a patch changeset for `@mastra/server`.

## Testing

- Targeted agent controller tests passed.
- The broader server suite has four unrelated Google-provider environment failures in `agents.test.ts`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->