### PR TITLE
test(mastracode): stabilize github-signals multi-subscribe e2e

### DIFF
--- a/mastracode/tui/e2e/fixtures/github-signals-tool-multi-subscribe.json
+++ b/mastracode/tui/e2e/fixtures/github-signals-tool-multi-subscribe.json
@@ -4,7 +4,8 @@
       "match": {
         "endpoint": "chat",
         "model": "gpt-5.4-mini",
-        "userMessage": "Subscribe to both GitHub PRs with the tool."
+        "userMessage": "Subscribe to both GitHub PRs with the tool.",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -13,8 +14,16 @@
             "name": "github_subscribe_pr",
             "arguments": {
               "prs": [
-                { "owner": "mastra-ai", "repo": "mastra", "number": 17637 },
-                { "owner": "mastra-ai", "repo": "mastra", "number": 17638 }
+                {
+                  "owner": "mastra-ai",
+                  "repo": "mastra",
+                  "number": 17637
+                },
+                {
+                  "owner": "mastra-ai",
+                  "repo": "mastra",
+                  "number": 17638
+                }
               ]
             }
           }
@@ -25,7 +34,8 @@
       "match": {
         "endpoint": "chat",
         "model": "gpt-5.4-mini",
-        "userMessage": "Unsubscribe one GitHub PR with the tool."
+        "userMessage": "Unsubscribe one GitHub PR with the tool.",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -33,7 +43,13 @@
             "id": "call_github_single_unsubscribe_e2e",
             "name": "github_unsubscribe_pr",
             "arguments": {
-              "prs": [{ "owner": "mastra-ai", "repo": "mastra", "number": 17637 }]
+              "prs": [
+                {
+                  "owner": "mastra-ai",
+                  "repo": "mastra",
+                  "number": 17637
+                }
+              ]
             }
           }
         ]
@@ -43,16 +59,28 @@
       "match": {
         "endpoint": "chat",
         "model": "gpt-5.4-mini",
-        "userMessage": "Unsubscribe all GitHub PRs with the tool."
+        "userMessage": "Unsubscribe all GitHub PRs with the tool.",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
           {
             "id": "call_github_all_unsubscribe_e2e",
             "name": "github_unsubscribe_pr",
-            "arguments": { "all": true }
+            "arguments": {
+              "all": true
+            }
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.4-mini"
+      },
+      "response": {
+        "content": "GitHub signal tool step complete."
       }
     }
   ]

--- a/mastracode/tui/e2e/tui/github-signals-tool-multi-subscribe.ts
+++ b/mastracode/tui/e2e/tui/github-signals-tool-multi-subscribe.ts
@@ -23,6 +23,12 @@ export const githubSignalsToolMultiSubscribeScenario = {
   },
   inProcessApp: githubSignalsInProcessApp,
   async run({ terminal, runtime }) {
+    // The AIMock fixture answers every post-tool request with the same text. Waiting for the Nth
+    // occurrence in the scrollback guarantees the agent run finished before `/github debug`
+    // is submitted, so later assistant output cannot scroll the debug summary off screen.
+    const stepComplete = (count: number) =>
+      new RegExp(Array.from({ length: count }, () => 'GitHub signal tool step complete\\.').join('[^]*'), 'i');
+
     runtime.startLiveOutput(terminal);
     await runtime.waitForScreenText(/Project: mastra/i, terminal);
 
@@ -31,17 +37,20 @@ export const githubSignalsToolMultiSubscribeScenario = {
 
     terminal.submit('Subscribe to both GitHub PRs with the tool.');
     await runtime.waitForScreenText(/github_subscribe_pr.*✓/i, terminal, 30_000);
+    await runtime.waitForOutputText(stepComplete(1), terminal, 30_000);
     terminal.submit('/github debug');
     await runtime.waitForScreenText(/2 subscriptions/i, terminal);
 
     terminal.submit('Unsubscribe one GitHub PR with the tool.');
     await runtime.waitForScreenText(/github_unsubscribe_pr.*✓/i, terminal, 30_000);
+    await runtime.waitForOutputText(stepComplete(2), terminal, 30_000);
     terminal.submit('/github debug');
     await runtime.waitForScreenText(/1 subscription/i, terminal);
     await runtime.waitForScreenText(/mastra-ai\/mastra#17638/i, terminal);
 
     terminal.submit('Unsubscribe all GitHub PRs with the tool.');
     await runtime.waitForScreenText(/github_unsubscribe_pr all=true ✓/i, terminal, 30_000);
+    await runtime.waitForOutputText(stepComplete(3), terminal, 30_000);
     terminal.submit('/github debug');
     await runtime.waitForScreenText(/no subscribed PRs/i, terminal);
     runtime.printScreen('github tool multi-subscribe final state', terminal);


### PR DESCRIPTION
## Summary
The `github-signals-tool-multi-subscribe` Mastra Code E2E scenario was failing intermittently on CI (seen on #22838 and main).

Root cause: the AIMock fixture only matched on `userMessage`. After the tool result, a notification-summary user message is injected, so the follow-up request never matched a text response and the agent re-issued the same tool call on every step until the step limit. The repeated tool-result boxes scrolled the `/github debug` output off screen, so waiting for `mastra-ai/mastra#17638` timed out.

Fix:
- Fixture: match each tool call once per step (`sequenceIndex: 0`) and answer all follow-up requests with a fixed completion message (same pattern as `notification-inbox-tool-flow.json`).
- Scenario: wait for the Nth completion message in scrollback before submitting `/github debug`, so the run is finished and nothing displaces the debug summary.

## Test plan
- [x] `MC_E2E_VITEST_SCENARIOS=github-signals-tool-multi-subscribe pnpm exec vitest run --config e2e/vitest.config.ts` — passes 5/5 consecutive runs (previously failing)
- [x] Verified each tool call now fires exactly once per step


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the GitHub subscription test wait for each operation to finish before it checks the debug result. This prevents timing issues that caused occasional CI failures.

## Changes

- Updated the AIMock fixture to match each tool call once with `sequenceIndex: 0`.
- Added a fixed completion response for follow-up requests.
- Added synchronization after subscribe, single unsubscribe, and bulk unsubscribe operations.
- The scenario now waits for the expected completion message before submitting `/github debug`.
- Verified five consecutive successful test runs.
- Verified that each tool call runs exactly once per step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->