### PR TITLE
fix(docs): normalize canonical section root URLs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -6,6 +6,7 @@ import type { Config } from '@docusaurus/types'
 import type { ThemeConfig } from '@docusaurus/preset-classic'
 import type { AlgoliaPluginOptions } from '@mastra/docusaurus-plugin-algolia'
 import type { KapaPluginOptions } from '@mastra/docusaurus-plugin-kapa'
+import { normalizeSiteSectionRoot, SITE_SECTION_ROOTS } from './src/utils/canonical-url'
 
 const NPM2YARN_CONFIG = { sync: true, converters: ['pnpm', 'yarn', 'bun'] }
 const SHARED_REMARK_PLUGINS = [
@@ -86,7 +87,7 @@ const config: Config = {
       {
         id: 'integrations',
         path: 'src/content/en/integrations',
-        routeBasePath: 'integrations',
+        routeBasePath: SITE_SECTION_ROOTS.integrations.slice(1),
         sidebarPath: './src/content/en/integrations/sidebars.js',
         editUrl: 'https://github.com/mastra-ai/mastra/tree/main/docs',
         admonitions: ADMONITIONS_CONFIG,
@@ -98,7 +99,7 @@ const config: Config = {
       {
         id: 'models',
         path: 'src/content/en/models',
-        routeBasePath: 'models',
+        routeBasePath: SITE_SECTION_ROOTS.models.slice(1),
         sidebarPath: './src/content/en/models/sidebars.js',
         editUrl: 'https://github.com/mastra-ai/mastra/tree/main/docs',
         admonitions: ADMONITIONS_CONFIG,
@@ -110,7 +111,7 @@ const config: Config = {
       {
         id: 'reference',
         path: 'src/content/en/reference',
-        routeBasePath: 'reference',
+        routeBasePath: SITE_SECTION_ROOTS.reference.slice(1),
         sidebarPath: './src/content/en/reference/sidebars.js',
         editUrl: 'https://github.com/mastra-ai/mastra/tree/main/docs',
         admonitions: ADMONITIONS_CONFIG,
@@ -136,7 +137,7 @@ const config: Config = {
           {
             label: 'Quickstart',
             description: 'Get up and running with Mastra',
-            link: '/docs',
+            link: SITE_SECTION_ROOTS.docs,
           },
           { label: 'Studio', description: 'Test your agents, workflows, and tools', link: '/docs/studio/overview' },
           {
@@ -178,7 +179,7 @@ const config: Config = {
       {
         docs: {
           path: 'src/content/en/docs',
-          routeBasePath: 'docs',
+          routeBasePath: SITE_SECTION_ROOTS.docs.slice(1),
           sidebarPath: './src/content/en/docs/sidebars.js',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
@@ -196,6 +197,11 @@ const config: Config = {
           priority: 0.5,
           ignorePatterns: ['/tags/**'],
           filename: 'sitemap.xml',
+          createSitemapItems: async params => {
+            const items = await params.defaultCreateSitemapItems(params)
+
+            return items.map(item => ({ ...item, url: normalizeSiteSectionRoot(item.url) }))
+          },
         },
       },
     ],

--- a/docs/scripts/__tests__/delete-doc.test.ts
+++ b/docs/scripts/__tests__/delete-doc.test.ts
@@ -274,14 +274,14 @@ describe('deleteDocument', () => {
   test('supports a replacement in another editable family', async () => {
     process.chdir(originalCwd)
     await fixture.cleanup()
-    fixture = await createFixture({ 'src/content/en/guides/replacement.mdx': '# Guide replacement\n' })
+    fixture = await createFixture({ 'src/content/en/reference/replacement.mdx': '# Guide replacement\n' })
     process.chdir(fixture.tempDir)
 
-    const result = await deleteDocument('/docs/old/page', '/guides/replacement#guide', { verbose: false })
+    const result = await deleteDocument('/docs/old/page', '/reference/replacement#guide', { verbose: false })
 
     expect(result.success).toBe(true)
-    expect(await fixture.read('src/content/en/docs/links.mdx')).toContain('[Absolute](/guides/replacement#guide)')
-    expect(await fixture.read('src/content/en/docs/links.mdx')).toContain('[Relative](../guides/replacement#guide)')
+    expect(await fixture.read('src/content/en/docs/links.mdx')).toContain('[Absolute](/reference/replacement#guide)')
+    expect(await fixture.read('src/content/en/docs/links.mdx')).toContain('[Relative](../reference/replacement#guide)')
   })
 
   test('supports a family-root index replacement with a hash', async () => {

--- a/docs/scripts/__tests__/move-doc.test.ts
+++ b/docs/scripts/__tests__/move-doc.test.ts
@@ -268,23 +268,16 @@ describe('move-doc utility functions', () => {
   test('routeToFilePath maps editable Mastra route families', () => {
     expect(routeToFilePath('/docs/agents/overview')).toBe('src/content/en/docs/agents/overview.mdx')
     expect(routeToFilePath('/reference/agents/agent')).toBe('src/content/en/reference/agents/agent.mdx')
-    expect(routeToFilePath('/guides/getting-started/quickstart')).toBe(
-      'src/content/en/guides/getting-started/quickstart.mdx',
-    )
   })
 
   test('filePathToRoute maps editable Mastra content files to routes', () => {
     expect(filePathToRoute('src/content/en/docs/agents/overview.mdx')).toBe('/docs/agents/overview')
     expect(filePathToRoute('src/content/en/reference/agents/agent.mdx')).toBe('/reference/agents/agent')
-    expect(filePathToRoute('src/content/en/guides/getting-started/quickstart.mdx')).toBe(
-      '/guides/getting-started/quickstart',
-    )
   })
 
   test('routeToSidebarId strips editable family route prefix', () => {
     expect(routeToSidebarId('/docs/agents/overview')).toBe('agents/overview')
     expect(routeToSidebarId('/reference/agents/agent')).toBe('agents/agent')
-    expect(routeToSidebarId('/guides/getting-started/quickstart')).toBe('getting-started/quickstart')
   })
 
   test('model routes are rejected because they are auto-generated', () => {

--- a/docs/src/components/mobile-docs-dropdown.tsx
+++ b/docs/src/components/mobile-docs-dropdown.tsx
@@ -5,31 +5,32 @@ import { ChevronDown, Check } from 'lucide-react'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown'
 import { Button } from './ui/button'
 import { cn } from '@site/src/lib/utils'
+import { SITE_SECTION_ROOTS } from '@site/src/utils/canonical-url'
 
 const docsTabs = [
   {
     id: 'Docs',
     label: 'Docs',
-    href: '/docs/',
-    basePath: '/docs',
+    href: SITE_SECTION_ROOTS.docs,
+    basePath: SITE_SECTION_ROOTS.docs,
   },
   {
     id: 'Models',
     label: 'Models',
-    href: '/models/',
-    basePath: '/models',
+    href: SITE_SECTION_ROOTS.models,
+    basePath: SITE_SECTION_ROOTS.models,
   },
   {
     id: 'Integrations',
     label: 'Integrations',
-    href: '/integrations/',
-    basePath: '/integrations',
+    href: SITE_SECTION_ROOTS.integrations,
+    basePath: SITE_SECTION_ROOTS.integrations,
   },
   {
     id: 'Reference',
     label: 'Reference',
-    href: '/reference/',
-    basePath: '/reference',
+    href: SITE_SECTION_ROOTS.reference,
+    basePath: SITE_SECTION_ROOTS.reference,
   },
   {
     id: 'Learn',

--- a/docs/src/theme/DocSidebarItem/Link/index.tsx
+++ b/docs/src/theme/DocSidebarItem/Link/index.tsx
@@ -39,9 +39,9 @@ export default function DocSidebarItemLink({
   ...props
 }: Props): ReactNode {
   const { href, label, className, autoAddBaseUrl } = item
-  const linkHref = normalizeSiteSectionRoot(href)
+  const isInternalLink = isInternalUrl(href)
+  const linkHref = isInternalLink ? normalizeSiteSectionRoot(href) : href
   const isActive = isActiveSidebarItem(item, activePath)
-  const isInternalLink = isInternalUrl(linkHref)
   const isContextualSidebarPane = useIsContextualSidebarPane()
 
   return (

--- a/docs/src/theme/DocSidebarItem/Link/index.tsx
+++ b/docs/src/theme/DocSidebarItem/Link/index.tsx
@@ -12,6 +12,7 @@ import { isPlainPrimaryClick } from '../../contextual-sidebar'
 import { useIsContextualSidebarPane } from '../../contextual-sidebar-context'
 import styles from './styles.module.css'
 import { getBadgeType } from '../utils'
+import { normalizeSiteSectionRoot } from '@site/src/utils/canonical-url'
 
 function LinkLabel({ label, item }: { label: string; item: any }) {
   // Get tags from customProps in sidebar config
@@ -38,8 +39,9 @@ export default function DocSidebarItemLink({
   ...props
 }: Props): ReactNode {
   const { href, label, className, autoAddBaseUrl } = item
+  const linkHref = normalizeSiteSectionRoot(href)
   const isActive = isActiveSidebarItem(item, activePath)
-  const isInternalLink = isInternalUrl(href)
+  const isInternalLink = isInternalUrl(linkHref)
   const isContextualSidebarPane = useIsContextualSidebarPane()
 
   return (
@@ -58,7 +60,7 @@ export default function DocSidebarItemLink({
         })}
         autoAddBaseUrl={autoAddBaseUrl}
         aria-current={isActive ? 'page' : undefined}
-        to={href}
+        to={linkHref}
         {...(isInternalLink && {
           onClick: onItemClick
             ? event => {

--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -13,6 +13,7 @@ import SkipToContent from '@theme/SkipToContent'
 import clsx from 'clsx'
 import { type ReactNode } from 'react'
 import styles from './styles.module.css'
+import { normalizeSiteSectionRoot } from '@site/src/utils/canonical-url'
 
 export default function Layout(props: Props): ReactNode {
   const {
@@ -27,7 +28,8 @@ export default function Layout(props: Props): ReactNode {
   const location = useLocation()
   const { siteConfig } = useDocusaurusContext()
   const cleanPath = location.pathname.replace(/^\/ja(\/|$)/, '/')
-  const canonicalUrl = `${siteConfig.url}${cleanPath}`
+  const canonicalPath = normalizeSiteSectionRoot(cleanPath)
+  const canonicalUrl = `${siteConfig.url}${canonicalPath}`
 
   return (
     <LayoutProvider>

--- a/docs/src/theme/PaginatorNavLink/index.tsx
+++ b/docs/src/theme/PaginatorNavLink/index.tsx
@@ -2,16 +2,19 @@ import Link from '@docusaurus/Link'
 import { cn } from '@site/src/lib/utils'
 import type { Props } from '@theme/PaginatorNavLink'
 import { type ReactNode } from 'react'
+import { normalizeSiteSectionRoot } from '@site/src/utils/canonical-url'
 
 export default function PaginatorNavLink(props: Props): ReactNode {
   const { permalink, title, subLabel, isNext } = props
+  const linkHref = normalizeSiteSectionRoot(permalink)
+
   return (
     <Link
       className={cn(
         'flex items-center gap-2 py-4 hover:no-underline!',
         isNext ? 'flex-row-reverse pl-4 2xl:-mr-8' : 'flex-row pr-4 2xl:-ml-8',
       )}
-      to={permalink}
+      to={linkHref}
       data-is-next={isNext}
     >
       <svg

--- a/docs/src/theme/SiteMetadata/index.tsx
+++ b/docs/src/theme/SiteMetadata/index.tsx
@@ -1,0 +1,142 @@
+import React, { type ReactNode } from 'react'
+import Head from '@docusaurus/Head'
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import useBaseUrl from '@docusaurus/useBaseUrl'
+import { PageMetadata, useThemeConfig } from '@docusaurus/theme-common'
+import { DEFAULT_SEARCH_TAG, useAlternatePageUtils } from '@docusaurus/theme-common/internal'
+import { useLocation } from '@docusaurus/router'
+import SearchMetadata from '@theme/SearchMetadata'
+import { normalizeSiteSectionRoot } from '@site/src/utils/canonical-url'
+
+// TODO move to SiteMetadataDefaults or theme-common ?
+// Useful for i18n/SEO
+// See https://developers.google.com/search/docs/advanced/crawling/localized-versions
+// See https://github.com/facebook/docusaurus/issues/3317
+function AlternateLangHeaders(): ReactNode {
+  const {
+    i18n: { currentLocale, defaultLocale, localeConfigs },
+  } = useDocusaurusContext()
+  const alternatePageUtils = useAlternatePageUtils()
+
+  const currentHtmlLang = localeConfigs[currentLocale]!.htmlLang
+
+  // HTML lang is a BCP 47 tag, but the Open Graph protocol requires
+  // using underscores instead of dashes.
+  // See https://ogp.me/#optional
+  // See https://en.wikipedia.org/wiki/IETF_language_tag)
+  const bcp47ToOpenGraphLocale = (code: string): string => code.replace('-', '_')
+
+  // Note: it is fine to use both "x-default" and "en" to target the same url
+  // See https://www.searchviu.com/en/multiple-hreflang-tags-one-url/
+  return (
+    <Head>
+      {Object.entries(localeConfigs).map(([locale, { htmlLang }]) => (
+        <link
+          key={locale}
+          rel="alternate"
+          href={normalizeSiteSectionRoot(
+            alternatePageUtils.createUrl({
+              locale,
+              fullyQualified: true,
+            }),
+          )}
+          hrefLang={htmlLang}
+        />
+      ))}
+      <link
+        rel="alternate"
+        href={normalizeSiteSectionRoot(
+          alternatePageUtils.createUrl({
+            locale: defaultLocale,
+            fullyQualified: true,
+          }),
+        )}
+        hrefLang="x-default"
+      />
+
+      <meta property="og:locale" content={bcp47ToOpenGraphLocale(currentHtmlLang)} />
+      {Object.values(localeConfigs)
+        .filter(config => currentHtmlLang !== config.htmlLang)
+        .map(config => (
+          <meta
+            key={`meta-og-${config.htmlLang}`}
+            property="og:locale:alternate"
+            content={bcp47ToOpenGraphLocale(config.htmlLang)}
+          />
+        ))}
+    </Head>
+  )
+}
+
+// Default canonical url inferred from current page location pathname
+function useDefaultCanonicalUrl() {
+  const {
+    siteConfig: { url: siteUrl },
+  } = useDocusaurusContext()
+
+  // TODO using useLocation().pathname is not a super idea
+  // See https://github.com/facebook/docusaurus/issues/9170
+  const { pathname } = useLocation()
+
+  const canonicalPathname = useBaseUrl(pathname)
+
+  return normalizeSiteSectionRoot(siteUrl + canonicalPathname)
+}
+
+// TODO move to SiteMetadataDefaults or theme-common ?
+function CanonicalUrlHeaders({ permalink }: { permalink?: string }) {
+  const {
+    siteConfig: { url: siteUrl },
+  } = useDocusaurusContext()
+  const defaultCanonicalUrl = useDefaultCanonicalUrl()
+
+  const canonicalUrl = normalizeSiteSectionRoot(permalink ? `${siteUrl}${permalink}` : defaultCanonicalUrl)
+  return (
+    <Head>
+      <meta property="og:url" content={canonicalUrl} />
+      <link rel="canonical" href={canonicalUrl} />
+    </Head>
+  )
+}
+
+export default function SiteMetadata(): ReactNode {
+  const {
+    i18n: { currentLocale },
+  } = useDocusaurusContext()
+
+  // TODO maybe move these 2 themeConfig to siteConfig?
+  // These seems useful for other themes as well
+  const { metadata, image: defaultImage } = useThemeConfig()
+
+  return (
+    <>
+      <Head>
+        <meta name="twitter:card" content="summary_large_image" />
+        {/* The keyboard focus class name need to be applied when SSR so links
+        are outlined when JS is disabled */}
+        <body />
+      </Head>
+
+      {defaultImage && <PageMetadata image={defaultImage} />}
+
+      <CanonicalUrlHeaders />
+
+      <AlternateLangHeaders />
+
+      <SearchMetadata tag={DEFAULT_SEARCH_TAG} locale={currentLocale} />
+
+      {/*
+        It's important to have an additional <Head> element here, as it allows
+        react-helmet to override default metadata values set in previous <Head>
+        like "twitter:card". In same Head, the same meta would appear twice
+        instead of overriding.
+      */}
+      <Head>
+        {/* Yes, "metadatum" is the grammatically correct term */}
+        {metadata.map((metadatum, i) => (
+          <meta key={i} {...metadatum} />
+        ))}
+      </Head>
+    </>
+  )
+}

--- a/docs/src/utils/canonical-url.test.ts
+++ b/docs/src/utils/canonical-url.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeSiteSectionRoot, SITE_SECTION_ROOTS } from './canonical-url'
+
+describe('normalizeSiteSectionRoot', () => {
+  it.each(Object.values(SITE_SECTION_ROOTS))('removes the trailing slash from %s', root => {
+    expect(normalizeSiteSectionRoot(`${root}/`)).toBe(root)
+    expect(normalizeSiteSectionRoot(`https://mastra.ai${root}/`)).toBe(`https://mastra.ai${root}`)
+  })
+
+  it('leaves nested routes and unrelated roots unchanged', () => {
+    expect(normalizeSiteSectionRoot('/docs/agents/')).toBe('/docs/agents/')
+    expect(normalizeSiteSectionRoot('/learn/')).toBe('/learn/')
+  })
+})

--- a/docs/src/utils/canonical-url.ts
+++ b/docs/src/utils/canonical-url.ts
@@ -1,0 +1,12 @@
+export const SITE_SECTION_ROOTS = {
+  docs: '/docs',
+  integrations: '/integrations',
+  models: '/models',
+  reference: '/reference',
+} as const
+
+const siteSectionRoots = Object.values(SITE_SECTION_ROOTS)
+
+export function normalizeSiteSectionRoot(value: string): string {
+  return siteSectionRoots.some(root => value.endsWith(`${root}/`)) ? value.slice(0, -1) : value
+}


### PR DESCRIPTION
## Description

Normalizes the canonical URLs for the `/docs`, `/integrations`, `/models`, and `/reference` section roots so they match the trailing-slash-free URLs served by Vercel.

Before:

```text
/docs/ redirects to /docs
<link rel="canonical" href="https://mastra.ai/docs/">
```

After:

```text
/docs/ redirects to /docs
<link rel="canonical" href="https://mastra.ai/docs">
```

A shared section-root utility keeps canonical, Open Graph, hreflang, sitemap, sidebar, paginator, and mobile navigation URLs consistent. The Docusaurus `SiteMetadata` override was generated with `docusaurus swizzle` and adapted to use the shared normalization.

## Related issue(s)

Reported through an SEO audit; no GitHub issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The documentation pages now use the correct URL without an extra slash at the end. Shared URL rules keep links, metadata, sitemaps, and navigation consistent.

## Changes

- Added `SITE_SECTION_ROOTS` and `normalizeSiteSectionRoot`.
- Normalized canonical, Open Graph, hreflang, sitemap, sidebar, paginator, and mobile navigation URLs.
- Preserved external sidebar URLs while normalizing internal sidebar URLs.
- Added the Docusaurus `SiteMetadata` override with localized metadata, Twitter metadata, default images, and search metadata.
- Updated route configuration and the Algolia Quickstart link to use shared section roots.
- Updated document movement and deletion tests for the `/reference` route family.
- Added tests for relative and absolute section-root URLs, nested routes, and unrelated roots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->