### PR TITLE
fix(factory): age board cards from when the issue/PR was opened upstream

### DIFF
--- a/.changeset/nice-icons-add.md
+++ b/.changeset/nice-icons-add.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed board cards for imported GitHub and Linear issues/PRs showing "just now" — cards now show how long ago the issue or PR was opened upstream instead of when the factory first saw it.

--- a/.changeset/plenty-humans-try.md
+++ b/.changeset/plenty-humans-try.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed "Linked card could not be filed: A work item cannot relate to itself" on Review cards. When GitHub polling re-observed a pull request that already had a card, the dispatcher tried to link the card to itself as its parent.

--- a/mastracode/factory-ui/src/ui/domains/factory/boardItems.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardItems.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { workItemMeta } from './boardItems';
+import type { WorkItem } from './services/workItems';
+
+function workItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'item-1',
+    orgId: 'org1',
+    factoryProjectId: 'factory-1',
+    board: 'review',
+    source: 'github-pr',
+    sourceKey: 'github-pr:22765',
+    parentWorkItemId: null,
+    title: 'docs: improve generated model page metadata',
+    stage: 'intake',
+    url: 'https://github.com/acme/repo/pull/22765',
+    stages: ['intake', 'review'],
+    stageHistory: [],
+    sessions: {},
+    metadata: { githubPullRequestNumber: 22765, author: 'LekoArts' },
+    commentCount: 0,
+    feedActivityAt: null,
+    revision: 1,
+    createdAt: '2026-09-02T12:00:00.000Z',
+    updatedAt: '2026-09-02T12:00:00.000Z',
+    ...overrides,
+  } as WorkItem;
+}
+
+describe('workItemMeta', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-02T12:00:30.000Z'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('ages the card from when the issue/PR was opened upstream, not when the factory imported it', () => {
+    const item = workItem({
+      metadata: { githubPullRequestNumber: 22765, author: 'LekoArts', sourceCreatedAt: '2026-08-30T12:00:00.000Z' },
+    });
+    expect(workItemMeta(item)).toBe('#22765 · LekoArts · 3d');
+  });
+
+  it('falls back to the factory import time when the source date is unknown', () => {
+    expect(workItemMeta(workItem())).toBe('#22765 · LekoArts · just now');
+  });
+});

--- a/mastracode/factory-ui/src/ui/domains/factory/boardItems.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardItems.test.ts
@@ -45,4 +45,11 @@ describe('workItemMeta', () => {
   it('falls back to the factory import time when the source date is unknown', () => {
     expect(workItemMeta(workItem())).toBe('#22765 · LekoArts · just now');
   });
+
+  it('falls back to the factory import time when the source date is not a valid timestamp', () => {
+    const item = workItem({
+      metadata: { githubPullRequestNumber: 22765, author: 'LekoArts', sourceCreatedAt: 'not-a-date' },
+    });
+    expect(workItemMeta(item)).toBe('#22765 · LekoArts · just now');
+  });
 });

