### PR TITLE
feat(playground): improve trace panel header

### DIFF
--- a/.changeset/plenty-radios-heal.md
+++ b/.changeset/plenty-radios-heal.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Redesigned the trace side panel summary in Studio. The metadata grid was replaced with a compact, single-line description under the trace title using icons and tooltips for the linked entity, start time, duration, input and output tokens, and estimated cost. The "Details" tab is now labeled "Spans", and secondary trace header actions are consolidated into a single actions menu.

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -19,6 +19,8 @@ const baseProps: TraceDataPanelViewProps = {
   placement: 'traces-list',
 };
 
+const openTraceActions = () => fireEvent.click(screen.getByRole('button', { name: 'Trace actions' }));
+
 // jsdom has no layout, so it ships no scrollIntoView.
 const scrollIntoView = vi.fn();
 Element.prototype.scrollIntoView = scrollIntoView;
@@ -174,20 +176,34 @@ describe('TraceDataPanelView — Add tool mocks to item', () => {
     const onAddTraceMocksToItem = vi.fn();
     render(<TraceDataPanelView {...baseProps} onAddTraceMocksToItem={onAddTraceMocksToItem} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /add tool mocks to item/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /add tool mocks to item/i }));
 
     expect(onAddTraceMocksToItem).toHaveBeenCalledTimes(1);
     expect(onAddTraceMocksToItem).toHaveBeenCalledWith({ traceId: 'trace-1' });
   });
 
-  it('does not render the button when the prop is omitted', () => {
+  it('does not render the action when the prop is omitted', () => {
     render(<TraceDataPanelView {...baseProps} />);
 
-    expect(screen.queryByRole('button', { name: /add tool mocks to item/i })).toBeNull();
+    openTraceActions();
+    expect(screen.queryByRole('menuitem', { name: /add tool mocks to item/i })).toBeNull();
   });
 });
 
 describe('TraceDataPanelView — header actions', () => {
+  it('keeps navigation and close visible while secondary actions stay in the menu', () => {
+    render(<TraceDataPanelView {...baseProps} onPrevious={vi.fn()} onNext={vi.fn()} onEvaluateTrace={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /previous trace/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /next trace/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /close panel/i })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: /evaluate trace/i })).toBeNull();
+
+    openTraceActions();
+    expect(screen.getByRole('menuitem', { name: /evaluate trace/i })).toBeTruthy();
+  });
+
   it('keeps the trace actions reachable in the header even while the panel is collapsed', () => {
     render(
       <TraceDataPanelView
@@ -200,11 +216,12 @@ describe('TraceDataPanelView — header actions', () => {
       />,
     );
 
-    // The body is hidden while collapsed, so these can only come from the header.
+    // The body is hidden while collapsed, so these can only come from the header menu.
     expect(screen.queryByText('agent run')).toBeNull();
-    expect(screen.getByRole('button', { name: /evaluate trace/i })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /add full trace to dataset/i })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /add tool mocks to item/i })).toBeTruthy();
+    openTraceActions();
+    expect(screen.getByRole('menuitem', { name: /evaluate trace/i })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: /add full trace to dataset/i })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: /add tool mocks to item/i })).toBeTruthy();
   });
 
   it('still saves the dataset item against the root span from the header', () => {
@@ -218,55 +235,37 @@ describe('TraceDataPanelView — header actions', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'root' });
   });
 });
 
