### PR TITLE
feat(agent): allow onDelegationStart to reuse sub-agent threadId

### DIFF
--- a/.changeset/reuse-subagent-thread.md
+++ b/.changeset/reuse-subagent-thread.md
@@ -1,0 +1,23 @@
+---
+'@mastra/core': minor
+---
+
+Added `modifiedSubAgentThreadId` on `onDelegationStart` so a supervisor can reuse a subagent's thread and load prior conversation history. Delegations still mint a fresh thread and disable `lastMessages` unless you opt in.
+
+```ts
+let specialistThreadId: string | undefined
+
+await supervisor.generate(prompt, {
+  memory: { thread: 'user-thread', resource: 'user-1' },
+  delegation: {
+    onDelegationStart: async () => {
+      if (specialistThreadId) {
+        return { modifiedSubAgentThreadId: specialistThreadId }
+      }
+    },
+    onDelegationComplete: async ({ result }) => {
+      specialistThreadId = result?.subAgentThreadId
+    },
+  },
+})
+```

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -188,15 +188,15 @@ When a [supervisor agent](/docs/subagents) delegates to a subagent, Mastra isola
 
 ### How delegation scopes memory
 
-Each delegation creates a fresh `threadId` and a deterministic `resourceId` for the subagent:
+Each delegation creates a fresh `threadId` by default and a deterministic `resourceId` for the subagent:
 
-- **Thread ID**: Unique per delegation. The subagent starts with a clean message history every time it's called.
+- **Thread ID**: Unique per delegation by default. The subagent starts with a clean message history every time it's called, because Mastra forces `lastMessages: false` on that ephemeral thread. Return `modifiedSubAgentThreadId` from [`onDelegationStart`](/docs/subagents#ondelegationstart) to reuse a previous subagent thread. Reused threads load the memory instance's default message history so the specialist can continue a prior conversation.
 - **Resource ID**: Derived as `{parentResourceId}-{agentName}`. Because the resource ID is stable across delegations, resource-scoped memory persists between calls. A subagent remembers facts from previous delegations by the same user.
 - **Memory instance**: A subagent without its own memory inherits the supervisor's `Memory` instance and all configured options. If the subagent defines its own, that takes precedence.
 
 :::note
 
-Title generation (`generateTitle`) is a top-level thread concern and **isn't** applied to inherited subagent threads. Because each delegation creates an ephemeral thread that no one sees, running title generation for it would waste an LLM call per delegation. To generate titles for a subagent's own threads, give that subagent its own memory configuration.
+Title generation (`generateTitle`) is a top-level thread concern and **isn't** applied to inherited subagent threads by default. Ephemeral delegation threads are never surfaced, so running title generation for them would waste an LLM call per delegation. Return `modifiedMemoryOptions: { generateTitle: true }` from `onDelegationStart` when a reused thread should get a title, or give the subagent its own memory configuration.
 
 :::
 

--- a/docs/src/content/en/docs/subagents.mdx
+++ b/docs/src/content/en/docs/subagents.mdx
@@ -85,6 +85,8 @@ Called before the parent agent delegates to a subagent. Return an object to cont
 - `proceed: false`: Reject the delegation with a `rejectionReason`
 - `modifiedPrompt`: Rewrite the prompt sent to the subagent
 - `modifiedMaxSteps`: Limit the subagent's iteration count
