### PR TITLE
fix(core): keep the injected tool schema on the builder, not the shared tool

### DIFF
--- a/.changeset/lucky-pugs-repeat.md
+++ b/.changeset/lucky-pugs-repeat.md
@@ -1,0 +1,21 @@
+---
+'@mastra/core': patch
+---
+
+Stop `_background` from leaking between agents that share a tool instance.
+
+`CoreToolBuilder` wrote the schema it splices (`_background`, `suspendedToolRunId`, `resumeData`)
+back onto `originalTool.inputSchema` — the caller's own tool object, which is normally a
+module-level singleton registered on several agents. That was harmless while eligibility was a
+single Mastra-level flag, but since eligibility became per agent and per tool, the first agent to
+convert a tool decided what every other agent's model saw: an agent that opted nothing in was
+still advertised `_background`, which the runtime then refused to honor.
+
+The spliced schema now lives on the builder, so the shared tool object is never mutated. Because
+the injected keys are consequently no longer declared on the tool's own schema, the builder marks
+its arguments as already validated whenever it injected keys — it validates them itself against
+the spliced schema — so `Tool.execute` does not strip `suspendedToolRunId` and sub-agent and
+workflow resume keep working.
+
+This also stops repeated conversions of a Zod v3 or JSON Schema tool from nesting an extra
+override validator on every call.

--- a/packages/core/src/tools/tool-builder/background-override-injection.test.ts
+++ b/packages/core/src/tools/tool-builder/background-override-injection.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { z as z3 } from 'zod/v3';
 import { z as z4 } from 'zod/v4';
 import { RequestContext } from '../../request-context';
-import { isStandardSchemaWithJSON, standardSchemaToJSONSchema, toStandardSchema } from '../../schema';
+import { toStandardSchema } from '../../schema';
 import { createTool } from '../../tools';
 import { CoreToolBuilder } from './builder';
 
@@ -32,13 +32,15 @@ function baseOptions() {
   };
 }
 
-function extractJsonProperties(tool: { inputSchema?: unknown }) {
-  const schema = tool.inputSchema;
-  expect(schema).toBeDefined();
-  expect(isStandardSchemaWithJSON(schema)).toBe(true);
-  const json = standardSchemaToJSONSchema(schema as any, { io: 'input' });
-  expect(json && typeof json === 'object' && (json as any).type === 'object').toBe(true);
-  return (json as any).properties as Record<string, any>;
+// The spliced schema lives on the builder, never on the caller's tool object,
+// so assertions read what the model actually receives: the built tool's
+// `parameters`.
+function extractJsonProperties(builder: CoreToolBuilder) {
+  const parameters = builder.build().parameters as { jsonSchema?: { type?: string; properties?: Record<string, any> } };
+  expect(parameters?.jsonSchema).toBeDefined();
+  const json = parameters.jsonSchema!;
+  expect(json.type).toBe('object');
+  return json.properties!;
 }
 
 describe('CoreToolBuilder background override injection', () => {
@@ -79,13 +81,13 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
         backgroundTaskEnabled: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).toHaveProperty('_background');
     });
@@ -141,17 +143,17 @@ describe('CoreToolBuilder background override injection', () => {
         execute,
       });
 
-      new CoreToolBuilder({
+      const built = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
         backgroundTaskEnabled: true,
-      });
+      }).build();
 
-      const schema = tool.inputSchema as any;
-      const result = schema['~standard'].validate({ query: 'ok', _background: { enabled: 'yes' } });
-      const resolved = result && typeof result.then === 'function' ? await result : result;
-      expect(resolved).toHaveProperty('issues');
-      expect((resolved as { issues: readonly unknown[] }).issues.length).toBeGreaterThan(0);
+      const parameters = built.parameters as { validate?: (value: unknown) => unknown };
+      expect(typeof parameters.validate).toBe('function');
+      const result = parameters.validate!({ query: 'ok', _background: { enabled: 'yes' } });
+      const resolved = result && typeof (result as Promise<unknown>).then === 'function' ? await result : result;
+      expect(resolved).toHaveProperty('success', false);
     });
   });
 
@@ -175,14 +177,13 @@ describe('CoreToolBuilder background override injection', () => {
         backgroundTaskEnabled: true,
       });
 
