### PR TITLE
Improve Studio traces list layout and status display

### DIFF
--- a/.changeset/tame-peas-relate.md
+++ b/.changeset/tame-peas-relate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved the Studio traces list: combined the Date and Time columns into a single Created column, capped the Input column width so other columns stay visible, rendered trace status as a colored badge, and made the list shrink to the viewport instead of scrolling horizontally. Renamed the trace panel action to "Add full trace to dataset".

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -203,7 +203,7 @@ describe('TraceDataPanelView — header actions', () => {
     // The body is hidden while collapsed, so these can only come from the header.
     expect(screen.queryByText('agent run')).toBeNull();
     expect(screen.getByRole('button', { name: /evaluate trace/i })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /save as dataset item/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /add full trace to dataset/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /add tool mocks to item/i })).toBeTruthy();
   });
 
@@ -218,7 +218,7 @@ describe('TraceDataPanelView — header actions', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /save as dataset item/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'root' });
   });
@@ -486,7 +486,7 @@ describe('TraceDataPanelView — the actions row', () => {
     const onSaveAsDatasetItem = vi.fn();
     render(<TraceDataPanelView {...baseProps} onSaveAsDatasetItem={onSaveAsDatasetItem} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /save as dataset item/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'root' });
   });
@@ -555,7 +555,7 @@ describe('TraceDataPanelView — an anchored subtrace', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /save as dataset item/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'child' });
   });
@@ -564,7 +564,7 @@ describe('TraceDataPanelView — an anchored subtrace', () => {
     const onSaveAsDatasetItem = vi.fn();
     render(<TraceDataPanelView {...baseProps} spans={nestedSpanFixture} onSaveAsDatasetItem={onSaveAsDatasetItem} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /save as dataset item/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'root' });
   });
@@ -580,7 +580,7 @@ describe('TraceDataPanelView — an anchored subtrace', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /save as dataset item/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'root' });
   });
@@ -694,7 +694,7 @@ describe('TraceDataPanelView — an anchor the trace does not have', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /save as dataset item/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: undefined });
   });
@@ -715,7 +715,7 @@ describe('TraceDataPanelView — following the spans it is given', () => {
     const otherRoot = [{ ...(rootSpanFixture[0] as (typeof rootSpanFixture)[number]), spanId: 'other-root' }];
     rerender(<TraceDataPanelView {...baseProps} spans={otherRoot} onSaveAsDatasetItem={onSaveAsDatasetItem} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /save as dataset item/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'other-root' });
   });
@@ -740,7 +740,7 @@ describe('TraceDataPanelView — following the spans it is given', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /save as dataset item/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'child' });
   });
@@ -755,7 +755,7 @@ describe('TraceDataPanelView — following the spans it is given', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /save as dataset item/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'root' });
   });

--- a/packages/playground-ui/src/domains/traces/components/__tests__/traces-list-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/traces-list-view.test.tsx
@@ -61,7 +61,7 @@ describe('TracesListView columns', () => {
 
       const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
       assert(grid);
-      expect(grid.style.gridTemplateColumns).toBe('6rem 9rem 14rem minmax(8rem,1fr) 14rem 6rem');
+      expect(grid.style.gridTemplateColumns).toBe('11rem 14rem minmax(8rem,1fr) 14rem 6rem');
     });
   });
 
