### PR TITLE
fix(core): ignore stale replayed suspensions

### DIFF
--- a/.changeset/fiery-dryers-push.md
+++ b/.changeset/fiery-dryers-push.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed reconnected thread subscribers reactivating completed approval and tool suspension prompts.

--- a/packages/core/src/agent-controller/__tests__/run-engine-replay-suspension.test.ts
+++ b/packages/core/src/agent-controller/__tests__/run-engine-replay-suspension.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AgentThreadStreamRuntime, markReplayedStreamPart } from '../../agent/thread-stream-runtime';
+import { PubSub } from '../../events/pubsub';
+import type { EventCallback } from '../../events/types';
+import { RequestContext } from '../../request-context';
+import { Workspace } from '../../workspace';
+import { LocalFilesystem } from '../../workspace/filesystem/local-filesystem';
+import type { SessionMachinery } from '../session';
+import { Session } from '../session';
+import { SessionRunEngine } from '../session-run-engine';
+import type { AgentControllerEvent } from '../types';
+
+class RetainedPubSub extends PubSub {
+  #history = new Map<string, any[]>();
+  #subscribers = new Map<string, Set<EventCallback>>();
+  #index = 0;
+
+  async publish(topic: string, event: any): Promise<void> {
+    const envelope = { ...event, id: `event-${this.#index++}`, createdAt: new Date() };
+    const history = this.#history.get(topic) ?? [];
+    history.push(envelope);
+    this.#history.set(topic, history);
+    for (const subscriber of this.#subscribers.get(topic) ?? []) subscriber(envelope);
+  }
+
+  async subscribe(topic: string, callback: EventCallback): Promise<void> {
+    const subscribers = this.#subscribers.get(topic) ?? new Set<EventCallback>();
+    subscribers.add(callback);
+    this.#subscribers.set(topic, subscribers);
+    for (const event of this.#history.get(topic) ?? []) callback(event);
+  }
+
+  async unsubscribe(topic: string, callback: EventCallback): Promise<void> {
+    this.#subscribers.get(topic)?.delete(callback);
+  }
+
+  async flush(): Promise<void> {}
+}
+
+function createHarness() {
+  const events: AgentControllerEvent[] = [];
+  const agent = {
+    id: 'agent-stub',
+    listSuspendedRuns: vi.fn(async (): Promise<any> => ({ runs: [] })),
+    sendToolApproval: vi.fn(async () => {}),
+  };
+  const session = new Session({
+    resourceId: 'resource-1',
+    id: 'session-1',
+    ownerId: 'owner-1',
+    workspace: new Workspace({
+      id: 'workspace-1',
+      filesystem: new LocalFilesystem({ basePath: '/tmp' }),
+    }),
+  });
+  session.thread.set({ threadId: 'thread-1' });
+  session.subscribe(event => {
+    events.push(event);
+  });
+
+  const machinery: SessionMachinery = {
+    getAgent: () => agent as any,
+    getRunScope: () => undefined,
+    subscribeToThread: async () => {
+      throw new Error('subscribeToThread is not used by these tests');
+    },
+    buildStreamOptions: async () => ({}),
+    buildSharedRunOptions: () => ({}),
+    buildToolsets: async () => ({}),
+    buildRequestContext: async requestContext => requestContext ?? new RequestContext(),
+    persistTokenUsage: vi.fn(async () => {}),
+    generateId: () => 'msg-1',
+    resolveTransitionModeId: () => undefined,
+    saveSystemReminder: vi.fn(async () => null),
+  };
+
+  return { agent, engine: new SessionRunEngine(session, machinery), events, session };
+}
+
+function replaySubscription(chunks: any[]) {
+  return {
+    stream: (async function* () {
+      yield* chunks.map(markReplayedStreamPart);
+    })(),
+    activeRunId: () => null,
+    abort: () => false,
+    unsubscribe: vi.fn(),
+  };
+}
+
+describe('SessionRunEngine — replayed interactive suspensions', () => {
+  it('ignores obsolete replayed approval and suspension events', async () => {
+    const { agent, engine, events, session } = createHarness();
+    session.state.set({ yolo: true });
+    const subscription = replaySubscription([
+      { type: 'start', runId: 'completed-run' },
+      {
+        type: 'tool-call-approval',
+        runId: 'completed-run',
+        payload: { toolCallId: 'approval-call', toolName: 'write_file', args: {} },
+      },
+      {
+        type: 'tool-call-suspended',
+        runId: 'completed-run',
+        payload: { toolCallId: 'suspended-call', toolName: 'ask_user', args: {}, suspendPayload: {} },
+      },
+    ]);
+    session.stream.attach({ subscription, key: 'thread-1' });
+
+    await engine.processSubscribedThreadStream(subscription as any);
+
+    expect(agent.sendToolApproval).not.toHaveBeenCalled();
+    expect(session.suspensions.hasPending()).toBe(false);
+    expect(events).not.toContainEqual(expect.objectContaining({ type: 'tool_suspended' }));
+    expect(events).not.toContainEqual(expect.objectContaining({ type: 'error' }));
+  });
+
+  it('replays a suspended generation before a completed continuation without reviving its side effects', async () => {
+    const { agent, engine, events, session } = createHarness();
+    session.state.set({ yolo: true });
+    const pubsub = new RetainedPubSub();
+    const runtime = new AgentThreadStreamRuntime();
+    const runId = 'continued-run';
+    const topic = `agent.thread-stream.${encodeURIComponent('resource-1\u0000thread-1')}`;
+
+    const publish = (type: string, data: Record<string, unknown>) => pubsub.publish(topic, { type, data });
+    await publish('run-registered', { type: 'run-registered', runId, streamId: 'suspended-stream', streamSeq: 1 });
+    await publish('stream-part', { type: 'stream-part', runId, streamId: 'suspended-stream', part: { type: 'start' } });
+    await publish('stream-part', {
+      type: 'stream-part',
+      runId,
+      streamId: 'suspended-stream',
+      part: {
+        type: 'tool-call-approval',
+        payload: { toolCallId: 'approval-call', toolName: 'write_file', args: {} },
+      },
+    });
+    await publish('stream-part', {
+      type: 'stream-part',
+      runId,
+      streamId: 'suspended-stream',
+      part: {
+        type: 'tool-call-suspended',
+        payload: { toolCallId: 'suspended-call', toolName: 'ask_user', args: {}, suspendPayload: {} },
+      },
+    });
+    await publish('run-suspended', { type: 'run-suspended', runId, streamId: 'suspended-stream' });
+    await publish('run-registered', { type: 'run-registered', runId, streamId: 'completed-stream', streamSeq: 2 });
+    await publish('stream-part', { type: 'stream-part', runId, streamId: 'completed-stream', part: { type: 'start' } });
+    await publish('stream-part', {
+      type: 'stream-part',
+      runId,
+      streamId: 'completed-stream',
+      part: { type: 'finish', payload: { stepResult: { reason: 'stop' } } },
+    });
+    await publish('run-completed', { type: 'run-completed', runId, streamId: 'completed-stream', persisted: true });
+
+    const subscription = await runtime.subscribeToThread(
+      agent as any,
+      { threadId: 'thread-1', resourceId: 'resource-1' },
+      pubsub,
+    );
+    session.stream.attach({ subscription, key: 'thread-1' });
+    const processing = engine.processSubscribedThreadStream(subscription as any);
+    await vi.waitFor(() => expect(agent.listSuspendedRuns).toHaveBeenCalledTimes(2));
+    subscription.unsubscribe();
+    await processing;
+
+    expect(agent.sendToolApproval).not.toHaveBeenCalled();
+    expect(session.suspensions.hasPending()).toBe(false);
+    expect(events).not.toContainEqual(expect.objectContaining({ type: 'tool_suspended' }));
+    expect(events).not.toContainEqual(expect.objectContaining({ type: 'error' }));
+  });
+
+  it('restores replayed suspension events with a durable snapshot', async () => {
+    const { agent, engine, events, session } = createHarness();
+    agent.listSuspendedRuns.mockResolvedValueOnce({
+      runs: [{ runId: 'durable-run', toolCalls: [{ toolCallId: 'durable-call' }] }],
+    });
+    const subscription = replaySubscription([
+      { type: 'start', runId: 'durable-run' },
+      {
+        type: 'tool-call-suspended',
+        runId: 'durable-run',
+        payload: { toolCallId: 'durable-call', toolName: 'ask_user', args: {}, suspendPayload: {} },
+      },
+    ]);
+    session.stream.attach({ subscription, key: 'thread-1' });
+
+    await engine.processSubscribedThreadStream(subscription as any);
+
+    expect(session.suspensions.hasPending()).toBe(true);
+    expect(events).toContainEqual(expect.objectContaining({ type: 'tool_suspended', toolCallId: 'durable-call' }));
+  });
+});

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -5,6 +5,7 @@ import type {
   MastraProviderMetadata,
   MastraToolInvocationPart,
 } from '../agent/message-list/state/types';
+import { isReplayedStreamPart } from '../agent/thread-stream-runtime';
 import type { AgentThreadSubscription } from '../agent/types';
 import { getErrorFromUnknown } from '../error';
 import type { RequestContext } from '../request-context';
@@ -268,6 +269,18 @@ export class SessionRunEngine {
       content: { format: 2, parts: [] },
       createdAt: new Date(),
     };
+  }
+
+  private async hasDurableSuspension(agent: Agent, toolCallId: string): Promise<boolean> {
+    const threadId = this.#session.thread.getId();
+    const runId = this.#session.run.getRunId();
+    if (!threadId || !runId) return false;
+
+    const { runs } = await agent.listSuspendedRuns({
+      threadId,
+      resourceId: this.#session.identity.getResourceId(),
+    });
+    return runs.some(run => run.runId === runId && run.toolCalls.some(toolCall => toolCall.toolCallId === toolCallId));
   }
 
   /**
@@ -679,6 +692,10 @@ export class SessionRunEngine {
           ? approvalTransform.transformed
           : getDisplayTransform(chunk.metadata, 'input-available', getPayload(chunk).args);
 
+        if (isReplayedStreamPart(chunk) && !(await this.hasDurableSuspension(agent, toolCallId))) {
+          break;
+        }
+
         const policy = this.#session.resolveToolApproval(toolName);
 
         if (policy === 'allow') {
@@ -737,6 +754,10 @@ export class SessionRunEngine {
         const suspArgs = getDisplayTransform(chunk.metadata, 'input-available', getPayload(chunk).args);
         const suspPayload = getDisplayTransform(chunk.metadata, 'suspend', getPayload(chunk).suspendPayload);
         const suspResumeSchema = getString(getPayload(chunk).resumeSchema);
+
+        if (isReplayedStreamPart(chunk) && !(await this.hasDurableSuspension(agent, suspToolCallId))) {
+          break;
+        }
 
         const suspRunId = this.#session.run.getRunId();
         if (suspRunId) {

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -28,7 +28,7 @@ import {
   signalToDataPartFormat,
   signalToMastraDBMessage,
 } from '../signals';
-import { AgentThreadStreamRuntime, agentThreadStreamRuntime } from '../thread-stream-runtime';
+import { AgentThreadStreamRuntime, agentThreadStreamRuntime, isReplayedStreamPart } from '../thread-stream-runtime';
 
 function createTextStreamModel(responseText: string) {
   return new MockLanguageModelV2({
@@ -1109,6 +1109,62 @@ describe('Agent signals', () => {
       await pubsub.flush();
       await nextTick();
       await pubsub.flush();
+    }
+  });
+
+  it('keeps replay metadata scoped to each retained stream generation of the same run', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new ControlledLeasePubSub();
+    const threadId = 'replayed-stream-thread';
+    const resourceId = 'replayed-stream-resource';
+    const runId = 'replayed-run';
+    const key = `${resourceId}\u0000${threadId}`;
+    const topic = `agent.thread-stream.${encodeURIComponent(key)}`;
+    const agent = { id: 'replayed-stream-agent' } as Agent<any, any, any, any>;
+    pubsub.owners.set(key, runId);
+
+    const publishGeneration = async (
+      streamId: string,
+      streamSeq: number,
+      terminal: 'run-suspended' | 'run-completed',
+    ) => {
+      await pubsub.publish(topic, {
+        type: 'run-registered',
+        data: { type: 'run-registered', runId, streamId, streamSeq },
+      });
+      await pubsub.publish(topic, {
+        type: 'stream-part',
+        data: { type: 'stream-part', runId, streamId, sourceId: 'origin', part: { type: 'start' } },
+      });
+      await pubsub.publish(topic, {
+        type: terminal,
+        data: { type: terminal, runId, streamId, ...(terminal === 'run-completed' ? { persisted: true } : {}) },
+      });
+    };
+
+    await publishGeneration('replayed-stream-1', 1, 'run-suspended');
+    await publishGeneration('replayed-stream-2', 2, 'run-completed');
+    await pubsub.flush();
+
+    const subscription = await runtime.subscribeToThread(agent, { threadId, resourceId }, pubsub);
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+    try {
+      const retainedSuspension = await withTimeout(iterator.next(), 'Timed out waiting for retained suspension');
+      expect(retainedSuspension).toMatchObject({ value: { type: 'start', runId } });
+      expect(isReplayedStreamPart(retainedSuspension.value)).toBe(true);
+      expect(JSON.stringify(retainedSuspension.value)).toBe(JSON.stringify({ type: 'start', runId }));
+
+      const retainedContinuation = await withTimeout(iterator.next(), 'Timed out waiting for retained continuation');
+      expect(retainedContinuation).toMatchObject({ value: { type: 'start', runId } });
+      expect(isReplayedStreamPart(retainedContinuation.value)).toBe(true);
+
+      await publishGeneration('live-stream-3', 3, 'run-completed');
+      await pubsub.flush();
+      const liveContinuation = await withTimeout(iterator.next(), 'Timed out waiting for live continuation');
+      expect(liveContinuation).toMatchObject({ value: { type: 'start', runId } });
+      expect(isReplayedStreamPart(liveContinuation.value)).toBe(false);
+    } finally {
+      subscription.unsubscribe();
     }
   });
 

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -61,6 +61,17 @@ const AGENT_THREAD_LEASE_RENEW_INTERVAL_MS = readPositiveIntEnv(
 const AGENT_SUSPENDED_RUN_TTL_MS = readPositiveIntEnv('MASTRA_SUSPENDED_RUN_TTL_MS', 30 * 60 * 1000);
 
 export const AGENT_THREAD_LEASE_CONFLICT_CODE = 'AGENT_THREAD_LEASE_CONFLICT';
+export const REPLAYED_STREAM_PART = Symbol('mastra.replayedStreamPart');
+
+export function markReplayedStreamPart<T extends object>(part: T): T {
+  const markedPart = { ...part };
+  Object.defineProperty(markedPart, REPLAYED_STREAM_PART, { value: true, enumerable: false });
+  return markedPart as T;
+}
+
+export function isReplayedStreamPart(part: unknown): boolean {
+  return Boolean(part && typeof part === 'object' && REPLAYED_STREAM_PART in part);
+}
 
 export class AgentThreadLeaseConflictError extends Error {
   readonly code = AGENT_THREAD_LEASE_CONFLICT_CODE;
@@ -153,6 +164,8 @@ type AgentThreadRunRecord<OUTPUT = unknown> = {
   resourceId?: string;
   streamOptions: AgentExecutionOptions<OUTPUT>;
   createSubscriberStream?: () => ReadableStream<unknown>;
+  /** Whether this record was reconstructed from retained pubsub history. */
+  isReplay?: boolean;
   /** Settles once every stream-part broadcast publish for this run completed. */
   broadcastFinished?: Promise<void>;
 };
