### PR TITLE
fix(playground): restore thread delete action on the standalone agent sidebar

### DIFF
--- a/.changeset/quiet-donkeys-write.md
+++ b/.changeset/quiet-donkeys-write.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground': patch
+---
+
+Restore the missing delete action on the standalone agent thread sidebar (`/agents/<agentId>/threads/<threadId>`), lost in the #22675 redesign. Each thread row now offers a guarded delete control (confirmation dialog, `memory:delete` permission check) wired to the existing memory-thread delete endpoint, and deleting the active thread navigates back to a new thread.

--- a/packages/playground/src/domains/agents/components/chat-threads.tsx
+++ b/packages/playground/src/domains/agents/components/chat-threads.tsx
@@ -95,7 +95,7 @@ interface DeleteThreadDialogProps {
   onOpenChange: (n: boolean) => void;
   onDelete: () => void;
 }
-const DeleteThreadDialog = ({ open, onOpenChange, onDelete }: DeleteThreadDialogProps) => {
+export const DeleteThreadDialog = ({ open, onOpenChange, onDelete }: DeleteThreadDialogProps) => {
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialog.Content>

--- a/packages/playground/src/pages/agents/agent/__tests__/thread-page.msw.test.tsx
+++ b/packages/playground/src/pages/agents/agent/__tests__/thread-page.msw.test.tsx
@@ -170,6 +170,43 @@ describe('Standalone thread page', () => {
     });
   });
 
