### PR TITLE
fix(mcp): support modern resource subscriptions

### DIFF
--- a/.changeset/modern-mice-listen.md
+++ b/.changeset/modern-mice-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Route resource subscriptions through `subscriptions/listen` on MCP 2026-07-28 connections while preserving the legacy resource subscription methods for older protocol versions.

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -621,9 +621,9 @@ console.log('Current weather:', content.contents[0].text)
 
 #### `resources.subscribe(serverName: string, uri: string)`
 
-Subscribes to updates for a specific resource on a server. On a `2026-07-28` connection, Mastra adds the URI to a managed `subscriptions/listen` stream. Subscribing to the same URI more than once has no effect. Mastra restores the stream after a reconnect and closes it when the client disconnects.
+Subscribes to updates for a specific resource on a server. On a `2026-07-28` connection, Mastra adds the URI to a managed `subscriptions/listen` stream. Subscribing to the same URI more than once has no effect while the stream is active. Mastra restores the stream after a reconnect and closes it when the client disconnects.
 
-On a legacy connection, this method sends a `resources/subscribe` request.
+The method rejects if the server doesn't honor the requested URI. If stream restoration fails after a reconnect, the connection remains available and calling `subscribe()` again retries the stream. On a legacy connection, this method sends a `resources/subscribe` request.
 
 ```typescript oxfmt:false
 async subscribe(serverName: string, uri: string): Promise<object>

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -621,7 +621,9 @@ console.log('Current weather:', content.contents[0].text)
 
 #### `resources.subscribe(serverName: string, uri: string)`
 
-Subscribes to updates for a specific resource on a server.
+Subscribes to updates for a specific resource on a server. On a `2026-07-28` connection, Mastra adds the URI to a managed `subscriptions/listen` stream. Subscribing to the same URI more than once has no effect. Mastra restores the stream after a reconnect and closes it when the client disconnects.
+
+On a legacy connection, this method sends a `resources/subscribe` request.
 
 ```typescript oxfmt:false
 async subscribe(serverName: string, uri: string): Promise<object>
@@ -635,7 +637,7 @@ await mcpClient.resources.subscribe('myWeatherServer', 'weather://current')
 
 #### `resources.unsubscribe(serverName: string, uri: string)`
 
