### PR TITLE
fix(template-agent-harness): resolve workspace from project root

### DIFF
--- a/packages/cli/src/commands/create/agent-harness-workspace-path.test.ts
+++ b/packages/cli/src/commands/create/agent-harness-workspace-path.test.ts
@@ -1,0 +1,49 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  getProjectRoot,
+  getWorkspacePath,
+} from '../../../../../templates/template-agent-harness/src/mastra/workspace-path';
+
+const projectRoot = path.resolve('/tmp', 'offline-agent');
+const publicCwd = path.join(projectRoot, 'src', 'mastra', 'public');
+const buildCwd = path.join(projectRoot, '.mastra', 'output');
+
+describe('template-agent-harness workspace path', () => {
+  it('uses MASTRA_PROJECT_ROOT when mastra dev runs from src/mastra/public', () => {
+    const env = { MASTRA_PROJECT_ROOT: projectRoot };
+    expect(getProjectRoot(env, publicCwd)).toBe(path.resolve(projectRoot));
+    expect(getWorkspacePath(env, publicCwd)).toBe(path.join(path.resolve(projectRoot), 'workspace'));
+  });
+
+  it('resolves a relative workspace from the repository root cwd', () => {
+    expect(getProjectRoot({}, projectRoot)).toBe(projectRoot);
+    expect(getWorkspacePath({}, projectRoot)).toBe(path.join(projectRoot, 'workspace'));
+  });
+
+  it('strips src/mastra/public from cwd when MASTRA_PROJECT_ROOT is unset', () => {
+    expect(getProjectRoot({}, publicCwd)).toBe(projectRoot);
+    expect(getWorkspacePath({}, publicCwd)).toBe(path.join(projectRoot, 'workspace'));
+  });
+
+  it('strips .mastra/output from cwd when MASTRA_PROJECT_ROOT is unset', () => {
+    expect(getProjectRoot({}, buildCwd)).toBe(projectRoot);
+    expect(getWorkspacePath({}, buildCwd)).toBe(path.join(projectRoot, 'workspace'));
+  });
+
+  it('honors an absolute WORKSPACE_PATH regardless of cwd', () => {
+    const absolute = path.join(os.tmpdir(), 'custom-mastra-workspace');
+    expect(getWorkspacePath({ WORKSPACE_PATH: absolute, MASTRA_PROJECT_ROOT: projectRoot }, publicCwd)).toBe(
+      path.resolve(absolute),
+    );
+  });
+
+  it('joins a relative WORKSPACE_PATH to the project root, not the public cwd', () => {
+    expect(getWorkspacePath({ WORKSPACE_PATH: 'data/files', MASTRA_PROJECT_ROOT: projectRoot }, publicCwd)).toBe(
+      path.join(path.resolve(projectRoot), 'data', 'files'),
+    );
+  });
+});

--- a/templates/template-agent-harness/README.md
+++ b/templates/template-agent-harness/README.md
@@ -34,7 +34,7 @@ The agent asks for approval before it changes files or runs commands. When it cr
 
 ## Workspace safety
 
-The local filesystem tools stay inside the project-level `workspace/` directory. Shell commands start in that directory, but `LocalSandbox` does not provide operating-system isolation by default. Review command approvals carefully, and do not expose this template through an unauthenticated public server.
+The local filesystem tools stay inside the project-level `workspace/` directory (next to `package.json`, not under `src/mastra/public`). Relative workspace paths are resolved from `MASTRA_PROJECT_ROOT` when `mastra dev` sets it, otherwise from the project root inferred from the process cwd. Set `WORKSPACE_PATH` to override the directory. Shell commands start in that directory, but `LocalSandbox` does not provide operating-system isolation by default. Review command approvals carefully, and do not expose this template through an unauthenticated public server.
 
 ## Storage
 

--- a/templates/template-agent-harness/src/mastra/agents/agent.ts
+++ b/templates/template-agent-harness/src/mastra/agents/agent.ts
@@ -5,8 +5,9 @@ import { askUserTool, webFetchTool, webSearchTool } from '@mastra/core/tools';
 import { LocalFilesystem, LocalSandbox, WORKSPACE_TOOLS, Workspace } from '@mastra/core/workspace';
 import { Memory } from '@mastra/memory';
 import { startScheduleTool, stopScheduleTool } from '../tools/schedule-tools';
+import { getWorkspacePath } from '../workspace-path';
 
-const workspacePath = 'workspace';
+const workspacePath = getWorkspacePath();
 
 const workspace = new Workspace({
   id: 'agent-workspace',

--- a/templates/template-agent-harness/src/mastra/workspace-path.ts
+++ b/templates/template-agent-harness/src/mastra/workspace-path.ts
@@ -1,0 +1,38 @@
+import path from 'node:path';
+
+const DEV_RUNTIME_SEGMENT = `${path.sep}src${path.sep}mastra${path.sep}public`;
+const BUILD_RUNTIME_SEGMENT = `${path.sep}.mastra${path.sep}output`;
+
+/**
+ * Resolve the generated project root even when `mastra dev` / `mastra start`
+ * run with cwd under `src/mastra/public` or `.mastra/output`.
+ */
+export function getProjectRoot(env: NodeJS.ProcessEnv = process.env, cwd: string = process.cwd()): string {
+  const fromEnv = env.MASTRA_PROJECT_ROOT?.trim();
+  if (fromEnv) {
+    return path.resolve(fromEnv);
+  }
+
+  const devIndex = cwd.indexOf(DEV_RUNTIME_SEGMENT);
+  if (devIndex !== -1) {
+    return cwd.slice(0, devIndex);
+  }
+
+  const buildIndex = cwd.indexOf(BUILD_RUNTIME_SEGMENT);
+  if (buildIndex !== -1) {
+    return cwd.slice(0, buildIndex);
+  }
+
+  return cwd;
+}
+
+/**
+ * Absolute path to the project-level `workspace/` directory (or `WORKSPACE_PATH`).
+ */
+export function getWorkspacePath(env: NodeJS.ProcessEnv = process.env, cwd: string = process.cwd()): string {
+  const configured = env.WORKSPACE_PATH?.trim() || 'workspace';
+  if (path.isAbsolute(configured)) {
+    return path.resolve(configured);
+  }
+  return path.resolve(getProjectRoot(env, cwd), configured);
+}


### PR DESCRIPTION
## Description

The agent-harness starter README describes a project-level `workspace/` directory, but the generated agent passed the relative string `'workspace'` to `LocalFilesystem` and `LocalSandbox`.

`mastra dev` starts the runtime with `cwd` under `src/mastra/public`, so file tools and shell commands resolved to `<project>/src/mastra/public/workspace` instead of `<project>/workspace`.

This resolves an absolute workspace path from `MASTRA_PROJECT_ROOT` (set by the CLI), with fallbacks that strip `src/mastra/public` and `.mastra/output` from cwd when the env var is missing. `WORKSPACE_PATH` can override the directory. Filesystem, sandbox, and the instruction file URL all use that same absolute path.

## Related issue(s)

Fixes #22740

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
