### PR TITLE
fix(playground-ui): align section heading weight

### DIFF
--- a/.changeset/curly-turkeys-drum.md
+++ b/.changeset/curly-turkeys-drum.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Adjusted flat and factory section headings to use medium weight.
+Fixed flat and factory section headings to use medium weight.

--- a/.changeset/curly-turkeys-drum.md
+++ b/.changeset/curly-turkeys-drum.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Adjusted flat and factory section headings to use medium weight.

--- a/packages/playground-ui/src/ds/components/Section/section-heading.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section-heading.tsx
@@ -13,8 +13,8 @@ export function SectionHeading({ headingLevel = 'h2', children, className, ...pr
       data-slot="section-heading"
       className={cn(
         'group-data-[variant=default]/section:flex group-data-[variant=default]/section:items-center group-data-[variant=default]/section:gap-2 group-data-[variant=default]/section:text-ui-lg group-data-[variant=default]/section:font-bold group-data-[variant=default]/section:text-neutral4 group-data-[variant=default]/section:[&>svg]:size-[1.2em] group-data-[variant=default]/section:[&>svg]:opacity-50',
-        'group-data-[variant=flat]/section:text-ui-lg group-data-[variant=flat]/section:leading-ui-lg group-data-[variant=flat]/section:font-semibold group-data-[variant=flat]/section:text-balance group-data-[variant=flat]/section:text-neutral5',
-        'group-data-[variant=factory]/section:text-ui-lg group-data-[variant=factory]/section:leading-ui-lg group-data-[variant=factory]/section:font-semibold group-data-[variant=factory]/section:text-balance group-data-[variant=factory]/section:text-neutral5',
+        'group-data-[variant=flat]/section:text-ui-lg group-data-[variant=flat]/section:leading-ui-lg group-data-[variant=flat]/section:font-medium group-data-[variant=flat]/section:text-balance group-data-[variant=flat]/section:text-neutral5',
+        'group-data-[variant=factory]/section:text-ui-lg group-data-[variant=factory]/section:leading-ui-lg group-data-[variant=factory]/section:font-medium group-data-[variant=factory]/section:text-balance group-data-[variant=factory]/section:text-neutral5',
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/Section/section.test.tsx
+++ b/packages/playground-ui/src/ds/components/Section/section.test.tsx
@@ -17,7 +17,9 @@ describe('Section', () => {
       </Section>,
     );
 
-    expect(screen.getByRole('heading', { name: 'Overview' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Overview' }).className).toContain(
+      'group-data-[variant=default]/section:font-bold',
+    );
     expect(screen.getByText('Section content').closest('[data-slot="section"]')?.dataset.variant).toBe('default');
   });
 
@@ -79,9 +81,13 @@ describe('Section', () => {
       </div>,
     );
 
-    const factory = screen.getByRole('heading', { name: 'Factory' }).closest('[data-slot="section"]');
-    const flat = screen.getByRole('heading', { name: 'Flat' }).closest('[data-slot="section"]');
+    const factoryHeading = screen.getByRole('heading', { name: 'Factory' });
+    const flatHeading = screen.getByRole('heading', { name: 'Flat' });
+    const factory = factoryHeading.closest('[data-slot="section"]');
+    const flat = flatHeading.closest('[data-slot="section"]');
 
+    expect(factoryHeading.className).toContain('group-data-[variant=factory]/section:font-medium');
+    expect(flatHeading.className).toContain('group-data-[variant=flat]/section:font-medium');
     expect(factory?.className).toContain('w-full');
     expect(flat?.className).toContain('w-full');
     expect(factory?.querySelector('[data-slot="section-header"]')?.className).toContain(


### PR DESCRIPTION
Flat and factory `Section.Heading` now use medium weight. This keeps settings section titles consistent with the page heading while leaving the legacy default variant unchanged.

Verified with the focused Section tests, package build, typecheck, lint, 100% mutation score, Storybook, Agent Browser, and Playwright.

**Before**

![Factory section heading at semibold weight](https://github.com/user-attachments/assets/5404964c-4cb6-4d24-81fc-b169b3703bf8)

**After**

![Factory section heading at medium weight](https://github.com/user-attachments/assets/88a9be39-2387-4227-b5ad-d22980701d51)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Section headings on settings pages now use a medium font weight. This matches page headings while preserving the legacy default style.

## Changes

- Updated `flat` and `factory` `Section.Heading` variants from `font-semibold` to `font-medium`.
- Updated Section tests to verify variant-specific heading classes.
- Added a patch changeset for `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->