### PR TITLE
fix(factory): session activity refreshes on project stream frames, polls slow under the stream

### DIFF
--- a/.changeset/quiet-frames-hum.md
+++ b/.changeset/quiet-frames-hum.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed session activity lagging behind reality. The server now announces every run start and end, every decision transition, and every workspace materialization on the project feed stream, so board cards, sidebar rows, and the open chat refresh the moment something happens instead of waiting on the next poll. Every poll slows to one safety tick per 30 seconds while the stream is connected, and resumes its full cadence the moment the stream drops.

--- a/mastracode/factory-ui/e2e/ui/feed-stream.ts
+++ b/mastracode/factory-ui/e2e/ui/feed-stream.ts
@@ -35,6 +35,10 @@ export function pushableFeedStream(factoryProjectId: string) {
       const data = JSON.stringify(workItemId ? { workItemId } : {});
       controller?.enqueue(encoder.encode(`event: feed\ndata: ${data}\n\n`));
     },
+    pushRun(sessionId: string) {
+      const data = JSON.stringify({ sessionId });
+      controller?.enqueue(encoder.encode(`event: feed\ndata: ${data}\n\n`));
+    },
     close() {
       controller?.close();
       controller = undefined;

--- a/mastracode/factory-ui/src/api/keys.ts
+++ b/mastracode/factory-ui/src/api/keys.ts
@@ -74,6 +74,7 @@ export const queryKeys = {
   factoryAudit: (githubProjectId: string | undefined, group: string, actorKey?: string) =>
     ['factory', 'audit', githubProjectId ?? null, group, actorKey ?? null] as const,
   factoryAuditPortal: () => ['factory', 'audit-portal'] as const,
+  sessionsRoot: () => ['sessions'] as const,
   sessions: (projectRepositoryId: string | undefined) => ['sessions', projectRepositoryId ?? null] as const,
   workspaces: (projectRepositoryId: string | undefined) => ['sessions', projectRepositoryId ?? null] as const,
   userSession: (sessionId: string | undefined) => ['user-session', sessionId ?? null] as const,

--- a/mastracode/factory-ui/src/hooks/useActiveRunResources.ts
+++ b/mastracode/factory-ui/src/hooks/useActiveRunResources.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
 import { createAgentControllerClient, requireAgentController } from '../ui/domains/chat/services/agentControllerClient';
+import { useFeedPollInterval } from '../ui/domains/factory/context/FeedEventsProvider';
 
 interface ActiveRunResourcesOptions {
   agentControllerId: string;
@@ -11,14 +12,16 @@ interface ActiveRunResourcesOptions {
 
 /**
  * Which of the given resources have a run in flight. `/active-runs` returns the
- * controller's whole registry, so every caller shares one poll — workspaces and
- * user sessions alike, both keyed by their own sessionId as resourceId.
+ * controller's whole registry, so every caller shares one cache — workspaces
+ * and user sessions alike, both keyed by their own sessionId as resourceId.
+ * The feed stream announces every run start and end.
  */
 export function useActiveRunResources({
   agentControllerId,
   resourceIds,
 }: ActiveRunResourcesOptions): Record<string, boolean> {
   const { baseUrl } = useApiConfig();
+  const refetchInterval = useFeedPollInterval(5_000);
   const query = useQuery({
     queryKey: queryKeys.agentControllerActivity(agentControllerId, baseUrl),
     queryFn: async () => {
@@ -26,7 +29,7 @@ export function useActiveRunResources({
       return requireAgentController(controller).listActiveRuns();
     },
     enabled: resourceIds.length > 0,
-    refetchInterval: 5_000,
+    refetchInterval,
     retry: false,
   });
   const running = new Set((query.data ?? []).map(run => run.resourceId));

--- a/mastracode/factory-ui/src/hooks/useFactoryAttention.ts
+++ b/mastracode/factory-ui/src/hooks/useFactoryAttention.ts
@@ -2,7 +2,7 @@ import { skipToken, useInfiniteQuery, useMutation, useQuery, useQueryClient } fr
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
-import { useFeedEventsConnected } from '../ui/domains/factory/context/FeedEventsProvider';
+import { useFeedPollInterval } from '../ui/domains/factory/context/FeedEventsProvider';
 import {
   fetchFactoryAttention,
   markAllFactoryAttentionRead,
@@ -25,13 +25,14 @@ export function useFactoryAttention(
   tier?: FactoryAttentionTier,
 ) {
   const { baseUrl } = useApiConfig();
+  const refetchInterval = useFeedPollInterval(ATTENTION_POLL_MS);
   return useQuery({
     queryKey: queryKeys.factoryAttention(factoryProjectId, view, limit, tier),
     queryFn: factoryProjectId
       ? ({ signal }) =>
           fetchFactoryAttention(baseUrl, factoryProjectId, { view, limit, signal, ...(tier ? { tier } : {}) })
       : skipToken,
-    refetchInterval: ATTENTION_POLL_MS,
+    refetchInterval,
     staleTime: 2_000,
   });
 }
@@ -42,7 +43,7 @@ export function useFactoryAttentionHistory(
   search: string,
 ) {
   const { baseUrl } = useApiConfig();
-  const connected = useFeedEventsConnected();
+  const refetchInterval = useFeedPollInterval(ATTENTION_POLL_MS);
   const initialPageParam: string | undefined = undefined;
   const queryFn = factoryProjectId
     ? ({ pageParam, signal }: { pageParam: string | undefined; signal: AbortSignal }) =>
@@ -53,9 +54,7 @@ export function useFactoryAttentionHistory(
     queryFn,
     initialPageParam,
     getNextPageParam: lastPage => lastPage.nextCursor,
-    // The stream announces every attention change; the poll only bridges
-    // the window where no stream is up.
-    refetchInterval: connected ? false : ATTENTION_POLL_MS,
+    refetchInterval,
     staleTime: 2_000,
   });
 }

--- a/mastracode/factory-ui/src/hooks/useFactoryDecisions.ts
+++ b/mastracode/factory-ui/src/hooks/useFactoryDecisions.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tansta
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
+import { useFeedPollInterval } from '../ui/domains/factory/context/FeedEventsProvider';
 import { actOnFactoryDecision, fetchFactoryDecisions } from '../ui/domains/factory/services/decisions';
 import type {
   FactoryDecisionAction,
@@ -12,11 +13,12 @@ import type {
 export function useFactoryDecisionStatus(githubProjectId: string | undefined, statuses: FactoryDecisionStatus[]) {
   const { baseUrl } = useApiConfig();
   const statusKey = statuses.join(',');
+  const refetchInterval = useFeedPollInterval(2_000);
   return useQuery({
     queryKey: queryKeys.factoryDecisions(githubProjectId, statusKey),
     queryFn: () => fetchFactoryDecisions(baseUrl, githubProjectId!, { statuses, limit: 50 }),
     enabled: Boolean(githubProjectId),
-    refetchInterval: 2_000,
+    refetchInterval,
     staleTime: 1_000,
   });
 }

--- a/mastracode/factory-ui/src/hooks/useWorkspaces.ts
+++ b/mastracode/factory-ui/src/hooks/useWorkspaces.ts
@@ -12,6 +12,7 @@ import { useNavigate, useParams } from 'react-router';
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
+import { useFeedPollInterval } from '../ui/domains/factory/context/FeedEventsProvider';
 import { stripCachedSessionRefs } from './useWorkItems';
 import {
   createUserSession,
@@ -141,11 +142,10 @@ const UNMATERIALIZED_POLL_MS = 15_000;
 const UNMATERIALIZED_POLL_WINDOW_MS = 10 * 60_000;
 
 /**
- * Poll gently while any listed session has not been materialized yet. The
- * sidebar status dots derive "initializing" from `materializedAt`, which the
- * server stamps out-of-band (the session's first command, or another tab) —
- * with no poll the cached `null` never resolved and dots wedged on
- * "initializing".
+ * With no feed stream, poll gently while any listed session has not been
+ * materialized yet: the sidebar status dots derive "initializing" from
+ * `materializedAt`, which the server stamps out-of-band and announces with a
+ * session frame.
  */
 export function sessionsRefetchInterval(data: WorkspacesData | undefined, now = Date.now()): number | false {
   if (!data) return false;
@@ -157,12 +157,13 @@ export function sessionsRefetchInterval(data: WorkspacesData | undefined, now = 
 
 export function useWorkspacesQuery(projectRepositoryId: string | undefined) {
   const { baseUrl } = useApiConfig();
+  const streamedPollMs = useFeedPollInterval(false);
   return useQuery({
     queryKey: queryKeys.sessions(projectRepositoryId),
     queryFn: projectRepositoryId
       ? ({ signal }): Promise<WorkspacesData> => loadWorkspaces(baseUrl, projectRepositoryId, signal)
       : skipToken,
-    refetchInterval: query => sessionsRefetchInterval(query.state.data),
+    refetchInterval: query => streamedPollMs || sessionsRefetchInterval(query.state.data),
   });
 }
 

--- a/mastracode/factory-ui/src/ui/domains/factory/context/FeedEventsProvider.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/context/FeedEventsProvider.tsx
@@ -1,10 +1,11 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import { useApiConfig } from '../../../../api/config';
 import { queryKeys } from '../../../../api/keys';
 import { useDocumentVisible } from '../../../lib/hooks/useDocumentVisible';
+import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 import { streamFeedEvents } from '../services/feedEvents';
 import { RequestError } from '../services/request';
 
@@ -17,10 +18,19 @@ export function useFeedEventsConnected(): boolean {
   return useContext(FeedEventsContext);
 }
 
+const FEED_FALLBACK_POLL_MS = 30_000;
+
+/** Under a live stream frames drive refresh; the slow tick only heals a frame that never arrived. */
+export function useFeedPollInterval<T extends number | false>(noStreamMs: T): number | T {
+  return useFeedEventsConnected() ? FEED_FALLBACK_POLL_MS : noStreamMs;
+}
+
 /**
  * Holds the project's feed stream for every surface under the factory route.
- * A frame carries a work item id at most; the queries it invalidates refetch
- * through their own authed GET.
+ * Three frame kinds: a session frame (run started/ended, workspace
+ * materialized) refreshes session-scoped truths, a work-item frame refreshes
+ * its comments, and a plain frame refreshes the attention and decision
+ * projections. The queries refetch through their own authed GET.
  */
 export function FeedEventsProvider({ factoryProjectId, children }: { factoryProjectId: string; children: ReactNode }) {
   const { baseUrl } = useApiConfig();
@@ -29,6 +39,10 @@ export function FeedEventsProvider({ factoryProjectId, children }: { factoryProj
   // per host, so a few background tabs starve every other request to the app.
   const visible = useDocumentVisible();
   const [connected, setConnected] = useState(false);
+  // Frames can only have been missed after a stream was lost (drop, hidden
+  // tab, failed attempt). The first connect lands right after the queries'
+  // own initial fetches, where a blanket refresh would only duplicate them.
+  const streamWasLost = useRef(false);
 
   useEffect(() => {
     if (!visible) return;
@@ -38,25 +52,43 @@ export function FeedEventsProvider({ factoryProjectId, children }: { factoryProj
 
     const refreshAttention = () =>
       void queryClient.invalidateQueries({ queryKey: queryKeys.factoryAttentionRoot(factoryProjectId) });
+    const refreshRunActivity = () =>
+      void queryClient.invalidateQueries({ queryKey: queryKeys.agentControllerActivity(AGENT_CONTROLLER_ID, baseUrl) });
+    // The stream is scoped to the factory project, the sessions cache to a
+    // repository: without the repository id on the frame, refresh them all.
+    const refreshSessions = () => void queryClient.invalidateQueries({ queryKey: queryKeys.sessionsRoot() });
+    const refreshDecisions = () =>
+      void queryClient.invalidateQueries({ queryKey: queryKeys.factoryDecisionsRoot(factoryProjectId) });
 
     const connect = () => {
       streamFeedEvents(
         baseUrl,
         factoryProjectId,
         {
-          onEvent: ({ workItemId }) => {
-            // Card counts stay on the board's own 5s poll: a fetch per event
-            // would double its load to save under 5s of badge latency.
+          onEvent: ({ workItemId, sessionId }) => {
+            // A session frame moves session-scoped truths only; the attention
+            // and decision projections did not change.
+            if (sessionId) {
+              refreshRunActivity();
+              refreshSessions();
+              return;
+            }
             if (workItemId) {
               void queryClient.invalidateQueries({ queryKey: queryKeys.workItemCommentsRoot(workItemId) });
             }
             refreshAttention();
+            refreshDecisions();
           },
           onConnected: () => {
             setConnected(true);
+            if (!streamWasLost.current) return;
+            streamWasLost.current = false;
             // Whatever landed while this tab held no stream was never announced.
             void queryClient.invalidateQueries({ queryKey: queryKeys.workItemCommentsAll() });
             refreshAttention();
+            refreshRunActivity();
+            refreshSessions();
+            refreshDecisions();
           },
         },
         abort.signal,
@@ -64,6 +96,7 @@ export function FeedEventsProvider({ factoryProjectId, children }: { factoryProj
         .then(() => false)
         .catch((error: unknown) => error instanceof RequestError && error.status >= 400 && error.status < 500)
         .then(fatal => {
+          streamWasLost.current = true;
           if (abort.signal.aborted) return;
           setConnected(false);
           // An expired session or a deleted project never heals by retrying;
@@ -74,6 +107,7 @@ export function FeedEventsProvider({ factoryProjectId, children }: { factoryProj
     connect();
 
     return () => {
+      streamWasLost.current = true;
       abort.abort();
       if (retry) clearTimeout(retry);
       setConnected(false);

--- a/mastracode/factory-ui/src/ui/domains/factory/context/__tests__/FeedEventsProvider.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/factory/context/__tests__/FeedEventsProvider.msw.test.tsx
@@ -7,11 +7,16 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { pushableFeedStream } from '../../../../../../e2e/ui/feed-stream';
 import { server } from '../../../../../../e2e/ui/msw-server';
 import { renderHookWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../../../../e2e/ui/render';
+import { useActiveRunResources } from '../../../../../hooks/useActiveRunResources';
 import { useFactoryAttentionHistory } from '../../../../../hooks/useFactoryAttention';
+import { useFactoryDecisionStatus } from '../../../../../hooks/useFactoryDecisions';
 import { useWorkItemComments } from '../../../../../hooks/useWorkItemComments';
+import { useWorkspacesQuery } from '../../../../../hooks/useWorkspaces';
+import { AGENT_CONTROLLER_ID } from '../../../chat/services/constants';
 import { FeedEventsProvider, useFeedEventsConnected } from '../FeedEventsProvider';
 
 const PROJECT_ID = 'project-1';
+const REPOSITORY_ID = 'repository-1';
 const ITEM_ID = 'item-1';
 const COMMENTS_URL = `${TEST_BASE_URL}/web/factory/work-items/${ITEM_ID}/comments`;
 const ATTENTION_URL = `${TEST_BASE_URL}/web/factory/projects/${PROJECT_ID}/attention`;
@@ -28,10 +33,34 @@ function watch() {
     connected: useFeedEventsConnected(),
     comments: useWorkItemComments({ workItemId: ITEM_ID }),
     attention: useFactoryAttentionHistory(PROJECT_ID, 'open', ''),
+    activity: useActiveRunResources({ agentControllerId: AGENT_CONTROLLER_ID, resourceIds: ['session-1'] }),
+    sessions: useWorkspacesQuery(REPOSITORY_ID),
+    decisions: useFactoryDecisionStatus(PROJECT_ID, ['leased']),
   };
 }
 
-/** Connected, plus the catch-up refetch every fresh stream fires. */
+function countSessions(count: () => void) {
+  return http.get('*/web/github/projects/:projectRepositoryId/sessions', () => {
+    count();
+    return HttpResponse.json({ sessions: [] });
+  });
+}
+
+function countDecisions(count: () => void) {
+  return http.get(`${TEST_BASE_URL}/web/factory/projects/${PROJECT_ID}/decisions`, () => {
+    count();
+    return HttpResponse.json({ decisions: [] });
+  });
+}
+
+function countActivity(count: () => void) {
+  return http.get('*/api/agent-controller/:controllerId/active-runs', () => {
+    count();
+    return HttpResponse.json({ runs: [] });
+  });
+}
+
+/** Connected, with any in-flight refetches drained. */
 async function settle(rendered: { result: { current: { connected: boolean } }; client: QueryClient }): Promise<void> {
   await waitFor(() => expect(rendered.result.current.connected).toBe(true));
   await waitForMutationsIdle(rendered.client);
@@ -87,25 +116,84 @@ describe('FeedEventsProvider', () => {
     await waitFor(() => expect(attentionRequests).toBe(before.attention + 1));
   });
 
-  it('moves attention alone on a frame that names no work item', async () => {
+  it('moves attention and decisions on a frame that names no work item', async () => {
     const stream = pushableFeedStream(PROJECT_ID);
     let commentRequests = 0;
     let attentionRequests = 0;
+    let decisionRequests = 0;
     server.use(
       stream.handler,
       countComments(() => (commentRequests += 1)),
       countAttention(() => (attentionRequests += 1)),
+      countDecisions(() => (decisionRequests += 1)),
     );
 
     const rendered = renderHookWithProviders(watch, { inner });
     const { result } = rendered;
     await settle(rendered);
-    const before = { comments: commentRequests, attention: attentionRequests };
+    const before = { comments: commentRequests, attention: attentionRequests, decisions: decisionRequests };
 
     stream.push();
     await waitFor(() => expect(attentionRequests).toBe(before.attention + 1));
+    await waitFor(() => expect(decisionRequests).toBe(before.decisions + 1));
     // No work item is named, so no comment feed has a reason to move.
     expect(commentRequests).toBe(before.comments);
+  });
+
+  it('refetches the run registry and the sessions list alone on a session frame', async () => {
+    const stream = pushableFeedStream(PROJECT_ID);
+    let attentionRequests = 0;
+    let activityRequests = 0;
+    let sessionsRequests = 0;
+    let decisionRequests = 0;
+    server.use(
+      stream.handler,
+      countAttention(() => (attentionRequests += 1)),
+      countActivity(() => (activityRequests += 1)),
+      countSessions(() => (sessionsRequests += 1)),
+      countDecisions(() => (decisionRequests += 1)),
+    );
+
+    const rendered = renderHookWithProviders(watch, { inner });
+    await settle(rendered);
+    const before = {
+      attention: attentionRequests,
+      activity: activityRequests,
+      sessions: sessionsRequests,
+      decisions: decisionRequests,
+    };
+
+    stream.pushRun('session-1');
+    await waitFor(() => expect(activityRequests).toBe(before.activity + 1));
+    // The stamped session row must be re-read too: attention marks and the
+    // initializing state derive from it.
+    await waitFor(() => expect(sessionsRequests).toBe(before.sessions + 1));
+    // A session frame moves session truths only; the attention inbox and the
+    // decision projection did not change.
+    expect(attentionRequests).toBe(before.attention);
+    expect(decisionRequests).toBe(before.decisions);
+  });
+
+  it('stays quiet on the first connect — the mount fetches are already fresh', async () => {
+    const stream = pushableFeedStream(PROJECT_ID);
+    let commentRequests = 0;
+    let attentionRequests = 0;
+    let sessionsRequests = 0;
+    server.use(
+      stream.handler,
+      countComments(() => (commentRequests += 1)),
+      countAttention(() => (attentionRequests += 1)),
+      countSessions(() => (sessionsRequests += 1)),
+    );
+
+    const rendered = renderHookWithProviders(watch, { inner });
+    await settle(rendered);
+
+    // One fetch per query mount, none added by the connect: a refresh here
+    // would duplicate them and burn error retries app-wide.
+    expect(commentRequests).toBe(1);
+    expect(attentionRequests).toBe(1);
+    expect(sessionsRequests).toBe(1);
   });
 
   it('leaves another work item alone', async () => {

--- a/mastracode/factory-ui/src/ui/domains/factory/services/feedEvents.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/feedEvents.ts
@@ -5,6 +5,8 @@ import { RequestError } from './request';
 export interface FeedEvent {
   /** Absent when the project's attention moved but no work item's comments did. */
   workItemId?: string;
+  /** A run started or ended on this session: the run registry has news. */
+  sessionId?: string;
 }
 
 export async function streamFeedEvents(
@@ -26,6 +28,9 @@ export async function streamFeedEvents(
     if (event !== 'feed') return;
     const parsed: unknown = JSON.parse(data);
     if (!isRecord(parsed)) return;
-    handlers.onEvent(typeof parsed.workItemId === 'string' ? { workItemId: parsed.workItemId } : {});
+    handlers.onEvent({
+      ...(typeof parsed.workItemId === 'string' ? { workItemId: parsed.workItemId } : {}),
+      ...(typeof parsed.sessionId === 'string' ? { sessionId: parsed.sessionId } : {}),
+    });
   });
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/RunEndObserver.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/RunEndObserver.tsx
@@ -1,7 +1,5 @@
-import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
-import { queryKeys } from '../../../../api/keys';
 import { useActiveRunResources } from '../../../../hooks/useActiveRunResources';
 import { allSessionRows, useWorkspacesQuery } from '../../../../hooks/useWorkspaces';
 import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
@@ -13,9 +11,8 @@ export function resetRunEndObserverForTests(): void {
   runningBySession.clear();
 }
 
-/** A run this tab watched in flight ended: ring the done sound, refetch the sessions list it may have materialized. */
+/** Rings the done sound when a run this tab watched in flight ends. */
 export function RunEndObserver({ projectRepositoryId }: { projectRepositoryId: string | undefined }) {
-  const queryClient = useQueryClient();
   const { data } = useWorkspacesQuery(projectRepositoryId);
   const running = useActiveRunResources({
     agentControllerId: AGENT_CONTROLLER_ID,
@@ -28,10 +25,8 @@ export function RunEndObserver({ projectRepositoryId }: { projectRepositoryId: s
       if (runningBySession.get(sessionId) === true && !isRunning) runEnded = true;
       runningBySession.set(sessionId, isRunning);
     }
-    if (!runEnded) return;
-    playDoneSound();
-    void queryClient.invalidateQueries({ queryKey: queryKeys.sessions(projectRepositoryId) });
-  }, [running, queryClient, projectRepositoryId]);
+    if (runEnded) playDoneSound();
+  }, [running]);
 
   return null;
 }

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/RunEndObserver.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/RunEndObserver.msw.test.tsx
@@ -48,19 +48,16 @@ const session: FactoryUserSession = {
 };
 
 function stubRegistry(running: () => boolean) {
-  const sessionsList = { requests: 0 };
   server.use(
-    http.get(`${TEST_BASE_URL}/web/github/projects/${REPOSITORY_ID}/sessions`, () => {
-      sessionsList.requests += 1;
-      return HttpResponse.json({ sessions: [session] });
-    }),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPOSITORY_ID}/sessions`, () =>
+      HttpResponse.json({ sessions: [session] }),
+    ),
     http.get(`${TEST_BASE_URL}/api/agent-controller/${AGENT_CONTROLLER_ID}/active-runs`, () =>
       HttpResponse.json({
         runs: running() ? [{ runId: 'run-1', resourceId: SESSION_ID, threadId: SESSION_ID }] : [],
       }),
     ),
   );
-  return sessionsList;
 }
 
 async function refetchRegistry(client: QueryClient) {
@@ -76,27 +73,23 @@ beforeEach(() => {
 });
 
 describe('RunEndObserver', () => {
-  it('rings and refetches the sessions list once when a run it watched in flight ends', async () => {
+  it('rings once when a run it watched in flight ends, never on mount or on an idle refetch', async () => {
     let running = false;
-    const sessionsList = stubRegistry(() => running);
+    stubRegistry(() => running);
     const { client } = renderWithProviders(<RunEndObserver projectRepositoryId={REPOSITORY_ID} />);
     await waitForMutationsIdle(client);
-    expect(sessionsList.requests).toBe(1);
 
     running = true;
     await refetchRegistry(client);
     expect(oscillatorStart).not.toHaveBeenCalled();
-    expect(sessionsList.requests).toBe(1);
 
     running = false;
     await refetchRegistry(client);
     expect(oscillatorStart).toHaveBeenCalled();
-    expect(sessionsList.requests).toBe(2);
 
     oscillatorStart.mockClear();
     await refetchRegistry(client);
     expect(oscillatorStart).not.toHaveBeenCalled();
-    expect(sessionsList.requests).toBe(2);
   });
 
   it('stays silent for a run already over when the tab opened', async () => {

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsActivity.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/UserSessionsActivity.msw.test.tsx
@@ -117,9 +117,9 @@ describe('User sessions sidebar activity', () => {
     let settled = false;
     const active = new Set(['sess-4']);
     stubProjectAndSessions([]);
-    // Serve a mutable session row so the next sessions refetch observes the
-    // stamped `materializedAt` (registered after the base stub — the most
-    // recent handler wins).
+    // Serve a mutable session row so the refetch on the run's feed frames
+    // observes the stamped `materializedAt` (registered after the base stub —
+    // the most recent handler wins).
     server.use(
       http.get(`${TEST_BASE_URL}/web/github/projects/${projectRepositoryId}/sessions`, () =>
         HttpResponse.json({
@@ -139,8 +139,8 @@ describe('User sessions sidebar activity', () => {
     await waitForMutationsIdle(client);
     await screen.findByRole('status', { name: 'Agent working in feature-d' });
 
-    // The run finishes and the server stamps materializedAt; the sessions
-    // list refetches on its own cadence.
+    // The run finishes: the server stamps materializedAt, and its feed frames
+    // invalidate the registry and the sessions list.
     settled = true;
     active.delete('sess-4');
     await client.invalidateQueries({

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -76,6 +76,7 @@ import { observeSessionFirstExec } from './session/first-exec-capture.js';
 import { observeSessionFirstMessage } from './session/first-message-capture.js';
 import { hydrateSessionMemorySettings } from './session/memory-settings-hydration.js';
 import { hydrateSessionModelPack } from './session/model-pack-hydration.js';
+import { observeSessionRunLifecycle } from './session/run-lifecycle-feed.js';
 import { observeSessionThreadTitle } from './session/thread-title-mirror.js';
 import { createSpaStaticMiddleware, resolveUiDistDir } from './spa-static.js';
 import { createStateSigner } from './state-signing.js';
@@ -370,7 +371,7 @@ export class MastraFactory {
     const intakeStorage = storage.registerDomain(new IntakeStorage());
     const auditStorage = storage.registerDomain(new AuditStorage());
     const workItemsStorage = storage.registerDomain(new WorkItemsStorage());
-    workItemsStorage.onAttentionChanged(scope => touchFeed(eventBus, scope));
+    workItemsStorage.onFeedTouch(scope => touchFeed(eventBus, scope));
     const modelCredentialsStorage = storage.registerDomain(new ModelCredentialsStorage(secretEncryption));
     const modelPacksStorage = storage.registerDomain(new ModelPacksStorage());
     const memorySettingsStorage = storage.registerDomain(new MemorySettingsStorage());
@@ -649,6 +650,7 @@ export class MastraFactory {
           ...(githubIntegration ? { github: githubIntegration } : {}),
           ...(workItemsStorage ? { workItems: workItemsStorage } : {}),
           workspaceRegistry,
+          pubsub: eventBus,
         }),
         disableGithubSignals: true,
         // Memory settings live in the factory's `memory-settings` app table (per
@@ -890,6 +892,10 @@ export class MastraFactory {
       });
       observeSessionThreadTitle(session, {
         sourceControl: sourceControlStorage.forIntegration('github'),
+      });
+      observeSessionRunLifecycle(session, {
+        sourceControl: sourceControlStorage.forIntegration('github'),
+        pubsub: eventBus,
       });
     });
 

--- a/mastracode/factory/src/feed-events.ts
+++ b/mastracode/factory/src/feed-events.ts
@@ -15,11 +15,29 @@ export function feedTopic(orgId: string, factoryProjectId: string): string {
  * — a slow or dead broker must not hold up the write it describes.
  */
 export function touchFeed(pubsub: PubSub, scope: FeedScope, workItemId?: string): void {
+  publishFeedFrame(pubsub, scope, workItemId ? { workItemId } : {}, workItemId ?? scope.factoryProjectId);
+}
+
+/**
+ * Something about `sessionId` changed server-side — a run started or ended,
+ * or its workspace materialized. Readers of session-scoped truths (the run
+ * registry, the sessions listing) should refetch now.
+ */
+export function touchSessionFeed(pubsub: Pick<PubSub, 'publish'>, scope: FeedScope, sessionId: string): void {
+  publishFeedFrame(pubsub, scope, { sessionId }, sessionId);
+}
+
+function publishFeedFrame(
+  pubsub: Pick<PubSub, 'publish'>,
+  scope: FeedScope,
+  data: Record<string, string>,
+  runId: string,
+): void {
   pubsub
     .publish(feedTopic(scope.orgId, scope.factoryProjectId), {
       type: 'factory.feed.touched',
-      runId: workItemId ?? scope.factoryProjectId,
-      data: workItemId ? { workItemId } : {},
+      runId,
+      data,
     })
     .catch((error: unknown) => {
       console.warn('[Factory] Failed to publish a feed touch', {

--- a/mastracode/factory/src/session/run-lifecycle-feed.test.ts
+++ b/mastracode/factory/src/session/run-lifecycle-feed.test.ts
@@ -1,0 +1,110 @@
+import type { AgentControllerEvent } from '@mastra/core/agent-controller';
+import { describe, expect, it, vi } from 'vitest';
+
+import { feedTopic } from '../feed-events.js';
+import {
+  observeSessionRunLifecycle,
+  type RunLifecycleFeedDependencies,
+  type RunLifecycleFeedSession,
+} from './run-lifecycle-feed.js';
+
+const SESSION_ID = 'session-1';
+const ORG_ID = 'org-1';
+const PROJECT_ID = 'project-1';
+
+function createSession() {
+  const listeners: Array<(event: AgentControllerEvent) => void> = [];
+  const session: RunLifecycleFeedSession = {
+    identity: { getResourceId: () => SESSION_ID },
+    subscribe: listener => {
+      listeners.push(listener);
+      return () => {
+        const index = listeners.indexOf(listener);
+        if (index !== -1) listeners.splice(index, 1);
+      };
+    },
+  };
+  const emit = (event: AgentControllerEvent) => {
+    for (const listener of [...listeners]) listener(event);
+  };
+  return { session, emit };
+}
+
+function createDependencies({ sessionRow = true }: { sessionRow?: boolean } = {}) {
+  const publish = vi.fn().mockResolvedValue(undefined);
+  const getBySessionId = vi
+    .fn()
+    .mockResolvedValue(sessionRow ? { orgId: ORG_ID, projectRepositoryId: 'repo-1' } : null);
+  const dependencies: RunLifecycleFeedDependencies = {
+    sourceControl: {
+      sessions: { getBySessionId },
+      projectRepositories: { get: vi.fn().mockResolvedValue({ connectionId: 'connection-1' }) },
+      connections: { get: vi.fn().mockResolvedValue({ factoryProjectId: PROJECT_ID }) },
+    },
+    pubsub: { publish },
+  };
+  return { dependencies, publish, getBySessionId };
+}
+
+async function settled() {
+  await new Promise(resolve => setImmediate(resolve));
+}
+
+describe('observeSessionRunLifecycle', () => {
+  it('publishes a run frame on the project feed for agent_start and agent_end', async () => {
+    const { session, emit } = createSession();
+    const { dependencies, publish } = createDependencies();
+    observeSessionRunLifecycle(session, dependencies);
+
+    emit({ type: 'agent_start' });
+    emit({ type: 'agent_end', reason: 'complete' });
+    await settled();
+
+    expect(publish).toHaveBeenCalledTimes(2);
+    expect(publish).toHaveBeenCalledWith(feedTopic(ORG_ID, PROJECT_ID), {
+      type: 'factory.feed.touched',
+      runId: SESSION_ID,
+      data: { sessionId: SESSION_ID },
+    });
+  });
+
+  it('resolves the session project once for the session lifetime', async () => {
+    const { session, emit } = createSession();
+    const { dependencies, publish, getBySessionId } = createDependencies();
+    observeSessionRunLifecycle(session, dependencies);
+
+    emit({ type: 'agent_start' });
+    emit({ type: 'agent_end', reason: 'complete' });
+    await settled();
+
+    expect(publish).toHaveBeenCalledTimes(2);
+    expect(getBySessionId).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays silent for a session with no source-control row, and retries on the next event', async () => {
+    const { session, emit } = createSession();
+    const { dependencies, publish, getBySessionId } = createDependencies({ sessionRow: false });
+    observeSessionRunLifecycle(session, dependencies);
+
+    emit({ type: 'agent_start' });
+    await settled();
+    expect(publish).not.toHaveBeenCalled();
+
+    getBySessionId.mockResolvedValue({ orgId: ORG_ID, projectRepositoryId: 'repo-1' });
+    emit({ type: 'agent_end', reason: 'complete' });
+    await settled();
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores every other event type', async () => {
+    const { session, emit } = createSession();
+    const { dependencies, publish, getBySessionId } = createDependencies();
+    observeSessionRunLifecycle(session, dependencies);
+
+    emit({ type: 'display_state_changed', displayState: { isRunning: true } } as AgentControllerEvent);
+    await settled();
+
+    expect(publish).not.toHaveBeenCalled();
+    expect(getBySessionId).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/factory/src/session/run-lifecycle-feed.ts
+++ b/mastracode/factory/src/session/run-lifecycle-feed.ts
@@ -1,0 +1,69 @@
+import type { AgentControllerEvent } from '@mastra/core/agent-controller';
+import type { PubSub } from '@mastra/core/events';
+
+import { touchSessionFeed } from '../feed-events.js';
+import type { FeedScope } from '../feed-events.js';
+
+export interface RunLifecycleFeedSession {
+  readonly identity: { getResourceId(): string };
+  subscribe(listener: (event: AgentControllerEvent) => void): () => void;
+}
+
+export interface RunLifecycleFeedDependencies {
+  sourceControl: {
+    sessions: { getBySessionId(sessionId: string): Promise<{ orgId: string; projectRepositoryId: string } | null> };
+    projectRepositories: { get(args: { orgId: string; id: string }): Promise<{ connectionId: string } | null> };
+    connections: { get(args: { orgId: string; id: string }): Promise<{ factoryProjectId: string } | null> };
+  };
+  pubsub: Pick<PubSub, 'publish'>;
+}
+
+/**
+ * Announce every run start and end on the project's feed stream, so board
+ * cards and sidebar rows refetch the run registry on the event instead of
+ * discovering it on their next poll tick. A run shorter than one poll
+ * interval is otherwise invisible to every surface outside the open session.
+ */
+export function observeSessionRunLifecycle(
+  session: RunLifecycleFeedSession,
+  { sourceControl, pubsub }: RunLifecycleFeedDependencies,
+): () => void {
+  const sessionId = session.identity.getResourceId();
+  let scopePromise: Promise<FeedScope | null> | undefined;
+
+  const resolveScope = async (): Promise<FeedScope | null> => {
+    const sessionRow = await sourceControl.sessions.getBySessionId(sessionId);
+    if (!sessionRow) return null;
+    const repository = await sourceControl.projectRepositories.get({
+      orgId: sessionRow.orgId,
+      id: sessionRow.projectRepositoryId,
+    });
+    if (!repository) return null;
+    const connection = await sourceControl.connections.get({ orgId: sessionRow.orgId, id: repository.connectionId });
+    if (!connection) return null;
+    return { orgId: sessionRow.orgId, factoryProjectId: connection.factoryProjectId };
+  };
+
+  return session.subscribe(event => {
+    if (event.type !== 'agent_start' && event.type !== 'agent_end') return;
+    const pending = scopePromise ?? resolveScope();
+    scopePromise = pending;
+    void pending
+      .then(scope => {
+        // Null is not cached: the session row can land after the controller
+        // session exists, and a chat-only session simply has no row at all.
+        if (!scope) {
+          scopePromise = undefined;
+          return;
+        }
+        touchSessionFeed(pubsub, scope, sessionId);
+      })
+      .catch(error => {
+        scopePromise = undefined;
+        console.warn('[Factory run feed] Unable to publish a run frame.', {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+  });
+}

--- a/mastracode/factory/src/storage/domains/comments/feed-events.test.ts
+++ b/mastracode/factory/src/storage/domains/comments/feed-events.test.ts
@@ -10,7 +10,7 @@ import type { EventCallback, SubscribeOptions } from '@mastra/core/events';
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { feedTopic } from '../../../feed-events.js';
+import { feedTopic, touchSessionFeed } from '../../../feed-events.js';
 import { fakeRouteAuth, mountApiRoutes } from '../../../routes/test-utils.js';
 import type { TestAuthUser } from '../../../routes/test-utils.js';
 import { createFactoryStorageForTests } from '../../test-utils.js';
@@ -258,6 +258,23 @@ describe('project-wide touches on the feed stream', () => {
 
     await vi.waitFor(() => expect(feed.frames).toHaveLength(1));
     expect(feed.frames[0]).toEqual({ event: 'feed', data: '{}' });
+    await feed.stop();
+  });
+
+  it('forwards a run frame with its session id', async () => {
+    const seed = await createFactoryStorageForTests();
+    const { project } = await seedProjectItem(seed);
+    const emitter = new EventEmitter();
+    const pubsub = new EventEmitterPubSub(emitter);
+    const { app } = buildApp(seed, pubsub, asAlice);
+    const topic = feedTopic(ORG, project.id);
+
+    const feed = openFeed(await app.request(`/web/factory/projects/${project.id}/feed-events`));
+    await vi.waitFor(() => expect(emitter.listenerCount(topic)).toBe(1));
+    touchSessionFeed(pubsub, { orgId: ORG, factoryProjectId: project.id }, 'session-9');
+
+    await vi.waitFor(() => expect(feed.frames).toHaveLength(1));
+    expect(feed.frames[0]).toEqual({ event: 'feed', data: '{"sessionId":"session-9"}' });
     await feed.stop();
   });
 });

--- a/mastracode/factory/src/storage/domains/comments/routes.ts
+++ b/mastracode/factory/src/storage/domains/comments/routes.ts
@@ -304,7 +304,9 @@ export function buildCommentRoutes(dependencies: CommentRouteDependencies): ApiR
             if (stream.aborted) return;
             const data = event.data;
             const workItemId = isRecord(data) && typeof data.workItemId === 'string' ? data.workItemId : undefined;
-            await stream.writeSSE({ event: 'feed', data: JSON.stringify(workItemId ? { workItemId } : {}) });
+            const sessionId = isRecord(data) && typeof data.sessionId === 'string' ? data.sessionId : undefined;
+            const frame = { ...(workItemId ? { workItemId } : {}), ...(sessionId ? { sessionId } : {}) };
+            await stream.writeSSE({ event: 'feed', data: JSON.stringify(frame) });
           };
           // Claimed before any await: `onAbort` handlers registered after the
           // reader is gone never run, and a broker subscribe is a round trip.

--- a/mastracode/factory/src/storage/domains/work-items/attention-events.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/attention-events.test.ts
@@ -1,7 +1,8 @@
 /**
- * The announcement every attention-changing write owes its readers: clients
- * stop polling while their feed stream is up, so a write that stays silent
- * leaves every open page stale until it is reloaded.
+ * The announcement every feed-relevant write owes its readers — attention
+ * items and board decisions alike: clients stop polling while their feed
+ * stream is up, so a write that stays silent leaves every open page stale
+ * until it is reloaded.
  */
 
 import { LibSQLFactoryStorage } from '@mastra/libsql';
@@ -21,7 +22,7 @@ async function makeStorage(): Promise<{ storage: WorkItemsStorage; announced: Fa
   const storage = backend.registerDomain(new WorkItemsStorage());
   await backend.init();
   const announced: FactoryAttentionScope[] = [];
-  storage.onAttentionChanged(scope => announced.push({ orgId: scope.orgId, factoryProjectId: scope.factoryProjectId }));
+  storage.onFeedTouch(scope => announced.push({ orgId: scope.orgId, factoryProjectId: scope.factoryProjectId }));
   return { storage, announced };
 }
 
@@ -30,11 +31,7 @@ async function seedWorkItem(storage: WorkItemsStorage): Promise<string> {
   return created.item.id;
 }
 
-async function claimDecision(
-  storage: WorkItemsStorage,
-  workItemId: string,
-  key: string,
-): Promise<FactoryDeferredDecisionRecord> {
+async function queueDecision(storage: WorkItemsStorage, workItemId: string, key: string): Promise<void> {
   const workItem = await storage.get({ orgId: SCOPE.orgId, id: workItemId });
   if (!workItem) throw new Error('Expected the seeded work item');
   await storage.commitRuleEvaluation({
@@ -49,6 +46,14 @@ async function claimDecision(
     causalChain: [],
     now: NOW,
   });
+}
+
+async function claimDecision(
+  storage: WorkItemsStorage,
+  workItemId: string,
+  key: string,
+): Promise<FactoryDeferredDecisionRecord> {
+  await queueDecision(storage, workItemId, key);
   const [claimed] = await storage.claimDeferredDecisions(LEASE);
   if (!claimed) throw new Error('Expected a claimed decision');
   return claimed;
@@ -68,6 +73,7 @@ describe('attention announcements', () => {
     const { storage, announced } = await makeStorage();
     const workItemId = await seedWorkItem(storage);
     const claimed = await claimDecision(storage, workItemId, 'park');
+    announced.length = 0;
 
     const proposed = await storage.proposeDeferredDecision(leaseOf(claimed), NOW);
     expect(announced).toEqual([SCOPE]);
@@ -77,18 +83,41 @@ describe('attention announcements', () => {
     expect(announced).toEqual([SCOPE, SCOPE]);
   });
 
-  it('stays quiet on a retryable failure and announces the terminal one', async () => {
+  it('announces every lease transition: claim, retryable failure, reclaim, terminal failure', async () => {
     const { storage, announced } = await makeStorage();
     const workItemId = await seedWorkItem(storage);
     const claimed = await claimDecision(storage, workItemId, 'fail');
+    expect(announced).toEqual([SCOPE]);
     const failure = { now: NOW, availableAt: NOW, lastError: 'nope', failureCode: 'session_unavailable' } as const;
 
     await storage.failDeferredDecision({ ...leaseOf(claimed), ...failure, terminal: false });
-    expect(announced).toEqual([]);
+    expect(announced).toEqual([SCOPE, SCOPE]);
 
     const [reclaimed] = await storage.claimDeferredDecisions(LEASE);
     if (!reclaimed) throw new Error('Expected the decision back on the queue');
     await storage.failDeferredDecision({ ...leaseOf(reclaimed), ...failure, terminal: true });
+    expect(announced).toEqual([SCOPE, SCOPE, SCOPE, SCOPE]);
+  });
+
+  it('announces a claimed batch once per project, not once per decision', async () => {
+    const { storage, announced } = await makeStorage();
+    const workItemId = await seedWorkItem(storage);
+    await queueDecision(storage, workItemId, 'batch-a');
+    await queueDecision(storage, workItemId, 'batch-b');
+    announced.length = 0;
+
+    const claimed = await storage.claimDeferredDecisions({ ...LEASE, limit: 2 });
+    expect(claimed).toHaveLength(2);
+    expect(announced).toEqual([SCOPE]);
+  });
+
+  it('announces a completed decision', async () => {
+    const { storage, announced } = await makeStorage();
+    const workItemId = await seedWorkItem(storage);
+    const claimed = await claimDecision(storage, workItemId, 'complete');
+    announced.length = 0;
+
+    await storage.completeDeferredDecision(leaseOf(claimed), NOW);
     expect(announced).toEqual([SCOPE]);
   });
 

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -1053,19 +1053,20 @@ export interface FactoryAttentionScope {
 }
 
 export class WorkItemsStorage extends FactoryStorageDomain {
-  #attentionChanged: (scope: FactoryAttentionScope) => void = () => {};
+  #announceFeedTouch: (scope: FactoryAttentionScope) => void = () => {};
 
   constructor() {
     super('work-items');
   }
 
   /**
-   * Wired once at boot. Every write below that changes what this project's
-   * attention list projects announces it here — the one place a new such write
-   * has to remember, since clients stop polling while their stream is up.
+   * Wired once at boot to publish a project feed frame. Every write below that
+   * changes what a live surface projects — the attention list, the board's
+   * decisions — announces it here, the one place a new such write has to
+   * remember, since clients stop polling while their stream is up.
    */
-  onAttentionChanged(listener: (scope: FactoryAttentionScope) => void): void {
-    this.#attentionChanged = listener;
+  onFeedTouch(listener: (scope: FactoryAttentionScope) => void): void {
+    this.#announceFeedTouch = listener;
   }
 
   async init(): Promise<void> {
@@ -1978,7 +1979,10 @@ export class WorkItemsStorage extends FactoryStorageDomain {
   }
 
   async claimDeferredDecisions(input: FactoryLeaseClaimInput): Promise<FactoryDeferredDecisionRecord[]> {
-    return this.#claimLeases('factory_deferred_decisions', input, toDeferredDecision);
+    const claimed = await this.#claimLeases('factory_deferred_decisions', input, toDeferredDecision);
+    const byProject = new Map(claimed.map(record => [`${record.orgId}:${record.factoryProjectId}`, record]));
+    for (const scope of byProject.values()) this.#announceFeedTouch(scope);
+    return claimed;
   }
 
   async renewDeferredDecisionLease(identity: FactoryLeaseIdentity, leaseExpiresAt: Date): Promise<boolean> {
@@ -1990,15 +1994,19 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     now: Date,
   ): Promise<FactoryDeferredDecisionRecord | null> {
     const row = await this.#completeLease('factory_deferred_decisions', identity, now);
-    return row ? toDeferredDecision(row) : null;
+    if (!row) return null;
+    const record = toDeferredDecision(row);
+    this.#announceFeedTouch(record);
+    return record;
   }
 
   async failDeferredDecision(input: FactoryDispatchFailureInput): Promise<FactoryDeferredDecisionRecord | null> {
     const row = await this.#failLease('factory_deferred_decisions', input);
     if (!row) return null;
     const record = toDeferredDecision(row);
-    // A retryable failure surfaces nothing; only a terminal one mints an item.
-    if (input.terminal) this.#attentionChanged(record);
+    // Terminal mints an attention item; a retryable failure still moves the
+    // card's copy, so both deserve the frame.
+    this.#announceFeedTouch(record);
     return record;
   }
 
@@ -2026,7 +2034,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     );
     if (!proposed || !row) return null;
     const record = toDeferredDecision(row);
-    this.#attentionChanged(record);
+    this.#announceFeedTouch(record);
     return record;
   }
 
@@ -2070,7 +2078,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
       }
       return record;
     });
-    if (approved) this.#attentionChanged(approved);
+    if (approved) this.#announceFeedTouch(approved);
     return approved;
   }
 
@@ -2146,7 +2154,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     );
     if (!settled || !row) return null;
     const record = toDeferredDecision(row);
-    this.#attentionChanged(record);
+    this.#announceFeedTouch(record);
     return record;
   }
 
@@ -2184,7 +2192,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
       });
       return toDeferredDecision(row);
     });
-    if (resolved) this.#attentionChanged(resolved);
+    if (resolved) this.#announceFeedTouch(resolved);
     return resolved;
   }
 
@@ -2296,7 +2304,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
       });
       return toDeferredDecision(row);
     });
-    if (retriedRecord) this.#attentionChanged(retriedRecord);
+    if (retriedRecord) this.#announceFeedTouch(retriedRecord);
     return retriedRecord;
   }
 
@@ -2952,7 +2960,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
       );
       return toWorkItem(existing);
     });
-    if (removed) this.#attentionChanged(removed);
+    if (removed) this.#announceFeedTouch(removed);
     return removed;
   }
 }

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -7,6 +7,7 @@ import type { getDynamicWorkspace, WorkspaceSkillExtension } from '@mastra/code-
 import { DEFAULT_CONFIG_DIR } from '@mastra/code-sdk/constants';
 import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
+import type { PubSub } from '@mastra/core/events';
 import { LocalSkillSource, Workspace } from '@mastra/core/workspace';
 import type {
   SandboxStartHook,
@@ -17,6 +18,7 @@ import type {
 } from '@mastra/core/workspace';
 import { getFactoryAuthUserFromContext, getFactoryAuthUserId } from './auth.js';
 import type { MastraFactorySandboxConfig } from './factory.js';
+import { touchSessionFeed } from './feed-events.js';
 import type { GithubIntegration } from './integrations/github/integration.js';
 import { getGithubPat } from './integrations/github/pat.js';
 import type { GithubPatKind } from './integrations/github/pat.js';
@@ -228,6 +230,8 @@ export interface CreateWorkspaceFactoryOptions {
   workItems?: Pick<WorkItemsStorage, 'findRunBindingBySession'>;
   /** Runtime workspace/token registrations invalidated when a session retires. */
   workspaceRegistry?: FactoryWorkspaceRegistry;
+  /** Project feed bus: announces the session's first materialization so clients refetch instead of polling for the stamp. */
+  pubsub?: Pick<PubSub, 'publish'>;
 }
 
 type WorkspaceUnregister = () => Promise<void> | void;
@@ -269,7 +273,7 @@ export class FactoryWorkspaceRegistry {
 }
 
 export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = {}) {
-  const { sandbox: sandboxConfig, github, workItems } = options;
+  const { sandbox: sandboxConfig, github, workItems, pubsub } = options;
   const workspaceRegistry = options.workspaceRegistry ?? new FactoryWorkspaceRegistry();
   type GithubTokenRegistration = {
     inject: (token: string) => void;
@@ -603,6 +607,15 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         token,
         storage: storage.sessions,
       });
+      // First materialization only: resumes re-run setup but the stamp is
+      // write-once, and re-announcing every sandbox start would be noise.
+      if (pubsub && !session.materializedAt) {
+        touchSessionFeed(
+          pubsub,
+          { orgId: session.orgId, factoryProjectId: connection.factoryProjectId },
+          session.sessionId,
+        );
+      }
       await checkoutSessionBranch(target, workdir, {
         branch: session.branch,
         baseBranch: session.baseBranch || projectRepository.branch || repository.defaultBranch,


### PR DESCRIPTION
**─────── TLDR ───────**
> Board cards, sidebar rows and the open chat refresh the moment a run starts or ends, a workspace materializes, or a card decision moves, instead of on the next poll.

Stacked on #22786, which makes every surface derive a session's status from the same server facts. Freshness there is still the poll cadence: five seconds for the run registry, two for decisions, fifteen for a session still materializing.

The server now publishes one frame for each of those transitions on the project stream it already had for comments and attention. Every consumer refetches on the frame, and while the stream is up each poll slows to one safety tick per 30 seconds.

### Behavior changed

a run starts or ends on a session
&nbsp;&nbsp;├─ **was** — sidebar row and board card catch up on the next 5s registry poll
&nbsp;&nbsp;└─ **now** — a session frame refetches the registry and the sessions list at once

a workspace materializes for the first time
&nbsp;&nbsp;├─ **was** — the row leaves "initializing" on the next 15s sessions poll
&nbsp;&nbsp;└─ **now** — the materialization publishes a session frame; a resumed sandbox stays silent

a card decision is claimed, completed, or fails
&nbsp;&nbsp;├─ **was** — a frame only when the attention inbox changed; the board polled decisions every 2s
&nbsp;&nbsp;└─ **now** — a frame on every decision write, one per project per claimed batch

a visible tab with a healthy stream
&nbsp;&nbsp;├─ **was** — decisions polled every 2s, attention 5s, registry 5s, sessions 15s, always
&nbsp;&nbsp;└─ **now** — each poll drops to one tick per 30s; the full cadence returns the moment the stream drops

the stream connects
&nbsp;&nbsp;├─ **was** — comments and attention refetched on every connect, the first included
&nbsp;&nbsp;└─ **now** — a catch-up refetch of comments, attention, registry, sessions and decisions, only after a lost stream

### Shape changed

| | | |
|---|---|---|
| **+** | `touchSessionFeed` | a frame naming a session, beside `touchFeed` naming a card |
| **+** | `observeSessionRunLifecycle` | run start and end to a frame, beside the thread-title mirror |
| **+** | `useFeedPollInterval` | one rule for every poll a frame can replace |
| **~** | `onAttentionChanged` → `onFeedTouch` | every decision write, not only attention |
| **~** | `RunEndObserver` | only rings; the frame refetches the sessions list, in every tab |

what the reviewer now lives with
&nbsp;&nbsp;&nbsp;&nbsp;`sessionId` on the feed frame · `touchSessionFeed(pubsub, scope, sessionId)` · `observeSessionRunLifecycle(session, { sourceControl, pubsub })` · `WorkItemsStorage.onFeedTouch` · `useFeedPollInterval(noStreamMs)` · `queryKeys.sessionsRoot()`

### Decisions

- **polls slow to 30s under a stream, not off** — a frame that never arrived, or a write nobody taught to announce, heals in 30s instead of never; `false` in one hook if you want silence
- **a session frame refetches every repository's sessions** — the stream is per project and the frame carries no repository id; add it to the frame if a factory grows many repositories
- **the first connect skips the catch-up refetch** — the queries just ran their own initial fetch; one flag if you want the old blanket refresh back

### Watch

> [!WARNING]
> A busy dispatcher now produces <mark>a refetch burst per decision write</mark> in every open tab, where the board used to run a flat 2s poll; a claim batch is one frame, each completion and failure is its own.

### Not verified

- [ ] the frame → refetch path against a live factory server — the SSE stream is stubbed in tests

---

> ██████████████████ **tests** `+268 −20` — 56% of the additions
> ██████████████ **source** `+205 −44`
> █ **changeset** `+7`
