### PR TITLE
fix(factory): cache collaborator permissions and sweep GitHub hourly

### DIFF
--- a/.changeset/factory-github-reconcile-budget.md
+++ b/.changeset/factory-github-reconcile-budget.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the GitHub integration exhausting the installation's REST rate limit: collaborator permission lookups are now cached for 30 minutes per repo and login (the reconcile sweep re-checked every open card's author on every pass), and the PR/issue reconcile sweeps default to hourly instead of every 5 minutes since event polling and webhooks are the primary sync. Override the interval with `MASTRACODE_PLATFORM_GITHUB_RECONCILE_INTERVAL_MS` (platform) or `MASTRACODE_GITHUB_RECONCILE_INTERVAL_MS` (direct), or the `_PR_` / `_ISSUE_` variants.

--- a/.changeset/factory-github-reconcile-budget.md
+++ b/.changeset/factory-github-reconcile-budget.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Fixed the GitHub integration exhausting the installation's REST rate limit: collaborator permission lookups are now cached for 30 minutes per repo and login (the reconcile sweep re-checked every open card's author on every pass), and the PR/issue reconcile sweeps default to hourly instead of every 5 minutes since event polling and webhooks are the primary sync. Override the interval with `MASTRACODE_PLATFORM_GITHUB_RECONCILE_INTERVAL_MS` (platform) or `MASTRACODE_GITHUB_RECONCILE_INTERVAL_MS` (direct), or the `_PR_` / `_ISSUE_` variants.
+Reduced the GitHub integration's REST request volume. Collaborator permission lookups are cached for 30 minutes per repo and login, and the PR/issue reconcile sweeps default to hourly instead of every 5 minutes; event polling and webhooks remain the primary sync. Override the interval with `MASTRACODE_PLATFORM_GITHUB_RECONCILE_INTERVAL_MS` (platform) or `MASTRACODE_GITHUB_RECONCILE_INTERVAL_MS` (direct), or the `_PR_` / `_ISSUE_` variants.

--- a/mastracode/factory/src/integrations/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/github/integration.test.ts
@@ -162,6 +162,30 @@ describe('GithubIntegration collaborator permission coalescing', () => {
   });
 });
 
