### PR TITLE
fix(observability): don't let undefined explicit metadata erase requestContextKeys values

### DIFF
--- a/.changeset/violet-knives-attack.md
+++ b/.changeset/violet-knives-attack.md
@@ -1,5 +1,6 @@
 ---
 '@mastra/observability': patch
+'@mastra/core': patch
 ---
 
-Fixed request context values configured via requestContextKeys being silently dropped when a span's own metadata names the same key with an undefined value. A threadId set on a RequestContext now reaches exported spans even when the agent has no memory configured, so exporters like Arize can group traces into sessions again. Fixes [#22597](https://github.com/mastra-ai/mastra/issues/22597).
+Fixed span metadata values being silently erased by keys whose value is undefined. Values extracted via requestContextKeys (for example a threadId set on a RequestContext) now reach exported spans even when the agent has no memory configured, so exporters like Arize can group traces into sessions again. Keys passed in tracingOptions.metadata with undefined values no longer remove values the span already has; keys with real values still take precedence. Fixes [#22597](https://github.com/mastra-ai/mastra/issues/22597).

--- a/.changeset/violet-knives-attack.md
+++ b/.changeset/violet-knives-attack.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed request context values configured via requestContextKeys being silently dropped when a span's own metadata names the same key with an undefined value. A threadId set on a RequestContext now reaches exported spans even when the agent has no memory configured, so exporters like Arize can group traces into sessions again. Fixes [#22597](https://github.com/mastra-ai/mastra/issues/22597).

--- a/.changeset/yummy-kiwis-hear.md
+++ b/.changeset/yummy-kiwis-hear.md
@@ -1,6 +1,0 @@
----
-'@mastra/observability': patch
-'@mastra/core': patch
----
-
-Fixed per-call tracing metadata with undefined values erasing span metadata. A key passed in tracingOptions.metadata whose value is undefined (for example from optional chaining) no longer removes the value the span already has; keys with real values still take precedence.

--- a/.changeset/yummy-kiwis-hear.md
+++ b/.changeset/yummy-kiwis-hear.md
@@ -1,0 +1,6 @@
+---
+'@mastra/observability': patch
+'@mastra/core': patch
+---
+
+Fixed per-call tracing metadata with undefined values erasing span metadata. A key passed in tracingOptions.metadata whose value is undefined (for example from optional chaining) no longer removes the value the span already has; keys with real values still take precedence.

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -233,9 +233,10 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
       traceState = this.computeTraceState(tracingOptions);
     }
 
-    // Merge tracingOptions.metadata with span metadata (tracingOptions.metadata takes precedence for root spans)
+    // Merge tracingOptions.metadata with span metadata (tracingOptions.metadata takes precedence for root
+    // spans, but a key it merely names with an `undefined` value must not erase the span's own value)
     const tracingMetadata = !options.parent ? tracingOptions?.metadata : undefined;
-    const mergedMetadata = mergeMetadata(metadata, tracingMetadata);
+    const mergedMetadata = mergeMetadata(stripUndefined(metadata), stripUndefined(tracingMetadata));
 
     // Extract metadata from RequestContext
     const enrichedMetadata = this.extractMetadataFromRequestContext(requestContext, mergedMetadata, traceState);

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -41,7 +41,7 @@ import { emitAutoExtractedMetrics, emitTokenMetricsForUsage } from '../metrics/a
 import { CardinalityFilter } from '../metrics/cardinality';
 import { resolveModelId } from '../model-id';
 import { NoOpSpan } from '../spans';
-import { isPlainRecord, mergeMetadata } from '../spans/metadata';
+import { isPlainRecord, mergeMetadata, stripUndefined } from '../spans/metadata';
 import { addUsageStats } from '../usage';
 
 function hasMetadataKey(metadata: unknown, key: string): boolean {
@@ -665,8 +665,9 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
       return undefined;
     }
 
