### PR TITLE
refactor(playground): merge trace + span panels into a shared TraceSpanPanel

### DIFF
--- a/packages/playground/src/domains/traces/components/__tests__/fixtures/thread-traces.ts
+++ b/packages/playground/src/domains/traces/components/__tests__/fixtures/thread-traces.ts
@@ -53,6 +53,11 @@ export const traceASpans: GetTraceResponse = {
   spans: [{ ...baseTrace, parentSpanId: null }],
 };
 
+export const traceBSpans: GetTraceResponse = {
+  traceId: 'trace-b',
+  spans: [{ ...threadTracesList.spans[1], parentSpanId: null }],
+};
+
 export const spanADetail: GetSpanResponse = {
   span: { ...baseTrace, parentSpanId: null, input: { message: 'cook pasta' }, output: { text: 'carbonara' } },
 };

--- a/packages/playground/src/domains/traces/components/__tests__/fixtures/trace-span-panel.ts
+++ b/packages/playground/src/domains/traces/components/__tests__/fixtures/trace-span-panel.ts
@@ -1,0 +1,47 @@
+import type { MastraClient } from '@mastra/client-js';
+import { SpanType } from '@mastra/core/observability';
+import { TraceStatus } from '@mastra/core/storage';
+
+type GetTraceResponse = Awaited<ReturnType<MastraClient['getTrace']>>;
+type GetSpanResponse = Awaited<ReturnType<MastraClient['getSpan']>>;
+
+export const TRACE_ID = 'trace-panel';
+
+const baseSpan = {
+  traceId: TRACE_ID,
+  spanType: SpanType.AGENT_RUN,
+  isEvent: false,
+  startedAt: new Date('2026-08-30T12:00:00.000Z'),
+  endedAt: new Date('2026-08-30T12:00:01.000Z'),
+  createdAt: new Date('2026-08-30T12:00:00.000Z'),
+  updatedAt: null,
+  status: TraceStatus.SUCCESS,
+};
+
+export const rootSpan = { ...baseSpan, spanId: 'span-root', name: 'Root agent run', parentSpanId: null };
+export const childSpanOne = {
+  ...baseSpan,
+  spanId: 'span-child-1',
+  name: 'First tool call',
+  spanType: SpanType.TOOL_CALL,
+  parentSpanId: 'span-root',
+};
+export const childSpanTwo = {
+  ...baseSpan,
+  spanId: 'span-child-2',
+  name: 'Second tool call',
+  spanType: SpanType.TOOL_CALL,
+  parentSpanId: 'span-root',
+};
+
+/** Full trace tree: root with two children — enough to exercise prev/next span navigation. */
+export const panelTraceSpans: GetTraceResponse = {
+  traceId: TRACE_ID,
+  spans: [rootSpan, childSpanOne, childSpanTwo],
+};
+
+export const spanDetailById: Record<string, GetSpanResponse> = {
+  'span-root': { span: { ...rootSpan, input: { message: 'go' }, output: { text: 'done' } } },
+  'span-child-1': { span: { ...childSpanOne, input: { arg: 1 }, output: { ok: true } } },
+  'span-child-2': { span: { ...childSpanTwo, input: { arg: 2 }, output: { ok: true } } },
+};

--- a/packages/playground/src/domains/traces/components/__tests__/thread-traces.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/thread-traces.msw.test.tsx
@@ -3,7 +3,14 @@ import { http, HttpResponse } from 'msw';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { ThreadTraces } from '../thread-traces';
-import { THREAD_ID, emptyThreadTracesList, spanADetail, threadTracesList, traceASpans } from './fixtures/thread-traces';
+import {
+  THREAD_ID,
+  emptyThreadTracesList,
+  spanADetail,
+  threadTracesList,
+  traceASpans,
+  traceBSpans,
+} from './fixtures/thread-traces';
 import { TestLinkProvider } from '@/test/link-provider';
 import { server } from '@/test/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '@/test/render';
