### PR TITLE
fix(loggers): serialize Errors logged under the `error` key

### DIFF
--- a/.changeset/pino-error-key-serialization.md
+++ b/.changeset/pino-error-key-serialization.md
@@ -1,0 +1,17 @@
+---
+'@mastra/loggers': patch
+---
+
+Fixed Errors logged under the `error` key being recorded as an empty object.
+
+Pino only applies its error serializer to the `err` key, and an Error's `message` and `stack` are non-enumerable. So `logger.warn('...', { error })`, the convention used throughout Mastra, was written as `error: {}` and the real failure was lost. The most visible symptom was `Error listing tools for agent` with no details.
+
+`PinoLogger` now applies Pino's standard error serializer to the `error` key as well, so the type, message, and stack are recorded. The built-in `err` key keeps working. Values under `error` that are not error-like (no string `message` property) are passed through unchanged. Error-like plain objects are normalized to the same `{ type, message, stack }` shape with their own fields preserved.
+
+A new `serializers` option lets you override or extend the defaults:
+
+```ts
+new PinoLogger({
+  serializers: { error: err => ({ message: err.message }) },
+});
+```

--- a/docs/src/content/en/reference/logging/pino-logger.mdx
+++ b/docs/src/content/en/reference/logging/pino-logger.mdx
@@ -82,6 +82,13 @@ export const mastra = new Mastra({
     description:
       'Custom log levels and numeric values, forwarded to Pino. Standard severity is still logged via `debug`, `info`, `warn`, and `error`; extra levels follow Pino’s custom-level behavior.',
   },
+  {
+    name: 'serializers',
+    type: "pino.LoggerOptions['serializers']",
+    isOptional: true,
+    description:
+      'Custom Pino serializers, merged over the defaults. By default the `error` key uses Pino’s standard error serializer (alongside the built-in `err`), so `logger.warn("...", { error })` records the type, message, and stack instead of an empty object.',
+  },
 ]}
 />
 

--- a/packages/loggers/src/pino.test.ts
+++ b/packages/loggers/src/pino.test.ts
@@ -699,3 +699,65 @@ describe('PinoLogger.child()', () => {
     expect(childLogger.getTransports()).toEqual(baseLogger.getTransports());
   });
 });
+
+describe('PinoLogger error serialization', () => {
+  let memoryStream: MemoryStream;
+
+  beforeEach(() => {
+    memoryStream = new MemoryStream();
+  });
+
+  it('serializes an Error logged under the `error` key', async () => {
+    const logger = new PinoLogger({ transports: { memory: memoryStream } });
+
+    logger.warn('Error listing tools for agent', {
+      agentName: 'test-agent',
+      error: new Error('ARCADE_API_KEY is missing or empty'),
+    });
+
+    await waitForLogs(memoryStream);
+    const [log] = await memoryStream.listLogs();
+
+    expect(log.error).toMatchObject({
+      type: 'Error',
+      message: 'ARCADE_API_KEY is missing or empty',
+    });
+    expect(log.error.stack).toContain('ARCADE_API_KEY is missing or empty');
+  });
+
+  it("still serializes an Error logged under pino's `err` key", async () => {
+    const logger = new PinoLogger({ transports: { memory: memoryStream } });
+
+    logger.warn('failed', { err: new Error('boom') });
+
+    await waitForLogs(memoryStream);
+    const [log] = await memoryStream.listLogs();
+
+    expect(log.err).toMatchObject({ type: 'Error', message: 'boom' });
+  });
+
+  it('leaves non-Error values under `error` untouched', async () => {
+    const logger = new PinoLogger({ transports: { memory: memoryStream } });
+
+    logger.warn('failed', { error: { code: 'E42', detail: 'plain object' } });
+
+    await waitForLogs(memoryStream);
+    const [log] = await memoryStream.listLogs();
+
+    expect(log.error).toEqual({ code: 'E42', detail: 'plain object' });
+  });
+
+  it('allows callers to override the default serializers', async () => {
+    const logger = new PinoLogger({
+      transports: { memory: memoryStream },
+      serializers: { error: () => 'redacted' },
+    });
+
+    logger.warn('failed', { error: new Error('secret') });
+
+    await waitForLogs(memoryStream);
+    const [log] = await memoryStream.listLogs();
+
+    expect(log.error).toBe('redacted');
+  });
+});

--- a/packages/loggers/src/pino.ts
+++ b/packages/loggers/src/pino.ts
@@ -31,6 +31,14 @@ export interface PinoLoggerOptions<CustomLevels extends string = never> {
    * @example 'message'
    */
   messageKey?: string;
+  /**
+   * Custom pino serializers, merged over Mastra's defaults.
+   * By default the `error` key is serialized with pino's standard error
+   * serializer (alongside pino's built-in `err`), so that
+   * `logger.warn('...', { error })` records the message and stack rather
+   * than an empty object.
+   */
+  serializers?: pino.LoggerOptions['serializers'];
 }
 
 interface PinoLoggerInternalOptions<CustomLevels extends string = never> extends PinoLoggerOptions<CustomLevels> {
@@ -99,6 +107,10 @@ export class PinoLogger<CustomLevels extends string = never> extends MastraLogge
         mixin: correlationMixin,
         customLevels: options.customLevels,
         messageKey: options.messageKey ?? 'msg',
+        // Pino applies its error serializer only to `errorKey` (default `err`).
+        // Mastra logs errors as `{ error }` throughout, and an Error's `message`
+        // and `stack` are non-enumerable, so without this they serialize to `{}`.
+        serializers: { error: pino.stdSerializers.err, ...options.serializers },
       },
       options.overrideDefaultTransports
         ? options?.transports?.default


### PR DESCRIPTION
## Description

Pino only runs its error serializer on the `err` key, and an Error's message and stack are non-enumerable. Mastra logs errors as `{ error }` pretty much everywhere, so they came out as `error: {}` and the actual failure was lost. I hit this when an agent's tools failed to load and the log gave me nothing to go on.

Before:

```
WARN (Mastra): Error listing tools for agent
    agentName: "myAgent"
    error: {}
```

After:

```
WARN (Mastra): Error listing tools for agent
    agentName: "myAgent"
    error: {
      "type": "Error",
      "message": "ARCADE_API_KEY is missing or empty",
      "stack": "Error: ARCADE_API_KEY is missing or empty\n    at ..."
    }
```

This registers pino's standard error serializer for the `error` key next to the built-in `err`, and adds a `serializers` option on `PinoLogger` so you can override or extend it if you need to. `err` keeps working as before, and values under `error` that aren't error-like pass through unchanged. I went with an extra serializer rather than changing `errorKey` so nothing about the existing `err` behavior moves.

## Related issue(s)

Fixes #22870

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Errors logged as `error` no longer appear as empty objects. PinoLogger now records their type, message, and stack, while keeping existing `err` behavior unchanged.

## Changes

- Add Pino’s standard error serializer for the `error` key.
- Preserve non-error values under `error`.
- Add a `serializers` option for custom or extended serializers.
- Add tests for error serialization, `err` compatibility, non-error values, and overrides.
- Update documentation and add a changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->