### PR TITLE
fix(memory): scope recall to selected messages

### DIFF
--- a/.changeset/curly-kids-allow.md
+++ b/.changeset/curly-kids-allow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added per-request message selection so branched conversations can recall only their active path.

--- a/.changeset/easy-humans-rest.md
+++ b/.changeset/easy-humans-rest.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed per-request history and Observational Memory overrides, including active-branch message selection.

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -108,6 +108,28 @@ Observational memory still relies on stored conversation history. Sending the fu
 For an AI SDK example, see [Using Mastra Memory](/integrations/agentic-ui/ai-sdk-ui#using-mastra-memory).
 :::
 
+## Per-request history controls
+
+Override Observational Memory or raw message history for one request through `memory.options`. Setting `observationalMemory: false` disables OM for that request. Setting `lastMessages: false` keeps stored transcript messages out of the model context while leaving configured OM observations available.
+
+For a branched conversation stored in one thread, pass the active path's message IDs:
+
+```typescript
+await agent.stream('Continue this branch.', {
+  memory: {
+    resource: 'user-123',
+    thread: 'conversation-123',
+    options: {
+      selectMessages: {
+        ids: ['root-message', 'active-branch-message'],
+      },
+    },
+  },
+})
+```
+
+The selection filters raw transcript history, including semantic recall results. It doesn't filter condensed OM observations.
+
 :::note
 
 OM currently only supports `@mastra/pg`, `@mastra/libsql`, `@mastra/mysql`, `@mastra/mongodb`, `@mastra/convex`, and `@mastra/oracledb` storage adapters.

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -182,6 +182,26 @@ Each memory feature is added to either the system messages or the conversation m
 
 Conversation messages are ordered by timestamp and deduplicated by message ID, so recalled older messages appear before recent history. Context messages passed at call time are stamped with the current time, which places them after history and recall but before your new message. To inspect the exact context for a real request, use [Tracing](/docs/observability/tracing/overview) and open the LLM call spans, see [Observability](#observability) below.
 
+### Scope branched conversation history
+
+Store multiple conversation branches in one thread and pass the active path's message IDs for each request. Mastra recalls only those raw transcript messages. Observational Memory observations remain available because they are condensed memory rather than raw history.
+
+```typescript
+const response = await memoryAgent.stream('Continue this branch.', {
+  memory: {
+    resource: 'user-123',
+    thread: 'conversation-123',
+    options: {
+      selectMessages: {
+        ids: ['root-message', 'active-branch-message'],
+      },
+    },
+  },
+})
+```
+
+Build the ID list from your application's branch model, such as a `parentMessageId` chain. Pass the selection on every request that must exclude sibling branches.
+
 ## Memory in multi-agent systems
 
 When a [supervisor agent](/docs/subagents) delegates to a subagent, Mastra isolates subagent memory automatically. No flag enables this as it happens on every delegation. Understanding how this scoping works lets you decide what stays private and what to share intentionally.

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -522,7 +522,7 @@ const stream = await agent.stream('message for agent')
                     type: 'MemoryConfig',
                     isOptional: true,
                     description:
-                      'Configuration for memory behavior including lastMessages, readOnly, semanticRecall, workingMemory, and filterIncompleteToolCalls.',
+                      'Configuration for memory behavior including lastMessages, selectMessages, readOnly, semanticRecall, observationalMemory, workingMemory, and filterIncompleteToolCalls.',
                   },
                 ],
               },

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -809,6 +809,7 @@ https://mastra.ai/en/docs/memory/overview`,
           new MessageHistory({
             storage: memoryStore,
             lastMessages: typeof lastMessages === 'number' ? lastMessages : undefined,
+            selectMessages: effectiveConfig.selectMessages,
           }),
         );
       }

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -955,6 +955,26 @@ type BaseMemoryConfig = {
   lastMessages?: number | false;
 
   /**
+   * Restricts recalled conversation history to an explicit set of message IDs.
+   * Use this to pass only the active path of a branched conversation while
+   * keeping every branch in the same stored thread.
+   *
+   * The selection applies to conversation history and semantic recall results.
+   * Observational Memory observations remain available because they are
+   * condensed memory rather than raw transcript messages.
+   *
+   * @example
+   * ```typescript
+   * selectMessages: {
+   *   ids: ['root-message', 'active-branch-message'],
+   * }
+   * ```
+   */
+  selectMessages?: {
+    ids: string[];
+  };
+
+  /**
    * Semantic recall configuration for RAG-based retrieval of relevant past messages.
    * Uses vector embeddings for similarity search across conversation history.
    * Can be a boolean to enable/disable with defaults, or an object for detailed configuration.
@@ -1249,8 +1269,7 @@ export type SharedMemoryConfig = {
 export type WorkingMemoryFormat = 'json' | 'markdown';
 
 export type WorkingMemoryTemplate =
-  | { format: 'markdown'; content: string }
-  | { format: 'json'; content: string | Record<string, unknown> };
+  { format: 'markdown'; content: string } | { format: 'json'; content: string | Record<string, unknown> };
 
 // Type for flexible message deletion input
 export type MessageDeleteInput = string[] | { id: string }[];

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1269,7 +1269,8 @@ export type SharedMemoryConfig = {
 export type WorkingMemoryFormat = 'json' | 'markdown';
 
 export type WorkingMemoryTemplate =
-  { format: 'markdown'; content: string } | { format: 'json'; content: string | Record<string, unknown> };
+  | { format: 'markdown'; content: string }
+  | { format: 'json'; content: string | Record<string, unknown> };
 
 // Type for flexible message deletion input
 export type MessageDeleteInput = string[] | { id: string }[];

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -170,6 +170,51 @@ describe('MessageHistory', () => {
       expect(resultMessages[2].id).toBe('msg-4');
     });
 
+    it('loads only selected messages without letting siblings consume the history window', async () => {
+      mockStorage.setMessages([
+        {
+          id: 'root',
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'Root' }] },
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date('2026-01-01T00:00:00Z'),
+        },
+        {
+          id: 'active',
+          role: 'assistant',
+          content: { format: 2, parts: [{ type: 'text', text: 'Active path' }] },
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date('2026-01-01T00:01:00Z'),
+        },
+        {
+          id: 'sibling',
+          role: 'assistant',
+          content: { format: 2, parts: [{ type: 'text', text: 'Sibling path' }] },
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date('2026-01-01T00:02:00Z'),
+        },
+      ]);
+      processor = new MessageHistory({
+        storage: mockStorage,
+        lastMessages: 2,
+        selectMessages: { ids: ['root', 'active'] },
+      });
+      const messageList = new MessageList();
+
+      const result = await processor.processInput({
+        messages: [],
+        messageList,
+        abort: mockAbort,
+        requestContext: createRuntimeContextWithMemory('thread-1', 'resource-1'),
+      });
+
+      const resultMessages = result instanceof MessageList ? result.get.all.db() : result;
+      expect(resultMessages.map(message => message.id)).toEqual(['root', 'active']);
+    });
+
     it('reuses the same history read within a memory run', async () => {
       mockStorage.setMessages([
         {

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -14,6 +14,9 @@ import type { MemoryStorage } from '../../storage';
 export interface MessageHistoryOptions {
   storage: MemoryStorage;
   lastMessages?: number;
+  selectMessages?: {
+    ids: string[];
+  };
 }
 
 /**
@@ -29,10 +32,12 @@ export class MessageHistory implements Processor {
   readonly name = 'MessageHistory';
   private storage: MemoryStorage;
   private lastMessages?: number;
+  private selectedMessageIds?: string[];
 
   constructor(options: MessageHistoryOptions) {
     this.storage = options.storage;
     this.lastMessages = options.lastMessages;
+    this.selectedMessageIds = options.selectMessages?.ids;
   }
 
   /**
@@ -112,8 +117,26 @@ export class MessageHistory implements Processor {
 
     try {
       // 1. Fetch historical messages from storage (as DB format)
-      const cacheKey = `history:${threadId}:${resourceId ?? ''}:${this.lastMessages ?? 'all'}`;
+      const selectionKey = this.selectedMessageIds?.slice().sort().join(',') ?? 'all';
+      const cacheKey = `history:${threadId}:${resourceId ?? ''}:${this.lastMessages ?? 'all'}:${selectionKey}`;
       const loadMessages = async () => {
+        if (this.selectedMessageIds) {
+          if (this.selectedMessageIds.length === 0) {
+            return [];
+          }
+
+          const result = await this.storage.listMessagesById({
+            messageIds: this.selectedMessageIds,
+          });
+          const selectedMessages = result.messages
+            .filter(message => message.threadId === threadId && (!resourceId || message.resourceId === resourceId))
+            .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime());
+
+          return typeof this.lastMessages === 'number'
+            ? selectedMessages.slice(0, this.lastMessages)
+            : selectedMessages;
+        }
+
         const result = await this.storage.listMessages({
           threadId,
           resourceId,

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -2583,6 +2583,126 @@ describe('Memory', () => {
     });
   });
 
+  describe('per-request observational memory history controls', () => {
+    const resourceId = 'runtime-memory-resource';
+    const threadId = 'runtime-memory-thread';
+
+    async function createMemoryWithObservationalMemory() {
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        options: {
+          lastMessages: 10,
+          observationalMemory: true,
+        },
+      });
+
+      await memory.saveThread({
+        thread: {
+          id: threadId,
+          resourceId,
+          title: 'Runtime memory controls',
+          createdAt: new Date('2024-01-01T00:00:00Z'),
+          updatedAt: new Date('2024-01-01T00:00:00Z'),
+        },
+      });
+
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'branch-root',
+            threadId,
+            resourceId,
+            role: 'user',
+            content: { format: 2, parts: [{ type: 'text', text: 'Root message' }] },
+            createdAt: new Date('2024-01-01T10:00:00Z'),
+          },
+          {
+            id: 'branch-active',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: { format: 2, parts: [{ type: 'text', text: 'Active branch' }] },
+            createdAt: new Date('2024-01-01T10:01:00Z'),
+          },
+          {
+            id: 'branch-sibling',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: { format: 2, parts: [{ type: 'text', text: 'Sibling branch' }] },
+            createdAt: new Date('2024-01-01T10:02:00Z'),
+          },
+        ],
+      });
+
+      const om = await memory.omEngine;
+      await om!.getOrCreateRecord(threadId, resourceId);
+
+      return memory;
+    }
+
+    it('disables the instance observational-memory processor for one request', async () => {
+      const memory = await createMemoryWithObservationalMemory();
+      const requestContext = new RequestContext();
+      requestContext.set('MastraMemory', {
+        thread: { id: threadId },
+        resourceId,
+        memoryConfig: {
+          observationalMemory: false,
+          lastMessages: 2,
+        },
+      });
+
+      const processors = await memory.getInputProcessors([], requestContext);
+
+      expect(processors.find(processor => processor.id === 'observational-memory')).toBeUndefined();
+      expect(processors.find(processor => processor.id === 'message-history')).toBeDefined();
+    });
+
+    it('loads no transcript messages when lastMessages is disabled for one OM request', async () => {
+      const memory = await createMemoryWithObservationalMemory();
+
+      const context = await memory.getContext({
+        threadId,
+        resourceId,
+        memoryConfig: { lastMessages: false },
+      });
+
+      expect(context.messages).toEqual([]);
+      expect(context.omRecord).not.toBeNull();
+    });
+
+    it('recalls only selected active-branch messages in chronological order', async () => {
+      const memory = await createMemoryWithObservationalMemory();
+
+      const result = await memory.recall({
+        threadId,
+        resourceId,
+        threadConfig: {
+          lastMessages: 10,
+          selectMessages: { ids: ['branch-active', 'branch-root'] },
+        },
+      });
+
+      expect(result.messages.map(message => message.id)).toEqual(['branch-root', 'branch-active']);
+    });
+
+    it('loads only selected active-branch transcript messages with OM enabled', async () => {
+      const memory = await createMemoryWithObservationalMemory();
+
+      const context = await memory.getContext({
+        threadId,
+        resourceId,
+        memoryConfig: {
+          selectMessages: { ids: ['branch-root', 'branch-active'] },
+        },
+      });
+
+      expect(context.messages.map(message => message.id)).toEqual(['branch-root', 'branch-active']);
+      expect(context.omRecord).not.toBeNull();
+    });
+  });
+
   describe('thread-scoped processors attach without thread context', () => {
     // Processor attachment must be permissive: `MastraMemory` may not be
     // populated on requestContext at discovery time (agent processor discovery

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -711,6 +711,7 @@ export class Memory extends MastraMemory {
       }
 
       let usage: { tokens: number } | undefined;
+      const memoryStore = await this.getMemoryStore();
 
       // If history is disabled and there's no semantic recall to perform, return empty immediately
       if (historyDisabledByConfig && (!config.semanticRecall || !vectorSearchString || !this.vector)) {
@@ -724,6 +725,63 @@ export class Memory extends MastraMemory {
         };
         span?.end({ output: { success: true }, attributes: { messageCount: 0 } });
         return result;
+      }
+
+      if (config.selectMessages) {
+        const selectedIds = config.selectMessages.ids;
+        const selectedResult = selectedIds.length
+          ? await memoryStore.listMessagesById({ messageIds: selectedIds })
+          : { messages: [] };
+        const dateRange = filter?.dateRange;
+        const selectedMessages = selectedResult.messages.filter(message => {
+          if (message.threadId !== threadId || (resourceId && message.resourceId !== resourceId)) {
+            return false;
+          }
+          if (dateRange?.start) {
+            const startsAfter = dateRange.startExclusive
+              ? message.createdAt > dateRange.start
+              : message.createdAt >= dateRange.start;
+            if (!startsAfter) return false;
+          }
+          if (dateRange?.end) {
+            const endsBefore = dateRange.endExclusive
+              ? message.createdAt < dateRange.end
+              : message.createdAt <= dateRange.end;
+            if (!endsBefore) return false;
+          }
+          return true;
+        });
+
+        const direction = effectiveOrderBy?.direction ?? 'ASC';
+        selectedMessages.sort((left, right) => {
+          const comparison = left.createdAt.getTime() - right.createdAt.getTime();
+          return direction === 'DESC' ? -comparison : comparison;
+        });
+
+        const resultPage = page ?? 0;
+        const resultPerPage = perPage ?? false;
+        const offset = resultPerPage === false ? 0 : resultPage * resultPerPage;
+        const pageMessages =
+          resultPerPage === false ? selectedMessages : selectedMessages.slice(offset, offset + resultPerPage);
+        const rawMessages = shouldGetNewestAndReverse ? pageMessages.reverse() : pageMessages;
+        const list = new MessageList({ threadId, resourceId }).add(rawMessages, 'memory');
+        const messages = filterSystemReminderMessages(list.get.all.db(), includeSystemReminders);
+        const total = selectedMessages.length;
+        const hasMore = resultPerPage === false ? false : offset + resultPerPage < total;
+        const recallResult = {
+          messages,
+          usage,
+          total,
+          page: resultPage,
+          perPage: resultPerPage,
+          hasMore,
+        };
+
+        span?.end({
+          output: { success: true },
+          attributes: { messageCount: messages.length },
+        });
+        return recallResult;
       }
 
       if (config?.semanticRecall && vectorSearchString && this.vector) {
@@ -760,9 +818,6 @@ export class Memory extends MastraMemory {
       const threshold = semanticConfig?.threshold;
       const filteredVectorResults =
         threshold !== undefined ? vectorResults.filter(r => r.score >= threshold) : vectorResults;
-
-      // Get raw messages from storage
-      const memoryStore = await this.getMemoryStore();
 
       // When history is disabled by config, use perPage: 0 so only semantic recall
       // include results are returned (not the full message history)
@@ -1754,6 +1809,32 @@ ${workingMemory}`;
     const { threadId, resourceId, memoryConfig, runState } = opts;
     const config = this.getMergedThreadConfig(memoryConfig);
     const memoryStore = await this.getMemoryStore();
+    const selectedMessageIds = config.selectMessages?.ids;
+
+    const loadSelectedMessages = async ({
+      resourceScope = false,
+      after,
+    }: {
+      resourceScope?: boolean;
+      after?: Date;
+    }): Promise<MastraDBMessage[]> => {
+      if (!selectedMessageIds?.length) {
+        return [];
+      }
+
+      const result = await memoryStore.listMessagesById({
+        messageIds: selectedMessageIds,
+      });
+
+      return result.messages
+        .filter(message => {
+          const belongsToScope = resourceScope
+            ? message.resourceId === resourceId
+            : message.threadId === threadId && (!resourceId || message.resourceId === resourceId);
+          return belongsToScope && (!after || message.createdAt > after);
+        })
+        .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime());
+    };
 
     // Build system message parts
     const systemParts: string[] = [];
@@ -1764,7 +1845,8 @@ ${workingMemory}`;
     let continuationMessage: MastraDBMessage | undefined;
     let otherThreadsContext: string | undefined;
 
-    const omEngine = await this.omEngine;
+    const omEnabled = Boolean(normalizeObservationalMemoryConfig(config.observationalMemory));
+    const omEngine = omEnabled ? await this.omEngine : null;
     if (omEngine) {
       const loadOmRecord = () => omEngine.getRecord(threadId, resourceId);
       omRecord = runState
@@ -1828,17 +1910,27 @@ ${workingMemory}`;
 
     // 3. Load messages — unobserved if OM is active, or recent N
     let messages: MastraDBMessage[];
-    if (omEngine && omRecord) {
+    if (config.lastMessages === false) {
+      messages = [];
+    } else if (omEngine && omRecord) {
       // OM is active: load unobserved messages.
       // When lastObservedAt exists, load only messages after the boundary.
       // When lastObservedAt is NULL (no observations yet), load ALL messages
       // so the threshold check can fire on the full context.
-      const dateFilter = omRecord.lastObservedAt
-        ? { dateRange: { start: new Date(new Date(omRecord.lastObservedAt).getTime() + 1) } }
-        : undefined;
+      const after = omRecord.lastObservedAt ? new Date(new Date(omRecord.lastObservedAt).getTime() + 1) : undefined;
+      const dateFilter = after ? { dateRange: { start: after } } : undefined;
 
       const boundary = omRecord.lastObservedAt ? new Date(omRecord.lastObservedAt).toISOString() : '';
-      if (omEngine.scope === 'resource' && resourceId) {
+      if (selectedMessageIds) {
+        const resourceScope = omEngine.scope === 'resource' && Boolean(resourceId);
+        const loadMessages = () => loadSelectedMessages({ resourceScope, after });
+        messages = runState
+          ? await runState.load(
+              `observational-memory:messages:selected:${threadId}:${resourceId ?? ''}:${boundary}:${selectedMessageIds.join(',')}`,
+              loadMessages,
+            )
+          : await loadMessages();
+      } else if (omEngine.scope === 'resource' && resourceId) {
         const loadMessages = async () => {
           const result = await memoryStore.listMessagesByResourceId({
             resourceId,
@@ -1868,8 +1960,12 @@ ${workingMemory}`;
     } else {
       // No OM: load recent messages
       const lastMessages = config.lastMessages;
-      if (lastMessages === false) {
-        messages = [];
+      if (selectedMessageIds) {
+        const selectedMessages = await loadSelectedMessages({});
+        messages =
+          typeof lastMessages === 'number'
+            ? selectedMessages.slice(Math.max(0, selectedMessages.length - lastMessages))
+            : selectedMessages;
       } else {
         const result = await memoryStore.listMessages({
           threadId,
@@ -3429,14 +3525,8 @@ Notes:
     // (e.g. workflow agent steps) are handled at runtime: the processor no-ops
     // when `getThreadContext` resolves no thread.
     const runtimeMemory = context?.get('MastraMemory') as { memoryConfig?: RuntimeMemoryConfig } | undefined;
-    const runtimeObservationalMemory = normalizeObservationalMemoryConfig(
-      runtimeMemory?.memoryConfig?.observationalMemory,
-    );
-    const threadConfig = runtimeObservationalMemory
-      ? this.getMergedThreadConfig({
-          ...runtimeMemory?.memoryConfig,
-          observationalMemory: runtimeObservationalMemory,
-        } as MemoryConfigInternal)
+    const threadConfig = runtimeMemory?.memoryConfig
+      ? this.getMergedThreadConfig(runtimeMemory.memoryConfig as MemoryConfigInternal)
       : this.threadConfig;
 
     const effectiveConfig = normalizeObservationalMemoryConfig(threadConfig.observationalMemory);

--- a/packages/memory/src/processors/observational-memory/observation-turn/load-memory-context.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/load-memory-context.ts
@@ -1,5 +1,5 @@
 import type { MessageList } from '@mastra/core/agent';
-import type { MemoryRunState } from '@mastra/core/memory';
+import type { MemoryConfigInternal, MemoryRunState } from '@mastra/core/memory';
 
 import type { MemoryContextProvider } from '../processor';
 
@@ -8,15 +8,17 @@ export async function loadMemoryContextMessages({
   messageList,
   threadId,
   resourceId,
+  memoryConfig,
   runState,
 }: {
   memory: MemoryContextProvider;
   messageList: MessageList;
   threadId: string;
   resourceId?: string;
+  memoryConfig?: MemoryConfigInternal;
   runState?: MemoryRunState;
 }): Promise<Awaited<ReturnType<MemoryContextProvider['getContext']>>> {
-  const ctx = await memory.getContext({ threadId, resourceId, runState });
+  const ctx = await memory.getContext({ threadId, resourceId, memoryConfig, runState });
 
   for (const msg of ctx.messages) {
     if (msg.role !== 'system') {

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -1,5 +1,5 @@
 import type { MessageList } from '@mastra/core/agent';
-import type { MemoryRunState } from '@mastra/core/memory';
+import type { MemoryConfigInternal, MemoryRunState } from '@mastra/core/memory';
 import type { ObservabilityContext } from '@mastra/core/observability';
 import type { ProcessorContext, ProcessorStreamWriter } from '@mastra/core/processors';
 import type { RequestContext } from '@mastra/core/request-context';
@@ -137,7 +137,11 @@ export class ObservationTurn {
    * If a MemoryContextProvider is passed, loads historical messages and adds
    * them to the MessageList. Without a provider, only fetches/caches the record.
    */
-  async start(memory?: MemoryContextProvider, runState?: MemoryRunState): Promise<TurnContext> {
+  async start(
+    memory?: MemoryContextProvider,
+    runState?: MemoryRunState,
+    memoryConfig?: MemoryConfigInternal,
+  ): Promise<TurnContext> {
     if (this._started) throw new Error('Turn already started');
     this._started = true;
 
@@ -152,6 +156,7 @@ export class ObservationTurn {
         messageList: this.messageList,
         threadId: this.threadId,
         resourceId: this.resourceId,
+        memoryConfig,
         runState,
       });
 

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -1,6 +1,6 @@
 import type { MastraDBMessage, MessageList } from '@mastra/core/agent';
 import { parseMemoryRequestContext } from '@mastra/core/memory';
-import type { MemoryRunState } from '@mastra/core/memory';
+import type { MemoryConfigInternal, MemoryRunState } from '@mastra/core/memory';
 import type { ObservabilityContext } from '@mastra/core/observability';
 import type { Processor, ProcessInputStepArgs, ProcessOutputResultArgs } from '@mastra/core/processors';
 import type { ObservationalMemoryRecord } from '@mastra/core/storage';
@@ -30,7 +30,12 @@ function asLiveTurn(value: unknown): ObservationTurn | undefined {
 
 /** Subset of Memory that the processor needs — avoids circular imports. */
 export interface MemoryContextProvider {
-  getContext(opts: { threadId: string; resourceId?: string; runState?: MemoryRunState }): Promise<{
+  getContext(opts: {
+    threadId: string;
+    resourceId?: string;
+    memoryConfig?: MemoryConfigInternal;
+    runState?: MemoryRunState;
+  }): Promise<{
     systemMessage: string | undefined;
     messages: MastraDBMessage[];
     hasObservations: boolean;
@@ -176,6 +181,7 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
     const { threadId, resourceId } = context;
     const memoryContext = parseMemoryRequestContext(requestContext);
     const runState = memoryContext?.runState?.();
+    const memoryConfig = memoryContext?.memoryConfig;
     const readOnly = memoryContext?.memoryConfig?.readOnly;
 
     const actorModelContext = model?.modelId
@@ -203,6 +209,7 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
           messageList,
           threadId,
           resourceId,
+          memoryConfig,
           runState,
         });
         // Pass the record through even without observations — resource-scoped
@@ -266,7 +273,7 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
         this.turn.sendStateSignal = args.sendStateSignal;
         this.turn.agent = args.agent;
         this.turn.requestContext = requestContext;
-        await this.turn.start(this.memory, runState);
+        await this.turn.start(this.memory, runState, memoryConfig);
         if (stepNumber === 0 && this.temporalMarkers) {
           await insertTemporalGapMarkers({ messageList, sendSignal: args.sendSignal });
         }


### PR DESCRIPTION
## Summary
- honor per-request `observationalMemory: false` and `lastMessages: false` when OM is configured on the memory instance
- add `selectMessages.ids` so branched conversations can recall only the active transcript path
- document branch-scoped history and add focused regression coverage

Closes #18943

## Test plan
- [x] `pnpm build:core`
- [x] `pnpm build:memory`
- [x] `pnpm --filter ./packages/core check`
- [x] `pnpm --filter ./packages/memory check`
- [x] `pnpm --filter ./packages/core exec vitest run src/processors/memory/message-history.test.ts --reporter=dot --bail 1`
- [x] `pnpm --filter ./packages/memory exec vitest run src/index.test.ts --reporter=dot --bail 1`
- [ ] `pnpm validate` in `docs` (blocked by existing Windows ESM path/sidebar validation failures)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Memory recall can now follow the active branch of a conversation instead of mixing sibling branches. Each request can also disable transcript history or Observational Memory when needed.

## Changes

- Added `memory.options.selectMessages.ids` to limit recalled messages to explicit IDs.
- Honored per-request `lastMessages: false` and `observationalMemory: false` overrides.
- Applied message selection to raw history and semantic recall results.
- Preserved Observational Memory observations when raw transcript history is filtered.
- Added documentation for per-request controls and branched conversation history.
- Added regression tests for message selection and Observational Memory overrides.
- Added patch changesets for `@mastra/core` and `@mastra/memory`.

## Validation

- Core and memory package checks and targeted Vitest suites pass.
- Documentation validation remains blocked by existing Windows ESM path and sidebar validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->