-describe('TraceDataPanelView — trace usage summary', () => {
-  it('renders token and cost rows when usage is provided', () => {
-    render(
-      <TraceDataPanelView
-        {...baseProps}
-        usage={{ inputTokens: 1200, outputTokens: 300, estimatedCost: 0.0042, costUnit: 'usd' }}
-      />,
-    );
+describe('TraceDataPanelView — trace summary description', () => {
+  it('shows the start date, duration and entity right under the heading', () => {
+    render(<TraceDataPanelView {...baseProps} spans={deepTraceFixture} entityHref="/agents/weather-agent/chat/new" />);
 
-    expect(screen.getByText('Trace input tokens')).not.toBeNull();
-    expect(screen.getByText('1.2K')).not.toBeNull();
-    expect(screen.getByText('Trace output tokens')).not.toBeNull();
-    expect(screen.getByText('300')).not.toBeNull();
-    expect(screen.getByText('Trace est. cost')).not.toBeNull();
-    expect(screen.getByText('$0.0042')).not.toBeNull();
+    expect(screen.getByLabelText(/^Started at /)).toBeTruthy();
+    // 1s between the fixture's startedAt and endedAt.
+    expect(screen.getAllByText('1.0s').length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: /weather-agent/ })).toBeTruthy();
   });
 
-  it('renders a placeholder when the store produced no cost for the trace', () => {
-    render(<TraceDataPanelView {...baseProps} usage={{ inputTokens: 1200, outputTokens: 300 }} />);
+  it('renders the entity as plain text when no href is provided', () => {
+    render(<TraceDataPanelView {...baseProps} spans={deepTraceFixture} />);
 
-    expect(screen.getByText('Trace est. cost')).not.toBeNull();
-    expect(screen.getByText('—')).not.toBeNull();
+    expect(screen.queryByRole('link', { name: /weather-agent/ })).toBeNull();
+    expect(screen.getAllByText(/weather-agent/).length).toBeGreaterThan(0);
   });
 
-  it('renders no usage rows when the prop is omitted', () => {
+  it('no longer renders the old key-value metadata rows', () => {
     render(<TraceDataPanelView {...baseProps} />);
 
-    expect(screen.queryByText('Trace est. cost')).toBeNull();
+    expect(screen.queryByText('Status')).toBeNull();
+    expect(screen.queryByText('Ended at')).toBeNull();
     expect(screen.queryByText('Trace input tokens')).toBeNull();
-  });
-
-  it('does not render full-trace usage for a subtrace anchor', () => {
-    render(
-      <TraceDataPanelView
-        {...baseProps}
-        spans={nestedSpanFixture}
-        anchorSpanId="child"
-        usage={{ inputTokens: 12_500, outputTokens: 405, estimatedCost: 0.01, costUnit: 'usd' }}
-      />,
-    );
-
     expect(screen.queryByText('Trace est. cost')).toBeNull();
-    expect(screen.queryByText('12.5K')).toBeNull();
   });
 });
 
@@ -335,8 +334,9 @@ describe('TraceDataPanelView — the header', () => {
     expect(screen.queryByText(/# trace-1/)).toBeNull();
     expect(screen.queryByRole('button', { name: /previous trace/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /collapse panel/i })).toBeNull();
-    // The download is the one control both layouts keep.
-    expect(screen.getByRole('button', { name: 'Download trace JSON' })).toBeTruthy();
+    openTraceActions();
+    expect(screen.queryByRole('menuitem', { name: /collapse panel/i })).toBeNull();
+    expect(screen.getByRole('menuitem', { name: 'Download trace JSON' })).toBeTruthy();
   });
 
   it('offers a collapse toggle only to a caller that owns the state', () => {
@@ -349,15 +349,17 @@ describe('TraceDataPanelView — the header', () => {
     const onCollapsedChange = vi.fn();
     render(<TraceDataPanelView {...baseProps} onCollapsedChange={onCollapsedChange} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /collapse panel/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /collapse panel/i }));
     expect(onCollapsedChange).toHaveBeenCalledWith(true);
   });
 
   it('reads its collapsed label from the state the caller passes in', () => {
     render(<TraceDataPanelView {...baseProps} collapsed onCollapsedChange={vi.fn()} />);
 
-    expect(screen.getByRole('button', { name: /expand panel/i })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: /collapse panel/i })).toBeNull();
+    openTraceActions();
+    expect(screen.getByRole('menuitem', { name: /expand panel/i })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: /collapse panel/i })).toBeNull();
   });
 
   it('hides the whole body while collapsed', () => {
@@ -389,23 +391,27 @@ describe('TraceDataPanelView — the header', () => {
     );
 
     const noHref = render(<TraceDataPanelView {...baseProps} LinkComponent={Anchor} />);
-    expect(screen.queryByLabelText('Open trace page')).toBeNull();
+    openTraceActions();
+    expect(screen.queryByRole('menuitem', { name: 'Open trace page' })).toBeNull();
     expect(noHref.container).toBeTruthy();
 
     cleanup();
 
     render(<TraceDataPanelView {...baseProps} traceHref="/traces/trace-1" />);
-    expect(screen.queryByLabelText('Open trace page')).toBeNull();
+    openTraceActions();
+    expect(screen.queryByRole('menuitem', { name: 'Open trace page' })).toBeNull();
 
     cleanup();
 
     render(<TraceDataPanelView {...baseProps} />);
-    expect(screen.queryByLabelText('Open trace page')).toBeNull();
+    openTraceActions();
+    expect(screen.queryByRole('menuitem', { name: 'Open trace page' })).toBeNull();
 
     cleanup();
 
     render(<TraceDataPanelView {...baseProps} LinkComponent={Anchor} traceHref="/traces/trace-1" />);
-    expect(screen.getByRole('link', { name: 'Open trace page' }).getAttribute('href')).toBe('/traces/trace-1');
+    openTraceActions();
+    expect(screen.getByRole('menuitem', { name: 'Open trace page' }).getAttribute('href')).toBe('/traces/trace-1');
   });
 
   it('never links out from the trace page itself', () => {
@@ -419,7 +425,8 @@ describe('TraceDataPanelView — the header', () => {
       <TraceDataPanelView {...baseProps} placement="trace-page" LinkComponent={Anchor} traceHref="/traces/trace-1" />,
     );
 
-    expect(screen.queryByRole('link', { name: 'Open trace page' })).toBeNull();
+    openTraceActions();
+    expect(screen.queryByRole('menuitem', { name: 'Open trace page' })).toBeNull();
   });
 });
 
@@ -445,13 +452,13 @@ describe('TraceDataPanelView — the body', () => {
 
   it('shows the trace summary in the side panel but not on the trace page', () => {
     const sidePanel = render(<TraceDataPanelView {...baseProps} />);
-    expect(screen.getByText('Status')).toBeTruthy();
+    expect(screen.getByLabelText(/^Started at /)).toBeTruthy();
     expect(sidePanel.container).toBeTruthy();
 
     cleanup();
 
     render(<TraceDataPanelView {...baseProps} placement="trace-page" />);
-    expect(screen.queryByText('Status')).toBeNull();
+    expect(screen.queryByLabelText(/^Started at /)).toBeNull();
   });
 });
 
@@ -472,13 +479,15 @@ describe('TraceDataPanelView — the actions row', () => {
     render(<TraceDataPanelView {...baseProps} onEvaluateTrace={vi.fn()} />);
 
     expect(screen.queryByText(/available in Mastra Studio/)).toBeNull();
-    expect(screen.getByRole('button', { name: /evaluate trace/i })).toBeTruthy();
+    openTraceActions();
+    expect(screen.getByRole('menuitem', { name: /evaluate trace/i })).toBeTruthy();
   });
 
   it('never shows the actions row on the trace page', () => {
     render(<TraceDataPanelView {...baseProps} placement="trace-page" onEvaluateTrace={vi.fn()} />);
 
-    expect(screen.queryByRole('button', { name: /evaluate trace/i })).toBeNull();
+    openTraceActions();
+    expect(screen.queryByRole('menuitem', { name: /evaluate trace/i })).toBeNull();
     expect(screen.queryByText(/available in Mastra Studio/)).toBeNull();
   });
 
@@ -486,7 +495,8 @@ describe('TraceDataPanelView — the actions row', () => {
     const onSaveAsDatasetItem = vi.fn();
     render(<TraceDataPanelView {...baseProps} onSaveAsDatasetItem={onSaveAsDatasetItem} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'root' });
   });
@@ -495,7 +505,8 @@ describe('TraceDataPanelView — the actions row', () => {
     const onEvaluateTrace = vi.fn();
     render(<TraceDataPanelView {...baseProps} onEvaluateTrace={onEvaluateTrace} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /evaluate trace/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /evaluate trace/i }));
 
     expect(onEvaluateTrace).toHaveBeenCalledTimes(1);
   });
@@ -555,7 +566,8 @@ describe('TraceDataPanelView — an anchored subtrace', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'child' });
   });
@@ -564,7 +576,8 @@ describe('TraceDataPanelView — an anchored subtrace', () => {
     const onSaveAsDatasetItem = vi.fn();
     render(<TraceDataPanelView {...baseProps} spans={nestedSpanFixture} onSaveAsDatasetItem={onSaveAsDatasetItem} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'root' });
   });
