### PR TITLE
fix(factory): preserve tenant credentials in workspace skill runs

### DIFF
--- a/.changeset/green-buses-train.md
+++ b/.changeset/green-buses-train.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Improved diagnostics and error guidance when deployed tenant credential resolution fails closed.

--- a/.changeset/loose-kiwis-march.md
+++ b/.changeset/loose-kiwis-march.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed authenticated workspace skill runs so tenant OAuth credentials remain available to agent and memory models.

--- a/mastracode/factory/src/routes/skills.test.ts
+++ b/mastracode/factory/src/routes/skills.test.ts
@@ -1,3 +1,4 @@
+import { RequestContext } from '@mastra/core/request-context';
 import type { Skill } from '@mastra/core/workspace';
 import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -24,10 +25,11 @@ function createHarness(
   options: {
     authorized?: boolean;
     workspaceBThrows?: boolean;
+    user?: unknown;
   } = {},
 ) {
-  const sendA = vi.fn(async (_input: { content: string }) => {});
-  const sendB = vi.fn(async (_input: { content: string }) => {});
+  const sendA = vi.fn(async (_input: { content: string; requestContext?: RequestContext }) => {});
+  const sendB = vi.fn(async (_input: { content: string; requestContext?: RequestContext }) => {});
   const refreshA = vi.fn(async () => {});
   const refreshB = vi.fn(async () => {});
   const getA = vi.fn(async (name: string) => (name === skill.name ? skill : undefined));
@@ -64,7 +66,13 @@ function createHarness(
         }
       : { allowed: true as const },
   );
+  const requestContext = new RequestContext();
+  requestContext.set('user', options.user ?? { workosId: 'user-1', organizationId: 'org-1' });
   const app = new Hono();
