### PR TITLE
docs: move datasets and experiments under evals

### DIFF
--- a/docs/src/content/en/docs/evals/datasets.mdx
+++ b/docs/src/content/en/docs/evals/datasets.mdx
@@ -5,9 +5,6 @@ packages:
   - "@mastra/core"
 ---
 
-import Steps from "@site/src/components/Steps";
-import StepItem from "@site/src/components/StepItem";
-
 # Datasets
 
 **Added in:** `@mastra/core@1.4.0`
@@ -59,7 +56,7 @@ Visit the [`DatasetsManager` reference](/reference/datasets/datasets-manager) fo
 
 You can also manage datasets in [Studio](/docs/studio/overview). After opening Studio, select **Datasets** from the sidebar to see all your available datasets or create a new one.
 
-To get started, select **Create Dataset** and set a name, description, and optional schemas. After confirming, you'll see the dataset details page with two tabs: **Items** and [**Experiments**](/docs/datasets/running-experiments#studio).
+To get started, select **Create Dataset** and set a name, description, and optional schemas. After confirming, you'll see the dataset details page with two tabs: **Items** and [**Experiments**](/docs/evals/experiments#run-experiments-in-studio).
 
 In the **Items** view you can add, update, and delete items, and view version history. Select **Add Item** to insert a new item with JSON editors for input and ground truth. From this view you can also import items in bulk from a CSV or JSON file. When importing, map each column to the corresponding dataset field.
 
