### PR TITLE
fix(mcp): support JSON Schema 2020-12 interoperability

### DIFF
--- a/.changeset/modern-schemas-validate.md
+++ b/.changeset/modern-schemas-validate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Support JSON Schema 2020-12 tool schemas and validate structured results consistently for live and cached MCP tools.

--- a/.changeset/modern-schemas-validate.md
+++ b/.changeset/modern-schemas-validate.md
@@ -2,4 +2,4 @@
 '@mastra/mcp': patch
 ---
 
-Support JSON Schema 2020-12 tool schemas and validate structured results consistently for live and cached MCP tools.
+Support JSON Schema 2020-12 tool schemas and validate structured results consistently for live and cached MCP tools. Input and output schemas are bounded to 128 nested subschema levels and 10,000 subschema nodes.

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -432,11 +432,11 @@ When called without options, the method omits only `durations`; `definitions`, `
 
 Rebuilds a single executable tool from a cached definition. No connection is opened here. The client connects lazily, the first time the tool is executed.
 
-The returned tool behaves exactly like one from `listTools()`, with the same strict-mode metadata, approval policy, structured content handling, tool error handling, and reconnect behavior. Successful structured results are validated against the advertised `outputSchema` on both paths. Invalid results reject the tool call; MCP error results skip output validation.
+The returned tool behaves exactly like one from `listTools()`, with the same strict-mode metadata, approval policy, structured content handling, tool error handling, and reconnect behavior. Successful structured results are validated against the advertised `outputSchema` on both paths. Invalid results reject the tool call. MCP error results skip output validation.
 
 MCP schemas without a `$schema` declaration use JSON Schema 2020-12. Local `$ref` and `$defs` references, composition keywords, and boolean subschemas are supported. To bound validation work from untrusted tool catalogs, input and output schemas are limited to 128 nested subschema levels and 10,000 subschema nodes.
 
-`structuredContent` can be any JSON value, including strings, numbers, booleans, and `null`. Object and array results also expose the MCP content and `_meta` envelopes through non-enumerable Mastra metadata properties. Scalar and `null` results cannot carry those properties and remain unchanged rather than being wrapped.
+`structuredContent` can be any JSON value, including strings, numbers, booleans, and `null`. Object and array results also expose the MCP content and `_meta` envelopes through non-enumerable Mastra metadata properties. Scalar and `null` results can't carry those properties and remain unchanged rather than being wrapped.
 
 ```typescript
 const definitions = JSON.parse(await cache.get('mcp-tools'))

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -182,6 +182,13 @@ Each server in the `servers` map is configured using the `MastraMCPServerDefinit
     description:
       "Opt-in MCP protocol version negotiation. Omitted keeps the legacy (2025-era) connect sequence unchanged. 'auto' probes the server at connect time and uses the stateless '2026-07-28' revision when the server supports it, with a safe fallback to the legacy handshake. '2026-07-28' pins that revision exactly and fails with a typed error when the server does not offer it. Elicitation handlers work on both eras: on a '2026-07-28' connection, embedded elicitation requests from input_required results are dispatched through the same registered handler and the originating call retries automatically.",
   },
+  {
+    name: 'jsonSchemaValidator',
+    type: 'JsonSchemaValidator',
+    isOptional: true,
+    description:
+      'Validator used for MCP tool schemas and structured results. The default supports JSON Schema 2020-12. Provide a compatible validator such as CfWorkerJsonSchemaValidator in runtimes that disallow dynamic code generation.',
+  },
 ]}
 />
 
@@ -425,7 +432,11 @@ When called without options, the method omits only `durations`; `definitions`, `
 
 Rebuilds a single executable tool from a cached definition. No connection is opened here. The client connects lazily, the first time the tool is executed.
 
-The returned tool behaves exactly like one from `listTools()`, with the same strict-mode metadata, approval policy, structured content handling, tool error handling, and reconnect behavior.
+The returned tool behaves exactly like one from `listTools()`, with the same strict-mode metadata, approval policy, structured content handling, tool error handling, and reconnect behavior. Successful structured results are validated against the advertised `outputSchema` on both paths. Invalid results reject the tool call; MCP error results skip output validation.
+
+MCP schemas without a `$schema` declaration use JSON Schema 2020-12. Local `$ref` and `$defs` references, composition keywords, and boolean subschemas are supported. To bound validation work from untrusted tool catalogs, output schemas are limited to 128 nested subschema levels and 10,000 subschema nodes.
+
+`structuredContent` can be any JSON value, including strings, numbers, booleans, and `null`. Object and array results also expose the MCP content and `_meta` envelopes through non-enumerable Mastra metadata properties. Scalar and `null` results cannot carry those properties and remain unchanged rather than being wrapped.
 
 ```typescript
 const definitions = JSON.parse(await cache.get('mcp-tools'))

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -434,7 +434,7 @@ Rebuilds a single executable tool from a cached definition. No connection is ope
 
 The returned tool behaves exactly like one from `listTools()`, with the same strict-mode metadata, approval policy, structured content handling, tool error handling, and reconnect behavior. Successful structured results are validated against the advertised `outputSchema` on both paths. Invalid results reject the tool call; MCP error results skip output validation.
 
-MCP schemas without a `$schema` declaration use JSON Schema 2020-12. Local `$ref` and `$defs` references, composition keywords, and boolean subschemas are supported. To bound validation work from untrusted tool catalogs, output schemas are limited to 128 nested subschema levels and 10,000 subschema nodes.
+MCP schemas without a `$schema` declaration use JSON Schema 2020-12. Local `$ref` and `$defs` references, composition keywords, and boolean subschemas are supported. To bound validation work from untrusted tool catalogs, input and output schemas are limited to 128 nested subschema levels and 10,000 subschema nodes.
 
 `structuredContent` can be any JSON value, including strings, numbers, booleans, and `null`. Object and array results also expose the MCP content and `_meta` envelopes through non-enumerable Mastra metadata properties. Scalar and `null` results cannot carry those properties and remain unchanged rather than being wrapped.
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -57,7 +57,7 @@ const server = new MCPServer({
 
 ## Tool schemas and structured results
 
-On the `2026-07-28` protocol revision, MCP tool input and output schemas use JSON Schema 2020-12 when they don't declare a dialect. The server preserves supported references, composition keywords, and boolean subschemas when it advertises converted Mastra tool schemas.
+On the `2026-07-28` protocol revision, MCP tool input and output schemas use JSON Schema 2020-12 when they don't declare a dialect. Modern responses preserve a converted schema's explicit dialect declaration, while responses to legacy clients retain the established declaration-free wire shape. The server preserves supported references, composition keywords, and boolean subschemas when it advertises converted Mastra tool schemas.
 
 A tool with an `outputSchema` can return any JSON value, including an object, array, string, number, boolean, or `null`. The value is sent as `structuredContent` without wrapping it in an object. The server validates successful structured output against the tool's output schema before returning it.
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -57,7 +57,7 @@ const server = new MCPServer({
 
 ## Tool schemas and structured results
 
-On the `2026-07-28` protocol revision, MCP tool input and output schemas use JSON Schema 2020-12 when they don't declare a dialect. Modern responses preserve a converted schema's explicit dialect declaration, while responses to legacy clients retain the established declaration-free wire shape. The server preserves supported references, composition keywords, and boolean subschemas when it advertises converted Mastra tool schemas.
+On the `2026-07-28` protocol revision, MCP tool input and output schemas use JSON Schema 2020-12 when they don't declare a dialect. Modern responses preserve a converted schema's explicit dialect declaration, while responses to legacy clients retain the established declaration-free wire shape. Advertised Mastra tool schemas preserve supported references and composition keywords. Boolean subschemas are preserved as well.
 
 A tool with an `outputSchema` can return any JSON value, including an object, array, string, number, boolean, or `null`. The value is sent as `structuredContent` without wrapping it in an object. The server validates successful structured output against the tool's output schema before returning it.
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -55,6 +55,12 @@ const server = new MCPServer({
 })
 ```
 
