### PR TITLE
test(playground): fix compare-experiments E2E after experiments page move

### DIFF
--- a/packages/playground/e2e/tests/datasets/compare-experiments.spec.ts
+++ b/packages/playground/e2e/tests/datasets/compare-experiments.spec.ts
@@ -71,8 +71,8 @@ test.afterEach(async () => {
 /**
  * FEATURE: Dataset experiment comparison
  * USER STORY: As a user, I want to select two experiments from a dataset so I can compare their results.
- * BEHAVIOR UNDER TEST: Selecting compare checkboxes must keep me on the dataset page until I explicitly trigger comparison,
- * then navigate to the comparison view with both experiment IDs encoded in the URL.
+ * BEHAVIOR UNDER TEST: Selecting compare checkboxes must keep me on the experiments page until I explicitly trigger
+ * comparison, then navigate to the comparison view with the dataset and both experiment IDs encoded in the URL.
  */
 test.describe('Dataset experiment comparison', () => {
   test.describe('when two experiments are selected in compare mode', () => {
@@ -80,9 +80,9 @@ test.describe('Dataset experiment comparison', () => {
       const { datasetId, experimentIds } = await seedDatasetWithExperiments();
       const [baselineId, contenderId] = experimentIds;
 
-      await page.goto(`/datasets/${datasetId}?tab=experiments`);
+      await page.goto(`/experiments?dataset=${datasetId}`);
 
-      await expect(page.getByText('weather-agent')).toHaveCount(2);
+      await expect(page.getByText('Weather Agent')).toHaveCount(2);
 
       await page.getByRole('button', { name: 'Compare' }).click();
 
@@ -91,7 +91,7 @@ test.describe('Dataset experiment comparison', () => {
       const compareButton = page.getByRole('button', { name: 'Compare Experiments' });
 
       await baselineCheckbox.click();
-      await expect(page).toHaveURL(`${BASE_URL}/datasets/${datasetId}?tab=experiments`);
+      await expect(page).toHaveURL(`${BASE_URL}/experiments?dataset=${datasetId}`);
       await expect(baselineCheckbox).toBeChecked();
       await expect(compareButton).toBeDisabled();
 
@@ -102,7 +102,7 @@ test.describe('Dataset experiment comparison', () => {
       await compareButton.click();
 
       await expect(page).toHaveURL(
-        `${BASE_URL}/datasets/${datasetId}/experiments?baseline=${baselineId}&contender=${contenderId}`,
+        `${BASE_URL}/experiments/compare?dataset=${datasetId}&baseline=${baselineId}&contender=${contenderId}`,
       );
       await expect(page.getByRole('table', { name: 'Experiments comparison' })).toBeVisible();
     });


### PR DESCRIPTION
## Summary

The kitchen-sink E2E `compare-experiments.spec.ts` has failed on every PR since #22867 ("move experiments off the dataset page") merged. That PR removed the dataset page's experiments tab and moved the comparison entry point to `/experiments`, but the spec still navigated to `/datasets/:id?tab=experiments` and asserted the old comparison URL. The experiments list also now shows the target's display name ("Weather Agent") rather than its id.

This updates the spec to the current flow:
- start at `/experiments?dataset=<id>`
- expect the comparison view at `/experiments/compare?dataset=&baseline=&contender=`
- match the agent display name

No product code changes.

## Test plan
- [x] `playwright test e2e/tests/datasets/compare-experiments.spec.ts` against a local `mastra dev` kitchen-sink built from `main` — passes
- [x] E2E kitchen-sink shard 3/4 goes green in CI

Unblocks #22872 and any other open PR hitting `E2E kitchen-sink (3/4)`.

Fixes #22902

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The test now follows the new location of experiments. It checks that users can select experiments and compare them from the `/experiments` page.

## Changes

- Updated `compare-experiments.spec.ts` to start at `/experiments?dataset=<id>`.
- Updated comparison navigation expectations to `/experiments/compare?dataset=&baseline=&contender=`.
- Updated the agent assertion to use “Weather Agent” instead of its ID.
- No product code changes.

## Validation

- Updated test passes locally.
- Kitchen-sink E2E shard 3/4 passes in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->