### PR TITLE
fix(playground): unify experiment trace details

### DIFF
--- a/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
@@ -1,15 +1,21 @@
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   DATASET_ID,
   EXPERIMENT_ID,
   emptyScoresResponse,
   experiment,
+  experimentSpanDetailById,
+  experimentResultScoresResponse,
+  experimentSpanFeedback,
+  experimentTraceFeedback,
+  experimentTraceScores,
+  experimentTraceSpans,
   experimentsResponse,
   noAgents,
   noScorers,
@@ -25,6 +31,20 @@ import { TEST_BASE_URL } from '@/test/render';
  * Renders the real experiment route tree (parent list page + nested
  * `items/:itemId` child) inside a memory router, mirroring App.tsx.
  */
+const originalOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')!;
+const originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth')!;
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 800 });
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, value: 800 });
+});
+
+afterAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight);
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', originalOffsetWidth);
+});
+
 const renderExperimentRoute = (initialPath = `/experiments/${EXPERIMENT_ID}`) => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
@@ -66,6 +86,18 @@ beforeEach(() => {
     ),
     http.get(`${TEST_BASE_URL}/api/datasets/${DATASET_ID}/experiments/${EXPERIMENT_ID}/results`, () =>
       HttpResponse.json(resultsResponse),
+    ),
+    http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId/light`, () => HttpResponse.json(experimentTraceSpans)),
+    http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId/spans/:spanId`, ({ params }) => {
+      const detail = experimentSpanDetailById[String(params.spanId)];
+      return detail ? HttpResponse.json(detail) : HttpResponse.json({ error: 'not found' }, { status: 404 });
+    }),
+    http.get(`${TEST_BASE_URL}/api/observability/feedback`, ({ request }) => {
+      const spanId = new URL(request.url).searchParams.get('spanId');
+      return HttpResponse.json(spanId ? experimentSpanFeedback : experimentTraceFeedback);
+    }),
+    http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId/:spanId/scores`, () =>
+      HttpResponse.json(experimentTraceScores),
     ),
     http.get(`${TEST_BASE_URL}/api/scores/run/${EXPERIMENT_ID}`, () => HttpResponse.json(emptyScoresResponse)),
   );
@@ -164,6 +196,143 @@ describe('experiment item sub-route', () => {
       await waitFor(() => {
         expect(dialog.textContent).toContain('Item not found');
       });
+    });
+  });
+
+  describe('when the user opens a result trace and selects a span', () => {
+    it('shows trace feedback and anchor-span evaluations with badge counts', async () => {
+      renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-1`);
+
+      await screen.findByRole('dialog');
+      fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
+
+      const evaluationsTab = await screen.findByRole('tab', { name: /evaluations \(1\)/i });
+      const feedbackTab = screen.getByRole('tab', { name: /feedback \(1\)/i });
+
+      fireEvent.click(evaluationsTab);
+      expect((await screen.findAllByText('Experiment relevance')).length).toBeGreaterThan(0);
+
+      fireEvent.click(feedbackTab);
+      expect(await screen.findByText('Trace feedback for the experiment run')).toBeDefined();
+    });
+
+    it('opens the existing experiment score details for a matching trace score', async () => {
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/scores/run/${EXPERIMENT_ID}`, () =>
+          HttpResponse.json(experimentResultScoresResponse),
+        ),
+      );
+      renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-1`);
+
+      await screen.findByRole('dialog');
+      fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
+      fireEvent.click(await screen.findByRole('tab', { name: /evaluations \(1\)/i }));
+      fireEvent.click(await screen.findByRole('button', { name: /0\.9Experiment relevance/i }));
+
+      expect(await screen.findByText('Matches the experiment result score')).toBeDefined();
+    });
+
+    it('keeps the trace evaluations open when a trace score has no experiment score match', async () => {
+      renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-1`);
+
+      await screen.findByRole('dialog');
+      fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
+      const evaluationsTab = await screen.findByRole('tab', { name: /evaluations \(1\)/i });
+      fireEvent.click(evaluationsTab);
+      fireEvent.click(await screen.findByRole('button', { name: /0\.9Experiment relevance/i }));
+
+      expect(evaluationsTab.getAttribute('aria-selected')).toBe('true');
+      expect(screen.queryByText('Matches the experiment result score')).toBeNull();
+      expect(screen.getByRole('tab', { name: /evaluations \(1\)/i })).toBeDefined();
+    });
+
+    it('shows selected-span feedback and widens the route overlay', async () => {
+      renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-1`);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
+      expect(dialog.parentElement?.className).toContain('grid-cols-[1fr_1fr]');
+
+      fireEvent.click(await screen.findByText('Experiment tool call'));
+      const spanHeading = await screen.findByText(/# experiment-span-child/);
+      const spanSection = spanHeading.closest('section');
+      if (!spanSection) throw new Error('Expected span detail section');
+
+      expect(dialog.parentElement?.className).toContain('grid-cols-[1fr_4fr]');
+      expect(spanSection.className).toContain('rounded-none');
+      expect(spanSection.className).toContain('border-0');
+      expect(spanSection.className).toContain('bg-transparent');
+
+      fireEvent.click(await within(spanSection).findByRole('tab', { name: /feedback \(1\)/i }));
+      expect(await screen.findByText('Child span feedback for the tool call')).toBeDefined();
+
+      fireEvent.click(within(spanSection).getByLabelText('Close Panel'));
+      await waitFor(() => expect(dialog.parentElement?.className).toContain('grid-cols-[1fr_1fr]'));
+      expect(screen.getByText('Experiment agent run')).toBeDefined();
+    });
+
+    it('shows the span details inside the shared trace card', async () => {
+      renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-1`);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
+      fireEvent.click(await screen.findByText('Experiment tool call'));
+
+      expect(await screen.findByText(/# experiment-span-child/)).toBeDefined();
+      const traceSection = screen.getByText('Experiment agent run').closest('section');
+      const panelGrid = traceSection?.parentElement;
+      const topLevelPanels = Array.from(panelGrid?.children ?? []).filter(child => child.tagName === 'SECTION');
+      expect(topLevelPanels).toHaveLength(2);
+      await waitFor(() => expect(screen.queryByText('Loading span details...')).toBeNull());
+      expect(dialog.isConnected).toBe(true);
+    });
+
+    it('navigates between adjacent spans inside the shared trace card', async () => {
+      renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-1`);
+
+      await screen.findByRole('dialog');
+      fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
+      fireEvent.click(await screen.findByText('Experiment tool call'));
+      expect(await screen.findByText(/# experiment-span-child/)).toBeDefined();
+
+      fireEvent.click(screen.getByLabelText('Previous span'));
+      expect(await screen.findByText(/# experiment-span-root/)).toBeDefined();
+
+      fireEvent.click(screen.getByLabelText('Next span'));
+      expect(await screen.findByText(/# experiment-span-child/)).toBeDefined();
+    });
+
+    it('closes span details without closing the trace card', async () => {
+      renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-1`);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
+      fireEvent.click(await screen.findByText('Experiment tool call'));
+      expect(await screen.findByText(/# experiment-span-child/)).toBeDefined();
+
+      const spanSection = screen.getByText(/# experiment-span-child/).closest('section');
+      if (!spanSection) throw new Error('Expected span detail section');
+      fireEvent.click(within(spanSection).getByLabelText('Close Panel'));
+
+      await waitFor(() => expect(screen.queryByText(/# experiment-span-child/)).toBeNull());
+      expect(screen.getByText('Experiment agent run')).toBeDefined();
+      expect(dialog.isConnected).toBe(true);
+    });
+
+    it('closes the trace card without closing the result dialog', async () => {
+      renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-1`);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
+      expect(await screen.findByText('Experiment agent run')).toBeDefined();
+
+      const traceSection = screen.getByText('Experiment agent run').closest('section');
+      if (!traceSection) throw new Error('Expected trace section');
+      fireEvent.click(within(traceSection).getByLabelText('Close Panel'));
+
+      await waitFor(() => expect(screen.queryByText('Experiment agent run')).toBeNull());
+      expect(dialog.isConnected).toBe(true);
+      expect(dialog.textContent).toContain('first question');
     });
   });
 

--- a/packages/playground/src/domains/experiments/__tests__/fixtures/experiment-item-route.ts
+++ b/packages/playground/src/domains/experiments/__tests__/fixtures/experiment-item-route.ts
@@ -5,11 +5,55 @@ import type {
   GetScorerResponse,
   GetWorkflowResponse,
   ListScoresResponse,
+  MastraClient,
+  RouteResponse,
 } from '@mastra/client-js';
-import type { PaginationInfo } from '@mastra/core/storage';
+import { SpanType } from '@mastra/core/observability';
+import { TraceStatus, type PaginationInfo } from '@mastra/core/storage';
+
+type GetTraceResponse = Awaited<ReturnType<MastraClient['getTrace']>>;
+type GetSpanResponse = Awaited<ReturnType<MastraClient['getSpan']>>;
 
 export const DATASET_ID = 'ds-1';
 export const EXPERIMENT_ID = 'exp-1';
+export const TRACE_ID = 'experiment-trace-1';
+
+const baseSpan = {
+  traceId: TRACE_ID,
+  spanType: SpanType.AGENT_RUN,
+  isEvent: false,
+  startedAt: new Date('2026-07-21T00:00:10.000Z'),
+  endedAt: new Date('2026-07-21T00:00:20.000Z'),
+  createdAt: new Date('2026-07-21T00:00:10.000Z'),
+  updatedAt: null,
+  status: TraceStatus.SUCCESS,
+};
+
+export const experimentTraceRootSpan = {
+  ...baseSpan,
+  spanId: 'experiment-span-root',
+  name: 'Experiment agent run',
+  parentSpanId: null,
+};
+export const experimentTraceChildSpan = {
+  ...baseSpan,
+  spanId: 'experiment-span-child',
+  name: 'Experiment tool call',
+  spanType: SpanType.TOOL_CALL,
+  parentSpanId: experimentTraceRootSpan.spanId,
+};
+export const experimentTraceSpans: GetTraceResponse = {
+  traceId: TRACE_ID,
+  spans: [experimentTraceRootSpan, experimentTraceChildSpan],
+};
+export const experimentSpanDetailById: Record<string, GetSpanResponse> = {
+  [experimentTraceRootSpan.spanId]: {
+    span: { ...experimentTraceRootSpan, input: { q: 'first question' }, output: { a: 'first answer' } },
+  },
+  [experimentTraceChildSpan.spanId]: {
+    span: { ...experimentTraceChildSpan, input: { query: 'Mastra' }, output: { found: true } },
+  },
+};
 
 export const noAgents: Record<string, GetAgentResponse> = {};
 export const noWorkflows: Record<string, GetWorkflowResponse> = {};
@@ -64,7 +108,7 @@ const baseResult: DatasetExperimentResult = {
   startedAt: '2026-07-21T00:00:10.000Z',
   completedAt: '2026-07-21T00:00:20.000Z',
   retryCount: 0,
-  traceId: null,
+  traceId: TRACE_ID,
   status: null,
   tags: [],
   comment: null,
@@ -94,4 +138,62 @@ export const resultsResponse: { results: DatasetExperimentResult[]; pagination: 
 export const emptyScoresResponse: ListScoresResponse = {
   scores: [],
   pagination: { total: 0, page: 0, perPage: 100, hasMore: false },
+};
+
+export const experimentTraceFeedback: RouteResponse<'GET /observability/feedback'> = {
+  feedback: [
+    {
+      feedbackId: 'experiment-trace-feedback',
+      traceId: TRACE_ID,
+      feedbackType: 'comment',
+      value: 'Trace feedback for the experiment run',
+      timestamp: new Date('2026-07-21T00:00:21.000Z'),
+    },
+  ],
+  pagination: { total: 1, page: 0, perPage: 10, hasMore: false },
+};
+
+export const experimentSpanFeedback: RouteResponse<'GET /observability/feedback'> = {
+  feedback: [
+    {
+      feedbackId: 'experiment-span-feedback',
+      traceId: TRACE_ID,
+      spanId: experimentTraceChildSpan.spanId,
+      feedbackType: 'comment',
+      value: 'Child span feedback for the tool call',
+      timestamp: new Date('2026-07-21T00:00:22.000Z'),
+    },
+  ],
+  pagination: { total: 1, page: 0, perPage: 10, hasMore: false },
+};
+
+export const experimentTraceScores: ListScoresResponse = {
+  scores: [
+    {
+      id: 'experiment-trace-score',
+      scorerId: 'experiment-scorer',
+      entityId: 'agent-1',
+      runId: 'experiment-run-1',
+      output: { reason: 'Relevant answer' },
+      score: 0.9,
+      scorer: { id: 'experiment-scorer', name: 'Experiment relevance' },
+      source: 'LIVE',
+      entity: { id: 'agent-1' },
+      traceId: TRACE_ID,
+      spanId: experimentTraceRootSpan.spanId,
+      createdAt: new Date('2026-07-21T00:00:23.000Z'),
+      updatedAt: null,
+    },
+  ],
+  pagination: { total: 1, page: 0, perPage: 10, hasMore: false },
+};
+
+export const experimentResultScoresResponse: ListScoresResponse = {
+  scores: experimentTraceScores.scores.map(score => ({
+    ...score,
+    entityId: 'item-1',
+    reason: 'Matches the experiment result score',
+    scorer: { ...score.scorer, hasJudge: false },
+  })),
+  pagination: { total: 1, page: 0, perPage: 100, hasMore: false },
 };

--- a/packages/playground/src/domains/traces/components/trace-span-panel.tsx
+++ b/packages/playground/src/domains/traces/components/trace-span-panel.tsx
@@ -43,6 +43,9 @@ export interface TraceSpanPanelProps {
   scoresTabSlot?: TraceDataPanelViewProps['scoresTabSlot'];
   usage?: TraceDataPanelViewProps['usage'];
   traceHref?: string;
+  collapsed?: TraceDataPanelViewProps['collapsed'];
+  onCollapsedChange?: TraceDataPanelViewProps['onCollapsedChange'];
+  showUnavailableFeaturesMsg?: TraceDataPanelViewProps['showUnavailableFeaturesMsg'];
   className?: string;
 
   // Span-panel pass-through.
@@ -78,6 +81,9 @@ export function TraceSpanPanel({
   scoresTabSlot,
   usage,
   traceHref,
+  collapsed,
+  onCollapsedChange,
+  showUnavailableFeaturesMsg,
   className,
   spanActiveTab,
   onSpanTabChange,
@@ -113,6 +119,9 @@ export function TraceSpanPanel({
       placement="traces-list"
       LinkComponent={Link}
       traceHref={traceHref}
+      collapsed={collapsed}
+      onCollapsedChange={onCollapsedChange}
+      showUnavailableFeaturesMsg={showUnavailableFeaturesMsg}
       feedbackTabBadge={feedbackTabBadge}
       feedbackTabSlot={feedbackTabSlot}
       scoresTabBadge={scoresTabBadge}

--- a/packages/playground/src/pages/experiments/experiment/item/index.tsx
+++ b/packages/playground/src/pages/experiments/experiment/item/index.tsx
@@ -1,10 +1,6 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
-import { SpanDataPanelView } from '@mastra/playground-ui/domains/traces/components/span-data-panel-view';
-import { TraceDataPanelView } from '@mastra/playground-ui/domains/traces/components/trace-data-panel-view';
-import { useSpanDetail } from '@mastra/playground-ui/domains/traces/hooks/use-span-detail';
-import { useTraceSpanNavigation } from '@mastra/playground-ui/domains/traces/hooks/use-trace-span-navigation';
 import { PlayCircle } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
@@ -15,7 +11,13 @@ import { ExperimentResultPanel } from '@/domains/experiments/components/experime
 import { ExperimentScorePanel } from '@/domains/experiments/components/experiment-score-panel';
 import { useExperimentItemPanel } from '@/domains/experiments/context/experiment-item-panel-context';
 import { useExperimentTrace } from '@/domains/experiments/hooks/use-experiment-trace';
-import { Link } from '@/lib/link';
+import { useTraceSpanScores } from '@/domains/scores/hooks/use-trace-span-scores';
+import { SpanFeedbackTab } from '@/domains/traces/components/span-feedback-tab';
+import { TraceFeedbackTab } from '@/domains/traces/components/trace-feedback-tab';
+import { TraceScoresTab } from '@/domains/traces/components/trace-scores-tab';
+import { TraceSpanPanel } from '@/domains/traces/components/trace-span-panel';
+import { useSpanFeedback } from '@/domains/traces/hooks/use-span-feedback';
+import { useTraceFeedback } from '@/domains/traces/hooks/use-trace-feedback';
 
 function ExperimentItemPage() {
   const { itemId } = useParams<{ itemId: string }>();
@@ -79,28 +81,33 @@ function ExperimentItemPageContent({ itemId }: { itemId: string }) {
 
   const { data: traceData, isLoading: isTraceLoading } = useExperimentTrace(featuredTraceId);
   const traceSpans = traceData?.spans;
+  const anchorSpan = traceSpans?.find(span => !span.parentSpanId);
+  const anchorSpanEntityType =
+    anchorSpan?.entityType === 'agent' ? 'Agent' : anchorSpan?.entityType === 'workflow_run' ? 'Workflow' : undefined;
+  const { data: traceFeedback } = useTraceFeedback({ traceId: featuredTraceId ?? undefined });
+  const { data: spanFeedback } = useSpanFeedback({
+    traceId: featuredTraceId ?? undefined,
+    spanId: featuredSpanId,
+  });
+  const { data: anchorSpanScores } = useTraceSpanScores({
+    traceId: featuredTraceId ?? undefined,
+    spanId: anchorSpan?.spanId,
+  });
 
-  const { data: spanDetailData, isLoading: isSpanLoading } = useSpanDetail(featuredTraceId, featuredSpanId);
-  const featuredSpan = spanDetailData?.span;
-
-  const { handlePreviousSpan: toPreviousSpan, handleNextSpan: toNextSpan } = useTraceSpanNavigation(
-    traceSpans,
-    featuredSpanId ?? null,
-    setFeaturedSpanId,
-  );
-
-  // Row stack: Result (with score split inside) → Trace → Span.
+  // Row stack: Result (with score split inside) → shared Trace/Span panel.
   const gridRows = (() => {
     const rows: string[] = [];
     const showTrace = !!featuredTraceId;
     rows.push(resultCollapsed ? 'auto' : showTrace ? '2fr' : '1fr');
     if (showTrace) rows.push(traceCollapsed ? 'auto' : '3fr');
-    if (showTrace && featuredSpanId) rows.push('3fr');
     return rows.join(' ');
   })();
 
   return (
-    <RouteItemOverlay label={`Experiment item ${itemId}`} wide={!!featuredScore && !resultCollapsed}>
+    <RouteItemOverlay
+      label={`Experiment item ${itemId}`}
+      wide={!!featuredSpanId || (!!featuredScore && !resultCollapsed)}
+    >
       {result ? (
         <div
           className="[&>section]:bg-surface3 grid h-full min-h-0 content-start gap-4 p-3 [&>section]:rounded-lg [&>section]:shadow-lg"
@@ -146,38 +153,49 @@ function ExperimentItemPageContent({ itemId }: { itemId: string }) {
           />
 
           {featuredTraceId && (
-            <>
-              <TraceDataPanelView
-                traceId={featuredTraceId}
-                spans={traceSpans}
-                isLoading={isTraceLoading}
-                onClose={() => {
-                  setFeaturedTraceId(null);
-                  setFeaturedSpanId(undefined);
-                  setResultCollapsed(false);
-                }}
-                onSpanSelect={setFeaturedSpanId}
-                initialSpanId={featuredSpanId ?? null}
-                placement="traces-list"
-                showUnavailableFeaturesMsg={false}
-                collapsed={traceCollapsed}
-                onCollapsedChange={setTraceCollapsed}
-                LinkComponent={Link}
-                traceHref={`/traces?traceId=${encodeURIComponent(featuredTraceId)}`}
-              />
-
-              {featuredSpanId && (
-                <SpanDataPanelView
-                  traceId={featuredTraceId}
-                  spanId={featuredSpanId}
-                  span={featuredSpan}
-                  isLoading={isSpanLoading}
-                  onPrevious={toPreviousSpan}
-                  onNext={toNextSpan}
-                  onClose={() => setFeaturedSpanId(undefined)}
-                />
-              )}
-            </>
+            <TraceSpanPanel
+              traceId={featuredTraceId}
+              spans={traceSpans}
+              isLoadingSpans={isTraceLoading}
+              selectedSpanId={featuredSpanId ?? null}
+              onClose={() => {
+                setFeaturedTraceId(null);
+                setFeaturedSpanId(undefined);
+                setResultCollapsed(false);
+              }}
+              onSpanSelect={setFeaturedSpanId}
+              showUnavailableFeaturesMsg={false}
+              collapsed={traceCollapsed}
+              onCollapsedChange={setTraceCollapsed}
+              traceHref={`/traces?traceId=${encodeURIComponent(featuredTraceId)}`}
+              anchorSpanId={anchorSpan?.spanId}
+              feedbackTabBadge={traceFeedback?.pagination?.total ?? undefined}
+              feedbackTabSlot={({ traceId }) => <TraceFeedbackTab traceId={traceId} />}
+              scoresTabBadge={anchorSpanScores?.pagination?.total ?? undefined}
+              scoresTabSlot={({ traceId, rootSpanId }) =>
+                rootSpanId ? (
+                  <TraceScoresTab
+                    traceId={traceId}
+                    spanId={rootSpanId}
+                    isTopLevelSpan={!anchorSpan?.parentSpanId}
+                    entityType={anchorSpanEntityType}
+                    onScoreSelect={scoreId => {
+                      if (resultScores?.some(score => score.id === scoreId)) {
+                        setFeaturedScoreId(scoreId);
+                        setResultCollapsed(false);
+                      }
+                    }}
+                  />
+                ) : null
+              }
+              spanFeedbackTabBadge={spanFeedback?.pagination?.total ?? undefined}
+              spanFeedbackTabSlot={({ traceId, spanId }) =>
+                traceId && spanId ? (
+                  <SpanFeedbackTab key={`${traceId}:${spanId}`} traceId={traceId} spanId={spanId} />
+                ) : null
+              }
+              spanPanelClassName="rounded-none border-0 bg-transparent"
+            />
           )}
         </div>
       ) : isLoadingResults || hasNextPage ? (

--- a/packages/playground/src/pages/experiments/experiment/item/index.tsx
+++ b/packages/playground/src/pages/experiments/experiment/item/index.tsx
@@ -92,6 +92,7 @@ function ExperimentItemPageContent({ itemId }: { itemId: string }) {
   const { data: anchorSpanScores } = useTraceSpanScores({
     traceId: featuredTraceId ?? undefined,
     spanId: anchorSpan?.spanId,
+    page: 0,
   });
 
   // Row stack: Result (with score split inside) → shared Trace/Span panel.


### PR DESCRIPTION
Experiment result traces previously rendered trace and span details separately, which left feedback and evaluations unavailable in the result overlay. They now reuse the shared trace/span panel so users can inspect trace feedback, anchor-span evaluations, selected-span feedback, and navigate spans without leaving the experiment result.\n\nValidated with the playground lint and focused MSW coverage for trace interactions and score selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The experiment view now uses the same trace and span viewer as the rest of the playground. Users can inspect feedback, scores, and spans without leaving the experiment result.

## Changes

- Replaced separate trace and span panels with the shared `TraceSpanPanel`.
- Reused the same initial page for experiment badges and trace score tabs so React Query shares one cache and polling cycle.
- Added trace feedback, span feedback, evaluations, score tabs, and span navigation.
- Added support for selecting experiment scores from trace scores.
- Added collapsed-state and unavailable-feature handling to `TraceSpanPanel`.
- Added MSW fixtures and tests for trace loading, feedback, score matching, span selection, navigation, nested panels, and panel closing.
- Validated the changes with playground lint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->