+## Tool schemas and structured results
+
+On the `2026-07-28` protocol revision, MCP tool input and output schemas use JSON Schema 2020-12 when they don't declare a dialect. The server preserves supported references, composition keywords, and boolean subschemas when it advertises converted Mastra tool schemas.
+
+A tool with an `outputSchema` can return any JSON value, including an object, array, string, number, boolean, or `null`. The value is sent as `structuredContent` without wrapping it in an object. The server validates successful structured output against the tool's output schema before returning it.
+
 ### Configuration Properties
 
 The constructor accepts an `MCPServerConfig` object with the following properties:

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -265,6 +265,73 @@ describe('InternalMastraMCPClient - jsonSchemaValidator pass-through', () => {
     expect(sdkClient._jsonSchemaValidator).toBe(customValidator);
   });
 
+  it('should use the configured validator for hydrated tool output', async () => {
+    const validate = vi.fn((input: unknown) => ({
+      valid: input === 'valid',
+      data: input === 'valid' ? input : undefined,
+      errorMessage: input === 'valid' ? undefined : 'expected valid',
+    }));
+    const customValidator = { getValidator: vi.fn(() => validate) };
+    const client = new InternalMastraMCPClient({
+      name: 'hydrated-validator-client',
+      server: {
+        url: new URL('http://127.0.0.1:0/mcp'),
+        jsonSchemaValidator: customValidator,
+      },
+    });
+    vi.spyOn(client, 'connect').mockResolvedValue();
+    // @ts-expect-error - accessing internal SDK client for isolated wrapper testing
+    const sdkClient = client.client as Client;
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent: 'invalid',
+      content: [{ type: 'text', text: 'invalid' }],
+      isError: false,
+    });
+    const tool = client.toolFromDefinition({
+      definition: {
+        name: 'validated',
+        inputSchema: { type: 'object' },
+        outputSchema: { type: 'string' },
+        server: { name: 'hydrated-validator-client' },
+      },
+    });
+
+    await expect(tool.execute?.({})).rejects.toThrow(/structured content does not match/i);
+    expect(customValidator.getValidator).toHaveBeenCalledWith({ type: 'string' });
+    expect(validate).toHaveBeenCalledWith('invalid');
+  });
+
+  it('should not validate structuredContent from an error result', async () => {
+    const customValidator = { getValidator: vi.fn() };
+    const client = new InternalMastraMCPClient({
+      name: 'error-result-validator-client',
+      server: {
+        url: new URL('http://127.0.0.1:0/mcp'),
+        jsonSchemaValidator: customValidator,
+        onToolError: 'return',
+      },
+    });
+    vi.spyOn(client, 'connect').mockResolvedValue();
+    // @ts-expect-error - accessing internal SDK client for isolated wrapper testing
+    const sdkClient = client.client as Client;
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent: 42,
+      content: [{ type: 'text', text: 'failed' }],
+      isError: true,
+    });
+    const tool = client.toolFromDefinition({
+      definition: {
+        name: 'failed',
+        inputSchema: { type: 'object' },
+        outputSchema: { type: 'string' },
+        server: { name: 'error-result-validator-client' },
+      },
+    });
+
+    await expect(tool.execute?.({})).resolves.toBe(42);
+    expect(customValidator.getValidator).not.toHaveBeenCalled();
+  });
+
   it('should leave the SDK Client default validator in place when omitted', () => {
     const client = new InternalMastraMCPClient({
       name: 'default-validator-client',
@@ -543,6 +610,29 @@ describe('MastraMCPClient - outputSchema without structuredContent', () => {
 
     expect(storedSchema.properties?.root?.$ref).toBe('#/$defs/node');
     expect(storedSchema.$defs?.node?.properties?.children?.items?.$ref).toBe('#/$defs/node');
+  });
+
+  it('uses JSON Schema 2020-12 by default for input validation', async () => {
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'tuple_input',
+          inputSchema: {
+            type: 'array' as const,
+            prefixItems: [{ type: 'string' as const }, { type: 'integer' as const }],
+            items: false,
+          },
+        },
+      ],
+    });
+    const callTool = vi.spyOn(sdkClient, 'callTool');
+
+    const tool = (await client.tools()).tuple_input;
+    const result = await tool.execute?.(['invalid', 1, true] as any);
+
+    expect(result).toMatchObject({ error: true, message: expect.stringMatching(/input validation failed/i) });
+    expect(callTool).not.toHaveBeenCalled();
   });
 
   it('preserves JSON Schema 2020-12 identity, composition, and boolean subschemas', async () => {
@@ -1359,6 +1449,38 @@ describe('MastraMCPClient - outputSchema with structuredContent', () => {
     });
 
     const tool = (await client.tools()).validated_tool;
+    await expect(tool.execute?.({})).rejects.toThrow(/structured content does not match/i);
+  });
+
+  it('uses JSON Schema 2020-12 by default when validating structuredContent', async () => {
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'tuple_tool',
+          inputSchema: { type: 'object' as const, properties: {} },
+          outputSchema: {
+            type: 'array' as const,
+            prefixItems: [{ type: 'string' as const }, { type: 'integer' as const }],
+            items: false,
+          },
+        },
+      ],
+    });
+    vi.spyOn(sdkClient, 'callTool')
+      .mockResolvedValueOnce({
+        structuredContent: ['valid', 1],
+        content: [{ type: 'text', text: 'valid' }],
+        isError: false,
+      })
+      .mockResolvedValueOnce({
+        structuredContent: ['invalid', 1, true],
+        content: [{ type: 'text', text: 'invalid' }],
+        isError: false,
+      });
+
+    const tool = (await client.tools()).tuple_tool;
+    await expect(tool.execute?.({})).resolves.toEqual(['valid', 1]);
     await expect(tool.execute?.({})).rejects.toThrow(/structured content does not match/i);
   });
 

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -296,7 +296,10 @@ describe('InternalMastraMCPClient - jsonSchemaValidator pass-through', () => {
       },
     });
 
