### PR TITLE
fix(playground): Fix playground form utility handling

### DIFF
--- a/packages/playground/src/lib/form/__tests__/utils.test.ts
+++ b/packages/playground/src/lib/form/__tests__/utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { removeEmptyValues } from '../utils';
+
+describe('removeEmptyValues', () => {
+  describe('when values include empty containers', () => {
+    it('removes empty plain objects and arrays', () => {
+      const plainObjectWithoutPrototype = Object.assign(Object.create(null), {
+        value: 'kept',
+      });
+
+      const cleaned = removeEmptyValues({
+        missing: null,
+        unset: undefined,
+        emptyArray: [],
+        emptyObject: {},
+        nested: {
+          emptyValue: '',
+        },
+        items: [{ emptyValue: '' }, null, { value: 'kept' }],
+        plainObjectWithoutPrototype,
+        populated: {
+          value: 'kept',
+        },
+      });
+
+      expect(cleaned).not.toHaveProperty('missing');
+      expect(cleaned).not.toHaveProperty('unset');
+      expect(Object.getPrototypeOf(cleaned.plainObjectWithoutPrototype)).toBe(Object.prototype);
+      expect(cleaned).toStrictEqual({
+        items: [{ value: 'kept' }],
+        plainObjectWithoutPrototype: {
+          value: 'kept',
+        },
+        populated: {
+          value: 'kept',
+        },
+      });
+    });
+  });
+
+  describe('when values include non-plain objects', () => {
+    it('preserves them instead of treating them as empty plain objects', () => {
+      const startDate = new Date('2026-09-02T00:00:00.000Z');
+      const metadata = new Map([['source', 'playground']]);
+
+      expect(
+        removeEmptyValues({
+          startDate,
+          metadata,
+          nested: {
+            uploadedAt: startDate,
+          },
+          entries: [{ value: startDate }, metadata],
+        }),
+      ).toEqual({
+        startDate,
+        metadata,
+        nested: {
+          uploadedAt: startDate,
+        },
+        entries: [{ value: startDate }, metadata],
+      });
+    });
+  });
+});

--- a/packages/playground/src/lib/form/utils.ts
+++ b/packages/playground/src/lib/form/utils.ts
@@ -10,17 +10,24 @@ export const fieldConfig: FieldConfig = buildZodFieldConfig<
   }
 >();
 
+function isPlainObject(value: unknown): value is Record<string, any> {
+  if (value === null || typeof value !== 'object') return false;
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
 export function removeEmptyValues<T extends Record<string, any>>(values: T): Partial<T> {
   const result: Partial<T> = {};
   for (const key in values) {
     const value = values[key];
-    if ([null, undefined, '', [], {}].includes(value)) {
+    if (value === null || value === undefined || value === '') {
       continue;
     }
 
     if (Array.isArray(value)) {
       const newArray = value.map((item: any) => {
-        if (typeof item === 'object') {
+        if (isPlainObject(item)) {
           const cleanedItem = removeEmptyValues(item);
           if (Object.keys(cleanedItem).length > 0) {
             return cleanedItem;
@@ -33,7 +40,7 @@ export function removeEmptyValues<T extends Record<string, any>>(values: T): Par
       if (filteredArray.length > 0) {
         result[key] = filteredArray;
       }
-    } else if (typeof value === 'object') {
+    } else if (isPlainObject(value)) {
       const cleanedValue = removeEmptyValues(value);
       if (Object.keys(cleanedValue).length > 0) {
         result[key] = cleanedValue as any;


### PR DESCRIPTION
## Summary

Fixes the form utility behavior described in #22736 and adds regression coverage for the affected case.

### Changes

* Updated `packages/playground/src/lib/form/utils.ts` to correctly handle the affected form utility behavior.
* Added tests covering the regression in `packages/playground/src/lib/form/__tests__/utils.test.ts`.

### Testing

* Added regression tests for the affected behavior.
* Verified the existing form utility behavior remains intact.

## Related Issue

Closes #22736
