### PR TITLE
fix(memory): read reminder questions from persisted signal rows

### DIFF
--- a/.changeset/remind-signal-rows.md
+++ b/.changeset/remind-signal-rows.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fix reminder sidekick continuation not recognizing persisted questions.

--- a/.changeset/remind-signal-rows.md
+++ b/.changeset/remind-signal-rows.md
@@ -2,4 +2,4 @@
 '@mastra/memory': patch
 ---
 
-Fix reminder sidekick continuation not recognizing persisted questions.
+Fix the reminder sidekick not recognizing its own persisted question and passive-check rows, which blocked continuation nudges and reply authorization.

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-continuation.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-continuation.test.ts
@@ -100,6 +100,7 @@ describe('Subconscious reminder continuation', () => {
 
     await processor.processOutputResult(resultArgs([question]));
 
+    expect(sendMessage).toHaveBeenCalledOnce();
     expect(sendMessage.mock.calls[0]![0].metadata[REMIND_MESSAGE_METADATA_KEY]).toEqual({
       type: 'continuation',
       replyIds: ['reply-1'],

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-continuation.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-continuation.test.ts
@@ -78,7 +78,8 @@ function persistedSignalRow(id: string, contents: string, metadata?: Record<stri
 describe('Subconscious reminder continuation', () => {
   it('finds pending questions in rows persisted by sendMessage (role signal, nested metadata)', async () => {
     const { processor, sendMessage } = createHarness();
-    const question = persistedSignalRow('question-1', 'Memory question reply-1\n\nWhat happened?', {
+    // Text deliberately does not match the fallback parser so only the nested metadata can identify the question.
+    const question = persistedSignalRow('question-1', 'What happened?', {
       [REMIND_MESSAGE_METADATA_KEY]: { type: 'question', replyId: 'reply-1', askedAt: Date.now() },
     });
     expect(question.role).toBe('signal');

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-continuation.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-continuation.test.ts
@@ -1,4 +1,5 @@
 import type { MastraDBMessage } from '@mastra/core/agent';
+import { signalToMastraDBMessage } from '@mastra/core/agent';
 import { describe, expect, it, vi } from 'vitest';
 
 import { RemindContinuationProcessor } from '../subconscious/remind-continuation';
@@ -66,7 +67,46 @@ function resultArgs(messages: MastraDBMessage[], steps: unknown[] = []) {
   } as any;
 }
 
+/** Build the row exactly as `agent.sendMessage()` persists it: role `signal`, metadata nested under `signal`. */
+function persistedSignalRow(id: string, contents: string, metadata?: Record<string, unknown>): MastraDBMessage {
+  return signalToMastraDBMessage(
+    { id, type: 'user', tagName: 'user', contents, ...(metadata ? { metadata } : {}) },
+    { threadId: reminderThreadId, resourceId },
+  );
+}
+
 describe('Subconscious reminder continuation', () => {
+  it('finds pending questions in rows persisted by sendMessage (role signal, nested metadata)', async () => {
+    const { processor, sendMessage } = createHarness();
+    const question = persistedSignalRow('question-1', 'Memory question reply-1\n\nWhat happened?', {
+      [REMIND_MESSAGE_METADATA_KEY]: { type: 'question', replyId: 'reply-1', askedAt: Date.now() },
+    });
+    expect(question.role).toBe('signal');
+    expect(question.content.metadata?.[REMIND_MESSAGE_METADATA_KEY]).toBeUndefined();
+
+    await processor.processOutputResult(resultArgs([question]));
+
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(sendMessage.mock.calls[0]![0].metadata[REMIND_MESSAGE_METADATA_KEY]).toEqual({
+      type: 'continuation',
+      replyIds: ['reply-1'],
+      attempt: 1,
+    });
+  });
+
+  it('reconstructs a question from persisted signal text when transport metadata is absent', async () => {
+    const { processor, sendMessage } = createHarness();
+    const question = persistedSignalRow('question-1', 'Memory question reply-1\n\nWhat happened?');
+
+    await processor.processOutputResult(resultArgs([question]));
+
+    expect(sendMessage.mock.calls[0]![0].metadata[REMIND_MESSAGE_METADATA_KEY]).toEqual({
+      type: 'continuation',
+      replyIds: ['reply-1'],
+      attempt: 1,
+    });
+  });
+
   it('sends a direct continuation for an unanswered question', async () => {
     const { processor, sendMessage, consumeStream } = createHarness();
     const question = message('question-1', { type: 'question', replyId: 'reply-1', askedAt: Date.now() });

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-questions.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-questions.test.ts
@@ -1,4 +1,4 @@
-import { Agent } from '@mastra/core/agent';
+import { Agent, signalToMastraDBMessage } from '@mastra/core/agent';
 import type { MastraDBMessage } from '@mastra/core/agent';
 import { RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
@@ -168,6 +168,29 @@ describe('Subconscious reminder questions', () => {
     const result = await tool.execute?.(
       { replyId: 'reply-1', answer: 'January 15.', moreComing: false },
       replyToolContext([providerMessage]),
+    );
+
+    expect(result).toMatchObject({ delivered: true, replyId: 'reply-1', moreComing: false });
+  });
+
+  it('authorizes replies against question rows persisted by sendMessage (role signal, nested metadata)', async () => {
+    const parentAgent = createParentAgent();
+    const tool = createReplyToMemoryQuestionTool({ parentAgent, parentThreadId, resourceId });
+    const persisted = signalToMastraDBMessage(
+      {
+        id: 'reply-1:message',
+        type: 'user',
+        tagName: 'user',
+        contents: 'Memory question reply-1\n\nWhat did I decide?',
+        metadata: { [REMIND_MESSAGE_METADATA_KEY]: { type: 'question', replyId: 'reply-1', askedAt: Date.now() } },
+      },
+      { threadId: `subconscious:${parentThreadId}:remind`, resourceId },
+    );
+    expect(persisted.role).toBe('signal');
+
+    const result = await tool.execute?.(
+      { replyId: 'reply-1', answer: 'January 15.', moreComing: false },
+      replyToolContext([persisted]),
     );
 
     expect(result).toMatchObject({ delivered: true, replyId: 'reply-1', moreComing: false });

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-questions.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-questions.test.ts
@@ -196,6 +196,29 @@ describe('Subconscious reminder questions', () => {
     expect(result).toMatchObject({ delivered: true, replyId: 'reply-1', moreComing: false });
   });
 
+  it('does not text-match a row that already carries a different remind type', async () => {
+    const parentAgent = createParentAgent();
+    const tool = createReplyToMemoryQuestionTool({ parentAgent, parentThreadId, resourceId });
+    const passiveCheck = signalToMastraDBMessage(
+      {
+        id: 'check-1:message',
+        type: 'user',
+        tagName: 'user',
+        contents: 'Memory question reply-1\n\nlooks like a question but is a passive check',
+        metadata: { [REMIND_MESSAGE_METADATA_KEY]: { type: 'passive-check', eventId: 'e1', candidateIds: [] } },
+      },
+      { threadId: `subconscious:${parentThreadId}:remind`, resourceId },
+    );
+
+    const result = await tool.execute?.(
+      { replyId: 'reply-1', answer: 'January 15.', moreComing: false },
+      replyToolContext([passiveCheck]),
+    );
+
+    expect(result).toEqual({ delivered: false, replyId: 'reply-1', reason: 'question-not-in-current-conversation' });
+    expect(parentAgent.sendSignal).not.toHaveBeenCalled();
+  });
+
   it('delivers partial replies with content-derived deterministic IDs', async () => {
     const parentAgent = createParentAgent();
     const tool = createReplyToMemoryQuestionTool({ parentAgent, parentThreadId, resourceId });

--- a/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-questions.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/subconscious-remind-questions.test.ts
@@ -181,7 +181,8 @@ describe('Subconscious reminder questions', () => {
         id: 'reply-1:message',
         type: 'user',
         tagName: 'user',
-        contents: 'Memory question reply-1\n\nWhat did I decide?',
+        // Text deliberately does not match the fallback parser so only the nested metadata can authorize the reply.
+        contents: 'What did I decide?',
         metadata: { [REMIND_MESSAGE_METADATA_KEY]: { type: 'question', replyId: 'reply-1', askedAt: Date.now() } },
       },
       { threadId: `subconscious:${parentThreadId}:remind`, resourceId },

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-agent.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-agent.ts
@@ -9,7 +9,7 @@ import type { JSONSchema7 } from 'json-schema';
 import type { Memory } from '../../..';
 import { createKnowledgeTools } from './knowledge-tools';
 import { RemindContinuationProcessor } from './remind-continuation';
-import { getRemindMessageMetadata } from './remind-protocol';
+import { getRemindMessageMetadata, isRemindInputMessage } from './remind-protocol';
 import type { SubconsciousModel } from './types';
 
 const DEFAULT_INSTRUCTIONS = `Review passive reminder checks and memory questions in this conversation. Use the knowledge tools when more context is needed.
@@ -82,7 +82,7 @@ function passiveCheck(
     if (isStoredMessage && (dbMessage.threadId !== threadId || dbMessage.resourceId !== resourceId)) continue;
     const metadata = getRemindMessageMetadata(dbMessage);
     if (metadata?.type === 'passive-check' && metadata.eventId === eventId) return metadata;
-    if (dbMessage.role !== 'user') continue;
+    if (metadata || !isRemindInputMessage(dbMessage)) continue;
 
     const text = messageText(message);
     if (!text.startsWith(`Passive reminder check ${eventId}\n`)) continue;

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-agent.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-agent.ts
@@ -82,6 +82,7 @@ function passiveCheck(
     if (isStoredMessage && (dbMessage.threadId !== threadId || dbMessage.resourceId !== resourceId)) continue;
     const metadata = getRemindMessageMetadata(dbMessage);
     if (metadata?.type === 'passive-check' && metadata.eventId === eventId) return metadata;
+    // A row that already declares some other remind type is never text-matched as a passive check.
     if (metadata || !isRemindInputMessage(dbMessage)) continue;
 
     const text = messageText(message);

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-continuation.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-continuation.ts
@@ -8,7 +8,12 @@ import type {
 
 import { withOmInternalThreadId } from '../internal-request-context';
 import { publishSubconsciousError } from './activity';
-import { getRemindMessageMetadata, getRemindMessageText, REMIND_MESSAGE_METADATA_KEY } from './remind-protocol';
+import {
+  getRemindMessageMetadata,
+  getRemindMessageText,
+  isRemindInputMessage,
+  REMIND_MESSAGE_METADATA_KEY,
+} from './remind-protocol';
 
 const NUDGE_AFTER_MS = 20_000;
 const MAX_CONTINUATION_ATTEMPTS = 2;
@@ -59,7 +64,7 @@ function terminalReplies(messages: MastraDBMessage[], result?: ProcessOutputResu
 function messageMetadata(message: MastraDBMessage) {
   const metadata = getRemindMessageMetadata(message);
   if (metadata) return metadata;
-  if (message.role !== 'user') return undefined;
+  if (!isRemindInputMessage(message)) return undefined;
 
   const text = getRemindMessageText(message);
   const question = text.match(/^Memory question (\S+)\n/);

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-protocol.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-protocol.ts
@@ -90,9 +90,23 @@ function parseMetadata(value: unknown): RemindMessageMetadata | undefined {
   }
 }
 
+/**
+ * Every message the reminder agent receives arrives through `agent.sendMessage()`, which persists it as a
+ * `role: 'signal'` row with the signal's metadata nested under `content.metadata.signal.metadata`. Messages built
+ * directly (tests, in-flight model input) carry it at the top level. Check both.
+ */
 export function getRemindMessageMetadata(message: MastraDBMessage): RemindMessageMetadata | undefined {
   const metadata = message.content.metadata as Record<string, unknown> | undefined;
-  return parseMetadata(metadata?.[REMIND_MESSAGE_METADATA_KEY]);
+  const direct = parseMetadata(metadata?.[REMIND_MESSAGE_METADATA_KEY]);
+  if (direct) return direct;
+  const signal = metadata?.signal as Record<string, unknown> | undefined;
+  const signalMetadata = signal?.metadata as Record<string, unknown> | undefined;
+  return parseMetadata(signalMetadata?.[REMIND_MESSAGE_METADATA_KEY]);
+}
+
+/** True for rows that carry input to the reminder agent: persisted signals and directly built user messages. */
+export function isRemindInputMessage(message: MastraDBMessage): boolean {
+  return message.role === 'user' || message.role === 'signal';
 }
 
 export function getRemindMessageText(message: MastraDBMessage): string {

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-protocol.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-protocol.ts
@@ -92,8 +92,8 @@ function parseMetadata(value: unknown): RemindMessageMetadata | undefined {
 
 /**
  * Every message the reminder agent receives arrives through `agent.sendMessage()`, which persists it as a
- * `role: 'signal'` row with the signal's metadata nested under `content.metadata.signal.metadata`. Messages built
- * directly (tests, in-flight model input) carry it at the top level. Check both.
+ * `role: 'signal'` row with the signal's metadata nested under `content.metadata.signal.metadata`. Rows built
+ * directly as `MastraDBMessage` (tests) carry it at the top level. Check both.
  */
 export function getRemindMessageMetadata(message: MastraDBMessage): RemindMessageMetadata | undefined {
   const metadata = message.content.metadata as Record<string, unknown> | undefined;
@@ -104,7 +104,10 @@ export function getRemindMessageMetadata(message: MastraDBMessage): RemindMessag
   return parseMetadata(signalMetadata?.[REMIND_MESSAGE_METADATA_KEY]);
 }
 
-/** True for rows that carry input to the reminder agent: persisted signals and directly built user messages. */
+/**
+ * True for rows that carry input to the reminder agent: persisted signals and directly built user messages.
+ * Callers scope rows to the owned reminder thread first, so any signal row here was addressed to this agent.
+ */
 export function isRemindInputMessage(message: MastraDBMessage): boolean {
   return message.role === 'user' || message.role === 'signal';
 }

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-questions.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-questions.ts
@@ -95,6 +95,8 @@ function trustedQuestion(messages: unknown, replyId: string, threadId: string, r
     if (!dbMessage) return false;
     const metadata = getRemindMessageMetadata(dbMessage);
     if (metadata?.type === 'question' && metadata.replyId === replyId) return true;
+    // A row that already declares some other remind type is never text-matched as a question.
+    if (metadata) return false;
     return isRemindInputMessage(dbMessage) && messageText(message).startsWith(`Memory question ${replyId}\n`);
   });
 }

--- a/packages/memory/src/processors/observational-memory/subconscious/remind-questions.ts
+++ b/packages/memory/src/processors/observational-memory/subconscious/remind-questions.ts
@@ -17,6 +17,7 @@ import {
   ensureOwnedRemindThread,
   getRemindMessageMetadata,
   getRemindThreadId,
+  isRemindInputMessage,
   REMIND_MESSAGE_METADATA_KEY,
 } from './remind-protocol';
 import type { ResolvedSubconsciousAgent } from './types';
@@ -94,7 +95,7 @@ function trustedQuestion(messages: unknown, replyId: string, threadId: string, r
     if (!dbMessage) return false;
     const metadata = getRemindMessageMetadata(dbMessage);
     if (metadata?.type === 'question' && metadata.replyId === replyId) return true;
-    return dbMessage.role === 'user' && messageText(message).startsWith(`Memory question ${replyId}\n`);
+    return isRemindInputMessage(dbMessage) && messageText(message).startsWith(`Memory question ${replyId}\n`);
   });
 }
 


### PR DESCRIPTION
## Problem

Everything the reminder sidekick receives (questions, passive checks, continuation nudges) is delivered via `agent.sendMessage()`, which core persists as a `role: 'signal'` row with the signal's metadata nested at `content.metadata.signal.metadata` (`packages/core/src/agent/signals.ts`, `signalToDBMessage`).

Three places read those rows back and expected a different shape — top-level `content.metadata`, with a text fallback gated on `role === 'user'`:

- `getPendingQuestions` (`remind-continuation.ts`) — so the 20s nudge, attempt counter, and "unable to answer" terminal signal never fire. If the sidekick ends a turn without calling `reply_to_memory_question`, no answer and no terminal signal ever reaches the parent thread.
- `trustedQuestion` (`remind-questions.ts`) — `reply_to_memory_question` can't authorize a reply against a persisted question row (matters for continuation runs, where the question isn't in this turn's input).
- `passiveCheck` (`remind-agent.ts`) — the text fallback for `send_reminder` grounding is unreachable for persisted rows.

## Fix

- `getRemindMessageMetadata` also reads the nested `signal.metadata` location.
- New `isRemindInputMessage` accepts `signal` rows alongside `user` rows for the text fallbacks. Rows are already scoped to the owned reminder thread before this check.
- Text fallbacks are skipped for rows that already declare a different remind type, so a passive-check row can't be text-matched as a question.

## Tests

Four regressions build rows with core's `signalToMastraDBMessage` (same serializer `sendMessage` persists through) instead of hand-built `role: 'user'` fixtures. The three signal-shape tests fail on #22783's head and pass here; the fourth proves a passive-check row cannot be text-matched as a question. They don't round-trip through storage or `MessageList`; the row shape is asserted directly.

- `@mastra/memory` unit: 1528 passed, 1 todo
- `tsc --noEmit`, oxlint, eslint clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Saved reminder messages were not always recognized later. This PR reads persisted signal messages correctly, so follow-up prompts, replies, and checks work as expected.

## Changes

- Read reminder metadata from nested signal metadata.
- Treat `user` and `signal` rows as reminder inputs.
- Prevent text matching when a row has a different reminder type.
- Update continuation, question, and passive-check handling.
- Add regression tests for rows created by `signalToMastraDBMessage`.
- Add a patch changeset for `@mastra/memory`.

## Result

Persisted reminder inputs now support continuation nudges, attempt counting, terminal signals, reply authorization, and passive-check grounding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->