+  app.use('*', async (context, next) => {
+    context.set('requestContext' as never, requestContext);
+    await next();
+  });
   mountApiRoutes(
     app as never,
     new SkillRoutes({
@@ -84,6 +92,7 @@ function createHarness(
     getB,
     getSessionByResource,
     authorizeSessionAddress,
+    requestContext,
   };
 }
 
@@ -141,7 +150,28 @@ describe('workspace skill invocation route', () => {
     expect(harness.refreshA).toHaveBeenCalledOnce();
     expect(harness.refreshA.mock.invocationCallOrder[0]!).toBeLessThan(harness.getA.mock.invocationCallOrder[0]!);
     expect(harness.sendA).toHaveBeenCalledOnce();
-    expect(harness.sendA).toHaveBeenCalledWith({ content: message });
+    expect(harness.sendA).toHaveBeenCalledWith({ content: message, requestContext: harness.requestContext });
+  });
+
+  it('forwards a Better Auth session-shaped principal unchanged', async () => {
+    const user = {
+      session: { activeOrganizationId: 'org-1' },
+      user: { id: 'user-1' },
+    };
+    const harness = createHarness({ user });
+
+    const response = await invoke(harness.app, {
+      resourceId: 'resource-1',
+      scope: '/worktrees/a',
+      name: 'understand-pr',
+    });
+
+    expect(response.status).toBe(200);
+    expect(harness.requestContext.get('user')).toBe(user);
+    expect(harness.sendA).toHaveBeenCalledWith({
+      content: expect.stringContaining('<skill name="understand-pr">'),
+      requestContext: harness.requestContext,
+    });
   });
 
   it('prepares the exact activation envelope without dispatching it', async () => {

--- a/mastracode/factory/src/routes/skills.ts
+++ b/mastracode/factory/src/routes/skills.ts
@@ -1,5 +1,6 @@
 import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentController } from '@mastra/core/agent-controller';
+import type { RequestContext } from '@mastra/core/request-context';
 import type { ApiRoute } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
@@ -177,9 +178,12 @@ export class SkillRoutes extends Route<SkillRoutesDeps> {
       try {
         const resolved = await resolveSkillInvocation(controller, body);
         if (dispatch) {
-          void resolved.session.sendMessage({ content: resolved.message }).catch((error: unknown) => {
-            console.error('Workspace skill dispatch failed after acceptance', error);
-          });
+          const requestContext = c.get('requestContext' as never) as RequestContext | undefined;
+          void resolved.session
+            .sendMessage({ content: resolved.message, ...(requestContext ? { requestContext } : {}) })
+            .catch((error: unknown) => {
+              console.error('Workspace skill dispatch failed after acceptance', error);
+            });
         }
         return c.json({ ok: true, skill: resolved.skillName, message: resolved.message });
       } catch (error) {

--- a/mastracode/factory/src/skills/service.ts
+++ b/mastracode/factory/src/skills/service.ts
@@ -14,7 +14,7 @@ export interface SkillInvocationInput {
 
 export interface SkillSession {
   getWorkspace(): Workspace;
-  sendMessage(input: { content: string }): Promise<unknown>;
+  sendMessage(input: { content: string; requestContext?: RequestContext }): Promise<unknown>;
   sendNotificationSignal(
     input: {
       source: string;
@@ -83,8 +83,9 @@ export async function resolveSkillInvocation(
 export async function dispatchSkillInvocation(
   controller: Pick<AgentController<MastraCodeState>, 'getSessionByResource'>,
   input: SkillInvocationInput,
+  requestContext?: RequestContext,
 ): Promise<{ skillName: string; message: string }> {
   const resolved = await resolveSkillInvocation(controller, input);
-  await resolved.session.sendMessage({ content: resolved.message });
+  await resolved.session.sendMessage({ content: resolved.message, ...(requestContext ? { requestContext } : {}) });
   return { skillName: resolved.skillName, message: resolved.message };
 }

--- a/mastracode/sdk/src/agents/__tests__/model.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/model.test.ts
@@ -196,6 +196,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MODEL_TOKENS } from '../../../../../docs/src/plugins/remark-model-tokens/models.js';
 import { opencodeClaudeMaxProvider, buildAnthropicOAuthFetch } from '../../providers/claude-max.js';
 import { openaiCodexProvider, buildOpenAICodexOAuthFetch } from '../../providers/openai-codex.js';
+import { setCredentialStoreProvider } from '../credential-resolver.js';
 import {
   createMastraCodeGateway,
   resolveModel,
@@ -241,6 +242,7 @@ describe('resolveModel', () => {
   });
 
   afterEach(() => {
+    setCredentialStoreProvider(undefined);
     process.env = { ...originalEnv };
   });
 
@@ -475,6 +477,22 @@ describe('resolveModel', () => {
       mockAuthStorageInstance.get.mockReturnValue(undefined);
       const result = resolveModel('openai/gpt-4o') as Record<string, unknown>;
       expect(result.__provider).toBe('model-router');
+    });
+
+    it('reports a missing signed-in Factory credential instead of an environment variable', () => {
+      setCredentialStoreProvider(() => ({
+        allowEnvironmentFallback: false,
+        reload() {},
+        get: () => undefined,
+        getStoredApiKey: () => undefined,
+        getApiKey: async () => undefined,
+      }));
+      const requestContext = makeRequestContext();
+      requestContext.set('user', { workosId: 'user-1', organizationId: 'org-1' });
+
+      expect(() => resolveModel('openai/gpt-4o', { requestContext })).toThrow(
+        'No usable openai credential is configured for this signed-in Factory account.',
+      );
     });
 
     it('passes controller headers to the OpenAI OAuth provider', () => {

--- a/mastracode/sdk/src/agents/credential-resolver.test.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.test.ts
@@ -1,5 +1,5 @@
 import { RequestContext } from '@mastra/core/request-context';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AuthCredential, CredentialStore } from '../auth/types.js';
 import {
   hasCredentialStoreProvider,
@@ -52,6 +52,7 @@ describe('credential store provider registry', () => {
   });
 
   it('fails closed without an authenticated tenant on the request context', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     setCredentialStoreProvider(() => fakeStore({}));
     const withoutContext = resolveCredentialStore(undefined);
     const emptyContext = resolveCredentialStore(new RequestContext());
@@ -59,9 +60,21 @@ describe('credential store provider registry', () => {
     expect(withoutContext).toMatchObject({ allowEnvironmentFallback: false });
     expect(emptyContext).toBe(withoutContext);
     await expect(withoutContext?.getApiKey('anthropic')).resolves.toBeUndefined();
+    expect(warn).toHaveBeenNthCalledWith(1, '[MastraCode] Tenant credential resolution failed closed', {
+      reason: 'missing-user-context',
+      hasRequestContext: false,
+      factorySession: false,
+    });
+    expect(warn).toHaveBeenNthCalledWith(2, '[MastraCode] Tenant credential resolution failed closed', {
+      reason: 'missing-user-context',
+      hasRequestContext: true,
+      factorySession: false,
+    });
+    warn.mockRestore();
   });
 
   it('fails closed when the tenant store provider cannot resolve a store', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     setCredentialStoreProvider(() => undefined);
     const ctx = new RequestContext();
     ctx.set('user', { workosId: 'user_1', organizationId: 'org_1' });
@@ -69,6 +82,12 @@ describe('credential store provider registry', () => {
     const store = resolveCredentialStore(ctx);
     expect(store).toMatchObject({ allowEnvironmentFallback: false });
     await expect(store?.getApiKey('anthropic')).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith('[MastraCode] Tenant credential resolution failed closed', {
+      reason: 'credential-store-unavailable',
+      hasOrganization: true,
+      orgFirst: false,
+    });
+    warn.mockRestore();
   });
 
   it('falls back to the provider id when workosId is absent', () => {

--- a/mastracode/sdk/src/agents/credential-resolver.ts
+++ b/mastracode/sdk/src/agents/credential-resolver.ts
@@ -146,6 +146,23 @@ export function resolveTenantFromRequestContext(requestContext?: RequestContext)
 export function resolveCredentialStore(requestContext?: RequestContext): CredentialStore | undefined {
   if (!credentialStoreProvider) return undefined;
   const tenant = resolveTenantFromRequestContext(requestContext);
-  if (!tenant) return unavailableTenantCredentialStore;
-  return credentialStoreProvider(tenant) ?? unavailableTenantCredentialStore;
+  if (!tenant) {
+    const rawUser = requestContext?.get('user');
+    console.warn('[MastraCode] Tenant credential resolution failed closed', {
+      reason: rawUser === undefined ? 'missing-user-context' : 'invalid-principal-shape',
+      hasRequestContext: requestContext !== undefined,
+      factorySession: isFactorySessionContext(requestContext),
+    });
+    return unavailableTenantCredentialStore;
+  }
+  const store = credentialStoreProvider(tenant);
+  if (!store) {
+    console.warn('[MastraCode] Tenant credential resolution failed closed', {
+      reason: 'credential-store-unavailable',
+      hasOrganization: tenant.orgId !== undefined,
+      orgFirst: tenant.orgFirst === true,
+    });
+    return unavailableTenantCredentialStore;
+  }
+  return store;
 }

--- a/mastracode/sdk/src/agents/memory.test.ts
+++ b/mastracode/sdk/src/agents/memory.test.ts
@@ -80,6 +80,7 @@ type RequestContextStub = {
 function createRequestContext(state: Record<string, unknown>, sessionId = 'session-1'): RequestContextStub {
   const getState = () => state;
   const values = new Map<string, unknown>([
+    ['user', { workosId: 'user-1', organizationId: 'org-1' }],
     [
       'controller',
       {
@@ -166,6 +167,7 @@ describe('getDynamicMemory', () => {
     expect(om.reflection.instruction).toBeUndefined();
 
     expect(om.observation.model({ requestContext })).toEqual({ modelId: 'google/gemini-3.5-flash' });
+    expect(requestContext.get('user')).toEqual({ workosId: 'user-1', organizationId: 'org-1' });
     expect(resolveModelMock).toHaveBeenLastCalledWith('google/gemini-3.5-flash', {
       remapForCodexOAuth: true,
       requestContext,

--- a/mastracode/sdk/src/agents/model.ts
+++ b/mastracode/sdk/src/agents/model.ts
@@ -159,6 +159,12 @@ export function resolveModel(
     routerId,
   });
 
+  if (!auth && credentialStore?.allowEnvironmentFallback === false) {
+    throw new Error(
+      `No usable ${providerId} credential is configured for this signed-in Factory account. Connect the provider or add an organization credential, then try again.`,
+    );
+  }
+
   return gateway.resolveLanguageModel({
     providerId,
     modelId: bareModelId,


### PR DESCRIPTION
Workspace skill dispatch was starting agent runs without forwarding the authenticated server request context. In deployed Factory environments, that prevents model resolution from identifying the tenant and makes OAuth or stored provider credentials appear missing.\n\nThis forwards the trusted request context through skill dispatch for all tenant-backed providers, keeps observational-memory model resolution on the same identity, and adds safe fail-closed diagnostics plus clearer signed-in credential guidance.\n\nBefore: `sendMessage({ content })`\n\nAfter: `sendMessage({ content, requestContext })`\n\nTests cover flat and Better Auth session-shaped principals, primary and memory model context, tenant credential failures, OAuth/config resolution, automated dispatch, and agent-controller forwarding. Typechecks and builds pass for code-sdk, core, and Factory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR keeps the signed-in user's workspace information when skills run. This allows the system to use the correct tenant credentials and gives clearer errors when those credentials are missing.

## Changes

- Forward `requestContext` through skill dispatch and `sendMessage`.
- Preserve session-shaped principals from authenticated Factory requests.
- Use tenant-aware credentials for agent and observational-memory model resolution.
- Fail closed when tenant credentials are unavailable instead of using environment credentials.
- Add structured warnings for missing request context and unavailable tenant stores.
- Improve missing-credential error guidance.
- Add coverage for credential resolution, OAuth and provider configuration, automated dispatch, memory runs, and agent-controller forwarding.
- Add patch changesets for `@mastra/code-sdk` and `@mastra/factory`.

## Validation

- Typechecks and builds pass for code-sdk, core, and Factory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->