### PR TITLE
fix(factory): one session status truth for board cards and sidebar rows

### DIFF
--- a/.changeset/session-status-ssot.md
+++ b/.changeset/session-status-ssot.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Board cards now read the same session status as the sidebar rows. A card used to show one static dot for any bound session, whatever the session was doing; it now resolves running, initializing and attention through the same precedence the sidebar uses, so a cloning workspace shows initializing, a run in flight shows working on any bound role session, and a finished run nobody opened holds the same "your turn" mark as its row.

--- a/.changeset/session-status-ssot.md
+++ b/.changeset/session-status-ssot.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Board cards now read the same session status as the sidebar rows. A card used to show one static dot for any bound session, whatever the session was doing; it now resolves running, initializing and attention through the same precedence the sidebar uses, so a cloning workspace shows initializing, a run in flight shows working on any bound role session, and a finished run nobody opened holds the same "your turn" mark as its row.
+Factory board cards now show live session status: idle, initializing, working, and ready. Cards and sidebar rows read the same status, so they always agree. A cloning workspace shows initializing, a running session shows working, and a finished run waiting for you shows ready.

--- a/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
@@ -12,7 +12,9 @@ import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../e2e/ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '../../../e2e/ui/render';
+import { queryKeys } from '../../api/keys';
 import { createQueryClient } from '../../query-client';
+import { AGENT_CONTROLLER_ID } from '../domains/chat/services/constants';
 import { createAppRoutes } from '../router';
 
 const FACTORY_ID = 'fp-1';
