### PR TITLE
feat(playground): add trace messages view

### DIFF
--- a/.changeset/curvy-zebras-help.md
+++ b/.changeset/curvy-zebras-help.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added a Messages tab to trace details so developers can review the user message, response, and tool calls for an agent turn.

--- a/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/trace-data-panel-view.test.tsx
@@ -802,18 +802,44 @@ describe('TraceDataPanelView — following the URL to another span', () => {
 });
 
 describe('TraceDataPanelView — trace-level tabs', () => {
+  describe('when a partial thread slot is provided', () => {
+    it('renders Messages immediately after Spans', () => {
+      render(<TraceDataPanelView {...baseProps} partialThreadTabSlot={() => <div>partial thread here</div>} />);
+
+      expect(screen.getAllByRole('tab').map(tab => tab.textContent)).toEqual(['Spans', 'Messages']);
+      expect(screen.getByText('agent run')).toBeTruthy();
+      expect(screen.queryByText('partial thread here')).toBeNull();
+    });
+
+    it('renders the selected trace in the Messages tab', () => {
+      const partialThreadTabSlot = vi.fn(({ traceId }: { traceId: string }) => <div>partial thread for {traceId}</div>);
+
+      render(
+        <TraceDataPanelView
+          {...baseProps}
+          activeTab="partial-thread"
+          onTabChange={vi.fn()}
+          partialThreadTabSlot={partialThreadTabSlot}
+        />,
+      );
+
+      expect(partialThreadTabSlot).toHaveBeenCalledWith({ traceId: 'trace-1' });
+      expect(screen.getByText('partial thread for trace-1')).toBeTruthy();
+    });
+  });
+
   it('renders no tabs when no scores slot is provided', () => {
     render(<TraceDataPanelView {...baseProps} />);
 
     expect(screen.queryByRole('tab', { name: /spans/i })).toBeNull();
-    expect(screen.queryByRole('tab', { name: /evaluations/i })).toBeNull();
+    expect(screen.queryByRole('tab', { name: /scores/i })).toBeNull();
   });
 
   it('renders Spans and Scores tabs when a scores slot is provided', () => {
     render(<TraceDataPanelView {...baseProps} scoresTabSlot={() => <div>trace scores here</div>} />);
 
     expect(screen.getByRole('tab', { name: /spans/i })).toBeTruthy();
-    expect(screen.getByRole('tab', { name: /evaluations/i })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /scores/i })).toBeTruthy();
     // Spans is the default tab.
     expect(screen.getByText('agent run')).toBeTruthy();
     expect(screen.queryByText('trace scores here')).toBeNull();
@@ -844,7 +870,7 @@ describe('TraceDataPanelView — trace-level tabs', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('tab', { name: /evaluations/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /scores/i }));
 
     expect(onTabChange).toHaveBeenCalledWith('scores');
   });
