### PR TITLE
feat(factory): session activity rail and rim

### DIFF
--- a/.changeset/session-activity-markers.md
+++ b/.changeset/session-activity-markers.md
@@ -2,8 +2,6 @@
 '@mastra/factory': patch
 ---
 
-Session lifecycle stops being a coloured dot. A sidebar row now carries an activity rail down its left edge: pills travelling down it while a run is underway — in the setup colour while the sandbox is still coming up — and breathing in place once the session is waiting on you. Board cards read the same thing on the shape they have room for — their own outline. A lit head runs the rim with a long tail behind it while work is in flight, and the whole rim comes up lit under it once the card is waiting on you; a session that is merely bound shows no marker at all, on cards and rows alike.
+Improved how a session says what it is doing. A sidebar row now carries an activity rail down its left edge instead of a dot in its trailing slot: marks travel down the rail while a run is underway, in the setup colour while the sandbox is still starting, and settle into a slow breath once the session is waiting on you. A board card shows the same thing on its own border — a lit head running the outline while work is in flight, the whole outline lit once the card is waiting on you.
 
-The rail and the rim are driven by the same amplitudes — travel, breath, fill — so a session changing state morphs rather than cutting to a different marker. A sandbox finishing its setup is just the colour sliding over; watching a run start and finish reads as one continuous object, where before four dots swapped places and only the colour said which one you were looking at.
-
-Moving lifecycle off the trailing slot frees it: the actions menu no longer displaces the marker on hover, and the merge badge shows on sessions with no lifecycle left to report. Surfaces that already spell the state out in text — the sidebar hover card, the work item panel — are left alone.
+Removed the marker for a session that is merely bound to a card: the card offers an Open session button instead, and the work item panel drops its dot for the same reason. Moving lifecycle off the row's trailing slot frees it — the actions menu no longer displaces the marker on hover, and a merged pull request keeps its badge.

--- a/.changeset/session-activity-markers.md
+++ b/.changeset/session-activity-markers.md
@@ -1,0 +1,9 @@
+---
+'@mastra/factory': patch
+---
+
+Session lifecycle stops being a coloured dot. A sidebar row now carries an activity rail down its left edge: pills travelling down it while a run is underway — in the setup colour while the sandbox is still coming up — and breathing in place once the session is waiting on you. Board cards read the same thing on the shape they have room for — their own outline. A lit head runs the rim with a long tail behind it while work is in flight, and the whole rim comes up lit under it once the card is waiting on you; a session that is merely bound shows no marker at all, on cards and rows alike.
+
+The rail and the rim are driven by the same amplitudes — travel, breath, fill — so a session changing state morphs rather than cutting to a different marker. A sandbox finishing its setup is just the colour sliding over; watching a run start and finish reads as one continuous object, where before four dots swapped places and only the colour said which one you were looking at.
+
+Moving lifecycle off the trailing slot frees it: the actions menu no longer displaces the marker on hover, and the merge badge shows on sessions with no lifecycle left to report. Surfaces that already spell the state out in text — the sidebar hover card, the work item panel — are left alone.

