### PR TITLE
fix(factory): dismiss session attention on the route, whatever door opened it

### DIFF
--- a/.changeset/session-attention-dismiss.md
+++ b/.changeset/session-attention-dismiss.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the "ready — your turn" mark only going away when a session was opened from the sidebar. Opening the same thread through a board card, a deep link, or the attention inbox left the mark lit, and a run finishing in the very thread being read marked it as needing attention. Landing on a session's route — through any door — now dismisses its mark, and the open session never gets marked at all. The completion sound still plays for it, so a backgrounded tab still calls you back.

--- a/mastracode/factory-ui/src/hooks/__tests__/useWorkspaceAttention.msw.test.tsx
+++ b/mastracode/factory-ui/src/hooks/__tests__/useWorkspaceAttention.msw.test.tsx
@@ -24,6 +24,7 @@ function useActivityAttention({ workspaceIds }: { workspaceIds: string[] }) {
       sessionKind: 'factory',
       runningByPath,
       ready: true,
+      openPath: undefined,
     }),
   };
 }

--- a/mastracode/factory-ui/src/hooks/useWorkspaceAttention.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkspaceAttention.ts
@@ -1,4 +1,4 @@
-import { type QueryClient, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useEffectEvent } from 'react';
 
 import { queryKeys } from '../api/keys';
@@ -17,6 +17,11 @@ interface WorkspaceAttentionScope {
 interface WorkspaceAttentionOptions extends WorkspaceAttentionScope {
   runningByPath: Record<string, boolean>;
   ready: boolean;
+  /**
+   * Session the viewer has open: it never advertises attention — the reader is
+   * already there. Its done sound still plays, calling back a backgrounded tab.
+   */
+  openPath: string | undefined;
   onRunsFinished?: () => void;
 }
 
@@ -24,18 +29,6 @@ function recordsMatch(a: Record<string, boolean>, b: Record<string, boolean>): b
   const aEntries = Object.entries(a);
   if (aEntries.length !== Object.keys(b).length) return false;
   return aEntries.every(([path, running]) => b[path] === running);
-}
-
-function clearWorkspaceAttention(queryClient: QueryClient, scope: WorkspaceAttentionScope, path: string) {
-  queryClient.setQueryData<WorkspaceAttentionState>(
-    queryKeys.workspaceAttention(scope.projectRepositoryId, scope.sessionKind),
-    current => {
-      if (!current?.attentionByPath[path]) return current;
-      const attentionByPath = { ...current.attentionByPath };
-      delete attentionByPath[path];
-      return { ...current, attentionByPath };
-    },
-  );
 }
 
 function useWorkspaceAttentionCache({ projectRepositoryId, sessionKind }: WorkspaceAttentionScope) {
@@ -47,14 +40,12 @@ function useWorkspaceAttentionCache({ projectRepositoryId, sessionKind }: Worksp
     enabled: false,
     initialData: () => ({ runningByPath: {}, attentionByPath: {} }),
   });
