### PR TITLE
Scroll first search match into view in the traces span detail panel

### DIFF
--- a/.changeset/fuzzy-dolls-press.md
+++ b/.changeset/fuzzy-dolls-press.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed span search results being hidden below the fold: opening a span from the traces search now scrolls the first highlighted match in the span detail panel into view

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -25,6 +25,7 @@ import { SearchFieldBlock } from '@/ds/components/FormFieldBlocks';
 import { Notice } from '@/ds/components/Notice';
 import { Tab, TabContent, TabList, Tabs } from '@/ds/components/Tabs';
 import type { LinkComponent } from '@/ds/types/link-component';
+import { useScrollToFirstHighlight } from '@/hooks/use-scroll-to-first-highlight';
 import { useTextHighlight } from '@/hooks/use-text-highlight';
 import { truncateString } from '@/lib/truncate-string';
 
@@ -287,7 +288,7 @@ export function TraceDataPanelView({
       </DataPanel.Header>
 
       {!collapsed && (
-        <SplitWithSpanPanel spanPanelSlot={spanPanelSlot} highlightQuery={query}>
+        <SplitWithSpanPanel spanPanelSlot={spanPanelSlot} highlightQuery={query} spanPanelKey={selectedSpanId}>
           {isLoading ? (
             <DataPanel.LoadingData>Loading trace...</DataPanel.LoadingData>
           ) : !spans?.length ? (
@@ -399,15 +400,23 @@ export function TraceDataPanelView({
 function SplitWithSpanPanel({
   spanPanelSlot,
   highlightQuery,
+  spanPanelKey,
   children,
 }: {
   spanPanelSlot?: ReactNode;
   highlightQuery: string;
+  /** Identity of the span shown in the panel; changing it re-triggers the match scroll. */
+  spanPanelKey?: string;
   children: ReactNode;
 }) {
   // A single hook call on the common ancestor covers both the timeline tree and
   // the span detail, so span names and payload values highlight together.
   const { ref: highlightRef } = useTextHighlight<HTMLDivElement>(highlightQuery);
+
+  // Scoped to the span-panel column only: a match deep in a large payload sits below
+  // the fold, so the first painted match is brought into view when the panel opens.
+  // The timeline column must never be scrolled by this.
+  const { ref: scrollToMatchRef } = useScrollToFirstHighlight<HTMLDivElement>(highlightQuery, spanPanelKey);
 
   if (!spanPanelSlot) {
     return (
@@ -422,6 +431,7 @@ function SplitWithSpanPanel({
       <div className="flex min-h-0 flex-col overflow-hidden">{children}</div>
       {/* Searchable: the span detail is where a match hides inside a large payload. */}
       <div
+        ref={scrollToMatchRef}
         data-highlight
         className="animate-in border-border1 fade-in-0 flex min-h-0 flex-col overflow-hidden border-l duration-300"
       >

--- a/packages/playground-ui/src/hooks/__tests__/use-scroll-to-first-highlight.test.tsx
+++ b/packages/playground-ui/src/hooks/__tests__/use-scroll-to-first-highlight.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useScrollToFirstHighlight } from '../use-scroll-to-first-highlight';
+
+// jsdom has no layout, so it ships no scrollIntoView.
+const scrollIntoView = vi.fn();
+Element.prototype.scrollIntoView = scrollIntoView;
+
+afterEach(() => {
+  cleanup();
+  scrollIntoView.mockClear();
+});
+
+function Harness({ search, resetKey, children }: { search: string; resetKey?: string; children?: React.ReactNode }) {
+  const { ref } = useScrollToFirstHighlight<HTMLDivElement>(search, resetKey);
+  return (
+    <div ref={ref} data-highlight>
+      {children}
+    </div>
+  );
+}
+
+describe('useScrollToFirstHighlight', () => {
+  it('scrolls the parent element of the first match under [data-highlight]', () => {
+    render(
+      <Harness search="needle">
+        <p>nothing here</p>
+        <p data-testid="hit">a needle in a haystack</p>
+        <p>another needle later</p>
+      </Harness>,
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    const target = scrollIntoView.mock.instances[0] as HTMLElement;
+    expect(target.textContent).toBe('a needle in a haystack');
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'center' });
+  });
+
+  it('matches case-insensitively and literally', () => {
+    render(
+      <Harness search="Nee.le">
+        <p>a needle would match a pattern, not a literal</p>
+        <p data-testid="hit">but nee.le is UPPER: NEE.LE</p>
+      </Harness>,
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect((scrollIntoView.mock.instances[0] as HTMLElement).textContent).toContain('nee.le');
+  });
+
+  it('does nothing for queries shorter than 2 characters', () => {
+    render(
+      <Harness search="n">
+        <p>a needle in a haystack</p>
+      </Harness>,
+    );
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when nothing matches and nothing ever arrives', () => {
+    render(
+      <Harness search="unicorn">
+        <p>a needle in a haystack</p>
+      </Harness>,
+    );
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('ignores text outside a data-highlight subtree', () => {
+    function OutsideHarness() {
+      const { ref } = useScrollToFirstHighlight<HTMLDivElement>('needle');
+      return (
+        <div ref={ref}>
+          <p>a needle outside any opted-in region</p>
+        </div>
+      );
+    }
+
+    render(<OutsideHarness />);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('scrolls only once per key, then re-scrolls when search changes', () => {
+    const { rerender } = render(
+      <Harness search="needle">
+        <p>a needle in a haystack</p>
+      </Harness>,
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    // Same key: content re-render must not scroll again.
+    rerender(
+      <Harness search="needle">
+        <p>a needle in a haystack</p>
+        <p>more content</p>
+      </Harness>,
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Harness search="haystack">
+        <p>a needle in a haystack</p>
+      </Harness>,
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-scrolls when resetKey changes with the same search', () => {
+    const { rerender } = render(
+      <Harness search="needle" resetKey="span-1">
+        <p>a needle in a haystack</p>
+      </Harness>,
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Harness search="needle" resetKey="span-2">
+        <p>a needle in a haystack</p>
+      </Harness>,
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-scrolls when the scrolled-to content is replaced by new content with the same match', async () => {
+    // Selecting another span re-runs the effect while the panel still shows the previous
+    // span's DOM: the first scan hits the stale match, then the real content swaps in.
+    const { rerender } = render(
+      <Harness search="needle" resetKey="span-2">
+        <p>span-1 has a needle too</p>
+      </Harness>,
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Harness search="needle" resetKey="span-2">
+        <p data-testid="fresh">span-2 needle payload</p>
+      </Harness>,
+    );
+
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledTimes(2));
+    expect((scrollIntoView.mock.instances[1] as HTMLElement).textContent).toBe('span-2 needle payload');
+  });
+
+  it('does not re-scroll on mutations that leave the scrolled-to content in place', async () => {
+    const { rerender } = render(
+      <Harness search="needle" resetKey="span-1">
+        <p>a needle in a haystack</p>
+      </Harness>,
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Harness search="needle" resetKey="span-1">
+        <p>a needle in a haystack</p>
+        <p>late sibling, also a needle</p>
+      </Harness>,
+    );
+
+    // Give the observer's rAF a chance to run before asserting nothing happened.
+    await new Promise(resolve => requestAnimationFrame(() => resolve(null)));
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it('scrolls to late-arriving content via the mutation observer', async () => {
+    const { rerender } = render(<Harness search="needle">{null}</Harness>);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    // The async payload lands after mount, like the span detail finishing its fetch.
+    rerender(
+      <Harness search="needle">
+        <p>a needle in a haystack</p>
+      </Harness>,
+    );
+
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledTimes(1));
+    expect((scrollIntoView.mock.instances[0] as HTMLElement).textContent).toBe('a needle in a haystack');
+  });
+});

--- a/packages/playground-ui/src/hooks/use-scroll-to-first-highlight.ts
+++ b/packages/playground-ui/src/hooks/use-scroll-to-first-highlight.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import type { RefCallback } from 'react';
+
+import { MIN_SEARCH_LENGTH, findFirstMatchTextNode } from './use-text-highlight';
+
+export interface UseScrollToFirstHighlightResult<TElement extends HTMLElement> {
+  ref: RefCallback<TElement>;
+}
+
+/**
+ * Scrolls the first text-highlight match inside the referenced subtree into view. The
+ * CSS Custom Highlight API paints ranges without wrapping DOM nodes, so there is no
+ * `<mark>` to scroll to — instead the first text node `useTextHighlight` would paint is
+ * located (same matching rules) and its parent element is brought into view.
+ *
+ * Content often arrives after the effect runs: the span payload loads async, and when a
+ * different span is selected the panel briefly still shows the previous span's DOM. So a
+ * MutationObserver stays attached for the effect's lifetime (rescans coalesced to one per
+ * frame) and re-scrolls whenever the previously scrolled-to node is gone or no longer
+ * contains the term — i.e. the content it scrolled to was replaced. While the matched
+ * node stays put, mutations never re-scroll, so the user can scroll freely afterwards.
+ * Pass `resetKey` to re-trigger the scroll for the same query, e.g. when a different
+ * span is selected.
+ */
+export function useScrollToFirstHighlight<TElement extends HTMLElement = HTMLElement>(
+  search: string,
+  resetKey?: unknown,
+): UseScrollToFirstHighlightResult<TElement> {
+  const [root, setRoot] = useState<TElement | null>(null);
+
+  useEffect(() => {
+    if (!root || search.trim().length < MIN_SEARCH_LENGTH) return;
+
+    let animationFrame: number | null = null;
+    let scrolledTo: Text | null = null;
+    let scrolledToData = '';
+
+    const scan = () => {
+      const match = findFirstMatchTextNode(root, search);
+      if (!match) return;
+
+      scrolledTo = match;
+      scrolledToData = match.data;
+      const target = match.parentElement;
+      // jsdom guard: scrollIntoView is not implemented there.
+      if (target && typeof target.scrollIntoView === 'function') {
+        target.scrollIntoView({ block: 'center' });
+      }
+    };
+
+    // The scrolled-to content survived the mutation iff the node is still attached with
+    // its text unchanged. React reuses text nodes and edits characterData in place, so
+    // swapped-in content (e.g. another span's payload matching the same term) shows up
+    // as a data change on the same node, not as a removal.
+    const scrolledContentIntact = () =>
+      scrolledTo !== null && scrolledTo.isConnected && scrolledTo.data === scrolledToData;
+
+    scan();
+
+    const observer = new MutationObserver(() => {
+      if (animationFrame !== null) return;
+
+      animationFrame = requestAnimationFrame(() => {
+        animationFrame = null;
+        if (!scrolledContentIntact()) scan();
+      });
+    });
+    observer.observe(root, { subtree: true, childList: true, characterData: true });
+
+    return () => {
+      observer.disconnect();
+      if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+    };
+  }, [root, search, resetKey]);
+
+  return { ref: setRoot };
+}

--- a/packages/playground-ui/src/hooks/use-text-highlight.ts
+++ b/packages/playground-ui/src/hooks/use-text-highlight.ts
@@ -18,7 +18,7 @@ const INDIRECT_HIGHLIGHT_NAME = 'search-result-indirect';
  * A single character matches almost everywhere, which paints noise instead of results.
  * Highlighting only starts once the term is discriminating enough.
  */
-const MIN_SEARCH_LENGTH = 2;
+export const MIN_SEARCH_LENGTH = 2;
 
 /**
  * Opt-in marker: only text inside a `data-highlight` subtree can be painted. Highlighting
@@ -36,6 +36,40 @@ const INDIRECT_SELECTOR = '[data-highlight-indirect]';
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * The first text node the highlighter would paint under `root` for `search`, or `null`.
+ * Mirrors the walker below exactly: only `data-highlight` / `data-highlight-indirect`
+ * subtrees count; indirect text is painted whole, so any non-empty text node in one is a
+ * hit; direct text needs a literal, case-insensitive occurrence of the term. Colocated
+ * here so the scroll target (`useScrollToFirstHighlight`) can't drift from the paint.
+ */
+export function findFirstMatchTextNode(root: HTMLElement, search: string): Text | null {
+  const regex = new RegExp(escapeRegExp(search), 'iu');
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const parent = node.parentElement as HTMLElement;
+      return parent.closest(`${INCLUDED_SELECTOR}, ${INDIRECT_SELECTOR}`)
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_REJECT;
+    },
+  });
+
+  while (walker.nextNode()) {
+    const textNode = walker.currentNode as Text;
+    const parent = textNode.parentElement as HTMLElement;
+
+    if (parent.closest(INDIRECT_SELECTOR)) {
+      if (textNode.data.length > 0) return textNode;
+      continue;
+    }
+
+    if (regex.test(textNode.data)) return textNode;
+  }
+
+  return null;
 }
 
 export interface UseTextHighlightResult<TElement extends HTMLElement> {


### PR DESCRIPTION
## Summary

When searching spans in the traces UI, matches are highlighted everywhere — including inside the span detail panel. But if the matched value sits deep in a large payload, it's below the fold of the panel's scroll container, so opening the span gives no visible indication of why it matched.

This PR auto-scrolls the first highlighted match in the span detail panel into view when the panel opens, when the search query changes, or when a different span is selected.

Since the CSS Custom Highlight API paints ranges without wrapping DOM nodes, there is no `<mark>` element to scroll to. A new `useScrollToFirstHighlight` hook re-walks the text nodes of the span-panel subtree using the exact same matching rules as `useTextHighlight` (shared `findFirstMatchTextNode` helper, `[data-highlight]` scoping, min length 2, case-insensitive literal match) and calls `scrollIntoView({ block: 'center' })` on the first match's parent element.

Details:

- Span payloads load async, so a `MutationObserver` (rAF-coalesced) rescans until content with a match arrives.
- Selecting another span re-triggers the scroll — including when React reuses text nodes and swaps content in place (detected via a data snapshot of the scrolled-to node), so two spans matching the same term both scroll correctly.
- While the matched content stays put, mutations never re-scroll, so the user can scroll freely without being yanked back.
- Scoped to the span detail column only; the timeline tree is never scrolled.

## Test plan

- [x] New jsdom tests for `useScrollToFirstHighlight` (10 tests): first-match scrolling, case-insensitive literal matching, min-length/no-match no-ops, `[data-highlight]` scoping, single scroll per key, re-scroll on query/span change, in-place content replacement, late-arriving content, no re-scroll on unrelated mutations.
- [x] Full `@mastra/playground-ui` suite passes (2917 tests).
- [x] `tsc --noEmit` and lint (0 errors) clean.
- [ ] Manual in Studio: search a term matching deep in a span payload → click the span → panel scrolls the match into view; manual scrolling isn't overridden; switching spans/query re-scrolls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a search finds text in a trace span, the detail panel now automatically shows the first match. It does this when the panel opens, the search changes, or a different span is selected.

## Changes

- Added `useScrollToFirstHighlight` to find and center the first matching text node.
- Added `MutationObserver` support for asynchronously loaded or replaced span content.
- Limited scrolling to the span detail column.
- Prevented repeated scrolling while matched content remains unchanged.
- Exported shared matching logic from `use-text-highlight`.
- Added 10 jsdom tests covering matching, rescans, mutations, and scrolling behavior.
- Added a patch changeset for `@mastra/playground-ui`.

UI tests, TypeScript checks, and linting pass. Manual Studio testing remains pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->