@@ -2112,7 +2125,12 @@ export class AgentThreadStreamRuntime {
       wake();
     };
 
-    const createRemoteRun = (runId: string, streamId: string, streamSeq: number): AgentThreadRunRecord<any> => {
+    const createRemoteRun = (
+      runId: string,
+      streamId: string,
+      streamSeq: number,
+      isReplay: boolean,
+    ): AgentThreadRunRecord<any> => {
       const remoteRun = {
         parts: [] as unknown[],
         waiters: [] as Array<() => void>,
@@ -2163,6 +2181,7 @@ export class AgentThreadStreamRuntime {
         streamId,
         streamSeq,
         lifecycle: 'running',
+        isReplay,
         threadId: options.threadId,
         resourceId: options.resourceId,
         streamOptions: {},
@@ -2185,6 +2204,7 @@ export class AgentThreadStreamRuntime {
     let activeReaderRunId: string | null = null;
     let activeReaderStreamId: string | null = null;
     let currentRunRequestContext: RequestContext | undefined;
+    let isSubscribing = true;
     let cancelledByAbort = false;
 
     const markActiveIfLive = async (runId: string, streamId: string, local: boolean) => {
@@ -2293,7 +2313,7 @@ export class AgentThreadStreamRuntime {
       );
     };
 
-    const handleEvent = async (event: Parameters<EventCallback>[0]) => {
+    const handleEvent = async (event: Parameters<EventCallback>[0], deliveredWhileSubscribing: boolean) => {
       if (done) return;
       const data = event.data as AgentThreadStreamRuntimeEvent | undefined;
       if (!data) return;
@@ -2326,7 +2346,7 @@ export class AgentThreadStreamRuntime {
         const record =
           localRecord ??
           deferredRunsByStreamId.get(data.streamId) ??
-          createRemoteRun(data.runId, data.streamId, data.streamSeq);
+          createRemoteRun(data.runId, data.streamId, data.streamSeq, deliveredWhileSubscribing || !live);
         if (live) {
           deferredRunsByStreamId.delete(data.streamId);
           enqueueRun(record);
@@ -2356,8 +2376,14 @@ export class AgentThreadStreamRuntime {
           // A subscriber can attach after another runtime already broadcast run-registered.
           // Treat the first stream-part on this thread topic as proof of the remote run and
           // create the local proxy stream from that point forward.
-          const record = createRemoteRun(data.runId, data.streamId, state.streamSeqByRunId.get(data.runId) ?? 1);
-          if (await this.#hasLiveThreadLease(resolvedPubSub, key, data.runId)) {
+          const live = await this.#hasLiveThreadLease(resolvedPubSub, key, data.runId);
+          const record = createRemoteRun(
+            data.runId,
+            data.streamId,
+            state.streamSeqByRunId.get(data.runId) ?? 1,
+            deliveredWhileSubscribing || !live,
+          );
+          if (live) {
             enqueueRun(record);
           } else {
             deferredRunsByStreamId.set(data.streamId, record);
@@ -2404,7 +2430,7 @@ export class AgentThreadStreamRuntime {
         let errorRun: AgentThreadRunRecord<any> | undefined;
         let remoteRun = remoteRuns.get(eventStreamId);
         if (!remoteRun) {
-          errorRun = createRemoteRun(data.runId, eventStreamId, state.streamSeqByRunId.get(data.runId) ?? 1);
+          errorRun = createRemoteRun(data.runId, eventStreamId, state.streamSeqByRunId.get(data.runId) ?? 1, false);
           remoteRun = remoteRuns.get(eventStreamId);
         }
         if (remoteRun) {
@@ -2502,12 +2528,13 @@ export class AgentThreadStreamRuntime {
 
     let eventTail = Promise.resolve();
     const onEvent: EventCallback = (event, ack) => {
+      const deliveredWhileSubscribing = isSubscribing;
       // Events are processed strictly in publish order, but each delivery is
       // acknowledged on its own outcome. Every delivered event is acked once it
       // has been inspected — including events this subscriber filters out —
       // because a persistent backend (Redis consumer groups) keeps unacked
       // deliveries pending for the lifetime of the subscription.
-      const processed = eventTail.then(() => handleEvent(event));
+      const processed = eventTail.then(() => handleEvent(event, deliveredWhileSubscribing));
       // The tail must survive a failed event so later events still run.
       eventTail = processed.then(
         () => {},
@@ -2517,7 +2544,11 @@ export class AgentThreadStreamRuntime {
       return processed.then(() => ack?.());
     };
 
-    await resolvedPubSub.subscribe(topic, onEvent);
+    try {
+      await resolvedPubSub.subscribe(topic, onEvent);
+    } finally {
+      isSubscribing = false;
+    }
 
     const currentRunId = activeRunId();
     const currentRecord = currentRunId ? state.threadRunsById.get(currentRunId) : undefined;
@@ -2576,7 +2607,7 @@ export class AgentThreadStreamRuntime {
                   typedPart && typeof typedPart === 'object' && !('runId' in typedPart)
                     ? { ...typedPart, runId: run.runId }
                     : typedPart;
-                yield partWithRunId;
+                yield run.isReplay ? markReplayedStreamPart(partWithRunId) : partWithRunId;
                 if (done) break;
                 const finishReason = typedPart.finishReason ?? typedPart.payload?.finishReason;
                 const terminalBoundary =


### PR DESCRIPTION
Reconnected thread subscribers could replay an old approval or tool suspension and expose it as actionable after the run had already completed. This keeps replay metadata attached to each retained chunk and verifies durable suspension state before triggering interactive side effects, while preserving genuinely pending suspensions after restart.

Before: reconnecting could reopen a settled prompt and fail when the user continued. After: settled prompts remain historical, while durable pending prompts remain actionable and resume normally.

Covered by retained multi-generation replay regressions, focused core tests, type checks, and a manual Factory reconnect and suspension-resume check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When someone reconnects, the system no longer treats old approval prompts as new requests. It still restores prompts when the run is genuinely paused and needs action.

## What changed

- Marked retained stream chunks as replayed.
- Ignored replayed approval and tool-suspension events unless matching durable suspension data still exists.
- Preserved replay metadata across multiple retained run generations.
- Prevented completed, failed, aborted, or incomplete replays from reviving interactive side effects.
- Added replay and suspension regression tests.
- Added a patch changeset for `@mastra/core`.
- Added exported replay helpers:
  - `REPLAYED_STREAM_PART`
  - `markReplayedStreamPart`
  - `isReplayedStreamPart`

## Validation

- Added focused core tests for replay and suspension behavior.
- Added type checks.
- Performed a manual Factory reconnect and suspension-resume check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->