### PR TITLE
fix(platform-workspace,e2b): resolve github.com heads via the REST API

### DIFF
--- a/.changeset/resolve-head-github-api.md
+++ b/.changeset/resolve-head-github-api.md
@@ -1,0 +1,6 @@
+---
+'@mastra/platform-workspace': patch
+'@mastra/e2b': patch
+---
+
+Resolve a github.com repository's default-branch head through the GitHub REST API instead of `git ls-remote`, so repo templates build on hosts without a git binary (deployed Mastra servers). Non-GitHub clone URLs keep using `git ls-remote`.

--- a/.changeset/resolve-head-github-api.md
+++ b/.changeset/resolve-head-github-api.md
@@ -3,4 +3,4 @@
 '@mastra/e2b': patch
 ---
 
-Fixed repo templates silently degrading to a repo-less template on hosts without a `git` binary (deployed Mastra servers), which made every session cold-clone at runtime. github.com clone URLs now resolve the default-branch head through the GitHub REST API; other hosts keep using `git ls-remote`.
+Fixed repo templates silently degrading to a repo-less template on hosts without a `git` binary (deployed Mastra servers), which made every session cold-clone at runtime. GitHub (github.com) clone URLs now resolve the default-branch head through the GitHub REST API; other hosts keep using `git ls-remote`.

--- a/.changeset/resolve-head-github-api.md
+++ b/.changeset/resolve-head-github-api.md
@@ -3,4 +3,4 @@
 '@mastra/e2b': patch
 ---
 
-Resolve a github.com repository's default-branch head through the GitHub REST API instead of `git ls-remote`, so repo templates build on hosts without a git binary (deployed Mastra servers). Non-GitHub clone URLs keep using `git ls-remote`.
+Fixed repo templates silently degrading to a repo-less template on hosts without a `git` binary (deployed Mastra servers), which made every session cold-clone at runtime. github.com clone URLs now resolve the default-branch head through the GitHub REST API; other hosts keep using `git ls-remote`.

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -25,14 +25,9 @@ import { E2BSandbox } from './index';
 /** Access to a public repo: a clone URL and no credential. */
 const repoAccess = (cloneUrl: string) => async () => ({ cloneUrl });
 
