### PR TITLE
feat(factory): session activity markers for sidebar rows and board cards

### DIFF
--- a/.changeset/session-activity-markers.md
+++ b/.changeset/session-activity-markers.md
@@ -1,0 +1,9 @@
+---
+'@mastra/factory': patch
+---
+
+Session markers stop being dots that only differ by colour. The sidebar row grows an activity rail down its left edge — pills travelling while the agent works, the same pills breathing in place once the session is waiting on you. Both states run on one clock, so a session that finishes its turn morphs from travelling to breathing instead of cutting to a new marker.
+
+Moving lifecycle to the left edge frees the trailing slot: the actions menu no longer displaces the marker on hover, and the merge badge shows on sessions that have no lifecycle left to report.
+
+Cards get the same reading in the shape they have room for — two ends with beads crossing between them while work is in flight, both ends holding and the beads swelling once it is your turn. It carries on the session preview card and on board cards, where it now says more than the dot it replaces: a card bound to a session with a run in flight travels, and one bound to an idle session rests. Before, both looked identical.

--- a/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
@@ -167,9 +167,24 @@ describe('Board card session liveness', () => {
 
     const card = await screen.findByTestId('work-item-card');
     await waitFor(() => expect(card.querySelector('[data-live-session-indicator]')).not.toBeNull());
+    // Bound but idle: the belt rests instead of advertising work that is not happening.
+    expect(card.querySelector('.session-pentad.session-ready')).not.toBeNull();
 
     await user.click(screen.getByRole('button', { name: 'Details for Fix login bug' }));
     expect(await screen.findByRole('link', { name: 'Open session' })).toBeInTheDocument();
+  });
+
+  it('runs the belt while the bound session has a run in flight', async () => {
+    stubFactoryWithBoundSession();
+    server.use(
+      http.get('*/api/agent-controller/:controllerId/active-runs', () =>
+        HttpResponse.json({ runs: [{ runId: 'run-1', resourceId: SESSION_ID, threadId: SESSION_ID }] }),
+      ),
+    );
+    renderWorkBoard();
+
+    const card = await screen.findByTestId('work-item-card');
+    await waitFor(() => expect(card.querySelector('.session-pentad.session-working')).not.toBeNull());
   });
 
   it('drops the session indicator as soon as its session is deleted from the sidebar', async () => {

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -11,6 +11,9 @@ import { useParams } from 'react-router';
 import type { FactoryRunPhase } from '../../../../hooks/useStartFactoryRun';
 import { boardCardStatus } from '../boardCardStatus';
 import { setDragPayload } from '../boardDrag';
+import { useActiveRunResources } from '../../../../hooks/useActiveRunResources';
+import { SessionActivityPentad } from '../../workspaces/components/SessionActivity';
+import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 import { itemThreadSession, metadataLabels, pullRequestStatusForItem, workItemMeta } from '../boardItems';
 import { itemRunSpec } from '../boardRunSpecs';
 import type { ItemRunSpec, RunAction } from '../boardRunSpecs';
@@ -131,6 +134,12 @@ export function WorkItemCard({
       ? runSpec.actions.find(action => FACTORY_ROLE_STAGES[action.role] === columnStage && action.role in sessions)
       : undefined;
   const threadSession = itemThreadSession(sessions);
+  // One poll for the whole controller, shared by every card and the sidebar alike.
+  const running = useActiveRunResources({
+    agentControllerId: AGENT_CONTROLLER_ID,
+    resourceIds: threadSession ? [threadSession.sessionId] : [],
+  });
+  const sessionStatus = threadSession && running[threadSession.sessionId] ? 'working' : 'ready';
   const primaryAction = cardPrimaryAction({
     item,
     runSpec,
@@ -298,7 +307,7 @@ export function WorkItemCard({
             <div className="flex min-w-0 items-center gap-1.5 pr-8">
               <span className="text-ui-xs text-icon2 min-w-0 truncate">{workItemMeta(item)}</span>
               {threadSession !== undefined && (
-                <span data-live-session-indicator aria-hidden className="bg-accent1 size-2 shrink-0 rounded-full" />
+                <SessionActivityPentad data-live-session-indicator status={sessionStatus} className="shrink-0" />
               )}
               {relatedItems.map(relatedLink)}
               {item.commentCount > 0 && (
@@ -374,6 +383,7 @@ export function WorkItemCard({
         morph={morph}
         relatedLinks={relatedItems.map(relatedLink)}
         threadSession={threadSession}
+        sessionStatus={sessionStatus}
         status={status}
         retryingDecisionId={retryingDecisionId}
         onRetryDecision={onRetryDecision}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemDetailsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemDetailsPanel.tsx
@@ -7,6 +7,8 @@ import { useId } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router';
 
 import { useFactoryAuth } from '../../../../hooks/useFactoryAuth';
+import { SessionActivityPentad } from '../../workspaces/components/SessionActivity';
+import type { SessionRowStatus } from '../../workspaces/components/SessionActivity';
 import type { BoardCardStatus } from '../boardCardStatus';
 import { externalLinkLabel, metadataLabels, pullRequestStatusForItem, workItemMeta } from '../boardItems';
 import { itemStageLabel } from '../boardStages';
@@ -33,6 +35,7 @@ export function WorkItemDetailsPanel({
   morph,
   relatedLinks,
   threadSession,
+  sessionStatus,
   status,
   retryingDecisionId,
   onRetryDecision,
@@ -48,6 +51,7 @@ export function WorkItemDetailsPanel({
   morph: CardMorph;
   relatedLinks: ReactNode;
   threadSession?: WorkItemSessionRef;
+  sessionStatus: SessionRowStatus;
   status: BoardCardStatus;
   retryingDecisionId?: string;
   onRetryDecision: (decisionId: string) => void;
@@ -80,7 +84,7 @@ export function WorkItemDetailsPanel({
           <div className="flex min-w-0 items-center gap-1.5">
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
               <span className="text-ui-xs text-icon2 min-w-0 truncate">{workItemMeta(item)}</span>
-              {threadSession !== undefined && <span aria-hidden className="bg-accent1 size-2 shrink-0 rounded-full" />}
+              {threadSession !== undefined && <SessionActivityPentad status={sessionStatus} className="shrink-0" />}
               {relatedLinks}
             </div>
             {item.url !== null && (

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionActivity.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionActivity.tsx
@@ -1,0 +1,88 @@
+import { cn } from '@mastra/playground-ui/utils/cn';
+import type { ComponentProps } from 'react';
+
+import './sessionActivity.css';
+
+/**
+ * Session lifecycle states surfaced by the activity markers. The color scheme
+ * mirrors `SessionFavicon` so the sidebar and the tab-favicon read the same
+ * way at a glance.
+ */
+export type SessionRowStatus = 'initializing' | 'working' | 'ready';
+
+const PILLS = [0, 1, 2, 3, 4];
+
+const PENTAD = [0, 72, 144, 216, 288];
+
+const STATUS_TITLE: Record<SessionRowStatus, string> = {
+  initializing: 'Initializing',
+  working: 'Working',
+  ready: 'Ready',
+};
+
+function statusAttributes(status: SessionRowStatus, label: string | undefined) {
+  return label ? { role: 'status', 'aria-label': label, title: STATUS_TITLE[status] } : { 'aria-hidden': true };
+}
+
+/**
+ * The sidebar row's left rail: pills travelling down it while the agent works,
+ * the same pills breathing in place once it is your turn. One clock for both,
+ * so a session that finishes its turn morphs rather than swapping markers.
+ */
+export function SessionActivityBelt({
+  status,
+  label,
+  className,
+  ...props
+}: ComponentProps<'span'> & {
+  status: SessionRowStatus;
+  /** Omit where the status is already spelled out in adjacent text: the marker is then decorative. */
+  label?: string;
+}) {
+  return (
+    <span
+      {...props}
+      {...statusAttributes(status, label)}
+      className={cn('session-belt', `session-${status}`, className)}
+    >
+      <span className="session-belt-sway">
+        <span className="session-belt-jam">
+          {PILLS.map(pill => (
+            <i key={pill} />
+          ))}
+        </span>
+      </span>
+    </span>
+  );
+}
+
+/**
+ * The card's marker: five on a ring, swelling in turn while the agent works,
+ * stuttering round while the sandbox is still coming up, and settling into an
+ * even ring with a slow wave once it is your turn.
+ */
+export function SessionActivityPentad({
+  status,
+  label,
+  className,
+  ...props
+}: ComponentProps<'svg'> & {
+  status: SessionRowStatus;
+  /** Omit where the status is already spelled out in adjacent text: the marker is then decorative. */
+  label?: string;
+}) {
+  return (
+    <svg
+      {...props}
+      {...statusAttributes(status, label)}
+      viewBox="0 0 24 24"
+      className={cn('session-pentad', `session-${status}`, className)}
+    >
+      {PENTAD.map(angle => (
+        <g key={angle} style={{ transform: `rotate(${angle}deg)` }}>
+          <circle cx="12" cy="5.4" r="2.8" />
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -9,17 +9,20 @@ import { useRef } from 'react';
 import type { RefObject } from 'react';
 
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
+import { SessionActivityBelt } from './SessionActivity';
+import type { SessionRowStatus } from './SessionActivity';
 import { SessionPreviewCard } from './SessionPreviewCard';
 import type { SessionPreviewDetails } from './SessionPreviewCard';
 
 /**
  * Shared sidebar row for workspace/user sessions. Built on `MainSidebar.NavLink`
  * so every session list (work, review, user) renders with identical density,
- * hover, and active states. Spinner, status dot and actions menu share one
- * trailing slot beside the label: they swap in place, and the slot collapses
- * when there is nothing to show so the label gets the full row. Because that
- * slot comes and goes, the menu and the preview card anchor to the row box
- * instead — a resized or hidden anchor would drag them across the screen.
+ * hover, and active states. Lifecycle lives on the left as an activity belt;
+ * the trailing slot beside the label is left to the spinner, the merge badge
+ * and the actions menu, which swap in place and collapse the slot when there is
+ * nothing to show so the label gets the full row. Because that slot comes and
+ * goes, the belt, the menu and the preview card anchor to the row box instead —
+ * a resized or hidden anchor would drag them across the screen.
  */
 export function SessionNavRow({
   name,
@@ -80,23 +83,37 @@ export function SessionNavRow({
       ) : null}
     </button>
   );
-  const indicator = indicatorKind({ loading, status, merged });
+  const belt = loading ? undefined : status;
+  const trailing = trailingKind({ loading, status, merged });
   const action = (
-    <span className={cn(trailingSlot, indicator ? 'grid' : revealedSlot)}>
-      {indicator ? <SessionRowIndicator kind={indicator} name={name} /> : null}
-      {indicator === 'loading' ? null : (
-        <SessionActionsMenu
-          name={name}
-          anchor={anchor}
-          disabled={disabled}
-          pinned={pinned}
-          onPinChange={onPinChange}
-          onDelete={onDelete}
-          onRegenerateTitle={onRegenerateTitle}
-          regeneratingTitle={regeneratingTitle}
-        />
-      )}
-    </span>
+    <>
+      {belt ? <SessionActivityBelt status={belt} label={beltLabel(belt, name)} /> : null}
+      <span className={cn(trailingSlot, trailing ? 'grid' : revealedSlot)}>
+        {trailing === 'loading' ? <Spinner size="sm" aria-label={`Opening ${name}`} className="text-icon3" /> : null}
+        {trailing === 'merged' ? (
+          <span
+            role="img"
+            aria-label={`Pull request merged for ${name}`}
+            title="Pull request merged"
+            className={cn('flex', yieldsToActions)}
+          >
+            <PullRequestStatusIcon status="merged" className="size-3!" decorative />
+          </span>
+        ) : null}
+        {trailing === 'loading' ? null : (
+          <SessionActionsMenu
+            name={name}
+            anchor={anchor}
+            disabled={disabled}
+            pinned={pinned}
+            onPinChange={onPinChange}
+            onDelete={onDelete}
+            onRegenerateTitle={onRegenerateTitle}
+            regeneratingTitle={regeneratingTitle}
+          />
+        )}
+      </span>
+    </>
   );
   const row = (
     <MainSidebar.NavLink
@@ -126,27 +143,16 @@ const trailingSlot = 'size-form-sm shrink-0 place-items-center *:col-start-1 *:r
 const revealedSlot =
   'hidden group-focus-within/session:grid group-hover/session:grid group-has-[[data-popup-open]]/session:grid';
 
-/**
- * Session lifecycle states surfaced by the row's status dot. The color scheme
- * mirrors `SessionFavicon` so the sidebar and the tab-favicon read the same
- * way at a glance.
- */
-export type SessionRowStatus = 'initializing' | 'working' | 'ready';
+function beltLabel(status: SessionRowStatus, name: string) {
+  if (status === 'initializing') return `Initializing ${name}`;
+  if (status === 'working') return `Agent working in ${name}`;
+  return `${name} ready — open to dismiss`;
+}
 
-type IndicatorKind = 'loading' | SessionRowStatus | 'merged';
-
-function indicatorKind({
-  loading,
-  status,
-  merged,
-}: {
-  loading?: boolean;
-  status?: SessionRowStatus;
-  merged?: boolean;
-}): IndicatorKind | undefined {
+/** A merge badge is worth the slot only on a session with no lifecycle left to report. */
+function trailingKind({ loading, status, merged }: { loading?: boolean; status?: SessionRowStatus; merged?: boolean }) {
   if (loading) return 'loading';
-  if (status) return status;
-  return merged ? 'merged' : undefined;
+  return merged && !status ? 'merged' : undefined;
 }
 
 function SessionActionsMenu({
@@ -209,48 +215,3 @@ function SessionActionsMenu({
 // The actions menu owns the slot as soon as the row is hovered, focused, or its menu is open.
 const yieldsToActions =
   'group-hover/session:hidden group-focus-within/session:hidden group-has-[[data-popup-open]]/session:hidden';
-
-function SessionRowIndicator({ kind, name }: { kind: IndicatorKind; name: string }) {
-  if (kind === 'loading') return <Spinner size="sm" aria-label={`Opening ${name}`} className="text-icon3" />;
-
-  if (kind === 'initializing')
-    return (
-      <span
-        role="status"
-        aria-label={`Initializing ${name}`}
-        title="Initializing"
-        className={cn('bg-warning1 size-2 animate-pulse rounded-full', yieldsToActions)}
-      />
-    );
-
-  if (kind === 'working')
-    return (
-      <span
-        role="status"
-        aria-label={`Agent working in ${name}`}
-        title="Working"
-        className={cn('bg-positive1 size-2 animate-pulse rounded-full', yieldsToActions)}
-      />
-    );
-
-  if (kind === 'ready')
-    return (
-      <span
-        role="status"
-        aria-label={`${name} ready — open to dismiss`}
-        title="Ready"
-        className={cn('bg-accent3 size-2 rounded-full', yieldsToActions)}
-      />
-    );
-
-  return (
-    <span
-      role="img"
-      aria-label={`Pull request merged for ${name}`}
-      title="Pull request merged"
-      className={cn('flex', yieldsToActions)}
-    >
-      <PullRequestStatusIcon status="merged" className="size-3!" decorative />
-    </span>
-  );
-}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionPreviewCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionPreviewCard.tsx
@@ -7,7 +7,8 @@ import type { ReactNode, RefObject } from 'react';
 
 import { relativeTime } from '../../../../lib/date/relativeTime';
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
-import type { SessionRowStatus } from './SessionNavRow';
+import { SessionActivityPentad } from './SessionActivity';
+import type { SessionRowStatus } from './SessionActivity';
 import type { SessionOwnerDetails } from '../services/sessionPresentation';
 
 export interface SessionPreviewDetails {
@@ -88,20 +89,23 @@ export function SessionPreviewCard({
       className="w-80 max-w-[calc(100vw-2rem)]"
     >
       <div className="flex flex-col gap-2.5">
-        <div className="flex flex-col gap-0.5">
-          <div className="flex items-baseline gap-3">
-            <Txt as="p" variant="ui-sm" className="text-icon6 m-0 min-w-0 flex-1 font-medium wrap-anywhere">
-              {name}
-            </Txt>
-            {updated && (
-              <Txt as="span" variant="ui-xs" className="text-icon3 shrink-0">
-                {updated}
+        <div className="flex items-center gap-2.5">
+          {status && <SessionActivityPentad status={status} className="shrink-0" />}
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <div className="flex items-baseline gap-3">
+              <Txt as="p" variant="ui-sm" className="text-icon6 m-0 min-w-0 flex-1 font-medium wrap-anywhere">
+                {name}
               </Txt>
-            )}
+              {updated && (
+                <Txt as="span" variant="ui-xs" className="text-icon3 shrink-0">
+                  {updated}
+                </Txt>
+              )}
+            </div>
+            <Txt as="p" variant="ui-xs" className="text-icon3 m-0">
+              {statusLabel ? `${details.kind} · ${statusLabel}` : details.kind}
+            </Txt>
           </div>
-          <Txt as="p" variant="ui-xs" className="text-icon3 m-0">
-            {statusLabel ? `${details.kind} · ${statusLabel}` : details.kind}
-          </Txt>
         </div>
         <div className="flex flex-col gap-1.5">
           <DetailRow icon={<Avatar src={details.owner.avatarUrl} name={ownerName} size="sm" />} label="Owner" centered>

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -22,7 +22,7 @@ import { deleteUserSession, regenerateSessionTitle } from '../services/user-sess
 import type { FactoryUserSession } from '../services/user-sessions';
 import { getSessionOwnerDetails, getUserSessionLabel } from '../services/sessionPresentation';
 import { SessionNavRow } from './SessionNavRow';
-import type { SessionRowStatus } from './SessionNavRow';
+import type { SessionRowStatus } from './SessionActivity';
 
 function userSessionStatus({
   session,

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -24,7 +24,7 @@ import type { FactoryUserSession } from '../services/user-sessions';
 import { getFactorySessionKind, getSessionOwnerDetails } from '../services/sessionPresentation';
 import type { SessionViewerProfile } from '../services/sessionPresentation';
 import { SessionNavRow } from './SessionNavRow';
-import type { SessionRowStatus } from './SessionNavRow';
+import type { SessionRowStatus } from './SessionActivity';
 import type { SessionPreviewDetails } from './SessionPreviewCard';
 
 const COLLAPSED_ROW_COUNT = 5;

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/SessionHoverDetails.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/SessionHoverDetails.msw.test.tsx
@@ -110,6 +110,16 @@ describe('Workspace session hover details', () => {
       expect(workRow).not.toHaveAttribute('title');
     });
 
+    it('carries the same activity state as the sidebar row', async () => {
+      const { user, workRow } = await setupSessionRows();
+
+      await user.hover(workRow);
+
+      // Decorative here — the card already spells the status out in text beside it.
+      const card = await screen.findByLabelText(`${workName} session details`);
+      expect(card.querySelector('.session-pentad.session-working')).toBeInTheDocument();
+    });
+
     it('names the icon-only rows for screen readers', async () => {
       const { user, workRow } = await setupSessionRows();
 

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsActivity.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsActivity.msw.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Sidebar activity dot for user sessions.
+ * Sidebar activity belt for user sessions.
  *
  * User sessions are addressed by their own `sessionId` as `resourceId`, so they
  * read the same active-run registry as factory workspaces. This suite pins down
@@ -102,7 +102,7 @@ function renderSection() {
 }
 
 describe('User sessions sidebar activity', () => {
-  it('lights the working dot when the session has an active thread', async () => {
+  it('lights the working belt when the session has an active thread', async () => {
     stubProjectAndSessions([makeSession({ sessionId: 'sess-1', branch: 'user/feature-a' })]);
     stubActiveSessions(new Set(['sess-1']));
 
@@ -112,7 +112,7 @@ describe('User sessions sidebar activity', () => {
     await screen.findByRole('status', { name: 'Agent working in feature-a' });
   });
 
-  it('shows the initializing dot for a session that has not materialized yet', async () => {
+  it('shows the initializing belt for a session that has not materialized yet', async () => {
     stubProjectAndSessions([makeSession({ sessionId: 'sess-2', branch: 'user/feature-b', materializedAt: null })]);
     stubActiveSessions(new Set());
 
@@ -122,7 +122,7 @@ describe('User sessions sidebar activity', () => {
     await screen.findByRole('status', { name: 'Initializing feature-b' });
   });
 
-  it('resolves the initializing dot once the run that materialized the session finishes', async () => {
+  it('resolves the initializing belt once the run that materialized the session finishes', async () => {
     let materialized = false;
     const active = new Set(['sess-4']);
     stubProjectAndSessions([]);
@@ -157,13 +157,13 @@ describe('User sessions sidebar activity', () => {
     });
     await waitForMutationsIdle(client);
 
-    // Run end must refetch the sessions list: the dot lands on solid attention,
+    // Run end must refetch the sessions list: the belt lands on solid attention,
     // not back on (or stuck at) initializing.
     await screen.findByRole('status', { name: 'feature-d ready — open to dismiss' });
     expect(screen.queryByRole('status', { name: 'Initializing feature-d' })).not.toBeInTheDocument();
   });
 
-  it('leaves an idle materialized session without a status dot', async () => {
+  it('leaves an idle materialized session without a status belt', async () => {
     stubProjectAndSessions([makeSession({ sessionId: 'sess-3', branch: 'user/feature-c' })]);
     stubActiveSessions(new Set());
 

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceActivityIndicators.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceActivityIndicators.msw.test.tsx
@@ -72,29 +72,30 @@ function renderAt(path: string, entry: string) {
 }
 
 describe('Workspace activity indicators', () => {
-  it('lights the running dot for a session with an active run', async () => {
+  it('lights the running belt for a session with an active run', async () => {
     stubWith([workSessionId]);
 
     renderSection();
 
-    const dot = await screen.findByRole('status', { name: `Agent working in ${workName}` });
+    const belt = await screen.findByRole('status', { name: `Agent working in ${workName}` });
     const actions = screen.getByRole('button', { name: `Session actions for ${workName}` });
-    // Same trailing slot: the menu takes the dot's place on hover instead of covering the label.
-    expect(dot.parentElement).toBe(actions.parentElement);
+    // Its own slot on the row box: the trailing slot collapses on hover and would take the belt with it.
+    expect(belt.parentElement).not.toBe(actions.parentElement);
+    expect(belt.closest('li')).toBe(actions.closest('li'));
   });
 
-  it('leaves a session without an active run undotted', async () => {
+  it('leaves a session without an active run unmarked', async () => {
     stubWith([]);
 
     renderSection();
 
-    // The row must exist before the absence of its dot means anything.
+    // The row must exist before the absence of its belt means anything.
     const row = (await screen.findByRole('button', { name: workName })).closest('li');
     assert(row);
     expect(within(row).queryByRole('status', { name: `Agent working in ${workName}` })).not.toBeInTheDocument();
   });
 
-  it('lights the dot on a page that has no workspace session open', async () => {
+  it('lights the belt on a page that has no workspace session open', async () => {
     stubWith([workSessionId]);
 
     renderAt('/factories/:factoryId/work', `/factories/${factoryId}/work`);

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceSidebarStatuses.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceSidebarStatuses.msw.test.tsx
@@ -231,7 +231,7 @@ const newestPullRequestCases: Array<{
 ];
 
 describe('Workspace sidebar statuses', () => {
-  it('shows the running status dot instead of a merged icon while the agent is active', async () => {
+  it('shows the running status belt instead of a merged icon while the agent is active', async () => {
     stubWorkspaceStatuses({
       items: baseItems(true),
       activeSessionIds: [workSession.sessionId],

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
@@ -1,0 +1,325 @@
+/* Two markers, one grammar: the row's belt travels, jams or breathes down the
+ * sidebar; the card's pentad passes its swell round a ring, stutters it, or
+ * settles it. Neither is a recolour of the other state — what a state sets is
+ * an amplitude, not a hue. That is what lets working → initializing → ready morph instead of
+ * cutting, and it rests on one rule: a rate has to be expressed as a distance,
+ * never as an `animation-duration`. Durations cannot cross-fade; lengths can. */
+
+@property --belt-pitch {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 9px;
+}
+
+@property --belt-jam {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0;
+}
+
+@property --belt-sway {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0;
+}
+
+@property --belt-hue {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: currentcolor;
+}
+
+/* One declaration of what each state means, read by whichever slot is drawing.
+ * Every off-diagonal is zero, so a handover is one amplitude fading out through
+ * zero while the next fades in. */
+.session-working {
+  --belt-pitch: 9px;
+  --belt-jam: 0;
+  --belt-sway: 0;
+  --belt-hue: var(--positive1);
+}
+
+/* Travel continues and a jam rides on top of it — hold, shudder, lurch — so a
+ * sandbox that has not started yet reads as motion that fails to advance rather
+ * than as working in another colour. */
+.session-initializing {
+  --belt-pitch: 9px;
+  --belt-jam: 1;
+  --belt-sway: 0;
+  --belt-hue: var(--warning1);
+}
+
+/* Travel drops to zero and one slow breath takes over on a clock four times
+ * longer: parked on you, not stuck. */
+.session-ready {
+  --belt-pitch: 0px;
+  --belt-jam: 0;
+  --belt-sway: 1;
+  --belt-hue: var(--accent3);
+}
+
+.session-belt {
+  --belt-beat: 1.4s;
+
+  transition:
+    --belt-pitch 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --belt-jam 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --belt-sway 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --belt-hue 520ms ease;
+}
+
+/* The row's left rail. Absolute against the row box rather than the trailing
+ * slot, which comes and goes with hover and would drag the belt with it. */
+.session-belt {
+  position: absolute;
+  inset-block: 4px;
+  left: 3px;
+  width: 6px;
+  overflow: hidden;
+  mask: linear-gradient(to bottom, transparent, #000 16%, #000 84%, transparent);
+}
+
+.session-belt-sway,
+.session-belt-jam {
+  position: absolute;
+  inset: 0;
+}
+
+.session-belt-sway {
+  animation: session-belt-sway calc(var(--belt-beat) * 4) ease-in-out infinite;
+}
+
+/* The jam stays on the flow's clock because it cancels the flow and the pair
+ * still has to net exactly one pitch per loop. */
+.session-belt-jam {
+  animation: session-belt-jam calc(var(--belt-beat) * 0.9) linear infinite;
+}
+
+.session-belt-jam i {
+  position: absolute;
+  top: calc(var(--belt-k) * 9px - 9px);
+  left: 50%;
+  width: 2px;
+  height: 5px;
+  margin-left: -1px;
+  border-radius: 999px;
+  background: var(--belt-hue);
+  animation: session-belt-flow calc(var(--belt-beat) * 0.9) linear infinite;
+}
+
+.session-belt-jam i:nth-child(1) {
+  --belt-k: 0;
+}
+
+.session-belt-jam i:nth-child(2) {
+  --belt-k: 1;
+}
+
+.session-belt-jam i:nth-child(3) {
+  --belt-k: 2;
+}
+
+.session-belt-jam i:nth-child(4) {
+  --belt-k: 3;
+}
+
+.session-belt-jam i:nth-child(5) {
+  --belt-k: 4;
+}
+
+/* Exactly one pitch per loop, so the last frame is the first frame with every
+ * pill in its neighbour's place and the belt never jumps. */
+@keyframes session-belt-flow {
+  to {
+    transform: translateY(var(--belt-pitch));
+  }
+}
+
+/* Cancels the flow for the first four tenths, shudders against the stop, then
+ * lurches through and holds — and nets zero, so the loop still lands on a pitch. */
+@keyframes session-belt-jam {
+  0% {
+    transform: translateY(0);
+  }
+
+  40% {
+    transform: translateY(calc(var(--belt-pitch) * -0.4 * var(--belt-jam)));
+  }
+
+  46% {
+    transform: translateY(calc(var(--belt-pitch) * -0.41 * var(--belt-jam)));
+  }
+
+  52% {
+    transform: translateY(calc(var(--belt-pitch) * -0.52 * var(--belt-jam)));
+  }
+
+  58% {
+    transform: translateY(calc(var(--belt-pitch) * -0.52 * var(--belt-jam)));
+  }
+
+  62% {
+    transform: translateY(calc(var(--belt-pitch) * -0.6 * var(--belt-jam)));
+    animation-timing-function: cubic-bezier(0.2, 0, 0.1, 1);
+  }
+
+  85% {
+    transform: translateY(calc(var(--belt-pitch) * 0.15 * var(--belt-jam)));
+  }
+
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes session-belt-sway {
+  0%,
+  100% {
+    transform: translateY(calc(-3px * var(--belt-sway)));
+  }
+
+  50% {
+    transform: translateY(calc(3px * var(--belt-sway)));
+  }
+}
+
+/* The card's pentad — five on a ring, swelling in turn. Same grammar as the
+ * belt in its own vocabulary: the round-robin passes cleanly, stutters against
+ * itself, or settles into an even ring with one slow wave going round. */
+.session-pentad {
+  --pentad-beat: 1.4s;
+
+  display: block;
+  width: 16px;
+  height: auto;
+}
+
+.session-pentad g {
+  transform-box: view-box;
+  transform-origin: 12px 12px;
+}
+
+.session-pentad circle {
+  fill: var(--belt-hue);
+  transform-box: fill-box;
+  transform-origin: 50% 50%;
+  animation: session-pentad-swell calc(var(--pentad-beat) * 1.8) ease-in-out infinite;
+}
+
+.session-pentad g:nth-of-type(1) circle {
+  animation-delay: calc(var(--pentad-beat) * -1.8);
+}
+
+.session-pentad g:nth-of-type(2) circle {
+  animation-delay: calc(var(--pentad-beat) * -1.44);
+}
+
+.session-pentad g:nth-of-type(3) circle {
+  animation-delay: calc(var(--pentad-beat) * -1.08);
+}
+
+.session-pentad g:nth-of-type(4) circle {
+  animation-delay: calc(var(--pentad-beat) * -0.72);
+}
+
+.session-pentad g:nth-of-type(5) circle {
+  animation-delay: calc(var(--pentad-beat) * -0.36);
+}
+
+@keyframes session-pentad-swell {
+  0%,
+  100% {
+    transform: scale(0.5);
+  }
+
+  14% {
+    transform: scale(1.2);
+  }
+
+  42% {
+    transform: scale(0.5);
+  }
+}
+
+.session-initializing.session-pentad circle {
+  animation-name: session-pentad-snag;
+}
+
+@keyframes session-pentad-snag {
+  0%,
+  100% {
+    transform: scale(0.5);
+  }
+
+  9% {
+    transform: scale(1.08);
+  }
+
+  14% {
+    transform: scale(0.84);
+  }
+
+  20% {
+    transform: scale(1.18);
+  }
+
+  26% {
+    transform: scale(0.9);
+  }
+
+  33% {
+    transform: scale(1.04);
+  }
+
+  48% {
+    transform: scale(0.5);
+  }
+}
+
+.session-ready.session-pentad circle {
+  animation: session-pentad-rest calc(var(--pentad-beat) * 3) ease-in-out infinite;
+}
+
+.session-ready.session-pentad g:nth-of-type(1) circle {
+  animation-delay: calc(var(--pentad-beat) * -3);
+}
+
+.session-ready.session-pentad g:nth-of-type(2) circle {
+  animation-delay: calc(var(--pentad-beat) * -2.4);
+}
+
+.session-ready.session-pentad g:nth-of-type(3) circle {
+  animation-delay: calc(var(--pentad-beat) * -1.8);
+}
+
+.session-ready.session-pentad g:nth-of-type(4) circle {
+  animation-delay: calc(var(--pentad-beat) * -1.2);
+}
+
+.session-ready.session-pentad g:nth-of-type(5) circle {
+  animation-delay: calc(var(--pentad-beat) * -0.6);
+}
+
+@keyframes session-pentad-rest {
+  0%,
+  100% {
+    transform: scale(0.8);
+  }
+
+  50% {
+    transform: scale(1.04);
+  }
+}
+
+/* Ready has no travel to begin with, so it and working collapse to the same
+ * still frame here and only the colour tells them apart. */
+@media (prefers-reduced-motion: reduce) {
+  .session-belt,
+  .session-belt-sway,
+  .session-belt-jam,
+  .session-belt-jam i,
+  .session-pentad circle {
+    transition: none;
+    animation: none;
+  }
+}

--- a/mastracode/factory-ui/src/ui/pages/MarkerPreviewPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/MarkerPreviewPage.tsx
@@ -1,0 +1,193 @@
+/**
+ * TEMPORARY — a bench for the session activity markers at `/markers`, so every
+ * state can be looked at side by side without arranging real sessions to be in
+ * it. Delete once the markers are settled.
+ */
+import { Avatar } from '@mastra/playground-ui/components/Avatar';
+import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { MessageSquare } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import { CardLabels } from '../domains/factory/components/BoardCardParts';
+import { SourceIcon } from '../domains/factory/components/BoardIcons';
+import { SessionActivityPentad } from '../domains/workspaces/components/SessionActivity';
+import type { SessionRowStatus } from '../domains/workspaces/components/SessionActivity';
+import { SessionNavRow } from '../domains/workspaces/components/SessionNavRow';
+import type { SessionPreviewDetails } from '../domains/workspaces/components/SessionPreviewCard';
+
+interface MockItem {
+  status?: SessionRowStatus;
+  meta: string;
+  title: string;
+  labels: string[];
+  comments: number;
+  owner: string;
+}
+
+const CARDS: MockItem[] = [
+  {
+    status: 'working',
+    meta: '#22532 · daneatmastra · 3d',
+    title: 'cannot abort suspend run',
+    labels: ['bug', 'Workflows', 'trio-tnt', 'storage', 'cli', 'memory', 'triage'],
+    comments: 3,
+    owner: 'Schneider Damien',
+  },
+  {
+    status: 'initializing',
+    meta: '#22509 · daneatmastra · 4d',
+    title: 'Ingest durable agents tweaks',
+    labels: ['Workflows', 'trio-tnt', 'trio-tb', 'cli', 'memory', 'storage', 'triage'],
+    comments: 0,
+    owner: 'daneatmastra',
+  },
+  {
+    status: 'ready',
+    meta: 'COR-1188 · daneatmastra · 1h',
+    title: 'Review the memory page draft',
+    labels: ['linear', 'docs'],
+    comments: 1,
+    owner: 'Schneider Damien',
+  },
+  {
+    meta: '#22488 · daneatmastra · 6d',
+    title: 'Bump the pubsub retry ceiling',
+    labels: ['Workflows'],
+    comments: 0,
+    owner: 'daneatmastra',
+  },
+];
+
+const ROWS: { status: SessionRowStatus; label: string }[] = [
+  { status: 'working', label: 'fix: transcript duplicates' },
+  { status: 'initializing', label: 'feat: attention inbox' },
+  { status: 'ready', label: 'docs: memory page' },
+];
+
+function previewDetails(branch: string): SessionPreviewDetails {
+  return {
+    kind: 'Work session',
+    owner: { name: 'Damien Schneider' },
+    itemLabel: 'Work item: Issue #42',
+    itemTitle: 'Authentication fails after token refresh',
+    branch,
+    baseBranch: 'main',
+    updatedAt: new Date(Date.now() - 14 * 60_000).toISOString(),
+  };
+}
+
+function noop() {}
+
+/** The board card's own markup, so the marker is judged at the width and density it ships at. */
+function MockCard({ item }: { item: MockItem }) {
+  return (
+    <article className="border-border1/50 bg-neutral6/5 relative flex flex-col gap-3 rounded-xl border p-3">
+      <div className="flex min-w-0 flex-col gap-1.5">
+        <div className="flex min-w-0 items-center gap-1.5 pr-8">
+          <span className="text-ui-xs text-icon2 min-w-0 truncate">{item.meta}</span>
+          {item.status && <SessionActivityPentad status={item.status} className="shrink-0" />}
+          {item.comments > 0 && (
+            <span className="text-ui-xs text-icon2 flex shrink-0 items-center gap-1">
+              <MessageSquare size={11} aria-hidden />
+              {item.comments}
+            </span>
+          )}
+        </div>
+        <div className="flex min-w-0 items-center gap-1.5 tracking-tight">
+          <SourceIcon source="github-issue" />
+          <span className="text-ui-smd text-icon6 min-w-0 flex-1 truncate font-[550]">{item.title}</span>
+        </div>
+      </div>
+      <CardLabels labels={item.labels} />
+      <div className="text-ui-xs text-icon4 flex items-center gap-1.5">
+        <Avatar name={item.owner} size="sm" />
+        {item.owner}
+      </div>
+    </article>
+  );
+}
+
+function Column({ title }: { title: string }) {
+  return (
+    <div className="flex w-80 shrink-0 flex-col gap-2">
+      <Txt as="h2" variant="ui-sm" className="text-icon3 m-0 font-medium">
+        {title}
+      </Txt>
+      {CARDS.map(item => (
+        <MockCard key={item.title} item={item} />
+      ))}
+    </div>
+  );
+}
+
+export function MarkerPreviewPage() {
+  return (
+    <div className="bg-surface1 min-h-dvh p-10">
+      <div className="mx-auto flex max-w-6xl flex-col gap-10">
+        <div className="flex flex-col gap-1">
+          <Txt as="h1" variant="header-md" className="text-icon6 m-0">
+            Session activity markers
+          </Txt>
+          <Txt as="p" variant="ui-sm" className="text-icon3 m-0">
+            Green marches, amber holds and lurches against its stop, blue stops travelling and breathes. Hover a sidebar
+            row for its preview card.
+          </Txt>
+        </div>
+
+        <div className="flex flex-wrap items-start gap-10">
+          <div className="flex flex-col gap-2">
+            <Txt as="h2" variant="ui-sm" className="text-icon3 m-0 font-medium">
+              Sidebar rows
+            </Txt>
+            <div className="bg-surface2 border-border1 w-72 rounded-lg border p-2">
+              <MainSidebar.NavList>
+                {ROWS.map(row => (
+                  <SessionNavRow
+                    key={row.label}
+                    name={row.label}
+                    url="#"
+                    active={false}
+                    disabled={false}
+                    status={row.status}
+                    preview={previewDetails(row.label.replace(/^\w+: /, '').replace(/ /g, '-'))}
+                    onSelect={noop}
+                    onPinChange={noop}
+                  />
+                ))}
+                <SessionNavRow
+                  name="opening a session…"
+                  url="#"
+                  active={false}
+                  disabled={false}
+                  loading
+                  onSelect={noop}
+                  onPinChange={noop}
+                />
+                <SessionNavRow
+                  name="chore: bump deps"
+                  url="#"
+                  active={false}
+                  disabled={false}
+                  onSelect={noop}
+                  onPinChange={noop}
+                />
+                <SessionNavRow
+                  name="feat: merged already"
+                  url="#"
+                  active={false}
+                  disabled={false}
+                  merged
+                  onSelect={noop}
+                  onPinChange={noop}
+                />
+              </MainSidebar.NavList>
+            </div>
+          </div>
+
+          <Column title="Board cards" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mastracode/factory-ui/src/ui/router.tsx
+++ b/mastracode/factory-ui/src/ui/router.tsx
@@ -20,6 +20,7 @@ import { AuditPage } from './pages/AuditPage';
 import { ActivityPage } from './pages/ActivityPage';
 import { AttentionPage } from './pages/AttentionPage';
 import { KnowledgePage } from './pages/KnowledgePage';
+import { MarkerPreviewPage } from './pages/MarkerPreviewPage';
 import { ReviewBoardPage, WorkBoardPage } from './pages/BoardPage';
 import { CreateFactoryPage } from './pages/CreateFactoryPage';
 import { NewPage } from './pages/NewPage';
@@ -196,6 +197,8 @@ export function createAppRoutes(): RouteObject[] {
       ],
     },
     { path: '/signin', element: <SignInPage /> },
+    // TEMPORARY: activity-marker bench, unauthenticated so it needs no factory.
+    { path: '/markers', element: <MarkerPreviewPage /> },
   ];
 }
 


### PR DESCRIPTION
**─────── TLDR ───────**
> Session rows and board cards get living activity markers: travel while the agent works, a jam while the sandbox comes up, a slow breath once it is your turn.

Until now every surface showed the same dot in a different colour, so telling "working" from "waiting on you" meant remembering a hue. The new markers make the state readable from motion alone, and both surfaces speak the same grammar: a state sets an amplitude, not a hue, which is what lets working → initializing → ready morph instead of cutting.

### Behavior changed

a sidebar row whose session has a run in flight
&nbsp;&nbsp;└─ **new** — pills travel down a belt on the row's left rail

a session whose sandbox is still materializing
&nbsp;&nbsp;└─ **new** — the travel jams: holds, shudders against the stop, lurches through

a session that finished while you were elsewhere
&nbsp;&nbsp;├─ **was** — a solid dot in the trailing slot, displaced by the actions menu on hover
&nbsp;&nbsp;└─ **now** — the belt stops travelling and breathes in place; the trailing slot is free for the menu and the merge badge

a board card bound to a session
&nbsp;&nbsp;└─ **new** — a five-dot ring passes a swell around, stutters it, or settles it — same grammar in the card's own vocabulary

### Shape changed

| | | |
|---|---|---|
| **+** | `SessionActivityBelt` | the row rail; replaces the trailing status dot |
| **+** | `SessionActivityPentad` | the card marker, shared by card, panel, preview |
| **+** | `sessionActivity.css` | all the motion, one `--belt-*` amplitude contract |
| **+** | `MarkerPreviewPage` | `/markers` bench to judge the states side by side |

what card, panel and preview now render
&nbsp;&nbsp;&nbsp;&nbsp;`WorkItemCard` · `WorkItemDetailsPanel` · `SessionPreviewCard` · `SessionNavRow`

### Decisions

- **the `/markers` bench ships with the feature** — states are judged side by side without arranging real sessions; delete once the markers settle

### Not verified

- [ ] the markers against real session churn — judged on the `/markers` bench and in MSW tests, not against a live factory

---

> ██████████████████ **source** `+497 −109`
> ███████ **bench page** `+193` — temporary `/markers`
> ██ **tests** `+40`
> █ **changeset** `+9`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds animated markers that show whether a session is starting, working, or ready for input. The markers appear in the sidebar and on session cards, while keeping space free for actions and merge badges.

## Changes

- Added `SessionActivityBelt` for sidebar session rows.
- Added `SessionActivityPentad` for cards, panels, and previews.
- Added shared `sessionActivity.css` animations.
- Replaced the trailing sidebar status dot with a left-side activity belt.
- Updated `WorkItemCard`, `WorkItemDetailsPanel`, `SessionPreviewCard`, and `SessionNavRow`.
- Added the temporary `/markers` preview page.
- Added MSW tests for working and ready session states.
- Added a patch changeset for `@mastra/factory`.

## Validation

- Validated marker states with the `/markers` preview page.
- Updated and added MSW test coverage.
- Real-session activity churn was not verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->