### PR TITLE
fix(core): mount /dev and allow device writes in native sandbox isolation

### DIFF
--- a/.changeset/brave-lions-jump.md
+++ b/.changeset/brave-lions-jump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix LocalSandbox native isolation being unable to open `/dev/null`, which broke `git`, `ssh`, and ordinary shell redirections inside the sandbox. The Bubblewrap backend now mounts a fresh `/dev` (`--dev /dev`), and the macOS Seatbelt profile grants `file-write-data` on the standard device nodes so opening them read-write no longer falls through to the default deny.

--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -764,6 +764,29 @@ describe('LocalSandbox', () => {
     });
 
     describe('readOnly option', () => {
+      it('mounts a fresh /dev so device nodes exist inside the namespace', () => {
+        const workspacePath = '/path/to/workspace';
+        const { args } = buildBwrapCommand('echo 1', workspacePath, { readOnly: true });
+
+        // Without a device mount, /dev/null does not exist in the namespace and
+        // shell redirections / git / ssh fail with ENOENT.
+        const devIndex = args.indexOf('--dev');
+        expect(devIndex).toBeGreaterThanOrEqual(0);
+        expect(args[devIndex + 1]).toBe('/dev');
+      });
+
+      it('allows writes to standard device nodes in the seatbelt profile', () => {
+        const workspacePath = '/path/to/workspace';
+        const profile = generateSeatbeltProfile(workspacePath, {});
+
+        // `file-ioctl` alone is not enough for opening devices O_RDWR; without
+        // `file-write-data` the default-deny profile rejects the open.
+        for (const device of ['/dev/null', '/dev/zero', '/dev/random', '/dev/urandom', '/dev/tty']) {
+          expect(profile).toContain(`(allow file-ioctl (literal "${device}"))`);
+          expect(profile).toContain(`(allow file-write-data (literal "${device}"))`);
+        }
+      });
+
       it('should generate a bwrap command with --ro-bind when readOnly is true', () => {
         const workspacePath = '/path/to/workspace';
         const { args } = buildBwrapCommand('echo 1', workspacePath, { readOnly: true });

--- a/packages/core/src/workspace/sandbox/native-sandbox/bubblewrap.ts
+++ b/packages/core/src/workspace/sandbox/native-sandbox/bubblewrap.ts
@@ -67,6 +67,11 @@ export function buildBwrapCommand(
   // Mount a new /proc for the PID namespace
   bwrapArgs.push('--proc', '/proc');
 
+  // Mount a fresh /dev with the standard device nodes (null, zero, random,
+  // urandom, tty, ...). Without it the namespace has no devices at all, so
+  // git/ssh and ordinary shell redirections (`2>/dev/null`) fail with ENOENT.
+  bwrapArgs.push('--dev', '/dev');
+
   // Mount a tmpfs at /tmp
   bwrapArgs.push('--tmpfs', '/tmp');
 

--- a/packages/core/src/workspace/sandbox/native-sandbox/seatbelt.ts
+++ b/packages/core/src/workspace/sandbox/native-sandbox/seatbelt.ts
@@ -134,12 +134,14 @@ export function generateSeatbeltProfile(workspacePath: string, config: NativeSan
   lines.push('');
 
   // Device files
+  // `file-ioctl` alone is not enough: opening a device node O_RDWR also needs
+  // `file-write-data`, which the default-deny profile otherwise withholds
+  // (write rules are workspace/temp-scoped below).
   lines.push('; Device files');
-  lines.push('(allow file-ioctl (literal "/dev/null"))');
-  lines.push('(allow file-ioctl (literal "/dev/zero"))');
-  lines.push('(allow file-ioctl (literal "/dev/random"))');
-  lines.push('(allow file-ioctl (literal "/dev/urandom"))');
-  lines.push('(allow file-ioctl (literal "/dev/tty"))');
+  for (const device of ['/dev/null', '/dev/zero', '/dev/random', '/dev/urandom', '/dev/tty']) {
+    lines.push(`(allow file-ioctl (literal "${device}"))`);
+    lines.push(`(allow file-write-data (literal "${device}"))`);
+  }
   lines.push('');
 
   // File read access - allow all reads (macOS limitation: can't use subpath without this)


### PR DESCRIPTION
Fixes #22702

`LocalSandbox` with native isolation could not open `/dev/null` — `git`, `ssh`, and ordinary shell redirections (`2>/dev/null`) failed inside the sandbox, for different reasons on each backend:

- **Bubblewrap (Linux)**: `buildBwrapCommand` mounted `/proc` and a `/tmp` tmpfs but never `/dev`, so the namespace had no device nodes at all (ENOENT). A read-only bind of `/dev` is not a fix — opening the nodes `O_RDWR` then fails with EACCES (as the reproduction matrix in the issue shows), so the backend now mounts a fresh device tree via `--dev /dev`.
- **Seatbelt (macOS)**: the generated profile allowed only `file-ioctl` on the device nodes, and its `file-write*` rules are workspace/temp-scoped, so opening a device `O_RDWR` fell through to `(deny default)`. The profile now grants `file-write-data` on the standard nodes (`null`, `zero`, `random`, `urandom`, `tty`) alongside the existing `file-ioctl`.

**Verification**
- New unit tests: bwrap args include `--dev /dev`; the seatbelt profile contains `file-ioctl` + `file-write-data` for all five standard device nodes.
- Full sandbox suite: the pre-existing real-execution tests are skipped/fail identically on unmodified `main` in environments without `bwrap` (verified by reverting this diff); all profile/args assertions pass.