@@ -166,10 +168,82 @@ describe('Board card session liveness', () => {
     renderWorkBoard();
 
     const card = await screen.findByTestId('work-item-card');
-    await waitFor(() => expect(card.querySelector('[data-live-session-indicator]')).not.toBeNull());
+    // Bound but idle: the dot rests muted — `ready` is reserved for a finished
+    // run awaiting its reader, same as the sidebar rows.
+    await waitFor(() => expect(card.querySelector('[data-live-session-indicator="idle"]')).not.toBeNull());
 
     await user.click(screen.getByRole('button', { name: 'Details for Fix login bug' }));
     expect(await screen.findByRole('link', { name: 'Open session' })).toBeInTheDocument();
+  });
+
+  it('shows the initializing dot while a bound session is still materializing', async () => {
+    stubFactoryWithBoundSession();
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+        HttpResponse.json({ sessions: [{ ...boundSession, materializedAt: null }] }),
+      ),
+    );
+    renderWorkBoard();
+
+    const card = await screen.findByTestId('work-item-card');
+    await waitFor(() => expect(card.querySelector('[data-live-session-indicator="initializing"]')).not.toBeNull());
+  });
+
+  it('lights the working dot when any bound session runs, not just the newest ref', async () => {
+    // Each role keeps its own session; a role re-run rewrites an existing key,
+    // so the running session is not necessarily the last ref on the item.
+    stubFactoryWithBoundSession();
+    const reviewSession = {
+      sessionId: 'session-2',
+      branch: 'factory/issue-1',
+      threadId: 'session-2',
+      startedBy: 'user-1',
+    };
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items`, () =>
+        HttpResponse.json({
+          workItems: [{ ...workItem, sessions: { ...workItemSessions, review: reviewSession } }],
+        }),
+      ),
+      http.get('*/api/agent-controller/:controllerId/active-runs', () =>
+        HttpResponse.json({ runs: [{ runId: 'run-1', resourceId: SESSION_ID, threadId: SESSION_ID }] }),
+      ),
+    );
+    renderWorkBoard();
+
+    const card = await screen.findByTestId('work-item-card');
+    await waitFor(() => expect(card.querySelector('[data-live-session-indicator="working"]')).not.toBeNull());
+  });
+
+  it('walks idle → working → ready as a run starts and finishes unseen', async () => {
+    stubFactoryWithBoundSession();
+    const active = new Set<string>();
+    server.use(
+      // Ungated sessions list: the attention pass refetches it on run end.
+      http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+        HttpResponse.json({ sessions: [boundSession] }),
+      ),
+      http.get('*/api/agent-controller/:controllerId/active-runs', () =>
+        HttpResponse.json({
+          runs: [...active].map(resourceId => ({ runId: `run-${resourceId}`, resourceId, threadId: resourceId })),
+        }),
+      ),
+    );
+    const { client } = renderWorkBoard();
+    const activityKey = queryKeys.agentControllerActivity(AGENT_CONTROLLER_ID, TEST_BASE_URL);
+
+    const card = await screen.findByTestId('work-item-card');
+    await waitFor(() => expect(card.querySelector('[data-live-session-indicator="idle"]')).not.toBeNull());
+
+    active.add(SESSION_ID);
+    await client.invalidateQueries({ queryKey: activityKey });
+    await waitFor(() => expect(card.querySelector('[data-live-session-indicator="working"]')).not.toBeNull());
+
+    active.delete(SESSION_ID);
+    await client.invalidateQueries({ queryKey: activityKey });
+    // The finish was never opened, so the card holds the same "your turn" mark
+    // the sidebar row shows, instead of sliding silently back to idle.
+    await waitFor(() => expect(card.querySelector('[data-live-session-indicator="ready"]')).not.toBeNull());
   });
 
   it('drops the session indicator as soon as its session is deleted from the sidebar', async () => {

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardCardParts.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardCardParts.tsx
@@ -24,7 +24,8 @@ export function SessionLivenessDot({ status, className }: { status: SessionCardS
   return (
     <span
       data-live-session-indicator={status}
-      aria-hidden
+      role="status"
+      aria-label={dot.title}
       title={dot.title}
       className={cn('size-2 shrink-0 rounded-full', dot.className, className)}
     />

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardCardParts.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardCardParts.tsx
@@ -8,6 +8,28 @@ import type { ReactElement, ReactNode } from 'react';
 import type { BoardCardStatus } from '../boardCardStatus';
 import { HIDDEN_CARD_LABELS, SOURCE_LABELS } from '../boardItems';
 import type { WorkItemSource } from '../services/workItems';
+import type { SessionCardStatus } from '../../workspaces/services/sessionStatus';
+
+// Same palette as the sidebar's SessionRowIndicator, so both surfaces read alike.
+const SESSION_DOT: Record<SessionCardStatus, { className: string; title: string }> = {
+  idle: { className: 'bg-accent1', title: 'Session bound' },
+  initializing: { className: 'bg-warning1 animate-pulse', title: 'Initializing' },
+  working: { className: 'bg-positive1 animate-pulse', title: 'Working' },
+  ready: { className: 'bg-accent3', title: 'Ready' },
+};
+
+/** The card's session marker; carries its status on the data attribute. */
+export function SessionLivenessDot({ status, className }: { status: SessionCardStatus; className?: string }) {
+  const dot = SESSION_DOT[status];
+  return (
+    <span
+      data-live-session-indicator={status}
+      aria-hidden
+      title={dot.title}
+      className={cn('size-2 shrink-0 rounded-full', dot.className, className)}
+    />
+  );
+}
 
 export function SourceTitle({ source, title }: { source: WorkItemSource; title: string }) {
   return (

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -23,12 +23,14 @@ import { relationshipPath } from '../services/relationships';
 import type { WorkItem } from '../services/workItems';
 import type { BoardStageId } from '../stages';
 import { workItemActivity } from '../workItemActivity';
+import type { SessionCardStatus } from '../../workspaces/services/sessionStatus';
 import {
   CardDetailsHint,
   CardLabels,
   CardStatus,
   CardTitleTooltip,
   REVEAL_ON_CARD_HOVER,
+  SessionLivenessDot,
   SourceTitle,
 } from './BoardCardParts';
 import { SourceIcon } from './BoardIcons';
@@ -60,6 +62,7 @@ export function WorkItemCard({
   onDismissProposal,
   onRetryDecision,
   pendingRunRoles,
+  sessionStatus = 'idle',
   onCreateSession,
   onStartRun,
   onRestartRun,
@@ -93,6 +96,8 @@ export function WorkItemCard({
   onDismissProposal: (decisionId: string) => void;
   onRetryDecision: (decisionId: string) => void;
   pendingRunRoles: ReadonlyMap<string, FactoryRunPhase | undefined>;
+  /** Live status of the card's bound sessions, resolved once for the whole board. */
+  sessionStatus?: SessionCardStatus;
   /** Detail-panel fallback when the item has no run spec: open an empty session (no run). */
   onCreateSession: (spec: { branch: string; threadTitle: string }) => void;
   onStartRun: (spec: ItemRunSpec, action: RunAction, options?: { preapprovePlans?: boolean }) => void;
@@ -297,9 +302,7 @@ export function WorkItemCard({
           <div className="flex min-w-0 flex-col gap-1.5">
             <div className="flex min-w-0 items-center gap-1.5 pr-8">
               <span className="text-ui-xs text-icon2 min-w-0 truncate">{workItemMeta(item)}</span>
-              {threadSession !== undefined && (
-                <span data-live-session-indicator aria-hidden className="bg-accent1 size-2 shrink-0 rounded-full" />
-              )}
+              {threadSession !== undefined && <SessionLivenessDot status={sessionStatus} />}
               {relatedItems.map(relatedLink)}
               {item.commentCount > 0 && (
                 <span
@@ -374,6 +377,7 @@ export function WorkItemCard({
         morph={morph}
         relatedLinks={relatedItems.map(relatedLink)}
         threadSession={threadSession}
+        sessionStatus={sessionStatus}
         status={status}
         retryingDecisionId={retryingDecisionId}
         onRetryDecision={onRetryDecision}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemDetailsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemDetailsPanel.tsx
@@ -14,10 +14,11 @@ import type { CardPrimaryAction } from '../cardPrimaryAction';
 import type { CardMorph } from '../hooks/useCardMorph';
 import type { AuditEventPage } from '../services/audit';
 import type { WorkItem, WorkItemSessionRef } from '../services/workItems';
+import type { SessionCardStatus } from '../../workspaces/services/sessionStatus';
 import type { BoardStageId } from '../stages';
 import { workItemActivity } from '../workItemActivity';
 import { CardSourceDescription } from './BoardCardDetails';
-import { CardLabels, CardStatus } from './BoardCardParts';
+import { CardLabels, CardStatus, SessionLivenessDot } from './BoardCardParts';
 import { SourceIcon } from './BoardIcons';
 import { CardDetailsBody, CardDetailsPanel } from './CardDetailsPanel';
 import { CommentsSection } from './feed/CommentsSection';
@@ -33,6 +34,7 @@ export function WorkItemDetailsPanel({
   morph,
   relatedLinks,
   threadSession,
+  sessionStatus,
   status,
   retryingDecisionId,
   onRetryDecision,
@@ -48,6 +50,7 @@ export function WorkItemDetailsPanel({
   morph: CardMorph;
   relatedLinks: ReactNode;
   threadSession?: WorkItemSessionRef;
+  sessionStatus: SessionCardStatus;
   status: BoardCardStatus;
   retryingDecisionId?: string;
   onRetryDecision: (decisionId: string) => void;
@@ -80,7 +83,7 @@ export function WorkItemDetailsPanel({
           <div className="flex min-w-0 items-center gap-1.5">
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
               <span className="text-ui-xs text-icon2 min-w-0 truncate">{workItemMeta(item)}</span>
-              {threadSession !== undefined && <span aria-hidden className="bg-accent1 size-2 shrink-0 rounded-full" />}
+              {threadSession !== undefined && <SessionLivenessDot status={sessionStatus} />}
               {relatedLinks}
             </div>
             {item.url !== null && (

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useItemSessionStatuses.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useItemSessionStatuses.ts
@@ -1,0 +1,46 @@
+import { useActiveRunResources } from '../../../../hooks/useActiveRunResources';
+import { useWorkspaceAttentionState } from '../../../../hooks/useWorkspaceAttention';
+import { useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
+import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
+import { sessionRowStatus } from '../../workspaces/services/sessionStatus';
+import type { SessionCardStatus } from '../../workspaces/services/sessionStatus';
+import type { WorkItem } from '../services/workItems';
+
+/**
+ * Live status per board card, from the same inputs the sidebar rows read: the
+ * shared controller poll, the workspace records, and the attention marks. One
+ * resolution for the whole board — cards render what they are handed.
+ */
+export function useItemSessionStatuses({
+  projectRepositoryId,
+  items,
+}: {
+  projectRepositoryId: string;
+  items: readonly WorkItem[];
+}): ReadonlyMap<string, SessionCardStatus> {
+  const boundSessionIds = items.flatMap(item => Object.values(item.sessions).map(ref => ref.sessionId));
+  const runningBySessionId = useActiveRunResources({
+    agentControllerId: AGENT_CONTROLLER_ID,
+    resourceIds: boundSessionIds,
+  });
+  const workspaces = useWorkspacesQuery(projectRepositoryId);
+  const { attentionByPath } = useWorkspaceAttentionState({ projectRepositoryId, sessionKind: 'factory' });
+  const materializingSessionIds = new Set(
+    [...(workspaces.data?.workspaces ?? []), ...(workspaces.data?.userSessions ?? [])]
+      .filter(session => !session.materializedAt)
+      .map(session => session.sessionId),
+  );
+
+  const statuses = new Map<string, SessionCardStatus>();
+  for (const item of items) {
+    const refs = Object.values(item.sessions);
+    if (refs.length === 0) continue;
+    const status = sessionRowStatus({
+      running: refs.some(ref => runningBySessionId[ref.sessionId] === true),
+      initializing: refs.some(ref => materializingSessionIds.has(ref.sessionId)),
+      attention: refs.some(ref => attentionByPath[ref.sessionId] === true),
+    });
+    statuses.set(item.id, status ?? 'idle');
+  }
+  return statuses;
+}

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useItemSessionStatuses.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useItemSessionStatuses.ts
@@ -18,7 +18,7 @@ export function useItemSessionStatuses({
   projectRepositoryId: string;
   items: readonly WorkItem[];
 }): ReadonlyMap<string, SessionCardStatus> {
-  const boundSessionIds = items.flatMap(item => Object.values(item.sessions).map(ref => ref.sessionId));
+  const boundSessionIds = items.flatMap(item => Object.values(item.sessions ?? {}).map(ref => ref.sessionId));
   const runningBySessionId = useActiveRunResources({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceIds: boundSessionIds,
@@ -33,7 +33,7 @@ export function useItemSessionStatuses({
 
   const statuses = new Map<string, SessionCardStatus>();
   for (const item of items) {
-    const refs = Object.values(item.sessions);
+    const refs = Object.values(item.sessions ?? {});
     if (refs.length === 0) continue;
     const status = sessionRowStatus({
       running: refs.some(ref => runningBySessionId[ref.sessionId] === true),

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -22,22 +22,7 @@ import { deleteUserSession, regenerateSessionTitle } from '../services/user-sess
 import type { FactoryUserSession } from '../services/user-sessions';
 import { getSessionOwnerDetails, getUserSessionLabel } from '../services/sessionPresentation';
 import { SessionNavRow } from './SessionNavRow';
-import type { SessionRowStatus } from './SessionNavRow';
-
-function userSessionStatus({
-  session,
-  running,
-  attention,
-}: {
-  session: FactoryUserSession;
-  running: boolean;
-  attention: boolean;
-}): SessionRowStatus | undefined {
-  if (running) return 'working';
-  if (!session.materializedAt) return 'initializing';
-  if (attention) return 'ready';
-  return undefined;
-}
+import { sessionRowStatus } from '../services/sessionStatus';
 
 export function UserSessionsSection() {
   const { baseUrl } = useApiConfig();
@@ -145,9 +130,9 @@ export function UserSessionsSection() {
             const url = `/factories/${factoryId}/user/threads/${session.sessionId}`;
             const active = location.pathname === url;
 
-            const status = userSessionStatus({
-              session,
+            const status = sessionRowStatus({
               running: runningBySessionId[session.sessionId] === true,
+              initializing: !session.materializedAt,
               attention: attentionBySessionId[session.sessionId] === true,
             });
             return (

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -24,7 +24,7 @@ import type { FactoryUserSession } from '../services/user-sessions';
 import { getFactorySessionKind, getSessionOwnerDetails } from '../services/sessionPresentation';
 import type { SessionViewerProfile } from '../services/sessionPresentation';
 import { SessionNavRow } from './SessionNavRow';
-import type { SessionRowStatus } from './SessionNavRow';
+import { sessionRowStatus } from '../services/sessionStatus';
 import type { SessionPreviewDetails } from './SessionPreviewCard';
 
 const COLLAPSED_ROW_COUNT = 5;
@@ -57,15 +57,6 @@ const bySessionPriority = (a: FactoryWorkspaceRow, b: FactoryWorkspaceRow) =>
   watchRank(a) - watchRank(b) ||
   b.createdAt.localeCompare(a.createdAt) ||
   b.workspace.sessionId.localeCompare(a.workspace.sessionId);
-
-function workspaceStatus(row: FactoryWorkspaceRow): SessionRowStatus | undefined {
-  // An active thread means work is happening even if the workspace record has
-  // not yet been stamped materialized — surface the more informative state.
-  if (row.running) return 'working';
-  if (row.initializing) return 'initializing';
-  if (row.attention) return 'ready';
-  return undefined;
-}
 
 export function WorkspacesSection() {
   const { factoryId, sessionId } = useParams<{ factoryId: string; sessionId: string }>();
@@ -324,7 +315,7 @@ function WorkspaceGroup({
             active={row.active}
             disabled={pending}
             merged={mergedByPath[row.workspace.sessionId] ?? row.knownMerged}
-            status={workspaceStatus(row)}
+            status={sessionRowStatus(row)}
             pinned={row.pinned}
             preview={{
               kind,

--- a/mastracode/factory-ui/src/ui/domains/workspaces/services/sessionStatus.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/services/sessionStatus.ts
@@ -1,0 +1,24 @@
+import type { SessionRowStatus } from '../components/SessionNavRow';
+
+/**
+ * A board card also has to say "bound but nothing to report". Rows hide their
+ * dot instead, so `ready` keeps one meaning everywhere — it is your turn.
+ */
+export type SessionCardStatus = SessionRowStatus | 'idle';
+
+/**
+ * The one precedence every session surface reads: an active run means work is
+ * happening even before the workspace record is stamped materialized, and an
+ * attention mark only speaks once nothing louder does. `undefined` is a session
+ * with nothing to report — rows hide their dot, cards fall back to `idle`.
+ */
+export function sessionRowStatus(input: {
+  running: boolean;
+  initializing: boolean;
+  attention: boolean;
+}): SessionRowStatus | undefined {
+  if (input.running) return 'working';
+  if (input.initializing) return 'initializing';
+  if (input.attention) return 'ready';
+  return undefined;
+}

--- a/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
+++ b/mastracode/factory-ui/src/ui/pages/BoardPage.tsx
@@ -28,6 +28,7 @@ import { useBoardComposer } from '../domains/factory/hooks/useBoardComposer';
 import { useBoardDeepLink } from '../domains/factory/hooks/useBoardDeepLink';
 import { useBoardDecisions } from '../domains/factory/hooks/useBoardDecisions';
 import { useBoardIntake } from '../domains/factory/hooks/useBoardIntake';
+import { useItemSessionStatuses } from '../domains/factory/hooks/useItemSessionStatuses';
 import { useBoardItems } from '../domains/factory/hooks/useBoardItems';
 import { useBoardRuns } from '../domains/factory/hooks/useBoardRuns';
 import { isTerminalStage } from '../domains/factory/stages';
@@ -135,6 +136,10 @@ function BoardContent({
     refetchItems: items.refetch,
   });
   const relatedItemsFor = relatedWorkItemIndex(items.all);
+  const sessionStatuses = useItemSessionStatuses({
+    projectRepositoryId: repository.projectRepositoryId,
+    items: items.all,
+  });
   const decisions = useBoardDecisions(factoryProjectId);
   const composer = useBoardComposer(factoryProjectId);
   const activityProfileActorIds = [...new Set(items.all.flatMap(workItemHumanActorIds))];
@@ -400,6 +405,7 @@ function BoardContent({
                           highlighted={targetItemId === item.id}
                           columnStage={stage.id}
                           relatedItems={relatedItemsFor(item)}
+                          sessionStatus={sessionStatuses.get(item.id)}
                           projectRepositoryId={repository.projectRepositoryId}
                           activityPage={activityPage}
                           runDisabled={runs.disabled}


### PR DESCRIPTION
**─────── TLDR ───────**
> Board cards read the same session status as the sidebar rows — one resolver, one board-level poll — instead of one static dot for any bound session.

A card showed the same muted dot whether its session was cloning, running, or finished and waiting for you. The sidebar rows resolved running, initializing and attention — each section with its own private copy of the precedence. `sessionRowStatus` is now the one precedence every surface reads: working beats initializing beats ready, and nothing to report is its own state.

Supersedes #22745, rebuilt directly on `main` so it does not ride the marker redesign (#22744).

### Behavior changed

a card whose workspace is still cloning
&nbsp;&nbsp;├─ **was** — the same static dot as a finished session
&nbsp;&nbsp;└─ **now** — the amber initializing pulse, same as its sidebar row

a run in flight on any of the card's bound sessions
&nbsp;&nbsp;├─ **was** — nothing moved on the card
&nbsp;&nbsp;└─ **now** — the green working pulse, whichever role session runs

a run finishes on a card nobody is watching
&nbsp;&nbsp;├─ **was** — still the same dot
&nbsp;&nbsp;└─ **now** — it walks working → ready, the same mark the sidebar row shows

a card bound to a session with nothing to report
&nbsp;&nbsp;└─ **unchanged** — today's muted dot, now the explicit `idle` state

### Shape changed

| | | |
|---|---|---|
| **+** | `sessionRowStatus(input)` | the one precedence, 10 lines, no hooks |
| **+** | `useItemSessionStatuses` | resolves every card once at board level |
| **+** | `SessionLivenessDot` | the card dot; status rides `data-live-session-indicator` |
| **+** | `SessionCardStatus` | `SessionRowStatus \| 'idle'` — cards only; rows hide their dot |
| **−** | `workspaceStatus` / `userSessionStatus` | two private copies of the same precedence |

what the board now hands each card
&nbsp;&nbsp;&nbsp;&nbsp;`WorkItemCard.sessionStatus?: SessionCardStatus` · `WorkItemDetailsPanel.sessionStatus`

### Decisions

- **`idle` is a fourth card state rather than a reuse of `ready`** — `ready` keeps one meaning everywhere; delete the union member if you want the old look back
- **status rides the existing `data-live-session-indicator` attribute** — the coming marker redesign restyles the dot without touching this resolution

---

> ██████████████████ **source** `+115 −34`
> ████████████ **tests** `+75 −1`
> █ **changeset** `+5`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Board cards and sidebar rows now show the same session status. Users can see when a session is starting, working, ready for attention, or idle.

## Changes

- Added shared `sessionRowStatus` logic with consistent precedence: `working` → `initializing` → `ready`.
- Added `useItemSessionStatuses` to resolve status across all sessions bound to each board card.
- Added `SessionLivenessDot` with status-specific colors, tooltips, and `data-live-session-indicator` values.
- Updated `WorkItemCard` and `WorkItemDetailsPanel` to display live session status.
- Replaced separate workspace and user-session status logic with the shared resolver.
- Added accessibility exposure for card session status.
- Handled cards with missing session references.
- Added board-card liveness tests for idle, initializing, working, and ready states.
- Added a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->