### PR TITLE
feat(clickhouse): add feedback reviewStatus support

### DIFF
--- a/.changeset/feedback-review-status-clickhouse.md
+++ b/.changeset/feedback-review-status-clickhouse.md
@@ -1,0 +1,5 @@
+---
+'@mastra/clickhouse': patch
+---
+
+Add `reviewStatus` support to observability feedback storage: new column with migration (defaults to `needs-review`), read/write mapping, `reviewStatus` list filtering, and `updateFeedbackReviewStatus` implementation.

--- a/stores/_test-utils/src/domains/observability-vnext/index.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/index.ts
@@ -3300,7 +3300,11 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
         expect(updated.feedbackId).toBe('feedback-review-update');
         expect(updated.reviewStatus).toBe('reviewed');
 
+        // Append-only stores (ClickHouse) implement the update as a replacement
+        // row; the read side must still expose a single, latest version.
         const result = await storage.listFeedback({ filters: { traceId: 'trace-review-update' } });
+        expect(result.feedback).toHaveLength(1);
+        expect(result.pagination?.total).toBe(1);
         expect(result.feedback[0]!.reviewStatus).toBe('reviewed');
       });
 

--- a/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
@@ -808,6 +808,9 @@ CREATE TABLE IF NOT EXISTS ${TABLE_FEEDBACK_EVENTS} (
   feedbackUserId     Nullable(String),
   sourceId           Nullable(String),
 
+  -- Review workflow
+  reviewStatus       LowCardinality(String) DEFAULT 'needs-review',
+
   -- Feedback identity
   feedbackSource     LowCardinality(String),
   feedbackType       LowCardinality(String),
@@ -1133,6 +1136,7 @@ export const ALL_MIGRATIONS: readonly MigrationEntry[] = [
   addColumn(TABLE_SCORE_EVENTS, 'rootEntityVersionId', 'Nullable(String)'),
   // Feedback
   addColumn(TABLE_FEEDBACK_EVENTS, 'entityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_FEEDBACK_EVENTS, 'reviewStatus', "LowCardinality(String) DEFAULT 'needs-review'"),
   addColumn(TABLE_FEEDBACK_EVENTS, 'parentEntityVersionId', 'Nullable(String)'),
   addColumn(TABLE_FEEDBACK_EVENTS, 'rootEntityVersionId', 'Nullable(String)'),
   // Metric skip indexes — additive, instant DDL. Existing parts keep no index

--- a/stores/clickhouse/src/storage/domains/observability/v-next/feedback.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/feedback.ts
@@ -194,7 +194,7 @@ export async function updateFeedbackReviewStatus(
 
   const existing = await queryJson<Record<string, any>>(
     client,
-    `SELECT * FROM ${TABLE_FEEDBACK_EVENTS} WHERE feedbackId = {feedbackId:String} ORDER BY timestamp DESC LIMIT 1`,
+    `SELECT * FROM ${TABLE_FEEDBACK_EVENTS} FINAL WHERE feedbackId = {feedbackId:String} LIMIT 1`,
     { feedbackId },
   );
   if (!existing[0]) {
@@ -207,14 +207,20 @@ export async function updateFeedbackReviewStatus(
     });
   }
 
-  // `mutations_sync = 1` makes the mutation visible to the read-back below.
-  await client.command({
-    query: `ALTER TABLE ${TABLE_FEEDBACK_EVENTS} UPDATE reviewStatus = {reviewStatus:String} WHERE feedbackId = {feedbackId:String}`,
-    query_params: { feedbackId, reviewStatus },
-    clickhouse_settings: { mutations_sync: '1' },
+  // ClickHouse is append-only in practice: never mutate a written row. Instead
+  // insert a replacement row with the same ReplacingMergeTree key
+  // (traceId, timestamp, feedbackId). Background merges collapse the
+  // duplicates keeping the last inserted row, and every read on this table
+  // uses FINAL so the latest version wins before merges happen.
+  const updated = rowToFeedbackRecord({ ...existing[0], reviewStatus });
+  await client.insert({
+    table: TABLE_FEEDBACK_EVENTS,
+    values: [feedbackRecordToRow(updated)],
+    format: 'JSONEachRow',
+    clickhouse_settings: CH_INSERT_SETTINGS,
   });
 
-  return rowToFeedbackRecord({ ...existing[0], reviewStatus });
+  return updated;
 }
 
 // ============================================================================
@@ -261,13 +267,13 @@ export async function listFeedback(
   const currentDeltaCursor = deltaCursorEnabled ? await getDeltaCursor(client, whereClause, filter.params) : undefined;
   const countResult = await queryJson<{ total?: number }>(
     client,
-    `SELECT count() AS total FROM ${TABLE_FEEDBACK_EVENTS} AS f ${whereClause}`,
+    `SELECT count() AS total FROM ${TABLE_FEEDBACK_EVENTS} AS f FINAL ${whereClause}`,
     filter.params,
   );
 
   const rows = await queryJson<Record<string, any>>(
     client,
-    `SELECT * FROM ${TABLE_FEEDBACK_EVENTS} AS f ${whereClause} ORDER BY ${orderBy} LIMIT {limit:UInt32} OFFSET {offset:UInt32}`,
+    `SELECT * FROM ${TABLE_FEEDBACK_EVENTS} AS f FINAL ${whereClause} ORDER BY ${orderBy} LIMIT {limit:UInt32} OFFSET {offset:UInt32}`,
     { ...filter.params, limit: pagination.limit, offset: pagination.offset },
   );
 
@@ -309,7 +315,7 @@ async function queryFeedbackAfterCursor(
         f.feedbackId AS feedbackId,
         toString(d.cursorId) AS cursorId
       FROM ${TABLE_FEEDBACK_EVENTS_DELTA} d
-      INNER JOIN ${TABLE_FEEDBACK_EVENTS} f
+      INNER JOIN ${TABLE_FEEDBACK_EVENTS} f FINAL
         ON ((f.traceId = d.traceId) OR (f.traceId IS NULL AND d.traceId IS NULL))
        AND f.timestamp = d.timestamp
        AND f.feedbackId = d.feedbackId
@@ -331,7 +337,7 @@ async function getDeltaCursor(
     `
       SELECT toString(max(d.cursorId)) AS cursorId
       FROM ${TABLE_FEEDBACK_EVENTS_DELTA} d
-      INNER JOIN ${TABLE_FEEDBACK_EVENTS} f
+      INNER JOIN ${TABLE_FEEDBACK_EVENTS} f FINAL
         ON ((f.traceId = d.traceId) OR (f.traceId IS NULL AND d.traceId IS NULL))
        AND f.timestamp = d.timestamp
        AND f.feedbackId = d.feedbackId
@@ -382,7 +388,7 @@ export async function getFeedbackAggregate(
   const combined = mergeFilters(identity, signalFilter);
   const whereClause = toWhereClause(combined);
 
-  const sql = `SELECT ${aggSql} AS value FROM ${TABLE_FEEDBACK_EVENTS} ${whereClause}`;
+  const sql = `SELECT ${aggSql} AS value FROM ${TABLE_FEEDBACK_EVENTS} FINAL ${whereClause}`;
   const result = await queryJson<Record<string, unknown>>(client, sql, combined.params);
   const value = result[0]?.value == null ? null : Number(result[0]?.value);
 
@@ -421,7 +427,7 @@ export async function getFeedbackAggregate(
 
       const prevResult = await queryJson<Record<string, unknown>>(
         client,
-        `SELECT ${aggSql} AS value FROM ${TABLE_FEEDBACK_EVENTS} ${prevWhereClause}`,
+        `SELECT ${aggSql} AS value FROM ${TABLE_FEEDBACK_EVENTS} FINAL ${prevWhereClause}`,
         prevCombined.params,
       );
       const previousValue = prevResult[0]?.value == null ? null : Number(prevResult[0]?.value);
@@ -449,7 +455,7 @@ export async function getFeedbackBreakdown(
   const whereClause = toWhereClause(combined);
   const resolved = resolveFeedbackGroupBy(args.groupBy);
 
-  const sql = `SELECT ${resolved.map(e => e.selectSql).join(', ')}, ${aggSql} AS value FROM ${TABLE_FEEDBACK_EVENTS} ${whereClause} GROUP BY ${resolved.map(e => e.groupSql).join(', ')} ORDER BY value DESC`;
+  const sql = `SELECT ${resolved.map(e => e.selectSql).join(', ')}, ${aggSql} AS value FROM ${TABLE_FEEDBACK_EVENTS} FINAL ${whereClause} GROUP BY ${resolved.map(e => e.groupSql).join(', ')} ORDER BY value DESC`;
   const rows = await queryJson<Record<string, unknown>>(client, sql, combined.params);
 
   return {
@@ -482,7 +488,7 @@ export async function getFeedbackTimeSeries(
       SELECT toStartOfInterval(timestamp, ${intervalSql}) AS bucket,
              ${resolved.map(e => e.selectSql).join(', ')},
              ${aggSql} AS value
-      FROM ${TABLE_FEEDBACK_EVENTS} ${whereClause}
+      FROM ${TABLE_FEEDBACK_EVENTS} FINAL ${whereClause}
       GROUP BY bucket, ${resolved.map(e => e.groupSql).join(', ')}
       ORDER BY bucket
     `;
@@ -507,7 +513,7 @@ export async function getFeedbackTimeSeries(
   const sql = `
     SELECT toStartOfInterval(timestamp, ${intervalSql}) AS bucket,
            ${aggSql} AS value
-    FROM ${TABLE_FEEDBACK_EVENTS} ${whereClause}
+    FROM ${TABLE_FEEDBACK_EVENTS} FINAL ${whereClause}
     GROUP BY bucket
     ORDER BY bucket
   `;
@@ -548,7 +554,7 @@ export async function getFeedbackPercentiles(
     const sql = `
       SELECT toStartOfInterval(timestamp, ${intervalSql}) AS bucket,
              quantile(${p})(valueNumber) AS pvalue
-      FROM ${TABLE_FEEDBACK_EVENTS}
+      FROM ${TABLE_FEEDBACK_EVENTS} FINAL
       ${whereClause}
       GROUP BY bucket
       ORDER BY bucket

--- a/stores/clickhouse/src/storage/domains/observability/v-next/feedback.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/feedback.ts
@@ -1,10 +1,13 @@
 import type { ClickHouseClient } from '@clickhouse/client';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { listFeedbackArgsSchema } from '@mastra/core/storage';
 import type {
   AggregationInterval,
   AggregationType,
   BatchCreateFeedbackArgs,
   CreateFeedbackArgs,
+  FeedbackRecord,
+  UpdateFeedbackReviewStatusArgs,
   ListFeedbackArgs,
   ListFeedbackResponse,
   GetFeedbackAggregateArgs,
@@ -24,6 +27,7 @@ import type { FilterResult } from './filters';
 import { CH_INSERT_SETTINGS, CH_SETTINGS, feedbackRecordToRow, rowToFeedbackRecord } from './helpers';
 import type { ClickHouseDeltaCursorStrategy } from './polling';
 import { assertDeltaPollingSupported, deltaPollingSupported, validateCursorId } from './polling';
+import { parseUpdateFeedbackReviewStatusArgs } from './review-status';
 
 // ============================================================================
 // Helpers
@@ -176,6 +180,41 @@ export async function batchCreateFeedback(client: ClickHouseClient, args: BatchC
     format: 'JSONEachRow',
     clickhouse_settings: CH_INSERT_SETTINGS,
   });
+}
+
+// ============================================================================
+// Review status
+// ============================================================================
+
+export async function updateFeedbackReviewStatus(
+  client: ClickHouseClient,
+  args: UpdateFeedbackReviewStatusArgs,
+): Promise<FeedbackRecord> {
+  const { feedbackId, reviewStatus } = parseUpdateFeedbackReviewStatusArgs(args);
+
+  const existing = await queryJson<Record<string, any>>(
+    client,
+    `SELECT * FROM ${TABLE_FEEDBACK_EVENTS} WHERE feedbackId = {feedbackId:String} ORDER BY timestamp DESC LIMIT 1`,
+    { feedbackId },
+  );
+  if (!existing[0]) {
+    throw new MastraError({
+      id: 'OBSERVABILITY_UPDATE_FEEDBACK_REVIEW_STATUS_NOT_FOUND',
+      domain: ErrorDomain.MASTRA_OBSERVABILITY,
+      category: ErrorCategory.USER,
+      text: 'Feedback record not found',
+      details: { feedbackId },
+    });
+  }
+
+  // `mutations_sync = 1` makes the mutation visible to the read-back below.
+  await client.command({
+    query: `ALTER TABLE ${TABLE_FEEDBACK_EVENTS} UPDATE reviewStatus = {reviewStatus:String} WHERE feedbackId = {feedbackId:String}`,
+    query_params: { feedbackId, reviewStatus },
+    clickhouse_settings: { mutations_sync: '1' },
+  });
+
+  return rowToFeedbackRecord({ ...existing[0], reviewStatus });
 }
 
 // ============================================================================

--- a/stores/clickhouse/src/storage/domains/observability/v-next/filters.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/filters.ts
@@ -388,6 +388,7 @@ export function buildFeedbackFilterConditions(filters: FeedbackFilter | undefine
   addEq(col('feedbackUserId'), fbActor, 'feedbackUserId', 'String', out);
 
   addEq(col('feedbackSource'), filters.feedbackSource, 'feedbackSource', 'String', out);
+  addEq(col('reviewStatus'), filters.reviewStatus, 'reviewStatus', 'String', out);
 
   if (typeof filters.feedbackType === 'string') {
     addEq(col('feedbackType'), filters.feedbackType, 'feedbackType', 'String', out);

--- a/stores/clickhouse/src/storage/domains/observability/v-next/helpers.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/helpers.ts
@@ -20,6 +20,7 @@ import type {
   CreateFeedbackRecord,
 } from '@mastra/core/storage';
 import { buildInputPreview, computeTraceStatus, EntityType } from '@mastra/core/storage';
+import { coerceFeedbackReviewStatus } from './review-status';
 
 // ---------------------------------------------------------------------------
 // ClickHouse query settings
@@ -562,6 +563,7 @@ export function rowToFeedbackRecord(row: Record<string, any>): FeedbackRecord {
     serviceName: nullableString(row.serviceName),
     feedbackUserId,
     sourceId: nullableString(row.sourceId),
+    reviewStatus: coerceFeedbackReviewStatus(row.reviewStatus),
     feedbackSource,
     feedbackType: row.feedbackType,
     value: hasNumber ? Number(row.valueNumber) : (nullableString(row.valueString) ?? ''),
@@ -607,6 +609,7 @@ export function feedbackRecordToRow(feedback: CreateFeedbackRecord): Record<stri
     serviceName: feedback.serviceName ?? null,
     feedbackUserId,
     sourceId: feedback.sourceId ?? null,
+    reviewStatus: feedback.reviewStatus ?? 'needs-review',
     feedbackSource,
     feedbackType: feedback.feedbackType,
     valueString: typeof feedback.value === 'string' ? feedback.value : null,

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
@@ -67,6 +67,8 @@ import type {
   BatchCreateFeedbackArgs,
   ListFeedbackArgs,
   ListFeedbackResponse,
+  FeedbackRecord,
+  UpdateFeedbackReviewStatusArgs,
   GetFeedbackAggregateArgs,
   GetFeedbackAggregateResponse,
   GetFeedbackBreakdownArgs,
@@ -1015,6 +1017,23 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: { count: args.feedbacks.length },
+        },
+        error,
+      );
+    }
+  }
+
+  override async updateFeedbackReviewStatus(args: UpdateFeedbackReviewStatusArgs): Promise<FeedbackRecord> {
+    try {
+      return await feedbackOps.updateFeedbackReviewStatus(this.#client, args);
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('CLICKHOUSE', 'UPDATE_FEEDBACK_REVIEW_STATUS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { feedbackId: args.feedbackId },
         },
         error,
       );


### PR DESCRIPTION
## Summary
Adds `reviewStatus` support to the ClickHouse observability feedback store, matching what pg and duckdb already have on `magical-muscle`:

- `reviewStatus` column with an `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` migration (defaults to `needs-review`)
- read/write mapping in the feedback row helpers
- `reviewStatus` filter in `listFeedback`
- `updateFeedbackReviewStatus` implementation (synchronous update mutation to avoid duplicate rows before merges)
- local `review-status` schema shim so `@mastra/core/storage` imports stay type-only within the peer floor

Split out of #22805 so the ClickHouse store can be reviewed on its own.

## Test plan
- [x] `tsc --noEmit` in `stores/clickhouse`
- [ ] `Combined Store Tests / test (clickhouse)` on CI (shared `createObservabilityVNextTests` review-status cases)
- [x] Previously verified locally against a real `clickhouse-test-db` container