@@ -852,30 +878,29 @@ describe('TraceDataPanelView — trace-level tabs', () => {
   it('shows the badge count in the Scores tab label', () => {
     render(<TraceDataPanelView {...baseProps} scoresTabSlot={() => null} scoresTabBadge={3} />);
 
-    expect(screen.getByRole('tab', { name: /evaluations \(3\)/i })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /scores \(3\)/i })).toBeTruthy();
   });
 });
 
 describe('TraceDataPanelView — trace feedback tab', () => {
-  it('renders a Feedback tab next to Spans and Evaluations', () => {
+  it('renders Feedback before Scores and after Messages', () => {
     render(
       <TraceDataPanelView
         {...baseProps}
+        partialThreadTabSlot={() => <div>trace messages here</div>}
         scoresTabSlot={() => <div>trace scores here</div>}
         feedbackTabSlot={() => <div>trace feedback here</div>}
       />,
     );
 
-    expect(screen.getByRole('tab', { name: /spans/i })).toBeTruthy();
-    expect(screen.getByRole('tab', { name: /evaluations/i })).toBeTruthy();
-    expect(screen.getByRole('tab', { name: /feedback/i })).toBeTruthy();
+    expect(screen.getAllByRole('tab').map(tab => tab.textContent)).toEqual(['Spans', 'Messages', 'Feedback', 'Scores']);
   });
 
   it('renders the Feedback tab even when no scores slot is provided', () => {
     render(<TraceDataPanelView {...baseProps} feedbackTabSlot={() => <div>trace feedback here</div>} />);
 
     expect(screen.getByRole('tab', { name: /feedback/i })).toBeTruthy();
-    expect(screen.queryByRole('tab', { name: /evaluations/i })).toBeNull();
+    expect(screen.queryByRole('tab', { name: /scores/i })).toBeNull();
   });
 
   it('shows the feedback slot with the trace id — and no span id — when the tab is active', () => {

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -33,7 +33,7 @@ import { truncateString } from '@/lib/truncate-string';
 
 export type TraceDataPanelPlacement = 'traces-list' | 'trace-page';
 
-export type TraceDataPanelTab = 'details' | 'scores' | 'feedback';
+export type TraceDataPanelTab = 'details' | 'partial-thread' | 'scores' | 'feedback';
 
 export interface TraceDataPanelViewProps {
   traceId: string;
@@ -89,6 +89,8 @@ export interface TraceDataPanelViewProps {
   feedbackTabSlot?: (args: { traceId: string }) => ReactNode;
   /** Optional count shown in the "Feedback" tab label. */
   feedbackTabBadge?: ReactNode;
+  /** When provided, a "Messages" tab renders the trace as one reconstructed agent turn. */
+  partialThreadTabSlot?: (args: { traceId: string }) => ReactNode;
   activeTab?: TraceDataPanelTab;
   onTabChange?: (tab: TraceDataPanelTab) => void;
   /**
@@ -126,6 +128,7 @@ export function TraceDataPanelView({
   scoresTabBadge,
   feedbackTabSlot,
   feedbackTabBadge,
+  partialThreadTabSlot,
   activeTab,
   onTabChange,
   spanPanelSlot,
@@ -338,7 +341,7 @@ export function TraceDataPanelView({
                 );
 
                 // No extra tab slots → render details directly without the Tabs wrapper.
-                if (!scoresTabSlot && !feedbackTabSlot) return detailsBody;
+                if (!partialThreadTabSlot && !scoresTabSlot && !feedbackTabSlot) return detailsBody;
 
                 return (
                   <Tabs<TraceDataPanelTab>
@@ -346,30 +349,36 @@ export function TraceDataPanelView({
                     value={activeTab}
                     onValueChange={onTabChange}
                     className={
-                      activeTab === 'scores' || activeTab === 'feedback'
+                      activeTab === 'partial-thread' || activeTab === 'scores' || activeTab === 'feedback'
                         ? 'grid h-full min-h-0 grid-rows-[auto_1fr]'
                         : undefined
                     }
                   >
                     <TabList variant="pill-ghost" className="px-0">
                       <Tab value="details">Spans</Tab>
-                      {scoresTabSlot && (
-                        <Tab value="scores">Evaluations {scoresTabBadge != null && <>({scoresTabBadge})</>}</Tab>
-                      )}
+                      {partialThreadTabSlot && <Tab value="partial-thread">Messages</Tab>}
                       {feedbackTabSlot && (
-                        <Tab value="feedback">Feedback {feedbackTabBadge != null && <>({feedbackTabBadge})</>}</Tab>
+                        <Tab value="feedback">Feedback{feedbackTabBadge != null && <> ({feedbackTabBadge})</>}</Tab>
+                      )}
+                      {scoresTabSlot && (
+                        <Tab value="scores">Scores{scoresTabBadge != null && <> ({scoresTabBadge})</>}</Tab>
                       )}
                     </TabList>
 
                     <TabContent value="details">{detailsBody}</TabContent>
-                    {scoresTabSlot && (
-                      <TabContent value="scores" className="h-full min-h-0">
-                        {scoresTabSlot({ traceId, rootSpanId: rootSpan?.spanId })}
+                    {partialThreadTabSlot && (
+                      <TabContent value="partial-thread" className="h-full min-h-0">
+                        {partialThreadTabSlot({ traceId })}
                       </TabContent>
                     )}
                     {feedbackTabSlot && (
                       <TabContent value="feedback" className="h-full min-h-0">
                         {feedbackTabSlot({ traceId })}
+                      </TabContent>
+                    )}
+                    {scoresTabSlot && (
+                      <TabContent value="scores" className="h-full min-h-0">
+                        {scoresTabSlot({ traceId, rootSpanId: rootSpan?.spanId })}
                       </TabContent>
                     )}
                   </Tabs>

--- a/packages/playground/e2e/tests/traces/partial-thread.spec.ts
+++ b/packages/playground/e2e/tests/traces/partial-thread.spec.ts
@@ -1,0 +1,137 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+import { resetStorage } from '../__utils__/reset-storage';
+
+const TRACE_ID = 'partial-thread-trace';
+const USER_INPUT = 'Find the weather in Paris';
+const ASSISTANT_OUTPUT = 'Paris will be sunny today.';
+const COMMENT = 'Verified against the tool result.';
+
+const rootSpan = {
+  traceId: TRACE_ID,
+  spanId: 'agent-root',
+  parentSpanId: null,
+  name: 'Weather agent run',
+  spanType: 'agent_run',
+  isEvent: false,
+  threadId: 'partial-thread-id',
+  entityType: 'agent',
+  entityId: 'weather-agent',
+  entityName: 'Weather Agent',
+  startedAt: '2026-08-30T12:00:00.000Z',
+  endedAt: '2026-08-30T12:00:01.000Z',
+  createdAt: '2026-08-30T12:00:00.000Z',
+  updatedAt: null,
+  input: {
+    __isCreatedSignal: true,
+    id: 'user-signal-1',
+    type: 'user',
+    tagName: 'user',
+    contents: [{ type: 'text', text: USER_INPUT }],
+    createdAt: '2026-08-30T12:00:00.000Z',
+  },
+  output: { text: ASSISTANT_OUTPUT },
+};
+
+const toolSpan = {
+  ...rootSpan,
+  spanId: 'weather-tool',
+  parentSpanId: 'agent-root',
+  name: 'Weather lookup',
+  spanType: 'tool_call',
+  entityType: 'tool',
+  entityId: 'weatherInfo',
+  entityName: 'weatherInfo',
+  startedAt: '2026-08-30T12:00:00.200Z',
+  input: { location: 'Paris' },
+  output: { temperature: 19, conditions: 'sunny' },
+  attributes: { toolCallId: 'weather-call' },
+};
+
+async function mockPartialThread(page: Page) {
+  let comments: Array<Record<string, unknown>> = [];
+
+  await page.route('**/api/observability/traces/light?**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ spans: [], pagination: { page: 0, perPage: 25, total: 0, hasMore: false } }),
+    }),
+  );
+  await page.route(`**/api/observability/traces/${TRACE_ID}`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ traceId: TRACE_ID, spans: [rootSpan, toolSpan] }),
+    }),
+  );
+  await page.route('**/api/mcp/v0/servers', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ servers: [], totalCount: 0 }),
+    }),
+  );
+  await page.route('**/api/observability/feedback?**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        feedback: comments,
+        pagination: { page: 0, perPage: 10, total: comments.length, hasMore: false },
+      }),
+    }),
+  );
+  await page.route('**/api/observability/feedback', route => {
+    const body = route.request().postDataJSON();
+    comments = [
+      {
+        feedbackId: 'comment-1',
+        timestamp: '2026-08-30T12:01:00.000Z',
+        traceId: TRACE_ID,
+        feedbackSource: 'user',
+        feedbackType: 'comment',
+        value: body.feedback.value,
+      },
+    ];
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) });
+  });
+}
+
+async function openPartialThread(page: Page) {
+  await mockPartialThread(page);
+  await page.goto(`/traces?traceId=${TRACE_ID}`);
+  await page.getByRole('tab', { name: 'Messages' }).click();
+}
+
+/**
+ * FEATURE: Messages trace view
+ * USER STORY: A trace reviewer can inspect an agent turn with its chat presentation and leave a trace comment.
+ * BEHAVIOR UNDER TEST: Stored spans become a read-only chat turn, while feedback stays in its dedicated tab.
+ */
+test.describe('Messages trace view', () => {
+  test.afterEach(async () => {
+    await resetStorage();
+  });
+
+  test.describe('when an agent trace with a thread is selected', () => {
+    test('renders the user input, assistant response, and tool execution', async ({ page }) => {
+      await openPartialThread(page);
+
+      await expect(page.getByText(USER_INPUT)).toBeVisible();
+      await expect(page.getByText(ASSISTANT_OUTPUT)).toBeVisible();
+      await expect(page.getByRole('button', { name: 'weatherInfo' })).toBeVisible();
+    });
+
+    test('keeps feedback submission in the dedicated Feedback tab', async ({ page }) => {
+      await openPartialThread(page);
+
+      await expect(page.getByPlaceholder('Leave feedback...')).toHaveCount(0);
+      await page.getByRole('tab', { name: /^Feedback/ }).click();
+      await page.getByPlaceholder('Leave feedback...').fill(COMMENT);
+      await page.getByRole('button', { name: 'Send feedback' }).click();
+
+      await expect(page.getByText(COMMENT)).toBeVisible();
+    });
+  });
+});

--- a/packages/playground/src/domains/mcps/components/mcp-app-tool-result.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-app-tool-result.tsx
@@ -9,6 +9,7 @@ interface McpAppToolResultProps {
   toolArgs?: Record<string, unknown>;
   toolResult?: unknown;
   onSendMessage?: (content: string) => void;
+  readOnly?: boolean;
 }
 
 /**
@@ -19,7 +20,7 @@ interface McpAppToolResultProps {
  * (ui/notifications/tool-input and ui/notifications/tool-result), enabling
  * the app to hydrate with data from the tool call.
  */