-  const clearAttention = (path: string) =>
-    clearWorkspaceAttention(queryClient, { projectRepositoryId, sessionKind }, path);
-  return { queryClient, data, clearAttention };
+  return { queryClient, data };
 }
 
 export function useWorkspaceAttentionState(scope: WorkspaceAttentionScope) {
-  const { data, clearAttention } = useWorkspaceAttentionCache(scope);
-  return { attentionByPath: data.attentionByPath, clearAttention };
+  const { data } = useWorkspaceAttentionCache(scope);
+  return { attentionByPath: data.attentionByPath };
 }
 
 export function useWorkspaceAttention({
@@ -62,12 +53,12 @@ export function useWorkspaceAttention({
   sessionKind,
   runningByPath,
   ready,
+  openPath,
   onRunsFinished,
 }: WorkspaceAttentionOptions): {
   attentionByPath: Record<string, true>;
-  clearAttention: (path: string) => void;
 } {
-  const { queryClient, data, clearAttention } = useWorkspaceAttentionCache({
+  const { queryClient, data } = useWorkspaceAttentionCache({
     projectRepositoryId,
     sessionKind,
   });
@@ -84,12 +75,12 @@ export function useWorkspaceAttention({
     const finished: string[] = [];
 
     for (const path of Object.keys(attentionByPath)) {
-      if (!(path in runningByPath)) delete attentionByPath[path];
+      if (!(path in runningByPath) || path === openPath) delete attentionByPath[path];
     }
     for (const [path, running] of Object.entries(runningByPath)) {
       if (running) delete attentionByPath[path];
       else if (current.runningByPath[path] === true) {
-        attentionByPath[path] = true;
+        if (path !== openPath) attentionByPath[path] = true;
         finished.push(path);
       }
     }
@@ -104,7 +95,7 @@ export function useWorkspaceAttention({
       playDoneSound();
       runsFinished();
     }
-  }, [projectRepositoryId, queryClient, ready, runningByPath, sessionKind]);
+  }, [openPath, projectRepositoryId, queryClient, ready, runningByPath, sessionKind]);
 
-  return { attentionByPath: data.attentionByPath, clearAttention };
+  return { attentionByPath: data.attentionByPath };
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -51,7 +51,7 @@ export function UserSessionsSection() {
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceIds: sessions.map(session => session.sessionId),
   });
-  const { attentionByPath: attentionBySessionId, clearAttention } = useWorkspaceAttentionState({
+  const { attentionByPath: attentionBySessionId } = useWorkspaceAttentionState({
     projectRepositoryId: repository?.projectRepositoryId,
     sessionKind: 'user',
   });
@@ -151,10 +151,7 @@ export function UserSessionsSection() {
                 disabled={pending}
                 status={status}
                 pinned={pinnedSessions.has(session.sessionId)}
-                onSelect={() => {
-                  clearAttention(session.sessionId);
-                  void navigate(url);
-                }}
+                onSelect={() => void navigate(url)}
                 onPinChange={pinned => setPinned(session.sessionId, pinned)}
                 // The DELETE route is owner-only and 404s for non-owners, which
                 // deleteUserSession treats as an idempotent success; offering

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspaceAttentionObserver.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspaceAttentionObserver.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
+import { useMatch } from 'react-router';
 
 import { queryKeys } from '../../../../api/keys';
 import { useActiveRunResources } from '../../../../hooks/useActiveRunResources';
@@ -8,6 +9,12 @@ import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 
 export function WorkspaceAttentionObserver({ projectRepositoryId }: { projectRepositoryId: string | undefined }) {
   const queryClient = useQueryClient();
+  // `useParams` above the thread routes can't see their params, so match them
+  // explicitly. Whatever door opened the session — sidebar row, board card,
+  // deep link — landing on its route is what dismisses its attention mark.
+  const workspaceMatch = useMatch('/factories/:factoryId/workspaces/:sessionId/*');
+  const userThreadMatch = useMatch('/factories/:factoryId/user/threads/:threadId');
+  const openSessionId = workspaceMatch?.params.sessionId ?? userThreadMatch?.params.threadId;
   const sessions = useWorkspacesQuery(projectRepositoryId);
   const factorySessions = sessions.data?.workspaces ?? [];
   const userSessions = sessions.data?.userSessions ?? [];
@@ -29,6 +36,7 @@ export function WorkspaceAttentionObserver({ projectRepositoryId }: { projectRep
     sessionKind: 'factory',
     runningByPath: factoryRunning,
     ready: sessions.isSuccess,
+    openPath: openSessionId,
     onRunsFinished: refreshSessions,
   });
   useWorkspaceAttention({
@@ -36,6 +44,7 @@ export function WorkspaceAttentionObserver({ projectRepositoryId }: { projectRep
     sessionKind: 'user',
     runningByPath: userRunning,
     ready: sessions.isSuccess,
+    openPath: openSessionId,
     onRunsFinished: refreshSessions,
   });
   return null;

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -78,7 +78,7 @@ export function WorkspacesSection() {
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceIds: workspaceIds,
   });
-  const { attentionByPath, clearAttention } = useWorkspaceAttentionState({
+  const { attentionByPath } = useWorkspaceAttentionState({
     projectRepositoryId,
     sessionKind: 'factory',
   });
@@ -164,7 +164,6 @@ export function WorkspacesSection() {
   const pending = deleteWorkspace.isPending;
 
   const openWorkspaceThread = (workspace: FactoryUserSession) => {
-    clearAttention(workspace.sessionId);
     // A workspace's thread id is its own session id (FactoryStartCoordinator
     // seeds the session with threadId = sessionId), so navigate straight there
     // instead of blocking on a session create + thread listing round-trip. The

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceAttentionObserver.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceAttentionObserver.msw.test.tsx
@@ -1,5 +1,7 @@
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
+import { MemoryRouter, useNavigate } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { queryKeys } from '../../../../../api/keys';
@@ -41,6 +43,22 @@ const secondSession: FactoryUserSession = {
   branch: 'factory/pr-24',
 };
 
+const siblingSession: FactoryUserSession = {
+  ...session,
+  id: 'workspace-3',
+  sessionId: 'session-sibling',
+  title: 'Review the loader fix',
+  branch: 'factory/pr-31',
+};
+
+const scratchSession: FactoryUserSession = {
+  ...session,
+  id: 'workspace-4',
+  sessionId: 'session-scratch',
+  title: 'Scratchpad',
+  branch: 'user/scratchpad',
+};
+
 function AttentionProbe() {
   const first = useWorkspaceAttentionState({ projectRepositoryId: REPOSITORY_ID, sessionKind: 'factory' });
   const second = useWorkspaceAttentionState({ projectRepositoryId: SECOND_REPOSITORY_ID, sessionKind: 'factory' });
@@ -49,6 +67,26 @@ function AttentionProbe() {
       <output aria-label="Ready sessions one">{Object.keys(first.attentionByPath).length}</output>
       <output aria-label="Ready sessions two">{Object.keys(second.attentionByPath).length}</output>
     </>
+  );
+}
+
+function AttentionKeysProbe() {
+  const factory = useWorkspaceAttentionState({ projectRepositoryId: REPOSITORY_ID, sessionKind: 'factory' });
+  const user = useWorkspaceAttentionState({ projectRepositoryId: REPOSITORY_ID, sessionKind: 'user' });
+  return (
+    <>
+      <output aria-label="Factory attention">{Object.keys(factory.attentionByPath).join(' ') || 'none'}</output>
+      <output aria-label="User attention">{Object.keys(user.attentionByPath).join(' ') || 'none'}</output>
+    </>
+  );
+}
+
+function OpenSessionButton({ to }: { to: string }) {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => void navigate(to)}>
+      Open session
+    </button>
   );
 }
 
@@ -86,15 +124,41 @@ function stubActivity() {
   };
 }
 
+function stubRepositoryActivity(initiallyRunning: string[]) {
+  const running = new Set(initiallyRunning);
+  let sessionsRequests = 0;
+  server.use(
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPOSITORY_ID}/sessions`, () => {
+      sessionsRequests += 1;
+      return HttpResponse.json({ sessions: [session, siblingSession, scratchSession] });
+    }),
+    http.get(`${TEST_BASE_URL}/api/agent-controller/${AGENT_CONTROLLER_ID}/active-runs`, () =>
+      HttpResponse.json({
+        runs: [...running].map(sessionId => ({
+          runId: `run-${sessionId}`,
+          resourceId: sessionId,
+          threadId: sessionId,
+        })),
+      }),
+    ),
+  );
+  return {
+    finishRun: (sessionId: string) => {
+      running.delete(sessionId);
+    },
+    sessionsRequests: () => sessionsRequests,
+  };
+}
+
 describe('WorkspaceAttentionObserver', () => {
   it('keeps Ready state across every linked repository', async () => {
     const activity = stubActivity();
     const { client } = renderWithProviders(
-      <>
+      <MemoryRouter initialEntries={['/factories/factory-1/work']}>
         <WorkspaceAttentionObserver projectRepositoryId={REPOSITORY_ID} />
         <WorkspaceAttentionObserver projectRepositoryId={SECOND_REPOSITORY_ID} />
         <AttentionProbe />
-      </>,
+      </MemoryRouter>,
     );
 
     await waitFor(() => expect(activity.activityRequests()).toBeGreaterThan(0));
@@ -115,10 +179,10 @@ describe('WorkspaceAttentionObserver', () => {
   it('does not derive Ready state from activity when session loading fails', async () => {
     const activity = stubActivity();
     const { client } = renderWithProviders(
-      <>
+      <MemoryRouter initialEntries={['/factories/factory-1/work']}>
         <WorkspaceAttentionObserver projectRepositoryId={REPOSITORY_ID} />
         <AttentionProbe />
-      </>,
+      </MemoryRouter>,
     );
     await waitFor(() => expect(activity.activityRequests()).toBeGreaterThan(0));
     await waitForMutationsIdle(client);
@@ -133,5 +197,81 @@ describe('WorkspaceAttentionObserver', () => {
     await waitForMutationsIdle(client);
 
     expect(screen.getByRole('status', { name: 'Ready sessions one' })).toHaveTextContent('0');
+  });
+
+  it('keeps the open session out of attention while still refreshing when its run finishes', async () => {
+    const activity = stubRepositoryActivity([SESSION_ID, 'session-sibling']);
+    const { client } = renderWithProviders(
+      <MemoryRouter initialEntries={[`/factories/factory-1/workspaces/${SESSION_ID}/threads/${SESSION_ID}`]}>
+        <WorkspaceAttentionObserver projectRepositoryId={REPOSITORY_ID} />
+        <AttentionKeysProbe />
+      </MemoryRouter>,
+    );
+    await waitForMutationsIdle(client);
+    expect(screen.getByRole('status', { name: 'Factory attention' })).toHaveTextContent('none');
+    const sessionsRequestsBefore = activity.sessionsRequests();
+
+    activity.finishRun(SESSION_ID);
+    await client.invalidateQueries({
+      queryKey: queryKeys.agentControllerActivity(AGENT_CONTROLLER_ID, TEST_BASE_URL),
+    });
+    await waitForMutationsIdle(client);
+
+    expect(screen.getByRole('status', { name: 'Factory attention' })).toHaveTextContent('none');
+    expect(activity.sessionsRequests()).toBeGreaterThan(sessionsRequestsBefore);
+
+    activity.finishRun('session-sibling');
+    await client.invalidateQueries({
+      queryKey: queryKeys.agentControllerActivity(AGENT_CONTROLLER_ID, TEST_BASE_URL),
+    });
+    await waitForMutationsIdle(client);
+
+    expect(screen.getByRole('status', { name: 'Factory attention' })).toHaveTextContent('session-sibling');
+  });
+
+  it('dismisses a marked session through whichever door opens its thread', async () => {
+    const activity = stubRepositoryActivity([SESSION_ID]);
+    const user = userEvent.setup();
+    const { client } = renderWithProviders(
+      <MemoryRouter initialEntries={['/factories/factory-1/work']}>
+        <WorkspaceAttentionObserver projectRepositoryId={REPOSITORY_ID} />
+        <AttentionKeysProbe />
+        <OpenSessionButton to={`/factories/factory-1/workspaces/${SESSION_ID}`} />
+      </MemoryRouter>,
+    );
+    await waitForMutationsIdle(client);
+    activity.finishRun(SESSION_ID);
+    await client.invalidateQueries({
+      queryKey: queryKeys.agentControllerActivity(AGENT_CONTROLLER_ID, TEST_BASE_URL),
+    });
+    await waitForMutationsIdle(client);
+    expect(screen.getByRole('status', { name: 'Factory attention' })).toHaveTextContent(SESSION_ID);
+
+    await user.click(screen.getByRole('button', { name: 'Open session' }));
+
+    await waitFor(() => expect(screen.getByRole('status', { name: 'Factory attention' })).toHaveTextContent('none'));
+  });
+
+  it('dismisses a marked user session on its thread route', async () => {
+    const activity = stubRepositoryActivity(['session-scratch']);
+    const user = userEvent.setup();
+    const { client } = renderWithProviders(
+      <MemoryRouter initialEntries={['/factories/factory-1/work']}>
+        <WorkspaceAttentionObserver projectRepositoryId={REPOSITORY_ID} />
+        <AttentionKeysProbe />
+        <OpenSessionButton to="/factories/factory-1/user/threads/session-scratch" />
+      </MemoryRouter>,
+    );
+    await waitForMutationsIdle(client);
+    activity.finishRun('session-scratch');
+    await client.invalidateQueries({
+      queryKey: queryKeys.agentControllerActivity(AGENT_CONTROLLER_ID, TEST_BASE_URL),
+    });
+    await waitForMutationsIdle(client);
+    expect(screen.getByRole('status', { name: 'User attention' })).toHaveTextContent('session-scratch');
+
+    await user.click(screen.getByRole('button', { name: 'Open session' }));
+
+    await waitFor(() => expect(screen.getByRole('status', { name: 'User attention' })).toHaveTextContent('none'));
   });
 });


### PR DESCRIPTION
**─────── TLDR ───────**
> Opening a session dismisses its "your turn" mark whatever door you came through, and the thread you are already reading never gets marked.

Dismissal lived in two sidebar `onSelect` handlers, so a board card link, a deep link or the attention inbox opened the thread and left the mark lit. And a run finishing in the very thread being read marked it as needing you, with the done sound on top. The attention observer now watches the route: the open session's mark is cleared on arrival and never set while you stay.

Stacked on #22748; supersedes #22746.

### Behavior changed

opening a marked session from a board card, deep link, or the attention inbox
&nbsp;&nbsp;├─ **was** — the mark stayed until its sidebar row was clicked
&nbsp;&nbsp;└─ **now** — landing on the session's route dismisses it

a run finishes in the thread being read
&nbsp;&nbsp;├─ **was** — the thread got marked as needing you
&nbsp;&nbsp;└─ **now** — never marked; the done sound still plays, so a backgrounded tab is still called back

clicking a marked session's sidebar row
&nbsp;&nbsp;└─ **unchanged** — dismisses, now through the same route rule instead of its own handler

### Shape changed

| | | |
|---|---|---|
| **+** | `openPath` | option on `useWorkspaceAttention`: the session the viewer has open |
| **−** | `clearAttention` / `clearWorkspaceAttention` | the manual dismissal path, deleted with both call sites |

the observer now reads the route
&nbsp;&nbsp;&nbsp;&nbsp;`useMatch('/factories/:factoryId/workspaces/:sessionId/*')` · `useMatch('/factories/:factoryId/user/threads/:threadId')`

removed: `useWorkspaceAttentionState` no longer returns `clearAttention` — nothing consumed it after the handlers went

### Decisions

- **the done sound survives for the open session** — a backgrounded tab with the thread open still gets called back; one condition away if you disagree

---

> ██████████████████ **tests** `+145 −4`
> ████ **source** `+27 −31` — net −4
> █ **changeset** `+5`
