### PR TITLE
Enforce trusted scope in ClickHouse observability analytics

### DIFF
--- a/.changeset/giant-snails-relate.md
+++ b/.changeset/giant-snails-relate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/clickhouse': minor
+---
+
+Added trusted query scoping for ClickHouse observability analytics so hosted services can enforce tenant boundaries before aggregation.

--- a/stores/clickhouse/src/storage/domains/observability/v-next/feedback.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/feedback.ts
@@ -335,12 +335,13 @@ function buildFeedbackCursor(row: FeedbackDeltaRow): string {
 
 export async function getFeedbackAggregate(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetFeedbackAggregateArgs,
 ): Promise<GetFeedbackAggregateResponse> {
   const aggSql = getAggregationSql(args.aggregation);
   const identity = buildFeedbackIdentityFilter(args);
   const signalFilter = buildFeedbackFilterConditions(args.filters);
-  const combined = mergeFilters(identity, signalFilter);
+  const combined = mergeFilters(trustedScope, identity, signalFilter);
   const whereClause = toWhereClause(combined);
 
   const sql = `SELECT ${aggSql} AS value FROM ${TABLE_FEEDBACK_EVENTS} ${whereClause}`;
@@ -377,7 +378,7 @@ export async function getFeedbackAggregate(
         timestamp: { start: prevStart, end: prevEnd, startExclusive: ts.startExclusive, endExclusive: ts.endExclusive },
       };
       const prevSignalFilter = buildFeedbackFilterConditions(prevFilters);
-      const prevCombined = mergeFilters(identity, prevSignalFilter);
+      const prevCombined = mergeFilters(trustedScope, identity, prevSignalFilter);
       const prevWhereClause = toWhereClause(prevCombined);
 
       const prevResult = await queryJson<Record<string, unknown>>(
@@ -401,12 +402,13 @@ export async function getFeedbackAggregate(
 
 export async function getFeedbackBreakdown(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetFeedbackBreakdownArgs,
 ): Promise<GetFeedbackBreakdownResponse> {
   const aggSql = getAggregationSql(args.aggregation);
   const identity = buildFeedbackIdentityFilter(args);
   const signalFilter = buildFeedbackFilterConditions(args.filters);
-  const combined = mergeFilters(identity, signalFilter);
+  const combined = mergeFilters(trustedScope, identity, signalFilter);
   const whereClause = toWhereClause(combined);
   const resolved = resolveFeedbackGroupBy(args.groupBy);
 
@@ -428,13 +430,14 @@ export async function getFeedbackBreakdown(
 
 export async function getFeedbackTimeSeries(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetFeedbackTimeSeriesArgs,
 ): Promise<GetFeedbackTimeSeriesResponse> {
   const aggSql = getAggregationSql(args.aggregation);
   const intervalSql = getIntervalSql(args.interval);
   const identity = buildFeedbackIdentityFilter(args);
   const signalFilter = buildFeedbackFilterConditions(args.filters);
-  const combined = mergeFilters(identity, signalFilter);
+  const combined = mergeFilters(trustedScope, identity, signalFilter);
   const whereClause = toWhereClause(combined);
 
   if (args.groupBy && args.groupBy.length > 0) {
@@ -489,12 +492,13 @@ export async function getFeedbackTimeSeries(
 
 export async function getFeedbackPercentiles(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetFeedbackPercentilesArgs,
 ): Promise<GetFeedbackPercentilesResponse> {
   const intervalSql = getIntervalSql(args.interval);
   const identity = buildFeedbackIdentityFilter(args);
   const signalFilter = buildFeedbackFilterConditions(args.filters);
-  const combined = mergeFilters(identity, signalFilter);
+  const combined = mergeFilters(trustedScope, identity, signalFilter);
   const whereClause = toWhereClause(combined);
 
   if (!Array.isArray(args.percentiles) || args.percentiles.length === 0) {

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
@@ -115,14 +115,6 @@ import {
   parseTtlExpression,
 } from './ddl';
 import type { MigrationEntry, RetentionEntry, RetentionConfig } from './ddl';
-export type { RetentionConfig } from './ddl';
-
-/** Extended config for v-next observability, adding per-signal retention. */
-export type VNextObservabilityConfig = ClickhouseDomainConfig & {
-  retention?: RetentionConfig;
-  /** @internal Test-only override for the ClickHouse delta cursor strategy. */
-  deltaCursorStrategy?: ClickHouseDeltaCursorStrategy;
-};
 import * as discoveryOps from './discovery';
 import * as feedbackOps from './feedback';
 import * as logsOps from './logs';
@@ -139,6 +131,24 @@ import { deltaPollingSupported } from './polling';
 import * as scoresOps from './scores';
 import * as traceRootsOps from './trace-roots';
 import * as tracingOps from './tracing';
+import { buildTrustedQueryScopeFilter, CLICKHOUSE_TRUSTED_QUERY_SCOPE } from './trusted-query-scope';
+import type { TrustedQueryScope } from './trusted-query-scope';
+
+export type { RetentionConfig } from './ddl';
+export { CLICKHOUSE_TRUSTED_QUERY_SCOPE } from './trusted-query-scope';
+export type { TrustedQueryScope } from './trusted-query-scope';
+
+/** Extended config for v-next observability, adding per-signal retention. */
+export type VNextObservabilityConfig = ClickhouseDomainConfig & {
+  retention?: RetentionConfig;
+  /**
+   * Mandatory constraints applied inside every OLAP query before aggregation.
+   * Values must come from trusted infrastructure, never application request data.
+   */
+  [CLICKHOUSE_TRUSTED_QUERY_SCOPE]?: TrustedQueryScope;
+  /** @internal Test-only override for the ClickHouse delta cursor strategy. */
+  deltaCursorStrategy?: ClickHouseDeltaCursorStrategy;
+};
 
 function buildSignalMigrationRequiredMessage(args: {
   store: 'ClickHouse';
@@ -443,6 +453,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
   readonly #client: ClickHouseClient;
   readonly #retention?: RetentionConfig;
   readonly #replication?: ClickhouseReplicationConfig;
+  readonly #trustedQueryScopeFilter: ReturnType<typeof buildTrustedQueryScopeFilter>;
   readonly #deltaCursorStrategyOverride?: ClickHouseDeltaCursorStrategy;
   #deltaCursorStrategy: ClickHouseDeltaCursorStrategy | null = 'fallback';
 
@@ -452,6 +463,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
     this.#client = client;
     this.#replication = replication;
     this.#retention = config.retention;
+    this.#trustedQueryScopeFilter = buildTrustedQueryScopeFilter(config[CLICKHOUSE_TRUSTED_QUERY_SCOPE]);
     this.#deltaCursorStrategyOverride = config.deltaCursorStrategy;
   }
 
@@ -1043,7 +1055,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getScoreAggregate(args: GetScoreAggregateArgs): Promise<GetScoreAggregateResponse> {
     try {
-      return await scoresOps.getScoreAggregate(this.#client, args);
+      return await scoresOps.getScoreAggregate(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(
@@ -1059,7 +1071,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getScoreBreakdown(args: GetScoreBreakdownArgs): Promise<GetScoreBreakdownResponse> {
     try {
-      return await scoresOps.getScoreBreakdown(this.#client, args);
+      return await scoresOps.getScoreBreakdown(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(
@@ -1075,7 +1087,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getScoreTimeSeries(args: GetScoreTimeSeriesArgs): Promise<GetScoreTimeSeriesResponse> {
     try {
-      return await scoresOps.getScoreTimeSeries(this.#client, args);
+      return await scoresOps.getScoreTimeSeries(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(
@@ -1091,7 +1103,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getScorePercentiles(args: GetScorePercentilesArgs): Promise<GetScorePercentilesResponse> {
     try {
-      return await scoresOps.getScorePercentiles(this.#client, args);
+      return await scoresOps.getScorePercentiles(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(
@@ -1111,7 +1123,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getFeedbackAggregate(args: GetFeedbackAggregateArgs): Promise<GetFeedbackAggregateResponse> {
     try {
-      return await feedbackOps.getFeedbackAggregate(this.#client, args);
+      return await feedbackOps.getFeedbackAggregate(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(
@@ -1127,7 +1139,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getFeedbackBreakdown(args: GetFeedbackBreakdownArgs): Promise<GetFeedbackBreakdownResponse> {
     try {
-      return await feedbackOps.getFeedbackBreakdown(this.#client, args);
+      return await feedbackOps.getFeedbackBreakdown(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(
@@ -1143,7 +1155,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getFeedbackTimeSeries(args: GetFeedbackTimeSeriesArgs): Promise<GetFeedbackTimeSeriesResponse> {
     try {
-      return await feedbackOps.getFeedbackTimeSeries(this.#client, args);
+      return await feedbackOps.getFeedbackTimeSeries(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(
@@ -1159,7 +1171,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getFeedbackPercentiles(args: GetFeedbackPercentilesArgs): Promise<GetFeedbackPercentilesResponse> {
     try {
-      return await feedbackOps.getFeedbackPercentiles(this.#client, args);
+      return await feedbackOps.getFeedbackPercentiles(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(
@@ -1179,7 +1191,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getMetricAggregate(args: GetMetricAggregateArgs): Promise<GetMetricAggregateResponse> {
     try {
-      return await metricsOps.getMetricAggregate(this.#client, args);
+      return await metricsOps.getMetricAggregate(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(
@@ -1195,7 +1207,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getMetricBreakdown(args: GetMetricBreakdownArgs): Promise<GetMetricBreakdownResponse> {
     try {
-      return await metricsOps.getMetricBreakdown(this.#client, args);
+      return await metricsOps.getMetricBreakdown(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(
@@ -1211,7 +1223,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getMetricTimeSeries(args: GetMetricTimeSeriesArgs): Promise<GetMetricTimeSeriesResponse> {
     try {
-      return await metricsOps.getMetricTimeSeries(this.#client, args);
+      return await metricsOps.getMetricTimeSeries(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(
@@ -1227,7 +1239,7 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
 
   override async getMetricPercentiles(args: GetMetricPercentilesArgs): Promise<GetMetricPercentilesResponse> {
     try {
-      return await metricsOps.getMetricPercentiles(this.#client, args);
+      return await metricsOps.getMetricPercentiles(this.#client, this.#trustedQueryScopeFilter, args);
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(

--- a/stores/clickhouse/src/storage/domains/observability/v-next/metrics.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/metrics.ts
@@ -411,12 +411,13 @@ function buildMetricsCursor(row: MetricDeltaRow): string {
 
 export async function getMetricAggregate(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetMetricAggregateArgs,
 ): Promise<GetMetricAggregateResponse> {
   const aggSql = getAggregationSql(args.aggregation, 'value', args.distinctColumn);
   const nameFilter = buildMetricNameFilter(args.name);
   const signalFilter = buildMetricsFilterConditions(args.filters);
-  const combined = mergeFilters(nameFilter, signalFilter);
+  const combined = mergeFilters(trustedScope, nameFilter, signalFilter);
   const whereClause = toWhereClause(combined);
 
   const sql = `SELECT ${aggSql} AS value, ${getCostSummarySelect()} FROM ${TABLE_METRIC_EVENTS} ${whereClause}`;
@@ -461,7 +462,7 @@ export async function getMetricAggregate(
         },
       };
       const prevSignalFilter = buildMetricsFilterConditions(prevFilters);
-      const prevCombined = mergeFilters(nameFilter, prevSignalFilter);
+      const prevCombined = mergeFilters(trustedScope, nameFilter, prevSignalFilter);
       const prevWhereClause = toWhereClause(prevCombined);
 
       const prevSql = `SELECT ${aggSql} AS value, ${getCostSummarySelect()} FROM ${TABLE_METRIC_EVENTS} ${prevWhereClause}`;
@@ -504,12 +505,13 @@ export async function getMetricAggregate(
 
 export async function getMetricBreakdown(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetMetricBreakdownArgs,
 ): Promise<GetMetricBreakdownResponse> {
   const aggSql = getAggregationSql(args.aggregation, 'value', args.distinctColumn);
   const nameFilter = buildMetricNameFilter(args.name);
   const signalFilter = buildMetricsFilterConditions(args.filters);
-  const combined = mergeFilters(nameFilter, signalFilter);
+  const combined = mergeFilters(trustedScope, nameFilter, signalFilter);
 
   const resolvedGroupBy = resolveGroupBy(args.groupBy);
   const labelParams = addGroupByLabelParams(resolvedGroupBy);
@@ -559,13 +561,14 @@ export async function getMetricBreakdown(
 
 export async function getMetricTimeSeries(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetMetricTimeSeriesArgs,
 ): Promise<GetMetricTimeSeriesResponse> {
   const aggSql = getAggregationSql(args.aggregation, 'value', args.distinctColumn);
   const intervalSql = getIntervalSql(args.interval);
   const nameFilter = buildMetricNameFilter(args.name);
   const signalFilter = buildMetricsFilterConditions(args.filters);
-  const combined = mergeFilters(nameFilter, signalFilter);
+  const combined = mergeFilters(trustedScope, nameFilter, signalFilter);
   const whereClause = toWhereClause(combined);
 
   if (args.groupBy && args.groupBy.length > 0) {
@@ -665,6 +668,7 @@ export async function getMetricTimeSeries(
 
 export async function getMetricPercentiles(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetMetricPercentilesArgs,
 ): Promise<GetMetricPercentilesResponse> {
   const intervalSql = getIntervalSql(args.interval);
@@ -673,7 +677,7 @@ export async function getMetricPercentiles(
     conditions: [`name = {percentileName:String}`],
     params: { percentileName: args.name },
   };
-  const combined = mergeFilters(nameFilter, signalFilter);
+  const combined = mergeFilters(trustedScope, nameFilter, signalFilter);
   const whereClause = toWhereClause(combined);
 
   const series = [];

--- a/stores/clickhouse/src/storage/domains/observability/v-next/scores.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/scores.ts
@@ -340,12 +340,13 @@ export async function getScoreById(client: ClickHouseClient, scoreId: string): P
 
 export async function getScoreAggregate(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetScoreAggregateArgs,
 ): Promise<GetScoreAggregateResponse> {
   const aggSql = getAggregationSql(args.aggregation);
   const identity = buildScoreIdentityFilter(args);
   const signalFilter = buildScoresFilterConditions(args.filters);
-  const combined = mergeFilters(identity, signalFilter);
+  const combined = mergeFilters(trustedScope, identity, signalFilter);
   const whereClause = toWhereClause(combined);
 
   const sql = `SELECT ${aggSql} AS value FROM ${TABLE_SCORE_EVENTS} ${whereClause}`;
@@ -382,7 +383,7 @@ export async function getScoreAggregate(
         timestamp: { start: prevStart, end: prevEnd, startExclusive: ts.startExclusive, endExclusive: ts.endExclusive },
       };
       const prevSignalFilter = buildScoresFilterConditions(prevFilters);
-      const prevCombined = mergeFilters(identity, prevSignalFilter);
+      const prevCombined = mergeFilters(trustedScope, identity, prevSignalFilter);
       const prevWhereClause = toWhereClause(prevCombined);
 
       const prevResult = await queryJson<Record<string, unknown>>(
@@ -406,12 +407,13 @@ export async function getScoreAggregate(
 
 export async function getScoreBreakdown(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetScoreBreakdownArgs,
 ): Promise<GetScoreBreakdownResponse> {
   const aggSql = getAggregationSql(args.aggregation);
   const identity = buildScoreIdentityFilter(args);
   const signalFilter = buildScoresFilterConditions(args.filters);
-  const combined = mergeFilters(identity, signalFilter);
+  const combined = mergeFilters(trustedScope, identity, signalFilter);
   const whereClause = toWhereClause(combined);
   const resolved = resolveScoreGroupBy(args.groupBy);
 
@@ -433,13 +435,14 @@ export async function getScoreBreakdown(
 
 export async function getScoreTimeSeries(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetScoreTimeSeriesArgs,
 ): Promise<GetScoreTimeSeriesResponse> {
   const aggSql = getAggregationSql(args.aggregation);
   const intervalSql = getIntervalSql(args.interval);
   const identity = buildScoreIdentityFilter(args);
   const signalFilter = buildScoresFilterConditions(args.filters);
-  const combined = mergeFilters(identity, signalFilter);
+  const combined = mergeFilters(trustedScope, identity, signalFilter);
   const whereClause = toWhereClause(combined);
 
   if (args.groupBy && args.groupBy.length > 0) {
@@ -494,12 +497,13 @@ export async function getScoreTimeSeries(
 
 export async function getScorePercentiles(
   client: ClickHouseClient,
+  trustedScope: FilterResult,
   args: GetScorePercentilesArgs,
 ): Promise<GetScorePercentilesResponse> {
   const intervalSql = getIntervalSql(args.interval);
   const identity = buildScoreIdentityFilter(args);
   const signalFilter = buildScoresFilterConditions(args.filters);
-  const combined = mergeFilters(identity, signalFilter);
+  const combined = mergeFilters(trustedScope, identity, signalFilter);
   const whereClause = toWhereClause(combined);
 
   if (!Array.isArray(args.percentiles) || args.percentiles.length === 0) {

--- a/stores/clickhouse/src/storage/domains/observability/v-next/trusted-query-scope.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/trusted-query-scope.test.ts
@@ -1,0 +1,59 @@
+import type { ClickHouseClient } from '@clickhouse/client';
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildTrustedQueryScopeFilter, CLICKHOUSE_TRUSTED_QUERY_SCOPE } from './trusted-query-scope';
+import { ObservabilityStorageClickhouseVNext } from './index';
+
+describe('buildTrustedQueryScopeFilter', () => {
+  it('builds parameterized AND constraints for trusted infrastructure scope', () => {
+    expect(
+      buildTrustedQueryScopeFilter({
+        organizationId: 'org-1',
+        projectId: 'project-1',
+      }),
+    ).toEqual({
+      conditions: [
+        'organizationId = {trustedScope_organizationId:String}',
+        'projectId = {trustedScope_projectId:String}',
+      ],
+      params: {
+        trustedScope_organizationId: 'org-1',
+        trustedScope_projectId: 'project-1',
+      },
+    });
+  });
+
+  it('applies trusted scope inside an aggregate query', async () => {
+    const query = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue([{ value: 3 }]),
+    });
+    const client = { query } as unknown as ClickHouseClient;
+    const storage = new ObservabilityStorageClickhouseVNext({
+      client,
+      [CLICKHOUSE_TRUSTED_QUERY_SCOPE]: {
+        organizationId: 'org-1',
+        projectId: 'project-1',
+      },
+    });
+
+    await storage.getScoreAggregate({ scorerId: 'quality', aggregation: 'count' });
+
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.stringContaining(
+          'WHERE organizationId = {trustedScope_organizationId:String} AND projectId = {trustedScope_projectId:String}',
+        ),
+        query_params: expect.objectContaining({
+          trustedScope_organizationId: 'org-1',
+          trustedScope_projectId: 'project-1',
+        }),
+      }),
+    );
+  });
+
+  it('rejects identifiers that could inject SQL', () => {
+    expect(() => buildTrustedQueryScopeFilter({ 'projectId) OR 1=1 --': 'project-1' })).toThrow(
+      'Invalid trusted query scope column',
+    );
+  });
+});

--- a/stores/clickhouse/src/storage/domains/observability/v-next/trusted-query-scope.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/trusted-query-scope.ts
@@ -1,0 +1,24 @@
+import type { FilterResult } from './filters';
+
+export const CLICKHOUSE_TRUSTED_QUERY_SCOPE = Symbol('CLICKHOUSE_TRUSTED_QUERY_SCOPE');
+
+export type TrustedQueryScope = Readonly<Record<string, string>>;
+
+const CLICKHOUSE_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function buildTrustedQueryScopeFilter(scope: TrustedQueryScope | undefined): FilterResult {
+  const result: FilterResult = { conditions: [], params: {} };
+  if (!scope) return result;
+
+  for (const [column, value] of Object.entries(scope)) {
+    if (!CLICKHOUSE_IDENTIFIER.test(column)) {
+      throw new Error(`Invalid trusted query scope column: ${column}`);
+    }
+
+    const param = `trustedScope_${column}`;
+    result.conditions.push(`${column} = {${param}:String}`);
+    result.params[param] = value;
+  }
+
+  return result;
+}

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -7,13 +7,14 @@ import { addOnClusterToDDL, validateReplicationConfig } from './db/replication';
 import type { ClickhouseReplicationConfig } from './db/replication';
 import { MemoryStorageClickhouse } from './domains/memory';
 import { ObservabilityStorageClickhouse } from './domains/observability';
-import { ObservabilityStorageClickhouseVNext } from './domains/observability/v-next';
-export type { VNextObservabilityConfig, RetentionConfig } from './domains/observability/v-next';
+import { CLICKHOUSE_TRUSTED_QUERY_SCOPE, ObservabilityStorageClickhouseVNext } from './domains/observability/v-next';
+export type { VNextObservabilityConfig, RetentionConfig, TrustedQueryScope } from './domains/observability/v-next';
 import { ScoresStorageClickhouse } from './domains/scores';
 import { WorkflowsStorageClickhouse } from './domains/workflows';
 
 // Export domain classes for direct use with MastraStorage composition
 export {
+  CLICKHOUSE_TRUSTED_QUERY_SCOPE,
   MemoryStorageClickhouse,
   ObservabilityStorageClickhouse,
   ObservabilityStorageClickhouseVNext,


### PR DESCRIPTION
## Summary

- add a symbol-keyed trusted query scope for hosted infrastructure without exposing tenant identity as an application observability filter
- AND trusted constraints into score, feedback, and metric aggregate, breakdown, time-series, percentile, and comparison-period queries before aggregation
- parameterize values and validate ClickHouse column identifiers
- export the extension point from `@mastra/clickhouse` and add a minor changeset

## Test plan

- `pnpm exec vitest run src/storage/domains/observability/v-next/trusted-query-scope.test.ts`
- `pnpm exec tsc --noEmit`
- targeted ESLint on changed files

Full ClickHouse integration startup was blocked locally because port 8123 is occupied by another authenticated ClickHouse instance; direct unit coverage verifies the generated pre-aggregation SQL and parameters.