-export function McpAppToolResult({ appInfo, toolArgs, toolResult, onSendMessage }: McpAppToolResultProps) {
+export function McpAppToolResult({ appInfo, toolArgs, toolResult, onSendMessage, readOnly }: McpAppToolResultProps) {
   const client = useMastraClient();
 
   const { data: html, isLoading } = useQuery({
@@ -53,8 +54,8 @@ export function McpAppToolResult({ appInfo, toolArgs, toolResult, onSendMessage 
       toolName={appInfo.toolName}
       toolInput={toolArgs}
       toolResult={toolResult}
-      onToolCall={handleToolCall}
-      onSendMessage={onSendMessage}
+      onToolCall={readOnly ? undefined : handleToolCall}
+      onSendMessage={readOnly ? undefined : onSendMessage}
       className="border-border1 rounded-md border"
     />
   );

--- a/packages/playground/src/domains/traces/components/__tests__/fixtures/trace-span-panel.ts
+++ b/packages/playground/src/domains/traces/components/__tests__/fixtures/trace-span-panel.ts
@@ -26,6 +26,9 @@ export const rootSpan = {
   entityType: 'agent',
   entityId: 'weather-agent',
   entityName: 'Weather Agent',
+  threadId: 'weather-thread',
+  input: { messages: [{ role: 'user', content: 'Will it rain?' }] },
+  output: { text: 'No rain is expected.' },
 };
 export const childSpanOne = {
   ...baseSpan,

--- a/packages/playground/src/domains/traces/components/__tests__/fixtures/trace-thread-item.ts
+++ b/packages/playground/src/domains/traces/components/__tests__/fixtures/trace-thread-item.ts
@@ -1,0 +1,201 @@
+import type { GetWorkflowResponse, ListWorkflowRunsResponse, MastraClient } from '@mastra/client-js';
+import { SpanType } from '@mastra/core/observability';
+import { TraceStatus } from '@mastra/core/storage';
+
+type GetTraceResponse = Awaited<ReturnType<MastraClient['getTrace']>>;
+
+export const TRACE_THREAD_ITEM_ID = 'trace-thread-item';
+export const TRACE_THREAD_ID = 'thread-partial';
+export const TRACE_WORKFLOW_ID = 'tripPlanner';
+export const TRACE_WORKFLOW_RUN_ID = 'workflow-run-1';
+
+const baseSpan = {
+  traceId: TRACE_THREAD_ITEM_ID,
+  isEvent: false,
+  threadId: TRACE_THREAD_ID,
+  startedAt: new Date('2026-08-30T12:00:00.000Z'),
+  endedAt: new Date('2026-08-30T12:00:01.000Z'),
+  createdAt: new Date('2026-08-30T12:00:00.000Z'),
+  updatedAt: null,
+  status: TraceStatus.SUCCESS,
+};
+
+export const basicAgentTrace: GetTraceResponse = {
+  traceId: TRACE_THREAD_ITEM_ID,
+  spans: [
+    {
+      ...baseSpan,
+      spanId: 'agent-root',
+      parentSpanId: null,
+      name: 'Travel agent run',
+      spanType: SpanType.AGENT_RUN,
+      entityType: 'agent',
+      entityId: 'travel-agent',
+      entityName: 'Travel Agent',
+      input: {
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'Plan a weekend in Paris' }] }],
+      },
+      output: { text: 'Your Paris itinerary is ready.' },
+    },
+  ],
+};
+
+const rootSpan = basicAgentTrace.spans[0];
+
+export const agentTraceWithTools: GetTraceResponse = {
+  traceId: TRACE_THREAD_ITEM_ID,
+  spans: [
+    rootSpan,
+    {
+      ...baseSpan,
+      spanId: 'model-generation',
+      parentSpanId: 'agent-root',
+      name: 'Model generation',
+      spanType: SpanType.MODEL_GENERATION,
+      startedAt: new Date('2026-08-30T12:00:00.100Z'),
+    },
+    {
+      ...baseSpan,
+      spanId: 'workflow-tool',
+      parentSpanId: 'model-generation',
+      name: 'Trip planner workflow',
+      spanType: SpanType.TOOL_CALL,
+      entityType: 'tool',
+      entityId: 'workflow-tripPlanner',
+      entityName: 'workflow-tripPlanner',
+      input: { inputData: { city: 'Paris' } },
+      output: { runId: TRACE_WORKFLOW_RUN_ID, result: { days: 2 } },
+      attributes: { toolCallId: 'call-workflow' },
+      startedAt: new Date('2026-08-30T12:00:00.200Z'),
+    },
+    {
+      ...baseSpan,
+      spanId: 'workflow-run',
+      parentSpanId: 'workflow-tool',
+      name: 'Trip planner run',
+      spanType: SpanType.WORKFLOW_RUN,
+      entityType: 'workflow_run',
+      entityId: 'tripPlanner',
+      entityName: 'Trip planner',
+      startedAt: new Date('2026-08-30T12:00:00.210Z'),
+    },
+    {
+      ...baseSpan,
+      spanId: 'nested-workflow-tool',
+      parentSpanId: 'workflow-run',
+      name: 'Internal weather lookup',
+      spanType: SpanType.TOOL_CALL,
+      entityType: 'tool',
+      entityId: 'internalWeather',
+      entityName: 'internalWeather',
+      input: { city: 'Paris' },
+      output: { temperature: 22 },
+      attributes: { toolCallId: 'call-internal' },
+      startedAt: new Date('2026-08-30T12:00:00.220Z'),
+    },
+    {
+      ...baseSpan,
+      spanId: 'mcp-tool',
+      parentSpanId: 'model-generation',
+      name: 'Hotel search',
+      spanType: SpanType.MCP_TOOL_CALL,
+      entityType: 'tool',
+      entityId: 'searchHotels',
+      entityName: 'searchHotels',
+      input: { city: 'Paris' },
+      output: { hotels: ['Left Bank'] },
+      attributes: { mcpServer: 'travel', toolCallId: 'call-mcp' },
+      startedAt: new Date('2026-08-30T12:00:00.300Z'),
+    },
+    {
+      ...baseSpan,
+      spanId: 'client-tool',
+      parentSpanId: 'model-generation',
+      name: 'Client location',
+      spanType: SpanType.CLIENT_TOOL_CALL,
+      entityType: 'tool',
+      entityId: 'browser_location',
+      entityName: 'browser_location',
+      input: { permission: true },
+      output: { city: 'Paris' },
+      startedAt: new Date('2026-08-30T12:00:00.400Z'),
+    },
+    {
+      ...baseSpan,
+      spanId: 'provider-tool',
+      parentSpanId: 'model-generation',
+      name: 'Provider web search',
+      spanType: SpanType.PROVIDER_TOOL_CALL,
+      entityType: 'tool',
+      entityId: 'web_search',
+      entityName: 'web_search',
+      input: { query: 'Paris events' },
+      output: { events: ['Exhibition'] },
+      attributes: { toolCallId: 'call-provider' },
+      startedAt: new Date('2026-08-30T12:00:00.500Z'),
+    },
+  ],
+};
+
+export const agentTraceWithSkill: GetTraceResponse = {
+  traceId: TRACE_THREAD_ITEM_ID,
+  spans: [
+    rootSpan,
+    {
+      ...baseSpan,
+      spanId: 'skill-model-generation',
+      parentSpanId: 'agent-root',
+      name: 'Model generation',
+      spanType: SpanType.MODEL_GENERATION,
+      startedAt: new Date('2026-08-30T12:00:00.100Z'),
+    },
+    {
+      ...baseSpan,
+      spanId: 'skill-tool',
+      parentSpanId: 'skill-model-generation',
+      name: 'Activate skill',
+      spanType: SpanType.TOOL_CALL,
+      entityType: 'tool',
+      entityId: 'skill',
+      entityName: 'skill',
+      input: { name: 'trip-planning' },
+      output: { content: 'Skill loaded' },
+      attributes: { toolCallId: 'call-skill' },
+      startedAt: new Date('2026-08-30T12:00:00.200Z'),
+    },
+  ],
+};
+
+export const traceWorkflow = {
+  name: 'Trip planner workflow',
+  stepGraph: [{ type: 'step', step: { id: 'build-itinerary', description: '' } }],
+} satisfies Pick<GetWorkflowResponse, 'name' | 'stepGraph'>;
+
+type WorkflowRunSnapshot = Exclude<ListWorkflowRunsResponse['runs'][number]['snapshot'], string>;
+
+const workflowRunDate = new Date('2026-08-30T12:00:00.200Z');
+
+export const traceWorkflowRuns: ListWorkflowRunsResponse = {
+  runs: [
+    {
+      workflowName: traceWorkflow.name,
+      runId: TRACE_WORKFLOW_RUN_ID,
+      snapshot: {
+        runId: TRACE_WORKFLOW_RUN_ID,
+        status: 'success',
+        value: {},
+        context: {},
+        serializedStepGraph: traceWorkflow.stepGraph,
+        activePaths: [],
+        activeStepsPath: {},
+        suspendedPaths: {},
+        resumeLabels: {},
+        waitingPaths: {},
+        timestamp: workflowRunDate.getTime(),
+      } satisfies WorkflowRunSnapshot,
+      createdAt: workflowRunDate,
+      updatedAt: workflowRunDate,
+    },
+  ],
+  total: 1,
+};

--- a/packages/playground/src/domains/traces/components/__tests__/format-trace-thread-messages.test.ts
+++ b/packages/playground/src/domains/traces/components/__tests__/format-trace-thread-messages.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatTraceThreadMessages } from '../format-trace-thread-messages';
+import { agentTraceWithTools, basicAgentTrace } from './fixtures/trace-thread-item';
+
+describe('formatTraceThreadMessages', () => {
+  describe('when an agent trace contains one user input and a text response', () => {
+    it('returns the corresponding chat turn', () => {
+      const messages = formatTraceThreadMessages(basicAgentTrace.spans);
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: 'user',
+        content: { parts: [{ type: 'text', text: 'Plan a weekend in Paris' }] },
+      });
+      expect(messages[1]).toMatchObject({
+        role: 'assistant',
+        content: { parts: [{ type: 'text', text: 'Your Paris itinerary is ready.' }] },
+      });
+    });
+  });
+
+  describe('when an agent turn contains different kinds of tool calls', () => {
+    it('includes each visible tool once in chronological order', () => {
+      const messages = formatTraceThreadMessages(agentTraceWithTools.spans);
+      const toolNames = messages[1]?.content.parts.flatMap(part =>
+        part.type === 'tool-invocation' ? [part.toolInvocation.toolName] : [],
+      );
+
+      expect(toolNames).toEqual(['workflow-tripPlanner', 'searchHotels', 'browser_location', 'web_search']);
+    });
+  });
+
+  describe('when the user input contains persisted message parts', () => {
+    it('preserves text and file parts for the chat renderer', () => {
+      const spans = basicAgentTrace.spans.map(span => ({
+        ...span,
+        input: {
+          messages: [
+            {
+              role: 'user',
+              content: {
+                format: 2,
+                parts: [
+                  { type: 'text', text: 'Inspect this map' },
+                  { type: 'file', mimeType: 'image/png', data: 'https://example.com/map.png' },
+                ],
+              },
+            },
+          ],
+        },
+      }));
+
+      const messages = formatTraceThreadMessages(spans);
+
+      expect(messages[0]?.content.parts).toEqual([
+        { type: 'text', text: 'Inspect this map' },
+        { type: 'file', mimeType: 'image/png', data: 'https://example.com/map.png' },
+      ]);
+    });
+  });
+
+  describe('when a thread signal triggered the agent trace', () => {
+    it('renders the signal contents as the user message', () => {
+      const spans = basicAgentTrace.spans.map(span => ({
+        ...span,
+        input: {
+          __isCreatedSignal: true,
+          id: 'user-signal-1',
+          type: 'user',
+          tagName: 'user',
+          contents: [{ type: 'text', text: 'Plan a weekend in Paris' }],
+          createdAt: new Date('2026-08-30T12:00:00.000Z'),
+        },
+      }));
+
+      const messages = formatTraceThreadMessages(spans);
+
+      expect(messages[0]?.content.parts).toEqual([{ type: 'text', text: 'Plan a weekend in Paris' }]);
+    });
+  });
+
+  describe('when the agent returns structured output without text', () => {
+    it('renders the structured result as the assistant response', () => {
+      const spans = basicAgentTrace.spans.map(span => ({ ...span, output: { object: { city: 'Paris', days: 2 } } }));
+
+      const messages = formatTraceThreadMessages(spans);
+
+      expect(messages[1]?.content.parts).toEqual([{ type: 'text', text: '{"city":"Paris","days":2}' }]);
+    });
+  });
+});