@@ -208,11 +205,11 @@ Fetch the exact items that existed at a past version:
 const items = await dataset.listItems({ version: 2 })
 ```
 
-You can also pin experiments to a version, see [running experiments](/docs/datasets/running-experiments). Visit the [`Dataset` reference](/reference/datasets/dataset) for the full list of methods and parameters.
+You can also pin experiments to a version, see [running experiments](/docs/evals/experiments). Visit the [`Dataset` reference](/reference/datasets/dataset) for the full list of methods and parameters.
 
 ## Related
 
-- [Running experiments](/docs/datasets/running-experiments)
+- [Experiments](/docs/evals/experiments)
 - [Scorers overview](/docs/evals/overview)
 - [DatasetsManager reference](/reference/datasets/datasets-manager)
 - [Dataset reference](/reference/datasets/dataset)

--- a/docs/src/content/en/docs/evals/evals-with-memory.mdx
+++ b/docs/src/content/en/docs/evals/evals-with-memory.mdx
@@ -149,6 +149,6 @@ The inline `task` receives the item's `metadata`, so each row can drive its own 
 ## Related
 
 - [Running scorers in CI](/docs/evals/running-in-ci)
-- [Running experiments](/docs/datasets/running-experiments)
+- [Running experiments](/docs/evals/experiments)
 - [Observational memory](/docs/memory/observational-memory)
 - [runEvals API reference](/reference/evals/run-evals)

--- a/docs/src/content/en/docs/evals/experiments.mdx
+++ b/docs/src/content/en/docs/evals/experiments.mdx
@@ -1,14 +1,14 @@
 ---
-title: 'Running experiments | Datasets'
+title: "Experiments"
 description: "Run Mastra dataset experiments against registered agents or workflows, apply scorers, compare results, and inspect experiment output in Studio."
 packages:
-  - '@mastra/core'
+  - "@mastra/core"
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Running experiments
+# Experiments
 
 **Added in:** `@mastra/core@1.4.0`
 
@@ -41,7 +41,7 @@ console.log(summary.failedCount) // number of items that failed
 
 `startExperiment()` blocks until all items finish. For fire-and-forget execution, see [async experiments](#async-experiments).
 
-## Studio
+## Run experiments in Studio
 
 You can also run experiments in [Studio](/docs/studio/overview). After you've added a dataset item, open it and select **Run Experiment** and configure the target, scorers, and options.
 
@@ -645,7 +645,7 @@ Visit the [`startExperiment` reference](/reference/datasets/startExperiment) for
 
 ## Related
 
-- [Datasets overview](/docs/datasets/overview)
+- [Datasets](/docs/evals/datasets)
 - [Scorers overview](/docs/evals/overview)
 - [`startExperiment` reference](/reference/datasets/startExperiment)
 - [`listExperimentResults` reference](/reference/datasets/listExperimentResults)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -621,22 +621,14 @@ const sidebars = {
               id: 'evals/evals-with-memory',
               label: 'Evals with Memory',
             },
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Datasets',
-          link: {
-            type: 'doc',
-            id: 'datasets/overview',
-          },
-          customProps: {
-            contextualSidebar: true,
-          },
-          items: [
             {
               type: 'doc',
-              id: 'datasets/running-experiments',
+              id: 'evals/datasets',
+              label: 'Datasets',
+            },
+            {
+              type: 'doc',
+              id: 'evals/experiments',
               label: 'Experiments',
             },
           ],

--- a/docs/src/content/en/docs/studio/editor.mdx
+++ b/docs/src/content/en/docs/studio/editor.mdx
@@ -306,7 +306,7 @@ See the [Editor versioning reference](/reference/editor/versioning) for version 
 
 ## Programmatic access
 
-Everything available in Studio is also available programmatically through [`mastra.getEditor()`](/reference/core/getEditor), the REST API, or the Client SDK. Use it to script bulk updates or seed stored configurations from code. It can also power automation that tunes agents based on [evaluation results](/docs/datasets/running-experiments).
+Everything available in Studio is also available programmatically through [`mastra.getEditor()`](/reference/core/getEditor), the REST API, or the Client SDK. Use it to script bulk updates or seed stored configurations from code. It can also power automation that tunes agents based on [evaluation results](/docs/evals/experiments).
 
 Call `mastra.getEditor()` when application code has access to the Mastra instance:
 

--- a/docs/src/content/en/docs/studio/overview.mdx
+++ b/docs/src/content/en/docs/studio/overview.mdx
@@ -94,13 +94,13 @@ The Scorers tab displays the results of your agent's scorers as they run. When m
 
 Create and manage collections of test cases to evaluate your agents and workflows. Import items from CSV or JSON and define input and ground-truth schemas, plus pin to specific versions so you can reproduce experiments exactly. Run experiments with [scorers](/docs/evals/overview) to compare quality across prompts, models, or code changes.
 
-See [datasets overview](/docs/datasets/overview) for the full API and versioning details.
+See [datasets overview](/docs/evals/datasets) for the full API and versioning details.
 
 ### Experiments
 
 Run all items in a dataset against an agent, workflow, or scorer and collect the results in one place. Select a target, optionally attach scorers, and trigger the experiment. The results view shows each item's input, output, status, and individual score breakdowns. Compare two experiments side by side to measure the impact of prompt, model, or code changes.
 
-See [datasets overview](/docs/datasets/overview) for setup details.
+See [datasets overview](/docs/evals/datasets) for setup details.
 
 ## Observability
 

--- a/docs/src/content/en/reference/client-js/datasets.mdx
+++ b/docs/src/content/en/reference/client-js/datasets.mdx
@@ -279,7 +279,7 @@ Returns `Promise<DatasetExperiment>`, the updated experiment record.
 
 ## Related
 
-- [Running experiments](/docs/datasets/running-experiments#caller-driven-experiments)
+- [Running experiments](/docs/evals/experiments#caller-driven-experiments)
 - [dataset.createExperiment()](/reference/datasets/createExperiment)
 - [dataset.runExperimentItem()](/reference/datasets/runExperimentItem)
 - [dataset.submitExperimentResult()](/reference/datasets/submitExperimentResult)

--- a/docs/src/content/en/reference/datasets/createExperiment.mdx
+++ b/docs/src/content/en/reference/datasets/createExperiment.mdx
@@ -152,4 +152,4 @@ Passing your own `id` makes creation idempotent, so another call with the same `
 - [dataset.runExperimentItem()](/reference/datasets/runExperimentItem)
 - [dataset.submitExperimentResult()](/reference/datasets/submitExperimentResult)
 - [dataset.finalizeExperiment()](/reference/datasets/finalizeExperiment)