@@ -88,9 +88,7 @@ describe('TracesListView columns', () => {
 
       const grid = container.querySelector<HTMLElement>('[style*="grid-template-columns"]');
       assert(grid);
-      expect(grid.style.gridTemplateColumns).toBe(
-        '6rem 9rem minmax(14rem,1fr) 6rem 7rem 8rem 8rem 8rem minmax(8rem,14rem)',
-      );
+      expect(grid.style.gridTemplateColumns).toBe('11rem minmax(8rem,1fr) 6rem 7rem 8rem 8rem 8rem minmax(8rem,14rem)');
     });
   });
 });

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -46,7 +46,7 @@ export interface TraceDataPanelViewProps {
   onClose: () => void;
   onSpanSelect?: (spanId: string | undefined) => void;
   onEvaluateTrace?: () => void;
-  /** When set, a "Save as Dataset Item" button appears; the consumer owns the dialog. */
+  /** When set, an "Add full trace to dataset" button appears; the consumer owns the dialog. */
   onSaveAsDatasetItem?: (args: { traceId: string; rootSpanId: string | undefined }) => void;
   /** When set, an "Add tool mocks to item" button appears; the consumer owns the dialog. */
   onAddTraceMocksToItem?: (args: { traceId: string }) => void;
@@ -243,8 +243,8 @@ export function TraceDataPanelView({
               {onSaveAsDatasetItem && (
                 <Button
                   size="md"
-                  tooltip="Save as Dataset Item"
-                  aria-label="Save as Dataset Item"
+                  tooltip="Add full trace to dataset"
+                  aria-label="Add full trace to dataset"
                   onClick={() => onSaveAsDatasetItem({ traceId, rootSpanId: rootSpan?.spanId })}
                 >
                   <SaveIcon />

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -118,7 +118,7 @@ export function TracesListView({
   }, [isLoading]);
 
   if (isLoading) {
-    return <DataListSkeleton columns={columns} />;
+    return <DataListSkeleton columns={columns} fit="container" />;
   }
 
   const virtualItems = virtualizer.getVirtualItems();
@@ -128,10 +128,9 @@ export function TracesListView({
     virtualItems.length > 0 ? Math.max(0, totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0)) : 0;
 
   return (
-    <TracesDataList columns={columns} variant="striped" scrollRef={scrollRef} className="min-w-0">
+    <TracesDataList columns={columns} variant="striped" fit="container" scrollRef={scrollRef} className="min-w-0">
       <TracesDataList.Top>
-        <TracesDataList.TopCell>Date</TracesDataList.TopCell>
-        <TracesDataList.TopCell>Time</TracesDataList.TopCell>
+        <TracesDataList.TopCell>Created</TracesDataList.TopCell>
         <TracesDataList.TopCell>Name</TracesDataList.TopCell>
         {hasTraceColumn(columnPreferences, 'input') && <TracesDataList.TopCell>Input</TracesDataList.TopCell>}
         {hasTraceColumn(columnPreferences, 'entity') && <TracesDataList.TopCell>Entity</TracesDataList.TopCell>}
@@ -184,8 +183,7 @@ export function TracesListView({
                 featured={isFeatured}
                 className={cn(isRecentlyAdded && 'animate-row-highlight')}
               >
-                <TracesDataList.DateCell timestamp={displayDate} />
-                <TracesDataList.TimeCell timestamp={displayDate} />
+                <TracesDataList.CreatedCell timestamp={displayDate} />
                 <TracesDataList.NameCell
                   name={trace.name}
                   parentSpanId={trace.parentSpanId}

--- a/packages/playground-ui/src/domains/traces/trace-list-columns.test.ts
+++ b/packages/playground-ui/src/domains/traces/trace-list-columns.test.ts
@@ -56,9 +56,7 @@ describe('trace list columns', () => {
 
   describe('when the grid is built', () => {
     it('keeps the existing default layout', () => {
-      expect(buildTraceListColumns(DEFAULT_TRACE_COLUMN_PREFERENCES)).toBe(
-        '6rem 9rem 14rem minmax(8rem,1fr) 14rem 6rem',
-      );
+      expect(buildTraceListColumns(DEFAULT_TRACE_COLUMN_PREFERENCES)).toBe('11rem 14rem minmax(8rem,1fr) 14rem 6rem');
     });
 
     it('adds bounded tracks for optional and metadata columns', () => {
@@ -67,7 +65,7 @@ describe('trace list columns', () => {
           visibleColumns: ['duration', 'inputTokens', 'outputTokens', 'estimatedCost'],
           metadataKeys: ['tenant'],
         }),
-      ).toBe('6rem 9rem minmax(14rem,1fr) 6rem 7rem 8rem 8rem 8rem minmax(8rem,14rem)');
+      ).toBe('11rem minmax(8rem,1fr) 6rem 7rem 8rem 8rem 8rem minmax(8rem,14rem)');
     });
   });
 
@@ -167,23 +165,23 @@ describe('trace list columns', () => {
 
   describe('when a single optional column is toggled', () => {
     it.each([
-      ['input', '6rem 9rem 14rem minmax(8rem,1fr) 6rem'],
-      ['entity', '6rem 9rem minmax(14rem,1fr) 14rem 6rem'],
-      ['duration', '6rem 9rem minmax(14rem,1fr) 6rem 7rem'],
-      ['inputTokens', '6rem 9rem minmax(14rem,1fr) 6rem 8rem'],
-      ['outputTokens', '6rem 9rem minmax(14rem,1fr) 6rem 8rem'],
-      ['estimatedCost', '6rem 9rem minmax(14rem,1fr) 6rem 8rem'],
+      ['input', '11rem 14rem minmax(8rem,1fr) 6rem'],
+      ['entity', '11rem minmax(8rem,1fr) 14rem 6rem'],
+      ['duration', '11rem minmax(8rem,1fr) 6rem 7rem'],
+      ['inputTokens', '11rem minmax(8rem,1fr) 6rem 8rem'],
+      ['outputTokens', '11rem minmax(8rem,1fr) 6rem 8rem'],
+      ['estimatedCost', '11rem minmax(8rem,1fr) 6rem 8rem'],
     ] as const)('lays out %s on its own', (column, expected) => {
       expect(buildTraceListColumns({ visibleColumns: [column], metadataKeys: [] })).toBe(expected);
     });
 
     it('widens the second track only when input is hidden', () => {
-      expect(buildTraceListColumns({ visibleColumns: [], metadataKeys: [] })).toBe('6rem 9rem minmax(14rem,1fr) 6rem');
+      expect(buildTraceListColumns({ visibleColumns: [], metadataKeys: [] })).toBe('11rem minmax(8rem,1fr) 6rem');
     });
 
     it('adds one bounded track per metadata key', () => {
       expect(buildTraceListColumns({ visibleColumns: [], metadataKeys: ['a', 'b'] })).toBe(
-        '6rem 9rem minmax(14rem,1fr) 6rem minmax(8rem,14rem) minmax(8rem,14rem)',
+        '11rem minmax(8rem,1fr) 6rem minmax(8rem,14rem) minmax(8rem,14rem)',
       );
     });
   });

--- a/packages/playground-ui/src/domains/traces/trace-list-columns.ts
+++ b/packages/playground-ui/src/domains/traces/trace-list-columns.ts
@@ -87,7 +87,9 @@ export function serializeTraceColumnPreferences(preferences: TraceColumnPreferen
 
 export function buildTraceListColumns(preferences: TraceColumnPreferences): string {
   const visible = new Set(preferences.visibleColumns);
-  const columns = ['6rem', '9rem', visible.has('input') ? '14rem' : 'minmax(14rem,1fr)'];
+  // Name is bounded when Input is visible so Input (1fr) absorbs the free space;
+  // without Input, Name is the flexible track that fills the grid.
+  const columns = ['11rem', visible.has('input') ? '14rem' : 'minmax(8rem,1fr)'];
 
   if (visible.has('input')) columns.push('minmax(8rem,1fr)');
   if (visible.has('entity')) columns.push('14rem');

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/__tests__/traces-data-list-cells.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/__tests__/traces-data-list-cells.test.tsx
@@ -34,9 +34,9 @@ describe('TracesDataListEntityCell entity icon', () => {
 
 describe('TracesDataListStatusCell', () => {
   describe('when the trace API returns a computed status', () => {
-    it('renders a successful trace', () => {
+    it('renders a successful trace as a green badge', () => {
       render(<TracesDataListStatusCell status={TraceStatus.SUCCESS} />);
-      expect(screen.getByText('OK').style.color).toBe('var(--accent1)');
+      expect(screen.getByText('OK').className).toContain('text-badge-green-fg');
     });
 
     it('renders a running trace', () => {

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
@@ -1,9 +1,10 @@
 import { CornerDownRightIcon, ListTreeIcon } from 'lucide-react';
 import { DataListCell, DataListTextCell } from '../data-list-cells';
+import { Badge } from '@/ds/components/Badge';
+import type { BadgeVariant } from '@/ds/components/Badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { WorkflowIcon } from '@/ds/icons/WorkflowIcon';
-import { Colors } from '@/ds/tokens/colors';
 import { cn } from '@/lib/utils';
 
 // ---------------------------------------------------------------------------
@@ -94,14 +95,14 @@ export function TracesDataListEntityCell({ entityType, entityName }: TracesDataL
 // StatusCell
 // ---------------------------------------------------------------------------
 
-const UNSET_STATUS_CONFIG = { label: '-', color: Colors.neutral4 };
+const UNSET_STATUS_CONFIG: { label: string; variant: BadgeVariant } = { label: '-', variant: 'neutral' };
 
-const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
-  completed: { label: 'OK', color: Colors.accent1 },
-  ok: { label: 'OK', color: Colors.accent1 },
-  success: { label: 'OK', color: Colors.accent1 },
-  error: { label: 'ERR', color: Colors.error },
-  running: { label: 'RUN', color: Colors.neutral4 },
+const STATUS_CONFIG: Record<string, { label: string; variant: BadgeVariant }> = {
+  completed: { label: 'OK', variant: 'green' },
+  ok: { label: 'OK', variant: 'green' },
+  success: { label: 'OK', variant: 'green' },
+  error: { label: 'ERR', variant: 'red' },
+  running: { label: 'RUN', variant: 'neutral' },
   unset: UNSET_STATUS_CONFIG,
 };
 
@@ -115,9 +116,9 @@ export function TracesDataListStatusCell({ status }: TracesDataListStatusCellPro
 
   return (
     <DataListCell>
-      <span className="text-ui-sm font-semibold uppercase" style={{ color: config.color }}>
+      <Badge size="xs" variant={config.variant}>
         {config.label}
-      </span>
+      </Badge>
     </DataListCell>
   );
 }

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from 'react';
-import { DataListDateCell, DataListIdCell, DataListTimeCell } from '../data-list-cells';
+import { DataListCreatedCell, DataListIdCell } from '../data-list-cells';
 import { DataListNextPageLoading } from '../data-list-next-page-loading';
 import { DataListNoMatch } from '../data-list-no-match';
 import { DataListRoot } from '../data-list-root';
@@ -16,6 +16,8 @@ import {
   TracesDataListStatusCell,
 } from './traces-data-list-cells';
 
+// oxlint-disable-next-line react/only-export-components -- compound component root, same pattern as ScoresDataList
+// eslint-disable-next-line react-refresh/only-export-components -- compound component root, same pattern as ScoresDataList
 function TracesDataListRoot(props: ComponentProps<typeof DataListRoot>) {
   return <DataListRoot {...props} />;
 }
@@ -30,8 +32,7 @@ export const TracesDataList = Object.assign(TracesDataListRoot, {
   SubHeading: DataListSubHeading,
   Spacer: DataListSpacer,
   IdCell: DataListIdCell,
-  DateCell: DataListDateCell,
-  TimeCell: DataListTimeCell,
+  CreatedCell: DataListCreatedCell,
   NameCell: TracesDataListNameCell,
   InputCell: TracesDataListInputCell,
   EntityCell: TracesDataListEntityCell,

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   DataListActionsCell,
   DataListCell,
+  DataListCreatedCell,
   DataListDateCell,
   DataListDescriptionCell,
   DataListIdCell,
@@ -374,6 +375,26 @@ describe('DataListDateCell', () => {
     const { container } = render(<DataListDateCell timestamp="not a date" />);
 
     // The cell's own em-dash placeholder stands in, rather than "Invalid Date".
+    expect(container.textContent).toBe('');
+  });
+});
+
+describe('DataListCreatedCell', () => {
+  it('shows date and 12-hour time without milliseconds', () => {
+    const { container } = render(<DataListCreatedCell timestamp={new Date(2026, 7, 31, 13, 7, 47, 657)} />);
+
+    expect(container.textContent).toBe('Aug 31 1:07:47 pm');
+  });
+
+  it('reads a timestamp given as a string', () => {
+    const { container } = render(<DataListCreatedCell timestamp={new Date(2026, 4, 19, 9, 5, 3).toISOString()} />);
+
+    expect(container.textContent).toBe('May 19 9:05:03 am');
+  });
+
+  it('shows nothing for a date it cannot read', () => {
+    const { container } = render(<DataListCreatedCell timestamp="not a date" />);
+
     expect(container.textContent).toBe('');
   });
 });

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -240,6 +240,20 @@ export function DataListDateCell({ timestamp }: DataListDateCellProps) {
   );
 }
 
+export interface DataListCreatedCellProps {
+  timestamp: Date | string;
+}
+
+/** Combined date + time cell — `MMM dd h:mm:ss a` (e.g. `Aug 31 1:07:47 pm`), no milliseconds. */
+export function DataListCreatedCell({ timestamp }: DataListCreatedCellProps) {
+  const date = toDate(timestamp);
+  return (
+    <DataListCell className="text-ui-smd text-neutral3 tabular-nums">
+      {date ? format(date, 'MMM dd h:mm:ss aaa') : null}
+    </DataListCell>
+  );
+}
+
 export interface DataListTimeCellProps {
   timestamp: Date | string;
 }

--- a/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
+++ b/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
@@ -247,7 +247,7 @@ describe('Traces side panel header actions', () => {
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
 
     expect(screen.getByRole('button', { name: 'Evaluate trace' })).not.toBeNull();
-    expect(screen.getByRole('button', { name: 'Save as Dataset Item' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Add full trace to dataset' })).not.toBeNull();
     // The parent trace panel is no longer collapsible.
     expect(screen.queryByRole('button', { name: /collapse panel/i })).toBeNull();
   });


### PR DESCRIPTION
## Summary

Improves the Studio Traces list readability, especially on smaller screens:

- **Single "Created" column** — the separate Date and Time columns are merged into one column formatted `MMM dd h:mm:ss a` (e.g. `Aug 31 1:07:47 pm`), dropping millisecond precision.
- **Input column no longer starves other columns** — Input is now the flexible (`1fr`) track with Name bounded at `14rem` when Input is visible, so Entity, Status, and the metric columns stay on screen.
- **List fits the viewport** — the traces list now uses `fit="container"`, so cells truncate with an ellipsis when the window shrinks instead of forcing a horizontal scrollbar.
- **Status as a Badge** — the Status column renders the design-system `Badge` (green OK / red ERR / neutral RUN) instead of raw colored text.
- **Renamed trace panel action** — "Save as Dataset Item" → "Add full trace to dataset".

Scoped to the Traces list only; Logs and Scores keep their existing Date/Time cells.

## Test plan

- [x] `@mastra/playground-ui` unit tests (DataList + traces domain): 707 passing
- [x] `@internal/playground` traces page MSW tests: 11 passing
- [x] `tsc --noEmit` clean, lint 0 errors
- [ ] Manual check in Studio: single Created column, Input capped, no horizontal scroll on a normal viewport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Traces list is easier to read and uses less screen space. It now shows clearer timestamps, status badges, and a more descriptive dataset action.

## Changes

- Combined Date and Time into a single Created column using `MMM dd h:mm:ss a`.
- Updated column sizing:
  - Input is flexible.
  - Name is limited to `14rem` when Input is visible.
  - Cells use `fit="container"` and truncate instead of causing horizontal scrolling.
- Replaced custom status styling with the design-system `Badge`.
- Mapped statuses to green, red, or neutral badge variants.
- Renamed “Save as Dataset Item” to “Add full trace to dataset”.
- Updated component APIs and tests for the new Created cell and layouts.
- Logs and Scores retain their existing Date/Time cells.

Tests and type checking pass. Manual Studio verification remains pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->