--- a/packages/playground/src/domains/traces/components/__tests__/trace-span-panel.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/trace-span-panel.msw.test.tsx
@@ -34,6 +34,10 @@ const installHandlers = () => {
       const detail = spanDetailById[spanId];
       return detail ? HttpResponse.json(detail) : HttpResponse.json({ error: 'not found' }, { status: 404 });
     }),
+    http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId`, () => HttpResponse.json(panelTraceSpans)),
+    http.get(`${TEST_BASE_URL}/api/observability/feedback`, () =>
+      HttpResponse.json({ feedback: [], pagination: { page: 0, perPage: 10, total: 0, hasMore: false } }),
+    ),
   );
 };
 
@@ -72,6 +76,38 @@ const renderPanel = (props: Partial<TraceSpanPanelProps> & { initialSpanId?: str
   );
 
 describe('TraceSpanPanel', () => {
+  describe('when partial thread is enabled for an agent trace with a thread id', () => {
+    it('renders the selected trace as a chat turn in the Messages tab', async () => {
+      installHandlers();
+      const { queryClient } = renderPanel({ showPartialThread: true });
+
+      fireEvent.click(await screen.findByRole('tab', { name: 'Messages' }));
+
+      expect(await screen.findByText('Will it rain?')).not.toBeNull();
+      expect(screen.getByText('No rain is expected.')).not.toBeNull();
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+    });
+  });
+
+  describe('when partial thread is enabled without a complete agent thread context', () => {
+    it('hides the tab for a trace without a thread id', () => {
+      installHandlers();
+      renderPanel({
+        showPartialThread: true,
+        spans: panelTraceSpans.spans.map(span => (span.parentSpanId == null ? { ...span, threadId: null } : span)),
+      });
+
+      expect(screen.queryByRole('tab', { name: 'Messages' })).toBeNull();
+    });
+
+    it('hides the tab for a branch view', () => {
+      installHandlers();
+      renderPanel({ showPartialThread: true, anchorSpanId: 'span-root' });
+
+      expect(screen.queryByRole('tab', { name: 'Messages' })).toBeNull();
+    });
+  });
+
   it('given a trace with spans, when it renders, then the trace header and span tree are shown', async () => {
     installHandlers();
     const { queryClient } = renderPanel();

--- a/packages/playground/src/domains/traces/components/__tests__/trace-thread-item-view.msw.test.tsx
+++ b/packages/playground/src/domains/traces/components/__tests__/trace-thread-item-view.msw.test.tsx
@@ -1,0 +1,127 @@
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { TraceThreadItemView } from '../trace-thread-item-view';
+import {
+  agentTraceWithTools,
+  agentTraceWithSkill,
+  basicAgentTrace,
+  TRACE_THREAD_ITEM_ID,
+  TRACE_WORKFLOW_ID,
+  traceWorkflow,
+  traceWorkflowRuns,
+} from './fixtures/trace-thread-item';
+import { ActivatedSkillsProvider, useActivatedSkills } from '@/domains/agents/context/activated-skills-context';
+import { BrowserToolCallsProvider, useBrowserToolCalls } from '@/domains/agents/context/browser-tool-calls-context';
+import { server } from '@/test/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '@/test/render';
+
+const installToolTraceHandlers = () => {
+  server.use(
+    http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId`, () => HttpResponse.json(agentTraceWithTools)),
+    http.get(`${TEST_BASE_URL}/api/mcp/v0/servers`, () => HttpResponse.json({ servers: [], totalCount: 0 })),
+    http.get(`${TEST_BASE_URL}/api/workflows/${TRACE_WORKFLOW_ID}`, () => HttpResponse.json(traceWorkflow)),
+    http.get(`${TEST_BASE_URL}/api/workflows/${TRACE_WORKFLOW_ID}/runs`, () => HttpResponse.json(traceWorkflowRuns)),
+    http.get(`${TEST_BASE_URL}/api/workflows/${TRACE_WORKFLOW_ID}/runs/:runId`, () =>
+      HttpResponse.json(traceWorkflowRuns.runs[0]),
+    ),
+  );
+};
+
+const BrowserToolCallCount = () => {
+  const { toolCalls } = useBrowserToolCalls();
+  return <output data-testid="browser-tool-count">{toolCalls.length}</output>;
+};
+
+const SkillActivationStatus = () => {
+  const { isSkillActivated } = useActivatedSkills();
+  return <output data-testid="skill-activation-status">{String(isSkillActivated('trip-planning'))}</output>;
+};
+
+describe('TraceThreadItemView', () => {
+  describe('when the trace contains a completed agent turn', () => {
+    it('renders the user input and assistant response through the chat UI', async () => {
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId`, () => HttpResponse.json(basicAgentTrace)),
+      );
+
+      const { queryClient } = renderWithProviders(<TraceThreadItemView traceId={TRACE_THREAD_ITEM_ID} />);
+
+      expect(await screen.findByText('Plan a weekend in Paris')).not.toBeNull();
+      expect(screen.getByText('Your Paris itinerary is ready.')).not.toBeNull();
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+    });
+
+    it('leaves feedback controls to the dedicated Feedback tab', async () => {
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId`, () => HttpResponse.json(basicAgentTrace)),
+        http.get(`${TEST_BASE_URL}/api/observability/feedback`, () =>
+          HttpResponse.json({ feedback: [], pagination: { page: 0, perPage: 10, total: 0, hasMore: false } }),
+        ),
+      );
+
+      const { queryClient } = renderWithProviders(<TraceThreadItemView traceId={TRACE_THREAD_ITEM_ID} />);
+
+      expect(await screen.findByText('Plan a weekend in Paris')).not.toBeNull();
+      expect(screen.queryByPlaceholderText('Leave feedback...')).toBeNull();
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+    });
+  });
+
+  describe('when the trace contains tool and workflow executions', () => {
+    it('renders every top-level execution with the agent chat cards', async () => {
+      installToolTraceHandlers();
+
+      const { queryClient } = renderWithProviders(<TraceThreadItemView traceId={TRACE_THREAD_ITEM_ID} />, {
+        router: true,
+      });
+
+      expect(await screen.findByTestId('workflow-badge')).not.toBeNull();
+      expect(await screen.findByTestId('workflow-graph-viewport')).not.toBeNull();
+      expect(screen.getAllByTestId('tool-badge')).toHaveLength(3);
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+    });
+  });
+
+  describe('when historical browser tools are rendered', () => {
+    it('does not register them as active browser calls', async () => {
+      installToolTraceHandlers();
+
+      const { queryClient } = renderWithProviders(
+        <BrowserToolCallsProvider>
+          <TraceThreadItemView traceId={TRACE_THREAD_ITEM_ID} />
+          <BrowserToolCallCount />
+        </BrowserToolCallsProvider>,
+        { router: true },
+      );
+
+      expect(await screen.findByTestId('workflow-badge')).not.toBeNull();
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+      expect(screen.getByTestId('browser-tool-count').textContent).toBe('0');
+    });
+  });
+
+  describe('when a historical skill tool is rendered', () => {
+    it('does not activate the skill in the current chat', async () => {
+      server.use(
+        http.get(`${TEST_BASE_URL}/api/observability/traces/:traceId`, () => HttpResponse.json(agentTraceWithSkill)),
+        http.get(`${TEST_BASE_URL}/api/mcp/v0/servers`, () => HttpResponse.json({ servers: [], totalCount: 0 })),
+        http.get(`${TEST_BASE_URL}/api/observability/feedback`, () =>
+          HttpResponse.json({ feedback: [], pagination: { page: 0, perPage: 10, total: 0, hasMore: false } }),
+        ),
+      );
+
+      const { queryClient } = renderWithProviders(
+        <ActivatedSkillsProvider>
+          <TraceThreadItemView traceId={TRACE_THREAD_ITEM_ID} />
+          <SkillActivationStatus />
+        </ActivatedSkillsProvider>,
+      );
+
+      expect(await screen.findByTestId('tool-badge')).not.toBeNull();
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+      expect(screen.getByTestId('skill-activation-status').textContent).toBe('false');
+    });
+  });
+});

