### PR TITLE
fix(mastracode): rebuild dev output on startup

### DIFF
--- a/mastracode/web/package.json
+++ b/mastracode/web/package.json
@@ -10,7 +10,7 @@
     "db:down": "docker compose down",
     "prebuild": "cd ../.. && pnpm turbo build --filter ./mastracode/sdk --filter ./mastracode/factory --filter ./auth/workos --filter ./client-sdks/client-js --filter ./stores/libsql --filter ./stores/pg --filter ./server-adapters/hono --filter ./workspaces/platform-workspace --filter ./pubsub/redis-streams --filter ./packages/cli",
     "api": "PORT=${PORT:-4111} MASTRACODE_PUBLIC_URL=${MASTRACODE_PUBLIC_URL:-http://localhost:5173} MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra factory dev --dir src/mastra",
-    "dev": "PORT=5873 MASTRACODE_PUBLIC_URL=${MASTRACODE_PUBLIC_URL:-http://localhost:5873} MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra factory dev --dir src/mastra",
+    "dev": "PORT=5873 MASTRACODE_PUBLIC_URL=${MASTRACODE_PUBLIC_URL:-http://localhost:5873} MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- sh -c 'rm -rf .mastra/output && mastra factory dev --dir src/mastra'",
     "dev:ui": "pnpm db:up && cd ../.. && pnpm turbo run dev dev:api --filter ./mastracode/factory-ui --filter ./packages/playground-ui --env-mode=loose",
     "dev:github": "pnpm db:up && pnpm dev",
     "build": "node scripts/monorepo-deps.mjs run -- mastra build --dir src/mastra",


### PR DESCRIPTION
Clears Factory's generated dev output after the development lock is acquired, so rebuilt linked workspace packages are included when the server starts.

Previously, restarting dev could reuse older generated Factory output after linked workspace packages were rebuilt. Now pnpm dev removes that output inside varlock before starting Factory.