--- a/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardCardSessionLiveness.msw.test.tsx
@@ -168,12 +168,14 @@ describe('Board card session liveness', () => {
     renderWorkBoard();
 
     const card = await screen.findByTestId('work-item-card');
-    // Bound but idle: the dot rests muted — `ready` is reserved for a finished
-    // run awaiting its reader, same as the sidebar rows.
-    await waitFor(() => expect(card.querySelector('[data-live-session-indicator="idle"]')).not.toBeNull());
-
-    await user.click(screen.getByRole('button', { name: 'Details for Fix login bug' }));
+    // Bound but idle: no marker runs — the Open session button on the card is
+    // the advertisement, and only session-bound cards carry one.
     expect(await screen.findByRole('link', { name: 'Open session' })).toBeInTheDocument();
+    expect(card.querySelector('[data-live-session-indicator]')).toBeNull();
+
+    // The details panel keeps its own way in beside the card's.
+    await user.click(screen.getByRole('button', { name: 'Details for Fix login bug' }));
+    await waitFor(() => expect(screen.getAllByRole('link', { name: 'Open session' })).toHaveLength(2));
   });
 
   it('shows the initializing dot while a bound session is still materializing', async () => {
@@ -233,11 +235,14 @@ describe('Board card session liveness', () => {
     const activityKey = queryKeys.agentControllerActivity(AGENT_CONTROLLER_ID, TEST_BASE_URL);
 
     const card = await screen.findByTestId('work-item-card');
-    await waitFor(() => expect(card.querySelector('[data-live-session-indicator="idle"]')).not.toBeNull());
+    expect(await screen.findByRole('link', { name: 'Open session' })).toBeInTheDocument();
+    expect(card.querySelector('[data-live-session-indicator]')).toBeNull();
 
     active.add(SESSION_ID);
     await client.invalidateQueries({ queryKey: activityKey });
     await waitFor(() => expect(card.querySelector('[data-live-session-indicator="working"]')).not.toBeNull());
+    // The button is the idle marker only; a running session hands over to the wick.
+    expect(screen.queryByRole('link', { name: 'Open session' })).toBeNull();
 
     active.delete(SESSION_ID);
     await client.invalidateQueries({ queryKey: activityKey });
@@ -251,8 +256,8 @@ describe('Board card session liveness', () => {
     const user = userEvent.setup();
     renderWorkBoard();
 
-    const card = await screen.findByTestId('work-item-card');
-    await waitFor(() => expect(card.querySelector('[data-live-session-indicator]')).not.toBeNull());
+    await screen.findByTestId('work-item-card');
+    expect(await screen.findByRole('link', { name: 'Open session' })).toBeInTheDocument();
 
     await user.click(await screen.findByRole('button', { name: 'Session actions for factory/issue-1' }));
     await user.click(await screen.findByRole('menuitem', { name: 'Delete' }));
@@ -262,13 +267,9 @@ describe('Board card session liveness', () => {
 
     // The reconciling refetch is still in flight. The card must already have
     // stopped advertising a thread it can no longer open.
-    await waitFor(() =>
-      expect(screen.getByTestId('work-item-card').querySelector('[data-live-session-indicator]')).toBeNull(),
-    );
+    await waitFor(() => expect(screen.queryByRole('link', { name: 'Open session' })).toBeNull());
 
     refetchGate.resolve();
-    await waitFor(() =>
-      expect(screen.getByTestId('work-item-card').querySelector('[data-live-session-indicator]')).toBeNull(),
-    );
+    await waitFor(() => expect(screen.queryByRole('link', { name: 'Open session' })).toBeNull());
   });
 });

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -477,8 +477,9 @@ describe('Board card pending states', () => {
     );
     if (!started || !unstarted) throw new Error('Expected both work item cards');
 
-    expect(started.querySelector('[data-live-session-indicator]')).toBeInTheDocument();
-    expect(unstarted.querySelector('[data-live-session-indicator]')).not.toBeInTheDocument();
+    // A bound session with nothing to report runs no marker: the way in is the mark.
+    expect(within(started).getByRole('link', { name: 'Open session' })).toBeInTheDocument();
+    expect(within(unstarted).queryByRole('link', { name: 'Open session' })).toBeNull();
   });
 
   it('acknowledges a session start from the card details while it is still resolving the session', async () => {

--- a/mastracode/factory-ui/src/ui/domains/factory/components/BoardCardParts.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/BoardCardParts.tsx
@@ -8,29 +8,6 @@ import type { ReactElement, ReactNode } from 'react';
 import type { BoardCardStatus } from '../boardCardStatus';
 import { HIDDEN_CARD_LABELS, SOURCE_LABELS } from '../boardItems';
 import type { WorkItemSource } from '../services/workItems';
-import type { SessionCardStatus } from '../../workspaces/services/sessionStatus';
-
-// Same palette as the sidebar's SessionRowIndicator, so both surfaces read alike.
-const SESSION_DOT: Record<SessionCardStatus, { className: string; title: string }> = {
-  idle: { className: 'bg-accent1', title: 'Session bound' },
-  initializing: { className: 'bg-warning1 animate-pulse', title: 'Initializing' },
-  working: { className: 'bg-positive1 animate-pulse', title: 'Working' },
-  ready: { className: 'bg-accent3', title: 'Ready' },
-};
-
-/** The card's session marker; carries its status on the data attribute. */
-export function SessionLivenessDot({ status, className }: { status: SessionCardStatus; className?: string }) {
-  const dot = SESSION_DOT[status];
-  return (
-    <span
-      data-live-session-indicator={status}
-      role="status"
-      aria-label={dot.title}
-      title={dot.title}
-      className={cn('size-2 shrink-0 rounded-full', dot.className, className)}
-    />
-  );
-}
 
 export function SourceTitle({ source, title }: { source: WorkItemSource; title: string }) {
   return (

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -367,7 +367,7 @@ export function WorkItemCard({
               />
             </div>
           )}
-          {threadSession !== undefined && sessionStatus === undefined && (
+          {threadSession !== undefined && wickStatus === undefined && (
             <Link
               to={`/factories/${factoryId}/workspaces/${threadSession.sessionId}/threads/${threadSession.threadId}`}
               draggable={false}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -24,7 +24,7 @@ import type { WorkItem } from '../services/workItems';
 import type { BoardStageId } from '../stages';
 import { workItemActivity } from '../workItemActivity';
 import { SessionActivityWick } from '../../workspaces/components/SessionActivity';
-import type { SessionCardStatus } from '../../workspaces/services/sessionStatus';
+import type { SessionRowStatus } from '../../workspaces/services/sessionStatus';
 import {
   CardDetailsHint,
   CardLabels,
@@ -62,7 +62,7 @@ export function WorkItemCard({
   onDismissProposal,
   onRetryDecision,
   pendingRunRoles,
-  sessionStatus = 'idle',
+  sessionStatus,
   onCreateSession,
   onStartRun,
   onRestartRun,
@@ -97,7 +97,7 @@ export function WorkItemCard({
   onRetryDecision: (decisionId: string) => void;
   pendingRunRoles: ReadonlyMap<string, FactoryRunPhase | undefined>;
   /** Live status of the card's bound sessions, resolved once for the whole board. */
-  sessionStatus?: SessionCardStatus;
+  sessionStatus?: SessionRowStatus;
   /** Detail-panel fallback when the item has no run spec: open an empty session (no run). */
   onCreateSession: (spec: { branch: string; threadTitle: string }) => void;
   onStartRun: (spec: ItemRunSpec, action: RunAction, options?: { preapprovePlans?: boolean }) => void;
@@ -136,9 +136,7 @@ export function WorkItemCard({
       ? runSpec.actions.find(action => FACTORY_ROLE_STAGES[action.role] === columnStage && action.role in sessions)
       : undefined;
   const threadSession = itemThreadSession(sessions);
-  // The wick only runs for a session with something to say. Bound-but-quiet
-  // shows an Open session button instead: the button's presence is the marker.
-  const wickStatus = threadSession !== undefined && sessionStatus !== 'idle' ? sessionStatus : undefined;
+  const wickStatus = threadSession !== undefined ? sessionStatus : undefined;
   const primaryAction = cardPrimaryAction({
     item,
     runSpec,
@@ -265,19 +263,14 @@ export function WorkItemCard({
           }}
           className={cn(
             'group relative flex flex-col gap-3 rounded-xl border border-border1/50 bg-neutral6/5 p-3 outline-none transition-colors hover:bg-surface3',
-            // Offscreen cards skip layout and paint; a column can hold hundreds.
-            // Its clip stops at the padding box, which is where the wick has to
-            // reach past, so only cards actually running one pay full paint.
-            wickStatus !== undefined
-              ? // The wick paints the border itself, one line rather than two.
-                'border-transparent'
-              : '[content-visibility:auto] [contain-intrinsic-size:auto_7rem]',
+            // `content-visibility` clips at the padding box, which the wick's ring has to reach past.
+            wickStatus ? 'border-transparent' : '[content-visibility:auto] [contain-intrinsic-size:auto_7rem]',
             evaluating ? 'cursor-wait' : 'cursor-grab active:cursor-grabbing',
             runPending && 'opacity-70',
             highlighted && 'border-warning1/40 bg-warning1/5 ring-1 ring-warning1/30',
           )}
         >
-          {wickStatus !== undefined && <SessionActivityWick status={wickStatus} />}
+          {wickStatus && <SessionActivityWick status={wickStatus} />}
           <button
             ref={deepLinkRef}
             type="button"
@@ -374,7 +367,7 @@ export function WorkItemCard({
               />
             </div>
           )}
-          {threadSession !== undefined && sessionStatus === 'idle' && (
+          {threadSession !== undefined && sessionStatus === undefined && (
             <Link
               to={`/factories/${factoryId}/workspaces/${threadSession.sessionId}/threads/${threadSession.threadId}`}
               draggable={false}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemCard.tsx
@@ -1,12 +1,12 @@
 import { FACTORY_ROLE_STAGES, knownExternalAuthor } from '@mastra/factory/rules/types';
 import { Badge } from '@mastra/playground-ui/components/Badge';
-import { Button } from '@mastra/playground-ui/components/Button';
+import { Button, buttonVariants } from '@mastra/playground-ui/components/Button';
 import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { EllipsisVertical, MessageSquare } from 'lucide-react';
 import type { ReactElement } from 'react';
-import { useParams } from 'react-router';
+import { Link, useParams } from 'react-router';
 
 import type { FactoryRunPhase } from '../../../../hooks/useStartFactoryRun';
 import { boardCardStatus } from '../boardCardStatus';
@@ -23,6 +23,7 @@ import { relationshipPath } from '../services/relationships';
 import type { WorkItem } from '../services/workItems';
 import type { BoardStageId } from '../stages';
 import { workItemActivity } from '../workItemActivity';
+import { SessionActivityWick } from '../../workspaces/components/SessionActivity';
 import type { SessionCardStatus } from '../../workspaces/services/sessionStatus';
 import {
   CardDetailsHint,
@@ -30,7 +31,6 @@ import {
   CardStatus,
   CardTitleTooltip,
   REVEAL_ON_CARD_HOVER,
-  SessionLivenessDot,
   SourceTitle,
 } from './BoardCardParts';
 import { SourceIcon } from './BoardIcons';
@@ -136,6 +136,9 @@ export function WorkItemCard({
       ? runSpec.actions.find(action => FACTORY_ROLE_STAGES[action.role] === columnStage && action.role in sessions)
       : undefined;
   const threadSession = itemThreadSession(sessions);
+  // The wick only runs for a session with something to say. Bound-but-quiet
+  // shows an Open session button instead: the button's presence is the marker.
+  const wickStatus = threadSession !== undefined && sessionStatus !== 'idle' ? sessionStatus : undefined;
   const primaryAction = cardPrimaryAction({
     item,
     runSpec,
@@ -263,12 +266,18 @@ export function WorkItemCard({
           className={cn(
             'group relative flex flex-col gap-3 rounded-xl border border-border1/50 bg-neutral6/5 p-3 outline-none transition-colors hover:bg-surface3',
             // Offscreen cards skip layout and paint; a column can hold hundreds.
-            '[content-visibility:auto] [contain-intrinsic-size:auto_7rem]',
+            // Its clip stops at the padding box, which is where the wick has to
+            // reach past, so only cards actually running one pay full paint.
+            wickStatus !== undefined
+              ? // The wick paints the border itself, one line rather than two.
+                'border-transparent'
+              : '[content-visibility:auto] [contain-intrinsic-size:auto_7rem]',
             evaluating ? 'cursor-wait' : 'cursor-grab active:cursor-grabbing',
             runPending && 'opacity-70',
             highlighted && 'border-warning1/40 bg-warning1/5 ring-1 ring-warning1/30',
           )}
         >
+          {wickStatus !== undefined && <SessionActivityWick status={wickStatus} />}
           <button
             ref={deepLinkRef}
             type="button"
@@ -302,7 +311,6 @@ export function WorkItemCard({
           <div className="flex min-w-0 flex-col gap-1.5">
             <div className="flex min-w-0 items-center gap-1.5 pr-8">
               <span className="text-ui-xs text-icon2 min-w-0 truncate">{workItemMeta(item)}</span>
-              {threadSession !== undefined && <SessionLivenessDot status={sessionStatus} />}
               {relatedItems.map(relatedLink)}
               {item.commentCount > 0 && (
                 <span
@@ -366,6 +374,15 @@ export function WorkItemCard({
               />
             </div>
           )}
+          {threadSession !== undefined && sessionStatus === 'idle' && (
+            <Link
+              to={`/factories/${factoryId}/workspaces/${threadSession.sessionId}/threads/${threadSession.threadId}`}
+              draggable={false}
+              className={cn(buttonVariants({ variant: 'outline', size: 'xs' }), 'relative z-10 self-start')}
+            >
+              Open session
+            </Link>
+          )}
         </article>
       </CardTitleTooltip>
 
@@ -377,7 +394,6 @@ export function WorkItemCard({
         morph={morph}
         relatedLinks={relatedItems.map(relatedLink)}
         threadSession={threadSession}
-        sessionStatus={sessionStatus}
         status={status}
         retryingDecisionId={retryingDecisionId}
         onRetryDecision={onRetryDecision}

--- a/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemDetailsPanel.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/components/WorkItemDetailsPanel.tsx
@@ -14,11 +14,10 @@ import type { CardPrimaryAction } from '../cardPrimaryAction';
 import type { CardMorph } from '../hooks/useCardMorph';
 import type { AuditEventPage } from '../services/audit';
 import type { WorkItem, WorkItemSessionRef } from '../services/workItems';
-import type { SessionCardStatus } from '../../workspaces/services/sessionStatus';
 import type { BoardStageId } from '../stages';
 import { workItemActivity } from '../workItemActivity';
 import { CardSourceDescription } from './BoardCardDetails';
-import { CardLabels, CardStatus, SessionLivenessDot } from './BoardCardParts';
+import { CardLabels, CardStatus } from './BoardCardParts';
 import { SourceIcon } from './BoardIcons';
 import { CardDetailsBody, CardDetailsPanel } from './CardDetailsPanel';
 import { CommentsSection } from './feed/CommentsSection';
@@ -34,7 +33,6 @@ export function WorkItemDetailsPanel({
   morph,
   relatedLinks,
   threadSession,
-  sessionStatus,
   status,
   retryingDecisionId,
   onRetryDecision,
@@ -50,7 +48,6 @@ export function WorkItemDetailsPanel({
   morph: CardMorph;
   relatedLinks: ReactNode;
   threadSession?: WorkItemSessionRef;
-  sessionStatus: SessionCardStatus;
   status: BoardCardStatus;
   retryingDecisionId?: string;
   onRetryDecision: (decisionId: string) => void;
@@ -83,7 +80,6 @@ export function WorkItemDetailsPanel({
           <div className="flex min-w-0 items-center gap-1.5">
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
               <span className="text-ui-xs text-icon2 min-w-0 truncate">{workItemMeta(item)}</span>
-              {threadSession !== undefined && <SessionLivenessDot status={sessionStatus} />}
               {relatedLinks}
             </div>
             {item.url !== null && (

--- a/mastracode/factory-ui/src/ui/domains/factory/hooks/useItemSessionStatuses.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/hooks/useItemSessionStatuses.ts
@@ -3,7 +3,7 @@ import { useWorkspaceAttentionState } from '../../../../hooks/useWorkspaceAttent
 import { useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
 import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 import { sessionRowStatus } from '../../workspaces/services/sessionStatus';
-import type { SessionCardStatus } from '../../workspaces/services/sessionStatus';
+import type { SessionRowStatus } from '../../workspaces/services/sessionStatus';
 import type { WorkItem } from '../services/workItems';
 
 /**
@@ -17,7 +17,7 @@ export function useItemSessionStatuses({
 }: {
   projectRepositoryId: string;
   items: readonly WorkItem[];
-}): ReadonlyMap<string, SessionCardStatus> {
+}): ReadonlyMap<string, SessionRowStatus> {
   const boundSessionIds = items.flatMap(item => Object.values(item.sessions ?? {}).map(ref => ref.sessionId));
   const runningBySessionId = useActiveRunResources({
     agentControllerId: AGENT_CONTROLLER_ID,
@@ -31,7 +31,7 @@ export function useItemSessionStatuses({
       .map(session => session.sessionId),
   );
 
-  const statuses = new Map<string, SessionCardStatus>();
+  const statuses = new Map<string, SessionRowStatus>();
   for (const item of items) {
     const refs = Object.values(item.sessions ?? {});
     if (refs.length === 0) continue;
@@ -40,7 +40,7 @@ export function useItemSessionStatuses({
       initializing: refs.some(ref => materializingSessionIds.has(ref.sessionId)),
       attention: refs.some(ref => attentionByPath[ref.sessionId] === true),
     });
-    statuses.set(item.id, status ?? 'idle');
+    if (status !== undefined) statuses.set(item.id, status);
   }
   return statuses;
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionActivity.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionActivity.tsx
@@ -1,0 +1,113 @@
+import { cn } from '@mastra/playground-ui/utils/cn';
+import type { ComponentProps } from 'react';
+
+import type { SessionRowStatus } from '../services/sessionStatus';
+
+import './sessionActivity.css';
+
+const PILLS = [0, 1, 2, 3, 4];
+
+const PENTAD = [0, 72, 144, 216, 288];
+
+const STATUS_TITLE: Record<SessionRowStatus, string> = {
+  initializing: 'Initializing',
+  working: 'Working',
+  ready: 'Ready',
+};
+
+function statusAttributes(status: SessionRowStatus, label: string | undefined) {
+  return label ? { role: 'status', 'aria-label': label, title: STATUS_TITLE[status] } : { 'aria-hidden': true };
+}
+
+/**
+ * The sidebar row's left rail: pills travelling down it while the agent works,
+ * the same pills breathing in place once it is your turn. One clock for both,
+ * so a session that finishes its turn morphs rather than swapping markers.
+ */
+export function SessionActivityBelt({
+  status,
+  label,
+  className,
+  ...props
+}: ComponentProps<'span'> & {
+  status: SessionRowStatus;
+  /** Omit where the status is already spelled out in adjacent text: the marker is then decorative. */
+  label?: string;
+}) {
+  return (
+    <span
+      {...props}
+      {...statusAttributes(status, label)}
+      className={cn('session-belt', `session-${status}`, className)}
+    >
+      <span className="session-belt-sway">
+        {PILLS.map(pill => (
+          <i key={pill} />
+        ))}
+      </span>
+    </span>
+  );
+}
+
+/**
+ * The card's marker: a lit head running the card's own outline, dragging a long
+ * decaying tail. It runs in the setup hue while the sandbox comes up, and the
+ * rim comes up lit under it once it is your turn. A bound session with nothing
+ * to report gets no wick — the card shows its Open session button instead.
+ * Nothing on the card spells the state out, so it always announces. It paints
+ * the card's own 1px border, taking its radius from it: the card has to be
+ * `relative`, hand that border over (`border-transparent`) and not clip its
+ * own paint.
+ */
+export function SessionActivityWick({
+  status,
+  label,
+  className,
+  ...props
+}: ComponentProps<'span'> & {
+  status: SessionRowStatus;
+  label?: string;
+}) {
+  return (
+    <span
+      {...props}
+      data-live-session-indicator={status}
+      role="status"
+      aria-label={label ?? STATUS_TITLE[status]}
+      title={STATUS_TITLE[status]}
+      className={cn('session-wick', `session-${status}`, className)}
+    />
+  );
+}
+
+/**
+ * The inline marker, for a header row where there is no outline to run: five on
+ * a ring, swelling in turn while the agent works — in the setup hue while the
+ * sandbox is still coming up — and settling into an even ring with a slow wave
+ * once it is your turn.
+ */
+export function SessionActivityPentad({
+  status,
+  label,
+  className,
+  ...props
+}: ComponentProps<'svg'> & {
+  status: SessionRowStatus;
+  /** Omit where the status is already spelled out in adjacent text: the marker is then decorative. */
+  label?: string;
+}) {
+  return (
+    <svg
+      {...props}
+      {...statusAttributes(status, label)}
+      viewBox="0 0 24 24"
+      className={cn('session-pentad', `session-${status}`, className)}
+    >
+      {PENTAD.map(angle => (
+        <g key={angle} style={{ transform: `rotate(${angle}deg)` }}>
+          <circle cx="12" cy="5.4" r="2.8" />
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionActivity.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionActivity.tsx
@@ -7,8 +7,6 @@ import './sessionActivity.css';
 
 const PILLS = [0, 1, 2, 3, 4];
 
-const PENTAD = [0, 72, 144, 216, 288];
-
 const STATUS_TITLE: Record<SessionRowStatus, string> = {
   initializing: 'Initializing',
   working: 'Working',
@@ -77,37 +75,5 @@ export function SessionActivityWick({
       title={STATUS_TITLE[status]}
       className={cn('session-wick', `session-${status}`, className)}
     />
-  );
-}
-
-/**
- * The inline marker, for a header row where there is no outline to run: five on
- * a ring, swelling in turn while the agent works — in the setup hue while the
- * sandbox is still coming up — and settling into an even ring with a slow wave
- * once it is your turn.
- */
-export function SessionActivityPentad({
-  status,
-  label,
-  className,
-  ...props
-}: ComponentProps<'svg'> & {
-  status: SessionRowStatus;
-  /** Omit where the status is already spelled out in adjacent text: the marker is then decorative. */
-  label?: string;
-}) {
-  return (
-    <svg
-      {...props}
-      {...statusAttributes(status, label)}
-      viewBox="0 0 24 24"
-      className={cn('session-pentad', `session-${status}`, className)}
-    >
-      {PENTAD.map(angle => (
-        <g key={angle} style={{ transform: `rotate(${angle}deg)` }}>
-          <circle cx="12" cy="5.4" r="2.8" />
-        </g>
-      ))}
-    </svg>
   );
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionNavRow.tsx
@@ -9,17 +9,20 @@ import { useRef } from 'react';
 import type { RefObject } from 'react';
 
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
+import type { SessionRowStatus } from '../services/sessionStatus';
+import { SessionActivityBelt } from './SessionActivity';
 import { SessionPreviewCard } from './SessionPreviewCard';
 import type { SessionPreviewDetails } from './SessionPreviewCard';
 
 /**
  * Shared sidebar row for workspace/user sessions. Built on `MainSidebar.NavLink`
  * so every session list (work, review, user) renders with identical density,
- * hover, and active states. Spinner, status dot and actions menu share one
- * trailing slot beside the label: they swap in place, and the slot collapses
- * when there is nothing to show so the label gets the full row. Because that
- * slot comes and goes, the menu and the preview card anchor to the row box
- * instead — a resized or hidden anchor would drag them across the screen.
+ * hover, and active states. Lifecycle lives on the left as an activity belt;
+ * the trailing slot beside the label is left to the spinner, the merge badge
+ * and the actions menu, which swap in place and collapse the slot when there is
+ * nothing to show so the label gets the full row. Because that slot comes and
+ * goes, the belt, the menu and the preview card anchor to the row box instead —
+ * a resized or hidden anchor would drag them across the screen.
  */
 export function SessionNavRow({
   name,
@@ -80,23 +83,37 @@ export function SessionNavRow({
       ) : null}
     </button>
   );
-  const indicator = indicatorKind({ loading, status, merged });
+  const belt = loading ? undefined : status;
+  const trailing = trailingKind({ loading, status, merged });
   const action = (
-    <span className={cn(trailingSlot, indicator ? 'grid' : revealedSlot)}>
-      {indicator ? <SessionRowIndicator kind={indicator} name={name} /> : null}
-      {indicator === 'loading' ? null : (
-        <SessionActionsMenu
-          name={name}
-          anchor={anchor}
-          disabled={disabled}
-          pinned={pinned}
-          onPinChange={onPinChange}
-          onDelete={onDelete}
-          onRegenerateTitle={onRegenerateTitle}
-          regeneratingTitle={regeneratingTitle}
-        />
-      )}
-    </span>
+    <>
+      {belt ? <SessionActivityBelt status={belt} label={beltLabel(belt, name)} /> : null}
+      <span className={cn(trailingSlot, trailing ? 'grid' : revealedSlot)}>
+        {trailing === 'loading' ? <Spinner size="sm" aria-label={`Opening ${name}`} className="text-icon3" /> : null}
+        {trailing === 'merged' ? (
+          <span
+            role="img"
+            aria-label={`Pull request merged for ${name}`}
+            title="Pull request merged"
+            className={cn('flex', yieldsToActions)}
+          >
+            <PullRequestStatusIcon status="merged" className="size-3!" decorative />
+          </span>
+        ) : null}
+        {trailing === 'loading' ? null : (
+          <SessionActionsMenu
+            name={name}
+            anchor={anchor}
+            disabled={disabled}
+            pinned={pinned}
+            onPinChange={onPinChange}
+            onDelete={onDelete}
+            onRegenerateTitle={onRegenerateTitle}
+            regeneratingTitle={regeneratingTitle}
+          />
+        )}
+      </span>
+    </>
   );
   const row = (
     <MainSidebar.NavLink
@@ -126,27 +143,16 @@ const trailingSlot = 'size-form-sm shrink-0 place-items-center *:col-start-1 *:r
 const revealedSlot =
   'hidden group-focus-within/session:grid group-hover/session:grid group-has-[[data-popup-open]]/session:grid';
 
-/**
- * Session lifecycle states surfaced by the row's status dot. The color scheme
- * mirrors `SessionFavicon` so the sidebar and the tab-favicon read the same
- * way at a glance.
- */
-export type SessionRowStatus = 'initializing' | 'working' | 'ready';
+function beltLabel(status: SessionRowStatus, name: string) {
+  if (status === 'initializing') return `Initializing ${name}`;
+  if (status === 'working') return `Agent working in ${name}`;
+  return `${name} ready — open to dismiss`;
+}
 
-type IndicatorKind = 'loading' | SessionRowStatus | 'merged';
-
-function indicatorKind({
-  loading,
-  status,
-  merged,
-}: {
-  loading?: boolean;
-  status?: SessionRowStatus;
-  merged?: boolean;
-}): IndicatorKind | undefined {
+/** A merge badge is worth the slot only on a session with no lifecycle left to report. */
+function trailingKind({ loading, status, merged }: { loading?: boolean; status?: SessionRowStatus; merged?: boolean }) {
   if (loading) return 'loading';
-  if (status) return status;
-  return merged ? 'merged' : undefined;
+  return merged && !status ? 'merged' : undefined;
 }
 
 function SessionActionsMenu({
@@ -209,48 +215,3 @@ function SessionActionsMenu({
 // The actions menu owns the slot as soon as the row is hovered, focused, or its menu is open.
 const yieldsToActions =
   'group-hover/session:hidden group-focus-within/session:hidden group-has-[[data-popup-open]]/session:hidden';
-
-function SessionRowIndicator({ kind, name }: { kind: IndicatorKind; name: string }) {
-  if (kind === 'loading') return <Spinner size="sm" aria-label={`Opening ${name}`} className="text-icon3" />;
-
-  if (kind === 'initializing')
-    return (
-      <span
-        role="status"
-        aria-label={`Initializing ${name}`}
-        title="Initializing"
-        className={cn('bg-warning1 size-2 animate-pulse rounded-full', yieldsToActions)}
-      />
-    );
-
-  if (kind === 'working')
-    return (
-      <span
-        role="status"
-        aria-label={`Agent working in ${name}`}
-        title="Working"
-        className={cn('bg-positive1 size-2 animate-pulse rounded-full', yieldsToActions)}
-      />
-    );
-
-  if (kind === 'ready')
-    return (
-      <span
-        role="status"
-        aria-label={`${name} ready — open to dismiss`}
-        title="Ready"
-        className={cn('bg-accent3 size-2 rounded-full', yieldsToActions)}
-      />
-    );
-
-  return (
-    <span
-      role="img"
-      aria-label={`Pull request merged for ${name}`}
-      title="Pull request merged"
-      className={cn('flex', yieldsToActions)}
-    >
-      <PullRequestStatusIcon status="merged" className="size-3!" decorative />
-    </span>
-  );
-}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionPreviewCard.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/SessionPreviewCard.tsx
@@ -7,7 +7,7 @@ import type { ReactNode, RefObject } from 'react';
 
 import { relativeTime } from '../../../../lib/date/relativeTime';
 import { PullRequestStatusIcon } from '../../factory/components/PullRequestStatusIcon';
-import type { SessionRowStatus } from './SessionNavRow';
+import type { SessionRowStatus } from '../services/sessionStatus';
 import type { SessionOwnerDetails } from '../services/sessionPresentation';
 
 export interface SessionPreviewDetails {

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/SessionHoverDetails.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/SessionHoverDetails.msw.test.tsx
@@ -110,6 +110,15 @@ describe('Workspace session hover details', () => {
       expect(workRow).not.toHaveAttribute('title');
     });
 
+    it('carries the same activity state as the sidebar row', async () => {
+      const { user, workRow } = await setupSessionRows();
+
+      await user.hover(workRow);
+
+      const card = await screen.findByLabelText(`${workName} session details`);
+      expect(within(card).getByText('Work session · Agent working')).toBeInTheDocument();
+    });
+
     it('names the icon-only rows for screen readers', async () => {
       const { user, workRow } = await setupSessionRows();
 

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/SessionHoverDetails.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/SessionHoverDetails.msw.test.tsx
@@ -110,15 +110,6 @@ describe('Workspace session hover details', () => {
       expect(workRow).not.toHaveAttribute('title');
     });
 
-    it('carries the same activity state as the sidebar row', async () => {
-      const { user, workRow } = await setupSessionRows();
-
-      await user.hover(workRow);
-
-      const card = await screen.findByLabelText(`${workName} session details`);
-      expect(within(card).getByText('Work session · Agent working')).toBeInTheDocument();
-    });
-
     it('names the icon-only rows for screen readers', async () => {
       const { user, workRow } = await setupSessionRows();
 

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsActivity.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsActivity.msw.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Sidebar activity dot for user sessions.
+ * Sidebar activity belt for user sessions.
  *
  * User sessions are addressed by their own `sessionId` as `resourceId`, so they
  * read the same active-run registry as factory workspaces. This suite pins down
@@ -102,7 +102,7 @@ function renderSection() {
 }
 
 describe('User sessions sidebar activity', () => {
-  it('lights the working dot when the session has an active thread', async () => {
+  it('lights the working belt when the session has an active thread', async () => {
     stubProjectAndSessions([makeSession({ sessionId: 'sess-1', branch: 'user/feature-a' })]);
     stubActiveSessions(new Set(['sess-1']));
 
@@ -112,7 +112,7 @@ describe('User sessions sidebar activity', () => {
     await screen.findByRole('status', { name: 'Agent working in feature-a' });
   });
 
-  it('shows the initializing dot for a session that has not materialized yet', async () => {
+  it('shows the initializing belt for a session that has not materialized yet', async () => {
     stubProjectAndSessions([makeSession({ sessionId: 'sess-2', branch: 'user/feature-b', materializedAt: null })]);
     stubActiveSessions(new Set());
 
@@ -122,7 +122,7 @@ describe('User sessions sidebar activity', () => {
     await screen.findByRole('status', { name: 'Initializing feature-b' });
   });
 
-  it('resolves the initializing dot once the run that materialized the session finishes', async () => {
+  it('resolves the initializing belt once the run that materialized the session finishes', async () => {
     let materialized = false;
     const active = new Set(['sess-4']);
     stubProjectAndSessions([]);
@@ -157,13 +157,13 @@ describe('User sessions sidebar activity', () => {
     });
     await waitForMutationsIdle(client);
 
-    // Run end must refetch the sessions list: the dot lands on solid attention,
+    // Run end must refetch the sessions list: the belt lands on solid attention,
     // not back on (or stuck at) initializing.
     await screen.findByRole('status', { name: 'feature-d ready — open to dismiss' });
     expect(screen.queryByRole('status', { name: 'Initializing feature-d' })).not.toBeInTheDocument();
   });
 
-  it('leaves an idle materialized session without a status dot', async () => {
+  it('leaves an idle materialized session without a status belt', async () => {
     stubProjectAndSessions([makeSession({ sessionId: 'sess-3', branch: 'user/feature-c' })]);
     stubActiveSessions(new Set());
 

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceActivityIndicators.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceActivityIndicators.msw.test.tsx
@@ -72,29 +72,30 @@ function renderAt(path: string, entry: string) {
 }
 
 describe('Workspace activity indicators', () => {
-  it('lights the running dot for a session with an active run', async () => {
+  it('lights the running belt for a session with an active run', async () => {
     stubWith([workSessionId]);
 
     renderSection();
 
-    const dot = await screen.findByRole('status', { name: `Agent working in ${workName}` });
+    const belt = await screen.findByRole('status', { name: `Agent working in ${workName}` });
     const actions = screen.getByRole('button', { name: `Session actions for ${workName}` });
-    // Same trailing slot: the menu takes the dot's place on hover instead of covering the label.
-    expect(dot.parentElement).toBe(actions.parentElement);
+    // Its own slot on the row box: the trailing slot collapses on hover and would take the belt with it.
+    expect(belt.parentElement).not.toBe(actions.parentElement);
+    expect(belt.closest('li')).toBe(actions.closest('li'));
   });
 
-  it('leaves a session without an active run undotted', async () => {
+  it('leaves a session without an active run unmarked', async () => {
     stubWith([]);
 
     renderSection();
 
-    // The row must exist before the absence of its dot means anything.
+    // The row must exist before the absence of its belt means anything.
     const row = (await screen.findByRole('button', { name: workName })).closest('li');
     assert(row);
     expect(within(row).queryByRole('status', { name: `Agent working in ${workName}` })).not.toBeInTheDocument();
   });
 
-  it('lights the dot on a page that has no workspace session open', async () => {
+  it('lights the belt on a page that has no workspace session open', async () => {
     stubWith([workSessionId]);
 
     renderAt('/factories/:factoryId/work', `/factories/${factoryId}/work`);

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceSidebarStatuses.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceSidebarStatuses.msw.test.tsx
@@ -231,7 +231,7 @@ const newestPullRequestCases: Array<{
 ];
 
 describe('Workspace sidebar statuses', () => {
-  it('shows the running status dot instead of a merged icon while the agent is active', async () => {
+  it('shows the running status belt instead of a merged icon while the agent is active', async () => {
     stubWorkspaceStatuses({
       items: baseItems(true),
       activeSessionIds: [workSession.sessionId],

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
@@ -1,7 +1,6 @@
 /* Three markers, one grammar: the row's belt travels or breathes down the
  * sidebar; the card's wick runs a lit head round its outline until the whole rim
- * comes up under it; the inline pentad passes its swell round a ring or settles
- * it. Working and ready differ by amplitude — travel, breath, fill — so a run
+ * comes up under it. Working and ready differ by amplitude — travel, breath, fill — so a run
  * finishing morphs instead of cutting; initializing is working in the setup hue,
  * one 520ms colour slide away. The amplitudes rest on one rule: a rate has to be
  * expressed as a distance, never as an `animation-duration`. Durations cannot
@@ -153,99 +152,6 @@
   }
 }
 
-/* The card's pentad — five on a ring, swelling in turn. Same grammar as the
- * belt in its own vocabulary: the round-robin passes round, or settles into an
- * even ring with one slow wave going round. */
-.session-pentad {
-  --pentad-beat: 1.4s;
-
-  display: block;
-  width: 16px;
-  height: auto;
-}
-
-.session-pentad g {
-  transform-box: view-box;
-  transform-origin: 12px 12px;
-}
-
-.session-pentad circle {
-  fill: var(--belt-hue);
-  transform-box: fill-box;
-  transform-origin: 50% 50%;
-  animation: session-pentad-swell calc(var(--pentad-beat) * 1.8) ease-in-out infinite;
-}
-
-.session-pentad g:nth-of-type(1) circle {
-  animation-delay: calc(var(--pentad-beat) * -1.8);
-}
-
-.session-pentad g:nth-of-type(2) circle {
-  animation-delay: calc(var(--pentad-beat) * -1.44);
-}
-
-.session-pentad g:nth-of-type(3) circle {
-  animation-delay: calc(var(--pentad-beat) * -1.08);
-}
-
-.session-pentad g:nth-of-type(4) circle {
-  animation-delay: calc(var(--pentad-beat) * -0.72);
-}
-
-.session-pentad g:nth-of-type(5) circle {
-  animation-delay: calc(var(--pentad-beat) * -0.36);
-}
-
-@keyframes session-pentad-swell {
-  0%,
-  100% {
-    transform: scale(0.5);
-  }
-
-  14% {
-    transform: scale(1.2);
-  }
-
-  42% {
-    transform: scale(0.5);
-  }
-}
-
-.session-ready.session-pentad circle {
-  animation: session-pentad-rest calc(var(--pentad-beat) * 3) ease-in-out infinite;
-}
-
-.session-ready.session-pentad g:nth-of-type(1) circle {
-  animation-delay: calc(var(--pentad-beat) * -3);
-}
-
-.session-ready.session-pentad g:nth-of-type(2) circle {
-  animation-delay: calc(var(--pentad-beat) * -2.4);
-}
-
-.session-ready.session-pentad g:nth-of-type(3) circle {
-  animation-delay: calc(var(--pentad-beat) * -1.8);
-}
-
-.session-ready.session-pentad g:nth-of-type(4) circle {
-  animation-delay: calc(var(--pentad-beat) * -1.2);
-}
-
-.session-ready.session-pentad g:nth-of-type(5) circle {
-  animation-delay: calc(var(--pentad-beat) * -0.6);
-}
-
-@keyframes session-pentad-rest {
-  0%,
-  100% {
-    transform: scale(0.8);
-  }
-
-  50% {
-    transform: scale(1.04);
-  }
-}
-
 /* The card's wick. The head never stops — an angle cannot cross-fade its sweep
  * without snapping at the loop seam, so `--wick-fill` brings the rim up under
  * it. */
@@ -320,15 +226,14 @@
   }
 }
 
-/* Belt and pentad have nothing left once travel is off: ready and working
- * collapse to the same still frame and only the colour tells them apart. The
- * wick still reads — a parked head against a rim that is lit or not. */
+/* The belt has nothing left once travel is off: ready and working collapse to
+ * the same still frame and only the colour tells them apart. The wick still
+ * reads — a parked head against a rim that is lit or not. */
 @media (prefers-reduced-motion: reduce) {
   .session-wick,
   .session-belt,
   .session-belt-sway,
-  .session-belt-sway i,
-  .session-pentad circle {
+  .session-belt-sway i {
     transition: none;
     animation: none;
   }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
@@ -257,11 +257,13 @@
 
 .session-wick {
   --belt-beat: 1.4s;
+
   /* Lap length, in belt beats. Long, because the head is crossing a whole card
    * rather than a 6px rail: it has to read as travelling, not as spinning. */
   --wick-lap: 6;
 
   position: absolute;
+
   /* The ring is the card's border, not a line inside it: the card turns its own
    * 1px border transparent and the wick paints that exact strip — same box,
    * same radius, same width, resting colour included. Reaching the border box

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
@@ -226,9 +226,9 @@
   }
 }
 
-/* The belt has nothing left once travel is off: ready and working collapse to
- * the same still frame and only the colour tells them apart. The wick still
- * reads — a parked head against a rim that is lit or not. */
+/* The belt has nothing left once travel is off: its states collapse to the same
+ * still frame and only the colour tells them apart. The wick keeps reading —
+ * a parked head against a rim lit none, part or whole. */
 @media (prefers-reduced-motion: reduce) {
   .session-wick,
   .session-belt,
@@ -236,5 +236,12 @@
   .session-belt-sway i {
     transition: none;
     animation: none;
+  }
+
+  /* Motion was what told working from initializing. With it off, the setup state
+   * takes the middle of the fill it already owns, so the rim reads at three
+   * coverages — none, part, whole — and never by hue alone. */
+  .session-wick.session-initializing {
+    --wick-fill: 0.4;
   }
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/sessionActivity.css
@@ -1,0 +1,333 @@
+/* Three markers, one grammar: the row's belt travels or breathes down the
+ * sidebar; the card's wick runs a lit head round its outline until the whole rim
+ * comes up under it; the inline pentad passes its swell round a ring or settles
+ * it. Working and ready differ by amplitude — travel, breath, fill — so a run
+ * finishing morphs instead of cutting; initializing is working in the setup hue,
+ * one 520ms colour slide away. The amplitudes rest on one rule: a rate has to be
+ * expressed as a distance, never as an `animation-duration`. Durations cannot
+ * cross-fade; lengths can. */
+
+@property --belt-pitch {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 9px;
+}
+
+@property --belt-sway {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0;
+}
+
+@property --belt-hue {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: currentcolor;
+}
+
+/* How much of the wick's rim is already lit behind the travelling head. The head
+ * never stops; at 1 the rim it is running on has caught up with it. */
+@property --wick-fill {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0;
+}
+
+/* How much of the travelling head is drawn. At 0 the rim is all there is. */
+@property --wick-head {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 1;
+}
+
+/* One declaration of what each state means, read by whichever slot is drawing.
+ * Every off-diagonal is zero, so a handover is one amplitude fading out through
+ * zero while the next fades in. */
+
+/* There is no idle state here: a session merely attached is not a point in the
+ * lifecycle. Rows drop their belt, and a card shows its Open session button
+ * instead of running a marker. */
+
+.session-working {
+  --belt-pitch: 9px;
+  --belt-sway: 0;
+  --wick-fill: 0;
+  --wick-head: 1;
+  --belt-hue: var(--positive1);
+}
+
+/* Working's own motion in the setup hue: the sandbox coming up is the run
+ * already underway, and materializing is nothing but the colour arriving. */
+.session-initializing {
+  --belt-pitch: 9px;
+  --belt-sway: 0;
+  --wick-fill: 0;
+  --wick-head: 1;
+  --belt-hue: var(--warning1);
+}
+
+/* Travel drops to zero and one slow breath takes over on a clock four times
+ * longer: parked on you, not stuck. */
+.session-ready {
+  --belt-pitch: 0px;
+  --belt-sway: 1;
+  --wick-fill: 1;
+  --wick-head: 1;
+  --belt-hue: var(--accent3);
+}
+
+.session-belt {
+  --belt-beat: 1.4s;
+
+  transition:
+    --belt-pitch 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --belt-sway 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --belt-hue 520ms ease;
+}
+
+/* The row's left rail. Absolute against the row box rather than the trailing
+ * slot, which comes and goes with hover and would drag the belt with it. */
+.session-belt {
+  position: absolute;
+  inset-block: 4px;
+  left: 3px;
+  width: 6px;
+  overflow: hidden;
+  mask: linear-gradient(to bottom, transparent, #000 16%, #000 84%, transparent);
+}
+
+.session-belt-sway {
+  position: absolute;
+  inset: 0;
+  animation: session-belt-sway calc(var(--belt-beat) * 4) ease-in-out infinite;
+}
+
+.session-belt-sway i {
+  position: absolute;
+  top: calc(var(--belt-k) * 9px - 9px);
+  left: 50%;
+  width: 2px;
+  height: 6px;
+  margin-left: -1px;
+  border-radius: 999px;
+  background: var(--belt-hue);
+  animation: session-belt-flow calc(var(--belt-beat) * 0.9) linear infinite;
+}
+
+.session-belt-sway i:nth-child(1) {
+  --belt-k: 0;
+}
+
+.session-belt-sway i:nth-child(2) {
+  --belt-k: 1;
+}
+
+.session-belt-sway i:nth-child(3) {
+  --belt-k: 2;
+}
+
+.session-belt-sway i:nth-child(4) {
+  --belt-k: 3;
+}
+
+.session-belt-sway i:nth-child(5) {
+  --belt-k: 4;
+}
+
+/* Exactly one pitch per loop, so the last frame is the first frame with every
+ * pill in its neighbour's place and the belt never jumps. */
+@keyframes session-belt-flow {
+  to {
+    transform: translateY(var(--belt-pitch));
+  }
+}
+
+@keyframes session-belt-sway {
+  0%,
+  100% {
+    transform: translateY(calc(-3px * var(--belt-sway)));
+  }
+
+  50% {
+    transform: translateY(calc(3px * var(--belt-sway)));
+  }
+}
+
+/* The card's pentad — five on a ring, swelling in turn. Same grammar as the
+ * belt in its own vocabulary: the round-robin passes round, or settles into an
+ * even ring with one slow wave going round. */
+.session-pentad {
+  --pentad-beat: 1.4s;
+
+  display: block;
+  width: 16px;
+  height: auto;
+}
+
+.session-pentad g {
+  transform-box: view-box;
+  transform-origin: 12px 12px;
+}
+
+.session-pentad circle {
+  fill: var(--belt-hue);
+  transform-box: fill-box;
+  transform-origin: 50% 50%;
+  animation: session-pentad-swell calc(var(--pentad-beat) * 1.8) ease-in-out infinite;
+}
+
+.session-pentad g:nth-of-type(1) circle {
+  animation-delay: calc(var(--pentad-beat) * -1.8);
+}
+
+.session-pentad g:nth-of-type(2) circle {
+  animation-delay: calc(var(--pentad-beat) * -1.44);
+}
+
+.session-pentad g:nth-of-type(3) circle {
+  animation-delay: calc(var(--pentad-beat) * -1.08);
+}
+
+.session-pentad g:nth-of-type(4) circle {
+  animation-delay: calc(var(--pentad-beat) * -0.72);
+}
+
+.session-pentad g:nth-of-type(5) circle {
+  animation-delay: calc(var(--pentad-beat) * -0.36);
+}
+
+@keyframes session-pentad-swell {
+  0%,
+  100% {
+    transform: scale(0.5);
+  }
+
+  14% {
+    transform: scale(1.2);
+  }
+
+  42% {
+    transform: scale(0.5);
+  }
+}
+
+.session-ready.session-pentad circle {
+  animation: session-pentad-rest calc(var(--pentad-beat) * 3) ease-in-out infinite;
+}
+
+.session-ready.session-pentad g:nth-of-type(1) circle {
+  animation-delay: calc(var(--pentad-beat) * -3);
+}
+
+.session-ready.session-pentad g:nth-of-type(2) circle {
+  animation-delay: calc(var(--pentad-beat) * -2.4);
+}
+
+.session-ready.session-pentad g:nth-of-type(3) circle {
+  animation-delay: calc(var(--pentad-beat) * -1.8);
+}
+
+.session-ready.session-pentad g:nth-of-type(4) circle {
+  animation-delay: calc(var(--pentad-beat) * -1.2);
+}
+
+.session-ready.session-pentad g:nth-of-type(5) circle {
+  animation-delay: calc(var(--pentad-beat) * -0.6);
+}
+
+@keyframes session-pentad-rest {
+  0%,
+  100% {
+    transform: scale(0.8);
+  }
+
+  50% {
+    transform: scale(1.04);
+  }
+}
+
+/* The card's wick. The head never stops — an angle cannot cross-fade its sweep
+ * without snapping at the loop seam, so `--wick-fill` brings the rim up under
+ * it. */
+@property --wick-run {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
+.session-wick {
+  --belt-beat: 1.4s;
+  /* Lap length, in belt beats. Long, because the head is crossing a whole card
+   * rather than a 6px rail: it has to read as travelling, not as spinning. */
+  --wick-lap: 6;
+
+  position: absolute;
+  /* The ring is the card's border, not a line inside it: the card turns its own
+   * 1px border transparent and the wick paints that exact strip — same box,
+   * same radius, same width, resting colour included. Reaching the border box
+   * means reaching out of the padding box, so a card carrying a wick drops
+   * `content-visibility`, whose clip stops there. The radius is inherited
+   * rather than named: the card owns it, and a guess is a corner that misses. */
+  inset: -1px;
+  border-radius: inherit;
+  padding: 1px;
+  pointer-events: none;
+  background:
+    conic-gradient(
+      from var(--wick-run),
+      transparent 0deg 120deg,
+      color-mix(in oklab, var(--belt-hue) calc(var(--wick-head) * 12%), transparent) 250deg,
+      color-mix(in oklab, var(--belt-hue) calc(var(--wick-head) * 45%), transparent) 330deg,
+      color-mix(in oklab, var(--belt-hue) calc(var(--wick-head) * 80%), transparent) 352deg,
+      color-mix(in oklab, var(--belt-hue) calc(var(--wick-head) * 100%), transparent) 358deg,
+      color-mix(in oklab, color-mix(in oklab, white 55%, var(--belt-hue)) calc(var(--wick-head) * 100%), transparent)
+        360deg
+    ),
+    linear-gradient(color-mix(in oklab, var(--belt-hue) calc(var(--wick-fill) * 62%), transparent) 0 0),
+    linear-gradient(color-mix(in oklab, var(--border1) 50%, transparent) 0 0);
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  transition:
+    --wick-fill 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --wick-head 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --belt-sway 700ms cubic-bezier(0.4, 0, 0.2, 1),
+    --belt-hue 520ms ease;
+  animation:
+    session-wick-run calc(var(--belt-beat) * var(--wick-lap)) linear infinite,
+    session-wick-breathe calc(var(--belt-beat) * 4) ease-in-out infinite;
+}
+
+@keyframes session-wick-run {
+  to {
+    --wick-run: 360deg;
+  }
+}
+
+/* The belt's slow breath, in opacity — off everywhere `--belt-sway` is 0, where
+ * both stops are 1 and the keyframe cannot show. */
+@keyframes session-wick-breathe {
+  0%,
+  100% {
+    opacity: calc(1 - 0.5 * var(--belt-sway));
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+/* Belt and pentad have nothing left once travel is off: ready and working
+ * collapse to the same still frame and only the colour tells them apart. The
+ * wick still reads — a parked head against a rim that is lit or not. */
+@media (prefers-reduced-motion: reduce) {
+  .session-wick,
+  .session-belt,
+  .session-belt-sway,
+  .session-belt-sway i,
+  .session-pentad circle {
+    transition: none;
+    animation: none;
+  }
+}

--- a/mastracode/factory-ui/src/ui/domains/workspaces/services/sessionStatus.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/services/sessionStatus.ts
@@ -1,4 +1,8 @@
-import type { SessionRowStatus } from '../components/SessionNavRow';
+/**
+ * Session lifecycle states a sidebar row can surface. The colour scheme mirrors
+ * `SessionFavicon`, so the sidebar and the tab favicon read the same way.
+ */
+export type SessionRowStatus = 'initializing' | 'working' | 'ready';
 
 /**
  * A board card also has to say "bound but nothing to report". Rows hide their

--- a/mastracode/factory-ui/src/ui/domains/workspaces/services/sessionStatus.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/services/sessionStatus.ts
@@ -1,20 +1,14 @@
 /**
- * Session lifecycle states a sidebar row can surface. The colour scheme mirrors
+ * Session lifecycle states a marker can surface. The colour scheme mirrors
  * `SessionFavicon`, so the sidebar and the tab favicon read the same way.
  */
 export type SessionRowStatus = 'initializing' | 'working' | 'ready';
 
 /**
- * A board card also has to say "bound but nothing to report". Rows hide their
- * dot instead, so `ready` keeps one meaning everywhere — it is your turn.
- */
-export type SessionCardStatus = SessionRowStatus | 'idle';
-
-/**
  * The one precedence every session surface reads: an active run means work is
  * happening even before the workspace record is stamped materialized, and an
  * attention mark only speaks once nothing louder does. `undefined` is a session
- * with nothing to report — rows hide their dot, cards fall back to `idle`.
+ * with nothing to report, which runs no marker at all.
  */
 export function sessionRowStatus(input: {
   running: boolean;


### PR DESCRIPTION
**─────── TLDR ───────**
> Session lifecycle stops being a coloured dot: a sidebar row grows an activity rail down its left edge, and a board card runs a lit head around its own border.

Four states used to be four dots swapping places in the same 8px slot, and only the colour said which one you were looking at — a run starting and finishing read as a recolour. Now travel, breath and fill are amplitudes a state sets, and the marker morphs between them on one clock.

A sandbox coming up is a run already underway, so it is working's own motion in the setup hue: materializing is the colour arriving, nothing else.

### Behavior changed

a sidebar row while the agent is working
&nbsp;&nbsp;├─ **was** — a green dot pulsing in the trailing slot, gone the moment you hover
&nbsp;&nbsp;└─ **now** — pills travelling down a rail on the row's left edge, which hover leaves alone

a sidebar row waiting on you
&nbsp;&nbsp;├─ **was** — a static blue dot
&nbsp;&nbsp;└─ **now** — travel drops to zero and the pills breathe in place, on a clock four times longer

a board card whose session is running
&nbsp;&nbsp;├─ **was** — a dot in the meta row, and a plain border
&nbsp;&nbsp;└─ **now** — the border itself: a lit head running the rim, the whole rim lit under it once it waits on you

a board card bound to a session with nothing to report
&nbsp;&nbsp;├─ **was** — a green dot, the same green the working state uses
&nbsp;&nbsp;└─ **now** — no marker at all, and an Open session button on the card

the work item panel
&nbsp;&nbsp;├─ **was** — its own copy of the dot
&nbsp;&nbsp;└─ **now** — nothing: lifecycle is the card's job

### Shape changed

| | | |
|---|---|---|
| **+** | `SessionActivityBelt` | the rail, for a row that has a left edge |
| **+** | `SessionActivityWick` | the rim, for a card that has a border |
| **−** | `SessionRowIndicator` | four hand-written dots, one per state |
| **−** | `SessionLivenessDot` | the card's copy of the same four |
| **−** | `SessionCardStatus` | `idle` existed for that dot; `undefined` says it |
| **~** | `SessionRowStatus` | moved out of `SessionNavRow` into `services/sessionStatus.ts`, beside the resolver |

- `domains/workspaces/components/`
  - └─ `SessionActivity.tsx` — the two markers, `+79`
  - └─ `sessionActivity.css` — the grammar, `+233`

the resolver and the test hook are untouched
&nbsp;&nbsp;&nbsp;&nbsp;`sessionRowStatus()` · `[data-live-session-indicator]`
removed: `WorkItemDetailsPanel`'s `sessionStatus` prop · `SessionCardStatus`

### Decisions

- **the rim paints the card's own border, so a card running one drops `content-visibility`** — that clip is what cut the ring off the border; only cards with a live session pay for it
- **the belt stays colour-only under reduced motion** — frozen pills have no second channel to carry the state; the rim gained one, the rail needs a static form designed for it
- **a session merely bound gets no marker** — it is not a point in the lifecycle, and the button says it better; one condition away if you disagree

### Not verified

- [ ] the rim under `prefers-reduced-motion` on a real board — the three fill levels are asserted by eye, not by a test

---

> ██████████████████ **source** `+394 −134` — 233 of it the CSS grammar
> █ **tests** `+32 −29` — selectors follow the markup, no new cases
> █ **changeset** `+7`