--- a/packages/playground/src/domains/traces/components/format-trace-thread-messages.ts
+++ b/packages/playground/src/domains/traces/components/format-trace-thread-messages.ts
@@ -1,0 +1,146 @@
+import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent/message-list';
+import { SpanType } from '@mastra/core/observability';
+import type { SpanRecord } from '@mastra/core/storage';
+import { formatHierarchicalSpans } from '@mastra/playground-ui/domains/traces/components/format-hierarchical-spans';
+import type { UISpan } from '@mastra/playground-ui/domains/traces/types';
+
+const TOOL_SPAN_TYPES = new Set<string>([
+  SpanType.TOOL_CALL,
+  SpanType.MCP_TOOL_CALL,
+  SpanType.CLIENT_TOOL_CALL,
+  SpanType.PROVIDER_TOOL_CALL,
+]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const toTextParts = (content: unknown): MastraMessagePart[] => {
+  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  if (isRecord(content) && Array.isArray(content.parts)) return toTextParts(content.parts);
+  if (!Array.isArray(content)) return [];
+
+  return content.flatMap<MastraMessagePart>(part => {
+    if (!isRecord(part)) return [];
+    if (part.type === 'text' && typeof part.text === 'string') {
+      return [{ type: 'text' as const, text: part.text }];
+    }
+    if (part.type === 'file' && typeof part.mimeType === 'string' && typeof part.data === 'string') {
+      return [{ type: 'file' as const, mimeType: part.mimeType, data: part.data }];
+    }
+    return [];
+  });
+};
+
+const getUserParts = (input: unknown): MastraMessagePart[] => {
+  if (typeof input === 'string') return toTextParts(input);
+  if (isRecord(input) && (input.type === 'user' || input.type === 'user-message')) {
+    return toTextParts(input.contents);
+  }
+
+  const messages = Array.isArray(input)
+    ? input
+    : isRecord(input) && Array.isArray(input.messages)
+      ? input.messages
+      : [];
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (isRecord(message) && message.role === 'user') return toTextParts(message.content);
+  }
+
+  return [];
+};
+
+const getResponseText = (output: unknown): string => {
+  if (!isRecord(output)) return '';
+  if (typeof output.text === 'string') return output.text;
+  if (output.object === undefined) return '';
+  return typeof output.object === 'string' ? output.object : JSON.stringify(output.object);
+};
+
+const readString = (value: unknown, key: string): string | undefined => {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === 'string' ? field : undefined;
+};
+
+const toToolPart = (span: SpanRecord): MastraMessagePart => {
+  const failed = Boolean(span.error);
+  const settled = Boolean(span.endedAt);
+  const state = failed ? 'output-error' : settled ? 'result' : 'call';
+
+  return {
+    type: 'tool-invocation',
+    toolInvocation: {
+      toolCallId: readString(span.attributes, 'toolCallId') ?? span.spanId,
+      toolName: span.entityName ?? span.entityId ?? span.name,
+      args: span.input ?? {},
+      state,
+      ...(settled ? { result: span.output } : {}),
+      ...(failed ? { isError: true, errorText: readString(span.error, 'message') } : {}),
+    },
+    providerExecuted: span.spanType === SpanType.PROVIDER_TOOL_CALL,
+  };
+};
+
+const collectVisibleToolParts = (root: UISpan, spans: SpanRecord[]): MastraMessagePart[] => {
+  const spanById = new Map(spans.map(span => [span.spanId, span]));
+  const parts: MastraMessagePart[] = [];
+
+  const visit = (nodes: UISpan[]) => {
+    for (const node of nodes) {
+      const span = spanById.get(node.id);
+      if (!span) continue;
+      if (TOOL_SPAN_TYPES.has(span.spanType)) {
+        parts.push(toToolPart(span));
+        continue;
+      }
+      visit(node.spans ?? []);
+    }
+  };
+
+  visit(root.spans ?? []);
+  return parts;
+};
+
+const messageContent = (parts: MastraMessagePart[]) =>
+  parts.flatMap(part => (part.type === 'text' && typeof part.text === 'string' ? [part.text] : [])).join('\n');
+
+export function formatTraceThreadMessages(spans: SpanRecord[]): MastraDBMessage[] {
+  const hierarchy = formatHierarchicalSpans(
+    spans.map(span => ({
+      spanId: span.spanId,
+      name: span.name,
+      spanType: span.spanType,
+      startedAt: span.startedAt,
+      endedAt: span.endedAt,
+      parentSpanId: span.parentSpanId,
+    })),
+  );
+  const hierarchicalRoot = hierarchy.find(span => span.type === SpanType.AGENT_RUN);
+  if (!hierarchicalRoot) return [];
+  const root = spans.find(span => span.spanId === hierarchicalRoot.id);
+  if (!root) return [];
+
+  const userParts = getUserParts(root.input);
+  const responseText = getResponseText(root.output);
+  const assistantParts = collectVisibleToolParts(hierarchicalRoot, spans);
+  if (responseText) assistantParts.push({ type: 'text', text: responseText });
+
+  return [
+    {
+      id: `${root.traceId}:${root.spanId}:user`,
+      role: 'user',
+      createdAt: new Date(root.startedAt),
+      threadId: root.threadId ?? undefined,
+      content: { format: 2, parts: userParts, content: messageContent(userParts) },
+    },
+    {
+      id: `${root.traceId}:${root.spanId}:assistant`,
+      role: 'assistant',
+      createdAt: new Date(root.endedAt ?? root.startedAt),
+      threadId: root.threadId ?? undefined,
+      content: { format: 2, parts: assistantParts, content: responseText },
+    },
+  ];
+}

