### PR TITLE
test(core): unblock run-engine tests broken by eager getAgent default

### DIFF
--- a/packages/core/src/agent-controller/__tests__/run-engine-abort-deadline.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-abort-deadline.test.ts
@@ -28,8 +28,6 @@ function createHarness() {
   });
 
   const machinery: SessionMachinery = {
-    // processStreamChunk resolves the agent eagerly as a default parameter, so this
-    // stub must not throw; these tests never reach the suspension path that reads it.
     getAgent: () => ({ id: 'agent-stub' }) as unknown as ReturnType<SessionMachinery['getAgent']>,
     subscribeToThread: async () => {
       throw new Error('subscribeToThread is not used by these tests');

--- a/packages/core/src/agent-controller/__tests__/run-engine-abort-deadline.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-abort-deadline.test.ts
@@ -28,9 +28,9 @@ function createHarness() {
   });
 
   const machinery: SessionMachinery = {
-    getAgent: () => {
-      throw new Error('getAgent is not used by these tests');
-    },
+    // processStreamChunk resolves the agent eagerly as a default parameter, so this
+    // stub must not throw; these tests never reach the suspension path that reads it.
+    getAgent: () => ({ id: 'agent-stub' }) as unknown as ReturnType<SessionMachinery['getAgent']>,
     subscribeToThread: async () => {
       throw new Error('subscribeToThread is not used by these tests');
     },

--- a/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
@@ -38,8 +38,6 @@ function createHarness() {
   });
 
   const machinery: SessionMachinery = {
-    // processStreamChunk resolves the agent eagerly as a default parameter, so this
-    // stub must not throw; these stream-folding tests never reach the suspension path that reads it.
     getAgent: () => ({ id: 'agent-stub' }) as unknown as ReturnType<SessionMachinery['getAgent']>,
     subscribeToThread: async () => {
       throw new Error('subscribeToThread is not used by these stream-folding tests');

--- a/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-db-message.test.ts
@@ -38,9 +38,9 @@ function createHarness() {
   });
 
   const machinery: SessionMachinery = {
-    getAgent: () => {
-      throw new Error('getAgent is not used by these stream-folding tests');
-    },
+    // processStreamChunk resolves the agent eagerly as a default parameter, so this
+    // stub must not throw; these stream-folding tests never reach the suspension path that reads it.
+    getAgent: () => ({ id: 'agent-stub' }) as unknown as ReturnType<SessionMachinery['getAgent']>,
     subscribeToThread: async () => {
       throw new Error('subscribeToThread is not used by these stream-folding tests');
     },


### PR DESCRIPTION
## Summary
Two agent-controller test files (`run-engine-db-message.test.ts`, `run-engine-abort-deadline.test.ts`) fail on `main` with 24 failures: their `SessionMachinery` stubs throw `getAgent is not used by these tests`, but #22476 gave `processStreamChunk` a default parameter (`agent: Agent = this.#machinery.getAgent()`) that eagerly resolves the agent on every chunk. This turns the required **Merge Test Reports** check red for every core-touching PR.

This replaces the throwing stubs with benign ones, matching the stub updates #22476 made to its other test files. The agent value is only read on the suspension path, which these tests never reach. Test-only change, no production code.

## Test plan
- `vitest run src/agent-controller/__tests__/` locally: **17 files, 100 passed | 3 skipped** (was 24 failed on plain `origin/main`)

cc @wardpeet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Some tests expected an agent lookup to fail, but the code now performs that lookup earlier. These tests now provide a safe placeholder agent so they can run as intended.

## Changes

- Updated `run-engine-abort-deadline.test.ts`.
- Updated `run-engine-db-message.test.ts`.
- Replaced throwing `getAgent()` stubs with benign agent stubs.
- Made no production code changes.

## Validation

- 17 test files passed.
- 100 tests passed.
- 3 tests skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->