### PR TITLE
fix(core): skip durable-agent workflows in generic recovery

### DIFF
--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -711,6 +711,7 @@ export class Mastra<
   #workflows: TWorkflows;
   #harnesses: Record<string, Harness<any>> = {};
   #hiddenWorkflowKeys = new Set<string>();
+  #durableWorkflowKeys = new Set<string>();
   #observability: ObservabilityEntrypoint;
   #observabilityExplicit = false;
   #onScorerHook?: ReturnType<typeof createOnScorerHook>;
@@ -2512,8 +2513,13 @@ export class Mastra<
 
       // Register durable workflows if the wrapper provides them
       const durableWorkflows = durableAgent.getDurableWorkflows?.() ?? [];
+      const workflows = this.#workflows as Record<string, AnyWorkflow>;
       for (const workflow of durableWorkflows) {
+        if (workflows[workflow.id]) {
+          continue;
+        }
         this.addWorkflow(workflow, workflow.id);
+        this.#durableWorkflowKeys.add(workflow.id);
       }
 
       // Register configured processor workflows from the agent
@@ -3781,8 +3787,11 @@ export class Mastra<
       return { runs: [], total: 0 };
     }
 
-    // Get all workflows with default engine type
-    const defaultEngineWorkflows = Object.values(this.#workflows).filter(workflow => workflow.engineType === 'default');
+    // Get all workflows with default engine type, excluding durable-agent-owned
+    // definitions that are recovered through the dedicated durable path.
+    const defaultEngineWorkflows = Object.entries(this.#workflows)
+      .filter(([key, workflow]) => workflow.engineType === 'default' && !this.#durableWorkflowKeys.has(key))
+      .map(([, workflow]) => workflow);
 
     const activeRunsByWorkflow = await Promise.all(
       defaultEngineWorkflows.map(workflow => workflow.listActiveWorkflowRuns()),
@@ -4762,6 +4771,7 @@ export class Mastra<
     if (workflows[keyOrId]) {
       delete workflows[keyOrId];
       this.#hiddenWorkflowKeys.delete(keyOrId);
+      this.#durableWorkflowKeys.delete(keyOrId);
       return true;
     }
 
@@ -4769,6 +4779,7 @@ export class Mastra<
     if (key) {
       delete workflows[key];
       this.#hiddenWorkflowKeys.delete(key);
+      this.#durableWorkflowKeys.delete(key);
       return true;
     }
 

--- a/packages/core/src/mastra/list-active-workflow-runs.test.ts
+++ b/packages/core/src/mastra/list-active-workflow-runs.test.ts
@@ -3,6 +3,8 @@ import { z } from 'zod/v4';
 import type { WorkflowRuns } from '../storage';
 import { MockStore } from '../storage/mock';
 import { createEmptyWorkflowSnapshot } from '../storage/workflow-snapshot';
+import { Agent } from '../agent';
+import { createDurableAgent } from '../agent/durable/create-durable-agent';
 import { createWorkflow } from '../workflows';
 import type { WorkflowRunStatus } from '../workflows';
 import { Mastra } from './index';
@@ -35,6 +37,15 @@ function createWorkflowRun(
     createdAt: new Date(),
     updatedAt: new Date(),
   };
+}
+
+function makeAgent(id: string) {
+  return new Agent({
+    id,
+    name: id,
+    instructions: 'x',
+    model: 'openai/gpt-4o',
+  });
 }
 
 describe('Mastra listActiveWorkflowRuns', () => {
@@ -112,5 +123,52 @@ describe('Mastra listActiveWorkflowRuns', () => {
       runs: [...firstRunning.runs, ...firstWaiting.runs, ...secondRunning.runs, ...secondWaiting.runs],
       total: 4,
     });
+  });
+
+  it('skips durable-agent-owned workflows during generic boot recovery discovery', async () => {
+    const firstDurableAgent = createDurableAgent({ agent: makeAgent('durable-agent-a') });
+    const secondDurableAgent = createDurableAgent({ agent: makeAgent('durable-agent-b') });
+    const firstDurableWorkflow = firstDurableAgent.getWorkflow();
+    const secondDurableWorkflow = secondDurableAgent.getWorkflow();
+    const firstDurableSpy = vi.spyOn(firstDurableWorkflow, 'listWorkflowRuns').mockImplementation(() => {
+      throw new Error('durable-agent-owned workflows must not be enumerated by generic recovery');
+    });
+    const secondDurableSpy = vi.spyOn(secondDurableWorkflow, 'listWorkflowRuns').mockImplementation(() => {
+      throw new Error('durable-agent-owned workflows must not be enumerated by generic recovery');
+    });
+
+    const plainWorkflow = createWorkflow({
+      id: 'plain-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+    }).commit();
+    vi.spyOn(plainWorkflow, 'listWorkflowRuns').mockImplementation(({ status }) => {
+      if (status === 'running') {
+        return Promise.resolve({
+          runs: [createWorkflowRun('plain-workflow', 'plain-running', 'running')],
+          total: 1,
+        });
+      }
+
+      return Promise.resolve({ runs: [], total: 0 });
+    });
+
+    const mastra = new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      agents: {
+        durableA: firstDurableAgent as any,
+        durableB: secondDurableAgent as any,
+      },
+      workflows: { plainWorkflow } as any,
+    });
+
+    await expect(mastra.listActiveWorkflowRuns()).resolves.toEqual({
+      runs: [createWorkflowRun('plain-workflow', 'plain-running', 'running')],
+      total: 1,
+    });
+
+    expect(firstDurableSpy).not.toHaveBeenCalled();
+    expect(secondDurableSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description

Exclude DurableAgent-owned workflows from generic boot recovery so the dedicated durable path remains the only owner of those runs.

## Related issue(s)

Fixes #22598

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Reviewers

@wardpeet @abhiaiyer91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The server no longer tries to restart durable-agent workflows as ordinary workflows. Durable-agent runs remain handled by their dedicated recovery process, while regular workflows continue to recover during boot.

## Changes

- Track durable-agent-owned workflow definitions separately.
- Exclude those definitions from `listActiveWorkflowRuns` generic recovery discovery.
- Avoid re-registering a durable workflow when the same workflow ID already exists.
- Clear durable workflow tracking when workflows are removed.
- Add regression coverage to verify that generic recovery returns only regular workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->