### PR TITLE
fix(core): mount device nodes in native sandbox backends

### DIFF
--- a/.changeset/slick-humans-jam.md
+++ b/.changeset/slick-humans-jam.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': patch
+---
+
+Fixed device file access in both native sandbox backends of `LocalSandbox`, which made `git`, `ssh`, and shell redirections fail inside an isolated sandbox.
+
+**Linux (`isolation: 'bwrap'`)**
+
+The bubblewrap namespace was built with `/proc` and a tmpfs at `/tmp` but no `/dev`, so `/dev/null` did not exist and `git` failed with `No such file or directory`. It is now mounted as a minimal device filesystem.
+
+Adding `/dev` or `/dev/null` to `readOnlyPaths` was not a workaround. bwrap marks every bind mount `nodev`, and opening a character device on a `nodev` mount fails with `Permission denied` on any open, so that route produced nodes that looked correct but could not be used at all. Devices beyond the standard set still need `--dev-bind` passed through `bwrapArgs`.
+
+**macOS (`isolation: 'seatbelt'`)**
+
+The generated profile allowed `file-ioctl` on `/dev/null` and friends but never `file-write-data`, and its `file-write*` rules are scoped to the workspace. Opening a device for reading and writing was therefore denied, so `git` failed with `fatal: could not open '/dev/null' for reading and writing`. Writes to `/dev/null`, `/dev/zero`, `/dev/random`, `/dev/urandom`, and `/dev/tty` are now allowed. Unlinking and chmod on those nodes stay denied.
+
+Passing `nativeSandbox.bwrapArgs` still replaces the default arguments entirely, so include `--dev /dev` yourself when you override them.