+  it('renders a delete control for each persisted thread in the sidebar', async () => {
+    installHandlers();
+    renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
+
+    await screen.findByText('Tonight we cook carbonara.');
+    const deleteButtons = await screen.findAllByRole('button', { name: 'delete thread' });
+    expect(deleteButtons.length).toBe(threadsResponse.threads.length);
+  });
+
+  it('deletes the current thread after confirmation and navigates to a new thread', async () => {
+    const deleteRequests: string[] = [];
+    installHandlers();
+    server.use(
+      http.delete(`${BASE_URL}/api/memory/threads/:threadId`, ({ request }) => {
+        deleteRequests.push(new URL(request.url).pathname);
+        return HttpResponse.json({ result: 'success' });
+      }),
+    );
+    renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);
+
+    await screen.findByText('Tonight we cook carbonara.');
+    const [deleteButton] = await screen.findAllByRole('button', { name: 'delete thread' });
+    fireEvent.click(deleteButton);
+
+    // Confirmation dialog guards the destructive action.
+    expect(await screen.findByText('Are you absolutely sure?')).not.toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(deleteRequests).toHaveLength(1);
+    });
+    expect(deleteRequests[0]).toBe(`/api/memory/threads/${THREAD_ID}`);
+    await waitFor(() => {
+      expect(screen.getByTestId('location-probe').textContent).toBe(`/agents/${AGENT_ID}/threads/new`);
+    });
+  });
+
   it('shows the Mastra logo and a back link to the agent overview in the sidebar', async () => {
     installHandlers();
     renderAt(`/agents/${AGENT_ID}/threads/${THREAD_ID}`);

--- a/packages/playground/src/pages/agents/agent/thread.tsx
+++ b/packages/playground/src/pages/agents/agent/thread.tsx
@@ -7,11 +7,12 @@ import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDen
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
-import { ArrowLeft, ChartNoAxesGantt, Plus } from 'lucide-react';
+import { ArrowLeft, ChartNoAxesGantt, Plus, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import { AgentChat } from '@/domains/agents/components/agent-chat';
 import { AgentChatLoadingSkeleton } from '@/domains/agents/components/agent-loading-skeletons';
+import { DeleteThreadDialog } from '@/domains/agents/components/chat-threads';
 import { MemorySidebarBody } from '@/domains/agents/components/memory-sidebar/memory-sidebar';
 import { ActivatedSkillsProvider } from '@/domains/agents/context/activated-skills-context';
 import { AgentSettingsProvider } from '@/domains/agents/context/agent-context';
@@ -23,9 +24,10 @@ import { MemoryTimelineProvider } from '@/domains/agents/context/memory-timeline
 import { useAgent } from '@/domains/agents/hooks/use-agent';
 import { buildAgentDefaultSettings } from '@/domains/agents/utils/agent-default-settings';
 import { getAgentSuggestedPrompts } from '@/domains/agents/utils/agent-suggested-prompts';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
 import { ThreadAside } from '@/domains/conversation/components/thread-aside';
 import { ThreadInputProvider } from '@/domains/conversation/context/ThreadInputContext';
-import { useMemory, useThreads } from '@/domains/memory/hooks/use-memory';
+import { useDeleteThread, useMemory, useThreads } from '@/domains/memory/hooks/use-memory';
 import { TracingSettingsProvider } from '@/domains/observability/context/tracing-settings-context';
 import { SchemaRequestContextProvider } from '@/domains/request-context/context/schema-request-context';
 import { ThreadTraces } from '@/domains/traces/components/thread-traces';
@@ -53,6 +55,22 @@ function AgentThread() {
     isMemoryEnabled: hasMemory,
     resourceId: agentId!,
   });
+
+  const deleteThreadMutation = useDeleteThread();
+
+  const handleDeleteThread = (deletedThreadId: string) => {
+    deleteThreadMutation.mutate(
+      { threadId: deletedThreadId, agentId: agentId! },
+      {
+        onSuccess: () => {
+          void refreshThreads();
+          if (deletedThreadId === threadId) {
+            void navigate(`/agents/${agentId}/threads/new`);
+          }
+        },
+      },
+    );
+  };
 
   const sidebarThreads = useMemo(
     () =>
@@ -129,6 +147,7 @@ function AgentThread() {
                               threads={sidebarThreads}
                               threadId={actualThreadId}
                               isLoading={isThreadsLoading}
+                              onDelete={handleDeleteThread}
                             />
                             <div className="relative min-h-0">
                               <div className="rounded-studio-frame border-border1 bg-surface2 shadow-main-frame m-1.5 h-[calc(100%-0.75rem)] min-h-0 overflow-hidden border [--studio-frame-inset:0.5rem] [--studio-frame-radius:1.5rem] lg:m-2 lg:ml-0 lg:h-[calc(100%-1rem)]">
@@ -226,11 +245,15 @@ interface ThreadSidebarProps {
   threads: Array<{ id: string; title?: string; createdAt: Date }>;
   threadId: string;
   isLoading: boolean;
+  onDelete?: (threadId: string) => void;
 }
 
-const ThreadSidebar = ({ agentId, agentName, threads, threadId, isLoading }: ThreadSidebarProps) => {
+const ThreadSidebar = ({ agentId, agentName, threads, threadId, isLoading, onDelete }: ThreadSidebarProps) => {
   const { Link } = useLinkComponent();
   const { state } = useMainSidebar();
+  const { canDelete } = usePermissions();
+  const canDeleteThread = canDelete('memory');
+  const [deleteId, setDeleteId] = useState<string | null>(null);
 
   const threadsNav = (
     <MainSidebar.Nav>
@@ -247,6 +270,22 @@ const ThreadSidebar = ({ agentId, agentName, threads, threadId, isLoading }: Thr
                 state={state}
                 isActive={thread.id === threadId}
                 link={{ name: threadDisplayName(thread), url: `/agents/${agentId}/threads/${thread.id}` }}
+                action={
+                  canDeleteThread && onDelete ? (
+                    <button
+                      type="button"
+                      aria-label="delete thread"
+                      className="text-icon3 hover:text-icon6 cursor-pointer"
+                      onClick={event => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        setDeleteId(thread.id);
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  ) : undefined
+                }
               />
             ))}
           </MainSidebar.NavList>
@@ -257,6 +296,15 @@ const ThreadSidebar = ({ agentId, agentName, threads, threadId, isLoading }: Thr
 
   return (
     <MainSidebar>
+      <DeleteThreadDialog
+        open={!!deleteId}
+        onOpenChange={() => setDeleteId(null)}
+        onDelete={() => {
+          if (deleteId && onDelete) {
+            onDelete(deleteId);
+          }
+        }}
+      />
       <div className="mb-1.5 pt-2.5">
         <span className="flex h-7 items-center gap-2 pr-2 pl-3">
           <LogoWithoutText className="h-[1.5rem] w-[1.5rem] shrink-0" />


### PR DESCRIPTION
Fixes #22763

The standalone agent thread sidebar introduced in #22675 renders each thread as a plain `MainSidebar.NavLink` with no delete control, so persisted threads can no longer be removed from Studio (the `delete a thread` smoke test times out waiting for the control).

Each row now offers a guarded delete action: a trash button (aria-label `delete thread`, matching the smoke-test selector) opens the shared confirmation dialog, the mutation goes through the existing memory-thread delete endpoint, the thread list is invalidated, and deleting the active thread navigates back to `threads/new`. The control is gated on the `memory:delete` permission, consistent with the chat sidebar's behavior.

**Verification**
- New tests in `thread-page.msw.test.tsx`: every persisted thread renders a `delete thread` control, and confirming the dialog issues `DELETE /api/memory/threads/:threadId` and navigates to `threads/new` when the active thread is deleted (18/18 in the file passing).
- `typecheck`, `oxlint`, `eslint`, and `oxfmt` clean on the touched files.
