### PR TITLE
fix(factory): use organization model credentials in project sessions

### DIFF
--- a/.changeset/quiet-places-strive.md
+++ b/.changeset/quiet-places-strive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory project sessions using organization model credentials.

--- a/mastracode/factory/src/routes/tenant-credentials.test.ts
+++ b/mastracode/factory/src/routes/tenant-credentials.test.ts
@@ -221,17 +221,21 @@ describe('createTenantCredentialPrimer', () => {
     return app;
   }
 
-  it('primes the caller snapshot so the first model call sees tenant credentials', async () => {
+  it('primes snapshots for both credential precedence modes', async () => {
     await seed.credentials.setCredential(USER_TENANT, 'openai', { type: 'api_key', key: 'user-key' });
+    await seed.credentials.setCredential(ORG_TENANT, 'openai', { type: 'api_key', key: 'org-key' });
     registerTenantCredentialResolver(seed.credentials);
 
     const res = await buildApp({ workosId: USER, organizationId: ORG }).request('/ok');
     expect(res.status).toBe(200);
 
-    const ctx = new RequestContext();
-    ctx.set('user', { workosId: USER, organizationId: ORG });
-    // Snapshot already hydrated by the primer — sync read works immediately.
-    expect(resolveCredentialStore(ctx)!.getStoredApiKey('openai')).toBe('user-key');
+    const userFirstContext = new RequestContext();
+    userFirstContext.set('user', { workosId: USER, organizationId: ORG });
+    expect(resolveCredentialStore(userFirstContext)!.getStoredApiKey('openai')).toBe('user-key');
+
+    const orgFirstContext = new RequestContext();
+    orgFirstContext.set('user', { workosId: USER, organizationId: ORG, orgFirstCredentials: true });
+    expect(resolveCredentialStore(orgFirstContext)!.getStoredApiKey('openai')).toBe('org-key');
   });
 
   it('passes unauthenticated requests through untouched', async () => {

--- a/mastracode/factory/src/routes/tenant-credentials.ts
+++ b/mastracode/factory/src/routes/tenant-credentials.ts
@@ -205,10 +205,10 @@ export function invalidateTenantCredentialSnapshots(tenant: { orgId: string; use
 }
 
 /**
- * Middleware mounted after the web auth gate: primes the caller's credential
- * snapshot so the request's first model call sees their credentials without an
- * async seam in model resolution. Cheap when fresh (TTL check), best-effort
- * when not — a failed hydrate falls back to env vars, never blocks a request.
+ * Middleware mounted after the web auth gate: primes both credential precedence
+ * modes so the request's first model call can resolve user → organization when
+ * `orgFirst` is false or organization → user when `orgFirst` is true. Cheap when
+ * fresh because each store has a TTL.
  */
 export async function primeTenantCredentials({
   tenant,
@@ -217,7 +217,10 @@ export async function primeTenantCredentials({
   tenant: SdkCredentialTenant;
   credentials: ModelCredentialsStorage;
 }): Promise<void> {
-  await storeFor(tenant, credentials).ensureFresh();
+  await Promise.all([
+    storeFor({ ...tenant, orgFirst: false }, credentials).ensureFresh(),
+    storeFor({ ...tenant, orgFirst: true }, credentials).ensureFresh(),
+  ]);
 }
 
 export function createTenantCredentialPrimer({
@@ -231,9 +234,13 @@ export function createTenantCredentialPrimer({
     const tenant = auth.tenant(c);
     if (tenant) {
       try {
-        await storeFor(tenant, credentials).ensureFresh();
-      } catch {
-        // Fail open: model calls fall back to env credentials.
+        await primeTenantCredentials({ tenant, credentials });
+      } catch (error) {
+        console.warn('[factory] Failed to prime tenant model credentials', {
+          orgId: tenant.orgId,
+          userId: tenant.userId,
+          error,
+        });
       }
     }
     await next();


### PR DESCRIPTION
Factory can resolve model credentials in either user-first or organization-first order. Previously, request middleware prepared only the user-first snapshot, so project sessions could miss an available organization credential and report a misleading missing environment variable error.\n\nThis prepares both precedence snapshots before the first model call and adds coverage confirming each mode selects the expected credential.