-    // Explicit metadata always wins.
-    return mergeMetadata(extracted, explicitMetadata);
+    // Explicit metadata always wins, but a key it merely names with an
+    // `undefined` value must not erase the extracted RequestContext value.
+    return mergeMetadata(extracted, stripUndefined(explicitMetadata));
   }
 
   /**

--- a/observability/mastra/src/spans/metadata.ts
+++ b/observability/mastra/src/spans/metadata.ts
@@ -29,26 +29,30 @@ export function isPlainRecord(value: unknown): value is Record<string, unknown> 
  * Returns `metadata` without own data properties whose value is `undefined`,
  * so callers can merge it without erasing keys another source provides.
  * Accessor properties are kept without invoking their getters. Non-plain
- * values are returned as-is; when nothing is stripped the original reference
- * is returned.
+ * values are returned as-is; when nothing is stripped (or reflection on the
+ * value throws) the original reference is returned.
  */
 export function stripUndefined(metadata: Record<string, any> | undefined): Record<string, any> | undefined {
   if (!metadata || !isPlainRecord(metadata)) {
     return metadata;
   }
 
-  const result: Record<string, any> = {};
-  let stripped = false;
-  for (const key of Reflect.ownKeys(metadata)) {
-    const descriptor = Object.getOwnPropertyDescriptor(metadata, key)!;
-    if ('value' in descriptor && descriptor.value === undefined) {
-      stripped = true;
-      continue;
+  try {
+    const result: Record<string, any> = {};
+    let stripped = false;
+    for (const key of Reflect.ownKeys(metadata)) {
+      const descriptor = Object.getOwnPropertyDescriptor(metadata, key)!;
+      if ('value' in descriptor && descriptor.value === undefined) {
+        stripped = true;
+        continue;
+      }
+      Object.defineProperty(result, key, descriptor);
     }
-    Object.defineProperty(result, key, descriptor);
-  }
 
-  return stripped ? result : metadata;
+    return stripped ? result : metadata;
+  } catch {
+    return metadata;
+  }
 }
 
 /**

--- a/observability/mastra/src/spans/metadata.ts
+++ b/observability/mastra/src/spans/metadata.ts
@@ -26,6 +26,32 @@ export function isPlainRecord(value: unknown): value is Record<string, unknown> 
 }
 
 /**
+ * Returns `metadata` without own data properties whose value is `undefined`,
+ * so callers can merge it without erasing keys another source provides.
+ * Accessor properties are kept without invoking their getters. Non-plain
+ * values are returned as-is; when nothing is stripped the original reference
+ * is returned.
+ */
+export function stripUndefined(metadata: Record<string, any> | undefined): Record<string, any> | undefined {
+  if (!metadata || !isPlainRecord(metadata)) {
+    return metadata;
+  }
+
+  const result: Record<string, any> = {};
+  let stripped = false;
+  for (const key of Reflect.ownKeys(metadata)) {
+    const descriptor = Object.getOwnPropertyDescriptor(metadata, key)!;
+    if ('value' in descriptor && descriptor.value === undefined) {
+      stripped = true;
+      continue;
+    }
+    Object.defineProperty(result, key, descriptor);
+  }
+
+  return stripped ? result : metadata;
+}
+
+/**
  * Merges two metadata values while preserving property descriptors (so getters
  * are copied as accessors rather than eagerly invoked). Only plain records are
  * merged; if either side is non-plain the second argument is returned as-is,

--- a/observability/mastra/src/tracing.test.ts
+++ b/observability/mastra/src/tracing.test.ts
@@ -1897,6 +1897,34 @@ describe('Tracing', () => {
       span.end();
     });
 
+    it('does not let undefined tracingOptions metadata erase span metadata', () => {
+      const observability = new DefaultObservabilityInstance({
+        serviceName: 'test-service',
+        name: 'test',
+        exporters: [testExporter],
+      });
+
+      const span = observability.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'test-agent',
+        attributes: { agentId: 'agent-1' },
+        metadata: { threadId: 'thread-explicit', runId: 'run-1' },
+        tracingOptions: {
+          metadata: { threadId: undefined, experiment: 'v2' },
+        },
+      });
+
+      // A key tracingOptions.metadata merely names with undefined must not
+      // erase the span's own value; defined keys still take precedence.
+      expect(span.metadata).toEqual({
+        threadId: 'thread-explicit',
+        runId: 'run-1',
+        experiment: 'v2',
+      });
+
+      span.end();
+    });
+
     it('should preserve tags across span lifecycle', () => {
       const observability = new DefaultObservabilityInstance({
         serviceName: 'test-service',

--- a/observability/mastra/src/tracing.test.ts
+++ b/observability/mastra/src/tracing.test.ts
@@ -1925,6 +1925,32 @@ describe('Tracing', () => {
       span.end();
     });
 
+    it('contains metadata whose ownKeys reflection throws instead of failing span creation', () => {
+      const observability = new DefaultObservabilityInstance({
+        serviceName: 'test-service',
+        name: 'test',
+        exporters: [testExporter],
+      });
+
+      const hostileMetadata = new Proxy(
+        { tenantId: 'tenant-1' },
+        {
+          ownKeys() {
+            throw new Error('ownKeys failed');
+          },
+        },
+      );
+
+      expect(() =>
+        observability.startSpan({
+          type: SpanType.AGENT_RUN,
+          name: 'test-agent',
+          attributes: { agentId: 'agent-1' },
+          metadata: hostileMetadata as Record<string, any>,
+        }),
+      ).not.toThrow();
+    });
+
     it('should preserve tags across span lifecycle', () => {
       const observability = new DefaultObservabilityInstance({
         serviceName: 'test-service',

--- a/observability/mastra/src/tracing.test.ts
+++ b/observability/mastra/src/tracing.test.ts
@@ -2221,6 +2221,72 @@ describe('Tracing', () => {
 
       span.end();
     });
+
+    it('should fall back to the RequestContext value when explicit metadata sets the key to undefined', () => {
+      const observability = new DefaultObservabilityInstance({
+        serviceName: 'test-service',
+        name: 'test',
+        requestContextKeys: ['threadId', 'userId'],
+        exporters: [testExporter],
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('threadId', 'thread-123');
+      requestContext.set('userId', 'user-456');
+
+      // Mirrors the agent run span, which always names threadId in its
+      // metadata even when no thread is resolved.
+      const span = observability.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'test-agent',
+        attributes: {
+          agentId: 'agent-1',
+        },
+        metadata: {
+          runId: 'run-789',
+          threadId: undefined,
+        },
+        requestContext,
+      });
+
+      expect(span.metadata).toEqual({
+        threadId: 'thread-123',
+        userId: 'user-456',
+        runId: 'run-789',
+      });
+
+      span.end();
+    });
+
+    it('should keep explicit metadata precedence when the value is defined', () => {
+      const observability = new DefaultObservabilityInstance({
+        serviceName: 'test-service',
+        name: 'test',
+        requestContextKeys: ['threadId'],
+        exporters: [testExporter],
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('threadId', 'thread-from-context');
+
+      const span = observability.startSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'test-agent',
+        attributes: {
+          agentId: 'agent-1',
+        },
+        metadata: {
+          threadId: 'thread-explicit',
+        },
+        requestContext,
+      });
+
+      expect(span.metadata).toEqual({
+        threadId: 'thread-explicit',
+      });
+
+      span.end();
+    });
   });
 
   describe('RequestContext Snapshot on Spans', () => {

--- a/packages/core/src/observability/utils.test.ts
+++ b/packages/core/src/observability/utils.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import type { Span } from './types';
 import { SpanType } from './types';
-import { getEntityTypeForSpan, getStepAvailableToolNames } from './utils';
+import { getEntityTypeForSpan, getOrCreateSpan, getStepAvailableToolNames } from './utils';
 
 describe('getEntityTypeForSpan', () => {
   it('maps rag ingestion spans to the rag_ingestion entity type', () => {
@@ -38,5 +39,49 @@ describe('getStepAvailableToolNames', () => {
 
   it('returns undefined when tools is undefined', () => {
     expect(getStepAvailableToolNames(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('getOrCreateSpan', () => {
+  it('does not let undefined tracingOptions metadata erase span metadata', () => {
+    let received: { metadata?: Record<string, unknown> } | undefined;
+    const currentSpan = {
+      createChildSpan: (options: { metadata?: Record<string, unknown> }) => {
+        received = options;
+        return {} as Span<SpanType.AGENT_RUN>;
+      },
+    } as unknown as Span<SpanType.AGENT_RUN>;
+
+    getOrCreateSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'test-agent',
+      attributes: {},
+      metadata: { runId: 'run-1' },
+      tracingContext: { currentSpan },
+      tracingOptions: { metadata: { runId: undefined, experiment: 'v2' } },
+    });
+
+    expect(received?.metadata).toEqual({ runId: 'run-1', experiment: 'v2' });
+  });
+
+  it('keeps defined tracingOptions metadata precedence', () => {
+    let received: { metadata?: Record<string, unknown> } | undefined;
+    const currentSpan = {
+      createChildSpan: (options: { metadata?: Record<string, unknown> }) => {
+        received = options;
+        return {} as Span<SpanType.AGENT_RUN>;
+      },
+    } as unknown as Span<SpanType.AGENT_RUN>;
+
+    getOrCreateSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'test-agent',
+      attributes: {},
+      metadata: { runId: 'run-1' },
+      tracingContext: { currentSpan },
+      tracingOptions: { metadata: { runId: 'run-override' } },
+    });
+
+    expect(received?.metadata).toEqual({ runId: 'run-override' });
   });
 });

--- a/packages/core/src/observability/utils.ts
+++ b/packages/core/src/observability/utils.ts
@@ -133,9 +133,11 @@ export function resolveExportedSpanId(
 export function getOrCreateSpan<T extends SpanType>(options: GetOrCreateSpanOptions<T>): Span<T> | undefined {
   const { type, attributes, tracingContext, requestContext, tracingOptions, resumedFromSpanId, ...rest } = options;
 
+  // tracingOptions.metadata takes precedence, but a key it merely names with
+  // an `undefined` value must not erase the span's own metadata value.
   const metadata = {
     ...(rest.metadata ?? {}),
-    ...(tracingOptions?.metadata ?? {}),
+    ...Object.fromEntries(Object.entries(tracingOptions?.metadata ?? {}).filter(([, value]) => value !== undefined)),
   };
 
   // If we have a current span, create a child span


### PR DESCRIPTION
## Description

Fixes `requestContextKeys` silently dropping any key that a span's own metadata also names with an `undefined` value. With `requestContextKeys: ['threadId', 'userId']` and both set on the `RequestContext`, `threadId` never reached exported spans while `userId` did — because the agent run span always names `threadId` in its metadata (`threadId: threadFromArgs?.id`), which resolves to `undefined` when no memory is configured, and the metadata merge let that `undefined` own property shadow the extracted value.

- Added a `stripUndefined` helper in `observability/mastra/src/spans/metadata.ts` that removes own data properties with `undefined` values while keeping accessor properties without invoking their getters
- `extractMetadataFromRequestContext` now strips `undefined` explicit values before the merge, so a key the span merely names falls back to the `RequestContext` value — a key with a defined value still wins, keeping the documented precedence
- Added regression tests for both directions (fallback on `undefined`, precedence on defined values)

Verified end-to-end against a real OpenAI model: before the fix `threadId` was absent from all exported spans; after the fix it arrives on every span alongside `userId`.

## Related Issue(s)

Fixes #22597

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When metadata has no value, it no longer hides useful information from the request. This keeps values such as `threadId` and `userId` available on exported spans.

## Changes

- Ignore `undefined` metadata during span and tracing-option merges.
- Preserve request-context values when explicit metadata is `undefined`.
- Keep defined explicit metadata as the higher-priority value.
- Add `stripUndefined` without invoking getters or changing accessor properties.
- Prevent reflection failures during metadata processing from escaping.
- Add regression tests for fallback, precedence, and resilience behavior.
- Add patch changesets for `@mastra/core` and `@mastra/observability`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->