-Unsubscribes from updates for a specific resource on a server.
+Unsubscribes from updates for a specific resource on a server. On a `2026-07-28` connection, Mastra removes the URI from the managed `subscriptions/listen` filter and replaces the stream. When no URIs remain, Mastra closes the stream. On a legacy connection, this method sends a `resources/unsubscribe` request.
 
 ```typescript oxfmt:false
 async unsubscribe(serverName: string, uri: string): Promise<object>

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -28,6 +28,7 @@
     "test:client": "vitest run ./src/client/client.test.ts ./src/client/configuration.test.ts ./src/client/error-utils.test.ts ./src/client/oauth.test.ts ./src/client/oauth-callback-server.test.ts ./src/client/oauth-flow.test.ts ./src/client/url-policy.test.ts ./src/client/stdio-env.test.ts",
     "test:server": "vitest run ./src/server",
     "test:integration": "cd integration-tests && pnpm test:mcp",
+    "test:conformance": "tsx ./src/conformance/run.ts",
     "test": "pnpm test:server && pnpm test:client && pnpm test:integration",
     "lint": "oxlint . && eslint .",
     "lint:fix": "oxlint --fix . && eslint --fix ."
@@ -60,6 +61,7 @@
     "@mastra/observability": "workspace:*",
     "@mastra/schema-compat": "workspace:*",
     "@mendable/firecrawl-js": "^1.29.3",
+    "@modelcontextprotocol/conformance": "0.2.0-alpha.11",
     "@modelcontextprotocol/server-filesystem": "2026.8.31",
     "@types/node": "22.20.1",
     "@types/semver": "^7.7.1",

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -399,6 +399,26 @@ describe('MastraMCPClient with Streamable HTTP', () => {
         content: [{ type: 'text', text: 'Hello, Stateful!' }],
       });
     });
+
+    it('preserves resource subscription requests on legacy connections', async () => {
+      const sdkClient = (client as unknown as { client: Client }).client;
+      const request = vi.spyOn(sdkClient, 'request').mockResolvedValue({});
+
+      await client.subscribeResource('resource://test');
+      await client.unsubscribeResource('resource://test');
+
+      expect(request).toHaveBeenNthCalledWith(
+        1,
+        { method: 'resources/subscribe', params: { uri: 'resource://test' } },
+        { timeout: 60000 },
+      );
+      expect(request).toHaveBeenNthCalledWith(
+        2,
+        { method: 'resources/unsubscribe', params: { uri: 'resource://test' } },
+        { timeout: 60000 },
+      );
+      request.mockRestore();
+    });
   });
 });
 
@@ -2778,16 +2798,19 @@ describe('MastraMCPClient - Roots Capability (Issue #8660)', () => {
     });
 
     await client.connect();
+    const sdkClient = (client as unknown as { client: Client }).client;
+    const notification = vi.spyOn(sdkClient, 'notification');
 
     // Verify sendRootsListChanged method exists
     expect(typeof client.sendRootsListChanged).toBe('function');
 
-    // Update roots - this should also send the notification
+    // Update roots - this should also send the notification on a legacy connection
     await client.setRoots([{ uri: 'file:///new-root', name: 'New Root' }]);
 
     // Verify roots were updated
     expect(client.roots).toHaveLength(1);
     expect(client.roots[0].uri).toBe('file:///new-root');
+    expect(notification).toHaveBeenCalledWith({ method: 'notifications/roots/list_changed' });
 
     await client.disconnect();
   });

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -503,7 +503,7 @@ export class InternalMastraMCPClient extends MastraBase {
       this.log('debug', 'Cannot send roots/list_changed: not connected');
       return;
     }
-    if (this.client.getNegotiatedProtocolVersion() === '2026-07-28') {
+    if (this.isModernConnection()) {
       this.log('debug', 'Skipping removed roots/list_changed notification on modern connection');
       return;
     }
@@ -844,9 +844,15 @@ export class InternalMastraMCPClient extends MastraBase {
 
         this.refreshServerInstructions();
         if (this.isModernConnection() && this.resourceSubscriptionUris.size > 0) {
-          await this.enqueueResourceSubscriptionUpdate(async () => {
-            await this.replaceModernResourceSubscription(new Set(this.resourceSubscriptionUris));
-          });
+          try {
+            await this.enqueueResourceSubscriptionUpdate(async () => {
+              await this.replaceModernResourceSubscription(new Set(this.resourceSubscriptionUris));
+            });
+          } catch (error) {
+            this.log('error', 'Failed to restore resource subscriptions after reconnect', {
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
         }
 
         resolve(true);

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -25,6 +25,7 @@ import type {
   LoggingLevel,
   ReadResourceResult,
   ClientCapabilities,
+  McpSubscription,
 } from '@modelcontextprotocol/client';
 import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import { asyncExitHook, gracefulExit } from 'exit-hook';
@@ -318,6 +319,9 @@ export class InternalMastraMCPClient extends MastraBase {
   private sigHupHandler?: () => void;
   private serverInstructions?: string;
   private _roots: Root[];
+  private resourceSubscriptionUris = new Set<string>();
+  private resourceSubscription?: McpSubscription;
+  private resourceSubscriptionUpdate: Promise<unknown> = Promise.resolve();
   private hasElicitationCapability: boolean;
   private readonly requireToolApproval: RequireToolApproval | undefined;
   private readonly onToolError: 'throw' | 'return';
@@ -498,6 +502,10 @@ export class InternalMastraMCPClient extends MastraBase {
   async sendRootsListChanged(): Promise<void> {
     if (!this.transport) {
       this.log('debug', 'Cannot send roots/list_changed: not connected');
+      return;
+    }
+    if (this.client.getNegotiatedProtocolVersion() === '2026-07-28') {
+      this.log('debug', 'Skipping removed roots/list_changed notification on modern connection');
       return;
     }
     this.log('debug', 'Sending notifications/roots/list_changed');
@@ -836,6 +844,11 @@ export class InternalMastraMCPClient extends MastraBase {
         }
 
         this.refreshServerInstructions();
+        if (this.isModernConnection() && this.resourceSubscriptionUris.size > 0) {
+          await this.enqueueResourceSubscriptionUpdate(async () => {
+            await this.replaceModernResourceSubscription(new Set(this.resourceSubscriptionUris));
+          });
+        }
 
         resolve(true);
 
@@ -854,6 +867,7 @@ export class InternalMastraMCPClient extends MastraBase {
             // synchronously first so a concurrent connect() sees a clean slate.
             const staleTransport = this.transport;
             this.transport = undefined;
+            this.resourceSubscription = undefined;
             if (this.isConnected === connectionPromise) {
               this.isConnected = null;
             }
@@ -969,6 +983,7 @@ export class InternalMastraMCPClient extends MastraBase {
       this.log('debug', 'Disconnect called but no transport was connected.');
       return;
     }
+    await this.closeModernResourceSubscription();
     this.log('debug', `Disconnecting from MCP server`);
     const disconnectedTransport = this.transport;
     try {
@@ -1029,6 +1044,7 @@ export class InternalMastraMCPClient extends MastraBase {
       const disconnectedTransport = this.transport;
       try {
         if (disconnectedTransport) {
+          await this.closeModernResourceSubscription();
           await disconnectedTransport.close();
         }
       } catch (e) {
@@ -1112,8 +1128,60 @@ export class InternalMastraMCPClient extends MastraBase {
     );
   }
 
+  private isModernConnection(): boolean {
+    return this.client.getNegotiatedProtocolVersion() === '2026-07-28';
+  }
+
+  private enqueueResourceSubscriptionUpdate<T>(update: () => Promise<T>): Promise<T> {
+    const operation = this.resourceSubscriptionUpdate.catch(() => {}).then(update);
+    this.resourceSubscriptionUpdate = operation;
+    return operation;
+  }
+
+  private async replaceModernResourceSubscription(nextUris: Set<string>): Promise<void> {
+    const previous = this.resourceSubscription;
+    const replacement =
+      nextUris.size > 0
+        ? await this.client.listen(
+            { resourceSubscriptions: [...nextUris].sort() },
+            {
+              timeout: this.timeout,
+            },
+          )
+        : undefined;
+
+    this.resourceSubscription = replacement;
+    this.resourceSubscriptionUris = nextUris;
+    if (replacement) {
+      void replacement.closed.then(() => {
+        if (this.resourceSubscription === replacement) {
+          this.resourceSubscription = undefined;
+        }
+      });
+    }
+    await previous?.close();
+  }
+
+  private async closeModernResourceSubscription(): Promise<void> {
+    await this.resourceSubscriptionUpdate.catch(() => {});
+    const subscription = this.resourceSubscription;
+    this.resourceSubscription = undefined;
+    await subscription?.close();
+  }
+
   async subscribeResource(uri: string): Promise<EmptyResult> {
     this.log('debug', `Subscribing to resource on MCP server: ${uri}`);
+    if (this.isModernConnection()) {
+      return await this.enqueueResourceSubscriptionUpdate(async () => {
+        if (this.resourceSubscriptionUris.has(uri)) {
+          return {};
+        }
+        const nextUris = new Set(this.resourceSubscriptionUris);
+        nextUris.add(uri);
+        await this.replaceModernResourceSubscription(nextUris);
+        return {};
+      });
+    }
     return await this.client.request(
       { method: 'resources/subscribe', params: { uri } },
       {
@@ -1124,6 +1192,17 @@ export class InternalMastraMCPClient extends MastraBase {
 
   async unsubscribeResource(uri: string): Promise<EmptyResult> {
     this.log('debug', `Unsubscribing from resource on MCP server: ${uri}`);
+    if (this.isModernConnection()) {
+      return await this.enqueueResourceSubscriptionUpdate(async () => {
+        if (!this.resourceSubscriptionUris.has(uri)) {
+          return {};
+        }
+        const nextUris = new Set(this.resourceSubscriptionUris);
+        nextUris.delete(uri);
+        await this.replaceModernResourceSubscription(nextUris);
+        return {};
+      });
+    }
     return await this.client.request(
       { method: 'resources/unsubscribe', params: { uri } },
       {

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -471,10 +471,10 @@ export class InternalMastraMCPClient extends MastraBase {
   }
 
   /**
-   * Update the list of filesystem roots and notify the server.
+   * Update the list of filesystem roots and notify a legacy server.
    *
-   * Per MCP spec, when roots change, the client sends a `notifications/roots/list_changed`
-   * notification to inform the server that it should re-fetch the roots list.
+   * On legacy connections, the client sends `notifications/roots/list_changed` so the
+   * server can re-fetch the roots list. The notification was removed in MCP 2026-07-28.
    *
    * @param roots - New list of filesystem roots
    *
@@ -493,11 +493,10 @@ export class InternalMastraMCPClient extends MastraBase {
   }
 
   /**
-   * Send a roots/list_changed notification to the server.
+   * Send a roots/list_changed notification to a legacy server.
    *
-   * Per MCP spec, clients that support `listChanged` MUST send this notification
-   * when the list of roots changes. The server will then call roots/list to get
-   * the updated list.
+   * Clients that support legacy `listChanged` send this notification when the
+   * roots change. MCP 2026-07-28 removed the notification.
    */
   async sendRootsListChanged(): Promise<void> {
     if (!this.transport) {
@@ -884,6 +883,14 @@ export class InternalMastraMCPClient extends MastraBase {
         this.clientConnectionOnClose = connectionOnClose;
         this.client.onclose = connectionOnClose;
       } catch (e) {
+        const failedTransport = this.transport;
+        this.transport = undefined;
+        this.resourceSubscription = undefined;
+        this.serverInstructions = undefined;
+        if (failedTransport) {
+          this.severClientTransportLink(failedTransport);
+          await failedTransport.close().catch(() => {});
+        }
         this.isConnected = null;
         reject(e);
       }
@@ -1150,6 +1157,15 @@ export class InternalMastraMCPClient extends MastraBase {
           )
         : undefined;
 
+    if (replacement) {
+      const honoredUris = new Set(replacement.honoredFilter.resourceSubscriptions ?? []);
+      const declinedUris = [...nextUris].filter(uri => !honoredUris.has(uri));
+      if (declinedUris.length > 0) {
+        await replacement.close();
+        throw new Error(`Server declined resource subscriptions for: ${declinedUris.join(', ')}`);
+      }
+    }
+
     this.resourceSubscription = replacement;
     this.resourceSubscriptionUris = nextUris;
     if (replacement) {
@@ -1159,6 +1175,7 @@ export class InternalMastraMCPClient extends MastraBase {
         }
       });
     }
+    // Open the replacement before closing the old stream so notifications aren't lost between filters.
     await previous?.close();
   }
 
@@ -1173,7 +1190,7 @@ export class InternalMastraMCPClient extends MastraBase {
     this.log('debug', `Subscribing to resource on MCP server: ${uri}`);
     if (this.isModernConnection()) {
       return await this.enqueueResourceSubscriptionUpdate(async () => {
-        if (this.resourceSubscriptionUris.has(uri)) {
+        if (this.resourceSubscriptionUris.has(uri) && this.resourceSubscription) {
           return {};
         }
         const nextUris = new Set(this.resourceSubscriptionUris);

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -275,7 +275,7 @@ export type BaseServerOptions = {
    * When configured, the client will:
    * 1. Automatically advertise the `roots` capability to the server
    * 2. Respond to `roots/list` requests with these roots
-   * 3. Send `notifications/roots/list_changed` when roots are updated via `setRoots()`
+   * 3. Send `notifications/roots/list_changed` on legacy connections when roots are updated via `setRoots()`
    *
    * @example
    * ```typescript

