### PR TITLE
fix(mastracode): prevent duplicate status footers

### DIFF
--- a/.changeset/quiet-rivers-smile.md
+++ b/.changeset/quiet-rivers-smile.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed duplicate status rows after a response completes.

--- a/mastracode/tui/src/tui/__tests__/footer-animation-renderer.test.ts
+++ b/mastracode/tui/src/tui/__tests__/footer-animation-renderer.test.ts
@@ -76,7 +76,7 @@ describe('FooterAnimationRenderer', () => {
     expect(harness.ui.previousLines.slice(-2)).toEqual(['new status<reset>', 'new memory<reset>']);
   });
 
-  it('redraws the current footer while a normal render is queued', () => {
+  it('defers footer animation while a normal render is queued', () => {
     const harness = createHarness();
     harness.completeFullRender();
     harness.setFooterLines(['new footer']);
@@ -84,8 +84,8 @@ describe('FooterAnimationRenderer', () => {
     const renderTimer = setTimeout(() => {}, 1_000);
     Object.assign(harness.ui, { renderTimer });
 
-    expect(harness.renderer.renderFrame()).toBe(true);
-    expect(harness.terminal.write).toHaveBeenCalledOnce();
+    expect(harness.renderer.renderFrame()).toBe(false);
+    expect(harness.terminal.write).not.toHaveBeenCalled();
     clearTimeout(renderTimer);
   });
 

--- a/mastracode/tui/src/tui/footer-animation-renderer.ts
+++ b/mastracode/tui/src/tui/footer-animation-renderer.ts
@@ -11,6 +11,7 @@ interface PiTuiInternals {
   previousWidth: number;
   previousHeight: number;
   previousViewportTop: number;
+  renderRequested: boolean;
   stopped: boolean;
   hasOverlay(): boolean;
   applyLineResets(lines: string[]): string[];
@@ -42,6 +43,7 @@ export class FooterAnimationRenderer {
     if (
       this.disposed ||
       ui.stopped ||
+      ui.renderRequested ||
       ui.hasOverlay() ||
       ui.children.at(-1) !== this.footer ||
       ui.previousWidth !== width ||


### PR DESCRIPTION
The TUI can render the mode, model, timing, token rate, branch, and context meter twice after a response.

Defer footer animation while a normal render is queued so the TUI keeps one status footer during idle and completed states.

Tested with the focused footer renderer suite and the TUI type check.

Model: gpt-5.6-sol
Harness: Codex CLI in Terminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The TUI sometimes showed the same status information twice after a response ended. This change waits for the normal screen update before running the footer animation, so the status appears once.

## Changes

- Skip footer animation when a normal render is already requested.
- Add `renderRequested` to `PiTuiInternals`.
- Update the queued-render test to verify that no footer frame is written.
- Add a patch changeset for `mastracode`.

## Testing

- Focused footer renderer test suite.
- TUI type check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->