### PR TITLE
test(core): update TypeScript search-path assertion

### DIFF
--- a/packages/core/src/workspace/lsp/servers.test.ts
+++ b/packages/core/src/workspace/lsp/servers.test.ts
@@ -665,16 +665,27 @@ describe('buildServerDefs', () => {
   });
 
   describe('searchPaths', () => {
-    it('finds typescript/lib/tsserver.js from searchPaths for module resolution', () => {
-      // Use a root dir that does NOT contain typescript so resolution can only succeed via searchPaths.
+    it('finds TypeScript 6 tsserver.js from searchPaths for module resolution', () => {
       const emptyRoot = join(tempDir, 'empty-root');
+      const searchDir = join(tempDir, 'search');
+      const pkgDir = join(searchDir, 'node_modules', 'typescript');
       mkdirSync(emptyRoot, { recursive: true });
+      mkdirSync(join(pkgDir, 'lib'), { recursive: true });
+      writeFileSync(join(searchDir, 'package.json'), '{}');
+      writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'typescript', version: '6.0.3' }));
+      writeFileSync(join(pkgDir, 'lib', 'tsserver.js'), '');
 
-      // searchPaths points to cwd (monorepo root) which has typescript installed.
-      const defs = buildServerDefs({ searchPaths: [process.cwd()] });
-      const init = defs.typescript!.initialization!(emptyRoot);
-      expect(init).toBeDefined();
-      expect((init as { tsserver: { path: string } }).tsserver.path).toContain('tsserver.js');
+      const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(emptyRoot);
+      try {
+        const defs = buildServerDefs({ searchPaths: [searchDir] });
+        const init = defs.typescript!.initialization!(emptyRoot);
+
+        expect(init).toEqual({
+          tsserver: { path: join(pkgDir, 'lib', 'tsserver.js'), logVerbosity: 'off' },
+        });
+      } finally {
+        cwdSpy.mockRestore();
+      }
     });
 
     it('finds binary in searchPaths node_modules/.bin', () => {

--- a/packages/core/src/workspace/lsp/servers.test.ts
+++ b/packages/core/src/workspace/lsp/servers.test.ts
@@ -665,27 +665,13 @@ describe('buildServerDefs', () => {
   });
 
   describe('searchPaths', () => {
-    it('finds TypeScript 6 tsserver.js from searchPaths for module resolution', () => {
+    it('returns undefined when TypeScript does not expose tsserver.js', () => {
       const emptyRoot = join(tempDir, 'empty-root');
-      const searchDir = join(tempDir, 'search');
-      const pkgDir = join(searchDir, 'node_modules', 'typescript');
       mkdirSync(emptyRoot, { recursive: true });
-      mkdirSync(join(pkgDir, 'lib'), { recursive: true });
-      writeFileSync(join(searchDir, 'package.json'), '{}');
-      writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'typescript', version: '6.0.3' }));
-      writeFileSync(join(pkgDir, 'lib', 'tsserver.js'), '');
 
-      const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(emptyRoot);
-      try {
-        const defs = buildServerDefs({ searchPaths: [searchDir] });
-        const init = defs.typescript!.initialization!(emptyRoot);
-
-        expect(init).toEqual({
-          tsserver: { path: join(pkgDir, 'lib', 'tsserver.js'), logVerbosity: 'off' },
-        });
-      } finally {
-        cwdSpy.mockRestore();
-      }
+      const defs = buildServerDefs({ searchPaths: [process.cwd()] });
+      const init = defs.typescript!.initialization!(emptyRoot);
+      expect(init).toBeUndefined();
     });
 
     it('finds binary in searchPaths node_modules/.bin', () => {

--- a/packages/core/src/workspace/lsp/servers.test.ts
+++ b/packages/core/src/workspace/lsp/servers.test.ts
@@ -665,13 +665,16 @@ describe('buildServerDefs', () => {
   });
 
   describe('searchPaths', () => {
-    it('returns undefined when TypeScript does not expose tsserver.js', () => {
+    it('finds typescript/bin/tsc from searchPaths for module resolution', () => {
+      // Use a root dir that does NOT contain typescript so resolution can only succeed via searchPaths.
       const emptyRoot = join(tempDir, 'empty-root');
       mkdirSync(emptyRoot, { recursive: true });
 
+      // searchPaths points to cwd (monorepo root) which has typescript installed.
       const defs = buildServerDefs({ searchPaths: [process.cwd()] });
-      const init = defs.typescript!.initialization!(emptyRoot);
-      expect(init).toBeUndefined();
+      const command = defs.typescript!.command(emptyRoot);
+      const tsc = realpathSync(join(process.cwd(), 'node_modules', 'typescript', 'bin', 'tsc'));
+      expect(command).toBe(`node ${tsc} --lsp --stdio`);
     });
 
     it('finds binary in searchPaths node_modules/.bin', () => {


### PR DESCRIPTION
The workspace LSP search-path test still expected the TypeScript 6 `tsserver.js` initialization shape after the monorepo moved to TypeScript 7.

This updates only that test to assert the exact native TypeScript 7 `tsc --lsp --stdio` command resolved through `searchPaths`.

Verified with the focused workspace LSP suite (87 tests).

Closes #22784