### PR TITLE
feat(factory,e2b,platform-workspace): skip setup on warm template sandboxes

### DIFF
--- a/.changeset/factory-setup-marker.md
+++ b/.changeset/factory-setup-marker.md
@@ -1,7 +1,5 @@
 ---
 '@mastra/factory': minor
-'@mastra/e2b': patch
-'@mastra/platform-workspace': patch
 ---
 
-Sandboxes booted from a warm repo template no longer re-run the setup command at session start. Repo templates write `.mastra-sandbox/setup` beside the checkout as their last build step, containing a digest of the setup commands they ran; Factory computes the same digest from the project's setup command and runs setup at start only when that marker is missing or names a different command. Repo materialization and the session branch checkout are unchanged. An existing sandbox whose project setup command was edited runs the new command once on its next start and updates the marker.
+Session start checks for the `.mastra-sandbox/setup` marker beside the checkout and skips the setup command when it names the project's current setup command. Sandboxes booted from a warm repo template carry the marker already; setup runs once when it is missing or stale and writes the marker afterwards.

--- a/.changeset/factory-setup-marker.md
+++ b/.changeset/factory-setup-marker.md
@@ -4,4 +4,4 @@
 '@mastra/platform-workspace': patch
 ---
 
-Warm repo-template sandboxes no longer re-run the setup command on every session start. Repo templates now write `.mastra-sandbox/setup` beside the checkout as their last build step, containing a digest of the setup commands they ran; Factory computes the same digest from the project's setup command and at start runs setup only when that marker is missing or names a different command. Materialize and checkout still run on every start, so a warm boot stays current, and editing the setup command re-runs setup once.
+Sandboxes booted from a warm repo template no longer re-run the setup command at session start. Repo templates write `.mastra-sandbox/setup` beside the checkout as their last build step, containing a digest of the setup commands they ran; Factory computes the same digest from the project's setup command and runs setup at start only when that marker is missing or names a different command. Repo materialization and the session branch checkout are unchanged. An existing sandbox whose project setup command was edited runs the new command once on its next start and updates the marker.

--- a/.changeset/factory-setup-marker.md
+++ b/.changeset/factory-setup-marker.md
@@ -2,4 +2,4 @@
 '@mastra/factory': minor
 ---
 
-Session start checks for the `.mastra-sandbox/setup` marker beside the checkout and skips the setup command when it names the project's current setup command. Sandboxes booted from a warm repo template carry the marker already; setup runs once when it is missing or stale and writes the marker afterwards.
+Session start checks for the `.mastra-sandbox/setup` marker beside the checkout and skips the setup command when the marker holds the sha256 digest of the project's current setup command. Sandboxes booted from a warm repo template carry the marker already; setup runs once when it is missing or stale and writes the marker afterwards.

--- a/.changeset/factory-setup-marker.md
+++ b/.changeset/factory-setup-marker.md
@@ -1,0 +1,7 @@
+---
+'@mastra/factory': minor
+'@mastra/e2b': patch
+'@mastra/platform-workspace': patch
+---
+
+Warm repo-template sandboxes no longer re-run the setup command on every session start. Repo templates now write `.mastra-sandbox/setup` beside the checkout as their last build step, containing a digest of the setup commands they ran; Factory computes the same digest from the project's setup command and at start runs setup only when that marker is missing or names a different command. Materialize and checkout still run on every start, so a warm boot stays current, and editing the setup command re-runs setup once.

--- a/.changeset/repo-template-setup-marker.md
+++ b/.changeset/repo-template-setup-marker.md
@@ -1,0 +1,6 @@
+---
+'@mastra/e2b': patch
+'@mastra/platform-workspace': patch
+---
+
+Repo templates now write `.mastra-sandbox/setup` beside the checkout as their last build step. It contains `sha256:<digest of the setup commands>`, so a sandbox booted from the template can tell that this setup already ran.

--- a/mastracode/factory/package.json
+++ b/mastracode/factory/package.json
@@ -69,6 +69,7 @@
     "@mastra/libsql": "workspace:*",
     "@mastra/pg": "workspace:*",
     "@internal/types-builder": "workspace:*",
+    "@internal/workspace": "workspace:*",
     "@types/node": "22.20.1",
     "eslint": "^10.7.0",
     "tsdown": "0.22.9",

--- a/mastracode/factory/src/index.ts
+++ b/mastracode/factory/src/index.ts
@@ -1,6 +1,6 @@
 export { MastraFactory } from './factory.js';
 export type { MastraArgs, MastraFactoryConfig, MastraFactorySandboxConfig } from './factory.js';
