### PR TITLE
refactor(factory): rename checkout directory vocabulary to repoDir

### DIFF
--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -284,7 +284,7 @@ describe('MastraFactory.prepare', () => {
       repositoryId: repository.id,
       createdByUserId: 'user-1',
       sandboxProvider: 'local',
-      sandboxWorkdir: '/sandbox/mastra',
+      sandboxRepoDir: '/sandbox/mastra',
     });
     await sourceControl.sessions.create({
       sessionId: 'session-1',

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -660,7 +660,7 @@ export class MastraFactory {
         // Blank project identity for the same reason: the SDK's defaults seed
         // sessions with the HOST process's own project root / name / branch,
         // which must never reach a hosted session's prompt. Repo-backed
-        // sessions get their real workdir pinned by workspace resolution;
+        // sessions get their real repo dir pinned by workspace resolution;
         // chat-only sessions legitimately have no project.
         // Factory sessions also start fail-closed on org classification: the
         // unresolved marker is set at birth, a successful org seed clears it,

--- a/mastracode/factory/src/integrations/github/org-isolation-scenario.test.ts
+++ b/mastracode/factory/src/integrations/github/org-isolation-scenario.test.ts
@@ -116,7 +116,7 @@ function projectRepositoryRow(row: Record<string, any>) {
     repositoryId,
     branch: 'main',
     sandboxProvider: 'railway',
-    sandboxWorkdir: '/workspace/hello',
+    sandboxRepoDir: '/workspace/hello',
     setupCommand: null,
     teardownCommand: null,
     createdAt: now,
@@ -443,7 +443,7 @@ describe('two users in one org each get their own sandbox + session workspace', 
     await sourceControlStorage.sessions.setSandbox({
       id: session.id,
       sandboxId: 'sb-a1-session',
-      sandboxWorkdir: '/workspace/a1/feat-x',
+      sandboxRepoDir: '/workspace/a1/feat-x',
     });
     // Materialization memoizes the session sandbox in-process; git write
     // routes resolve through the memo, not persisted columns.
@@ -453,7 +453,7 @@ describe('two users in one org each get their own sandbox + session workspace', 
         provider: 'stub',
         executeCommand: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
       }) as never,
-    ).workdir = '/workspace/a1/feat-x';
+    ).repoDir = '/workspace/a1/feat-x';
 
     // User 2 cannot address user 1's session workspace.
     const crossCommit = await postJson(user2, '/web/github/projects/p1/commit', {
@@ -492,7 +492,7 @@ describe('cross-user session workspaces are rejected', () => {
       await sourceControlStorage.sessions.setSandbox({
         id: session.id,
         sandboxId: `sb-${userId}`,
-        sandboxWorkdir: `/workspace/sessions/${userId}/feat-x`,
+        sandboxRepoDir: `/workspace/sessions/${userId}/feat-x`,
       });
       getSessionSandbox(session.id, `sessions/${userId}`, () =>
         ({
@@ -500,7 +500,7 @@ describe('cross-user session workspaces are rejected', () => {
           provider: 'stub',
           executeCommand: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
         }) as never,
-      ).workdir = `/workspace/sessions/${userId}/feat-x`;
+      ).repoDir = `/workspace/sessions/${userId}/feat-x`;
       sessions.set(userId, session);
     }
 
@@ -581,7 +581,7 @@ describe('install flow binds the installation to the org', () => {
           repositoryStorageId: tables.repositories[0]!.id,
           sandboxProvider: 'custom',
           // Display-only listing guess: repos clone into the VM's home.
-          sandboxWorkdir: '~/hello',
+          sandboxRepoDir: '~/hello',
         },
       ],
     });

--- a/mastracode/factory/src/integrations/github/provenance.test.ts
+++ b/mastracode/factory/src/integrations/github/provenance.test.ts
@@ -58,7 +58,7 @@ async function setup() {
     repositoryId: repository.id,
     createdByUserId: 'user-1',
     sandboxProvider: 'local',
-    sandboxWorkdir: '/workspace',
+    sandboxRepoDir: '/workspace',
   });
   const pullsGet = vi.fn().mockResolvedValue({
     data: { number: 17, html_url: 'https://github.com/acme/repo/pull/17', base: { repo: { id: 10 } } },

--- a/mastracode/factory/src/integrations/github/routes-scenario.test.ts
+++ b/mastracode/factory/src/integrations/github/routes-scenario.test.ts
@@ -85,7 +85,7 @@ function projectRepositoryRow(row: Record<string, any>) {
     repositoryId,
     branch: row.defaultBranch ?? null,
     sandboxProvider: 'railway',
-    sandboxWorkdir: row.sandboxWorkdir,
+    sandboxRepoDir: row.sandboxRepoDir,
     setupCommand: null,
     teardownCommand: null,
     createdAt: now,
@@ -406,7 +406,7 @@ describe('S1: full write-back journey through the real route handlers', () => {
         repoFullName: 'octo/hello',
         repoId: 99,
         defaultBranch: 'main',
-        sandboxWorkdir: '/workspace/hello',
+        sandboxRepoDir: '/workspace/hello',
       }),
     );
     const app = buildApp({ workosId: 'u1', organizationId: 'org1' });
@@ -426,7 +426,7 @@ describe('S1: full write-back journey through the real route handlers', () => {
     expect(materializeRepo).not.toHaveBeenCalled();
     expect(sandboxCallback).not.toHaveBeenCalled();
     expect(tables.worktrees).toHaveLength(0);
-    const persistedSessionWorkdir = '/workspace/session-feat-x';
+    const persistedSessionRepoDir = '/workspace/session-feat-x';
     // Local-provider seed: the memo derives `<workingDirectory>/<repo name>`.
     getSessionSandbox(session.id, 'seed/session-feat-x', () =>
       ({
@@ -439,7 +439,7 @@ describe('S1: full write-back journey through the real route handlers', () => {
     await sourceControlStorage.sessions.setSandbox({
       id: session.id,
       sandboxId: 'sb-session',
-      sandboxWorkdir: persistedSessionWorkdir,
+      sandboxRepoDir: persistedSessionRepoDir,
     });
 
     // 4. Git operations address the materialized workspace by session id.
@@ -449,7 +449,7 @@ describe('S1: full write-back journey through the real route handlers', () => {
     });
     expect(commitRes.status).toBe(200);
     expect(await commitRes.json()).toMatchObject({ committed: true });
-    expect((commitAll.mock.calls[0] as unknown as any[])[1]).toBe(persistedSessionWorkdir);
+    expect((commitAll.mock.calls[0] as unknown as any[])[1]).toBe(persistedSessionRepoDir);
 
     // 5. Push that session branch with fresh repository-scoped access for this operation.
     const accessBeforePush = repositoryAccess.mock.calls.length;
@@ -462,8 +462,8 @@ describe('S1: full write-back journey through the real route handlers', () => {
     expect(repositoryAccess.mock.calls.length).toBe(accessBeforePush + 1);
     expect(githubStub.mintInstallationToken).not.toHaveBeenCalled();
     const pushCall = pushBranch.mock.calls[0] as unknown as any[];
-    // pushBranch(sandbox, workdir, branch, token, repoFullName)
-    expect(pushCall[1]).toBe(persistedSessionWorkdir);
+    // pushBranch(sandbox, repoDir, branch, token, repoFullName)
+    expect(pushCall[1]).toBe(persistedSessionRepoDir);
     expect(pushCall[2]).toBe('feat/x');
     const pushToken = pushCall[3] as string;
     expect(pushToken).toMatch(/^repo-token-/);
@@ -515,7 +515,7 @@ describe('S1: full write-back journey through the real route handlers', () => {
         repoFullName: 'octo/hello',
         repoId: 99,
         defaultBranch: 'main',
-        sandboxWorkdir: '/workspace/hello',
+        sandboxRepoDir: '/workspace/hello',
       }),
     );
     const response = await postJson(app, `/web/github/projects/${projectId}/pr`, {
@@ -541,7 +541,7 @@ describe('S2: concurrent pushes', () => {
         repoFullName: `octo/${id}`,
         repoId: id,
         defaultBranch: 'main',
-        sandboxWorkdir: '/workspace/hello',
+        sandboxRepoDir: '/workspace/hello',
       }),
     );
     const now = new Date();
@@ -563,7 +563,7 @@ describe('S2: concurrent pushes', () => {
       title: null,
       baseBranch: 'main',
       sandboxId: `sb-${id}`,
-      sandboxWorkdir: `/workspace/${id}`,
+      sandboxRepoDir: `/workspace/${id}`,
       materializedAt: now,
       createdAt: now,
       updatedAt: now,

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -106,7 +106,7 @@ function projectRepositoryRow(row: Record<string, any>) {
     repositoryId,
     branch: row.defaultBranch ?? null,
     sandboxProvider: row.sandboxProvider ?? 'railway',
-    sandboxWorkdir: row.sandboxWorkdir,
+    sandboxRepoDir: row.sandboxRepoDir,
     setupCommand: row.setupCommand ?? null,
     teardownCommand: row.teardownCommand ?? null,
     createdAt: now,
@@ -1319,7 +1319,7 @@ function seedMaterializedProject(
       repoFullName: 'octo/hello',
       repoId: 99,
       defaultBranch: 'main',
-      sandboxWorkdir: '/workspace/hello',
+      sandboxRepoDir: '/workspace/hello',
       setupCommand: opts.setupCommand ?? null,
       teardownCommand: opts.teardownCommand ?? null,
     }),
@@ -1330,7 +1330,7 @@ function seedMaterializedProject(
       projectRepositoryId: 'p1',
       userId,
       sandboxId: 'sb-1',
-      sandboxWorkdir: '/workspace/hello',
+      sandboxRepoDir: '/workspace/hello',
       materializedAt: new Date(),
     }),
   );
@@ -1349,7 +1349,7 @@ function seedMaterializedSession() {
     title: null,
     baseBranch: 'main',
     sandboxId: 'sb-1',
-    sandboxWorkdir: '/workspace/worktrees/feat-x',
+    sandboxRepoDir: '/workspace/worktrees/feat-x',
     materializedAt: now,
     createdAt: now,
     updatedAt: now,
@@ -1364,14 +1364,14 @@ function seedMaterializedSession() {
 
 /**
  * Seed the per-process session-sandbox memo with a live instance whose
- * derived workdir equals `workdir` exactly: a local-provider instance checks
+ * derived repoDir equals `repoDir` exactly: a local-provider instance checks
  * out under `<workingDirectory>/<repo name>`.
  */
-function seedLiveSandbox(sessionRowId: string, workdir: string, sandbox: Record<string, unknown>) {
-  const cut = workdir.lastIndexOf('/');
+function seedLiveSandbox(sessionRowId: string, repoDir: string, sandbox: Record<string, unknown>) {
+  const cut = repoDir.lastIndexOf('/');
   // Mutate in place so callers can assert on the exact seeded instance.
-  Object.assign(sandbox, { provider: 'local', workingDirectory: workdir.slice(0, cut) });
-  getSessionSandbox(sessionRowId, `seed/${workdir.slice(cut + 1)}`, () => sandbox as never);
+  Object.assign(sandbox, { provider: 'local', workingDirectory: repoDir.slice(0, cut) });
+  getSessionSandbox(sessionRowId, `seed/${repoDir.slice(cut + 1)}`, () => sandbox as never);
 }
 
 function postJson(app: ReturnType<typeof buildApp>, path: string, body: unknown) {
@@ -1751,7 +1751,7 @@ describe('Factory session routes', () => {
       title: null,
       visibility: 'org',
       sandboxId: null,
-      sandboxWorkdir: null,
+      sandboxRepoDir: null,
     });
     expect(session.sessionId).toEqual(expect.any(String));
     expect(tables.sessions).toHaveLength(1);
@@ -1930,7 +1930,7 @@ describe('Factory session routes', () => {
       baseBranch: 'main',
       visibility: 'private',
       sandboxId: null,
-      sandboxWorkdir: null,
+      sandboxRepoDir: null,
       materializedAt: null,
       createdAt: now,
       updatedAt: now,
@@ -1959,7 +1959,7 @@ describe('Factory session routes', () => {
       title: null,
       baseBranch: 'main',
       sandboxId: null,
-      sandboxWorkdir: null,
+      sandboxRepoDir: null,
       materializedAt: null,
       createdAt: now,
       updatedAt: now,
@@ -2413,7 +2413,7 @@ describe('push route', () => {
     });
     expect(githubStub.mintInstallationToken).not.toHaveBeenCalled();
     expect(pushBranch).toHaveBeenCalledOnce();
-    // pushBranch(sandbox, workdir, branch, token, repoFullName)
+    // pushBranch(sandbox, repoDir, branch, token, repoFullName)
     const call = pushBranch.mock.calls[0] as unknown as any[];
     expect(call[2]).toBe('feat/x');
     expect(call[3]).toBe('repo-token-repository-99');

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -23,9 +23,9 @@ import type { Context } from 'hono';
 import type { RouteAuth } from '../../routes/route.js';
 import { requireExec } from '../../sandbox/materialization.js';
 import type { ExecutableSandbox } from '../../sandbox/materialization.js';
+import { sanitizeSegment } from '../../sandbox/repo-dir.js';
 import type { MastraFactorySandboxConfig } from '../../sandbox/session-sandbox.js';
 import { peekSessionSandbox } from '../../sandbox/session-sandbox.js';
-import { sanitizeSegment } from '../../sandbox/workdir.js';
 import { normalizeSessionTitle } from '../../session/session-title.js';
 import type { StateSigner } from '../../state-signing.js';
 import type { AuditEmitter } from '../../storage/domains/audit/domain.js';
@@ -681,11 +681,11 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
                 installationStorageId: inst.id,
                 repositoryStorageId: repository.id,
                 sandboxProvider: sandbox ? 'custom' : 'none',
-                // Display only — the runtime workdir is resolved from the
+                // Display only — the runtime repoDir is resolved from the
                 // live sandbox at open time, never read from this row. Repos
                 // clone into the VM's home; `~/<repo>` is the honest
                 // listing-time guess.
-                sandboxWorkdir: `~/${sanitizeSegment(repo.fullName.split('/', 2)[1] || 'repo')}`,
+                sandboxRepoDir: `~/${sanitizeSegment(repo.fullName.split('/', 2)[1] || 'repo')}`,
               };
             }),
           );
@@ -1492,13 +1492,13 @@ function buildProjectGitRoutes({
         if (!sessionWorkspace) {
           return c.json({ error: 'Invalid sessionId' }, 400);
         }
-        const { workdir, sandbox: sessionSandbox } = sessionWorkspace;
+        const { repoDir, sandbox: sessionSandbox } = sessionWorkspace;
 
         try {
           return await withSessionOperationLock(sessionWorkspace.session.sessionId, async () => {
             const result = await commitAll(
               sessionSandbox,
-              workdir,
+              repoDir,
               body.message as string,
               identityFromUser(await auth.ensureUser(loose(c))),
             );
@@ -1571,7 +1571,7 @@ function buildProjectGitRoutes({
         if (!sessionWorkspace) {
           return c.json({ error: 'Invalid sessionId' }, 400);
         }
-        const { workdir, sandbox: sessionSandbox } = sessionWorkspace;
+        const { repoDir, sandbox: sessionSandbox } = sessionWorkspace;
 
         try {
           return await withSessionOperationLock(sessionWorkspace.session.sessionId, async () => {
@@ -1580,7 +1580,7 @@ function buildProjectGitRoutes({
               repositoryId: project.repository.id,
             });
             if (!access.authorization) throw new Error('Repository access did not include a bearer token.');
-            await pushBranch(sessionSandbox, workdir, branch, access.authorization.token, project.repository.slug);
+            await pushBranch(sessionSandbox, repoDir, branch, access.authorization.token, project.repository.slug);
             await emitAudit?.({
               context: loose(c),
               input: {
@@ -1721,13 +1721,13 @@ async function resolveSessionWorkspace(
   }
   // Session sandboxes live in the per-process memo, keyed by the session row
   // id. Passive resolution only — git write routes never provision. An
-  // unresolved workdir means the sandbox never started here: nothing is
+  // unresolved repoDir means the sandbox never started here: nothing is
   // materialized, so there is no workspace to operate on.
   const entry = peekSessionSandbox(session.id);
-  if (!entry?.workdir) return undefined;
+  if (!entry?.repoDir) return undefined;
   return {
     session,
-    workdir: entry.workdir,
+    repoDir: entry.repoDir,
     sandbox: requireExec(entry.sandbox),
   };
 }

--- a/mastracode/factory/src/integrations/github/rules.test.ts
+++ b/mastracode/factory/src/integrations/github/rules.test.ts
@@ -45,7 +45,7 @@ async function setup(permission: string | undefined) {
     repositoryId: repository.id,
     createdByUserId: 'user-1',
     sandboxProvider: 'local',
-    sandboxWorkdir: '/workspace',
+    sandboxRepoDir: '/workspace',
   });
   const github = {
     slug: 'factory-app',
@@ -1805,7 +1805,7 @@ describe('GithubRules', () => {
       repositoryId: repository.id,
       createdByUserId: 'user-2',
       sandboxProvider: 'local',
-      sandboxWorkdir: '/workspace',
+      sandboxRepoDir: '/workspace',
     });
     const service = new GithubRules({
       github,

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -63,7 +63,7 @@ class FakeSandbox implements ExecutableSandbox {
   async executeCommand(command: string, args?: string[]): Promise<SandboxCommandResult> {
     const script = command === 'sh' && args?.[0] === '-c' ? args[1]! : [command, ...(args ?? [])].join(' ');
     this.calls.push(script);
-    // The workdir resolver probes the VM's default cwd (its home dir).
+    // The repoDir resolver probes the VM's default cwd (its home dir).
     if (script === 'pwd') return { exitCode: 0, stdout: '/home/user\n', stderr: '' };
     return this.responder(script);
   }
@@ -75,7 +75,7 @@ function makeRow(overrides: Partial<ProjectRepositorySandbox> = {}): ProjectRepo
     projectRepositoryId: 'project-repository-1',
     userId: 'user-1',
     sandboxId: null,
-    sandboxWorkdir: '/workspace/hello',
+    sandboxRepoDir: '/workspace/hello',
     materializedAt: null,
     createdAt: new Date(),
     ...overrides,
@@ -143,7 +143,7 @@ describe('materializeRepo', () => {
   it('re-clones when the DB says materialized but the sandbox disk was wiped', async () => {
     // A platform/remote sandbox can expire and come back with an empty disk
     // while the binding row still says `materializedAt`. Trusting the row made
-    // every `git -C <workdir>` fail with "cannot change to ...: No such file
+    // every `git -C <repoDir>` fail with "cannot change to ...: No such file
     // or directory" and the workspace never recovered. Disk is the truth: no
     // checkout on disk means clone, regardless of the row.
     const sandbox = new FakeSandbox(script => {
@@ -163,9 +163,9 @@ describe('materializeRepo', () => {
     expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
   });
 
-  it('clears a non-empty workdir before cloning so a partial tree cannot wedge the workspace', async () => {
+  it('clears a non-empty repoDir before cloning so a partial tree cannot wedge the workspace', async () => {
     // A checkpoint seed or a clone killed partway (crashed/OOM-killed server)
-    // leaves a populated workdir with no usable checkout. `git clone` refuses
+    // leaves a populated repoDir with no usable checkout. `git clone` refuses
     // a non-empty destination with a non-retryable fatal, so every later
     // workspace operation failed with "destination path ... already exists and
     // is not an empty directory" until the sandbox was wiped by hand.
@@ -184,8 +184,8 @@ describe('materializeRepo', () => {
     expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
   });
 
-  it('pulls (not clones) when the DB says first open but the workdir already holds this repo', async () => {
-    // DB/disk drift: a fresh binding row (materializedAt null) over a workdir
+  it('pulls (not clones) when the DB says first open but the repoDir already holds this repo', async () => {
+    // DB/disk drift: a fresh binding row (materializedAt null) over a repoDir
     // that was already cloned by an earlier flow or before a dev DB reset.
     const sandbox = new FakeSandbox(script => {
       if (script.includes('remote get-url origin')) {
@@ -201,7 +201,7 @@ describe('materializeRepo', () => {
     expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
   });
 
-  it('still clones when the workdir holds a checkout of a different repo', async () => {
+  it('still clones when the repoDir holds a checkout of a different repo', async () => {
     const sandbox = new FakeSandbox(script => {
       if (script.includes('remote get-url origin')) {
         return { exitCode: 0, stdout: 'https://github.com/someone/else.git\n', stderr: '' };
@@ -254,7 +254,7 @@ describe('materializeRepo', () => {
     expect(err.code).toBe('egress-blocked');
   });
 
-  it('surfaces the clone failure when the token scrub throws on a missing workdir', async () => {
+  it('surfaces the clone failure when the token scrub throws on a missing repoDir', async () => {
     const sandbox = new FakeSandbox(script => {
       if (script === 'git --version') return OK;
       if (script.includes('git clone')) {
@@ -353,7 +353,7 @@ describe('materializeRepo', () => {
   });
 
   it('keeps a diverged session branch on re-open instead of failing the pull', async () => {
-    // The shared workdir is routinely left on a session's working branch with
+    // The shared repoDir is routinely left on a session's working branch with
     // local commits. When its upstream moved, `git pull --ff-only` aborts with
     // "Not possible to fast-forward" — that is the session's work, not an
     // error, so materialization must succeed and leave the checkout alone.
@@ -823,7 +823,7 @@ describe('resolveGitIdentity', () => {
 });
 
 describe('configureGitIdentity', () => {
-  it('configures user.name and user.email in the workdir, quoted', async () => {
+  it('configures user.name and user.email in the repoDir, quoted', async () => {
     const sandbox = new FakeSandbox();
     await configureGitIdentity(sandbox, '/workspace/hello', { name: 'Ada Lovelace', email: 'ada@example.com' });
 
@@ -1014,7 +1014,7 @@ describe('runSetupCommand', () => {
 });
 
 describe('runTeardownCommand', () => {
-  it('uses the same quoted workdir shell and reports bounded command output', async () => {
+  it('uses the same quoted repoDir shell and reports bounded command output', async () => {
     const sandbox = new FakeSandbox(() => ({ exitCode: 9, stdout: '', stderr: `prefix-${'x'.repeat(3000)}` }));
     const err = await runTeardownCommand(
       sandbox,

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -10,7 +10,7 @@
  *   scrubbed from the git remote afterwards so it never persists in the VM.
  *
  * This module owns everything git/GitHub: clone/pull, commit/push, setup/teardown commands,
- * and `gh pr create`. Workdir layout lives in `../sandbox/workdir`.
+ * and `gh pr create`. Repo-dir layout lives in `../sandbox/repoDir`.
  */
 
 import type { ExecutableSandbox, SandboxCommandResult } from '../../sandbox/materialization.js';
@@ -21,7 +21,7 @@ type MaterializationStore = Pick<SourceControlStorageHandle['sessions'], 'markMa
 
 interface RepoMaterializationBinding {
   id: string;
-  sandboxWorkdir: string;
+  sandboxRepoDir: string;
   materializedAt: Date | null;
 }
 
@@ -213,7 +213,7 @@ export interface RepoMaterializeInfo {
 
 /** Options for {@link materializeRepo}. */
 export interface MaterializeRepoOptions {
-  /** The per-(project,user) sandbox binding whose workdir this materializes into. */
+  /** The per-(project,user) sandbox binding whose repoDir this materializes into. */
   row: RepoMaterializationBinding;
   /** Repo metadata from the org-owned project row. */
   repoInfo: RepoMaterializeInfo;
@@ -235,7 +235,7 @@ export async function materializeRepo(options: MaterializeRepoOptions): Promise<
 
 async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<void> {
   const { row: sandboxRow, repoInfo, sandbox, token, storage } = options;
-  const workdir = sandboxRow.sandboxWorkdir;
+  const repoDir = sandboxRow.sandboxRepoDir;
   const repo = repoInfo.repoFullName;
 
   // 0. Defense in depth: never build a git command from values that aren't
@@ -263,36 +263,36 @@ async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<voi
   const authUrl = tokenUrl(repo, token);
 
   // The DB's `materializedAt` can drift from disk in both directions: a fresh
-  // binding row over an already-populated workdir (local dev DB resets,
+  // binding row over an already-populated repoDir (local dev DB resets,
   // repaired rows, earlier flows) must pull instead of failing `git clone` on
   // the non-empty directory, and a stale `materializedAt` over an empty
   // sandbox (an expired/recreated VM whose disk was wiped) must re-clone
-  // instead of running `git -C <workdir>` against a directory that no longer
+  // instead of running `git -C <repoDir>` against a directory that no longer
   // exists. Disk is the source of truth: detect the checkout instead of
   // trusting the row.
-  const alreadyMaterialized = await hasExistingCheckout(sandbox, workdir, repo);
+  const alreadyMaterialized = await hasExistingCheckout(sandbox, repoDir, repo);
 
   let tokenInRemote = false;
   try {
     if (!alreadyMaterialized) {
-      // 2a. First open: shallow-clone the default branch into the workdir. A
+      // 2a. First open: shallow-clone the default branch into the repoDir. A
       // shallow single-branch clone is dramatically faster for large repos; the
       // later re-open uses `git pull --ff-only`, which works on shallow clones.
-      // The workdir holds no usable checkout of this repo, but it may not be
+      // The repoDir holds no usable checkout of this repo, but it may not be
       // empty: a checkpoint seed or a clone that died partway (a crashed or
       // OOM-killed server) leaves a partial tree behind, and `git clone`
       // refuses a non-empty destination with a non-retryable fatal. Nothing
       // here is recoverable — `hasExistingCheckout` already ruled out a
       // checkout of this repo — so clear its contents before cloning, exactly
-      // as the retry path does. Keep the workdir itself because LocalSandbox
+      // as the retry path does. Keep the repoDir itself because LocalSandbox
       // runs commands with this directory as the child process cwd.
       await sh(
         sandbox,
-        `mkdir -p ${shellQuote(workdir)} && find ${shellQuote(workdir)} -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +`,
+        `mkdir -p ${shellQuote(repoDir)} && find ${shellQuote(repoDir)} -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +`,
       );
       const clone = await gitTransfer(
         sandbox,
-        `git clone --depth=1 --single-branch --branch ${shellQuote(repoInfo.defaultBranch)} ${shellQuote(authUrl)} ${shellQuote(workdir)}`,
+        `git clone --depth=1 --single-branch --branch ${shellQuote(repoInfo.defaultBranch)} ${shellQuote(authUrl)} ${shellQuote(repoDir)}`,
         {
           phase: 'repository clone',
           beforeRetry: async () => {
@@ -301,7 +301,7 @@ async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<voi
             // clean without removing LocalSandbox's process cwd.
             await sh(
               sandbox,
-              `mkdir -p ${shellQuote(workdir)} && find ${shellQuote(workdir)} -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +`,
+              `mkdir -p ${shellQuote(repoDir)} && find ${shellQuote(repoDir)} -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +`,
             );
           },
         },
@@ -310,25 +310,25 @@ async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<voi
         // git can fail after creating the checkout ("Clone succeeded, but
         // checkout failed") with the tokenized origin persisted — probe the
         // disk instead of assuming the failed clone left nothing behind.
-        tokenInRemote = await hasGitDir(sandbox, workdir);
+        tokenInRemote = await hasGitDir(sandbox, repoDir);
         throw classifyGitFailure(clone, 'clone-failed');
       }
       tokenInRemote = true;
     } else {
       // 2b. Re-open: refresh remote to the token URL and fast-forward pull.
-      const setUrl = await sh(sandbox, `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(authUrl)}`);
+      const setUrl = await sh(sandbox, `git -C ${shellQuote(repoDir)} remote set-url origin ${shellQuote(authUrl)}`);
       if (setUrl.exitCode !== 0) {
         throw new MaterializeError(`Failed to set git remote: ${setUrl.stderr}`, 'pull-failed');
       }
       tokenInRemote = true;
-      const pull = await gitTransfer(sandbox, `git -C ${shellQuote(workdir)} pull --ff-only`, {
+      const pull = await gitTransfer(sandbox, `git -C ${shellQuote(repoDir)} pull --ff-only`, {
         phase: 'repository pull',
       });
       if (pull.exitCode !== 0) {
         if (!isBenignNonFastForward(pull)) {
           throw classifyGitFailure(pull, 'pull-failed');
         }
-        // The workdir was left on a session's working branch that can't be
+        // The repoDir was left on a session's working branch that can't be
         // fast-forwarded (diverged from upstream, no upstream, or detached
         // HEAD), or its configured upstream ref was deleted after merge.
         // That checkout still holds usable work — never rebase or reset it
@@ -341,12 +341,12 @@ async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<voi
     // config. The scrub must never hide the actionable failure, but once the
     // token reached the remote its own failure can't stay silent either:
     // report both, primary cause and classification first.
-    throw await scrubbedFailure(sandbox, workdir, repo, tokenInRemote, primary, 'pull-failed');
+    throw await scrubbedFailure(sandbox, repoDir, repo, tokenInRemote, primary, 'pull-failed');
   }
 
-  // 3b. Success — the token is in the remote and the workdir has a `.git`, so
+  // 3b. Success — the token is in the remote and the repoDir has a `.git`, so
   // a failed scrub means the token may still be persisted: surface it.
-  await scrubRemote(sandbox, workdir, repo, tokenInRemote);
+  await scrubRemote(sandbox, repoDir, repo, tokenInRemote);
 
   // 4. Mark materialized.
   await storage.markMaterialized({ id: sandboxRow.id });
@@ -355,15 +355,15 @@ async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<voi
 /** Check out a session's branch inside its isolated repository clone. */
 export async function checkoutSessionBranch(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   options: { branch: string; baseBranch: string; token: string; repoFullName: string },
 ): Promise<void> {
-  return timedPhase('workspace.checkout', () => checkoutSessionBranchImpl(sandbox, workdir, options));
+  return timedPhase('workspace.checkout', () => checkoutSessionBranchImpl(sandbox, repoDir, options));
 }
 
 async function checkoutSessionBranchImpl(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   {
     branch,
     baseBranch,
@@ -375,15 +375,15 @@ async function checkoutSessionBranchImpl(
     throw new MaterializeError('Refusing to create a session from an invalid branch name.', 'clone-failed');
   }
 
-  const current = await sh(sandbox, `git -C ${shellQuote(workdir)} branch --show-current`);
+  const current = await sh(sandbox, `git -C ${shellQuote(repoDir)} branch --show-current`);
   if (current.exitCode === 0 && current.stdout.trim() === branch) return;
 
   const local = await sh(
     sandbox,
-    `git -C ${shellQuote(workdir)} show-ref --verify --quiet refs/heads/${shellQuote(branch)}`,
+    `git -C ${shellQuote(repoDir)} show-ref --verify --quiet refs/heads/${shellQuote(branch)}`,
   );
   if (local.exitCode === 0) {
-    const checkout = await sh(sandbox, `git -C ${shellQuote(workdir)} checkout ${shellQuote(branch)}`);
+    const checkout = await sh(sandbox, `git -C ${shellQuote(repoDir)} checkout ${shellQuote(branch)}`);
     if (checkout.exitCode !== 0) {
       // The session's agent may have switched branches itself (e.g. `gh pr
       // checkout`) and left uncommitted work in the tree. Git refuses to
@@ -399,11 +399,11 @@ async function checkoutSessionBranchImpl(
 
   const authUrl = tokenUrl(repoFullName, token);
   try {
-    const setUrl = await sh(sandbox, `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(authUrl)}`);
+    const setUrl = await sh(sandbox, `git -C ${shellQuote(repoDir)} remote set-url origin ${shellQuote(authUrl)}`);
     if (setUrl.exitCode !== 0) throw classifyGitFailure(setUrl, 'pull-failed');
     const fetch = await sh(
       sandbox,
-      `git -C ${shellQuote(workdir)} fetch origin ${shellQuote(baseBranch)} && git -C ${shellQuote(workdir)} checkout -b ${shellQuote(branch)} FETCH_HEAD`,
+      `git -C ${shellQuote(repoDir)} fetch origin ${shellQuote(baseBranch)} && git -C ${shellQuote(repoDir)} checkout -b ${shellQuote(branch)} FETCH_HEAD`,
       { timeoutMs: CHECKOUT_COMMAND_TIMEOUT_MS, phase: 'branch checkout' },
     );
     if (fetch.exitCode !== 0) {
@@ -417,7 +417,7 @@ async function checkoutSessionBranchImpl(
       // broken loose ref the probe cannot resolve (replace it and retry —
       // "already exists" means the fetch half succeeded, so FETCH_HEAD is
       // set).
-      const adopt = await sh(sandbox, `git -C ${shellQuote(workdir)} checkout ${shellQuote(branch)}`);
+      const adopt = await sh(sandbox, `git -C ${shellQuote(repoDir)} checkout ${shellQuote(branch)}`);
       if (adopt.exitCode === 0 || isBlockedByLocalWork(adopt)) return;
       const drop = await sh(
         sandbox,
@@ -426,10 +426,10 @@ async function checkoutSessionBranchImpl(
         // a broken ref; fall back to removing the loose ref file (branch
         // passed isValidGitRef, so the interpolation inside the double quotes
         // is inert).
-        `git -C ${shellQuote(workdir)} update-ref --no-deref -d refs/heads/${shellQuote(branch)} || rm -f -- "$(git -C ${shellQuote(workdir)} rev-parse --absolute-git-dir)/refs/heads/${branch}"`,
+        `git -C ${shellQuote(repoDir)} update-ref --no-deref -d refs/heads/${shellQuote(branch)} || rm -f -- "$(git -C ${shellQuote(repoDir)} rev-parse --absolute-git-dir)/refs/heads/${branch}"`,
       );
       if (drop.exitCode !== 0) throw classifyGitFailure(fetch, 'clone-failed');
-      const retry = await sh(sandbox, `git -C ${shellQuote(workdir)} checkout -b ${shellQuote(branch)} FETCH_HEAD`, {
+      const retry = await sh(sandbox, `git -C ${shellQuote(repoDir)} checkout -b ${shellQuote(branch)} FETCH_HEAD`, {
         timeoutMs: CHECKOUT_COMMAND_TIMEOUT_MS,
         phase: 'branch checkout retry',
       });
@@ -439,7 +439,7 @@ async function checkoutSessionBranchImpl(
       }
     }
   } finally {
-    await sh(sandbox, `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(cleanUrl(repoFullName))}`);
+    await sh(sandbox, `git -C ${shellQuote(repoDir)} remote set-url origin ${shellQuote(cleanUrl(repoFullName))}`);
   }
 }
 
@@ -467,25 +467,25 @@ function isBlockedByLocalWork(result: SandboxCommandResult): boolean {
 }
 
 /**
- * True when the workdir already holds a git checkout whose `origin` points at
+ * True when the repoDir already holds a git checkout whose `origin` points at
  * this exact repo. Matches both the clean and token-auth URL forms; any other
  * remote (or no git dir at all) falls back to the clone path.
  */
 export async function hasExistingCheckout(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   repoFullName: string,
 ): Promise<boolean> {
-  const result = await sh(sandbox, `git -C ${shellQuote(workdir)} remote get-url origin`);
+  const result = await sh(sandbox, `git -C ${shellQuote(repoDir)} remote get-url origin`);
   if (result.exitCode !== 0) return false;
   const url = result.stdout.trim().toLowerCase();
   const suffix = `github.com/${repoFullName.toLowerCase()}`;
   return url.endsWith(`${suffix}.git`) || url.endsWith(suffix);
 }
 
-/** Probed without `git -C` so a missing workdir returns false instead of throwing. */
-async function hasGitDir(sandbox: ExecutableSandbox, workdir: string): Promise<boolean> {
-  const probe = await sh(sandbox, `test -d ${shellQuote(`${workdir}/.git`)}`).catch(() => null);
+/** Probed without `git -C` so a missing repoDir returns false instead of throwing. */
+async function hasGitDir(sandbox: ExecutableSandbox, repoDir: string): Promise<boolean> {
+  const probe = await sh(sandbox, `test -d ${shellQuote(`${repoDir}/.git`)}`).catch(() => null);
   return probe?.exitCode === 0;
 }
 
@@ -493,18 +493,18 @@ async function hasGitDir(sandbox: ExecutableSandbox, workdir: string): Promise<b
  * Reset the git remote back to the tokenless URL. Strict when the token
  * reached the remote: any failure — a non-zero exit or a provider throw —
  * means the token may still be persisted, so it is thrown for the caller to
- * surface. Best-effort when it never did: the workdir may not exist (e.g. a
+ * surface. Best-effort when it never did: the repoDir may not exist (e.g. a
  * failed clone), which makes providers that spawn with `cwd` throw rather
  * than return a non-zero exit code; both outcomes are tolerated so neither
  * masks the primary failure.
  */
 async function scrubRemote(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   repoFullName: string,
   tokenInRemote: boolean,
 ): Promise<void> {
-  const scrub = `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(cleanUrl(repoFullName))}`;
+  const scrub = `git -C ${shellQuote(repoDir)} remote set-url origin ${shellQuote(cleanUrl(repoFullName))}`;
   if (!tokenInRemote) {
     await sh(sandbox, scrub).catch(() => undefined);
     return;
@@ -528,14 +528,14 @@ async function scrubRemote(
  */
 async function scrubbedFailure(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   repoFullName: string,
   tokenInRemote: boolean,
   primary: unknown,
   fallback: MaterializeError['code'],
 ): Promise<unknown> {
   try {
-    await scrubRemote(sandbox, workdir, repoFullName, tokenInRemote);
+    await scrubRemote(sandbox, repoDir, repoFullName, tokenInRemote);
     return primary;
   } catch (scrubError) {
     const scrubMessage = scrubError instanceof Error ? scrubError.message : String(scrubError);
@@ -550,7 +550,7 @@ async function scrubbedFailure(
 /**
  * True when a failed `git pull --ff-only` on re-open just means the current
  * branch can't be fast-forwarded — not that anything is broken. The shared
- * workdir is routinely left on a session's working branch, which may have
+ * repoDir is routinely left on a session's working branch, which may have
  * local commits diverging from upstream, no upstream at all (session branches
  * are created from `FETCH_HEAD`), or a detached HEAD. A checkout can also
  * hold uncommitted or untracked files (a build or script run left residue,
@@ -651,15 +651,15 @@ export function resolveGitIdentity(identity: GitIdentity): { name: string; email
  */
 export async function configureGitIdentity(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   identity: GitIdentity,
 ): Promise<void> {
   const { name, email } = resolveGitIdentity(identity);
-  const setName = await sh(sandbox, `git -C ${shellQuote(workdir)} config user.name ${shellQuote(name)}`);
+  const setName = await sh(sandbox, `git -C ${shellQuote(repoDir)} config user.name ${shellQuote(name)}`);
   if (setName.exitCode !== 0) {
     throw new MaterializeError(`Failed to set git user.name: ${setName.stderr.trim()}`, 'commit-failed');
   }
-  const setEmail = await sh(sandbox, `git -C ${shellQuote(workdir)} config user.email ${shellQuote(email)}`);
+  const setEmail = await sh(sandbox, `git -C ${shellQuote(repoDir)} config user.email ${shellQuote(email)}`);
   if (setEmail.exitCode !== 0) {
     throw new MaterializeError(`Failed to set git user.email: ${setEmail.stderr.trim()}`, 'commit-failed');
   }
@@ -679,7 +679,7 @@ export async function configureGitIdentity(
  */
 export async function withInstallToken<T>(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   repoFullName: string,
   token: string,
   fn: () => Promise<T>,
@@ -690,11 +690,11 @@ export async function withInstallToken<T>(
 
   const setUrl = await sh(
     sandbox,
-    `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(tokenUrl(repoFullName, token))}`,
+    `git -C ${shellQuote(repoDir)} remote set-url origin ${shellQuote(tokenUrl(repoFullName, token))}`,
   );
   if (setUrl.exitCode !== 0) {
     // Best-effort scrub even though set-url failed, then surface the failure.
-    await scrubRemote(sandbox, workdir, repoFullName, false);
+    await scrubRemote(sandbox, repoDir, repoFullName, false);
     throw new MaterializeError(`Failed to set git remote: ${setUrl.stderr.trim()}`, 'push-failed');
   }
 
@@ -702,11 +702,11 @@ export async function withInstallToken<T>(
   try {
     result = await fn();
   } catch (primary) {
-    throw await scrubbedFailure(sandbox, workdir, repoFullName, true, primary, 'push-failed');
+    throw await scrubbedFailure(sandbox, repoDir, repoFullName, true, primary, 'push-failed');
   }
-  // Restore the tokenless remote. The workdir has a `.git` (we just rewrote
+  // Restore the tokenless remote. The repoDir has a `.git` (we just rewrote
   // its remote) so a scrub failure means the token may still persist — surface it.
-  await scrubRemote(sandbox, workdir, repoFullName, true);
+  await scrubRemote(sandbox, repoDir, repoFullName, true);
   return result;
 }
 
@@ -718,7 +718,7 @@ export async function withInstallToken<T>(
  */
 export async function pushBranch(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   branch: string,
   token: string,
   repoFullName: string,
@@ -727,8 +727,8 @@ export async function pushBranch(
     throw new MaterializeError(`Refusing to push: invalid branch name '${branch}'.`, 'push-failed');
   }
 
-  await withInstallToken(sandbox, workdir, repoFullName, token, async () => {
-    const push = await sh(sandbox, `git -C ${shellQuote(workdir)} push -u origin ${shellQuote(branch)}`);
+  await withInstallToken(sandbox, repoDir, repoFullName, token, async () => {
+    const push = await sh(sandbox, `git -C ${shellQuote(repoDir)} push -u origin ${shellQuote(branch)}`);
     if (push.exitCode !== 0) {
       throw classifyGitFailure(push, 'push-failed');
     }
@@ -747,31 +747,31 @@ export interface CommitResult {
  * error, so callers can safely commit-then-push without first diffing.
  *
  * @param sandbox  the live sandbox containing the checkout
- * @param workdir  the session workdir to commit in
+ * @param repoDir  the session repoDir to commit in
  * @param message  the commit message (quoted; arbitrary text is safe)
  * @param identity authorship identity for the commit
  */
 export async function commitAll(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   message: string,
   identity: GitIdentity,
 ): Promise<CommitResult> {
-  await configureGitIdentity(sandbox, workdir, identity);
+  await configureGitIdentity(sandbox, repoDir, identity);
 
-  const add = await sh(sandbox, `git -C ${shellQuote(workdir)} add -A`);
+  const add = await sh(sandbox, `git -C ${shellQuote(repoDir)} add -A`);
   if (add.exitCode !== 0) {
     throw new MaterializeError(`git add failed: ${add.stderr.trim() || add.stdout.trim()}`, 'commit-failed');
   }
 
   // Nothing staged → nothing to commit. `git diff --cached --quiet` exits 1 when
   // there are staged changes, 0 when the index is clean.
-  const staged = await sh(sandbox, `git -C ${shellQuote(workdir)} diff --cached --quiet`);
+  const staged = await sh(sandbox, `git -C ${shellQuote(repoDir)} diff --cached --quiet`);
   if (staged.exitCode === 0) {
     return { committed: false };
   }
 
-  const commit = await sh(sandbox, `git -C ${shellQuote(workdir)} commit -m ${shellQuote(message)}`);
+  const commit = await sh(sandbox, `git -C ${shellQuote(repoDir)} commit -m ${shellQuote(message)}`);
   if (commit.exitCode !== 0) {
     throw new MaterializeError(`git commit failed: ${commit.stderr.trim() || commit.stdout.trim()}`, 'commit-failed');
   }
@@ -783,7 +783,7 @@ export async function commitAll(
 // Phase 2 — setup / teardown lifecycle commands
 //
 // The org-configured setup and teardown shell commands run in the session's
-// materialized workdir. The workdir is always resolved server-side from the
+// materialized repoDir. The repoDir is always resolved server-side from the
 // live sandbox; client input never reaches a filesystem path.
 // ---------------------------------------------------------------------------
 
@@ -800,7 +800,7 @@ export class SetupCommandError extends Error {
 
 /**
  * Run the project's setup command (e.g. `pnpm i && pnpm build`) inside the
- * freshly materialized session workdir. Called before the checkout is handed
+ * freshly materialized session repoDir. Called before the checkout is handed
  * to any agent run so it is ready to build/test. A non-zero exit is a hard
  * error — starting agent work in a half-set-up tree is worse than failing the
  * request.
@@ -816,16 +816,16 @@ export class SetupCommandError extends Error {
  * provides.
  *
  * @param sandbox  live sandbox containing the checkout
- * @param workdir  the server-resolved session workdir the command runs in
+ * @param repoDir  the server-resolved session repoDir the command runs in
  * @param command  the org-configured setup shell command
  */
 async function runLifecycleCommand(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   command: string,
   options: { phase: 'setup' | 'teardown'; timeoutMs?: number },
 ): Promise<void> {
-  const result = await sh(sandbox, `cd ${shellQuote(workdir)} && { ${command}\n}`, {
+  const result = await sh(sandbox, `cd ${shellQuote(repoDir)} && { ${command}\n}`, {
     phase: `${options.phase} command`,
     ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
   });
@@ -841,25 +841,25 @@ async function runLifecycleCommand(
 
 export async function runSetupCommand(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   command: string,
 ): Promise<void> {
-  return runLifecycleCommand(sandbox, workdir, command, { phase: 'setup' });
+  return runLifecycleCommand(sandbox, repoDir, command, { phase: 'setup' });
 }
 
 /**
  * Run the repository's best-effort teardown command from the materialized
- * session workdir. Callers own lifecycle policy: this helper reports failures
+ * session repoDir. Callers own lifecycle policy: this helper reports failures
  * so the retirement coordinator can log them while still continuing with
  * scrub, pooling/destruction, cache invalidation, and row deletion.
  */
 export async function runTeardownCommand(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   command: string,
   options: { timeoutMs?: number } = {},
 ): Promise<void> {
-  return runLifecycleCommand(sandbox, workdir, command, {
+  return runLifecycleCommand(sandbox, repoDir, command, {
     phase: 'teardown',
     ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
   });
@@ -911,11 +911,11 @@ function parsePullRequestUrl(stdout: string): string | undefined {
  * PR URL is parsed from stdout.
  *
  * @param sandbox live sandbox containing the checkout
- * @param workdir the worktree (or repo) path the PR head branch is checked out in
+ * @param repoDir the worktree (or repo) path the PR head branch is checked out in
  */
 export async function createPullRequest(
   sandbox: ExecutableSandbox,
-  workdir: string,
+  repoDir: string,
   { token, base, head, title, body }: CreatePullRequestArgs,
 ): Promise<CreatePullRequestResult> {
   if (!isValidGitRef(base)) {
@@ -937,7 +937,7 @@ export async function createPullRequest(
     `--title ${shellQuote(title)}`,
     `--body ${shellQuote(body ?? '')}`,
   ].join(' ');
-  const script = `cd ${shellQuote(workdir)} && ${ghCommand}`;
+  const script = `cd ${shellQuote(repoDir)} && ${ghCommand}`;
 
   const result = await sh(sandbox, script);
   if (result.exitCode !== 0) {

--- a/mastracode/factory/src/integrations/issue-reconciler.test.ts
+++ b/mastracode/factory/src/integrations/issue-reconciler.test.ts
@@ -65,7 +65,7 @@ async function githubSetup(input: {
     repositoryId: storedRepository.id,
     createdByUserId: project.createdBy,
     sandboxProvider: 'local',
-    sandboxWorkdir: '/workspace',
+    sandboxRepoDir: '/workspace',
   });
   const workItem = (
     await seeded.workItems.upsert({

--- a/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.lifecycle.test.ts
@@ -171,7 +171,7 @@ describe('Platform GitHub event worker factory lifecycle', () => {
         repositoryId: repository.id,
         createdByUserId: 'user-1',
         sandboxProvider: 'local',
-        sandboxWorkdir: '/tmp/app',
+        sandboxRepoDir: '/tmp/app',
       });
       await github.sourceControlStorage.sessions.create({
         sessionId: 'session-1',

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -878,7 +878,7 @@ describe('PlatformGithubIntegration', () => {
       repositoryId: repository.id,
       createdByUserId: 'user-1',
       sandboxProvider: 'local',
-      sandboxWorkdir: '/tmp/app',
+      sandboxRepoDir: '/tmp/app',
     });
     const onEvent = vi.fn();
     const context = {

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -500,7 +500,7 @@ describe('model pack routes with a tenant', () => {
       title: null,
       baseBranch: 'main',
       sandboxId: 'sandbox-1',
-      sandboxWorkdir: `/tmp/${sessionId}`,
+      sandboxRepoDir: `/tmp/${sessionId}`,
       materializedAt: null,
       firstMessageAt: null,
       firstMeaningfulExecAt: null,
@@ -698,8 +698,8 @@ describe('model pack routes with a tenant', () => {
     expect(await listed.json()).toMatchObject({ activePackId: null, sessionPackId: pack.id });
   });
 
-  it('rejects a scoped request when only the persisted workdir column matches (fail closed)', async () => {
-    // The persisted sandboxWorkdir is observability, never an authorization
+  it('rejects a scoped request when only the persisted repoDir column matches (fail closed)', async () => {
+    // The persisted sandboxRepoDir is observability, never an authorization
     // input — a row written under a previous provider could authorize a
     // stale scope. With no live memo entry, a scope matching the persisted
     // column must NOT authorize.
@@ -713,9 +713,9 @@ describe('model pack routes with a tenant', () => {
     expect(sessionController.getSessionByResource).not.toHaveBeenCalled();
   });
 
-  it('authorizes a scoped request against the live memoized workdir', async () => {
+  it('authorizes a scoped request against the live memoized repoDir', async () => {
     __clearSessionSandboxesForTests();
-    // Local-provider memo seed: the derived workdir is <workingDirectory>/<repo name>.
+    // Local-provider memo seed: the derived repoDir is <workingDirectory>/<repo name>.
     getSessionSandbox(
       'row-session-1',
       'seed/session-1',

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -440,16 +440,16 @@ async function authorizePackSession({
   if (!sessions) return c.json({ error: 'session_authorization_unavailable' }, 503);
 
   const sourceSession = await sessions.getBySessionId(resourceId);
-  // Scope matches against the live memoized workdir ONLY (the deterministic
+  // Scope matches against the live memoized repoDir ONLY (the deterministic
   // truth). The persisted column is observability, never an authorization
   // input — a row written under a previous provider could authorize a stale
   // scope. No live memo entry means no scoped grant (fail closed).
-  const liveWorkdir = peekSessionSandbox(sourceSession?.id ?? '')?.workdir;
+  const liveRepoDir = peekSessionSandbox(sourceSession?.id ?? '')?.repoDir;
   if (
     !sourceSession ||
     sourceSession.orgId !== packContext.orgId ||
     sourceSession.userId !== packContext.userId ||
-    (scope !== undefined && scope !== liveWorkdir)
+    (scope !== undefined && scope !== liveRepoDir)
   ) {
     return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
   }

--- a/mastracode/factory/src/routes/fs.test.ts
+++ b/mastracode/factory/src/routes/fs.test.ts
@@ -209,7 +209,7 @@ describe('readWorkspaceFile', () => {
 
 // ── Session-backed (sandbox) workspace access ────────────────────────────────
 
-const WORKDIR = '/workspaces/acme/repo';
+const REPO_DIR = '/workspaces/acme/repo';
 
 function makeSession(overrides: Partial<SourceControlSession> = {}): SourceControlSession {
   return {
@@ -222,7 +222,7 @@ function makeSession(overrides: Partial<SourceControlSession> = {}): SourceContr
     title: null,
     baseBranch: 'main',
     sandboxId: 'sbx-1',
-    sandboxWorkdir: WORKDIR,
+    sandboxRepoDir: REPO_DIR,
     materializedAt: new Date(),
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -238,14 +238,14 @@ function makeSession(overrides: Partial<SourceControlSession> = {}): SourceContr
  */
 function seedSessionSandbox(
   respond: (script: string, command: string, args: string[]) => { exitCode: number; stdout: string; stderr?: string },
-  { sessionRowId = 'row-1', workdir = WORKDIR } = {},
+  { sessionRowId = 'row-1', repoDir = REPO_DIR } = {},
 ) {
   const executeCommand = vi.fn(async (command: string, args: string[] = []) => {
     const script = args[1] ?? '';
     const result = respond(script, command, args);
     return { exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr ?? '' };
   });
-  // The memo derives the workdir from the constructed instance: a local
+  // The memo derives the repoDir from the constructed instance: a local
   // provider checks out under <workingDirectory>/<repo name>.
   getSessionSandbox(
     sessionRowId,
@@ -254,7 +254,7 @@ function seedSessionSandbox(
       ({
         id: 'sbx-1',
         provider: 'local',
-        workingDirectory: workdir.slice(0, workdir.lastIndexOf('/')),
+        workingDirectory: repoDir.slice(0, repoDir.lastIndexOf('/')),
         executeCommand,
       }) as never,
   );
@@ -360,12 +360,12 @@ describe('persisted session workspace files routes', () => {
 describe('listSessionRenderedPath', () => {
   it('lists rendered entries from the session sandbox in one command', async () => {
     const { executeCommand } = seedSessionSandbox(script => {
-      expect(script).toContain(`'${WORKDIR}/.artifacts'`);
+      expect(script).toContain(`'${REPO_DIR}/.artifacts'`);
       return {
         exitCode: 0,
         stdout: [
-          `d\t0\t1700000000.0\t${WORKDIR}/.artifacts/understand-pr`,
-          `f\t5\t1700000100.5\t${WORKDIR}/.artifacts/understand-pr/HISTORY.md`,
+          `d\t0\t1700000000.0\t${REPO_DIR}/.artifacts/understand-pr`,
+          `f\t5\t1700000100.5\t${REPO_DIR}/.artifacts/understand-pr/HISTORY.md`,
           '',
         ].join('\n'),
       };
@@ -376,7 +376,7 @@ describe('listSessionRenderedPath', () => {
 
     expect(listing.workspacePath).toBe(session.sessionId);
     expect(listing.root).toBe('.artifacts');
-    expect(listing.rootPath).toBe(`${WORKDIR}/.artifacts`);
+    expect(listing.rootPath).toBe(`${REPO_DIR}/.artifacts`);
     expect(listing.entries).toEqual([
       expect.objectContaining({ name: 'understand-pr', path: 'understand-pr', type: 'directory', size: 0 }),
       expect.objectContaining({ name: 'HISTORY.md', path: 'understand-pr/HISTORY.md', type: 'file', size: 5 }),
@@ -423,9 +423,9 @@ describe('listSessionRenderedPath', () => {
 
 describe('readSessionWorkspaceFile', () => {
   function respondForFile(content: string) {
-    const abs = `${WORKDIR}/.artifacts/understand-pr/HISTORY.md`;
+    const abs = `${REPO_DIR}/.artifacts/understand-pr/HISTORY.md`;
     return (script: string) => {
-      if (script.includes(`p='${abs}'`)) return { exitCode: 0, stdout: `${WORKDIR}\n${abs}` };
+      if (script.includes(`p='${abs}'`)) return { exitCode: 0, stdout: `${REPO_DIR}\n${abs}` };
       if (script.startsWith('stat -c')) return { exitCode: 0, stdout: `regular file|${content.length}|1700000000|0\n` };
       if (script.includes('base64 <')) return { exitCode: 0, stdout: Buffer.from(content, 'utf8').toString('base64') };
       return { exitCode: 1, stdout: '', stderr: `unexpected script: ${script}` };
@@ -467,8 +467,8 @@ describe('readSessionWorkspaceFile', () => {
 
   it('rejects directories', async () => {
     seedSessionSandbox(script => {
-      if (script.includes(`p='${WORKDIR}/.artifacts'`)) {
-        return { exitCode: 0, stdout: `${WORKDIR}\n${WORKDIR}/.artifacts` };
+      if (script.includes(`p='${REPO_DIR}/.artifacts'`)) {
+        return { exitCode: 0, stdout: `${REPO_DIR}\n${REPO_DIR}/.artifacts` };
       }
       if (script.startsWith('stat -c')) return { exitCode: 0, stdout: `directory|0|1700000000|0\n` };
       return { exitCode: 1, stdout: '' };
@@ -519,7 +519,7 @@ describe('workspace changes', () => {
   it('lists pending changes with per-file and total line counts', async () => {
     const { executeCommand } = seedSessionSandbox((script, command, args) => {
       if (command === 'git') {
-        expect(args).toEqual(['-C', WORKDIR, 'status', '--porcelain=v1', '-z', '--untracked-files=all']);
+        expect(args).toEqual(['-C', REPO_DIR, 'status', '--porcelain=v1', '-z', '--untracked-files=all']);
         return { exitCode: 0, stdout: ' M src/edited.ts\0?? src/new.ts\0' };
       }
 
@@ -527,7 +527,7 @@ describe('workspace changes', () => {
       expect(script).toContain('diff --numstat -z --find-renames');
       expect(script).toContain('ls-files --others --exclude-standard -z');
       expect(script).toContain('GIT_OBJECT_DIRECTORY="$object_dir"');
-      expect(args.slice(2)).toEqual(['mastracode-numstat', WORKDIR]);
+      expect(args.slice(2)).toEqual(['mastracode-numstat', REPO_DIR]);
       return { exitCode: 0, stdout: '3\t1\tsrc/edited.ts\0' + '5\t0\t\0/dev/null\0src/new.ts\0' };
     });
 
@@ -577,7 +577,7 @@ describe('workspace changes', () => {
         '0',
         '--literal-pathspecs',
         '-C',
-        WORKDIR,
+        REPO_DIR,
         'diff',
         '--find-renames',
         '--no-ext-diff',
@@ -629,7 +629,7 @@ describe('workspace changes', () => {
         '0',
         '--literal-pathspecs',
         '-C',
-        WORKDIR,
+        REPO_DIR,
         'diff',
         '--find-renames',
         '--no-ext-diff',
@@ -656,7 +656,7 @@ describe('workspace changes', () => {
         '0',
         '--literal-pathspecs',
         '-C',
-        WORKDIR,
+        REPO_DIR,
         'diff',
         '--find-renames',
         '--no-ext-diff',
@@ -687,7 +687,7 @@ describe('workspace changes', () => {
         expect(args).toEqual([
           '--literal-pathspecs',
           '-C',
-          WORKDIR,
+          REPO_DIR,
           'ls-files',
           '--others',
           '--exclude-standard',
@@ -701,7 +701,7 @@ describe('workspace changes', () => {
       expect(args.slice(3)).toEqual([
         '1',
         '-C',
-        WORKDIR,
+        REPO_DIR,
         'diff',
         '--no-index',
         '--no-ext-diff',

--- a/mastracode/factory/src/routes/fs.ts
+++ b/mastracode/factory/src/routes/fs.ts
@@ -475,12 +475,12 @@ export async function listSessionFilesystemFiles(
 interface SessionSandboxHandle {
   sandbox: ExecutableSandbox;
   filesystem: SandboxFilesystem;
-  workdir: string;
+  repoDir: string;
 }
 
 /**
  * Resolve the session's sandbox from the per-process memo and wrap its
- * workdir in a `SandboxFilesystem`. Returns `null` when the session has no
+ * repoDir in a `SandboxFilesystem`. Returns `null` when the session has no
  * sandbox in this process (never opened here, or evicted by retirement).
  * This is a passive read path, so it never constructs or provisions: the
  * session's files come back the next time the workspace is actually opened
@@ -488,25 +488,25 @@ interface SessionSandboxHandle {
  */
 async function sessionSandbox(session: SourceControlSession): Promise<SessionSandboxHandle | null> {
   const entry = peekSessionSandbox(session.id);
-  // An unresolved workdir means the sandbox never started in this process —
+  // An unresolved repoDir means the sandbox never started in this process —
   // nothing is materialized, so there are no files to browse.
-  if (!entry?.workdir) return null;
+  if (!entry?.repoDir) return null;
   const sandbox = requireExec(entry.sandbox);
   return {
     sandbox,
-    filesystem: new SandboxFilesystem({ sandbox, workdir: entry.workdir }),
-    workdir: entry.workdir,
+    filesystem: new SandboxFilesystem({ sandbox, workdir: entry.repoDir }),
+    repoDir: entry.repoDir,
   };
 }
 
-/** List an approved rendered root inside a Factory session's sandbox workdir. */
+/** List an approved rendered root inside a Factory session's sandbox repoDir. */
 export async function listSessionRenderedPath(
   session: SourceControlSession,
   renderedRoot: string,
 ): Promise<WorkspaceRenderedListing> {
   const safeRoot = assertApprovedRenderedRoot(renderedRoot);
   const handle = await sessionSandbox(session);
-  const rootPath = posixPath.join(handle?.workdir ?? '', safeRoot);
+  const rootPath = posixPath.join(handle?.repoDir ?? '', safeRoot);
   const empty: WorkspaceRenderedListing = { workspacePath: session.sessionId, root: safeRoot, rootPath, entries: [] };
   if (!handle) return empty;
 
@@ -653,10 +653,10 @@ export async function listSessionWorkspaceChanges(session: SourceControlSession)
   const [statusResult, statsResult] = await Promise.all([
     handle.sandbox.executeCommand(
       'git',
-      ['-C', handle.workdir, 'status', '--porcelain=v1', '-z', '--untracked-files=all'],
+      ['-C', handle.repoDir, 'status', '--porcelain=v1', '-z', '--untracked-files=all'],
       { timeout: 30_000 },
     ),
-    handle.sandbox.executeCommand('sh', ['-c', WORKSPACE_NUMSTAT_SCRIPT, 'mastracode-numstat', handle.workdir], {
+    handle.sandbox.executeCommand('sh', ['-c', WORKSPACE_NUMSTAT_SCRIPT, 'mastracode-numstat', handle.repoDir], {
       timeout: 30_000,
     }),
   ]);
@@ -709,7 +709,7 @@ export async function readSessionWorkspaceDiff(
   let result = await executeBoundedGitDiff(handle.sandbox, [
     '--literal-pathspecs',
     '-C',
-    handle.workdir,
+    handle.repoDir,
     'diff',
     '--find-renames',
     '--no-ext-diff',
@@ -724,7 +724,7 @@ export async function readSessionWorkspaceDiff(
   if (!result.stdout) {
     const untracked = await handle.sandbox.executeCommand(
       'git',
-      ['--literal-pathspecs', '-C', handle.workdir, 'ls-files', '--others', '--exclude-standard', '--', safePath],
+      ['--literal-pathspecs', '-C', handle.repoDir, 'ls-files', '--others', '--exclude-standard', '--', safePath],
       { timeout: 30_000 },
     );
     if (untracked.exitCode === 0 && untracked.stdout.trim()) {
@@ -732,7 +732,7 @@ export async function readSessionWorkspaceDiff(
         handle.sandbox,
         [
           '-C',
-          handle.workdir,
+          handle.repoDir,
           'diff',
           '--no-index',
           '--no-ext-diff',

--- a/mastracode/factory/src/routes/projects.test.ts
+++ b/mastracode/factory/src/routes/projects.test.ts
@@ -113,7 +113,7 @@ describe('ProjectRoutes', () => {
       repositoryId: repository.id,
       createdByUserId: 'user-1',
       sandboxProvider: 'local',
-      sandboxWorkdir: '/workspace/acme/api',
+      sandboxRepoDir: '/workspace/acme/api',
       teardownCommand: 'pnpm local teardown',
     });
     await github.sessions.create({
@@ -175,7 +175,7 @@ describe('ProjectRoutes', () => {
       repositoryId: repository.id,
       createdByUserId: 'user-1',
       sandboxProvider: 'local',
-      sandboxWorkdir: '/workspace/acme/api',
+      sandboxRepoDir: '/workspace/acme/api',
       teardownCommand: 'pnpm local teardown',
     });
     const session = await github.sessions.create({
@@ -189,7 +189,7 @@ describe('ProjectRoutes', () => {
     await github.sessions.setSandbox({
       id: session.id,
       sandboxId: 'sandbox-1',
-      sandboxWorkdir: '/workspace/acme/api/session-1',
+      sandboxRepoDir: '/workspace/acme/api/session-1',
     });
     const app = new Hono();
     app.use('*', async (context, next) => {
@@ -269,7 +269,7 @@ describe('ProjectRoutes', () => {
             repositoryId,
             branch,
             sandboxProvider: 'local',
-            sandboxWorkdir: `/workspace/${repositoryId}`,
+            sandboxRepoDir: `/workspace/${repositoryId}`,
             setupCommand: 'pnpm install',
             teardownCommand: 'pnpm local worktree teardown',
           }),
@@ -368,7 +368,7 @@ describe('ProjectRoutes', () => {
             body: JSON.stringify({
               repositoryId: repository.id,
               sandboxProvider: 'local',
-              sandboxWorkdir: '/workspace/repo',
+              sandboxRepoDir: '/workspace/repo',
             }),
           },
         )
@@ -438,7 +438,7 @@ describe('ProjectRoutes', () => {
           repositoryId: repository.id,
           branch: 'main',
           sandboxProvider: 'local',
-          sandboxWorkdir: '/workspace/acme/api',
+          sandboxRepoDir: '/workspace/acme/api',
         }),
       },
     );

--- a/mastracode/factory/src/routes/projects.ts
+++ b/mastracode/factory/src/routes/projects.ts
@@ -24,7 +24,7 @@ const MAX_DESCRIPTION_LENGTH = 2_000;
 const MAX_REPOSITORY_COMMAND_LENGTH = 2_000;
 const MAX_BRANCH_LENGTH = 255;
 const MAX_SANDBOX_PROVIDER_LENGTH = 100;
-const MAX_SANDBOX_WORKDIR_LENGTH = 1_000;
+const MAX_SANDBOX_REPO_DIR_LENGTH = 1_000;
 const CONTROL_CHAR_RE = /[\0-\x08\x0b\x0c\x0e-\x1f\x7f]/;
 
 function loose(context: unknown): Context {
@@ -113,7 +113,7 @@ function parseRepositoryLinkInput(value: unknown): {
   repositoryId: string;
   branch: string | null;
   sandboxProvider: string;
-  sandboxWorkdir: string;
+  sandboxRepoDir: string;
   setupCommand: string | null;
   teardownCommand: string | null;
 } | null {
@@ -122,7 +122,7 @@ function parseRepositoryLinkInput(value: unknown): {
   if (typeof input.repositoryId !== 'string' || !UUID_RE.test(input.repositoryId)) return null;
   const branch = parseOptionalString(input.branch, { maxLength: MAX_BRANCH_LENGTH, nullable: true });
   const sandboxProvider = parseOptionalString(input.sandboxProvider, { maxLength: MAX_SANDBOX_PROVIDER_LENGTH });
-  const sandboxWorkdir = parseOptionalString(input.sandboxWorkdir, { maxLength: MAX_SANDBOX_WORKDIR_LENGTH });
+  const sandboxRepoDir = parseOptionalString(input.sandboxRepoDir, { maxLength: MAX_SANDBOX_REPO_DIR_LENGTH });
   const setupCommand = parseOptionalString(input.setupCommand, {
     maxLength: MAX_REPOSITORY_COMMAND_LENGTH,
     nullable: true,
@@ -134,7 +134,7 @@ function parseRepositoryLinkInput(value: unknown): {
   if (
     branch === false ||
     typeof sandboxProvider !== 'string' ||
-    typeof sandboxWorkdir !== 'string' ||
+    typeof sandboxRepoDir !== 'string' ||
     setupCommand === false ||
     teardownCommand === false
   )
@@ -143,7 +143,7 @@ function parseRepositoryLinkInput(value: unknown): {
     repositoryId: input.repositoryId,
     branch: branch ?? null,
     sandboxProvider,
-    sandboxWorkdir,
+    sandboxRepoDir,
     setupCommand: setupCommand ?? null,
     teardownCommand: teardownCommand ?? null,
   };
@@ -155,7 +155,7 @@ function parseRepositoryUpdateInput(value: unknown): UpdateProjectRepositoryInpu
   const patch: UpdateProjectRepositoryInput = {};
   const branch = parseOptionalString(input.branch, { maxLength: MAX_BRANCH_LENGTH, nullable: true });
   const sandboxProvider = parseOptionalString(input.sandboxProvider, { maxLength: MAX_SANDBOX_PROVIDER_LENGTH });
-  const sandboxWorkdir = parseOptionalString(input.sandboxWorkdir, { maxLength: MAX_SANDBOX_WORKDIR_LENGTH });
+  const sandboxRepoDir = parseOptionalString(input.sandboxRepoDir, { maxLength: MAX_SANDBOX_REPO_DIR_LENGTH });
   const setupCommand = parseOptionalString(input.setupCommand, {
     maxLength: MAX_REPOSITORY_COMMAND_LENGTH,
     nullable: true,
@@ -168,15 +168,15 @@ function parseRepositoryUpdateInput(value: unknown): UpdateProjectRepositoryInpu
     branch === false ||
     sandboxProvider === false ||
     sandboxProvider === null ||
-    sandboxWorkdir === false ||
-    sandboxWorkdir === null ||
+    sandboxRepoDir === false ||
+    sandboxRepoDir === null ||
     setupCommand === false ||
     teardownCommand === false
   )
     return null;
   if (branch !== undefined) patch.branch = branch;
   if (sandboxProvider !== undefined) patch.sandboxProvider = sandboxProvider;
-  if (sandboxWorkdir !== undefined) patch.sandboxWorkdir = sandboxWorkdir;
+  if (sandboxRepoDir !== undefined) patch.sandboxRepoDir = sandboxRepoDir;
   if (setupCommand !== undefined) patch.setupCommand = setupCommand;
   if (teardownCommand !== undefined) patch.teardownCommand = teardownCommand;
   return Object.keys(patch).length > 0 ? patch : null;

--- a/mastracode/factory/src/routes/skills.test.ts
+++ b/mastracode/factory/src/routes/skills.test.ts
@@ -313,7 +313,7 @@ describe('workspace skill invocation route', () => {
     expect(harness.sendA).not.toHaveBeenCalled();
   });
 
-  it('enforces a viewer-visible session with a live workdir at the scope before session lookup', async () => {
+  it('enforces a viewer-visible session with a live repoDir at the scope before session lookup', async () => {
     const sourceControlStorage = new SourceControlStorageInMemory();
     const sendMessage = vi.fn(async () => {});
     const getSessionByResource = vi.fn(async () => ({
@@ -392,7 +392,7 @@ describe('workspace skill invocation route', () => {
       repositoryId: repository.id,
       createdByUserId: 'user-1',
       sandboxProvider: 'local',
-      sandboxWorkdir: '/workspace/repository',
+      sandboxRepoDir: '/workspace/repository',
     });
     const sessionRow = await sourceControlStorage.sessions.create({
       sessionId: '00000000-0000-4000-8000-00000000abcd',
@@ -404,18 +404,18 @@ describe('workspace skill invocation route', () => {
     });
 
     // A session row alone is not enough: the scope must match a LIVE memoized
-    // sandbox workdir (fail closed when no VM has resolved one).
-    const noLiveWorkdir = await invoke(app, {
+    // sandbox repoDir (fail closed when no VM has resolved one).
+    const noLiveRepoDir = await invoke(app, {
       resourceId: factoryProjectId,
       projectRepositoryId: projectRepository.id,
       scope: '/worktrees/review-42',
       name: 'understand-pr',
     });
-    expect(noLiveWorkdir.status).toBe(403);
+    expect(noLiveRepoDir.status).toBe(403);
     expect(getSessionByResource).not.toHaveBeenCalled();
 
     const entry = getSessionSandbox(sessionRow.id, 'acme/repository', () => ({ provider: 'fake' }) as never);
-    entry.workdir = '/worktrees/review-42';
+    entry.repoDir = '/worktrees/review-42';
 
     const allowed = await invoke(app, {
       resourceId: factoryProjectId,

--- a/mastracode/factory/src/routes/skills.ts
+++ b/mastracode/factory/src/routes/skills.ts
@@ -126,19 +126,19 @@ export class SkillRoutes extends Route<SkillRoutesDeps> {
     if (!connection || connection.factoryProjectId !== address.resourceId) {
       return { allowed: false, status: 403, code: 'session_forbidden', message: 'Session access denied.' };
     }
-    // The scope must be the live workdir of a session the viewer can see under
+    // The scope must be the live repoDir of a session the viewer can see under
     // this repository. The live memoized sandbox entry is the only truth for
-    // workdirs (persisted columns are observability); no running/memoized
+    // repoDirs (persisted columns are observability); no running/memoized
     // sandbox at that path means no grant (fail closed).
     const sessions = await storage.sessions.list({
       projectRepositoryId: address.projectRepositoryId,
       viewerUserId: tenant.userId,
     });
-    const scopeIsLiveSessionWorkdir = sessions.some(row => {
-      const liveWorkdir = peekSessionSandbox(row.id)?.workdir;
-      return liveWorkdir !== undefined && liveWorkdir === address.scope;
+    const scopeIsLiveSessionRepoDir = sessions.some(row => {
+      const liveRepoDir = peekSessionSandbox(row.id)?.repoDir;
+      return liveRepoDir !== undefined && liveRepoDir === address.scope;
     });
-    return scopeIsLiveSessionWorkdir
+    return scopeIsLiveSessionRepoDir
       ? { allowed: true }
       : { allowed: false, status: 403, code: 'session_forbidden', message: 'Session access denied.' };
   }

--- a/mastracode/factory/src/routes/surface.test.ts
+++ b/mastracode/factory/src/routes/surface.test.ts
@@ -39,7 +39,7 @@ async function seedFactoryWithRepository(options?: { defaultModelId?: string }) 
     repositoryId: repository.id,
     createdByUserId: 'user-1',
     sandboxProvider: 'local',
-    sandboxWorkdir: '/sandbox/mastra',
+    sandboxRepoDir: '/sandbox/mastra',
   });
   const github = { id: 'github', sourceControlStorage: sourceControl } as unknown as GithubIntegration;
   return { seeded, sourceControl, project, projectRepository, github };
@@ -165,7 +165,7 @@ describe('prepareFactoryRuleBinding', () => {
       repositoryId: doomedRepository.id,
       createdByUserId: 'user-1',
       sandboxProvider: 'local',
-      sandboxWorkdir: '/sandbox/old',
+      sandboxRepoDir: '/sandbox/old',
     });
     const orphaned = await sourceControl.sessions.create({
       sessionId: 'sess-orphaned',
@@ -223,7 +223,7 @@ describe('prepareFactoryRuleBinding', () => {
       repositoryId: otherRepository.id,
       createdByUserId: 'user-1',
       sandboxProvider: 'local',
-      sandboxWorkdir: '/sandbox/other',
+      sandboxRepoDir: '/sandbox/other',
     });
     const foreign = await sourceControl.sessions.create({
       sessionId: 'sess-foreign',

--- a/mastracode/factory/src/sandbox/repo-dir.test.ts
+++ b/mastracode/factory/src/sandbox/repo-dir.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { deriveLocalWorkdir, repoDirUnder, resolveContainedLocalWorkdir, sanitizeSegment } from './workdir.js';
+import { deriveLocalRepoDir, repoDirUnder, resolveContainedLocalRepoDir, sanitizeSegment } from './repo-dir.js';
 
 describe('sanitizeSegment', () => {
   it('keeps safe characters and replaces separators and traversal', () => {
@@ -40,45 +40,45 @@ describe('repoDirUnder', () => {
   });
 });
 
-describe('deriveLocalWorkdir', () => {
+describe('deriveLocalRepoDir', () => {
   const root = path.resolve('/srv/sandboxes');
 
   it('nests the repo under a local sandbox workingDirectory so the marker sits beside the clone', () => {
     const sandbox = { provider: 'local', workingDirectory: path.join(root, 'sess-1') };
-    expect(deriveLocalWorkdir(sandbox, 'acme/api')).toBe(path.join(root, 'sess-1', 'api'));
+    expect(deriveLocalRepoDir(sandbox, 'acme/api')).toBe(path.join(root, 'sess-1', 'api'));
   });
 
   it('keeps same-name repos apart when callbacks use per-session directories', () => {
     const a = { provider: 'local', workingDirectory: path.join(root, 'sess-a') };
     const b = { provider: 'local', workingDirectory: path.join(root, 'sess-b') };
-    expect(deriveLocalWorkdir(a, 'acme/api')).not.toBe(deriveLocalWorkdir(b, 'acme/api'));
+    expect(deriveLocalRepoDir(a, 'acme/api')).not.toBe(deriveLocalRepoDir(b, 'acme/api'));
   });
 
   it('refuses escapes through hostile repo names', () => {
     const sandbox = { provider: 'local', workingDirectory: path.join(root, 'sess') };
     // Sanitization neutralizes traversal rather than throwing.
-    expect(deriveLocalWorkdir(sandbox, 'acme/../../..')!.startsWith(root + path.sep)).toBe(true);
+    expect(deriveLocalRepoDir(sandbox, 'acme/../../..')!.startsWith(root + path.sep)).toBe(true);
   });
 
-  it('answers undefined for remote providers — their workdir is a runtime fact of the VM', () => {
-    expect(deriveLocalWorkdir({ provider: 'e2b' }, 'acme/api')).toBeUndefined();
-    expect(deriveLocalWorkdir({ provider: 'platform', workingDirectory: undefined }, 'acme/api')).toBeUndefined();
+  it('answers undefined for remote providers — their repoDir is a runtime fact of the VM', () => {
+    expect(deriveLocalRepoDir({ provider: 'e2b' }, 'acme/api')).toBeUndefined();
+    expect(deriveLocalRepoDir({ provider: 'platform', workingDirectory: undefined }, 'acme/api')).toBeUndefined();
   });
 
   it('answers undefined for a local sandbox without a usable workingDirectory', () => {
-    expect(deriveLocalWorkdir({ provider: 'local', workingDirectory: '' }, 'acme/api')).toBeUndefined();
+    expect(deriveLocalRepoDir({ provider: 'local', workingDirectory: '' }, 'acme/api')).toBeUndefined();
   });
 });
 
-describe('resolveContainedLocalWorkdir', () => {
+describe('resolveContainedLocalRepoDir', () => {
   const root = path.resolve('/srv/sandboxes');
 
   it('resolves nested segments under the root', () => {
-    expect(resolveContainedLocalWorkdir(root, 'a', 'b')).toBe(path.join(root, 'a', 'b'));
+    expect(resolveContainedLocalRepoDir(root, 'a', 'b')).toBe(path.join(root, 'a', 'b'));
   });
 
   it('throws when the resolved path escapes the root', () => {
-    expect(() => resolveContainedLocalWorkdir(root, '..', 'outside')).toThrow(/outside configured root/);
-    expect(() => resolveContainedLocalWorkdir(root)).toThrow(/outside configured root/);
+    expect(() => resolveContainedLocalRepoDir(root, '..', 'outside')).toThrow(/outside configured root/);
+    expect(() => resolveContainedLocalRepoDir(root)).toThrow(/outside configured root/);
   });
 });

--- a/mastracode/factory/src/sandbox/repo-dir.ts
+++ b/mastracode/factory/src/sandbox/repo-dir.ts
@@ -1,15 +1,15 @@
 import * as path from 'node:path';
 
 /**
- * Session workdir derivation. Workdirs are never persisted or trusted from
- * storage or client input — the stale-workdir class of production bugs came
- * from reading `session.sandboxWorkdir` written under a different provider.
+ * Session repoDir derivation. Repo dirs are never persisted or trusted from
+ * storage or client input — the stale-repoDir class of production bugs came
+ * from reading `session.sandboxRepoDir` written under a different provider.
  *
- * Local sandboxes derive their workdir synchronously from the sandbox's own
+ * Local sandboxes derive their repoDir synchronously from the sandbox's own
  * `workingDirectory` (the per-session directory the deploy's callback chose).
  * Remote sandboxes have no invented path: the repo clones into the VM's own
- * default cwd (its home dir), so the workdir is only knowable once a VM is
- * running — resolved lazily by `resolveSessionWorkdir` via a one-time `pwd`
+ * default cwd (its home dir), so the repoDir is only knowable once a VM is
+ * running — resolved lazily by `resolveSessionRepoDir` via a one-time `pwd`
  * probe and memoized on the session entry.
  */
 
@@ -20,20 +20,20 @@ export function sanitizeSegment(segment: string): string {
 }
 
 /**
- * Synchronously derivable workdir: local sandboxes expose their host
+ * Synchronously derivable repoDir: local sandboxes expose their host
  * `workingDirectory`; the repo checks out as a contained subdirectory so the
  * setup marker sits beside the clone instead of polluting `git status`
- * inside it. Returns undefined for remote providers, whose workdir is a
+ * inside it. Returns undefined for remote providers, whose repoDir is a
  * runtime fact of the VM (`<home>/<repo>`).
  */
-export function deriveLocalWorkdir(
+export function deriveLocalRepoDir(
   sandbox: { provider: string; workingDirectory?: unknown },
   repoFullName: string,
 ): string | undefined {
   const wd = sandbox.workingDirectory;
   if (sandbox.provider === 'local' && typeof wd === 'string' && wd.length > 0) {
     const [, name] = repoFullName.split('/', 2);
-    return resolveContainedLocalWorkdir(wd, sanitizeSegment(name || 'repo'));
+    return resolveContainedLocalRepoDir(wd, sanitizeSegment(name || 'repo'));
   }
   return undefined;
 }
@@ -58,8 +58,8 @@ export function repoDirUnder(parent: string, repoFullName: string): string {
   return `${parent.slice(0, end)}/${sanitizeSegment(name || 'repo')}`;
 }
 
-/** Resolve a workdir under `root`, refusing any path that escapes the configured root. */
-export function resolveContainedLocalWorkdir(root: string, ...segments: string[]): string {
+/** Resolve a repoDir under `root`, refusing any path that escapes the configured root. */
+export function resolveContainedLocalRepoDir(root: string, ...segments: string[]): string {
   const resolvedRoot = path.resolve(root);
   const resolved = path.resolve(resolvedRoot, ...segments);
   if (resolved !== resolvedRoot && resolved.startsWith(`${resolvedRoot}${path.sep}`)) return resolved;

--- a/mastracode/factory/src/sandbox/session-retirement.test.ts
+++ b/mastracode/factory/src/sandbox/session-retirement.test.ts
@@ -74,7 +74,7 @@ function seedRepositoryLink(storage: SourceControlStorageInMemory, teardownComma
     createdByUserId: 'user-1',
     branch: null,
     sandboxProvider: 'railway',
-    sandboxWorkdir: '/workspace/mastra',
+    sandboxRepoDir: '/workspace/mastra',
     setupCommand: null,
     teardownCommand,
     createdAt: now,
@@ -121,8 +121,8 @@ function seedMemoSandbox(
     },
   };
   const entry = getSessionSandbox(session.id, 'acme/mastra', () => fake as never);
-  // Model a sandbox whose first start already resolved the workdir.
-  entry.workdir = '/workspace/mastra';
+  // Model a sandbox whose first start already resolved the repoDir.
+  entry.repoDir = '/workspace/mastra';
   return fake;
 }
 

--- a/mastracode/factory/src/sandbox/session-retirement.ts
+++ b/mastracode/factory/src/sandbox/session-retirement.ts
@@ -151,11 +151,11 @@ export class SessionRetirementCoordinator {
       });
     }
 
-    // An unresolved workdir means the sandbox never started in this process:
+    // An unresolved repoDir means the sandbox never started in this process:
     // nothing was set up, so there is nothing for a teardown command to undo.
-    if (projectRepository?.teardownCommand && entry.workdir) {
+    if (projectRepository?.teardownCommand && entry.repoDir) {
       try {
-        await runTeardownCommand(requireExec(entry.sandbox), entry.workdir, projectRepository.teardownCommand, {
+        await runTeardownCommand(requireExec(entry.sandbox), entry.repoDir, projectRepository.teardownCommand, {
           timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS,
         });
       } catch (error) {

--- a/mastracode/factory/src/sandbox/session-sandbox.test.ts
+++ b/mastracode/factory/src/sandbox/session-sandbox.test.ts
@@ -10,7 +10,7 @@ import {
   evictSessionSandbox,
   getSessionSandbox,
   peekSessionSandbox,
-  resolveSessionWorkdir,
+  resolveSessionRepoDir,
 } from './session-sandbox.js';
 
 afterEach(() => {
@@ -25,8 +25,8 @@ describe('session sandbox memo', () => {
     const first = getSessionSandbox('sess-1', 'acme/api', factory);
     const second = getSessionSandbox('sess-1', 'acme/api', factory);
     expect(second).toBe(first);
-    // Remote workdirs are a runtime fact of the VM — unresolved until start.
-    expect(first.workdir).toBeUndefined();
+    // Remote repoDirs are a runtime fact of the VM — unresolved until start.
+    expect(first.repoDir).toBeUndefined();
     expect(factory).toHaveBeenCalledTimes(1);
   });
 
@@ -40,20 +40,20 @@ describe('session sandbox memo', () => {
     expect(peekSessionSandbox('sess-1')).toBeUndefined();
     const made = getSessionSandbox('sess-1', 'acme/api', () => construct('sb-1'));
     expect(peekSessionSandbox('sess-1')?.sandbox).toBe(made.sandbox);
-    expect(peekSessionSandbox('sess-1')?.workdir).toBeUndefined();
+    expect(peekSessionSandbox('sess-1')?.repoDir).toBeUndefined();
   });
 
-  it('resolves a remote workdir from the live VM home and memoizes it on the entry', async () => {
+  it('resolves a remote repoDir from the live VM home and memoizes it on the entry', async () => {
     const executeCommand = vi.fn(async () => ({ exitCode: 0, stdout: '/home/user\n', stderr: '' }));
     const sandbox = { id: 'sb-1', provider: 'e2b', executeCommand } as unknown as WorkspaceSandbox;
     const entry = getSessionSandbox('sess-1', 'acme/api', () => sandbox);
-    expect(entry.workdir).toBeUndefined();
+    expect(entry.repoDir).toBeUndefined();
 
-    await expect(resolveSessionWorkdir('sess-1', sandbox, 'acme/api')).resolves.toBe('/home/user/api');
-    expect(peekSessionSandbox('sess-1')?.workdir).toBe('/home/user/api');
+    await expect(resolveSessionRepoDir('sess-1', sandbox, 'acme/api')).resolves.toBe('/home/user/api');
+    expect(peekSessionSandbox('sess-1')?.repoDir).toBe('/home/user/api');
 
     // Memoized: the second resolution never probes again.
-    await expect(resolveSessionWorkdir('sess-1', sandbox, 'acme/api')).resolves.toBe('/home/user/api');
+    await expect(resolveSessionRepoDir('sess-1', sandbox, 'acme/api')).resolves.toBe('/home/user/api');
     expect(executeCommand).toHaveBeenCalledTimes(1);
     expect(executeCommand).toHaveBeenCalledWith('pwd');
   });
@@ -68,7 +68,7 @@ describe('session sandbox memo', () => {
     } as unknown as WorkspaceSandbox;
     getSessionSandbox('sess-1', 'acme/api', () => sandbox);
 
-    await expect(resolveSessionWorkdir('sess-1', sandbox, 'acme/api')).resolves.toBe('/workspace/api');
+    await expect(resolveSessionRepoDir('sess-1', sandbox, 'acme/api')).resolves.toBe('/workspace/api');
     expect(executeCommand).not.toHaveBeenCalled();
   });
 
@@ -82,7 +82,7 @@ describe('session sandbox memo', () => {
     } as unknown as WorkspaceSandbox;
     getSessionSandbox('sess-1', 'acme/api', () => sandbox);
 
-    await expect(resolveSessionWorkdir('sess-1', sandbox, 'acme/api')).resolves.toBe('/home/user/api');
+    await expect(resolveSessionRepoDir('sess-1', sandbox, 'acme/api')).resolves.toBe('/home/user/api');
     expect(executeCommand).toHaveBeenCalledWith('pwd');
   });
 
@@ -94,17 +94,17 @@ describe('session sandbox memo', () => {
     const sandbox = { id: 'sb-1', provider: 'e2b', executeCommand } as unknown as WorkspaceSandbox;
     getSessionSandbox('sess-1', 'acme/api', () => sandbox);
 
-    await expect(resolveSessionWorkdir('sess-1', sandbox, 'acme/api')).rejects.toThrow(/default cwd probe failed/);
-    expect(peekSessionSandbox('sess-1')?.workdir).toBeUndefined();
-    await expect(resolveSessionWorkdir('sess-1', sandbox, 'acme/api')).resolves.toBe('/home/user/api');
+    await expect(resolveSessionRepoDir('sess-1', sandbox, 'acme/api')).rejects.toThrow(/default cwd probe failed/);
+    expect(peekSessionSandbox('sess-1')?.repoDir).toBeUndefined();
+    await expect(resolveSessionRepoDir('sess-1', sandbox, 'acme/api')).resolves.toBe('/home/user/api');
   });
 
-  it('resolves a local workdir synchronously at construction', async () => {
+  it('resolves a local repoDir synchronously at construction', async () => {
     const local = { id: 'sb-l', provider: 'local', workingDirectory: '/srv/sess-1' } as unknown as WorkspaceSandbox;
     const entry = getSessionSandbox('sess-l', 'acme/api', () => local);
-    expect(entry.workdir).toBe(path.resolve('/srv/sess-1', 'api'));
+    expect(entry.repoDir).toBe(path.resolve('/srv/sess-1', 'api'));
     // Resolution answers from the memo without any probe.
-    await expect(resolveSessionWorkdir('sess-l', local, 'acme/api')).resolves.toBe(entry.workdir);
+    await expect(resolveSessionRepoDir('sess-l', local, 'acme/api')).resolves.toBe(entry.repoDir);
   });
 
   it('evict drops the instance so the next access reconstructs', () => {
@@ -152,7 +152,7 @@ describe('session setup hook', () => {
 
   it('the hook skips setup on reconnect when the marker and checkout are present', async () => {
     const boot = path.join(dir, 'reconnect');
-    const workdir = path.join(boot, 'repo');
+    const repoDir = path.join(boot, 'repo');
     const first = new LocalSandbox({
       workingDirectory: boot,
       onStart: createSessionSetupHook(
@@ -178,7 +178,7 @@ describe('session setup hook', () => {
 
   it('a marker without its checkout does not skip setup (removed checkout heals)', async () => {
     const boot = path.join(dir, 'wiped');
-    const workdir = path.join(boot, 'repo');
+    const repoDir = path.join(boot, 'repo');
     const first = new LocalSandbox({
       workingDirectory: boot,
       onStart: createSessionSetupHook(
@@ -191,7 +191,7 @@ describe('session setup hook', () => {
 
     // The checkout is removed but the marker (beside it) survives — a stale
     // skip cache must not defeat disk truth.
-    await fs.rm(workdir, { recursive: true, force: true });
+    await fs.rm(repoDir, { recursive: true, force: true });
     const second = new LocalSandbox({
       workingDirectory: boot,
       onStart: createSessionSetupHook(

--- a/mastracode/factory/src/sandbox/session-sandbox.ts
+++ b/mastracode/factory/src/sandbox/session-sandbox.ts
@@ -1,6 +1,6 @@
 import type { MastraSandbox, SandboxStartHook, WorkspaceSandbox } from '@mastra/core/workspace';
 import type { RepositoryAccess } from '../capabilities/version-control.js';
-import { deriveLocalWorkdir, deriveRemoteRepoDir, repoDirUnder } from './workdir.js';
+import { deriveLocalRepoDir, deriveRemoteRepoDir, repoDirUnder } from './repo-dir.js';
 
 /**
  * Everything factory knows about a session's sandbox needs — the whole
@@ -57,7 +57,7 @@ export interface FactorySandboxContext {
 export type MastraFactorySandboxConfig = (ctx: FactorySandboxContext) => MastraSandbox;
 
 /** The session's setup work, run against a started sandbox. Must be idempotent. */
-export type SessionSetupRun = (sandbox: WorkspaceSandbox, workdir: string) => Promise<void>;
+export type SessionSetupRun = (sandbox: WorkspaceSandbox, repoDir: string) => Promise<void>;
 
 /**
  * Per-process session-id → sandbox instance memo.
@@ -75,10 +75,10 @@ interface SessionSandboxEntry {
    * The session's repo checkout root, recorded for passive readers (fs
    * routes, capture, authz). Local sandboxes derive it at construction;
    * remote sandboxes clone into the VM's own home, so it is undefined until
-   * `resolveSessionWorkdir` probes the first started VM — passive readers
-   * treat an unresolved workdir as "nothing materialized".
+   * `resolveSessionRepoDir` probes the first started VM — passive readers
+   * treat an unresolved repoDir as "nothing materialized".
    */
-  workdir?: string;
+  repoDir?: string;
 }
 
 const sessionSandboxes = new Map<string, SessionSandboxEntry>();
@@ -86,8 +86,8 @@ const sessionSandboxes = new Map<string, SessionSandboxEntry>();
 /**
  * Get the session's memoized sandbox entry, constructing (and memoizing) it on
  * first access. Construction is cheap and side-effect-free by contract; VMs
- * are provisioned on `start()` only. Local sandboxes get their workdir here;
- * remote workdirs are a runtime fact of the VM, resolved on first start.
+ * are provisioned on `start()` only. Local sandboxes get their repoDir here;
+ * remote repoDirs are a runtime fact of the VM, resolved on first start.
  */
 export function getSessionSandbox(
   sessionId: string,
@@ -97,8 +97,8 @@ export function getSessionSandbox(
   const existing = sessionSandboxes.get(sessionId);
   if (existing) return existing;
   const sandbox = construct();
-  const local = deriveLocalWorkdir(sandbox, repoFullName);
-  const entry: SessionSandboxEntry = { sandbox, ...(local ? { workdir: local } : {}) };
+  const local = deriveLocalRepoDir(sandbox, repoFullName);
+  const entry: SessionSandboxEntry = { sandbox, ...(local ? { repoDir: local } : {}) };
   sessionSandboxes.set(sessionId, entry);
   return entry;
 }
@@ -110,27 +110,27 @@ export function getSessionSandbox(
  * so the first resolution probes it with one `pwd` — the VM tells us where
  * home is, we never invent a path. Calling this against a stopped sandbox
  * lazily starts it (the probe is a command), so passive readers must peek
- * `entry.workdir` instead.
+ * `entry.repoDir` instead.
  */
-export async function resolveSessionWorkdir(
+export async function resolveSessionRepoDir(
   sessionId: string,
   sandbox: WorkspaceSandbox,
   repoFullName: string,
 ): Promise<string> {
   const entry = sessionSandboxes.get(sessionId);
-  if (entry?.workdir && entry.sandbox === sandbox) return entry.workdir;
-  const workdir =
-    deriveLocalWorkdir(sandbox, repoFullName) ??
+  if (entry?.repoDir && entry.sandbox === sandbox) return entry.repoDir;
+  const repoDir =
+    deriveLocalRepoDir(sandbox, repoFullName) ??
     deriveRemoteRepoDir(sandbox, repoFullName) ??
     repoDirUnder(await probeHome(sandbox), repoFullName);
-  if (entry && entry.sandbox === sandbox) entry.workdir = workdir;
-  return workdir;
+  if (entry && entry.sandbox === sandbox) entry.repoDir = repoDir;
+  return repoDir;
 }
 
 /** One `pwd` in the VM's default shell cwd — its home dir, by provider convention. */
 async function probeHome(sandbox: WorkspaceSandbox): Promise<string> {
   if (!sandbox.executeCommand) {
-    throw new Error(`Sandbox '${sandbox.id}' cannot resolve its workdir: no executeCommand implementation`);
+    throw new Error(`Sandbox '${sandbox.id}' cannot resolve its repoDir: no executeCommand implementation`);
   }
   const probe = await sandbox.executeCommand('pwd');
   const home = probe.stdout.trim().split('\n').pop()?.trim() ?? '';
@@ -145,7 +145,7 @@ async function probeHome(sandbox: WorkspaceSandbox): Promise<string> {
 }
 
 /**
- * The session's memoized sandbox (and its workdir) when one was already
+ * The session's memoized sandbox (and its repoDir) when one was already
  * constructed in this process, else undefined. Never constructs — passive
  * read paths use this so browsing files cannot provision a VM.
  */
@@ -200,11 +200,11 @@ function markerShellPath(sandbox: Pick<WorkspaceSandbox, 'provider'>): string {
   return sandbox.provider === 'local' ? `./${SESSION_SETUP_MARKER}` : `$HOME/${SESSION_SETUP_MARKER}`;
 }
 
-async function markerPresent(sandbox: WorkspaceSandbox, workdir: string): Promise<boolean> {
+async function markerPresent(sandbox: WorkspaceSandbox, repoDir: string): Promise<boolean> {
   // The marker is a skip cache — it sits beside the checkout, not inside it,
   // so it can outlive a removed checkout (e.g. a wiped local session dir or
   // a recovered VM). Trust it only when the checkout it describes exists.
-  const probe = await sandbox.executeCommand!(`test -f "${markerShellPath(sandbox)}" && test -d "${workdir}/.git"`);
+  const probe = await sandbox.executeCommand!(`test -f "${markerShellPath(sandbox)}" && test -d "${repoDir}/.git"`);
   return probe.exitCode === 0;
 }
 
@@ -230,9 +230,9 @@ async function runGuardedSetup(
   }
   // Resolved from the live instance (the hook runs inside `start()`, so the
   // VM is up) and memoized on the session entry for passive readers.
-  const workdir = await resolveSessionWorkdir(sessionId, sandbox, repoFullName);
-  if (!skipMarkerProbe && (await markerPresent(sandbox, workdir))) return;
-  await run(sandbox, workdir);
+  const repoDir = await resolveSessionRepoDir(sessionId, sandbox, repoFullName);
+  if (!skipMarkerProbe && (await markerPresent(sandbox, repoDir))) return;
+  await run(sandbox, repoDir);
   await writeMarker(sandbox);
 }
 

--- a/mastracode/factory/src/session/factory-session.test.ts
+++ b/mastracode/factory/src/session/factory-session.test.ts
@@ -38,7 +38,7 @@ async function seedLinkedRepository(options?: { pinnedBranch?: string }) {
     repositoryId: repository.id,
     createdByUserId: 'user-1',
     sandboxProvider: 'local',
-    sandboxWorkdir: '/sandbox/mastra',
+    sandboxRepoDir: '/sandbox/mastra',
     ...(options?.pinnedBranch ? { branch: options.pinnedBranch } : {}),
   });
   return { seeded, sourceControl, project, repository, projectRepository };
@@ -393,7 +393,7 @@ describe('resolveFactorySourceRepository', () => {
       repositoryId: staleRepository.id,
       createdByUserId: 'user-1',
       sandboxProvider: 'local',
-      sandboxWorkdir: '/sandbox/mastra',
+      sandboxRepoDir: '/sandbox/mastra',
     });
     // The reinstall: the installation row goes away, the connection stays.
     await sourceControl.installations.delete({ orgId: 'org-1', id: staleInstallation.id });
@@ -424,7 +424,7 @@ describe('resolveFactorySourceRepository', () => {
       repositoryId: freshRepository.id,
       createdByUserId: 'user-2',
       sandboxProvider: 'local',
-      sandboxWorkdir: '/sandbox/mastra',
+      sandboxRepoDir: '/sandbox/mastra',
     });
 
     await expect(

--- a/mastracode/factory/src/session/filesystem-capture.test.ts
+++ b/mastracode/factory/src/session/filesystem-capture.test.ts
@@ -69,12 +69,12 @@ function createSession(results = [commandResult(), commandResult()], resourceId 
 }
 
 /**
- * Seed the per-process memo with a live sandbox whose derived workdir is
+ * Seed the per-process memo with a live sandbox whose derived repoDir is
  * `/worktree` (local provider: `<workingDirectory>/<repo name>`). Capture
- * reads the workdir from the memo ONLY — the persisted column is
+ * reads the repoDir from the memo ONLY — the persisted column is
  * observability, never a decision input.
  */
-function seedLiveWorkdir(sessionRowId = 'source-session-1', status = 'running') {
+function seedLiveRepoDir(sessionRowId = 'source-session-1', status = 'running') {
   getSessionSandbox(
     sessionRowId,
     'seed/worktree',
@@ -96,7 +96,7 @@ function createDependencies(): FilesystemCaptureDependencies {
           branch: 'main',
           baseBranch: 'main',
           sandboxId: 'sandbox-1',
-          sandboxWorkdir: '/sessions/s1/worktree',
+          sandboxRepoDir: '/sessions/s1/worktree',
           materializedAt: new Date(),
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -125,11 +125,11 @@ describe('parseFilesystemCaptureFiles', () => {
 describe('captureSessionFilesystem', () => {
   beforeEach(() => {
     __clearSessionSandboxesForTests();
-    seedLiveWorkdir();
+    seedLiveRepoDir();
   });
 
-  it('skips capture when only the persisted workdir column exists (never a decision input)', async () => {
-    // The stale-workdir incident class: a row written under a previous
+  it('skips capture when only the persisted repoDir column exists (never a decision input)', async () => {
+    // The stale-repoDir incident class: a row written under a previous
     // provider points at a path that no longer exists. With no live memo
     // entry there is nothing trustworthy to capture against.
     __clearSessionSandboxesForTests();
@@ -147,7 +147,7 @@ describe('captureSessionFilesystem', () => {
     // chat-only turn whose sandbox was constructed but never started must
     // not have a VM provisioned just to read an empty git status.
     __clearSessionSandboxesForTests();
-    seedLiveWorkdir('source-session-1', 'pending');
+    seedLiveRepoDir('source-session-1', 'pending');
     const { session, executeCommand } = createSession([]);
     const dependencies = createDependencies();
 
@@ -225,7 +225,7 @@ describe('captureSessionFilesystem', () => {
 describe('observeSessionFilesystem', () => {
   beforeEach(() => {
     __clearSessionSandboxesForTests();
-    seedLiveWorkdir();
+    seedLiveRepoDir();
   });
 
   it.each(['complete', 'aborted', 'error', 'suspended'] as const)(

--- a/mastracode/factory/src/session/filesystem-capture.ts
+++ b/mastracode/factory/src/session/filesystem-capture.ts
@@ -56,10 +56,10 @@ export async function captureSessionFilesystem(
     // Chat-only sessions run without a workspace; there is nothing to capture.
     const sandbox = session.getWorkspace()?.sandbox;
     if (!sourceSession || !sandbox?.executeCommand) return;
-    // The live workdir comes from the per-process memo (the deterministic
+    // The live repoDir comes from the per-process memo (the deterministic
     // truth) ONLY — never the persisted observability column, which a row
-    // written under a previous provider can point at a workdir that no
-    // longer exists (the stale-workdir incident class). No memo entry means
+    // written under a previous provider can point at a repoDir that no
+    // longer exists (the stale-repoDir incident class). No memo entry means
     // no live sandbox worth capturing in this replica; capture is
     // best-effort telemetry, so skip.
     const entry = peekSessionSandbox(sourceSession.id);
@@ -71,11 +71,11 @@ export async function captureSessionFilesystem(
     // running sandbox.
     if (entry.sandbox.status !== 'running') return;
     // Running-but-unresolved should not happen (the start hook resolves the
-    // workdir), but capture is best-effort — skip rather than guess.
-    const workdir = entry.workdir;
-    if (!workdir) return;
+    // repoDir), but capture is best-effort — skip rather than guess.
+    const repoDir = entry.repoDir;
+    if (!repoDir) return;
 
-    const result = await sandbox.executeCommand('git', ['-C', workdir, ...GIT_STATUS_ARGS], {
+    const result = await sandbox.executeCommand('git', ['-C', repoDir, ...GIT_STATUS_ARGS], {
       timeout: 30_000,
     });
     if (result.exitCode !== 0) {
@@ -83,7 +83,7 @@ export async function captureSessionFilesystem(
       return;
     }
 
-    const artifacts = await sandbox.executeCommand('sh', ['-c', ARTIFACTS_LIST_COMMAND, 'sh', workdir], {
+    const artifacts = await sandbox.executeCommand('sh', ['-c', ARTIFACTS_LIST_COMMAND, 'sh', repoDir], {
       timeout: 30_000,
     });
     if (artifacts.exitCode !== 0) {

--- a/mastracode/factory/src/session/memory-settings-hydration.test.ts
+++ b/mastracode/factory/src/session/memory-settings-hydration.test.ts
@@ -38,7 +38,7 @@ function sourceControlRow(): SourceControlSession {
     title: null,
     baseBranch: 'main',
     sandboxId: null,
-    sandboxWorkdir: null,
+    sandboxRepoDir: null,
     materializedAt: null,
     firstMessageAt: null,
     firstMeaningfulExecAt: null,

--- a/mastracode/factory/src/session/model-pack-hydration.test.ts
+++ b/mastracode/factory/src/session/model-pack-hydration.test.ts
@@ -36,7 +36,7 @@ function sourceControlRow(): SourceControlSession {
     title: null,
     baseBranch: 'main',
     sandboxId: null,
-    sandboxWorkdir: null,
+    sandboxRepoDir: null,
     materializedAt: null,
     firstMessageAt: null,
     firstMeaningfulExecAt: null,

--- a/mastracode/factory/src/session/thread-title-mirror.test.ts
+++ b/mastracode/factory/src/session/thread-title-mirror.test.ts
@@ -48,7 +48,7 @@ function createRow(title: string | null): SourceControlSession {
     visibility: 'private',
     baseBranch: 'main',
     sandboxId: null,
-    sandboxWorkdir: null,
+    sandboxRepoDir: null,
     materializedAt: null,
     firstMessageAt: null,
     firstMeaningfulExecAt: null,

--- a/mastracode/factory/src/storage/domains/source-control/base.test.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.test.ts
@@ -17,7 +17,7 @@ const projectRepositoryInput = {
   createdByUserId: 'user-1',
   branch: null,
   sandboxProvider: 'local',
-  sandboxWorkdir: '/workspace/mastra',
+  sandboxRepoDir: '/workspace/mastra',
 };
 
 describe('SourceControlStorage', () => {
@@ -547,7 +547,7 @@ describe('SourceControlStorageInMemory sessions.markMaterialized', () => {
       repositoryId: repository.id,
       createdByUserId: 'user-1',
       sandboxProvider: 'local',
-      sandboxWorkdir: '/sandbox/mastra',
+      sandboxRepoDir: '/sandbox/mastra',
     });
     const session = await store.sessions.create({
       sessionId: '00000000-0000-4000-8000-00000000aaaa',

--- a/mastracode/factory/src/storage/domains/source-control/base.ts
+++ b/mastracode/factory/src/storage/domains/source-control/base.ts
@@ -207,7 +207,7 @@ export interface ProjectRepository {
   createdByUserId: string;
   branch: string | null;
   sandboxProvider: string;
-  sandboxWorkdir: string;
+  sandboxRepoDir: string;
   setupCommand: string | null;
   teardownCommand: string | null;
   createdAt: Date;
@@ -233,7 +233,7 @@ export interface LinkProjectRepositoryInput {
   createdByUserId: string;
   branch?: string | null;
   sandboxProvider: string;
-  sandboxWorkdir: string;
+  sandboxRepoDir: string;
   setupCommand?: string | null;
   teardownCommand?: string | null;
 }
@@ -241,7 +241,7 @@ export interface LinkProjectRepositoryInput {
 export interface UpdateProjectRepositoryInput {
   branch?: string | null;
   sandboxProvider?: string;
-  sandboxWorkdir?: string;
+  sandboxRepoDir?: string;
   setupCommand?: string | null;
   teardownCommand?: string | null;
 }
@@ -264,7 +264,7 @@ export interface SourceControlSession {
   visibility: SourceControlSessionVisibility;
   baseBranch: string;
   sandboxId: string | null;
-  sandboxWorkdir: string | null;
+  sandboxRepoDir: string | null;
   materializedAt: Date | null;
   /** When the first user message reached the session's agent. Write-once. */
   firstMessageAt: Date | null;
@@ -356,7 +356,7 @@ export interface SourceControlStorageHandle {
       branch: string;
     }): Promise<SourceControlSession | null>;
     create(input: CreateSourceControlSessionInput): Promise<SourceControlSession>;
-    setSandbox(args: { id: string; sandboxId: string | null; sandboxWorkdir: string }): Promise<void>;
+    setSandbox(args: { id: string; sandboxId: string | null; sandboxRepoDir: string }): Promise<void>;
     /**
      * Record when the session's workspace was first materialized. Write-once:
      * the guarded update only lands while the column is still NULL, so resumes
@@ -495,7 +495,7 @@ function toProjectRepository(row: ProjectRepositoryDbRow): ProjectRepository {
     createdByUserId: row.created_by_user_id,
     branch: row.branch,
     sandboxProvider: row.sandbox_provider,
-    sandboxWorkdir: row.sandbox_workdir,
+    sandboxRepoDir: row.sandbox_workdir,
     setupCommand: row.setup_command,
     teardownCommand: row.teardown_command,
     createdAt: row.created_at,
@@ -515,7 +515,7 @@ function toSession(row: SessionDbRow): SourceControlSession {
     visibility: row.visibility === 'private' ? 'private' : 'org',
     baseBranch: row.base_branch,
     sandboxId: row.sandbox_id,
-    sandboxWorkdir: row.sandbox_workdir,
+    sandboxRepoDir: row.sandbox_workdir,
     materializedAt: row.materialized_at,
     firstMessageAt: row.first_message_at,
     firstMeaningfulExecAt: row.first_meaningful_exec_at,
@@ -860,7 +860,7 @@ export class SourceControlStorage extends FactoryStorageDomain {
               created_by_user_id: input.createdByUserId,
               branch: input.branch ?? null,
               sandbox_provider: input.sandboxProvider,
-              sandbox_workdir: input.sandboxWorkdir,
+              sandbox_workdir: input.sandboxRepoDir,
               setup_command: input.setupCommand ?? null,
               teardown_command: input.teardownCommand ?? null,
               created_at: now,
@@ -885,7 +885,7 @@ export class SourceControlStorage extends FactoryStorageDomain {
           const patch: Record<string, unknown> = { updated_at: new Date() };
           if (input.branch !== undefined) patch.branch = input.branch;
           if (input.sandboxProvider !== undefined) patch.sandbox_provider = input.sandboxProvider;
-          if (input.sandboxWorkdir !== undefined) patch.sandbox_workdir = input.sandboxWorkdir;
+          if (input.sandboxRepoDir !== undefined) patch.sandbox_workdir = input.sandboxRepoDir;
           if (input.setupCommand !== undefined) patch.setup_command = input.setupCommand;
           if (input.teardownCommand !== undefined) patch.teardown_command = input.teardownCommand;
           await db().updateMany(PROJECT_REPOSITORIES, { id }, patch);
@@ -973,11 +973,11 @@ export class SourceControlStorage extends FactoryStorageDomain {
             return toSession(row);
           }
         },
-        setSandbox: async ({ id, sandboxId, sandboxWorkdir }) => {
+        setSandbox: async ({ id, sandboxId, sandboxRepoDir }) => {
           await db().updateMany(
             SESSIONS,
             { id },
-            { sandbox_id: sandboxId, sandbox_workdir: sandboxWorkdir, updated_at: new Date() },
+            { sandbox_id: sandboxId, sandbox_workdir: sandboxRepoDir, updated_at: new Date() },
           );
         },
         markMaterialized: async ({ id }) => {

--- a/mastracode/factory/src/storage/domains/source-control/inmemory.ts
+++ b/mastracode/factory/src/storage/domains/source-control/inmemory.ts
@@ -291,7 +291,7 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
         createdByUserId: input.createdByUserId,
         branch: input.branch ?? null,
         sandboxProvider: input.sandboxProvider,
-        sandboxWorkdir: input.sandboxWorkdir,
+        sandboxRepoDir: input.sandboxRepoDir,
         setupCommand: input.setupCommand ?? null,
         teardownCommand: input.teardownCommand ?? null,
         createdAt: now,
@@ -372,7 +372,7 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
         title: input.title ?? null,
         visibility: input.visibility ?? 'org',
         sandboxId: null,
-        sandboxWorkdir: null,
+        sandboxRepoDir: null,
         materializedAt: null,
         firstMessageAt: null,
         firstMeaningfulExecAt: null,
@@ -385,14 +385,14 @@ export class SourceControlStorageInMemory implements SourceControlStorageHandle 
     setSandbox: async ({
       id,
       sandboxId,
-      sandboxWorkdir,
+      sandboxRepoDir,
     }: {
       id: string;
       sandboxId: string | null;
-      sandboxWorkdir: string;
+      sandboxRepoDir: string;
     }) => {
       const row = this.sessionsRows.find(candidate => candidate.id === id);
-      if (row) Object.assign(row, { sandboxId, sandboxWorkdir, updatedAt: new Date() });
+      if (row) Object.assign(row, { sandboxId, sandboxRepoDir, updatedAt: new Date() });
     },
     markMaterialized: async ({ id }: { id: string }) => {
       const row = this.sessionsRows.find(candidate => candidate.id === id);

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -57,7 +57,7 @@ const mocks = vi.hoisted(() => ({
       }),
       executeCommand: vi.fn(async (command: string) => {
         await sandbox.ensureRunning();
-        // The workdir resolver probes the VM's default cwd (its home dir).
+        // The repoDir resolver probes the VM's default cwd (its home dir).
         if (command === 'pwd') return { exitCode: 0, stdout: '/home/user\n', stderr: '' };
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
@@ -213,7 +213,7 @@ function addProject(overrides: Record<string, unknown> = {}) {
     repoId: 456,
     defaultBranch: 'main',
     sandboxProvider: 'local',
-    sandboxWorkdir: '/workspace/octocat/hello',
+    sandboxRepoDir: '/workspace/octocat/hello',
     setupCommand: null,
     teardownCommand: null,
     createdAt: new Date(),
@@ -233,7 +233,7 @@ function addSession(overrides: Record<string, unknown> = {}) {
     branch: 'feature-a',
     baseBranch: 'main',
     sandboxId: null,
-    sandboxWorkdir: null,
+    sandboxRepoDir: null,
     materializedAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -244,10 +244,10 @@ function addSession(overrides: Record<string, unknown> = {}) {
 }
 
 function fakeGithubIntegration() {
-  const setSandbox = vi.fn(async ({ id, sandboxId, sandboxWorkdir }) => {
+  const setSandbox = vi.fn(async ({ id, sandboxId, sandboxRepoDir }) => {
     const session = mocks.sessions.find(row => row.id === id);
-    if (session) Object.assign(session, { sandboxId, sandboxWorkdir, updatedAt: new Date() });
-    mocks.updates.push({ set: { sandboxId, sandboxWorkdir }, where: { id } });
+    if (session) Object.assign(session, { sandboxId, sandboxRepoDir, updatedAt: new Date() });
+    mocks.updates.push({ set: { sandboxId, sandboxRepoDir }, where: { id } });
   });
   return {
     id: 'github',
@@ -283,7 +283,7 @@ function fakeGithubIntegration() {
                 connectionId: 'connection-1',
                 repositoryId: 'repository-1',
                 branch: project.defaultBranch,
-                sandboxWorkdir: project.sandboxWorkdir,
+                sandboxRepoDir: project.sandboxRepoDir,
                 setupCommand: project.setupCommand,
                 teardownCommand: project.teardownCommand,
               }
@@ -740,8 +740,8 @@ describe('GitHub session workspace preparation', () => {
     const workspaceA = await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
     const workspaceB = await workspace({ requestContext: createGithubRequestContext('project-1', 'session-b') });
 
-    const workdirA = path.join(root, 'session-a', 'hello');
-    const workdirB = path.join(root, 'session-b', 'hello');
+    const repoDirA = path.join(root, 'session-a', 'hello');
+    const repoDirB = path.join(root, 'session-b', 'hello');
     expect(workspaceA.id).toContain('project-1-session-a');
     expect(workspaceB.id).toContain('project-1-session-b');
     expect(mocks.createSandbox).toHaveBeenNthCalledWith(
@@ -762,7 +762,7 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.materializeRepo).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        row: expect.objectContaining({ id: 'session-a', sandboxWorkdir: workdirA }),
+        row: expect.objectContaining({ id: 'session-a', sandboxRepoDir: repoDirA }),
         repoInfo: expect.objectContaining({ repoFullName: 'octocat/hello' }),
         token: 'repo-token-repository-1',
       }),
@@ -770,12 +770,12 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.checkoutSessionBranch).toHaveBeenNthCalledWith(
       2,
       expect.any(Object),
-      workdirB,
+      repoDirB,
       expect.objectContaining({ branch: 'feature-b', baseBranch: 'main' }),
     );
     expect(mocks.runSetupCommand).toHaveBeenCalledTimes(2);
-    expect(mocks.sessions.find(session => session.id === 'session-a')?.sandboxWorkdir).toBe(workdirA);
-    expect(mocks.sessions.find(session => session.id === 'session-b')?.sandboxWorkdir).toBe(workdirB);
+    expect(mocks.sessions.find(session => session.id === 'session-a')?.sandboxRepoDir).toBe(repoDirA);
+    expect(mocks.sessions.find(session => session.id === 'session-b')?.sandboxRepoDir).toBe(repoDirB);
   });
 
   it('resolves bundled Factory skills without waiting on sandbox materialization (kickoff path stays lazy)', async () => {
@@ -793,7 +793,7 @@ describe('GitHub session workspace preparation', () => {
     // The repo checkout never happened, so project skill roots were guarded
     // (reported empty) instead of forcing the sandbox to exist. Resolution
     // constructs the instance (cheap, side-effect-free by contract) to derive
-    // the workdir, but nothing may start it.
+    // the repoDir, but nothing may start it.
     expect(mocks.materializeRepo).not.toHaveBeenCalled();
     expect(mocks.createSandbox).toHaveBeenCalledTimes(1);
     const constructed = await mocks.createSandbox.mock.results[0]!.value;
@@ -839,7 +839,7 @@ describe('GitHub session workspace preparation', () => {
       expect.objectContaining({
         row: expect.objectContaining({
           id: 'session-a',
-          sandboxWorkdir: path.join(root, 'session-a', 'hello'),
+          sandboxRepoDir: path.join(root, 'session-a', 'hello'),
         }),
       }),
     );
@@ -876,7 +876,7 @@ describe('GitHub session workspace preparation', () => {
     );
   });
 
-  it('pins the session workdir into controller state so the agent prompt never points at the host checkout', async () => {
+  it('pins the session repoDir into controller state so the agent prompt never points at the host checkout', async () => {
     const { root, workspace } = await createLocalFactory();
     addProject();
     addSession({ id: 'session-a' });
@@ -1129,7 +1129,7 @@ describe('GitHub session workspace preparation', () => {
   });
 
   it('surfaces a missing command without rebuilding the checkout it ran in', async () => {
-    // Same ENOENT code as a removed checkout, so the workdir is what tells
+    // Same ENOENT code as a removed checkout, so the repoDir is what tells
     // the two apart. Rebuilding a healthy sandbox because the agent typed an
     // unknown command would be an expensive way to report "not found".
     const { root, workspace } = await createLocalFactory();
@@ -1160,7 +1160,7 @@ describe('GitHub session workspace preparation', () => {
     const resolved = await resolver({ requestContext: createGithubRequestContext('project-1', 'session-a') });
 
     // Resolution is fully lazy: it constructs the instance (cheap,
-    // side-effect-free by contract) to derive the workdir, but nothing may
+    // side-effect-free by contract) to derive the repoDir, but nothing may
     // START it no matter how many microtask turns have elapsed.
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(mocks.createSandbox).toHaveBeenCalledTimes(1);
@@ -1224,7 +1224,7 @@ describe('GitHub session workspace preparation', () => {
   });
 
   function createRemoteFactory() {
-    // No localRoot: the factory takes the remote path (in-VM workdirs).
+    // No localRoot: the factory takes the remote path (in-VM repoDirs).
     return eager(
       createWorkspaceFactory({
         sandbox: mocks.createSandbox as any,
@@ -1267,9 +1267,9 @@ describe('GitHub session workspace preparation', () => {
         repoFullName: 'octocat/hello',
       }),
     );
-    // The workdir came from the live VM's probed home, never a persisted row.
+    // The repoDir came from the live VM's probed home, never a persisted row.
     expect(mocks.materializeRepo).toHaveBeenCalledWith(
-      expect.objectContaining({ row: expect.objectContaining({ sandboxWorkdir: '/home/user/hello' }) }),
+      expect.objectContaining({ row: expect.objectContaining({ sandboxRepoDir: '/home/user/hello' }) }),
     );
   });
 

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -38,7 +38,7 @@ import {
   getSessionSandbox,
   hasFailedSetupCommand,
   recordFailedSetupCommand,
-  resolveSessionWorkdir,
+  resolveSessionRepoDir,
 } from './sandbox/session-sandbox.js';
 
 import type { WorkItemsStorage } from './storage/domains/work-items/base.js';
@@ -341,15 +341,15 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     // Construct (or fetch) the session's memoized sandbox instance.
     // Construction is cheap and side-effect-free by the callback contract —
     // the VM is provisioned on `start()`, which only the materialization
-    // pipeline calls. The workdir is never persisted or trusted from storage
-    // or client input (the stale-workdir incident class came from reusing
-    // `session.sandboxWorkdir` written under a different provider): local
+    // pipeline calls. The repoDir is never persisted or trusted from storage
+    // or client input (the stale-repoDir incident class came from reusing
+    // `session.sandboxRepoDir` written under a different provider): local
     // sandboxes derive it at construction, remote sandboxes clone into the
     // VM's own home so it resolves lazily at first start.
     // `runSetupOn` references `runSessionSetup`, defined below — it is only
     // invoked during start, long after this closure fully initializes.
-    const runSetupOn = (target: unknown, workdir: string) =>
-      runSessionSetup(requireExec(target as WorkspaceSandbox), workdir);
+    const runSetupOn = (target: unknown, repoDir: string) =>
+      runSessionSetup(requireExec(target as WorkspaceSandbox), repoDir);
     const guardedSetup = createSessionSetupHook(runSetupOn, session.id, repoFullName);
     // Composed start hook: marker-guarded repo setup, then per-start
     // credential install. It runs inside the provider's start lifecycle on
@@ -381,9 +381,9 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         (await getGithubPat(() => github.integrationStorage, session.orgId, patKind)) ?? (await getRepositoryToken());
       target.setEnv?.(env => ({ ...env, GH_TOKEN: ghCliToken }));
       // Observability only — nothing reads these columns for decisions. The
-      // workdir was resolved (and memoized on the entry) by the guarded setup.
+      // repoDir was resolved (and memoized on the entry) by the guarded setup.
       void storage.sessions
-        .setSandbox({ id: session.id, sandboxId: target.id, sandboxWorkdir: sessionEntry.workdir ?? '' })
+        .setSandbox({ id: session.id, sandboxId: target.id, sandboxRepoDir: sessionEntry.repoDir ?? '' })
         .catch(() => {});
       const tokenRegistration: GithubTokenRegistration = {
         inject: freshToken => {
@@ -430,16 +430,16 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         return sandbox;
       });
     const sessionEntry = constructSessionEntry();
-    const workdir = sessionEntry.workdir;
+    const repoDir = sessionEntry.repoDir;
     const isLocalSandbox = sessionEntry.sandbox.provider === 'local';
     // The system prompt derives its working directory from `state.projectPath`
     // and falls back to the server's own process.cwd() when unset — which
     // points the agent at the host checkout (and lets it run `git checkout`
-    // there instead of in its session workdir). Pin it to the session workdir
-    // once known. A remote workdir resolves at the sandbox's first start, so
+    // there instead of in its session repoDir). Pin it to the session repoDir
+    // once known. A remote repoDir resolves at the sandbox's first start, so
     // the pin self-heals on the next resolution after the VM has run.
-    if (ctx && workdir && ctx.getState()?.projectPath !== workdir) {
-      await ctx.setState({ projectPath: workdir, projectName: repoFullName });
+    if (ctx && repoDir && ctx.getState()?.projectPath !== repoDir) {
+      await ctx.setState({ projectPath: repoDir, projectName: repoFullName });
     }
 
     const extensionId = effectiveSkillExtension ? `-${effectiveSkillExtension.id}` : '';
@@ -586,7 +586,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     // check out the session branch, run the configured setup command. Minted
     // tokens are fetched inside the run so a replacement VM healed mid-session
     // gets fresh credentials, not ones captured at workspace construction.
-    const runSessionSetup = async (target: SessionSandbox, workdir: string): Promise<void> => {
+    const runSessionSetup = async (target: SessionSandbox, repoDir: string): Promise<void> => {
       const token = await getRepositoryToken();
       // The configured setup command may shell out to `gh`/https fetches, so
       // GH_TOKEN must exist before setup runs — and it must be the same
@@ -597,13 +597,13 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       const setupGhToken = (await getGithubPat(() => github.integrationStorage, session.orgId, setupPatKind)) ?? token;
       target.setEnv?.(env => ({ ...env, GH_TOKEN: setupGhToken }));
       await materializeRepo({
-        row: { id: session.id, sandboxWorkdir: workdir, materializedAt: session.materializedAt },
+        row: { id: session.id, sandboxRepoDir: repoDir, materializedAt: session.materializedAt },
         repoInfo: { repoFullName: repoFullName, defaultBranch: repository.defaultBranch },
         sandbox: target,
         token,
         storage: storage.sessions,
       });
-      await checkoutSessionBranch(target, workdir, {
+      await checkoutSessionBranch(target, repoDir, {
         branch: session.branch,
         baseBranch: session.baseBranch || projectRepository.branch || repository.defaultBranch,
         token,
@@ -625,11 +625,11 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
           return;
         }
         try {
-          await runSetupCommand(target, workdir, projectRepository.setupCommand);
+          await runSetupCommand(target, repoDir, projectRepository.setupCommand);
         } catch (setupError) {
           if (projectRepository.teardownCommand) {
             try {
-              await runTeardownCommand(target, workdir, projectRepository.teardownCommand, {
+              await runTeardownCommand(target, repoDir, projectRepository.teardownCommand, {
                 timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS,
               });
             } catch (teardownError) {
@@ -666,10 +666,10 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     const filesystem = new SandboxFilesystem({
       id: `sandbox-fs:${workspaceId}`,
       sandbox: sessionSandbox,
-      // Lazy: a remote workdir is only knowable once a VM runs. The first
+      // Lazy: a remote repoDir is only knowable once a VM runs. The first
       // file operation resolves it (starting the VM — which materializes the
       // repo via the onStart hook — when needed) and memoizes it.
-      workdir: () => resolveSessionWorkdir(session.id, sessionEntry.sandbox, repoFullName),
+      workdir: () => resolveSessionRepoDir(session.id, sessionEntry.sandbox, repoFullName),
     });
     const projectSkillPaths = [path.join(configDir, 'skills'), '.claude/skills', '.agents/skills'];
     const guardedSkillFallback = new UnmaterializedAwareSkillSource(


### PR DESCRIPTION
Rename Factory's internal checkout-directory vocabulary from `workdir` to `repoDir`.

This is a mechanical rename with no behavior change. The existing `sandbox_workdir` database column and shell-script-local variables remain unchanged.

Verified with the full Factory suite: 1976 passed, 6 skipped.