--- a/packages/mcp/src/conformance/README.md
+++ b/packages/mcp/src/conformance/README.md
@@ -18,15 +18,15 @@ The modern command deliberately runs the official `tools-list` scenario rather t
 
 ## 2026 coverage matrix
 
-| Requirement                                                                                           | Coverage                                                                                                                                 |
-| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `server/discover`, per-request protocol metadata, required `resultType`, and HTTP method/name headers | Official `tools-list` scenario through `startHTTP()` plus `server-modern-era-http.test.ts`                                               |
-| Stateless Streamable HTTP and built-in legacy fallback                                                | `server-modern-era-http.test.ts`; explicit legacy mode in this launcher                                                                  |
-| Modern stdio opening exchange                                                                         | Modern stdio smoke in this launcher and `server-modern-era-stdio.test.ts`                                                                |
-| `subscriptions/listen` acknowledgement, filtering, and closure                                        | `server-modern-era-http.test.ts` and `server-modern-era-stdio.test.ts`; client resource-subscription coverage is added in the next phase |
-| Removed resource subscription and roots-list-changed methods                                          | Client assertions added in the next phase                                                                                                |
-| Progress routing                                                                                      | `server/__tests__/logging-progress-emission.test.ts` and client progress tests                                                           |
-| Cancellation and disconnect cleanup                                                                   | SDK transport behavior plus focused server/client lifecycle tests; no parallel cancellation implementation lives here                    |
-| Explicit 2025 fallback                                                                                | `--mode legacy-interoperability` over HTTP and stdio                                                                                     |
+| Requirement                                                                                           | Coverage                                                                                                              |
+| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `server/discover`, per-request protocol metadata, required `resultType`, and HTTP method/name headers | Official `tools-list` scenario through `startHTTP()` plus `server-modern-era-http.test.ts`                            |
+| Stateless Streamable HTTP and built-in legacy fallback                                                | `server-modern-era-http.test.ts`; explicit legacy mode in this launcher                                               |
+| Modern stdio opening exchange                                                                         | Modern stdio smoke in this launcher and `server-modern-era-stdio.test.ts`                                             |
+| `subscriptions/listen` acknowledgement, filtering, replacement, reconnect, and closure                | `server-modern-era-http.test.ts` and `server-modern-era-stdio.test.ts`                                                |
+| Removed resource subscription and roots-list-changed methods                                          | Era-scoped wire assertions in `server-modern-era-http.test.ts` and legacy routing assertions in `client.test.ts`      |
+| Progress routing                                                                                      | `server/__tests__/logging-progress-emission.test.ts` and client progress tests                                        |
+| Cancellation and disconnect cleanup                                                                   | SDK transport behavior plus focused server/client lifecycle tests; no parallel cancellation implementation lives here |
+| Explicit 2025 fallback                                                                                | `--mode legacy-interoperability` over HTTP and stdio                                                                  |
 
 `@modelcontextprotocol/conformance` is pinned exactly. A version bump must update this matrix and the exercised scenarios deliberately.