-export type { FactorySandboxContext, SessionSetupRun } from './sandbox/session-sandbox.js';
+export type { FactorySandboxContext, SessionSetupGate, SessionSetupRun } from './sandbox/session-sandbox.js';
 export { ChannelIdentityStorage } from './storage/domains/channel-identity/base.js';
 export type {
   ChannelAccountLink,

--- a/mastracode/factory/src/sandbox/session-sandbox.test.ts
+++ b/mastracode/factory/src/sandbox/session-sandbox.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -11,7 +12,9 @@ import {
   getSessionSandbox,
   peekSessionSandbox,
   resolveSessionWorkdir,
+  setupMarkerContent,
 } from './session-sandbox.js';
+import type { SessionSetupGate } from './session-sandbox.js';
 
 afterEach(() => {
   __clearSessionSandboxesForTests();
@@ -126,6 +129,16 @@ describe('session sandbox memo', () => {
 
 describe('session setup hook', () => {
   let dir: string;
+  const SETUP = 'pnpm install';
+  const digest = () => setupMarkerContent(SETUP)!;
+
+  /** A run that materializes a fake checkout and, when the gate says so, "runs setup". */
+  const runWith = (setupTouch: string) => async (sb: WorkspaceSandbox, _workdir: string, gate: SessionSetupGate) => {
+    await sb.executeCommand!('mkdir -p repo/.git && touch materialized.txt');
+    if (gate.setupDone) return;
+    await sb.executeCommand!(`touch ${setupTouch}`);
+    await gate.markSetupDone();
+  };
 
   beforeEach(async () => {
     dir = await fs.mkdtemp(path.join(os.tmpdir(), 'factory-bootstrap-'));
@@ -135,73 +148,121 @@ describe('session setup hook', () => {
     await fs.rm(dir, { recursive: true, force: true });
   });
 
-  it('runs setup inside start() via the hook and writes the marker', async () => {
-    // The callback forwarded ctx.onStart: setup runs during _start() on the
-    // create branch (fresh directory → outcome: 'created').
-    const boot = path.join(dir, 'fresh');
-    const hook = createSessionSetupHook(
-      async sb => void (await sb.executeCommand!('mkdir -p repo/.git && touch hook-ran.txt')),
-      'sess-hook',
-      'acme/repo',
-    );
-    const sandbox = new LocalSandbox({ workingDirectory: boot, onStart: hook });
-    await sandbox._start();
-    await expect(fs.stat(path.join(boot, 'hook-ran.txt'))).resolves.toBeDefined();
-    await expect(fs.stat(path.join(boot, '.mastra-factory/bootstrap'))).resolves.toBeDefined();
+  it('digests the setup command the same way the repo templates do, and has no marker for blank commands', () => {
+    expect(setupMarkerContent(SETUP)).toMatch(/^sha256:[0-9a-f]{64}$/);
+    // Same recipe as @mastra/e2b and @mastra/platform-workspace: the raw
+    // command list joined by newlines, so a template's marker matches.
+    expect(setupMarkerContent(SETUP)).toBe(`sha256:${createHash('sha256').update(SETUP).digest('hex')}`);
+    expect(setupMarkerContent('pnpm ci')).not.toBe(setupMarkerContent(SETUP));
+    expect(setupMarkerContent(undefined)).toBeUndefined();
+    expect(setupMarkerContent('   ')).toBeUndefined();
   });
 
-  it('the hook skips setup on reconnect when the marker and checkout are present', async () => {
+  it('runs setup inside start() on a fresh sandbox and writes the digest marker', async () => {
+    const boot = path.join(dir, 'fresh');
+    const sandbox = new LocalSandbox({
+      workingDirectory: boot,
+      onStart: createSessionSetupHook(runWith('setup-ran.txt'), 'sess-hook', 'acme/repo', SETUP),
+    });
+    await sandbox._start();
+    await expect(fs.stat(path.join(boot, 'setup-ran.txt'))).resolves.toBeDefined();
+    await expect(fs.readFile(path.join(boot, '.mastra-sandbox/setup'), 'utf8')).resolves.toBe(digest());
+  });
+
+  it('a fresh sandbox that already carries the marker (warm template image) skips setup but still materializes', async () => {
+    const boot = path.join(dir, 'warm');
+    // What a repo template leaves behind: marker beside a checkout.
+    await fs.mkdir(path.join(boot, 'repo/.git'), { recursive: true });
+    await fs.mkdir(path.join(boot, '.mastra-factory'), { recursive: true });
+    await fs.mkdir(path.join(boot, '.mastra-sandbox'));
+    await fs.writeFile(path.join(boot, '.mastra-sandbox/setup'), digest());
+
+    const sandbox = new LocalSandbox({
+      workingDirectory: boot,
+      onStart: createSessionSetupHook(runWith('setup-ran.txt'), 'sess-hook', 'acme/repo', SETUP),
+    });
+    await sandbox._start();
+    await expect(fs.stat(path.join(boot, 'materialized.txt'))).resolves.toBeDefined();
+    await expect(fs.stat(path.join(boot, 'setup-ran.txt'))).rejects.toThrow();
+  });
+
+  it('the hook skips setup on reconnect when the marker matches and the checkout exists', async () => {
     const boot = path.join(dir, 'reconnect');
-    const workdir = path.join(boot, 'repo');
     const first = new LocalSandbox({
       workingDirectory: boot,
-      onStart: createSessionSetupHook(
-        async sb => void (await sb.executeCommand!('mkdir -p repo/.git && touch first.txt')),
-        'sess-hook',
-        'acme/repo',
-      ),
+      onStart: createSessionSetupHook(runWith('first.txt'), 'sess-hook', 'acme/repo', SETUP),
     });
     await first._start();
 
-    // Second instance reattaches (outcome: 'connected') → marker probe skips setup.
     const second = new LocalSandbox({
       workingDirectory: boot,
-      onStart: createSessionSetupHook(
-        async sb => void (await sb.executeCommand!('touch second.txt')),
-        'sess-hook',
-        'acme/repo',
-      ),
+      onStart: createSessionSetupHook(runWith('second.txt'), 'sess-hook', 'acme/repo', SETUP),
     });
     await second._start();
     await expect(fs.stat(path.join(boot, 'second.txt'))).rejects.toThrow();
   });
 
+  it('an edited setup command (or a legacy touch-only marker) re-runs setup and rewrites the marker', async () => {
+    const boot = path.join(dir, 'edited');
+    await fs.mkdir(path.join(boot, 'repo/.git'), { recursive: true });
+    await fs.mkdir(path.join(boot, '.mastra-factory'), { recursive: true });
+    await fs.mkdir(path.join(boot, '.mastra-sandbox'));
+    await fs.writeFile(path.join(boot, '.mastra-sandbox/setup'), '');
+
+    const legacy = new LocalSandbox({
+      workingDirectory: boot,
+      onStart: createSessionSetupHook(runWith('legacy-rerun.txt'), 'sess-hook', 'acme/repo', SETUP),
+    });
+    await legacy._start();
+    await expect(fs.stat(path.join(boot, 'legacy-rerun.txt'))).resolves.toBeDefined();
+    await expect(fs.readFile(path.join(boot, '.mastra-sandbox/setup'), 'utf8')).resolves.toBe(digest());
+
+    const edited = new LocalSandbox({
+      workingDirectory: boot,
+      onStart: createSessionSetupHook(runWith('edited-rerun.txt'), 'sess-hook', 'acme/repo', 'pnpm ci'),
+    });
+    await edited._start();
+    await expect(fs.stat(path.join(boot, 'edited-rerun.txt'))).resolves.toBeDefined();
+    await expect(fs.readFile(path.join(boot, '.mastra-sandbox/setup'), 'utf8')).resolves.toBe(
+      setupMarkerContent('pnpm ci')!,
+    );
+  });
+
   it('a marker without its checkout does not skip setup (removed checkout heals)', async () => {
     const boot = path.join(dir, 'wiped');
-    const workdir = path.join(boot, 'repo');
     const first = new LocalSandbox({
       workingDirectory: boot,
-      onStart: createSessionSetupHook(
-        async sb => void (await sb.executeCommand!('mkdir -p repo/.git && touch first.txt')),
-        'sess-hook',
-        'acme/repo',
-      ),
+      onStart: createSessionSetupHook(runWith('first.txt'), 'sess-hook', 'acme/repo', SETUP),
     });
     await first._start();
 
-    // The checkout is removed but the marker (beside it) survives — a stale
+    // The checkout is removed but the marker (beside it) survives: a stale
     // skip cache must not defeat disk truth.
-    await fs.rm(workdir, { recursive: true, force: true });
+    await fs.rm(path.join(boot, 'repo'), { recursive: true, force: true });
     const second = new LocalSandbox({
       workingDirectory: boot,
-      onStart: createSessionSetupHook(
-        async sb => void (await sb.executeCommand!('mkdir -p repo/.git && touch rebuilt.txt')),
-        'sess-hook',
-        'acme/repo',
-      ),
+      onStart: createSessionSetupHook(runWith('rebuilt.txt'), 'sess-hook', 'acme/repo', SETUP),
     });
     await second._start();
     await expect(fs.stat(path.join(boot, 'rebuilt.txt'))).resolves.toBeDefined();
+  });
+
+  it('with no setup command the gate reports done and nothing is written', async () => {
+    const boot = path.join(dir, 'none');
+    const gates: SessionSetupGate[] = [];
+    const sandbox = new LocalSandbox({
+      workingDirectory: boot,
+      onStart: createSessionSetupHook(
+        async (_sb, _workdir, gate) => void gates.push(gate),
+        'sess-hook',
+        'acme/repo',
+        undefined,
+      ),
+    });
+    await sandbox._start();
+    expect(gates[0]?.setupDone).toBe(true);
+    await gates[0]!.markSetupDone();
+    await expect(fs.stat(path.join(boot, '.mastra-sandbox/setup'))).rejects.toThrow();
   });
 
   it('a failed setup fails start() loudly, writes no marker, and the next start self-heals', async () => {
@@ -214,23 +275,19 @@ describe('session setup hook', () => {
         },
         'sess-hook',
         'acme/repo',
+        SETUP,
       ),
     });
 
     await expect(failing._start()).rejects.toThrow(/Session setup failed \(exit 7\)/);
-    await expect(fs.stat(path.join(boot, '.mastra-factory/bootstrap'))).rejects.toThrow();
+    await expect(fs.stat(path.join(boot, '.mastra-sandbox/setup'))).rejects.toThrow();
 
-    // Reconnect (outcome: 'connected'), marker absent → setup re-runs and heals.
     const healed = new LocalSandbox({
       workingDirectory: boot,
-      onStart: createSessionSetupHook(
-        async sb => void (await sb.executeCommand!('mkdir -p repo/.git && touch healed.txt')),
-        'sess-hook',
-        'acme/repo',
-      ),
+      onStart: createSessionSetupHook(runWith('healed.txt'), 'sess-hook', 'acme/repo', SETUP),
     });
     await healed._start();
     await expect(fs.stat(path.join(boot, 'healed.txt'))).resolves.toBeDefined();
-    await expect(fs.stat(path.join(boot, '.mastra-factory/bootstrap'))).resolves.toBeDefined();
+    await expect(fs.readFile(path.join(boot, '.mastra-sandbox/setup'), 'utf8')).resolves.toBe(digest());
   });
 });

--- a/mastracode/factory/src/sandbox/session-sandbox.test.ts
+++ b/mastracode/factory/src/sandbox/session-sandbox.test.ts
@@ -1,7 +1,7 @@
-import { createHash } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { setupMarkerContent } from '@internal/workspace';
 import type { WorkspaceSandbox } from '@mastra/core/workspace';
 import { LocalSandbox } from '@mastra/core/workspace';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -12,7 +12,6 @@ import {
   getSessionSandbox,
   peekSessionSandbox,
   resolveSessionWorkdir,
-  setupMarkerContent,
 } from './session-sandbox.js';
 import type { SessionSetupGate } from './session-sandbox.js';
 
@@ -130,7 +129,7 @@ describe('session sandbox memo', () => {
 describe('session setup hook', () => {
   let dir: string;
   const SETUP = 'pnpm install';
-  const digest = () => setupMarkerContent(SETUP)!;
+  const digest = () => setupMarkerContent(SETUP);
 
   /** A run that materializes a fake checkout and, when the gate says so, "runs setup". */
   const runWith = (setupTouch: string) => async (sb: WorkspaceSandbox, _workdir: string, gate: SessionSetupGate) => {
@@ -146,16 +145,6 @@ describe('session setup hook', () => {
 
   afterEach(async () => {
     await fs.rm(dir, { recursive: true, force: true });
-  });
-
-  it('digests the setup command the same way the repo templates do, and has no marker for blank commands', () => {
-    expect(setupMarkerContent(SETUP)).toMatch(/^sha256:[0-9a-f]{64}$/);
-    // Same recipe as @mastra/e2b and @mastra/platform-workspace: the raw
-    // command list joined by newlines, so a template's marker matches.
-    expect(setupMarkerContent(SETUP)).toBe(`sha256:${createHash('sha256').update(SETUP).digest('hex')}`);
-    expect(setupMarkerContent('pnpm ci')).not.toBe(setupMarkerContent(SETUP));
-    expect(setupMarkerContent(undefined)).toBeUndefined();
-    expect(setupMarkerContent('   ')).toBeUndefined();
   });
 
   it('runs setup inside start() on a fresh sandbox and writes the digest marker', async () => {
@@ -224,7 +213,7 @@ describe('session setup hook', () => {
     await edited._start();
     await expect(fs.stat(path.join(boot, 'edited-rerun.txt'))).resolves.toBeDefined();
     await expect(fs.readFile(path.join(boot, '.mastra-sandbox/setup'), 'utf8')).resolves.toBe(
-      setupMarkerContent('pnpm ci')!,
+      setupMarkerContent('pnpm ci'),
     );
   });
 

--- a/mastracode/factory/src/sandbox/session-sandbox.ts
+++ b/mastracode/factory/src/sandbox/session-sandbox.ts
@@ -1,5 +1,5 @@
-import { createHash } from 'node:crypto';
 import path from 'node:path';
+import { SETUP_MARKER_PATH, setupMarkerContent } from '@internal/workspace';
 
 import type { MastraSandbox, SandboxStartHook, WorkspaceSandbox } from '@mastra/core/workspace';
 import type { RepositoryAccess } from '../capabilities/version-control.js';
@@ -204,27 +204,14 @@ export function hasFailedSetupCommand(sessionId: string, command: string): boole
 }
 
 /**
- * Setup completion marker, a convention shared with the repo templates in
- * `@mastra/e2b` and `@mastra/platform-workspace` (keep the three in sync):
- * `.mastra-sandbox/setup` beside the checkout, containing a digest of the
- * setup commands. Templates write it as their last build step, so a sandbox
- * booted from a warm image already carries it; the start hook writes it
- * after a successful runtime setup. It is a skip cache, not a correctness
- * mechanism: the setup command is assumed idempotent, and a missing or
- * mismatched marker only re-runs it.
- */
-const SETUP_MARKER_PATH = '.mastra-sandbox/setup';
-
-/**
- * Same recipe as the templates: the non-blank commands joined by newlines.
- * Factory has a single command string, so that is the whole list.
- */
-export function setupMarkerContent(setupCommand: string | undefined): string | undefined {
-  if (setupCommand === undefined || setupCommand.trim() === '') return undefined;
-  return `sha256:${createHash('sha256').update(setupCommand).digest('hex')}`;
-}
-
-/**
+ * The setup completion marker is a convention shared with the repo templates
+ * (`@internal/workspace`): `.mastra-sandbox/setup` beside the checkout,
+ * containing a digest of the setup commands. Templates write it as their last
+ * build step, so a sandbox booted from a warm image already carries it; the
+ * start hook writes it after a successful runtime setup. It is a skip cache,
+ * not a correctness mechanism: the setup command is assumed idempotent, and a
+ * missing or mismatched marker only re-runs it.
+ *
  * The working directory is the parent of the repo dir, which is also the
  * template's build cwd, so this is the file the template's marker step wrote.
  */
@@ -265,7 +252,8 @@ export function createSessionSetupHook(
   repoFullName: string,
   setupCommand: string | undefined,
 ): SandboxStartHook {
-  const marker = setupMarkerContent(setupCommand);
+  // No command, no marker: nothing to gate.
+  const marker = setupCommand?.trim() ? setupMarkerContent(setupCommand) : undefined;
   return async ({ sandbox }) => {
     if (!sandbox.executeCommand) {
       throw new Error(`Sandbox '${sandbox.id}' cannot run the session setup: no executeCommand implementation`);

--- a/mastracode/factory/src/sandbox/session-sandbox.ts
+++ b/mastracode/factory/src/sandbox/session-sandbox.ts
@@ -1,3 +1,6 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
 import type { MastraSandbox, SandboxStartHook, WorkspaceSandbox } from '@mastra/core/workspace';
 import type { RepositoryAccess } from '../capabilities/version-control.js';
 import { deriveLocalWorkdir, deriveRemoteRepoDir, repoDirUnder } from './workdir.js';
@@ -56,8 +59,23 @@ export interface FactorySandboxContext {
  */
 export type MastraFactorySandboxConfig = (ctx: FactorySandboxContext) => MastraSandbox;
 
-/** The session's setup work, run against a started sandbox. Must be idempotent. */
-export type SessionSetupRun = (sandbox: WorkspaceSandbox, workdir: string) => Promise<void>;
+/**
+ * What the start hook learned about the setup command before running the
+ * session setup, and how to record its completion afterwards.
+ */
+export interface SessionSetupGate {
+  /** True when the sandbox already carries a marker for the current setup command. */
+  setupDone: boolean;
+  /** Write the marker once the setup command succeeded. Best-effort. */
+  markSetupDone: () => Promise<void>;
+}
+
+/**
+ * The session's setup work, run against a started sandbox on EVERY start.
+ * Materialize and checkout are idempotent and must always run (a warm boot
+ * still needs its pull); only the setup command consults `gate`.
+ */
+export type SessionSetupRun = (sandbox: WorkspaceSandbox, workdir: string, gate: SessionSetupGate) => Promise<void>;
 
 /**
  * Per-process session-id → sandbox instance memo.
@@ -186,70 +204,81 @@ export function hasFailedSetupCommand(sessionId: string, command: string): boole
 }
 
 /**
- * Completion marker for the session setup. Factory owns this end-to-end:
- * the `onStart` hook and the post-start fallback guard the exact same path,
- * so setup never double-runs regardless of which layer executed it. It is a
- * skip cache, not a correctness mechanism — the setup work is idempotent by
- * construction (materialize probes the disk, checkout/setup re-run safely).
+ * Setup completion marker, a convention shared with the repo templates in
+ * `@mastra/e2b` and `@mastra/platform-workspace` (keep the three in sync):
+ * `.mastra-sandbox/setup` beside the checkout, containing a digest of the
+ * setup commands. Templates write it as their last build step, so a sandbox
+ * booted from a warm image already carries it; the start hook writes it
+ * after a successful runtime setup. It is a skip cache, not a correctness
+ * mechanism: the setup command is assumed idempotent, and a missing or
+ * mismatched marker only re-runs it.
  */
-const SESSION_SETUP_MARKER = '.mastra-factory/bootstrap';
+const SETUP_MARKER_PATH = '.mastra-sandbox/setup';
 
-function markerShellPath(sandbox: Pick<WorkspaceSandbox, 'provider'>): string {
-  // Local sandboxes exec with cwd = the session working directory; remote
-  // VMs are one-per-session so $HOME is private to the session.
-  return sandbox.provider === 'local' ? `./${SESSION_SETUP_MARKER}` : `$HOME/${SESSION_SETUP_MARKER}`;
-}
-
-async function markerPresent(sandbox: WorkspaceSandbox, workdir: string): Promise<boolean> {
-  // The marker is a skip cache — it sits beside the checkout, not inside it,
-  // so it can outlive a removed checkout (e.g. a wiped local session dir or
-  // a recovered VM). Trust it only when the checkout it describes exists.
-  const probe = await sandbox.executeCommand!(`test -f "${markerShellPath(sandbox)}" && test -d "${workdir}/.git"`);
-  return probe.exitCode === 0;
-}
-
-async function writeMarker(sandbox: WorkspaceSandbox): Promise<void> {
-  // Best-effort: a missing marker only re-runs the idempotent setup later.
-  const marker = markerShellPath(sandbox);
-  await sandbox.executeCommand!(`mkdir -p "$(dirname "${marker}")" && touch "${marker}"`).catch(() => {});
+/**
+ * Same recipe as the templates: the non-blank commands joined by newlines.
+ * Factory has a single command string, so that is the whole list.
+ */
+export function setupMarkerContent(setupCommand: string | undefined): string | undefined {
+  if (setupCommand === undefined || setupCommand.trim() === '') return undefined;
+  return `sha256:${createHash('sha256').update(setupCommand).digest('hex')}`;
 }
 
 /**
- * Run the session setup, marker-guarded: skip when the marker exists (unless
- * the VM is known-fresh), otherwise run and write the marker only on
- * success. Setup failures propagate — no marker is written, so the next
- * attempt re-runs.
+ * The working directory is the parent of the repo dir, which is also the
+ * template's build cwd, so this is the file the template's marker step wrote.
  */
-async function runGuardedSetup(
-  sandbox: WorkspaceSandbox,
-  run: SessionSetupRun,
-  { skipMarkerProbe, sessionId, repoFullName }: { skipMarkerProbe: boolean; sessionId: string; repoFullName: string },
-): Promise<void> {
-  if (!sandbox.executeCommand) {
-    throw new Error(`Sandbox '${sandbox.id}' cannot run the session setup: no executeCommand implementation`);
-  }
-  // Resolved from the live instance (the hook runs inside `start()`, so the
-  // VM is up) and memoized on the session entry for passive readers.
-  const workdir = await resolveSessionWorkdir(sessionId, sandbox, repoFullName);
-  if (!skipMarkerProbe && (await markerPresent(sandbox, workdir))) return;
-  await run(sandbox, workdir);
-  await writeMarker(sandbox);
+function markerShellPath(workdir: string): string {
+  return `${path.posix.dirname(workdir)}/${SETUP_MARKER_PATH}`;
+}
+
+async function markerMatches(sandbox: WorkspaceSandbox, workdir: string, content: string): Promise<boolean> {
+  // The marker sits beside the checkout, not inside it, so it can outlive a
+  // removed checkout (a wiped local session dir, a recovered VM). Trust it
+  // only when the checkout it describes exists and it names this command.
+  const marker = markerShellPath(workdir);
+  const probe = await sandbox.executeCommand!(
+    `test -d "${workdir}/.git" && test -f "${marker}" && [ "$(cat "${marker}")" = "${content}" ]`,
+  );
+  return probe.exitCode === 0;
+}
+
+async function writeMarker(sandbox: WorkspaceSandbox, workdir: string, content: string): Promise<void> {
+  // Best-effort: a missing marker only re-runs the idempotent setup later.
+  const marker = markerShellPath(workdir);
+  await sandbox.executeCommand!(`mkdir -p "$(dirname "${marker}")" && printf '%s' '${content}' > "${marker}"`).catch(
+    () => {},
+  );
 }
 
 /**
  * Build the session setup hook, which factory attaches to the constructed
- * sandbox with `setOnStart`. Runs inside the sandbox start
- * lifecycle: a fresh VM (`outcome: 'created'`) runs setup with no probe; a
- * reconnect probes the marker first, which re-runs setup after a failed or
- * crash-interrupted attempt. Throwing fails `start()` loudly — core treats
- * onStart errors as fatal.
+ * sandbox with `setOnStart`. Runs inside the sandbox start lifecycle on
+ * every start, fresh VM or reconnect: materialize and checkout always run,
+ * and the setup command runs unless the sandbox already carries the marker
+ * for it (a warm template image, or an earlier successful start). Throwing
+ * fails `start()` loudly; core treats onStart errors as fatal.
  */
 export function createSessionSetupHook(
   run: SessionSetupRun,
   sessionId: string,
   repoFullName: string,
+  setupCommand: string | undefined,
 ): SandboxStartHook {
-  return async ({ sandbox, outcome }) => {
-    await runGuardedSetup(sandbox, run, { skipMarkerProbe: outcome === 'created', sessionId, repoFullName });
+  const marker = setupMarkerContent(setupCommand);
+  return async ({ sandbox }) => {
+    if (!sandbox.executeCommand) {
+      throw new Error(`Sandbox '${sandbox.id}' cannot run the session setup: no executeCommand implementation`);
+    }
+    // Resolved from the live instance (the hook runs inside `start()`, so the
+    // VM is up) and memoized on the session entry for passive readers.
+    const workdir = await resolveSessionWorkdir(sessionId, sandbox, repoFullName);
+    // Probed before materialize so a wiped checkout reads as "not done" even
+    // though materialize is about to restore it.
+    const setupDone = marker ? await markerMatches(sandbox, workdir, marker) : true;
+    await run(sandbox, workdir, {
+      setupDone,
+      markSetupDone: () => (marker ? writeMarker(sandbox, workdir, marker) : Promise.resolve()),
+    });
   };
 }

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -8,6 +8,10 @@ import type { LocalFilesystem } from '@mastra/core/workspace';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  /** Whether the mock VM already carries a matching setup marker (warm template image). */
+  markerPresent: false,
+  /** The marker probe the setup hook runs before materializing. */
+  isMarkerProbe: (command: string) => command.includes('.mastra-sandbox/setup') && command.includes('test -f'),
   projects: [] as any[],
   sessions: [] as any[],
   updates: [] as Array<{ set: Record<string, unknown>; where: unknown }>,
@@ -59,6 +63,8 @@ const mocks = vi.hoisted(() => ({
         await sandbox.ensureRunning();
         // The workdir resolver probes the VM's default cwd (its home dir).
         if (command === 'pwd') return { exitCode: 0, stdout: '/home/user\n', stderr: '' };
+        // A fresh VM carries no setup marker unless a test plants one.
+        if (mocks.isMarkerProbe(command)) return { exitCode: mocks.markerPresent ? 0 : 1, stdout: '', stderr: '' };
         return { exitCode: 0, stdout: '', stderr: '' };
       }),
       setEnv: mocks.setEnv,
@@ -135,6 +141,7 @@ afterEach(async () => {
   mocks.updates.splice(0);
   mocks.createSandbox.mockClear();
   mocks.localRoot = null;
+  mocks.markerPresent = false;
   __clearSessionSandboxesForTests();
   mocks.materializeRepo.mockClear();
   mocks.checkoutSessionBranch.mockClear();
@@ -778,6 +785,42 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.sessions.find(session => session.id === 'session-b')?.sandboxWorkdir).toBe(workdirB);
   });
 
+  it('skips the setup command on a VM that already carries the marker, but still materializes and checks out', async () => {
+    const { workspace } = await createLocalFactory();
+    addProject({ setupCommand: 'pnpm i' });
+    addSession({ id: 'session-a' });
+    mocks.markerPresent = true;
+
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+    expect(mocks.materializeRepo).toHaveBeenCalledTimes(1);
+    expect(mocks.checkoutSessionBranch).toHaveBeenCalledTimes(1);
+    expect(mocks.runSetupCommand).not.toHaveBeenCalled();
+  });
+
+  it('writes the digest marker only after the setup command succeeds', async () => {
+    const { workspace } = await createLocalFactory();
+    addProject({ setupCommand: 'pnpm i' });
+    addSession({ id: 'session-a' });
+    mocks.runSetupCommand.mockRejectedValueOnce(new SetupCommandError('Setup command failed (exit 1)', 'setup-failed'));
+
+    await expect(workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') })).rejects.toThrow(
+      /setup-failed|Setup command failed/,
+    );
+    const exec = (mocks.createSandbox.mock.results[0]!.value as { executeCommand: ReturnType<typeof vi.fn> })
+      .executeCommand;
+    const markerWrites = () =>
+      exec.mock.calls.filter(([command]) => String(command).includes("printf '%s' 'sha256:")).length;
+    expect(markerWrites()).toBe(0);
+
+    // A session whose setup succeeds records the marker exactly once.
+    mocks.createSandbox.mockClear();
+    addSession({ id: 'session-b' });
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-b') });
+    const exec2 = (mocks.createSandbox.mock.results[0]!.value as { executeCommand: ReturnType<typeof vi.fn> })
+      .executeCommand;
+    expect(exec2.mock.calls.filter(([command]) => String(command).includes("printf '%s' 'sha256:")).length).toBe(1);
+  });
+
   it('resolves bundled Factory skills without waiting on sandbox materialization (kickoff path stays lazy)', async () => {
     const { resolver } = await createLocalFactory();
     addProject();
@@ -936,19 +979,6 @@ describe('GitHub session workspace preparation', () => {
    * sandbox mock answers exit 0 to every probe. Force the marker probe to
    * report "absent" so reconnect starts exercise the real re-run path.
    */
-  function forceMarkerAbsent() {
-    const sandboxInstance = mocks.createSandbox.mock.results[0]!.value as {
-      executeCommand: ReturnType<typeof vi.fn>;
-    };
-    const baseExec = sandboxInstance.executeCommand.getMockImplementation()!;
-    sandboxInstance.executeCommand.mockImplementation(async (command: string) => {
-      if (command.includes('.mastra-factory/bootstrap') && command.includes('test -f')) {
-        return { exitCode: 1, stdout: '', stderr: '' };
-      }
-      return baseExec(command);
-    });
-  }
-
   it('recovers on the next attempt after the setup command itself fails', async () => {
     const { workspace } = await createLocalFactory();
     addProject({ setupCommand: 'pnpm install' });
@@ -961,8 +991,6 @@ describe('GitHub session workspace preparation', () => {
     await expect(workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') })).rejects.toThrow(
       /skipped for the rest of the session/,
     );
-    forceMarkerAbsent();
-
     // Second attempt skips the known-bad command instead of wedging the
     // session behind a permanently failing start.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -40,6 +40,7 @@ import {
   recordFailedSetupCommand,
   resolveSessionWorkdir,
 } from './sandbox/session-sandbox.js';
+import type { SessionSetupGate } from './sandbox/session-sandbox.js';
 
 import type { WorkItemsStorage } from './storage/domains/work-items/base.js';
 
@@ -348,9 +349,14 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     // VM's own home so it resolves lazily at first start.
     // `runSetupOn` references `runSessionSetup`, defined below — it is only
     // invoked during start, long after this closure fully initializes.
-    const runSetupOn = (target: unknown, workdir: string) =>
-      runSessionSetup(requireExec(target as WorkspaceSandbox), workdir);
-    const guardedSetup = createSessionSetupHook(runSetupOn, session.id, repoFullName);
+    const runSetupOn = (target: unknown, workdir: string, gate: SessionSetupGate) =>
+      runSessionSetup(requireExec(target as WorkspaceSandbox), workdir, gate);
+    const guardedSetup = createSessionSetupHook(
+      runSetupOn,
+      session.id,
+      repoFullName,
+      projectRepository.setupCommand ?? undefined,
+    );
     // Composed start hook: marker-guarded repo setup, then per-start
     // credential install. It runs inside the provider's start lifecycle on
     // EVERY start (create or reconnect) — providers own lazy start
@@ -586,7 +592,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     // check out the session branch, run the configured setup command. Minted
     // tokens are fetched inside the run so a replacement VM healed mid-session
     // gets fresh credentials, not ones captured at workspace construction.
-    const runSessionSetup = async (target: SessionSandbox, workdir: string): Promise<void> => {
+    const runSessionSetup = async (target: SessionSandbox, workdir: string, gate: SessionSetupGate): Promise<void> => {
       const token = await getRepositoryToken();
       // The configured setup command may shell out to `gh`/https fetches, so
       // GH_TOKEN must exist before setup runs — and it must be the same
@@ -609,7 +615,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         token,
         repoFullName: repoFullName,
       });
-      if (projectRepository.setupCommand) {
+      if (projectRepository.setupCommand && !gate.setupDone) {
         // A setup command that already failed this session is skipped rather
         // than failing every start: the first failure surfaced loudly in the
         // tool result that triggered it, and a permanently failing onStart
@@ -626,6 +632,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         }
         try {
           await runSetupCommand(target, workdir, projectRepository.setupCommand);
+          await gate.markSetupDone();
         } catch (setupError) {
           if (projectRepository.teardownCommand) {
             try {

--- a/mastracode/factory/tsdown.config.ts
+++ b/mastracode/factory/tsdown.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   dts: false,
   sourcemap: true,
   deps: {
-    alwaysBundle: ['@mastra/libsql'],
+    alwaysBundle: ['@mastra/libsql', '@internal/workspace'],
     neverBundle: [/^@mastra\//, '@octokit/auth-app', '@octokit/rest', 'chat', 'hono', /^hono\//, 'zod'],
   },
   inputOptions: {

--- a/packages/_internals/workspace/eslint.config.js
+++ b/packages/_internals/workspace/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/packages/_internals/workspace/package.json
+++ b/packages/_internals/workspace/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "@mastra/e2b",
-  "version": "0.11.0-alpha.2",
-  "description": "E2B cloud sandbox provider for Mastra workspaces",
+  "name": "@internal/workspace",
+  "version": "0.0.1",
+  "description": "Internal conventions shared by Mastra sandbox providers and their consumers",
+  "private": true,
   "type": "module",
+  "files": [
+    "dist"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -20,48 +24,27 @@
   },
   "scripts": {
     "build": "tsdown --silent --config tsdown.config.ts",
-    "build:lib": "pnpm build",
-    "build:watch": "pnpm build --watch",
-    "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
-    "test:watch": "vitest watch",
-    "test": "vitest run ./src/**/*.integration.test.ts",
-    "test:cloud": "pnpm test",
+    "build:watch": "tsdown --watch --silent --config tsdown.config.ts",
+    "test": "vitest run",
     "lint": "oxlint . && eslint .",
-    "lint:fix": "oxlint --fix . && eslint --fix ."
+    "lint:fix": "oxlint --fix . && eslint --fix .",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json"
   },
   "license": "Apache-2.0",
-  "dependencies": {
-    "e2b": "^2.36.0",
-    "esbuild": "^0.28.0"
-  },
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
-    "@internal/workspace": "workspace:*",
-    "@internal/workspace-test-utils": "workspace:*",
-    "@mastra/core": "workspace:*",
-    "@mastra/gcs": "workspace:*",
-    "@mastra/s3": "workspace:*",
     "@types/node": "22.20.1",
-    "@vitest/coverage-v8": "catalog:",
-    "@vitest/ui": "catalog:",
-    "dotenv": "^17.4.2",
     "eslint": "^10.7.0",
     "tsdown": "0.22.9",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
-  "peerDependencies": {
-    "@mastra/core": ">=1.55.0-0 <2.0.0-0"
-  },
-  "files": [
-    "dist"
-  ],
   "homepage": "https://mastra.ai",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mastra-ai/mastra.git",
-    "directory": "workspaces/e2b"
+    "directory": "packages/_internals/workspace"
   },
   "bugs": {
     "url": "https://github.com/mastra-ai/mastra/issues"

--- a/packages/_internals/workspace/src/index.ts
+++ b/packages/_internals/workspace/src/index.ts
@@ -1,0 +1,1 @@
+export { SETUP_MARKER_PATH, normalizeSetupCommands, setupMarkerContent, setupMarkerCommand } from './setup-marker';

--- a/packages/_internals/workspace/src/setup-marker.test.ts
+++ b/packages/_internals/workspace/src/setup-marker.test.ts
@@ -1,0 +1,30 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import { SETUP_MARKER_PATH, normalizeSetupCommands, setupMarkerCommand, setupMarkerContent } from './setup-marker';
+
+describe('setup marker', () => {
+  it('digests the non-blank commands joined by newlines, in order', () => {
+    const expected = `sha256:${createHash('sha256').update('pnpm i\npnpm build').digest('hex')}`;
+    expect(setupMarkerContent(['pnpm i', '', '  ', 'pnpm build'])).toBe(expected);
+    expect(setupMarkerContent(['pnpm build', 'pnpm i'])).not.toBe(expected);
+    // A single string is a one-entry list, so factory's string and a template's array agree.
+    expect(setupMarkerContent('pnpm i')).toBe(setupMarkerContent(['pnpm i']));
+    expect(setupMarkerContent(undefined)).toBe(setupMarkerContent([]));
+  });
+
+  it('normalizes blank entries away without trimming the rest', () => {
+    expect(normalizeSetupCommands([' pnpm i ', '', '   '])).toEqual([' pnpm i ']);
+    expect(normalizeSetupCommands('pnpm i')).toEqual(['pnpm i']);
+    expect(normalizeSetupCommands(undefined)).toEqual([]);
+  });
+
+  it('writes the marker beside the cwd with a shell-safe digest', () => {
+    const content = setupMarkerContent('pnpm i');
+    expect(content).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(setupMarkerCommand(content)).toBe(
+      `mkdir -p "$(dirname "${SETUP_MARKER_PATH}")" && printf '%s' '${content}' > "${SETUP_MARKER_PATH}"`,
+    );
+    expect(SETUP_MARKER_PATH).toBe('.mastra-sandbox/setup');
+  });
+});

--- a/packages/_internals/workspace/src/setup-marker.ts
+++ b/packages/_internals/workspace/src/setup-marker.ts
@@ -1,0 +1,30 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Setup completion marker shared by repo templates and their consumers.
+ *
+ * A repo template writes this file beside the checkout as its last build
+ * step, so it exists only in images where every setup command succeeded. Its
+ * content is a digest of the setup commands the image ran, letting a sandbox
+ * booted from the image tell whether the setup it is about to run already
+ * happened. Relative to the template's build cwd, which is also the runtime
+ * working directory the repo was cloned into.
+ */
+export const SETUP_MARKER_PATH = '.mastra-sandbox/setup';
+
+/** Blank entries never become build steps, so they never count toward the digest either. */
+export function normalizeSetupCommands(setupCommand: string | readonly string[] | undefined): string[] {
+  const list = setupCommand === undefined ? [] : Array.isArray(setupCommand) ? setupCommand : [setupCommand];
+  return (list as string[]).filter(command => command.trim() !== '');
+}
+
+/** The marker content for a setup command list: `sha256:<hex>` over the commands joined by newlines. */
+export function setupMarkerContent(setupCommand: string | readonly string[] | undefined): string {
+  const digest = createHash('sha256').update(normalizeSetupCommands(setupCommand).join('\n')).digest('hex');
+  return `sha256:${digest}`;
+}
+
+/** Shell step that writes the marker relative to the cwd. `content` is a digest, so it is shell-safe. */
+export function setupMarkerCommand(content: string): string {
+  return `mkdir -p "$(dirname "${SETUP_MARKER_PATH}")" && printf '%s' '${content}' > "${SETUP_MARKER_PATH}"`;
+}

--- a/packages/_internals/workspace/tsconfig.build.json
+++ b/packages/_internals/workspace/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/_internals/workspace/tsconfig.json
+++ b/packages/_internals/workspace/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "include": ["src/**/*", "tsdown.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/_internals/workspace/tsdown.config.ts
+++ b/packages/_internals/workspace/tsdown.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
   dts: false,
   treeshake: true,
   sourcemap: true,
-  deps: {
-    alwaysBundle: ['@internal/workspace'],
-    neverBundle: ['@mastra/core'],
-  },
   onSuccess: async () => {
     await generateTypes(process.cwd());
   },

--- a/packages/_internals/workspace/vitest.config.ts
+++ b/packages/_internals/workspace/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:packages/_internals/workspace',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2403,6 +2403,9 @@ importers:
       '@internal/types-builder':
         specifier: workspace:*
         version: link:../../packages/_types-builder
+      '@internal/workspace':
+        specifier: workspace:*
+        version: link:../../packages/_internals/workspace
       '@mastra/libsql':
         specifier: workspace:*
         version: link:../../stores/libsql
@@ -3835,6 +3838,30 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
+
+  packages/_internals/workspace:
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../_types-builder
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      eslint:
+        specifier: ^10.7.0
+        version: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
+      tsdown:
+        specifier: 0.22.9
+        version: 0.22.9(@volar/typescript@2.4.23(typescript@7.0.2))(oxc-resolver@11.20.0)(tsx@4.23.1)(typescript@7.0.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0)(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.15)(typescript@7.0.2))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/_llm-recorder:
     dependencies:
@@ -9796,6 +9823,9 @@ importers:
       '@internal/types-builder':
         specifier: workspace:*
         version: link:../../packages/_types-builder
+      '@internal/workspace':
+        specifier: workspace:*
+        version: link:../../packages/_internals/workspace
       '@internal/workspace-test-utils':
         specifier: workspace:*
         version: link:../_test-utils
@@ -10084,6 +10114,9 @@ importers:
       '@internal/types-builder':
         specifier: workspace:*
         version: link:../../packages/_types-builder
+      '@internal/workspace':
+        specifier: workspace:*
+        version: link:../../packages/_internals/workspace
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core

--- a/workspaces/e2b/src/index.ts
+++ b/workspaces/e2b/src/index.ts
@@ -18,8 +18,6 @@ export {
   type RepoTemplateOptions,
   type RepoTemplateIdentity,
   type RepositoryAccess,
-  SETUP_MARKER_PATH,
-  setupMarkerContent,
   type RefreshRepoTemplateResult,
 } from './utils/repo-template';
 export {

--- a/workspaces/e2b/src/index.ts
+++ b/workspaces/e2b/src/index.ts
@@ -18,6 +18,8 @@ export {
   type RepoTemplateOptions,
   type RepoTemplateIdentity,
   type RepositoryAccess,
+  SETUP_MARKER_PATH,
+  setupMarkerContent,
   type RefreshRepoTemplateResult,
 } from './utils/repo-template';
 export {

--- a/workspaces/e2b/src/utils/repo-template.test.ts
+++ b/workspaces/e2b/src/utils/repo-template.test.ts
@@ -1,7 +1,13 @@
 import { Template } from 'e2b';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createRepoTemplate, refreshRepoTemplate, repoTemplateRef } from './repo-template';
+import {
+  createRepoTemplate,
+  refreshRepoTemplate,
+  repoTemplateRef,
+  SETUP_MARKER_PATH,
+  setupMarkerContent,
+} from './repo-template';
 import type { RepoTemplateOptions } from './repo-template';
 import type { NamedTemplateSpec } from './template';
 
@@ -223,6 +229,19 @@ describe('createRepoTemplate', () => {
     const resolved = await resolve(BASE);
     expect(resolved.ref).toBe(repoTemplateRef({ cloneUrl: CLONE_URL, setupCommand: SETUP, sha: head }));
     expect(await serializedSteps(resolved)).toContain(`checkout ${head}`);
+  });
+
+  it('always writes the setup marker beside the checkout as the last build step', async () => {
+    const resolved = await resolve(BASE);
+    const steps = await serializedSteps(resolved);
+    const content = setupMarkerContent([SETUP]);
+    expect(content).toMatch(/^sha256:[0-9a-f]{64}$/);
+    const markerStep = `mkdir -p \\"$(dirname \\"${SETUP_MARKER_PATH}\\")\\" && printf '%s' '${content}' > \\"${SETUP_MARKER_PATH}\\"`;
+    expect(steps).toContain(markerStep);
+    expect(steps.lastIndexOf(markerStep)).toBeGreaterThan(steps.lastIndexOf(SETUP));
+    // The digest covers exactly the commands the image ran, in order.
+    expect(setupMarkerContent(['a', 'b'])).not.toBe(setupMarkerContent(['b', 'a']));
+    expect(setupMarkerContent([])).toMatch(/^sha256:/);
   });
 
   it('looks a github.com head up through the REST API, without git or a clone', async () => {

--- a/workspaces/e2b/src/utils/repo-template.test.ts
+++ b/workspaces/e2b/src/utils/repo-template.test.ts
@@ -1,13 +1,8 @@
+import { SETUP_MARKER_PATH, setupMarkerContent } from '@internal/workspace';
 import { Template } from 'e2b';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  createRepoTemplate,
-  refreshRepoTemplate,
-  repoTemplateRef,
-  SETUP_MARKER_PATH,
-  setupMarkerContent,
-} from './repo-template';
+import { createRepoTemplate, refreshRepoTemplate, repoTemplateRef } from './repo-template';
 import type { RepoTemplateOptions } from './repo-template';
 import type { NamedTemplateSpec } from './template';
 

--- a/workspaces/e2b/src/utils/repo-template.ts
+++ b/workspaces/e2b/src/utils/repo-template.ts
@@ -374,6 +374,24 @@ export async function refreshRepoTemplate(
  * so it is checked before it can be interpolated into one. The repoDir is
  * derived from it rather than supplied, so it needs no separate guard.
  */
+/**
+ * Setup completion marker, written beside the checkout as the template's last
+ * build step so it only exists in images where every setup command succeeded.
+ * The content is a digest of the setup commands, so a sandbox booted from the
+ * image can tell whether *this* setup already ran. Path and recipe are a
+ * convention shared with `@mastra/factory` (session-sandbox.ts) and
+ * `@mastra/platform-workspace`; keep the three in sync.
+ */
+export const SETUP_MARKER_PATH = '.mastra-sandbox/setup';
+
+export function setupMarkerContent(setupCommands: readonly string[]): string {
+  return `sha256:${createHash('sha256').update(setupCommands.join('\n')).digest('hex')}`;
+}
+
+function setupMarkerCommand(content: string): string {
+  return `mkdir -p "$(dirname "${SETUP_MARKER_PATH}")" && printf '%s' '${content}' > "${SETUP_MARKER_PATH}"`;
+}
+
 function assertCloneUrl(cloneUrl: string): void {
   if (!isValidCloneUrl(cloneUrl)) {
     throw new Error(`Invalid cloneUrl '${cloneUrl}': expected an https URL with a plain host and path`);
@@ -428,9 +446,12 @@ function buildRepoTemplateSpec(identity: RepoTemplateIdentity, token?: string): 
       .runCmd(`git -C "${repoDir}" checkout ${sha}`);
   }
   // Build steps use fresh shells, so each setup command needs its own `cd`.
-  for (const command of normalizeSetupCommands(setupCommand)) {
+  const setupCommands = normalizeSetupCommands(setupCommand);
+  for (const command of setupCommands) {
     template = template.runCmd(`cd "${repoDir}" && ${command}`);
   }
+  // Last, so it only exists in images where every step above succeeded.
+  template = template.runCmd(setupMarkerCommand(setupMarkerContent(setupCommands)));
 
   return {
     ref: repoTemplateRef(identity),

--- a/workspaces/e2b/src/utils/repo-template.ts
+++ b/workspaces/e2b/src/utils/repo-template.ts
@@ -30,6 +30,7 @@
 import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { promisify } from 'node:util';
+import { setupMarkerCommand, setupMarkerContent } from '@internal/workspace';
 
 import { Template } from 'e2b';
 import type { ConnectionOpts, TemplateClass } from 'e2b';
@@ -374,23 +375,6 @@ export async function refreshRepoTemplate(
  * so it is checked before it can be interpolated into one. The repoDir is
  * derived from it rather than supplied, so it needs no separate guard.
  */
-/**
- * Setup completion marker, written beside the checkout as the template's last
- * build step so it only exists in images where every setup command succeeded.
- * The content is a digest of the setup commands, so a sandbox booted from the
- * image can tell whether *this* setup already ran. Path and recipe are a
- * convention shared with `@mastra/factory` (session-sandbox.ts) and
- * `@mastra/platform-workspace`; keep the three in sync.
- */
-export const SETUP_MARKER_PATH = '.mastra-sandbox/setup';
-
-export function setupMarkerContent(setupCommands: readonly string[]): string {
-  return `sha256:${createHash('sha256').update(setupCommands.join('\n')).digest('hex')}`;
-}
-
-function setupMarkerCommand(content: string): string {
-  return `mkdir -p "$(dirname "${SETUP_MARKER_PATH}")" && printf '%s' '${content}' > "${SETUP_MARKER_PATH}"`;
-}
 
 function assertCloneUrl(cloneUrl: string): void {
   if (!isValidCloneUrl(cloneUrl)) {

--- a/workspaces/e2b/tsdown.config.ts
+++ b/workspaces/e2b/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   treeshake: true,
   sourcemap: true,
   deps: {
+    alwaysBundle: ['@internal/workspace'],
     neverBundle: ['@mastra/core', '@e2b/code-interpreter', 'esbuild'],
   },
   onSuccess: async () => {

--- a/workspaces/platform-workspace/package.json
+++ b/workspaces/platform-workspace/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
+    "@internal/workspace": "workspace:*",
     "@mastra/core": "workspace:*",
     "@types/node": "22.20.1",
     "@vitest/coverage-v8": "catalog:",

--- a/workspaces/platform-workspace/src/index.ts
+++ b/workspaces/platform-workspace/src/index.ts
@@ -35,8 +35,6 @@ export {
   createRepoTemplate,
   type PlatformRepoTemplateOptions,
   type PlatformRepoTemplateResolver,
-  SETUP_MARKER_PATH,
-  setupMarkerContent,
 } from './repo-template.js';
 export { platformFilesystemProvider, platformSandboxProvider } from './provider.js';
 export {

--- a/workspaces/platform-workspace/src/index.ts
+++ b/workspaces/platform-workspace/src/index.ts
@@ -35,6 +35,8 @@ export {
   createRepoTemplate,
   type PlatformRepoTemplateOptions,
   type PlatformRepoTemplateResolver,
+  SETUP_MARKER_PATH,
+  setupMarkerContent,
 } from './repo-template.js';
 export { platformFilesystemProvider, platformSandboxProvider } from './provider.js';
 export {

--- a/workspaces/platform-workspace/src/repo-template.test.ts
+++ b/workspaces/platform-workspace/src/repo-template.test.ts
@@ -1,12 +1,7 @@
+import { SETUP_MARKER_PATH, setupMarkerContent } from '@internal/workspace';
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  createRepoTemplate,
-  redactSecrets,
-  resolveDefaultBranchHead,
-  SETUP_MARKER_PATH,
-  setupMarkerContent,
-} from './repo-template.js';
+import { createRepoTemplate, redactSecrets, resolveDefaultBranchHead } from './repo-template.js';
 import { getSandboxTemplateBuildEnvs, serializeSandboxTemplate } from './template.js';
 
 const SHA_1 = '0123456789abcdef0123456789abcdef01234567';

--- a/workspaces/platform-workspace/src/repo-template.test.ts
+++ b/workspaces/platform-workspace/src/repo-template.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { createRepoTemplate, redactSecrets, resolveDefaultBranchHead } from './repo-template.js';
+import {
+  createRepoTemplate,
+  redactSecrets,
+  resolveDefaultBranchHead,
+  SETUP_MARKER_PATH,
+  setupMarkerContent,
+} from './repo-template.js';
 import { getSandboxTemplateBuildEnvs, serializeSandboxTemplate } from './template.js';
 
 const SHA_1 = '0123456789abcdef0123456789abcdef01234567';
@@ -12,6 +18,15 @@ function accessFor(cloneUrl: string) {
 
 function headOf(sha: string) {
   return vi.fn().mockResolvedValue(sha);
+}
+
+/** The marker step every repo template ends with, for the commands it ran. */
+function markerStep(...setupCommands: string[]) {
+  const content = setupMarkerContent(setupCommands);
+  return {
+    method: 'runCmd',
+    args: [`mkdir -p "$(dirname "${SETUP_MARKER_PATH}")" && printf '%s' '${content}' > "${SETUP_MARKER_PATH}"`],
+  };
 }
 
 describe('createRepoTemplate', () => {
@@ -38,9 +53,23 @@ describe('createRepoTemplate', () => {
         { method: 'runCmd', args: [`git -C "widgets" fetch origin ${SHA_1}`] },
         { method: 'runCmd', args: [`git -C "widgets" checkout ${SHA_1}`] },
         { method: 'runCmd', args: ['cd "widgets" && pnpm install --frozen-lockfile'] },
+        markerStep('pnpm install --frozen-lockfile'),
       ],
       family: 'repo:https://github.com/acme/widgets:/widgets',
     });
+  });
+
+  it('always writes the setup marker beside the checkout as the last build step, digesting the commands it ran', async () => {
+    const template = await createRepoTemplate({
+      getRepositoryAccess: accessFor('https://github.com/acme/widgets.git'),
+      setupCommand: ['pnpm i', '', 'pnpm build'],
+      resolveHead: headOf(SHA_1),
+    })!();
+    const operations = serializeSandboxTemplate(template!).operations;
+    expect(setupMarkerContent(['pnpm i', 'pnpm build'])).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(operations.at(-1)).toEqual(markerStep('pnpm i', 'pnpm build'));
+    expect(operations.at(-2)).toEqual({ method: 'runCmd', args: ['cd "widgets" && pnpm build'] });
+    expect(setupMarkerContent(['pnpm i'])).not.toBe(setupMarkerContent(['pnpm i', 'pnpm build']));
   });
 
   it('runs each setupCommand array entry as its own build step with its own cd prefix', async () => {
@@ -51,9 +80,10 @@ describe('createRepoTemplate', () => {
     })!();
 
     const operations = serializeSandboxTemplate(template!).operations;
-    expect(operations.slice(-2)).toEqual([
+    expect(operations.slice(-3)).toEqual([
       { method: 'runCmd', args: ['cd "widgets" && pnpm i'] },
       { method: 'runCmd', args: ['cd "widgets" && pnpm build'] },
+      markerStep('pnpm i', 'pnpm build'),
     ]);
   });
 
@@ -77,7 +107,8 @@ describe('createRepoTemplate', () => {
     })!();
 
     const operations = serializeSandboxTemplate(template!).operations;
-    expect(operations.filter(op => op.method === 'runCmd')).toHaveLength(3);
+    expect(operations.filter(op => op.method === 'runCmd')).toHaveLength(4);
+    expect(operations.at(-1)).toEqual(markerStep());
   });
 
   it('creates an explicit workingDirectory, sets it as the cwd before cloning, and keys the family on it', async () => {
@@ -98,7 +129,8 @@ describe('createRepoTemplate', () => {
       { method: 'runCmd', args: ['git clone https://github.com/acme/widgets "widgets"'] },
     ]);
     const commands = serialized.operations.filter(op => op.method === 'runCmd').map(op => String(op.args[0]));
-    expect(commands.at(-1)).toBe('cd "widgets" && pnpm i');
+    expect(commands.at(-2)).toBe('cd "widgets" && pnpm i');
+    expect(commands.at(-1)).toBe(markerStep('pnpm i').args[0]);
     expect(serialized.family).toBe('repo:https://github.com/acme/widgets:/workspace/widgets');
   });
 
@@ -143,6 +175,7 @@ describe('createRepoTemplate', () => {
       { method: 'runCmd', args: ['git clone https://github.com/acme/widgets "widgets"'] },
       { method: 'runCmd', args: [`git -C "widgets" fetch origin ${SHA_1}`] },
       { method: 'runCmd', args: [`git -C "widgets" checkout ${SHA_1}`] },
+      markerStep(),
     ]);
     // Sizing never leaks into the commit-independent family key; the platform
     // namespaces warm fallbacks by size server-side.
@@ -386,6 +419,7 @@ describe('createRepoTemplate', () => {
       { method: 'runCmd', args: [expect.stringContaining('$MASTRA_REPOSITORY_ACCESS_TOKEN')] },
       { method: 'runCmd', args: [expect.stringContaining('$MASTRA_REPOSITORY_ACCESS_TOKEN')] },
       { method: 'runCmd', args: [`git -C "widgets" checkout ${SHA_1}`] },
+      markerStep(),
     ]);
     expect(JSON.stringify(definition)).not.toContain('ghs_secret_token');
   });

--- a/workspaces/platform-workspace/src/repo-template.ts
+++ b/workspaces/platform-workspace/src/repo-template.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { promisify } from 'node:util';
 
 import { Template, type SandboxTemplateBuilder } from './template.js';
@@ -76,6 +77,24 @@ export interface PlatformRepoTemplateOptions {
   buildEnv?: Record<string, string>;
   /** Test/integration seam for resolving the default-branch head. */
   resolveHead?: (cloneUrl: string, token?: string) => Promise<string | undefined>;
+}
+
+/**
+ * Setup completion marker, written beside the checkout as the template's last
+ * build step so it only exists in images where every setup command succeeded.
+ * The content is a digest of the setup commands, so a sandbox booted from the
+ * image can tell whether *this* setup already ran. Path and recipe are a
+ * convention shared with `@mastra/factory` (session-sandbox.ts) and
+ * `@mastra/e2b`; keep the three in sync.
+ */
+export const SETUP_MARKER_PATH = '.mastra-sandbox/setup';
+
+export function setupMarkerContent(setupCommands: readonly string[]): string {
+  return `sha256:${createHash('sha256').update(setupCommands.join('\n')).digest('hex')}`;
+}
+
+function setupMarkerCommand(content: string): string {
+  return `mkdir -p "$(dirname "${SETUP_MARKER_PATH}")" && printf '%s' '${content}' > "${SETUP_MARKER_PATH}"`;
 }
 
 export type PlatformRepoTemplateResolver = () => Promise<SandboxTemplateBuilder | undefined>;
@@ -181,6 +200,8 @@ export function createRepoTemplate(options: PlatformRepoTemplateOptions): Platfo
       .runCmd(`git -C "${repoDir}" checkout ${sha}`);
     // Build steps use fresh shells, so each setup command needs its own `cd`.
     for (const command of setupCommands) template = template.runCmd(`cd "${repoDir}" && ${command}`);
+    // Last, so it only exists in images where every step above succeeded.
+    template = template.runCmd(setupMarkerCommand(setupMarkerContent(setupCommands)));
     return template.withFamily(family);
   };
 }

--- a/workspaces/platform-workspace/src/repo-template.ts
+++ b/workspaces/platform-workspace/src/repo-template.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
-import { createHash } from 'node:crypto';
 import { promisify } from 'node:util';
+import { setupMarkerCommand, setupMarkerContent } from '@internal/workspace';
 
 import { Template, type SandboxTemplateBuilder } from './template.js';
 
@@ -77,24 +77,6 @@ export interface PlatformRepoTemplateOptions {
   buildEnv?: Record<string, string>;
   /** Test/integration seam for resolving the default-branch head. */
   resolveHead?: (cloneUrl: string, token?: string) => Promise<string | undefined>;
-}
-
-/**
- * Setup completion marker, written beside the checkout as the template's last
- * build step so it only exists in images where every setup command succeeded.
- * The content is a digest of the setup commands, so a sandbox booted from the
- * image can tell whether *this* setup already ran. Path and recipe are a
- * convention shared with `@mastra/factory` (session-sandbox.ts) and
- * `@mastra/e2b`; keep the three in sync.
- */
-export const SETUP_MARKER_PATH = '.mastra-sandbox/setup';
-
-export function setupMarkerContent(setupCommands: readonly string[]): string {
-  return `sha256:${createHash('sha256').update(setupCommands.join('\n')).digest('hex')}`;
-}
-
-function setupMarkerCommand(content: string): string {
-  return `mkdir -p "$(dirname "${SETUP_MARKER_PATH}")" && printf '%s' '${content}' > "${SETUP_MARKER_PATH}"`;
 }
 
 export type PlatformRepoTemplateResolver = () => Promise<SandboxTemplateBuilder | undefined>;


### PR DESCRIPTION
A session booted from a warm repo template already has the setup command's output baked into the image, yet Factory re-ran the full setup (install + build, minutes) on every fresh VM: the completion marker only ever lived inside the VM, and the created-VM branch skipped the marker probe outright.

Repo templates in `@mastra/e2b` and `@mastra/platform-workspace` now always write `.mastra-sandbox/setup` beside the checkout as their last build step, so it exists only in images where every setup step succeeded. Its content is `sha256:<digest of the setup commands the image ran>`. Factory computes the same digest from the project's setup command and checks for that file next to the repo dir. No option or context field is threaded through; the path and recipe are a shared convention across the three packages.

The start hook now runs the setup command only when the sandbox carries no marker for that exact command, and writes the marker after a successful runtime setup. Repo materialization and the session branch checkout are unchanged. An existing sandbox whose project setup command was edited runs the new command once on its next start (new sessions get a rebuilt template instead). Failure semantics (teardown, failed-once skip, `SetupCommandError`) are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Sandboxes now remember which setup commands they already ran. If the commands have not changed, the system skips the repeated work and starts faster.

## Changes

- Added shared setup-marker utilities in `@internal/workspace`.
- Added SHA-256 markers at `.mastra-sandbox/setup`.
- Updated `@mastra/e2b` and `@mastra/platform-workspace` templates to write markers after successful setup.
- Updated Factory to:
  - Compare the marker with the current setup command.
  - Skip setup when the marker matches.
  - Run setup when the marker is missing or outdated.
  - Write the marker only after successful setup.
  - Preserve materialization and session branch checkout on every start.
- Added the public `SessionSetupGate` type.
- Added tests for warm sandboxes, changed commands, failures, empty commands, marker placement, and digest behavior.
- Added changesets for the affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->