--- a/docs/src/content/en/reference/workspace/local-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/local-sandbox.mdx
@@ -135,7 +135,8 @@ Configuration options for native OS sandboxing (used with `isolation: 'seatbelt'
   {
     name: 'bwrapArgs',
     type: 'string[]',
-    description: 'Additional arguments to pass to bwrap (Linux only).',
+    description:
+      'Custom arguments for bwrap (Linux only). These replace all default arguments, including namespace isolation and the other options in this table, so supply a complete set.',
     isOptional: true,
   },
   {

--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -937,6 +937,31 @@ describe('LocalSandbox', () => {
       await seatbeltSandbox._destroy();
     });
 
+    it('should allow opening device files for writing', async () => {
+      if (os.platform() !== 'darwin') {
+        return;
+      }
+
+      const seatbeltSandbox = new LocalSandbox({
+        workingDirectory: tempDir,
+        isolation: 'seatbelt',
+      });
+
+      await seatbeltSandbox._start();
+
+      // Devices need file-write-data, which the workspace-scoped file-write* rules
+      // do not cover. git opens /dev/null O_RDWR before doing anything else.
+      const redirect = await seatbeltSandbox.executeCommand('sh', ['-c', 'echo x > /dev/null && echo ok']);
+      expect(redirect.stderr).not.toMatch(/not permitted|Permission denied/);
+      expect(redirect.success).toBe(true);
+
+      const git = await seatbeltSandbox.executeCommand('git', ['init', '-q', 'devnull-probe']);
+      expect(git.stderr).not.toMatch(/could not open '\/dev\/null'/);
+      expect(git.success).toBe(true);
+
+      await seatbeltSandbox._destroy();
+    });
+
     it('should block file writes outside workspace', async () => {
       if (os.platform() !== 'darwin') {
         return;
@@ -1386,6 +1411,31 @@ describe('LocalSandbox', () => {
       const readResult = await bwrapSandbox.executeCommand('cat', [`${tempDir}/bwrap-test.txt`]);
       expect(readResult.success).toBe(true);
       expect(readResult.stdout.trim()).toBe('bwrap content');
+
+      await bwrapSandbox._destroy();
+    });
+
+    it('should provide working device nodes', async () => {
+      if (os.platform() !== 'linux' || !isBwrapAvailable()) {
+        return;
+      }
+
+      const bwrapSandbox = new LocalSandbox({
+        workingDirectory: tempDir,
+        isolation: 'bwrap',
+      });
+
+      await bwrapSandbox._start();
+
+      // The namespace needs an explicit --dev; a bind of the host /dev would be
+      // mounted nodev, which makes opening a character device fail with EACCES.
+      const redirect = await bwrapSandbox.executeCommand('sh', ['-c', 'echo x > /dev/null && echo ok']);
+      expect(redirect.stderr).not.toMatch(/No such file or directory|Permission denied/);
+      expect(redirect.success).toBe(true);
+
+      const git = await bwrapSandbox.executeCommand('git', ['init', '-q', 'devnull-probe']);
+      expect(git.stderr).not.toMatch(/could not open '\/dev\/null'/);
+      expect(git.success).toBe(true);
 
       await bwrapSandbox._destroy();
     });

--- a/packages/core/src/workspace/sandbox/native-sandbox/bubblewrap.test.ts
+++ b/packages/core/src/workspace/sandbox/native-sandbox/bubblewrap.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { buildBwrapCommand } from './bubblewrap';
+
+/**
+ * Find the value that follows a flag in the arg list.
+ */
+function valueAfter(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+describe('buildBwrapCommand', () => {
+  it('should mount a minimal /dev so tools that open /dev/null work', () => {
+    const { args } = buildBwrapCommand('git status', '/workspace', {});
+
+    expect(valueAfter(args, '--dev')).toBe('/dev');
+  });
+
+  it('should mount /dev before the binds so a path under /dev is not shadowed', () => {
+    const { args } = buildBwrapCommand('ls', '/workspace', {
+      readOnlyPaths: ['/dev/dri'],
+    });
+
+    // bwrap applies operations in order, so a --dev emitted after this bind would
+    // replace it with the fresh tmpfs.
+    const devIndex = args.indexOf('--dev');
+    expect(devIndex).toBeGreaterThanOrEqual(0);
+    expect(devIndex).toBeLessThan(args.indexOf('/dev/dri'));
+  });
+
+  it('should mount /proc and a tmpfs at /tmp', () => {
+    const { args } = buildBwrapCommand('ls', '/workspace', {});
+
+    expect(valueAfter(args, '--proc')).toBe('/proc');
+    expect(valueAfter(args, '--tmpfs')).toBe('/tmp');
+  });
+
+  it('should not inject defaults when custom bwrapArgs are provided', () => {
+    const { command, args } = buildBwrapCommand('ls', '/workspace', {
+      bwrapArgs: ['--ro-bind', '/usr', '/usr'],
+    });
+
+    expect(command).toBe('bwrap');
+    expect(args).toEqual(['--ro-bind', '/usr', '/usr', '--', 'sh', '-c', 'ls']);
+  });
+});

--- a/packages/core/src/workspace/sandbox/native-sandbox/bubblewrap.ts
+++ b/packages/core/src/workspace/sandbox/native-sandbox/bubblewrap.ts
@@ -70,6 +70,22 @@ export function buildBwrapCommand(
   // Mount a tmpfs at /tmp
   bwrapArgs.push('--tmpfs', '/tmp');
 
+  // Synthesize a minimal /dev: null, zero, full, random, urandom, tty, a devpts
+  // instance and the stdin/stdout/stderr symlinks. Without this the namespace has
+  // no /dev at all, so anything that opens /dev/null - git, ssh, most shell
+  // redirections - fails.
+  //
+  // This must be `--dev` rather than a bind of the host /dev. bwrap applies
+  // MS_NODEV to every bind except the device nodes `--dev` sets up itself, and
+  // opening a character device on a nodev mount fails with EACCES even for
+  // O_RDONLY. So binding /dev or /dev/null via readOnlyPaths produces nodes that
+  // look correct but report "Permission denied" on every open.
+  //
+  // Emitted before the binds below so a caller-supplied path under /dev is not
+  // shadowed by this tmpfs. Such a bind is still nodev, so a device beyond the
+  // standard set needs `--dev-bind` supplied through bwrapArgs.
+  bwrapArgs.push('--dev', '/dev');
+
   // Mount system paths read-only
   for (const path of DEFAULT_READONLY_BINDS) {
     // Use --ro-bind-try to skip paths that don't exist on this system

--- a/packages/core/src/workspace/sandbox/native-sandbox/seatbelt.test.ts
+++ b/packages/core/src/workspace/sandbox/native-sandbox/seatbelt.test.ts
@@ -1,0 +1,73 @@
+import { execFileSync } from 'node:child_process';
+import os from 'node:os';
+import { describe, it, expect } from 'vitest';
+import { buildSeatbeltCommand, generateSeatbeltProfile } from './seatbelt';
+
+const isDarwin = os.platform() === 'darwin';
+
+/**
+ * Run a shell command under the given profile, returning combined output.
+ */
+function runSandboxed(profile: string, command: string): { ok: boolean; output: string } {
+  const { command: bin, args } = buildSeatbeltCommand(command, profile);
+  try {
+    return { ok: true, output: execFileSync(bin, args, { encoding: 'utf8', stdio: 'pipe' }) };
+  } catch (error) {
+    const err = error as { stderr?: string; message?: string };
+    return { ok: false, output: err.stderr ?? err.message ?? '' };
+  }
+}
+
+describe('generateSeatbeltProfile', () => {
+  it('should allow writes to device files, not just ioctl', () => {
+    const profile = generateSeatbeltProfile('/workspace', {});
+
+    // Opening a device O_RDWR needs file-write-data; file-ioctl does not cover it.
+    for (const device of ['/dev/null', '/dev/zero', '/dev/random', '/dev/urandom', '/dev/tty']) {
+      expect(profile).toContain(`(allow file-write-data (literal "${device}"))`);
+      expect(profile).toContain(`(allow file-ioctl (literal "${device}"))`);
+    }
+  });
+
+  it('should not grant unlink or chmod on device files', () => {
+    const profile = generateSeatbeltProfile('/workspace', {});
+
+    expect(profile).not.toContain('(allow file-write* (literal "/dev/null"))');
+    expect(profile).not.toContain('(allow file-write-unlink');
+  });
+
+  it('should still restrict writes to the workspace', () => {
+    const profile = generateSeatbeltProfile('/workspace', {});
+
+    expect(profile).toContain('(deny default (with message "mastra-sandbox"))');
+    expect(profile).toContain('(allow file-write* (subpath "/workspace"))');
+  });
+
+  it('should throw when allowSystemBinaries is disabled', () => {
+    expect(() => generateSeatbeltProfile('/workspace', { allowSystemBinaries: false })).toThrow(
+      /not supported by seatbelt/,
+    );
+  });
+});
+
+describe.skipIf(!isDarwin)('seatbelt profile under sandbox-exec (macOS)', () => {
+  const workspace = os.tmpdir();
+
+  it('should permit opening /dev/null for reading and writing', () => {
+    const profile = generateSeatbeltProfile(workspace, { readWritePaths: [workspace] });
+
+    const result = runSandboxed(profile, 'echo written > /dev/null && echo ok');
+
+    expect(result.output).not.toMatch(/not permitted|Permission denied/);
+    expect(result.ok).toBe(true);
+  });
+
+  it('should permit git, which opens /dev/null O_RDWR', () => {
+    const profile = generateSeatbeltProfile(workspace, { readWritePaths: [workspace] });
+
+    const result = runSandboxed(profile, 'git --version');
+
+    expect(result.output).not.toMatch(/could not open '\/dev\/null'/);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/core/src/workspace/sandbox/native-sandbox/seatbelt.ts
+++ b/packages/core/src/workspace/sandbox/native-sandbox/seatbelt.ts
@@ -55,6 +55,14 @@ export function isGeneratedSeatbeltProfile(profile: string): boolean {
 }
 
 /**
+ * Device files that need both ioctl and write access.
+ * Writes to these are discarded (null, zero), mix entropy (random, urandom),
+ * or go to the already-inherited terminal (tty), so allowing them grants no
+ * access the sandboxed process does not effectively have.
+ */
+const DEVICE_FILES = ['/dev/null', '/dev/zero', '/dev/random', '/dev/urandom', '/dev/tty'];
+
+/**
  * Escape a path for use in SBPL profile.
  * Uses JSON.stringify for proper escaping.
  */
@@ -133,13 +141,17 @@ export function generateSeatbeltProfile(workspacePath: string, config: NativeSan
   lines.push('(allow sysctl-read)');
   lines.push('');
 
-  // Device files
+  // Device files.
+  // file-ioctl alone is not enough: opening a device O_RDWR needs file-write-data,
+  // which the workspace-scoped file-write* rules below do not cover. Without it,
+  // git fails with "could not open '/dev/null' for reading and writing" and shell
+  // redirections to /dev/null are denied. file-write-data (not file-write*) keeps
+  // unlink and chmod on these nodes denied.
   lines.push('; Device files');
-  lines.push('(allow file-ioctl (literal "/dev/null"))');
-  lines.push('(allow file-ioctl (literal "/dev/zero"))');
-  lines.push('(allow file-ioctl (literal "/dev/random"))');
-  lines.push('(allow file-ioctl (literal "/dev/urandom"))');
-  lines.push('(allow file-ioctl (literal "/dev/tty"))');
+  for (const device of DEVICE_FILES) {
+    lines.push(`(allow file-ioctl (literal "${device}"))`);
+    lines.push(`(allow file-write-data (literal "${device}"))`);
+  }
   lines.push('');
 
   // File read access - allow all reads (macOS limitation: can't use subpath without this)


### PR DESCRIPTION
## Description

`LocalSandbox` with native isolation cannot open `/dev/null`, so `git`, `ssh`, and ordinary shell redirections fail inside the sandbox. Both backends are affected, for unrelated reasons.

- **Linux (`bwrap`)**: `buildBwrapCommand` mounts `/proc` and a tmpfs at `/tmp` but never `/dev`, so no device nodes exist. Adds `--dev /dev`.
- **macOS (`seatbelt`)**: the profile allows `file-ioctl` on the device nodes but never `file-write-data`, and its `file-write*` rules are scoped to the workspace, so opening a device `O_RDWR` falls through to `(deny default)`. Adds `file-write-data` for the same five nodes. Unlink and chmod stay denied.

### Root cause, measured

Linux (Arch, kernel 7.1.9, bwrap 0.11.2), raw bwrap with the base arguments this builder emits and only the `/dev` strategy varied:

| strategy | `stat /dev/null` | `open`, both `O_RDONLY` and `O_RDWR` |
| --- | --- | --- |
| none, current behaviour | ENOENT | ENOENT, "No such file or directory" |
| `--ro-bind /dev /dev` | chardev 0666 | EACCES, "Permission denied" |
| `--ro-bind /dev/null /dev/null` | chardev 0666 | EACCES, "Permission denied" |
| `--dev /dev` | chardev 0666 | ok |
| `--dev-bind /dev /dev` | chardev 0666 | ok |

`--dev` is the only reachable fix. bwrap applies `MS_NODEV` to every bind except the nodes `--dev` creates itself (`bind-mount.c`: `new_flags = current_flags | (devices ? 0 : MS_NODEV) | ...`), and the kernel's `may_open()` returns `-EACCES` for a character device on a `nodev` mount. So the workaround a user naturally reaches for, `readOnlyPaths: ['/dev']`, yields nodes that pass `ls` and `stat` but fail every open including `O_RDONLY`. Before this change there is no configuration that produces a usable `/dev`.

macOS (darwin 25.6.0), measured through `LocalSandbox.executeCommand`, with the pre-fix profile supplied via `seatbeltProfilePath`:

| probe | before | after |
| --- | --- | --- |
| `git init` | `fatal: could not open '/dev/null' for reading and writing: Operation not permitted` | ok |
| `echo x > /dev/null` | `sh: /dev/null: Operation not permitted` | ok |
| `fs.openSync('/dev/null', 'r+')` | EPERM | ok |

### Deliberately out of scope

Routing `readOnlyPaths` entries under `/dev` through `--dev-bind` is not included. bwrap has no read-only device bind, so doing that would silently upgrade a path the caller declared read-only into read-write. Devices beyond the standard set still need `--dev-bind` via `bwrapArgs`; this is called out in the code comment and the changeset.

### Docs

The `bwrapArgs` reference entry described it as "additional arguments to pass to bwrap", but the option replaces every default argument, including namespace and network isolation. Corrected, since following the old description would silently disable the sandbox.

## Related issue(s)

Fixes #22702

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test plan

- New unit coverage for `buildBwrapCommand` and `generateSeatbeltProfile`. Neither builder had any tests before.
- Platform-gated end-to-end cases added to the existing `seatbelt isolation (macOS)` and `bwrap isolation (Linux)` blocks in `local-sandbox.test.ts`, running `git init` and a `/dev/null` redirection through `executeCommand`. Confirmed failing without the fix, with `sh: /dev/null: Operation not permitted`.
- `pnpm --filter ./packages/core test -- src/workspace/sandbox/`: 364 passed, 2 skipped.
- `pnpm --filter ./packages/core check`: no new type errors versus the same command on `main`.
- The Linux behaviour was verified by executing this branch's `buildBwrapCommand` output on an Arch host, not only by unit assertions.
