### PR TITLE
fix(libsql): coordinate local vector mutations

### DIFF
--- a/.changeset/brown-maps-chew.md
+++ b/.changeset/brown-maps-chew.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Fixed local LibSQL vector corruption during concurrent writes.

--- a/docs/src/content/en/reference/vectors/libsql.mdx
+++ b/docs/src/content/en/reference/vectors/libsql.mdx
@@ -91,6 +91,12 @@ const results = await store.query({
 ]}
 />
 
+### Local file concurrency
+
+For ordinary local `file:` databases, `LibSQLVector` applies write-ahead logging (WAL) and a five-second busy timeout before running vector operations. Multiple `LibSQLVector` instances in the same Node.js process coordinate mutations when they target the same database file.
+
+This coordination is process-local. If separate application processes write concurrently, use Turso or another server-backed libSQL deployment. Alternatively, provide a deployment-level single-writer boundary for the local file.
+
 ## Methods
 
 ### `createIndex()`

--- a/docs/src/content/en/reference/vectors/libsql.mdx
+++ b/docs/src/content/en/reference/vectors/libsql.mdx
@@ -91,12 +91,6 @@ const results = await store.query({
 ]}
 />
 
-### Local file concurrency
-
-For ordinary local `file:` databases, `LibSQLVector` applies write-ahead logging (WAL) and a five-second busy timeout before running vector operations. Multiple `LibSQLVector` instances in the same Node.js process coordinate mutations when they target the same database file.
-
-This coordination is process-local. If separate application processes write concurrently, use Turso or another server-backed libSQL deployment. Alternatively, provide a deployment-level single-writer boundary for the local file.
-
 ## Methods
 
 ### `createIndex()`

--- a/stores/libsql/src/vector/index.test.ts
+++ b/stores/libsql/src/vector/index.test.ts
@@ -3,7 +3,8 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { createVectorTestSuite } from '@internal/storage-test-utils';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createClient } from '@libsql/client';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 
 import { LibSQLVector } from './index.js';
 
@@ -267,5 +268,109 @@ describe('LibSQLVector - Store Specific', () => {
 
       expect(results.length).toBe(0);
     });