--- a/packages/mcp/src/conformance/README.md
+++ b/packages/mcp/src/conformance/README.md
@@ -1,0 +1,32 @@
+# MCP protocol conformance coverage
+
+This directory launches the real `MCPServer` entry points. HTTP requests are routed through `startHTTP()` by an outer Node server; stdio runs `startStdio()` in a child process. Both paths are closed through `MCPServer.close()`.
+
+Run the official 2026 HTTP smoke plus modern stdio interoperability:
+
+```sh
+pnpm --filter ./packages/mcp test:conformance -- --mode modern
+```
+
+Run the explicit 2025 compatibility smoke over HTTP and stdio:
+
+```sh
+pnpm --filter ./packages/mcp test:conformance -- --mode legacy-interoperability
+```
+
+The modern command deliberately runs the official `tools-list` scenario rather than the full server suite. The full suite requires fixture APIs that `MCPServer` does not advertise, including completions and deprecated sampling/roots behavior. Omitting those optional capabilities is not a conformance failure.
+
+## 2026 coverage matrix
+
+| Requirement                                                                                           | Coverage                                                                                                                                 |
+| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/discover`, per-request protocol metadata, required `resultType`, and HTTP method/name headers | Official `tools-list` scenario through `startHTTP()` plus `server-modern-era-http.test.ts`                                               |
+| Stateless Streamable HTTP and built-in legacy fallback                                                | `server-modern-era-http.test.ts`; explicit legacy mode in this launcher                                                                  |
+| Modern stdio opening exchange                                                                         | Modern stdio smoke in this launcher and `server-modern-era-stdio.test.ts`                                                                |
+| `subscriptions/listen` acknowledgement, filtering, and closure                                        | `server-modern-era-http.test.ts` and `server-modern-era-stdio.test.ts`; client resource-subscription coverage is added in the next phase |
+| Removed resource subscription and roots-list-changed methods                                          | Client assertions added in the next phase                                                                                                |
+| Progress routing                                                                                      | `server/__tests__/logging-progress-emission.test.ts` and client progress tests                                                           |
+| Cancellation and disconnect cleanup                                                                   | SDK transport behavior plus focused server/client lifecycle tests; no parallel cancellation implementation lives here                    |
+| Explicit 2025 fallback                                                                                | `--mode legacy-interoperability` over HTTP and stdio                                                                                     |
+
+`@modelcontextprotocol/conformance` is pinned exactly. A version bump must update this matrix and the exercised scenarios deliberately.

--- a/packages/mcp/src/conformance/fixture.ts
+++ b/packages/mcp/src/conformance/fixture.ts
@@ -1,0 +1,19 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod/v3';
+import { MCPServer } from '../server/server';
+
+export function createConformanceServer() {
+  return new MCPServer({
+    name: 'Mastra MCP Conformance Server',
+    version: '1.0.0',
+    protocolVersion: '2026-07-28',
+    tools: {
+      conformanceEcho: createTool({
+        id: 'conformanceEcho',
+        description: 'Echoes a value for MCP conformance smoke tests',
+        inputSchema: z.object({ value: z.string().optional() }),
+        execute: async ({ value }) => value ?? 'ok',
+      }),
+    },
+  });
+}

--- a/packages/mcp/src/conformance/run.ts
+++ b/packages/mcp/src/conformance/run.ts
@@ -1,0 +1,136 @@
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+import { createConformanceServer } from './fixture';
+
+const require = createRequire(import.meta.url);
+const modeIndex = process.argv.indexOf('--mode');
+const mode = modeIndex === -1 ? undefined : process.argv[modeIndex + 1];
+
+if (mode !== 'modern' && mode !== 'legacy-interoperability') {
+  throw new Error('Usage: pnpm test:conformance -- --mode modern|legacy-interoperability');
+}
+
+async function startHttpServer() {
+  const mcpServer = createConformanceServer();
+  const httpServer = http.createServer(async (req, res) => {
+    try {
+      await mcpServer.startHTTP({
+        url: new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`),
+        httpPath: '/mcp',
+        req,
+        res,
+      });
+    } catch (error) {
+      if (!res.headersSent) {
+        res.writeHead(500, { 'content-type': 'text/plain' });
+      }
+      res.end(error instanceof Error ? error.message : String(error));
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(0, '127.0.0.1', resolve);
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Conformance HTTP server did not bind to a TCP port');
+  }
+
+  return {
+    url: new URL(`http://127.0.0.1:${address.port}/mcp`),
+    close: async () => {
+      await mcpServer.close();
+      httpServer.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close(error => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+async function runCommand(command: string, args: string[]) {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: path.resolve(fileURLToPath(new URL('../..', import.meta.url))),
+      stdio: 'inherit',
+    });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with ${signal ? `signal ${signal}` : `code ${code}`}`));
+      }
+    });
+  });
+}
+
+async function assertStdioInteroperability(protocolVersion: '2025-11-25' | '2026-07-28') {
+  const tsxCli = path.join(path.dirname(require.resolve('tsx/package.json')), 'dist', 'cli.mjs');
+  const fixturePath = fileURLToPath(new URL('./stdio-server.ts', import.meta.url));
+  const client = new Client(
+    { name: `mastra-conformance-${protocolVersion}`, version: '1.0.0' },
+    { versionNegotiation: { mode: protocolVersion === '2026-07-28' ? { pin: protocolVersion } : 'legacy' } },
+  );
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [tsxCli, fixturePath],
+    stderr: 'pipe',
+  });
+  transport.stderr?.on('data', chunk => process.stderr.write(chunk));
+
+  await client.connect(transport);
+  try {
+    const result = await client.listTools();
+    if (!result.tools.some(tool => tool.name === 'conformanceEcho')) {
+      throw new Error(`stdio ${protocolVersion} tools/list omitted conformanceEcho`);
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+if (mode === 'modern') {
+  const server = await startHttpServer();
+  try {
+    await runCommand('pnpm', [
+      'exec',
+      'conformance',
+      'server',
+      '--url',
+      server.url.href,
+      '--scenario',
+      'tools-list',
+      '--spec-version',
+      '2026-07-28',
+    ]);
+  } finally {
+    await server.close();
+  }
+  await assertStdioInteroperability('2026-07-28');
+  console.log('MCP conformance smoke passed: official 2026 HTTP scenario and modern stdio');
+} else {
+  const server = await startHttpServer();
+  const client = new Client(
+    { name: 'mastra-conformance-legacy', version: '1.0.0' },
+    { versionNegotiation: { mode: 'legacy' } },
+  );
+  try {
+    await client.connect(new StreamableHTTPClientTransport(server.url));
+    const result = await client.listTools();
+    if (!result.tools.some(tool => tool.name === 'conformanceEcho')) {
+      throw new Error('HTTP 2025 interoperability tools/list omitted conformanceEcho');
+    }
+  } finally {
+    await client.close().catch(() => {});
+    await server.close();
+  }
+  await assertStdioInteroperability('2025-11-25');
+  console.log('MCP legacy interoperability smoke passed: explicit 2025 HTTP and stdio');
+}

--- a/packages/mcp/src/conformance/run.ts
+++ b/packages/mcp/src/conformance/run.ts
@@ -26,10 +26,11 @@ async function startHttpServer() {
         res,
       });
     } catch (error) {
+      console.error('Conformance server request failed', error);
       if (!res.headersSent) {
         res.writeHead(500, { 'content-type': 'text/plain' });
       }
-      res.end(error instanceof Error ? error.message : String(error));
+      res.end('Internal server error');
     }
   });
 

--- a/packages/mcp/src/conformance/stdio-server.ts
+++ b/packages/mcp/src/conformance/stdio-server.ts
@@ -1,0 +1,12 @@
+import { createConformanceServer } from './fixture';
+
+const server = createConformanceServer();
+
+const close = async () => {
+  await server.close();
+};
+
+process.once('SIGINT', close);
+process.once('SIGTERM', close);
+
+await server.startStdio();

--- a/packages/mcp/src/server/server-modern-era-http.test.ts
+++ b/packages/mcp/src/server/server-modern-era-http.test.ts
@@ -236,6 +236,78 @@ describe('MCPServer with protocolVersion 2026-07-28 (dual-era HTTP)', () => {
     }
   });
 
+  it('manages modern resource subscriptions through one replaceable listen stream', async () => {
+    const wireMethods: string[] = [];
+    const client = new InternalMastraMCPClient({
+      name: 'mastra-resource-listen-client',
+      server: {
+        url: baseUrl,
+        protocolVersion: '2026-07-28',
+        fetch: async (url, init) => {
+          if (typeof init?.body === 'string') {
+            const message = JSON.parse(init.body) as { method?: string };
+            if (message.method) wireMethods.push(message.method);
+          }
+          return fetch(url, init);
+        },
+      },
+    });
+    const updated = new Promise<string>(resolve => {
+      client.setResourceUpdatedNotificationHandler(params => resolve(params.uri));
+    });
+
+    await client.connect();
+    try {
+      await client.subscribeResource('test://resource');
+      await client.subscribeResource('test://resource');
+      expect(wireMethods.filter(method => method === 'subscriptions/listen')).toHaveLength(1);
+
+      await client.subscribeResource('test://second');
+      await client.unsubscribeResource('test://resource');
+      await client.forceReconnect();
+      await server.resources.notifyUpdated({ uri: 'test://second' });
+      await expect(updated).resolves.toBe('test://second');
+
+      await client.unsubscribeResource('test://second');
+      await client.subscribeResource('test://second');
+    } finally {
+      await client.disconnect();
+    }
+
+    expect(wireMethods.filter(method => method === 'subscriptions/listen')).toHaveLength(5);
+    expect(wireMethods.filter(method => method === 'notifications/cancelled')).toHaveLength(5);
+    expect(wireMethods).not.toContain('resources/subscribe');
+    expect(wireMethods).not.toContain('resources/unsubscribe');
+  });
+
+  it('does not emit removed roots notifications on the modern leg', async () => {
+    const wireMethods: string[] = [];
+    const client = new InternalMastraMCPClient({
+      name: 'modern-roots-client',
+      server: {
+        url: baseUrl,
+        protocolVersion: '2026-07-28',
+        roots: [{ uri: 'file:///initial' }],
+        fetch: async (url, init) => {
+          if (typeof init?.body === 'string') {
+            const message = JSON.parse(init.body) as { method?: string };
+            if (message.method) wireMethods.push(message.method);
+          }
+          return fetch(url, init);
+        },
+      },
+    });
+
+    await client.connect();
+    try {
+      await client.setRoots([{ uri: 'file:///updated' }]);
+    } finally {
+      await client.disconnect();
+    }
+
+    expect(wireMethods).not.toContain('notifications/roots/list_changed');
+  });
+
   it('delivers toolsChanged via subscriptions/listen on the modern leg', async () => {
     const client = new Client(
       { name: 'listen-client', version: '1.0.0' },

--- a/packages/mcp/src/server/server-modern-era-http.test.ts
+++ b/packages/mcp/src/server/server-modern-era-http.test.ts
@@ -280,6 +280,51 @@ describe('MCPServer with protocolVersion 2026-07-28 (dual-era HTTP)', () => {
     expect(wireMethods).not.toContain('resources/unsubscribe');
   });
 
+  it('serializes concurrent subscription mutations and replays only the final filter after reconnect', async () => {
+    const wireMethods: string[] = [];
+    const client = new InternalMastraMCPClient({
+      name: 'concurrent-resource-listen-client',
+      server: {
+        url: baseUrl,
+        protocolVersion: '2026-07-28',
+        fetch: async (url, init) => {
+          if (typeof init?.body === 'string') {
+            const message = JSON.parse(init.body) as { method?: string };
+            if (message.method) wireMethods.push(message.method);
+          }
+          return fetch(url, init);
+        },
+      },
+    });
+    const uris = Array.from({ length: 12 }, (_, index) => `test://concurrent/${index}`);
+    const retainedUris = uris.filter((_, index) => index % 2 === 1);
+    const removedUris = uris.filter((_, index) => index % 2 === 0);
+    const updatedUris: string[] = [];
+    client.setResourceUpdatedNotificationHandler(params => updatedUris.push(params.uri));
+
+    await client.connect();
+    try {
+      await Promise.all(uris.map(uri => client.subscribeResource(uri)));
+      await Promise.all(removedUris.map(uri => client.unsubscribeResource(uri)));
+      await client.forceReconnect();
+
+      await server.resources.notifyUpdated({ uri: removedUris[0]! });
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(updatedUris).not.toContain(removedUris[0]);
+
+      await server.resources.notifyUpdated({ uri: retainedUris[0]! });
+      await vi.waitFor(() => expect(updatedUris).toContain(retainedUris[0]));
+    } finally {
+      await client.disconnect();
+    }
+
+    const listenCount = wireMethods.filter(method => method === 'subscriptions/listen').length;
+    expect(listenCount).toBeGreaterThan(0);
+    expect(wireMethods.filter(method => method === 'notifications/cancelled')).toHaveLength(listenCount);
+    expect(wireMethods).not.toContain('resources/subscribe');
+    expect(wireMethods).not.toContain('resources/unsubscribe');
+  });
+
   it('keeps the connection usable when restoring resource subscriptions fails', async () => {
     const client = new InternalMastraMCPClient({
       name: 'resource-listen-restore-failure-client',

--- a/packages/mcp/src/server/server-modern-era-http.test.ts
+++ b/packages/mcp/src/server/server-modern-era-http.test.ts
@@ -280,6 +280,62 @@ describe('MCPServer with protocolVersion 2026-07-28 (dual-era HTTP)', () => {
     expect(wireMethods).not.toContain('resources/unsubscribe');
   });
 
+  it('detaches the transport when restoring resource subscriptions fails', async () => {
+    const client = new InternalMastraMCPClient({
+      name: 'resource-listen-restore-failure-client',
+      server: {
+        url: baseUrl,
+        protocolVersion: '2026-07-28',
+      },
+    });
+
+    await client.connect();
+    await client.subscribeResource('test://resource');
+    const sdkClient = (client as unknown as { client: Client }).client;
+    const listenSpy = vi.spyOn(sdkClient, 'listen').mockRejectedValueOnce(new Error('listen restore failed'));
+
+    try {
+      await expect(client.forceReconnect()).rejects.toThrow('listen restore failed');
+      expect(sdkClient.transport).toBeUndefined();
+      expect((client as unknown as { transport?: unknown }).transport).toBeUndefined();
+
+      listenSpy.mockRestore();
+      await client.connect();
+    } finally {
+      listenSpy.mockRestore();
+      await client.disconnect();
+    }
+  });
+
+  it('rejects a resource subscription the server does not honor', async () => {
+    const client = new InternalMastraMCPClient({
+      name: 'resource-listen-declined-client',
+      server: {
+        url: baseUrl,
+        protocolVersion: '2026-07-28',
+      },
+    });
+
+    await client.connect();
+    const sdkClient = (client as unknown as { client: Client }).client;
+    const close = vi.fn().mockResolvedValue(undefined);
+    const listenSpy = vi.spyOn(sdkClient, 'listen').mockResolvedValueOnce({
+      honoredFilter: {},
+      close,
+      closed: new Promise(() => {}),
+    });
+
+    try {
+      await expect(client.subscribeResource('test://declined')).rejects.toThrow(
+        'Server declined resource subscriptions for: test://declined',
+      );
+      expect(close).toHaveBeenCalledOnce();
+    } finally {
+      listenSpy.mockRestore();
+      await client.disconnect();
+    }
+  });
+
   it('does not emit removed roots notifications on the modern leg', async () => {
     const wireMethods: string[] = [];
     const client = new InternalMastraMCPClient({

--- a/packages/mcp/src/server/server-modern-era-http.test.ts
+++ b/packages/mcp/src/server/server-modern-era-http.test.ts
@@ -280,7 +280,7 @@ describe('MCPServer with protocolVersion 2026-07-28 (dual-era HTTP)', () => {
     expect(wireMethods).not.toContain('resources/unsubscribe');
   });
 
-  it('detaches the transport when restoring resource subscriptions fails', async () => {
+  it('keeps the connection usable when restoring resource subscriptions fails', async () => {
     const client = new InternalMastraMCPClient({
       name: 'resource-listen-restore-failure-client',
       server: {
@@ -289,18 +289,23 @@ describe('MCPServer with protocolVersion 2026-07-28 (dual-era HTTP)', () => {
       },
     });
 
+    const updated = new Promise<string>(resolve => {
+      client.setResourceUpdatedNotificationHandler(params => resolve(params.uri));
+    });
     await client.connect();
     await client.subscribeResource('test://resource');
     const sdkClient = (client as unknown as { client: Client }).client;
     const listenSpy = vi.spyOn(sdkClient, 'listen').mockRejectedValueOnce(new Error('listen restore failed'));
 
     try {
-      await expect(client.forceReconnect()).rejects.toThrow('listen restore failed');
-      expect(sdkClient.transport).toBeUndefined();
-      expect((client as unknown as { transport?: unknown }).transport).toBeUndefined();
+      await expect(client.forceReconnect()).resolves.toBeUndefined();
+      expect(sdkClient.transport).toBeDefined();
+      expect(Object.keys(await client.tools())).toContain('echoTool');
 
-      listenSpy.mockRestore();
-      await client.connect();
+      await client.subscribeResource('test://resource');
+      expect(listenSpy).toHaveBeenCalledTimes(2);
+      await server.resources.notifyUpdated({ uri: 'test://resource' });
+      await expect(updated).resolves.toBe('test://resource');
     } finally {
       listenSpy.mockRestore();
       await client.disconnect();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5325,6 +5325,9 @@ importers:
       '@mendable/firecrawl-js':
         specifier: ^1.29.3
         version: 1.29.3(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@modelcontextprotocol/conformance':
+        specifier: 0.2.0-alpha.11
+        version: 0.2.0-alpha.11(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)
       '@modelcontextprotocol/server-filesystem':
         specifier: 2026.8.31
         version: 2026.8.31(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)
@@ -16024,6 +16027,10 @@ packages:
   '@modelcontextprotocol/client@2.0.0':
     resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
     engines: {node: '>=20'}
+
+  '@modelcontextprotocol/conformance@0.2.0-alpha.11':
+    resolution: {integrity: sha512-imPK9tx5gQsL6ZKQq4MrsyDYfSaIwpRmX6+ogjbeAXs9LGvxkBxWcY7KcS7TvwaBk/ZiVWl6b/naF4q83UwDRA==}
+    hasBin: true
 
   '@modelcontextprotocol/core@2.0.0':
     resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
@@ -40610,6 +40617,23 @@ snapshots:
       jose: 6.2.3
       pkce-challenge: 5.0.0
       zod: 4.4.3
+
+  '@modelcontextprotocol/conformance@0.2.0-alpha.11(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3)
+      '@octokit/rest': 22.0.1
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      commander: 14.0.3
+      eventsource-parser: 3.0.8
+      express: 5.2.1(supports-color@10.2.2)
+      jose: 6.2.3
+      undici: 7.29.0
+      yaml: 2.9.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
 
   '@modelcontextprotocol/core@2.0.0':
     dependencies:


### PR DESCRIPTION
## Summary

- route `MCPClient.resources.subscribe()` and `unsubscribe()` through a managed `subscriptions/listen` stream on MCP 2026-07-28 connections
- preserve explicit legacy resource subscription requests and suppress the removed modern roots-list-changed notification
- add a pinned official conformance smoke harness for 2026 HTTP and stdio, plus explicit 2025 interoperability coverage
- document stream replacement, reconnect, cleanup, and declined-filter behavior

This is Segment 1 of the MCP 2026-07-28 adoption stack. It is independently releasable as an `@mastra/mcp` patch.

## Test plan

- `pnpm turbo build --filter=@mastra/mcp...`
- `pnpm --filter ./packages/mcp test:client`
- `pnpm --filter ./packages/mcp test:server`
- `pnpm --filter ./packages/mcp test:conformance -- --mode modern`
- `pnpm --filter ./packages/mcp test:conformance -- --mode legacy-interoperability`
- `pnpm --filter ./packages/mcp exec oxlint . && pnpm --filter ./packages/mcp exec eslint .`
- `pnpm --filter mastra-docs exec pnpm format:check`
- packed-package before/after proof in `.mastracode/plans/mcp-2026-adoption-stack.proof/01-subscriptions/demo.sh` (local uncommitted artifact)
