### PR TITLE
fix(core): wire up tool observe on the agent path

### DIFF
--- a/.changeset/tool-observe-agent-path.md
+++ b/.changeset/tool-observe-agent-path.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `observe.log()` and `observe.span()` being silent no-ops for agent-invoked tools. The agent tool-call path hardcoded `noopObserve`, so structured logs and child spans emitted from a tool's `execute` via `context.observe` were discarded even when a tracing context was active. `CoreToolBuilder` now derives a real, span-correlated `ToolObserve` from the tool span (the same span that backs `tracing`/`loggerVNext`), falling back to a no-op only when no tracing context is active. This also enables `observe` for workflow- and directly-invoked tools.

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -22,7 +22,6 @@ import {
 import { findProviderToolByName } from '../../../tools/provider-tool-utils';
 import { getNeedsApprovalFn } from '../../../tools/toolchecks';
 import type { MastraToolInvocationOptions, ToolApprovalContext } from '../../../tools/types';
-import { noopObserve } from '../../../tools/types';
 import { ensureSerializable } from '../../../utils';
 import type { SuspendOptions } from '../../../workflows/step';
 import { createStep } from '../../../workflows/workflow';
@@ -687,7 +686,9 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           // uses a fresh unique thread, so storing this context in that thread is scoped and safe.
           messages: isAgentTool ? messageList.get.all.aiV5.model() : messageList.get.input.aiV5.model(),
           outputWriter,
-          observe: noopObserve,
+          // Leave `observe` unset so CoreToolBuilder derives a real, span-correlated
+          // ToolObserve from the tool span. Passing noopObserve here made observe.log()
+          // and observe.span() silent no-ops even when tracing was active.
           // Pass current step span as parent for tool call spans
           tracingContext: modelSpanTracker?.getTracingContext(),
           // Pass workspace from the run scope (set by llmExecutionStep via prepareStep/processInputStep)

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -46,8 +46,8 @@ import type {
   VercelTool,
   VercelToolV5,
 } from '../types';
-import { noopObserve } from '../types';
 import { validateToolInput, validateToolOutput, validateToolSuspendData } from '../validation';
+import { deriveToolObserve } from './tool-observe';
 
 /**
  * Merge two RequestContexts so non-serializable values survive the evented
@@ -643,6 +643,9 @@ export class CoreToolBuilder extends MastraBase {
           const wrappedMastra = options.mastra ? wrapMastra(options.mastra, { currentSpan: toolSpan }) : options.mastra;
 
           const resumeSchema = this.getResumeSchema();
+          // Derive once so `observe` and the spread ObservabilityContext (tracing,
+          // loggerVNext, metrics) all share the same span-correlated backing.
+          const observabilityContext = createObservabilityContext({ currentSpan: toolSpan });
           // Pass raw args as first parameter, context as second
           // Properly structure context based on execution source
           const baseContext = {
@@ -658,7 +661,10 @@ export class CoreToolBuilder extends MastraBase {
             workspace: execOptions.workspace ?? options.workspace,
             // Browser for web automation (lazily initialized on first use)
             browser: options.browser,
-            observe: execOptions.observe ?? noopObserve,
+            // Fall back to a real, span-correlated observe (not noopObserve) so
+            // `observe.span()` / `observe.log()` work whenever a tracing context
+            // is active, even when no caller supplied one (e.g. the agent path).
+            observe: execOptions.observe ?? deriveToolObserve(observabilityContext),
             writer: new ToolStream(
               {
                 prefix: 'tool',
@@ -668,7 +674,7 @@ export class CoreToolBuilder extends MastraBase {
               },
               options.outputWriter || execOptions.outputWriter,
             ),
-            ...createObservabilityContext({ currentSpan: toolSpan }),
+            ...observabilityContext,
             abortSignal: execOptions.abortSignal,
             suspend: (args: any, suspendOptions?: SuspendOptions) => {
               suspendData = args;

--- a/packages/core/src/tools/tool-builder/tool-observe.test.ts
+++ b/packages/core/src/tools/tool-builder/tool-observe.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createObservabilityContext } from '../../observability';
+import type { AnySpan, ObservabilityContext } from '../../observability';
+import { deriveToolObserve } from './tool-observe';
+
+/** Minimal child-span stub capturing end/error and running fn in-context. */
+function makeChildSpan() {
+  return {
+    end: vi.fn(),
+    error: vi.fn(),
+    executeInContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  };
+}
+
+/** Minimal parent span exposing just what deriveToolObserve touches. */
+function makeParentSpan(childSpan: ReturnType<typeof makeChildSpan>) {
+  return {
+    createChildSpan: vi.fn(() => childSpan),
+  } as unknown as AnySpan;
+}
+
+/** An ObservabilityContext with a spy logger and the given current span. */
+function makeContext(currentSpan?: AnySpan): {
+  ctx: ObservabilityContext;
+  logger: Record<string, ReturnType<typeof vi.fn>>;
+} {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  };
+  const ctx: ObservabilityContext = {
+    tracing: { currentSpan },
+    tracingContext: { currentSpan },
+    loggerVNext: logger as unknown as ObservabilityContext['loggerVNext'],
+    metrics: {} as ObservabilityContext['metrics'],
+  };
+  return { ctx, logger };
+}
+
+describe('deriveToolObserve', () => {
+  it('returns a no-op observe when no span is active', async () => {
+    // createObservabilityContext with no span yields no-op logger/tracing.
+    const observe = deriveToolObserve(createObservabilityContext());
+
+    // span still runs the function...
+    await expect(observe.span('x', () => 42)).resolves.toBe(42);
+    // ...and log does not throw.
+    expect(() => observe.log('info', 'hello')).not.toThrow();
+  });
+
+  it('opens a GENERIC child span, ends it with the output, and returns the result', async () => {
+    const childSpan = makeChildSpan();
+    const parentSpan = makeParentSpan(childSpan);
+    const { ctx } = makeContext(parentSpan);
+
+    const observe = deriveToolObserve(ctx);
+    const result = await observe.span('fetch user', async () => 'user-1', { userId: 'u1' });
+
+    expect(result).toBe('user-1');
+    expect(parentSpan.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'generic', name: 'fetch user', metadata: { userId: 'u1' } }),
+    );
+    expect(childSpan.executeInContext).toHaveBeenCalledTimes(1);
+    expect(childSpan.end).toHaveBeenCalledWith({ output: 'user-1' });
+    expect(childSpan.error).not.toHaveBeenCalled();
+  });
+
+  it('records the error on the child span and rethrows when fn throws', async () => {
+    const childSpan = makeChildSpan();
+    const parentSpan = makeParentSpan(childSpan);
+    const { ctx } = makeContext(parentSpan);
+
+    const observe = deriveToolObserve(ctx);
+    const boom = new Error('boom');
+
+    await expect(
+      observe.span('failing', async () => {
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+
+    expect(childSpan.error).toHaveBeenCalledWith({ error: boom });
+    expect(childSpan.end).not.toHaveBeenCalled();
+  });
+
+  it('forwards log() to the span-derived logger at the matching level', () => {
+    const childSpan = makeChildSpan();
+    const parentSpan = makeParentSpan(childSpan);
+    const { ctx, logger } = makeContext(parentSpan);
+
+    const observe = deriveToolObserve(ctx);
+    observe.log('warn', 'careful', { code: 7 });
+
+    expect(logger.warn).toHaveBeenCalledWith('careful', { code: 7 });
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/tools/tool-builder/tool-observe.ts
+++ b/packages/core/src/tools/tool-builder/tool-observe.ts
@@ -1,0 +1,56 @@
+import { SpanType } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
+import { noopObserve } from '../types';
+import type { ToolObserve } from '../types';
+
+/**
+ * Builds a real {@link ToolObserve} from the tool's observability context so
+ * that `observe.span()` creates trace-correlated child spans and `observe.log()`
+ * emits trace-correlated structured logs.
+ *
+ * The `observe` helper is a thin façade over the same span that backs the
+ * context's `tracing` / `loggerVNext` surfaces:
+ * - `span(name, fn)` opens a {@link SpanType.GENERIC} child under the current
+ *   span, runs `fn`, then ends the child with its output (or records the error).
+ * - `log(level, message, data)` forwards to the span-derived `loggerVNext`, so
+ *   entries are correlated to the active trace.
+ *
+ * When no span is active (observability disabled, or no tracing context on this
+ * path) the derived logger/span are already no-ops, so we return the shared
+ * {@link noopObserve} and callers still never need to null-check `observe`.
+ */
+export function deriveToolObserve(observabilityContext: ObservabilityContext): ToolObserve {
+  const parentSpan = observabilityContext.tracingContext?.currentSpan;
+
+  // No active span → nothing to correlate to. Return the shared no-op so
+  // `observe.span` still runs the function and `observe.log` stays inert.
+  if (!parentSpan) {
+    return noopObserve;
+  }
+
+  const logger = observabilityContext.loggerVNext;
+
+  return {
+    async span<T>(name: string, fn: () => Promise<T> | T, attributes?: Record<string, unknown>): Promise<T> {
+      // Arbitrary user data belongs in `metadata` (Record<string, any>); the
+      // typed `attributes` slot is reserved for span-type-specific fields.
+      const childSpan = parentSpan.createChildSpan({
+        type: SpanType.GENERIC,
+        name,
+        metadata: attributes,
+      });
+
+      try {
+        const result = await childSpan.executeInContext(async () => fn());
+        childSpan.end({ output: result });
+        return result;
+      } catch (error) {
+        childSpan.error({ error: error as Error });
+        throw error;
+      }
+    },
+    log(level, message, data) {
+      logger[level](message, data);
+    },
+  };
+}


### PR DESCRIPTION
## Description

`ToolExecutionContext.observe` was hardcoded to `noopObserve` on the agent tool-call path, so `observe.log()` and `observe.span()` were silent no-ops for every agent-invoked tool — even when a tracing context was active. The sibling `tracing`/`loggerVNext` surface worked because CoreToolBuilder derives it from the tool span; `observe` was the one surface never derived from the span.

CoreToolBuilder now builds a real `ToolObserve` from the tool span via `deriveToolObserve`: `observe.span()` opens a GENERIC child span (ending it with the output or recording the error), and `observe.log()` forwards to the span-derived `loggerVNext`. It falls back to `noopObserve` only when no tracing context is active, so user code still never needs to null-check `observe`. The agent call site no longer passes `noopObserve`, letting the real fallback apply; workflow- and directly-invoked tools gain a working `observe` too.


## Related issue(s)

fixes #22854

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [X] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Agent-run tools can now create logs and child traces instead of silently losing them. The change uses the active trace when available and keeps no-op behavior when tracing is unavailable.

## Changes

- Added `deriveToolObserve` to create a trace-correlated `ToolObserve`.
- `observe.span()` now creates child spans and records results or errors.
- `observe.log()` now forwards logs to the trace logger.
- Removed the agent call path’s forced `noopObserve`.
- Enabled the same behavior for workflow- and directly-invoked tools.
- Added tests for traced, untraced, successful, failing, and logging scenarios.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->