### PR TITLE
perf(factory): skip the git pull in materialize; share the repo clone with templates

### DIFF
--- a/.changeset/factory-detached-pull.md
+++ b/.changeset/factory-detached-pull.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Session start no longer runs `git pull` on a checkout with a detached HEAD, which is what a sandbox booted from a repo template image carries: the pull had nothing to fast-forward but still paid for its fetch. The session branch checkout that follows fetches the base branch itself. Start-path phases (`workspace.onStart`, `workspace.setup-marker`, `workspace.setup`) now log their timings alongside materialize and checkout.

--- a/.changeset/factory-detached-pull.md
+++ b/.changeset/factory-detached-pull.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Session start no longer runs `git pull` on a checkout with a detached HEAD, which is what a sandbox booted from a repo template image carries: the pull had nothing to fast-forward but still paid for its fetch. The session branch checkout that follows fetches the base branch itself. Start-path phases (`workspace.onStart`, `workspace.setup-marker`, `workspace.setup`) now log their timings alongside materialize and checkout.
+Session start no longer runs `git pull` on a checkout that is already in the sandbox. A sandbox booted from a repo template image, or resumed after idling, has the repo on disk; materialize now leaves it as it is and only clones when no checkout of the repo exists. The pull cost a network round-trip on every start and, on a template image (detached at its pinned commit), had nothing to fast-forward. The session branch checkout that follows still fetches the base branch it needs. Start-path phases (`workspace.onStart`, `workspace.setup-marker`, `workspace.setup`) now log their timings alongside materialize and checkout.

--- a/.changeset/factory-detached-pull.md
+++ b/.changeset/factory-detached-pull.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Session start no longer runs `git pull` on a checkout that is already in the sandbox. A sandbox booted from a repo template image, or resumed after idling, has the repo on disk; materialize now leaves it as it is and only clones when no checkout of the repo exists. The pull cost a network round-trip on every start and, on a template image (detached at its pinned commit), had nothing to fast-forward. The session branch checkout that follows still fetches the base branch it needs. Start-path phases (`workspace.onStart`, `workspace.setup-marker`, `workspace.setup`) now log their timings alongside materialize and checkout.
+Session start no longer runs `git pull` on an existing checkout; it only clones when the repo is missing from the sandbox. Start-path phases (`workspace.onStart`, `workspace.setup-marker`, `workspace.setup`) now log their timings.

--- a/.changeset/repo-template-shallow-clone.md
+++ b/.changeset/repo-template-shallow-clone.md
@@ -3,4 +3,4 @@
 '@mastra/platform-workspace': patch
 ---
 
-Repo templates now clone with `--depth=1 --single-branch`, the same clone Factory makes at session start when no template image is available, so both paths produce the same checkout and template builds transfer far less history.
+Repo templates now clone with `--depth=1 --single-branch`, the same clone Factory makes at session start.

--- a/.changeset/repo-template-shallow-clone.md
+++ b/.changeset/repo-template-shallow-clone.md
@@ -1,0 +1,6 @@
+---
+'@mastra/e2b': patch
+'@mastra/platform-workspace': patch
+---
+
+Repo templates now clone with `--depth=1 --single-branch`, the same clone Factory makes at session start when no template image is available, so both paths produce the same checkout and template builds transfer far less history.

--- a/.changeset/repo-template-shallow-clone.md
+++ b/.changeset/repo-template-shallow-clone.md
@@ -3,4 +3,4 @@
 '@mastra/platform-workspace': patch
 ---
 
-Repo templates now clone with `--depth=1 --single-branch`, the same clone Factory makes at session start.
+Repository templates now clone with `--depth=1 --single-branch`, so template builds transfer less history.

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@ om-reflector-fixture.json
 
 # Local git worktrees (scratch checkouts; never part of a commit)
 .worktrees/