@@ -580,23 +593,10 @@ describe('TraceDataPanelView — an anchored subtrace', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'root' });
-  });
-
-  it('keeps the full-trace totals when the anchor is the trace root after all', () => {
-    render(
-      <TraceDataPanelView
-        {...baseProps}
-        spans={nestedSpanFixture}
-        anchorSpanId="root"
-        usage={{ inputTokens: 12_500, outputTokens: 800, estimatedCost: 0.05, costUnit: 'usd' }}
-      />,
-    );
-
-    // Anchoring on the root span is still the whole trace, so its totals stand.
-    expect(screen.getByText('12.5K')).toBeTruthy();
   });
 });
 
@@ -616,12 +616,17 @@ describe('TraceDataPanelView — downloading the trace', () => {
 
     render(withClient(<TraceDataPanelView {...baseProps} />));
 
-    const download = screen.getByRole('button', { name: 'Download trace JSON' });
-    expect(download.hasAttribute('disabled')).toBe(false);
+    openTraceActions();
+    const download = screen.getByRole('menuitem', { name: 'Download trace JSON' });
+    expect(download.hasAttribute('data-disabled')).toBe(false);
 
     fireEvent.click(download);
 
-    await waitFor(() => expect(download.hasAttribute('disabled')).toBe(true));
+    await waitFor(() => expect(screen.queryByRole('menuitem', { name: 'Download trace JSON' })).toBeNull());
+    openTraceActions();
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', { name: 'Download trace JSON' }).hasAttribute('data-disabled')).toBe(true),
+    );
   });
 });
 
@@ -679,7 +684,7 @@ describe('TraceDataPanelView — an anchor the trace does not have', () => {
     render(<TraceDataPanelView {...baseProps} spans={nestedSpanFixture} anchorSpanId="ghost" />);
 
     // No root span to describe, so the summary rows are left out entirely.
-    expect(screen.queryByText('Status')).toBeNull();
+    expect(screen.queryByLabelText(/^Started at /)).toBeNull();
     expect(screen.getByText('agent run')).toBeTruthy();
   });
 
@@ -694,7 +699,8 @@ describe('TraceDataPanelView — an anchor the trace does not have', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: undefined });
   });
@@ -715,7 +721,8 @@ describe('TraceDataPanelView — following the spans it is given', () => {
     const otherRoot = [{ ...(rootSpanFixture[0] as (typeof rootSpanFixture)[number]), spanId: 'other-root' }];
     rerender(<TraceDataPanelView {...baseProps} spans={otherRoot} onSaveAsDatasetItem={onSaveAsDatasetItem} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'other-root' });
   });
@@ -740,7 +747,8 @@ describe('TraceDataPanelView — following the spans it is given', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'child' });
   });
@@ -755,7 +763,8 @@ describe('TraceDataPanelView — following the spans it is given', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /add full trace to dataset/i }));
+    openTraceActions();
+    fireEvent.click(screen.getByRole('menuitem', { name: /add full trace to dataset/i }));
 
     expect(onSaveAsDatasetItem).toHaveBeenCalledWith({ traceId: 'trace-1', rootSpanId: 'root' });
   });
