### PR TITLE
fix(core): cap UnixSocketPubSub inbound frame size

### DIFF
--- a/.changeset/unix-socket-inbound-frame-limit.md
+++ b/.changeset/unix-socket-inbound-frame-limit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Cap UnixSocketPubSub inbound newline-delimited JSON frames and close connections that exceed the limit so a client cannot grow the broker buffer without bound.

--- a/docs/src/content/en/reference/pubsub/unix-socket-pubsub.mdx
+++ b/docs/src/content/en/reference/pubsub/unix-socket-pubsub.mdx
@@ -50,6 +50,14 @@ export const mastra = new Mastra({
         isOptional: true,
         defaultValue: '67108864',
       },
+      {
+        name: 'maxInboundFrameBytes',
+        type: 'number',
+        description:
+          'Maximum size of a single inbound newline-delimited JSON frame, including an incomplete frame that never sends a newline. Connections that exceed this limit are closed without parsing the oversized payload.',
+        isOptional: true,
+        defaultValue: '67108864',
+      },
     ],
   },
 ]}

--- a/packages/core/src/events/unix-socket-pubsub.test.ts
+++ b/packages/core/src/events/unix-socket-pubsub.test.ts
@@ -333,7 +333,7 @@ describe('UnixSocketPubSub', () => {
   it('closes a client that sends an incomplete inbound frame larger than the configured limit', async () => {
     const path = await socketPath();
     const broker = new UnixSocketPubSub(path, { maxInboundFrameBytes: 64 });
-    const healthy = new UnixSocketPubSub(path, { maxInboundFrameBytes: 64 });
+    const healthy = new UnixSocketPubSub(path);
     pubsubs.push(broker, healthy);
 
     const brokerCb = vi.fn();
@@ -376,7 +376,7 @@ describe('UnixSocketPubSub', () => {
   it('does not parse an oversized complete inbound frame and keeps other clients working', async () => {
     const path = await socketPath();
     const broker = new UnixSocketPubSub(path, { maxInboundFrameBytes: 64 });
-    const healthy = new UnixSocketPubSub(path, { maxInboundFrameBytes: 64 });
+    const healthy = new UnixSocketPubSub(path);
     pubsubs.push(broker, healthy);
 
     const brokerCb = vi.fn();

--- a/packages/core/src/events/unix-socket-pubsub.test.ts
+++ b/packages/core/src/events/unix-socket-pubsub.test.ts
@@ -330,6 +330,148 @@ describe('UnixSocketPubSub', () => {
     }
   });
 
+  it('closes a client that sends an incomplete inbound frame larger than the configured limit', async () => {
+    const path = await socketPath();
+    const broker = new UnixSocketPubSub(path, { maxInboundFrameBytes: 64 });
+    const healthy = new UnixSocketPubSub(path, { maxInboundFrameBytes: 64 });
+    pubsubs.push(broker, healthy);
+
+    const brokerCb = vi.fn();
+    const healthyCb = vi.fn();
+    await broker.subscribe('topic-a', brokerCb);
+    await healthy.subscribe('topic-a', healthyCb);
+
+    const oversized = net.createConnection(path);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        oversized.once('connect', resolve);
+        oversized.once('error', reject);
+      });
+      await waitFor(() => {
+        expect(broker.remoteClientCount).toBe(2);
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        oversized.write('x'.repeat(128), (error?: Error | null) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+
+      await waitFor(() => {
+        expect(broker.remoteClientCount).toBe(1);
+      });
+
+      await broker.publish('topic-a', makeEvent({ type: 'after-oversize' }));
+      await waitFor(() => {
+        expect(brokerCb).toHaveBeenCalledTimes(1);
+        expect(healthyCb).toHaveBeenCalledTimes(1);
+      });
+      expect(brokerCb.mock.calls[0]![0].type).toBe('after-oversize');
+    } finally {
+      oversized.destroy();
+    }
+  });
+
+  it('does not parse an oversized complete inbound frame and keeps other clients working', async () => {
+    const path = await socketPath();
+    const broker = new UnixSocketPubSub(path, { maxInboundFrameBytes: 64 });
+    const healthy = new UnixSocketPubSub(path, { maxInboundFrameBytes: 64 });
+    pubsubs.push(broker, healthy);
+
+    const brokerCb = vi.fn();
+    const healthyCb = vi.fn();
+    await broker.subscribe('topic-a', brokerCb);
+    await healthy.subscribe('topic-a', healthyCb);
+
+    const oversized = net.createConnection(path);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        oversized.once('connect', resolve);
+        oversized.once('error', reject);
+      });
+      await waitFor(() => {
+        expect(broker.remoteClientCount).toBe(2);
+      });
+
+      const hugePublish = `${JSON.stringify({
+        type: 'publish',
+        topic: 'topic-a',
+        event: makeEvent({ type: 'should-not-dispatch', data: { payload: 'x'.repeat(256) } }),
+      })}\n`;
+      expect(Buffer.byteLength(hugePublish.slice(0, -1), 'utf8')).toBeGreaterThan(64);
+
+      await new Promise<void>((resolve, reject) => {
+        oversized.write(hugePublish, (error?: Error | null) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+
+      await waitFor(() => {
+        expect(broker.remoteClientCount).toBe(1);
+      });
+      expect(brokerCb).not.toHaveBeenCalled();
+      expect(healthyCb).not.toHaveBeenCalled();
+
+      await healthy.publish('topic-a', makeEvent({ type: 'still-alive' }));
+      await waitFor(() => {
+        expect(brokerCb).toHaveBeenCalledTimes(1);
+        expect(healthyCb).toHaveBeenCalledTimes(1);
+      });
+      expect(brokerCb.mock.calls[0]![0].type).toBe('still-alive');
+    } finally {
+      oversized.destroy();
+    }
+  });
+
+  it('accepts a valid inbound frame that arrives in fragments under the size limit', async () => {
+    const path = await socketPath();
+    const broker = new UnixSocketPubSub(path, { maxInboundFrameBytes: 1024 });
+    pubsubs.push(broker);
+
+    const brokerCb = vi.fn();
+    await broker.subscribe('topic-a', brokerCb);
+
+    const rawClient = net.createConnection(path);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        rawClient.once('connect', resolve);
+        rawClient.once('error', reject);
+      });
+
+      const frame = `${JSON.stringify({
+        type: 'publish',
+        topic: 'topic-a',
+        event: makeEvent({ type: 'fragmented' }),
+      })}\n`;
+      const midpoint = Math.floor(frame.length / 2);
+      await new Promise<void>((resolve, reject) => {
+        rawClient.write(frame.slice(0, midpoint), (error?: Error | null) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+      expect(brokerCb).not.toHaveBeenCalled();
+      expect(broker.remoteClientCount).toBe(1);
+
+      await new Promise<void>((resolve, reject) => {
+        rawClient.write(frame.slice(midpoint), (error?: Error | null) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+
+      await waitFor(() => {
+        expect(brokerCb).toHaveBeenCalledTimes(1);
+      });
+      expect(brokerCb.mock.calls[0]![0].type).toBe('fragmented');
+      expect(broker.remoteClientCount).toBe(1);
+    } finally {
+      rawClient.destroy();
+    }
+  });
+
   it('isolates local subscriber failures from other subscribers', async () => {
     const path = await socketPath();
     const pubsub = new UnixSocketPubSub(path);

--- a/packages/core/src/events/unix-socket-pubsub.test.ts
+++ b/packages/core/src/events/unix-socket-pubsub.test.ts
@@ -375,7 +375,7 @@ describe('UnixSocketPubSub', () => {
 
   it('does not parse an oversized complete inbound frame and keeps other clients working', async () => {
     const path = await socketPath();
-    const broker = new UnixSocketPubSub(path, { maxInboundFrameBytes: 64 });
+    const broker = new UnixSocketPubSub(path, { maxInboundFrameBytes: 512 });
     const healthy = new UnixSocketPubSub(path);
     pubsubs.push(broker, healthy);
 
@@ -397,9 +397,9 @@ describe('UnixSocketPubSub', () => {
       const hugePublish = `${JSON.stringify({
         type: 'publish',
         topic: 'topic-a',
-        event: makeEvent({ type: 'should-not-dispatch', data: { payload: 'x'.repeat(256) } }),
+        event: makeEvent({ type: 'should-not-dispatch', data: { payload: 'x'.repeat(2048) } }),
       })}\n`;
-      expect(Buffer.byteLength(hugePublish.slice(0, -1), 'utf8')).toBeGreaterThan(64);
+      expect(Buffer.byteLength(hugePublish.slice(0, -1), 'utf8')).toBeGreaterThan(512);
 
       await new Promise<void>((resolve, reject) => {
         oversized.write(hugePublish, (error?: Error | null) => {

--- a/packages/core/src/events/unix-socket-pubsub.ts
+++ b/packages/core/src/events/unix-socket-pubsub.ts
@@ -20,6 +20,7 @@ type ServerFrame = { type: 'event'; topic: string; event: Event } | { type: 'sub
 
 type UnixSocketPubSubOptions = {
   maxRemoteClientQueuedBytes?: number;
+  maxInboundFrameBytes?: number;
 };
 
 type BrokerClient = {
@@ -35,6 +36,7 @@ type SubscribeWaiter = {
 };
 
 const DEFAULT_MAX_REMOTE_CLIENT_QUEUED_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MAX_INBOUND_FRAME_BYTES = 64 * 1024 * 1024;
 
 /**
  * Max number of times a local subscriber callback may be redelivered after a
@@ -124,15 +126,38 @@ function nextTick(): Promise<void> {
   return new Promise(resolve => setImmediate(resolve));
 }
 
-function readFrames(socket: net.Socket, onFrame: (frame: any) => void) {
+function inboundByteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function readFrames(socket: net.Socket, onFrame: (frame: any) => void, maxInboundFrameBytes: number) {
   let buffer = '';
+  let closedForLimit = false;
   socket.setEncoding('utf8');
+
+  const exceedInboundLimit = () => {
+    if (closedForLimit) return;
+    closedForLimit = true;
+    buffer = '';
+    socket.destroy();
+  };
+
   socket.on('data', chunk => {
+    if (closedForLimit) return;
     buffer += chunk;
     while (true) {
       const newlineIndex = buffer.indexOf('\n');
-      if (newlineIndex === -1) break;
+      if (newlineIndex === -1) {
+        if (inboundByteLength(buffer) > maxInboundFrameBytes) {
+          exceedInboundLimit();
+        }
+        break;
+      }
       const line = buffer.slice(0, newlineIndex);
+      if (inboundByteLength(line) > maxInboundFrameBytes) {
+        exceedInboundLimit();
+        break;
+      }
       buffer = buffer.slice(newlineIndex + 1);
       if (!line.trim()) continue;
       try {
@@ -157,11 +182,13 @@ export class UnixSocketPubSub extends PubSub {
   #pendingWrites = new Set<Promise<void>>();
   #recovering?: Promise<void>;
   #maxRemoteClientQueuedBytes: number;
+  #maxInboundFrameBytes: number;
 
   constructor(socketPath: string, options: UnixSocketPubSubOptions = {}) {
     super();
     this.socketPath = socketPath;
     this.#maxRemoteClientQueuedBytes = options.maxRemoteClientQueuedBytes ?? DEFAULT_MAX_REMOTE_CLIENT_QUEUED_BYTES;
+    this.#maxInboundFrameBytes = options.maxInboundFrameBytes ?? DEFAULT_MAX_INBOUND_FRAME_BYTES;
   }
 
   override get supportedModes(): ReadonlyArray<PubSubDeliveryMode> {
@@ -379,7 +406,7 @@ export class UnixSocketPubSub extends PubSub {
         socket.off('error', onError);
         this.#clientSocket = socket;
         this.#isBroker = false;
-        readFrames(socket, frame => this.#handleServerFrame(frame));
+        readFrames(socket, frame => this.#handleServerFrame(frame), this.#maxInboundFrameBytes);
         // NOTE: keep this exact message in sync with the transient-error
         // classifier in #sendToBroker (search for 'broker connection closed').
         socket.on('close', () =>
@@ -540,17 +567,21 @@ export class UnixSocketPubSub extends PubSub {
       queuedBytes: 0,
     };
     this.#brokerClients.set(socket, client);
-    readFrames(socket, frame => {
-      const clientFrame = frame as ClientFrame;
-      if (clientFrame.type === 'subscribe') {
-        client.subscriptions.add(clientFrame.topic);
-        this.#enqueueBrokerClientWrite(client, { type: 'subscribed', topic: clientFrame.topic });
-      } else if (clientFrame.type === 'unsubscribe') {
-        client.subscriptions.delete(clientFrame.topic);
-      } else if (clientFrame.type === 'publish') {
-        void this.#publishFromBroker(clientFrame.topic, clientFrame.event, client, clientFrame.localOnly);
-      }
-    });
+    readFrames(
+      socket,
+      frame => {
+        const clientFrame = frame as ClientFrame;
+        if (clientFrame.type === 'subscribe') {
+          client.subscriptions.add(clientFrame.topic);
+          this.#enqueueBrokerClientWrite(client, { type: 'subscribed', topic: clientFrame.topic });
+        } else if (clientFrame.type === 'unsubscribe') {
+          client.subscriptions.delete(clientFrame.topic);
+        } else if (clientFrame.type === 'publish') {
+          void this.#publishFromBroker(clientFrame.topic, clientFrame.event, client, clientFrame.localOnly);
+        }
+      },
+      this.#maxInboundFrameBytes,
+    );
     socket.on('close', () => this.#removeBrokerClient(client));
     socket.on('error', () => this.#removeBrokerClient(client));
   }


### PR DESCRIPTION
## Description

`UnixSocketPubSub` buffered inbound newline-delimited JSON with no size limit, so a connected client could grow the broker process by sending data without a newline (or one very large frame).

This adds `maxInboundFrameBytes` (default 64 MiB, matching the existing outbound queue cap). When a connection exceeds that limit:

- the oversized payload is not parsed or dispatched
- the socket is closed and the buffer is dropped
- the broker and other clients keep working
- valid frames that arrive in fragments under the limit still decode normally

Fixes #22376

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGESET if necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR stops Unix socket clients from sending unlimited data without a complete message. It closes clients that exceed the limit while keeping the broker and other clients working.

## Changes

- Added `maxInboundFrameBytes` to `UnixSocketPubSub`.
- Set the default limit to 64 MiB.
- Close connections that exceed the limit.
- Prevent parsing and dispatching oversized frames.
- Documented the new option.
- Added a patch changeset for `@mastra/core`.

## Tests

- Verify incomplete oversized frames close the client.
- Verify complete oversized frames are not parsed or dispatched.
- Verify other subscribers remain operational.
- Verify fragmented frames under the limit decode and dispatch correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->