### PR TITLE
docs: add computer sandbox page

### DIFF
--- a/docs/src/content/en/docs/sandbox/computer.mdx
+++ b/docs/src/content/en/docs/sandbox/computer.mdx
@@ -1,0 +1,58 @@
+---
+title: 'Computer'
+description: 'Give Mastra agents screenshot, mouse, and keyboard control in supported desktop sandboxes.'
+packages:
+  - '@mastra/core'
+---
+
+# Computer
+
+Sandboxes that run a desktop environment can expose screenshot, mouse, and keyboard control. The workspace registers computer tools when a statically configured sandbox supports the computer capability.
+
+[`DaytonaSandbox`](/integrations/sandboxes/daytona) and [`E2BDesktopSandbox`](/integrations/sandboxes/e2b-desktop) support this capability. Other sandbox backends don't register the computer tools. Resolver-backed sandboxes don't register them because the workspace can't inspect the resolved sandbox's capabilities when it creates the tool list.
+
+## Computer tools
+
+| Tool | Does |
+| - | - |
+| `computer_screenshot` | Captures the desktop as a PNG image and returns it to the model as native media. |
+| `computer_click` | Presses and releases the left mouse button at pixel coordinates. |
+| `computer_double_click` | Presses the left mouse button twice at pixel coordinates. |
+| `computer_right_click` | Presses and releases the right mouse button at pixel coordinates. |
+| `computer_move_mouse` | Moves the cursor to pixel coordinates without pressing a button. |
+| `computer_drag` | Presses, drags, and releases between two points. |
+| `computer_type` | Types text into the focused element. |
+| `computer_press_key` | Presses a key or key combination, such as `Enter` or `ctrl+s`. |
+| `computer_scroll` | Scrolls up or down. |
+| `computer_get_screen_info` | Gets the screen dimensions and cursor position. |
+| `computer_wait` | Waits for the interface to settle. |
+
+## Configure computer tools
+
+Action tools take a screenshot after each action by default. Configure the screenshot behavior for each tool:
+
+```typescript title="src/mastra/workspaces.ts"
+import { Workspace, WORKSPACE_TOOLS } from '@mastra/core/workspace'
+import { E2BDesktopSandbox } from '@mastra/e2b-desktop'
+
+const workspace = new Workspace({
+  sandbox: new E2BDesktopSandbox(),
+  tools: {
+    [WORKSPACE_TOOLS.COMPUTER.CLICK]: {
+      screenshotAfterAction: true,
+      screenshotDelayMs: 1000,
+    },
+    [WORKSPACE_TOOLS.COMPUTER.TYPE]: {
+      requireApproval: true,
+    },
+  },
+})
+```
+
+Computer tools accept the same per-tool `enabled` and `requireApproval` configuration as other workspace tools.
+
+## Related
+
+- [Sandboxes](/docs/sandbox/overview)
+- [Computer capability reference](/reference/workspace/sandbox#computer-capability)
+- [Workspace tool configuration](/reference/workspace/workspace-class#tool-configuration)

--- a/docs/src/content/en/docs/sandbox/overview.mdx
+++ b/docs/src/content/en/docs/sandbox/overview.mdx
@@ -88,48 +88,6 @@ Set `{ enabled: false }` on one tool to remove it, or set the top-level `enabled
 
 See the [sandbox tools reference](/reference/workspace/workspace-class#sandbox-tools) for all generated tools and the [tool configuration reference](/reference/workspace/workspace-class#tool-configuration) for approvals, output limits, and hooks.
 
-### Computer-use tools
-
-Sandboxes that run a desktop environment can expose screenshot, mouse, and keyboard control. The workspace registers these tools when a statically configured sandbox supports the computer capability:
-
-| Tool | Does |
-| - | - |
-| `computer_screenshot` | Captures the desktop as a PNG image and returns it to the model as native media. |
-| `computer_click` | Presses and releases the left mouse button at pixel coordinates. |
-| `computer_double_click` | Presses the left mouse button twice at pixel coordinates. |
-| `computer_right_click` | Presses and releases the right mouse button at pixel coordinates. |
-| `computer_move_mouse` | Moves the cursor to pixel coordinates without pressing a button. |
-| `computer_drag` | Presses, drags, and releases between two points. |
-| `computer_type` | Types text into the focused element. |
-| `computer_press_key` | Presses a key or key combination, such as `Enter` or `ctrl+s`. |
-| `computer_scroll` | Scrolls up or down. |
-| `computer_get_screen_info` | Gets the screen dimensions and cursor position. |
-| `computer_wait` | Waits for the interface to settle. |
-
-[`DaytonaSandbox`](/integrations/sandboxes/daytona) and [`E2BDesktopSandbox`](/integrations/sandboxes/e2b-desktop) support this capability. Other sandbox backends don't register the computer tools. Resolver-backed sandboxes don't register them because the workspace can't inspect the resolved sandbox's capabilities when it creates the tool list.
-
-Action tools take a screenshot after each action by default. Configure the screenshot behavior for each tool:
-
-```typescript title="src/mastra/workspaces.ts"
-import { Workspace, WORKSPACE_TOOLS } from '@mastra/core/workspace'
-import { E2BDesktopSandbox } from '@mastra/e2b-desktop'
-
-const workspace = new Workspace({
-  sandbox: new E2BDesktopSandbox(),
-  tools: {
-    [WORKSPACE_TOOLS.COMPUTER.CLICK]: {
-      screenshotAfterAction: true,
-      screenshotDelayMs: 1000,
-    },
-    [WORKSPACE_TOOLS.COMPUTER.TYPE]: {
-      requireApproval: true,
-    },
-  },
-})
-```
-
-Computer tools accept the same per-tool `enabled` and `requireApproval` configuration as other workspace tools.
-
 {/* vale ai-tells.VerbTricolon = NO */}
 
 Authored runtime functions, including tools and workflow steps, can get the live sandbox from their execution context. Use it to execute commands, install dependencies, process files, or spawn a long-running process.
@@ -201,6 +159,10 @@ Every sandbox has a filesystem for commands. `LocalSandbox` uses the host filesy
 Mastra filesystems connect agents and sandboxes to provider-backed storage such as Amazon S3, Google Cloud Storage, or Google Drive. Configuring one gives the agent tools to read, write, and search files. When a remote sandbox and provider support mounting, Mastra automatically mounts the storage through Filesystem in Userspace (FUSE). Commands use normal file paths while the provider stores changes outside the sandbox.
 
 See [Filesystem](/docs/sandbox/filesystem) for providers, file tools, and mounts.
+
+## Computer use
+
+Supported desktop sandboxes give agents screenshot, mouse, and keyboard control. See [Computer](/docs/sandbox/computer) for supported sandboxes and configuration.
 
 ## Sandboxes per user or thread
 

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -288,6 +288,11 @@ const sidebars = {
             },
             {
               type: 'doc',
+              id: 'sandbox/computer',
+              label: 'Computer',
+            },
+            {
+              type: 'doc',
               id: 'sandbox/lsp',
               label: 'LSP',
             },

--- a/docs/src/content/en/integrations/sandboxes/daytona.mdx
+++ b/docs/src/content/en/integrations/sandboxes/daytona.mdx
@@ -290,7 +290,7 @@ Inside the sandbox, the environment variable holds an opaque placeholder. Dayton
 
 ### Computer use (desktop)
 
-Enable the [computer capability](/docs/sandbox/overview#computer-use-tools) with `computerUse`. This adds screenshot, mouse, and keyboard control to the sandbox. When the sandbox is used in a workspace, agents automatically get the `mastra_workspace_computer_*` tools.
+Enable the [computer capability](/docs/sandbox/computer) with `computerUse`. This adds screenshot, mouse, and keyboard control to the sandbox. When the sandbox is used in a workspace, agents automatically get the `mastra_workspace_computer_*` tools.
 
 Computer use is disabled by default. Set `computerUse: true` to start the desktop processes (Xvfb, xfce4, x11vnc, noVNC) lazily on the first computer operation:
 

--- a/docs/src/content/en/integrations/sandboxes/e2b-desktop.mdx
+++ b/docs/src/content/en/integrations/sandboxes/e2b-desktop.mdx
@@ -19,7 +19,7 @@ Set your E2B API key with the `E2B_API_KEY` environment variable or the `apiKey`
 
 ## Usage
 
-Add an `E2BDesktopSandbox` to a workspace and assign it to an agent. Because the sandbox supports the [computer capability](/docs/sandbox/overview#computer-use-tools), the workspace registers the `mastra_workspace_computer_*` tools alongside the shell and process tools:
+Add an `E2BDesktopSandbox` to a workspace and assign it to an agent. Because the sandbox supports the [computer capability](/docs/sandbox/computer), the workspace registers the `mastra_workspace_computer_*` tools alongside the shell and process tools:
 
 ```typescript
 import { Agent } from '@mastra/core/agent'
@@ -139,7 +139,7 @@ The default `desktop` template has no FUSE tooling, so [cloud storage mounting](
 
 ## Related
 
-- [Computer-use tools](/docs/sandbox/overview#computer-use-tools)
+- [Computer-use tools](/docs/sandbox/computer#computer-tools)
 - [`E2BSandbox` reference](/integrations/sandboxes/e2b)
 - [`WorkspaceSandbox` interface](/reference/workspace/sandbox)
 - [Sandbox](/docs/sandbox/overview)

--- a/docs/src/content/en/reference/workspace/sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/sandbox.mdx
@@ -307,7 +307,7 @@ const instructions = sandbox.getInstructions?.()
 
 ## Computer capability
 
-Sandboxes with a controllable desktop environment implement the optional `SandboxComputer` interface on the `computer` property. When present on a statically configured sandbox, the workspace tools factory registers the `mastra_workspace_computer_*` tools automatically. See [Computer-use tools](/docs/sandbox/overview#computer-use-tools).
+Sandboxes with a controllable desktop environment implement the optional `SandboxComputer` interface on the `computer` property. When present on a statically configured sandbox, the workspace tools factory registers the `mastra_workspace_computer_*` tools automatically. See [Computer-use tools](/docs/sandbox/computer#computer-tools).
 
 Coordinates are pixels from the top-left corner of the display. Providers normalize their SDK semantics (key names, scroll units) onto this surface and expose richer native APIs through their own accessors.
 


### PR DESCRIPTION
## Summary

- move computer-use guidance from the Sandboxes overview to a dedicated Computer page
- add Computer above LSP in the Sandboxes sidebar
- update integration and reference links to the new canonical route

## Testing

- `pnpm validate`
- `pnpm lint:remark -- src/content/en/docs/sandbox/computer.mdx src/content/en/docs/sandbox/overview.mdx src/content/en/reference/workspace/sandbox.mdx src/content/en/integrations/sandboxes/e2b-desktop.mdx src/content/en/integrations/sandboxes/daytona.mdx`
- `pnpm build`
- focused MDX formatting and Vale checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR gives computer-use guidance its own documentation page. It also updates navigation and links so users can find the guidance easily.

## Changes

- Added `sandbox/computer.mdx` with:
  - Supported computer-control backends.
  - Screenshot, mouse, keyboard, scrolling, and screen-information tools.
  - Per-tool screenshot settings.
  - Approval configuration.
  - Related references.
- Replaced the detailed Computer-use section in the Sandboxes overview with a link to the new page.
- Added the Computer page to the Sandboxes sidebar above LSP.
- Updated Daytona, E2B Desktop, and workspace sandbox references to use the new canonical route.
- Validation included `pnpm validate`, targeted Remark linting, `pnpm build`, MDX formatting checks, and Vale checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->