+- `modifiedSubAgentThreadId`: Reuse a previous subagent thread instead of minting a new one
+- `modifiedMemoryOptions`: Override memory options for this delegated run
 
 ```typescript title="src/mastra/agents/parent-agent.ts"
 const stream = await parentAgent.stream('Research AI trends', {
@@ -111,6 +113,32 @@ const stream = await parentAgent.stream('Research AI trends', {
       }
 
       return { proceed: true }
+    },
+  },
+})
+```
+
+By default each delegation mints a fresh subagent `threadId` and forces `lastMessages: false`, so thread-scoped history does not load. Persist `context.result.subAgentThreadId` from `onDelegationComplete` and return it as `modifiedSubAgentThreadId` on a later supervisor call when the specialist should continue a prior conversation. Reused threads load the memory instance's default message history. `generateTitle` stays off unless `modifiedMemoryOptions` overrides it:
+
+```typescript title="src/mastra/agents/parent-agent.ts"
+let researchThreadId: string | undefined
+
+const stream = await parentAgent.stream('Continue the research', {
+  maxSteps: 10,
+  memory: {
+    thread: 'user-thread',
+    resource: 'user-1',
+  },
+  delegation: {
+    onDelegationStart: async context => {
+      if (context.primitiveId === 'research-agent' && researchThreadId) {
+        return { modifiedSubAgentThreadId: researchThreadId }
+      }
+    },
+    onDelegationComplete: async context => {
+      if (context.primitiveId === 'research-agent') {
+        researchThreadId = context.result?.subAgentThreadId
+      }
     },
   },
 })

--- a/docs/src/content/en/reference/migrations/network-to-supervisor.mdx
+++ b/docs/src/content/en/reference/migrations/network-to-supervisor.mdx
@@ -138,7 +138,7 @@ If you were handling specific `.network()` events, update them to use the standa
 
 Supervisor agents let you hook into the delegation lifecycle to monitor, modify, or reject delegations. These hooks can be configured in the agent's `defaultOptions` or passed per-call.
 
-`onDelegationStart` is called before the supervisor delegates to a subagent. You can modify the prompt or limit the subagent's steps. The hook can also reject the delegation entirely:
+`onDelegationStart` is called before the supervisor delegates to a subagent. You can modify the prompt, limit the subagent's steps, or return `modifiedSubAgentThreadId` to reuse a previous subagent thread so thread-scoped history can load. The hook can also reject the delegation entirely:
 
 ```typescript
 const stream = await supervisorAgent.stream('Research AI in education', {

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -1592,6 +1592,178 @@ describe('Supervisor Pattern - Working memory across delegations', () => {
 });
 
 /**
+ * Opt-in reuse of a sub-agent thread across delegations (issue #21944).
+ * Default remains a fresh thread with lastMessages forced off. Returning
+ * modifiedSubAgentThreadId from onDelegationStart reuses that thread and
+ * loads thread-scoped history so the specialist can continue a prior turn.
+ */
+describe('Supervisor Pattern - reused sub-agent thread', () => {
+  const FIRST_REPLY = 'Found prior turn ALPHA-7-TOKEN';
+
+  async function runTwoDelegations(args: {
+    reuseThread?: boolean;
+    emptyThreadId?: boolean;
+    forceLastMessagesOff?: boolean;
+    collectPrompts?: string[];
+  }) {
+    const sharedStore = new InMemoryStore();
+    const sharedMemory = new MockMemory({
+      storage: sharedStore,
+    });
+
+    const threadIds: string[] = [];
+    let storedSubAgentThreadId: string | undefined;
+    const prompts: string[] = args.collectPrompts ?? [];
+
+    let subCallCount = 0;
+    const subAgentModel = new MockLanguageModelV2({
+      doGenerate: async ({ prompt }) => {
+        subCallCount++;
+        prompts.push(JSON.stringify(prompt));
+        const text = subCallCount === 1 ? FIRST_REPLY : 'Continued the prior work';
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text,
+          content: [{ type: 'text' as const, text }],
+          warnings: [],
+        };
+      },
+    });
+
+    const subAgent = new Agent({
+      id: 'worker-agent',
+      name: 'worker-agent',
+      description: 'A worker agent that handles entity operations',
+      instructions: 'You handle entity operations.',
+      model: subAgentModel,
+    });
+
+    let supervisorCallCount = 0;
+    const supervisorModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        supervisorCallCount++;
+        if (supervisorCallCount % 2 === 1) {
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'tool-calls' as const,
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            text: '',
+            content: [
+              {
+                type: 'tool-call' as const,
+                toolCallId: `call-${supervisorCallCount}`,
+                toolName: 'agent-workerAgent',
+                input: JSON.stringify({
+                  prompt: supervisorCallCount === 1 ? 'Find the prior record' : 'Continue from last time',
+                }),
+              },
+            ],
+            warnings: [],
+          };
+        }
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          text: 'Done',
+          content: [{ type: 'text' as const, text: 'Done' }],
+          warnings: [],
+        };
+      },
+    });
+
+    const supervisor = new Agent({
+      id: 'supervisor',
+      name: 'supervisor',
+      instructions: 'You orchestrate sub-agents for entity operations.',
+      model: supervisorModel,
+      agents: { workerAgent: subAgent },
+      memory: sharedMemory,
+    });
+
+    const threadId = 'supervisor-thread';
+    const resourceId = 'test-user';
+    const messageFilter = () => [] as MastraDBMessage[];
+
+    const delegationHooks = {
+      messageFilter,
+      onDelegationStart: async () => {
+        if (args.emptyThreadId) {
+          return { modifiedSubAgentThreadId: '' };
+        }
+        if (args.reuseThread && storedSubAgentThreadId) {
+          return {
+            modifiedSubAgentThreadId: storedSubAgentThreadId,
+            ...(args.forceLastMessagesOff ? { modifiedMemoryOptions: { lastMessages: false as const } } : {}),
+          };
+        }
+      },
+      onDelegationComplete: (ctx: DelegationCompleteContext) => {
+        const id = ctx.result?.subAgentThreadId;
+        if (id) {
+          threadIds.push(id);
+          storedSubAgentThreadId = id;
+        }
+      },
+    };
+
+    await supervisor.generate('Find the prior record', {
+      maxSteps: 5,
+      memory: { thread: threadId, resource: resourceId },
+      delegation: delegationHooks,
+    });
+
+    await supervisor.generate('Now continue from last time', {
+      maxSteps: 5,
+      memory: { thread: threadId, resource: resourceId },
+      delegation: delegationHooks,
+    });
+
+    return { threadIds, prompts };
+  }
+
+  it('mints a fresh sub-agent thread per delegation by default', async () => {
+    const { threadIds, prompts } = await runTwoDelegations({ collectPrompts: [] });
+
+    expect(threadIds).toHaveLength(2);
+    expect(threadIds[0]).toBeDefined();
+    expect(threadIds[1]).toBeDefined();
+    expect(threadIds[1]).not.toBe(threadIds[0]);
+    expect(prompts[1]).not.toContain(FIRST_REPLY);
+  });
+
+  it('reuses a sub-agent thread and loads prior turns when onDelegationStart returns modifiedSubAgentThreadId', async () => {
+    const { threadIds, prompts } = await runTwoDelegations({ reuseThread: true, collectPrompts: [] });
+
+    expect(threadIds).toHaveLength(2);
+    expect(threadIds[1]).toBe(threadIds[0]);
+    expect(prompts[1]).toContain(FIRST_REPLY);
+  });
+
+  it('does not reuse a thread when modifiedSubAgentThreadId is an empty string', async () => {
+    const { threadIds, prompts } = await runTwoDelegations({ emptyThreadId: true, collectPrompts: [] });
+
+    expect(threadIds).toHaveLength(2);
+    expect(threadIds[1]).not.toBe(threadIds[0]);
+    expect(prompts[1]).not.toContain(FIRST_REPLY);
+  });
+
+  it('lets modifiedMemoryOptions keep lastMessages disabled on a reused thread', async () => {
+    const { threadIds, prompts } = await runTwoDelegations({
+      reuseThread: true,
+      forceLastMessagesOff: true,
+      collectPrompts: [],
+    });
+
+    expect(threadIds).toHaveLength(2);
+    expect(threadIds[1]).toBe(threadIds[0]);
+    expect(prompts[1]).not.toContain(FIRST_REPLY);
+  });
+});
+
+/**
  * Suspension in supervisor pattern.
  * Tests that when a sub-agent calls suspend(), the suspension propagates
  * through the supervisor's generate() and can be resumed.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4948,8 +4948,9 @@ export class Agent<
             };
 
             // Generate sub-agent thread and resource IDs early (before any rejection)
-            // These are needed for both successful execution and rejection cases
-            const subAgentThreadId = inputData.threadId
+            // These are needed for both successful execution and rejection cases.
+            // `let` so onDelegationStart can opt into a reused thread (issue #21944).
+            let subAgentThreadId = inputData.threadId
               ? `${inputData.threadId}-${randomUUID()}`
               : context?.mastra?.generateId({
                   idType: 'thread',
@@ -5214,6 +5215,12 @@ export class Agent<
               if (startResult.modifiedMaxSteps !== undefined) {
                 effectiveMaxSteps = startResult.modifiedMaxSteps;
               }
+              if (
+                typeof startResult.modifiedSubAgentThreadId === 'string' &&
+                startResult.modifiedSubAgentThreadId.length > 0
+              ) {
+                subAgentThreadId = startResult.modifiedSubAgentThreadId;
+              }
             }
 
             this.logger.debug('Delegation accepted', {
@@ -5222,6 +5229,9 @@ export class Agent<
               modifiedPrompt: effectivePrompt !== inputData.prompt,
               modifiedInstructions: effectiveInstructions !== inputData.instructions,
               modifiedMaxSteps: effectiveMaxSteps !== inputData.maxSteps,
+              modifiedSubAgentThreadId:
+                typeof startResult?.modifiedSubAgentThreadId === 'string' &&
+                startResult.modifiedSubAgentThreadId.length > 0,
             });
 
             // Append LLM-provided instructions to the sub-agent's own instructions
@@ -5293,6 +5303,9 @@ export class Agent<
               // config of its own. The prompt message format and the memory option passed to
               // generate/stream below must stay in lockstep on this condition.
               const injectSupervisorMemory = Boolean(resourceId && threadId && !resolvedHasOwnMemoryConfig);
+              const reuseSubAgentThread =
+                typeof startResult?.modifiedSubAgentThreadId === 'string' &&
+                startResult.modifiedSubAgentThreadId.length > 0;
               const subAgentMemoryOption = injectSupervisorMemory
                 ? {
                     // A resumed delegation must continue on the thread/resource pair the
@@ -5309,11 +5322,14 @@ export class Agent<
                     memory: {
                       ...(shouldResumeSubAgent ? {} : { resource: subAgentResourceId, thread: subAgentThreadId }),
                       options: {
-                        lastMessages: false as const,
                         // Title generation is a top-level thread concern. Ephemeral subagent
                         // delegation threads are never surfaced, so suppress it here to avoid
                         // an extra title-generation LLM call per delegation (issue #18738).
                         generateTitle: false,
+                        // Fresh threads skip message-history recall. Reused threads
+                        // (issue #21944) keep the instance default so prior turns can load.
+                        ...(reuseSubAgentThread ? {} : { lastMessages: false as const }),
+                        ...startResult?.modifiedMemoryOptions,
                       },
                     } as AgentMemoryOption,
                   }

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -131,6 +131,19 @@ export interface DelegationStartResult {
   modifiedInstructions?: string;
   /** Modified maxSteps for the sub-agent (optional) */
   modifiedMaxSteps?: number;
