### PR TITLE
fix(factory): seed personal OM models from the provider you sign in with

### DIFF
--- a/.changeset/wise-pumas-build.md
+++ b/.changeset/wise-pumas-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed personal memory settings in the web app showing (and running) the default Gemini observer model after signing in with another provider. Signing in with a provider OAuth flow or saving a personal API key now seeds your unset observer and reflector models from that provider, matching the TUI onboarding behavior.

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -276,6 +276,7 @@ describe('provider key routes with a tenant', () => {
         controller,
         authStorage,
         modelCredentials: seed.credentials,
+        memorySettings: seed.memorySettings,
       }).routes(),
     );
     return app;
@@ -310,6 +311,19 @@ describe('provider key routes with a tenant', () => {
       key: 'sk-mine',
     });
     expect(await seed.credentials.resolveCredential('org1', 'user-b', 'anthropic')).toBeUndefined();
+  });
+
+  it("seeds the caller's unset OM models from the provider of a user-scoped key", async () => {
+    await putKey(buildApp(userA), { key: 'sk-mine' });
+    expect(await seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).toMatchObject({
+      observerModelId: 'anthropic/claude-haiku-4-5',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+    });
+  });
+
+  it('does not seed OM models for an org-scoped key', async () => {
+    await putKey(buildApp(userA), { key: 'sk-shared', scope: 'org' });
+    expect(await seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).toBeNull();
   });
 
   it('stores an org-scoped key that all members inherit when the caller is an admin', async () => {

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -326,6 +326,22 @@ describe('provider key routes with a tenant', () => {
     expect(await seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).toBeNull();
   });
 
+  it('still saves the key and returns 200 when OM seeding fails', async () => {
+    vi.spyOn(seed.memorySettings, 'patch').mockRejectedValueOnce(new Error('memory settings unavailable'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const res = await putKey(buildApp(userA), { key: 'sk-mine' });
+
+    expect(res.status).toBe(200);
+    expect(await seed.credentials.getCredential({ orgId: 'org1', userId: 'user-a' }, 'anthropic')).toMatchObject({
+      type: 'api_key',
+      key: 'sk-mine',
+    });
+    expect(await seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('seed personal OM defaults'), expect.anything());
+    warn.mockRestore();
+  });
+
   it('stores an org-scoped key that all members inherit when the caller is an admin', async () => {
     const res = await putKey(buildApp(userA), { key: 'sk-shared', scope: 'org' });
     expect(res.status).toBe(200);

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -37,6 +37,7 @@ import type {
 import type { ModelPackRecord, ModelPacksStorage } from '../storage/domains/model-packs/base.js';
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type { SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
+import { seedPersonalOmDefaults } from './om-seed.js';
 import {
   getAuthProviderId,
   listTenantCredentialsForRequest,
@@ -771,6 +772,7 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
               // per-request, never written into process.env.
               await ctx.storage.setCredential(tenant, getAuthProviderId(provider), { type: 'api_key', key });
               onCredentialsChanged(tenant);
+              await seedPersonalOmDefaults({ memorySettings: options.memorySettings, tenant, provider });
               const records = await ctx.storage.listCredentials(ctx.orgId, ctx.userId);
               const providers = await listProviders({ controller, tenantCredentials: records });
               return c.json({ ok: true, provider: providers.find(p => p.provider === provider) });

--- a/mastracode/factory/src/routes/oauth.test.ts
+++ b/mastracode/factory/src/routes/oauth.test.ts
@@ -386,6 +386,25 @@ describe('personal OM defaults follow login', () => {
     await post(app, '/web/config/providers/github-copilot/oauth/poll', { sessionId: copilotSession });
     expect(await seed.memorySettings.get(TENANT_A)).toBeNull();
   });
+
+  it('still reports login success and releases the session when OM seeding fails', async () => {
+    vi.spyOn(seed.memorySettings, 'patch').mockRejectedValueOnce(new Error('memory settings unavailable'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const app = buildApp(userA);
+    const { sessionId } = await (await post(app, '/web/config/providers/anthropic/oauth/start')).json();
+
+    const res = await post(app, '/web/config/providers/anthropic/oauth/complete', { sessionId, code: 'c' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ status: 'complete' });
+    expect(await seed.credentials.getCredential(TENANT_A, 'anthropic')).toMatchObject({ type: 'oauth' });
+    expect(await seed.memorySettings.get(TENANT_A)).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('seed personal OM defaults'), expect.anything());
+    // Session was deleted, not left claimed.
+    const replay = await post(app, '/web/config/providers/anthropic/oauth/complete', { sessionId, code: 'c' });
+    expect(replay.status).toBe(404);
+    warn.mockRestore();
+  });
 });
 
 describe('org-scoped sign-in', () => {

--- a/mastracode/factory/src/routes/oauth.test.ts
+++ b/mastracode/factory/src/routes/oauth.test.ts
@@ -73,6 +73,7 @@ function buildApp(
       auth: fakeRouteAuth({ enabled: opts?.enabled, isOrganizationAdmin: opts?.isOrganizationAdmin }),
       authStorage,
       modelCredentials: opts?.noCredentials ? undefined : seed.credentials,
+      memorySettings: seed.memorySettings,
     }).routes(),
   );
   return app;
@@ -333,6 +334,59 @@ describe('session cancel and sign-out', () => {
 });
 
 // ── Org-scoped sign-in ───────────────────────────────────────────────────
+
+describe('personal OM defaults follow login', () => {
+  it("seeds the caller's unset OM models from the provider on paste-code completion", async () => {
+    const app = buildApp(userA);
+    const { sessionId } = await (await post(app, '/web/config/providers/anthropic/oauth/start')).json();
+    await post(app, '/web/config/providers/anthropic/oauth/complete', { sessionId, code: 'c' });
+
+    expect(await seed.memorySettings.get(TENANT_A)).toMatchObject({
+      observerModelId: 'anthropic/claude-haiku-4-5',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+    });
+    expect(await seed.memorySettings.get({ orgId: 'org1', userId: 'user-b' })).toBeNull();
+  });
+
+  it('seeds from the device-code provider on poll completion', async () => {
+    pollCodexDeviceLogin.mockResolvedValue({ status: 'complete', credentials: CODEX_CREDS });
+    const app = buildApp(userA);
+    const { sessionId } = await (await post(app, '/web/config/providers/openai/oauth/start')).json();
+    await makePollable(sessionId);
+    await post(app, '/web/config/providers/openai/oauth/poll', { sessionId });
+
+    expect(await seed.memorySettings.get(TENANT_A)).toMatchObject({ observerModelId: 'openai/gpt-5.4-mini' });
+  });
+
+  it('keeps an OM model the user already chose', async () => {
+    await seed.memorySettings.patch({ ...TENANT_A, patch: { observerModelId: 'openai/gpt-5.4-mini' } });
+    const app = buildApp(userA);
+    const { sessionId } = await (await post(app, '/web/config/providers/anthropic/oauth/start')).json();
+    await post(app, '/web/config/providers/anthropic/oauth/complete', { sessionId, code: 'c' });
+
+    expect(await seed.memorySettings.get(TENANT_A)).toMatchObject({
+      observerModelId: 'openai/gpt-5.4-mini',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+    });
+  });
+
+  it('does not seed for org-scoped sign-in or providers without a built-in OM pack', async () => {
+    const app = buildApp(userA);
+    const { sessionId } = await (
+      await post(app, '/web/config/providers/anthropic/oauth/start', { scope: 'org' })
+    ).json();
+    await post(app, '/web/config/providers/anthropic/oauth/complete', { sessionId, code: 'c' });
+    expect(await seed.memorySettings.get(TENANT_A)).toBeNull();
+
+    pollGitHubCopilotDeviceLogin.mockResolvedValue({ status: 'complete', credentials: CODEX_CREDS });
+    const { sessionId: copilotSession } = await (
+      await post(app, '/web/config/providers/github-copilot/oauth/start')
+    ).json();
+    await makePollable(copilotSession);
+    await post(app, '/web/config/providers/github-copilot/oauth/poll', { sessionId: copilotSession });
+    expect(await seed.memorySettings.get(TENANT_A)).toBeNull();
+  });
+});
 
 describe('org-scoped sign-in', () => {
   it('complete stores an org-scoped credential when the flow was started with scope org', async () => {

--- a/mastracode/factory/src/routes/oauth.ts
+++ b/mastracode/factory/src/routes/oauth.ts
@@ -36,6 +36,8 @@ import type { Context } from 'hono';
 
 import { ModelCredentialsStorage } from '../storage/domains/credentials/base.js';
 import type { LoginCredentialScope, LoginSessionKind, LoginSessionRow } from '../storage/domains/credentials/base.js';
+import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+import { seedPersonalOmDefaults } from './om-seed.js';
 import { getAuthProviderId, resolveCredentialContext } from './provider-credentials.js';
 import type { CredentialContext } from './provider-credentials.js';
 import { Route } from './route.js';
@@ -209,6 +211,7 @@ async function persistOAuthCredential({
   scope,
   credentials,
   authStorage,
+  memorySettings,
   onCredentialsChanged,
 }: {
   ctx: CredentialContext;
@@ -216,6 +219,7 @@ async function persistOAuthCredential({
   scope: LoginCredentialScope | undefined;
   credentials: OAuthCredentials;
   authStorage: AuthStorage | undefined;
+  memorySettings: MemorySettingsStorage | undefined;
   onCredentialsChanged: (tenant: { orgId: string; userId?: string }) => void;
 }): Promise<void> {
   const authProviderId = getAuthProviderId(provider);
@@ -226,6 +230,7 @@ async function persistOAuthCredential({
       ...credentials,
     });
     onCredentialsChanged(tenant);
+    await seedPersonalOmDefaults({ memorySettings, tenant, provider });
     return;
   }
   if (!authStorage) throw new Error('Credential storage is not available');
@@ -246,6 +251,8 @@ export interface OAuthRoutesDeps extends RouteDependencies {
   authStorage?: AuthStorage;
   /** Tenant credential domain handle; absent in local (no-DB) mode. */
   modelCredentials?: ModelCredentialsStorage;
+  /** Personal OM settings; seeded from the login provider after a user-scoped sign-in. */
+  memorySettings?: MemorySettingsStorage;
   /** Notifies the host after tenant credentials change so caches can be dropped. */
   onCredentialsChanged?: (tenant: { orgId: string; userId?: string }) => void;
 }
@@ -260,7 +267,7 @@ export interface OAuthRoutesDeps extends RouteDependencies {
  */
 export class OAuthRoutes extends Route<OAuthRoutesDeps> {
   routes(): ApiRoute[] {
-    const { auth, authStorage, modelCredentials } = this.deps;
+    const { auth, authStorage, modelCredentials, memorySettings } = this.deps;
     const onCredentialsChanged = this.deps.onCredentialsChanged ?? (() => {});
 
     return [
@@ -378,6 +385,7 @@ export class OAuthRoutes extends Route<OAuthRoutesDeps> {
             scope: session.credentialScope,
             credentials,
             authStorage,
+            memorySettings,
             onCredentialsChanged,
           });
           await (await sessionStore(ctx)).deleteLoginSession(sessionId);
@@ -446,6 +454,7 @@ export class OAuthRoutes extends Route<OAuthRoutesDeps> {
               scope: session.credentialScope,
               credentials: result.credentials,
               authStorage,
+              memorySettings,
               onCredentialsChanged,
             });
             await (await sessionStore(ctx)).deleteLoginSession(sessionId);

--- a/mastracode/factory/src/routes/om-seed.ts
+++ b/mastracode/factory/src/routes/om-seed.ts
@@ -1,0 +1,32 @@
+import { resolveProviderOMDefault } from '@mastra/code-sdk/onboarding/packs';
+
+import type { MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
+
+/**
+ * Seed a user's personal observational-memory model from the provider they
+ * just signed in with — the web counterpart of the TUI's "OM follows login"
+ * onboarding step. Only fills knobs that are still unset, so a user who has
+ * already chosen an OM model keeps it. Org-shared credentials and providers
+ * without a built-in OM pack (e.g. GitHub Copilot) are skipped: the former
+ * has no single user to seed, the latter has no sensible model to seed with.
+ */
+export async function seedPersonalOmDefaults({
+  memorySettings,
+  tenant,
+  provider,
+}: {
+  memorySettings: MemorySettingsStorage | undefined;
+  tenant: { orgId: string; userId?: string };
+  provider: string;
+}): Promise<void> {
+  if (!memorySettings || !tenant.userId) return;
+  const pack = resolveProviderOMDefault(provider);
+  if (pack.id === 'custom') return;
+  await memorySettings.ensureReady();
+  await memorySettings.patch({
+    orgId: tenant.orgId,
+    userId: tenant.userId,
+    patch: {},
+    fillIfUnset: { observerModelId: pack.modelId, reflectorModelId: pack.modelId },
+  });
+}

--- a/mastracode/factory/src/routes/om-seed.ts
+++ b/mastracode/factory/src/routes/om-seed.ts
@@ -9,6 +9,10 @@ import type { MemorySettingsStorage } from '../storage/domains/memory-settings/b
  * already chosen an OM model keeps it. Org-shared credentials and providers
  * without a built-in OM pack (e.g. GitHub Copilot) are skipped: the former
  * has no single user to seed, the latter has no sensible model to seed with.
+ *
+ * Never rejects: it runs after the credential has been persisted, so a
+ * memory-settings failure must not turn a successful login or key save into
+ * an error response (or leave a completed OAuth session unclaimed).
  */
 export async function seedPersonalOmDefaults({
   memorySettings,
@@ -22,11 +26,18 @@ export async function seedPersonalOmDefaults({
   if (!memorySettings || !tenant.userId) return;
   const pack = resolveProviderOMDefault(provider);
   if (pack.id === 'custom') return;
-  await memorySettings.ensureReady();
-  await memorySettings.patch({
-    orgId: tenant.orgId,
-    userId: tenant.userId,
-    patch: {},
-    fillIfUnset: { observerModelId: pack.modelId, reflectorModelId: pack.modelId },
-  });
+  try {
+    await memorySettings.ensureReady();
+    await memorySettings.patch({
+      orgId: tenant.orgId,
+      userId: tenant.userId,
+      patch: {},
+      fillIfUnset: { observerModelId: pack.modelId, reflectorModelId: pack.modelId },
+    });
+  } catch (error) {
+    console.warn('[factory] Failed to seed personal OM defaults after storing a credential', {
+      provider,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -513,6 +513,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
       auth: deps.auth,
       authStorage: deps.authStorage,
       modelCredentials: deps.domains.modelCredentials,
+      memorySettings: deps.domains.memorySettings,
       onCredentialsChanged: invalidateTenantCredentialSnapshots,
     }).routes(),
     ...new SkillRoutes({


### PR DESCRIPTION
When onboarding the web app with Anthropic OAuth, Memory settings showed haiku-4-5 for the factory but gemini for the user's personal settings. Only the factory-scoped memory_settings row was ever written, so the personal scope fell through to the hardcoded google/gemini-3.5-flash default. That's not just a display issue — personal sessions would actually try to run OM on Gemini with no Google credential.

This seeds the user's unset observer/reflector models from the login provider whenever a user-scoped credential is stored (OAuth paste-code, OAuth device-code, and personal API key), the same "OM follows login" behavior the TUI has. It only fills unset values, skips org-shared credentials, and skips providers without a built-in OM pack like GitHub Copilot.

After signing in with Anthropic:

```
GET /web/config/om
{ "observerModelId": "anthropic/claude-haiku-4-5", "reflectorModelId": "anthropic/claude-haiku-4-5", ... }
```

Existing rows aren't backfilled; signing in again (or picking a model in settings) populates them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a user signs in or adds a personal API key, web onboarding now selects memory models recommended by that provider instead of defaulting to Gemini. It fills only empty personal settings and preserves existing choices.

## Changes

- Added `seedPersonalOmDefaults` to seed observer and reflector models from the provider’s built-in OM pack.
- Applied best-effort seeding after personal OAuth sign-in and personal API-key setup.
- Covered OAuth paste-code and device-code flows.
- Skipped organization-scoped credentials, custom providers, and providers without a built-in OM pack.
- Logged seeding failures without failing login or API-key save requests.
- Wired `memorySettings` through `OAuthRoutes` and `ConfigRoutes`.
- Added tests for defaults, existing selections, organization credentials, unsupported providers, and seeding failures.
- Added a patch changeset for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->