### PR TITLE
ci: keep the docs build out of the changed-tests gate

### DIFF
--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -130,7 +130,11 @@ jobs:
         env:
           TURBO_CACHE: local:rw
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm turbo --filter "!./examples/**/*" --filter "!./docs/" --filter "!./explorations/**/*" build
+        # @mastra/mcp-docs-server#build depends on mastra-docs#build, which
+        # runs `git log --name-status` across the repo. In this blobless,
+        # credential-less checkout that lazy-fetches blobs and fails. Nothing
+        # else depends on it, so leave it out of the gate build.
+        run: pnpm turbo --filter "!./examples/**/*" --filter "!./docs/" --filter "!./explorations/**/*" --filter "!@mastra/mcp-docs-server" build
 
       - name: Run changed tests against base
         if: ${{ steps.changed_tests.outputs.has_tests == 'true' }}


### PR DESCRIPTION
The `changed-tests` gate has been failing on most PRs since this morning with the docs build blowing up:

```
mastra-docs#build: Error: Unable to build website for locale en.
  [cause]: Command failed with exit code 128: git --no-pager -c log.showSignature=false log --format=t:%ct,a:%an --name-status
  fatal: could not read Username for 'https://github.com': No such device or address
```

The gate checks out the repo with `filter: blob:none` and `persist-credentials: false`. Docusaurus runs `git log --name-status` over the whole repo to compute last-updated metadata, and git's rename detection needs blob contents when it sees adds and deletes with similar content. Until now that mostly got by on the exact-rename fast path, but #22869 moved and edited the datasets docs, so git tries to lazily fetch blobs from `origin`, has no credentials, and dies.

The docs build only ends up in this job because `@mastra/mcp-docs-server#build` depends on `mastra-docs#build`. Nothing else in the workspace depends on `@mastra/mcp-docs-server`, so this just filters it out of the gate's build. Turbo dry-run goes from 243 tasks to 239 with exactly `mastra-docs#build` and the three `@mastra/mcp-docs-server` tasks removed. It also shaves the docs build off every gate run.

Trade-off: if a PR only changes `@mastra/mcp-docs-server` tests that need `.docs/` prepared, the gate won't have built it. That's rare and those tests still run in the main test suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This change stops the changed-tests check from building documentation tasks that can fail because the CI checkout does not include Git file contents. The documentation tests still run in the main test suite.

## Changes

- Excludes `@mastra/mcp-docs-server` tasks from the changed-tests build.
- Keeps the existing exclusions for examples, documentation, and explorations.
- Reduces the changed-tests dry-run task count from 243 to 239.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->