### PR TITLE
feat(observability): execute DuckDB trace queries

### DIFF
--- a/.changeset/slimy-hornets-bet.md
+++ b/.changeset/slimy-hornets-bet.md
@@ -1,0 +1,7 @@
+---
+'@mastra/duckdb': minor
+---
+
+Added advanced trace query support to DuckDB observability storage, including filtering, grouping, ordering, cursor pagination, shared cross-adapter semantics, and query-shape-aware relation reads.
+
+Repeated writes for a score ID now retain the latest record so trace queries evaluate the current score consistently with other observability adapters.

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -18,6 +18,7 @@ createObservabilityVNextTests({
   capabilities: {
     label: 'DuckDB',
     preferredStrategy: 'event-sourced',
+    traceQuery: true,
   },
   getStorage: async () => {
     sharedSuiteStore = new DuckDBStore({ path: ':memory:' });
@@ -106,11 +107,11 @@ describe('ObservabilityStorageDuckDB', () => {
 
     try {
       coreFeatures.add('observability-delta-polling');
-      expect(storage.getFeatures()).toEqual(['metrics', 'logs', 'delta-polling']);
+      expect(storage.getFeatures()).toEqual(['metrics', 'logs', 'delta-polling', 'trace-query']);
 
       coreFeatures.delete('observability-delta-polling');
 
-      expect(storage.getFeatures()).toEqual(['metrics', 'logs']);
+      expect(storage.getFeatures()).toEqual(['metrics', 'logs', 'trace-query']);
       await expect(storage.listLogs({ mode: 'delta' })).rejects.toThrow(
         'This storage provider does not support observability delta polling',
       );
@@ -128,10 +129,10 @@ describe('ObservabilityStorageDuckDB', () => {
 
     try {
       coreFeatures.add('observability-delta-polling');
-      expect(lazyStore.observability.getFeatures()).toEqual(['metrics', 'logs', 'delta-polling']);
+      expect(lazyStore.observability.getFeatures()).toEqual(['metrics', 'logs', 'delta-polling', 'trace-query']);
 
       coreFeatures.delete('observability-delta-polling');
-      expect(lazyStore.observability.getFeatures()).toEqual(['metrics', 'logs']);
+      expect(lazyStore.observability.getFeatures()).toEqual(['metrics', 'logs', 'trace-query']);
     } finally {
       coreFeatures.clear();
       for (const feature of originalFeatures) {
@@ -2383,7 +2384,7 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(result.metrics[0]!.metricId).toBe('metric-retry-1');
     });
 
-    it('re-inserting the same scoreId does not throw or duplicate', async () => {
+    it('re-inserting the same scoreId replaces the current record without duplicating it', async () => {
       const score = {
         scoreId: 'score-retry-1',
         timestamp: new Date('2026-01-01T00:00:00Z'),
@@ -2396,10 +2397,10 @@ describe('ObservabilityStorageDuckDB', () => {
         metadata: null,
       };
       await storage.createScore({ score });
-      await storage.createScore({ score });
+      await storage.createScore({ score: { ...score, score: 0.4 } });
       const result = await storage.listScores({ filters: { traceId: 'trace-retry-score' } });
       expect(result.scores).toHaveLength(1);
-      expect(result.scores[0]!.scoreId).toBe('score-retry-1');
+      expect(result.scores[0]).toMatchObject({ scoreId: 'score-retry-1', score: 0.4 });
     });
 
     it('re-inserting the same feedbackId does not throw or duplicate', async () => {

--- a/stores/duckdb/src/storage/domains/observability/index.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.ts
@@ -76,6 +76,8 @@ import type {
   GetTagsArgs,
   GetTagsResponse,
   ObservabilityStorageStrategy,
+  TraceQueryResponse,
+  TrustedTraceQueryPlan,
 } from '@mastra/core/storage';
 import type { DuckDBConnection } from '../../db/index';
 import { ALL_DDL, ALL_MIGRATIONS } from './ddl';
@@ -86,6 +88,7 @@ import * as metricOps from './metrics';
 import { checkSignalTablesMigrationStatus, dropLegacyCursorIdDefaults, migrateSignalTables } from './migration';
 import { deltaPollingFeatureEnabled } from './polling';
 import * as scoreOps from './scores';
+import * as traceQueryOps from './trace-query';
 import * as tracingOps from './tracing';
 
 function buildSignalMigrationRequiredMessage(args: { tables: Array<{ table: string }> }): string {
@@ -204,10 +207,10 @@ export class ObservabilityStorageDuckDB extends ObservabilityStorage {
 
   override getFeatures() {
     if (!deltaPollingFeatureEnabled()) {
-      return ['metrics', 'logs'] as const;
+      return ['metrics', 'logs', 'trace-query'] as const;
     }
 
-    return ['metrics', 'logs', 'delta-polling'] as const;
+    return ['metrics', 'logs', 'delta-polling', 'trace-query'] as const;
   }
 
   // Tracing
@@ -237,6 +240,9 @@ export class ObservabilityStorageDuckDB extends ObservabilityStorage {
   }
   async listTraces(args: ListTracesArgs): Promise<ListTracesResponse> {
     return tracingOps.listTraces(this.db, args);
+  }
+  override async queryTraces(plan: TrustedTraceQueryPlan): Promise<TraceQueryResponse> {
+    return traceQueryOps.queryTraces(this.db, plan);
   }
   async listTracesLight(args: ListTracesArgs): Promise<ListTracesLightResponse> {
     if (args.mode === 'delta') {

--- a/stores/duckdb/src/storage/domains/observability/scores.ts
+++ b/stores/duckdb/src/storage/domains/observability/scores.ts
@@ -240,7 +240,7 @@ export async function createScore(db: DuckDBConnection, args: CreateScoreArgs): 
   const s = args.score as LegacyScoreRecord;
   const scoreSource = s.scoreSource ?? s.source ?? null;
   await db.execute(
-    `INSERT INTO score_events (
+    `INSERT OR REPLACE INTO score_events (
       scoreId, timestamp, cursorId, traceId, spanId, experimentId, scoreTraceId,
       entityType, entityId, entityName, entityVersionId, parentEntityVersionId, parentEntityType, parentEntityId, parentEntityName, rootEntityVersionId, rootEntityType, rootEntityId, rootEntityName,
       userId, organizationId, resourceId, runId, sessionId, threadId, requestId, environment, executionSource, serviceName,
@@ -284,8 +284,7 @@ export async function createScore(db: DuckDBConnection, args: CreateScoreArgs): 
        jsonV(s.tags ?? null),
        jsonV(s.metadata),
        jsonV(s.scope ?? null),
-     ].join(', ')})
-     ON CONFLICT DO NOTHING`,
+     ].join(', ')})`,
   );
 }
 
@@ -338,14 +337,13 @@ export async function batchCreateScores(db: DuckDBConnection, args: BatchCreateS
   });
 
   await db.execute(
-    `INSERT INTO score_events (
+    `INSERT OR REPLACE INTO score_events (
       scoreId, timestamp, cursorId, traceId, spanId, experimentId, scoreTraceId,
       entityType, entityId, entityName, entityVersionId, parentEntityVersionId, parentEntityType, parentEntityId, parentEntityName, rootEntityVersionId, rootEntityType, rootEntityId, rootEntityName,
       userId, organizationId, resourceId, runId, sessionId, threadId, requestId, environment, executionSource, serviceName,
       scorerId, scorerVersion, scoreSource, score, reason, tags, metadata, scope
     )
-     VALUES ${tuples.join(',\n       ')}
-     ON CONFLICT DO NOTHING`,
+     VALUES ${tuples.join(',\n       ')}`,
   );
 }
 

--- a/stores/duckdb/src/storage/domains/observability/trace-query.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/trace-query.test.ts
@@ -1,0 +1,166 @@
+import { encodeTraceQueryCursor, parseTraceQueryRequest, planTraceQuery } from '@mastra/core/storage';
+import type { TrustedTraceQueryPlan } from '@mastra/core/storage';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DuckDBConnection } from '../../db/index';
+import { compileDuckDBTraceQuery, queryTraces } from './trace-query';
+
+const TIME_RANGE = { from: '2026-01-01T00:00:00.000Z', to: '2026-01-02T00:00:00.000Z' };
+
+function plan(input: Record<string, unknown> = {}): TrustedTraceQueryPlan {
+  return planTraceQuery(parseTraceQueryRequest({ timeRange: TIME_RANGE, ...input }));
+}
+
+describe('DuckDB advanced trace query', () => {
+  it('parameterizes literals and compiles one correlated existence check per collection clause', () => {
+    const compiled = compileDuckDBTraceQuery(
+      plan({
+        where: {
+          scores: {
+            some: {
+              op: 'and',
+              args: [
+                { op: 'eq', left: { path: 'scorerId' }, right: { literal: "factuality' OR TRUE --" } },
+                { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    expect(compiled.sql).not.toContain("factuality' OR TRUE --");
+    expect(compiled.values).toContain("factuality' OR TRUE --");
+    expect(compiled.sql.match(/EXISTS \(/g)).toHaveLength(1);
+    expect(compiled.sql).toContain('s.traceId = r.traceId');
+    expect(compiled.sql).toContain('FROM current_scores s');
+  });
+
+  it('selects the latest logical root before applying completion and time filters', () => {
+    const compiled = compileDuckDBTraceQuery(plan());
+
+    expect(compiled.sql).toContain('row_number() OVER (PARTITION BY traceId ORDER BY cursorId DESC)');
+    expect(compiled.sql).toContain('FROM current_roots r');
+    expect(compiled.sql).toContain('r.endedAt IS NOT NULL');
+  });
+
+  it('emits only referenced signal work and reuses current-record CTEs', () => {
+    const traceOnly = compileDuckDBTraceQuery(plan());
+    const scoreOnly = compileDuckDBTraceQuery(
+      plan({
+        where: { scores: { some: { op: 'lt', left: { path: 'score' }, right: { literal: 0.5 } } } },
+      }),
+    );
+    const spanOnly = compileDuckDBTraceQuery(
+      plan({
+        where: { spans: { some: { op: 'eq', left: { path: 'spanType' }, right: { literal: 'tool_call' } } } },
+      }),
+    );
+    const repeatedSpans = compileDuckDBTraceQuery(
+      plan({
+        where: {
+          op: 'and',
+          args: [
+            { spans: { some: { op: 'eq', left: { path: 'spanType' }, right: { literal: 'tool_call' } } } },
+            { spans: { none: { op: 'exists', path: 'error' } } },
+          ],
+        },
+      }),
+    );
+
+    expect(traceOnly.sql.match(/FROM span_events/g)).toHaveLength(1);
+    expect(traceOnly.sql).not.toContain('score_events');
+    expect(traceOnly.sql).not.toContain('current_spans AS');
+
+    expect(scoreOnly.sql.match(/FROM span_events/g)).toHaveLength(1);
+    expect(scoreOnly.sql.match(/current_scores AS/g)).toHaveLength(1);
+    expect(scoreOnly.sql).not.toContain('current_spans AS');
+
+    expect(spanOnly.sql.match(/FROM span_events/g)).toHaveLength(2);
+    expect(spanOnly.sql.match(/current_spans AS/g)).toHaveLength(1);
+    expect(spanOnly.sql).not.toContain('score_events');
+
+    expect(repeatedSpans.sql.match(/current_spans AS/g)).toHaveLength(1);
+  });
+
+  it('uses total null semantics for negative predicates', () => {
+    const compiled = compileDuckDBTraceQuery(
+      plan({ where: { op: 'ne', left: { path: 'threadId' }, right: { literal: 'excluded' } } }),
+    );
+
+    expect(compiled.sql).toContain('r.threadId IS DISTINCT FROM ?');
+  });
+
+  it('matches the requested keyset order and always ties on traceId ascending', () => {
+    const first = plan({ orderBy: [{ field: 'endedAt', direction: 'desc' }], page: { limit: 2 } });
+    const after = plan({
+      orderBy: [{ field: 'endedAt', direction: 'desc' }],
+      page: {
+        limit: 2,
+        after: queryCursor(first, { sortValue: '2026-01-01T12:00:00.000Z', traceId: 'trace-b' }),
+      },
+    });
+    const compiled = compileDuckDBTraceQuery(after);
+
+    expect(compiled.sql).toContain('endedAt < CAST(? AS TIMESTAMP)');
+    expect(compiled.sql).toContain('traceId > ?');
+    expect(compiled.sql).toContain('ORDER BY endedAt DESC, traceId ASC');
+    expect(compiled.values.at(-1)).toBe(3);
+  });
+
+  it('compiles grouped queries as distinct non-null thread IDs', () => {
+    const compiled = compileDuckDBTraceQuery(plan({ group: { by: ['threadId'] }, page: { limit: 4 } }));
+
+    expect(compiled.sql).toContain('WHERE threadId IS NOT NULL');
+    expect(compiled.sql).toContain('GROUP BY threadId');
+    expect(compiled.sql).toContain('ORDER BY threadId ASC');
+    expect(compiled.values.at(-1)).toBe(5);
+  });
+
+  it('fails closed when a trusted plan contains an unmapped field', () => {
+    const trusted = plan({ where: { op: 'eq', left: { path: 'traceId' }, right: { literal: 'trace-a' } } });
+    const invalid = {
+      ...trusted,
+      where: { type: 'comparison', field: 'rawSql', operator: 'eq', value: 'x' },
+    } as unknown as TrustedTraceQueryPlan;
+
+    expect(() => compileDuckDBTraceQuery(invalid)).toThrow('Unsupported trusted trace-query field');
+  });
+
+  it('returns fixed records and computes the next cursor from the last visible row', async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValue([
+        traceRow('trace-a', '2026-01-01T12:00:00.000Z'),
+        traceRow('trace-b', '2026-01-01T11:00:00.000Z'),
+      ]);
+    const response = await queryTraces({ query } as unknown as DuckDBConnection, plan({ page: { limit: 1 } }));
+
+    expect(response).toMatchObject({
+      traces: [{ traceId: 'trace-a', rootSpanId: 'root-trace-a', status: 'success' }],
+      page: { next: expect.any(String) },
+    });
+    if (!('traces' in response)) throw new Error('Expected trace results');
+    expect(Object.keys(response.traces[0]!)).toHaveLength(10);
+  });
+});
+
+function queryCursor(plan: TrustedTraceQueryPlan, values: { sortValue: string; traceId: string }): string {
+  if (plan.result !== 'traces') throw new Error('Expected a trace plan');
+  return encodeTraceQueryCursor(plan, { result: 'traces', ...values });
+}
+
+function traceRow(traceId: string, startedAt: string) {
+  return {
+    traceId,
+    rootSpanId: `root-${traceId}`,
+    threadId: null,
+    resourceId: null,
+    startedAt: new Date(startedAt),
+    endedAt: new Date(new Date(startedAt).getTime() + 1_000),
+    entityName: null,
+    entityType: null,
+    environment: null,
+    status: 'success',
+  };
+}

--- a/stores/duckdb/src/storage/domains/observability/trace-query.ts
+++ b/stores/duckdb/src/storage/domains/observability/trace-query.ts
@@ -1,0 +1,337 @@
+import * as coreStorage from '@mastra/core/storage';
+import type {
+  TraceQueryCanonicalField,
+  TraceQueryField,
+  TraceQueryResponse,
+  TraceQueryScoreField,
+  TraceQuerySpanField,
+  TrustedTraceQueryPlan,
+  TrustedTraceQueryPredicate,
+  TrustedTraceQueryScalarPredicate,
+} from '@mastra/core/storage';
+
+import type { DuckDBConnection } from '../../db/index';
+
+type ParameterType = 'scalar' | 'timestamp';
+type FieldDefinition = { sql: string; parameterType: ParameterType };
+type FieldRegistry<TField extends string> = Record<TField, FieldDefinition>;
+type SqlFragment = { sql: string; values: unknown[] };
+
+const TRACE_STATUS_SQL = `CASE WHEN r.error IS NOT NULL THEN 'error' ELSE 'success' END`;
+
+const TRACE_FIELDS = {
+  traceId: { sql: 'r.traceId', parameterType: 'scalar' },
+  threadId: { sql: 'r.threadId', parameterType: 'scalar' },
+  resourceId: { sql: 'r.resourceId', parameterType: 'scalar' },
+  startedAt: { sql: 'r.startedAt', parameterType: 'timestamp' },
+  endedAt: { sql: 'r.endedAt', parameterType: 'timestamp' },
+  entityName: { sql: 'r.entityName', parameterType: 'scalar' },
+  entityType: { sql: 'r.entityType', parameterType: 'scalar' },
+  environment: { sql: 'r.environment', parameterType: 'scalar' },
+  status: { sql: TRACE_STATUS_SQL, parameterType: 'scalar' },
+} satisfies FieldRegistry<TraceQueryField>;
+
+const SPAN_FIELDS = {
+  spanType: { sql: 's.spanType', parameterType: 'scalar' },
+  error: { sql: 's.error', parameterType: 'scalar' },
+} satisfies FieldRegistry<TraceQuerySpanField>;
+
+const SCORE_FIELDS = {
+  scorerId: { sql: 's.scorerId', parameterType: 'scalar' },
+  score: { sql: 's.score', parameterType: 'scalar' },
+} satisfies FieldRegistry<TraceQueryScoreField>;
+
+const TRACE_SELECT = `
+  r.traceId AS traceId,
+  r.spanId AS rootSpanId,
+  r.threadId AS threadId,
+  r.resourceId AS resourceId,
+  r.startedAt AS startedAt,
+  r.endedAt AS endedAt,
+  r.entityName AS entityName,
+  r.entityType AS entityType,
+  r.environment AS environment,
+  ${TRACE_STATUS_SQL} AS status`;
+
+function fieldDefinition<TField extends string>(
+  registry: Partial<FieldRegistry<TField>>,
+  field: TraceQueryCanonicalField,
+): FieldDefinition {
+  const definition = registry[field as TField];
+  if (definition === undefined) throw new Error(`Unsupported trusted trace-query field: ${field}`);
+  return definition;
+}
+
+function parameterSql(type: ParameterType): string {
+  return type === 'timestamp' ? 'CAST(? AS TIMESTAMP)' : '?';
+}
+
+function compileScalarPredicate<TField extends string>(
+  predicate: TrustedTraceQueryScalarPredicate,
+  registry: Partial<FieldRegistry<TField>>,
+): SqlFragment {
+  if (predicate.type === 'boolean') {
+    const values: unknown[] = [];
+    const parts = predicate.args.map(arg => {
+      const compiled = compileScalarPredicate(arg, registry);
+      values.push(...compiled.values);
+      return `(${compiled.sql})`;
+    });
+    return { sql: parts.join(predicate.operator === 'and' ? ' AND ' : ' OR '), values };
+  }
+
+  if (predicate.type === 'not') {
+    const compiled = compileScalarPredicate(predicate.arg, registry);
+    return { sql: `NOT (${compiled.sql})`, values: compiled.values };
+  }
+
+  const field = fieldDefinition(registry, predicate.field);
+  if (predicate.type === 'presence') {
+    return {
+      sql: `${field.sql} IS ${predicate.operator === 'exists' ? 'NOT ' : ''}NULL`,
+      values: [],
+    };
+  }
+
+  if (predicate.type === 'membership') {
+    const list = predicate.values.map(() => parameterSql(field.parameterType)).join(', ');
+    if (predicate.operator === 'in') {
+      return { sql: `${field.sql} IS NOT NULL AND ${field.sql} IN (${list})`, values: predicate.values };
+    }
+    return { sql: `${field.sql} IS NULL OR ${field.sql} NOT IN (${list})`, values: predicate.values };
+  }
+
+  const parameter = parameterSql(field.parameterType);
+  const operators = { lt: '<', lte: '<=', gt: '>', gte: '>=' } as const;
+  if (predicate.operator === 'eq') {
+    return { sql: `${field.sql} IS NOT DISTINCT FROM ${parameter}`, values: [predicate.value] };
+  }
+  if (predicate.operator === 'ne') {
+    return { sql: `${field.sql} IS DISTINCT FROM ${parameter}`, values: [predicate.value] };
+  }
+  const operator = operators[predicate.operator];
+  if (operator === undefined) throw new Error(`Unsupported trusted trace-query operator: ${predicate.operator}`);
+  return {
+    sql: `${field.sql} IS NOT NULL AND ${field.sql} ${operator} ${parameter}`,
+    values: [predicate.value],
+  };
+}
+
+function compilePredicate(predicate: TrustedTraceQueryPredicate): SqlFragment {
+  if (predicate.type === 'relation') {
+    const registry = predicate.collection === 'spans' ? SPAN_FIELDS : SCORE_FIELDS;
+    const compiled = compileScalarPredicate(predicate.predicate, registry);
+    const table = predicate.collection === 'spans' ? 'current_spans' : 'current_scores';
+    const existence = `EXISTS (
+      SELECT 1 FROM ${table} s
+      WHERE s.traceId IS NOT NULL
+        AND s.traceId = r.traceId
+        AND (${compiled.sql})
+    )`;
+    return {
+      sql: predicate.quantifier === 'some' ? existence : `NOT ${existence}`,
+      values: compiled.values,
+    };
+  }
+
+  if (predicate.type === 'boolean') {
+    const values: unknown[] = [];
+    const parts = predicate.args.map(arg => {
+      const compiled = compilePredicate(arg);
+      values.push(...compiled.values);
+      return `(${compiled.sql})`;
+    });
+    return { sql: parts.join(predicate.operator === 'and' ? ' AND ' : ' OR '), values };
+  }
+
+  if (predicate.type === 'not') {
+    const compiled = compilePredicate(predicate.arg);
+    return { sql: `NOT (${compiled.sql})`, values: compiled.values };
+  }
+
+  return compileScalarPredicate(predicate, TRACE_FIELDS);
+}
+
+function collectRelatedCollections(
+  predicate: TrustedTraceQueryPredicate | undefined,
+  collections = new Set<'spans' | 'scores'>(),
+): Set<'spans' | 'scores'> {
+  if (!predicate) return collections;
+  if (predicate.type === 'relation') {
+    collections.add(predicate.collection);
+  } else if (predicate.type === 'boolean') {
+    for (const arg of predicate.args) collectRelatedCollections(arg, collections);
+  } else if (predicate.type === 'not') {
+    collectRelatedCollections(predicate.arg, collections);
+  }
+  return collections;
+}
+
+export interface CompiledDuckDBTraceQuery {
+  sql: string;
+  values: unknown[];
+}
+
+export function compileDuckDBTraceQuery(plan: TrustedTraceQueryPlan): CompiledDuckDBTraceQuery {
+  const values: unknown[] = [plan.timeRange.from, plan.timeRange.to];
+  const conditions = [
+    `r.endedAt IS NOT NULL`,
+    `r.startedAt >= CAST(? AS TIMESTAMP)`,
+    `r.startedAt < CAST(? AS TIMESTAMP)`,
+  ];
+
+  if (plan.where) {
+    const predicate = compilePredicate(plan.where);
+    conditions.push(`(${predicate.sql})`);
+    values.push(...predicate.values);
+  }
+
+  const relatedCollections = collectRelatedCollections(plan.where);
+  const ctes = [
+    `root_events AS (
+      SELECT
+        *,
+        CASE
+          WHEN eventType = 'start' THEN timestamp
+          ELSE lag(timestamp) OVER (PARTITION BY traceId, spanId ORDER BY cursorId)
+        END AS startedAt
+      FROM span_events
+      WHERE parentSpanId IS NULL
+    )`,
+    `current_roots AS (
+      SELECT * EXCLUDE (rootRank)
+      FROM (
+        SELECT *, row_number() OVER (PARTITION BY traceId ORDER BY cursorId DESC) AS rootRank
+        FROM root_events
+      )
+      WHERE rootRank = 1
+    )`,
+    `root_scope AS (
+      SELECT *
+      FROM current_roots r
+      WHERE r.endedAt IS NOT NULL
+        AND r.startedAt >= CAST(? AS TIMESTAMP)
+        AND r.startedAt < CAST(? AS TIMESTAMP)
+    )`,
+  ];
+
+  if (relatedCollections.has('spans')) {
+    ctes.push(`current_spans AS (
+      SELECT * EXCLUDE (currentRank)
+      FROM (
+        SELECT
+          e.*,
+          row_number() OVER (
+            PARTITION BY e.traceId, e.spanId
+            ORDER BY CASE WHEN e.endedAt IS NULL THEN 1 ELSE 0 END ASC, e.cursorId DESC
+          ) AS currentRank
+        FROM span_events e
+        INNER JOIN root_scope roots ON roots.traceId = e.traceId
+      )
+      WHERE currentRank = 1
+    )`);
+  }
+
+  if (relatedCollections.has('scores')) {
+    ctes.push(`current_scores AS (
+      SELECT s.*
+      FROM score_events s
+      INNER JOIN root_scope roots ON roots.traceId = s.traceId
+    )`);
+  }
+
+  ctes.push(`candidates AS (
+    SELECT ${TRACE_SELECT}
+    FROM root_scope r
+    WHERE ${conditions.slice(3).join('\n      AND ') || 'TRUE'}
+  )`);
+
+  const candidates = `WITH ${ctes.join(',\n  ')}`;
+
+  if (plan.result === 'groups') {
+    const pageCondition = plan.cursor ? `AND threadId > ?` : '';
+    if (plan.cursor) values.push(plan.cursor.threadId);
+    values.push(plan.limit + 1);
+    return {
+      sql: `${candidates}
+SELECT threadId
+FROM candidates
+WHERE threadId IS NOT NULL ${pageCondition}
+GROUP BY threadId
+ORDER BY threadId ASC
+LIMIT ?`,
+      values,
+    };
+  }
+
+  const orderField = plan.orderBy.field;
+  const direction = plan.orderBy.direction === 'asc' ? 'ASC' : 'DESC';
+  let pageCondition = '';
+  if (plan.cursor) {
+    const comparison = plan.orderBy.direction === 'asc' ? '>' : '<';
+    pageCondition = `WHERE (${orderField} ${comparison} CAST(? AS TIMESTAMP) OR (${orderField} = CAST(? AS TIMESTAMP) AND traceId > ?))`;
+    values.push(plan.cursor.sortValue, plan.cursor.sortValue, plan.cursor.traceId);
+  }
+  values.push(plan.limit + 1);
+
+  return {
+    sql: `${candidates}
+SELECT *
+FROM candidates
+${pageCondition}
+ORDER BY ${orderField} ${direction}, traceId ASC
+LIMIT ?`,
+    values,
+  };
+}
+
+function asIsoTimestamp(value: unknown): string {
+  return value instanceof Date ? value.toISOString() : new Date(value as string | number).toISOString();
+}
+
+export async function queryTraces(db: DuckDBConnection, plan: TrustedTraceQueryPlan): Promise<TraceQueryResponse> {
+  const query = compileDuckDBTraceQuery(plan);
+  const rows = await db.query<Record<string, unknown>>(query.sql, query.values);
+  const visibleRows = rows.slice(0, plan.limit);
+
+  if (plan.result === 'groups') {
+    const groups = visibleRows.map(row => ({ threadId: String(row.threadId) }));
+    const last = groups.at(-1);
+    return coreStorage.traceQueryResponseSchema.parse({
+      groups,
+      page: {
+        next:
+          rows.length > plan.limit && last
+            ? coreStorage.encodeTraceQueryCursor(plan, { result: 'groups', threadId: last.threadId })
+            : null,
+      },
+    });
+  }
+
+  const traces = visibleRows.map(row => ({
+    traceId: String(row.traceId),
+    rootSpanId: String(row.rootSpanId),
+    threadId: row.threadId == null ? null : String(row.threadId),
+    resourceId: row.resourceId == null ? null : String(row.resourceId),
+    startedAt: asIsoTimestamp(row.startedAt),
+    endedAt: asIsoTimestamp(row.endedAt),
+    entityName: row.entityName == null ? null : String(row.entityName),
+    entityType: row.entityType == null ? null : String(row.entityType),
+    environment: row.environment == null ? null : String(row.environment),
+    status: row.status,
+  }));
+  const last = traces.at(-1);
+  return coreStorage.traceQueryResponseSchema.parse({
+    traces,
+    page: {
+      next:
+        rows.length > plan.limit && last
+          ? coreStorage.encodeTraceQueryCursor(plan, {
+              result: 'traces',
+              sortValue: last[plan.orderBy.field],
+              traceId: last.traceId,
+            })
+          : null,
+    },
+  });
+}

--- a/stores/duckdb/src/storage/index.ts
+++ b/stores/duckdb/src/storage/index.ts
@@ -12,8 +12,8 @@ import type {
 const OBSERVABILITY_UPGRADE_MESSAGE =
   'DuckDB observability storage requires `@mastra/core` with observability storage support. Upgrade `@mastra/core` to use this store.';
 const OBSERVABILITY_DELTA_POLLING_FEATURE = 'observability-delta-polling';
-const DUCKDB_OBSERVABILITY_FEATURES = ['metrics', 'logs'] as const;
-const DUCKDB_OBSERVABILITY_DELTA_FEATURES = ['metrics', 'logs', 'delta-polling'] as const;
+const DUCKDB_OBSERVABILITY_FEATURES = ['metrics', 'logs', 'trace-query'] as const;
+const DUCKDB_OBSERVABILITY_DELTA_FEATURES = ['metrics', 'logs', 'delta-polling', 'trace-query'] as const;
 
 function isObservabilityCompatibilityError(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -201,6 +201,13 @@ export class ObservabilityStorageDuckDB extends CoreObservabilityStorage {
   ): ReturnType<ObservabilityStoreImpl['listTraces']> {
     const delegate = await this.requireDelegate();
     return delegate.listTraces(...args);
+  }
+
+  async queryTraces(
+    ...args: Parameters<ObservabilityStoreImpl['queryTraces']>
+  ): ReturnType<ObservabilityStoreImpl['queryTraces']> {
+    const delegate = await this.requireDelegate();
+    return delegate.queryTraces(...args);
   }
 
   async listTracesLight(


### PR DESCRIPTION
## Summary

Adds DuckDB support to the portable advanced trace-query API established by #22726, implemented for PostgreSQL and ClickHouse in #22727, and exposed through the server and client in #22728.

The adapter compiles recursive trace, span, and score predicates against DuckDB's event-sourced observability schema. It supports the fixed lightweight trace projection, distinct thread grouping, deterministic ordering, and opaque cursor pagination, and advertises the `trace-query` capability through both DuckDB storage entry points.

Repeated writes for a score ID now retain the latest record so current-score predicates behave consistently across DuckDB, PostgreSQL, and ClickHouse. The compiler builds the completed root scope first, emits current-span or current-score CTEs only when referenced, constrains them to candidate trace IDs, and reuses one reconstruction for repeated clauses.

The current `@duckdb/node-api` wrapper exposes no query-scoped timeout, cancellation signal, or interrupt API. This PR intentionally avoids unsafe Promise racing or connection-global interruption; the precise limitation and future isolated-cancellation work are tracked in OBS-285. The canonical trace-query documentation in #22728 now states that database-timeout `504` responses apply to PostgreSQL and ClickHouse only.

```ts
await mastraClient.queryTraces({
  timeRange: { from, to },
  where: {
    op: 'eq',
    left: { path: 'threadId' },
    right: { literal: threadId },
  },
  orderBy: [{ field: 'endedAt', direction: 'desc' }],
})
```

## Stack

This is PR 4 of 4 for OBS-20:

1. **#22726** — Core contract, planner, cursor, evaluator, and fixtures
2. **#22727** — PostgreSQL and ClickHouse execution
3. **#22728** — Server endpoint, OpenAPI, client method, and documentation
4. **#22801** — DuckDB execution

## Test plan

- DuckDB package suite: 332 passing
- Trace-query compiler tests: 8 passing, including exact referenced-table and reusable-CTE shapes
- Shared DuckDB observability suite: 172 passing, including nullable negative predicates, ordinal mixed-case/non-ASCII pagination, and tied replacements
- DuckDB typecheck, lint, and build
- Default `examples/agent` DuckDB smoke: two same-thread memory turns plus one separate-thread/resource turn; trace-only, score-only, span-only, grouped, and two-page cursor queries; no duplicates or omissions; generated databases cleaned up



