### PR TITLE
fix(dsql): write memory and resource timestamps as UTC

### DIFF
--- a/.changeset/dsql-utc-timestamps.md
+++ b/.changeset/dsql-utc-timestamps.md
@@ -1,0 +1,5 @@
+---
+'@mastra/dsql': patch
+---
+
+Fixed DSQL memory timestamps to stay aligned across server timezones.

--- a/.changeset/dsql-utc-timestamps.md
+++ b/.changeset/dsql-utc-timestamps.md
@@ -2,4 +2,4 @@
 '@mastra/dsql': patch
 ---
 
-Fixed DSQL memory timestamps to stay aligned across server timezones.
+Fixed DSQL memory timestamps to stay aligned across server timezones. Thread and resource `createdAt`/`updatedAt` were bound to the driver as raw `Date` objects, which node-postgres renders in the process's local timezone, so `timestamp` columns stored local wall clock instead of the instant.

--- a/stores/dsql/src/storage/db/index.ts
+++ b/stores/dsql/src/storage/db/index.ts
@@ -193,6 +193,14 @@ export class DsqlDB extends MastraBase {
       if (columnSchema?.type === 'jsonb' && value !== null && value !== undefined && typeof value === 'object') {
         return JSON.stringify(value);
       }
+      // Bind dates as UTC strings. node-postgres renders a Date parameter using
+      // the process's local timezone, which a TIMESTAMP column then stores as
+      // local wall clock rather than the instant. Callers that already pass an
+      // ISO string are unaffected. Runs after addTimestampZColumns, so the Z
+      // copies are converted here too.
+      if (value instanceof Date) {
+        return value.toISOString();
+      }
       return value;
     });
   }