-    await expect(tool.execute?.({})).rejects.toThrow(/structured content does not match/i);
+    await expect(tool.execute?.({})).resolves.toMatchObject({
+      error: true,
+      message: expect.stringMatching(/tool output validation failed for validated/i),
+    });
     expect(customValidator.getValidator).toHaveBeenCalledWith({ type: 'string' });
     expect(validate).toHaveBeenCalledWith('invalid');
   });
@@ -1467,7 +1470,10 @@ describe('MastraMCPClient - outputSchema with structuredContent', () => {
     });
 
     const tool = (await client.tools()).validated_tool;
-    await expect(tool.execute?.({})).rejects.toThrow(/structured content does not match/i);
+    await expect(tool.execute?.({})).resolves.toMatchObject({
+      error: true,
+      message: expect.stringMatching(/tool output validation failed for validated_tool/i),
+    });
   });
 
   it('uses JSON Schema 2020-12 by default when validating structuredContent', async () => {
@@ -1499,7 +1505,10 @@ describe('MastraMCPClient - outputSchema with structuredContent', () => {
 
     const tool = (await client.tools()).tuple_tool;
     await expect(tool.execute?.({})).resolves.toEqual(['valid', 1]);
-    await expect(tool.execute?.({})).rejects.toThrow(/structured content does not match/i);
+    await expect(tool.execute?.({})).resolves.toMatchObject({
+      error: true,
+      message: expect.stringMatching(/tool output validation failed for tuple_tool/i),
+    });
   });
 
   it('validates output schemas that explicitly declare draft-07', async () => {
@@ -1532,7 +1541,10 @@ describe('MastraMCPClient - outputSchema with structuredContent', () => {
 
     const tool = (await client.tools()).draft7_tuple_tool;
     await expect(tool.execute?.({})).resolves.toEqual(['valid', 1]);
-    await expect(tool.execute?.({})).rejects.toThrow(/structured content does not match/i);
+    await expect(tool.execute?.({})).resolves.toMatchObject({
+      error: true,
+      message: expect.stringMatching(/tool output validation failed for draft7_tuple_tool/i),
+    });
   });
 
   it('should use scalar structuredContent as JSON model output', async () => {

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -635,6 +635,24 @@ describe('MastraMCPClient - outputSchema without structuredContent', () => {
     expect(callTool).not.toHaveBeenCalled();
   });
 
+  it('bounds nested input subschemas before compiling them', async () => {
+    const sdkClient = (client as any).client as Client;
+    let nestedSchema: Record<string, unknown> = { type: 'string' };
+    for (let depth = 0; depth < 150; depth++) {
+      nestedSchema = { unevaluatedItems: nestedSchema };
+    }
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [{ name: 'deep_input', inputSchema: nestedSchema as any }],
+    });
+    const callTool = vi.spyOn(sdkClient, 'callTool');
+
+    const tool = (await client.tools()).deep_input;
+    const result = await tool.execute?.({} as any);
+
+    expect(result).toMatchObject({ error: true, message: expect.stringMatching(/maximum depth/i) });
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
   it('preserves JSON Schema 2020-12 identity, composition, and boolean subschemas', async () => {
     const sdkClient = (client as any).client as Client;
     const schema2020 = {
@@ -1480,6 +1498,39 @@ describe('MastraMCPClient - outputSchema with structuredContent', () => {
       });
 
     const tool = (await client.tools()).tuple_tool;
+    await expect(tool.execute?.({})).resolves.toEqual(['valid', 1]);
+    await expect(tool.execute?.({})).rejects.toThrow(/structured content does not match/i);
+  });
+
+  it('validates output schemas that explicitly declare draft-07', async () => {
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'draft7_tuple_tool',
+          inputSchema: { type: 'object' as const, properties: {} },
+          outputSchema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'array' as const,
+            items: [{ type: 'string' as const }, { type: 'integer' as const }],
+            additionalItems: false,
+          },
+        },
+      ],
+    });
+    vi.spyOn(sdkClient, 'callTool')
+      .mockResolvedValueOnce({
+        structuredContent: ['valid', 1],
+        content: [{ type: 'text', text: 'valid' }],
+        isError: false,
+      })
+      .mockResolvedValueOnce({
+        structuredContent: ['invalid', 1, true],
+        content: [{ type: 'text', text: 'invalid' }],
+        isError: false,
+      });
+
+    const tool = (await client.tools()).draft7_tuple_tool;
     await expect(tool.execute?.({})).resolves.toEqual(['valid', 1]);
     await expect(tool.execute?.({})).rejects.toThrow(/structured content does not match/i);
   });

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -545,6 +545,45 @@ describe('MastraMCPClient - outputSchema without structuredContent', () => {
     expect(storedSchema.$defs?.node?.properties?.children?.items?.$ref).toBe('#/$defs/node');
   });
 
+  it('preserves JSON Schema 2020-12 identity, composition, and boolean subschemas', async () => {
+    const sdkClient = (client as any).client as Client;
+    const schema2020 = {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $id: 'https://example.test/schemas/tree',
+      type: 'object' as const,
+      $defs: {
+        leaf: {
+          type: 'array' as const,
+          prefixItems: [{ type: 'string' as const }, { type: 'integer' as const }],
+          items: false,
+          minItems: 2,
+          maxItems: 2,
+        },
+      },
+      properties: {
+        value: {
+          anyOf: [{ $ref: '#/$defs/leaf' }, { type: 'null' as const }],
+        },
+      },
+      required: ['value'],
+      unevaluatedProperties: false,
+    };
+
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'schema_2020',
+          inputSchema: schema2020,
+          outputSchema: schema2020,
+        },
+      ],
+    });
+
+    const tool = (await client.tools()).schema_2020;
+    expect(tool.inputSchema?.['~standard'].jsonSchema.input({ target: 'draft-2020-12' })).toEqual(schema2020);
+    expect(tool.outputSchema?.['~standard'].jsonSchema.output({ target: 'draft-2020-12' })).toEqual(schema2020);
+  });
+
   it('exposes output JSON schema for documentation while Mastra validation always succeeds', async () => {
     const sdkClient = (client as any).client as Client;
     const outputSchema = {
@@ -1264,6 +1303,63 @@ describe('MastraMCPClient - outputSchema with structuredContent', () => {
       type: 'text',
       value: JSON.stringify(fullResult),
     });
+  });
+
+  it.each([
+    ['object', { value: 1 }],
+    ['array', [1, 'two', null]],
+    ['string', 'hello'],
+    ['number', 0],
+    ['boolean', false],
+    ['null', null],
+  ] as const)('preserves %s structuredContent without wrapping it', async (_kind, structuredContent) => {
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'json_value_tool',
+          inputSchema: { type: 'object' as const, properties: {} },
+          outputSchema: {},
+        },
+      ],
+    });
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent,
+      content: [{ type: 'text', text: 'summary' }],
+      _meta: { trace: 'value' },
+      isError: false,
+    });
+
+    const tool = (await client.tools()).json_value_tool;
+    const result = await tool.execute?.({});
+
+    expect(result).toBe(structuredContent);
+    expect(result).toEqual(structuredContent);
+    if (structuredContent === null || typeof structuredContent !== 'object') {
+      expect(getMcpCallToolContent(result)).toBeUndefined();
+      expect(getMcpCallToolMeta(result)).toBeUndefined();
+    }
+  });
+
+  it('rejects invalid structuredContent on the live discovery path', async () => {
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'validated_tool',
+          inputSchema: { type: 'object' as const, properties: {} },
+          outputSchema: { type: 'string' as const },
+        },
+      ],
+    });
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent: 42,
+      content: [{ type: 'text', text: '42' }],
+      isError: false,
+    });
+
+    const tool = (await client.tools()).validated_tool;
+    await expect(tool.execute?.({})).rejects.toThrow(/structured content does not match/i);
   });
 
   it('should use scalar structuredContent as JSON model output', async () => {

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1511,6 +1511,67 @@ describe('MastraMCPClient - outputSchema with structuredContent', () => {
     });
   });
 