-/** Make the head lookup (`git ls-remote`) report a fixed sha. */
+/** Make the github.com head lookup (REST API) report a fixed sha. */
 function mockHead(sha: string): void {
-  execFileMock.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
-    (cb as (e: Error | null, o: { stdout: string; stderr: string }) => void)(null, {
-      stdout: `${sha}\tHEAD\n`,
-      stderr: '',
-    });
-  });
+  fetchMock.mockImplementation(async () => new Response(`${sha}\n`, { status: 200 }));
 }
 
 /**
@@ -190,9 +185,9 @@ const { mockSandbox, createMockSandboxApi, resetMockDefaults, createMockCommandH
 // Mock the E2B SDK
 vi.mock('e2b', () => createMockSandboxApi());
 
-// Repo templates resolve their head sha through `git ls-remote`.
-const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }));
-vi.mock('node:child_process', () => ({ execFile: (...args: unknown[]) => execFileMock(...args) }));
+// Repo templates resolve a github.com head sha through the GitHub REST API.
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
 
 describe('E2BSandbox', () => {
   beforeEach(async () => {

--- a/workspaces/e2b/src/utils/repo-template.test.ts
+++ b/workspaces/e2b/src/utils/repo-template.test.ts
@@ -5,20 +5,29 @@ import { createRepoTemplate, refreshRepoTemplate, repoTemplateRef } from './repo
 import type { RepoTemplateOptions } from './repo-template';
 import type { NamedTemplateSpec } from './template';
 
-// The head sha is always resolved live, through `git ls-remote`. Driving it
-// by mocking git exercises the real resolution path instead of stepping
-// around it.
+// The head sha is always resolved live: github.com through the REST API,
+// other hosts through `git ls-remote`. Driving both by mocking their
+// transports exercises the real resolution path instead of stepping around it.
 const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }));
 vi.mock('node:child_process', () => ({
   execFile: (...args: unknown[]) => execFileMock(...args),
 }));
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
 
 const CLONE_URL = 'https://github.com/octocat/hello.git';
 const SHA = 'a'.repeat(40);
 const SETUP = 'pnpm install';
 
-/** Make `git ls-remote` report `sha`, or fail when it is undefined. */
+/** Make the GitHub API report `sha`, or fail when it is undefined. */
 function mockHead(sha: string | undefined): void {
+  fetchMock.mockImplementation(async () =>
+    sha === undefined ? new Response('not found', { status: 404 }) : new Response(`${sha}\n`, { status: 200 }),
+  );
+}
+
+/** Make `git ls-remote` report `sha`, or fail when it is undefined. */
+function mockGitHead(sha: string | undefined): void {
   execFileMock.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
     const done = cb as (err: Error | null, out?: { stdout: string; stderr: string }) => void;
     if (sha === undefined) done(new Error('ls-remote failed'));
@@ -35,6 +44,8 @@ const BASE: RepoTemplateOptions = {
 };
 
 beforeEach(() => {
+  fetchMock.mockReset();
+  execFileMock.mockReset();
   mockHead(SHA);
 });
 
@@ -214,12 +225,34 @@ describe('createRepoTemplate', () => {
     expect(await serializedSteps(resolved)).toContain(`checkout ${head}`);
   });
 
-  it('looks the head up against the clone URL without cloning', async () => {
+  it('looks a github.com head up through the REST API, without git or a clone', async () => {
     await resolve(BASE);
+    expect(execFileMock).not.toHaveBeenCalled();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.github.com/repos/octocat/hello/commits/HEAD');
+    expect(init.headers).toMatchObject({ Accept: 'application/vnd.github.sha' });
+    expect(init.headers).not.toHaveProperty('Authorization');
+  });
+
+  it('sends the repository credential as a bearer token to the GitHub API', async () => {
+    await resolve({
+      ...BASE,
+      getRepositoryAccess: async () => ({ cloneUrl: CLONE_URL, authorization: { scheme: 'bearer', token: 'ghs_t' } }),
+    });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer ghs_t' });
+  });
+
+  it('looks a non-GitHub head up with git ls-remote against the clone URL', async () => {
+    const other = 'https://gitlab.com/octocat/hello.git';
+    mockGitHead(SHA);
+    const resolved = await resolve({ ...BASE, getRepositoryAccess: async () => ({ cloneUrl: other }) });
+    expect(fetchMock).not.toHaveBeenCalled();
     const [command, args] = execFileMock.mock.calls[0] as [string, string[]];
     expect(command).toBe('git');
     expect(args).toContain('ls-remote');
-    expect(args).toContain(CLONE_URL);
+    expect(args).toContain(other);
+    expect(resolved.ref).toBe(repoTemplateRef({ cloneUrl: other, setupCommand: SETUP, sha: SHA }));
   });
 
   it('degrades to the sha-less name when head resolution fails', async () => {

--- a/workspaces/e2b/src/utils/repo-template.test.ts
+++ b/workspaces/e2b/src/utils/repo-template.test.ts
@@ -234,12 +234,6 @@ describe('createRepoTemplate', () => {
     expect(init.headers).not.toHaveProperty('Authorization');
   });
 
-  it('resolves a github.com clone URL with a trailing slash through the API too', async () => {
-    await resolve({ ...BASE, getRepositoryAccess: async () => ({ cloneUrl: 'https://github.com/octocat/hello/' }) });
-    expect(execFileMock).not.toHaveBeenCalled();
-    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.github.com/repos/octocat/hello/commits/HEAD');
-  });
-
   it('sends the repository credential as a bearer token to the GitHub API', async () => {
     await resolve({
       ...BASE,

--- a/workspaces/e2b/src/utils/repo-template.test.ts
+++ b/workspaces/e2b/src/utils/repo-template.test.ts
@@ -234,6 +234,12 @@ describe('createRepoTemplate', () => {
     expect(init.headers).not.toHaveProperty('Authorization');
   });
 
+  it('resolves a github.com clone URL with a trailing slash through the API too', async () => {
+    await resolve({ ...BASE, getRepositoryAccess: async () => ({ cloneUrl: 'https://github.com/octocat/hello/' }) });
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.github.com/repos/octocat/hello/commits/HEAD');
+  });
+
   it('sends the repository credential as a bearer token to the GitHub API', async () => {
     await resolve({
       ...BASE,

--- a/workspaces/e2b/src/utils/repo-template.ts
+++ b/workspaces/e2b/src/utils/repo-template.ts
@@ -465,7 +465,7 @@ function parseGithubRepo(cloneUrl: string): { owner: string; repo: string } | un
     return undefined;
   }
   if (url.hostname.toLowerCase() !== 'github.com') return undefined;
-  const [owner, repo, ...rest] = url.pathname.replace(/^\/+/, '').split('/');
+  const [owner, repo, ...rest] = url.pathname.split('/').filter(Boolean);
   if (!owner || !repo || rest.length > 0) return undefined;
   return { owner, repo: repo.replace(/\.git$/i, '') };
 }

--- a/workspaces/e2b/src/utils/repo-template.ts
+++ b/workspaces/e2b/src/utils/repo-template.ts
@@ -453,13 +453,52 @@ function buildRepoTemplateSpec(identity: RepoTemplateIdentity, token?: string): 
 }
 
 /**
- * Resolve the repository's current default-branch head over HTTPS
- * (`git ls-remote <url> HEAD` — no clone; authenticated via an in-process
- * `http.extraheader` when a token is provided). Returns undefined when the
+ * `owner/repo` for a github.com clone URL, else undefined. Only the public
+ * host is API-resolvable: GitHub Enterprise and other forges keep the git
+ * path.
+ */
+function parseGithubRepo(cloneUrl: string): { owner: string; repo: string } | undefined {
+  let url: URL;
+  try {
+    url = new URL(cloneUrl);
+  } catch {
+    return undefined;
+  }
+  if (url.hostname.toLowerCase() !== 'github.com') return undefined;
+  const [owner, repo, ...rest] = url.pathname.replace(/^\/+/, '').split('/');
+  if (!owner || !repo || rest.length > 0) return undefined;
+  return { owner, repo: repo.replace(/\.git$/i, '') };
+}
+
+/**
+ * Resolve the repository's current default-branch head without cloning.
+ * github.com repositories go through the REST API so resolution works
+ * wherever the host runs, including images without a git binary; other
+ * hosts use `git ls-remote <url> HEAD`, authenticated via an in-process
+ * `http.extraheader` when a token is provided. Returns undefined when the
  * head cannot be resolved (inaccessible repo, offline, no git binary);
  * callers degrade to the untagged template ref.
  */
 async function resolveDefaultBranchHead(cloneUrl: string, token?: string): Promise<string | undefined> {
+  const github = parseGithubRepo(cloneUrl);
+  if (github) {
+    try {
+      const response = await fetch(`https://api.github.com/repos/${github.owner}/${github.repo}/commits/HEAD`, {
+        headers: {
+          Accept: 'application/vnd.github.sha',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'User-Agent': 'mastra-e2b',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) return undefined;
+      const sha = (await response.text()).trim();
+      return SHA_PATTERN.test(sha) ? sha : undefined;
+    } catch {
+      return undefined;
+    }
+  }
   try {
     const authArgs = token
       ? ['-c', `http.extraheader=AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString('base64')}`]

--- a/workspaces/platform-workspace/src/repo-template.test.ts
+++ b/workspaces/platform-workspace/src/repo-template.test.ts
@@ -294,7 +294,40 @@ describe('createRepoTemplate', () => {
     expect(redactSecrets({ code: 1 })).toBe('[object Object]');
   });
 
-  it('keeps the repository token out of git process arguments while resolving the default branch', async () => {
+  it('resolves github.com heads through the REST API, so no git binary is needed', async () => {
+    const execute = vi.fn();
+    const fetchImpl = vi.fn(async () => new Response(`${SHA_1}\n`, { status: 200 }));
+
+    await expect(
+      resolveDefaultBranchHead('https://github.com/acme/widgets.git', 'ghs_secret_token', execute, fetchImpl),
+    ).resolves.toBe(SHA_1);
+
+    expect(execute).not.toHaveBeenCalled();
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://api.github.com/repos/acme/widgets/commits/HEAD');
+    expect(init.headers).toMatchObject({
+      Accept: 'application/vnd.github.sha',
+      Authorization: 'Bearer ghs_secret_token',
+    });
+  });
+
+  it('sends no Authorization header for public repositories without a token', async () => {
+    const fetchImpl = vi.fn(async () => new Response(SHA_1, { status: 200 }));
+    await expect(
+      resolveDefaultBranchHead('https://github.com/acme/widgets', undefined, vi.fn(), fetchImpl),
+    ).resolves.toBe(SHA_1);
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(init.headers).not.toHaveProperty('Authorization');
+  });
+
+  it('surfaces a non-2xx GitHub API response without leaking the token', async () => {
+    const fetchImpl = vi.fn(async () => new Response('rate limited', { status: 403, statusText: 'Forbidden' }));
+    await expect(
+      resolveDefaultBranchHead('https://github.com/acme/widgets', 'ghs_secret_token', vi.fn(), fetchImpl),
+    ).rejects.toThrow('GitHub head lookup failed: 403 Forbidden');
+  });
+
+  it('keeps the repository token out of git process arguments while resolving a non-GitHub head', async () => {
     const execute = vi.fn(
       async (
         _file: string,
@@ -302,14 +335,16 @@ describe('createRepoTemplate', () => {
         _options: { timeout: number; maxBuffer: number; env: Record<string, string | undefined> },
       ) => ({ stdout: `${SHA_1}\tHEAD\n` }),
     );
+    const fetchImpl = vi.fn();
 
     await expect(
-      resolveDefaultBranchHead('https://github.com/acme/widgets', 'ghs_secret_token', execute),
+      resolveDefaultBranchHead('https://gitlab.com/acme/widgets', 'ghs_secret_token', execute, fetchImpl),
     ).resolves.toBe(SHA_1);
+    expect(fetchImpl).not.toHaveBeenCalled();
 
     const [file, args, options] = execute.mock.calls[0]!;
     expect(file).toBe('git');
-    expect(args).toEqual(['ls-remote', '--', 'https://github.com/acme/widgets', 'HEAD']);
+    expect(args).toEqual(['ls-remote', '--', 'https://gitlab.com/acme/widgets', 'HEAD']);
     expect(JSON.stringify(args)).not.toContain('ghs_secret_token');
     expect(options.env).toMatchObject({
       GIT_CONFIG_COUNT: '1',
@@ -324,7 +359,7 @@ describe('createRepoTemplate', () => {
       throw Object.assign(new Error('Command failed'), { stderr: 'fatal: unable to access: 429 Too Many Requests\n' });
     });
 
-    await expect(resolveDefaultBranchHead('https://github.com/acme/widgets', undefined, execute)).rejects.toThrow(
+    await expect(resolveDefaultBranchHead('https://gitlab.com/acme/widgets', undefined, execute)).rejects.toThrow(
       'git ls-remote failed: fatal: unable to access: 429 Too Many Requests',
     );
   });

--- a/workspaces/platform-workspace/src/repo-template.test.ts
+++ b/workspaces/platform-workspace/src/repo-template.test.ts
@@ -314,8 +314,9 @@ describe('createRepoTemplate', () => {
   it('sends no Authorization header for public repositories without a token', async () => {
     const fetchImpl = vi.fn(async () => new Response(SHA_1, { status: 200 }));
     await expect(
-      resolveDefaultBranchHead('https://github.com/acme/widgets', undefined, vi.fn(), fetchImpl),
+      resolveDefaultBranchHead('https://github.com/acme/widgets/', undefined, vi.fn(), fetchImpl),
     ).resolves.toBe(SHA_1);
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe('https://api.github.com/repos/acme/widgets/commits/HEAD');
     const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     expect(init.headers).not.toHaveProperty('Authorization');
   });

--- a/workspaces/platform-workspace/src/repo-template.ts
+++ b/workspaces/platform-workspace/src/repo-template.ts
@@ -268,11 +268,55 @@ function gitAuthFlag(): string {
   return `-c http.extraheader="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$${BUILD_TOKEN_ENV}" | base64 -w0)"`;
 }
 
+/**
+ * `owner/repo` for a github.com clone URL, else undefined. Only the public
+ * host is API-resolvable: GitHub Enterprise and other forges keep the git
+ * path below.
+ */
+function parseGithubRepo(cloneUrl: string): { owner: string; repo: string } | undefined {
+  let url: URL;
+  try {
+    url = new URL(cloneUrl);
+  } catch {
+    return undefined;
+  }
+  if (url.hostname.toLowerCase() !== 'github.com') return undefined;
+  const [owner, repo, ...rest] = url.pathname.replace(/^\/+/, '').split('/');
+  if (!owner || !repo || rest.length > 0) return undefined;
+  return { owner, repo: repo.replace(/\.git$/i, '') };
+}
+
+/**
+ * Resolve the default-branch head. github.com repositories go through the
+ * REST API so resolution works wherever the host runs, including deployed
+ * images without a git binary; other hosts shell out to `git ls-remote`.
+ * Throws with a redaction-safe message when the head cannot be resolved.
+ */
 export async function resolveDefaultBranchHead(
   cloneUrl: string,
   token?: string,
   execute: GitExec = execFileAsync as GitExec,
+  fetchImpl: typeof fetch = fetch,
 ): Promise<string | undefined> {
+  const github = parseGithubRepo(cloneUrl);
+  if (github) {
+    const response = await fetchImpl(`https://api.github.com/repos/${github.owner}/${github.repo}/commits/HEAD`, {
+      headers: {
+        Accept: 'application/vnd.github.sha',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'mastra-platform-workspace',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      signal: AbortSignal.timeout(10_000),
+    }).catch((error: unknown) => {
+      throw new Error(`GitHub head lookup failed: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub head lookup failed: ${response.status} ${response.statusText}`.trim());
+    }
+    const sha = (await response.text()).trim();
+    return SHA_PATTERN.test(sha) ? sha : undefined;
+  }
   try {
     const env: NodeJS.ProcessEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
     if (token) {

--- a/workspaces/platform-workspace/src/repo-template.ts
+++ b/workspaces/platform-workspace/src/repo-template.ts
@@ -281,7 +281,7 @@ function parseGithubRepo(cloneUrl: string): { owner: string; repo: string } | un
     return undefined;
   }
   if (url.hostname.toLowerCase() !== 'github.com') return undefined;
-  const [owner, repo, ...rest] = url.pathname.replace(/^\/+/, '').split('/');
+  const [owner, repo, ...rest] = url.pathname.split('/').filter(Boolean);
   if (!owner || !repo || rest.length > 0) return undefined;
   return { owner, repo: repo.replace(/\.git$/i, '') };
 }


### PR DESCRIPTION
Deployed Mastra servers run on `node:22-slim` images with no `git` binary, so `resolveDefaultBranchHead` failed with `spawn git ENOENT`, the repo template degraded to the resources-only bail (`sandbox-template-…`, no family), and every session cold-cloned at runtime.

github.com clone URLs now resolve HEAD through `GET /repos/{owner}/{repo}/commits/HEAD` (`Accept: application/vnd.github.sha`, bearer token when the access resolver provides one). Non-GitHub hosts keep `git ls-remote`. Same change in `@mastra/platform-workspace` and `@mastra/e2b`.

Verified: the API and `git ls-remote` return the same sha for `mastra-ai/mastra`; both package test suites, tsc and lint are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The code can now find the latest GitHub commit without Git installed. This keeps repository templates working in lightweight deployment environments.

## What changed

- Resolve GitHub repository heads through `GET /repos/{owner}/{repo}/commits/HEAD`.
- Support optional bearer-token authentication.
- Add timeouts, response checks, and SHA validation.
- Keep `git ls-remote` for non-GitHub hosts.
- Preserve fallback behavior when the GitHub API cannot resolve a head.
- Add injectable `fetchImpl` support for testing.
- Add patch release notes for `@mastra/platform-workspace` and `@mastra/e2b`.

## Testing

- Add coverage for GitHub API resolution, authentication, errors, SHA validation, and non-GitHub fallback.
- Verify that GitHub resolution does not invoke Git.
- Confirm matching SHAs from the GitHub API and `git ls-remote`.
- Package tests, TypeScript checks, and lint pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->