+  });
+});
+
+describe('LibSQLVector local-file concurrency', () => {
+  let tmpDir: string;
+  let vectors: LibSQLVector[];
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'libsql-vector-concurrency-'));
+    vectors = [];
+  });
+
+  afterEach(async () => {
+    await Promise.all(vectors.map(vector => vector.close()));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('serializes concurrent index creation and preserves every write with a clean database', async () => {
+    const dbPath = path.join(tmpDir, 'shared.db');
+    const indexName = 'concurrent_vectors';
+    const instanceCount = 12;
+    vectors = Array.from(
+      { length: instanceCount },
+      (_, index) => new LibSQLVector({ id: `concurrent-${index}`, url: `file:${dbPath}` }),
+    );
+
+    await Promise.all(
+      vectors.map(async (vector, index) => {
+        await vector.createIndex({ indexName, dimension: 4 });
+        await vector.upsert({
+          indexName,
+          ids: [`vector-${index}`],
+          vectors: [[index + 1, 0, 0, 0]],
+          metadata: [{ label: `write-${index}` }],
+        });
+      }),
+    );
+
+    await expect(vectors[0]!.describeIndex({ indexName })).resolves.toMatchObject({ count: instanceCount });
+
+    const integrityClient = createClient({ url: `file:${dbPath}` });
+    try {
+      const records = await integrityClient.execute(`SELECT metadata FROM ${indexName}`);
+      expect(new Set(records.rows.map(record => JSON.parse(record.metadata as string).label))).toEqual(
+        new Set(Array.from({ length: instanceCount }, (_, index) => `write-${index}`)),
+      );
+
+      const integrity = await integrityClient.execute('PRAGMA integrity_check;');
+      expect(integrity.rows).toHaveLength(1);
+      expect(Object.values(integrity.rows[0]!)).toEqual(['ok']);
+    } finally {
+      integrityClient.close();
+    }
+  });
+
+  it('canonicalizes relative, absolute, percent-encoded, and symlinked-parent file URLs to one queue', async () => {
+    const realParent = path.join(tmpDir, 'real parent');
+    const linkedParent = path.join(tmpDir, 'linked-parent');
+    fs.mkdirSync(realParent);
+    fs.symlinkSync(realParent, linkedParent, 'dir');
+
+    const absolutePath = path.join(realParent, 'aliases.db');
+    const relativePath = path.relative(process.cwd(), absolutePath);
+    const encodedPath = absolutePath.replaceAll(' ', '%20');
+    const linkedPath = path.join(linkedParent, 'aliases.db');
+    const urls = [`file:${relativePath}`, `file:${absolutePath}`, `file:${encodedPath}`, `file:${linkedPath}`];
+    vectors = urls.map((url, index) => new LibSQLVector({ id: `alias-${index}`, url }));
+
+    await Promise.all(vectors.map(vector => vector.createIndex({ indexName: 'aliases', dimension: 2 })));
+    await Promise.all(
+      vectors.map((vector, index) =>
+        vector.upsert({
+          indexName: 'aliases',
+          ids: [`alias-${index}`],
+          vectors: [[index + 1, 0]],
+          metadata: [{ spelling: index }],
+        }),
+      ),
+    );
+
+    await expect(vectors[0]!.describeIndex({ indexName: 'aliases' })).resolves.toMatchObject({ count: urls.length });
+  });
+
+  it('awaits initialization before a public operation touches the client', async () => {
+    const vector = new LibSQLVector({ id: 'initialization-order', url: `file:${path.join(tmpDir, 'order.db')}` });
+    vectors.push(vector);
+    const internals = vector as unknown as {
+      initialization: Promise<void>;
+      turso: ReturnType<typeof createClient>;
+    };
+    await internals.initialization;
+
+    let releaseInitialization!: () => void;
+    internals.initialization = new Promise<void>(resolve => {
+      releaseInitialization = resolve;
+    });
+    const executeSpy = vi.spyOn(internals.turso, 'execute');
+    const operation = vector.listIndexes();
+
+    await Promise.resolve();
+    expect(executeSpy).not.toHaveBeenCalled();
+    releaseInitialization();
+    await expect(operation).resolves.toEqual([]);
+    expect(executeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/stores/libsql/src/vector/index.ts
+++ b/stores/libsql/src/vector/index.ts
@@ -20,6 +20,7 @@ import type {
 import type { LibSQLVectorFilter } from './filter';
 import { LibSQLFilterTranslator } from './filter';
 import { buildFilterQuery } from './sql-builder';
+import { getLocalFileDatabaseKey, withLocalFileDatabaseWriteLock } from './write-lock';
 
 interface LibSQLQueryVectorParams extends QueryVectorParams<LibSQLVectorFilter> {
   minScore?: number;
@@ -60,7 +61,9 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   private readonly initialBackoffMs: number;
   private readonly overFetchMultiplier: number;
   private readonly isMemoryDb: boolean;
-  private vectorIndexes: Promise<Set<string>>;
+  private readonly initialization: Promise<void>;
+  private databaseKey: string | undefined;
+  private vectorIndexes = new Set<string>();
 
   constructor({
     url,
@@ -74,11 +77,16 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   }: LibSQLVectorConfig & { id: string }) {
     super({ id });
 
+    this.isMemoryDb = url.includes(':memory:');
+    const isLocalDb = (url.startsWith('file:') || this.isMemoryDb) && !syncUrl;
+    const cwd = process.cwd();
+
     this.turso = createClient({
       url,
       syncUrl,
       authToken,
       syncInterval,
+      ...(isLocalDb ? { timeout: 5000 } : {}),
     });
     this.maxRetries = maxRetries;
     this.initialBackoffMs = initialBackoffMs;
@@ -86,20 +94,55 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
       throw new Error('vectorTopKOverFetchMultiplier must be a positive integer');
     }
     this.overFetchMultiplier = vectorTopKOverFetchMultiplier;
-    this.isMemoryDb = url.includes(':memory:');
+    this.initialization = this.initialize({ url, syncUrl, cwd, isLocalDb });
+  }
 
-    if (url.includes(`file:`) || this.isMemoryDb) {
-      this.turso
-        .execute('PRAGMA journal_mode=WAL;')
-        .then(() => this.logger.debug('LibSQLStore: PRAGMA journal_mode=WAL set.'))
-        .catch(err => this.logger.warn('LibSQLStore: Failed to set PRAGMA journal_mode=WAL.', err));
-      this.turso
-        .execute('PRAGMA busy_timeout = 5000;')
-        .then(() => this.logger.debug('LibSQLStore: PRAGMA busy_timeout=5000 set.'))
-        .catch(err => this.logger.warn('LibSQLStore: Failed to set PRAGMA busy_timeout=5000.', err));
+  private async initialize({
+    url,
+    syncUrl,
+    cwd,
+    isLocalDb,
+  }: {
+    url: string;
+    syncUrl?: string;
+    cwd: string;
+    isLocalDb: boolean;
+  }): Promise<void> {
+    if (isLocalDb) {
+      await this.applyLocalPragmas();
+      this.databaseKey = await getLocalFileDatabaseKey({ url, syncUrl, cwd });
     }
 
-    this.vectorIndexes = this.isMemoryDb ? Promise.resolve(new Set<string>()) : this.discoverVectorIndexes();
+    if (!this.isMemoryDb) {
+      this.vectorIndexes = await this.discoverVectorIndexes();
+    }
+  }
+
+  private async applyLocalPragmas(): Promise<void> {
+    const pragmas = [
+      ['journal_mode=WAL', 'PRAGMA journal_mode=WAL;'],
+      ['busy_timeout=5000', 'PRAGMA busy_timeout = 5000;'],
+    ] as const;
+
+    for (const [label, sql] of pragmas) {
+      try {
+        await this.turso.execute(sql);
+        this.logger.debug(`LibSQLStore: PRAGMA ${label} set.`);
+      } catch (err) {
+        this.logger.warn(`LibSQLStore: Failed to set PRAGMA ${label}.`, err);
+      }
+    }
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    await this.initialization;
+  }
+
+  private async executeMutation<T>(operation: () => Promise<T>, isTransaction = false): Promise<T> {
+    await this.ensureInitialized();
+    return withLocalFileDatabaseWriteLock(this.databaseKey, () =>
+      this.executeWriteOperationWithRetry(operation, isTransaction),
+    );
   }
 
   /**
@@ -108,6 +151,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
    * Safe to call more than once; subsequent calls are no-ops.
    */
   async close(): Promise<void> {
+    await this.ensureInitialized();
     if (!this.turso.closed) {
       this.turso.close();
     }
@@ -165,9 +209,8 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
     return translator.translate(filter);
   }
 
-  private async hasVectorIndex(parsedIndexName: string): Promise<boolean> {
-    const indexes = await this.vectorIndexes;
-    return indexes.has(`${parsedIndexName}_vector_idx`);
+  private hasVectorIndex(parsedIndexName: string): boolean {
+    return this.vectorIndexes.has(`${parsedIndexName}_vector_idx`);
   }
 
   private async queryWithIndex(
@@ -243,11 +286,12 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
     }
 
     try {
+      await this.ensureInitialized();
       const parsedIndexName = parseSqlIdentifier(indexName, 'index name');
 
       const vectorStr = `[${queryVector.join(',')}]`;
 
-      if (!this.isMemoryDb && (await this.hasVectorIndex(parsedIndexName))) {
+      if (!this.isMemoryDb && this.hasVectorIndex(parsedIndexName)) {
         try {
           const indexedResults = await this.queryWithIndex(
             parsedIndexName,
@@ -311,7 +355,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
 
   public upsert(args: UpsertVectorParams): Promise<string[]> {
     try {
-      return this.executeWriteOperationWithRetry(() => this.doUpsert(args), true);
+      return this.executeMutation(() => this.doUpsert(args), true);
     } catch (error) {
       throw new MastraError(
         {
@@ -372,7 +416,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
 
   public createIndex(args: CreateIndexParams): Promise<void> {
     try {
-      return this.executeWriteOperationWithRetry(() => this.doCreateIndex(args));
+      return this.executeMutation(() => this.doCreateIndex(args));
     } catch (error) {
       throw new MastraError(
         {
@@ -409,12 +453,12 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
         `,
       args: [],
     });
-    void this.vectorIndexes.then(indexes => indexes.add(`${parsedIndexName}_vector_idx`));
+    this.vectorIndexes.add(`${parsedIndexName}_vector_idx`);
   }
 
   public deleteIndex(args: DeleteIndexParams): Promise<void> {
     try {
-      return this.executeWriteOperationWithRetry(() => this.doDeleteIndex(args));
+      return this.executeMutation(() => this.doDeleteIndex(args));
     } catch (error) {
       throw new MastraError(
         {
@@ -434,11 +478,12 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
       sql: `DROP TABLE IF EXISTS ${parsedIndexName}`,
       args: [],
     });
-    void this.vectorIndexes.then(indexes => indexes.delete(`${parsedIndexName}_vector_idx`));
+    this.vectorIndexes.delete(`${parsedIndexName}_vector_idx`);
   }
 
   async listIndexes(): Promise<string[]> {
     try {
+      await this.ensureInitialized();
       const vectorTablesQuery = `
         SELECT name FROM sqlite_master 
         WHERE type='table' 
@@ -469,6 +514,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
    */
   async describeIndex({ indexName }: DescribeIndexParams): Promise<IndexStats> {
     try {
+      await this.ensureInitialized();
       const parsedIndexName = parseSqlIdentifier(indexName, 'index name');
       // Get table info including column info
       const tableInfoQuery = `
@@ -532,7 +578,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
    * @throws Will throw an error if no updates are provided or if the update operation fails.
    */
   public updateVector(args: UpdateVectorParams<LibSQLVectorFilter>): Promise<void> {
-    return this.executeWriteOperationWithRetry(() => this.doUpdateVector(args));
+    return this.executeMutation(() => this.doUpdateVector(args));
   }
 
   private async doUpdateVector(params: UpdateVectorParams<LibSQLVectorFilter>): Promise<void> {
@@ -686,7 +732,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
    */
   public deleteVector(args: DeleteVectorParams): Promise<void> {
     try {
-      return this.executeWriteOperationWithRetry(() => this.doDeleteVector(args));
+      return this.executeMutation(() => this.doDeleteVector(args));
     } catch (error) {
       throw new MastraError(
         {
@@ -712,7 +758,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   }
 
   public deleteVectors(args: DeleteVectorsParams<LibSQLVectorFilter>): Promise<void> {
-    return this.executeWriteOperationWithRetry(() => this.doDeleteVectors(args));
+    return this.executeMutation(() => this.doDeleteVectors(args));
   }
 
   private async doDeleteVectors({ indexName, filter, ids }: DeleteVectorsParams<LibSQLVectorFilter>): Promise<void> {
@@ -830,7 +876,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
 
   public truncateIndex(args: DeleteIndexParams): Promise<void> {
     try {
-      return this.executeWriteOperationWithRetry(() => this._doTruncateIndex(args));
+      return this.executeMutation(() => this._doTruncateIndex(args));
     } catch (error) {
       throw new MastraError(
         {

--- a/stores/libsql/src/vector/index.ts
+++ b/stores/libsql/src/vector/index.ts
@@ -353,9 +353,9 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
     }
   }
 
-  public upsert(args: UpsertVectorParams): Promise<string[]> {
+  public async upsert(args: UpsertVectorParams): Promise<string[]> {
     try {
-      return this.executeMutation(() => this.doUpsert(args), true);
+      return await this.executeMutation(() => this.doUpsert(args), true);
     } catch (error) {
       throw new MastraError(
         {
@@ -414,9 +414,9 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
     }
   }
 
-  public createIndex(args: CreateIndexParams): Promise<void> {
+  public async createIndex(args: CreateIndexParams): Promise<void> {
     try {
-      return this.executeMutation(() => this.doCreateIndex(args));
+      return await this.executeMutation(() => this.doCreateIndex(args));
     } catch (error) {
       throw new MastraError(
         {
@@ -456,9 +456,9 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
     this.vectorIndexes.add(`${parsedIndexName}_vector_idx`);
   }
 
-  public deleteIndex(args: DeleteIndexParams): Promise<void> {
+  public async deleteIndex(args: DeleteIndexParams): Promise<void> {
     try {
-      return this.executeMutation(() => this.doDeleteIndex(args));
+      return await this.executeMutation(() => this.doDeleteIndex(args));
     } catch (error) {
       throw new MastraError(
         {
@@ -730,9 +730,9 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
    * @returns A promise that resolves when the deletion is complete.
    * @throws Will throw an error if the deletion operation fails.
    */
-  public deleteVector(args: DeleteVectorParams): Promise<void> {
+  public async deleteVector(args: DeleteVectorParams): Promise<void> {
     try {
-      return this.executeMutation(() => this.doDeleteVector(args));
+      return await this.executeMutation(() => this.doDeleteVector(args));
     } catch (error) {
       throw new MastraError(
         {
@@ -874,9 +874,9 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
     }
   }
 
-  public truncateIndex(args: DeleteIndexParams): Promise<void> {
+  public async truncateIndex(args: DeleteIndexParams): Promise<void> {
     try {
-      return this.executeMutation(() => this._doTruncateIndex(args));
+      return await this.executeMutation(() => this._doTruncateIndex(args));
     } catch (error) {
       throw new MastraError(
         {

--- a/stores/libsql/src/vector/write-lock.test.ts
+++ b/stores/libsql/src/vector/write-lock.test.ts
@@ -1,0 +1,182 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { getLocalFileDatabaseKey, withLocalFileDatabaseWriteLock } from './write-lock';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe('withLocalFileDatabaseWriteLock', () => {
+  it('serializes calls with the same database key in FIFO order', async () => {
+    const firstCanFinish = deferred();
+    const order: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+
+    const task = (label: string, wait?: Promise<void>) =>
+      withLocalFileDatabaseWriteLock('/tmp/shared.db', async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        order.push(`${label}:start`);
+        await wait;
+        order.push(`${label}:end`);
+        active--;
+        return label;
+      });
+
+    const first = task('first', firstCanFinish.promise);
+    const second = task('second');
+    const third = task('third');
+
+    await Promise.resolve();
+    expect(order).toEqual(['first:start']);
+    firstCanFinish.resolve();
+
+    await expect(Promise.all([first, second, third])).resolves.toEqual(['first', 'second', 'third']);
+    expect(maxActive).toBe(1);
+    expect(order).toEqual(['first:start', 'first:end', 'second:start', 'second:end', 'third:start', 'third:end']);
+  });
+
+  it('allows calls for different database keys to run concurrently', async () => {
+    const bothStarted = deferred();
+    const canFinish = deferred();
+    let active = 0;
+    let maxActive = 0;
+
+    const task = (key: string) =>
+      withLocalFileDatabaseWriteLock(key, async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        if (active === 2) bothStarted.resolve();
+        await canFinish.promise;
+        active--;
+      });
+
+    const tasks = Promise.all([task('/tmp/first.db'), task('/tmp/second.db')]);
+    await bothStarted.promise;
+    canFinish.resolve();
+    await tasks;
+
+    expect(maxActive).toBe(2);
+  });
+
+  it('continues the queue after a callback rejects', async () => {
+    const order: string[] = [];
+
+    const failed = withLocalFileDatabaseWriteLock('/tmp/recovery.db', async () => {
+      order.push('failed');
+      throw new Error('boom');
+    });
+    const following = withLocalFileDatabaseWriteLock('/tmp/recovery.db', async () => {
+      order.push('following');
+      return 'ok';
+    });
+
+    await expect(failed).rejects.toThrow('boom');
+    await expect(following).resolves.toBe('ok');
+    expect(order).toEqual(['failed', 'following']);
+  });
+
+  it('does not let stale cleanup remove a newer queue tail', async () => {
+    const firstCanFinish = deferred();
+    const secondCanFinish = deferred();
+    const order: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+
+    const task = (label: string, wait: Promise<void>) =>
+      withLocalFileDatabaseWriteLock('/tmp/cleanup.db', async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        order.push(`${label}:start`);
+        await wait;
+        order.push(`${label}:end`);
+        active--;
+      });
+
+    const first = task('first', firstCanFinish.promise);
+    const second = task('second', secondCanFinish.promise);
+    firstCanFinish.resolve();
+    await first;
+    await Promise.resolve();
+
+    const third = task('third', Promise.resolve());
+    await Promise.resolve();
+    expect(order).toEqual(['first:start', 'first:end', 'second:start']);
+
+    secondCanFinish.resolve();
+    await Promise.all([second, third]);
+
+    expect(maxActive).toBe(1);
+    expect(order).toEqual(['first:start', 'first:end', 'second:start', 'second:end', 'third:start', 'third:end']);
+  });
+});
+
+describe('getLocalFileDatabaseKey', () => {
+  it('returns one canonical key for equivalent local file spellings', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'libsql-vector-key-'));
+    try {
+      const realParent = path.join(tmpDir, 'real parent');
+      const linkedParent = path.join(tmpDir, 'linked-parent');
+      fs.mkdirSync(realParent);
+      fs.symlinkSync(realParent, linkedParent, 'dir');
+      const databasePath = path.join(realParent, 'vectors.db');
+      fs.writeFileSync(databasePath, '');
+
+      const keys = await Promise.all([
+        getLocalFileDatabaseKey({
+          url: `file:${path.relative(process.cwd(), databasePath)}`,
+          cwd: process.cwd(),
+        }),
+        getLocalFileDatabaseKey({ url: `file:${databasePath}`, cwd: process.cwd() }),
+        getLocalFileDatabaseKey({
+          url: `file:${databasePath.replaceAll(' ', '%20')}?mode=rwc#ignored`,
+          cwd: process.cwd(),
+        }),
+        getLocalFileDatabaseKey({
+          url: `file:${path.join(linkedParent, 'vectors.db')}`,
+          cwd: process.cwd(),
+        }),
+      ]);
+
+      expect(new Set(keys)).toEqual(new Set([fs.realpathSync(databasePath)]));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the canonical parent when the database file does not exist yet', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'libsql-vector-key-parent-'));
+    try {
+      const realParent = path.join(tmpDir, 'real');
+      const linkedParent = path.join(tmpDir, 'linked');
+      fs.mkdirSync(realParent);
+      fs.symlinkSync(realParent, linkedParent, 'dir');
+
+      await expect(
+        getLocalFileDatabaseKey({ url: `file:${path.join(linkedParent, 'future.db')}`, cwd: process.cwd() }),
+      ).resolves.toBe(path.join(fs.realpathSync(realParent), 'future.db'));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    { url: 'libsql://example.turso.io' },
+    { url: 'file::memory:' },
+    { url: 'file:embedded.db', syncUrl: 'libsql://example.turso.io' },
+  ])('does not key remote, in-memory, or embedded-replica configuration: $url', async config => {
+    await expect(getLocalFileDatabaseKey({ ...config, cwd: process.cwd() })).resolves.toBeUndefined();
+  });
+
+  it('propagates malformed percent encoding instead of falling back to the raw URL', async () => {
+    await expect(getLocalFileDatabaseKey({ url: 'file:invalid%ZZ.db', cwd: process.cwd() })).rejects.toThrow(URIError);
+  });
+});

--- a/stores/libsql/src/vector/write-lock.ts
+++ b/stores/libsql/src/vector/write-lock.ts
@@ -1,0 +1,54 @@
+import { realpath } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
+
+const databaseWriteChains = new Map<string, Promise<void>>();
+
+export async function getLocalFileDatabaseKey({
+  url,
+  syncUrl,
+  cwd,
+}: {
+  url: string;
+  syncUrl?: string;
+  cwd: string;
+}): Promise<string | undefined> {
+  if (!url.startsWith('file:') || url.includes(':memory:') || syncUrl) {
+    return undefined;
+  }
+
+  const uriPath = url.slice('file:'.length).split(/[?#]/, 1)[0]!;
+  const decodedPath = decodeURIComponent(uriPath);
+  const absolutePath = isAbsolute(decodedPath) ? decodedPath : resolve(cwd, decodedPath);
+
+  try {
+    return await realpath(absolutePath);
+  } catch (error) {
+    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  return join(await realpath(dirname(absolutePath)), basename(absolutePath));
+}
+
+export function withLocalFileDatabaseWriteLock<T>(key: string | undefined, fn: () => Promise<T>): Promise<T> {
+  if (!key) {
+    return fn();
+  }
+
+  const previous = databaseWriteChains.get(key) ?? Promise.resolve();
+  const result = previous.then(fn, fn);
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  databaseWriteChains.set(key, tail);
+
+  void tail.then(() => {
+    if (databaseWriteChains.get(key) === tail) {
+      databaseWriteChains.delete(key);
+    }
+  });
+
+  return result;
+}


### PR DESCRIPTION
Multiple `LibSQLVector` instances can own separate clients that point at the same local SQLite file. Concurrent index creation could interleave across those clients and produce `SQLITE_CORRUPT` schema errors.

This change waits for local WAL and busy-timeout initialization before vector operations, then serializes complete mutations by canonical local database path within one Node.js process. Different database files remain concurrent, while remote, in-memory, and embedded-replica connections keep relying on libSQL's existing coordination.

Before, concurrent clients could race the table and vector-index statements. After, same-file operations run FIFO around the existing retry and transaction boundaries. The public API is unchanged.

Verified with the full `@mastra/libsql` suite (1009 passed, 19 skipped), focused concurrency and integrity tests, package build and lint, and packed-package stress projects. The base package reproduced schema corruption in 20/20 trials; this branch completed 240/240 writes with integrity `ok` and 0/20 failures.
