### PR TITLE
feat(evals): add notScorable() outcome for scorer runs

### DIFF
--- a/.changeset/dark-queens-scream.md
+++ b/.changeset/dark-queens-scream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Experiment item run responses now type the optional `notScorable` field on each scorer result.

--- a/.changeset/dark-queens-scream.md
+++ b/.changeset/dark-queens-scream.md
@@ -2,4 +2,4 @@
 '@mastra/client-js': patch
 ---
 
-Experiment item run responses now type the optional `notScorable` field on each scorer result.
+Added the optional `notScorable` field to the scorer result type in experiment item run responses.

--- a/.changeset/frank-pans-accept.md
+++ b/.changeset/frank-pans-accept.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Experiment item results now accept an optional `notScorable` field on each scorer result, set when the scorer declared the run not scorable.

--- a/.changeset/frank-pans-accept.md
+++ b/.changeset/frank-pans-accept.md
@@ -2,4 +2,4 @@
 '@mastra/server': patch
 ---
 
-Experiment item results now accept an optional `notScorable` field on each scorer result, set when the scorer declared the run not scorable.
+Added an optional `notScorable` field to each scorer result in experiment item results, set when the scorer declared the run not scorable.

--- a/.changeset/olive-teams-crash.md
+++ b/.changeset/olive-teams-crash.md
@@ -3,3 +3,11 @@
 ---
 
 Added `notScorable()` for scorers. Return it from any scorer step when a run has nothing for that scorer to evaluate, for example a tool-call judge on a run that never called the tool. The remaining steps are skipped, so no judge model call is spent, no score is stored, and the run stays out of that scorer's averages instead of counting as a pass. Live scorer hooks, `scoreTraces` batches (which now report an `excludedCount`), `runEvals` gates and turns, and experiments all honor it.
+
+```ts
+import { createScorer, notScorable } from '@mastra/core/evals';
+
+const refundJudge = createScorer({ id: 'refund-judge', description: 'Judges refund handling' })
+  .preprocess(({ run }) => (calledRefundTool(run) ? { ok: true } : notScorable('refundCustomer was not called')))
+  .generateScore(({ results }) => (results.preprocessStepResult.ok ? 1 : 0));
+```

--- a/.changeset/olive-teams-crash.md
+++ b/.changeset/olive-teams-crash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added `notScorable()` for scorers. Return it from any scorer step when a run has nothing for that scorer to evaluate, for example a tool-call judge on a run that never called the tool. The remaining steps are skipped, so no judge model call is spent, no score is stored, and the run stays out of that scorer's averages instead of counting as a pass. Live scorer hooks, `scoreTraces` batches (which now report an `excludedCount`), `runEvals` gates and turns, and experiments all honor it.

--- a/.changeset/olive-teams-crash.md
+++ b/.changeset/olive-teams-crash.md
@@ -2,7 +2,7 @@
 '@mastra/core': minor
 ---
 
-Added `notScorable()` for scorers. Return it from any scorer step when a run has nothing for that scorer to evaluate, for example a tool-call judge on a run that never called the tool. The remaining steps are skipped, so no judge model call is spent, no score is stored, and the run stays out of that scorer's averages instead of counting as a pass. Live scorer hooks, `scoreTraces` batches (which now report an `excludedCount`), `runEvals` gates and turns, and experiments all honor it.
+Added `notScorable()` for scorers. Return it from a scorer step when a run has nothing for that scorer to evaluate, for example a tool-call judge on a run that never called the tool. Remaining steps are skipped, so no judge model call is spent, no score is stored, and the run stays out of that scorer's averages. Existing scorers that never return `notScorable()` are unchanged. `scoreTrace()` returns `null` only for this outcome; `scoreTraceBatch()` reports it as `excludedCount` rather than scored or failed. Live scorer hooks, `runEvals` gates and turns, and experiments all honor it.
 
 ```ts
 import { createScorer, notScorable } from '@mastra/core/evals';

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -18810,6 +18810,11 @@ export type PostDatasetsDatasetIdExperimentsExperimentIdItemsItemIdRun_Response 
     score: number | null;
     reason: string | null;
     error: string | null;
+    notScorable?:
+      | {
+          reason?: string | undefined;
+        }
+      | undefined;
     failedStep?: string | undefined;
     completedSteps?: string[] | undefined;
     targetScope?: ('span' | 'trajectory') | undefined;

--- a/docs/src/content/en/docs/evals/custom-scorers.mdx
+++ b/docs/src/content/en/docs/evals/custom-scorers.mdx
@@ -164,6 +164,23 @@ const glutenCheckerScorer = createScorer(...)
 
 **Data Flow:** Results are available to subsequent steps as `results.preprocessStepResult`
 
+**Skipping runs with nothing to evaluate:** Return `notScorable()` from any step when the run doesn't contain what the scorer judges. The remaining steps don't run, no judge model call is made, and no score is stored, so the run stays out of the scorer's averages instead of counting as a pass. See [`notScorable()`](/reference/evals/not-scorable).
+
+```typescript oxfmt:false
+import { createScorer, notScorable } from '@mastra/core/evals'
+
+const refundJudge = createScorer(...)
+.preprocess(({ run }) => {
+  const calledRefund = run.output.some(message =>
+    message.content.parts?.some(part => part.type === 'tool-invocation' && part.toolInvocation.toolName === 'refundCustomer')
+  );
+  if (!calledRefund) {
+    return notScorable('refundCustomer was not called');
+  }
+  return { calledRefund };
+})
+```
+
 ### analyze Step (Optional)
 
 Performs core evaluation analysis, gathering insights that will inform the scoring decision.

--- a/docs/src/content/en/docs/evals/custom-scorers.mdx
+++ b/docs/src/content/en/docs/evals/custom-scorers.mdx
@@ -164,7 +164,7 @@ const glutenCheckerScorer = createScorer(...)
 
 **Data Flow:** Results are available to subsequent steps as `results.preprocessStepResult`
 
-**Skipping runs with nothing to evaluate:** Return `notScorable()` from any step when the run doesn't contain what the scorer judges. The remaining steps don't run, no judge model call is made, and no score is stored, so the run stays out of the scorer's averages instead of counting as a pass. See [`notScorable()`](/reference/evals/not-scorable).
+**Skipping runs with nothing to evaluate:** Return `notScorable()` from any step when the run doesn't contain what the scorer judges. Mastra ends the pipeline at that step without a judge model call or a stored score, which keeps the run out of the scorer's averages rather than counting it as a pass. See [`notScorable()`](/reference/evals/not-scorable).
 
 ```typescript oxfmt:false
 import { createScorer, notScorable } from '@mastra/core/evals'

--- a/docs/src/content/en/docs/evals/custom-scorers.mdx
+++ b/docs/src/content/en/docs/evals/custom-scorers.mdx
@@ -168,16 +168,15 @@ const glutenCheckerScorer = createScorer(...)
 
 ```typescript oxfmt:false
 import { createScorer, notScorable } from '@mastra/core/evals'
+import { extractToolCalls } from '@mastra/evals/scorers/utils'
 
 const refundJudge = createScorer(...)
 .preprocess(({ run }) => {
-  const calledRefund = run.output.some(message =>
-    message.content.parts?.some(part => part.type === 'tool-invocation' && part.toolInvocation.toolName === 'refundCustomer')
-  );
-  if (!calledRefund) {
+  const { tools } = extractToolCalls(run.output);
+  if (!tools.includes('refundCustomer')) {
     return notScorable('refundCustomer was not called');
   }
-  return { calledRefund };
+  return { tools };
 })
 ```
 

--- a/docs/src/content/en/docs/evals/custom-scorers.mdx
+++ b/docs/src/content/en/docs/evals/custom-scorers.mdx
@@ -164,7 +164,7 @@ const glutenCheckerScorer = createScorer(...)
 
 **Data Flow:** Results are available to subsequent steps as `results.preprocessStepResult`
 
