### PR TITLE
feat(core): add opt-in apply_patch workspace tool

### DIFF
--- a/.changeset/sweet-goats-itch.md
+++ b/.changeset/sweet-goats-itch.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': minor
+'@mastra/server': patch
+---
+
+Added an opt-in `mastra_workspace_apply_patch` workspace tool so agents can create, update, move, and delete several files in one call. It stays off until you enable it; a top-level `tools.enabled: true` does not turn it on. Existing agents keep `write_file` and `edit_file`.
+
+```ts
+import { Workspace, LocalFilesystem, WORKSPACE_TOOLS } from '@mastra/core/workspace'
+
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  tools: {
+    [WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]: { enabled: true },
+  },
+})
+```

--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -185,7 +185,7 @@ const workspace = new Workspace({
 })
 ```
 
-With a static filesystem, write tools (`write_file`, `edit_file`, `delete`, `mkdir`) are excluded from the agent's toolset entirely. The agent can still read and list files.
+With a static filesystem, write tools (`write_file`, `edit_file`, `delete`, `mkdir`, and `apply_patch` when enabled) are excluded from the agent's toolset entirely. The agent can still read and list files.
 
 When using a [dynamic filesystem](#dynamic-filesystem), write tools are always included because `readOnly` isn't known until the resolver runs. Instead, write operations are blocked at runtime — the tool returns an error if the resolved filesystem is read-only.
 

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -253,7 +253,7 @@ const workspace = new Workspace({
 
 | Option | Type | Description |
 | - | - | - |
-| `enabled` | `boolean \| (context) => boolean` | Whether the tool is available (default: `true`). When a function, evaluated at tool-listing time. |
+| `enabled` | `boolean \| (context) => boolean` | Whether the tool is available (default: `true` for most tools). When a function, evaluated at tool-listing time. `mastra_workspace_apply_patch` stays off until you set `enabled: true` on that tool. |
 | `requireApproval` | `boolean \| (context) => boolean` | Whether the tool requires user approval before execution (default: `false`). When a function, evaluated at execution time with access to `args`. |
 | `requireReadBeforeWrite` | `boolean \| (context) => boolean` | For write tools: require reading the file first (default: `false`). When a function, evaluated at execution time with access to `args`. |
 | `name` | `string` | Custom name for the tool. Replaces the default `mastra_workspace_*` name. |
@@ -286,6 +286,38 @@ const workspace = new Workspace({
 ```
 
 Functions for `enabled` receive `{ requestContext, workspace }`. Functions for `requireApproval` and `requireReadBeforeWrite` also receive `args` since they're evaluated when the tool is called.
+
+### Apply patch
+
+`mastra_workspace_apply_patch` applies a multi-file change set in one call using the OpenCode/OpenAI patch language. It is **opt-in**. A top-level `tools.enabled: true` does not turn it on.
+
+```typescript title="src/mastra/workspaces.ts"
+import { Workspace, LocalFilesystem, WORKSPACE_TOOLS } from '@mastra/core/workspace'
+
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  tools: {
+    [WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]: { enabled: true },
+  },
+})
+```
+
+Use `write_file` to create one file and `edit_file` for a single unique string replacement. Enable `apply_patch` when the agent needs to create, update, move, or delete several files together.
+
+The patch text looks like this:
+
+```
+*** Begin Patch
+*** Add File: src/new.ts
++export const x = 1
+*** Update File: src/existing.ts
+@@
+ context line
+-old
++new
+*** Delete File: src/obsolete.ts
+*** End Patch
+```
 
 ### Tool name remapping
 

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -661,13 +661,27 @@ Added when a filesystem is configured:
 | `mastra_workspace_read_file` | Read file contents. Text files return as text (with optional line range). Images and PDFs return as native media parts the model can view directly. Other binaries return metadata only unless an explicit `encoding` is passed. |
 | `mastra_workspace_write_file` | Create or overwrite a file with new content. Creates parent directories automatically. |
 | `mastra_workspace_edit_file` | Edit an existing file by finding and replacing text. Useful for targeted changes without rewriting the entire file. |
+| `mastra_workspace_apply_patch` | Opt-in. Apply a multi-file patch that can create, update, move, and delete files in one call. Off by default; set `enabled: true` on this tool to register it. A top-level `tools.enabled: true` does not turn it on. |
 | `mastra_workspace_list_files` | List directory contents as a tree structure. Supports recursive listing with depth limits, glob patterns, and `.gitignore` filtering (enabled by default). |
 | `mastra_workspace_delete` | Delete a file or directory. Supports recursive deletion for directories. |
 | `mastra_workspace_file_stat` | Get metadata about a file or directory including size, type, and modification time. |
 | `mastra_workspace_mkdir` | Create a directory. Creates parent directories automatically if they don't exist. |
 | `mastra_workspace_grep` | Search file contents using regex patterns. Supports glob filtering, context lines, and case-insensitive search. |
 