-      expect(isStandardSchemaWithJSON(tool.inputSchema)).toBe(true);
-      const json = standardSchemaToJSONSchema(tool.inputSchema as any, { io: 'input' });
-      expect(json.properties).toMatchObject({
+      const built = builder.build();
+      const json = (built.parameters as { jsonSchema?: { properties?: Record<string, unknown> } }).jsonSchema;
+      expect(json?.properties).toMatchObject({
         query: expect.anything(),
         _background: expect.anything(),
       });
 
-      const built = builder.build();
       const result = await built.execute!(
         { query: 'docs', _background: { enabled: 'yes' } },
         { toolCallId: 'call-1', messages: [] },
@@ -214,7 +215,7 @@ describe('CoreToolBuilder background override injection', () => {
         ok: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).toHaveProperty('_background');
     });
@@ -245,7 +246,7 @@ describe('CoreToolBuilder background override injection', () => {
         ok: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).toHaveProperty('_background');
     });
@@ -260,12 +261,12 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('message');
       expect(properties).toHaveProperty('suspendedToolRunId');
       expect(properties).toHaveProperty('resumeData');
@@ -289,12 +290,12 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('suspendedToolRunId');
       expect(properties).toHaveProperty('resumeData');
     });
@@ -310,13 +311,13 @@ describe('CoreToolBuilder background override injection', () => {
         execute: vi.fn(),
       });
 
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: baseOptions(),
         backgroundTaskEnabled: true,
       });
 
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('message');
       expect(properties).toHaveProperty('_background');
       expect(properties).toHaveProperty('suspendedToolRunId');
