### PR TITLE
feat(core): let a delegation reference an earlier subagent result

### DIFF
--- a/.changeset/twenty-onions-beam.md
+++ b/.changeset/twenty-onions-beam.md
@@ -1,0 +1,47 @@
+---
+'@mastra/core': minor
+---
+
+Added an opt-in `delegation.enableResultReferences` option, so a parent agent can pass one subagent's result to another by reference instead of restating it.
+
+It's off by default. Turning it on adds a `contextFromRefs` field to each subagent tool and a `[ref: <id>]` line to every delegation result, so existing supervisors keep the tool surface and model context they have today until you ask for the change.
+
+**Why:** Subagents can't see each other's work. The parent forwards its conversation to each subagent, but tool calls and tool results are stripped first, and a subagent's response reaches the parent as a tool result. The only way to pass findings onward was for the parent model to retype them, which costs output tokens on every delegation and rewords the details.
+
+Every delegation result now carries a `ref` id, which the parent model sees as a `[ref: <id>]` line after the response text. Passing that id on a later delegation inserts the referenced text into that subagent's prompt, inside a block that names its source.
+
+**Before**, the parent model had to restate the research it received:
+
+```json
+{
+  "prompt": "Implement a fix. The research agent found that sessions live in src/auth/session.ts with a 30 minute window, refresh happens around line 88, and the retry wrapper swallows 401 errors. Use strict TypeScript."
+}
+```
+
+**After**, with the option enabled, it references the earlier result and writes only its own instructions:
+
+```typescript
+await parentAgent.generate('Fix the expired-session bug', {
+  delegation: { enableResultReferences: true },
+});
+```
+
+```json
+{
+  "prompt": "Implement a fix. Use strict TypeScript.",
+  "contextFromRefs": ["researchAgent-1"]
+}
+```
+
+Each entry accepts a bare id, or an object that adds a label and a caveat:
+
+```json
+{
+  "contextFromRefs": [
+    { "ref": "authAgent-1", "as": "auth findings" },
+    { "ref": "dbAgent-2", "as": "database findings", "note": "ignore section 3" }
+  ]
+}
+```
+
+References resolve only to delegations made during the same parent run. Unresolved references stay visible in the prompt instead of being dropped.

