### PR TITLE
Simplify Trace Intelligence UI controls

### DIFF
--- a/.changeset/tidy-signals-shine.md
+++ b/.changeset/tidy-signals-shine.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Simplify the Trace Intelligence signal settings pane and correct index controls and pending-signal elevation styling.

--- a/packages/playground-ui/src/ee/signals/components/__tests__/trace-intelligence-entity-index.test.tsx
+++ b/packages/playground-ui/src/ee/signals/components/__tests__/trace-intelligence-entity-index.test.tsx
@@ -11,7 +11,7 @@ import type { TraceSignalManagement } from '../../trace-intelligence-context';
 import { TraceIntelligenceProvider } from '../../trace-intelligence-provider';
 import { TraceIntelligenceEntityIndex } from '../trace-intelligence-entity-index';
 import type { TraceIntelligenceEntitySort, TraceIntelligenceEntityView } from '../trace-intelligence-entity-index';
-import { entityIndexResponse } from './fixtures/entity-index';
+import { customSignalEntityResponse, entityIndexResponse } from './fixtures/entity-index';
 
 beforeAll(() => {
   if (typeof window.PointerEvent === 'undefined') {
@@ -126,6 +126,20 @@ describe('TraceIntelligenceEntityIndex', () => {
   });
 
   describe('when enriched entities are available', () => {
+    it('explains the configured signals from the index header', async () => {
+      useEntityFixture(customSignalEntityResponse);
+      renderIndex();
+
+      await screen.findByText('custom-agent');
+      fireEvent.focus(screen.getByRole('button', { name: 'What is trace intelligence?' }));
+
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip.textContent).toContain('Tool usage');
+      expect(tooltip.textContent).toContain('How effectively the agent uses tools.');
+      expect(tooltip.textContent).toContain('Response quality');
+      expect(tooltip.textContent).toContain('How useful the final answer is.');
+    });
+
     it('renders entity metadata and canonical detail links', async () => {
       useEntityFixture();
       renderIndex();

--- a/packages/playground-ui/src/ee/signals/components/signals-empty-state.tsx
+++ b/packages/playground-ui/src/ee/signals/components/signals-empty-state.tsx
@@ -145,7 +145,7 @@ export function PendingSignalProgress({
         {pendingSignals.map(signal => {
           const value = progress?.signals[signal.name] ?? { generated: 0, embedded: 0 };
           return (
-            <li className="border-border1 bg-surface1 rounded-md border px-3 py-2" key={signal.name}>
+            <li className="border-border1 bg-surface3 rounded-md border px-3 py-2 font-sans" key={signal.name}>
               <div className="flex items-center justify-between gap-2">
                 <span className="text-sm font-semibold" style={signalStyle(signal.name)}>
                   {signalLabel(catalog, signal.name)}

--- a/packages/playground-ui/src/ee/signals/components/trace-intelligence-entity-index.tsx
+++ b/packages/playground-ui/src/ee/signals/components/trace-intelligence-entity-index.tsx
@@ -96,7 +96,7 @@ function EntityIndexControls({
         <ButtonsGroup spacing="close" aria-label="Entities view">
           <Button
             type="button"
-            variant={view === 'list' ? 'default' : 'ghost'}
+            variant={view === 'list' ? 'primary' : 'outline'}
             size="icon-md"
             tooltip="List view"
             aria-pressed={view === 'list'}
@@ -106,7 +106,7 @@ function EntityIndexControls({
           </Button>
           <Button
             type="button"
-            variant={view === 'compact' ? 'default' : 'ghost'}
+            variant={view === 'compact' ? 'primary' : 'outline'}
             size="icon-md"
             tooltip="Compact view"
             aria-pressed={view === 'compact'}

--- a/packages/playground-ui/src/ee/signals/components/trace-intelligence-entity-index.tsx
+++ b/packages/playground-ui/src/ee/signals/components/trace-intelligence-entity-index.tsx
@@ -1,9 +1,10 @@
-import type { ThemeLearningEntity } from '@mastra/client-js';
+import type { SignalCatalogEntry, ThemeLearningEntity } from '@mastra/client-js';
 import { Columns2, List, Radar } from 'lucide-react';
 import { useState, type ReactNode } from 'react';
 
 import { useThemeEntities } from '../hooks';
 import { TraceSignalSettingsButton, TraceSignalSettingsPanel } from '../settings/trace-signal-settings';
+import { TraceIntelligenceExplainer } from '../trace-intelligence-explainer';
 import { useTraceIntelligence } from '../use-trace-intelligence';
 import { EntityIndexCompactGrid } from './entity-index-compact-grid';
 import { EntityIndexList } from './entity-index-list';
@@ -67,10 +68,11 @@ function EntityIndexControls({
   onSortChange,
   onViewChange,
   headerAction,
+  signalCatalog,
 }: Pick<
   TraceIntelligenceEntityIndexProps,
   'search' | 'sort' | 'view' | 'onSearchChange' | 'onSortChange' | 'onViewChange' | 'headerAction'
->) {
+> & { signalCatalog: readonly SignalCatalogEntry[] }) {
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
       <div className="max-w-120 flex-1">
@@ -82,6 +84,7 @@ function EntityIndexControls({
         />
       </div>
       <div className="flex items-center justify-between gap-2 sm:ml-auto sm:justify-end">
+        <TraceIntelligenceExplainer signalCatalog={signalCatalog} />
         <Select<TraceIntelligenceEntitySort> value={sort} onValueChange={onSortChange}>
           <SelectTrigger aria-label="Sort entities" size="md" variant="ghost" className="w-auto min-w-36">
             <SelectValue />
@@ -132,12 +135,15 @@ export function TraceIntelligenceEntityIndex({
   headerAction,
 }: TraceIntelligenceEntityIndexProps) {
   const entitiesQuery = useThemeEntities(entityType);
-  const { LinkComponent, signalManagement } = useTraceIntelligence();
+  const { LinkComponent, signalCatalog: contextSignalCatalog, signalManagement } = useTraceIntelligence();
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   if (entitiesQuery.error) return <EntityIndexError error={entitiesQuery.error} />;
 
-  const entities = filterAndSortEntities(entitiesQuery.data?.entities ?? [], search, sort);
+  const sourceEntities = entitiesQuery.data?.entities ?? [];
+  const signalCatalog =
+    sourceEntities.find(entity => entity.signalCatalog?.length)?.signalCatalog ?? contextSignalCatalog;
+  const entities = filterAndSortEntities(sourceEntities, search, sort);
   const hasSearch = search.trim().length > 0;
   let body = (
     <EntityIndexList
@@ -182,6 +188,7 @@ export function TraceIntelligenceEntityIndex({
           onSearchChange={onSearchChange}
           onSortChange={onSortChange}
           onViewChange={onViewChange}
+          signalCatalog={signalCatalog}
           headerAction={
             headerAction || signalManagement ? (
               <>

--- a/packages/playground-ui/src/ee/signals/settings/__tests__/trace-signal-settings.test.tsx
+++ b/packages/playground-ui/src/ee/signals/settings/__tests__/trace-signal-settings.test.tsx
@@ -104,19 +104,19 @@ describe('TraceSignalSettingsButton', () => {
     expect(screen.queryByRole('button', { name: 'Signal settings' })).toBeNull();
   });
 
-  it('opens an in-page right-side section with scope copy, read-only built-ins, and organization usage', async () => {
+  it('opens a minimal in-page right-side section with custom signal usage', async () => {
     renderSettings(management());
     const settingsButton = screen.getByRole('button', { name: 'Signal settings' });
     expect(settingsButton.getAttribute('aria-expanded')).toBe('false');
     await openSettings();
 
     expect(settingsButton.getAttribute('aria-expanded')).toBe('true');
-    expect(await screen.findByText('Organization signal library')).toBeTruthy();
-    expect(screen.getByText(/definitions, prompts, and versions are shared by every project/i)).toBeTruthy();
-    expect(screen.getByText('Current project')).toBeTruthy();
-    expect(screen.getByText(/enable switches apply only to this project/i)).toBeTruthy();
-    expect(screen.getAllByText('Read only')).toHaveLength(4);
+    expect(await screen.findByText('Custom signals')).toBeTruthy();
     expect(screen.getByText('1 of 7 active organization definitions')).toBeTruthy();
+    expect(screen.queryByText('Organization signal library')).toBeNull();
+    expect(screen.queryByText('Current project')).toBeNull();
+    expect(screen.queryByText('Built-in signals')).toBeNull();
+    expect(screen.queryByText('Read only')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Close Panel' }));
     await waitFor(() => expect(screen.queryByRole('complementary', { name: 'Trace signal settings' })).toBeNull());
   });

--- a/packages/playground-ui/src/ee/signals/settings/trace-signal-settings.tsx
+++ b/packages/playground-ui/src/ee/signals/settings/trace-signal-settings.tsx
@@ -51,7 +51,7 @@ export function TraceSignalSettingsPanel({ onClose }: { onClose: () => void }) {
 }
 
 function TraceSignalSettingsContent() {
-  const { signalCatalog, signalManagement } = useTraceIntelligence();
+  const { signalManagement } = useTraceIntelligence();
   const query = useSignalManagementList();
   const mutations = useSignalManagementMutations();
   const [creating, setCreating] = useState(false);
@@ -110,49 +110,16 @@ function TraceSignalSettingsContent() {
 
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <div className="border-border1 grid gap-2 rounded-md border p-3 sm:grid-cols-2">
-          <div>
-            <p className="text-ui-sm text-neutral4 font-medium">Organization signal library</p>
-            <p className="text-ui-xs text-neutral3">Definitions, prompts, and versions are shared by every project.</p>
-          </div>
-          <div>
-            <p className="text-ui-sm text-neutral4 font-medium">Current project</p>
-            <p className="text-ui-xs text-neutral3">Enable switches apply only to this project.</p>
-          </div>
-        </div>
-        {!canManage ? (
-          <Notice variant="info">
-            <Notice.Message>You have read-only access. An organization admin can change these settings.</Notice.Message>
-          </Notice>
-        ) : null}
-        {actionError ? (
-          <Notice variant="destructive">
-            <Notice.Message>{actionError}</Notice.Message>
-          </Notice>
-        ) : null}
-      </div>
-
-      <section aria-labelledby="built-in-signals-heading">
-        <h3 id="built-in-signals-heading" className="text-ui-md text-neutral4 mb-2 font-medium">
-          Built-in signals
-        </h3>
-        <div className="divide-border1 border-border1 divide-y rounded-md border px-3">
-          {signalCatalog
-            .filter(signal => signal.builtIn)
-            .map(signal => (
-              <div key={signal.name} className="flex min-h-12 items-center justify-between gap-3 py-2">
-                <div className="min-w-0">
-                  <p className="text-ui-sm text-neutral4">{signal.label}</p>
-                  <p className="text-ui-xs text-neutral3 truncate">{signal.description}</p>
-                </div>
-                <Badge variant="neutral" size="sm">
-                  Read only
-                </Badge>
-              </div>
-            ))}
-        </div>
-      </section>
+      {!canManage ? (
+        <Notice variant="info">
+          <Notice.Message>You have read-only access. An organization admin can change these settings.</Notice.Message>
+        </Notice>
+      ) : null}
+      {actionError ? (
+        <Notice variant="destructive">
+          <Notice.Message>{actionError}</Notice.Message>
+        </Notice>
+      ) : null}
 
       <section aria-labelledby="custom-signals-heading">
         <div className="mb-2 flex flex-wrap items-center justify-between gap-3">

--- a/packages/playground-ui/src/ee/signals/trace-intelligence-explainer.tsx
+++ b/packages/playground-ui/src/ee/signals/trace-intelligence-explainer.tsx
@@ -25,7 +25,7 @@ export function TraceIntelligenceExplainer({ signalCatalog }: { signalCatalog: r
       </TooltipTrigger>
       <TooltipContent className="max-w-sm space-y-3 p-4 text-xs">
         <p className="text-neutral5">
-          Every trace from this agent is analyzed for {enabledSignals.length === 4 ? 'four' : enabledSignals.length}{' '}
+          Every trace is analyzed for {enabledSignals.length === 4 ? 'four' : enabledSignals.length}{' '}
           {enabledSignals.length === 1 ? 'signal' : 'signals'}, and traces with similar signals are clustered into named
           themes.
         </p>


### PR DESCRIPTION
## Summary

- remove the built-in signal list and organization/project scope explainer from the signal settings pane
- use the standard white-selected, bordered-unselected treatment for the entity list/compact toggle
- render pending custom-signal cards with sans typography and a lighter elevated surface in dark mode

## Test plan

- `pnpm test --run src/ee/signals/settings/__tests__/trace-signal-settings.test.tsx src/ee/signals/components/__tests__/trace-intelligence-entity-index.test.tsx src/ee/signals/__tests__/sankey-signals.test.tsx`
- `pnpm typecheck`
- `pnpm build`
- focused Prettier and ESLint checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes Trace Intelligence signal settings easier to understand by removing repeated details and moving signal explanations to the entity index. It also improves view controls and pending-signal card styling.

## Changes

- Removed built-in signal lists and organization/project scope explanations from the signal settings pane.
- Added the signal glossary to the Trace Intelligence entity index.
- Updated the explainer text to state that every trace is analyzed.
- Standardized entity list and compact view controls with selected and unselected styles.
- Improved pending custom-signal cards with sans typography and a lighter dark-mode surface.
- Updated tests for the simplified settings panel and signal explanations.
- Added a patch changeset for `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->