+  /**
+   * Thread ID to reuse for this delegated run (optional).
+   * When a non-empty string is returned, the sub-agent runs on that thread
+   * instead of a freshly minted one, and thread-scoped message history is loaded
+   * using the instance default instead of being forced off with `lastMessages: false`.
+   */
+  modifiedSubAgentThreadId?: string;
+  /**
+   * Memory options to apply to the delegated run (optional).
+   * Spread last over the delegation defaults so you can still disable
+   * `lastMessages` on a reused thread, or enable title generation.
+   */
+  modifiedMemoryOptions?: AgentMemoryOption['options'];
 }
 
 /**


### PR DESCRIPTION
Delegations still mint a fresh thread and force lastMessages off. Returning modifiedSubAgentThreadId opts into thread-scoped recall so specialists can continue a prior conversation.

Closes #21944

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A delegated sub-agent can now continue an earlier conversation instead of starting from zero. This helps it remember previous work while keeping new threads as the default.

## Changes

- Added `modifiedSubAgentThreadId` to `DelegationStartResult`.
- Added `modifiedMemoryOptions` to control memory behavior for reused threads.
- Reused threads load prior history by default.
- Fresh threads keep the existing behavior: `lastMessages: false`.
- Empty thread IDs do not enable reuse.
- Added integration tests for fresh threads, reused threads, and memory option overrides.
- Updated delegation and memory documentation.
- Added a changeset for the `@mastra/core` minor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->