-With a static filesystem, write tools (`write_file`, `edit_file`, `delete`, `mkdir`) are excluded when the filesystem is in read-only mode. With a [dynamic filesystem](/docs/workspace/filesystem#dynamic-filesystem), write tools are always included and read-only is enforced at runtime.
+With a static filesystem, write tools (`write_file`, `edit_file`, `delete`, `mkdir`, and `apply_patch` when enabled) are excluded when the filesystem is in read-only mode. With a [dynamic filesystem](/docs/workspace/filesystem#dynamic-filesystem), write tools are always included and read-only is enforced at runtime.
+
+To enable `apply_patch`:
+
+```typescript title="src/mastra/workspaces.ts"
+import { Workspace, LocalFilesystem, WORKSPACE_TOOLS } from '@mastra/core/workspace'
+
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  tools: {
+    [WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]: { enabled: true },
+  },
+})
+```
 
 The `read_file` tool accepts `mediaTypes` and `maxMediaBytes` options to control which mime types are surfaced to the model as native media parts and how large those files can be:
 

--- a/packages/core/src/workspace/constants/index.ts
+++ b/packages/core/src/workspace/constants/index.ts
@@ -24,6 +24,7 @@ export const WORKSPACE_TOOLS = {
     MKDIR: `${WORKSPACE_TOOLS_PREFIX}_mkdir` as const,
     GREP: `${WORKSPACE_TOOLS_PREFIX}_grep` as const,
     AST_EDIT: `${WORKSPACE_TOOLS_PREFIX}_ast_edit` as const,
+    APPLY_PATCH: `${WORKSPACE_TOOLS_PREFIX}_apply_patch` as const,
   },
   SANDBOX: {
     EXECUTE_COMMAND: `${WORKSPACE_TOOLS_PREFIX}_execute_command` as const,

--- a/packages/core/src/workspace/filesystem/file-write-lock.test.ts
+++ b/packages/core/src/workspace/filesystem/file-write-lock.test.ts
@@ -3,6 +3,26 @@ import { describe, it, expect } from 'vitest';
 import { InMemoryFileWriteLock } from './file-write-lock';
 
 describe('InMemoryFileWriteLock', () => {
+  it('should acquire multiple locks in sorted order without deadlock', async () => {
+    const lock = new InMemoryFileWriteLock();
+    const order: string[] = [];
+
+    const first = lock.withLocks(['/b.txt', '/a.txt'], async () => {
+      order.push('first-start');
+      await delay(30);
+      order.push('first-end');
+      return 'one';
+    });
+    const second = lock.withLocks(['/a.txt'], async () => {
+      order.push('second');
+      return 'two';
+    });
+
+    const results = await Promise.all([first, second]);
+    expect(results).toEqual(['one', 'two']);
+    expect(order).toEqual(['first-start', 'first-end', 'second']);
+  });
+
   it('should serialize operations on the same path (FIFO order)', async () => {
     const lock = new InMemoryFileWriteLock();
     const order: number[] = [];

--- a/packages/core/src/workspace/filesystem/file-write-lock.ts
+++ b/packages/core/src/workspace/filesystem/file-write-lock.ts
@@ -21,6 +21,12 @@ export interface FileWriteLock {
   /** Execute `fn` while holding an exclusive lock on `filePath`. */
   withLock<T>(filePath: string, fn: () => Promise<T>): Promise<T>;
 
+  /**
+   * Execute `fn` while holding exclusive locks on every path.
+   * Paths are de-duplicated and acquired in sorted order to avoid deadlock.
+   */
+  withLocks<T>(filePaths: string[], fn: () => Promise<T>): Promise<T>;
+
   /** Number of paths that currently have queued operations. */
   get size(): number;
 }
@@ -91,6 +97,23 @@ export class InMemoryFileWriteLock implements FileWriteLock {
     });
 
     return resultPromise;
+  }
+
+  withLocks<T>(filePaths: string[], fn: () => Promise<T>): Promise<T> {
+    const unique = [...new Set(filePaths.map(path => this.normalizePath(path)))].sort();
+    if (unique.length === 0) {
+      return fn();
+    }
+
+    const run = (index: number): Promise<T> => {
+      const path = unique[index];
+      if (path === undefined) {
+        return fn();
+      }
+      return this.withLock(path, () => run(index + 1));
+    };
+
+    return run(0);
   }
 
   private normalizePath(pathStr: string): string {

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -49,6 +49,7 @@ export {
   readFileTool,
   writeFileTool,
   editFileTool,
+  applyPatchTool,
   listFilesTool,
   deleteFileTool,
   fileStatTool,

--- a/packages/core/src/workspace/tools/__tests__/apply-patch.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/apply-patch.test.ts
@@ -1,0 +1,208 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { WORKSPACE_TOOLS } from '../../constants';
+import { FileReadRequiredError } from '../../errors';
+import { LocalFilesystem } from '../../filesystem';
+import { Workspace } from '../../workspace';
+import { createWorkspaceTools } from '../tools';
+
+function patch(body: string): string {
+  return `*** Begin Patch\n${body}*** End Patch\n`;
+}
+
+describe('workspace_apply_patch', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workspace-apply-patch-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function tools(options?: { requireReadBeforeWrite?: boolean; readOnly?: boolean }) {
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir, readOnly: options?.readOnly }),
+      tools: {
+        [WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]: {
+          enabled: true,
+          requireReadBeforeWrite: options?.requireReadBeforeWrite,
+        },
+      },
+    });
+    return { workspace, tools: await createWorkspaceTools(workspace) };
+  }
+
+  it('is absent by default', async () => {
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const created = await createWorkspaceTools(workspace);
+    expect(created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]).toBeUndefined();
+  });
+
+  it('is absent when only top-level tools.enabled is true', async () => {
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: { enabled: true },
+    });
+    const created = await createWorkspaceTools(workspace);
+    expect(created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]).toBeUndefined();
+  });
+
+  it('is registered when explicitly enabled', async () => {
+    const { tools: created } = await tools();
+    expect(created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]).toBeDefined();
+  });
+
+  it('is omitted on a static read-only filesystem even when enabled', async () => {
+    const { tools: created } = await tools({ readOnly: true });
+    expect(created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]).toBeUndefined();
+  });
+
+  it('creates multiple files in one call', async () => {
+    const { workspace, tools: created } = await tools();
+    const result = await created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH].execute(
+      {
+        patchText: patch(
+          ['*** Add File: a.ts', '+export const a = 1', '*** Add File: b.ts', '+export const b = 2', ''].join('\n'),
+        ),
+      },
+      { workspace },
+    );
+
+    expect(result).toContain('A a.ts');
+    expect(result).toContain('A b.ts');
+    expect(await fs.readFile(path.join(tempDir, 'a.ts'), 'utf-8')).toBe('export const a = 1\n');
+    expect(await fs.readFile(path.join(tempDir, 'b.ts'), 'utf-8')).toBe('export const b = 2\n');
+  });
+
+  it('updates, creates, and deletes in one call', async () => {
+    await fs.writeFile(path.join(tempDir, 'existing.ts'), 'const name = "old"\n');
+    await fs.writeFile(path.join(tempDir, 'gone.ts'), 'bye\n');
+    const { workspace, tools: created } = await tools();
+
+    const result = await created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH].execute(
+      {
+        patchText: patch(
+          [
+            '*** Add File: created.ts',
+            '+hello',
+            '*** Update File: existing.ts',
+            '@@',
+            '-const name = "old"',
+            '+const name = "new"',
+            '*** Delete File: gone.ts',
+            '',
+          ].join('\n'),
+        ),
+      },
+      { workspace },
+    );
+
+    expect(result).toContain('A created.ts');
+    expect(result).toContain('M existing.ts');
+    expect(result).toContain('D gone.ts');
+    expect(await fs.readFile(path.join(tempDir, 'existing.ts'), 'utf-8')).toBe('const name = "new"\n');
+    expect(await fs.readFile(path.join(tempDir, 'created.ts'), 'utf-8')).toBe('hello\n');
+    await expect(fs.stat(path.join(tempDir, 'gone.ts'))).rejects.toThrow();
+  });
+
+  it('applies nothing when a later hunk does not match', async () => {
+    await fs.writeFile(path.join(tempDir, 'keep.ts'), 'keep me\n');
+    const { workspace, tools: created } = await tools();
+
+    const result = await created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH].execute(
+      {
+        patchText: patch(
+          [
+            '*** Add File: new.ts',
+            '+created',
+            '*** Update File: keep.ts',
+            '@@',
+            '-does not exist',
+            '+replacement',
+            '',
+          ].join('\n'),
+        ),
+      },
+      { workspace },
+    );
+
+    expect(result).toContain('does not match');
+    await expect(fs.stat(path.join(tempDir, 'new.ts'))).rejects.toThrow();
+    expect(await fs.readFile(path.join(tempDir, 'keep.ts'), 'utf-8')).toBe('keep me\n');
+  });
+
+  it('returns a parse error for malformed patch text', async () => {
+    const { workspace, tools: created } = await tools();
+    const result = await created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH].execute(
+      { patchText: 'not a patch' },
+      { workspace },
+    );
+    expect(result).toContain('*** Begin Patch');
+  });
+
+  it('moves a file while updating its contents', async () => {
+    await fs.writeFile(path.join(tempDir, 'old.ts'), 'value = 1\n');
+    const { workspace, tools: created } = await tools();
+
+    const result = await created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH].execute(
+      {
+        patchText: patch(
+          ['*** Update File: old.ts', '*** Move to: new.ts', '@@', '-value = 1', '+value = 2', ''].join('\n'),
+        ),
+      },
+      { workspace },
+    );
+
+    expect(result).toContain('M new.ts');
+    expect(await fs.readFile(path.join(tempDir, 'new.ts'), 'utf-8')).toBe('value = 2\n');
+    await expect(fs.stat(path.join(tempDir, 'old.ts'))).rejects.toThrow();
+  });
+
+  it('enforces requireReadBeforeWrite on existing files', async () => {
+    await fs.writeFile(path.join(tempDir, 'existing.ts'), 'const name = "old"\n');
+    const { workspace, tools: created } = await tools({ requireReadBeforeWrite: true });
+
+    await expect(
+      created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH].execute(
+        {
+          patchText: patch(
+            ['*** Update File: existing.ts', '@@', '-const name = "old"', '+const name = "new"', ''].join('\n'),
+          ),
+        },
+        { workspace },
+      ),
+    ).rejects.toThrow(FileReadRequiredError);
+  });
+
+  it('allows apply_patch after read_file when requireReadBeforeWrite is set', async () => {
+    await fs.writeFile(path.join(tempDir, 'existing.ts'), 'const name = "old"\n');
+    const { workspace, tools: created } = await tools({ requireReadBeforeWrite: true });
+
+    await created[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'existing.ts' }, { workspace });
+    const result = await created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH].execute(
+      {
+        patchText: patch(
+          ['*** Update File: existing.ts', '@@', '-const name = "old"', '+const name = "new"', ''].join('\n'),
+        ),
+      },
+      { workspace },
+    );
+
+    expect(result).toContain('M existing.ts');
+    expect(await fs.readFile(path.join(tempDir, 'existing.ts'), 'utf-8')).toBe('const name = "new"\n');
+  });
+
+  it('does not require a prior read for Add File', async () => {
+    const { workspace, tools: created } = await tools({ requireReadBeforeWrite: true });
+    const result = await created[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH].execute(
+      { patchText: patch(['*** Add File: fresh.ts', '+ok', ''].join('\n')) },
+      { workspace },
+    );
+    expect(result).toContain('A fresh.ts');
+  });
+});