+describe('GithubIntegration collaborator permission cancellation', () => {
+  it("keeps a coalesced lookup alive for other callers when one caller's signal aborts", async () => {
+    const github = new GithubIntegration(validConfig());
+    let release!: (value: { data: { permission: string } }) => void;
+    const getCollaboratorPermissionLevel = vi.fn(() => new Promise(resolve => (release = resolve)));
+    vi.spyOn(github, 'getInstallationOctokit').mockReturnValue({
+      repos: { getCollaboratorPermissionLevel },
+    } as any);
+    const aborter = new AbortController();
+
+    const aborted = github.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace', aborter.signal);
+    const patient = github.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace');
+    aborter.abort();
+    await expect(aborted).resolves.toBeUndefined();
+
+    release({ data: { permission: 'write' } });
+    await expect(patient).resolves.toBe('write');
+    expect(getCollaboratorPermissionLevel).toHaveBeenCalledTimes(1);
+    const [request] = getCollaboratorPermissionLevel.mock.calls[0] as unknown as [{ request: { signal: AbortSignal } }];
+    expect(request.request.signal).not.toBe(aborter.signal);
+    expect(request.request.signal.aborted).toBe(false);
+  });
+});
+
 describe('GithubIntegration triage comment upsert', () => {
   it('updates the oldest Factory marker across pages and ignores human marker comments', async () => {
     const github = new GithubIntegration(validConfig());

--- a/mastracode/factory/src/integrations/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/github/integration.test.ts
@@ -144,6 +144,24 @@ describe('GithubIntegration collaborator permission', () => {
   });
 });
 
+describe('GithubIntegration collaborator permission coalescing', () => {
+  it('shares one in-flight request between overlapping lookups for the same login', async () => {
+    const github = new GithubIntegration(validConfig());
+    let release!: (value: { data: { permission: string } }) => void;
+    const getCollaboratorPermissionLevel = vi.fn(() => new Promise(resolve => (release = resolve)));
+    vi.spyOn(github, 'getInstallationOctokit').mockReturnValue({
+      repos: { getCollaboratorPermissionLevel },
+    } as any);
+
+    const first = github.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace');
+    const second = github.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace');
+    expect(getCollaboratorPermissionLevel).toHaveBeenCalledTimes(1);
+    release({ data: { permission: 'write' } });
+    await expect(Promise.all([first, second])).resolves.toEqual(['write', 'write']);
+    expect(getCollaboratorPermissionLevel).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('GithubIntegration triage comment upsert', () => {
   it('updates the oldest Factory marker across pages and ignores human marker comments', async () => {
     const github = new GithubIntegration(validConfig());

--- a/mastracode/factory/src/integrations/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/github/integration.test.ts
@@ -107,6 +107,32 @@ describe('GithubIntegration constructor', () => {
   });
 });
 
+describe('GithubIntegration collaborator permission', () => {
+  it('reuses a resolved permission per installation, repo, and login; failures are retried', async () => {
+    const github = new GithubIntegration(validConfig());
+    const getCollaboratorPermissionLevel = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { permission: 'write' } })
+      .mockRejectedValueOnce(new Error('rate limited'))
+      .mockResolvedValueOnce({ data: { permission: 'read' } });
+    vi.spyOn(github, 'getInstallationOctokit').mockReturnValue({
+      repos: { getCollaboratorPermissionLevel },
+    } as any);
+
+    await expect(github.getRepositoryCollaboratorPermission(7, 'acme/app', 'Grace')).resolves.toBe('write');
+    await expect(github.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace')).resolves.toBe('write');
+    expect(getCollaboratorPermissionLevel).toHaveBeenCalledTimes(1);
+
+    await expect(github.getRepositoryCollaboratorPermission(7, 'acme/app', 'hank')).resolves.toBeUndefined();
+    await expect(github.getRepositoryCollaboratorPermission(7, 'acme/app', 'hank')).resolves.toBe('read');
+    expect(getCollaboratorPermissionLevel).toHaveBeenCalledTimes(3);
+
+    // A different installation is a different token and a different answer.
+    await github.getRepositoryCollaboratorPermission(8, 'acme/app', 'grace');
+    expect(getCollaboratorPermissionLevel).toHaveBeenCalledTimes(4);
+  });
+});
+
 describe('GithubIntegration triage comment upsert', () => {
   it('updates the oldest Factory marker across pages and ignores human marker comments', async () => {
     const github = new GithubIntegration(validConfig());

--- a/mastracode/factory/src/integrations/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/github/integration.test.ts
@@ -127,9 +127,20 @@ describe('GithubIntegration collaborator permission', () => {
     await expect(github.getRepositoryCollaboratorPermission(7, 'acme/app', 'hank')).resolves.toBe('read');
     expect(getCollaboratorPermissionLevel).toHaveBeenCalledTimes(3);
 
+    // The entry expires: a lookup after the TTL goes back to GitHub.
+    vi.useFakeTimers();
+    try {
+      vi.advanceTimersByTime(31 * 60_000);
+      getCollaboratorPermissionLevel.mockResolvedValueOnce({ data: { permission: 'none' } });
+      await expect(github.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace')).resolves.toBe('none');
+      expect(getCollaboratorPermissionLevel).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+
     // A different installation is a different token and a different answer.
     await github.getRepositoryCollaboratorPermission(8, 'acme/app', 'grace');
-    expect(getCollaboratorPermissionLevel).toHaveBeenCalledTimes(4);
+    expect(getCollaboratorPermissionLevel).toHaveBeenCalledTimes(5);
   });
 });
 

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -112,6 +112,16 @@ export interface GithubTriageCommentUpsertResult {
 
 export type GithubRepositoryPermission = 'admin' | 'maintain' | 'write' | 'triage' | 'read' | 'none';
 
+/**
+ * How long a collaborator permission lookup may be reused. The reconcile
+ * sweep re-stamps every open card's author and webhook gating checks every
+ * human sender, so one login can cost dozens of identical requests per cycle
+ * against the installation's REST budget. Revoked access reads as trusted for
+ * at most this long.
+ */
+const COLLABORATOR_PERMISSION_CACHE_TTL_MS = 30 * 60_000;
+const COLLABORATOR_PERMISSION_CACHE_MAX_ENTRIES = 1000;
+
 export interface IssueSummary {
   number: number;
   title: string;
@@ -343,6 +353,11 @@ export class GithubIntegration implements FactoryIntegration {
   readonly #authorizedBots: readonly string[];
   #storage: IntegrationContext['storage'] | undefined;
   #sourceControlStorage: IntegrationContext['storage']['sourceControl'] | undefined;
+  /** `installationId:owner/repo:login` → cached collaborator permission (TTL-bounded). */
+  readonly #collaboratorPermissionCache = new Map<
+    string,
+    { permission: GithubRepositoryPermission; expiresAt: number }
+  >();
 
   constructor(config: GithubIntegrationConfig) {
     const missing = REQUIRED_FIELDS.filter(field => !config[field]);
@@ -509,13 +524,28 @@ export class GithubIntegration implements FactoryIntegration {
   ): Promise<GithubRepositoryPermission | undefined> {
     const parts = splitRepoFullName(repoFullName);
     if (!parts) return undefined;
+    const cacheKey = `${installationId}:${parts.owner}/${parts.repo}:${username.toLowerCase()}`;
+    const cached = this.#collaboratorPermissionCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) return cached.permission;
+    this.#collaboratorPermissionCache.delete(cacheKey);
     try {
       const { data } = await this.getInstallationOctokit(installationId).repos.getCollaboratorPermissionLevel({
         ...parts,
         username,
         request: { signal },
       });
-      return data.permission as GithubRepositoryPermission;
+      const permission = data.permission as GithubRepositoryPermission;
+      // Failures are not cached: a rate-limited or aborted lookup must retry
+      // on the next call rather than pin the login as unknown.
+      this.#collaboratorPermissionCache.set(cacheKey, {
+        permission,
+        expiresAt: Date.now() + COLLABORATOR_PERMISSION_CACHE_TTL_MS,
+      });
+      if (this.#collaboratorPermissionCache.size > COLLABORATOR_PERMISSION_CACHE_MAX_ENTRIES) {
+        const oldest = this.#collaboratorPermissionCache.keys().next().value;
+        if (oldest !== undefined) this.#collaboratorPermissionCache.delete(oldest);
+      }
+      return permission;
     } catch {
       return undefined;
     }

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -58,6 +58,7 @@ import {
   parseCreatedPullRequest,
   subscribeCurrentSessionToPullRequest,
 } from './session-subscriptions.js';
+import { settleOrAbort } from './settle-or-abort.js';
 import type { GithubSubscriptionStorage } from './subscriptions.js';
 
 type InputOf<TMethod extends keyof VersionControl> = VersionControl[TMethod] extends (input: infer TInput) => unknown
@@ -121,6 +122,8 @@ export type GithubRepositoryPermission = 'admin' | 'maintain' | 'write' | 'triag
  */
 const COLLABORATOR_PERMISSION_CACHE_TTL_MS = 30 * 60_000;
 const COLLABORATOR_PERMISSION_CACHE_MAX_ENTRIES = 1000;
+/** Bound on the shared upstream lookup; callers race their own signal against it. */
+const COLLABORATOR_PERMISSION_LOOKUP_TIMEOUT_MS = 10_000;
 
 export interface IssueSummary {
   number: number;
@@ -531,13 +534,13 @@ export class GithubIntegration implements FactoryIntegration {
     if (cached && cached.expiresAt > Date.now()) return cached.permission;
     this.#collaboratorPermissionCache.delete(cacheKey);
     const inFlight = this.#collaboratorPermissionInFlight.get(cacheKey);
-    if (inFlight) return inFlight;
+    if (inFlight) return settleOrAbort(inFlight, signal, undefined);
     const lookup = (async () => {
       try {
         const { data } = await this.getInstallationOctokit(installationId).repos.getCollaboratorPermissionLevel({
           ...parts,
           username,
-          request: { signal },
+          request: { signal: AbortSignal.timeout(COLLABORATOR_PERMISSION_LOOKUP_TIMEOUT_MS) },
         });
         const permission = data.permission as GithubRepositoryPermission;
         // Failures are not cached: a rate-limited or aborted lookup must retry
@@ -558,7 +561,7 @@ export class GithubIntegration implements FactoryIntegration {
       }
     })();
     this.#collaboratorPermissionInFlight.set(cacheKey, lookup);
-    return lookup;
+    return settleOrAbort(lookup, signal, undefined);
   }
 
   /**

--- a/mastracode/factory/src/integrations/github/integration.ts
+++ b/mastracode/factory/src/integrations/github/integration.ts
@@ -358,6 +358,8 @@ export class GithubIntegration implements FactoryIntegration {
     string,
     { permission: GithubRepositoryPermission; expiresAt: number }
   >();
+  /** Same key → lookup already in flight, so overlapping callers share one request. */
+  readonly #collaboratorPermissionInFlight = new Map<string, Promise<GithubRepositoryPermission | undefined>>();
 
   constructor(config: GithubIntegrationConfig) {
     const missing = REQUIRED_FIELDS.filter(field => !config[field]);
@@ -528,27 +530,35 @@ export class GithubIntegration implements FactoryIntegration {
     const cached = this.#collaboratorPermissionCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) return cached.permission;
     this.#collaboratorPermissionCache.delete(cacheKey);
-    try {
-      const { data } = await this.getInstallationOctokit(installationId).repos.getCollaboratorPermissionLevel({
-        ...parts,
-        username,
-        request: { signal },
-      });
-      const permission = data.permission as GithubRepositoryPermission;
-      // Failures are not cached: a rate-limited or aborted lookup must retry
-      // on the next call rather than pin the login as unknown.
-      this.#collaboratorPermissionCache.set(cacheKey, {
-        permission,
-        expiresAt: Date.now() + COLLABORATOR_PERMISSION_CACHE_TTL_MS,
-      });
-      if (this.#collaboratorPermissionCache.size > COLLABORATOR_PERMISSION_CACHE_MAX_ENTRIES) {
-        const oldest = this.#collaboratorPermissionCache.keys().next().value;
-        if (oldest !== undefined) this.#collaboratorPermissionCache.delete(oldest);
+    const inFlight = this.#collaboratorPermissionInFlight.get(cacheKey);
+    if (inFlight) return inFlight;
+    const lookup = (async () => {
+      try {
+        const { data } = await this.getInstallationOctokit(installationId).repos.getCollaboratorPermissionLevel({
+          ...parts,
+          username,
+          request: { signal },
+        });
+        const permission = data.permission as GithubRepositoryPermission;
+        // Failures are not cached: a rate-limited or aborted lookup must retry
+        // on the next call rather than pin the login as unknown.
+        this.#collaboratorPermissionCache.set(cacheKey, {
+          permission,
+          expiresAt: Date.now() + COLLABORATOR_PERMISSION_CACHE_TTL_MS,
+        });
+        if (this.#collaboratorPermissionCache.size > COLLABORATOR_PERMISSION_CACHE_MAX_ENTRIES) {
+          const oldest = this.#collaboratorPermissionCache.keys().next().value;
+          if (oldest !== undefined) this.#collaboratorPermissionCache.delete(oldest);
+        }
+        return permission;
+      } catch {
+        return undefined;
+      } finally {
+        this.#collaboratorPermissionInFlight.delete(cacheKey);
       }
-      return permission;
-    } catch {
-      return undefined;
-    }
+    })();
+    this.#collaboratorPermissionInFlight.set(cacheKey, lookup);
+    return lookup;
   }
 
   /**

--- a/mastracode/factory/src/integrations/github/reconcile-worker.ts
+++ b/mastracode/factory/src/integrations/github/reconcile-worker.ts
@@ -13,7 +13,8 @@ import type {
 import type { GithubIssueReconciler } from './issue-reconciler.js';
 import type { GithubPullRequestReconciler, ReconcileRepository } from './rules.js';
 
-export const DEFAULT_GITHUB_RECONCILE_INTERVAL_MS = 5 * 60_000;
+// Webhooks are the primary sync; the sweeps only catch drift, so hourly.
+export const DEFAULT_GITHUB_RECONCILE_INTERVAL_MS = 60 * 60_000;
 const MIN_LEASE_TTL_MS = 30_000;
 const LEASE_KEY = 'github:pull-request-reconcile';
 

--- a/mastracode/factory/src/integrations/github/settle-or-abort.ts
+++ b/mastracode/factory/src/integrations/github/settle-or-abort.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolve to `fallback` when `signal` aborts before `promise` settles, leaving
+ * `promise` itself running: callers that share one coalesced upstream request
+ * keep their own cancellation without cancelling each other's answer.
+ */
+export function settleOrAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined, fallback: T): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.resolve(fallback);
+  return new Promise<T>(resolve => {
+    const onAbort = () => resolve(fallback);
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      value => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      () => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(fallback);
+      },
+    );
+  });
+}

--- a/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
@@ -950,11 +950,20 @@ describe('PlatformGithubEventWorker', () => {
       failed: 0,
       errors: [],
     }));
+    const reconcileIssuesFactoryState = vi.fn<GithubIssueReconciler>(async () => ({
+      repositories: 1,
+      checked: 1,
+      updated: 0,
+      closed: 0,
+      failed: 0,
+      errors: [],
+    }));
     const worker = createWorker({
       fetchImpl,
       storage: settings.storage,
       now: () => clock,
       reconcileFactoryState,
+      reconcileIssuesFactoryState,
       intervalMs: 5 * 60_000,
       pollEventsEnabled: false,
     });
@@ -963,6 +972,7 @@ describe('PlatformGithubEventWorker', () => {
     await worker.start();
     await vi.advanceTimersByTimeAsync(0);
     expect(reconcileFactoryState).toHaveBeenCalledTimes(1);
+    expect(reconcileIssuesFactoryState).toHaveBeenCalledTimes(1);
 
     // Eleven more five-minute ticks stay inside the hour: no second sweep.
     for (let tick = 0; tick < 11; tick += 1) {
@@ -970,11 +980,13 @@ describe('PlatformGithubEventWorker', () => {
       await vi.advanceTimersByTimeAsync(5 * 60_000);
     }
     expect(reconcileFactoryState).toHaveBeenCalledTimes(1);
+    expect(reconcileIssuesFactoryState).toHaveBeenCalledTimes(1);
 
     clock += 5 * 60_000;
     await vi.advanceTimersByTimeAsync(5 * 60_000);
     await worker.stop();
     expect(reconcileFactoryState).toHaveBeenCalledTimes(2);
+    expect(reconcileIssuesFactoryState).toHaveBeenCalledTimes(2);
   });
 
   it('reconciles without tailing events when event polling is disabled', async () => {

--- a/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.test.ts
@@ -929,6 +929,54 @@ describe('PlatformGithubEventWorker', () => {
     expect(reconcileIssuesFactoryState).toHaveBeenCalledTimes(4);
   });
 
+  it('sweeps once on the first tick and then hourly by default', async () => {
+    const settings = createSettingsStorage();
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/installations')) {
+        return json({ installations: [{ installationId: 7, usable: true, suspendedAt: null }] });
+      }
+      if (url.pathname.endsWith('/installations/7/repositories')) {
+        return json({ repositories: [{ id: 101, fullName: 'acme/repo' }] });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    let clock = 1_000_000;
+    const reconcileFactoryState = vi.fn<GithubPullRequestReconciler>(async () => ({
+      repositories: 1,
+      checked: 1,
+      merged: 0,
+      closed: 0,
+      failed: 0,
+      errors: [],
+    }));
+    const worker = createWorker({
+      fetchImpl,
+      storage: settings.storage,
+      now: () => clock,
+      reconcileFactoryState,
+      intervalMs: 5 * 60_000,
+      pollEventsEnabled: false,
+    });
+
+    await worker.init(createDeps());
+    await worker.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reconcileFactoryState).toHaveBeenCalledTimes(1);
+
+    // Eleven more five-minute ticks stay inside the hour: no second sweep.
+    for (let tick = 0; tick < 11; tick += 1) {
+      clock += 5 * 60_000;
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+    }
+    expect(reconcileFactoryState).toHaveBeenCalledTimes(1);
+
+    clock += 5 * 60_000;
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await worker.stop();
+    expect(reconcileFactoryState).toHaveBeenCalledTimes(2);
+  });
+
   it('reconciles without tailing events when event polling is disabled', async () => {
     const settings = createSettingsStorage();
     const dispatch = vi.fn<typeof dispatchGithubWebhook>();

--- a/mastracode/factory/src/integrations/platform/github/event-worker.ts
+++ b/mastracode/factory/src/integrations/platform/github/event-worker.ts
@@ -23,7 +23,9 @@ import { PlatformApiError } from '../api-client.js';
 
 const API_PREFIX = '/v1/server/github-app';
 const DEFAULT_POLL_INTERVAL_MS = 20_000;
-const DEFAULT_RECONCILE_INTERVAL_MS = 5 * 60_000;
+// Event polling is the primary sync; the sweeps only catch drift (missed
+// events, cards ingested before polling was linked), so they run hourly.
+const DEFAULT_RECONCILE_INTERVAL_MS = 60 * 60_000;
 const EVENT_PAGE_SIZE = 500;
 const MIN_LEASE_TTL_MS = 30_000;
 const CURSOR_ORG_ID = '__platform_github_event_worker__';
@@ -128,8 +130,9 @@ export class PlatformGithubEventWorker extends MastraWorker {
   #leaseTtlMs: number;
   #hasLease = false;
   #startedAt = 0;
-  #lastPullRequestReconcileAt = 0;
-  #lastIssueReconcileAt = 0;
+  // Negative infinity so the first tick always sweeps, whatever the clock reads.
+  #lastPullRequestReconcileAt = Number.NEGATIVE_INFINITY;
+  #lastIssueReconcileAt = Number.NEGATIVE_INFINITY;
   #settings: PlatformGithubEventWorkerSettings = { version: 1, repositories: {} };
 
   constructor(config: PlatformGithubEventWorkerConfig) {

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -1187,6 +1187,24 @@ describe('PlatformGithubIntegration', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a coalesced lookup alive for other callers when one caller's signal aborts", async () => {
+    let release!: (value: Response) => void;
+    const fetchImpl = vi.fn<typeof fetch>(() => new Promise<Response>(resolve => (release = resolve)));
+    const integration = createIntegration(fetchImpl);
+    const aborter = new AbortController();
+
+    const aborted = integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace', aborter.signal);
+    const patient = integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace');
+    aborter.abort();
+    await expect(aborted).resolves.toBeUndefined();
+
+    release(json({ permission: 'write', roleName: 'write', user: actor }));
+    await expect(patient).resolves.toBe('write');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // The shared request never carried the caller's signal.
+    expect((fetchImpl.mock.calls[0]?.[1] as RequestInit).signal?.aborted).toBe(false);
+  });
+
   it('re-requests a collaborator permission once the cache entry expires', async () => {
     vi.useFakeTimers();
     try {

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -1174,6 +1174,19 @@ describe('PlatformGithubIntegration', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
 
+  it('shares one in-flight request between overlapping lookups for the same login', async () => {
+    let release!: (value: Response) => void;
+    const fetchImpl = vi.fn<typeof fetch>(() => new Promise<Response>(resolve => (release = resolve)));
+    const integration = createIntegration(fetchImpl);
+
+    const first = integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace');
+    const second = integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'GRACE');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    release(json({ permission: 'write', roleName: 'write', user: actor }));
+    await expect(Promise.all([first, second])).resolves.toEqual(['write', 'write']);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it('re-requests a collaborator permission once the cache entry expires', async () => {
     vi.useFakeTimers();
     try {

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -1174,6 +1174,28 @@ describe('PlatformGithubIntegration', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
 
+  it('re-requests a collaborator permission once the cache entry expires', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(json({ permission: 'write', roleName: 'write', user: actor }))
+        .mockResolvedValueOnce(json({ permission: 'read', roleName: 'read', user: actor }));
+      const integration = createIntegration(fetchImpl);
+
+      await expect(integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace')).resolves.toBe('write');
+      vi.advanceTimersByTime(29 * 60_000);
+      await expect(integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace')).resolves.toBe('write');
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(2 * 60_000);
+      await expect(integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace')).resolves.toBe('read');
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps the reconciliation worker alive when polling is disabled', async () => {
     vi.stubEnv('MASTRA_PLATFORM_GITHUB_POLLING_ENABLED', 'false');
     const seed = await createPlatformStorageForTests();

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -1156,6 +1156,24 @@ describe('PlatformGithubIntegration', () => {
     });
   });
 
+  it('reuses a resolved collaborator permission instead of re-requesting it per card and event', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(json({ permission: 'write', roleName: 'write', user: actor }))
+      .mockResolvedValueOnce(json({ error: 'rate limited' }, 403))
+      .mockResolvedValueOnce(json({ permission: 'read', roleName: 'read', user: actor }));
+    const integration = createIntegration(fetchImpl);
+
+    await expect(integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'Grace')).resolves.toBe('write');
+    await expect(integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'grace')).resolves.toBe('write');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    // A failed lookup is not cached: the next call for that login retries.
+    await expect(integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'hank')).resolves.toBeUndefined();
+    await expect(integration.getRepositoryCollaboratorPermission(7, 'acme/app', 'hank')).resolves.toBe('read');
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
   it('keeps the reconciliation worker alive when polling is disabled', async () => {
     vi.stubEnv('MASTRA_PLATFORM_GITHUB_POLLING_ENABLED', 'false');
     const seed = await createPlatformStorageForTests();

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -243,6 +243,8 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     string,
     { permission: GithubRepositoryPermission; expiresAt: number }
   >();
+  /** Same key → lookup already in flight, so overlapping callers share one request. */
+  readonly #collaboratorPermissionInFlight = new Map<string, Promise<GithubRepositoryPermission | undefined>>();
 
   readonly intake: Intake = {
     resolveIntakeDispatch: input => this.#resolveIntakeDispatch(input),
@@ -995,23 +997,31 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     const cached = this.#collaboratorPermissionCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) return cached.permission;
     this.#collaboratorPermissionCache.delete(cacheKey);
-    try {
-      const result = await this.#client.request<{ permission: GithubRepositoryPermission }>(
-        'GET',
-        `${API_PREFIX}/github/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/collaborators/${encodeURIComponent(username)}/permission`,
-        undefined,
-        { signal },
-      );
-      // Failures are not cached: a rate-limited or aborted lookup must retry
-      // on the next call rather than pin the login as unknown.
-      setBounded(this.#collaboratorPermissionCache, cacheKey, {
-        permission: result.permission,
-        expiresAt: Date.now() + COLLABORATOR_PERMISSION_CACHE_TTL_MS,
-      });
-      return result.permission;
-    } catch {
-      return undefined;
-    }
+    const inFlight = this.#collaboratorPermissionInFlight.get(cacheKey);
+    if (inFlight) return inFlight;
+    const lookup = (async () => {
+      try {
+        const result = await this.#client.request<{ permission: GithubRepositoryPermission }>(
+          'GET',
+          `${API_PREFIX}/github/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/collaborators/${encodeURIComponent(username)}/permission`,
+          undefined,
+          { signal },
+        );
+        // Failures are not cached: a rate-limited or aborted lookup must retry
+        // on the next call rather than pin the login as unknown.
+        setBounded(this.#collaboratorPermissionCache, cacheKey, {
+          permission: result.permission,
+          expiresAt: Date.now() + COLLABORATOR_PERMISSION_CACHE_TTL_MS,
+        });
+        return result.permission;
+      } catch {
+        return undefined;
+      } finally {
+        this.#collaboratorPermissionInFlight.delete(cacheKey);
+      }
+    })();
+    this.#collaboratorPermissionInFlight.set(cacheKey, lookup);
+    return lookup;
   }
 
   async listInstallationRepos(installationId: number): Promise<RepoSummary[]> {

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -172,6 +172,14 @@ const INSTALLATION_REPOS_CACHE_TTL_MS = 30_000;
  */
 const REPOSITORY_ACCESS_CACHE_TTL_MS = 5 * 60_000;
 /**
+ * How long a collaborator permission lookup may be reused. The reconcile
+ * sweep re-stamps every open card's author and the event tail gates every
+ * human-authored event on it, so one login can cost dozens of identical
+ * requests per cycle against the installation's REST budget. Revoked access
+ * reads as trusted for at most this long.
+ */
+const COLLABORATOR_PERMISSION_CACHE_TTL_MS = 30 * 60_000;
+/**
  * Upper bound for both TTL caches. Entries expire lazily on re-access, so
  * without a hard cap keys that stop being queried would accumulate for the
  * integration's (long) lifetime. Insertion-order eviction — matches the
@@ -230,6 +238,11 @@ export class PlatformGithubIntegration implements FactoryIntegration {
   readonly #installationReposCache = new Map<number, { repos: RepoSummary[]; expiresAt: number }>();
   /** `orgId:repositoryId` → cached repository access (TTL-bounded). */
   readonly #repositoryAccessCache = new Map<string, { access: RepositoryAccess; expiresAt: number }>();
+  /** `owner/repo:login` → cached collaborator permission (TTL-bounded). */
+  readonly #collaboratorPermissionCache = new Map<
+    string,
+    { permission: GithubRepositoryPermission; expiresAt: number }
+  >();
 
   readonly intake: Intake = {
     resolveIntakeDispatch: input => this.#resolveIntakeDispatch(input),
@@ -978,6 +991,10 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     } catch {
       return undefined;
     }
+    const cacheKey = `${repository.owner}/${repository.repo}:${username.toLowerCase()}`;
+    const cached = this.#collaboratorPermissionCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) return cached.permission;
+    this.#collaboratorPermissionCache.delete(cacheKey);
     try {
       const result = await this.#client.request<{ permission: GithubRepositoryPermission }>(
         'GET',
@@ -985,6 +1002,12 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         undefined,
         { signal },
       );
+      // Failures are not cached: a rate-limited or aborted lookup must retry
+      // on the next call rather than pin the login as unknown.
+      setBounded(this.#collaboratorPermissionCache, cacheKey, {
+        permission: result.permission,
+        expiresAt: Date.now() + COLLABORATOR_PERMISSION_CACHE_TTL_MS,
+      });
       return result.permission;
     } catch {
       return undefined;

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -62,6 +62,7 @@ import {
   parseCreatedPullRequest,
   subscribeCurrentSessionToPullRequest,
 } from '../../github/session-subscriptions.js';
+import { settleOrAbort } from '../../github/settle-or-abort.js';
 import type { GithubSubscriptionStorage } from '../../github/subscriptions.js';
 import { parseAuthorizedBotsEnv } from '../../github/webhook.js';
 import {
@@ -179,6 +180,8 @@ const REPOSITORY_ACCESS_CACHE_TTL_MS = 5 * 60_000;
  * reads as trusted for at most this long.
  */
 const COLLABORATOR_PERMISSION_CACHE_TTL_MS = 30 * 60_000;
+/** Bound on the shared upstream lookup; callers race their own signal against it. */
+const COLLABORATOR_PERMISSION_LOOKUP_TIMEOUT_MS = 10_000;
 /**
  * Upper bound for both TTL caches. Entries expire lazily on re-access, so
  * without a hard cap keys that stop being queried would accumulate for the
@@ -998,14 +1001,14 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     if (cached && cached.expiresAt > Date.now()) return cached.permission;
     this.#collaboratorPermissionCache.delete(cacheKey);
     const inFlight = this.#collaboratorPermissionInFlight.get(cacheKey);
-    if (inFlight) return inFlight;
+    if (inFlight) return settleOrAbort(inFlight, signal, undefined);
     const lookup = (async () => {
       try {
         const result = await this.#client.request<{ permission: GithubRepositoryPermission }>(
           'GET',
           `${API_PREFIX}/github/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/collaborators/${encodeURIComponent(username)}/permission`,
           undefined,
-          { signal },
+          { signal: AbortSignal.timeout(COLLABORATOR_PERMISSION_LOOKUP_TIMEOUT_MS) },
         );
         // Failures are not cached: a rate-limited or aborted lookup must retry
         // on the next call rather than pin the login as unknown.
@@ -1021,7 +1024,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       }
     })();
     this.#collaboratorPermissionInFlight.set(cacheKey, lookup);
-    return lookup;
+    return settleOrAbort(lookup, signal, undefined);
   }
 
   async listInstallationRepos(installationId: number): Promise<RepoSummary[]> {


### PR DESCRIPTION
The GitHub reconcile sweep fetches every open card's PR and re-checks its author's collaborator permission on every pass, every 5 minutes. On a board with a few hundred open cards that alone exceeds a GitHub App installation's 5,000/hr REST budget, and the event tail adds a permission lookup per human-authored event on top.

Two changes in `@mastra/factory`: collaborator permission lookups are cached for 30 minutes per repo and login (overlapping lookups for the same login share one request; failures are not cached, so a rate-limited lookup retries), and the PR/issue reconcile sweeps default to hourly instead of every 5 minutes. Event polling (platform) and webhooks (direct) are the primary sync; the sweeps only catch drift. The existing `MASTRACODE_*_RECONCILE_INTERVAL_MS` env overrides still apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR reduces GitHub API requests by reusing recent permission results and avoiding duplicate requests. It also runs background reconciliation hourly while keeping event polling and webhooks as the main sync methods.

## Changes

- Cache collaborator permissions for 30 minutes per installation, repository, and login.
- Coalesce concurrent lookups for the same collaborator.
- Keep failed and timed-out lookups uncached.
- Isolate caller cancellation from shared requests.
- Add a 10-second timeout for shared GitHub requests.
- Bound cache growth to 1,000 entries.
- Change default pull request and issue reconciliation to hourly.
- Run enabled reconciliation sweeps during the first polling cycle.
- Preserve existing `MASTRACODE_*_RECONCILE_INTERVAL_MS` overrides.
- Add tests for caching, expiration, retries, cancellation, request coalescing, and reconciliation cadence.
- Add the `@mastra/factory` patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->