### PR TITLE
feat(core): add a portable advanced trace query contract

### DIFF
--- a/.changeset/dry-eyes-scream.md
+++ b/.changeset/dry-eyes-scream.md
@@ -1,0 +1,12 @@
+---
+'@mastra/core': minor
+---
+
+Added a strict, size-bounded advanced trace-query contract, trusted planner, cursor binding, portable replacement semantics, execution-timeout identity, and storage capability.
+
+```ts
+const request = traceQueryRequestSchema.parse({
+  timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' },
+  where: { op: 'eq', left: { path: 'environment' }, right: { literal: 'production' } },
+})
+```

--- a/.changeset/dry-eyes-scream.md
+++ b/.changeset/dry-eyes-scream.md
@@ -2,7 +2,7 @@
 '@mastra/core': minor
 ---
 
-Added a strict, size-bounded advanced trace-query contract, trusted planner, cursor binding, portable replacement semantics, execution-timeout identity, and storage capability.
+Added a strict, size-bounded advanced trace-query contract, trusted planner, locale-independent cursor ordering, null-inclusive negative predicates, portable replacement semantics, execution-timeout identity, and storage capability.
 
 ```ts
 const request = traceQueryRequestSchema.parse({

--- a/.changeset/dry-eyes-scream.md
+++ b/.changeset/dry-eyes-scream.md
@@ -2,11 +2,11 @@
 '@mastra/core': minor
 ---
 
-Added a strict, size-bounded advanced trace-query contract, trusted planner, locale-independent cursor ordering, null-inclusive negative predicates, portable replacement semantics, execution-timeout identity, and storage capability.
+Added the core contract for advanced trace queries, including bounded time ranges, recursive trace, span, and score predicates, thread grouping, and deterministic cursor pagination. Invalid or overly complex requests are rejected before a storage adapter executes them.
 
 ```ts
 const request = traceQueryRequestSchema.parse({
   timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' },
   where: { op: 'eq', left: { path: 'environment' }, right: { literal: 'production' } },
-})
+});
 ```

--- a/packages/core/src/storage/domains/observability/base.ts
+++ b/packages/core/src/storage/domains/observability/base.ts
@@ -63,6 +63,7 @@ import type {
   GetScorePercentilesArgs,
   GetScorePercentilesResponse,
 } from './scores';
+import type { TraceQueryResponse, TrustedTraceQueryPlan } from './trace-query';
 import type {
   BatchCreateSpansArgs,
   BatchDeleteTracesArgs,
@@ -90,7 +91,7 @@ import type {
 import { extractBranchSpans, getBranchArgsSchema, toLightSpanRecord } from './tracing';
 import type { ObservabilityStorageStrategy, TracingStorageStrategy } from './types';
 
-export type ObservabilityStorageFeature = 'delta-polling' | 'metrics' | 'logs';
+export type ObservabilityStorageFeature = 'delta-polling' | 'metrics' | 'logs' | 'trace-query';
 
 /**
  * Base storage class for observability data (traces, metrics, logs, scores, feedback).
@@ -341,6 +342,18 @@ export class ObservabilityStorage extends StorageDomain {
   async listTracesLight(args: ListTracesArgs): Promise<ListTracesLightResponse> {
     const { spans, ...rest } = await this.listTraces(args);
     return { ...rest, spans: spans.map(toLightSpanRecord) };
+  }
+
+  /**
+   * Executes a validated advanced trace-query plan.
+   */
+  async queryTraces(_plan: TrustedTraceQueryPlan): Promise<TraceQueryResponse> {
+    throw new MastraError({
+      id: 'OBSERVABILITY_STORAGE_QUERY_TRACES_NOT_IMPLEMENTED',
+      domain: ErrorDomain.MASTRA_OBSERVABILITY,
+      category: ErrorCategory.SYSTEM,
+      text: 'This storage provider does not support advanced trace queries',
+    });
   }
 
   /**

--- a/packages/core/src/storage/domains/observability/index.ts
+++ b/packages/core/src/storage/domains/observability/index.ts
@@ -6,5 +6,6 @@ export * from './logs';
 export * from './metrics';
 export * from './scores';
 export * from './record-builders';
+export * from './trace-query';
 export * from './tracing';
 export * from './types';

--- a/packages/core/src/storage/domains/observability/trace-query.test.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ObservabilityStorage } from './base';
 import {
+  compareTraceQueryStrings,
   encodeTraceQueryCursor,
   parseTraceQueryRequest,
   planTraceQuery,
@@ -488,6 +489,22 @@ describe('planTraceQuery', () => {
 });
 
 describe('trace-query cursors', () => {
+  it('uses locale-independent ordering and stable cursor bindings', () => {
+    expect(['Ω', 'é', 'a', 'A'].sort(compareTraceQueryStrings)).toEqual(['A', 'a', 'é', 'Ω']);
+
+    const first = planTraceQuery({
+      timeRange: { from: baseRequest.timeRange.from, to: baseRequest.timeRange.to },
+      where: { op: 'eq', left: { path: 'traceId' }, right: { literal: 'A' } },
+      page: { limit: 100 },
+    });
+    const second = planTraceQuery({
+      page: { limit: 100 },
+      where: { right: { literal: 'A' }, left: { path: 'traceId' }, op: 'eq' },
+      timeRange: { to: baseRequest.timeRange.to, from: baseRequest.timeRange.from },
+    });
+    expect(second.binding).toBe(first.binding);
+  });
+
   it('round-trips trace and group keyset values', () => {
     const tracePlan = planTraceQuery(parsed());
     const traceCursor = encodeTraceQueryCursor(tracePlan, {

--- a/packages/core/src/storage/domains/observability/trace-query.test.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.test.ts
@@ -280,6 +280,34 @@ describe('planTraceQuery', () => {
     expect(organization.issues[0]).toMatchObject({ code: 'field_not_allowed' });
   });
 
+  it('rejects inherited predicate field names in every predicate context', () => {
+    const contexts = [
+      { where: (field: string) => ({ op: 'exists', path: field }), issuePath: ['where', 'path'] },
+      {
+        where: (field: string) => ({ spans: { some: { op: 'exists', path: field } } }),
+        issuePath: ['where', 'spans', 'some', 'path'],
+      },
+      {
+        where: (field: string) => ({ scores: { some: { op: 'exists', path: field } } }),
+        issuePath: ['where', 'scores', 'some', 'path'],
+      },
+    ];
+
+    for (const field of ['constructor', 'toString', '__proto__']) {
+      for (const context of contexts) {
+        const error = validationError(() => planTraceQuery(parsed({ ...baseRequest, where: context.where(field) })));
+        expect(error.issues).toEqual([
+          {
+            code: 'field_not_allowed',
+            path: context.issuePath,
+            message: 'The predicate field is not allowed here',
+          },
+        ]);
+        expect(JSON.stringify(error.issues)).not.toContain(field);
+      }
+    }
+  });
+
   it('rejects grouped orderBy and fixes grouped ordering', () => {
     const error = validationError(() =>
       planTraceQuery(

--- a/packages/core/src/storage/domains/observability/trace-query.test.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.test.ts
@@ -1,0 +1,525 @@
+import { describe, expect, it } from 'vitest';
+import { ObservabilityStorage } from './base';
+import {
+  encodeTraceQueryCursor,
+  parseTraceQueryRequest,
+  planTraceQuery,
+  TRACE_QUERY_MAX_DEPTH,
+  TRACE_QUERY_MAX_LITERAL_UNITS,
+  TRACE_QUERY_MAX_PATH_BYTES,
+  TRACE_QUERY_MAX_RELATED_CLAUSES,
+  TRACE_QUERY_MAX_SET_VALUES,
+  TRACE_QUERY_DEFAULT_TIMEOUT_MS,
+  TRACE_QUERY_MAX_STRING_BYTES,
+  TRACE_QUERY_MAX_TIMEOUT_MS,
+  resolveTraceQueryTimeoutMs,
+  traceQueryGroupResponseSchema,
+  traceQueryRequestSchema,
+  traceQueryTraceResponseSchema,
+  TraceQueryCursorError,
+  TraceQueryExecutionError,
+  TraceQueryValidationError,
+  type TraceQueryPredicate,
+} from './trace-query';
+
+const baseRequest = {
+  timeRange: {
+    from: '2026-08-01T00:00:00Z',
+    to: '2026-09-01T00:00:00Z',
+  },
+};
+
+function parsed(request: unknown = baseRequest) {
+  return parseTraceQueryRequest(request);
+}
+
+function validationError(fn: () => unknown): TraceQueryValidationError {
+  try {
+    fn();
+    throw new Error('Expected a TraceQueryValidationError');
+  } catch (error) {
+    expect(error).toBeInstanceOf(TraceQueryValidationError);
+    return error as TraceQueryValidationError;
+  }
+}
+
+describe('traceQueryRequestSchema', () => {
+  it('normalizes page defaults without coercing values', () => {
+    expect(parsed()).toMatchObject({ page: { limit: 100 } });
+    expect(traceQueryRequestSchema.safeParse({ ...baseRequest, page: { limit: '10' } }).success).toBe(false);
+  });
+
+  it('rejects unknown and experimental request properties', () => {
+    for (const property of ['groupBy', 'select', 'result', 'source', 'authorization']) {
+      const result = traceQueryRequestSchema.safeParse({ ...baseRequest, [property]: {} });
+      expect(result.success, property).toBe(false);
+    }
+  });
+
+  it('requires ISO timestamps and the exact group shape', () => {
+    expect(traceQueryRequestSchema.safeParse({ timeRange: { from: 'yesterday', to: 'tomorrow' } }).success).toBe(false);
+    expect(traceQueryRequestSchema.safeParse({ ...baseRequest, group: { by: ['environment'] } }).success).toBe(false);
+    expect(traceQueryRequestSchema.safeParse({ ...baseRequest, group: { by: ['threadId'], where: {} } }).success).toBe(
+      false,
+    );
+  });
+
+  it('bounds membership sets and predicate string payloads by UTF-8 bytes', () => {
+    const values = Array.from({ length: TRACE_QUERY_MAX_SET_VALUES }, (_, index) => `trace-${index}`);
+    expect(
+      traceQueryRequestSchema.safeParse({
+        ...baseRequest,
+        where: { op: 'in', value: { path: 'traceId' }, set: values },
+      }).success,
+    ).toBe(true);
+
+    const oversizedSet = validationError(() =>
+      parsed({
+        ...baseRequest,
+        where: { op: 'in', value: { path: 'traceId' }, set: [...values, 'trace-over-limit'] },
+      }),
+    );
+    expect(oversizedSet.issues).toContainEqual(
+      expect.objectContaining({ code: 'invalid_request', path: ['where', 'set'] }),
+    );
+
+    const maxString = 'é'.repeat(TRACE_QUERY_MAX_STRING_BYTES / 2);
+    expect(
+      traceQueryRequestSchema.safeParse({
+        ...baseRequest,
+        where: { op: 'eq', left: { path: 'traceId' }, right: { literal: maxString } },
+      }).success,
+    ).toBe(true);
+    const oversizedString = validationError(() =>
+      parsed({
+        ...baseRequest,
+        where: { op: 'eq', left: { path: 'traceId' }, right: { literal: `${maxString}a` } },
+      }),
+    );
+    expect(oversizedString.issues).toContainEqual(
+      expect.objectContaining({ code: 'invalid_request', path: ['where', 'right', 'literal'] }),
+    );
+  });
+
+  it('bounds raw predicate paths by UTF-8 bytes before allowlist resolution', () => {
+    const maxPath = 'p'.repeat(TRACE_QUERY_MAX_PATH_BYTES);
+    expect(traceQueryRequestSchema.safeParse({ ...baseRequest, where: { op: 'exists', path: maxPath } }).success).toBe(
+      true,
+    );
+
+    const error = validationError(() => parsed({ ...baseRequest, where: { op: 'exists', path: `${maxPath}p` } }));
+    expect(error.issues).toContainEqual(expect.objectContaining({ code: 'invalid_request', path: ['where', 'path'] }));
+  });
+
+  it('does not expose truthy or falsy predicates', () => {
+    expect(
+      traceQueryRequestSchema.safeParse({
+        ...baseRequest,
+        where: { op: 'truthy', value: { path: 'threadId' } },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('planTraceQuery', () => {
+  it('normalizes time, defaults ordering, and produces canonical fields', () => {
+    const plan = planTraceQuery(
+      parsed({
+        timeRange: {
+          from: '2026-08-01T02:00:00+02:00',
+          to: '2026-08-02T02:00:00+02:00',
+        },
+        where: {
+          op: 'eq',
+          left: { path: '${environment}' },
+          right: { literal: 'production' },
+        },
+      }),
+    );
+
+    expect(plan).toMatchObject({
+      result: 'traces',
+      timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-02T00:00:00.000Z' },
+      orderBy: { field: 'startedAt', direction: 'desc' },
+      limit: 100,
+      where: { type: 'comparison', field: 'environment', operator: 'eq', value: 'production' },
+    });
+  });
+
+  it('enforces ordered and maximum time ranges', () => {
+    const reversed = validationError(() =>
+      planTraceQuery(parsed({ timeRange: { from: '2026-08-02T00:00:00Z', to: '2026-08-01T00:00:00Z' } })),
+    );
+    expect(reversed.issues).toEqual([expect.objectContaining({ code: 'invalid_time_range', path: ['timeRange'] })]);
+
+    const tooLarge = validationError(() =>
+      planTraceQuery(parsed({ timeRange: { from: '2026-07-31T23:59:59Z', to: '2026-09-01T00:00:00Z' } })),
+    );
+    expect(tooLarge.issues[0]).toMatchObject({ code: 'time_range_too_large', path: ['timeRange'] });
+  });
+
+  it('plans recursive trace and same-record collection predicates', () => {
+    const plan = planTraceQuery(
+      parsed({
+        ...baseRequest,
+        where: {
+          op: 'and',
+          args: [
+            {
+              scores: {
+                some: {
+                  op: 'and',
+                  args: [
+                    { op: 'eq', left: { path: 'scorerId' }, right: { literal: 'factuality' } },
+                    { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
+                  ],
+                },
+              },
+            },
+            { spans: { none: { op: 'exists', path: 'error' } } },
+          ],
+        },
+      }),
+    );
+
+    expect(plan.where).toEqual({
+      type: 'boolean',
+      operator: 'and',
+      args: [
+        {
+          type: 'relation',
+          collection: 'scores',
+          quantifier: 'some',
+          predicate: {
+            type: 'boolean',
+            operator: 'and',
+            args: [
+              { type: 'comparison', field: 'scorerId', operator: 'eq', value: 'factuality' },
+              { type: 'comparison', field: 'score', operator: 'lt', value: 0.6 },
+            ],
+          },
+        },
+        {
+          type: 'relation',
+          collection: 'spans',
+          quantifier: 'none',
+          predicate: { type: 'presence', field: 'error', operator: 'exists' },
+        },
+      ],
+    });
+  });
+
+  it('enforces field-specific operators and literal types', () => {
+    const badErrorOperator = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          where: { spans: { some: { op: 'eq', left: { path: 'error' }, right: { literal: 'boom' } } } },
+        }),
+      ),
+    );
+    expect(badErrorOperator.issues).toContainEqual(
+      expect.objectContaining({ code: 'operator_not_allowed', path: ['where', 'spans', 'some', 'op'] }),
+    );
+
+    const badScoreLiteral = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          where: { scores: { some: { op: 'lt', left: { path: 'score' }, right: { literal: '0.6' } } } },
+        }),
+      ),
+    );
+    expect(badScoreLiteral.issues).toContainEqual(
+      expect.objectContaining({ code: 'invalid_literal', path: ['where', 'scores', 'some', 'right', 'literal'] }),
+    );
+  });
+
+  it('requires field-left/literal-right comparisons and homogeneous membership values', () => {
+    const operands = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          where: { op: 'eq', left: { literal: 'production' }, right: { path: 'environment' } },
+        }),
+      ),
+    );
+    expect(operands.issues[0]).toMatchObject({ code: 'invalid_operands', path: ['where'] });
+
+    const membership = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          where: { op: 'in', value: { path: 'resourceId' }, set: ['resource-1', 2] },
+        }),
+      ),
+    );
+    expect(membership.issues[0]).toMatchObject({ code: 'invalid_literal', path: ['where', 'set'] });
+  });
+
+  it('keeps correlation fields queryable and does not infer authorization fields', () => {
+    for (const field of ['resourceId', 'threadId'] as const) {
+      expect(
+        planTraceQuery(
+          parsed({
+            ...baseRequest,
+            where: { op: 'eq', left: { path: field }, right: { literal: `${field}-value` } },
+          }),
+        ).where,
+      ).toMatchObject({ field });
+    }
+
+    const organization = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          where: { op: 'eq', left: { path: 'organizationId' }, right: { literal: 'org-1' } },
+        }),
+      ),
+    );
+    expect(organization.issues[0]).toMatchObject({ code: 'field_not_allowed' });
+  });
+
+  it('rejects grouped orderBy and fixes grouped ordering', () => {
+    const error = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          group: { by: ['threadId'] },
+          orderBy: [{ field: 'startedAt', direction: 'desc' }],
+        }),
+      ),
+    );
+    expect(error.issues[0]).toMatchObject({ code: 'group_order_not_supported', path: ['orderBy'] });
+
+    expect(planTraceQuery(parsed({ ...baseRequest, group: { by: ['threadId'] } }))).toMatchObject({
+      result: 'groups',
+      orderBy: { field: 'threadId', direction: 'asc' },
+    });
+  });
+
+  it('rejects null comparisons in favor of presence operators', () => {
+    for (const op of ['eq', 'ne'] as const) {
+      const error = validationError(() =>
+        planTraceQuery(
+          parsed({
+            ...baseRequest,
+            where: { op, left: { path: 'threadId' }, right: { literal: null } },
+          }),
+        ),
+      );
+      expect(error.issues).toContainEqual(
+        expect.objectContaining({ code: 'invalid_literal', path: ['where', 'right', 'literal'] }),
+      );
+    }
+
+    expect(planTraceQuery(parsed({ ...baseRequest, where: { op: 'notExists', path: 'threadId' } })).where).toEqual({
+      type: 'presence',
+      field: 'threadId',
+      operator: 'notExists',
+    });
+  });
+
+  it('bounds related collection clauses at the accepted plan boundary', () => {
+    const relation = (index: number): TraceQueryPredicate => ({
+      scores: {
+        some: { op: 'eq', left: { path: 'scorerId' }, right: { literal: `scorer-${index}` } },
+      },
+    });
+    const atLimit = Array.from({ length: TRACE_QUERY_MAX_RELATED_CLAUSES }, (_, index) => relation(index));
+    expect(planTraceQuery(parsed({ ...baseRequest, where: { op: 'and', args: atLimit } })).where).toBeDefined();
+
+    const error = validationError(() =>
+      planTraceQuery(parsed({ ...baseRequest, where: { op: 'and', args: [...atLimit, relation(atLimit.length)] } })),
+    );
+    expect(error.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'predicate_too_complex',
+        path: ['where', 'args', TRACE_QUERY_MAX_RELATED_CLAUSES],
+      }),
+    );
+  });
+
+  it('counts every scalar and membership member toward the global literal budget', () => {
+    const setSize = TRACE_QUERY_MAX_SET_VALUES - 1;
+    const setCount = Math.floor(TRACE_QUERY_MAX_LITERAL_UNITS / setSize);
+    const comparisonCount = TRACE_QUERY_MAX_LITERAL_UNITS - setCount * setSize;
+    const memberships: TraceQueryPredicate[] = Array.from({ length: setCount }, (_, predicateIndex) => ({
+      op: 'in',
+      value: { path: 'traceId' },
+      set: Array.from({ length: setSize }, (_, valueIndex) => `trace-${predicateIndex}-${valueIndex}`),
+    }));
+    const comparisons: TraceQueryPredicate[] = Array.from({ length: comparisonCount }, (_, index) => ({
+      op: 'ne',
+      left: { path: 'traceId' },
+      right: { literal: `excluded-${index}` },
+    }));
+    const atLimit = [...memberships, ...comparisons];
+    expect(planTraceQuery(parsed({ ...baseRequest, where: { op: 'and', args: atLimit } })).where).toBeDefined();
+
+    const error = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          where: {
+            op: 'and',
+            args: [...atLimit, { op: 'eq', left: { path: 'traceId' }, right: { literal: 'one-too-many' } }],
+          },
+          page: { after: 'not-a-cursor' },
+        }),
+      ),
+    );
+    expect(error.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'predicate_too_complex',
+        path: ['where', 'args', atLimit.length, 'right', 'literal'],
+      }),
+    );
+  });
+
+  it('counts multiple individually valid sets toward the same literal budget', () => {
+    const args: TraceQueryPredicate[] = Array.from(
+      { length: TRACE_QUERY_MAX_LITERAL_UNITS / TRACE_QUERY_MAX_SET_VALUES + 1 },
+      (_, predicateIndex) => ({
+        op: 'in',
+        value: { path: 'traceId' },
+        set: Array.from(
+          { length: TRACE_QUERY_MAX_SET_VALUES },
+          (_, valueIndex) => `trace-${predicateIndex}-${valueIndex}`,
+        ),
+      }),
+    );
+    const error = validationError(() => planTraceQuery(parsed({ ...baseRequest, where: { op: 'or', args } })));
+    expect(error.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'predicate_too_complex',
+        path: ['where', 'args', args.length - 1, 'set'],
+      }),
+    );
+  });
+
+  it('bounds recursive predicate complexity', () => {
+    let where: TraceQueryPredicate = {
+      op: 'eq',
+      left: { path: 'traceId' },
+      right: { literal: 'trace-1' },
+    };
+    for (let index = 0; index < TRACE_QUERY_MAX_DEPTH; index += 1) where = { op: 'not', arg: where };
+
+    const error = validationError(() => planTraceQuery(parsed({ ...baseRequest, where })));
+    expect(error.issues[0]).toMatchObject({ code: 'predicate_too_complex' });
+  });
+
+  it('does not echo query literals in semantic issues', () => {
+    const secret = 'sensitive-customer-value';
+    const error = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          where: { op: 'eq', left: { path: 'unknown' }, right: { literal: secret } },
+        }),
+      ),
+    );
+    expect(JSON.stringify(error.issues)).not.toContain(secret);
+  });
+});
+
+describe('trace-query cursors', () => {
+  it('round-trips trace and group keyset values', () => {
+    const tracePlan = planTraceQuery(parsed());
+    const traceCursor = encodeTraceQueryCursor(tracePlan, {
+      result: 'traces',
+      sortValue: '2026-08-03T00:00:00.000Z',
+      traceId: 'trace-3',
+    });
+    expect(planTraceQuery(parsed({ ...baseRequest, page: { after: traceCursor } }))).toMatchObject({
+      cursor: { sortValue: '2026-08-03T00:00:00.000Z', traceId: 'trace-3' },
+    });
+
+    const groupPlan = planTraceQuery(parsed({ ...baseRequest, group: { by: ['threadId'] } }));
+    const groupCursor = encodeTraceQueryCursor(groupPlan, { result: 'groups', threadId: 'thread-2' });
+    expect(
+      planTraceQuery(parsed({ ...baseRequest, group: { by: ['threadId'] }, page: { after: groupCursor } })),
+    ).toMatchObject({ cursor: { threadId: 'thread-2' } });
+  });
+
+  it('distinguishes malformed cursors from binding conflicts', () => {
+    expect(() => planTraceQuery(parsed({ ...baseRequest, page: { after: 'not-json' } }))).toThrowError(
+      expect.objectContaining<Partial<TraceQueryCursorError>>({ code: 'TRACE_QUERY_CURSOR_MALFORMED' }),
+    );
+
+    const plan = planTraceQuery(parsed());
+    const cursor = encodeTraceQueryCursor(plan, {
+      result: 'traces',
+      sortValue: '2026-08-03T00:00:00.000Z',
+      traceId: 'trace-3',
+    });
+    expect(() =>
+      planTraceQuery(parsed({ ...baseRequest, where: { op: 'exists', path: 'threadId' }, page: { after: cursor } })),
+    ).toThrowError(expect.objectContaining<Partial<TraceQueryCursorError>>({ code: 'TRACE_QUERY_CURSOR_CONFLICT' }));
+  });
+
+  it('binds established shared authorization state only when supplied', () => {
+    const plan = planTraceQuery(parsed(), { authorizationBinding: 'scope-a' });
+    const cursor = encodeTraceQueryCursor(plan, {
+      result: 'traces',
+      sortValue: '2026-08-03T00:00:00.000Z',
+      traceId: 'trace-3',
+    });
+
+    expect(() =>
+      planTraceQuery(parsed({ ...baseRequest, page: { after: cursor } }), { authorizationBinding: 'scope-b' }),
+    ).toThrowError(expect.objectContaining<Partial<TraceQueryCursorError>>({ code: 'TRACE_QUERY_CURSOR_CONFLICT' }));
+  });
+});
+
+describe('trace-query execution timeout contract', () => {
+  it('uses a conservative default and rejects invalid timeout configuration', () => {
+    expect(resolveTraceQueryTimeoutMs()).toBe(TRACE_QUERY_DEFAULT_TIMEOUT_MS);
+    expect(resolveTraceQueryTimeoutMs(1)).toBe(1);
+    expect(resolveTraceQueryTimeoutMs(TRACE_QUERY_MAX_TIMEOUT_MS)).toBe(TRACE_QUERY_MAX_TIMEOUT_MS);
+
+    for (const timeout of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, TRACE_QUERY_MAX_TIMEOUT_MS + 1]) {
+      expect(() => resolveTraceQueryTimeoutMs(timeout), String(timeout)).toThrow(RangeError);
+    }
+  });
+
+  it('exposes a stable timeout identity without a driver message', () => {
+    expect(new TraceQueryExecutionError()).toMatchObject({
+      code: 'TRACE_QUERY_EXECUTION_TIMEOUT',
+      message: 'The trace query exceeded its execution timeout',
+    });
+  });
+});
+
+describe('trace-query responses and storage capability', () => {
+  it('enforces fixed trace and group projections', () => {
+    const trace = {
+      traceId: 'trace-1',
+      rootSpanId: 'span-1',
+      threadId: null,
+      resourceId: null,
+      startedAt: '2026-08-01T00:00:00Z',
+      endedAt: '2026-08-01T00:00:01Z',
+      entityName: null,
+      entityType: null,
+      environment: null,
+      status: 'success',
+    };
+    expect(traceQueryTraceResponseSchema.safeParse({ traces: [trace], page: { next: null } }).success).toBe(true);
+    expect(
+      traceQueryTraceResponseSchema.safeParse({ traces: [{ ...trace, scores: [] }], page: { next: null } }).success,
+    ).toBe(false);
+    expect(
+      traceQueryGroupResponseSchema.safeParse({ groups: [{ threadId: 'thread-1', count: 1 }], page: { next: null } })
+        .success,
+    ).toBe(false);
+  });
+
+  it('fails closed for stores that do not implement advanced trace queries', async () => {
+    const storage = new ObservabilityStorage();
+    await expect(storage.queryTraces(planTraceQuery(parsed()))).rejects.toMatchObject({
+      id: 'OBSERVABILITY_STORAGE_QUERY_TRACES_NOT_IMPLEMENTED',
+    });
+  });
+});

--- a/packages/core/src/storage/domains/observability/trace-query.test.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.test.ts
@@ -328,7 +328,7 @@ describe('planTraceQuery', () => {
     });
   });
 
-  it('rejects null comparisons in favor of presence operators', () => {
+  it('rejects null predicate literals in favor of presence operators', () => {
     for (const op of ['eq', 'ne'] as const) {
       const error = validationError(() =>
         planTraceQuery(
@@ -341,6 +341,13 @@ describe('planTraceQuery', () => {
       expect(error.issues).toContainEqual(
         expect.objectContaining({ code: 'invalid_literal', path: ['where', 'right', 'literal'] }),
       );
+    }
+
+    for (const op of ['in', 'notIn'] as const) {
+      const error = validationError(() =>
+        planTraceQuery(parsed({ ...baseRequest, where: { op, value: { path: 'threadId' }, set: [null] } })),
+      );
+      expect(error.issues).toContainEqual(expect.objectContaining({ code: 'invalid_literal', path: ['where', 'set'] }));
     }
 
     expect(planTraceQuery(parsed({ ...baseRequest, where: { op: 'notExists', path: 'threadId' } })).where).toEqual({

--- a/packages/core/src/storage/domains/observability/trace-query.test.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.test.ts
@@ -6,6 +6,7 @@ import {
   planTraceQuery,
   TRACE_QUERY_MAX_DEPTH,
   TRACE_QUERY_MAX_LITERAL_UNITS,
+  TRACE_QUERY_MAX_NODES,
   TRACE_QUERY_MAX_PATH_BYTES,
   TRACE_QUERY_MAX_RELATED_CLAUSES,
   TRACE_QUERY_MAX_SET_VALUES,
@@ -426,16 +427,50 @@ describe('planTraceQuery', () => {
     );
   });
 
-  it('bounds recursive predicate complexity', () => {
-    let where: TraceQueryPredicate = {
+  it('accepts predicate complexity limits and rejects limit plus one before planning', () => {
+    const leaf = (): TraceQueryPredicate => ({
       op: 'eq',
       left: { path: 'traceId' },
       right: { literal: 'trace-1' },
-    };
-    for (let index = 0; index < TRACE_QUERY_MAX_DEPTH; index += 1) where = { op: 'not', arg: where };
+    });
 
-    const error = validationError(() => planTraceQuery(parsed({ ...baseRequest, where })));
+    let atDepthLimit = leaf();
+    for (let index = 1; index < TRACE_QUERY_MAX_DEPTH; index += 1) atDepthLimit = { op: 'not', arg: atDepthLimit };
+    expect(planTraceQuery(parsed({ ...baseRequest, where: atDepthLimit })).where).toBeDefined();
+
+    const overDepthLimit: TraceQueryPredicate = { op: 'not', arg: atDepthLimit };
+    const depthError = validationError(() => parsed({ ...baseRequest, where: overDepthLimit }));
+    expect(depthError.issues).toEqual([
+      expect.objectContaining({
+        code: 'predicate_too_complex',
+        path: ['where', ...Array.from({ length: TRACE_QUERY_MAX_DEPTH }, () => 'arg')],
+      }),
+    ]);
+
+    const atNodeLimit: TraceQueryPredicate = {
+      op: 'and',
+      args: Array.from({ length: TRACE_QUERY_MAX_NODES - 1 }, leaf),
+    };
+    expect(planTraceQuery(parsed({ ...baseRequest, where: atNodeLimit })).where).toBeDefined();
+
+    const overNodeLimit: TraceQueryPredicate = { op: 'and', args: [...atNodeLimit.args, leaf()] };
+    const nodeError = validationError(() => parsed({ ...baseRequest, where: overNodeLimit }));
+    expect(nodeError.issues).toEqual([
+      expect.objectContaining({ code: 'predicate_too_complex', path: ['where', 'args', TRACE_QUERY_MAX_NODES - 1] }),
+    ]);
+  });
+
+  it('rejects adversarial recursive predicates without overflowing the parser stack', () => {
+    let where: unknown = { op: 'not' };
+    for (let index = 0; index < 10_000; index += 1) where = { op: 'not', arg: where };
+
+    const error = validationError(() => parsed({ ...baseRequest, where }));
     expect(error.issues[0]).toMatchObject({ code: 'predicate_too_complex' });
+  });
+
+  it('leaves ordinary malformed predicates to structural validation', () => {
+    const error = validationError(() => parsed({ ...baseRequest, where: { op: 'not', arg: { op: 'unknown' } } }));
+    expect(error.issues).toEqual([expect.objectContaining({ code: 'invalid_request' })]);
   });
 
   it('does not echo query literals in semantic issues', () => {

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -11,6 +11,8 @@ export const TRACE_QUERY_MAX_PATH_BYTES = 128;
 export const TRACE_QUERY_DEFAULT_TIMEOUT_MS = 15_000;
 export const TRACE_QUERY_MAX_TIMEOUT_MS = 300_000;
 
+const PREDICATE_COMPLEXITY_MESSAGE = `Predicates are limited to ${TRACE_QUERY_MAX_NODES} nodes and ${TRACE_QUERY_MAX_DEPTH} levels`;
+
 const hasMaxUtf8Bytes = (value: string, maxBytes: number) => Buffer.byteLength(value, 'utf8') <= maxBytes;
 const literalStringSchema = z
   .string()
@@ -109,7 +111,7 @@ const pageSchema = z
   .strict()
   .default({ limit: 100 });
 
-export const traceQueryRequestSchema = z
+const traceQueryRequestObjectSchema = z
   .object({
     timeRange: timeRangeSchema,
     where: traceQueryPredicateSchema.optional(),
@@ -131,6 +133,15 @@ export const traceQueryRequestSchema = z
     page: pageSchema,
   })
   .strict();
+
+export const traceQueryRequestSchema = z.preprocess((input, context) => {
+  const issuePath = findPredicateComplexityIssue(input);
+  if (issuePath) {
+    context.addIssue({ code: 'custom', path: issuePath, message: PREDICATE_COMPLEXITY_MESSAGE });
+    return z.NEVER;
+  }
+  return input;
+}, traceQueryRequestObjectSchema);
 
 export const traceQueryTraceSchema = z
   .object({
@@ -363,12 +374,63 @@ function addPredicateComplexityIssue(path: Array<string | number>, message: stri
   }
 }
 
+function findPredicateComplexityIssue(input: unknown): Array<string | number> | undefined {
+  if (!input || typeof input !== 'object' || !Object.hasOwn(input, 'where')) return undefined;
+
+  const where = (input as { where?: unknown }).where;
+  if (where === undefined) return undefined;
+
+  const stack: Array<{ predicate: unknown; path: Array<string | number>; depth: number }> = [
+    { predicate: where, path: ['where'], depth: 1 },
+  ];
+  let nodes = 0;
+
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    nodes += 1;
+    if (frame.depth > TRACE_QUERY_MAX_DEPTH || nodes > TRACE_QUERY_MAX_NODES) return frame.path;
+    if (!frame.predicate || typeof frame.predicate !== 'object') continue;
+
+    const predicate = frame.predicate as Record<string, unknown>;
+    if ((predicate.op === 'and' || predicate.op === 'or') && Array.isArray(predicate.args)) {
+      for (let index = predicate.args.length - 1; index >= 0; index -= 1) {
+        stack.push({ predicate: predicate.args[index], path: [...frame.path, 'args', index], depth: frame.depth + 1 });
+      }
+      continue;
+    }
+    if (predicate.op === 'not' && Object.hasOwn(predicate, 'arg')) {
+      stack.push({ predicate: predicate.arg, path: [...frame.path, 'arg'], depth: frame.depth + 1 });
+      continue;
+    }
+
+    for (const collection of ['scores', 'spans'] as const) {
+      const clause = predicate[collection];
+      if (!clause || typeof clause !== 'object') continue;
+      for (const quantifier of ['none', 'some'] as const) {
+        if (!Object.hasOwn(clause, quantifier)) continue;
+        stack.push({
+          predicate: (clause as Record<string, unknown>)[quantifier],
+          path: [...frame.path, collection, quantifier],
+          depth: frame.depth + 1,
+        });
+      }
+    }
+  }
+
+  return undefined;
+}
+
 export function formatTraceQuerySchemaIssues(error: z.ZodError): TraceQueryIssue[] {
-  return error.issues.map(issue => ({
-    code: 'invalid_request',
-    path: issue.path.map(part => (typeof part === 'symbol' ? String(part) : part)),
-    message: 'The value does not match the trace-query request contract',
-  }));
+  return error.issues.map(issue => {
+    const predicateTooComplex = issue.code === 'custom' && issue.message === PREDICATE_COMPLEXITY_MESSAGE;
+    return {
+      code: predicateTooComplex ? 'predicate_too_complex' : 'invalid_request',
+      path: issue.path.map(part => (typeof part === 'symbol' ? String(part) : part)),
+      message: predicateTooComplex
+        ? PREDICATE_COMPLEXITY_MESSAGE
+        : 'The value does not match the trace-query request contract',
+    };
+  });
 }
 
 export function parseTraceQueryRequest(input: unknown): NormalizedTraceQueryRequest {
@@ -497,11 +559,7 @@ function planPredicate(
 ): TrustedTraceQueryPredicate | TrustedTraceQueryScalarPredicate | undefined {
   state.nodes += 1;
   if (depth > TRACE_QUERY_MAX_DEPTH || state.nodes > TRACE_QUERY_MAX_NODES) {
-    addPredicateComplexityIssue(
-      path,
-      `Predicates are limited to ${TRACE_QUERY_MAX_NODES} nodes and ${TRACE_QUERY_MAX_DEPTH} levels`,
-      state,
-    );
+    addPredicateComplexityIssue(path, PREDICATE_COMPLEXITY_MESSAGE, state);
     return undefined;
   }
 

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -197,8 +197,8 @@ export type TraceQueryPredicate =
   | { spans: { some: TraceQueryScalarPredicate } | { none: TraceQueryScalarPredicate } }
   | { scores: { some: TraceQueryScalarPredicate } | { none: TraceQueryScalarPredicate } };
 
-export type TraceQueryRequest = z.input<typeof traceQueryRequestSchema>;
-export type NormalizedTraceQueryRequest = z.output<typeof traceQueryRequestSchema>;
+export type TraceQueryRequest = z.input<typeof traceQueryRequestObjectSchema>;
+export type NormalizedTraceQueryRequest = z.output<typeof traceQueryRequestObjectSchema>;
 export type TraceQueryTrace = z.infer<typeof traceQueryTraceSchema>;
 export type TraceQueryTraceResponse = z.infer<typeof traceQueryTraceResponseSchema>;
 export type TraceQueryGroupResponse = z.infer<typeof traceQueryGroupResponseSchema>;

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -1,0 +1,688 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod/v4';
+
+export const TRACE_QUERY_MAX_DEPTH = 12;
+export const TRACE_QUERY_MAX_NODES = 100;
+export const TRACE_QUERY_MAX_SET_VALUES = 100;
+export const TRACE_QUERY_MAX_RELATED_CLAUSES = 8;
+export const TRACE_QUERY_MAX_LITERAL_UNITS = 1000;
+export const TRACE_QUERY_MAX_STRING_BYTES = 4096;
+export const TRACE_QUERY_MAX_PATH_BYTES = 128;
+export const TRACE_QUERY_DEFAULT_TIMEOUT_MS = 15_000;
+export const TRACE_QUERY_MAX_TIMEOUT_MS = 300_000;
+
+const hasMaxUtf8Bytes = (value: string, maxBytes: number) => Buffer.byteLength(value, 'utf8') <= maxBytes;
+const literalStringSchema = z
+  .string()
+  .refine(value => hasMaxUtf8Bytes(value, TRACE_QUERY_MAX_STRING_BYTES), 'String literal is too large');
+const predicatePathSchema = z
+  .string()
+  .min(1)
+  .refine(value => hasMaxUtf8Bytes(value, TRACE_QUERY_MAX_PATH_BYTES), 'Predicate path is too large');
+const literalSchema = z.union([literalStringSchema, z.number(), z.boolean(), z.null()]);
+const pathRefSchema = z.object({ path: predicatePathSchema }).strict();
+const literalRefSchema = z.object({ literal: literalSchema }).strict();
+const pathOrLiteralSchema = z.union([pathRefSchema, literalRefSchema]);
+
+export const traceQueryScalarPredicateSchema: z.ZodType<TraceQueryScalarPredicate> = z.lazy(() =>
+  z.union([
+    z
+      .object({
+        op: z.enum(['eq', 'ne', 'lt', 'lte', 'gt', 'gte']),
+        left: pathOrLiteralSchema,
+        right: pathOrLiteralSchema,
+      })
+      .strict(),
+    z
+      .object({
+        op: z.enum(['in', 'notIn']),
+        value: pathOrLiteralSchema,
+        set: z.array(literalSchema).min(1).max(TRACE_QUERY_MAX_SET_VALUES),
+      })
+      .strict(),
+    z.object({ op: z.enum(['exists', 'notExists']), path: predicatePathSchema }).strict(),
+    z
+      .object({
+        op: z.enum(['and', 'or']),
+        args: z.array(traceQueryScalarPredicateSchema).min(1),
+      })
+      .strict(),
+    z.object({ op: z.literal('not'), arg: traceQueryScalarPredicateSchema }).strict(),
+  ]),
+);
+
+export const traceQueryPredicateSchema: z.ZodType<TraceQueryPredicate> = z.lazy(() =>
+  z.union([
+    z
+      .object({
+        op: z.enum(['eq', 'ne', 'lt', 'lte', 'gt', 'gte']),
+        left: pathOrLiteralSchema,
+        right: pathOrLiteralSchema,
+      })
+      .strict(),
+    z
+      .object({
+        op: z.enum(['in', 'notIn']),
+        value: pathOrLiteralSchema,
+        set: z.array(literalSchema).min(1).max(TRACE_QUERY_MAX_SET_VALUES),
+      })
+      .strict(),
+    z.object({ op: z.enum(['exists', 'notExists']), path: predicatePathSchema }).strict(),
+    z
+      .object({
+        op: z.enum(['and', 'or']),
+        args: z.array(traceQueryPredicateSchema).min(1),
+      })
+      .strict(),
+    z.object({ op: z.literal('not'), arg: traceQueryPredicateSchema }).strict(),
+    z
+      .object({
+        spans: z.union([
+          z.object({ some: traceQueryScalarPredicateSchema }).strict(),
+          z.object({ none: traceQueryScalarPredicateSchema }).strict(),
+        ]),
+      })
+      .strict(),
+    z
+      .object({
+        scores: z.union([
+          z.object({ some: traceQueryScalarPredicateSchema }).strict(),
+          z.object({ none: traceQueryScalarPredicateSchema }).strict(),
+        ]),
+      })
+      .strict(),
+  ]),
+);
+
+const timeRangeSchema = z
+  .object({
+    from: z.string().datetime({ offset: true }),
+    to: z.string().datetime({ offset: true }),
+  })
+  .strict();
+
+const pageSchema = z
+  .object({
+    limit: z.number().int().min(1).max(1000).default(100),
+    after: z.string().min(1).nullable().optional(),
+  })
+  .strict()
+  .default({ limit: 100 });
+
+export const traceQueryRequestSchema = z
+  .object({
+    timeRange: timeRangeSchema,
+    where: traceQueryPredicateSchema.optional(),
+    group: z
+      .object({ by: z.tuple([z.literal('threadId')]) })
+      .strict()
+      .optional(),
+    orderBy: z
+      .array(
+        z
+          .object({
+            field: z.enum(['startedAt', 'endedAt']),
+            direction: z.enum(['asc', 'desc']),
+          })
+          .strict(),
+      )
+      .length(1)
+      .optional(),
+    page: pageSchema,
+  })
+  .strict();
+
+export const traceQueryTraceSchema = z
+  .object({
+    traceId: z.string(),
+    rootSpanId: z.string(),
+    threadId: z.string().nullable(),
+    resourceId: z.string().nullable(),
+    startedAt: z.string().datetime({ offset: true }),
+    endedAt: z.string().datetime({ offset: true }),
+    entityName: z.string().nullable(),
+    entityType: z.string().nullable(),
+    environment: z.string().nullable(),
+    status: z.enum(['success', 'error']),
+  })
+  .strict();
+
+const responsePageSchema = z.object({ next: z.string().nullable() }).strict();
+
+export const traceQueryTraceResponseSchema = z
+  .object({ traces: z.array(traceQueryTraceSchema), page: responsePageSchema })
+  .strict();
+export const traceQueryGroupResponseSchema = z
+  .object({
+    groups: z.array(z.object({ threadId: z.string() }).strict()),
+    page: responsePageSchema,
+  })
+  .strict();
+export const traceQueryResponseSchema = z.union([traceQueryTraceResponseSchema, traceQueryGroupResponseSchema]);
+
+export type TraceQueryLiteral = string | number | boolean | null;
+export type TraceQueryPathOrLiteral = { path: string } | { literal: TraceQueryLiteral };
+export type TraceQueryScalarPredicate =
+  | {
+      op: 'eq' | 'ne' | 'lt' | 'lte' | 'gt' | 'gte';
+      left: TraceQueryPathOrLiteral;
+      right: TraceQueryPathOrLiteral;
+    }
+  | { op: 'in' | 'notIn'; value: TraceQueryPathOrLiteral; set: TraceQueryLiteral[] }
+  | { op: 'exists' | 'notExists'; path: string }
+  | { op: 'and' | 'or'; args: TraceQueryScalarPredicate[] }
+  | { op: 'not'; arg: TraceQueryScalarPredicate };
+
+export type TraceQueryPredicate =
+  | Exclude<TraceQueryScalarPredicate, { op: 'and' | 'or' } | { op: 'not' }>
+  | { op: 'and' | 'or'; args: TraceQueryPredicate[] }
+  | { op: 'not'; arg: TraceQueryPredicate }
+  | { spans: { some: TraceQueryScalarPredicate } | { none: TraceQueryScalarPredicate } }
+  | { scores: { some: TraceQueryScalarPredicate } | { none: TraceQueryScalarPredicate } };
+
+export type TraceQueryRequest = z.input<typeof traceQueryRequestSchema>;
+export type NormalizedTraceQueryRequest = z.output<typeof traceQueryRequestSchema>;
+export type TraceQueryTrace = z.infer<typeof traceQueryTraceSchema>;
+export type TraceQueryTraceResponse = z.infer<typeof traceQueryTraceResponseSchema>;
+export type TraceQueryGroupResponse = z.infer<typeof traceQueryGroupResponseSchema>;
+export type TraceQueryResponse = z.infer<typeof traceQueryResponseSchema>;
+
+export type TraceQueryField =
+  | 'traceId'
+  | 'threadId'
+  | 'resourceId'
+  | 'startedAt'
+  | 'endedAt'
+  | 'entityName'
+  | 'entityType'
+  | 'environment'
+  | 'status';
+export type TraceQuerySpanField = 'spanType' | 'error';
+export type TraceQueryScoreField = 'scorerId' | 'score';
+export type TraceQueryCanonicalField = TraceQueryField | TraceQuerySpanField | TraceQueryScoreField;
+export type TraceQueryComparisonOperator = 'eq' | 'ne' | 'lt' | 'lte' | 'gt' | 'gte';
+export type TraceQueryMembershipOperator = 'in' | 'notIn';
+export type TraceQueryPresenceOperator = 'exists' | 'notExists';
+
+export type TrustedTraceQueryScalarPredicate =
+  | {
+      type: 'comparison';
+      field: TraceQueryCanonicalField;
+      operator: TraceQueryComparisonOperator;
+      value: string | number;
+    }
+  | {
+      type: 'membership';
+      field: TraceQueryCanonicalField;
+      operator: TraceQueryMembershipOperator;
+      values: Array<string | number>;
+    }
+  | { type: 'presence'; field: TraceQueryCanonicalField; operator: TraceQueryPresenceOperator }
+  | { type: 'boolean'; operator: 'and' | 'or'; args: TrustedTraceQueryScalarPredicate[] }
+  | { type: 'not'; arg: TrustedTraceQueryScalarPredicate };
+
+export type TrustedTraceQueryPredicate =
+  | TrustedTraceQueryScalarPredicate
+  | { type: 'boolean'; operator: 'and' | 'or'; args: TrustedTraceQueryPredicate[] }
+  | { type: 'not'; arg: TrustedTraceQueryPredicate }
+  | {
+      type: 'relation';
+      collection: 'spans' | 'scores';
+      quantifier: 'some' | 'none';
+      predicate: TrustedTraceQueryScalarPredicate;
+    };
+
+export interface TrustedTraceQueryBasePlan {
+  timeRange: { from: string; to: string };
+  where?: TrustedTraceQueryPredicate;
+  limit: number;
+  binding: string;
+}
+
+export interface TrustedTraceQueryTracesPlan extends TrustedTraceQueryBasePlan {
+  result: 'traces';
+  orderBy: {
+    field: 'startedAt' | 'endedAt';
+    direction: 'asc' | 'desc';
+  };
+  cursor?: { sortValue: string; traceId: string };
+}
+
+export interface TrustedTraceQueryGroupsPlan extends TrustedTraceQueryBasePlan {
+  result: 'groups';
+  orderBy: { field: 'threadId'; direction: 'asc' };
+  cursor?: { threadId: string };
+}
+
+export type TrustedTraceQueryPlan = TrustedTraceQueryTracesPlan | TrustedTraceQueryGroupsPlan;
+export type TraceQueryCursorValues =
+  | { result: 'traces'; sortValue: string; traceId: string }
+  | { result: 'groups'; threadId: string };
+
+export type TraceQueryIssueCode =
+  | 'invalid_request'
+  | 'invalid_time_range'
+  | 'time_range_too_large'
+  | 'predicate_too_complex'
+  | 'field_not_allowed'
+  | 'operator_not_allowed'
+  | 'invalid_operands'
+  | 'invalid_literal'
+  | 'group_order_not_supported';
+
+export interface TraceQueryIssue {
+  code: TraceQueryIssueCode;
+  path: Array<string | number>;
+  message: string;
+}
+
+export class TraceQueryValidationError extends Error {
+  readonly code = 'TRACE_QUERY_INVALID';
+
+  constructor(readonly issues: TraceQueryIssue[]) {
+    super('The trace query is invalid');
+    this.name = 'TraceQueryValidationError';
+  }
+}
+
+export class TraceQueryCursorError extends Error {
+  constructor(readonly code: 'TRACE_QUERY_CURSOR_MALFORMED' | 'TRACE_QUERY_CURSOR_CONFLICT') {
+    super(
+      code === 'TRACE_QUERY_CURSOR_MALFORMED'
+        ? 'The trace query cursor is malformed'
+        : 'The cursor does not match the query',
+    );
+    this.name = 'TraceQueryCursorError';
+  }
+}
+
+export class TraceQueryExecutionError extends Error {
+  readonly code = 'TRACE_QUERY_EXECUTION_TIMEOUT';
+
+  constructor() {
+    super('The trace query exceeded its execution timeout');
+    this.name = 'TraceQueryExecutionError';
+  }
+}
+
+export function resolveTraceQueryTimeoutMs(timeoutMs = TRACE_QUERY_DEFAULT_TIMEOUT_MS): number {
+  if (
+    !Number.isFinite(timeoutMs) ||
+    !Number.isInteger(timeoutMs) ||
+    timeoutMs <= 0 ||
+    timeoutMs > TRACE_QUERY_MAX_TIMEOUT_MS
+  ) {
+    throw new RangeError(`traceQueryTimeoutMs must be an integer between 1 and ${TRACE_QUERY_MAX_TIMEOUT_MS}`);
+  }
+  return timeoutMs;
+}
+
+interface FieldRule {
+  type: 'string' | 'number' | 'timestamp' | 'presence';
+  operators: ReadonlySet<string>;
+}
+
+const STRING_OPERATORS = new Set(['eq', 'ne', 'in', 'notIn', 'exists', 'notExists']);
+const ORDERED_OPERATORS = new Set([...STRING_OPERATORS, 'lt', 'lte', 'gt', 'gte']);
+const PRESENCE_OPERATORS = new Set(['exists', 'notExists']);
+
+const TRACE_FIELD_RULES: Record<TraceQueryField, FieldRule> = {
+  traceId: { type: 'string', operators: STRING_OPERATORS },
+  threadId: { type: 'string', operators: STRING_OPERATORS },
+  resourceId: { type: 'string', operators: STRING_OPERATORS },
+  startedAt: { type: 'timestamp', operators: ORDERED_OPERATORS },
+  endedAt: { type: 'timestamp', operators: ORDERED_OPERATORS },
+  entityName: { type: 'string', operators: STRING_OPERATORS },
+  entityType: { type: 'string', operators: STRING_OPERATORS },
+  environment: { type: 'string', operators: STRING_OPERATORS },
+  status: { type: 'string', operators: STRING_OPERATORS },
+};
+
+const SPAN_FIELD_RULES: Record<TraceQuerySpanField, FieldRule> = {
+  spanType: { type: 'string', operators: STRING_OPERATORS },
+  error: { type: 'presence', operators: PRESENCE_OPERATORS },
+};
+
+const SCORE_FIELD_RULES: Record<TraceQueryScoreField, FieldRule> = {
+  scorerId: { type: 'string', operators: STRING_OPERATORS },
+  score: { type: 'number', operators: ORDERED_OPERATORS },
+};
+
+type PredicateContext = 'trace' | 'spans' | 'scores';
+
+interface PlannerState {
+  nodes: number;
+  relatedClauses: number;
+  literalUnits: number;
+  issues: TraceQueryIssue[];
+}
+
+function addPredicateComplexityIssue(path: Array<string | number>, message: string, state: PlannerState): void {
+  if (!state.issues.some(issue => issue.code === 'predicate_too_complex' && issue.message === message)) {
+    state.issues.push({ code: 'predicate_too_complex', path, message });
+  }
+}
+
+export function formatTraceQuerySchemaIssues(error: z.ZodError): TraceQueryIssue[] {
+  return error.issues.map(issue => ({
+    code: 'invalid_request',
+    path: issue.path.map(part => (typeof part === 'symbol' ? String(part) : part)),
+    message: 'The value does not match the trace-query request contract',
+  }));
+}
+
+export function parseTraceQueryRequest(input: unknown): NormalizedTraceQueryRequest {
+  const result = traceQueryRequestSchema.safeParse(input);
+  if (!result.success) throw new TraceQueryValidationError(formatTraceQuerySchemaIssues(result.error));
+  return result.data;
+}
+
+/**
+ * Converts a structurally valid trace-query request into the canonical plan consumed by
+ * observability storage adapters.
+ *
+ * @internal This is a trusted server/storage boundary, not a client-side query builder.
+ */
+export function planTraceQuery(
+  request: NormalizedTraceQueryRequest,
+  options: { authorizationBinding?: string } = {},
+): TrustedTraceQueryPlan {
+  const issues: TraceQueryIssue[] = [];
+  const from = new Date(request.timeRange.from);
+  const to = new Date(request.timeRange.to);
+  if (from >= to) {
+    issues.push({ code: 'invalid_time_range', path: ['timeRange'], message: '`from` must be earlier than `to`' });
+  } else if (to.getTime() - from.getTime() > 31 * 24 * 60 * 60 * 1000) {
+    issues.push({
+      code: 'time_range_too_large',
+      path: ['timeRange'],
+      message: 'The time range cannot exceed 31 days',
+    });
+  }
+
+  if (request.group && request.orderBy) {
+    issues.push({
+      code: 'group_order_not_supported',
+      path: ['orderBy'],
+      message: 'Grouped trace queries use fixed threadId ordering',
+    });
+  }
+
+  const state: PlannerState = { nodes: 0, relatedClauses: 0, literalUnits: 0, issues };
+  const where = request.where ? planPredicate(request.where, 'trace', ['where'], 1, state) : undefined;
+  if (issues.length > 0) throw new TraceQueryValidationError(issues);
+
+  const timeRange = { from: from.toISOString(), to: to.toISOString() };
+  const limit = request.page.limit;
+
+  if (request.group) {
+    const result = 'groups' as const;
+    const orderBy = { field: 'threadId', direction: 'asc' } as const;
+    const binding = digestBinding({ timeRange, where, result, orderBy, authorization: options.authorizationBinding });
+    const cursor = request.page.after ? decodeTraceQueryCursor(request.page.after, result, binding) : undefined;
+    return {
+      result,
+      timeRange,
+      where,
+      orderBy,
+      limit,
+      binding,
+      cursor: cursor?.result === 'groups' ? { threadId: cursor.threadId } : undefined,
+    };
+  }
+
+  const result = 'traces' as const;
+  const orderBy = request.orderBy?.[0] ?? ({ field: 'startedAt', direction: 'desc' } as const);
+  const binding = digestBinding({ timeRange, where, result, orderBy, authorization: options.authorizationBinding });
+  const cursor = request.page.after ? decodeTraceQueryCursor(request.page.after, result, binding) : undefined;
+  return {
+    result,
+    timeRange,
+    where,
+    orderBy,
+    limit,
+    binding,
+    cursor: cursor?.result === 'traces' ? { sortValue: cursor.sortValue, traceId: cursor.traceId } : undefined,
+  };
+}
+
+export function encodeTraceQueryCursor(plan: TrustedTraceQueryPlan, values: TraceQueryCursorValues): string {
+  if (values.result !== plan.result) throw new TraceQueryCursorError('TRACE_QUERY_CURSOR_CONFLICT');
+  return Buffer.from(JSON.stringify({ version: 1, binding: plan.binding, values }), 'utf8').toString('base64url');
+}
+
+function decodeTraceQueryCursor(
+  cursor: string,
+  expectedResult: 'traces' | 'groups',
+  expectedBinding: string,
+): TraceQueryCursorValues {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
+  } catch {
+    throw new TraceQueryCursorError('TRACE_QUERY_CURSOR_MALFORMED');
+  }
+
+  const envelope = cursorEnvelopeSchema.safeParse(parsed);
+  if (!envelope.success) throw new TraceQueryCursorError('TRACE_QUERY_CURSOR_MALFORMED');
+  if (envelope.data.binding !== expectedBinding || envelope.data.values.result !== expectedResult) {
+    throw new TraceQueryCursorError('TRACE_QUERY_CURSOR_CONFLICT');
+  }
+  return envelope.data.values;
+}
+
+const cursorEnvelopeSchema = z
+  .object({
+    version: z.literal(1),
+    binding: z.string().length(64),
+    values: z.discriminatedUnion('result', [
+      z
+        .object({
+          result: z.literal('traces'),
+          sortValue: z.string().datetime({ offset: true }),
+          traceId: z.string().min(1),
+        })
+        .strict(),
+      z.object({ result: z.literal('groups'), threadId: z.string().min(1) }).strict(),
+    ]),
+  })
+  .strict();
+
+function planPredicate(
+  predicate: TraceQueryPredicate | TraceQueryScalarPredicate,
+  context: PredicateContext,
+  path: Array<string | number>,
+  depth: number,
+  state: PlannerState,
+): TrustedTraceQueryPredicate | TrustedTraceQueryScalarPredicate | undefined {
+  state.nodes += 1;
+  if (depth > TRACE_QUERY_MAX_DEPTH || state.nodes > TRACE_QUERY_MAX_NODES) {
+    addPredicateComplexityIssue(
+      path,
+      `Predicates are limited to ${TRACE_QUERY_MAX_NODES} nodes and ${TRACE_QUERY_MAX_DEPTH} levels`,
+      state,
+    );
+    return undefined;
+  }
+
+  if ('spans' in predicate || 'scores' in predicate) {
+    state.relatedClauses += 1;
+    if (state.relatedClauses > TRACE_QUERY_MAX_RELATED_CLAUSES) {
+      addPredicateComplexityIssue(
+        path,
+        `Trace queries are limited to ${TRACE_QUERY_MAX_RELATED_CLAUSES} related collection clauses`,
+        state,
+      );
+    }
+    if (context !== 'trace') {
+      state.issues.push({
+        code: 'invalid_request',
+        path,
+        message: 'Related collections cannot be nested inside related-record predicates',
+      });
+      return undefined;
+    }
+    const collection = 'spans' in predicate ? 'spans' : 'scores';
+    const clause = 'spans' in predicate ? predicate.spans : predicate.scores;
+    const quantifier = 'some' in clause ? 'some' : 'none';
+    const nested = 'some' in clause ? clause.some : clause.none;
+    const planned = planPredicate(nested, collection, [...path, collection, quantifier], depth + 1, state);
+    return planned
+      ? { type: 'relation', collection, quantifier, predicate: planned as TrustedTraceQueryScalarPredicate }
+      : undefined;
+  }
+
+  if (predicate.op === 'and' || predicate.op === 'or') {
+    const args = predicate.args
+      .map((arg, index) => planPredicate(arg, context, [...path, 'args', index], depth + 1, state))
+      .filter((arg): arg is TrustedTraceQueryPredicate => arg !== undefined);
+    return { type: 'boolean', operator: predicate.op, args };
+  }
+  if (predicate.op === 'not') {
+    const arg = planPredicate(predicate.arg, context, [...path, 'arg'], depth + 1, state);
+    return arg ? { type: 'not', arg } : undefined;
+  }
+
+  const rules = rulesForContext(context);
+  if (predicate.op === 'exists' || predicate.op === 'notExists') {
+    const field = normalizePath(predicate.path);
+    const rule = getRule(field, rules, [...path, 'path'], state);
+    if (!rule) return undefined;
+    if (!rule.operators.has(predicate.op)) addOperatorIssue(predicate.op, field, [...path, 'op'], state);
+    return { type: 'presence', field: field as TraceQueryCanonicalField, operator: predicate.op };
+  }
+
+  if (predicate.op === 'in' || predicate.op === 'notIn') {
+    state.literalUnits += predicate.set.length;
+    if (state.literalUnits > TRACE_QUERY_MAX_LITERAL_UNITS) {
+      addPredicateComplexityIssue(
+        [...path, 'set'],
+        `Trace queries are limited to ${TRACE_QUERY_MAX_LITERAL_UNITS} literal units`,
+        state,
+      );
+    }
+    if (!('path' in predicate.value)) {
+      state.issues.push({
+        code: 'invalid_operands',
+        path: [...path, 'value'],
+        message: 'Membership predicates require an allowlisted field path',
+      });
+      return undefined;
+    }
+    const field = normalizePath(predicate.value.path);
+    const rule = getRule(field, rules, [...path, 'value', 'path'], state);
+    if (!rule) return undefined;
+    if (!rule.operators.has(predicate.op)) addOperatorIssue(predicate.op, field, [...path, 'op'], state);
+    const values = normalizeSet(predicate.set, rule);
+    if (!values) {
+      state.issues.push({
+        code: 'invalid_literal',
+        path: [...path, 'set'],
+        message: 'Membership values must be homogeneous and match the selected field type',
+      });
+      return undefined;
+    }
+    return {
+      type: 'membership',
+      field: field as TraceQueryCanonicalField,
+      operator: predicate.op,
+      values,
+    };
+  }
+
+  const comparison = predicate as Extract<TraceQueryScalarPredicate, { left: TraceQueryPathOrLiteral }>;
+  state.literalUnits += 1;
+  if (state.literalUnits > TRACE_QUERY_MAX_LITERAL_UNITS) {
+    addPredicateComplexityIssue(
+      [...path, 'right', 'literal'],
+      `Trace queries are limited to ${TRACE_QUERY_MAX_LITERAL_UNITS} literal units`,
+      state,
+    );
+  }
+  if (!('path' in comparison.left) || !('literal' in comparison.right)) {
+    state.issues.push({
+      code: 'invalid_operands',
+      path,
+      message: 'Comparison predicates require a field on the left and a literal on the right',
+    });
+    return undefined;
+  }
+  const field = normalizePath(comparison.left.path);
+  const rule = getRule(field, rules, [...path, 'left', 'path'], state);
+  if (!rule) return undefined;
+  if (!rule.operators.has(comparison.op)) addOperatorIssue(comparison.op, field, [...path, 'op'], state);
+  const value = normalizeLiteral(comparison.right.literal, rule);
+  if (value === undefined) {
+    state.issues.push({
+      code: 'invalid_literal',
+      path: [...path, 'right', 'literal'],
+      message: 'The literal does not match the selected field type',
+    });
+    return undefined;
+  }
+  return { type: 'comparison', field: field as TraceQueryCanonicalField, operator: comparison.op, value };
+}
+
+function rulesForContext(context: PredicateContext): Record<string, FieldRule> {
+  if (context === 'spans') return SPAN_FIELD_RULES;
+  if (context === 'scores') return SCORE_FIELD_RULES;
+  return TRACE_FIELD_RULES;
+}
+
+function getRule(
+  field: string,
+  rules: Record<string, FieldRule>,
+  path: Array<string | number>,
+  state: PlannerState,
+): FieldRule | undefined {
+  const rule = rules[field];
+  if (!rule) {
+    state.issues.push({ code: 'field_not_allowed', path, message: 'The predicate field is not allowed here' });
+  }
+  return rule;
+}
+
+function addOperatorIssue(operator: string, field: string, path: Array<string | number>, state: PlannerState): void {
+  state.issues.push({
+    code: 'operator_not_allowed',
+    path,
+    message: `Operator ${operator} is not supported for field ${field}`,
+  });
+}
+
+function normalizePath(path: string): string {
+  const match = /^\$\{([^}]+)\}$/.exec(path.trim());
+  return (match?.[1] ?? path).trim();
+}
+
+function normalizeLiteral(value: TraceQueryLiteral, rule: FieldRule): string | number | undefined {
+  if (rule.type === 'number') return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  if (rule.type === 'timestamp') {
+    if (typeof value !== 'string') return undefined;
+    const timestamp = new Date(value);
+    return Number.isNaN(timestamp.getTime()) ? undefined : timestamp.toISOString();
+  }
+  if (rule.type === 'string') return typeof value === 'string' ? value : undefined;
+  return undefined;
+}
+
+function normalizeSet(values: TraceQueryLiteral[], rule: FieldRule): Array<string | number> | undefined {
+  const normalized = values.map(value => normalizeLiteral(value, rule));
+  return normalized.some(value => value === undefined) ? undefined : (normalized as Array<string | number>);
+}
+
+function digestBinding(value: unknown): string {
+  return createHash('sha256').update(stableStringify(value)).digest('hex');
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .filter(([, nested]) => nested !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${stableStringify(nested)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -635,11 +635,11 @@ function getRule(
   path: Array<string | number>,
   state: PlannerState,
 ): FieldRule | undefined {
-  const rule = rules[field];
-  if (!rule) {
+  if (!Object.hasOwn(rules, field)) {
     state.issues.push({ code: 'field_not_allowed', path, message: 'The predicate field is not allowed here' });
+    return undefined;
   }
-  return rule;
+  return rules[field];
 }
 
 function addOperatorIssue(operator: string, field: string, path: Array<string | number>, state: PlannerState): void {

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -13,6 +13,12 @@ export const TRACE_QUERY_MAX_TIMEOUT_MS = 300_000;
 
 const PREDICATE_COMPLEXITY_MESSAGE = `Predicates are limited to ${TRACE_QUERY_MAX_NODES} nodes and ${TRACE_QUERY_MAX_DEPTH} levels`;
 
+export function compareTraceQueryStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
 const hasMaxUtf8Bytes = (value: string, maxBytes: number) => Buffer.byteLength(value, 'utf8') <= maxBytes;
 const literalStringSchema = z
   .string()
@@ -738,7 +744,7 @@ function stableStringify(value: unknown): string {
   if (value && typeof value === 'object') {
     return `{${Object.entries(value)
       .filter(([, nested]) => nested !== undefined)
-      .sort(([left], [right]) => left.localeCompare(right))
+      .sort(([left], [right]) => compareTraceQueryStrings(left, right))
       .map(([key, nested]) => `${JSON.stringify(key)}:${stableStringify(nested)}`)
       .join(',')}}`;
   }

--- a/stores/_test-utils/src/domains/observability-vnext/index.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/index.ts
@@ -1,3 +1,5 @@
+export * from './trace-query';
+
 import { coreFeatures } from '@mastra/core/features';
 import { EntityType, SpanType } from '@mastra/core/observability';
 import type { CreateSpanRecord, ObservabilityStorage } from '@mastra/core/storage';

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.test.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeTraceQueryResponse,
   TRACE_QUERY_CONFORMANCE_CASES,
   TRACE_QUERY_FIXTURE_DATA,
+  TRACE_QUERY_ORDINAL_FIXTURE_DATA,
   TRACE_QUERY_TIED_TIMESTAMP_CASES,
   TRACE_QUERY_TIED_TIMESTAMP_FIXTURE_DATA,
 } from './trace-query';
@@ -73,6 +74,22 @@ describe('trace-query reference evaluator', () => {
     expect(new Set(results.map(result => JSON.stringify(result))).size).toBe(results.length);
   });
 
+  it('paginates tied mixed-case and non-ASCII trace IDs using ordinal order', async () => {
+    const results = await collectTraceQueryPages(
+      async normalized => {
+        return evaluateTraceQuery(TRACE_QUERY_ORDINAL_FIXTURE_DATA, planTraceQuery(normalized));
+      },
+      {
+        timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' },
+        orderBy: [{ field: 'startedAt', direction: 'asc' }],
+        page: { limit: 1 },
+      },
+    );
+
+    expect(results).toEqual([{ traceId: 'A' }, { traceId: 'a' }, { traceId: 'é' }, { traceId: 'Ω' }]);
+    expect(new Set(results.map(result => JSON.stringify(result))).size).toBe(results.length);
+  });
+
   it('traverses group pages without duplicates or null thread IDs', async () => {
     const request = {
       timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' },
@@ -83,6 +100,21 @@ describe('trace-query reference evaluator', () => {
       return evaluateTraceQuery(TRACE_QUERY_FIXTURE_DATA, planTraceQuery(normalized));
     }, request);
     expect(results).toEqual([{ threadId: 'thread-1' }, { threadId: 'thread-2' }]);
+  });
+
+  it('paginates mixed-case and non-ASCII thread groups using ordinal order', async () => {
+    const results = await collectTraceQueryPages(
+      async normalized => {
+        return evaluateTraceQuery(TRACE_QUERY_ORDINAL_FIXTURE_DATA, planTraceQuery(normalized));
+      },
+      {
+        timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' },
+        group: { by: ['threadId'] },
+        page: { limit: 1 },
+      },
+    );
+
+    expect(results).toEqual([{ threadId: 'A' }, { threadId: 'a' }, { threadId: 'é' }, { threadId: 'Ω' }]);
   });
 
   it('applies timeRange to trace start time before predicates', () => {

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.test.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.test.ts
@@ -1,0 +1,97 @@
+import { parseTraceQueryRequest, planTraceQuery } from '@mastra/core/storage';
+import { describe, expect, it } from 'vitest';
+import {
+  collectTraceQueryPages,
+  evaluateTraceQuery,
+  evaluateTraceQueryRequest,
+  normalizeTraceQueryResponse,
+  TRACE_QUERY_CONFORMANCE_CASES,
+  TRACE_QUERY_FIXTURE_DATA,
+  TRACE_QUERY_TIED_TIMESTAMP_CASES,
+  TRACE_QUERY_TIED_TIMESTAMP_FIXTURE_DATA,
+} from './trace-query';
+
+describe('trace-query reference evaluator', () => {
+  for (const testCase of TRACE_QUERY_CONFORMANCE_CASES) {
+    it(testCase.name, () => {
+      expect(
+        normalizeTraceQueryResponse(evaluateTraceQueryRequest(TRACE_QUERY_FIXTURE_DATA, testCase.request)),
+      ).toEqual(testCase.expected);
+    });
+  }
+
+  for (const testCase of TRACE_QUERY_TIED_TIMESTAMP_CASES) {
+    it(testCase.name, () => {
+      expect(
+        normalizeTraceQueryResponse(
+          evaluateTraceQueryRequest(TRACE_QUERY_TIED_TIMESTAMP_FIXTURE_DATA, testCase.request),
+        ),
+      ).toEqual(testCase.expected);
+    });
+  }
+
+  it('projects only fixed lightweight fields', () => {
+    const response = evaluateTraceQueryRequest(TRACE_QUERY_FIXTURE_DATA, {
+      timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' },
+      where: { op: 'eq', left: { path: 'traceId' }, right: { literal: 'trace-a' } },
+    });
+    expect(response).toEqual({
+      traces: [
+        {
+          traceId: 'trace-a',
+          rootSpanId: 'root-a',
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          startedAt: '2026-08-05T10:00:00.000Z',
+          endedAt: '2026-08-05T10:00:02.000Z',
+          entityName: 'support-agent',
+          entityType: 'agent',
+          environment: 'production',
+          status: 'success',
+        },
+      ],
+      page: { next: null },
+    });
+  });
+
+  it('traverses tied trace pages without duplicates or omissions', async () => {
+    const request = {
+      timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' },
+      orderBy: [{ field: 'startedAt' as const, direction: 'asc' as const }],
+      page: { limit: 1 },
+    };
+    const results = await collectTraceQueryPages(async normalized => {
+      return evaluateTraceQuery(TRACE_QUERY_FIXTURE_DATA, planTraceQuery(normalized));
+    }, request);
+
+    expect(results).toEqual([
+      { traceId: 'trace-a' },
+      { traceId: 'trace-b' },
+      { traceId: 'trace-c' },
+      { traceId: 'trace-d' },
+    ]);
+    expect(new Set(results.map(result => JSON.stringify(result))).size).toBe(results.length);
+  });
+
+  it('traverses group pages without duplicates or null thread IDs', async () => {
+    const request = {
+      timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-09-01T00:00:00Z' },
+      group: { by: ['threadId'] as ['threadId'] },
+      page: { limit: 1 },
+    };
+    const results = await collectTraceQueryPages(async normalized => {
+      return evaluateTraceQuery(TRACE_QUERY_FIXTURE_DATA, planTraceQuery(normalized));
+    }, request);
+    expect(results).toEqual([{ threadId: 'thread-1' }, { threadId: 'thread-2' }]);
+  });
+
+  it('applies timeRange to trace start time before predicates', () => {
+    const normalized = parseTraceQueryRequest({
+      timeRange: { from: '2026-08-06T00:00:00Z', to: '2026-08-09T00:00:00Z' },
+      where: { op: 'exists', path: 'traceId' },
+    });
+    expect(
+      normalizeTraceQueryResponse(evaluateTraceQuery(TRACE_QUERY_FIXTURE_DATA, planTraceQuery(normalized))),
+    ).toEqual([{ traceId: 'trace-d' }, { traceId: 'trace-c' }]);
+  });
+});

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
@@ -1,4 +1,5 @@
 import {
+  compareTraceQueryStrings,
   encodeTraceQueryCursor,
   parseTraceQueryRequest,
   planTraceQuery,
@@ -156,6 +157,16 @@ export const TRACE_QUERY_FIXTURE_DATA: TraceQueryFixtureData = {
 const tiedStartedAt = '2026-08-20T10:00:00.000Z';
 const tiedEndedAt = '2026-08-20T10:00:01.000Z';
 const tiedScoreTimestamp = '2026-08-20T10:00:02.000Z';
+
+export const TRACE_QUERY_ORDINAL_FIXTURE_DATA: TraceQueryFixtureData = {
+  spans: [
+    span(201, 'A', 'root-A', { threadId: 'A', startedAt: tiedStartedAt, endedAt: tiedEndedAt }),
+    span(202, 'a', 'root-a', { threadId: 'a', startedAt: tiedStartedAt, endedAt: tiedEndedAt }),
+    span(203, 'é', 'root-accent', { threadId: 'é', startedAt: tiedStartedAt, endedAt: tiedEndedAt }),
+    span(204, 'Ω', 'root-omega', { threadId: 'Ω', startedAt: tiedStartedAt, endedAt: tiedEndedAt }),
+  ],
+  scores: [],
+};
 
 export const TRACE_QUERY_TIED_TIMESTAMP_FIXTURE_DATA: TraceQueryFixtureData = {
   spans: [
@@ -404,10 +415,10 @@ export function evaluateTraceQuery(data: TraceQueryFixtureData, plan: TrustedTra
     .filter(root => !plan.where || evaluateTracePredicate(plan.where, root, spans, scores));
 
   if (plan.result === 'groups') {
-    let groups = [
-      ...new Set(roots.map(root => root.threadId).filter((value): value is string => value !== null)),
-    ].sort();
-    if (plan.cursor) groups = groups.filter(threadId => threadId > plan.cursor!.threadId);
+    let groups = [...new Set(roots.map(root => root.threadId).filter((value): value is string => value !== null))].sort(
+      compareTraceQueryStrings,
+    );
+    if (plan.cursor) groups = groups.filter(threadId => compareTraceQueryStrings(threadId, plan.cursor!.threadId) > 0);
     const visible = groups.slice(0, plan.limit + 1);
     const hasNext = visible.length > plan.limit;
     const page = visible.slice(0, plan.limit);
@@ -589,9 +600,9 @@ function compareTraces(
   right: TraceQueryTrace,
   plan: Extract<TrustedTraceQueryPlan, { result: 'traces' }>,
 ): number {
-  const values = left[plan.orderBy.field].localeCompare(right[plan.orderBy.field]);
+  const values = compareTraceQueryStrings(left[plan.orderBy.field], right[plan.orderBy.field]);
   if (values !== 0) return plan.orderBy.direction === 'asc' ? values : -values;
-  return left.traceId.localeCompare(right.traceId);
+  return compareTraceQueryStrings(left.traceId, right.traceId);
 }
 
 function isTraceAfterCursor(
@@ -599,7 +610,7 @@ function isTraceAfterCursor(
   plan: Extract<TrustedTraceQueryPlan, { result: 'traces' }>,
 ): boolean {
   const cursor = plan.cursor!;
-  const sortComparison = trace[plan.orderBy.field].localeCompare(cursor.sortValue);
-  if (sortComparison === 0) return trace.traceId > cursor.traceId;
+  const sortComparison = compareTraceQueryStrings(trace[plan.orderBy.field], cursor.sortValue);
+  if (sortComparison === 0) return compareTraceQueryStrings(trace.traceId, cursor.traceId) > 0;
   return plan.orderBy.direction === 'asc' ? sortComparison > 0 : sortComparison < 0;
 }

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
@@ -1,0 +1,605 @@
+import {
+  encodeTraceQueryCursor,
+  parseTraceQueryRequest,
+  planTraceQuery,
+  type NormalizedTraceQueryRequest,
+  type TraceQueryGroupResponse,
+  type TraceQueryRequest,
+  type TraceQueryResponse,
+  type TraceQueryTrace,
+  type TraceQueryTraceResponse,
+  type TrustedTraceQueryPlan,
+  type TrustedTraceQueryPredicate,
+  type TrustedTraceQueryScalarPredicate,
+} from '@mastra/core/storage';
+
+export interface RawTraceQuerySpan {
+  cursorId: number;
+  traceId: string | null;
+  spanId: string;
+  parentSpanId: string | null;
+  isPending: boolean;
+  spanType: string;
+  error: unknown | null;
+  threadId: string | null;
+  resourceId: string | null;
+  startedAt: string;
+  endedAt: string | null;
+  entityName: string | null;
+  entityType: string | null;
+  environment: string | null;
+}
+
+export interface RawTraceQueryScore {
+  cursorId: number;
+  scoreId: string;
+  traceId: string | null;
+  scorerId: string;
+  score: number | null;
+  timestamp?: string;
+}
+
+export interface TraceQueryFixtureData {
+  spans: RawTraceQuerySpan[];
+  scores: RawTraceQueryScore[];
+}
+
+const span = (
+  cursorId: number,
+  traceId: string | null,
+  spanId: string,
+  overrides: Partial<RawTraceQuerySpan> = {},
+): RawTraceQuerySpan => ({
+  cursorId,
+  traceId,
+  spanId,
+  parentSpanId: null,
+  isPending: false,
+  spanType: 'agent_run',
+  error: null,
+  threadId: null,
+  resourceId: null,
+  startedAt: '2026-08-10T00:00:00.000Z',
+  endedAt: '2026-08-10T00:00:01.000Z',
+  entityName: 'agent',
+  entityType: 'agent',
+  environment: 'production',
+  ...overrides,
+});
+
+export const TRACE_QUERY_FIXTURE_DATA: TraceQueryFixtureData = {
+  spans: [
+    span(1, 'trace-a', 'root-a-old', {
+      threadId: 'thread-1',
+      resourceId: 'resource-old',
+      startedAt: '2026-08-01T10:00:00.000Z',
+      endedAt: '2026-08-01T10:00:01.000Z',
+    }),
+    span(10, 'trace-a', 'root-a', {
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      startedAt: '2026-08-05T10:00:00.000Z',
+      endedAt: '2026-08-05T10:00:02.000Z',
+      entityName: 'support-agent',
+    }),
+    span(11, 'trace-a', 'span-a-tool', {
+      parentSpanId: 'root-a',
+      spanType: 'tool_call',
+      startedAt: '2026-08-05T10:00:00.500Z',
+      endedAt: '2026-08-05T10:00:01.000Z',
+    }),
+    span(12, 'trace-a', 'span-a-tool', {
+      parentSpanId: 'root-a',
+      spanType: 'tool_call',
+      error: { message: 'latest failed attempt' },
+      startedAt: '2026-08-05T10:00:00.500Z',
+      endedAt: '2026-08-05T10:00:01.500Z',
+    }),
+    span(20, 'trace-b', 'root-b', {
+      threadId: 'thread-1',
+      resourceId: 'resource-2',
+      startedAt: '2026-08-05T10:00:00.000Z',
+      endedAt: '2026-08-05T10:00:03.000Z',
+      environment: 'staging',
+    }),
+    span(21, 'trace-b', 'span-b-tool', {
+      parentSpanId: 'root-b',
+      spanType: 'tool_call',
+      error: null,
+    }),
+    span(30, 'trace-c', 'root-c', {
+      threadId: 'thread-2',
+      resourceId: null,
+      startedAt: '2026-08-07T10:00:00.000Z',
+      endedAt: '2026-08-07T10:00:02.000Z',
+      error: { message: 'root failed' },
+    }),
+    span(40, 'trace-d', 'root-d', {
+      threadId: null,
+      resourceId: null,
+      startedAt: '2026-08-08T10:00:00.000Z',
+      endedAt: '2026-08-08T10:00:02.000Z',
+    }),
+    span(50, 'trace-running', 'root-running-old', {
+      threadId: 'thread-3',
+      startedAt: '2026-08-09T10:00:00.000Z',
+      endedAt: '2026-08-09T10:00:02.000Z',
+    }),
+    span(51, 'trace-running', 'root-running', {
+      threadId: 'thread-3',
+      isPending: true,
+      startedAt: '2026-08-09T11:00:00.000Z',
+      endedAt: null,
+    }),
+    span(60, 'trace-outside', 'root-outside', {
+      threadId: 'thread-4',
+      startedAt: '2026-07-01T00:00:00.000Z',
+      endedAt: '2026-07-01T00:00:01.000Z',
+    }),
+    span(70, null, 'span-uncorrelated', {
+      parentSpanId: 'other-root',
+      spanType: 'tool_call',
+      error: { message: 'must not correlate' },
+    }),
+  ],
+  scores: [
+    { cursorId: 1, scoreId: 'score-a-factuality', traceId: 'trace-a', scorerId: 'factuality', score: 0.9 },
+    { cursorId: 2, scoreId: 'score-a-factuality', traceId: 'trace-a', scorerId: 'factuality', score: 0.4 },
+    { cursorId: 3, scoreId: 'score-a-safety', traceId: 'trace-a', scorerId: 'safety', score: 0.95 },
+    { cursorId: 4, scoreId: 'score-b-factuality', traceId: 'trace-b', scorerId: 'factuality', score: 0.9 },
+    { cursorId: 5, scoreId: 'score-b-safety', traceId: 'trace-b', scorerId: 'safety', score: 0.4 },
+    { cursorId: 6, scoreId: 'score-c-factuality', traceId: 'trace-c', scorerId: 'factuality', score: null },
+    { cursorId: 7, scoreId: 'score-uncorrelated', traceId: null, scorerId: 'factuality', score: 0.1 },
+  ],
+};
+
+const tiedStartedAt = '2026-08-20T10:00:00.000Z';
+const tiedEndedAt = '2026-08-20T10:00:01.000Z';
+const tiedScoreTimestamp = '2026-08-20T10:00:02.000Z';
+
+export const TRACE_QUERY_TIED_TIMESTAMP_FIXTURE_DATA: TraceQueryFixtureData = {
+  spans: [
+    span(100, 'trace-tied', 'root-z-old', {
+      threadId: 'thread-tied',
+      resourceId: 'resource-old',
+      startedAt: tiedStartedAt,
+      endedAt: tiedEndedAt,
+      entityName: 'old-root',
+    }),
+    span(101, 'trace-tied', 'root-a-current', {
+      threadId: 'thread-tied',
+      resourceId: 'resource-current',
+      startedAt: tiedStartedAt,
+      endedAt: tiedEndedAt,
+      entityName: 'current-root',
+    }),
+    span(102, 'trace-tied', 'span-tied-tool', {
+      parentSpanId: 'root-a-current',
+      spanType: 'tool_call',
+      startedAt: tiedStartedAt,
+      endedAt: tiedEndedAt,
+    }),
+    span(103, 'trace-tied', 'span-tied-tool', {
+      parentSpanId: 'root-a-current',
+      spanType: 'tool_call',
+      error: { message: 'current attempt failed' },
+      startedAt: tiedStartedAt,
+      endedAt: tiedEndedAt,
+    }),
+  ],
+  scores: [
+    {
+      cursorId: 100,
+      scoreId: 'score-tied',
+      traceId: 'trace-tied',
+      scorerId: 'factuality',
+      score: 0.9,
+      timestamp: tiedScoreTimestamp,
+    },
+    {
+      cursorId: 101,
+      scoreId: 'score-tied',
+      traceId: 'trace-tied',
+      scorerId: 'factuality',
+      score: 0.2,
+      timestamp: tiedScoreTimestamp,
+    },
+  ],
+};
+
+const fullRange = {
+  from: '2026-08-01T00:00:00Z',
+  to: '2026-09-01T00:00:00Z',
+};
+
+export interface TraceQueryConformanceCase {
+  name: string;
+  request: TraceQueryRequest;
+  expected: Array<{ traceId: string } | { threadId: string }>;
+}
+
+export const TRACE_QUERY_TIED_TIMESTAMP_CASES: TraceQueryConformanceCase[] = [
+  {
+    name: 'selects the later root when root timestamps tie',
+    request: {
+      timeRange: fullRange,
+      where: { op: 'eq', left: { path: 'entityName' }, right: { literal: 'current-root' } },
+    },
+    expected: [{ traceId: 'trace-tied' }],
+  },
+  {
+    name: 'selects the later span when span timestamps tie',
+    request: {
+      timeRange: fullRange,
+      where: { spans: { some: { op: 'exists', path: 'error' } } },
+    },
+    expected: [{ traceId: 'trace-tied' }],
+  },
+  {
+    name: 'selects the later score when score timestamps tie',
+    request: {
+      timeRange: fullRange,
+      where: { scores: { some: { op: 'lt', left: { path: 'score' }, right: { literal: 0.5 } } } },
+    },
+    expected: [{ traceId: 'trace-tied' }],
+  },
+];
+
+export const TRACE_QUERY_CONFORMANCE_CASES: TraceQueryConformanceCase[] = [
+  {
+    name: 'returns one current completed root per trace in default order',
+    request: { timeRange: fullRange },
+    expected: [{ traceId: 'trace-d' }, { traceId: 'trace-c' }, { traceId: 'trace-a' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'evaluates recursive trace predicates',
+    request: {
+      timeRange: fullRange,
+      where: {
+        op: 'and',
+        args: [
+          { op: 'eq', left: { path: 'environment' }, right: { literal: 'production' } },
+          {
+            op: 'not',
+            arg: { op: 'eq', left: { path: 'status' }, right: { literal: 'error' } },
+          },
+        ],
+      },
+    },
+    expected: [{ traceId: 'trace-d' }, { traceId: 'trace-a' }],
+  },
+  {
+    name: 'binds scorer and score predicates to one current score record',
+    request: {
+      timeRange: fullRange,
+      where: {
+        scores: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'scorerId' }, right: { literal: 'factuality' } },
+              { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-a' }],
+  },
+  {
+    name: 'binds span type and error predicates to one current span record',
+    request: {
+      timeRange: fullRange,
+      where: {
+        spans: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'spanType' }, right: { literal: 'tool_call' } },
+              { op: 'exists', path: 'error' },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-a' }],
+  },
+  {
+    name: 'supports anti-existence and ignores uncorrelated records',
+    request: {
+      timeRange: fullRange,
+      where: { scores: { none: { op: 'lt', left: { path: 'score' }, right: { literal: 0.5 } } } },
+    },
+    expected: [{ traceId: 'trace-d' }, { traceId: 'trace-c' }],
+  },
+  {
+    name: 'binds none predicates to one current related record',
+    request: {
+      timeRange: fullRange,
+      where: {
+        scores: {
+          none: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'scorerId' }, right: { literal: 'factuality' } },
+              { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-d' }, { traceId: 'trace-c' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'never correlates related records whose trace ID is null',
+    request: {
+      timeRange: fullRange,
+      where: { scores: { some: { op: 'lt', left: { path: 'score' }, right: { literal: 0.2 } } } },
+    },
+    expected: [],
+  },
+  {
+    name: 'includes current root and child spans in span relations',
+    request: {
+      timeRange: fullRange,
+      where: { spans: { some: { op: 'exists', path: 'error' } } },
+    },
+    expected: [{ traceId: 'trace-c' }, { traceId: 'trace-a' }],
+  },
+  {
+    name: 'applies span none predicates to current root and child spans',
+    request: {
+      timeRange: fullRange,
+      where: { spans: { none: { op: 'exists', path: 'error' } } },
+    },
+    expected: [{ traceId: 'trace-d' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'allows related spans outside the root time range to participate',
+    request: {
+      timeRange: { from: '2026-08-05T00:00:00Z', to: '2026-08-06T00:00:00Z' },
+      where: {
+        spans: { some: { op: 'eq', left: { path: 'spanType' }, right: { literal: 'tool_call' } } },
+      },
+    },
+    expected: [{ traceId: 'trace-a' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'allows related scores outside the root time range to participate',
+    request: {
+      timeRange: { from: '2026-08-05T00:00:00Z', to: '2026-08-06T00:00:00Z' },
+      where: { scores: { some: { op: 'lt', left: { path: 'score' }, right: { literal: 0.5 } } } },
+    },
+    expected: [{ traceId: 'trace-a' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'does not resurrect an older root when the current root is pending',
+    request: {
+      timeRange: fullRange,
+      where: { op: 'eq', left: { path: 'traceId' }, right: { literal: 'trace-running' } },
+    },
+    expected: [],
+  },
+  {
+    name: 'does not resurrect an older root when the current root is outside the requested range',
+    request: {
+      timeRange: { from: '2026-08-01T00:00:00Z', to: '2026-08-02T00:00:00Z' },
+      where: { op: 'eq', left: { path: 'traceId' }, right: { literal: 'trace-a' } },
+    },
+    expected: [],
+  },
+  {
+    name: 'returns distinct non-null thread groups',
+    request: { timeRange: fullRange, group: { by: ['threadId'] } },
+    expected: [{ threadId: 'thread-1' }, { threadId: 'thread-2' }],
+  },
+];
+
+export function evaluateTraceQuery(data: TraceQueryFixtureData, plan: TrustedTraceQueryPlan): TraceQueryResponse {
+  const spans = currentSpans(data.spans);
+  const scores = currentScores(data.scores);
+  const roots = currentRoots(data.spans)
+    .filter(root => !root.isPending && root.endedAt !== null)
+    .filter(root => root.startedAt >= plan.timeRange.from && root.startedAt < plan.timeRange.to)
+    .filter(root => !plan.where || evaluateTracePredicate(plan.where, root, spans, scores));
+
+  if (plan.result === 'groups') {
+    let groups = [
+      ...new Set(roots.map(root => root.threadId).filter((value): value is string => value !== null)),
+    ].sort();
+    if (plan.cursor) groups = groups.filter(threadId => threadId > plan.cursor!.threadId);
+    const visible = groups.slice(0, plan.limit + 1);
+    const hasNext = visible.length > plan.limit;
+    const page = visible.slice(0, plan.limit);
+    const next = hasNext ? encodeTraceQueryCursor(plan, { result: 'groups', threadId: page[page.length - 1]! }) : null;
+    return { groups: page.map(threadId => ({ threadId })), page: { next } } satisfies TraceQueryGroupResponse;
+  }
+
+  let traces = roots.map(toTraceQueryTrace).sort((left, right) => compareTraces(left, right, plan));
+  if (plan.cursor) traces = traces.filter(trace => isTraceAfterCursor(trace, plan));
+  const visible = traces.slice(0, plan.limit + 1);
+  const hasNext = visible.length > plan.limit;
+  const page = visible.slice(0, plan.limit);
+  const last = page[page.length - 1];
+  const next =
+    hasNext && last
+      ? encodeTraceQueryCursor(plan, {
+          result: 'traces',
+          sortValue: last[plan.orderBy.field],
+          traceId: last.traceId,
+        })
+      : null;
+  return { traces: page, page: { next } } satisfies TraceQueryTraceResponse;
+}
+
+export function evaluateTraceQueryRequest(data: TraceQueryFixtureData, request: TraceQueryRequest): TraceQueryResponse {
+  return evaluateTraceQuery(data, planTraceQuery(parseTraceQueryRequest(request)));
+}
+
+export function normalizeTraceQueryResponse(
+  response: TraceQueryResponse,
+): Array<{ traceId: string } | { threadId: string }> {
+  return 'traces' in response
+    ? response.traces.map(trace => ({ traceId: trace.traceId }))
+    : response.groups.map(group => ({ threadId: group.threadId }));
+}
+
+export async function collectTraceQueryPages(
+  execute: (request: NormalizedTraceQueryRequest) => Promise<TraceQueryResponse>,
+  request: TraceQueryRequest,
+): Promise<Array<{ traceId: string } | { threadId: string }>> {
+  const results: Array<{ traceId: string } | { threadId: string }> = [];
+  let after: string | null | undefined;
+  do {
+    const normalized = parseTraceQueryRequest({
+      ...request,
+      page: { ...request.page, after },
+    });
+    const response = await execute(normalized);
+    results.push(...normalizeTraceQueryResponse(response));
+    after = response.page.next;
+  } while (after);
+  return results;
+}
+
+function currentRoots(spans: RawTraceQuerySpan[]): RawTraceQuerySpan[] {
+  const roots = new Map<string, RawTraceQuerySpan>();
+  for (const candidate of spans) {
+    if (candidate.traceId === null || candidate.parentSpanId !== null) continue;
+    const current = roots.get(candidate.traceId);
+    if (!current || candidate.cursorId > current.cursorId) roots.set(candidate.traceId, candidate);
+  }
+  return [...roots.values()];
+}
+
+function currentSpans(spans: RawTraceQuerySpan[]): RawTraceQuerySpan[] {
+  const records = new Map<string, RawTraceQuerySpan>();
+  for (const candidate of spans) {
+    if (candidate.traceId === null) continue;
+    const key = `${candidate.traceId}\u0000${candidate.spanId}`;
+    const current = records.get(key);
+    if (
+      !current ||
+      (current.isPending && !candidate.isPending) ||
+      (current.isPending === candidate.isPending && candidate.cursorId > current.cursorId)
+    ) {
+      records.set(key, candidate);
+    }
+  }
+  return [...records.values()];
+}
+
+function currentScores(scores: RawTraceQueryScore[]): RawTraceQueryScore[] {
+  const records = new Map<string, RawTraceQueryScore>();
+  for (const candidate of scores) {
+    const current = records.get(candidate.scoreId);
+    if (!current || candidate.cursorId > current.cursorId) records.set(candidate.scoreId, candidate);
+  }
+  return [...records.values()];
+}
+
+function evaluateTracePredicate(
+  predicate: TrustedTraceQueryPredicate,
+  root: RawTraceQuerySpan,
+  spans: RawTraceQuerySpan[],
+  scores: RawTraceQueryScore[],
+): boolean {
+  if (predicate.type === 'relation') {
+    const records = (predicate.collection === 'spans' ? spans : scores).filter(
+      record => root.traceId !== null && record.traceId !== null && record.traceId === root.traceId,
+    );
+    const matched = records.some(record => evaluateScalarPredicate(predicate.predicate, record));
+    return predicate.quantifier === 'some' ? matched : !matched;
+  }
+  if (predicate.type === 'boolean') {
+    return predicate.operator === 'and'
+      ? predicate.args.every(arg => evaluateTracePredicate(arg, root, spans, scores))
+      : predicate.args.some(arg => evaluateTracePredicate(arg, root, spans, scores));
+  }
+  if (predicate.type === 'not') return !evaluateTracePredicate(predicate.arg, root, spans, scores);
+  return evaluateScalarPredicate(predicate, traceValues(root));
+}
+
+function evaluateScalarPredicate(
+  predicate: TrustedTraceQueryScalarPredicate,
+  record: RawTraceQuerySpan | RawTraceQueryScore | Record<string, unknown>,
+): boolean {
+  if (predicate.type === 'boolean') {
+    return predicate.operator === 'and'
+      ? predicate.args.every(arg => evaluateScalarPredicate(arg, record))
+      : predicate.args.some(arg => evaluateScalarPredicate(arg, record));
+  }
+  if (predicate.type === 'not') return !evaluateScalarPredicate(predicate.arg, record);
+  const value = record[predicate.field as keyof typeof record] as unknown;
+  const missing = value === null || value === undefined;
+  if (predicate.type === 'presence') return predicate.operator === 'exists' ? !missing : missing;
+  if (predicate.type === 'membership') {
+    if (missing) return predicate.operator === 'notIn';
+    const included = predicate.values.includes(value as never);
+    return predicate.operator === 'in' ? included : !included;
+  }
+  if (missing) return false;
+  switch (predicate.operator) {
+    case 'eq':
+      return value === predicate.value;
+    case 'ne':
+      return value !== predicate.value;
+    case 'lt':
+      return value < predicate.value;
+    case 'lte':
+      return value <= predicate.value;
+    case 'gt':
+      return value > predicate.value;
+    case 'gte':
+      return value >= predicate.value;
+  }
+}
+
+function traceValues(root: RawTraceQuerySpan): Record<string, unknown> {
+  return {
+    traceId: root.traceId,
+    threadId: root.threadId,
+    resourceId: root.resourceId,
+    startedAt: root.startedAt,
+    endedAt: root.endedAt,
+    entityName: root.entityName,
+    entityType: root.entityType,
+    environment: root.environment,
+    status: root.error === null ? 'success' : 'error',
+  };
+}
+
+function toTraceQueryTrace(root: RawTraceQuerySpan): TraceQueryTrace {
+  return {
+    traceId: root.traceId!,
+    rootSpanId: root.spanId,
+    threadId: root.threadId,
+    resourceId: root.resourceId,
+    startedAt: root.startedAt,
+    endedAt: root.endedAt!,
+    entityName: root.entityName,
+    entityType: root.entityType,
+    environment: root.environment,
+    status: root.error === null ? 'success' : 'error',
+  };
+}
+
+function compareTraces(
+  left: TraceQueryTrace,
+  right: TraceQueryTrace,
+  plan: Extract<TrustedTraceQueryPlan, { result: 'traces' }>,
+): number {
+  const values = left[plan.orderBy.field].localeCompare(right[plan.orderBy.field]);
+  if (values !== 0) return plan.orderBy.direction === 'asc' ? values : -values;
+  return left.traceId.localeCompare(right.traceId);
+}
+
+function isTraceAfterCursor(
+  trace: TraceQueryTrace,
+  plan: Extract<TrustedTraceQueryPlan, { result: 'traces' }>,
+): boolean {
+  const cursor = plan.cursor!;
+  const sortComparison = trace[plan.orderBy.field].localeCompare(cursor.sortValue);
+  if (sortComparison === 0) return trace.traceId > cursor.traceId;
+  return plan.orderBy.direction === 'asc' ? sortComparison > 0 : sortComparison < 0;
+}

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
@@ -400,6 +400,48 @@ export const TRACE_QUERY_CONFORMANCE_CASES: TraceQueryConformanceCase[] = [
     expected: [],
   },
   {
+    name: 'eq excludes traces whose nullable field is null',
+    request: {
+      timeRange: fullRange,
+      where: { op: 'eq', left: { path: 'threadId' }, right: { literal: 'thread-1' } },
+    },
+    expected: [{ traceId: 'trace-a' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'ne includes traces whose nullable field is null',
+    request: {
+      timeRange: fullRange,
+      where: { op: 'ne', left: { path: 'threadId' }, right: { literal: 'thread-1' } },
+    },
+    expected: [{ traceId: 'trace-d' }, { traceId: 'trace-c' }],
+  },
+  {
+    name: 'in excludes traces whose nullable field is null',
+    request: {
+      timeRange: fullRange,
+      where: { op: 'in', value: { path: 'resourceId' }, set: ['resource-1'] },
+    },
+    expected: [{ traceId: 'trace-a' }],
+  },
+  {
+    name: 'notIn includes traces whose nullable field is null',
+    request: {
+      timeRange: fullRange,
+      where: { op: 'notIn', value: { path: 'resourceId' }, set: ['resource-1'] },
+    },
+    expected: [{ traceId: 'trace-d' }, { traceId: 'trace-c' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'exists excludes traces whose nullable field is null',
+    request: { timeRange: fullRange, where: { op: 'exists', path: 'threadId' } },
+    expected: [{ traceId: 'trace-c' }, { traceId: 'trace-a' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'notExists includes only traces whose nullable field is null',
+    request: { timeRange: fullRange, where: { op: 'notExists', path: 'threadId' } },
+    expected: [{ traceId: 'trace-d' }],
+  },
+  {
     name: 'returns distinct non-null thread groups',
     request: { timeRange: fullRange, group: { by: ['threadId'] } },
     expected: [{ threadId: 'thread-1' }, { threadId: 'thread-2' }],
@@ -549,7 +591,7 @@ function evaluateScalarPredicate(
     const included = predicate.values.includes(value as never);
     return predicate.operator === 'in' ? included : !included;
   }
-  if (missing) return false;
+  if (missing) return predicate.operator === 'ne';
   switch (predicate.operator) {
     case 'eq':
       return value === predicate.value;


### PR DESCRIPTION
## Summary

Adds the backend-independent contract and semantic foundation for advanced trace queries. This lets storage adapters execute the same validated logical plan without accepting caller-controlled table, column, join, or authorization input.

The public request requires a bounded trace start-time range and supports recursive trace predicates, same-record `spans.some/none` and `scores.some/none` predicates, optional `threadId` grouping, deterministic ordering, and opaque cursor pagination.

```ts
const request = traceQueryRequestSchema.parse({
  timeRange: {
    from: '2026-08-01T00:00:00.000Z',
    to: '2026-08-08T00:00:00.000Z',
  },
  where: {
    scores: {
      some: {
        op: 'and',
        args: [
          { op: 'eq', left: { path: 'scorerId' }, right: { literal: 'factuality' } },
          { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
        ],
      },
    },
  },
})
```

## How it works

```text
Client request
  → an iterative preflight bounds predicate depth and node count
  → Zod validates the JSON structure
  → the internal planner validates and normalizes semantics
  → TrustedTraceQueryPlan
      ├── reference evaluator — this PR
      └── storage adapter boundary — implemented in #22727
```

For example, `scores.some(score < 0.6)` becomes a trusted relation predicate:

```ts
{
  type: 'relation',
  collection: 'scores',
  quantifier: 'some',
  predicate: {
    type: 'comparison',
    field: 'score',
    operator: 'lt',
    value: 0.6,
  },
}
```

Storage adapters compile this into a parameterized, correlated existence query over current score records. Multiple conditions inside one `scores.some` clause remain in the same existence query, ensuring they match the same score record. PostgreSQL and ClickHouse implement that compilation in #22727.

The internal `planTraceQuery()` server/storage boundary walks the complete predicate tree, enforces own-property field/operator/literal allowlists and complexity limits, normalizes timestamps and ordering, and produces canonical field and relationship IDs. Adapters therefore compile a small canonical language rather than interpreting caller-provided paths as database identifiers. Prototype-derived names such as `constructor`, `toString`, and `__proto__` are rejected with the same structured `field_not_allowed` issue as any other unknown field.

Caller-controlled dimensions are bounded before cursor decoding or storage access: 31-day root range, 12 predicate levels, 100 predicate nodes, 8 related clauses, 100 values per membership set, 1,000 total literal units, 4,096 UTF-8 bytes per string literal, 128 UTF-8 bytes per raw path, and a page limit of 1,000. Every membership member counts toward the total literal budget. Predicate depth and node count are also checked iteratively before recursive Zod parsing, so adversarial nesting produces `predicate_too_complex` rather than overflowing the parser stack.

Queries return either a fixed query-specific completed-trace summary or distinct non-null thread IDs. Cursors are versioned and bound to normalized query properties, distinguishing malformed cursor data from valid cursors reused with a different query. Cursor binding, trace-ID tie-breaking, and grouped pagination use the same locale-independent ordinal string ordering. Authorization is intentionally outside the public grammar; `organizationId` is rejected, while `resourceId` and `threadId` remain ordinary observability fields.

Negative predicates use explicit total semantics for nullable fields: `ne` and `notIn` include missing/null values, while `eq`, `in`, and ordered comparisons exclude them. Literal null remains invalid and `exists`/`notExists` remain the explicit presence tests.

This also adds the `trace-query` storage capability and a default unsupported implementation, plus a pure reference evaluator and shared conformance fixtures covering current-root collapse, retries, pending-root exclusion, null correlation, nullable negative predicates, same-record predicates, grouping, ordinal tied ordering, and multi-page traversal.

## Stack

This is PR 1 of 4 for OBS-20:

1. **#22726** — Core contract, planner, cursor, evaluator, and fixtures
2. **#22727** — PostgreSQL and ClickHouse execution
3. **#22728** — Server endpoint, OpenAPI, client method, and documentation
4. **#22801** — DuckDB execution

This PR intentionally contains no HTTP route or production database implementation. It includes a scoped minor changeset for `@mastra/core`.

## Test plan

- Core trace-query schema, planner, cursor, error, and response tests: 30 passing
- Shared reference evaluator and conformance tests: 29 passing
- `pnpm --filter ./packages/core check`
- `pnpm build:core`
- Focused lint and formatting checks





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR defines a standard way to search traces across storage backends. It validates queries, supports grouping and pagination, and provides shared tests so each backend returns consistent results.

## Changes

- Added the `trace-query` observability storage capability.
- Added schemas and public types for requests, predicates, responses, cursors, and trusted query plans.
- Added bounded UTC time ranges, recursive predicates, related span and score predicates, and optional `threadId` grouping.
- Added field and operator allowlists, complexity limits, literal limits, authorization binding, and fail-closed validation.
- Added deterministic locale-independent ordering and versioned opaque cursors bound to the query plan.
- Defined portable null semantics for negative predicates and a bounded execution-timeout contract.
- Added a default unsupported `queryTraces` implementation for storage adapters.
- Added a pure reference evaluator, fixtures, and conformance cases.
- Added tests for parsing, planning, validation, cursors, grouping, pagination, filtering, ordering, and evaluator behavior.
- Added a minor changeset for `@mastra/core`.

This PR does not add HTTP routes or production database implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

