### PR TITLE
test(mastracode): read the /skills header from scrollback, not the visible screen

### DIFF
--- a/mastracode/tui/e2e/tui/workspace-commands.ts
+++ b/mastracode/tui/e2e/tui/workspace-commands.ts
@@ -15,6 +15,7 @@ export const workspaceCommandsScenario: McE2eScenario = {
     runtime.printScreen('after startup', terminal);
 
     terminal.submit('/skills');
+    await runtime.waitForOutputText(/No (skills configured|user-invokable skills found)|Skills \(/i, terminal);
     await runtime.waitForScreenText(/SKILL\.md|Skills are automatically activated|Install skills/i, terminal);
     runtime.printScreen('after /skills', terminal);
 

--- a/mastracode/tui/e2e/tui/workspace-commands.ts
+++ b/mastracode/tui/e2e/tui/workspace-commands.ts
@@ -15,7 +15,6 @@ export const workspaceCommandsScenario: McE2eScenario = {
     runtime.printScreen('after startup', terminal);
 
     terminal.submit('/skills');
-    await runtime.waitForScreenText(/No (skills configured|user-invokable skills found)|Skills \(/i, terminal);
     await runtime.waitForScreenText(/SKILL\.md|Skills are automatically activated|Install skills/i, terminal);
     runtime.printScreen('after /skills', terminal);
 


### PR DESCRIPTION
**─────── TLDR ───────**
> The `/skills` e2e reads the `Skills (N):` header from the terminal history instead of the visible screen, which it scrolls off now that the repo lists 28 skills.

Mastra Code E2E is red on every branch since #22849 landed: `shows skills and hooks command feedback in the real TUI` times out on `Skills \(`. The basic fixture has no `.git`, so the project root resolves to the mastra repo itself and `/skills` lists everything under `.mastracode/skills`, `.claude/skills` and `.agents/skills`. #22849 gave the `.agents` copy of `testing-core-processors` its frontmatter, the list went from 27 to 28 entries, and on a 36-row screen the header is now the one line above the top.

The TUI renders in the main buffer without clearing scrollback, so a user scrolls up and sees the header. The harness has `waitForOutputText` for exactly that, reading the full xterm buffer, and six other scenarios already use it. The footer wait that follows still checks the visible screen.

the `/skills` step of `workspace-commands`, 28 or more skills in scope
&nbsp;&nbsp;├─ **was** — times out waiting for a header one row above the screen
&nbsp;&nbsp;└─ **now** — finds the header in the history, then the footer on screen

### Decisions

- **fixture left non-hermetic** — a `git init` or a tmpdir root changes what all 178 scenarios see; that is its own change if you want it

---

> ██████████████████ **tests** `+1 −1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The `/skills` test now checks the full terminal history for the skill count. This prevents the test from missing the header when many skills push it off the visible screen.

## Changes

- Updated `mastracode/tui/e2e/tui/workspace-commands.ts` to use `waitForOutputText` for the `Skills (N):` header assertion.
- Kept the footer assertion on the visible screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->