### PR TITLE
feat(factory): audit docs changes during PR review

### DIFF
--- a/.changeset/tall-moons-clap.md
+++ b/.changeset/tall-moons-clap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved Factory PR review to audit documentation changes on mastra-ai/mastra with the repository's `docs-audit` skill, so docs changes are graded against the canonical authoring guidance instead of only general review judgement.

--- a/mastracode/factory/factory-skills/factory-review/SKILL.md
+++ b/mastracode/factory/factory-skills/factory-review/SKILL.md
@@ -74,6 +74,7 @@ Bots have false positives — verify, don't rubber-stamp. But a major finding fr
 - Is the diff coherent — one focused change, or unrelated changes mixed in?
 - Changeset present if the repo uses changesets and the change is runtime-visible?
 - Any evidence the author verified the change works (test output, repro, screenshots)?
+- For `mastra-ai/mastra`, audit documentation changes with the `docs-audit` skill.
 
 Gate failures don't stop the review — they become findings for the verdict.
 


### PR DESCRIPTION
Factory review had no docs-specific step, so documentation changes got general review judgement and nothing checked them against the authoring guidance the repo already maintains.

This adds one line to the review quality gate: for `mastra-ai/mastra`, audit documentation changes with the `docs-audit` skill.

```
- For `mastra-ai/mastra`, audit documentation changes with the `docs-audit` skill.
```

The skill stays in the repo rather than getting bundled into the Factory package. Review sessions clone the repo they're reviewing and project skill roots resolve against that checkout, so `.claude/skills/docs-audit` is already there — along with the `mastra-docs` references it reads for the styleguide and information architecture. Bundling it would shadow the repo copy and pin the rubric to a Factory release, which seems worse for something docs folks should be able to tune freely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes Factory check documentation changes during reviews. It uses the repository’s existing `docs-audit` skill so documentation follows the project’s writing and organization rules.

## Changes

- Added a documentation audit step to `factory-review`.
- Audits `mastra-ai/mastra` documentation with `.claude/skills/docs-audit`.
- Keeps the audit skill in the repository so the repository can update its review rules independently.
- Added a patch changeset for `@mastra/factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->