--- a/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
@@ -72,7 +72,10 @@ export function externalLinkLabel(source: WorkItemSource): string {
 
 export function workItemMeta(item: WorkItem): string {
   const author = typeof item.metadata.author === 'string' ? item.metadata.author : undefined;
-  const age = relativeTime(item.createdAt);
+  // Prefer when the issue/PR was opened upstream; `item.createdAt` is only
+  // when the factory first saw it, which is "just now" for every backfilled card.
+  const sourceCreatedAt = typeof item.metadata.sourceCreatedAt === 'string' ? item.metadata.sourceCreatedAt : undefined;
+  const age = relativeTime(sourceCreatedAt ?? item.createdAt);
   const githubNumber = githubNumberForItem(item);
   if (githubNumber !== undefined) return `#${githubNumber}${author ? ` · ${author}` : ''} · ${age}`;
   const linearIdentifier = linearIdentifierForItem(item);

--- a/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardItems.ts
@@ -1,3 +1,5 @@
+import { isValid } from 'date-fns';
+
 import { relativeTime } from '../../../lib/date/relativeTime';
 import type { WorkItem, WorkItemSessionRef, WorkItemSource } from './services/workItems';
 
@@ -74,7 +76,10 @@ export function workItemMeta(item: WorkItem): string {
   const author = typeof item.metadata.author === 'string' ? item.metadata.author : undefined;
   // Prefer when the issue/PR was opened upstream; `item.createdAt` is only
   // when the factory first saw it, which is "just now" for every backfilled card.
-  const sourceCreatedAt = typeof item.metadata.sourceCreatedAt === 'string' ? item.metadata.sourceCreatedAt : undefined;
+  const sourceCreatedAt =
+    typeof item.metadata.sourceCreatedAt === 'string' && isValid(new Date(item.metadata.sourceCreatedAt))
+      ? item.metadata.sourceCreatedAt
+      : undefined;
   const age = relativeTime(sourceCreatedAt ?? item.createdAt);
   const githubNumber = githubNumberForItem(item);
   if (githubNumber !== undefined) return `#${githubNumber}${author ? ` · ${author}` : ''} · ${age}`;

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -223,6 +223,7 @@ function issueOpened(context: FactoryGithubRuleContext) {
     metadata: {
       githubRepositoryId: context.repository.id,
       githubIssueNumber: context.issue.number,
+      ...(context.issue.createdAt ? { sourceCreatedAt: context.issue.createdAt } : {}),
       ...(githubActorLogin(context) ? { author: githubActorLogin(context) } : {}),
       authorTrusted: trustedGithubActor(context),
       autoStartCandidate:
@@ -276,6 +277,7 @@ function pullRequestOpened(context: FactoryGithubRuleContext) {
     metadata: {
       githubRepositoryId: context.repository.id,
       githubPullRequestNumber: context.pullRequest.number,
+      ...(context.pullRequest.createdAt ? { sourceCreatedAt: context.pullRequest.createdAt } : {}),
       factoryAuthored,
       authorTrusted: trustedGithubActor(context),
       autoStartCandidate,
@@ -483,6 +485,7 @@ function linearIssueObserved(context: FactoryLinearRuleContext) {
     metadata: {
       linearIssueId: context.issue.id,
       identifier: context.issue.identifier,
+      sourceCreatedAt: context.issue.createdAt,
       linearState: context.issue.state,
       linearStateType: context.issue.stateType,
       linearPriority: context.issue.priorityLabel,

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { AutomationFailedAttentionProvider } from '../routes/attention-providers.js';
 import { FactoryFeedReader } from '../storage/domains/comments/feed-context.js';
-import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import { FACTORY_RULE_MATERIALIZATION_KEY, type WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import { builtInFactoryRules, defaultFactoryRules } from './defaults.js';
 import { FACTORY_DISPATCH_CONSTANTS, FactoryDecisionDispatcher } from './dispatcher.js';
@@ -3235,6 +3235,76 @@ describe('FactoryDecisionDispatcher', () => {
     expect(pending.map(record => record.status)).toEqual(['succeeded']);
     expect(await storage.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID })).toHaveLength(1);
     expect((await storage.get({ orgId: 'org-1', id: card.id }))?.parentWorkItemId).toBeNull();
+  });
+
+  it('backfills missing source metadata on an already-filed card without overwriting or adopting it', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { item: card } = await storage.upsert({
+      orgId: 'org-1',
+      userId: 'test',
+      factoryProjectId: PROJECT_ID,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'pull-request',
+          externalId: 'github-pr:3',
+          url: 'https://github.com/acme/repo/pull/3',
+        },
+        parentWorkItemId: null,
+        title: 'Linked PR',
+        stages: ['review'],
+        sessions: {},
+        metadata: { author: 'human-edited' },
+      },
+      reuseMode: 'preserve',
+    });
+    await storage.commitRuleEvaluation({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: card.id,
+      ingress: { identity: 'poll:7:pull-request:3', triggerType: 'pull_request.opened' },
+      ruleSetVersion: 'rules-v1',
+      expectedRevision: card.revision,
+      actor: { type: 'system', id: 'rules' },
+      outcome: { status: 'accepted' },
+      decisions: [
+        {
+          type: 'upsertLinkedWorkItem',
+          idempotencyKey: 'linked-pr-backfill',
+          board: 'review',
+          source: 'github-pr',
+          sourceKey: 'github-pr:3',
+          title: 'Linked PR',
+          url: 'https://github.com/acme/repo/pull/3',
+          stage: 'intake',
+          metadata: { author: 'octocat', sourceCreatedAt: '2029-12-01T00:00:00Z' },
+        },
+      ],
+      causalChain: [],
+      now: new Date('2030-01-01T00:00:00Z'),
+    });
+    const transitionService = new FactoryTransitionService({
+      storage,
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+    });
+    const { controller } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      isAutoRunEnabled: async () => true,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
+
+    const pending = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(pending.map(record => record.status)).toEqual(['succeeded']);
+    const updated = await storage.get({ orgId: 'org-1', id: card.id });
+    expect(updated?.metadata).toMatchObject({ author: 'human-edited', sourceCreatedAt: '2029-12-01T00:00:00Z' });
+    expect(updated?.metadata?.[FACTORY_RULE_MATERIALIZATION_KEY]).toBeUndefined();
+    // Preserved: not re-entered into intake.
+    expect(updated?.stages).toEqual(['review']);
   });
 
   it('recovers linked-item materialization after an upsert crash and fires Intake onEnter exactly once', async () => {

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -3169,6 +3169,74 @@ describe('FactoryDecisionDispatcher', () => {
     expect(linked?.parentWorkItemId).toBe(parent.id);
   });
 
+  it('does not parent a linked card to itself when a poll re-emits "opened" for an already-filed PR', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { item: card } = await storage.upsert({
+      orgId: 'org-1',
+      userId: 'test',
+      factoryProjectId: PROJECT_ID,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'pull-request',
+          externalId: 'github-pr:3',
+          url: 'https://github.com/acme/repo/pull/3',
+        },
+        parentWorkItemId: null,
+        title: 'Linked PR',
+        stages: ['intake'],
+        sessions: {},
+        metadata: {},
+      },
+      reuseMode: 'preserve',
+    });
+    // The second evaluation resolves the PR card itself as the triggering item.
+    await storage.commitRuleEvaluation({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: card.id,
+      ingress: { identity: 'poll:7:pull-request:3', triggerType: 'pull_request.opened' },
+      ruleSetVersion: 'rules-v1',
+      expectedRevision: card.revision,
+      actor: { type: 'system', id: 'rules' },
+      outcome: { status: 'accepted' },
+      decisions: [
+        {
+          type: 'upsertLinkedWorkItem',
+          idempotencyKey: 'linked-pr-polled-again',
+          board: 'review',
+          source: 'github-pr',
+          sourceKey: 'github-pr:3',
+          title: 'Linked PR',
+          url: 'https://github.com/acme/repo/pull/3',
+          stage: 'intake',
+          metadata: { githubRepositoryId: 7, githubPullRequestNumber: 3 },
+        },
+      ],
+      causalChain: [],
+      now: new Date('2030-01-01T00:00:00Z'),
+    });
+    const transitionService = new FactoryTransitionService({
+      storage,
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+    });
+    const { controller } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      isAutoRunEnabled: async () => true,
+      transitionService,
+      storage,
+      ownerId: 'worker-1',
+    });
+
+    await dispatcher.runOnce(new Date('2030-01-01T00:00:01Z'));
+
+    const pending = await storage.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(pending.map(record => record.status)).toEqual(['succeeded']);
+    expect(await storage.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID })).toHaveLength(1);
+    expect((await storage.get({ orgId: 'org-1', id: card.id }))?.parentWorkItemId).toBeNull();
+  });
+
   it('recovers linked-item materialization after an upsert crash and fires Intake onEnter exactly once', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const parent = await createItem(storage);

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -860,6 +860,25 @@ export class FactoryDecisionDispatcher {
       });
       if (item) result = { ...result, item };
     }