--- a/packages/playground/src/domains/traces/components/thread-traces.tsx
+++ b/packages/playground/src/domains/traces/components/thread-traces.tsx
@@ -92,6 +92,7 @@ export function ThreadTraces({ threadId, onTraceOpenChange, onSpanOpenChange }: 
         onPrevious={handlePreviousTrace}
         onNext={handleNextTrace}
         traceHref={`/traces?traceId=${encodeURIComponent(featuredTraceId)}`}
+        showPartialThread
       />
     );
   }

--- a/packages/playground/src/domains/traces/components/trace-span-panel.tsx
+++ b/packages/playground/src/domains/traces/components/trace-span-panel.tsx
@@ -1,3 +1,4 @@
+import { SpanType } from '@mastra/core/observability';
 import { SpanDataPanelView } from '@mastra/playground-ui/domains/traces/components/span-data-panel-view';
 import type { TraceDataPanelView } from '@mastra/playground-ui/domains/traces/components/trace-data-panel-view';
 import { useSpanDetail } from '@mastra/playground-ui/domains/traces/hooks/use-span-detail';
@@ -5,6 +6,7 @@ import { useTraceSpanNavigation } from '@mastra/playground-ui/domains/traces/hoo
 import type { ComponentProps, ReactNode } from 'react';
 
 import { TraceDataPanel } from '@/domains/traces/components/trace-data-panel';