@@ -796,16 +805,16 @@ describe('TraceDataPanelView — trace-level tabs', () => {
   it('renders no tabs when no scores slot is provided', () => {
     render(<TraceDataPanelView {...baseProps} />);
 
-    expect(screen.queryByRole('tab', { name: /details/i })).toBeNull();
+    expect(screen.queryByRole('tab', { name: /spans/i })).toBeNull();
     expect(screen.queryByRole('tab', { name: /evaluations/i })).toBeNull();
   });
 
-  it('renders Details and Scores tabs when a scores slot is provided', () => {
+  it('renders Spans and Scores tabs when a scores slot is provided', () => {
     render(<TraceDataPanelView {...baseProps} scoresTabSlot={() => <div>trace scores here</div>} />);
 
-    expect(screen.getByRole('tab', { name: /details/i })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /spans/i })).toBeTruthy();
     expect(screen.getByRole('tab', { name: /evaluations/i })).toBeTruthy();
-    // Details is the default tab.
+    // Spans is the default tab.
     expect(screen.getByText('agent run')).toBeTruthy();
     expect(screen.queryByText('trace scores here')).toBeNull();
   });
@@ -848,7 +857,7 @@ describe('TraceDataPanelView — trace-level tabs', () => {
 });
 
 describe('TraceDataPanelView — trace feedback tab', () => {
-  it('renders a Feedback tab next to Details and Evaluations', () => {
+  it('renders a Feedback tab next to Spans and Evaluations', () => {
     render(
       <TraceDataPanelView
         {...baseProps}
@@ -857,7 +866,7 @@ describe('TraceDataPanelView — trace feedback tab', () => {
       />,
     );
 
-    expect(screen.getByRole('tab', { name: /details/i })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /spans/i })).toBeTruthy();
     expect(screen.getByRole('tab', { name: /evaluations/i })).toBeTruthy();
     expect(screen.getByRole('tab', { name: /feedback/i })).toBeTruthy();
   });
@@ -894,7 +903,7 @@ describe('TraceDataPanelView — trace feedback tab', () => {
     render(<TraceDataPanelView {...baseProps} />);
 
     expect(screen.queryByRole('tab', { name: /feedback/i })).toBeNull();
-    expect(screen.queryByRole('tab', { name: /details/i })).toBeNull();
+    expect(screen.queryByRole('tab', { name: /spans/i })).toBeNull();
   });
 });
 

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-summary-description.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-summary-description.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, assert, describe, expect, it } from 'vitest';
+import { TraceSummaryDescription } from '../trace-summary-description';
+
+afterEach(cleanup);
+
+const rootSpan = {
+  entityId: 'weather-agent',
+  entityName: 'Weather Agent',
+  entityType: 'agent',
+  startedAt: new Date(2026, 5, 1, 17, 9, 59, 665),
+  endedAt: new Date(2026, 5, 1, 17, 10, 45, 966),
+};
+
+describe('TraceSummaryDescription', () => {
+  it('shows the start time with full precision on hover and the duration next to it', async () => {
+    render(<TraceSummaryDescription rootSpan={rootSpan} />);
+
+    const startedAt = screen.getByText('5:09:59 PM');
+    expect(screen.getByText('46.3s')).not.toBeNull();
+
+    fireEvent.focus(startedAt);
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Started at Jun 1, 2026, 5:09:59.665 PM');
+  });
+
+  it('shows the readable entity type in a tooltip', async () => {
+    render(<TraceSummaryDescription rootSpan={rootSpan} />);
+
+    const entity = screen.getByText('Weather Agent').closest('[tabindex]');
+    assert(entity);
+    fireEvent.focus(entity);
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Agent');
+  });
+
+  it('links the entity name when a href is provided', () => {
+    render(
+      <TraceSummaryDescription
+        rootSpan={rootSpan}
+        entityHref="/agents/weather-agent/chat/new"
+        LinkComponent={props => <a {...props} />}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: /Weather Agent/ });
+    expect(link.getAttribute('href')).toBe('/agents/weather-agent/chat/new');
+  });
+
+  it('renders the entity name as plain text without a href', () => {
+    render(<TraceSummaryDescription rootSpan={rootSpan} />);
+
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('falls back to the entity id when the entity has no name', () => {
+    render(<TraceSummaryDescription rootSpan={{ ...rootSpan, entityName: '' }} />);
+
+    expect(screen.getByText('weather-agent')).not.toBeNull();
+  });
+
+  it('titles multi-word entity types in the tooltip', async () => {
+    render(<TraceSummaryDescription rootSpan={{ ...rootSpan, entityType: 'workflow_run' }} />);
+
+    const entity = screen.getByText('Weather Agent').closest('[tabindex]');
+    assert(entity);
+    fireEvent.focus(entity);
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Workflow Run');
+  });
+
+  it('shows input tokens, output tokens, and estimated cost inline with tooltip labels', async () => {
+    render(
+      <TraceSummaryDescription
+        rootSpan={rootSpan}
+        usage={{ inputTokens: 1200, outputTokens: 345, estimatedCost: 0.001, costUnit: 'usd' }}
+      />,
+    );
+
+    expect(screen.getByText('1.2K')).not.toBeNull();
+    expect(screen.getByText('345')).not.toBeNull();
+    expect(screen.getByText('$0.0010')).not.toBeNull();
+
+    fireEvent.focus(screen.getByLabelText('Input tokens'));
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Input tokens');
+  });
+
+  it('leaves out the entity block when the span never carried one', () => {
+    render(<TraceSummaryDescription rootSpan={{ startedAt: rootSpan.startedAt, endedAt: rootSpan.endedAt }} />);
+
+    expect(screen.queryByText('Agent')).toBeNull();
+    expect(screen.getByText('5:09:59 PM')).not.toBeNull();
+  });
+
+  it('shows no duration while the trace is still running', () => {
+    render(<TraceSummaryDescription rootSpan={{ ...rootSpan, endedAt: null }} />);
+
+    expect(screen.queryByText('46.3s')).toBeNull();
+    expect(screen.getByText('5:09:59 PM')).not.toBeNull();
+  });
+});

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -5,6 +5,7 @@ import {
   DownloadIcon,
   Link2Icon,
   Loader2Icon,
+  MoreHorizontalIcon,
   SaveIcon,
   WrenchIcon,
 } from 'lucide-react';
@@ -16,11 +17,12 @@ import { useTraceSearch } from '../hooks/use-trace-search';
 import type { TraceUsageSummary } from '../trace-list-columns';
 import type { SearchableSpan } from '../types';
 import { formatHierarchicalSpans } from './format-hierarchical-spans';
-import { TraceKeysAndValues } from './trace-keys-and-values';
+import { TraceSummaryDescription } from './trace-summary-description';
 import { TraceTimeline } from './trace-timeline';
 import { Button } from '@/ds/components/Button';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 import { DataPanel } from '@/ds/components/DataPanel';
+import { DropdownMenu } from '@/ds/components/DropdownMenu';
 import { SearchFieldBlock } from '@/ds/components/FormFieldBlocks';
 import { Notice } from '@/ds/components/Notice';
 import { Tab, TabContent, TabList, Tabs } from '@/ds/components/Tabs';
@@ -37,12 +39,6 @@ export interface TraceDataPanelViewProps {
   traceId: string;
   /** Lightweight spans for the trace. Caller fetches via useTraceLightSpans. */
   spans: SearchableSpan[] | undefined;
-  /**
-   * Token and estimated-cost totals for the trace (from `useTraceUsage`).
-   * Rendered in the trace summary when the panel is in the list side-panel
-   * placement; the trace page renders its own `TraceKeysAndValues` instead.
-   */
-  usage?: TraceUsageSummary;
   isLoading?: boolean;
   onClose: () => void;
   onSpanSelect?: (spanId: string | undefined) => void;
@@ -61,6 +57,10 @@ export interface TraceDataPanelViewProps {
   /** When both are provided, renders an "Open trace page" button. */
   LinkComponent?: LinkComponent;
   traceHref?: string;
+  /** When provided, the entity name in the trace summary links to the entity's page. */
+  entityHref?: string;
+  /** Token and estimated-cost totals shown in the compact trace summary. */
+  usage?: TraceUsageSummary;
   /**
    * Span treated as the displayed root of the timeline. Required for branch
    * subtrees from `getBranch` where the anchor has a real parent that's outside
@@ -103,7 +103,6 @@ export interface TraceDataPanelViewProps {
 export function TraceDataPanelView({
   traceId,
   spans,
-  usage,
   isLoading,
   onClose,
   onSpanSelect,
@@ -119,6 +118,8 @@ export function TraceDataPanelView({
   timelineChartWidth = 'default',
   LinkComponent,
   traceHref,
+  entityHref,
+  usage,
   anchorSpanId,
   showUnavailableFeaturesMsg = true,
   scoresTabSlot,
@@ -189,28 +190,58 @@ export function TraceDataPanelView({
     () => (anchorSpanId ? spans?.find(s => s.spanId === anchorSpanId) : spans?.find(s => s.parentSpanId == null)),
     [spans, anchorSpanId],
   );
-  const isSubtrace = anchorSpanId !== undefined && rootSpan?.parentSpanId != null;
-
   const handleSpanClick = (id: string) => {
     const newId = selectedSpanId === id ? undefined : id;
     setSelectedSpanId(newId);
     onSpanSelect?.(newId);
   };
 
-  const showOpenTracePageLink = !isOnTracePage && LinkComponent && traceHref;
-
-  // Shared across both header layouts (list side panel and full trace page) so a trace can be
-  // downloaded from wherever it's being inspected.
-  const downloadTraceButton = (
-    <Button
-      size="md"
-      tooltip="Download trace JSON"
-      aria-label="Download trace JSON"
-      disabled={isDownloadingTrace}
-      onClick={() => downloadTraceJson(traceId)}
-    >
-      {isDownloadingTrace ? <Loader2Icon className="animate-spin" /> : <DownloadIcon />}
-    </Button>
+  const traceActionsMenu = (
+    <DropdownMenu>
+      <DropdownMenu.Trigger
+        render={
+          <Button size="md" tooltip="Trace actions" aria-label="Trace actions">
+            <MoreHorizontalIcon />
+          </Button>
+        }
+      />
+      <DropdownMenu.Content align="end">
+        {!isOnTracePage && onCollapsedChange && (
+          <DropdownMenu.Item onSelect={() => setCollapsed(!collapsed)}>
+            {collapsed ? <ChevronsUpDownIcon /> : <ChevronsDownUpIcon />}
+            {collapsed ? 'Expand panel' : 'Collapse panel'}
+          </DropdownMenu.Item>
+        )}
+        {!isOnTracePage && onEvaluateTrace && (
+          <DropdownMenu.Item onSelect={onEvaluateTrace}>
+            <CircleGaugeIcon />
+            Evaluate trace
+          </DropdownMenu.Item>
+        )}
+        {!isOnTracePage && onSaveAsDatasetItem && (
+          <DropdownMenu.Item onSelect={() => onSaveAsDatasetItem({ traceId, rootSpanId: rootSpan?.spanId })}>
+            <SaveIcon />
+            Add full trace to dataset
+          </DropdownMenu.Item>
+        )}
+        {!isOnTracePage && onAddTraceMocksToItem && (
+          <DropdownMenu.Item onSelect={() => onAddTraceMocksToItem({ traceId })}>
+            <WrenchIcon />
+            Add tool mocks to item
+          </DropdownMenu.Item>
+        )}
+        {!isOnTracePage && LinkComponent && traceHref && (
+          <DropdownMenu.Item render={<LinkComponent href={traceHref} />}>
+            <Link2Icon />
+            Open trace page
+          </DropdownMenu.Item>
+        )}
+        <DropdownMenu.Item disabled={isDownloadingTrace} onSelect={() => downloadTraceJson(traceId)}>
+          {isDownloadingTrace ? <Loader2Icon className="animate-spin" /> : <DownloadIcon />}
+          Download trace JSON
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
   );
 
   return (
@@ -219,48 +250,25 @@ export function TraceDataPanelView({
         {isOnTracePage ? (
           <>
             <DataPanel.Heading>Trace Timeline</DataPanel.Heading>
-            <ButtonsGroup className="ml-auto shrink-0">{downloadTraceButton}</ButtonsGroup>
+            <ButtonsGroup className="ml-auto shrink-0">{traceActionsMenu}</ButtonsGroup>
           </>
         ) : (
           <>
-            <DataPanel.Heading>
-              Trace <b># {truncateString(traceId, 12)}</b>
-            </DataPanel.Heading>
-            <ButtonsGroup className="ml-auto shrink-0">
-              {onCollapsedChange && (
-                <Button
-                  size="md"
-                  tooltip={collapsed ? 'Expand panel' : 'Collapse panel'}
-                  onClick={() => setCollapsed(!collapsed)}
-                >
-                  {collapsed ? <ChevronsUpDownIcon /> : <ChevronsDownUpIcon />}
-                </Button>
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <DataPanel.Heading>
+                Trace <b># {truncateString(traceId, 12)}</b>
+              </DataPanel.Heading>
+              {!collapsed && rootSpan && (
+                <TraceSummaryDescription
+                  rootSpan={rootSpan}
+                  usage={usage}
+                  entityHref={entityHref}
+                  LinkComponent={LinkComponent}
+                />
               )}
-              {onEvaluateTrace && (
-                <Button size="md" tooltip="Evaluate trace" aria-label="Evaluate trace" onClick={onEvaluateTrace}>
-                  <CircleGaugeIcon />
-                </Button>
-              )}
-              {onSaveAsDatasetItem && (
-                <Button
-                  size="md"
-                  tooltip="Add full trace to dataset"
-                  aria-label="Add full trace to dataset"
-                  onClick={() => onSaveAsDatasetItem({ traceId, rootSpanId: rootSpan?.spanId })}
-                >
-                  <SaveIcon />
-                </Button>
-              )}
-              {onAddTraceMocksToItem && (
-                <Button
-                  size="md"
-                  tooltip="Add tool mocks to item"
-                  aria-label="Add tool mocks to item"
-                  onClick={() => onAddTraceMocksToItem({ traceId })}
-                >
-                  <WrenchIcon />
-                </Button>
-              )}
+            </div>
+            <ButtonsGroup className="ml-auto shrink-0 self-start">
+              {traceActionsMenu}
               {(onPrevious || onNext) && (
                 <DataPanel.NextPrevNav
                   onPrevious={onPrevious}
@@ -269,18 +277,6 @@ export function TraceDataPanelView({
                   nextLabel="Next trace"
                 />
               )}
-              {showOpenTracePageLink && (
-                <Button
-                  as={LinkComponent}
-                  href={traceHref}
-                  size="md"
-                  tooltip="Open trace page"
-                  aria-label="Open trace page"
-                >
-                  <Link2Icon />
-                </Button>
-              )}
-              {downloadTraceButton}
               <DataPanel.CloseButton onClick={onClose} />
             </ButtonsGroup>
           </>
@@ -298,10 +294,6 @@ export function TraceDataPanelView({
               {(() => {
                 const detailsBody = (
                   <>
-                    {!isOnTracePage && rootSpan && (
-                      <TraceKeysAndValues rootSpan={rootSpan} usage={isSubtrace ? undefined : usage} className="mb-6" />
-                    )}
-
                     {!isOnTracePage &&
                       !onEvaluateTrace &&
                       !onSaveAsDatasetItem &&
@@ -360,7 +352,7 @@ export function TraceDataPanelView({
                     }
                   >
                     <TabList variant="pill-ghost" className="px-0">
-                      <Tab value="details">Details</Tab>
+                      <Tab value="details">Spans</Tab>
                       {scoresTabSlot && (
                         <Tab value="scores">Evaluations {scoresTabBadge != null && <>({scoresTabBadge})</>}</Tab>
                       )}

--- a/packages/playground-ui/src/domains/traces/components/trace-summary-description.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-summary-description.tsx
@@ -1,0 +1,145 @@
+import {
+  ArrowDownToLineIcon,
+  ArrowUpFromLineIcon,
+  CalendarClockIcon,
+  CircleDollarSignIcon,
+  ExternalLinkIcon,
+  TimerIcon,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
+import type { TraceUsageSummary } from '../trace-list-columns';
+import {
+  formatSpanDuration,
+  formatSpanDurationExact,
+  formatSpanTimestamp,
+  formatSpanTimestampExact,
+} from '../utils/span-utils';
+import { formatCompact, formatCost } from '@/domains/metrics/components/metrics-utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
+import { AgentIcon, WorkflowIcon } from '@/ds/icons';
+import type { LinkComponent } from '@/ds/types/link-component';
+import { cn } from '@/lib/utils';
+
+function formatEntityType(entityType: string): string {
+  return entityType
+    .split('_')
+    .map(word => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+    .join(' ');
+}
+
+/** Lightweight root-span fields available from `useTraceLightSpans`. */
+type RootSpanSummary = {
+  entityId?: string | null;
+  entityName?: string | null;
+  entityType?: string | null;
+  startedAt: Date | string;
+  endedAt?: Date | string | null;
+};
+
+export interface TraceSummaryDescriptionProps {
+  rootSpan: RootSpanSummary;
+  usage?: TraceUsageSummary;
+  /** When provided (with `LinkComponent`), the entity name links to the entity's page. */
+  entityHref?: string;
+  LinkComponent?: LinkComponent;
+  className?: string;
+}
+
+function SummaryItem({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          tabIndex={0}
+          className="flex shrink-0 cursor-help items-center gap-1 whitespace-nowrap"
+          aria-label={label}
+        >
+          {children}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** Compact trace metadata shown under the trace side-panel heading. */
+export function TraceSummaryDescription({
+  rootSpan,
+  usage,
+  entityHref,
+  LinkComponent,
+  className,
+}: TraceSummaryDescriptionProps) {
+  const startedAt = rootSpan.startedAt ? new Date(rootSpan.startedAt) : null;
+  const endedAt = rootSpan.endedAt ? new Date(rootSpan.endedAt) : null;
+  const duration = formatSpanDuration(startedAt, endedAt);
+  const exactDuration = formatSpanDurationExact(startedAt, endedAt);
+  const startedAtTimestamp = formatSpanTimestamp(startedAt);
+  const exactStartedAtTimestamp = formatSpanTimestampExact(startedAt);
+
+  const entityName = rootSpan.entityName || rootSpan.entityId;
+  const entityType = rootSpan.entityType;
+  const formattedEntityType = entityType ? formatEntityType(entityType) : 'Entity';
+  const EntityIcon = entityType?.includes('workflow') ? WorkflowIcon : AgentIcon;
+  const Link = LinkComponent ?? 'a';
+
+  return (
+    <div
+      className={cn(
+        'flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-ui-xs leading-ui-xs text-neutral3',
+        className,
+      )}
+    >
+      {entityName && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            {entityHref ? (
+              <Link
+                href={entityHref}
+                className="text-neutral4 hover:text-neutral5 flex shrink-0 items-center gap-1 whitespace-nowrap hover:underline"
+              >
+                <EntityIcon className="size-3.5 shrink-0" aria-hidden="true" />
+                <span>{entityName}</span>
+                <ExternalLinkIcon className="size-3 shrink-0" aria-hidden="true" />
+              </Link>
+            ) : (
+              <span tabIndex={0} className="flex shrink-0 cursor-help items-center gap-1 whitespace-nowrap">
+                <EntityIcon className="size-3.5 shrink-0" aria-hidden="true" />
+                <span>{entityName}</span>
+              </span>
+            )}
+          </TooltipTrigger>
+          <TooltipContent>{formattedEntityType}</TooltipContent>
+        </Tooltip>
+      )}
+      {startedAtTimestamp && exactStartedAtTimestamp && (
+        <SummaryItem label={`Started at ${exactStartedAtTimestamp}`}>
+          <CalendarClockIcon className="size-3.5 shrink-0" aria-hidden="true" />
+          <span>{startedAtTimestamp}</span>
+        </SummaryItem>
+      )}
+      {duration && exactDuration && (
+        <SummaryItem label={`Duration ${exactDuration}`}>
+          <TimerIcon className="size-3.5 shrink-0" aria-hidden="true" />
+          <span>{duration}</span>
+        </SummaryItem>
+      )}
+      {usage && (
+        <>
+          <SummaryItem label="Input tokens">
+            <ArrowDownToLineIcon className="size-3.5 shrink-0" aria-hidden="true" />
+            <span>{usage.inputTokens === undefined ? '—' : formatCompact(usage.inputTokens)}</span>
+          </SummaryItem>
+          <SummaryItem label="Output tokens">
+            <ArrowUpFromLineIcon className="size-3.5 shrink-0" aria-hidden="true" />
+            <span>{usage.outputTokens === undefined ? '—' : formatCompact(usage.outputTokens)}</span>
+          </SummaryItem>
+          <SummaryItem label="Estimated cost">
+            <CircleDollarSignIcon className="size-3.5 shrink-0" aria-hidden="true" />
+            <span>{usage.estimatedCost === undefined ? '—' : formatCost(usage.estimatedCost, usage.costUnit)}</span>
+          </SummaryItem>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/playground/src/domains/traces/components/__tests__/fixtures/trace-span-panel.ts
+++ b/packages/playground/src/domains/traces/components/__tests__/fixtures/trace-span-panel.ts
@@ -18,7 +18,15 @@ const baseSpan = {
   status: TraceStatus.SUCCESS,
 };
 
-export const rootSpan = { ...baseSpan, spanId: 'span-root', name: 'Root agent run', parentSpanId: null };
+export const rootSpan = {
+  ...baseSpan,
+  spanId: 'span-root',
+  name: 'Root agent run',
+  parentSpanId: null,
+  entityType: 'agent',
+  entityId: 'weather-agent',
+  entityName: 'Weather Agent',
+};
 export const childSpanOne = {
   ...baseSpan,
   spanId: 'span-child-1',

--- a/packages/playground/src/domains/traces/components/__tests__/trace-span-panel.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/trace-span-panel.msw.test.tsx
@@ -144,6 +144,42 @@ describe('TraceSpanPanel', () => {
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
   });
 
+  it('given an agent root span, then the trace summary shows the entity linked to its agent page, start time, duration, and a Spans tab', async () => {
+    installHandlers();
+    const { queryClient } = renderPanel();
+
+    expect(await screen.findByText(`# ${TRACE_ID}`)).not.toBeNull();
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+
+    // Entity block: type label + name linking to the agent page. ("Agent" also
+    // appears as the span-type badge in the tree, so allow multiple matches.)
+    expect(screen.getAllByText('Agent').length).toBeGreaterThan(0);
+    const entityLink = screen.getByRole('link', { name: /Weather Agent/ });
+    expect(entityLink.getAttribute('href')).toBe('/agents/weather-agent/chat/new');
+
+    // Start time + duration are shown; the old key-value rows are gone.
+    expect(screen.getByLabelText(/^Started at /)).not.toBeNull();
+    expect(screen.getByText('1.0s')).not.toBeNull();
+    expect(screen.queryByText('Status')).toBeNull();
+    expect(screen.queryByText('Ended at')).toBeNull();
+    // Tab labels ("Spans") only render when score/feedback slots are provided;
+    // that rendering is covered by the playground-ui unit tests.
+  });
+
+  it('given a workflow root span, then the entity links to its workflow graph', async () => {
+    installHandlers();
+    renderPanel({
+      spans: panelTraceSpans.spans.map(span =>
+        span.parentSpanId == null
+          ? { ...span, entityType: 'workflow_run', entityId: 'daily-report', entityName: 'Daily report' }
+          : span,
+      ),
+    });
+
+    const entityLink = await screen.findByRole('link', { name: /Daily report/ });
+    expect(entityLink.getAttribute('href')).toBe('/workflows/daily-report/graph');
+  });
+
   it('given anchorSpanId (branches mode), then the selected anchor span shows trace-level metadata', async () => {
     installHandlers();
     const { queryClient } = renderPanel({ anchorSpanId: 'span-child-1', initialSpanId: 'span-child-1' });

--- a/packages/playground/src/domains/traces/components/trace-span-panel.tsx
+++ b/packages/playground/src/domains/traces/components/trace-span-panel.tsx
@@ -8,6 +8,14 @@ import { TraceDataPanel } from '@/domains/traces/components/trace-data-panel';
 import { Link } from '@/lib/link';
 
 type TraceDataPanelViewProps = ComponentProps<typeof TraceDataPanelView>;
+
+function getEntityHref(entityType: string | null | undefined, entityId: string | null | undefined) {
+  if (!entityId || !entityType) return undefined;
+  const normalizedEntityType = entityType.toLowerCase();
+  if (normalizedEntityType.includes('workflow')) return `/workflows/${encodeURIComponent(entityId)}/graph`;
+  if (normalizedEntityType.includes('agent')) return `/agents/${encodeURIComponent(entityId)}/chat/new`;
+  return undefined;
+}
 type SpanDataPanelViewProps = ComponentProps<typeof SpanDataPanelView>;
 
 export interface TraceSpanPanelProps {
@@ -23,7 +31,6 @@ export interface TraceSpanPanelProps {
   onSpanClose?: () => void;
 
   // Trace-panel pass-through.
-  usage?: TraceDataPanelViewProps['usage'];
   anchorSpanId?: string;
   initialSpanId?: string | null;
   onPrevious?: () => void;
@@ -34,6 +41,7 @@ export interface TraceSpanPanelProps {
   feedbackTabSlot?: TraceDataPanelViewProps['feedbackTabSlot'];
   scoresTabBadge?: ReactNode;
   scoresTabSlot?: TraceDataPanelViewProps['scoresTabSlot'];
+  usage?: TraceDataPanelViewProps['usage'];
   traceHref?: string;
   className?: string;
 
@@ -58,7 +66,6 @@ export function TraceSpanPanel({
   onSpanSelect,
   onClose,
   onSpanClose,
-  usage,
   anchorSpanId,
   initialSpanId,
   onPrevious,
@@ -69,6 +76,7 @@ export function TraceSpanPanel({
   feedbackTabSlot,
   scoresTabBadge,
   scoresTabSlot,
+  usage,
   traceHref,
   className,
   spanActiveTab,
@@ -80,13 +88,20 @@ export function TraceSpanPanel({
   const { data: spanDetailData, isLoading: isLoadingSpanDetail } = useSpanDetail(traceId, selectedSpanId ?? '');
   const { handlePreviousSpan, handleNextSpan } = useTraceSpanNavigation(spans, selectedSpanId, onSpanSelect);
 
+  // The trace summary links the entity to its Studio page; only Studio knows the routes.
+  const rootSpan = anchorSpanId
+    ? spans?.find(s => s.spanId === anchorSpanId)
+    : spans?.find(s => s.parentSpanId == null);
+  const entityHref = getEntityHref(rootSpan?.entityType, rootSpan?.entityId);
+
   return (
     <TraceDataPanel
       className={className}
       traceId={traceId}
       spans={spans}
-      usage={usage}
       anchorSpanId={anchorSpanId}
+      entityHref={entityHref}
+      usage={usage}
       isLoading={isLoadingSpans}
       onClose={onClose}
       onSpanSelect={onSpanSelect}

--- a/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
+++ b/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
@@ -102,7 +102,7 @@ describe('Traces page usage columns', () => {
       expect(screen.getByText('Input tokens')).not.toBeNull();
     });
 
-    it('reuses list usage data for a selected trace', async () => {
+    it('keeps usage totals in the trace list when a trace is selected', async () => {
       setTracePageHandlers(metricsCapableSystemPackages);
       server.use(
         http.get(`${TEST_BASE_URL}/api/observability/traces`, () => HttpResponse.json(traceListWithTwoTraces)),
@@ -111,11 +111,11 @@ describe('Traces page usage columns', () => {
         http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
       );
 
-      const { queryClient } = renderPage('/traces?traceId=trace-a');
+      renderPage('/traces?traceId=trace-a');
 
-      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
-      expect(onBreakdownRequest).toHaveBeenCalledTimes(1);
-      expect(screen.getByText('Trace est. cost')).not.toBeNull();
+      await waitFor(() => expect(onBreakdownRequest).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.getAllByText('Input tokens')).toHaveLength(1));
+      expect(screen.queryByText('Est. cost')).toBeNull();
     });
   });
 
@@ -132,7 +132,7 @@ describe('Traces page usage columns', () => {
   });
 
   describe('when a trace is opened from a direct link', () => {
-    it('shows the trace cost when the trace is outside the loaded list', async () => {
+    it('does not request or show usage in the side panel when usage columns are hidden', async () => {
       window.localStorage.setItem(
         TRACE_COLUMN_STORAGE_KEY,
         serializeTraceColumnPreferences({ visibleColumns: [], metadataKeys: [] }),
@@ -149,16 +149,17 @@ describe('Traces page usage columns', () => {
         http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
       );
 
-      renderPage('/traces?traceId=trace-a');
+      const { queryClient } = renderPage('/traces?traceId=trace-a');
 
-      await waitFor(() => expect(onBreakdownRequest).toHaveBeenCalled());
-      expect(await screen.findByText('Trace est. cost')).not.toBeNull();
-      expect(await screen.findByText('$0.0010')).not.toBeNull();
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+      expect(onBreakdownRequest).not.toHaveBeenCalled();
+      expect(screen.queryByText('Input tokens')).toBeNull();
+      expect(screen.queryByText('Est. cost')).toBeNull();
     });
   });
 
   describe('when Branches mode is selected', () => {
-    it('shows trace totals for a root trace panel', async () => {
+    it('does not show trace totals in a root trace panel', async () => {
       setTracePageHandlers(metricsCapableSystemPackages);
       server.use(
         http.get(`${TEST_BASE_URL}/api/observability/branches`, () => HttpResponse.json(rootBranchList)),
@@ -168,11 +169,11 @@ describe('Traces page usage columns', () => {
         http.get(`${TEST_BASE_URL}/api/observability/feedback`, () => HttpResponse.json(emptyFeedback)),
       );
 
-      renderPage('/traces?listMode=branches&traceId=trace-a&anchorSpanId=span-a');
+      const { queryClient } = renderPage('/traces?listMode=branches&traceId=trace-a&anchorSpanId=span-a');
 
-      await waitFor(() => expect(onBreakdownRequest).toHaveBeenCalled());
-      expect(await screen.findByText('Trace est. cost')).not.toBeNull();
-      expect(await screen.findByText('$0.0010')).not.toBeNull();
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+      expect(screen.queryByText('Trace est. cost')).toBeNull();
+      expect(onBreakdownRequest).not.toHaveBeenCalled();
     });
 
     it('suppresses usage columns and metric requests', async () => {

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -210,10 +210,6 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
         visibleColumns: traceColumns.preferences.visibleColumns.filter(column => !isTraceUsageColumn(column)),
       }
     : traceColumns.preferences;
-  const selectedBranchAnchor =
-    url.listMode === 'branches' && anchorSpanId ? traceSpans?.find(span => span.spanId === anchorSpanId) : undefined;
-  const canShowSelectedTraceUsage =
-    url.listMode === 'traces' || (selectedBranchAnchor !== undefined && selectedBranchAnchor.parentSpanId == null);
   const listUsageEnabled =
     !usageColumnsUnavailable && !observabilityCapabilities.isLoading && hasTraceUsageColumn(displayedColumnPreferences);
   const traceUsage = useTraceUsage({
@@ -221,27 +217,19 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
     enabled: listUsageEnabled,
     autoRefetch: autoRefetchTraces,
   });
-  const selectedTraceId = url.traceIdParam;
-  const selectedTraceCoveredByListUsage =
-    canShowSelectedTraceUsage &&
-    selectedTraceId !== undefined &&
-    listUsageEnabled &&
-    traces.some(trace => trace.traceId === selectedTraceId);
-  const selectedTraceUsageFromList = selectedTraceId ? traceUsage.data?.get(selectedTraceId) : undefined;
-  const selectedTraceNeedsOwnQuery =
-    canShowSelectedTraceUsage &&
-    selectedTraceId !== undefined &&
-    (!selectedTraceCoveredByListUsage ||
-      (!traceUsage.isFetching && traceUsage.data !== undefined && !traceUsage.data.has(selectedTraceId)));
-  // Fetch independently when the list query cannot supply the selected trace,
-  // such as when usage columns are hidden or a direct link is outside the loaded page.
+  const selectedTraceUsesListQuery = listUsageEnabled && traces.some(trace => trace.traceId === url.traceIdParam);
   const selectedTraceUsage = useTraceUsage({
-    traceIds: selectedTraceNeedsOwnQuery && selectedTraceId ? [selectedTraceId] : [],
+    traceIds: url.traceIdParam ? [url.traceIdParam] : [],
     enabled:
-      selectedTraceNeedsOwnQuery && !observabilityCapabilities.isLoading && observabilityCapabilities.supportsMetrics,
+      url.listMode === 'traces' &&
+      !observabilityCapabilities.isLoading &&
+      observabilityCapabilities.supportsMetrics &&
+      !selectedTraceUsesListQuery,
     autoRefetch: autoRefetchTraces,
   });
-
+  const selectedTraceUsageSummary = url.traceIdParam
+    ? (traceUsage.data?.get(url.traceIdParam) ?? selectedTraceUsage.data?.get(url.traceIdParam))
+    : undefined;
   // Storage providers that don't implement `listBranches` throw a known MastraError. When that
   // surfaces in branches mode, treat the provider as branches-incapable for the rest of the
   // session: flip the URL back to traces mode so the next query succeeds, and remove the
@@ -463,12 +451,8 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
               key={`${url.traceIdParam}:${url.anchorSpanIdParam ?? ''}`}
               traceId={url.traceIdParam}
               spans={traceSpans}
-              usage={
-                canShowSelectedTraceUsage
-                  ? (selectedTraceUsageFromList ?? selectedTraceUsage.data?.get(url.traceIdParam))
-                  : undefined
-              }
               anchorSpanId={anchorSpanId}
+              usage={selectedTraceUsageSummary}
               isLoadingSpans={isLoadingTraceSpans}
               selectedSpanId={url.spanIdParam ?? null}
               onClose={url.handleTraceClose}


### PR DESCRIPTION
Summary: Redesigns the trace side-panel header with compact wrapping metadata, canonical entity links, token and cost details, and an accessible dropdown for secondary actions. Previous/next navigation and close remain directly available, while the trace page keeps its detailed metadata and usage behavior.\n\nTest plan: Ran the focused playground-ui trace summary and data-panel tests, playground trace panel and traces-page MSW tests, package typechecks, oxlint, ESLint, Prettier, and git diff checks.