### PR TITLE
fix(factory): name the source system in linked-card sync status

### DIFF
--- a/.changeset/flat-impalas-sneeze.md
+++ b/.changeset/flat-impalas-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved the board card status shown while a linked card is synced. Instead of "Filing a linked card…", cards now name the system they mirror, for example "Syncing GitHub pull request…" or "Couldn't sync GitHub issue".

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPageCardTitleTooltip.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPageCardTitleTooltip.msw.test.tsx
@@ -61,6 +61,7 @@ const failedDecision: FactoryDecisionSummary = {
   status: 'failed',
   attempts: 1,
   failureOccurrence: 1,
+  source: null,
   failureCode: 'repository_clone_failed',
   canRetry: true,
   lastError: DECISION_ERROR,

--- a/mastracode/factory-ui/src/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -331,6 +331,7 @@ describe('Board card pending states', () => {
               status: 'failed',
               attempts: 5,
               failureOccurrence: 1,
+              source: null,
               failureCode: 'repository_clone_failed',
               canRetry: true,
               lastError: 'Command failed with ENOENT',

--- a/mastracode/factory-ui/src/ui/__tests__/RulesPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/__tests__/RulesPage.msw.test.tsx
@@ -24,6 +24,7 @@ const proposedDecision: FactoryDecisionSummary = {
   updatedAt: '2026-08-10T00:00:00.000Z',
   completedAt: null,
   failureOccurrence: 0,
+  source: null,
   failureCode: null,
   canRetry: false,
 };

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.test.ts
@@ -13,6 +13,7 @@ function decision(overrides: Partial<FactoryDecisionSummary> = {}): FactoryDecis
     status: 'leased',
     attempts: 1,
     failureOccurrence: 0,
+    source: null,
     failureCode: null,
     canRetry: true,
     lastError: null,
@@ -90,17 +91,36 @@ describe('boardCardStatus', () => {
     // board ends up showing failures nobody caused.
     expect(
       boardCardStatus({
-        decision: decision({ type: 'upsertLinkedWorkItem', status: 'retry', attempts: 0, lastError: null }),
+        decision: decision({
+          type: 'upsertLinkedWorkItem',
+          source: 'github-pr',
+          status: 'retry',
+          attempts: 0,
+          lastError: null,
+        }),
       }),
-    ).toEqual({ kind: 'busy', label: 'Filing a linked card…' });
+    ).toEqual({ kind: 'busy', label: 'Syncing GitHub pull request…' });
+  });
+
+  it('names the system a linked card is synced with', () => {
+    const sync = (source: FactoryDecisionSummary['source']) =>
+      boardCardStatus({ decision: decision({ type: 'upsertLinkedWorkItem', source, status: 'pending', attempts: 0 }) });
+    expect(sync('github-issue')).toEqual({ kind: 'busy', label: 'Syncing GitHub issue…' });
+    expect(sync('linear-issue')).toEqual({ kind: 'busy', label: 'Syncing Linear issue…' });
   });
 
   it('still reports an effect that has actually been tried and failed', () => {
     expect(
       boardCardStatus({
-        decision: decision({ type: 'upsertLinkedWorkItem', status: 'retry', attempts: 2, lastError: null }),
+        decision: decision({
+          type: 'upsertLinkedWorkItem',
+          source: 'github-issue',
+          status: 'retry',
+          attempts: 2,
+          lastError: null,
+        }),
       }),
-    ).toEqual({ kind: 'error', label: 'Linked card could not be filed — retrying…', detail: undefined });
+    ).toEqual({ kind: 'error', label: "Couldn't sync GitHub issue — retrying…", detail: undefined });
   });
 
   it('tells a run that is underway apart from one still waiting to start', () => {

--- a/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/boardCardStatus.ts
@@ -41,9 +41,28 @@ export function itemAwaitsPerson(
   return proposal !== undefined;
 }
 
+/** The system a linked card is synced with, named the way that system names the thing. */
+function linkedSourceName(source: FactoryDecisionSummary['source']): string {
+  switch (source) {
+    case 'github-issue':
+      return 'GitHub issue';
+    case 'github-pr':
+      return 'GitHub pull request';
+    case 'linear-issue':
+      return 'Linear issue';
+    default:
+      // Every linked-card decision carries its source; only a manual card would land here.
+      return 'card';
+  }
+}
+
 /** Human phrasing for a rule effect, by decision type. `underway` speaks for a leased decision. */
-function automationCopy(type: string): { busy: string; underway: string; failed: string } {
-  switch (type) {
+function automationCopy(decision: Pick<FactoryDecisionSummary, 'type' | 'source'>): {
+  busy: string;
+  underway: string;
+  failed: string;
+} {
+  switch (decision.type) {
     case 'invokeSkill':
       return {
         busy: 'Starting an automated run…',
@@ -55,8 +74,9 @@ function automationCopy(type: string): { busy: string; underway: string; failed:
       return { busy, underway: busy, failed: 'Automatic move failed' };
     }
     case 'upsertLinkedWorkItem': {
-      const busy = 'Filing a linked card…';
-      return { busy, underway: busy, failed: 'Linked card could not be filed' };
+      const source = linkedSourceName(decision.source);
+      const busy = `Syncing ${source}…`;
+      return { busy, underway: busy, failed: `Couldn't sync ${source}` };
     }
     case 'sendMessage':
     case 'notify': {
@@ -102,7 +122,7 @@ export function boardCardStatus(input: BoardCardStatusInput): BoardCardStatus {
   if (decision?.status === 'failed') {
     return {
       kind: 'error',
-      label: automationCopy(decision.type).failed,
+      label: automationCopy(decision).failed,
       ...(decision.canRetry ? { retryDecisionId: decision.id } : {}),
       detail: decision.lastError ?? undefined,
     };
@@ -116,12 +136,12 @@ export function boardCardStatus(input: BoardCardStatusInput): BoardCardStatus {
   if (decision?.status === 'retry' && (decision.attempts > 0 || decision.lastError)) {
     return {
       kind: 'error',
-      label: `${automationCopy(decision.type).failed} — retrying…`,
+      label: `${automationCopy(decision).failed} — retrying…`,
       detail: decision.lastError ?? undefined,
     };
   }
   if (decision) {
-    const copy = automationCopy(decision.type);
+    const copy = automationCopy(decision);
     if (decision.status !== 'leased') return { kind: 'busy', label: copy.busy };
     const label = decision.type === 'invokeSkill' ? leasedInvokeSkillLabel(input.sessionStatus, copy) : copy.underway;
     return { kind: 'busy', label };

--- a/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/cardPrimaryAction.test.ts
@@ -70,6 +70,7 @@ function proposalSummary(): FactoryDecisionSummary {
     status: 'proposed',
     attempts: 0,
     failureOccurrence: 0,
+    source: null,
     failureCode: null,
     canRetry: false,
     lastError: null,

--- a/mastracode/factory-ui/src/ui/domains/factory/services/decisions.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/decisions.ts
@@ -2,7 +2,14 @@ import type { FactoryDispatchFailureCode } from '@mastra/factory/storage/domains
 
 /** `dismissed` is human rejection; `superseded` means newer Factory state made a proposal obsolete. */
 export type FactoryDecisionStatus =
-  'pending' | 'proposed' | 'dismissed' | 'superseded' | 'leased' | 'retry' | 'succeeded' | 'failed';
+  | 'pending'
+  | 'proposed'
+  | 'dismissed'
+  | 'superseded'
+  | 'leased'
+  | 'retry'
+  | 'succeeded'
+  | 'failed';
 
 /** What a person can do to a queued effect from the board or the Rules page. */
 export type FactoryDecisionAction = 'approve' | 'dismiss' | 'retry';

--- a/mastracode/factory-ui/src/ui/domains/factory/services/decisions.ts
+++ b/mastracode/factory-ui/src/ui/domains/factory/services/decisions.ts
@@ -2,14 +2,7 @@ import type { FactoryDispatchFailureCode } from '@mastra/factory/storage/domains
 
 /** `dismissed` is human rejection; `superseded` means newer Factory state made a proposal obsolete. */
 export type FactoryDecisionStatus =
-  | 'pending'
-  | 'proposed'
-  | 'dismissed'
-  | 'superseded'
-  | 'leased'
-  | 'retry'
-  | 'succeeded'
-  | 'failed';
+  'pending' | 'proposed' | 'dismissed' | 'superseded' | 'leased' | 'retry' | 'succeeded' | 'failed';
 
 /** What a person can do to a queued effect from the board or the Rules page. */
 export type FactoryDecisionAction = 'approve' | 'dismiss' | 'retry';
@@ -21,6 +14,8 @@ export interface FactoryDecisionSummary {
   type: string;
   /** Session slot a proposed run fills, so the card can name what it starts. */
   role: string | null;
+  /** Where a linked card is synced from; `null` for effects that are not `upsertLinkedWorkItem`. */
+  source: 'github-issue' | 'github-pr' | 'linear-issue' | 'manual' | null;
   status: FactoryDecisionStatus;
   attempts: number;
   failureOccurrence: number;

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceSidebarStatuses.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/WorkspaceSidebarStatuses.msw.test.tsx
@@ -139,6 +139,7 @@ function decision(workItemId: string, status: FactoryDecisionStatus): FactoryDec
     status,
     attempts: status === 'proposed' ? 0 : 1,
     failureOccurrence: 0,
+    source: null,
     failureCode: null,
     canRetry: false,
     lastError: status === 'proposed' ? null : 'boom',

--- a/mastracode/factory-ui/src/ui/pages/__tests__/AttentionPage.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/pages/__tests__/AttentionPage.msw.test.tsx
@@ -48,6 +48,7 @@ function proposal(id: string, type: string, role: string, workItemId: string): F
     status: 'proposed',
     attempts: 0,
     failureOccurrence: 0,
+    source: null,
     failureCode: null,
     canRetry: false,
     lastError: null,

--- a/mastracode/factory/src/routes/work-items.test.ts
+++ b/mastracode/factory/src/routes/work-items.test.ts
@@ -741,6 +741,52 @@ describe('work item relations', () => {
   });
 });
 
+describe('GET /web/factory/projects/:id/decisions', () => {
+  it('names the linked-card source on the summary and leaves it null for other effects', async () => {
+    const now = new Date('2030-01-01T00:00:00.000Z');
+    await seed.workItems.commitRuleEvaluation({
+      orgId: 'org1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: null,
+      ingress: { identity: 'decision-source', triggerType: 'test' },
+      ruleSetVersion: 'rules-v1',
+      expectedRevision: null,
+      actor: { type: 'system', id: 'rules' },
+      outcome: { status: 'accepted' },
+      decisions: [
+        {
+          type: 'upsertLinkedWorkItem',
+          idempotencyKey: 'decision-source-linked',
+          board: 'review',
+          source: 'github-pr',
+          sourceKey: 'github-pr:7',
+          title: 'Fix the login flow',
+          url: null,
+          stage: 'intake',
+          metadata: {},
+        },
+        {
+          type: 'sendMessage',
+          role: 'work',
+          message: 'Notify the session.',
+          idempotencyKey: 'decision-source-message',
+        },
+      ],
+      causalChain: [],
+      now,
+    });
+
+    const body = await (await json('GET', `/web/factory/projects/${PROJECT_ID}/decisions`)).json();
+    expect(body.decisions).toHaveLength(2);
+    expect(body.decisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'upsertLinkedWorkItem', source: 'github-pr' }),
+        expect.objectContaining({ type: 'sendMessage', source: null }),
+      ]),
+    );
+  });
+});
+
 describe('GET /web/factory/projects/:id/attention', () => {
   it('tracks read and archived failure occurrences across retries', async () => {
     const created = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody());

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -20,7 +20,7 @@ import type {
 import { FactoryStartTransitionError } from '../rules/start-coordinator.js';
 import { roleForStage } from '../rules/transition-service.js';
 import type { FactoryTransitionRequest, FactoryTransitionService } from '../rules/transition-service.js';
-import type { FactoryRuleBoard } from '../rules/types.js';
+import type { FactoryRuleBoard, WorkItemSource } from '../rules/types.js';
 import { FACTORY_RULE_BOARDS, isFactoryRuleStage } from '../rules/types.js';
 import type { LiveSessions } from '../session/live-sessions.js';
 import type { AuditEmitter } from '../storage/domains/audit/domain.js';
@@ -410,6 +410,15 @@ function summaryRole(decision: Record<string, unknown>): string | null {
   return roleForStage(board, stage);
 }
 
+/** A linked-card decision names where the card is synced from, so the UI can say "GitHub" rather than "a linked card". */
+function summarySource(decision: Record<string, unknown>): WorkItemSource | null {
+  if (decision.type !== 'upsertLinkedWorkItem') return null;
+  const source = decision.source;
+  return source === 'github-issue' || source === 'github-pr' || source === 'linear-issue' || source === 'manual'
+    ? source
+    : null;
+}
+
 function decisionSummary(decision: FactoryDeferredDecisionRecord) {
   return {
     id: decision.id,
@@ -417,6 +426,7 @@ function decisionSummary(decision: FactoryDeferredDecisionRecord) {
     workItemId: decision.workItemId,
     type: factoryDecisionType(decision),
     role: summaryRole(decision.decision),
+    source: summarySource(decision.decision),
     status: decision.status,
     attempts: decision.attempts,
     failureOccurrence: decision.failureOccurrence,


### PR DESCRIPTION
## Summary

Board cards showed **"Filing a linked card…"** (and "Linked card could not be filed") while the server was creating or refreshing a card that mirrors an external issue/PR. "Filing" is internal vocabulary and didn't tell the user what the card was actually waiting on.

Cards now name the system they're synced with:

| Source | In progress | Failed |
|---|---|---|
| GitHub PR | Syncing GitHub pull request… | Couldn't sync GitHub pull request |
| GitHub issue | Syncing GitHub issue… | Couldn't sync GitHub issue |
| Linear issue | Syncing Linear issue… | Couldn't sync Linear issue |

## How

- `@mastra/factory` — `GET /decisions` summaries now include `source` for `upsertLinkedWorkItem` decisions (read from the decision payload; `null` for other effect types).
- `factory-ui` — `boardCardStatus` phrases the busy/failed label from `decision.source` instead of a fixed string.

## Test plan

- [x] `factory`: `tsc --noEmit`, `work-items.test.ts` (68 passed)
- [x] `factory-ui`: `tsc --noEmit`, board/rules/attention/sidebar suites (269 passed), including new `boardCardStatus` cases per source


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Linked cards now show which service they sync with, such as GitHub or Linear. This makes sync progress and failure messages clearer.

## Changes

- Added source-specific sync messages for GitHub issues, GitHub pull requests, and Linear issues.
- Added nullable `source` data to `FactoryDecisionSummary`.
- Updated `GET /decisions` to return `source` for `upsertLinkedWorkItem` decisions and `null` for other effects.
- Updated tests and added a patch changeset.

## Validation

- TypeScript checks passed.
- Factory and factory-ui test suites passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->