### PR TITLE
fix(core): resolve environment to development for mastra dev runs

### DIFF
--- a/.changeset/sour-states-lead.md
+++ b/.changeset/sour-states-lead.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed observability signals from Studio (mastra dev) being tagged with environment: production. Runs started through mastra dev now resolve to development unless an explicit environment is configured. Fixes #21941

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -149,7 +149,7 @@ export const mastra = new Mastra({
 })
 ```
 
-If `environment` isn't set, Mastra falls back to `process.env.NODE_ENV`. If neither is set, the field is left undefined rather than guessed.
+If `environment` isn't set, runs started through `mastra dev` resolve to `development` (even though the dev server itself runs with `NODE_ENV=production`); otherwise Mastra falls back to `process.env.NODE_ENV`. If none of these are set, the field is left undefined rather than guessed.
 
 Per-call `tracingOptions.metadata.environment` always takes precedence, so individual calls can override the value when needed.
 

--- a/docs/src/content/en/reference/core/mastra-class.mdx
+++ b/docs/src/content/en/reference/core/mastra-class.mdx
@@ -135,7 +135,7 @@ Visit the [Configuration reference](/reference/configuration) for detailed docum
     type: 'string',
     isOptional: true,
     description:
-      'Deployment environment name (e.g. `production`, `staging`, `development`). When set, automatically attached to all observability signals so they can be filtered by environment without passing `tracingOptions.metadata.environment` on each call. Falls back to `process.env.NODE_ENV` when unset; left undefined if neither is set. Per-call `tracingOptions.metadata.environment` always takes precedence.',
+      'Deployment environment name (e.g. `production`, `staging`, `development`). When set, automatically attached to all observability signals so they can be filtered by environment without passing `tracingOptions.metadata.environment` on each call. When unset, resolves to `development` for `mastra dev` runs, then falls back to `process.env.NODE_ENV`; left undefined if none are set. Per-call `tracingOptions.metadata.environment` always takes precedence.',
   },
   {
     name: 'deployer',

--- a/packages/core/src/mastra/environment.test.ts
+++ b/packages/core/src/mastra/environment.test.ts
@@ -50,9 +50,11 @@ function createMockEntrypoint() {
 
 describe('Mastra `environment` config', () => {
   const originalNodeEnv = process.env.NODE_ENV;
+  const originalMastraDev = process.env.MASTRA_DEV;
 
   beforeEach(() => {
     delete process.env.NODE_ENV;
+    delete process.env.MASTRA_DEV;
   });
 
   afterEach(() => {
@@ -60,6 +62,11 @@ describe('Mastra `environment` config', () => {
       delete process.env.NODE_ENV;
     } else {
       process.env.NODE_ENV = originalNodeEnv;
+    }
+    if (originalMastraDev === undefined) {
+      delete process.env.MASTRA_DEV;
+    } else {
+      process.env.MASTRA_DEV = originalMastraDev;
     }
   });
 
@@ -83,6 +90,26 @@ describe('Mastra `environment` config', () => {
     process.env.NODE_ENV = 'production';
     const mastra = new Mastra({ logger: false, environment: 'staging' });
     expect(mastra.getEnvironment()).toBe('staging');
+  });
+
+  it('resolves to development for `mastra dev` runs even though the dev server sets NODE_ENV=production', () => {
+    process.env.MASTRA_DEV = 'true';
+    process.env.NODE_ENV = 'production';
+    const mastra = new Mastra({ logger: false });
+    expect(mastra.getEnvironment()).toBe('development');
+  });
+
+  it('prefers explicit environment over the MASTRA_DEV signal', () => {
+    process.env.MASTRA_DEV = 'true';
+    const mastra = new Mastra({ logger: false, environment: 'staging' });
+    expect(mastra.getEnvironment()).toBe('staging');
+  });
+
+  it('ignores MASTRA_DEV values other than "true"', () => {
+    process.env.MASTRA_DEV = 'false';
+    process.env.NODE_ENV = 'production';
+    const mastra = new Mastra({ logger: false });
+    expect(mastra.getEnvironment()).toBe('production');
   });
 
   it('propagates the resolved environment to observability via setMastraContext', () => {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -562,8 +562,9 @@ export interface Config<
    * so they can be filtered by environment without passing
    * `tracingOptions.metadata.environment` on every call.
    *
-   * If unset, falls back to `process.env.NODE_ENV`. If neither is set the field
-   * is left undefined rather than guessed.
+   * If unset, resolves to `'development'` for `mastra dev` runs (detected via
+   * `MASTRA_DEV`), then falls back to `process.env.NODE_ENV`. If none of these
+   * are set the field is left undefined rather than guessed.
    *
    * Per-call `tracingOptions.metadata.environment` always takes precedence.
    *
@@ -1111,9 +1112,10 @@ export class Mastra<
   }
 
   /**
-   * Returns the deployment environment name configured on this Mastra instance,
-   * falling back to `process.env.NODE_ENV` when unset, or `undefined` if neither
-   * is provided.
+   * Returns the deployment environment name configured on this Mastra instance.
+   * When unset, resolves to `'development'` for `mastra dev` runs (detected via
+   * `MASTRA_DEV`), then falls back to `process.env.NODE_ENV`, or `undefined` if
+   * none are provided.
    *
    * Observability automatically reads this and attaches it to all signals so
    * consumers can filter by environment without passing
@@ -1339,9 +1341,13 @@ export class Mastra<
     // Store global version overrides
     this.#versions = config?.versions;
 
-    // Resolve deployment environment: explicit config wins, else fall back to
-    // NODE_ENV. Leave undefined if neither is set rather than guessing.
-    this.#environment = config?.environment ?? process.env.NODE_ENV;
+    // Resolve deployment environment: explicit config wins. `mastra dev` spawns
+    // its server with NODE_ENV=production so dependencies run in production
+    // mode, but flags the run with MASTRA_DEV — treat that as development so
+    // Studio telemetry isn't tagged as production. Otherwise fall back to
+    // NODE_ENV, leaving undefined if unset rather than guessing.
+    this.#environment =
+      config?.environment ?? (process.env.MASTRA_DEV === 'true' ? 'development' : process.env.NODE_ENV);
     this.#toolPayloadTransform = normalizeToolPayloadTransformPolicy(
       config?.transform ?? (config as any)?.toolPayloadProjection,
     );


### PR DESCRIPTION
## Description

`mastra dev` spawns its dev server with `NODE_ENV=production` (deliberate, so dependencies run in production mode), but `Mastra.getEnvironment()` falls back to `process.env.NODE_ENV` — so every trace, log, and metric produced through Studio on a developer's machine is tagged `environment: "production"`, split from the same project's app-process signals (`development`) in the same store. Traces then look missing depending on which environment bucket you filter.

- Resolve the environment as: explicit `environment` config → `'development'` when `MASTRA_DEV === 'true'` (set by the `mastra dev` spawn on the line next to the `NODE_ENV` default) → `process.env.NODE_ENV` → `undefined`
- Follows the existing precedent in the default log-level resolution, which already treats `NODE_ENV=production && MASTRA_DEV=true` as a dev run
- Fixing this in core (rather than the CLI spawn) keeps dependencies running in production mode and also corrects the tagging for projects on older CLI versions, which have set `MASTRA_DEV=true` for a long time
- Added unit tests for the new resolution order and updated the two docs mentions of the fallback

Verified end-to-end against a live store: before, a Studio agent run wrote spans with `environment = production` and a `?environment=development` trace query returned nothing; after, the same run writes `development` and shows up alongside app-process traces. An explicit `environment` config still wins, so anyone relying on the old tagging can keep it with one config line.

## Related Issue(s)

Fixes #21941

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When `mastra dev` runs, Studio now labels traces as `development` instead of `production`. This keeps Studio and application traces together, while explicit environment settings still take priority.

## Changes

- Updated `Mastra.getEnvironment()` resolution order:
  1. Explicit `environment` configuration
  2. `development` when `MASTRA_DEV=true`
  3. `process.env.NODE_ENV`
  4. `undefined`
- Added tests for `MASTRA_DEV`, configuration precedence, and unsupported values.
- Updated tracing and `Mastra` class documentation.
- Added a patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->