### PR TITLE
test(core): keep processor tracing mock exportable

### DIFF
--- a/packages/core/src/workflows/processor-step.test.ts
+++ b/packages/core/src/workflows/processor-step.test.ts
@@ -45,6 +45,9 @@ function createMockTracingContext() {
   };
   mockSpan.createChildSpan.mockReturnValue(mockSpan);
   const currentSpan = {
+    isValid: true,
+    isInternal: false,
+    parent: undefined,
     createChildSpan: vi.fn(() => mockSpan),
     findParent: vi.fn(() => undefined),
   };


### PR DESCRIPTION
## Summary

- mark the processor-step tracing mock as a valid public span
- allow the orphan-trace guard to use the mock as the parent for `PROCESSOR_RUN` spans
- restore the TripWire and processor error span assertions failing affected-unit CI

The failures appeared after the orphan-trace protection in `getRootExportSpan()` began rejecting incomplete span mocks. Production behavior is unchanged; this updates the test fixture to model an exportable span.

## Test plan

- `pnpm exec vitest run src/workflows/processor-step.test.ts` (49 tests, repeated 3 times)
- `pnpm --filter ./packages/core check`