@@ -33,7 +40,9 @@ const installHandlers = ({ list = threadTracesList }: { list?: typeof threadTrac
       return HttpResponse.json(list);
     }),
     http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId/spans/:spanId`, () => HttpResponse.json(spanADetail)),
-    http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId`, () => HttpResponse.json(traceASpans)),
+    http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId`, ({ params }) =>
+      HttpResponse.json(params.traceId === 'trace-b' ? traceBSpans : traceASpans),
+    ),
   );
 };
 
@@ -114,6 +123,28 @@ describe('ThreadTraces', () => {
     fireEvent.click(screen.getByLabelText('Close Panel'));
     await waitFor(() => expect(screen.queryByText(/# trace-a/)).toBeNull());
     expect(await screen.findByText('Chef agent follow-up')).not.toBeNull();
+  });
+
+  it('navigates to the adjacent trace with the previous/next arrows in the panel header', async () => {
+    installHandlers();
+    const { queryClient } = renderPanel();
+
+    fireEvent.click(await screen.findByText('Chef agent run'));
+    expect(await screen.findByText(/# trace-a/)).not.toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+
+    // trace-a is first in the list, so "Previous trace" is disabled.
+    expect(screen.getByLabelText<HTMLButtonElement>('Previous trace').disabled).toBe(true);
+
+    fireEvent.click(screen.getByLabelText('Next trace'));
+    expect(await screen.findByText(/# trace-b/)).not.toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+
+    // trace-b is last, so "Next trace" is disabled; going back restores trace-a.
+    expect(screen.getByLabelText<HTMLButtonElement>('Next trace').disabled).toBe(true);
+    fireEvent.click(screen.getByLabelText('Previous trace'));
+    expect(await screen.findByText(/# trace-a/)).not.toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
   });
 
   it('shows the span detail panel and notifies onSpanOpenChange when a span is selected', async () => {

--- a/packages/playground/src/domains/traces/components/__tests__/trace-span-panel.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/trace-span-panel.msw.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { useState } from 'react';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { TraceSpanPanel, type TraceSpanPanelProps } from '../trace-span-panel';
+import { TRACE_ID, panelTraceSpans, spanDetailById } from './fixtures/trace-span-panel';
+import { TestLinkProvider } from '@/test/link-provider';
+import { server } from '@/test/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '@/test/render';
+
+// jsdom reports zero-sized elements; give them a real size so the virtualized
+// timeline materializes its rows.
+const originalOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')!;
+const originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth')!;
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 800 });
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, value: 800 });
+});
+afterAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight);
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', originalOffsetWidth);
+});
+
+const onSpanDetailRequest = vi.fn<(spanId: string) => void>();
+
+const installHandlers = () => {
+  onSpanDetailRequest.mockClear();
+  server.use(
+    http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId/spans/:spanId`, ({ params }) => {
+      const spanId = String(params.spanId);
+      onSpanDetailRequest(spanId);
+      const detail = spanDetailById[spanId];
+      return detail ? HttpResponse.json(detail) : HttpResponse.json({ error: 'not found' }, { status: 404 });
+    }),
+  );
+};
+
+/**
+ * Controlled-selection harness: the panel is controlled by its parent in both real
+ * call sites (URL state on the traces page, local state in the chat aside).
+ */
+function Harness({
+  initialSpanId = null,
+  onSpanSelect,
+  ...props
+}: Partial<TraceSpanPanelProps> & { initialSpanId?: string | null }) {
+  const [selectedSpanId, setSelectedSpanId] = useState<string | null>(initialSpanId);
+  return (
+    <TraceSpanPanel
+      traceId={TRACE_ID}
+      spans={panelTraceSpans.spans}
+      isLoadingSpans={false}
+      selectedSpanId={selectedSpanId}
+      onSpanSelect={spanId => {
+        setSelectedSpanId(spanId ?? null);
+        onSpanSelect?.(spanId);
+      }}
+      onClose={() => {}}
+      {...props}
+    />
+  );
+}
+
+const renderPanel = (props: Partial<TraceSpanPanelProps> & { initialSpanId?: string | null } = {}) =>
+  renderWithProviders(
+    <TestLinkProvider>
+      <Harness {...props} />
+    </TestLinkProvider>,
+    { router: true },
+  );
+
+describe('TraceSpanPanel', () => {
+  it('given a trace with spans, when it renders, then the trace header and span tree are shown', async () => {
+    installHandlers();
+    const { queryClient } = renderPanel();
+
+    expect(await screen.findByText(`# ${TRACE_ID}`)).not.toBeNull();
+    expect(screen.getByText('Root agent run')).not.toBeNull();
+    expect(screen.getByText('First tool call')).not.toBeNull();
+    expect(screen.getByText('Second tool call')).not.toBeNull();
+    // No span selected → no span detail panel.
+    expect(screen.queryByText(/# span-/)).toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+  });
+
+  it('when a span is clicked, then the span detail panel opens with data fetched from the API', async () => {
+    installHandlers();
+    const onSpanSelect = vi.fn<(spanId: string | undefined) => void>();
+    const { queryClient } = renderPanel({ onSpanSelect });
+
+    fireEvent.click(await screen.findByText('First tool call'));
+
+    expect(onSpanSelect).toHaveBeenCalledWith('span-child-1');
+    expect(await screen.findByText(/# span-child-1/)).not.toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+    expect(onSpanDetailRequest).toHaveBeenCalledWith('span-child-1');
+  });
+
+  it('when next/previous is clicked, then the adjacent span in the tree is selected', async () => {
+    installHandlers();
+    const { queryClient } = renderPanel({ initialSpanId: 'span-child-1' });
+
+    expect(await screen.findByText(/# span-child-1/)).not.toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+
+    fireEvent.click(screen.getByLabelText('Next span'));
+    expect(await screen.findByText(/# span-child-2/)).not.toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+
+    fireEvent.click(screen.getByLabelText('Previous span'));
+    expect(await screen.findByText(/# span-child-1/)).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText('Previous span'));
+    expect(await screen.findByText(/# span-root/)).not.toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+  });
+
+  it('when the span panel is closed, then onSpanSelect(undefined) clears the selection', async () => {
+    installHandlers();
+    const onSpanSelect = vi.fn<(spanId: string | undefined) => void>();
+    const { queryClient } = renderPanel({ initialSpanId: 'span-child-1', onSpanSelect });
+
+    expect(await screen.findByText(/# span-child-1/)).not.toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+
+    // Two close buttons are visible (trace panel + span panel); the span panel's is the last.
+    const closeButtons = screen.getAllByLabelText('Close Panel');
+    fireEvent.click(closeButtons[closeButtons.length - 1]);
+
+    expect(onSpanSelect).toHaveBeenCalledWith(undefined);
+    await waitFor(() => expect(screen.queryByText(/# span-child-1/)).toBeNull());
+  });
+
+  it('when the trace panel is closed, then onClose is called', async () => {
+    installHandlers();
+    const onClose = vi.fn();
+    const { queryClient } = renderPanel({ onClose });
+
+    expect(await screen.findByText(`# ${TRACE_ID}`)).not.toBeNull();
+    fireEvent.click(screen.getByLabelText('Close Panel'));
+    expect(onClose).toHaveBeenCalledOnce();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+  });
+
+  it('given anchorSpanId (branches mode), then the selected anchor span shows trace-level metadata', async () => {
+    installHandlers();
+    const { queryClient } = renderPanel({ anchorSpanId: 'span-child-1', initialSpanId: 'span-child-1' });
+
+    expect(await screen.findByText(/# span-child-1/)).not.toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+    // Anchor spans render the trace-context fields even though they have a parent.
+    expect(screen.getByText('Trace Id')).not.toBeNull();
+  });
+});

--- a/packages/playground/src/domains/traces/components/thread-traces.tsx
+++ b/packages/playground/src/domains/traces/components/thread-traces.tsx
@@ -1,14 +1,11 @@
-import { SpanDataPanelView } from '@mastra/playground-ui/domains/traces/components/span-data-panel-view';
 import { TracesErrorContent } from '@mastra/playground-ui/domains/traces/components/traces-error-content';
 import { TracesListView } from '@mastra/playground-ui/domains/traces/components/traces-list-view';
-import { useSpanDetail } from '@mastra/playground-ui/domains/traces/hooks/use-span-detail';
+import { useTraceListNavigation } from '@mastra/playground-ui/domains/traces/hooks/use-trace-list-navigation';
 import { useTraceOrBranchSpans } from '@mastra/playground-ui/domains/traces/hooks/use-trace-or-branch-spans';
-import { useTraceSpanNavigation } from '@mastra/playground-ui/domains/traces/hooks/use-trace-span-navigation';
 import { useTraces } from '@mastra/playground-ui/domains/traces/hooks/use-traces';
 import { useMemo, useState } from 'react';
 
-import { TraceDataPanel } from '@/domains/traces/components/trace-data-panel';
-import { Link } from '@/lib/link';
+import { TraceSpanPanel } from '@/domains/traces/components/trace-span-panel';
 
 export interface ThreadTracesProps {
   threadId: string;
@@ -53,17 +50,23 @@ export function ThreadTraces({ threadId, onTraceOpenChange, onSpanOpenChange }: 
     onTraceOpenChange?.(false);
   };
 
+  // Prev/next trace arrows in the panel header, navigating within the thread's list.
+  // Trace navigation clears any open span (the new trace has its own span tree).
+  const { handlePreviousTrace, handleNextTrace } = useTraceListNavigation(
+    traces,
+    featuredTraceId ?? undefined,
+    null,
+    traceId => {
+      selectSpan(undefined);
+      setFeaturedTraceId(traceId);
+    },
+  );
+
   const { spans: traceSpans, isLoading: isLoadingTraceSpans } = useTraceOrBranchSpans({
     traceId: featuredTraceId,
     anchorSpanId: null,
     listMode: 'traces',
   });
-  const { data: spanDetailData, isLoading: isLoadingSpanDetail } = useSpanDetail(
-    featuredTraceId ?? '',
-    featuredSpanId ?? '',
-  );
-  const { handlePreviousSpan, handleNextSpan } = useTraceSpanNavigation(traceSpans, featuredSpanId ?? null, selectSpan);
-
   if (error) {
     return (
       <div className="flex h-full items-center justify-center p-4">
@@ -74,34 +77,21 @@ export function ThreadTraces({ threadId, onTraceOpenChange, onSpanOpenChange }: 
 
   if (featuredTraceId) {
     return (
-      <TraceDataPanel
+      <TraceSpanPanel
         key={featuredTraceId}
-        // The aside Card already draws the border/rounding — flatten the nested panel.
+        // The aside Card already draws the border/rounding — flatten the nested panels
+        // (the span slot wrapper draws its own `border-l` separator).
         className="h-full rounded-none border-0"
+        spanPanelClassName="rounded-none border-0"
         traceId={featuredTraceId}
         spans={traceSpans}
-        isLoading={isLoadingTraceSpans}
+        isLoadingSpans={isLoadingTraceSpans}
+        selectedSpanId={featuredSpanId ?? null}
         onClose={closeTrace}
         onSpanSelect={selectSpan}
-        initialSpanId={featuredSpanId ?? null}
-        placement="traces-list"
-        LinkComponent={Link}
+        onPrevious={handlePreviousTrace}
+        onNext={handleNextTrace}
         traceHref={`/traces?traceId=${encodeURIComponent(featuredTraceId)}`}
-        spanPanelSlot={
-          featuredSpanId ? (
-            <SpanDataPanelView
-              // The slot wrapper already draws a `border-l` separator — flatten the nested panel.
-              className="rounded-none border-0"
-              traceId={featuredTraceId}
-              spanId={featuredSpanId}
-              span={spanDetailData?.span}
-              isLoading={isLoadingSpanDetail}
-              onClose={() => selectSpan(undefined)}
-              onPrevious={handlePreviousSpan}
-              onNext={handleNextSpan}
-            />
-          ) : null
-        }
       />
     );
   }

--- a/packages/playground/src/domains/traces/components/trace-span-panel.tsx
+++ b/packages/playground/src/domains/traces/components/trace-span-panel.tsx
@@ -1,0 +1,126 @@
+import { SpanDataPanelView } from '@mastra/playground-ui/domains/traces/components/span-data-panel-view';
+import type { TraceDataPanelView } from '@mastra/playground-ui/domains/traces/components/trace-data-panel-view';
+import { useSpanDetail } from '@mastra/playground-ui/domains/traces/hooks/use-span-detail';
+import { useTraceSpanNavigation } from '@mastra/playground-ui/domains/traces/hooks/use-trace-span-navigation';
+import type { ComponentProps, ReactNode } from 'react';
+
+import { TraceDataPanel } from '@/domains/traces/components/trace-data-panel';
+import { Link } from '@/lib/link';
+
+type TraceDataPanelViewProps = ComponentProps<typeof TraceDataPanelView>;
+type SpanDataPanelViewProps = ComponentProps<typeof SpanDataPanelView>;
+
+export interface TraceSpanPanelProps {
+  traceId: string;
+  /** Spans returned by `useTraceOrBranchSpans` — the page owns the fetch, the panel renders it. */
+  spans: TraceDataPanelViewProps['spans'];
+  isLoadingSpans: boolean;
+  /** Controlled span selection (URL state on the traces page, local state in the chat aside). */
+  selectedSpanId: string | null;
+  onSpanSelect: (spanId: string | undefined) => void;
+  onClose: () => void;
+  /** Closes the span panel. Defaults to `onSpanSelect(undefined)`. */
+  onSpanClose?: () => void;
+
+  // Trace-panel pass-through.
+  usage?: TraceDataPanelViewProps['usage'];
+  anchorSpanId?: string;
+  initialSpanId?: string | null;
+  onPrevious?: () => void;
+  onNext?: () => void;
+  onSaveAsDatasetItem?: TraceDataPanelViewProps['onSaveAsDatasetItem'];
+  onAddTraceMocksToItem?: TraceDataPanelViewProps['onAddTraceMocksToItem'];
+  feedbackTabBadge?: ReactNode;
+  feedbackTabSlot?: TraceDataPanelViewProps['feedbackTabSlot'];
+  scoresTabBadge?: ReactNode;
+  scoresTabSlot?: TraceDataPanelViewProps['scoresTabSlot'];
+  traceHref?: string;
+  className?: string;
+
+  // Span-panel pass-through.
+  spanActiveTab?: string;
+  onSpanTabChange?: (tab: string) => void;
+  spanFeedbackTabBadge?: ReactNode;
+  spanFeedbackTabSlot?: SpanDataPanelViewProps['feedbackTabSlot'];
+  spanPanelClassName?: string;
+}
+
+/**
+ * Shared trace → span drilldown panel: `TraceDataPanel` with a nested `SpanDataPanelView`.
+ * Encapsulates the span-detail fetch and prev/next span navigation that the traces page
+ * and the agent chat traces aside used to duplicate.
+ */
+export function TraceSpanPanel({
+  traceId,
+  spans,
+  isLoadingSpans,
+  selectedSpanId,
+  onSpanSelect,
+  onClose,
+  onSpanClose,
+  usage,
+  anchorSpanId,
+  initialSpanId,
+  onPrevious,
+  onNext,
+  onSaveAsDatasetItem,
+  onAddTraceMocksToItem,
+  feedbackTabBadge,
+  feedbackTabSlot,
+  scoresTabBadge,
+  scoresTabSlot,
+  traceHref,
+  className,
+  spanActiveTab,
+  onSpanTabChange,
+  spanFeedbackTabBadge,
+  spanFeedbackTabSlot,
+  spanPanelClassName,
+}: TraceSpanPanelProps) {
+  const { data: spanDetailData, isLoading: isLoadingSpanDetail } = useSpanDetail(traceId, selectedSpanId ?? '');
+  const { handlePreviousSpan, handleNextSpan } = useTraceSpanNavigation(spans, selectedSpanId, onSpanSelect);
+
+  return (
+    <TraceDataPanel
+      className={className}
+      traceId={traceId}
+      spans={spans}
+      usage={usage}
+      anchorSpanId={anchorSpanId}
+      isLoading={isLoadingSpans}
+      onClose={onClose}
+      onSpanSelect={onSpanSelect}
+      onSaveAsDatasetItem={onSaveAsDatasetItem}
+      onAddTraceMocksToItem={onAddTraceMocksToItem}
+      initialSpanId={initialSpanId ?? selectedSpanId}
+      onPrevious={onPrevious}
+      onNext={onNext}
+      placement="traces-list"
+      LinkComponent={Link}
+      traceHref={traceHref}
+      feedbackTabBadge={feedbackTabBadge}
+      feedbackTabSlot={feedbackTabSlot}
+      scoresTabBadge={scoresTabBadge}
+      scoresTabSlot={scoresTabSlot}
+      spanPanelSlot={
+        selectedSpanId ? (
+          <SpanDataPanelView
+            className={spanPanelClassName}
+            traceId={traceId}
+            spanId={selectedSpanId}
+            span={spanDetailData?.span}
+            isAnchor={anchorSpanId ? selectedSpanId === anchorSpanId : undefined}
+            isLoading={isLoadingSpanDetail}
+            onClose={onSpanClose ?? (() => onSpanSelect(undefined))}
+            onPrevious={handlePreviousSpan}
+            onNext={handleNextSpan}
+            activeTab={spanActiveTab}
+            onTabChange={onSpanTabChange}
+            feedbackTabBadge={spanFeedbackTabBadge}
+            feedbackTabSlot={spanFeedbackTabSlot}
+          />
+        ) : null
+      }
+    />
+  );
+}

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -6,7 +6,6 @@ import { Notice } from '@mastra/playground-ui/components/Notice';
 import { PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PropertyFilterCreator } from '@mastra/playground-ui/components/PropertyFilter';
 import { NoTracesInfo } from '@mastra/playground-ui/domains/traces/components/no-traces-info';
-import { SpanDataPanelView } from '@mastra/playground-ui/domains/traces/components/span-data-panel-view';
 import { TraceColumnsMenu } from '@mastra/playground-ui/domains/traces/components/trace-columns-menu';
 import { TracesErrorContent } from '@mastra/playground-ui/domains/traces/components/traces-error-content';
 import { TracesLayout } from '@mastra/playground-ui/domains/traces/components/traces-layout';
@@ -15,13 +14,11 @@ import { TracesToolbar } from '@mastra/playground-ui/domains/traces/components/t
 import { useEntityNames } from '@mastra/playground-ui/domains/traces/hooks/use-entity-names';
 import { useEnvironments } from '@mastra/playground-ui/domains/traces/hooks/use-environments';
 import { useServiceNames } from '@mastra/playground-ui/domains/traces/hooks/use-service-names';
-import { useSpanDetail } from '@mastra/playground-ui/domains/traces/hooks/use-span-detail';
 import { useTags } from '@mastra/playground-ui/domains/traces/hooks/use-tags';
 import { useTraceColumnPreferences } from '@mastra/playground-ui/domains/traces/hooks/use-trace-column-preferences';
 import { useTraceFilterPersistence } from '@mastra/playground-ui/domains/traces/hooks/use-trace-filter-persistence';
 import { useTraceListNavigation } from '@mastra/playground-ui/domains/traces/hooks/use-trace-list-navigation';
 import { useTraceOrBranchSpans } from '@mastra/playground-ui/domains/traces/hooks/use-trace-or-branch-spans';
-import { useTraceSpanNavigation } from '@mastra/playground-ui/domains/traces/hooks/use-trace-span-navigation';
 import { useTraceUrlState } from '@mastra/playground-ui/domains/traces/hooks/use-trace-url-state';
 import { useTraceUsage } from '@mastra/playground-ui/domains/traces/hooks/use-trace-usage';
 import { useTraces } from '@mastra/playground-ui/domains/traces/hooks/use-traces';
@@ -41,12 +38,11 @@ import { TraceAsItemDialog } from '@/domains/observability/components/trace-as-i
 import { useTraceSpanScores } from '@/domains/scores/hooks/use-trace-span-scores';
 import { ScoreDataPanel } from '@/domains/traces/components/score-data-panel';
 import { SpanFeedbackTab } from '@/domains/traces/components/span-feedback-tab';
-import { TraceDataPanel } from '@/domains/traces/components/trace-data-panel';
 import { TraceFeedbackTab } from '@/domains/traces/components/trace-feedback-tab';
 import { TraceScoresTab } from '@/domains/traces/components/trace-scores-tab';
+import { TraceSpanPanel } from '@/domains/traces/components/trace-span-panel';
 import { useSpanFeedback } from '@/domains/traces/hooks/use-span-feedback';
 import { useTraceFeedback } from '@/domains/traces/hooks/use-trace-feedback';
-import { Link } from '@/lib/link';
 
 type TracesPageProps = {
   scopedEntityId?: string;
@@ -116,11 +112,6 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
     anchorSpanId: url.listMode === 'branches' ? (url.anchorSpanIdParam ?? null) : null,
     listMode: url.listMode,
   });
-  const { data: spanDetailData, isLoading: isLoadingSpanDetail } = useSpanDetail(
-    url.traceIdParam ?? '',
-    url.spanIdParam ?? '',
-  );
-
   // Displayed root of the current view: branch anchor in branches mode, trace root otherwise.
   const anchorSpan = useMemo(
     () =>
@@ -261,10 +252,6 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
     setBranchesUnsupported(true);
     if (url.listMode === 'branches') url.handleListModeChange('traces');
   }, [tracesError, branchesUnsupported, url]);
-
-  const { handlePreviousSpan, handleNextSpan } = useTraceSpanNavigation(traceSpans, url.spanIdParam ?? null, id =>
-    url.handleSpanChange(id),
-  );
 
   const persistence = useTraceFilterPersistence(searchParams, setSearchParams, {
     storageKey: isScoped ? `mastra:traces:saved-filters:${scopedEntityType}:${scopedEntityId}` : undefined,
@@ -472,7 +459,7 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
         }
         tracePanelSlot={
           url.traceIdParam && (url.listMode !== 'branches' || url.anchorSpanIdParam) ? (
-            <TraceDataPanel
+            <TraceSpanPanel
               key={`${url.traceIdParam}:${url.anchorSpanIdParam ?? ''}`}
               traceId={url.traceIdParam}
               spans={traceSpans}
@@ -482,16 +469,16 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
                   : undefined
               }
               anchorSpanId={anchorSpanId}
-              isLoading={isLoadingTraceSpans}
+              isLoadingSpans={isLoadingTraceSpans}
+              selectedSpanId={url.spanIdParam ?? null}
               onClose={url.handleTraceClose}
               onSpanSelect={id => url.handleSpanChange(id ?? null)}
+              onSpanClose={url.handleSpanClose}
               onSaveAsDatasetItem={args => setDatasetDialogTarget(args)}
               onAddTraceMocksToItem={isAgentTrace ? args => setAddMocksTarget(args) : undefined}
               initialSpanId={url.spanIdParam}
               onPrevious={handlePreviousTrace}
               onNext={handleNextTrace}
-              placement="traces-list"
-              LinkComponent={Link}
               feedbackTabBadge={traceFeedbackData?.pagination?.total ?? undefined}
               feedbackTabSlot={({ traceId: tid }) => <TraceFeedbackTab traceId={tid} />}
               scoresTabBadge={spanScoresData?.pagination?.total ?? undefined}
@@ -506,27 +493,13 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
                   />
                 ) : null
               }
-              spanPanelSlot={
-                url.spanIdParam ? (
-                  <SpanDataPanelView
-                    traceId={url.traceIdParam}
-                    spanId={url.spanIdParam}
-                    span={spanDetailData?.span}
-                    isAnchor={anchorSpanId ? url.spanIdParam === anchorSpanId : undefined}
-                    isLoading={isLoadingSpanDetail}
-                    onClose={url.handleSpanClose}
-                    onPrevious={handlePreviousSpan}
-                    onNext={handleNextSpan}
-                    activeTab={url.spanTabParam ?? 'details'}
-                    onTabChange={tab => url.handleSpanTabChange(tab as SpanTab)}
-                    feedbackTabBadge={spanFeedbackData?.pagination?.total ?? undefined}
-                    feedbackTabSlot={({ traceId: tid, spanId: sid }) =>
-                      tid && sid ? <SpanFeedbackTab key={`${tid}:${sid}`} traceId={tid} spanId={sid} /> : null
-                    }
-                    className="rounded-none border-0 bg-transparent"
-                  />
-                ) : null
+              spanActiveTab={url.spanTabParam ?? 'details'}
+              onSpanTabChange={tab => url.handleSpanTabChange(tab as SpanTab)}
+              spanFeedbackTabBadge={spanFeedbackData?.pagination?.total ?? undefined}
+              spanFeedbackTabSlot={({ traceId: tid, spanId: sid }) =>
+                tid && sid ? <SpanFeedbackTab key={`${tid}:${sid}`} traceId={tid} spanId={sid} /> : null
               }
+              spanPanelClassName="rounded-none border-0 bg-transparent"
             />
           ) : null
         }


### PR DESCRIPTION
## Summary

The traces page (`/traces`) and the agent thread Traces aside rendered the same block independently: a `TraceDataPanel` with a nested `SpanDataPanelView`, each wiring up its own `useSpanDetail` + `useTraceSpanNavigation`. This PR extracts that block into a single shared component, `TraceSpanPanel`:

- Receives the span list from `useTraceOrBranchSpans` as a prop (the page keeps ownership of span fetching mode).
- Handles span detail fetching and previous/next **span** navigation internally.
- Page-specific extras stay as optional props/slots: usage, feedback/scores tabs, dataset save / tool-mock actions, branches-mode anchor span, trace link, flattened aside styling.

Both call sites (`pages/traces/index.tsx` and `domains/traces/components/thread-traces.tsx`) are migrated to it, removing the duplicated wiring.

As a follow-up enabled by the shared component, the agent thread Traces aside now also gets previous/next **trace** arrows (via `useTraceListNavigation`), matching the traces page; switching traces clears any open span.

## Test plan

- New MSW/BDD specs: `trace-span-panel.msw.test.tsx` (render tree, span drilldown, prev/next span, close, branches anchor).
- Extended `thread-traces.msw.test.tsx` with prev/next trace navigation (arrows disabled at bounds).
- Existing page suites (`pages/traces/__tests__/index.msw.test.tsx`, `thread-page.msw.test.tsx`) pass unchanged as a non-regression net.
- Full playground test suite, typecheck, and lint pass.
- Manual Studio check: `/traces` drilldown, branches mode, and the agent chat Traces aside (styles, prev/next, open-in-traces link).