-- [Running experiments](/docs/datasets/running-experiments#caller-driven-experiments)
+- [Running experiments](/docs/evals/experiments#caller-driven-experiments)

--- a/docs/src/content/en/reference/datasets/finalizeExperiment.mdx
+++ b/docs/src/content/en/reference/datasets/finalizeExperiment.mdx
@@ -53,4 +53,4 @@ Returns a `Promise<Experiment>`, the updated experiment record with final status
 - [dataset.createExperiment()](/reference/datasets/createExperiment)
 - [dataset.runExperimentItem()](/reference/datasets/runExperimentItem)
 - [dataset.submitExperimentResult()](/reference/datasets/submitExperimentResult)
-- [Running experiments](/docs/datasets/running-experiments#caller-driven-experiments)
+- [Running experiments](/docs/evals/experiments#caller-driven-experiments)

--- a/docs/src/content/en/reference/datasets/runExperimentItem.mdx
+++ b/docs/src/content/en/reference/datasets/runExperimentItem.mdx
@@ -98,4 +98,4 @@ Each call executes the item exactly once, with no internal retry loop. Calling i
 
 - [dataset.createExperiment()](/reference/datasets/createExperiment)
 - [dataset.finalizeExperiment()](/reference/datasets/finalizeExperiment)
-- [Running experiments](/docs/datasets/running-experiments#caller-driven-experiments)
+- [Running experiments](/docs/evals/experiments#caller-driven-experiments)

--- a/docs/src/content/en/reference/datasets/submitExperimentResult.mdx
+++ b/docs/src/content/en/reference/datasets/submitExperimentResult.mdx
@@ -107,4 +107,4 @@ Returns a `Promise<ExperimentResult>`, the persisted result row, including its `
 
 - [dataset.createExperiment()](/reference/datasets/createExperiment)
 - [dataset.finalizeExperiment()](/reference/datasets/finalizeExperiment)
-- [Running experiments](/docs/datasets/running-experiments#caller-driven-experiments)
+- [Running experiments](/docs/evals/experiments#caller-driven-experiments)

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -857,12 +857,12 @@
     },
     {
       "source": "/docs/observability/datasets/overview",
-      "destination": "/docs/datasets/overview",
+      "destination": "/docs/evals/datasets",
       "permanent": true
     },
     {
       "source": "/docs/observability/datasets/running-experiments",
-      "destination": "/docs/datasets/running-experiments",
+      "destination": "/docs/evals/experiments",
       "permanent": true
     },
     {
@@ -1218,11 +1218,6 @@
     {
       "source": "/docs/voice/:path*",
       "destination": "/reference/voice/:path*",
-      "permanent": true
-    },
-    {
-      "source": "/docs/evals/datasets/:path*",
-      "destination": "/docs/datasets/:path*",
       "permanent": true
     },
     {
@@ -2211,6 +2206,26 @@
       "permanent": true
     },
     {
+      "source": "/docs/datasets/running-experiments",
+      "destination": "/docs/evals/experiments",
+      "permanent": true
+    },
+    {
+      "source": "/docs/datasets/:path*",
+      "destination": "/docs/evals/datasets",
+      "permanent": true
+    },
+    {
+      "source": "/docs/evals/datasets/overview",
+      "destination": "/docs/evals/datasets",
+      "permanent": true
+    },
+    {
+      "source": "/docs/evals/datasets/running-experiments",
+      "destination": "/docs/evals/experiments",
+      "permanent": true
+    },
+    {
       "source": "/docs/workspace/overview/llms.txt",
       "destination": "/docs/sandbox/overview/llms.txt",
       "permanent": true
@@ -2797,12 +2812,12 @@
     },
     {
       "source": "/docs/observability/datasets/overview/llms.txt",
-      "destination": "/docs/datasets/overview/llms.txt",
+      "destination": "/docs/evals/datasets/llms.txt",
       "permanent": true
     },
     {
       "source": "/docs/observability/datasets/running-experiments/llms.txt",
-      "destination": "/docs/datasets/running-experiments/llms.txt",
+      "destination": "/docs/evals/experiments/llms.txt",
       "permanent": true
     },
     {
@@ -3073,11 +3088,6 @@
     {
       "source": "/docs/voice/:path*/llms.txt",
       "destination": "/reference/voice/:path*/llms.txt",
-      "permanent": true
-    },
-    {
-      "source": "/docs/evals/datasets/:path*/llms.txt",
-      "destination": "/docs/datasets/:path*/llms.txt",
       "permanent": true
     },
     {
@@ -4013,6 +4023,26 @@
     {
       "source": "/docs/observability/metrics/querying/llms.txt",
       "destination": "/reference/observability/metrics/queries/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/datasets/running-experiments/llms.txt",
+      "destination": "/docs/evals/experiments/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/datasets/:path*/llms.txt",
+      "destination": "/docs/evals/datasets/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/evals/datasets/overview/llms.txt",
+      "destination": "/docs/evals/datasets/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/evals/datasets/running-experiments/llms.txt",
+      "destination": "/docs/evals/experiments/llms.txt",
       "permanent": true
     }
   ]

--- a/docs/vercel.redirects.json
+++ b/docs/vercel.redirects.json
@@ -842,12 +842,12 @@
     },
     {
       "source": "/docs/observability/datasets/overview",
-      "destination": "/docs/datasets/overview",
+      "destination": "/docs/evals/datasets",
       "permanent": true
     },
     {
       "source": "/docs/observability/datasets/running-experiments",
-      "destination": "/docs/datasets/running-experiments",
+      "destination": "/docs/evals/experiments",
       "permanent": true
     },
     {
@@ -1203,11 +1203,6 @@
     {
       "source": "/docs/voice/:path*",
       "destination": "/reference/voice/:path*",
-      "permanent": true
-    },
-    {
-      "source": "/docs/evals/datasets/:path*",
-      "destination": "/docs/datasets/:path*",
       "permanent": true
     },
     {
@@ -2193,6 +2188,26 @@
     {
       "source": "/docs/observability/metrics/querying",
       "destination": "/reference/observability/metrics/queries",
+      "permanent": true
+    },
+    {
+      "source": "/docs/datasets/running-experiments",
+      "destination": "/docs/evals/experiments",
+      "permanent": true
+    },
+    {
+      "source": "/docs/datasets/:path*",
+      "destination": "/docs/evals/datasets",
+      "permanent": true
+    },
+    {
+      "source": "/docs/evals/datasets/overview",
+      "destination": "/docs/evals/datasets",
+      "permanent": true
+    },
+    {
+      "source": "/docs/evals/datasets/running-experiments",
+      "destination": "/docs/evals/experiments",
       "permanent": true
     }
   ]

--- a/packages/playground/src/domains/datasets/components/datasets-list/no-datasets-info.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/no-datasets-info.tsx
@@ -28,7 +28,7 @@ export const NoDatasetsInfo = ({ onCreateClick }: NoDatasetsInfoProps = {}) => (
           <Button
             variant="ghost"
             as="a"
-            href="https://mastra.ai/en/docs/datasets/overview"
+            href="https://mastra.ai/docs/evals/datasets"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/packages/playground/src/domains/datasets/components/empty-datasets-table.tsx
+++ b/packages/playground/src/domains/datasets/components/empty-datasets-table.tsx
@@ -28,7 +28,7 @@ export function EmptyDatasetsTable({ onCreateClick }: EmptyDatasetsTableProps) {
               size="lg"
               variant="outline"
               as="a"
-              href="https://mastra.ai/docs/datasets/overview"
+              href="https://mastra.ai/docs/evals/datasets"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/packages/playground/src/domains/experiments/components/no-experiments-info.tsx
+++ b/packages/playground/src/domains/experiments/components/no-experiments-info.tsx
@@ -24,7 +24,7 @@ export const NoExperimentsInfo = ({ onRunExperiment }: { onRunExperiment?: () =>
           <Button
             variant="ghost"
             as="a"
-            href="https://mastra.ai/en/docs/datasets/running-experiments"
+            href="https://mastra.ai/docs/evals/experiments"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/packages/playground/src/lib/nav/nav-items.tsx
+++ b/packages/playground/src/lib/nav/nav-items.tsx
@@ -144,7 +144,7 @@ export const mainNav: NavSection[] = [
         name: 'Datasets',
         url: '/datasets',
         Icon: DatasetsIcon,
-        docs: { href: 'https://mastra.ai/en/docs/datasets/overview', label: 'Datasets documentation' },
+        docs: { href: 'https://mastra.ai/docs/evals/datasets', label: 'Datasets documentation' },
         isOnMastraPlatform: true,
       },
       {
@@ -152,7 +152,7 @@ export const mainNav: NavSection[] = [
         url: '/experiments',
         Icon: ExperimentsIcon,
         docs: {
-          href: 'https://mastra.ai/en/docs/datasets/running-experiments',
+          href: 'https://mastra.ai/docs/evals/experiments',
           label: 'Experiments documentation',
         },
         isOnMastraPlatform: true,


### PR DESCRIPTION
## Summary

- move Datasets and Experiments into top-level Evals routes
- update sidebar navigation and internal Studio/Playground links
- redirect historical Dataset and Experiment URLs to their new canonical pages

## Testing

- `pnpm validate`
- `pnpm format:check`
- `pnpm vitest run scripts/__tests__/generate-vercel-redirects.test.ts scripts/__tests__/move-doc.test.ts`
- `node .github/scripts/validate-redirects.js`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Datasets and Experiments now have clearer, top-level Evals pages. Old links redirect to the new pages, so existing users can still find the documentation.

## Changes

- Moved Datasets and Experiments to `/docs/evals/datasets` and `/docs/evals/experiments`.
- Updated sidebar navigation and internal Studio, Playground, and reference links.
- Updated related-documentation links and page headings.
- Added and updated redirects for legacy dataset and experiment URLs, including `/llms.txt` routes.
- Removed obsolete dataset route redirects.
- Removed unused imports from the Datasets documentation.

## Validation

- Formatting checks.
- Redirect tests and redirect validation.
- Full documentation build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->