### PR TITLE
ci(docs): diff changed MDX files against the merge-base

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -221,16 +221,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t files < <(
+          # Three-dot diff compares against the merge-base so files that main
+          # moved/deleted after the branch point are not reported as "added"
+          # by a stale branch. The checkout is the PR merge ref, so also drop
+          # anything that doesn't exist there.
+          mapfile -t changed < <(
             git diff --name-only --diff-filter=ACMRT \
-              "${{ github.event.pull_request.base.sha }}" \
-              "${{ github.event.pull_request.head.sha }}" \
+              "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
               -- \
               docs/src/content/en/docs \
               docs/src/content/en/integrations \
               docs/src/content/en/reference \
               | grep '\.mdx$' || true
           )
+
+          files=()
+          for f in "${changed[@]}"; do
+            if [ -f "$f" ]; then
+              files+=("$f")
+            fi
+          done
 
           if [ "${#files[@]}" -gt 0 ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The Lint docs job on #22838 failed with Vale complaining that `docs/src/content/en/docs/datasets/overview.mdx` doesn't exist. The MDX-changes step diffs `base.sha..head.sha` (two-dot), so when main moves or deletes docs after a branch is cut (here #22869 moved the datasets pages), a stale branch looks like it re-adds those files. They pass `--diff-filter=ACMRT`, but the job runs against the PR merge ref where they're gone, so Vale errors out.

This switches the diff to three-dot (against the merge-base) so only the PR's own changes are picked up, and drops any listed path that isn't present in the checkout as a safety net.

Verified against #22838's SHAs: the two-dot diff returned 10 phantom files, the three-dot diff returns 0. Ran the step script under bash 5 in Docker for both the empty and mixed existing/missing cases; `set -euo pipefail` is happy with both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The docs check now finds only the files changed in the pull request. It skips files that are no longer in the checkout.

## Changes

- Use a three-dot merge-base diff for MDX change detection.
- Filter changed paths to files that exist before running Vale.
- Prevent stale branch paths from being linted as new files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->