+  it('enforces JSON Schema 2020-12 dependentSchemas, unevaluatedProperties, and contains bounds', async () => {
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'dependent_tool',
+          inputSchema: { type: 'object' as const, properties: {} },
+          outputSchema: {
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            type: 'object' as const,
+            properties: {
+              amount: { type: 'number' as const },
+              currency: { enum: ['USD', 'EUR'] },
+            },
+            required: ['amount'],
+            dependentSchemas: { amount: { required: ['currency'] } },
+            unevaluatedProperties: false,
+          },
+        },
+        {
+          name: 'contains_tool',
+          inputSchema: { type: 'object' as const, properties: {} },
+          outputSchema: {
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            type: 'array' as const,
+            contains: { type: 'integer' as const },
+            minContains: 2,
+            maxContains: 2,
+          },
+        },
+      ],
+    });
+    vi.spyOn(sdkClient, 'callTool')
+      .mockResolvedValueOnce({
+        structuredContent: { amount: 10, currency: 'USD' },
+        content: [{ type: 'text', text: 'valid' }],
+        isError: false,
+      })
+      .mockResolvedValueOnce({
+        structuredContent: { amount: 10, unexpected: true },
+        content: [{ type: 'text', text: 'invalid' }],
+        isError: false,
+      })
+      .mockResolvedValueOnce({
+        structuredContent: [1, 'middle', 2],
+        content: [{ type: 'text', text: 'valid' }],
+        isError: false,
+      })
+      .mockResolvedValueOnce({
+        structuredContent: [1, 'only one integer'],
+        content: [{ type: 'text', text: 'invalid' }],
+        isError: false,
+      });
+
+    const tools = await client.tools();
+    await expect(tools.dependent_tool.execute?.({})).resolves.toEqual({ amount: 10, currency: 'USD' });
+    await expect(tools.dependent_tool.execute?.({})).resolves.toMatchObject({ error: true });
+    await expect(tools.contains_tool.execute?.({})).resolves.toEqual([1, 'middle', 2]);
+    await expect(tools.contains_tool.execute?.({})).resolves.toMatchObject({ error: true });
+  });
+
   it('validates output schemas that explicitly declare draft-07', async () => {
     const sdkClient = (client as any).client as Client;
     vi.spyOn(sdkClient, 'listTools').mockResolvedValue({

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -84,11 +84,20 @@ function getJsonSchemaComplexityError(schema: unknown): string | undefined {
   const seen = new Set<object>();
   let nodes = 0;
   const stack = [{ value: schema, depth: 0 }];
-  const schemaMapKeywords = ['$defs', 'definitions', 'properties', 'patternProperties', 'dependentSchemas'];
-  const schemaArrayKeywords = ['prefixItems', 'allOf', 'anyOf', 'oneOf'];
+  const schemaMapKeywords = [
+    '$defs',
+    'definitions',
+    'properties',
+    'patternProperties',
+    'dependentSchemas',
+    'dependencies',
+  ];
+  const schemaArrayKeywords = ['prefixItems', 'allOf', 'anyOf', 'oneOf', 'items'];
   const schemaKeywords = [
     'additionalProperties',
     'unevaluatedProperties',
+    'additionalItems',
+    'unevaluatedItems',
     'items',
     'contains',
     'propertyNames',
@@ -1410,10 +1419,20 @@ export class InternalMastraMCPClient extends MastraBase {
   private convertInputSchema(
     inputSchema: Awaited<ReturnType<Client['listTools']>>['tools'][0]['inputSchema'],
   ): StandardSchemaWithJSON {
-    const schema = ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
-    return toStandardSchema(
-      schema.$schema ? schema : { ...schema, $schema: 'https://json-schema.org/draft/2020-12/schema' },
-    );
+    const rawSchema = ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
+    const schema = rawSchema.$schema
+      ? rawSchema
+      : { ...rawSchema, $schema: 'https://json-schema.org/draft/2020-12/schema' };
+    const standardSchema = toStandardSchema(schema);
+    const complexityError = getJsonSchemaComplexityError(schema);
+    if (!complexityError) return standardSchema;
+
+    return {
+      '~standard': {
+        ...standardSchema['~standard'],
+        validate: () => ({ issues: [{ message: complexityError }] }),
+      },
+    };
   }
 
   /**

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -1610,8 +1610,8 @@ export class InternalMastraMCPClient extends MastraBase {
             : tool.outputSchema
           : undefined;
         const outputSchemaComplexityError = outputSchema ? getJsonSchemaComplexityError(outputSchema) : undefined;
-        let outputValidator: ReturnType<jsonSchemaValidator['getValidator']> | undefined;
-        const getOutputValidator = async () => {
+        let outputValidationSchema: StandardSchemaWithJSON | undefined;
+        const getOutputValidationSchema = async () => {
           if (!outputSchema) return undefined;
           if (outputSchemaComplexityError) {
             throw new MastraError({
@@ -1622,8 +1622,20 @@ export class InternalMastraMCPClient extends MastraBase {
               details: { toolName: tool.name, serverName: this.name },
             });
           }
-          outputValidator ??= (await this.getJsonSchemaValidator()).getValidator(outputSchema);
-          return outputValidator;
+          if (!outputValidationSchema) {
+            const validator = (await this.getJsonSchemaValidator()).getValidator(outputSchema);
+            const standardSchema = toStandardSchema(outputSchema)['~standard'];
+            outputValidationSchema = {
+              '~standard': {
+                ...standardSchema,
+                validate: value => {
+                  const result = validator(value);
+                  return result.valid ? { value: result.data } : { issues: [{ message: result.errorMessage }] };
+                },
+              },
+            };
+          }
+          return outputValidationSchema;
         };
         const mcpToolProps =
           toolMeta || annotations
@@ -1634,13 +1646,6 @@ export class InternalMastraMCPClient extends MastraBase {
                 },
               }
             : {};
-        // Real validator for structuredContent. Kept separate from the Tool's outputSchema
-        // (whose validator is a no-op — see convertOutputSchema) because only the
-        // structuredContent success path should be validated, not envelope returns.
-        const rawOutputSchema = tool.outputSchema
-          ? (('jsonSchema' in tool.outputSchema ? tool.outputSchema.jsonSchema : tool.outputSchema) as JSONSchema7)
-          : undefined;
-        const outputValidator = rawOutputSchema ? toStandardSchema(rawOutputSchema) : undefined;
         const mastraTool = createTool({
           id: `${this.name}_${tool.name}`,
           description: tool.description || '',
@@ -1719,20 +1724,6 @@ export class InternalMastraMCPClient extends MastraBase {
                   });
                 }
 
-                if (!res.isError && res.structuredContent !== undefined) {
-                  const validator = await getOutputValidator();
-                  const validation = validator?.(res.structuredContent);
-                  if (validation && !validation.valid) {
-                    throw new MastraError({
-                      id: 'MCP_CLIENT_OUTPUT_SCHEMA_VALIDATION_FAILED',
-                      domain: ErrorDomain.MCP,
-                      category: ErrorCategory.THIRD_PARTY,
-                      text: `Structured content does not match the tool's output schema: ${validation.errorMessage}`,
-                      details: { toolName: tool.name, serverName: this.name },
-                    });
-                  }
-                }
-
                 this.log('debug', `Tool executed successfully: ${tool.name}`);
 
                 if (res.structuredContent !== undefined) {
@@ -1743,8 +1734,9 @@ export class InternalMastraMCPClient extends MastraBase {
                   // return the same structured ValidationError shape createTool produces so
                   // the model can self-correct. Skipped for isError results, which are handled
                   // above / by the `onToolError: 'return'` envelope path.
-                  if (!res.isError && outputValidator) {
-                    const validation = validateToolOutput(outputValidator, res.structuredContent, tool.name);
+                  if (!res.isError && outputSchema) {
+                    const validationSchema = await getOutputValidationSchema();
+                    const validation = validateToolOutput(validationSchema, res.structuredContent, tool.name);
                     if (validation.error) {
                       this.log('debug', `Tool output failed schema validation: ${tool.name}`, {
                         message: validation.error.message,

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -26,6 +26,7 @@ import type {
   ReadResourceResult,
   ClientCapabilities,
   McpSubscription,
+  jsonSchemaValidator,
 } from '@modelcontextprotocol/client';
 import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import { asyncExitHook, gracefulExit } from 'exit-hook';
@@ -76,6 +77,61 @@ type MCPToolListEntry = Awaited<ReturnType<Client['listTools']>>['tools'][0];
 
 const DEFAULT_SERVER_CONNECT_TIMEOUT_MSEC = 3000;
 const DEFAULT_INSTRUCTIONS_MAX_LENGTH = 512;
+const MAX_JSON_SCHEMA_DEPTH = 128;
+const MAX_JSON_SCHEMA_NODES = 10_000;
+
+function getJsonSchemaComplexityError(schema: unknown): string | undefined {
+  const seen = new Set<object>();
+  let nodes = 0;
+  const stack = [{ value: schema, depth: 0 }];
+  const schemaMapKeywords = ['$defs', 'definitions', 'properties', 'patternProperties', 'dependentSchemas'];
+  const schemaArrayKeywords = ['prefixItems', 'allOf', 'anyOf', 'oneOf'];
+  const schemaKeywords = [
+    'additionalProperties',
+    'unevaluatedProperties',
+    'items',
+    'contains',
+    'propertyNames',
+    'not',
+    'if',
+    'then',
+    'else',
+    'contentSchema',
+  ];
+
+  while (stack.length > 0) {
+    const { value, depth } = stack.pop()!;
+    if (value === null || typeof value !== 'object' || Array.isArray(value) || seen.has(value)) continue;
+    seen.add(value);
+
+    nodes += 1;
+    if (depth > MAX_JSON_SCHEMA_DEPTH) {
+      return `JSON Schema exceeds the maximum depth of ${MAX_JSON_SCHEMA_DEPTH}`;
+    }
+    if (nodes > MAX_JSON_SCHEMA_NODES) {
+      return `JSON Schema exceeds the maximum node count of ${MAX_JSON_SCHEMA_NODES}`;
+    }
+
+    const record = value as Record<string, unknown>;
+    for (const keyword of schemaMapKeywords) {
+      const schemas = record[keyword];
+      if (schemas && typeof schemas === 'object' && !Array.isArray(schemas)) {
+        for (const child of Object.values(schemas)) stack.push({ value: child, depth: depth + 1 });
+      }
+    }
+    for (const keyword of schemaArrayKeywords) {
+      const schemas = record[keyword];
+      if (Array.isArray(schemas)) {
+        for (const child of schemas) stack.push({ value: child, depth: depth + 1 });
+      }
+    }
+    for (const keyword of schemaKeywords) {
+      if (record[keyword] !== undefined) stack.push({ value: record[keyword], depth: depth + 1 });
+    }
+  }
+
+  return undefined;
+}
 
 /**
  * OAuth authorization state of an MCP server connection.
@@ -325,6 +381,8 @@ export class InternalMastraMCPClient extends MastraBase {
   private hasElicitationCapability: boolean;
   private readonly requireToolApproval: RequireToolApproval | undefined;
   private readonly onToolError: 'throw' | 'return';
+  private jsonSchemaValidator?: jsonSchemaValidator;
+  private jsonSchemaValidatorPromise?: Promise<jsonSchemaValidator>;
 
   /** Provides access to resource operations (list, read, subscribe, etc.) */
   public readonly resources: ResourceClientActions;
@@ -354,6 +412,7 @@ export class InternalMastraMCPClient extends MastraBase {
     this.enableProgressTracking = !!server.enableProgressTracking;
     this.requireToolApproval = server.requireToolApproval;
     this.onToolError = server.onToolError ?? 'throw';
+    this.jsonSchemaValidator = server.jsonSchemaValidator;
 
     // Initialize roots from server config
     this._roots = server.roots ?? [];
@@ -1338,25 +1397,41 @@ export class InternalMastraMCPClient extends MastraBase {
     });
   }
 
+  private async getJsonSchemaValidator(): Promise<jsonSchemaValidator> {
+    if (this.jsonSchemaValidator) return this.jsonSchemaValidator;
+
+    this.jsonSchemaValidatorPromise ??= import('@modelcontextprotocol/client/validators/ajv').then(
+      ({ AjvJsonSchemaValidator }) => new AjvJsonSchemaValidator(),
+    );
+    this.jsonSchemaValidator = await this.jsonSchemaValidatorPromise;
+    return this.jsonSchemaValidator;
+  }
+
   private convertInputSchema(
     inputSchema: Awaited<ReturnType<Client['listTools']>>['tools'][0]['inputSchema'],
-  ): JSONSchema7 {
-    return ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
+  ): StandardSchemaWithJSON {
+    const schema = ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
+    return toStandardSchema(
+      schema.$schema ? schema : { ...schema, $schema: 'https://json-schema.org/draft/2020-12/schema' },
+    );
   }
 
   /**
    * Wraps the output schema with a validator that always succeeds. The tool's execute wrapper
    * returns the full CallToolResult envelope when there is no structuredContent (and for
    * in-band errors with `onToolError: 'return'`), which would never match the advertised
-   * outputSchema — so enforcement happens inside the execute wrapper, scoped to the
-   * structuredContent path (see buildToolFromListEntry). The JSON schema is surfaced here
-   * for documentation.
+   * outputSchema. Enforcement therefore happens inside the execute wrapper, scoped to the
+   * successful structuredContent path, so cached tools use the configured SDK validator too.
+   * The JSON schema is surfaced here for documentation.
    */
   private convertOutputSchema(
     outputSchema: Awaited<ReturnType<Client['listTools']>>['tools'][0]['outputSchema'],
   ): StandardSchemaWithJSON | undefined {
     if (!outputSchema) return outputSchema;
-    const schema = ('jsonSchema' in outputSchema ? outputSchema.jsonSchema : outputSchema) as JSONSchema7;
+    const rawSchema = ('jsonSchema' in outputSchema ? outputSchema.jsonSchema : outputSchema) as JSONSchema7;
+    const schema = rawSchema.$schema
+      ? rawSchema
+      : { ...rawSchema, $schema: 'https://json-schema.org/draft/2020-12/schema' };
     const standardSchema = toStandardSchema(schema)['~standard'];
     return {
       '~standard': {
@@ -1510,6 +1585,27 @@ export class InternalMastraMCPClient extends MastraBase {
         // Stamp serverId into _meta.ui so consumers can resolve app resources
         // back to the originating MCP server without scanning all servers.
         const toolMeta = rawMeta ? this.stampServerIdInMeta(rawMeta) : undefined;
+        const outputSchema = tool.outputSchema
+          ? 'jsonSchema' in tool.outputSchema
+            ? tool.outputSchema.jsonSchema
+            : tool.outputSchema
+          : undefined;
+        const outputSchemaComplexityError = outputSchema ? getJsonSchemaComplexityError(outputSchema) : undefined;
+        let outputValidator: ReturnType<jsonSchemaValidator['getValidator']> | undefined;
+        const getOutputValidator = async () => {
+          if (!outputSchema) return undefined;
+          if (outputSchemaComplexityError) {
+            throw new MastraError({
+              id: 'MCP_CLIENT_OUTPUT_SCHEMA_TOO_COMPLEX',
+              domain: ErrorDomain.MCP,
+              category: ErrorCategory.THIRD_PARTY,
+              text: `MCP tool "${tool.name}" has a schema that is too complex: ${outputSchemaComplexityError}`,
+              details: { toolName: tool.name, serverName: this.name },
+            });
+          }
+          outputValidator ??= (await this.getJsonSchemaValidator()).getValidator(outputSchema);
+          return outputValidator;
+        };
         const mcpToolProps =
           toolMeta || annotations
             ? {
@@ -1602,6 +1698,20 @@ export class InternalMastraMCPClient extends MastraBase {
                     text: errorText,
                     details: { toolName: tool.name, serverName: this.name },
                   });
+                }
+
+                if (!res.isError && res.structuredContent !== undefined) {
+                  const validator = await getOutputValidator();
+                  const validation = validator?.(res.structuredContent);
+                  if (validation && !validation.valid) {
+                    throw new MastraError({
+                      id: 'MCP_CLIENT_OUTPUT_SCHEMA_VALIDATION_FAILED',
+                      domain: ErrorDomain.MCP,
+                      category: ErrorCategory.THIRD_PARTY,
+                      text: `Structured content does not match the tool's output schema: ${validation.errorMessage}`,
+                      details: { toolName: tool.name, serverName: this.name },
+                    });
+                  }
                 }
 
                 this.log('debug', `Tool executed successfully: ${tool.name}`);

--- a/packages/mcp/src/client/serializable-tool-definitions.test.ts
+++ b/packages/mcp/src/client/serializable-tool-definitions.test.ts
@@ -248,6 +248,28 @@ describe('serializable MCP tool definitions (issue #20527)', () => {
         await coldClient.disconnect().catch(() => {});
       }
     });
+
+    it('does not count deeply nested annotation data as schema depth', async () => {
+      const definitions = await client.toolDefinitions();
+      const cached = JSON.parse(JSON.stringify(definitions.measure));
+      let deepDefault: Record<string, unknown> = {};
+      for (let depth = 0; depth < 150; depth++) {
+        deepDefault = { nested: deepDefault };
+      }
+      cached.outputSchema = {
+        type: 'object',
+        properties: { celsius: { type: 'number', default: deepDefault } },
+      };
+
+      const coldClient = new InternalMastraMCPClient({ name: 'defs', server: { url: testServer.baseUrl } });
+      const hydrated = coldClient.toolFromDefinition({ definition: cached });
+
+      try {
+        await expect(hydrated.execute!({ city: 'Berlin' } as any, {})).resolves.toMatchObject({ celsius: 21 });
+      } finally {
+        await coldClient.disconnect().catch(() => {});
+      }
+    });
   });
 
   describe('MCPClient', () => {

--- a/packages/mcp/src/client/serializable-tool-definitions.test.ts
+++ b/packages/mcp/src/client/serializable-tool-definitions.test.ts
@@ -222,9 +222,10 @@ describe('serializable MCP tool definitions (issue #20527)', () => {
       const hydrated = coldClient.toolFromDefinition({ definition: cached });
 
       try {
-        await expect(hydrated.execute!({ city: 'Berlin' } as any, {})).rejects.toThrow(
-          /structured content does not match/i,
-        );
+        await expect(hydrated.execute!({ city: 'Berlin' } as any, {})).resolves.toMatchObject({
+          error: true,
+          message: expect.stringMatching(/tool output validation failed for measure/i),
+        });
       } finally {
         await coldClient.disconnect().catch(() => {});
       }

--- a/packages/mcp/src/client/serializable-tool-definitions.test.ts
+++ b/packages/mcp/src/client/serializable-tool-definitions.test.ts
@@ -180,6 +180,74 @@ describe('serializable MCP tool definitions (issue #20527)', () => {
       const valid = await hydrated.execute!({ city: 'Berlin' } as any, {});
       expect(valid).toMatchObject({ celsius: 21 });
     });
+
+    it('preserves a 2020-12 schema exactly through catalog serialization and hydration', async () => {
+      const definitions = await client.toolDefinitions();
+      const schema2020 = {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        $id: 'https://example.test/schemas/measurement',
+        $defs: {
+          reading: {
+            anyOf: [{ type: 'number' }, { type: 'null' }],
+          },
+        },
+        type: 'object',
+        properties: {
+          readings: {
+            type: 'array',
+            prefixItems: [{ $ref: '#/$defs/reading' }],
+            items: false,
+          },
+        },
+        unevaluatedProperties: false,
+      };
+      definitions.measure.inputSchema = schema2020;
+      definitions.measure.outputSchema = schema2020;
+
+      const cached = JSON.parse(JSON.stringify(definitions.measure));
+      expect(cached.inputSchema).toEqual(schema2020);
+      expect(cached.outputSchema).toEqual(schema2020);
+
+      const hydrated = client.toolFromDefinition({ definition: cached });
+      expect(hydrated.inputSchema?.['~standard'].jsonSchema.input({ target: 'draft-2020-12' })).toEqual(schema2020);
+      expect(hydrated.outputSchema?.['~standard'].jsonSchema.output({ target: 'draft-2020-12' })).toEqual(schema2020);
+    });
+
+    it('enforces a cached output schema without requiring a tools/list request in the new process', async () => {
+      const definitions = await client.toolDefinitions();
+      const cached = JSON.parse(JSON.stringify(definitions.measure));
+      cached.outputSchema = { type: 'string' };
+
+      const coldClient = new InternalMastraMCPClient({ name: 'defs', server: { url: testServer.baseUrl } });
+      const hydrated = coldClient.toolFromDefinition({ definition: cached });
+
+      try {
+        await expect(hydrated.execute!({ city: 'Berlin' } as any, {})).rejects.toThrow(
+          /structured content does not match/i,
+        );
+      } finally {
+        await coldClient.disconnect().catch(() => {});
+      }
+    });
+
+    it('rejects an output schema that exceeds the composition-depth budget', async () => {
+      const definitions = await client.toolDefinitions();
+      const cached = JSON.parse(JSON.stringify(definitions.measure));
+      let deepSchema: Record<string, unknown> = { type: 'number' };
+      for (let depth = 0; depth < 150; depth++) {
+        deepSchema = { allOf: [deepSchema] };
+      }
+      cached.outputSchema = deepSchema;
+
+      const coldClient = new InternalMastraMCPClient({ name: 'defs', server: { url: testServer.baseUrl } });
+      const hydrated = coldClient.toolFromDefinition({ definition: cached });
+
+      try {
+        await expect(hydrated.execute!({ city: 'Berlin' } as any, {})).rejects.toThrow(/schema.*complex/i);
+      } finally {
+        await coldClient.disconnect().catch(() => {});
+      }
+    });
   });
 
   describe('MCPClient', () => {

--- a/packages/mcp/src/server/server-modern-era-http.test.ts
+++ b/packages/mcp/src/server/server-modern-era-http.test.ts
@@ -237,6 +237,7 @@ describe('MCPServer with protocolVersion 2026-07-28 (dual-era HTTP)', () => {
     try {
       const tools = await client.listTools();
       expect(tools.tools.map(t => t.name)).toContain('echoTool');
+      expect(tools.tools.find(tool => tool.name === 'nullTool')?.outputSchema?.$schema).toBeUndefined();
 
       const result = await client.callTool({ name: 'echoTool', arguments: { text: 'legacy' } });
       expect((result as any).content[0].text).toBe('echo: legacy');

--- a/packages/mcp/src/server/server-modern-era-http.test.ts
+++ b/packages/mcp/src/server/server-modern-era-http.test.ts
@@ -188,7 +188,10 @@ describe('MCPServer with protocolVersion 2026-07-28 (dual-era HTTP)', () => {
     );
     await client.connect(new StreamableHTTPClientTransport(baseUrl));
     try {
-      await client.listTools();
+      const tools = await client.listTools();
+      expect(tools.tools.find(tool => tool.name === 'nullTool')?.outputSchema?.$schema).toBe(
+        'http://json-schema.org/draft-07/schema#',
+      );
       const result = await client.callTool({ name: 'nullTool', arguments: {} });
 
       expect(result.isError).not.toBe(true);

--- a/packages/mcp/src/server/server-modern-era-http.test.ts
+++ b/packages/mcp/src/server/server-modern-era-http.test.ts
@@ -47,6 +47,13 @@ const makeTools = () => ({
     inputSchema: z.object({}),
     execute: async (_inputData, options) => options?.mcp?.extra?.authInfo?.clientId ?? 'missing',
   }),
+  nullTool: createTool({
+    id: 'nullTool',
+    description: 'Returns a null structured result',
+    inputSchema: z.object({}),
+    outputSchema: z.null(),
+    execute: async () => null,
+  }),
 });
 
 const authInfo: AuthInfo = {
@@ -169,6 +176,24 @@ describe('MCPServer with protocolVersion 2026-07-28 (dual-era HTTP)', () => {
 
       const result = await client.callTool({ name: 'echoTool', arguments: { text: 'hi' } });
       expect((result as any).content[0].text).toBe('echo: hi');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('preserves null structuredContent as a valid modern tool result', async () => {
+    const client = new Client(
+      { name: 'null-result-client', version: '1.0.0' },
+      { versionNegotiation: { mode: { pin: '2026-07-28' } } },
+    );
+    await client.connect(new StreamableHTTPClientTransport(baseUrl));
+    try {
+      await client.listTools();
+      const result = await client.callTool({ name: 'nullTool', arguments: {} });
+
+      expect(result.isError).not.toBe(true);
+      expect(result.structuredContent).toBeNull();
+      expect(result.content).toEqual([{ type: 'text', text: 'null' }]);
     } finally {
       await client.close();
     }

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -3011,7 +3011,7 @@ describe('MCPServer with Tool Output Schema', () => {
         },
         makeMockExtra(),
       ),
-    ).rejects.toThrow('expected record, received null');
+    ).rejects.toBeInstanceOf(Error);
 
     expect(validate).toHaveBeenCalledWith(null);
   });

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -2874,6 +2874,12 @@ describe('MCPServer with Tool Output Schema', () => {
         timestamp: mockDateISO,
       }),
     },
+    nullOutputTool: {
+      description: 'A tool that returns null structured output',
+      parameters: z.object({}),
+      outputSchema: z.null(),
+      execute: async () => null,
+    },
   };
 
   beforeAll(async () => {
@@ -2983,6 +2989,31 @@ describe('MCPServer with Tool Output Schema', () => {
     expect((result.content as Array<{ type: string; text: string }>)[0].text).not.toBe(
       JSON.stringify(expectedStructuredContent),
     );
+  });
+
+  it('validates null structured output as null instead of an empty object', async () => {
+    // @ts-expect-error - accessing internal for testing
+    const nullTool = serverWithOutputSchema.convertedTools.nullOutputTool;
+    const validate = vi.fn(value => ({ success: value === null, output: value }));
+    nullTool.outputSchema.validate = validate;
+
+    const serverInstance = serverWithOutputSchema.getServer();
+    // @ts-expect-error - accessing internal for testing
+    const callToolHandler = serverInstance._requestHandlers.get('tools/call');
+    // This direct invocation lacks modern request metadata, so the SDK's legacy result parser rejects null after our handler.
+    await expect(
+      callToolHandler!(
+        {
+          jsonrpc: '2.0' as const,
+          id: 'test-null-output',
+          method: 'tools/call' as const,
+          params: { name: 'nullOutputTool', arguments: {} },
+        },
+        makeMockExtra(),
+      ),
+    ).rejects.toThrow('expected record, received null');
+
+    expect(validate).toHaveBeenCalledWith(null);
   });
 });
 

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -2631,11 +2631,12 @@ export class MCPServer extends MCPServerBase {
 
   private convertSchema(schema: any) {
     const jsonSchema = isStandardSchemaWithJSON(schema)
-      ? standardSchemaToJSONSchema(schema)
+      ? standardSchemaToJSONSchema(schema, { target: this.servesModernEra() ? 'draft-2020-12' : 'draft-07' })
       : (schema?.jsonSchema ?? schema);
-    // The MCP 2.0 SDK default validator only supports the JSON Schema 2020-12
-    // dialect and rejects schemas declaring draft-07, so strip the dialect
-    // declaration before advertising the schema to clients.
+    if (this.servesModernEra()) return jsonSchema;
+
+    // Preserve the established legacy wire shape. Modern connections retain the
+    // declaration because their validators dispatch according to the schema dialect.
     if (jsonSchema && typeof jsonSchema === 'object' && '$schema' in jsonSchema) {
       const { $schema: _dialect, ...rest } = jsonSchema;
       return rest;

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -1176,7 +1176,7 @@ export class MCPServer extends MCPServerBase {
             structuredContent = result;
           }
 
-          const outputValidation = await tool.outputSchema.validate?.(structuredContent ?? {});
+          const outputValidation = await tool.outputSchema.validate?.(structuredContent);
           if (outputValidation && !outputValidation.success) {
             this.logger.warn('Invalid structured content', {
               tool: request.params.name,

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -972,17 +972,19 @@ export class MCPServer extends MCPServerBase {
   private registerHandlersOnServer(serverInstance: Server) {
     // List tools handler
     serverInstance.setRequestHandler('tools/list', async (_request, ctx) => {
-      const proxiedContext = await this.createProxiedRequestContext(toMCPRequestHandlerExtra(ctx));
+      const extra = toMCPRequestHandlerExtra(ctx);
+      const proxiedContext = await this.createProxiedRequestContext(extra);
       const tools = await this.getAuthorizedConvertedToolEntries(proxiedContext);
+      const modernRequest = isModernEraRequest(extra);
       return {
         tools: tools.map(([, tool]) => {
           const toolSpec: any = {
             name: tool.id || 'unknown',
             description: tool.description,
-            inputSchema: this.convertInputSchema(tool.parameters),
+            inputSchema: this.convertInputSchema(tool.parameters, modernRequest),
           };
           if (tool.outputSchema) {
-            toolSpec.outputSchema = this.convertSchema(tool.outputSchema);
+            toolSpec.outputSchema = this.convertSchema(tool.outputSchema, modernRequest);
           }
           // Include MCP tool annotations if present
           if (tool.mcp?.annotations) {
@@ -2629,14 +2631,14 @@ export class MCPServer extends MCPServerBase {
     };
   }
 
-  private convertSchema(schema: any) {
+  private convertSchema(schema: any, modernEra = this.servesModernEra()) {
     const jsonSchema = isStandardSchemaWithJSON(schema)
-      ? standardSchemaToJSONSchema(schema, { target: this.servesModernEra() ? 'draft-2020-12' : 'draft-07' })
+      ? standardSchemaToJSONSchema(schema, { target: modernEra ? 'draft-2020-12' : 'draft-07' })
       : (schema?.jsonSchema ?? schema);
-    if (this.servesModernEra()) return jsonSchema;
+    if (modernEra) return jsonSchema;
 
-    // Preserve the established legacy wire shape. Modern connections retain the
-    // declaration because their validators dispatch according to the schema dialect.
+    // Preserve the established legacy wire shape for legacy clients. Modern
+    // validators dispatch according to the schema's preserved dialect declaration.
     if (jsonSchema && typeof jsonSchema === 'object' && '$schema' in jsonSchema) {
       const { $schema: _dialect, ...rest } = jsonSchema;
       return rest;
@@ -2644,8 +2646,8 @@ export class MCPServer extends MCPServerBase {
     return jsonSchema;
   }
 
-  private convertInputSchema(schema: any) {
-    return this.convertSchema(schema) ?? { type: 'object', properties: {} };
+  private convertInputSchema(schema: any, modernEra = this.servesModernEra()) {
+    return this.convertSchema(schema, modernEra) ?? { type: 'object', properties: {} };
   }
 
   /**


### PR DESCRIPTION
## Summary

- preserve JSON Schema 2020-12 schemas, references, composition keywords, and boolean subschemas across live discovery and serialized tool catalogs
- validate successful structured tool results consistently on live and hydrated paths while preserving scalar and null JSON values
- bound schema traversal depth and node count, preserve explicit schema dialects for modern requests, and retain legacy wire behavior for explicit legacy clients
- document dialect behavior and scalar metadata limitations

## Test plan

- `pnpm turbo build --filter=@mastra/mcp...`
- `pnpm --filter ./packages/mcp test:client`
- `pnpm --filter ./packages/mcp test:server`
- `pnpm --filter ./packages/mcp test:conformance -- --mode modern`
- `pnpm --filter ./packages/mcp test:conformance -- --mode legacy-interoperability`
- `pnpm --filter ./packages/mcp exec oxlint .`
- `pnpm --dir docs exec oxfmt-mdx --check src/content/en/reference/tools/mcp-client.mdx src/content/en/reference/tools/mcp-server.mdx`
- `bash .mastracode/plans/mcp-2026-adoption-stack.proof/02-json-schema/demo.sh`