+import { TraceThreadItemView } from '@/domains/traces/components/trace-thread-item-view';
 import { Link } from '@/lib/link';
 
 type TraceDataPanelViewProps = ComponentProps<typeof TraceDataPanelView>;
@@ -39,6 +41,8 @@ export interface TraceSpanPanelProps {
   onAddTraceMocksToItem?: TraceDataPanelViewProps['onAddTraceMocksToItem'];
   feedbackTabBadge?: ReactNode;
   feedbackTabSlot?: TraceDataPanelViewProps['feedbackTabSlot'];
+  /** Enables the reconstructed turn tab when the displayed root is a complete agent trace with a thread id. */
+  showPartialThread?: boolean;
   scoresTabBadge?: ReactNode;
   scoresTabSlot?: TraceDataPanelViewProps['scoresTabSlot'];
   usage?: TraceDataPanelViewProps['usage'];
@@ -77,6 +81,7 @@ export function TraceSpanPanel({
   onAddTraceMocksToItem,
   feedbackTabBadge,
   feedbackTabSlot,
+  showPartialThread,
   scoresTabBadge,
   scoresTabSlot,
   usage,
@@ -99,6 +104,9 @@ export function TraceSpanPanel({
     ? spans?.find(s => s.spanId === anchorSpanId)
     : spans?.find(s => s.parentSpanId == null);
   const entityHref = getEntityHref(rootSpan?.entityType, rootSpan?.entityId);
+  const hasThreadId = rootSpan && 'threadId' in rootSpan && typeof rootSpan.threadId === 'string';
+  const canShowPartialThread =
+    showPartialThread && !anchorSpanId && rootSpan?.spanType === SpanType.AGENT_RUN && hasThreadId;
 
   return (
     <TraceDataPanel
@@ -124,6 +132,11 @@ export function TraceSpanPanel({
       showUnavailableFeaturesMsg={showUnavailableFeaturesMsg}
       feedbackTabBadge={feedbackTabBadge}
       feedbackTabSlot={feedbackTabSlot}
+      partialThreadTabSlot={
+        canShowPartialThread
+          ? ({ traceId: selectedTraceId }) => <TraceThreadItemView traceId={selectedTraceId} />
+          : undefined
+      }
       scoresTabBadge={scoresTabBadge}
       scoresTabSlot={scoresTabSlot}
       spanPanelSlot={

--- a/packages/playground/src/domains/traces/components/trace-thread-item-view.tsx
+++ b/packages/playground/src/domains/traces/components/trace-thread-item-view.tsx
@@ -1,0 +1,67 @@
+import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { TracesErrorContent } from '@mastra/playground-ui/domains/traces/components/traces-error-content';
+import { useTraceSpans } from '@mastra/playground-ui/domains/traces/hooks/use-trace-spans';
+
+import { formatTraceThreadMessages } from './format-trace-thread-messages';
+import { MessageRow } from '@/lib/ai-ui/messages/message-row';
+import { ToolCallProvider } from '@/services/tool-call-provider';
+
+export interface TraceThreadItemViewProps {
+  traceId: string;
+}
+
+const noop = () => {};
+
+export function TraceThreadItemView({ traceId }: TraceThreadItemViewProps) {
+  const { data, isLoading, error } = useTraceSpans(traceId);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center" aria-label="Loading partial thread">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center p-4">
+        <TracesErrorContent error={error} resource="trace" errorTitle="Failed to load partial thread" />
+      </div>
+    );
+  }
+
+  const messages = data ? formatTraceThreadMessages(data.spans) : [];
+  if (messages.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-4">
+        <Txt variant="ui-md" className="text-neutral3">
+          No agent turn found for this trace.
+        </Txt>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full min-h-0 overflow-y-auto p-4">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+        <ToolCallProvider
+          approveToolcall={noop}
+          declineToolcall={noop}
+          approveToolcallGenerate={noop}
+          declineToolcallGenerate={noop}
+          approveNetworkToolcall={noop}
+          declineNetworkToolcall={noop}
+          isRunning={false}
+          toolCallApprovals={{}}
+          networkToolCallApprovals={{}}
+        >
+          {messages.map(message => (
+            <MessageRow key={message.id} message={message} readOnly />
+          ))}
+        </ToolCallProvider>
+      </div>
+    </div>
+  );
+}

--- a/packages/playground/src/lib/ai-ui/messages/message-row.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/message-row.tsx
@@ -32,6 +32,8 @@ export interface MessageRowProps extends Omit<React.HTMLAttributes<HTMLDivElemen
   onReadAloud?: (text: string) => void;
   /** Stop the current read-aloud playback. */
   onStopSpeaking?: () => void;
+  /** Render historical tool calls without actions or chat/session side effects. */
+  readOnly?: boolean;
 }
 
 type MessagePart = MastraDBMessage['content']['parts'][number];
@@ -204,7 +206,7 @@ const AssistantActionBar = ({
 );
 
 export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
-  ({ message, hasModelList, isSpeaking, onReadAloud, onStopSpeaking, className, ...rootProps }, ref) => {
+  ({ message, hasModelList, isSpeaking, onReadAloud, onStopSpeaking, readOnly, className, ...rootProps }, ref) => {
     const dbMessage = toDisplayMessage(message);
     const metadata = getMessageMetadata(message);
     const modelMetadata = hasModelList ? getModelMetadata(metadata) : undefined;
@@ -226,16 +228,16 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
         ),
         ToolInvocation: part => (
           <Arriving>
-            <ToolInvocationPartRenderer part={part} metadata={metadata} dataParts={dataParts} />
+            <ToolInvocationPartRenderer part={part} metadata={metadata} dataParts={dataParts} readOnly={readOnly} />
           </Arriving>
         ),
         DynamicTool: part => (
           <Arriving>
-            <DynamicToolPartRenderer part={part} metadata={metadata} dataParts={dataParts} />
+            <DynamicToolPartRenderer part={part} metadata={metadata} dataParts={dataParts} readOnly={readOnly} />
           </Arriving>
         ),
       }),
-      [metadata, dataParts],
+      [metadata, dataParts, readOnly],
     );
 
     const userRenderers = useMemo<MessageRenderers>(

--- a/packages/playground/src/lib/ai-ui/messages/renderers/dynamic-tool-part-renderer.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/dynamic-tool-part-renderer.tsx
@@ -8,6 +8,7 @@ export interface DynamicToolPartRendererProps {
   part: DynamicToolPart;
   metadata?: MessageMetadata;
   dataParts?: ReadonlyArray<DataMessagePart>;
+  readOnly?: boolean;
 }
 
 /**
@@ -15,7 +16,7 @@ export interface DynamicToolPartRendererProps {
  * `tool-${string}` parts). Derives the display tool name from `toolName`,
  * falling back to the `tool-` prefixed part type.
  */
-export const DynamicToolPartRenderer = ({ part, metadata, dataParts }: DynamicToolPartRendererProps) => {
+export const DynamicToolPartRenderer = ({ part, metadata, dataParts, readOnly }: DynamicToolPartRendererProps) => {
   const toolName = part.toolName ?? part.type.replace(/^tool-/, '');
 
   return (
@@ -27,6 +28,7 @@ export const DynamicToolPartRenderer = ({ part, metadata, dataParts }: DynamicTo
       state={part.state}
       metadata={metadata}
       dataParts={dataParts}
+      readOnly={readOnly}
     />
   );
 };

--- a/packages/playground/src/lib/ai-ui/messages/renderers/tool-invocation-part-renderer.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/tool-invocation-part-renderer.tsx
@@ -8,6 +8,7 @@ export interface ToolInvocationPartRendererProps {
   part: ToolInvocationPart;
   metadata?: MessageMetadata;
   dataParts?: ReadonlyArray<DataMessagePart>;
+  readOnly?: boolean;
 }
 
 /**
@@ -15,7 +16,12 @@ export interface ToolInvocationPartRendererProps {
  * `toolInvocation` payload (`args`/`result`) into `ToolCard`'s plain
  * `input`/`output` contract.
  */
-export const ToolInvocationPartRenderer = ({ part, metadata, dataParts }: ToolInvocationPartRendererProps) => {
+export const ToolInvocationPartRenderer = ({
+  part,
+  metadata,
+  dataParts,
+  readOnly,
+}: ToolInvocationPartRendererProps) => {
   const inv = part.toolInvocation;
   const input = 'args' in inv ? inv.args : undefined;
   const output = 'result' in inv ? inv.result : undefined;
@@ -29,6 +35,7 @@ export const ToolInvocationPartRenderer = ({ part, metadata, dataParts }: ToolIn
       state={inv.state}
       metadata={metadata}
       dataParts={dataParts}
+      readOnly={readOnly}
     />
   );
 };

--- a/packages/playground/src/lib/ai-ui/tools/tool-card.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/tool-card.tsx
@@ -56,6 +56,8 @@ export interface ToolCardProps {
   metadata?: MessageMetadata;
   /** `data`-typed parts from the parent message, for badges that read live streaming metadata. */
   dataParts?: ReadonlyArray<DataMessagePart>;
+  /** Historical rendering mode: preserve presentation while suppressing executable actions and side effects. */
+  readOnly?: boolean;
 }
 
 const TASK_TOOL_NAMES = new Set(['task_write', 'task_update', 'task_complete', 'task_check']);
@@ -78,7 +80,16 @@ export const ToolCard = (props: ToolCardProps) => {
   );
 };
 
-export const ToolCardInner = ({ toolName, input, output, toolCallId, state, metadata, dataParts }: ToolCardProps) => {
+export const ToolCardInner = ({
+  toolName,
+  input,
+  output,
+  toolCallId,
+  state,
+  metadata,
+  dataParts,
+  readOnly = false,
+}: ToolCardProps) => {
   // All hooks must run unconditionally before any conditional returns.
   const browserCtx = useBrowserToolCallsSafe();
   const isBrowser = isBrowserTool(toolName);
@@ -103,7 +114,7 @@ export const ToolCardInner = ({ toolName, input, output, toolCallId, state, meta
   );
 
   useEffect(() => {
-    if (!isBrowser || !browserCtx) return;
+    if (readOnly || !isBrowser || !browserCtx) return;
 
     let status: 'pending' | 'complete' | 'error' = 'pending';
     if (result !== undefined) {
@@ -136,15 +147,16 @@ export const ToolCardInner = ({ toolName, input, output, toolCallId, state, meta
         return { ...prev, hasSession: true };
       });
     }
-  }, [isBrowser, toolCallId, toolName, args, result, browserCtx, queryClient]);
+  }, [readOnly, isBrowser, toolCallId, toolName, args, result, browserCtx, queryClient]);
 
   // Detect skill activation tool calls.
   useEffect(() => {
+    if (readOnly) return;
     if (toolName !== 'skill') return;
     if (!args?.name) return;
     if (!isComplete) return;
     activateSkill(args.name);
-  }, [toolName, args?.name, isComplete, activateSkill]);
+  }, [readOnly, toolName, args?.name, isComplete, activateSkill]);
 
   useWorkflowStream(result);
 
@@ -196,7 +208,7 @@ export const ToolCardInner = ({ toolName, input, output, toolCallId, state, meta
   }
 
   // ask_user tool renders a dedicated interactive component for answering questions.
-  if (toolName === 'ask_user') {
+  if (toolName === 'ask_user' && !readOnly) {
     return <AskUserTool toolName={toolName} toolCallId={toolCallId} output={output} metadata={metadata} />;
   }
 
@@ -355,6 +367,7 @@ export const ToolCardInner = ({ toolName, input, output, toolCallId, state, meta
           toolArgs={args}
           toolResult={result}
           onSendMessage={handleMcpAppSendMessage}
+          readOnly={readOnly}
         />
       )}
     </>

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -459,6 +459,7 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
               initialSpanId={url.spanIdParam}
               onPrevious={handlePreviousTrace}
               onNext={handleNextTrace}
+              showPartialThread
               feedbackTabBadge={traceFeedbackData?.pagination?.total ?? undefined}
               feedbackTabSlot={({ traceId: tid }) => <TraceFeedbackTab traceId={tid} />}
               scoresTabBadge={spanScoresData?.pagination?.total ?? undefined}


### PR DESCRIPTION


https://github.com/user-attachments/assets/603ee4ba-f517-4e33-b895-266bbcdbef90



Simplest message representation of a trace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a read-only Messages tab to trace details. It rebuilds user messages, assistant replies, tool calls, and workflow results from trace data, while keeping feedback and scores in separate tabs.

## What changed

- Added `formatTraceThreadMessages` to reconstruct agent turns from trace spans.
- Added `TraceThreadItemView` to display reconstructed messages.
- Added the optional Messages tab for eligible agent traces with a `threadId`.
- Kept Feedback and Scores in separate tabs.
- Added read-only support to message rows, tool cards, and MCP tool results.
- Prevented tool actions and side effects in the read-only view.
- Added loading, error, and empty states.
- Added MSW unit tests and Playwright coverage for messages, tools, workflows, and feedback.
- Added a changeset for `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->