--- a/docs/src/content/en/docs/subagents.mdx
+++ b/docs/src/content/en/docs/subagents.mdx
@@ -252,6 +252,48 @@ await parentAgent.generate('Research AI trends', {
 })
 ```
 
+## Passing a result to another subagent
+
+Subagents can't see each other's work. The parent forwards its conversation to each subagent, but tool calls and tool results are removed first, and a subagent's response reaches the parent as a tool result. Without help, the only way to give one subagent the findings of another is for the parent model to restate them, which costs output tokens on every delegation and rewords the details.
+
+Set `enableResultReferences` to turn this on. It's off by default, because it adds a `contextFromRefs` field to each subagent tool and a `[ref: <id>]` line to every delegation result, both of which change what the parent model sees.
+
+```typescript title="src/mastra/agents/parent-agent.ts"
+await parentAgent.generate('Fix the expired-session bug', {
+  maxSteps: 10,
+  delegation: {
+    enableResultReferences: true,
+  },
+})
+```
+
+With it on, every delegation result carries a `ref` id, which the parent model sees as a `[ref: <id>]` line after the response text. Pass those ids in `contextFromRefs` on a later delegation, and Mastra inserts the referenced text into that subagent's prompt.
+
+Here the parent delegates twice. The second delegation references the first result instead of repeating it, so the prompt carries only the parent's own instructions:
+
+```json
+{
+  "prompt": "Implement a fix. Use strict TypeScript.",
+  "contextFromRefs": ["researchAgent-1"]
+}
+```
+
+The research agent's full response arrives in the implementing subagent's prompt, inside a block that names its source, so the subagent can tell those findings apart from the parent's instructions.
+
+Each entry accepts a bare id, or an object that adds a label and a caveat:
+
+```json
+{
+  "prompt": "Reconcile the auth and database findings, then implement.",
+  "contextFromRefs": [
+    { "ref": "authAgent-1", "as": "auth findings" },
+    { "ref": "dbAgent-2", "as": "database findings", "note": "ignore section 3" }
+  ]
+}
+```
+
+References resolve only to delegations made during the same parent run. An id from an earlier run, or one a subagent named inside its own response, doesn't resolve. Unresolved references stay visible in the prompt instead of being dropped, so a mistake shows up rather than silently removing context.
+
 ## Iteration monitoring
 
 `onIterationComplete` is called after each iteration of the parent agent's loop. Use it to monitor execution or guide the next iteration. You can also stop execution early.

--- a/packages/core/src/agent/__tests__/delegation-context-refs.test.ts
+++ b/packages/core/src/agent/__tests__/delegation-context-refs.test.ts
@@ -1,0 +1,387 @@
+import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { MockMemory } from '../../memory/mock';
+import { Agent } from '../agent';
+
+/**
+ * `contextFromRefs` — passing an earlier delegation's output to a later one by
+ * reference instead of the supervisor restating it.
+ *
+ * A sub-agent cannot otherwise see what its siblings produced: forwarded parent
+ * history has every tool call and tool result stripped by `stripParentToolParts`,
+ * and a sub-agent's report reaches the supervisor as a tool result, so it is
+ * exactly what gets removed. Without this the supervisor's only option is to
+ * retype the report, which costs output tokens and paraphrases the detail away.
+ */
+
+const AUTH_REPORT = [
+  'AUTH EXPLORATION REPORT',
+  '- Sessions live in src/auth/session.ts on a 30 minute sliding window.',
+  '- Token refresh is handled by refreshToken() at src/auth/refresh.ts:88.',
+  '- The retry wrapper in src/net/retry.ts swallows 401s, so expired sessions',
+  '  surface as generic network failures rather than auth failures.',
+].join('\n');
+
+const DB_REPORT = [
+  'DATABASE EXPLORATION REPORT',
+  '- Connection pooling is configured in src/db/pool.ts with a max of 10.',
+  '- Migrations run through src/db/migrate.ts and are not transactional.',
+].join('\n');
+
+/** Sub-agent returning a fixed report, optionally after a delay. */
+function makeExplorer(id: string, report: string, delayMs = 0) {
+  return new Agent({
+    id,
+    name: id,
+    description: `Explores and reports: ${id}`,
+    instructions: 'You explore and report.',
+    model: new MockLanguageModelV2({
+      doGenerate: async () => {
+        if (delayMs) await new Promise(resolve => setTimeout(resolve, delayMs));
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: report,
+          content: [{ type: 'text', text: report }],
+          warnings: [],
+        };
+      },
+    }),
+  });
+}
+
+/** Sub-agent that records the prompt it was actually handed. */
+function makeImplementer(received: string[]) {
+  return new Agent({
+    id: 'implementer',
+    name: 'implementer',
+    description: 'Implements a change.',
+    instructions: 'You implement changes.',
+    model: new MockLanguageModelV2({
+      doGenerate: async ({ prompt }) => {
+        received.push(JSON.stringify(prompt));
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: 'Implemented.',
+          content: [{ type: 'text', text: 'Implemented.' }],
+          warnings: [],
+        };
+      },
+    }),
+  });
+}
+
+/**
+ * Reads the id an agent's result was filed under out of the supervisor's own
+ * context — the same read a real model performs before citing it. Parsing rather
+ * than hardcoding keeps these tests on the round trip instead of on the fixture.
+ */
+function refIdFor(agentName: string, supervisorContext: string): string {
+  const match = supervisorContext.match(new RegExp(`\\[ref: (${agentName}-\\d+)\\]`));
+  if (!match) throw new Error(`no [ref: ...] id for "${agentName}" in supervisor context`);
+  return match[1]!;
+}
+
+type ToolCall = { toolName: string; input: Record<string, unknown> };
+
+/**
+ * Drives a supervisor through scripted turns. `turns[i]` receives the context the
+ * supervisor model saw on that turn and returns the tool calls it emits — several
+ * in one turn means concurrent delegation. An empty array stops.
+ */
+async function runSupervisor(
+  agents: Record<string, Agent>,
+  turns: Array<(context: string) => ToolCall[]>,
+  { enableResultReferences = true }: { enableResultReferences?: boolean } = {},
+) {
+  const supervisorContexts: string[] = [];
+  const emittedArgs: string[] = [];
+
+  let turn = 0;
+  const supervisor = new Agent({
+    id: 'supervisor',
+    name: 'supervisor',
+    instructions: 'Delegate to sub-agents.',
+    model: new MockLanguageModelV2({
+      doGenerate: async ({ prompt }) => {
+        const context = JSON.stringify(prompt);
+        supervisorContexts.push(context);
+        const calls = turns[turn++]?.(context) ?? [];
+
+        if (!calls.length) {
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            text: 'Done',
+            content: [{ type: 'text' as const, text: 'Done' }],
+            warnings: [],
+          };
+        }
+
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'tool-calls' as const,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          text: '',
+          content: calls.map((call, i) => {
+            const serialized = JSON.stringify(call.input);
+            emittedArgs.push(serialized);
+            return {
+              type: 'tool-call' as const,
+              toolCallId: `call-${turn}-${i}`,
+              toolName: call.toolName,
+              input: serialized,
+            };
+          }),
+          warnings: [],
+        };
+      },
+    }),
+    agents,
+    memory: new MockMemory(),
+  });
+
+  await supervisor.generate('Fix the expired-session bug', {
+    maxSteps: 8,
+    delegation: { enableResultReferences },
+  });
+
+  return { supervisorContexts, emittedArgs };
+}
+
+describe('delegation contextFromRefs', () => {
+  it('inserts a referenced result into the next sub-agent prompt without the supervisor restating it', async () => {
+    const implementerPrompts: string[] = [];
+
+    const { supervisorContexts, emittedArgs } = await runSupervisor(
+      { explorer: makeExplorer('explorer', AUTH_REPORT), implementer: makeImplementer(implementerPrompts) },
+      [
+        () => [{ toolName: 'agent-explorer', input: { prompt: 'Explore the auth code', maxSteps: 3 } }],
+        context => [
+          {
+            toolName: 'agent-implementer',
+            input: {
+              prompt: 'Implement a fix. Also use strict TypeScript.',
+              contextFromRefs: [refIdFor('explorer', context)],
+              maxSteps: 3,
+            },
+          },
+        ],
+        () => [],
+      ],
+    );
+
+    expect(implementerPrompts.length).toBe(1);
+    const implementerPrompt = implementerPrompts[0]!;
+    const secondEmission = emittedArgs[1]!;
+
+    // The referenced output arrived verbatim, alongside the supervisor's own guidance.
+    expect(implementerPrompt).toContain('Sessions live in src/auth/session.ts');
+    expect(implementerPrompt).toContain('refreshToken() at src/auth/refresh.ts:88');
+    expect(implementerPrompt).toContain('strict TypeScript');
+
+    // ...and the supervisor never wrote it out. Comparing the two sides of the
+    // boundary is what tests the mechanism; asserting on the emitted args alone
+    // would only re-assert the fixture.
+    expect(secondEmission).not.toContain('Sessions live in src/auth/session.ts');
+    expect(implementerPrompt.length).toBeGreaterThan(secondEmission.length);
+
+    // The id is visible to the supervisor's model without needing
+    // `includeSubAgentToolResultsInModelContext`, which would push every nested
+    // tool result into its context.
+    expect(supervisorContexts[1]).toMatch(/\[ref: explorer-1\]/);
+
+    // The block is framed, and the frame carries a nonce so content cannot forge
+    // a closing tag and break out into instruction position.
+    expect(implementerPrompt).toMatch(/<delegated-context-[0-9a-f]{8} ref=\\?"explorer-1\\?"/);
+    expect(implementerPrompt).toContain('from=\\"explorer\\"');
+
+    // The stored copy is the report itself — the published id is not fed back in.
+    expect(implementerPrompt).not.toContain('[ref: explorer-1]');
+  });
+
+  it('keeps each reference paired with its own result across concurrent delegations', async () => {
+    const implementerPrompts: string[] = [];
+
+    // Both delegations are emitted in one turn, so they run concurrently.
+    // `explorerAuth` is called first but resolves last, so ids are minted in
+    // completion order — the case where a naive implementation would cross-wire.
+    const { supervisorContexts } = await runSupervisor(
+      {
+        explorerAuth: makeExplorer('explorerAuth', AUTH_REPORT, 40),
+        explorerDb: makeExplorer('explorerDb', DB_REPORT),
+        implementer: makeImplementer(implementerPrompts),
+      },
+      [
+        () => [
+          { toolName: 'agent-explorerAuth', input: { prompt: 'Explore auth', maxSteps: 3 } },
+          { toolName: 'agent-explorerDb', input: { prompt: 'Explore the database layer', maxSteps: 3 } },
+        ],
+        context => [
+          {
+            toolName: 'agent-implementer',
+            input: {
+              prompt: 'Fix the session bug.',
+              contextFromRefs: [refIdFor('explorerAuth', context)],
+              maxSteps: 3,
+            },
+          },
+        ],
+        () => [],
+      ],
+    );
+
+    const afterParallel = supervisorContexts[1]!;
+    expect(refIdFor('explorerAuth', afterParallel)).toBe('explorerAuth-2');
+    expect(refIdFor('explorerDb', afterParallel)).toBe('explorerDb-1');
+
+    // The citation resolved to the auth report, with nothing leaking from the
+    // concurrent database delegation.
+    const implementerPrompt = implementerPrompts[0]!;
+    expect(implementerPrompt).toContain('Sessions live in src/auth/session.ts');
+    expect(implementerPrompt).not.toContain('Connection pooling is configured');
+  });
+
+  it('accepts labels and notes, and renders them onto the block', async () => {
+    const implementerPrompts: string[] = [];
+
+    await runSupervisor(
+      { explorerDb: makeExplorer('explorerDb', DB_REPORT), implementer: makeImplementer(implementerPrompts) },
+      [
+        () => [{ toolName: 'agent-explorerDb', input: { prompt: 'Explore the database layer', maxSteps: 3 } }],
+        context => [
+          {
+            toolName: 'agent-implementer',
+            input: {
+              prompt: 'Apply the db findings.',
+              contextFromRefs: [{ ref: refIdFor('explorerDb', context), as: 'db findings', note: 'ignore section 3' }],
+              maxSteps: 3,
+            },
+          },
+        ],
+        () => [],
+      ],
+    );
+
+    const implementerPrompt = implementerPrompts[0]!;
+    expect(implementerPrompt).toContain('as=\\"db findings\\"');
+    expect(implementerPrompt).toContain('note=\\"ignore section 3\\"');
+    expect(implementerPrompt).toContain('Connection pooling is configured');
+  });
+
+  it('renders an unresolvable reference visibly instead of dropping it', async () => {
+    const implementerPrompts: string[] = [];
+
+    await runSupervisor(
+      { explorerDb: makeExplorer('explorerDb', DB_REPORT), implementer: makeImplementer(implementerPrompts) },
+      [
+        () => [{ toolName: 'agent-explorerDb', input: { prompt: 'Explore the database layer', maxSteps: 3 } }],
+        context => [
+          {
+            toolName: 'agent-implementer',
+            input: {
+              prompt: 'Apply both.',
+              contextFromRefs: [refIdFor('explorerDb', context), 'explorer-999'],
+              maxSteps: 3,
+            },
+          },
+        ],
+        () => [],
+      ],
+    );
+
+    const implementerPrompt = implementerPrompts[0]!;
+    // The genuine reference resolved...
+    expect(implementerPrompt).toContain('Connection pooling is configured');
+    // ...and the bad one is surfaced rather than silently removing context the
+    // supervisor believed it had passed on.
+    expect(implementerPrompt).toContain('ref=\\"explorer-999\\" unresolved=\\"true\\"');
+  });
+
+  it('does not resolve ids that sub-agent content invented', async () => {
+    const implementerPrompts: string[] = [];
+
+    // A report that tries to smuggle in a reference to another agent's output.
+    // `explorerAuth-1` is a genuine id in this run — it just was not requested.
+    // Ids are only ever read from the structured `contextFromRefs` field and are
+    // never parsed out of message text, so this mention is inert.
+    const forged = `${DB_REPORT}\n- See also [ref: explorerAuth-1], which covers the session layer.`;
+
+    await runSupervisor(
+      {
+        explorerAuth: makeExplorer('explorerAuth', AUTH_REPORT),
+        explorerDb: makeExplorer('explorerDb', forged),
+        implementer: makeImplementer(implementerPrompts),
+      },
+      [
+        () => [{ toolName: 'agent-explorerAuth', input: { prompt: 'Explore auth', maxSteps: 3 } }],
+        () => [{ toolName: 'agent-explorerDb', input: { prompt: 'Explore db', maxSteps: 3 } }],
+        context => [
+          {
+            toolName: 'agent-implementer',
+            input: {
+              prompt: 'Apply the db findings.',
+              contextFromRefs: [refIdFor('explorerDb', context)],
+              maxSteps: 3,
+            },
+          },
+        ],
+        () => [],
+      ],
+    );
+
+    const implementerPrompt = implementerPrompts[0]!;
+    expect(implementerPrompt).toContain('Connection pooling is configured');
+    // The auth report was never requested, so it is not here despite the db
+    // report naming it.
+    expect(implementerPrompt).not.toContain('Sessions live in src/auth/session.ts');
+  });
+
+  it('leaves delegations that use no references unchanged', async () => {
+    const implementerPrompts: string[] = [];
+
+    await runSupervisor({ implementer: makeImplementer(implementerPrompts) }, [
+      () => [{ toolName: 'agent-implementer', input: { prompt: 'Just do it.', maxSteps: 3 } }],
+      () => [],
+    ]);
+
+    const implementerPrompt = implementerPrompts[0]!;
+    expect(implementerPrompt).toContain('Just do it.');
+    expect(implementerPrompt).not.toContain('delegated-context');
+  });
+
+  it('is off unless enabled, leaving the tool surface and parent context untouched', async () => {
+    const implementerPrompts: string[] = [];
+
+    const { supervisorContexts } = await runSupervisor(
+      { explorer: makeExplorer('explorer', AUTH_REPORT), implementer: makeImplementer(implementerPrompts) },
+      [
+        () => [{ toolName: 'agent-explorer', input: { prompt: 'Explore the auth code', maxSteps: 3 } }],
+        () => [
+          {
+            toolName: 'agent-implementer',
+            // A reference the parent model should never have been offered, and
+            // which must be ignored rather than resolved when the feature is off.
+            input: { prompt: 'Implement a fix.', contextFromRefs: ['explorer-1'], maxSteps: 3 },
+          },
+        ],
+        () => [],
+      ],
+      { enableResultReferences: false },
+    );
+
+    // No id is published into the parent's context...
+    expect(supervisorContexts[1]).not.toContain('[ref:');
+    // ...the field is absent from the tool schema the model is shown...
+    expect(supervisorContexts[0]).not.toContain('contextFromRefs');
+    // ...and nothing is expanded even though the call carried the field.
+    const implementerPrompt = implementerPrompts[0]!;
+    expect(implementerPrompt).toContain('Implement a fix.');
+    expect(implementerPrompt).not.toContain('delegated-context');
+    expect(implementerPrompt).not.toContain('Sessions live in src/auth/session.ts');
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -252,7 +252,7 @@ interface StandaloneDurableWrapper {
   prepare: (...args: any[]) => any;
 }
 
-const createSubAgentInputSchema = () =>
+const createSubAgentInputSchema = ({ withResultRefs = false }: { withResultRefs?: boolean } = {}) =>
   z.object({
     prompt: z.string().describe('The prompt to send to the agent'),
     // Using .nullish() instead of .optional() because OpenAI sends null for unfilled optional fields
@@ -272,11 +272,38 @@ const createSubAgentInputSchema = () =>
       .describe('Maximum number of execution steps for the sub-agent (integer, minimum 3)'),
     // using minimum of 3 to ensure if the agent has a tool call, the llm gets executed again after the tool call step, using the tool call result
     // to return a proper llm response
+    // Only exposed when `delegation.enableResultReferences` is on, so a supervisor
+    // that does not use the feature keeps the tool surface it had before.
+    ...(withResultRefs
+      ? {
+          contextFromRefs: z
+            .array(
+              z.union([
+                z.string(),
+                z.object({
+                  ref: z.string().describe('The reference id of an earlier delegation result'),
+                  as: z.string().nullish().describe('Short label for this block, e.g. "auth findings"'),
+                  note: z.string().nullish().describe('A caveat that applies to this block, e.g. "ignore section 3"'),
+                }),
+              ]),
+            )
+            .nullish()
+            .describe(
+              'Reference ids of earlier delegation results to include, shown as "[ref: <id>]" at the end of a previous result. ' +
+                "Their full output is inserted into this sub-agent's prompt for you, so do not restate it. Reference it here " +
+                'and use the prompt only for your own instructions. Accepts a bare id or {ref, as, note}.',
+            ),
+        }
+      : {}),
   });
 
 const createSubAgentOutputSchema = () =>
   z.object({
     text: z.string().describe('The response from the agent'),
+    ref: z
+      .string()
+      .describe('Id this result was filed under, for a later delegation to pass on via contextFromRefs')
+      .optional(),
     subAgentThreadId: z.string().describe('The thread ID of the agent').optional(),
     subAgentResourceId: z.string().describe('The resource ID of the agent').optional(),
     subAgentToolResults: z
@@ -298,10 +325,103 @@ type SubAgentToolSchemas = {
   outputSchema: StandardSchemaWithJSON<SubAgentToolOutput>;
 };
 
+/** Declared explicitly because `contextFromRefs` is only present on the schema variant that exposes it. */
 type SubAgentToolInput = Omit<z.infer<ReturnType<typeof createSubAgentInputSchema>>, 'maxSteps'> & {
   maxSteps?: number | null;
+  contextFromRefs?: Array<string | { ref: string; as?: string | null; note?: string | null }> | null;
 };
 type SubAgentToolOutput = z.infer<ReturnType<typeof createSubAgentOutputSchema>>;
+
+/**
+ * Run-scoped store of delegation outputs, so a later delegation in the same run
+ * can reference an earlier one by id instead of the supervisor restating it.
+ *
+ * Deliberately not backed by storage. A reference id is model-authored and
+ * therefore untrusted; resolving one through storage would turn it into an
+ * arbitrary read across threads and tenants. Scoping the registry to a single
+ * run rules that out by construction rather than guarding against it.
+ */
+type DelegationRefRegistry = {
+  /**
+   * Frame element name, carrying a per-run nonce. Referenced output is inserted
+   * into a prompt that also carries the supervisor's own instructions, so
+   * content that contained a plain `</delegated-context>` could otherwise break
+   * out of its block and read as instruction. A nonce the content cannot know
+   * makes the closing tag unforgeable.
+   */
+  tag: string;
+  entries: Map<string, { text: string; agentName: string }>;
+  mint: (agentName: string) => string;
+};
+
+function createDelegationRefRegistry(): DelegationRefRegistry {
+  let counter = 0;
+  return {
+    tag: `delegated-context-${randomUUID().slice(0, 8)}`,
+    entries: new Map(),
+    mint: (agentName: string) => `${agentName}-${++counter}`,
+  };
+}
+
+/** What the parent model sees for a delegation: the sub-agent's text, plus the id it was filed under. */
+const renderSubAgentModelText = (output: SubAgentToolOutput): string => {
+  const text = output.text ?? '';
+  return output.ref && text ? `${text}\n\n[ref: ${output.ref}]` : text;
+};
+
+const escapeFrameAttr = (value: string): string =>
+  value.replace(/[<>"&]/g, ch => ({ '<': '&lt;', '>': '&gt;', '"': '&quot;', '&': '&amp;' })[ch] as string);
+
+/**
+ * Prepends referenced outputs to the sub-agent's prompt as labelled blocks.
+ *
+ * The blocks lead so the sub-agent reads the evidence before the instruction
+ * that acts on it, and they are framed rather than concatenated so a peer
+ * agent's findings stay distinguishable from the supervisor's own words.
+ */
+function resolveDelegationRefs({
+  refs,
+  registry,
+  prompt,
+}: {
+  refs: SubAgentToolInput['contextFromRefs'];
+  registry: DelegationRefRegistry;
+  prompt: string;
+}): { prompt: string; resolved: string[]; missing: string[] } {
+  if (!refs?.length) return { prompt, resolved: [], missing: [] };
+
+  const blocks: string[] = [];
+  const resolved: string[] = [];
+  const missing: string[] = [];
+
+  for (const entry of refs) {
+    const ref = typeof entry === 'string' ? entry : entry?.ref;
+    if (!ref) continue;
+    const as = typeof entry === 'string' ? undefined : (entry.as ?? undefined);
+    const note = typeof entry === 'string' ? undefined : (entry.note ?? undefined);
+
+    const hit = registry.entries.get(ref);
+    if (!hit) {
+      // Render the miss rather than dropping it, so a bad reference surfaces in
+      // the sub-agent's prompt instead of silently removing context the
+      // supervisor believed it had passed on.
+      missing.push(ref);
+      blocks.push(`<${registry.tag} ref="${escapeFrameAttr(ref)}" unresolved="true" />`);
+      continue;
+    }
+
+    const attrs = [
+      `ref="${escapeFrameAttr(ref)}"`,
+      `from="${escapeFrameAttr(hit.agentName)}"`,
+      ...(as ? [`as="${escapeFrameAttr(as)}"`] : []),
+      ...(note ? [`note="${escapeFrameAttr(note)}"`] : []),
+    ].join(' ');
+    blocks.push(`<${registry.tag} ${attrs}>\n${hit.text}\n</${registry.tag}>`);
+    resolved.push(ref);
+  }
+
+  return { prompt: `${blocks.join('\n\n')}\n\n${prompt}`, resolved, missing };
+}
 
 type ModelFallbacks = {
   id: string;
@@ -661,7 +781,7 @@ export class Agent<
   #standaloneDurable?: unknown;
   #legacyHandler?: AgentLegacyHandler;
   #config: AgentConfig<TAgentId, TTools, TOutput, TRequestContext, TEditor>;
-  #subAgentToolSchemas?: SubAgentToolSchemas;
+  #subAgentToolSchemas?: Partial<Record<'default' | 'withResultRefs', SubAgentToolSchemas>>;
 
   // This flag is for agent network messages. We should change the agent network formatting and remove this flag after.
   private _agentNetworkAppend = false;
@@ -4834,18 +4954,25 @@ export class Agent<
       .filter((message): message is MastraDBMessage => Boolean(message));
   }
 
-  private getSubAgentToolSchemas(): SubAgentToolSchemas {
-    if (!this.#subAgentToolSchemas) {
-      const inputSchema = createSubAgentInputSchema();
+  /**
+   * Memoized per variant: the input schema differs depending on whether result
+   * references are enabled for the run, so the two cannot share one cache entry.
+   */
+  private getSubAgentToolSchemas({ withResultRefs = false }: { withResultRefs?: boolean } = {}): SubAgentToolSchemas {
+    const variant = withResultRefs ? 'withResultRefs' : 'default';
+    this.#subAgentToolSchemas ??= {};
+
+    if (!this.#subAgentToolSchemas[variant]) {
+      const inputSchema = createSubAgentInputSchema({ withResultRefs });
       const outputSchema = createSubAgentOutputSchema();
 
-      this.#subAgentToolSchemas = {
+      this.#subAgentToolSchemas[variant] = {
         inputSchema: toStandardSchema(inputSchema) as StandardSchemaWithJSON<SubAgentToolInput>,
         outputSchema: toStandardSchema(outputSchema),
       };
     }
 
-    return this.#subAgentToolSchemas;
+    return this.#subAgentToolSchemas[variant];
   }
 
   /**
@@ -4876,9 +5003,20 @@ export class Agent<
     const convertedAgentTools: Record<string, CoreTool> = {};
     const agents = await this.listAgents({ requestContext });
 
+    // Opt-in: leaving this off keeps the tool schema and the parent's model
+    // context exactly as they were before the feature existed.
+    const resultRefsEnabled = delegation?.enableResultReferences === true;
+
+    // Shared by every sub-agent tool built below, so one delegation can reference
+    // an earlier one's output. Built here rather than per-agent because tools are
+    // assembled once per run, which is exactly the scope a reference may span.
+    const refRegistry = resultRefsEnabled ? createDelegationRefRegistry() : undefined;
+
     if (Object.keys(agents).length > 0) {
       for (const [agentName, agent] of Object.entries(agents)) {
-        const { inputSchema: agentInputSchema, outputSchema: agentOutputSchema } = this.getSubAgentToolSchemas();
+        const { inputSchema: agentInputSchema, outputSchema: agentOutputSchema } = this.getSubAgentToolSchemas({
+          withResultRefs: resultRefsEnabled,
+        });
 
         const toModelOutput = delegation?.includeSubAgentToolResultsInModelContext
           ? undefined
@@ -4889,7 +5027,11 @@ export class Agent<
               // task started...") instead of the agentOutputSchema object. Reading `output.text`
               // off that string is undefined, which serializes to a tool message with null content
               // that providers (e.g. Anthropic) reject with a 500. Use the string as-is in that case.
-              value: typeof output === 'string' ? output : (output.text ?? ''),
+              //
+              // The `[ref: id]` line is appended here rather than baked into the result,
+              // so the parent model learns the id it can pass to a later delegation's
+              // `contextFromRefs` while `output.text` stays exactly what the sub-agent said.
+              value: typeof output === 'string' ? output : renderSubAgentModelText(output),
             });
 
         const toolObj = createTool({
@@ -4935,11 +5077,31 @@ export class Agent<
               ),
             );
 
+            // Expand any referenced earlier delegations into the prompt before the
+            // hook runs, so `onDelegationStart` sees — and can still modify — the
+            // resolved prompt, matching the ordering rationale below.
+            const refResolution = refRegistry
+              ? resolveDelegationRefs({
+                  refs: inputData.contextFromRefs,
+                  registry: refRegistry,
+                  prompt: inputData.prompt,
+                })
+              : { prompt: inputData.prompt, resolved: [], missing: [] };
+            if (refResolution.missing.length > 0) {
+              this.logger.warn('Delegation referenced unknown results', {
+                agent: this.name,
+                targetAgent: agentName,
+                missing: refResolution.missing,
+                known: [...(refRegistry?.entries.keys() ?? [])],
+              });
+            }
+            const promptWithRefs = refResolution.prompt;
+
             // Build delegation start context
             const delegationStartContext: DelegationStartContext = {
               primitiveId: agent.id,
               primitiveType: 'agent',
-              prompt: inputData.prompt,
+              prompt: promptWithRefs,
               params: {
                 threadId: inputData.threadId || undefined,
                 resourceId: inputData.resourceId || undefined,
@@ -5102,7 +5264,7 @@ export class Agent<
               }
             }
 
-            let effectivePrompt = inputData.prompt;
+            let effectivePrompt = promptWithRefs;
             let effectiveInstructions = inputData.instructions;
             let effectiveMaxSteps = inputData.maxSteps;
             // Cap the LLM-provided maxSteps at the sub-agent's own configured
@@ -5229,7 +5391,10 @@ export class Agent<
             this.logger.debug('Delegation accepted', {
               agent: this.name,
               targetAgent: agentName,
-              modifiedPrompt: effectivePrompt !== inputData.prompt,
+              // Compared against the ref-resolved prompt so this reports whether the
+              // hook changed it, not whether references were expanded.
+              modifiedPrompt: effectivePrompt !== promptWithRefs,
+              expandedRefs: refResolution.resolved,
               modifiedInstructions: effectiveInstructions !== inputData.instructions,
               modifiedMaxSteps: effectiveMaxSteps !== inputData.maxSteps,
             });
@@ -5717,6 +5882,22 @@ export class Agent<
                   }
                 }
               }
+
+              // Register this result so a later delegation in the same run can
+              // reference it. The id is attached as its own field rather than
+              // spliced into `text`, so application code reading `toolResults`
+              // still sees the sub-agent's response exactly as it was produced;
+              // `toModelOutput` is what surfaces the id to the parent model.
+              //
+              // Registered after `onDelegationComplete` so a hook that replaced the
+              // text via `resultText` stores what the supervisor actually saw,
+              // rather than a version no one read.
+              if (refRegistry && result?.text) {
+                const refId = refRegistry.mint(agentName);
+                refRegistry.entries.set(refId, { text: result.text, agentName });
+                result = { ...result, ref: refId };
+              }
+
               return result;
             } catch (err) {
               let bailed = false;

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -357,6 +357,18 @@ export interface DelegationConfig {
   includeSubAgentToolResultsInModelContext?: boolean;
 
   /**
+   * Let a delegation reuse an earlier delegation's result instead of the parent
+   * model restating it.
+   *
+   * Off by default. Turning it on changes what the parent model sees: each
+   * subagent tool gains a `contextFromRefs` input field, and every delegation
+   * result gains a trailing `[ref: <id>]` line naming the id it was filed under.
+   * Passing those ids on a later delegation inserts the referenced text into that
+   * subagent's prompt. References resolve only within the current run.
+   */
+  enableResultReferences?: boolean;
+
+  /**
    * Callback that controls which parent messages are passed to each subagent as conversation
    * context. Receives the full parent message history along with delegation metadata, and
    * returns the messages that should be forwarded.


### PR DESCRIPTION
Proposing a new pattern here rather than fixing a bug, so I'd rather get agreement on the shape before it's polished. Happy to change the approach or drop it if it doesn't fit where subagents are heading.

Subagents can't see each other's work today, and it's structural rather than a prompting problem. The parent forwards its conversation to each subagent, but `stripParentToolParts` removes every tool call and tool result first, and a subagent's response reaches the parent as a tool result, so it's exactly what gets stripped. I checked with a two-step delegation and no hooks configured, and the second subagent's model receives only its own system prompt, the forwarded user turn, and the delegation prompt. The first subagent's report isn't in there anywhere.

That leaves the parent model restating the report into the next prompt as the only way to pass it on. It costs output tokens on every delegation, and because the parent is a language model it paraphrases rather than copies, so `refresh.ts:88` comes out as "around line 88". The strip itself looks right and I don't think it should change, since the receiving subagent has no `agent-explorer` tool and providers reject dangling tool references, so anything that fixes this has to reintroduce the text as something that isn't a tool message.

This adds an opt-in `delegation.enableResultReferences`. With it on, each delegation result gets a `ref` id that the parent model sees as a `[ref: <id>]` line after the response, and a later delegation can name those ids instead of restating them:

```ts
await parentAgent.generate('Fix the expired-session bug', {
  delegation: { enableResultReferences: true },
});
```

```json
{
  "prompt": "Implement a fix. Use strict TypeScript.",
  "contextFromRefs": ["researchAgent-1"]
}
```

The referenced text is inserted into that subagent's prompt inside a block naming its source, so the subagent can tell a peer's findings from its parent's instructions. Entries also accept `{ ref, as, note }` if you want to label a block or attach a caveat like "ignore section 3", and a bare id still works so a model emitting plain strings is fine.

It's off by default, following `includeSubAgentToolResultsInModelContext`, because turning it on changes the tool schema and the parent's context. With it off nothing differs from today, including a call that passes `contextFromRefs` anyway. References only resolve to delegations from the same parent run, and the registry is in-memory rather than storage-backed on purpose, since a model-authored id resolved through storage would be an arbitrary read across threads and tenants. The frame tag carries a per-run nonce so a report containing a closing tag can't break out into instruction position. Unresolved references stay visible in the prompt instead of being dropped.

Injecting through the prompt rather than as extra context messages was deliberate: the prompt is persisted with the run, so on resume it comes back from the snapshot, whereas context messages are re-passed per call and would need re-resolving against a registry that may be gone. It also can't be stripped by someone's `messageFilter`. The tidier version would persist the unexpanded prompt plus the ids and expand only on the way to the model, mirroring how `MessageList` already swaps in model-facing values for tool results, but I left that out since delegation threads are ephemeral and nothing reads them back.

Tests cover expansion, concurrent delegations keeping each reference paired with its own result, labels and notes, unresolved references staying visible, ids invented inside a subagent's response not resolving, and the whole thing staying inert when the option is off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This lets one subagent share its result with another without copying the full text. The feature is optional and keeps existing behavior unchanged when disabled.

## Changes

- Added `delegation.enableResultReferences`.
- Added `contextFromRefs` to reference earlier delegation results.
- Added reference IDs to delegation results.
- Added support for reference labels (`as`) and notes (`note`).
- Limited references to delegations in the same parent run.
- Kept unresolved references visible in prompts.
- Added run-scoped protection for prompt framing.
- Added documentation and a changeset.
- Added tests for expansion, concurrency, labels, notes, unresolved and invalid references, forged IDs, and disabled behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->