+    if (!result.created) {
+      // Backfill source facts (e.g. sourceCreatedAt) that older cards were filed
+      // without. Fill-only: never overwrite, and never adopt the card as
+      // materialized by this decision.
+      const missing = Object.fromEntries(
+        Object.entries(decision.metadata ?? {}).filter(
+          ([key]) => key !== FACTORY_RULE_MATERIALIZATION_KEY && result.item.metadata?.[key] === undefined,
+        ),
+      );
+      if (Object.keys(missing).length > 0) {
+        const filled = await this.#storage.update({
+          orgId: record.orgId,
+          id: result.item.id,
+          userId: 'factory-rule-dispatcher',
+          patch: { metadata: missing },
+        });
+        if (filled) result = { ...result, item: filled.item };
+      }
+    }
     const materializedByDecision = result.item.metadata?.[FACTORY_RULE_MATERIALIZATION_KEY] === record.idempotencyKey;
     if (!materializedByDecision && (decision.stage === 'intake' || !result.item.stages.includes('intake'))) return;
 

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -848,7 +848,10 @@ export class FactoryDecisionDispatcher {
       },
       reuseMode: 'preserve',
     });
-    if (!result.item.parentWorkItemId && parentWorkItemId) {
+    // A re-evaluation for an already-filed card (poll/reconcile re-emitting
+    // "opened") resolves the card itself as the triggering item; it is not
+    // its own parent.
+    if (!result.item.parentWorkItemId && parentWorkItemId && parentWorkItemId !== result.item.id) {
       const item = await this.#storage.setParentWorkItemIfMissing({
         orgId: record.orgId,
         id: result.item.id,


### PR DESCRIPTION
Every card on the Intake/Review boards showed "just now" after a fresh import, even for PRs that were days old on GitHub. The card was aging from the work item's own database createdAt (when the factory first saw it) rather than when the issue or PR was actually opened.

GitHub issue/PR and Linear intake now write the upstream createdAt into the work item's metadata as sourceCreatedAt, and the card meta uses that when present, falling back to the factory import time if missing.

Before: `#22765 · LekoArts · just now`
After: `#22765 · LekoArts · 3d`

Items already on the board pick up the new field the next time a webhook, poll, or reconcile sweep touches them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Board cards now show the age of the original GitHub issue, pull request, or Linear issue. Existing cards also avoid creating self-links when GitHub reports the same pull request again.

## Changes

- Store upstream creation time as `sourceCreatedAt`.
- Use valid `sourceCreatedAt` values for board card aging.
- Fall back to factory import time when `sourceCreatedAt` is missing or invalid.
- Backfill missing source metadata during webhook processing, polling, and reconciliation.
- Preserve existing metadata, materialization markers, and stage state during backfills.
- Prevent self-referential parent links for reused GitHub pull requests.
- Add tests for timestamp fallback, metadata backfilling, and duplicate pull-request events.
- Add patch changesets for `@mastra/factory`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->