### PR TITLE
fix(factory): one session status truth for board cards and sidebar rows

### DIFF
--- a/.changeset/session-status-ssot.md
+++ b/.changeset/session-status-ssot.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed board item cards reporting a different session status than the sidebar. Cards read their own poll and only knew two states, so a card looked ready while its workspace was still cloning, ignored runs on any session but the most recently bound one, and claimed "ready — your turn" the moment it had a session at all. Cards and sidebar rows now resolve status from the one shared rule: working while any bound session runs, initializing while the workspace is still materializing, ready only when a session actually finished under your nose, and a distinct still marker when there is nothing to report.

--- a/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
@@ -12,7 +12,9 @@ import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../e2e/ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import { queryKeys } from '../../api/keys';
 import { createQueryClient } from '../../query-client';
+import { AGENT_CONTROLLER_ID } from '../domains/chat/services/constants';
 import { createAppRoutes } from '../router';
 
 const FACTORY_ID = 'fp-1';
@@ -167,11 +169,82 @@ describe('Board card session liveness', () => {
 
     const card = await screen.findByTestId('work-item-card');
     await waitFor(() => expect(card.querySelector('[data-live-session-indicator]')).not.toBeNull());
-    // Bound but idle: the belt rests instead of advertising work that is not happening.
-    expect(card.querySelector('.session-pentad.session-ready')).not.toBeNull();
+    // Bound but idle: the marker rests muted — `ready` is reserved for a finished
+    // run awaiting its reader, same as the sidebar rows.
+    expect(card.querySelector('.session-pentad.session-idle')).not.toBeNull();
 
     await user.click(screen.getByRole('button', { name: 'Details for Fix login bug' }));
     expect(await screen.findByRole('link', { name: 'Open session' })).toBeInTheDocument();
+  });
+
+  it('shows the initializing marker while a bound session is still materializing', async () => {
+    stubFactoryWithBoundSession();
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+        HttpResponse.json({ sessions: [{ ...boundSession, materializedAt: null }] }),
+      ),
+    );
+    renderWorkBoard();
+
+    const card = await screen.findByTestId('work-item-card');
+    await waitFor(() => expect(card.querySelector('.session-pentad.session-initializing')).not.toBeNull());
+  });
+
+  it('lights the working marker when any bound session runs, not just the newest ref', async () => {
+    // Each role keeps its own session; a role re-run rewrites an existing key,
+    // so the running session is not necessarily the last ref on the item.
+    stubFactoryWithBoundSession();
+    const reviewSession = {
+      sessionId: 'session-2',
+      branch: 'factory/issue-1',
+      threadId: 'session-2',
+      startedBy: 'user-1',
+    };
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+        HttpResponse.json({
+          workItems: [{ ...workItem, sessions: { ...workItemSessions, review: reviewSession } }],
+        }),
+      ),
+      http.get('*/api/agent-controller/:controllerId/active-runs', () =>
+        HttpResponse.json({ runs: [{ runId: 'run-1', resourceId: SESSION_ID, threadId: SESSION_ID }] }),
+      ),
+    );
+    renderWorkBoard();
+
+    const card = await screen.findByTestId('work-item-card');
+    await waitFor(() => expect(card.querySelector('.session-pentad.session-working')).not.toBeNull());
+  });
+
+  it('walks idle → working → ready as a run starts and finishes unseen', async () => {
+    stubFactoryWithBoundSession();
+    const active = new Set<string>();
+    server.use(
+      // Ungated sessions list: the attention pass refetches it on run end.
+      http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+        HttpResponse.json({ sessions: [boundSession] }),
+      ),
+      http.get('*/api/agent-controller/:controllerId/active-runs', () =>
+        HttpResponse.json({
+          runs: [...active].map(resourceId => ({ runId: `run-${resourceId}`, resourceId, threadId: resourceId })),
+        }),
+      ),
+    );
+    const { client } = renderWorkBoard();
+    const activityKey = queryKeys.agentControllerActivity(AGENT_CONTROLLER_ID, TEST_BASE_URL);
+
+    const card = await screen.findByTestId('work-item-card');
+    await waitFor(() => expect(card.querySelector('.session-pentad.session-idle')).not.toBeNull());
+
+    active.add(SESSION_ID);
+    await client.invalidateQueries({ queryKey: activityKey });
+    await waitFor(() => expect(card.querySelector('.session-pentad.session-working')).not.toBeNull());
+
+    active.delete(SESSION_ID);
+    await client.invalidateQueries({ queryKey: activityKey });
+    // The finish was never opened, so the card holds the same "your turn" mark
+    // the sidebar row shows, instead of sliding silently back to idle.
+    await waitFor(() => expect(card.querySelector('.session-pentad.session-ready')).not.toBeNull());
   });
 
   it('runs the belt while the bound session has a run in flight', async () => {

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -11,9 +11,8 @@ import { useParams } from 'react-router';
 import type { FactoryRunPhase } from '../../../../hooks/useStartFactoryRun';
 import { boardCardStatus } from '../boardCardStatus';
 import { setDragPayload } from '../boardDrag';
-import { useActiveRunResources } from '../../../../hooks/useActiveRunResources';
 import { SessionActivityPentad } from '../../workspaces/components/SessionActivity';
-import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
+import type { SessionCardStatus } from '../../workspaces/components/SessionActivity';
 import { itemThreadSession, metadataLabels, pullRequestStatusForItem, workItemMeta } from '../boardItems';
 import { itemRunSpec } from '../boardRunSpecs';
 import type { ItemRunSpec, RunAction } from '../boardRunSpecs';
@@ -63,6 +62,7 @@ export function WorkItemCard({
   onDismissProposal,
   onRetryDecision,
   pendingRunRoles,
+  sessionStatus = 'idle',
   onCreateSession,
   onStartRun,
   onRestartRun,
@@ -96,6 +96,8 @@ export function WorkItemCard({
   onDismissProposal: (decisionId: string) => void;
   onRetryDecision: (decisionId: string) => void;
   pendingRunRoles: ReadonlyMap<string, FactoryRunPhase | undefined>;
+  /** Live status of the card's bound sessions, resolved once for the whole board. */
+  sessionStatus?: SessionCardStatus;
   /** Detail-panel fallback when the item has no run spec: open an empty session (no run). */
   onCreateSession: (spec: { branch: string; threadTitle: string }) => void;
   onStartRun: (spec: ItemRunSpec, action: RunAction, options?: { preapprovePlans?: boolean }) => void;
@@ -134,12 +136,6 @@ export function WorkItemCard({
       ? runSpec.actions.find(action => FACTORY_ROLE_STAGES[action.role] === columnStage && action.role in sessions)
       : undefined;
   const threadSession = itemThreadSession(sessions);
-  // One poll for the whole controller, shared by every card and the sidebar alike.
-  const running = useActiveRunResources({
-    agentControllerId: AGENT_CONTROLLER_ID,
-    resourceIds: threadSession ? [threadSession.sessionId] : [],
-  });
-  const sessionStatus = threadSession && running[threadSession.sessionId] ? 'working' : 'ready';
   const primaryAction = cardPrimaryAction({
     item,
     runSpec,

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemDetailsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemDetailsPanel.tsx
@@ -8,7 +8,7 @@ import { Link, useParams, useSearchParams } from 'react-router';
 
 import { useFactoryAuth } from '../../../../hooks/useFactoryAuth';
 import { SessionActivityPentad } from '../../workspaces/components/SessionActivity';
-import type { SessionRowStatus } from '../../workspaces/components/SessionActivity';
+import type { SessionCardStatus } from '../../workspaces/components/SessionActivity';
 import type { BoardCardStatus } from '../boardCardStatus';
 import { externalLinkLabel, metadataLabels, pullRequestStatusForItem, workItemMeta } from '../boardItems';
 import { itemStageLabel } from '../boardStages';
@@ -51,7 +51,7 @@ export function WorkItemDetailsPanel({
   morph: CardMorph;
   relatedLinks: ReactNode;
   threadSession?: WorkItemSessionRef;
-  sessionStatus: SessionRowStatus;
+  sessionStatus: SessionCardStatus;
   status: BoardCardStatus;
   retryingDecisionId?: string;
   onRetryDecision: (decisionId: string) => void;

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useItemSessionStatuses.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useItemSessionStatuses.ts
@@ -1,0 +1,48 @@
+import { useActiveRunResources } from '../../../../hooks/useActiveRunResources';
+import { useWorkspaceAttentionState } from '../../../../hooks/useWorkspaceAttention';
+import { useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
+import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
+import type { SessionCardStatus } from '../../workspaces/components/SessionActivity';
+import { sessionRowStatus } from '../../workspaces/services/sessionStatus';
+import type { WorkItem } from '../services/workItems';
+
+/**
+ * One live status per card, from the same inputs the sidebar rows read. A card
+ * watches every session bound to it — each role keeps its own session, so the
+ * newest ref alone can miss the one actually running. A ref the workspaces
+ * listing does not know yet still counts as bound: dispatcher-minted sessions
+ * reach the item before any sidebar refetch sees them.
+ */
+export function useItemSessionStatuses({
+  projectRepositoryId,
+  items,
+}: {
+  projectRepositoryId: string;
+  items: readonly WorkItem[];
+}): ReadonlyMap<string, SessionCardStatus> {
+  const boundSessionIds = items.flatMap(item => Object.values(item.sessions).map(ref => ref.sessionId));
+  const runningBySessionId = useActiveRunResources({
+    agentControllerId: AGENT_CONTROLLER_ID,
+    resourceIds: boundSessionIds,
+  });
+  const workspaces = useWorkspacesQuery(projectRepositoryId);
+  const { attentionByPath } = useWorkspaceAttentionState({ projectRepositoryId, sessionKind: 'factory' });
+  const materializingSessionIds = new Set(
+    [...(workspaces.data?.workspaces ?? []), ...(workspaces.data?.userSessions ?? [])]
+      .filter(session => !session.materializedAt)
+      .map(session => session.sessionId),
+  );
+
+  const statuses = new Map<string, SessionCardStatus>();
+  for (const item of items) {
+    const refs = Object.values(item.sessions);
+    if (refs.length === 0) continue;
+    const status = sessionRowStatus({
+      running: refs.some(ref => runningBySessionId[ref.sessionId] === true),
+      initializing: refs.some(ref => materializingSessionIds.has(ref.sessionId)),
+      attention: refs.some(ref => attentionByPath[ref.sessionId] === true),
+    });
+    statuses.set(item.id, status ?? 'idle');
+  }
+  return statuses;
+}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionActivity.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionActivity.tsx
@@ -10,17 +10,24 @@ import './sessionActivity.css';
  */
 export type SessionRowStatus = 'initializing' | 'working' | 'ready';
 
+/**
+ * A board card also has to say "bound but nothing to report". Rows hide their
+ * belt instead, so `ready` keeps one meaning everywhere — it is your turn.
+ */
+export type SessionCardStatus = SessionRowStatus | 'idle';
+
 const PILLS = [0, 1, 2, 3, 4];
 
 const PENTAD = [0, 72, 144, 216, 288];
 
-const STATUS_TITLE: Record<SessionRowStatus, string> = {
+const STATUS_TITLE: Record<SessionCardStatus, string> = {
   initializing: 'Initializing',
   working: 'Working',
   ready: 'Ready',
+  idle: 'Idle',
 };
 
-function statusAttributes(status: SessionRowStatus, label: string | undefined) {
+function statusAttributes(status: SessionCardStatus, label: string | undefined) {
   return label ? { role: 'status', 'aria-label': label, title: STATUS_TITLE[status] } : { 'aria-hidden': true };
 }
 
@@ -67,7 +74,7 @@ export function SessionActivityPentad({
   className,
   ...props
 }: ComponentProps<'svg'> & {
-  status: SessionRowStatus;
+  status: SessionCardStatus;
   /** Omit where the status is already spelled out in adjacent text: the marker is then decorative. */
   label?: string;
 }) {

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -22,22 +22,7 @@ import { deleteUserSession, regenerateSessionTitle } from '../services/user-sess
 import type { FactoryUserSession } from '../services/user-sessions';
 import { getSessionOwnerDetails, getUserSessionLabel } from '../services/sessionPresentation';
 import { SessionNavRow } from './SessionNavRow';
-import type { SessionRowStatus } from './SessionActivity';
-
-function userSessionStatus({
-  session,
-  running,
-  attention,
-}: {
-  session: FactoryUserSession;
-  running: boolean;
-  attention: boolean;
-}): SessionRowStatus | undefined {
-  if (running) return 'working';
-  if (!session.materializedAt) return 'initializing';
-  if (attention) return 'ready';
-  return undefined;
-}
+import { sessionRowStatus } from '../services/sessionStatus';
 
 export function UserSessionsSection() {
   const { baseUrl } = useApiConfig();
@@ -145,9 +130,9 @@ export function UserSessionsSection() {
             const url = `/factories/${factoryId}/user/threads/${session.sessionId}`;
             const active = location.pathname === url;
 
-            const status = userSessionStatus({
-              session,
+            const status = sessionRowStatus({
               running: runningBySessionId[session.sessionId] === true,
+              initializing: !session.materializedAt,
               attention: attentionBySessionId[session.sessionId] === true,
             });
             return (

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -24,7 +24,7 @@ import type { FactoryUserSession } from '../services/user-sessions';
 import { getFactorySessionKind, getSessionOwnerDetails } from '../services/sessionPresentation';
 import type { SessionViewerProfile } from '../services/sessionPresentation';
 import { SessionNavRow } from './SessionNavRow';
-import type { SessionRowStatus } from './SessionActivity';
+import { sessionRowStatus } from '../services/sessionStatus';
 import type { SessionPreviewDetails } from './SessionPreviewCard';
 
 const COLLAPSED_ROW_COUNT = 5;
@@ -57,15 +57,6 @@ const bySessionPriority = (a: FactoryWorkspaceRow, b: FactoryWorkspaceRow) =>
   watchRank(a) - watchRank(b) ||
   b.createdAt.localeCompare(a.createdAt) ||
   b.workspace.sessionId.localeCompare(a.workspace.sessionId);
-
-function workspaceStatus(row: FactoryWorkspaceRow): SessionRowStatus | undefined {
-  // An active thread means work is happening even if the workspace record has
-  // not yet been stamped materialized — surface the more informative state.
-  if (row.running) return 'working';
-  if (row.initializing) return 'initializing';
-  if (row.attention) return 'ready';
-  return undefined;
-}
 
 export function WorkspacesSection() {
   const { factoryId, sessionId } = useParams<{ factoryId: string; sessionId: string }>();
@@ -324,7 +315,7 @@ function WorkspaceGroup({
             active={row.active}
             disabled={pending}
             merged={mergedByPath[row.workspace.sessionId] ?? row.knownMerged}
-            status={workspaceStatus(row)}
+            status={sessionRowStatus(row)}
             pinned={row.pinned}
             preview={{
               kind,

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
@@ -58,6 +58,14 @@
   --belt-hue: var(--accent3);
 }
 
+/* Bound but with nothing to report: every amplitude at zero, muted. */
+.session-idle {
+  --belt-pitch: 0px;
+  --belt-jam: 0;
+  --belt-sway: 0;
+  --belt-hue: var(--neutral3);
+}
+
 .session-belt {
   --belt-beat: 1.4s;
 
@@ -309,6 +317,16 @@
   50% {
     transform: scale(1.04);
   }
+}
+
+/* The ring parks in the rest pose without the wave. */
+.session-idle.session-pentad {
+  opacity: 0.55;
+}
+
+.session-idle.session-pentad circle {
+  animation: none;
+  transform: scale(0.8);
 }
 
 /* Ready has no travel to begin with, so it and working collapse to the same

--- a/mastracode/factory-ui/src/ui/domains/workspaces/services/sessionStatus.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/services/sessionStatus.ts
@@ -1,0 +1,18 @@
+import type { SessionRowStatus } from '../components/SessionActivity';
+
+/**
+ * The one precedence every session surface reads: an active run means work is
+ * happening even before the workspace record is stamped materialized, and an
+ * attention mark only speaks once nothing louder does. `undefined` is a session
+ * with nothing to report — rows hide their belt, cards fall back to `idle`.
+ */
+export function sessionRowStatus(input: {
+  running: boolean;
+  initializing: boolean;
+  attention: boolean;
+}): SessionRowStatus | undefined {
+  if (input.running) return 'working';
+  if (input.initializing) return 'initializing';
+  if (input.attention) return 'ready';
+  return undefined;
+}

--- a/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
@@ -29,6 +29,7 @@ import { useBoardDeepLink } from '../domains/factory/hooks/useBoardDeepLink';
 import { useBoardDecisions } from '../domains/factory/hooks/useBoardDecisions';
 import { useBoardIntake } from '../domains/factory/hooks/useBoardIntake';
 import { useBoardItems } from '../domains/factory/hooks/useBoardItems';
+import { useItemSessionStatuses } from '../domains/factory/hooks/useItemSessionStatuses';
 import { useBoardRuns } from '../domains/factory/hooks/useBoardRuns';
 import { isTerminalStage } from '../domains/factory/stages';
 import {
@@ -135,6 +136,10 @@ function BoardContent({
     refetchItems: items.refetch,
   });
   const relatedItemsFor = relatedWorkItemIndex(items.all);
+  const sessionStatuses = useItemSessionStatuses({
+    projectRepositoryId: repository.projectRepositoryId,
+    items: items.all,
+  });
   const decisions = useBoardDecisions(factoryProjectId);
   const composer = useBoardComposer(factoryProjectId);
   const activityProfileActorIds = [...new Set(items.all.flatMap(workItemHumanActorIds))];
@@ -401,6 +406,7 @@ function BoardContent({
                           columnStage={stage.id}
                           relatedItems={relatedItemsFor(item)}
                           projectRepositoryId={repository.projectRepositoryId}
+                          sessionStatus={sessionStatuses.get(item.id)}
                           activityPage={activityPage}
                           runDisabled={runs.disabled}
                           preparing={runs.preparingFor(item.id)}

--- a/mastracode/factory-ui/src/ui/pages/MarkerPreviewPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/MarkerPreviewPage.tsx
@@ -12,12 +12,12 @@ import type { ReactNode } from 'react';
 import { CardLabels } from '../domains/factory/components/BoardCardParts';
 import { SourceIcon } from '../domains/factory/components/BoardIcons';
 import { SessionActivityPentad } from '../domains/workspaces/components/SessionActivity';
-import type { SessionRowStatus } from '../domains/workspaces/components/SessionActivity';
+import type { SessionCardStatus, SessionRowStatus } from '../domains/workspaces/components/SessionActivity';
 import { SessionNavRow } from '../domains/workspaces/components/SessionNavRow';
 import type { SessionPreviewDetails } from '../domains/workspaces/components/SessionPreviewCard';
 
 interface MockItem {
-  status?: SessionRowStatus;
+  status?: SessionCardStatus;
   meta: string;
   title: string;
   labels: string[];
@@ -49,6 +49,14 @@ const CARDS: MockItem[] = [
     labels: ['linear', 'docs'],
     comments: 1,
     owner: 'Schneider Damien',
+  },
+  {
+    status: 'idle',
+    meta: '#22501 · daneatmastra · 5d',
+    title: 'Session bound, agent resting',
+    labels: ['factory'],
+    comments: 0,
+    owner: 'daneatmastra',
   },
   {
     meta: '#22488 · daneatmastra · 6d',


### PR DESCRIPTION
**─────── TLDR ───────**
> Board cards read the same session status as the sidebar — one resolver, one board-level poll — instead of a private two-state guess.

A card derived its status alone: bound meant "ready", a run on the newest-bound session meant "working". The sidebar rows resolved running, initializing and attention from the shared poll and the workspace record. Same session, two stories. `sessionRowStatus` is now the one precedence every surface reads: working beats initializing beats ready, and nothing to report is its own state.

### Behavior changed

a card whose workspace is still cloning
&nbsp;&nbsp;├─ **was** — "ready", as if the session had finished
&nbsp;&nbsp;└─ **now** — the amber initializing marker, same as its sidebar row

a card with several role sessions where an older one runs
&nbsp;&nbsp;├─ **was** — nothing; only the newest-bound ref was watched
&nbsp;&nbsp;└─ **now** — working while any of its bound sessions runs

a card bound to a session with nothing happening
&nbsp;&nbsp;├─ **was** — "ready", indistinguishable from "your turn"
&nbsp;&nbsp;└─ **now** — rests muted (`idle`); `ready` is reserved for a finished run awaiting its reader

a run finishes on a card nobody is watching
&nbsp;&nbsp;├─ **was** — the card never changed
&nbsp;&nbsp;└─ **now** — it walks working → ready, the same mark the sidebar row shows

### Shape changed

| | | |
|---|---|---|
| **+** | `sessionRowStatus(input)` | the one precedence, 10 lines, no hooks |
| **+** | `useItemSessionStatuses` | resolves every card once at board level |
| **−** | `workspaceStatus` / `userSessionStatus` | two private copies of the same precedence |
| **−** | per-card `useActiveRunResources` | cards no longer subscribe to the poll individually |
| **+** | `SessionCardStatus` | `SessionRowStatus \| 'idle'` — cards only; rows hide their belt instead |

what the board now hands each card
&nbsp;&nbsp;&nbsp;&nbsp;`WorkItemCard.sessionStatus?: SessionCardStatus` · `WorkItemDetailsPanel.sessionStatus`

### Decisions

- **`idle` is a fourth card state rather than a reuse of `ready`** — `ready` keeps one meaning everywhere; delete the union member if you want the old look back

---

> ██████████████████ **source** `+111 −42`
> ████████████ **tests** `+75`
> ██ **bench page** `+10`
> █ **changeset** `+5`
