### PR TITLE
fix: add missing frontmatter to .agents/skills/testing-core-processors

### DIFF
--- a/.agents/skills/testing-core-processors/SKILL.md
+++ b/.agents/skills/testing-core-processors/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: testing-core-processors
+description: Use when writing or debugging integration tests for error processors in packages/core/src/processors/. Covers the MockLanguageModelV2 pattern for simulating API errors and verifying retry behavior, plus the build prerequisites for focused vitest runs.
+---
+
 # Testing Core Error Processors
 
 How to write integration tests for error processors in `packages/core/src/processors/`.


### PR DESCRIPTION
## Summary
`.agents/skills/testing-core-processors/SKILL.md` was committed without the `name`/`description` frontmatter, so the workspace skill loader rejects it and logs on every session:

```
[WorkspaceSkills] Failed to load skill from .agents/skills: Invalid skill metadata in .agents/skills/testing-core-processors/SKILL.md
```

This copies the frontmatter from the `.claude/skills` twin, making the two files identical.

## Test plan
- [ ] Start Mastra Code in the repo; no WorkspaceSkills load error is logged
- [ ] `testing-core-processors` appears in available skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The skill file now includes the information the workspace needs to recognize it. This prevents repeated metadata errors when the workspace loads.

## Changes

- Added `name` and `description` YAML frontmatter to `.agents/skills/testing-core-processors/SKILL.md`.
- Matched the corresponding `.claude/skills` file.
- Described testing coverage for error processors, mock language models, retries, and focused Vitest setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->