--- a/stores/dsql/src/storage/domains/memory/index.ts
+++ b/stores/dsql/src/storage/domains/memory/index.ts
@@ -48,6 +48,14 @@ type MessageRowFromDB = {
 function inPlaceholders(count: number, startIndex = 1): string {
   return Array.from({ length: count }, (_, i) => `$${i + startIndex}`).join(', ');
 }
+/**
+ * Bind dates as UTC strings because node-postgres serializes Date parameters
+ * for TIMESTAMP columns using the process's local timezone.
+ */
+function toUtcISOString(date: Date): string {
+  return date.toISOString();
+}
+
 export class MemoryDSQL extends MemoryStorage {
   override readonly supportsPartialThreadUpdate = true;
   #db: DsqlDB;
@@ -313,6 +321,8 @@ export class MemoryDSQL extends MemoryStorage {
 
   async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
     const tableName = getTableName({ indexName: TABLE_THREADS, schemaName: getSchemaName(this.#schema) });
+    const createdAt = toUtcISOString(thread.createdAt);
+    const updatedAt = toUtcISOString(thread.updatedAt);
 
     await withRetry(
       async () => {
@@ -340,10 +350,10 @@ export class MemoryDSQL extends MemoryStorage {
             thread.resourceId,
             thread.title,
             thread.metadata ? JSON.stringify(thread.metadata) : null,
-            thread.createdAt,
-            thread.createdAt,
-            thread.updatedAt,
-            thread.updatedAt,
+            createdAt,
+            createdAt,
+            updatedAt,
+            updatedAt,
           ],
         );
       },

--- a/stores/dsql/src/storage/domains/memory/save-thread.test.ts
+++ b/stores/dsql/src/storage/domains/memory/save-thread.test.ts
@@ -35,6 +35,7 @@ class RecordingDbClient {
   }
 }
 
+/** A minimal thread whose only interesting fields are the two timestamps under test. */
 function makeThread(createdAt: Date, updatedAt: Date): StorageThreadType {
   return {
     id: 'thread-1',
@@ -74,5 +75,38 @@ describe('MemoryDSQL.saveThread', () => {
     const insert = client.queries.find(q => q.query.includes('INSERT INTO'));
     expect(insert!.values![4]).toBe('2026-08-29T00:30:00.000Z');
     expect(String(insert!.values![4])).toMatch(/Z$/);
+  });
+});
+
+describe('MemoryDSQL.saveResource', () => {
+  /**
+   * saveResource does not bind its own parameters — it hands the record to
+   * db.insert, whose prepareValuesForInsert passed values through untouched, so
+   * a resource's Date timestamps reached the driver raw exactly as saveThread's
+   * did. addTimestampZColumns copies the same values into the Z columns, so both
+   * variants were affected.
+   */
+  it('binds UTC strings for the resource timestamps', async () => {
+    const client = new RecordingDbClient();
+    const memory = new MemoryDSQL({ client } as any);
+    const createdAt = new Date('2026-08-29T00:30:00.000Z');
+    const updatedAt = new Date('2026-08-29T01:45:00.000Z');
+
+    await memory.saveResource({
+      resource: { id: 'resource-1', workingMemory: 'wm', metadata: {}, createdAt, updatedAt },
+    });
+
+    const insert = client.queries.find(q => q.query.includes('INSERT INTO'));
+    expect(insert).toBeDefined();
+
+    const bound = insert!.values!;
+    expect(bound.some(v => v instanceof Date)).toBe(false);
+    expect(bound).toContain(createdAt.toISOString());
+    expect(bound).toContain(updatedAt.toISOString());
+    for (const value of bound) {
+      if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
+        expect(value).toMatch(/Z$/);
+      }
+    }
   });
 });

--- a/stores/dsql/src/storage/domains/memory/save-thread.test.ts
+++ b/stores/dsql/src/storage/domains/memory/save-thread.test.ts
@@ -1,0 +1,78 @@
+import type { StorageThreadType } from '@mastra/core/memory';
+import { describe, expect, it } from 'vitest';
+import { MemoryDSQL } from './index';
+
+type QueryValues = any[] | undefined;
+
+interface RecordedQuery {
+  query: string;
+  values: QueryValues;
+}
+
+/**
+ * node-postgres renders a Date parameter in the process's local timezone, so a raw Date bound to a
+ * TIMESTAMP column stores the local wall clock rather than the instant. Recording the bound values
+ * is enough to pin that; it does not need a live database.
+ */
+class RecordingDbClient {
+  readonly queries: RecordedQuery[] = [];
+
+  async none(query: string, values?: QueryValues): Promise<null> {
+    this.queries.push({ query, values });
+    return null;
+  }
+
+  async manyOrNone<T = any>(): Promise<T[]> {
+    return [] as T[];
+  }
+
+  async oneOrNone<T = any>(): Promise<T | null> {
+    return null;
+  }
+
+  async tx<T>(cb: (t: RecordingDbClient) => Promise<T>): Promise<T> {
+    return cb(this);
+  }
+}
+
+function makeThread(createdAt: Date, updatedAt: Date): StorageThreadType {
+  return {
+    id: 'thread-1',
+    resourceId: 'resource-1',
+    title: 'Test thread',
+    metadata: {},
+    createdAt,
+    updatedAt,
+  };
+}
+
+describe('MemoryDSQL.saveThread', () => {
+  it('binds UTC strings for both timestamp column variants', async () => {
+    const client = new RecordingDbClient();
+    const memory = new MemoryDSQL({ client } as any);
+    const createdAt = new Date('2026-07-01T12:34:56.789Z');
+    const updatedAt = new Date('2026-07-02T01:02:03.456Z');
+
+    await memory.saveThread({ thread: makeThread(createdAt, updatedAt) });
+
+    const insert = client.queries.find(q => q.query.includes('INSERT INTO'));
+    expect(insert).toBeDefined();
+    expect(insert!.values![4]).toBe(createdAt.toISOString());
+    expect(insert!.values![5]).toBe(createdAt.toISOString());
+    expect(insert!.values![6]).toBe(updatedAt.toISOString());
+    expect(insert!.values![7]).toBe(updatedAt.toISOString());
+  });
+
+  it('keeps the instant when the server runs behind UTC', async () => {
+    const client = new RecordingDbClient();
+    const memory = new MemoryDSQL({ client } as any);
+    // 00:30Z renders as the previous calendar day west of UTC.
+    const createdAt = new Date('2026-08-29T00:30:00.000Z');
+
+    await memory.saveThread({ thread: makeThread(createdAt, createdAt) });
+
+    const insert = client.queries.find(q => q.query.includes('INSERT INTO'));
+    expect(insert!.values![4]).toBe('2026-08-29T00:30:00.000Z');
+    expect(String(insert!.values![4])).toMatch(/Z$/);
+  });
+});


### PR DESCRIPTION
## Description

Replaces #22590, which the automation closed while #22589 still carried `status: needs triage`. That label was cleared on 1 Sep, so this reopens the change on the triaged issue. GitHub would not let me reopen the original, so this is a fresh PR from the same branch.

Thread and resource `createdAt`/`updatedAt` were bound to node-postgres as raw `Date` objects. The driver renders a `Date` parameter in the process's local timezone, so the plain `timestamp` columns stored local wall clock rather than the instant, while their `timestamptz` counterparts stored it correctly. Read paths fall back to `createdAtZ || createdAt`, so whichever a consumer lands on decides whether the value is right.

```
raw Date bound -> 2026-08-29T06:00:00.000+05:30
ISO string     -> 2026-08-29T00:30:00.000Z
```

Same instant, `TZ=Asia/Kolkata`. A plain `timestamp` column keeps `06:00`, and a host west of UTC lands on the previous calendar day, which is what makes date-bucketed reads and UI grouping drift.

This ports the `toUtcISOString` approach `stores/pg` adopted in #20831 and binds strings instead:

- `saveThread` converts both timestamps before binding all four columns.
- `prepareValuesForInsert` converts any `Date` it is handed. That covers `saveResource`, which does not bind its own parameters but delegates to `db.insert`, and it runs after `addTimestampZColumns`, so the Z copies are converted too.

The `saveResource` half came from the triage on #22589, which found the bug is wider than I originally reported. I verified it rather than taking it on trust: `StorageResourceType` declares `createdAt`/`updatedAt` as `Date`, and `prepareValuesForInsert` previously passed non-jsonb values through untouched.

Converting in `prepareValuesForInsert` rather than at each call site fixes every `db.insert` path in one place. Callers that already pass ISO strings — `saveMessages`, `updateThread`, `updateResource`, the workflows and observability domains — are unaffected, because the branch only fires on an actual `Date`.

## Related issue(s)

Fixes #22589

Supersedes #22590 (closed by the triage automation, not on the merits; coderabbit's review there found no actionable comments).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Testing

Three tests in `stores/dsql/src/storage/domains/memory/save-thread.test.ts`, recording the bound parameters so no live database is needed.

| test | without the fix |
|---|---|
| `saveThread` binds UTC strings for both column variants | **fails** |
| `saveThread` keeps the instant when the server runs behind UTC | **fails** |
| `saveResource` binds UTC strings for the resource timestamps | **fails** (needs the `db/index.ts` change specifically) |

`stores/dsql`: 48 tests pass, lint clean, and no typecheck errors in the package.

`src/storage/index.test.ts` fails to load and three typecheck errors appear under `packages/memory`, both from an unbuilt workspace dependency (`probe-image-size`, `@mastra/core/agent`). Identical on a clean checkout of `main` and outside this package, so not from this change.
