### PR TITLE
fix(langfuse): map root span input/output to trace-level input/output

### DIFF
--- a/.changeset/tidy-moons-repair.md
+++ b/.changeset/tidy-moons-repair.md
@@ -1,0 +1,5 @@
+---
+'@mastra/langfuse': patch
+---
+
+Map the root span's input/output to `langfuse.trace.input`/`langfuse.trace.output` so Langfuse traces carry trace-level input and output again. Previously the exporter only mapped input/output onto observations, leaving every trace's top-level input/output empty — which broke LLM-as-a-judge evaluators bound to Trace input/output and removed the request/response summary from the Langfuse trace view. User-facing behavior otherwise unchanged; existing trace name/tags/metadata mappings take the same precedence as before.

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -467,6 +467,17 @@ describe('LangfuseExporter', () => {
       expect(attrs['langfuse.trace.output']).toBeUndefined();
     });
 
+    it('omits trace input/output that cannot be serialized instead of failing the export', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      await exportSpan(exporter, makeSpan({ isRootSpan: true, input: circular, output: { text: 'ok' } } as any));
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.input']).toBeUndefined();
+      expect(attrs['langfuse.trace.output']).toBe(JSON.stringify({ text: 'ok' }));
+    });
+
     it('omits trace input/output when the root span has none', async () => {
       exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
       await exportSpan(exporter, makeSpan({ isRootSpan: true, input: undefined, output: undefined } as any));

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -432,6 +432,50 @@ describe('LangfuseExporter', () => {
       expect(attrs['mastra.metadata.sessionId']).toBeUndefined();
     });
 
+    it('maps root-span input/output to langfuse.trace.input/output', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          isRootSpan: true,
+          type: SpanType.AGENT_RUN,
+          input: { parts: [{ type: 'text', text: 'Hello' }] },
+          output: { text: 'Hi there' },
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.input']).toBe(JSON.stringify({ parts: [{ type: 'text', text: 'Hello' }] }));
+      expect(attrs['langfuse.trace.output']).toBe(JSON.stringify({ text: 'Hi there' }));
+    });
+
+    it('passes string root-span input/output through without re-serializing', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(exporter, makeSpan({ isRootSpan: true, input: 'plain question', output: 'plain answer' } as any));
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.input']).toBe('plain question');
+      expect(attrs['langfuse.trace.output']).toBe('plain answer');
+    });
+
+    it('does not set trace input/output for non-root spans', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(exporter, makeSpan({ isRootSpan: false } as any));
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.input']).toBeUndefined();
+      expect(attrs['langfuse.trace.output']).toBeUndefined();
+    });
+
+    it('omits trace input/output when the root span has none', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(exporter, makeSpan({ isRootSpan: true, input: undefined, output: undefined } as any));
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.input']).toBeUndefined();
+      expect(attrs['langfuse.trace.output']).toBeUndefined();
+    });
+
     it('maps tags to langfuse.trace.tags', async () => {
       exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
       await exportSpan(exporter, makeSpan({ isRootSpan: true, tags: ['prod', 'v2'] } as any));

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -355,6 +355,18 @@ function mapMastraToLangfuseAttributes(
   // filters. User-provided traceName (set via mastra.metadata.traceName) takes
   // precedence and is preserved.
   if (span.isRootSpan) {
+    // Trace input/output: mirror the root span's input/output onto the trace.
+    // Without this, Langfuse traces have empty trace-level input/output (the
+    // span data only reaches the root OBSERVATION), which breaks LLM-as-a-judge
+    // evaluators mapped to Trace input/output and leaves the trace view without
+    // the top-level request/response.
+    if (span.input !== undefined) {
+      attributes['langfuse.trace.input'] = typeof span.input === 'string' ? span.input : JSON.stringify(span.input);
+    }
+    if (span.output !== undefined) {
+      attributes['langfuse.trace.output'] =
+        typeof span.output === 'string' ? span.output : JSON.stringify(span.output);
+    }
     if (span.type === SpanType.AGENT_RUN) {
       if (!attributes['langfuse.trace.name'] && (span.entityName || span.entityId)) {
         attributes['langfuse.trace.name'] = span.entityName ?? span.entityId;

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -251,6 +251,21 @@ export class LangfuseExporter extends BaseExporter {
  * This function mutates the attributes object in place.
  * @see https://langfuse.com/integrations/native/opentelemetry#property-mapping
  */
+/**
+ * Serialize a root span's input/output for the trace-level attributes.
+ * Returns undefined (attribute omitted) for absent values and for values that
+ * cannot be JSON-serialized, so a bad payload never fails the span export.
+ */
+function serializeTraceIo(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
 function mapMastraToLangfuseAttributes(
   attributes: Record<string, any>,
   span: AnyExportedSpan,
@@ -359,13 +374,15 @@ function mapMastraToLangfuseAttributes(
     // Without this, Langfuse traces have empty trace-level input/output (the
     // span data only reaches the root OBSERVATION), which breaks LLM-as-a-judge
     // evaluators mapped to Trace input/output and leaves the trace view without
-    // the top-level request/response.
-    if (span.input !== undefined) {
-      attributes['langfuse.trace.input'] = typeof span.input === 'string' ? span.input : JSON.stringify(span.input);
+    // the top-level request/response. Serialization failures (circular refs,
+    // bigint) skip the attribute rather than failing the span export.
+    const traceInput = serializeTraceIo(span.input);
+    if (traceInput !== undefined) {
+      attributes['langfuse.trace.input'] = traceInput;
     }
-    if (span.output !== undefined) {
-      attributes['langfuse.trace.output'] =
-        typeof span.output === 'string' ? span.output : JSON.stringify(span.output);
+    const traceOutput = serializeTraceIo(span.output);
+    if (traceOutput !== undefined) {
+      attributes['langfuse.trace.output'] = traceOutput;
     }
     if (span.type === SpanType.AGENT_RUN) {
       if (!attributes['langfuse.trace.name'] && (span.entityName || span.entityId)) {


### PR DESCRIPTION
Fixes #22695

## Problem

The Langfuse exporter maps span input/output onto **observations**, but never sets `langfuse.trace.input` / `langfuse.trace.output` — so every trace exported through `@mastra/langfuse` has **empty trace-level input and output**.

Two consequences we hit in production after migrating to the new observability stack (core 1.61 / @mastra/langfuse 1.5.x):

1. **Langfuse LLM-as-a-judge evaluators silently break.** Evaluator variables mapped to *Trace input* / *Trace output* — a very common configuration, and the shape Langfuse's own evaluator UI defaults steer you toward — resolve to empty. In our case 9 production evaluators scored `0` on every trace with "MODEL_OUTPUT is empty" until we tracked it down.
2. **The trace view loses the top-level request/response** — you have to open the root observation to see what the trace was about.

Comparison of the same agent traffic before/after migrating from the legacy exporter:

```
trace (legacy exporter):  input=obj:135   output=obj:523
trace (this exporter):    input=EMPTY     output=EMPTY     ← root observation has the data, trace does not
```

## Fix

In `mapMastraToLangfuseAttributes`, on the **root span only**, mirror the span's input/output onto the trace via the official `langfuse.trace.input` / `langfuse.trace.output` span attributes (`LangfuseOtelSpanAttributes.TRACE_INPUT/TRACE_OUTPUT` — the same keys `@langfuse/tracing`'s `updateActiveTrace`/`createTraceAttributes` write, natively understood by the `LangfuseSpanProcessor` this exporter already uses). Serialization follows the file's existing convention: strings pass through, everything else is `JSON.stringify`'d.

Non-root spans are untouched, and existing trace name/tags/metadata mappings keep their precedence.

## Tests

Four new cases in `tracing.test.ts` (object I/O serialized, string I/O passed through, non-root spans untouched, absent I/O omitted); full package suite green (61 tests), lint clean, `turbo build --filter='@mastra/langfuse...'` green. Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The exporter now copies the first request and response to the Langfuse trace. This makes the data available in trace views and evaluators.

## Changes

- Map root span `input` and `output` to `langfuse.trace.input` and `langfuse.trace.output`.
- Pass strings through unchanged.
- Serialize other values with `JSON.stringify`.
- Omit values that cannot be serialized.
- Keep non-root span behavior unchanged.
- Preserve existing trace name, tag, and metadata precedence.
- Add tests for objects, strings, missing values, non-root spans, and circular references.
- Add a patch changeset for `@mastra/langfuse`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