--- a/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
@@ -33,6 +33,7 @@ describe('createWorkspaceTools', () => {
     expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT);
     expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.MKDIR);
     expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.GREP);
+    expect(tools).not.toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH);
   });
 
   it('should not create filesystem tools when no filesystem', async () => {
@@ -127,6 +128,7 @@ describe('createWorkspaceTools', () => {
     expect(WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT).toBe('mastra_workspace_file_stat');
     expect(WORKSPACE_TOOLS.FILESYSTEM.MKDIR).toBe('mastra_workspace_mkdir');
     expect(WORKSPACE_TOOLS.FILESYSTEM.GREP).toBe('mastra_workspace_grep');
+    expect(WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH).toBe('mastra_workspace_apply_patch');
     expect(WORKSPACE_TOOLS.SEARCH.SEARCH).toBe('mastra_workspace_search');
     expect(WORKSPACE_TOOLS.SEARCH.INDEX).toBe('mastra_workspace_index');
     expect(WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND).toBe('mastra_workspace_execute_command');

--- a/packages/core/src/workspace/tools/__tests__/workspace-tools-metadata.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/workspace-tools-metadata.test.ts
@@ -8,6 +8,7 @@ import { WORKSPACE_TOOLS } from '../../constants';
 import { LocalFilesystem } from '../../filesystem';
 import { LocalSandbox } from '../../sandbox';
 import { Workspace } from '../../workspace';
+import { applyPatchTool } from '../apply-patch';
 import { deleteFileTool } from '../delete-file';
 import { editFileTool } from '../edit-file';
 import { executeCommandTool } from '../execute-command';
@@ -82,6 +83,20 @@ describe('all workspace tools emit data-workspace-metadata', () => {
     );
 
     expectMetadataEmitted(writerCustom, WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE);
+  });
+
+  it('apply_patch emits metadata', async () => {
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const { context, writerCustom } = createContext(workspace);
+
+    await applyPatchTool.execute!(
+      {
+        patchText: '*** Begin Patch\n*** Add File: created.txt\n+hi\n*** End Patch\n',
+      },
+      context,
+    );
+
+    expectMetadataEmitted(writerCustom, WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH);
   });
 
   it('list_files emits metadata', async () => {

--- a/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
@@ -257,6 +257,26 @@ describe('workspace tool tracing integration', () => {
     expect(childSpans[0]!.ended).toBe(true);
   });
 
+  it('applyPatch tool creates a WORKSPACE_ACTION span on success', async () => {
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: { [WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]: { enabled: true } },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    await tools[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH].execute(
+      { patchText: '*** Begin Patch\n*** Add File: patched.txt\n+hello\n*** End Patch\n' },
+      { workspace, tracing: { currentSpan: mockParentSpan } },
+    );
+
+    expect(childSpans).toHaveLength(1);
+    expect(childSpans[0]!.attributes?.category).toBe('filesystem');
+    expect(childSpans[0]!.name).toBe('workspace:filesystem:applyPatch');
+    expect(childSpans[0]!.ended).toBe(true);
+  });
+
   it('deleteFile tool creates a WORKSPACE_ACTION span on success', async () => {
     await fs.writeFile(path.join(tempDir, 'del.txt'), 'delete me');
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });

--- a/packages/core/src/workspace/tools/__tests__/write-lock.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/write-lock.test.ts
@@ -77,6 +77,37 @@ describe('write-lock integration', () => {
     expect(contentB).toBe('goodbye_b');
   });
 
+  it('should serialize concurrent apply_patch calls on the same file', async () => {
+    await fs.writeFile(path.join(tempDir, 'test.txt'), 'AAA_MARKER\nBBB_MARKER\n');
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: { [WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]: { enabled: true } },
+    });
+    const tools = await createWorkspaceTools(workspace);
+    const applyPatch = tools[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH];
+
+    const [r1, r2] = await Promise.all([
+      applyPatch.execute(
+        {
+          patchText: '*** Begin Patch\n*** Update File: test.txt\n@@\n-AAA_MARKER\n+AAA_REPLACED\n*** End Patch\n',
+        },
+        { workspace },
+      ),
+      applyPatch.execute(
+        {
+          patchText: '*** Begin Patch\n*** Update File: test.txt\n@@\n-BBB_MARKER\n+BBB_REPLACED\n*** End Patch\n',
+        },
+        { workspace },
+      ),
+    ]);
+
+    expect(r1).toContain('M test.txt');
+    expect(r2).toContain('M test.txt');
+    const final = await fs.readFile(path.join(tempDir, 'test.txt'), 'utf-8');
+    expect(final).toContain('AAA_REPLACED');
+    expect(final).toContain('BBB_REPLACED');
+  });
+
   it('should serialize concurrent write_file calls on the same file', async () => {
     const workspace = new Workspace({
       filesystem: new LocalFilesystem({ basePath: tempDir }),

--- a/packages/core/src/workspace/tools/apply-patch-parser.test.ts
+++ b/packages/core/src/workspace/tools/apply-patch-parser.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  applyChunks,
+  ApplyPatchHunkError,
+  ApplyPatchParseError,
+  getApplyPatchWritePaths,
+  getPatchPaths,
+  parseApplyPatch,
+} from './apply-patch-parser';
+
+function patch(body: string): string {
+  return `*** Begin Patch\n${body}*** End Patch\n`;
+}
+
+describe('parseApplyPatch', () => {
+  it('parses add, update, move, and delete in one patch', () => {
+    const hunks = parseApplyPatch(
+      patch(
+        [
+          '*** Add File: src/new.ts',
+          '+export const x = 1',
+          '*** Update File: src/existing.ts',
+          '*** Move to: src/renamed.ts',
+          '@@',
+          ' context line',
+          '-old',
+          '+new',
+          '*** Delete File: src/obsolete.ts',
+          '',
+        ].join('\n'),
+      ),
+    );
+
+    expect(hunks).toEqual([
+      { type: 'add', path: 'src/new.ts', contents: 'export const x = 1\n' },
+      {
+        type: 'update',
+        path: 'src/existing.ts',
+        movePath: 'src/renamed.ts',
+        chunks: [
+          {
+            changeContext: undefined,
+            lines: [
+              { type: 'context', text: 'context line' },
+              { type: 'remove', text: 'old' },
+              { type: 'add', text: 'new' },
+            ],
+          },
+        ],
+      },
+      { type: 'delete', path: 'src/obsolete.ts' },
+    ]);
+  });
+
+  it('normalizes CRLF and ignores surrounding blank lines', () => {
+    const hunks = parseApplyPatch('\r\n*** Begin Patch\r\n*** Delete File: gone.txt\r\n*** End Patch\r\n');
+    expect(hunks).toEqual([{ type: 'delete', path: 'gone.txt' }]);
+  });
+
+  it('parses @@ change context headers', () => {
+    const hunks = parseApplyPatch(
+      patch(['*** Update File: src/app.ts', '@@ class BaseClass', ' foo', '-bar', '+baz', ''].join('\n')),
+    );
+    expect(hunks[0]).toMatchObject({
+      type: 'update',
+      path: 'src/app.ts',
+      chunks: [{ changeContext: 'class BaseClass' }],
+    });
+  });
+
+  it('rejects missing begin marker', () => {
+    expect(() => parseApplyPatch('*** Add File: a.ts\n+x\n*** End Patch\n')).toThrow(ApplyPatchParseError);
+  });
+
+  it('rejects missing end marker', () => {
+    expect(() => parseApplyPatch('*** Begin Patch\n*** Delete File: a.ts\n')).toThrow(ApplyPatchParseError);
+  });
+
+  it('rejects empty patch', () => {
+    expect(() => parseApplyPatch('*** Begin Patch\n*** End Patch\n')).toThrow(/empty patch/);
+  });
+
+  it('rejects empty patchText', () => {
+    expect(() => parseApplyPatch('   ')).toThrow(/patchText is required/);
+  });
+
+  it('rejects add-file lines without a + prefix', () => {
+    expect(() => parseApplyPatch(patch('*** Add File: a.ts\nnot plus\n'))).toThrow(/Invalid Add File line/);
+  });
+
+  it('rejects delete-file with a diff', () => {
+    expect(() => parseApplyPatch(patch('*** Delete File: a.ts\n-old\n'))).toThrow(/must not include a diff/);
+  });
+
+  it('rejects update-file without a hunk', () => {
+    expect(() => parseApplyPatch(patch('*** Update File: a.ts\n'))).toThrow(/must include a hunk/);
+  });
+
+  it('collects write paths including move destinations', () => {
+    const hunks = parseApplyPatch(
+      patch(['*** Update File: old.ts', '*** Move to: new.ts', '@@', ' a', '-b', '+c', ''].join('\n')),
+    );
+    expect(getPatchPaths(hunks)).toEqual(['old.ts', 'new.ts']);
+  });
+
+  it('returns no write paths for invalid patch text', () => {
+    expect(getApplyPatchWritePaths({ patchText: 'not a patch' })).toEqual([]);
+  });
+});
+
+describe('applyChunks', () => {
+  it('replaces a unique snippet', () => {
+    const result = applyChunks('one\ntwo\nthree\n', [
+      {
+        lines: [
+          { type: 'context', text: 'two' },
+          { type: 'remove', text: 'three' },
+          { type: 'add', text: 'THREE' },
+        ],
+      },
+    ]);
+    expect(result).toBe('one\ntwo\nTHREE\n');
+  });
+
+  it('fails when the hunk is not unique', () => {
+    expect(() =>
+      applyChunks('hello\nhello\n', [
+        {
+          lines: [
+            { type: 'remove', text: 'hello' },
+            { type: 'add', text: 'hi' },
+          ],
+        },
+      ]),
+    ).toThrow(ApplyPatchHunkError);
+  });
+
+  it('uses @@ context to pick the right occurrence', () => {
+    const content = ['class A {', '  foo()', '}', 'class B {', '  foo()', '}', ''].join('\n');
+    const result = applyChunks(content, [
+      {
+        changeContext: 'class B',
+        lines: [
+          { type: 'context', text: '  foo()' },
+          { type: 'add', text: '  bar()' },
+        ],
+      },
+    ]);
+    expect(result).toContain('class B {\n  foo()\n  bar()\n}');
+    expect(result).toContain('class A {\n  foo()\n}');
+  });
+
+  it('fails when context is missing', () => {
+    expect(() =>
+      applyChunks('hello\n', [
+        {
+          lines: [
+            { type: 'remove', text: 'world' },
+            { type: 'add', text: 'earth' },
+          ],
+        },
+      ]),
+    ).toThrow(/does not match/);
+  });
+});

--- a/packages/core/src/workspace/tools/apply-patch-parser.ts
+++ b/packages/core/src/workspace/tools/apply-patch-parser.ts
@@ -1,0 +1,328 @@
+/**
+ * OpenCode / OpenAI apply_patch parser.
+ *
+ * Accepts the marker-based patch language:
+ *
+ *   *** Begin Patch
+ *   *** Add File: path
+ *   +contents
+ *   *** Update File: path
+ *   *** Move to: new-path
+ *   @@ optional context
+ *    context
+ *   -old
+ *   +new
+ *   *** Delete File: path
+ *   *** End Patch
+ */
+
+export const BEGIN_PATCH = '*** Begin Patch';
+export const END_PATCH = '*** End Patch';
+export const ADD_FILE = '*** Add File: ';
+export const DELETE_FILE = '*** Delete File: ';
+export const UPDATE_FILE = '*** Update File: ';
+export const MOVE_TO = '*** Move to: ';
+export const END_OF_FILE = '*** End of File';
+
+export type PatchLineType = 'context' | 'add' | 'remove';
+
+export interface PatchLine {
+  type: PatchLineType;
+  text: string;
+}
+
+export interface PatchChunk {
+  /** Optional @@ header used to disambiguate repeated snippets. */
+  changeContext?: string;
+  lines: PatchLine[];
+  isEndOfFile?: boolean;
+}
+
+export type PatchHunk =
+  | { type: 'add'; path: string; contents: string }
+  | { type: 'delete'; path: string }
+  | { type: 'update'; path: string; movePath?: string; chunks: PatchChunk[] };
+
+export class ApplyPatchParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ApplyPatchParseError';
+  }
+}
+
+export class ApplyPatchHunkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ApplyPatchHunkError';
+  }
+}
+
+function normalizeNewlines(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+function parsePathHeader(line: string, prefix: string): string {
+  const path = line.slice(prefix.length).trim();
+  if (!path) {
+    throw new ApplyPatchParseError(`Missing path in apply_patch header: ${line}`);
+  }
+  return path;
+}
+
+function isFileOperationHeader(line: string): boolean {
+  return line.startsWith(ADD_FILE) || line.startsWith(DELETE_FILE) || line.startsWith(UPDATE_FILE);
+}
+
+/**
+ * Parse apply_patch text into file operations.
+ * @throws {ApplyPatchParseError} if the patch is empty or malformed
+ */
+export function parseApplyPatch(patchText: string): PatchHunk[] {
+  if (typeof patchText !== 'string' || patchText.trim() === '') {
+    throw new ApplyPatchParseError('patchText is required');
+  }
+
+  const text = normalizeNewlines(patchText);
+  const rawLines = text.split('\n');
+
+  let start = 0;
+  while (start < rawLines.length && rawLines[start] === '') start++;
+  let end = rawLines.length - 1;
+  while (end >= start && rawLines[end] === '') end--;
+
+  if (start > end || rawLines[start] !== BEGIN_PATCH) {
+    throw new ApplyPatchParseError("apply_patch input must start with '*** Begin Patch'");
+  }
+  if (rawLines[end] !== END_PATCH) {
+    throw new ApplyPatchParseError("apply_patch input must end with '*** End Patch'");
+  }
+
+  const inner = rawLines.slice(start + 1, end);
+  if (inner.length === 0) {
+    throw new ApplyPatchParseError('patch rejected: empty patch');
+  }
+
+  const hunks: PatchHunk[] = [];
+  let index = 0;
+  while (index < inner.length) {
+    const line = inner[index] ?? '';
+    if (line.startsWith(ADD_FILE)) {
+      const parsed = parseAddFile(inner, index);
+      hunks.push(parsed.hunk);
+      index = parsed.nextIndex;
+    } else if (line.startsWith(DELETE_FILE)) {
+      const parsed = parseDeleteFile(inner, index);
+      hunks.push(parsed.hunk);
+      index = parsed.nextIndex;
+    } else if (line.startsWith(UPDATE_FILE)) {
+      const parsed = parseUpdateFile(inner, index);
+      hunks.push(parsed.hunk);
+      index = parsed.nextIndex;
+    } else if (line === '') {
+      index++;
+    } else {
+      throw new ApplyPatchParseError(`Invalid apply_patch file operation header: ${line}`);
+    }
+  }
+
+  if (hunks.length === 0) {
+    throw new ApplyPatchParseError('apply_patch verification failed: no hunks found');
+  }
+
+  return hunks;
+}
+
+function parseAddFile(lines: string[], index: number): { hunk: PatchHunk; nextIndex: number } {
+  const path = parsePathHeader(lines[index] ?? '', ADD_FILE);
+  index += 1;
+  const contentLines: string[] = [];
+  while (index < lines.length && !isFileOperationHeader(lines[index] ?? '')) {
+    const line = lines[index] ?? '';
+    if (!line.startsWith('+')) {
+      throw new ApplyPatchParseError(`Invalid Add File line in ${path}: ${line}`);
+    }
+    contentLines.push(line.slice(1));
+    index += 1;
+  }
+  const contents = contentLines.length === 0 ? '' : `${contentLines.join('\n')}\n`;
+  return { hunk: { type: 'add', path, contents }, nextIndex: index };
+}
+
+function parseDeleteFile(lines: string[], index: number): { hunk: PatchHunk; nextIndex: number } {
+  const path = parsePathHeader(lines[index] ?? '', DELETE_FILE);
+  index += 1;
+  if (index < lines.length && !isFileOperationHeader(lines[index] ?? '') && lines[index] !== '') {
+    throw new ApplyPatchParseError(`Delete File patch for ${path} must not include a diff`);
+  }
+  return { hunk: { type: 'delete', path }, nextIndex: index };
+}
+
+function parseUpdateFile(lines: string[], index: number): { hunk: PatchHunk; nextIndex: number } {
+  const path = parsePathHeader(lines[index] ?? '', UPDATE_FILE);
+  index += 1;
+  let movePath: string | undefined;
+  if (index < lines.length && (lines[index] ?? '').startsWith(MOVE_TO)) {
+    movePath = parsePathHeader(lines[index] ?? '', MOVE_TO);
+    index += 1;
+  }
+
+  const chunks: PatchChunk[] = [];
+  let current: PatchChunk | undefined;
+
+  const flush = () => {
+    if (current && (current.lines.length > 0 || current.changeContext || current.isEndOfFile)) {
+      chunks.push(current);
+    }
+    current = undefined;
+  };
+
+  while (index < lines.length && !isFileOperationHeader(lines[index] ?? '')) {
+    const line = lines[index] ?? '';
+    if (line.startsWith('@@')) {
+      flush();
+      const header = line.slice(2).trim();
+      current = { changeContext: header || undefined, lines: [] };
+      index += 1;
+      continue;
+    }
+    if (line === END_OF_FILE) {
+      current ??= { lines: [] };
+      current.isEndOfFile = true;
+      flush();
+      index += 1;
+      continue;
+    }
+    if (line === '') {
+      // Blank lines between hunks are ignored; blank context is " \n".
+      index += 1;
+      continue;
+    }
+    const prefix = line[0];
+    if (prefix !== ' ' && prefix !== '-' && prefix !== '+') {
+      throw new ApplyPatchParseError(`Invalid Update File line in ${path}: ${line}`);
+    }
+    current ??= { lines: [] };
+    const type: PatchLineType = prefix === '+' ? 'add' : prefix === '-' ? 'remove' : 'context';
+    current.lines.push({ type, text: line.slice(1) });
+    index += 1;
+  }
+
+  flush();
+  if (chunks.length === 0) {
+    throw new ApplyPatchParseError(`Update File patch for ${path} must include a hunk`);
+  }
+
+  return { hunk: { type: 'update', path, movePath, chunks }, nextIndex: index };
+}
+
+/**
+ * Collect every path a parsed patch will write, create, delete, or move.
+ */
+export function getPatchPaths(hunks: PatchHunk[]): string[] {
+  const paths: string[] = [];
+  for (const hunk of hunks) {
+    paths.push(hunk.path);
+    if (hunk.type === 'update' && hunk.movePath) {
+      paths.push(hunk.movePath);
+    }
+  }
+  return paths;
+}
+
+/**
+ * Extract write paths from raw patch text.
+ * Returns an empty array when the text cannot be parsed so callers can
+ * skip locking and let the tool report the parse error.
+ */
+export function getApplyPatchWritePaths(input: { patchText?: string }): string[] {
+  try {
+    return getPatchPaths(parseApplyPatch(input.patchText ?? ''));
+  } catch {
+    return [];
+  }
+}
+
+function findUniqueSequence(lines: string[], pattern: string[], from: number): number {
+  if (pattern.length === 0) {
+    return from;
+  }
+
+  let found = -1;
+  const lastStart = lines.length - pattern.length;
+  for (let i = from; i <= lastStart; i++) {
+    let match = true;
+    for (let j = 0; j < pattern.length; j++) {
+      if (lines[i + j] !== pattern[j]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
+      if (found !== -1) {
+        throw new ApplyPatchHunkError(
+          'Hunk matches multiple locations. Add more context or a @@ header to make the match unique.',
+        );
+      }
+      found = i;
+    }
+  }
+
+  if (found === -1) {
+    throw new ApplyPatchHunkError('Hunk does not match file contents. Read the file and update the patch context.');
+  }
+
+  return found;
+}
+
+/**
+ * Apply update chunks to existing file content.
+ * @throws {ApplyPatchHunkError} if a hunk does not match uniquely
+ */
+export function applyChunks(content: string, chunks: PatchChunk[]): string {
+  const hadTrailingNewline = content.endsWith('\n');
+  let lines = content === '' ? [] : content.split('\n');
+  if (hadTrailingNewline && lines[lines.length - 1] === '') {
+    lines = lines.slice(0, -1);
+  }
+
+  for (const chunk of chunks) {
+    const oldLines: string[] = [];
+    const newLines: string[] = [];
+    for (const line of chunk.lines) {
+      if (line.type !== 'add') oldLines.push(line.text);
+      if (line.type !== 'remove') newLines.push(line.text);
+    }
+
+    let from = 0;
+    if (chunk.changeContext) {
+      const contextIndex = lines.findIndex(line => line.includes(chunk.changeContext!));
+      if (contextIndex === -1) {
+        throw new ApplyPatchHunkError(`Could not find context "${chunk.changeContext}" in the file.`);
+      }
+      from = contextIndex;
+    }
+
+    if (oldLines.length === 0) {
+      if (chunk.isEndOfFile || (from === 0 && !chunk.changeContext)) {
+        lines.push(...newLines);
+        continue;
+      }
+      const insertAt = chunk.changeContext ? from + 1 : lines.length;
+      lines.splice(insertAt, 0, ...newLines);
+      continue;
+    }
+
+    const matchIndex = findUniqueSequence(lines, oldLines, from);
+    lines.splice(matchIndex, oldLines.length, ...newLines);
+  }
+
+  if (lines.length === 0) {
+    return hadTrailingNewline ? '\n' : '';
+  }
+
+  let result = lines.join('\n');
+  if (hadTrailingNewline && !result.endsWith('\n')) {
+    result += '\n';
+  }
+  return result;
+}

--- a/packages/core/src/workspace/tools/apply-patch.ts
+++ b/packages/core/src/workspace/tools/apply-patch.ts
@@ -1,0 +1,167 @@
+import { z } from 'zod/v4';
+import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../constants';
+import { FileExistsError, FileNotFoundError, WorkspaceReadOnlyError } from '../errors';
+import { applyChunks, ApplyPatchHunkError, ApplyPatchParseError, parseApplyPatch } from './apply-patch-parser';
+import type { PatchHunk } from './apply-patch-parser';
+import { emitWorkspaceMetadata, getEditDiagnosticsText, requireFilesystem } from './helpers';
+import { startWorkspaceSpan } from './tracing';
+
+type PlannedChange =
+  | { action: 'add'; path: string; content: string }
+  | { action: 'update'; path: string; content: string }
+  | { action: 'move'; from: string; to: string; content: string }
+  | { action: 'delete'; path: string };
+
+function expectedMtimeFor(context: unknown, path: string): Date | undefined {
+  const ctx = context as { __expectedMtimes?: Record<string, Date>; __expectedMtime?: Date } | undefined;
+  return ctx?.__expectedMtimes?.[path] ?? ctx?.__expectedMtime;
+}
+
+export const applyPatchTool = createTool({
+  id: WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH,
+  description: `Apply a multi-file patch to the workspace filesystem.
+
+Use this when one change set should create, update, move, or delete several files. Prefer edit_file for a single unique string replacement and write_file to create or overwrite one file.
+
+The patch language:
+
+*** Begin Patch
+*** Add File: src/new.ts
++export const x = 1
+*** Update File: src/existing.ts
+@@
+ context line
+-old
++new
+*** Move to: src/renamed.ts
+*** Delete File: src/obsolete.ts
+*** End Patch
+
+Rules:
+- Wrap the entire change set in *** Begin Patch / *** End Patch.
+- Prefix every new line with + even when adding a file.
+- Update hunks use space (context), - (remove), and + (add). Include enough context so the hunk is unique. Use @@ headers to disambiguate repeated snippets.
+- Paths are workspace-relative, never absolute.
+- Read files you are updating before patching them.`,
+  inputSchema: z.object({
+    patchText: z.string().describe('The full apply_patch text, including Begin Patch / End Patch markers'),
+  }),
+  execute: async ({ patchText }, context) => {
+    const { workspace, filesystem } = requireFilesystem(context);
+    await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH);
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'filesystem',
+      operation: 'applyPatch',
+      input: { patchTextLength: patchText.length },
+      attributes: { filesystemProvider: filesystem.provider },
+    });
+
+    try {
+      if (filesystem.readOnly) {
+        throw new WorkspaceReadOnlyError('apply_patch');
+      }
+
+      let hunks: PatchHunk[];
+      try {
+        hunks = parseApplyPatch(patchText);
+      } catch (error) {
+        if (error instanceof ApplyPatchParseError) {
+          span.end({ success: false });
+          return error.message;
+        }
+        throw error;
+      }
+
+      const planned: PlannedChange[] = [];
+      try {
+        for (const hunk of hunks) {
+          if (hunk.type === 'add') {
+            if (await filesystem.exists(hunk.path)) {
+              span.end({ success: false });
+              return `File already exists: ${hunk.path}`;
+            }
+            planned.push({ action: 'add', path: hunk.path, content: hunk.contents });
+            continue;
+          }
+          if (hunk.type === 'delete') {
+            if (!(await filesystem.exists(hunk.path))) {
+              span.end({ success: false });
+              return `File not found: ${hunk.path}`;
+            }
+            planned.push({ action: 'delete', path: hunk.path });
+            continue;
+          }
+
+          const raw = await filesystem.readFile(hunk.path, { encoding: 'utf-8' });
+          if (typeof raw !== 'string') {
+            span.end({ success: false });
+            return `Cannot apply patch to binary file: ${hunk.path}`;
+          }
+          const content = applyChunks(raw, hunk.chunks);
+          if (hunk.movePath) {
+            planned.push({ action: 'move', from: hunk.path, to: hunk.movePath, content });
+          } else {
+            planned.push({ action: 'update', path: hunk.path, content });
+          }
+        }
+      } catch (error) {
+        if (error instanceof ApplyPatchHunkError || error instanceof FileNotFoundError) {
+          span.end({ success: false });
+          return error.message;
+        }
+        throw error;
+      }
+
+      let bytesTransferred = 0;
+      const summary: string[] = [];
+      for (const change of planned) {
+        if (change.action === 'add') {
+          await filesystem.writeFile(change.path, change.content, { overwrite: false });
+          bytesTransferred += Buffer.byteLength(change.content, 'utf-8');
+          summary.push(`A ${change.path}`);
+        } else if (change.action === 'update') {
+          await filesystem.writeFile(change.path, change.content, {
+            overwrite: true,
+            expectedMtime: expectedMtimeFor(context, change.path),
+          });
+          bytesTransferred += Buffer.byteLength(change.content, 'utf-8');
+          summary.push(`M ${change.path}`);
+        } else if (change.action === 'move') {
+          await filesystem.writeFile(change.to, change.content, {
+            overwrite: true,
+            expectedMtime: expectedMtimeFor(context, change.to),
+          });
+          await filesystem.deleteFile(change.from);
+          bytesTransferred += Buffer.byteLength(change.content, 'utf-8');
+          summary.push(`M ${change.to}`);
+        } else {
+          await filesystem.deleteFile(change.path);
+          summary.push(`D ${change.path}`);
+        }
+      }
+
+      let output = `Success. Updated the following files:\n${summary.join('\n')}`;
+      for (const change of planned) {
+        if (change.action === 'delete') continue;
+        const path = change.action === 'move' ? change.to : change.path;
+        output += await getEditDiagnosticsText(workspace, path, change.content);
+      }
+
+      span.end({ success: true }, { bytesTransferred });
+      return output;
+    } catch (error) {
+      if (
+        error instanceof FileExistsError ||
+        error instanceof FileNotFoundError ||
+        error instanceof ApplyPatchHunkError
+      ) {
+        span.end({ success: false });
+        return error.message;
+      }
+      span.error(error);
+      throw error;
+    }
+  },
+});

--- a/packages/core/src/workspace/tools/index.ts
+++ b/packages/core/src/workspace/tools/index.ts
@@ -8,6 +8,7 @@ export { createWorkspaceTools, resolveToolConfig, type ResolvedToolConfig } from
 export { readFileTool } from './read-file';
 export { writeFileTool } from './write-file';
 export { editFileTool } from './edit-file';
+export { applyPatchTool } from './apply-patch';
 export { listFilesTool } from './list-files';
 export { deleteFileTool } from './delete-file';
 export { fileStatTool } from './file-stat';

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -16,6 +16,8 @@ import { InMemoryFileReadTracker, InMemoryFileWriteLock } from '../filesystem';
 import type { FileReadTracker, FileWriteLock, WorkspaceFilesystem } from '../filesystem';
 import type { WorkspaceSandbox } from '../sandbox';
 import type { Workspace } from '../workspace';
+import { applyPatchTool } from './apply-patch';
+import { getApplyPatchWritePaths } from './apply-patch-parser';
 import { isAstGrepAvailable, astEditTool } from './ast-edit';
 import { deleteFileTool } from './delete-file';
 import { editFileTool } from './edit-file';
@@ -240,12 +242,18 @@ function wrapTool(tool: any, workspace: Workspace, targets: ResolveTargets): any
  * - mode 'read': records the read after execution
  * - mode 'write': checks before execution, clears after
  */
+function writePathsFromInput(input: any, getWritePaths?: (input: any) => string[]): string[] {
+  if (getWritePaths) return getWritePaths(input);
+  return input?.path ? [input.path] : [];
+}
+
 function wrapWithReadTracker(
   tool: any,
   workspace: Workspace,
   readTracker: FileReadTracker,
   config: { requireReadBeforeWrite?: DynamicToolConfigValue<ToolConfigWithArgsContext> },
   mode: 'read' | 'write',
+  getWritePaths?: (input: any) => string[],
 ): any {
   return {
     ...tool,
@@ -255,44 +263,56 @@ function wrapWithReadTracker(
       });
       let enrichedContext: any = { ...context, workspace: effectiveWorkspace };
       const fs: WorkspaceFilesystem | undefined = effectiveWorkspace.filesystem;
+      const paths = writePathsFromInput(input, getWritePaths);
 
       // Pre-execution: enforce read-before-write policy and/or attach
       // optimistic-concurrency mtime for write tools.
       if (mode === 'write' && fs) {
-        // Optimistic concurrency: attach the mtime from the last read
-        // *before* stat so it's preserved even when the file has been
-        // deleted externally (stat throws FileNotFoundError).
-        const record = readTracker.getReadRecord(input.path);
-        if (record) {
-          enrichedContext = { ...enrichedContext, __expectedMtime: record.modifiedAtRead };
-        }
+        const expectedMtimes: Record<string, Date> = {};
 
-        try {
-          const stat = await fs.stat(input.path);
+        for (const filePath of paths) {
+          // Optimistic concurrency: attach the mtime from the last read
+          // *before* stat so it's preserved even when the file has been
+          // deleted externally (stat throws FileNotFoundError).
+          const record = readTracker.getReadRecord(filePath);
+          if (record) {
+            expectedMtimes[filePath] = record.modifiedAtRead;
+          }
 
-          // Policy gate: require the agent to have read the file first.
-          // Only evaluate when explicitly configured (opt-in policy).
-          // Safe default true = fail-closed if a dynamic function throws.
-          if (config.requireReadBeforeWrite !== undefined) {
-            const shouldRequireRead = await resolveDynamicValue(
-              config.requireReadBeforeWrite,
-              { args: input, requestContext: enrichedContext.requestContext ?? {}, workspace: effectiveWorkspace },
-              true,
-            );
-            if (shouldRequireRead) {
-              const check = readTracker.needsReRead(input.path, stat.modifiedAt);
-              if (check.needsReRead) {
-                throw new FileReadRequiredError(input.path, check.reason!);
+          try {
+            const stat = await fs.stat(filePath);
+
+            // Policy gate: require the agent to have read the file first.
+            // Only evaluate when explicitly configured (opt-in policy).
+            // Safe default true = fail-closed if a dynamic function throws.
+            if (config.requireReadBeforeWrite !== undefined) {
+              const shouldRequireRead = await resolveDynamicValue(
+                config.requireReadBeforeWrite,
+                { args: input, requestContext: enrichedContext.requestContext ?? {}, workspace: effectiveWorkspace },
+                true,
+              );
+              if (shouldRequireRead) {
+                const check = readTracker.needsReRead(filePath, stat.modifiedAt);
+                if (check.needsReRead) {
+                  throw new FileReadRequiredError(filePath, check.reason!);
+                }
               }
             }
+          } catch (error) {
+            if (!(error instanceof FileNotFoundError)) {
+              throw error;
+            }
+            // Missing file: if a read record exists the expectedMtime is
+            // already attached, so downstream writeFile can treat this as
+            // stale. Otherwise it's a genuinely new file.
           }
-        } catch (error) {
-          if (!(error instanceof FileNotFoundError)) {
-            throw error;
-          }
-          // Missing file: if a read record exists the expectedMtime is
-          // already attached, so downstream writeFile can treat this as
-          // stale. Otherwise it's a genuinely new file.
+        }
+
+        if (paths.length === 1 && expectedMtimes[paths[0]!]) {
+          enrichedContext = { ...enrichedContext, __expectedMtime: expectedMtimes[paths[0]!] };
+        }
+        if (Object.keys(expectedMtimes).length > 0) {
+          enrichedContext = { ...enrichedContext, __expectedMtimes: expectedMtimes };
         }
       }
 
@@ -301,13 +321,18 @@ function wrapWithReadTracker(
       // Post-execution: track reads / clear write records
       if (mode === 'read' && fs) {
         try {
-          const stat = await fs.stat(input.path);
-          readTracker.recordRead(input.path, stat.modifiedAt);
+          const readPath = paths[0] ?? input.path;
+          if (readPath) {
+            const stat = await fs.stat(readPath);
+            readTracker.recordRead(readPath, stat.modifiedAt);
+          }
         } catch {
           // Ignore stat errors for tracking
         }
       } else if (mode === 'write') {
-        readTracker.clearReadRecord(input.path);
+        for (const filePath of paths) {
+          readTracker.clearReadRecord(filePath);
+        }
       }
 
       return result;
@@ -351,14 +376,19 @@ function wrapWithToolHooks(
   };
 }
 
-function wrapWithWriteLock(tool: any, writeLock: FileWriteLock): any {
+function wrapWithWriteLock(tool: any, writeLock: FileWriteLock, getWritePaths?: (input: any) => string[]): any {
   return {
     ...tool,
     execute: async (input: any, context: any = {}) => {
-      if (!input.path) {
+      const paths = writePathsFromInput(input, getWritePaths);
+      if (paths.length === 0) {
+        if (getWritePaths) {
+          // Parse failed (or patch named no paths). Let the tool report the error.
+          return tool.execute(input, context);
+        }
         throw new Error('wrapWithWriteLock: input.path is required');
       }
-      return writeLock.withLock(input.path, () => tool.execute(input, context));
+      return writeLock.withLocks(paths, () => tool.execute(input, context));
     },
   };
 }
@@ -404,6 +434,7 @@ export async function createWorkspaceTools(
       readTrackerMode?: 'read' | 'write';
       useWriteLock?: boolean;
       targets?: ResolveTargets;
+      getWritePaths?: (input: any) => string[];
     },
   ) => {
     const config = await resolveToolConfig(toolsConfig, name, effectiveConfigContext);
@@ -440,7 +471,7 @@ export async function createWorkspaceTools(
     }
 
     if (opts?.readTrackerMode) {
-      wrapped = wrapWithReadTracker(wrapped, workspace, readTracker, config, opts.readTrackerMode);
+      wrapped = wrapWithReadTracker(wrapped, workspace, readTracker, config, opts.readTrackerMode, opts.getWritePaths);
     } else {
       wrapped = wrapTool(wrapped, workspace, opts?.targets ?? {});
     }
@@ -466,7 +497,7 @@ export async function createWorkspaceTools(
 
     // Write lock is outermost — serializes the entire enriched execute pipeline
     if (opts?.useWriteLock) {
-      wrapped = wrapWithWriteLock(wrapped, writeLock);
+      wrapped = wrapWithWriteLock(wrapped, writeLock, opts.getWritePaths);
     }
 
     tools[exposedName] = wrapped;
@@ -501,6 +532,18 @@ export async function createWorkspaceTools(
         requireWrite: true,
         readTrackerMode: 'write',
         useWriteLock: true,
+      });
+    }
+
+    // apply_patch is opt-in: only register when per-tool enabled is true or a function.
+    // Top-level tools.enabled must not turn this on.
+    const applyPatchEnabled = toolsConfig?.[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]?.enabled;
+    if (applyPatchEnabled === true || typeof applyPatchEnabled === 'function') {
+      await addTool(WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH, applyPatchTool, {
+        requireWrite: true,
+        readTrackerMode: 'write',
+        useWriteLock: true,
+        getWritePaths: getApplyPatchWritePaths,
       });
     }
   }

--- a/packages/core/src/workspace/workspace-safety.test.ts
+++ b/packages/core/src/workspace/workspace-safety.test.ts
@@ -224,6 +224,44 @@ describe('Workspace Safety Features', () => {
 
       await workspace.destroy();
     });
+
+    it('should enforce requireReadBeforeWrite on apply_patch for existing files', async () => {
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        tools: {
+          [WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]: {
+            enabled: true,
+            requireReadBeforeWrite: true,
+          },
+        },
+      });
+      await workspace.init();
+      await workspace.filesystem!.writeFile('test.txt', 'hello world');
+
+      const tools = await createWorkspaceTools(workspace);
+      const readTool = tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE];
+      const applyPatch = tools[WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH];
+
+      await expect(
+        applyPatch.execute(
+          {
+            patchText: '*** Begin Patch\n*** Update File: test.txt\n@@\n-hello world\n+goodbye world\n*** End Patch\n',
+          },
+          { workspace },
+        ),
+      ).rejects.toThrow(FileReadRequiredError);
+
+      await readTool.execute({ path: 'test.txt' }, { workspace });
+      const result = await applyPatch.execute(
+        {
+          patchText: '*** Begin Patch\n*** Update File: test.txt\n@@\n-hello world\n+goodbye world\n*** End Patch\n',
+        },
+        { workspace },
+      );
+      expect(result).toContain('M test.txt');
+
+      await workspace.destroy();
+    });
   });
 
   describe('readOnly mode', () => {

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -388,7 +388,7 @@ export interface WorkspaceConfig<
   /**
    * Enable LSP diagnostics for edit tools.
    *
-   * When enabled, edit tools (edit_file, write_file, ast_edit) will append
+   * When enabled, edit tools (edit_file, write_file, ast_edit, apply_patch) will append
    * type errors, warnings, and other diagnostics from language servers after edits.
    *
    * LSP requires a sandbox with a process manager (`sandbox.processes`) to spawn

--- a/packages/server/src/server/constants.ts
+++ b/packages/server/src/server/constants.ts
@@ -68,6 +68,7 @@ export const WORKSPACE_TOOLS = {
     FILE_STAT: `${WORKSPACE_TOOLS_PREFIX}_file_stat` as const,
     MKDIR: `${WORKSPACE_TOOLS_PREFIX}_mkdir` as const,
     GREP: `${WORKSPACE_TOOLS_PREFIX}_grep` as const,
+    APPLY_PATCH: `${WORKSPACE_TOOLS_PREFIX}_apply_patch` as const,
   },
   SANDBOX: {
     EXECUTE_COMMAND: `${WORKSPACE_TOOLS_PREFIX}_execute_command` as const,


### PR DESCRIPTION
Adds an opt-in `mastra_workspace_apply_patch` workspace tool so agents can create, update, move, and delete several files in one call using the OpenCode/OpenAI patch format. It stays off until you enable it; a top-level `tools.enabled: true` does not turn it on. Existing agents keep `write_file` and `edit_file`.

```ts
import { Workspace, LocalFilesystem, WORKSPACE_TOOLS } from '@mastra/core/workspace'

const workspace = new Workspace({
  filesystem: new LocalFilesystem({ basePath: './workspace' }),
  tools: {
    [WORKSPACE_TOOLS.FILESYSTEM.APPLY_PATCH]: { enabled: true },
  },
})
```

Hunks are applied in memory first, so a mismatch applies nothing. Write-lock and read-before-write cover every path in the patch. There is no linked issue yet.