-**Skipping runs with nothing to evaluate:** Return `notScorable()` from any step when the run doesn't contain what the scorer judges. Mastra ends the pipeline at that step without a judge model call or a stored score, which keeps the run out of the scorer's averages rather than counting it as a pass. See [`notScorable()`](/reference/evals/not-scorable).
+**Skipping runs with nothing to evaluate:** Return `notScorable()` from a function step (typically `preprocess`) when the run doesn't contain what the scorer judges. Mastra ends the pipeline at that step without a judge model call or a stored score, which keeps the run out of the scorer's averages. See [`notScorable()`](/reference/evals/not-scorable).
 
 ```typescript oxfmt:false
 import { createScorer, notScorable } from '@mastra/core/evals'

--- a/docs/src/content/en/docs/evals/overview.mdx
+++ b/docs/src/content/en/docs/evals/overview.mdx
@@ -142,7 +142,7 @@ This scores 10% of enterprise-plan traffic and none of the rest. To score differ
 
 Predicates can reference `requestContext.*`, `entity.*`, `entityType`, `source`, `threadId`, `resourceId`, and `projectId`. They support comparisons (`eq`, `ne`, `lt`, `lte`, `gt`, `gte`), membership (`in`, `notIn`), existence (`exists`, `notExists`), truthiness (`truthy`, `falsy`), and boolean composition (`and`, `or`, `not`). A filter that references an unknown root fails at agent construction rather than silently skipping scoring at runtime. Filters are plain JSON, so they're unaffected by durable agent state serialization.
 
-Eligibility filters decide _whether a scorer runs_; to filter _which messages a scorer sees_ once it runs, use [`filterRun()`](/reference/evals/filter-run).
+Eligibility filters decide _whether a scorer runs_; to filter _which messages a scorer sees_ once it runs, use [`filterRun()`](/reference/evals/filter-run). Filters can't inspect the run's input or output. When a scorer needs to look at the run itself to know whether there is anything to judge, return [`notScorable()`](/reference/evals/not-scorable) from a scorer step instead.
 
 **Automatic storage**: All scoring results are automatically stored in the `mastra_scorers` table in your configured database, allowing you to analyze performance trends over time.
 

--- a/docs/src/content/en/reference/evals/not-scorable.mdx
+++ b/docs/src/content/en/reference/evals/not-scorable.mdx
@@ -1,0 +1,94 @@
+---
+title: 'Reference: notScorable() | Evals'
+description: 'Marks a scorer run as not scorable. Return it from a scorer step to skip the remaining steps and keep the run out of score aggregates.'
+packages:
+  - '@mastra/core'
+---
+
+# notScorable()
+
+Marks the current scorer run as not scorable. Return it from any scorer step when the run doesn't contain what the scorer evaluates, for example a tool-call judge on a run that never called the tool.
+
+When a step returns `notScorable()`:
+
+- The remaining steps are skipped, so no further judge model calls are made.
+- The run result has no `score`. It carries a `notScorable` outcome instead.
+- No score record is stored. Live scorer hooks, `scoreTraces` batches, `runEvals`, and experiments all exclude the run from that scorer's averages rather than counting it as a pass.
+
+Use an [eligibility filter](/docs/evals/overview#live-evaluations) when the decision can be made from the run context before the scorer runs. Use `notScorable()` when the decision needs the run's input or output.
+
+## Usage example
+
+```typescript title="src/mastra/scorers/refund-judge.ts"
+import { createScorer, notScorable } from '@mastra/core/evals'
+import { z } from 'zod'
+
+export const refundJudge = createScorer({
+  id: 'refund-judge',
+  description: 'Judges how well refund requests were handled',
+  type: 'agent',
+  judge: { model: '__GATEWAY_OPENAI_MODEL_MINI__', instructions: 'You judge refund handling.' },
+})
+  .preprocess(({ run }) => {
+    const calledRefund = run.output.some(message =>
+      message.content.parts?.some(
+        part =>
+          part.type === 'tool-invocation' && part.toolInvocation.toolName === 'refundCustomer',
+      ),
+    )
+    if (!calledRefund) {
+      return notScorable('refundCustomer was not called')
+    }
+    return { calledRefund }
+  })
+  .analyze({
+    description: 'Assess the refund handling',
+    outputSchema: z.object({ verdict: z.enum(['good', 'bad']) }),
+    createPrompt: ({ run }) => `Was this refund handled well?\n${JSON.stringify(run.output)}`,
+  })
+  .generateScore(({ results }) => (results.analyzeStepResult.verdict === 'good' ? 1 : 0))
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'reason',
+    type: 'string',
+    isOptional: true,
+    description: 'Why the run is not scorable. Surfaced on the run result and the scorer span.',
+  },
+]}
+/>
+
+## Returns
+
+A marker value. Return it directly from a scorer step; don't wrap it in another object.
+
+## Run result
+
+When a step returned `notScorable()`, `scorer.run()` resolves with:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'notScorable',
+    type: '{ reason?: string }',
+    description: 'Present only for not-scorable runs. Carries the reason passed to notScorable().',
+  },
+  {
+    name: 'score',
+    type: 'undefined',
+    description: 'No score is produced for a not-scorable run.',
+  },
+]}
+/>
+
+Step results from steps that ran before `notScorable()` was returned are still included.
+
+## Related
+
+- [`createScorer()`](/reference/evals/create-scorer)
+- [`filterRun()`](/reference/evals/filter-run)
+- [Custom scorers](/docs/evals/custom-scorers)