+
+# Throwaway probe scripts
+*.local.mjs
+*.local.ts

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -191,6 +191,10 @@ describe('materializeRepo', () => {
     'https://github.com.evil.example/octocat/hello.git',
     'https://github.com/other/hello.git',
     'https://github.com/octocat/hello-fork.git',
+    'https://github.com:8443/octocat/hello.git',
+    'https://github.com/octocat/hello.git?x=1',
+    'https://github.com//octocat/hello.git',
+    'http://github.com/octocat/hello.git',
   ])('re-clones over a checkout whose origin is %s', async origin => {
     const sandbox = new FakeSandbox(script => {
       if (script.includes('remote get-url origin')) return { exitCode: 0, stdout: `${origin}\n`, stderr: '' };

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -124,7 +124,11 @@ describe('materializeRepo', () => {
     expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
   });
 
-  it('pulls (not clones) on re-open', async () => {
+  it('leaves an existing checkout of this repo untouched on re-open, whatever it is on', async () => {
+    // A repo template image sits detached at its pinned sha; a resumed session
+    // sits on its branch. Neither gets a fetch or a pull here: the branch
+    // checkout that follows fetches what it needs, and syncing is the
+    // session's business.
     const sandbox = new FakeSandbox(script => {
       if (script.includes('remote get-url origin')) {
         return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
@@ -133,30 +137,53 @@ describe('materializeRepo', () => {
     });
     await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok-xyz');
 
-    const joined = sandbox.calls.join('\n');
-    expect(joined).toContain('git -C ');
-    expect(joined).toContain('pull --ff-only');
-    expect(sandbox.calls.some(c => c.includes('git clone'))).toBe(false);
-    expect(joined).toContain('https://x-access-token:tok-xyz@github.com/octocat/hello.git');
+    const gitCalls = sandbox.calls.filter(c => c.includes('git ') && !c.includes('git --version'));
+    expect(gitCalls).toEqual([expect.stringContaining('remote get-url origin')]);
+    expect(sandbox.calls.join('\n')).not.toContain('tok-xyz');
+    expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
   });
 
-  it('skips the pull on a detached HEAD (a VM booted from a repo template image)', async () => {
+  it('leaves the checkout alone when the DB says first open but the workdir already holds this repo', async () => {
     const sandbox = new FakeSandbox(script => {
       if (script.includes('remote get-url origin')) {
         return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
       }
-      // Detached at the template's pinned commit: no symbolic HEAD.
-      if (script.includes('symbolic-ref -q HEAD')) return { exitCode: 1, stdout: '', stderr: '' };
       return OK;
     });
-    await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok-xyz');
+    await materializeRepo(makeRow({ materializedAt: null }), makeRepoInfo(), sandbox, 'tok-abc');
 
-    const joined = sandbox.calls.join('\n');
-    expect(joined).not.toContain('pull --ff-only');
-    expect(joined).not.toContain('git clone');
-    // No pull, so the token never reaches the remote and there is nothing to scrub.
-    expect(joined).not.toContain('tok-xyz');
+    expect(sandbox.calls.some(c => c.includes('git clone'))).toBe(false);
     expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
+  });
+
+  it('scrubs a tokenized remote an earlier start left behind, without cloning', async () => {
+    const sandbox = new FakeSandbox(script => {
+      if (script.includes('remote get-url origin')) {
+        return { exitCode: 0, stdout: 'https://x-access-token:stale@github.com/octocat/hello.git\n', stderr: '' };
+      }
+      return OK;
+    });
+    await materializeRepo(makeRow({ materializedAt: null }), makeRepoInfo(), sandbox, 'tok-abc');
+
+    expect(sandbox.calls.some(c => c.includes('git clone'))).toBe(false);
+    const scrub = sandbox.calls.filter(c => c.includes('remote set-url origin')).at(-1);
+    expect(scrub).toContain('https://github.com/octocat/hello.git');
+    expect(scrub).not.toContain('stale');
+  });
+
+  it('surfaces a failed scrub of a stale tokenized remote instead of leaving the token in place', async () => {
+    const sandbox = new FakeSandbox(script => {
+      if (script.includes('remote get-url origin')) {
+        return { exitCode: 0, stdout: 'https://x-access-token:stale@github.com/octocat/hello.git\n', stderr: '' };
+      }
+      if (script.includes('remote set-url origin')) {
+        return { exitCode: 1, stdout: '', stderr: 'error: could not write config' };
+      }
+      return OK;
+    });
+    const err = await materializeRepo(makeRow({ materializedAt: null }), makeRepoInfo(), sandbox, 'tok').catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(String(err.message)).toContain('scrub');
   });
 
   it('re-clones when the DB says materialized but the sandbox disk was wiped', async () => {
@@ -203,23 +230,6 @@ describe('materializeRepo', () => {
     expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
   });
 
-  it('pulls (not clones) when the DB says first open but the workdir already holds this repo', async () => {
-    // DB/disk drift: a fresh binding row (materializedAt null) over a workdir
-    // that was already cloned by an earlier flow or before a dev DB reset.
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      return OK;
-    });
-    await materializeRepo(makeRow({ materializedAt: null }), makeRepoInfo(), sandbox, 'tok-abc');
-
-    const joined = sandbox.calls.join('\n');
-    expect(sandbox.calls.some(c => c.includes('git clone'))).toBe(false);
-    expect(joined).toContain('pull --ff-only');
-    expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
-  });
-
   it('still clones when the workdir holds a checkout of a different repo', async () => {
     const sandbox = new FakeSandbox(script => {
       if (script.includes('remote get-url origin')) {
@@ -231,24 +241,6 @@ describe('materializeRepo', () => {
 
     expect(sandbox.calls.some(c => c.includes('git clone'))).toBe(true);
     expect(sandbox.calls.some(c => c.includes('pull --ff-only'))).toBe(false);
-  });
-
-  it('detects an existing checkout even when a tokenized remote was left behind', async () => {
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://x-access-token:stale@github.com/octocat/hello.git\n', stderr: '' };
-      }
-      return OK;
-    });
-    await materializeRepo(makeRow({ materializedAt: null }), makeRepoInfo(), sandbox, 'tok-abc');
-
-    const joined = sandbox.calls.join('\n');
-    expect(sandbox.calls.some(c => c.includes('git clone'))).toBe(false);
-    expect(joined).toContain('pull --ff-only');
-    // scrub still resets to the tokenless URL
-    const scrub = sandbox.calls.filter(c => c.includes('remote set-url origin')).at(-1);
-    expect(scrub).toContain('https://github.com/octocat/hello.git');
-    expect(scrub).not.toContain('stale');
   });
 
   it('throws git-missing when git is absent', async () => {
@@ -309,46 +301,6 @@ describe('materializeRepo', () => {
     expect(err.message).toMatch(/checkout failed.*Failed to scrub installation token/s);
   });
 
-  it('surfaces a failed scrub over the pull failure once the token reached the remote', async () => {
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      if (script.includes('pull --ff-only')) {
-        return { exitCode: 128, stdout: '', stderr: 'fatal: unable to access: Could not resolve host: github.com' };
-      }
-      // The scrub resets to the tokenless URL; only the auth set-url carries the token.
-      if (script.includes('remote set-url origin') && !script.includes('x-access-token')) {
-        return { exitCode: 255, stdout: '', stderr: 'error: could not lock config file .git/config' };
-      }
-      return OK;
-    });
-    const err = await materializeRepo(makeRow(), makeRepoInfo(), sandbox, 'tok-secret').catch(e => e);
-    expect(err).toBeInstanceOf(MaterializeError);
-    expect(err.code).toBe('egress-blocked');
-    expect(err.message).toContain('Failed to scrub installation token');
-  });
-
-  it('surfaces a throwing scrub as a token error once the token reached the remote', async () => {
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      if (script.includes('pull --ff-only')) {
-        return { exitCode: 128, stdout: '', stderr: 'fatal: unable to access: Could not resolve host: github.com' };
-      }
-      if (script.includes('remote set-url origin') && !script.includes('x-access-token')) {
-        throw new Error('sandbox connection lost');
-      }
-      return OK;
-    });
-    const err = await materializeRepo(makeRow(), makeRepoInfo(), sandbox, 'tok-secret').catch(e => e);
-    expect(err).toBeInstanceOf(MaterializeError);
-    expect(err.code).toBe('egress-blocked');
-    expect(err.message).toContain('Failed to scrub installation token');
-    expect(err.message).toContain('sandbox connection lost');
-  });
-
   it('refuses to run git when the default branch is not git-ref-safe', async () => {
     const sandbox = new FakeSandbox();
     const err = await materializeRepo(
@@ -371,263 +323,6 @@ describe('materializeRepo', () => {
     expect(sandbox.calls).toHaveLength(0);
   });
 
-  it('keeps a diverged session branch on re-open instead of failing the pull', async () => {
-    // The shared workdir is routinely left on a session's working branch with
-    // local commits. When its upstream moved, `git pull --ff-only` aborts with
-    // "Not possible to fast-forward" — that is the session's work, not an
-    // error, so materialization must succeed and leave the checkout alone.
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      if (script.includes('pull --ff-only')) {
-        return {
-          exitCode: 128,
-          stdout: '',
-          stderr:
-            "hint: Diverging branches can't be fast-forwarded, you need to either:\nfatal: Not possible to fast-forward, aborting.\n",
-        };
-      }
-      return OK;
-    });
-
-    await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok-secret');
-
-    // No destructive recovery: never rebase, reset, or re-clone over the work.
-    const joined = sandbox.calls.join('\n');
-    expect(joined).not.toContain('git clone');
-    expect(joined).not.toMatch(/rebase|reset --hard/);
-    // Token scrubbed and the binding marked materialized as on any success.
-    const scrub = sandbox.calls.filter(c => c.includes('remote set-url origin')).at(-1);
-    expect(scrub).toContain('https://github.com/octocat/hello.git');
-    expect(scrub).not.toContain('tok-secret');
-    expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
-  });
-
-  it('keeps a dirty checkout as-is when local changes block the pull', async () => {
-    // A previous run left uncommitted modifications in the checkout (e.g. a
-    // changeset-version run or build residue); git refuses to merge over
-    // them. The checkout is intact — keep it, never discard the local state.
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      if (script.includes('pull --ff-only')) {
-        return {
-          exitCode: 1,
-          stdout: '',
-          stderr:
-            'error: Your local changes to the following files would be overwritten by merge:\n\tpackage.json\nPlease commit your changes or stash them before you merge.\nAborting\n',
-        };
-      }
-      return OK;
-    });
-
-    await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok-secret');
-
-    const joined = sandbox.calls.join('\n');
-    expect(joined).not.toContain('git clone');
-    expect(joined).not.toMatch(/rebase|reset --hard|stash|checkout --/);
-    expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
-  });
-
-  it('keeps a checkout with blocking untracked files as-is on re-open', async () => {
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      if (script.includes('pull --ff-only')) {
-        return {
-          exitCode: 1,
-          stdout: '',
-          stderr:
-            'error: The following untracked working tree files would be overwritten by merge:\n\t.changeset/new-note.md\nPlease move or remove them before you merge.\nAborting\n',
-        };
-      }
-      return OK;
-    });
-
-    await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok');
-
-    const joined = sandbox.calls.join('\n');
-    expect(joined).not.toContain('git clone');
-    expect(joined).not.toMatch(/rebase|reset --hard|stash|checkout --|clean -/);
-    expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
-  });
-
-  it('keeps a dirty checkout as-is when pull.rebase turns the refusal into rebase wording', async () => {
-    // Same dirty checkout, different git config: with `pull.rebase` set, git
-    // refuses in rebase's words rather than merge's. It is still the session's
-    // own uncommitted work — keep it, never discard it to force the pull.
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      if (script.includes('pull --ff-only')) {
-        return {
-          exitCode: 1,
-          stdout: '',
-          stderr:
-            'error: cannot pull with rebase: Your index contains uncommitted changes.\nerror: Please commit or stash them.\n',
-        };
-      }
-      return OK;
-    });
-
-    await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok');
-
-    const joined = sandbox.calls.join('\n');
-    expect(joined).not.toContain('git clone');
-    expect(joined).not.toMatch(/rebase|reset --hard|stash|checkout --|clean -/);
-    expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
-  });
-
-  it('treats a session branch without an upstream as materialized on re-open', async () => {
-    // Session branches are created from FETCH_HEAD and have no tracking
-    // branch; `git pull` then exits with "no tracking information".
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      if (script.includes('pull --ff-only')) {
-        return {
-          exitCode: 1,
-          stdout: '',
-          stderr: 'There is no tracking information for the current branch.\n',
-        };
-      }
-      return OK;
-    });
-
-    await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok');
-
-    expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
-  });
-
-  it('keeps a checkout when the upstream branch was deleted after merge', async () => {
-    // Session branch was auto-deleted on the remote after its PR merged;
-    // `git pull` reports the configured upstream ref is gone. The checkout
-    // is intact (and the work is already integrated) — keep it as-is.
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      if (script.includes('pull --ff-only')) {
-        return {
-          exitCode: 1,
-          stdout: '',
-          stderr:
-            "Your configuration specifies to merge with the ref 'refs/heads/factory/issue-1'\nfrom the remote, but no such ref was fetched.\n",
-        };
-      }
-      return OK;
-    });
-
-    await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok');
-
-    const joined = sandbox.calls.join('\n');
-    expect(joined).not.toContain('git clone');
-    expect(joined).not.toMatch(/rebase|reset --hard/);
-    expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
-  });
-
-  it('keeps a checkout when git cannot find the remote ref', async () => {
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      if (script.includes('pull --ff-only')) {
-        return {
-          exitCode: 1,
-          stdout: '',
-          stderr: "fatal: couldn't find remote ref refs/heads/factory/issue-1\n",
-        };
-      }
-      return OK;
-    });
-
-    await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok');
-
-    const joined = sandbox.calls.join('\n');
-    expect(joined).not.toContain('git clone');
-    expect(joined).not.toMatch(/rebase|reset --hard/);
-    expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
-  });
-
-  it('scrubs the tokenized remote even when the pull fails on re-open', async () => {
-    const sandbox = new FakeSandbox(script => {
-      if (script === 'git --version') return OK;
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      if (script.includes('pull --ff-only')) {
-        return { exitCode: 1, stdout: '', stderr: 'fatal: not a fast-forward' };
-      }
-      return OK;
-    });
-
-    const err = await materializeRepo(
-      makeRow({ materializedAt: new Date() }),
-      makeRepoInfo(),
-      sandbox,
-      'tok-secret',
-    ).catch(e => e);
-
-    // The pull failure is surfaced...
-    expect(err).toBeInstanceOf(MaterializeError);
-    expect(err.code).toBe('pull-failed');
-    // ...but the token is still scrubbed back to the tokenless URL afterwards,
-    // and no tokenized remote is left as the final remote state.
-    const scrub = sandbox.calls.filter(c => c.includes('remote set-url origin')).at(-1);
-    expect(scrub).toContain('https://github.com/octocat/hello.git');
-    expect(scrub).not.toContain('tok-secret');
-    // The repo is not marked materialized when the pull failed.
-    expect(dbUpdates.some(u => 'materializedAt' in u)).toBe(false);
-  });
-
-  it('reports the pull failure first and the scrub failure alongside when both fail', async () => {
-    // Regression: the scrub used to throw over the in-flight clone/pull
-    // error, hiding the actionable failure behind "Failed to scrub
-    // installation token". The pull failure keeps the lead — but the token
-    // reached the remote, so the failed scrub is reported too, not swallowed.
-    const sandbox = new FakeSandbox(script => {
-      if (script === 'git --version') return OK;
-      if (script.includes('remote get-url origin')) {
-        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-      }
-      if (script.includes('pull --ff-only')) {
-        return { exitCode: 1, stdout: '', stderr: 'fatal: not a fast-forward' };
-      }
-      if (script.includes('remote set-url origin') && !script.includes('x-access-token')) {
-        return { exitCode: 1, stdout: '', stderr: 'error: could not write config' };
-      }
-      return OK;
-    });
-
-    const err = await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok').catch(
-      e => e,
-    );
-    expect(err).toBeInstanceOf(MaterializeError);
-    expect(err.code).toBe('pull-failed');
-    expect(String(err.message)).toMatch(/not a fast-forward.*Failed to scrub installation token/s);
-  });
-
-  it('surfaces a scrub failure on the success path when the remote reset fails', async () => {
-    const sandbox = new FakeSandbox(script => {
-      if (script.includes('remote set-url origin') && script.includes('github.com/octocat/hello.git')) {
-        // The final tokenless scrub fails — the token may still be persisted.
-        return { exitCode: 1, stdout: '', stderr: 'error: could not write config' };
-      }
-      return OK;
-    });
-
-    const err = await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok').catch(
-      e => e,
-    );
-    expect(err).toBeInstanceOf(MaterializeError);
-    expect(err.code).toBe('pull-failed');
-    expect(String(err.message)).toContain('scrub');
-  });
 });
 
 describe('checkoutSessionBranch', () => {
@@ -1193,30 +888,6 @@ describe('git transfer retry', () => {
     expect(sandbox.calls.filter(call => call.includes('git clone'))).toHaveLength(1);
   });
 
-  it('retries a pull that lost the connection mid-transfer', async () => {
-    vi.useFakeTimers();
-    try {
-      let pulls = 0;
-      const sandbox = new FakeSandbox(script => {
-        // An origin pointing at this repo sends materialize down the pull path.
-        if (script.includes('remote get-url origin')) {
-          return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
-        }
-        if (script.includes('pull --ff-only')) return ++pulls === 1 ? HTTP2_GLITCH : OK;
-        return OK;
-      });
-
-      const pending = materializeRepo(makeRow(), makeRepoInfo(), sandbox, 'tok');
-      await vi.advanceTimersByTimeAsync(2000);
-      await pending;
-
-      expect(pulls).toBe(2);
-      // Nothing to clean up between pull attempts — the checkout is intact.
-      expect(sandbox.calls.some(call => call.startsWith('rm -rf'))).toBe(false);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
 });
 
 describe('createPullRequest', () => {

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -186,6 +186,21 @@ describe('materializeRepo', () => {
     expect(String(err.message)).toContain('scrub');
   });
 
+  it.each([
+    'https://evilgithub.com/octocat/hello.git',
+    'https://github.com.evil.example/octocat/hello.git',
+    'https://github.com/other/hello.git',
+    'https://github.com/octocat/hello-fork.git',
+  ])('re-clones over a checkout whose origin is %s', async origin => {
+    const sandbox = new FakeSandbox(script => {
+      if (script.includes('remote get-url origin')) return { exitCode: 0, stdout: `${origin}\n`, stderr: '' };
+      return OK;
+    });
+    await materializeRepo(makeRow({ materializedAt: null }), makeRepoInfo(), sandbox, 'tok');
+
+    expect(sandbox.calls.some(c => c.includes('git clone'))).toBe(true);
+  });
+
   it('re-clones when the DB says materialized but the sandbox disk was wiped', async () => {
     // A platform/remote sandbox can expire and come back with an empty disk
     // while the binding row still says `materializedAt`. Trusting the row made

--- a/mastracode/factory/src/integrations/github/sandbox.test.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.test.ts
@@ -140,6 +140,25 @@ describe('materializeRepo', () => {
     expect(joined).toContain('https://x-access-token:tok-xyz@github.com/octocat/hello.git');
   });
 
+  it('skips the pull on a detached HEAD (a VM booted from a repo template image)', async () => {
+    const sandbox = new FakeSandbox(script => {
+      if (script.includes('remote get-url origin')) {
+        return { exitCode: 0, stdout: 'https://github.com/octocat/hello.git\n', stderr: '' };
+      }
+      // Detached at the template's pinned commit: no symbolic HEAD.
+      if (script.includes('symbolic-ref -q HEAD')) return { exitCode: 1, stdout: '', stderr: '' };
+      return OK;
+    });
+    await materializeRepo(makeRow({ materializedAt: new Date() }), makeRepoInfo(), sandbox, 'tok-xyz');
+
+    const joined = sandbox.calls.join('\n');
+    expect(joined).not.toContain('pull --ff-only');
+    expect(joined).not.toContain('git clone');
+    // No pull, so the token never reaches the remote and there is nothing to scrub.
+    expect(joined).not.toContain('tok-xyz');
+    expect(dbUpdates.at(-1)).toHaveProperty('materializedAt');
+  });
+
   it('re-clones when the DB says materialized but the sandbox disk was wiped', async () => {
     // A platform/remote sandbox can expire and come back with an empty disk
     // while the binding row still says `materializedAt`. Trusting the row made

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -89,9 +89,23 @@ export async function sh(
   // remaining, so transport retries can never multiply the hang guard.
   const deadlineMs = Date.now() + (options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS);
   for (let attempt = 0; ; attempt++) {
+    const started = performance.now();
     try {
-      return await shOnce(sandbox, script, { ...options, timeoutMs: Math.max(deadlineMs - Date.now(), 1) });
+      const result = await shOnce(sandbox, script, { ...options, timeoutMs: Math.max(deadlineMs - Date.now(), 1) });
+      // Phased commands are the session start path; report each so a slow
+      // start names the command that took the time rather than the phase.
+      if (options.phase) {
+        process.stderr.write(
+          `[factory:timing] ${options.phase} attempt=${attempt + 1} exit=${result.exitCode} ${Math.round(performance.now() - started)}ms\n`,
+        );
+      }
+      return result;
     } catch (error) {
+      if (options.phase) {
+        process.stderr.write(
+          `[factory:timing] ${options.phase} attempt=${attempt + 1} threw after ${Math.round(performance.now() - started)}ms: ${error instanceof Error ? error.message : String(error)}\n`,
+        );
+      }
       if (attempt >= SH_RETRIES || !isTransientTransportError(error)) throw error;
       const delayMs = SH_RETRY_DELAY_MS * (attempt + 1);
       if (deadlineMs - Date.now() <= delayMs) throw error;
@@ -170,6 +184,7 @@ async function gitTransfer(
       timeoutMs: Math.max(deadlineMs - Date.now(), 1),
     });
     if (result.exitCode === 0 || attempt >= GIT_TRANSFER_RETRIES || !isTransientGitFailure(result)) return result;
+    process.stderr.write(`[factory:timing] git ${shOptions.phase ?? 'transfer'} retrying after attempt ${attempt + 1}\n`);
     const delayMs = GIT_TRANSFER_RETRY_DELAY_MS * (attempt + 1);
     if (deadlineMs - Date.now() <= delayMs) return result;
     await new Promise(resolve => setTimeout(resolve, delayMs));
@@ -386,7 +401,9 @@ async function checkoutSessionBranchImpl(
 
   const authUrl = tokenUrl(repoFullName, token);
   try {
-    const setUrl = await sh(sandbox, `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(authUrl)}`);
+    const setUrl = await sh(sandbox, `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(authUrl)}`, {
+      phase: 'branch checkout remote',
+    });
     if (setUrl.exitCode !== 0) throw classifyGitFailure(setUrl, 'pull-failed');
     const fetch = await sh(
       sandbox,

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -6,8 +6,9 @@
  * operate entirely against the remote checkout.
  *
  * - `materializeRepo(row, token)` runs `git clone` (first open) or `git pull`
- *   (re-open) inside the sandbox, using a short-lived installation token that is
- *   scrubbed from the git remote afterwards so it never persists in the VM.
+ *   (re-open on a branch; a detached template checkout is left as-is) inside
+ *   the sandbox, using a short-lived installation token that is scrubbed from
+ *   the git remote afterwards so it never persists in the VM.
  *
  * This module owns everything git/GitHub: clone/pull, commit/push, setup/teardown commands,
  * and `gh pr create`. Workdir layout lives in `../sandbox/workdir`.
@@ -314,8 +315,9 @@ async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<voi
         throw classifyGitFailure(clone, 'clone-failed');
       }
       tokenInRemote = true;
-    } else {
-      // 2b. Re-open: refresh remote to the token URL and fast-forward pull.
+    } else if ((await sh(sandbox, `git -C ${shellQuote(workdir)} symbolic-ref -q HEAD`)).exitCode === 0) {
+      // 2b. Re-open on a branch: refresh remote to the token URL and
+      // fast-forward pull.
       const setUrl = await sh(sandbox, `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(authUrl)}`);
       if (setUrl.exitCode !== 0) {
         throw new MaterializeError(`Failed to set git remote: ${setUrl.stderr}`, 'pull-failed');
@@ -329,12 +331,18 @@ async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<voi
           throw classifyGitFailure(pull, 'pull-failed');
         }
         // The workdir was left on a session's working branch that can't be
-        // fast-forwarded (diverged from upstream, no upstream, or detached
-        // HEAD), or its configured upstream ref was deleted after merge.
-        // That checkout still holds usable work — never rebase or reset it
-        // here. Leave it as-is and let the session reconcile with the remote
-        // itself.
+        // fast-forwarded (diverged from upstream, no upstream), or its
+        // configured upstream ref was deleted after merge. That checkout
+        // still holds usable work: never rebase or reset it here. Leave it
+        // as-is and let the session reconcile with the remote itself.
       }
+    } else {
+      // 2c. Re-open on a detached HEAD: a VM booted from a repo template
+      // image sits at the template's pinned commit with no branch to move, so
+      // a pull has nothing to fast-forward. `git pull` would still pay for its
+      // fetch before refusing, seconds on a fresh VM, and the session branch
+      // checkout that follows fetches the base branch itself. Skip it, and
+      // with it the token round-trip.
     }
   } catch (primary) {
     // 3a. The clone/pull failed — still scrub the token from the VM's git

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -483,9 +483,20 @@ async function existingCheckoutRemote(
   const result = await sh(sandbox, `git -C ${shellQuote(workdir)} remote get-url origin`);
   if (result.exitCode !== 0) return null;
   const url = result.stdout.trim();
-  const suffix = `github.com/${repoFullName.toLowerCase()}`;
-  const lower = url.toLowerCase();
-  return lower.endsWith(`${suffix}.git`) || lower.endsWith(suffix) ? url : null;
+  return isRemoteForRepo(url, repoFullName) ? url : null;
+}
+
+/** True only for `https://github.com/<repo>[.git]`, with or without embedded credentials. */
+function isRemoteForRepo(url: string, repoFullName: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:' || parsed.hostname.toLowerCase() !== 'github.com') return false;
+  const repoPath = parsed.pathname.replace(/\.git$/, '').replace(/^\/+/, '').toLowerCase();
+  return repoPath === repoFullName.toLowerCase();
 }
 
 /** Probed without `git -C` so a missing workdir returns false instead of throwing. */

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -495,8 +495,8 @@ function isRemoteForRepo(url: string, repoFullName: string): boolean {
     return false;
   }
   if (parsed.protocol !== 'https:' || parsed.hostname.toLowerCase() !== 'github.com') return false;
-  const repoPath = parsed.pathname.replace(/\.git$/, '').replace(/^\/+/, '').toLowerCase();
-  return repoPath === repoFullName.toLowerCase();
+  if (parsed.port !== '' || parsed.search !== '' || parsed.hash !== '') return false;
+  return parsed.pathname.replace(/\.git$/, '').toLowerCase() === `/${repoFullName.toLowerCase()}`;
 }
 
 /** Probed without `git -C` so a missing workdir returns false instead of throwing. */

--- a/mastracode/factory/src/integrations/github/sandbox.ts
+++ b/mastracode/factory/src/integrations/github/sandbox.ts
@@ -5,15 +5,17 @@
  * *inside* the session's sandbox, so the agent's file tools and command tools
  * operate entirely against the remote checkout.
  *
- * - `materializeRepo(row, token)` runs `git clone` (first open) or `git pull`
- *   (re-open on a branch; a detached template checkout is left as-is) inside
- *   the sandbox, using a short-lived installation token that is scrubbed from
- *   the git remote afterwards so it never persists in the VM.
+ * - `materializeRepo(row, token)` clones the repo inside the sandbox when no
+ *   checkout exists yet (a base-image boot, a wiped disk), using a short-lived
+ *   installation token that is scrubbed from the git remote afterwards so it
+ *   never persists in the VM. A checkout that is already there, from a repo
+ *   template image or an earlier start, is left exactly as it is.
  *
- * This module owns everything git/GitHub: clone/pull, commit/push, setup/teardown commands,
+ * This module owns everything git/GitHub: clone, commit/push, setup/teardown commands,
  * and `gh pr create`. Workdir layout lives in `../sandbox/workdir`.
  */
 
+import { repoCloneCommand } from '@internal/workspace';
 import type { ExecutableSandbox, SandboxCommandResult } from '../../sandbox/materialization.js';
 import type { SourceControlStorageHandle } from '../../storage/domains/source-control/base.js';
 import { timedPhase } from '../../timing.js';
@@ -226,9 +228,10 @@ export interface MaterializeRepoOptions {
 }
 
 /**
- * Materialize the repo inside the user's sandbox. Clones on first open, pulls on
- * re-open. Always scrubs the install token from the remote afterwards and sets
- * `materialized_at` on the per-user sandbox binding row.
+ * Materialize the repo inside the user's sandbox: clone when no checkout of
+ * this repo exists, otherwise nothing. Scrubs the install token from the
+ * remote after a clone and sets `materialized_at` on the per-user sandbox
+ * binding row.
  */
 export async function materializeRepo(options: MaterializeRepoOptions): Promise<void> {
   return timedPhase('workspace.materialize', () => materializeRepoImpl(options));
@@ -261,39 +264,43 @@ async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<voi
     );
   }
 
-  const authUrl = tokenUrl(repo, token);
-
   // The DB's `materializedAt` can drift from disk in both directions: a fresh
-  // binding row over an already-populated workdir (local dev DB resets,
-  // repaired rows, earlier flows) must pull instead of failing `git clone` on
-  // the non-empty directory, and a stale `materializedAt` over an empty
-  // sandbox (an expired/recreated VM whose disk was wiped) must re-clone
-  // instead of running `git -C <workdir>` against a directory that no longer
-  // exists. Disk is the source of truth: detect the checkout instead of
-  // trusting the row.
-  const alreadyMaterialized = await hasExistingCheckout(sandbox, workdir, repo);
-
-  let tokenInRemote = false;
-  try {
-    if (!alreadyMaterialized) {
-      // 2a. First open: shallow-clone the default branch into the workdir. A
-      // shallow single-branch clone is dramatically faster for large repos; the
-      // later re-open uses `git pull --ff-only`, which works on shallow clones.
-      // The workdir holds no usable checkout of this repo, but it may not be
-      // empty: a checkpoint seed or a clone that died partway (a crashed or
-      // OOM-killed server) leaves a partial tree behind, and `git clone`
-      // refuses a non-empty destination with a non-retryable fatal. Nothing
-      // here is recoverable — `hasExistingCheckout` already ruled out a
-      // checkout of this repo — so clear its contents before cloning, exactly
-      // as the retry path does. Keep the workdir itself because LocalSandbox
-      // runs commands with this directory as the child process cwd.
-      await sh(
-        sandbox,
-        `mkdir -p ${shellQuote(workdir)} && find ${shellQuote(workdir)} -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +`,
-      );
+  // binding row over an already-populated workdir (a repo template image,
+  // local dev DB resets, repaired rows) must not fail `git clone` on the
+  // non-empty directory, and a stale `materializedAt` over an empty sandbox
+  // (an expired/recreated VM whose disk was wiped) must re-clone instead of
+  // running `git -C <workdir>` against a directory that no longer exists.
+  // Disk is the source of truth: detect the checkout instead of trusting the
+  // row. An existing checkout is left as it is, whatever it is on: a template
+  // image sits detached at its pinned commit, a resumed session on its
+  // branch. Syncing with the remote is the session's business; the branch
+  // checkout that follows fetches the base branch it needs.
+  const existing = await existingCheckoutRemote(sandbox, workdir, repo);
+  if (existing !== null) {
+    // A token an earlier start failed to scrub must not outlive it; the
+    // remote already carries the plain URL otherwise, so this costs nothing
+    // on the common path.
+    if (/\/\/[^/]*@/.test(existing)) await scrubRemote(sandbox, workdir, repo, true);
+  } else {
+    // 2. First open: shallow-clone the default branch into the workdir, the
+    // same clone a repo template bakes into its image. The workdir holds no
+    // usable checkout of this repo, but it may not be empty: a checkpoint
+    // seed or a clone that died partway (a crashed or OOM-killed server)
+    // leaves a partial tree behind, and `git clone` refuses a non-empty
+    // destination with a non-retryable fatal. Nothing here is recoverable,
+    // the probe above already ruled out a checkout of this repo, so
+    // clear its contents before cloning, exactly as the retry path does. Keep
+    // the workdir itself because LocalSandbox runs commands with this
+    // directory as the child process cwd.
+    await sh(
+      sandbox,
+      `mkdir -p ${shellQuote(workdir)} && find ${shellQuote(workdir)} -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +`,
+    );
+    let tokenInRemote = false;
+    try {
       const clone = await gitTransfer(
         sandbox,
-        `git clone --depth=1 --single-branch --branch ${shellQuote(repoInfo.defaultBranch)} ${shellQuote(authUrl)} ${shellQuote(workdir)}`,
+        repoCloneCommand({ cloneUrl: tokenUrl(repo, token), destination: workdir, branch: repoInfo.defaultBranch }),
         {
           phase: 'repository clone',
           beforeRetry: async () => {
@@ -309,52 +316,24 @@ async function materializeRepoImpl(options: MaterializeRepoOptions): Promise<voi
       );
       if (clone.exitCode !== 0) {
         // git can fail after creating the checkout ("Clone succeeded, but
-        // checkout failed") with the tokenized origin persisted — probe the
+        // checkout failed") with the tokenized origin persisted: probe the
         // disk instead of assuming the failed clone left nothing behind.
         tokenInRemote = await hasGitDir(sandbox, workdir);
         throw classifyGitFailure(clone, 'clone-failed');
       }
       tokenInRemote = true;
-    } else if ((await sh(sandbox, `git -C ${shellQuote(workdir)} symbolic-ref -q HEAD`)).exitCode === 0) {
-      // 2b. Re-open on a branch: refresh remote to the token URL and
-      // fast-forward pull.
-      const setUrl = await sh(sandbox, `git -C ${shellQuote(workdir)} remote set-url origin ${shellQuote(authUrl)}`);
-      if (setUrl.exitCode !== 0) {
-        throw new MaterializeError(`Failed to set git remote: ${setUrl.stderr}`, 'pull-failed');
-      }
-      tokenInRemote = true;
-      const pull = await gitTransfer(sandbox, `git -C ${shellQuote(workdir)} pull --ff-only`, {
-        phase: 'repository pull',
-      });
-      if (pull.exitCode !== 0) {
-        if (!isBenignNonFastForward(pull)) {
-          throw classifyGitFailure(pull, 'pull-failed');
-        }
-        // The workdir was left on a session's working branch that can't be
-        // fast-forwarded (diverged from upstream, no upstream), or its
-        // configured upstream ref was deleted after merge. That checkout
-        // still holds usable work: never rebase or reset it here. Leave it
-        // as-is and let the session reconcile with the remote itself.
-      }
-    } else {
-      // 2c. Re-open on a detached HEAD: a VM booted from a repo template
-      // image sits at the template's pinned commit with no branch to move, so
-      // a pull has nothing to fast-forward. `git pull` would still pay for its
-      // fetch before refusing, seconds on a fresh VM, and the session branch
-      // checkout that follows fetches the base branch itself. Skip it, and
-      // with it the token round-trip.
+    } catch (primary) {
+      // 3a. The clone failed: still scrub the token from the VM's git config.
+      // The scrub must never hide the actionable failure, but once the token
+      // reached the remote its own failure can't stay silent either: report
+      // both, primary cause and classification first.
+      throw await scrubbedFailure(sandbox, workdir, repo, tokenInRemote, primary, 'clone-failed');
     }
-  } catch (primary) {
-    // 3a. The clone/pull failed — still scrub the token from the VM's git
-    // config. The scrub must never hide the actionable failure, but once the
-    // token reached the remote its own failure can't stay silent either:
-    // report both, primary cause and classification first.
-    throw await scrubbedFailure(sandbox, workdir, repo, tokenInRemote, primary, 'pull-failed');
-  }
 
-  // 3b. Success — the token is in the remote and the workdir has a `.git`, so
-  // a failed scrub means the token may still be persisted: surface it.
-  await scrubRemote(sandbox, workdir, repo, tokenInRemote);
+    // 3b. Success: the token is in the remote and the workdir has a `.git`, so
+    // a failed scrub means the token may still be persisted: surface it.
+    await scrubRemote(sandbox, workdir, repo, tokenInRemote);
+  }
 
   // 4. Mark materialized.
   await storage.markMaterialized({ id: sandboxRow.id });
@@ -475,20 +454,21 @@ function isBlockedByLocalWork(result: SandboxCommandResult): boolean {
 }
 
 /**
- * True when the workdir already holds a git checkout whose `origin` points at
- * this exact repo. Matches both the clean and token-auth URL forms; any other
- * remote (or no git dir at all) falls back to the clone path.
+ * The `origin` URL of a checkout of this exact repo in the workdir, or null
+ * when there is none. Matches both the clean and token-auth URL forms; any
+ * other remote (or no git dir at all) sends materialize down the clone path.
  */
-export async function hasExistingCheckout(
+async function existingCheckoutRemote(
   sandbox: ExecutableSandbox,
   workdir: string,
   repoFullName: string,
-): Promise<boolean> {
+): Promise<string | null> {
   const result = await sh(sandbox, `git -C ${shellQuote(workdir)} remote get-url origin`);
-  if (result.exitCode !== 0) return false;
-  const url = result.stdout.trim().toLowerCase();
+  if (result.exitCode !== 0) return null;
+  const url = result.stdout.trim();
   const suffix = `github.com/${repoFullName.toLowerCase()}`;
-  return url.endsWith(`${suffix}.git`) || url.endsWith(suffix);
+  const lower = url.toLowerCase();
+  return lower.endsWith(`${suffix}.git`) || lower.endsWith(suffix) ? url : null;
 }
 
 /** Probed without `git -C` so a missing workdir returns false instead of throwing. */
@@ -553,37 +533,6 @@ async function scrubbedFailure(
     primary.message = `${primary.message} — additionally: ${scrubMessage}`;
     return primary;
   }
-}
-
-/**
- * True when a failed `git pull --ff-only` on re-open just means the current
- * branch can't be fast-forwarded — not that anything is broken. The shared
- * workdir is routinely left on a session's working branch, which may have
- * local commits diverging from upstream, no upstream at all (session branches
- * are created from `FETCH_HEAD`), or a detached HEAD. A checkout can also
- * hold uncommitted or untracked files (a build or script run left residue,
- * or an older session worked directly in the shared checkout), which makes
- * git refuse the merge outright. A checkout carrying `pull.rebase` in its git
- * config refuses for the same reason but says so in rebase's words instead of
- * merge's. After a PR merges with branch auto-delete, the configured upstream
- * ref may also be gone (`no such ref was fetched` / `couldn't find remote ref`);
- * there is nothing to pull and the checkout is still intact. In all of these
- * cases materialization must keep it as-is rather than fail the workspace open
- * — and must never discard the local state to force the pull through.
- */
-function isDeletedUpstreamRef(result: SandboxCommandResult): boolean {
-  const output = `${result.stderr || ''}\n${result.stdout || ''}`;
-  return /no such ref was fetched|couldn't find remote ref/i.test(output);
-}
-
-function isBenignNonFastForward(result: SandboxCommandResult): boolean {
-  const output = `${result.stderr || ''}\n${result.stdout || ''}`;
-  return (
-    isDeletedUpstreamRef(result) ||
-    /Not possible to fast-forward|Diverging branches can't be fast-forwarded|no tracking information for the current branch|You are not currently on a branch|Your local changes to the following files would be overwritten by merge|untracked working tree files would be overwritten by merge|cannot pull with rebase|cannot rebase: You have unstaged changes|Your index contains uncommitted changes/i.test(
-      output,
-    )
-  );
 }
 
 /**

--- a/mastracode/factory/src/sandbox/session-sandbox.ts
+++ b/mastracode/factory/src/sandbox/session-sandbox.ts
@@ -3,6 +3,7 @@ import { SETUP_MARKER_PATH, setupMarkerContent } from '@internal/workspace';
 
 import type { MastraSandbox, SandboxStartHook, WorkspaceSandbox } from '@mastra/core/workspace';
 import type { RepositoryAccess } from '../capabilities/version-control.js';
+import { timedPhase } from '../timing.js';
 import { deriveLocalWorkdir, deriveRemoteRepoDir, repoDirUnder } from './workdir.js';
 
 /**
@@ -263,7 +264,14 @@ export function createSessionSetupHook(
     const workdir = await resolveSessionWorkdir(sessionId, sandbox, repoFullName);
     // Probed before materialize so a wiped checkout reads as "not done" even
     // though materialize is about to restore it.
-    const setupDone = marker ? await markerMatches(sandbox, workdir, marker) : true;
+    const setupDone = marker
+      ? await timedPhase('workspace.setup-marker', () => markerMatches(sandbox, workdir, marker))
+      : true;
+    if (marker) {
+      process.stderr.write(
+        `[factory:setup] ${setupDone ? 'marker matches, skipping setup command' : 'no matching marker, setup command will run'} (${markerShellPath(workdir)})\n`,
+      );
+    }
     await run(sandbox, workdir, {
       setupDone,
       markSetupDone: () => (marker ? writeMarker(sandbox, workdir, marker) : Promise.resolve()),

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -41,8 +41,8 @@ import {
   resolveSessionWorkdir,
 } from './sandbox/session-sandbox.js';
 import type { SessionSetupGate } from './sandbox/session-sandbox.js';
-
 import type { WorkItemsStorage } from './storage/domains/work-items/base.js';
+import { timedPhase } from './timing.js';
 
 const WORKSPACE_ID_PREFIX = 'mfw';
 const bundleDirectory = dirname(fileURLToPath(import.meta.url));
@@ -430,7 +430,9 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         // stack a wrapper per call. Factory's setup runs first: a hook the
         // callback installed itself expects a prepared workspace.
         sandbox.setOnStart(previous => async args => {
-          await setupHook(args);
+          await timedPhase(`workspace.onStart(${args.outcome})`, async () => {
+            await setupHook(args);
+          });
           await previous?.(args);
         });
         return sandbox;
@@ -631,7 +633,7 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
           return;
         }
         try {
-          await runSetupCommand(target, workdir, projectRepository.setupCommand);
+          await timedPhase('workspace.setup', () => runSetupCommand(target, workdir, projectRepository.setupCommand!));
           await gate.markSetupDone();
         } catch (setupError) {
           if (projectRepository.teardownCommand) {

--- a/packages/_internals/workspace/src/index.ts
+++ b/packages/_internals/workspace/src/index.ts
@@ -1,1 +1,2 @@
 export { SETUP_MARKER_PATH, normalizeSetupCommands, setupMarkerContent, setupMarkerCommand } from './setup-marker';
+export { repoCloneCommand, type RepoCloneCommandOptions } from './repo-clone';

--- a/packages/_internals/workspace/src/repo-clone.test.ts
+++ b/packages/_internals/workspace/src/repo-clone.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { repoCloneCommand } from './repo-clone';
+
+describe('repoCloneCommand', () => {
+  it('produces a shallow single-branch clone of the remote default branch', () => {
+    expect(repoCloneCommand({ cloneUrl: 'https://github.com/acme/widgets', destination: 'widgets' })).toBe(
+      `git clone --depth=1 --single-branch 'https://github.com/acme/widgets' 'widgets'`,
+    );
+  });
+
+  it('pins a branch and sends the token from an env var as a per-invocation header, never in the URL', () => {
+    const command = repoCloneCommand({
+      cloneUrl: 'https://github.com/acme/widgets.git',
+      destination: '/workspace/widgets',
+      branch: 'main',
+      tokenEnv: 'GH_TOKEN',
+    });
+    expect(command).toBe(
+      `git -c http.extraheader="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)" clone --depth=1 --single-branch --branch 'main' 'https://github.com/acme/widgets.git' '/workspace/widgets'`,
+    );
+    expect(command).not.toContain('x-access-token:GH_TOKEN@');
+  });
+
+  it('single-quotes every operand so shell metacharacters stay literal', () => {
+    const command = repoCloneCommand({
+      cloneUrl: 'https://github.com/a/b',
+      destination: "dir'; rm -rf /",
+      branch: 'x;y',
+    });
+    expect(command).toContain(`'dir'\\''; rm -rf /'`);
+    expect(command).toContain(`--branch 'x;y'`);
+  });
+});

--- a/packages/_internals/workspace/src/repo-clone.ts
+++ b/packages/_internals/workspace/src/repo-clone.ts
@@ -1,0 +1,35 @@
+/**
+ * The one way a repository is cloned into a sandbox, shared by the repo
+ * templates (which bake the clone into an image) and by Factory (which clones
+ * at session start when no image provided one), so both produce the same
+ * checkout: shallow, single branch, `origin` pointing at the plain URL.
+ *
+ * Credentials never enter the URL or `.git/config`. When `tokenEnv` is set,
+ * the token is read from that environment variable at run time and sent as a
+ * per-invocation `Authorization` header, so nothing persists in the checkout.
+ */
+export interface RepoCloneCommandOptions {
+  /** Plain https clone URL, without credentials. */
+  cloneUrl: string;
+  /** Directory to clone into; relative paths resolve against the cwd. */
+  destination: string;
+  /** Branch to check out. Omit for the remote's default branch. */
+  branch?: string;
+  /** Name of the environment variable holding a GitHub installation token. */
+  tokenEnv?: string;
+}
+
+export function repoCloneCommand({ cloneUrl, destination, branch, tokenEnv }: RepoCloneCommandOptions): string {
+  const auth = tokenEnv ? `${gitAuthFlag(tokenEnv)} ` : '';
+  const branchFlag = branch ? `--branch ${shellQuote(branch)} ` : '';
+  return `git ${auth}clone --depth=1 --single-branch ${branchFlag}${shellQuote(cloneUrl)} ${shellQuote(destination)}`;
+}
+
+/** Per-invocation auth header; `-c` config never reaches `.git/config`. */
+function gitAuthFlag(tokenEnv: string): string {
+  return `-c http.extraheader="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$${tokenEnv}" | base64 -w0)"`;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/workspaces/e2b/src/utils/repo-template.test.ts
+++ b/workspaces/e2b/src/utils/repo-template.test.ts
@@ -145,8 +145,7 @@ describe('createRepoTemplate', () => {
 
   it('clones relative to the build cwd, pins the sha, and runs the setup command in the checkout', async () => {
     const steps = await serializedSteps(await resolve(BASE));
-    // Serialized as JSON, so the shell double quotes appear escaped.
-    expect(steps).toContain('git clone https://github.com/octocat/hello \\"hello\\"');
+    expect(steps).toContain("git clone --depth=1 --single-branch 'https://github.com/octocat/hello' 'hello'");
     expect(steps).toContain(`checkout ${SHA}`);
     expect(steps).toContain('cd \\"hello\\" && pnpm install');
   });
@@ -190,7 +189,7 @@ describe('createRepoTemplate', () => {
     expect(ordered.slice(start, start + 3)).toEqual([
       'RUN mkdir -p "/workspace"',
       'WORKDIR /workspace',
-      'RUN git clone https://github.com/octocat/hello "hello"',
+      "RUN git clone --depth=1 --single-branch 'https://github.com/octocat/hello' 'hello'",
     ]);
     expect(ordered).toContain('RUN cd "hello" && pnpm install');
   });
@@ -275,7 +274,7 @@ describe('createRepoTemplate', () => {
       const resolved = await resolve(BASE);
       expect(resolved.ref).toBe(repoTemplateRef({ cloneUrl: CLONE_URL, setupCommand: SETUP }));
       const steps = await serializedSteps(resolved);
-      expect(steps).toContain('git clone https://github.com/octocat/hello');
+      expect(steps).toContain("git clone --depth=1 --single-branch 'https://github.com/octocat/hello'");
       expect(steps).not.toContain('checkout');
     }
   });
@@ -318,7 +317,7 @@ describe('createRepoTemplate', () => {
       expect(serialized).toContain('$GH_TOKEN');
       expect(serialized).toContain('http.extraheader');
       expect(serialized).not.toContain('@github.com');
-      expect(serialized).toContain('clone https://github.com/octocat/hello');
+      expect(serialized).toContain("clone --depth=1 --single-branch 'https://github.com/octocat/hello'");
     });
 
     it('names the credential GH_TOKEN, the same variable a session installs before setup', async () => {

--- a/workspaces/e2b/src/utils/repo-template.ts
+++ b/workspaces/e2b/src/utils/repo-template.ts
@@ -30,7 +30,7 @@
 import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { promisify } from 'node:util';
-import { setupMarkerCommand, setupMarkerContent } from '@internal/workspace';
+import { repoCloneCommand, setupMarkerCommand, setupMarkerContent } from '@internal/workspace';
 
 import { Template } from 'e2b';
 import type { ConnectionOpts, TemplateClass } from 'e2b';
@@ -420,8 +420,12 @@ function buildRepoTemplateSpec(identity: RepoTemplateIdentity, token?: string): 
     const dir = trimTrailingSlashes(workingDirectory);
     template = template.runCmd(`mkdir -p "${dir}"`).setWorkdir(dir);
   }
-  // Each command gets its own cached build layer.
-  template = template.runCmd(`git ${auth}clone ${cloneUrl} "${repoDir}"`);
+  // Each command gets its own cached build layer. Same shallow clone Factory
+  // makes at session start when no image provided one, so both paths yield
+  // the same checkout.
+  template = template.runCmd(
+    repoCloneCommand({ cloneUrl, destination: repoDir, ...(token ? { tokenEnv: BUILD_TOKEN_ENV } : {}) }),
+  );
   if (sha) {
     // GitHub serves fetches of reachable shas, so pinning after a default
     // clone is reliable without full-history flags.

--- a/workspaces/platform-workspace/src/repo-template.test.ts
+++ b/workspaces/platform-workspace/src/repo-template.test.ts
@@ -44,7 +44,7 @@ describe('createRepoTemplate', () => {
     expect(serializeSandboxTemplate(template!)).toEqual({
       schemaVersion: 1,
       operations: [
-        { method: 'runCmd', args: ['git clone https://github.com/acme/widgets "widgets"'] },
+        { method: 'runCmd', args: [`git clone --depth=1 --single-branch 'https://github.com/acme/widgets' 'widgets'`] },
         { method: 'runCmd', args: [`git -C "widgets" fetch origin ${SHA_1}`] },
         { method: 'runCmd', args: [`git -C "widgets" checkout ${SHA_1}`] },
         { method: 'runCmd', args: ['cd "widgets" && pnpm install --frozen-lockfile'] },
@@ -121,7 +121,7 @@ describe('createRepoTemplate', () => {
     expect(serialized.operations.slice(0, 3)).toEqual([
       { method: 'runCmd', args: ['mkdir -p "/workspace"'] },
       { method: 'setWorkdir', args: ['/workspace'] },
-      { method: 'runCmd', args: ['git clone https://github.com/acme/widgets "widgets"'] },
+      { method: 'runCmd', args: [`git clone --depth=1 --single-branch 'https://github.com/acme/widgets' 'widgets'`] },
     ]);
     const commands = serialized.operations.filter(op => op.method === 'runCmd').map(op => String(op.args[0]));
     expect(commands.at(-2)).toBe('cd "widgets" && pnpm i');
@@ -139,7 +139,7 @@ describe('createRepoTemplate', () => {
     expect(serialized.operations.map(op => op.method)).not.toContain('setWorkdir');
     expect(serialized.operations[0]).toEqual({
       method: 'runCmd',
-      args: ['git clone https://github.com/acme/widgets "widgets"'],
+      args: [`git clone --depth=1 --single-branch 'https://github.com/acme/widgets' 'widgets'`],
     });
   });
 
@@ -167,7 +167,7 @@ describe('createRepoTemplate', () => {
     expect(serialized.operations).toEqual([
       { method: 'cpuCount', args: [4] },
       { method: 'memoryMB', args: [8_192] },
-      { method: 'runCmd', args: ['git clone https://github.com/acme/widgets "widgets"'] },
+      { method: 'runCmd', args: [`git clone --depth=1 --single-branch 'https://github.com/acme/widgets' 'widgets'`] },
       { method: 'runCmd', args: [`git -C "widgets" fetch origin ${SHA_1}`] },
       { method: 'runCmd', args: [`git -C "widgets" checkout ${SHA_1}`] },
       markerStep(),

--- a/workspaces/platform-workspace/src/repo-template.ts
+++ b/workspaces/platform-workspace/src/repo-template.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { setupMarkerCommand, setupMarkerContent } from '@internal/workspace';
+import { repoCloneCommand, setupMarkerCommand, setupMarkerContent } from '@internal/workspace';
 
 import { Template, type SandboxTemplateBuilder } from './template.js';
 
@@ -175,9 +175,11 @@ export function createRepoTemplate(options: PlatformRepoTemplateOptions): Platfo
       // shell expansion.
       template = template.runCmd(`mkdir -p "${workingDirectory}"`).setWorkdir(workingDirectory);
     }
-    // Each operation gets its own cached provider build step.
+    // Each operation gets its own cached provider build step. Same shallow
+    // clone Factory makes at session start when no image provided one, so
+    // both paths yield the same checkout.
     template = template
-      .runCmd(`git ${auth}clone ${cloneUrl} "${repoDir}"`)
+      .runCmd(repoCloneCommand({ cloneUrl, destination: repoDir, ...(token ? { tokenEnv: BUILD_TOKEN_ENV } : {}) }))
       .runCmd(`git -C "${repoDir}" ${auth}fetch origin ${sha}`)
       .runCmd(`git -C "${repoDir}" checkout ${sha}`);
     // Build steps use fresh shells, so each setup command needs its own `cd`.


### PR DESCRIPTION
Every session start ran `git pull --ff-only` on a checkout that was already in the sandbox. That is the normal case: a VM booted from a repo template image has the repo on disk at the template's pinned commit (detached HEAD), and a VM resumed after idling is sitting on its session branch. `git pull` fetches before it checks whether HEAD can move, so on a fresh VM it was several seconds of network for a result git then discarded; the session branch checkout that runs right after fetches the base branch it needs anyway.

Materialize now leaves an existing checkout of the repo alone and clones only when there is none (a base-image boot, a wiped disk). The one thing it still does on re-open is scrub a tokenized `origin` an earlier failed start might have left behind. Syncing a session branch with the remote is the session's business, as it is for a human on a laptop.

The clone command itself moves into `@internal/workspace` (private, bundled into consumers) so the repo templates in `@mastra/e2b` and `@mastra/platform-workspace` bake the same `--depth=1 --single-branch` clone into their images that Factory makes at runtime. Both paths yield the same checkout, and template builds transfer far less history.

Start-path phases also log `[factory:timing]` lines now (`workspace.onStart(<outcome>)`, `workspace.setup-marker`, `workspace.setup`), plus a line saying whether the setup marker matched, so a slow start shows where the time went. `*.local.mjs` / `*.local.ts` probe scripts are gitignored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Factory now keeps existing repository checkouts unchanged instead of downloading them again. It clones missing repositories, verifies that reused checkouts belong to the expected repository, and logs startup progress.

## Changes

- Preserve existing Factory checkouts without running `git pull --ff-only`.
- Validate reused `origin` remotes against the expected GitHub repository format.
- Clone missing repositories and scrub tokens after failures.
- Add `[factory:timing]` logs for startup phases and setup-marker checks.
- Add `repoCloneCommand` and `RepoCloneCommandOptions` to `@internal/workspace`.
- Use shallow, single-branch clones in E2B and platform workspace templates.
- Add tests for checkout reuse, remote validation, token cleanup, clone commands, and template behavior.
- Ignore `*.local.mjs` and `*.local.ts` probe scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->