@@ -340,19 +341,19 @@ describe('CoreToolBuilder background override injection', () => {
 
     it('does NOT inject _background when the manager is enabled but the tool has no opt-in', () => {
       const tool = makeTool();
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: { ...baseOptions(), backgroundConfig: undefined },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('query');
       expect(properties).not.toHaveProperty('_background');
     });
 
     it('injects _background when the agent config whitelists the tool', () => {
       const tool = makeTool();
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: {
           ...baseOptions(),
@@ -361,13 +362,13 @@ describe('CoreToolBuilder background override injection', () => {
         },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('_background');
     });
 
     it('resolves agent whitelist entries for agent- prefixed tool names', () => {
       const tool = makeTool('agent-biExecutor');
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: {
           ...baseOptions(),
@@ -377,13 +378,13 @@ describe('CoreToolBuilder background override injection', () => {
         },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).toHaveProperty('_background');
     });
 
     it('does NOT inject _background when the agent whitelists other tools only', () => {
       const tool = makeTool();
-      new CoreToolBuilder({
+      const builder = new CoreToolBuilder({
         originalTool: tool,
         options: {
           ...baseOptions(),
@@ -392,7 +393,7 @@ describe('CoreToolBuilder background override injection', () => {
         },
         backgroundTaskEnabled: true,
       });
-      const properties = extractJsonProperties(tool);
+      const properties = extractJsonProperties(builder);
       expect(properties).not.toHaveProperty('_background');
     });
 

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -251,6 +251,8 @@ export class CoreToolBuilder extends MastraBase {
   private originalTool: ToolToConvert;
   private options: ToolOptions;
   private logType?: LogType;
+  /** EXPERIMENT: injected schema kept here instead of written back onto originalTool. */
+  private injectedInputSchema?: StandardSchemaWithJSON;
 
   constructor(input: {
     originalTool: ToolToConvert;
@@ -321,7 +323,7 @@ export class CoreToolBuilder extends MastraBase {
                 .optional(),
             });
           }
-          this.originalTool.inputSchema = toStandardSchema(nextSchema);
+          this.injectedInputSchema = toStandardSchema(nextSchema);
         } else {
           // Normalize to Standard Schema, extract JSON Schema, splice overrides.
           const standardSchema = isStandardSchemaWithJSON(schema) ? schema : toStandardSchema(schema);
@@ -352,11 +354,7 @@ export class CoreToolBuilder extends MastraBase {
             // `.transform()` / `.default()` / `.refine()` etc.) while exposing
             // the spliced JSON Schema for provider serialization. See
             // https://github.com/mastra-ai/mastra/pull/16915#discussion_r3282520408
-            this.originalTool.inputSchema = buildJsonOverrideSchema(
-              schema,
-              { ...jsonSchema, properties },
-              injectedKeys,
-            );
+            this.injectedInputSchema = buildJsonOverrideSchema(schema, { ...jsonSchema, properties }, injectedKeys);
           }
         }
       }
@@ -379,6 +377,10 @@ export class CoreToolBuilder extends MastraBase {
       }
 
       return schema;
+    }
+
+    if (this.injectedInputSchema) {
+      return this.injectedInputSchema;
     }
 
     // For Mastra tools, inputSchema might also be a function
@@ -760,7 +762,7 @@ export class CoreToolBuilder extends MastraBase {
           result = await executeWithContext({
             span: toolSpan,
             fn: async () => {
-              if (inputValidationSchema) {
+              if (inputValidationSchema || this.injectedInputSchema) {
                 markBuilderValidatedInput(toolContext);
               }
               return tool?.execute?.(args, toolContext);

--- a/packages/core/src/tools/tool-builder/cross-agent-background-leak.test.ts
+++ b/packages/core/src/tools/tool-builder/cross-agent-background-leak.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Reproduction for the cross-agent `_background` leak.
+ *
+ * `CoreToolBuilder` writes the schema it injects back onto
+ * `originalTool.inputSchema` — the caller's own tool object, which is typically
+ * a module-level singleton shared by several agents.
+ *
+ * That was harmless while eligibility was a single Mastra-level boolean: every
+ * agent in a process got the same answer, so the write-back was a no-op
+ * difference. Since #22777 eligibility is resolved per agent and per tool
+ * (`isToolBackgroundEligible`), but the object is still shared, so the first
+ * agent to convert the tool decides what every other agent's model sees.
+ *
+ * The second test is the control: reversing the conversion order flips the
+ * result, which rules out "the tool is simply always eligible".
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { RequestContext } from '../../request-context';
+import { isStandardSchemaWithJSON, standardSchemaToJSONSchema } from '../../schema';
+import { createTool } from '../../tools';
+import { CoreToolBuilder } from './builder';
+
+function toolOptions(name: string, agentBackgroundConfig?: unknown) {
+  return {
+    name,
+    logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), trackException: vi.fn() },
+    requestContext: new RequestContext(),
+    agentBackgroundConfig,
+  } as any;
+}
+
+/** The input properties the model actually receives for a built tool. */
+function modelFacingProperties(built: any): Record<string, unknown> {
+  const parameters = built.parameters;
+  if (parameters?.jsonSchema?.properties) return parameters.jsonSchema.properties;
+  if (isStandardSchemaWithJSON(parameters)) {
+    return ((standardSchemaToJSONSchema(parameters as any, { io: 'input' }) as any).properties ?? {}) as Record<
+      string,
+      unknown
+    >;
+  }
+  return {};
+}
+
+/** One module-level tool instance, as tools are normally authored. */
+function sharedSearchTool() {
+  return createTool({
+    id: 'search',
+    description: 'Search the web',
+    inputSchema: z.object({ query: z.string() }),
+    execute: vi.fn(),
+  });
+}
+
+const OPTED_IN = { tools: { search: true } };
+
+describe('cross-agent `_background` leak', () => {
+  it('leaks into an agent that opted nothing in, when the opted-in agent converts first', () => {
+    const searchTool = sharedSearchTool();
+
+    // Agent A whitelists `search` for background execution.
+    const builtForA = new CoreToolBuilder({
+      originalTool: searchTool,
+      options: toolOptions('search', OPTED_IN),
+      backgroundTaskEnabled: true,
+    }).build();
+
+    // Agent B shares the same tool instance and has no background config.
+    const builtForB = new CoreToolBuilder({
+      originalTool: searchTool,
+      options: toolOptions('search', undefined),
+      backgroundTaskEnabled: true,
+    }).build();
+
+    expect(modelFacingProperties(builtForA)).toHaveProperty('_background');
+
+    // B never opted in, so `resolveBackgroundConfig` would discard any
+    // `_background` its model emits. It should not be advertised the field.
+    expect(modelFacingProperties(builtForB)).not.toHaveProperty('_background');
+  });
+
+  it('control: the same two agents in the opposite order leave B clean', () => {
+    const searchTool = sharedSearchTool();
+
+    const builtForB = new CoreToolBuilder({
+      originalTool: searchTool,
+      options: toolOptions('search', undefined),
+      backgroundTaskEnabled: true,
+    }).build();
+
+    new CoreToolBuilder({
+      originalTool: searchTool,
+      options: toolOptions('search', OPTED_IN),
+      backgroundTaskEnabled: true,
+    }).build();
+
+    expect(modelFacingProperties(builtForB)).not.toHaveProperty('_background');
+  });
+});

--- a/packages/core/src/tools/tool-builder/cross-agent-background-leak.test.ts
+++ b/packages/core/src/tools/tool-builder/cross-agent-background-leak.test.ts
@@ -1,5 +1,5 @@
 /**
- * Reproduction for the cross-agent `_background` leak.
+ * Regression coverage for the cross-agent `_background` leak.
  *
  * `CoreToolBuilder` writes the schema it injects back onto
  * `originalTool.inputSchema` — the caller's own tool object, which is typically
@@ -11,8 +11,14 @@
  * (`isToolBackgroundEligible`), but the object is still shared, so the first
  * agent to convert the tool decides what every other agent's model sees.
  *
- * The second test is the control: reversing the conversion order flips the
- * result, which rules out "the tool is simply always eligible".
+ * The second test is the control: before the fix, reversing the conversion order
+ * flipped the result, which ruled out "the tool is simply always eligible".
+ *
+ * The third guards the coupling that makes the naive fix wrong: the write-back
+ * was also how the framework's own injected keys reached the tool body past
+ * `Tool.execute`'s validation, which strips undeclared keys. Nothing covered
+ * that, so removing the write-back could silently break sub-agent and workflow
+ * resume (`suspendedToolRunId` arrives in args and gates `shouldResumeSubAgent`).
  */
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
@@ -96,5 +102,57 @@ describe('cross-agent `_background` leak', () => {
     }).build();
 
     expect(modelFacingProperties(builtForB)).not.toHaveProperty('_background');
+  });
+  it('still delivers framework-injected keys to the tool body (no compat layer)', async () => {
+    const inner = vi.fn().mockResolvedValue({ ok: true });
+
+    // Mirrors a sub-agent tool: the framework's own schema does not declare
+    // `suspendedToolRunId`; the builder injects it because the id is `agent-`
+    // prefixed. `baseOptions` has no model, so no provider compat layer applies
+    // — the path where `Tool.execute` would otherwise run its own validation.
+    const subAgentTool = createTool({
+      id: 'agent-researcher',
+      description: 'Delegate to the researcher agent',
+      inputSchema: z.object({ prompt: z.string() }),
+      execute: inner,
+    });
+
+    const built = new CoreToolBuilder({
+      originalTool: subAgentTool,
+      options: toolOptions('agent-researcher'),
+    }).build();
+
+    await built.execute!(
+      { prompt: 'go', suspendedToolRunId: 'run_abc' } as any,
+      {
+        toolCallId: 'call-1',
+        messages: [],
+      } as any,
+    );
+
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(inner.mock.calls[0]![0]).toMatchObject({ prompt: 'go', suspendedToolRunId: 'run_abc' });
+  });
+
+  it('still rejects invalid input for a tool with injected keys', async () => {
+    const inner = vi.fn();
+
+    const subAgentTool = createTool({
+      id: 'agent-researcher',
+      description: 'Delegate to the researcher agent',
+      inputSchema: z.object({ prompt: z.string() }),
+      execute: inner,
+    });
+
+    const built = new CoreToolBuilder({
+      originalTool: subAgentTool,
+      options: toolOptions('agent-researcher'),
+    }).build();
+
+    // Skipping `Tool.execute`'s validation must not mean skipping validation:
+    // the builder validates against the injected schema instead.
+    await built.execute!({ prompt: 12345 } as any, { toolCallId: 'call-1', messages: [] } as any);
+
+    expect(inner).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description

`CoreToolBuilder` wrote the schema it splices (`_background`, `suspendedToolRunId`, `resumeData`)
back onto `originalTool.inputSchema` (`builder.ts:324`, `builder.ts:355`) — the caller's own tool
object, which is normally a module-level singleton registered on several agents.

That was harmless while background eligibility was a single Mastra-level flag: every agent in a
process got the same answer, so the write-back changed nothing observable. Since #22777 made
eligibility per agent and per tool, the first agent to convert a tool decides what every other
agent's model sees:

```ts
const searchTool = createTool({ id: 'search', /* ... */ });   // one instance

const agentA = new Agent({ tools: { searchTool }, backgroundTasks: { tools: { search: true } } });
const agentB = new Agent({ tools: { searchTool } });          // opted nothing in
```

`agentA` converting first leaves `_background` on the shared schema, and `agentB` — which never
enters the injection block — advertises it anyway. Reverse the order and `agentB` stays clean.
That returns the shared-tool case to what #22777 / #22724 fixed: the model is offered a field
`resolveBackgroundConfig` discards at dispatch.

### The coupling that makes the naive fix wrong

The write-back was also, incidentally, the only reason the framework's own injected keys reached
the tool body. `Tool.execute` re-validates against **its own** `this.inputSchema`
(`tool.ts:432-444`) and strips undeclared keys, and neither bypass covers this:

- `wasBuilderValidated` is only set when a provider compat layer applies (`builder.ts:763`, gated
  on `inputValidationSchema`, which `buildCompatValidationSchema` returns `undefined` from when no
  layer matches — `builder.ts:417-419`).
- `isResuming` reads `resumeData` from the *context*, while `suspendedToolRunId` arrives in *args*
  and is what gates `shouldResumeSubAgent` (`agent.ts:5270`).

So simply moving the schema onto the builder makes sub-agent and workflow resume start a fresh run
instead of resuming. I verified this rather than assuming it — see the table below.

### What changed

- The spliced schema is stored as `injectedInputSchema` on the builder and `getParameters()`
  prefers it. `originalTool` is never mutated.
- The builder marks its arguments as already validated whenever it injected keys, not only when a
  compat layer applied. It does still validate them: `builder.ts:885` uses
  `inputValidationSchema ?? this.getParameters()`, and `getParameters()` now returns the spliced
  schema — so skipping `Tool.execute`'s second validation does not mean skipping validation.

Removing the write-back also stops repeated conversions of a Zod v3 or raw JSON Schema tool from
wrapping an extra override validator around the previous one on every call, since each conversion
now starts from the pristine schema.

## Testing

`packages/core/src/tools/tool-builder/cross-agent-background-leak.test.ts` (new, 4 cases). Each was
checked against the failure mode it is meant to catch:

| Test | stock `main` | builder-local only, no mark change | this PR |
|---|---|---|---|
| leak: opted-in agent converts first | ❌ fails | ✓ | ✓ |
| control: reverse order leaves B clean | ✓ | ✓ | ✓ |
| injected keys reach the tool body, no compat layer | ✓ | ❌ fails | ✓ |
| invalid input is still rejected | ✓ | ✓ | ✓ |

The third row is the one that matters for review: it fails if the schema is moved onto the builder
without also widening the builder-validated marking, which is exactly the silent resume breakage.

`background-override-injection.test.ts` — the assertions that read `tool.inputSchema` after
construction now read the built tool's model-facing `parameters`, since that is the observable
contract rather than the mutation.

613 tests pass across `tools`, `background-tasks`, `loop/shared`, and the sub-agent / workflow
resume suites (`subagent-resume-without-suspension`, `delegated-resume-custom-frames`,
`tool-call-nested-approval`, `persisted-suspension-run-id-durable`). Typecheck and lint clean.

### Re: the open question in the triage note

> whether any caller invokes `Tool.execute` directly (not through the builder) and relies on
> injected keys

I checked, and I do not believe there is one. Both background-task dispatch paths take the
converted `CoreTool`, not the raw tool: `tool-call-step.ts:990-993` resolves `resolvedTool` from
`stepTools`, and the durable path's `tool` is the same object (`tool-call.ts:806` reads
`backgroundConfig` off it, which only `CoreToolBuilder.build()` sets). Both therefore go through
the builder's wrapper and its validation against `getParameters()`. The remaining direct
`tool.execute(...)` callers — `tools/code-mode/code-mode.ts:109` and `workspace/tools/tools.ts` —
do not deal in the injected keys.

## Related issue(s)

Fixes #22843

Follow-up to #22777, which introduced per-tool eligibility and thereby made this reachable.

For the maintainers' awareness: #22853 is a separate draft on the same issue. I wrote this while
investigating #22843 and am flagging the overlap rather than leaving you to find it.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A shared tool no longer changes for every agent when one agent adds special fields. Each agent now sees only the fields it needs, while framework data, resume behavior, and input validation continue to work.

## Changes

- Store injected schema fields on `CoreToolBuilder` instead of mutating the shared tool.
- Expose the injected schema through `getParameters()`.
- Mark injected arguments as builder-validated after validation.
- Prevent repeated schema wrapping during tool conversion.
- Add regression tests for:
  - Cross-agent `_background` schema leakage.
  - Delivery of `suspendedToolRunId` without a compatibility layer.
  - Rejection of invalid input.
- Update existing tests to inspect built tool parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->