### PR TITLE
fix(mcp): require compatible core version

### DIFF
--- a/.changeset/small-papers-sniff.md
+++ b/.changeset/small-papers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Required @mastra/core 1.64 or newer so MCP can use the tool output validation API added in that release.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,7 +47,7 @@
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.64.0-0 <2.0.0-0"
   },
   "devDependencies": {
     "@hono/node-server": "^2.0.0",


### PR DESCRIPTION
The MCP package now imports `validateToolOutput`, which was added to `@mastra/core/tools` in core 1.64. Previously, the peer dependency still allowed older core versions, so a valid-looking installation could fail when loading or invoking MCP.\n\nThis raises the minimum peer version from `>=1.0.0-0` to `>=1.64.0-0` so package managers can identify incompatible installations.\n\nBefore: `@mastra/core >=1.0.0-0 <2.0.0-0`\n\nAfter: `@mastra/core >=1.64.0-0 <2.0.0-0`\n\nVerified with `pnpm --filter ./packages/mcp build:lib` and Prettier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The MCP package now requires a newer version of `@mastra/core` because it uses a feature added in that version. This helps package managers prevent incompatible installations.

## Changes

- Raised the `@mastra/core` peer dependency minimum from `>=1.0.0-0` to `>=1.64.0-0`.
- Retained the upper bound of `<2.0.0-0`.
- Added a patch changeset for `@mastra/mcp`.
- Documented the requirement for the `validateToolOutput` export.
- MCP build and Prettier checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->