--- a/docs/src/content/en/reference/evals/not-scorable.mdx
+++ b/docs/src/content/en/reference/evals/not-scorable.mdx
@@ -64,7 +64,7 @@ export const refundJudge = createScorer({
 
 ## Returns
 
-A marker value. Return it directly from a scorer step; don't wrap it in another object.
+A marker value. Return it directly from a scorer step. Don't wrap it in another object.
 
 ## Run result
 

--- a/docs/src/content/en/reference/evals/not-scorable.mdx
+++ b/docs/src/content/en/reference/evals/not-scorable.mdx
@@ -21,6 +21,7 @@ Use an [eligibility filter](/docs/evals/overview#live-evaluations) when the deci
 
 ```typescript title="src/mastra/scorers/refund-judge.ts"
 import { createScorer, notScorable } from '@mastra/core/evals'
+import { extractToolCalls } from '@mastra/evals/scorers/utils'
 import { z } from 'zod'
 
 export const refundJudge = createScorer({
@@ -30,16 +31,11 @@ export const refundJudge = createScorer({
   judge: { model: '__GATEWAY_OPENAI_MODEL_MINI__', instructions: 'You judge refund handling.' },
 })
   .preprocess(({ run }) => {
-    const calledRefund = run.output.some(message =>
-      message.content.parts?.some(
-        part =>
-          part.type === 'tool-invocation' && part.toolInvocation.toolName === 'refundCustomer',
-      ),
-    )
-    if (!calledRefund) {
+    const { tools } = extractToolCalls(run.output)
+    if (!tools.includes('refundCustomer')) {
       return notScorable('refundCustomer was not called')
     }
-    return { calledRefund }
+    return { tools }
   })
   .analyze({
     description: 'Assess the refund handling',

--- a/docs/src/content/en/reference/evals/not-scorable.mdx
+++ b/docs/src/content/en/reference/evals/not-scorable.mdx
@@ -7,13 +7,13 @@ packages:
 
 # notScorable()
 
-Marks the current scorer run as not scorable. Return it from any scorer step when the run doesn't contain what the scorer evaluates, for example a tool-call judge on a run that never called the tool.
+Marks the current scorer run as not scorable. Return it from a function step (typically `preprocess`) when the run doesn't contain what the scorer evaluates, for example a tool-call judge on a run that never called the tool.
 
 When a step returns `notScorable()`:
 
 - The remaining steps are skipped, so no further judge model calls are made.
 - The run result has no `score`. It carries a `notScorable` outcome instead.
-- No score record is stored. Live scorer hooks, `scoreTraces` batches, `runEvals`, and experiments all exclude the run from that scorer's averages rather than counting it as a pass.
+- No score record is stored. Live scorer hooks, `scoreTraces` batches, `runEvals`, and experiments all exclude the run from that scorer's averages. Scorers that never return `notScorable()` keep their previous behavior.
 
 Use an [eligibility filter](/docs/evals/overview#live-evaluations) when the decision can be made from the run context before the scorer runs. Use `notScorable()` when the decision needs the run's input or output.
 

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -298,8 +298,8 @@ const sidebars = {
       items: [
         { type: 'doc', id: 'evals/create-scorer', label: 'createScorer()' },
         { type: 'doc', id: 'evals/filter-run', label: 'filterRun()' },
-        { type: 'doc', id: 'evals/not-scorable', label: 'notScorable()' },
         { type: 'doc', id: 'evals/mastra-scorer', label: 'MastraScorer' },
+        { type: 'doc', id: 'evals/not-scorable', label: 'notScorable()' },
         { type: 'doc', id: 'evals/checks', label: 'Quick Checks' },
         { type: 'doc', id: 'evals/run-evals', label: 'runEvals()' },
         { type: 'doc', id: 'evals/scorer-utils', label: 'Scorer Utils' },

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -298,6 +298,7 @@ const sidebars = {
       items: [
         { type: 'doc', id: 'evals/create-scorer', label: 'createScorer()' },
         { type: 'doc', id: 'evals/filter-run', label: 'filterRun()' },
+        { type: 'doc', id: 'evals/not-scorable', label: 'notScorable()' },
         { type: 'doc', id: 'evals/mastra-scorer', label: 'MastraScorer' },
         { type: 'doc', id: 'evals/checks', label: 'Quick Checks' },
         { type: 'doc', id: 'evals/run-evals', label: 'runEvals()' },

--- a/packages/core/src/datasets/experiment/__tests__/scorer-not-scorable.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/scorer-not-scorable.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createScorer } from '../../../evals/base';
+import { notScorable } from '../../../evals/not-scorable';
+import { runScorersForItem } from '../scorer';
+
+describe('runScorersForItem not scorable', () => {
+  it('reports a not-scorable scorer result without a score or an error', async () => {
+    const generateScore = vi.fn(() => 1);
+    const scorer = createScorer({ id: 'refund-judge', description: 'judges refund handling' })
+      .preprocess(() => notScorable('refund tool never called'))
+      .generateScore(generateScore);
+
+    const results = await runScorersForItem(
+      [scorer],
+      { input: 'hello' },
+      'hi there',
+      null,
+      'run-1',
+      'agent',
+      'agent-1',
+      'item-1',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+    );
+
+    expect(generateScore).not.toHaveBeenCalled();
+    expect(results).toEqual([
+      expect.objectContaining({
+        scorerId: 'refund-judge',
+        score: null,
+        reason: null,
+        error: null,
+        notScorable: { reason: 'refund tool never called' },
+      }),
+    ]);
+  });
+});

--- a/packages/core/src/datasets/experiment/scorer.ts
+++ b/packages/core/src/datasets/experiment/scorer.ts
@@ -295,6 +295,7 @@ interface ScorerPromptMetadata {
 function extractScorerRunFields(scoreResult: unknown): {
   score: number | null;
   reason: string | null;
+  notScorable?: { reason?: string };
   promptMetadata: ScorerPromptMetadata;
 } {
   if (typeof scoreResult !== 'object' || scoreResult === null) {
@@ -309,9 +310,14 @@ function extractScorerRunFields(scoreResult: unknown): {
     return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined;
   };
 
+  const notScorable = obj('notScorable');
+
   return {
     score: typeof fields.score === 'number' ? fields.score : null,
     reason: typeof fields.reason === 'string' ? fields.reason : null,
+    ...(notScorable
+      ? { notScorable: typeof notScorable.reason === 'string' ? { reason: notScorable.reason } : {} }
+      : {}),
     promptMetadata: {
       generateScorePrompt: str('generateScorePrompt'),
       generateReasonPrompt: str('generateReasonPrompt'),
@@ -393,7 +399,7 @@ async function runScorerSafe(
       };
     }
 
-    const { score, reason, promptMetadata } = extractScorerRunFields(scoreResult);
+    const { score, reason, notScorable, promptMetadata } = extractScorerRunFields(scoreResult);
 
     return {
       result: {
@@ -402,6 +408,7 @@ async function runScorerSafe(
         score,
         reason,
         error: null,
+        ...(notScorable ? { notScorable } : {}),
         targetScope: effectiveScope,
       },
       promptMetadata,
@@ -551,9 +558,7 @@ export async function runStepScorersForItem(
               stepId,
             };
           }
-          const fields = scoreResult as Record<string, unknown>;
-          const score = typeof fields.score === 'number' ? fields.score : null;
-          const reason = typeof fields.reason === 'string' ? fields.reason : null;
+          const { score, reason, notScorable } = extractScorerRunFields(scoreResult);
 
           // Persist score (best-effort, mirrors runScorersForItem)
           if (persistScores && storage && score !== null) {
@@ -592,6 +597,7 @@ export async function runStepScorersForItem(
             score,
             reason,
             error: null,
+            ...(notScorable ? { notScorable } : {}),
             targetScope: 'span' as const,
             stepId,
           };

--- a/packages/core/src/datasets/experiment/types.ts
+++ b/packages/core/src/datasets/experiment/types.ts
@@ -350,6 +350,8 @@ export interface ScorerResult {
   reason: string | null;
   /** Error message if scorer failed */
   error: string | null;
+  /** Set when the scorer declared the run not scorable; `score` is null and this is not an error */
+  notScorable?: { reason?: string };
   /** Scorer stage that failed, when the scorer exposes stage context */
   failedStep?: ScorerStepName;
   /** Scorer stages that completed before the failure */

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -42,7 +42,7 @@ import { selectFields } from '../utils';
 import { createWorkflow } from '../workflows/create';
 import { createStep } from '../workflows/workflow';
 import { isNotScorable } from './not-scorable';
-import type { NotScorableOutcome } from './not-scorable';
+import type { NotScorableOutcome, NotScorableResult } from './not-scorable';
 import type { ScoringFilter } from './predicate';
 import type {
   ScoringSamplingConfig,
@@ -354,15 +354,12 @@ export interface ScorerJudgeStepResult {
 
 export type ScorerJudgeResults = Partial<Record<ScorerJudgeStepName, ScorerJudgeStepResult>>;
 
-export type ScorerRunResult<
+type ScorerRunResultBase<
   TAccumulatedResults extends Record<string, any> = Record<string, any>,
   TInput = any,
   TRunOutput = any,
 > = ScorerRun<TInput, TRunOutput> & {
   scoreTraceId?: string;
-  score: TAccumulatedResults extends Record<'generateScoreStepResult', infer TScore> ? TScore : never;
-  /** Set when a step returned `notScorable()`: no score, remaining steps skipped. */
-  notScorable?: NotScorableOutcome;
   reason?: TAccumulatedResults extends Record<'generateReasonStepResult', infer TReason> ? TReason : undefined;
 
   // Prompts
@@ -379,6 +376,23 @@ export type ScorerRunResult<
 
   judge?: ScorerJudgeResults;
 } & { runId: string };
+
+export type ScorerRunResult<
+  TAccumulatedResults extends Record<string, any> = Record<string, any>,
+  TInput = any,
+  TRunOutput = any,
+> = ScorerRunResultBase<TAccumulatedResults, TInput, TRunOutput> &
+  (
+    | {
+        score: TAccumulatedResults extends Record<'generateScoreStepResult', infer TScore> ? TScore : never;
+        notScorable?: undefined;
+      }
+    | {
+        /** Set when a step returned `notScorable()`: no score, remaining steps skipped. */
+        notScorable: NotScorableOutcome;
+        score?: undefined;
+      }
+  );
 
 export type ScorerRunResultSnapshot<TResult extends ScorerRunResult = ScorerRunResult> = Omit<TResult, 'score'> &
   Partial<Pick<TResult, 'score'>>;
@@ -660,8 +674,8 @@ type GenerateReasonFunctionStep<TAccumulated extends Record<string, any>, TInput
   | ((context: GenerateReasonContext<TAccumulated, TInput, TRunOutput>) => Promise<any>);
 
 type GenerateScoreFunctionStep<TAccumulated extends Record<string, any>, TInput, TRunOutput> =
-  | ((context: StepContext<TAccumulated, TInput, TRunOutput>) => number)
-  | ((context: StepContext<TAccumulated, TInput, TRunOutput>) => Promise<number>);
+  | ((context: StepContext<TAccumulated, TInput, TRunOutput>) => number | NotScorableResult)
+  | ((context: StepContext<TAccumulated, TInput, TRunOutput>) => Promise<number | NotScorableResult>);
 
 // Special prompt object type for generateScore that always returns a number
 interface GenerateScorePromptObject<TAccumulated extends Record<string, any>, TInput, TRunOutput> {

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -41,6 +41,8 @@ import type { MastraOnStepFinishCallback } from '../stream/types';
 import { selectFields } from '../utils';
 import { createWorkflow } from '../workflows/create';
 import { createStep } from '../workflows/workflow';
+import { isNotScorable } from './not-scorable';
+import type { NotScorableOutcome } from './not-scorable';
 import type { ScoringFilter } from './predicate';
 import type {
   ScoringSamplingConfig,
@@ -359,6 +361,8 @@ export type ScorerRunResult<
 > = ScorerRun<TInput, TRunOutput> & {
   scoreTraceId?: string;
   score: TAccumulatedResults extends Record<'generateScoreStepResult', infer TScore> ? TScore : never;
+  /** Set when a step returned `notScorable()`: no score, remaining steps skipped. */
+  notScorable?: NotScorableOutcome;
   reason?: TAccumulatedResults extends Record<'generateReasonStepResult', infer TReason> ? TReason : undefined;
 
   // Prompts
@@ -1113,6 +1117,7 @@ class MastraScorer<
         success: true,
         score: typeof scorerResult.score === 'number' ? scorerResult.score : null,
         reason: typeof scorerResult.reason === 'string' ? scorerResult.reason : null,
+        ...(scorerResult.notScorable ? { notScorable: true, ...scorerResult.notScorable } : {}),
       },
     });
 
@@ -1197,7 +1202,7 @@ class MastraScorer<
         description: `Scorer step: ${scorerStep.name}`,
         inputSchema: z.any(),
         outputSchema: z.any(),
-        execute: async ({ inputData, getInitData, ...rest }) => {
+        execute: async ({ inputData, getInitData, bail, ...rest }) => {
           const observabilityContext = resolveObservabilityContext(rest);
           const { accumulatedResults = {}, generatedPrompts = {}, judge } = inputData;
           const { run } = getInitData<{ run: ScorerRun<TInput, TRunOutput> }>();
@@ -1263,8 +1268,6 @@ class MastraScorer<
             });
           }
 
-          stepSpan?.end({ output: stepResult });
-
           const newGeneratedPrompts =
             prompt !== undefined
               ? {
@@ -1273,10 +1276,6 @@ class MastraScorer<
                 }
               : generatedPrompts;
 
-          const newAccumulatedResults = {
-            ...accumulatedResults,
-            [`${scorerStep.name}StepResult`]: stepResult,
-          };
           const judgeStepName = scorerStep.name as ScorerJudgeStepName;
           const newJudge = judgeExecution
             ? {
@@ -1286,6 +1285,26 @@ class MastraScorer<
                 },
               }
             : judge;
+
+          // Not scorable: stop before any remaining steps or judge calls run.
+          if (isNotScorable(stepResult)) {
+            const notScorable: NotScorableOutcome =
+              stepResult.reason !== undefined ? { reason: stepResult.reason } : {};
+            stepSpan?.end({ output: { notScorable: true, ...notScorable } });
+            return bail({
+              notScorable,
+              accumulatedResults,
+              generatedPrompts: newGeneratedPrompts,
+              ...(newJudge ? { judge: newJudge } : {}),
+            });
+          }
+
+          stepSpan?.end({ output: stepResult });
+
+          const newAccumulatedResults = {
+            ...accumulatedResults,
+            [`${scorerStep.name}StepResult`]: stepResult,
+          };
 
           return {
             stepResult,
@@ -1826,6 +1845,7 @@ class MastraScorer<
     const accumulatedResults = finalStepResult?.accumulatedResults ?? {};
     const generatedPrompts = finalStepResult?.generatedPrompts ?? {};
     const judge = finalStepResult?.judge as ScorerJudgeResults | undefined;
+    const notScorable = finalStepResult?.notScorable as NotScorableOutcome | undefined;
     const score = accumulatedResults.generateScoreStepResult;
     const reason = accumulatedResults.generateReasonStepResult;
     const preprocessStepResult = accumulatedResults.preprocessStepResult;
@@ -1838,7 +1858,8 @@ class MastraScorer<
     if (includeUndefinedFields) {
       return {
         ...originalInput,
-        score,
+        ...(notScorable ? { notScorable } : {}),
+        ...(notScorable ? {} : { score }),
         generateScorePrompt,
         reason,
         generateReasonPrompt,
@@ -1852,6 +1873,7 @@ class MastraScorer<
 
     return {
       ...originalInput,
+      ...(notScorable ? { notScorable } : {}),
       ...(score !== undefined ? { score } : {}),
       ...(generateScorePrompt !== undefined ? { generateScorePrompt } : {}),
       ...(reason !== undefined ? { reason } : {}),

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -1300,7 +1300,6 @@ class MastraScorer<
               }
             : judge;
 
-          // Not scorable: stop before any remaining steps or judge calls run.
           if (isNotScorable(stepResult)) {
             const notScorable: NotScorableOutcome =
               stepResult.reason !== undefined ? { reason: stepResult.reason } : {};

--- a/packages/core/src/evals/index.ts
+++ b/packages/core/src/evals/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export * from './base';
 export * from './predicate';
+export * from './not-scorable';
 export * from './run';
 export * from './collect-tool-mocks';

--- a/packages/core/src/evals/not-scorable.test.ts
+++ b/packages/core/src/evals/not-scorable.test.ts
@@ -1,0 +1,114 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { createScorer } from './base';
+import { notScorable, isNotScorable } from './not-scorable';
+
+const runInput = {
+  input: [{ role: 'user', content: 'please help' }],
+  output: { role: 'assistant', text: 'done' },
+};
+
+describe('notScorable', () => {
+  it('creates a marker that isNotScorable recognizes', () => {
+    expect(isNotScorable(notScorable())).toBe(true);
+    expect(isNotScorable(notScorable('no refund call'))).toBe(true);
+    expect(isNotScorable({ reason: 'no refund call' })).toBe(false);
+    expect(isNotScorable(undefined)).toBe(false);
+    expect(isNotScorable(0.5)).toBe(false);
+  });
+
+  it('skips all remaining steps when preprocess returns notScorable', async () => {
+    const analyze = vi.fn(() => ({ verdict: 'irrelevant' }));
+    const generateScore = vi.fn(() => 1);
+    const generateReason = vi.fn(() => 'why');
+
+    const scorer = createScorer({
+      id: 'refund-judge',
+      description: 'judges refund handling',
+    })
+      .preprocess(() => notScorable('refundCustomer was not called'))
+      .analyze(analyze)
+      .generateScore(generateScore)
+      .generateReason(generateReason);
+
+    const result = await scorer.run(runInput);
+
+    expect(analyze).not.toHaveBeenCalled();
+    expect(generateScore).not.toHaveBeenCalled();
+    expect(generateReason).not.toHaveBeenCalled();
+    expect(result.notScorable).toEqual({ reason: 'refundCustomer was not called' });
+    expect(result.score).toBeUndefined();
+    expect(result.preprocessStepResult).toBeUndefined();
+    expect(result.runId).toBeDefined();
+  });
+
+  it('runs the full pipeline when preprocess returns a normal value', async () => {
+    const scorer = createScorer({
+      id: 'refund-judge',
+      description: 'judges refund handling',
+    })
+      .preprocess(() => ({ calls: 1 }))
+      .analyze(({ results }) => ({ calls: results.preprocessStepResult.calls }))
+      .generateScore(({ results }) => (results.analyzeStepResult.calls > 0 ? 1 : 0));
+
+    const result = await scorer.run(runInput);
+
+    expect(result.notScorable).toBeUndefined();
+    expect(result.score).toBe(1);
+    expect(result.preprocessStepResult).toEqual({ calls: 1 });
+  });
+
+  it('supports notScorable from analyze and keeps earlier step results', async () => {
+    const generateScore = vi.fn(() => 1);
+
+    const scorer = createScorer({
+      id: 'refund-judge',
+      description: 'judges refund handling',
+    })
+      .preprocess(() => ({ calls: 0 }))
+      .analyze(({ results }) => (results.preprocessStepResult.calls === 0 ? notScorable() : { ok: true }))
+      .generateScore(generateScore);
+
+    const result = await scorer.run(runInput);
+
+    expect(generateScore).not.toHaveBeenCalled();
+    expect(result.notScorable).toEqual({});
+    expect(result.preprocessStepResult).toEqual({ calls: 0 });
+    expect(result.analyzeStepResult).toBeUndefined();
+  });
+
+  it('never invokes the judge model when preprocess declares the run not scorable', async () => {
+    const doStream = vi.fn(async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: '{"verdict":"good"}' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+      ]),
+    }));
+    const judgeModel = new MockLanguageModelV2({ doStream });
+
+    const scorer = createScorer({
+      id: 'refund-judge',
+      description: 'judges refund handling',
+      judge: { model: judgeModel, instructions: 'Judge the refund.' },
+    })
+      .preprocess(() => notScorable('nothing to judge'))
+      .analyze({
+        description: 'judge the refund handling',
+        outputSchema: z.object({ verdict: z.string() }),
+        createPrompt: () => 'Was the refund handled well?',
+      })
+      .generateScore(({ results }) => (results.analyzeStepResult.verdict === 'good' ? 1 : 0));
+
+    const result = await scorer.run(runInput);
+
+    expect(doStream).not.toHaveBeenCalled();
+    expect(result.notScorable).toEqual({ reason: 'nothing to judge' });
+    expect(result.score).toBeUndefined();
+  });
+});

--- a/packages/core/src/evals/not-scorable.ts
+++ b/packages/core/src/evals/not-scorable.ts
@@ -1,0 +1,31 @@
+/**
+ * First-class "not scorable" outcome for scorer runs.
+ *
+ * A scorer step (typically `preprocess`) returns `notScorable(reason)` when the
+ * run contains nothing for this scorer to evaluate — e.g. a tool-call judge on a
+ * run that never called the tool. The scorer pipeline then stops before any
+ * remaining steps (no judge model calls), no score is recorded, and the run is
+ * excluded from the scorer's aggregates instead of counting as a vacuous pass.
+ */
+
+const NOT_SCORABLE = Symbol.for('mastra.scorer.notScorable');
+
+export interface NotScorableResult {
+  [NOT_SCORABLE]: true;
+  /** Why the run was not scorable (surfaced on the run result and span). */
+  reason?: string;
+}
+
+/** How a not-scorable run surfaces on a `ScorerRunResult`. */
+export interface NotScorableOutcome {
+  reason?: string;
+}
+
+/** Marks the current scorer run as not scorable. Return this from a scorer step. */
+export function notScorable(reason?: string): NotScorableResult {
+  return { [NOT_SCORABLE]: true, ...(reason !== undefined ? { reason } : {}) };
+}
+
+export function isNotScorable(value: unknown): value is NotScorableResult {
+  return typeof value === 'object' && value !== null && (value as Record<PropertyKey, unknown>)[NOT_SCORABLE] === true;
+}

--- a/packages/core/src/evals/not-scorable.ts
+++ b/packages/core/src/evals/not-scorable.ts
@@ -1,11 +1,7 @@
 /**
- * First-class "not scorable" outcome for scorer runs.
- *
- * A scorer step (typically `preprocess`) returns `notScorable(reason)` when the
- * run contains nothing for this scorer to evaluate — e.g. a tool-call judge on a
- * run that never called the tool. The scorer pipeline then stops before any
- * remaining steps (no judge model calls), no score is recorded, and the run is
- * excluded from the scorer's aggregates instead of counting as a vacuous pass.
+ * Sentinel returned from a scorer step (typically `preprocess`) when the run
+ * has nothing for this scorer to evaluate. The pipeline stops, no score is
+ * stored, and the run is left out of that scorer's averages.
  */
 
 const NOT_SCORABLE = Symbol.for('mastra.scorer.notScorable');

--- a/packages/core/src/evals/run/gates.scenario.test.ts
+++ b/packages/core/src/evals/run/gates.scenario.test.ts
@@ -13,6 +13,7 @@ import { z } from 'zod/v4';
 import { Agent } from '../../agent';
 import { createTool } from '../../tools';
 import { createScorer } from '../base';
+import { notScorable } from '../not-scorable';
 import { runEvals } from '.';
 
 // ─── AIMock lifecycle ───────────────────────────────────────────────────────────
@@ -102,6 +103,13 @@ const failingGate = createScorer({
   name: 'Always Fail',
 }).generateScore(() => 0);
 
+/** A gate scorer that declares every run not scorable. */
+const notScorableGate = createScorer({
+  id: 'not-scorable-gate',
+  description: 'Never applies',
+  name: 'Not Scorable',
+}).generateScore(() => notScorable('nothing to check'));
+
 /** A scorer that returns a fixed score (for threshold testing). */
 function fixedScorer(id: string, score: number) {
   return createScorer({
@@ -171,6 +179,20 @@ describe('Gates & Verdict — scenario tests via runEvals + AIMock', () => {
       expect(result.gateResults).toHaveLength(2);
       expect(result.gateResults![0]!.passed).toBe(true);
       expect(result.gateResults![1]!.passed).toBe(false);
+    });
+
+    it('leaves a gate out of the verdict when every run was not scorable', async () => {
+      const agent = textAgent('Sunny and 72°F in Brooklyn.');
+
+      const result = await runEvals({
+        data: [{ input: 'What is the weather?' }],
+        scorers: [fixedScorer('quality', 0.9)],
+        gates: [passingGate, notScorableGate],
+        target: agent,
+      });
+
+      expect(result.verdict).toBe('passed');
+      expect(result.gateResults).toEqual([{ id: 'always-pass-gate', passed: true, score: 1 }]);
     });
 
     it('allows gate-only runs when scorers is omitted', async () => {

--- a/packages/core/src/evals/run/index.ts
+++ b/packages/core/src/evals/run/index.ts
@@ -482,6 +482,7 @@ export async function runEvals(config: RunEvalsAnyConfig): Promise<RunEvalsResul
       result.gateResults = [];
       for (const gate of gates) {
         const scores = gateScoresByGateId[gate.id]!;
+        if (scores.length === 0) continue;
         const avgScore = average(scores);
         const passed = avgScore >= 1.0;
         if (!passed) allGatesPassed = false;
@@ -495,6 +496,7 @@ export async function runEvals(config: RunEvalsAnyConfig): Promise<RunEvalsResul
       result.thresholdResults = [];
       for (const [scorerId, threshold] of thresholdMap) {
         const scores = thresholdScoresByScorerID[scorerId]!;
+        if (scores.length === 0) continue;
         const averageScore = average(scores);
         const passed = checkThresholdPassed(averageScore, threshold);
         if (!passed) allThresholdsPassed = false;
@@ -602,6 +604,7 @@ async function scoreTurn(
           targetTraceId: record.traceId,
           targetSpanId: record.spanId,
         });
+        if (gateScore.notScorable) continue;
         score = gateScore.score as number;
         rawResults[gate.id] = gateScore;
       } catch (error) {
@@ -626,10 +629,10 @@ async function scoreTurn(
         targetTraceId: record.traceId,
         targetSpanId: record.spanId,
       });
-      rawResults[scorer.id] = scoreResult;
       if (scoreResult.notScorable) {
         continue;
       }
+      rawResults[scorer.id] = scoreResult;
       const score = scoreResult.score as number;
       scores.push({ id: scorer.id, score });
       const threshold = thresholdMap.get(scorer.id);

--- a/packages/core/src/evals/run/index.ts
+++ b/packages/core/src/evals/run/index.ts
@@ -373,7 +373,10 @@ export async function runEvals(config: RunEvalsAnyConfig): Promise<RunEvalsResul
               targetTraceId: targetResult.traceId,
               targetSpanId: targetResult.spanId,
             });
-            gateScoresByGateId[gate.id]!.push(gateScore.score as number);
+            // Not-scorable gate runs stay out of the gate average
+            if (!gateScore.notScorable) {
+              gateScoresByGateId[gate.id]!.push(gateScore.score as number);
+            }
           } catch (error) {
             // Gate failure = score 0. The contract stays, but the cause is
             // logged so a broken scorer is distinguishable from a real 0.
@@ -623,9 +626,12 @@ async function scoreTurn(
         targetTraceId: record.traceId,
         targetSpanId: record.spanId,
       });
+      rawResults[scorer.id] = scoreResult;
+      if (scoreResult.notScorable) {
+        continue;
+      }
       const score = scoreResult.score as number;
       scores.push({ id: scorer.id, score });
-      rawResults[scorer.id] = scoreResult;
       const threshold = thresholdMap.get(scorer.id);
       if (threshold !== undefined) {
         thresholds.push({ id: scorer.id, score, threshold });

--- a/packages/core/src/evals/run/index.ts
+++ b/packages/core/src/evals/run/index.ts
@@ -373,7 +373,6 @@ export async function runEvals(config: RunEvalsAnyConfig): Promise<RunEvalsResul
               targetTraceId: targetResult.traceId,
               targetSpanId: targetResult.spanId,
             });
-            // Not-scorable gate runs stay out of the gate average
             if (!gateScore.notScorable) {
               gateScoresByGateId[gate.id]!.push(gateScore.score as number);
             }
@@ -392,7 +391,7 @@ export async function runEvals(config: RunEvalsAnyConfig): Promise<RunEvalsResul
       // Track threshold scores
       for (const [scorerId] of thresholdMap) {
         const result = scorerResults[scorerId];
-        if (result && typeof result === 'object' && 'score' in result) {
+        if (typeof result?.score === 'number') {
           thresholdScoresByScorerID[scorerId]!.push(result.score);
         }
       }

--- a/packages/core/src/evals/run/scorerAccumulator.test.ts
+++ b/packages/core/src/evals/run/scorerAccumulator.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { ScoreAccumulator } from './scorerAccumulator';
+
+describe('ScoreAccumulator', () => {
+  it('averages numeric scores only and skips not-scorable results', () => {
+    const accumulator = new ScoreAccumulator();
+
+    accumulator.addScores({
+      relevancy: { score: 1 },
+      completeness: { score: 0.5 },
+    });
+    accumulator.addScores({
+      relevancy: { notScorable: { reason: 'tool never called' } },
+      completeness: { score: 1 },
+    });
+
+    expect(accumulator.getAverageScores()).toEqual({ relevancy: 1, completeness: 0.75 });
+  });
+});

--- a/packages/core/src/evals/run/scorerAccumulator.test.ts
+++ b/packages/core/src/evals/run/scorerAccumulator.test.ts
@@ -12,6 +12,7 @@ describe('ScoreAccumulator', () => {
     accumulator.addScores({
       relevancy: { notScorable: { reason: 'tool never called' } },
       completeness: { score: 1 },
+      refund: { notScorable: {} },
     });
 
     expect(accumulator.getAverageScores()).toEqual({ relevancy: 1, completeness: 0.75 });

--- a/packages/core/src/evals/run/scorerAccumulator.ts
+++ b/packages/core/src/evals/run/scorerAccumulator.ts
@@ -27,7 +27,7 @@ export class ScoreAccumulator {
       if (!this.flatScores[scorerName]) {
         this.flatScores[scorerName] = [];
       }
-      this.flatScores[scorerName].push((result as { score: number }).score);
+      this.pushScore(this.flatScores[scorerName], result);
     }
   }
 
@@ -37,7 +37,7 @@ export class ScoreAccumulator {
         if (!this.workflowScores[scorerName]) {
           this.workflowScores[scorerName] = [];
         }
-        this.workflowScores[scorerName].push((result as { score: number }).score);
+        this.pushScore(this.workflowScores[scorerName], result);
       }
     }
 
@@ -50,7 +50,7 @@ export class ScoreAccumulator {
           if (!this.stepScores[stepId][scorerName]) {
             this.stepScores[stepId][scorerName] = [];
           }
-          this.stepScores[stepId][scorerName].push((result as { score: number }).score);
+          this.pushScore(this.stepScores[stepId][scorerName], result);
         }
       }
     }
@@ -61,7 +61,7 @@ export class ScoreAccumulator {
         if (!this.trajectoryScores[scorerName]) {
           this.trajectoryScores[scorerName] = [];
         }
-        this.trajectoryScores[scorerName].push((result as { score: number }).score);
+        this.pushScore(this.trajectoryScores[scorerName], result);
       }
     }
   }
@@ -72,7 +72,7 @@ export class ScoreAccumulator {
         if (!this.agentScores[scorerName]) {
           this.agentScores[scorerName] = [];
         }
-        this.agentScores[scorerName].push((result as { score: number }).score);
+        this.pushScore(this.agentScores[scorerName], result);
       }
     }
 
@@ -81,7 +81,7 @@ export class ScoreAccumulator {
         if (!this.trajectoryScores[scorerName]) {
           this.trajectoryScores[scorerName] = [];
         }
-        this.trajectoryScores[scorerName].push((result as { score: number }).score);
+        this.pushScore(this.trajectoryScores[scorerName], result);
       }
     }
   }
@@ -95,8 +95,15 @@ export class ScoreAccumulator {
         if (!this.stepScores[stepId][scorerName]) {
           this.stepScores[stepId][scorerName] = [];
         }
-        this.stepScores[stepId][scorerName].push((result as { score: number }).score);
+        this.pushScore(this.stepScores[stepId][scorerName], result);
       }
+    }
+  }
+
+  private pushScore(bucket: number[], result: unknown) {
+    const score = (result as { score?: unknown } | null | undefined)?.score;
+    if (typeof score === 'number') {
+      bucket.push(score);
     }
   }
 

--- a/packages/core/src/evals/run/scorerAccumulator.ts
+++ b/packages/core/src/evals/run/scorerAccumulator.ts
@@ -24,33 +24,21 @@ export class ScoreAccumulator {
 
   private addFlatScores(scorerResults: Record<string, any>) {
     for (const [scorerName, result] of Object.entries(scorerResults)) {
-      if (!this.flatScores[scorerName]) {
-        this.flatScores[scorerName] = [];
-      }
-      this.pushScore(this.flatScores[scorerName], result);
+      this.pushScore(this.flatScores, scorerName, result);
     }
   }
 
   private addWorkflowScores(scorerResults: Record<string, any>) {
     if ('workflow' in scorerResults && scorerResults.workflow) {
       for (const [scorerName, result] of Object.entries(scorerResults.workflow)) {
-        if (!this.workflowScores[scorerName]) {
-          this.workflowScores[scorerName] = [];
-        }
-        this.pushScore(this.workflowScores[scorerName], result);
+        this.pushScore(this.workflowScores, scorerName, result);
       }
     }
 
     if ('steps' in scorerResults && scorerResults.steps) {
       for (const [stepId, stepResults] of Object.entries(scorerResults.steps)) {
-        if (!this.stepScores[stepId]) {
-          this.stepScores[stepId] = {};
-        }
         for (const [scorerName, result] of Object.entries(stepResults as Record<string, any>)) {
-          if (!this.stepScores[stepId][scorerName]) {
-            this.stepScores[stepId][scorerName] = [];
-          }
-          this.pushScore(this.stepScores[stepId][scorerName], result);
+          this.pushStepScore(stepId, scorerName, result);
         }
       }
     }
@@ -58,10 +46,7 @@ export class ScoreAccumulator {
     // Trajectory scores can come from workflow scorer configs too
     if ('trajectory' in scorerResults && scorerResults.trajectory) {
       for (const [scorerName, result] of Object.entries(scorerResults.trajectory)) {
-        if (!this.trajectoryScores[scorerName]) {
-          this.trajectoryScores[scorerName] = [];
-        }
-        this.pushScore(this.trajectoryScores[scorerName], result);
+        this.pushScore(this.trajectoryScores, scorerName, result);
       }
     }
   }
@@ -69,42 +54,36 @@ export class ScoreAccumulator {
   private addAgentScores(scorerResults: Record<string, any>) {
     if ('agent' in scorerResults && scorerResults.agent) {
       for (const [scorerName, result] of Object.entries(scorerResults.agent)) {
-        if (!this.agentScores[scorerName]) {
-          this.agentScores[scorerName] = [];
-        }
-        this.pushScore(this.agentScores[scorerName], result);
+        this.pushScore(this.agentScores, scorerName, result);
       }
     }
 
     if ('trajectory' in scorerResults && scorerResults.trajectory) {
       for (const [scorerName, result] of Object.entries(scorerResults.trajectory)) {
-        if (!this.trajectoryScores[scorerName]) {
-          this.trajectoryScores[scorerName] = [];
-        }
-        this.pushScore(this.trajectoryScores[scorerName], result);
+        this.pushScore(this.trajectoryScores, scorerName, result);
       }
     }
   }
 
   addStepScores(stepScorerResults: Record<string, Record<string, any>>) {
     for (const [stepId, stepResults] of Object.entries(stepScorerResults)) {
-      if (!this.stepScores[stepId]) {
-        this.stepScores[stepId] = {};
-      }
       for (const [scorerName, result] of Object.entries(stepResults)) {
-        if (!this.stepScores[stepId][scorerName]) {
-          this.stepScores[stepId][scorerName] = [];
-        }
-        this.pushScore(this.stepScores[stepId][scorerName], result);
+        this.pushStepScore(stepId, scorerName, result);
       }
     }
   }
 
-  private pushScore(bucket: number[], result: unknown) {
+  // Buckets are created on the first numeric score, so all-excluded scorers are omitted rather than averaged to 0
+  private pushScore(buckets: Record<string, number[]>, scorerName: string, result: unknown) {
     const score = (result as { score?: unknown } | null | undefined)?.score;
-    if (typeof score === 'number') {
-      bucket.push(score);
-    }
+    if (typeof score !== 'number') return;
+    (buckets[scorerName] ??= []).push(score);
+  }
+
+  private pushStepScore(stepId: string, scorerName: string, result: unknown) {
+    const score = (result as { score?: unknown } | null | undefined)?.score;
+    if (typeof score !== 'number') return;
+    ((this.stepScores[stepId] ??= {})[scorerName] ??= []).push(score);
   }
 
   getAverageScores(): Record<string, any> {

--- a/packages/core/src/evals/scoreTraces/scoreTrace.test.ts
+++ b/packages/core/src/evals/scoreTraces/scoreTrace.test.ts
@@ -345,6 +345,22 @@ describe('scoreTrace', () => {
     });
   });
 
+  describe('not scorable', () => {
+    it('returns null and persists nothing when the scorer declares the target not scorable', async () => {
+      const target = { traceId: 'trace-1' };
+      await testContext.setupSuccessfulScenario(target);
+      testContext.mockScorerRun.mockResolvedValue(
+        createMockScorerResult({ score: undefined, notScorable: { reason: 'nothing to judge' } }),
+      );
+
+      const result = await testContext.scoreTraceTarget(target);
+
+      expect(result).toBeNull();
+      expect(testContext.mockScoresStore.saveScore).not.toHaveBeenCalled();
+      expect(testContext.mockObservabilityStore.updateSpan).not.toHaveBeenCalled();
+    });
+  });
+
   describe('error handling', () => {
     it('throws when the trace cannot be found', async () => {
       const target = { traceId: 'nonexistent-trace' };
@@ -669,6 +685,38 @@ describe('scoreTraceBatch', () => {
       expect(result.results[1].error.message).toContain('Span not found for scoring');
     }
     expect(testContext.mockScoresStore.saveScore).toHaveBeenCalledTimes(2);
+  });
+
+  it('counts not-scorable targets as excluded rather than scored or failed', async () => {
+    const targets: ScoreTraceBatchTarget[] = [
+      { traceId: 'trace-1', datasetItemId: 'dataset-item-1' },
+      { traceId: 'trace-2', datasetItemId: 'dataset-item-2' },
+    ];
+
+    testContext.mockObservabilityStore.getTrace.mockImplementation(async ({ traceId }: { traceId: string }) =>
+      createMockTraceRecord({ traceId }),
+    );
+    testContext.mockScorerRun.mockImplementation(async ({ targetTraceId }: { targetTraceId: string }) =>
+      targetTraceId === 'trace-2'
+        ? createMockScorerResult({ score: undefined, notScorable: { reason: 'nothing to judge' } })
+        : createMockScorerResult({ input: { test: 'input' }, output: { test: 'output' } }),
+    );
+    testContext.setupSaveScorePassthrough();
+    testContext.mockObservabilityStore.updateSpan.mockResolvedValue(undefined);
+
+    const result = await testContext.scoreTraceBatchTargets(targets);
+
+    expect(result.scoredCount).toBe(1);
+    expect(result.excludedCount).toBe(1);
+    expect(result.failedCount).toBe(0);
+    expect(result.results[1]).toEqual({
+      ok: true,
+      excluded: true,
+      index: 1,
+      traceId: 'trace-2',
+      datasetItemId: 'dataset-item-2',
+    });
+    expect(testContext.mockScoresStore.saveScore).toHaveBeenCalledTimes(1);
   });
 
   it('isolates a failed scorer target without retrying or duplicating sibling targets', async () => {

--- a/packages/core/src/evals/scoreTraces/scoreTracesWorkflow.ts
+++ b/packages/core/src/evals/scoreTraces/scoreTracesWorkflow.ts
@@ -130,6 +130,15 @@ export type ScoreTraceBatchResult =
       score: ScoreRowData;
     }
   | {
+      /** The scorer declared the target not scorable: no score was persisted. */
+      ok: true;
+      excluded: true;
+      index: number;
+      traceId: string;
+      spanId?: string;
+      datasetItemId?: string;
+    }
+  | {
       ok: false;
       index: number;
       traceId: string;
@@ -256,11 +265,16 @@ export async function scoreTrace({
    * independent of how the trace is resolved. */
   datasetId?: string;
   datasetItemId?: string;
-}): Promise<ScoreRowData> {
+}): Promise<ScoreRowData | null> {
   const { trace, span } = await resolveTraceAndSpan({ storage, target });
   const tenancy = getSpanTenancy(span);
 
   const result = await runScorerForTrace({ scorer, trace, span });
+
+  // A not-scorable run produced no score: nothing to persist or attach.
+  if (result.notScorable) {
+    return null;
+  }
 
   const scorerResult = {
     ...result,
@@ -317,6 +331,7 @@ export async function scoreTraceBatch({
   datasetId?: string;
   scoredCount: number;
   failedCount: number;
+  excludedCount: number;
   results: ScoreTraceBatchResult[];
 }> {
   const results = await pMap(
@@ -331,6 +346,17 @@ export async function scoreTraceBatch({
           datasetId,
           datasetItemId: target.datasetItemId,
         });
+        if (!score) {
+          return {
+            ok: true,
+            excluded: true,
+            index,
+            traceId: target.traceId,
+            ...(target.spanId ? { spanId: target.spanId } : {}),
+            ...(target.datasetItemId ? { datasetItemId: target.datasetItemId } : {}),
+          };
+        }
+
         const spanId = score.spanId ?? target.spanId;
 
         if (!spanId) {
@@ -359,13 +385,15 @@ export async function scoreTraceBatch({
     { concurrency },
   );
 
-  const scoredCount = results.filter(result => result.ok).length;
+  const excludedCount = results.filter(result => result.ok && 'excluded' in result).length;
+  const scoredCount = results.filter(result => result.ok).length - excludedCount;
 
   return {
     ...(batchId ? { batchId } : {}),
     ...(datasetId ? { datasetId } : {}),
     scoredCount,
-    failedCount: results.length - scoredCount,
+    failedCount: results.length - scoredCount - excludedCount,
+    excludedCount,
     results,
   };
 }

--- a/packages/core/src/evals/scoreTraces/scoreTracesWorkflow.ts
+++ b/packages/core/src/evals/scoreTraces/scoreTracesWorkflow.ts
@@ -271,7 +271,6 @@ export async function scoreTrace({
 
   const result = await runScorerForTrace({ scorer, trace, span });
 
-  // A not-scorable run produced no score: nothing to persist or attach.
   if (result.notScorable) {
     return null;
   }
@@ -346,7 +345,7 @@ export async function scoreTraceBatch({
           datasetId,
           datasetItemId: target.datasetItemId,
         });
-        if (!score) {
+        if (score === null) {
           return {
             ok: true,
             excluded: true,

--- a/packages/core/src/mastra/hook.test.ts
+++ b/packages/core/src/mastra/hook.test.ts
@@ -317,6 +317,33 @@ describe('createOnScorerHook', () => {
     expect(mockScorer.run.mock.calls[0][0].output).toBe(output);
   });
 
+  it('does not save a score when the scorer declares the run not scorable', async () => {
+    const mockScorer = {
+      id: 'test-scorer',
+      name: 'test-scorer',
+      run: vi.fn().mockResolvedValue({ notScorable: { reason: 'tool never called' } }),
+    };
+    mockMastra.getAgentById.mockReturnValue({
+      listScorers: vi.fn().mockReturnValue({ 'test-scorer': { scorer: mockScorer } }),
+    });
+
+    await hook({
+      runId: 'test-run',
+      scorer: { id: 'test-scorer' },
+      input: [{ message: 'test' }],
+      output: { result: 'test' },
+      source: 'LIVE' as const,
+      entity: { id: 'test-entity' },
+      entityType: 'AGENT' as const,
+      entityId: 'test-entity',
+      scorerId: 'test-scorer',
+    });
+
+    expect(mockScorer.run).toHaveBeenCalledTimes(1);
+    expect(mockScoresStore.saveScore).not.toHaveBeenCalled();
+    expect(mockMastra.getLogger().error).not.toHaveBeenCalled();
+  });
+
   it('should pass live span correlation context and metadata into scorer.run', async () => {
     const correlationContext = {
       traceId: 'trace-live',

--- a/packages/core/src/mastra/hooks.ts
+++ b/packages/core/src/mastra/hooks.ts
@@ -80,6 +80,16 @@ export function createOnScorerHook(mastra: Mastra) {
         targetMetadata,
       } as any);
 
+      if (runResult.notScorable) {
+        mastra
+          .getLogger()
+          ?.debug?.(
+            `Scorer ${scorerId} skipped run ${hookData.runId} as not scorable` +
+              (runResult.notScorable.reason ? `: ${runResult.notScorable.reason}` : ''),
+          );
+        return;
+      }
+
       const payload = {
         ...rest,
         ...runResult,

--- a/packages/server/src/server/schemas/datasets.ts
+++ b/packages/server/src/server/schemas/datasets.ts
@@ -598,6 +598,7 @@ export const runExperimentItemResponseSchema = z.object({
       score: z.number().nullable(),
       reason: z.string().nullable(),
       error: z.string().nullable(),
+      notScorable: z.object({ reason: z.string().optional() }).optional(),
       failedStep: z.string().optional(),
       completedSteps: z.array(z.string()).optional(),
       targetScope: z.enum(['span', 'trajectory']).optional(),


### PR DESCRIPTION
## Description

Adds `notScorable()` so a scorer can declare that a run has nothing for it to evaluate. A live judge aimed at a rare tool call currently runs its full pipeline on every sampled run, spends a judge model call on runs the tool never appeared in, and stores a vacuous pass that skews the scorer's average. Returning `notScorable()` from a step stops the pipeline before any further judge calls, stores no score, and keeps the run out of aggregates.

- `notScorable(reason?)` sentinel in `packages/core/src/evals/not-scorable.ts`, exported from `@mastra/core/evals`
- `MastraScorer` step workflow bails when a step returns it; `ScorerRunResult` carries `notScorable: { reason? }` and no `score`
- Live scorer hook (`createOnScorerHook`) skips persistence for not-scorable runs
- `scoreTrace()` returns `null` and `scoreTraceBatch()` reports an `excludedCount` alongside `scoredCount` / `failedCount`
- `runEvals` gates and per-turn scoring, and `ScoreAccumulator`, skip not-scorable results instead of averaging them
- Experiment `ScorerResult` gains an optional `notScorable` field (`score: null`, `error: null`), mirrored in the server response schema
- Docs: new `notScorable()` reference page, custom-scorers section, and a pointer from the eligibility-filter docs, since filters can't inspect run input/output

Verified with a real OpenAI judge on an agent with a rare `refundCustomer` tool. On a run that never called the tool, the unguarded judge made 1 judge model call and stored a vacuous `score=1` row; the guarded judge made 0 judge calls and stored no row. On a run that did call the tool, the guarded judge still scored it.

## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Some runs have no data that can be scored. This change lets scorers mark those runs as `notScorable()`, so the system skips unnecessary judge calls and excludes those runs from saved scores and averages.

## Changes

- Added the `notScorable(reason?)` API to `@mastra/core/evals`.
- Stopped scorer pipelines after a `notScorable()` result.
- Prevented judge calls, score persistence, and aggregate updates for excluded runs.
- Added support across scorer workflows, live hooks, `runEvals`, `scoreTrace()`, `scoreTraceBatch()`, experiments, gates, and server schemas.
- Updated `scoreTrace()` to return `null` for excluded runs.
- Added excluded result entries and `excludedCount` to batch scoring.
- Updated scorer result types and experiment responses with optional exclusion reasons.
- Added documentation and tests for pipeline behavior, score aggregation, experiments, hooks, gates, and trace scoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->