### PR TITLE
fix(observability): raise @mastra/core peer floor to match required exports

### DIFF
--- a/.changeset/observability-core-peer-floor.md
+++ b/.changeset/observability-core-peer-floor.md
@@ -1,0 +1,25 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed the declared `@mastra/core` requirement, which was low enough to let a broken combination install cleanly and then crash on startup.
+
+Since 1.17.3 this package has imported `resolveExportedSpanId` from `@mastra/core/observability`, an export that only exists in `@mastra/core` 1.63.0 and later. The peer range still allowed anything from 1.16.0 up, so a project holding an older core installed with no warning and then failed the moment Node linked the module graph:
+
+```
+SyntaxError: The requested module '@mastra/core/observability'
+does not provide an export named 'resolveExportedSpanId'
+```
+
+Because the import is static, this happens before any application code runs, and it usually surfaces first in a deploy rather than locally.
+
+The floor now matches what the code actually calls:
+
+```diff
+  "peerDependencies": {
+-   "@mastra/core": ">=1.16.0-0 <2.0.0-0"
++   "@mastra/core": ">=1.63.0-0 <2.0.0-0"
+  }
+```
+
+Projects on an affected combination now get a resolvable install-time error naming the real requirement instead of a startup crash. If you hit it, upgrade `@mastra/core` to 1.63.0 or later.

--- a/observability/mastra/package.json
+++ b/observability/mastra/package.json
@@ -46,7 +46,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.16.0-0 <2.0.0-0",
+    "@mastra/core": ">=1.63.0-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "homepage": "https://mastra.ai",


### PR DESCRIPTION
Fixes #22885

## What

Raises the `@mastra/core` peer floor in `@mastra/observability` from `>=1.16.0-0` to `>=1.63.0-0`, so it matches what the code actually calls.

```diff
  "peerDependencies": {
-   "@mastra/core": ">=1.16.0-0 <2.0.0-0"
+   "@mastra/core": ">=1.63.0-0 <2.0.0-0"
  }
```

## Why

Since **1.17.3** this package imports `resolveExportedSpanId` from `@mastra/core/observability`. That export only exists in **`@mastra/core` 1.63.0+**. Both sides landed together in #22286 (`e3b796d29a`) without the floor being raised.

With the floor at 1.16.0, an older-core project installs cleanly, gets no peer warning, and then dies when Node links the module graph:

```
SyntaxError: The requested module '@mastra/core/observability'
does not provide an export named 'resolveExportedSpanId'
```

The import is static, so this precedes any application code — it presents as a hard boot failure, and typically surfaces first in a deploy rather than locally. It reached us as a customer's failed production deploy.

Most affected users never named this package: it arrives as an **exact** transitive pin (`1.17.4`) from ten exporters (`@mastra/langfuse`, `@mastra/langsmith`, `@mastra/braintrust`, `@mastra/datadog`, `@mastra/sentry`, `@mastra/posthog`, `@mastra/laminar`, `@mastra/otel-exporter`, `@mastra/otel-bridge`, `@mastra/deepeval`).

## Verification

Boundary established by unpacking published tarballs and grepping built `dist`, not by reading manifests:

| `@mastra/observability` | core ≤ 1.62.x | core ≥ 1.63.0 |
| --- | --- | --- |
| ≤ 1.17.2 | works | works |
| ≥ 1.17.3 | **SyntaxError on boot** | works |

Then I patched the peer range in the real published `1.17.4` tarball, repacked it, and reinstalled against `@mastra/core@1.62.0`:

**Before (today):** installs clean — *including* under `npm install --strict-peer-deps`. The range is satisfied; the range is what's wrong. No install-time lever we currently ship can see this.

**After (this change):**
```
npm error ERESOLVE unable to resolve dependency tree
npm error Found: @mastra/core@1.62.0
npm error Could not resolve dependency:
npm error peer @mastra/core@">=1.63.0-0 <2.0.0-0" from @mastra/observability@1.17.4
```

A resolvable install-time error naming the real requirement, instead of a build that cannot boot.

## Scope note

Marked `patch`: this cannot break anyone who was working, since every combination it now rejects was already crashing at startup.

Two related items are deliberately **left out** of this PR and raised in #22885 for a maintainer decision — the exporters' exact pin on `@mastra/observability` (which prevents the resolver from selecting a compatible pair), and whether the exporters' own core floors should rise in lockstep so the conflict is a default hard error rather than a warning when it arrives transitively. Both have a wider blast radius than this range correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoG32hizcTbRgoLqV5gHEv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This change tells package managers that `@mastra/observability` needs a newer `@mastra/core`. This prevents incompatible versions from installing successfully and failing when the application starts.

## Changes

- Raised the `@mastra/core` peer dependency floor from `>=1.16.0-0` to `>=1.63.0-0`.
- Added a changeset for the peer dependency update.
- Kept the `<2.0.0-0` upper bound unchanged.
- Left exporter pins and exporter peer floors unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->