### PR TITLE
feat(mcp): propagate W3C trace metadata per request

### DIFF
--- a/.changeset/eager-pans-relate.md
+++ b/.changeset/eager-pans-relate.md
@@ -1,0 +1,18 @@
+---
+'@mastra/mcp': minor
+---
+
+Added request-scoped W3C trace metadata propagation for MCP clients. Configure a provider on a server definition:
+
+```typescript
+const client = new MCPClient({
+  servers: {
+    reports: {
+      url: new URL('https://mcp.example.com/mcp'),
+      traceContext: () => currentTraceContext,
+    },
+  },
+});
+```
+
+The provider is resolved for every request. Explicit tool-call metadata takes precedence, and servers receive the values through `context.mcp.extra._meta`.

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -189,8 +189,33 @@ Each server in the `servers` map is configured using the `MastraMCPServerDefinit
     description:
       'Validator used for MCP tool schemas and structured results. The default supports JSON Schema 2020-12. Provide a compatible validator such as CfWorkerJsonSchemaValidator in runtimes that disallow dynamic code generation.',
   },
+  {
+    name: 'traceContext',
+    type: '() => MCPTraceContext | undefined',
+    isOptional: true,
+    description:
+      'Returns W3C traceparent, tracestate, and baggage values for each outgoing MCP request. The provider is called at request time so concurrent and reused clients do not share stale context.',
+  },
 ]}
 />
+
+## Trace context
+
+Use `traceContext` to add the W3C `traceparent`, `tracestate`, and `baggage` fields to MCP request `_meta`. The provider runs for each protocol request, including requests sent by live and cached tools, so read from your existing request-scoped trace carrier rather than storing a trace globally.
+
+```typescript
+const mcp = new MCPClient({
+  id: 'my-client',
+  servers: {
+    reports: {
+      url: new URL('https://mcp.example.com/mcp'),
+      traceContext: () => currentRequestTrace.getStore(),
+    },
+  },
+})
+```
+
+Explicit `_meta` supplied for a tool call takes precedence over provider values with the same key. Other caller metadata is preserved. Mastra passes the values through without creating spans or validating W3C formats. Treat inbound `baggage` as untrusted observability data. Don't use it for authentication or authorization.
 
 ## Tool approval
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1592,6 +1592,27 @@ const customMiddleware = createOAuthMiddleware({
 ]}
 />
 
+## W3C trace context
+
+MCP clients can send W3C `traceparent`, `tracestate`, and `baggage` fields in request `_meta`. Tools receive these values through the existing MCP request context on every transport:
+
+```typescript
+const tracedTool = createTool({
+  id: 'traced-tool',
+  inputSchema: z.object({}),
+  execute: async (_input, context) => {
+    const traceparent = context?.mcp?.extra?._meta?.traceparent
+    const tracestate = context?.mcp?.extra?._meta?.tracestate
+    const baggage = context?.mcp?.extra?._meta?.baggage
+
+    // Forward these values to your existing tracing system.
+    return { traceparent, tracestate, baggage }
+  },
+})
+```
+
+Mastra exposes the strings without creating spans or accepting them as credentials. Validate them before passing them to a trace processor, and never use `baggage` for authentication, authorization, or FGA decisions. Request metadata isn't stored in tool definitions or serialized tool catalogs.
+
 ## Authentication context
 
 Tools can access request metadata via `context.mcp.extra` when using HTTP-based transports. You can pass authentication info and user context, as well as custom data from your HTTP middleware to your MCP tools.

--- a/packages/mcp/src/__fixtures__/modern-era-notification-server.ts
+++ b/packages/mcp/src/__fixtures__/modern-era-notification-server.ts
@@ -14,11 +14,25 @@ const triggerToolListChanged = createTool({
   },
 });
 
+const traceContextTool = createTool({
+  id: 'traceContextTool',
+  description: 'Returns request trace metadata',
+  inputSchema: z.object({}),
+  execute: async (_inputData, options) => {
+    const meta = options?.mcp?.extra?._meta;
+    return JSON.stringify({
+      traceparent: meta?.traceparent,
+      tracestate: meta?.tracestate,
+      baggage: meta?.baggage,
+    });
+  },
+});
+
 server = new MCPServer({
   name: 'Modern Era Notification Server',
   version: '1.0.0',
   protocolVersion: '2026-07-28',
-  tools: { triggerToolListChanged },
+  tools: { triggerToolListChanged, traceContextTool },
 });
 
 await server.startStdio();

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -2461,6 +2461,49 @@ describe('MastraMCPClient - Custom _meta', () => {
     );
   });
 
+  it('should resolve fresh W3C trace context per tool request and preserve explicit caller precedence', async () => {
+    let activeTrace = {
+      traceparent: '00-11111111111111111111111111111111-1111111111111111-01',
+      tracestate: 'vendor=first',
+      baggage: 'tenant=one',
+    };
+    client = new InternalMastraMCPClient({
+      name: 'trace-context-client',
+      server: { url: testServer.baseUrl, traceContext: () => activeTrace },
+    });
+    await client.connect();
+
+    const sdkClient = (client as any).client as Client;
+    const callToolSpy = vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      isError: false,
+    });
+    const tools = await client.tools();
+
+    await tools['echo']?.execute?.({ msg: 'first' });
+    activeTrace = {
+      traceparent: '00-22222222222222222222222222222222-2222222222222222-01',
+      tracestate: 'vendor=second',
+      baggage: 'tenant=two',
+    };
+    await tools['echo']?.execute?.(
+      { msg: 'second' },
+      { _meta: { traceparent: '00-33333333333333333333333333333333-3333333333333333-01', custom: true } },
+    );
+
+    expect(callToolSpy.mock.calls[0]?.[0]._meta).toEqual({
+      traceparent: '00-11111111111111111111111111111111-1111111111111111-01',
+      tracestate: 'vendor=first',
+      baggage: 'tenant=one',
+    });
+    expect(callToolSpy.mock.calls[1]?.[0]._meta).toEqual({
+      traceparent: '00-33333333333333333333333333333333-3333333333333333-01',
+      tracestate: 'vendor=second',
+      baggage: 'tenant=two',
+      custom: true,
+    });
+  });
+
   it('should merge custom _meta with progressToken when progress tracking is enabled', async () => {
     client = new InternalMastraMCPClient({
       name: 'meta-progress-client',

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -2466,6 +2466,7 @@ describe('MastraMCPClient - Custom _meta', () => {
       traceparent: '00-11111111111111111111111111111111-1111111111111111-01',
       tracestate: 'vendor=first',
       baggage: 'tenant=one',
+      'io.modelcontextprotocol/protocolVersion': 'attacker-controlled',
     };
     client = new InternalMastraMCPClient({
       name: 'trace-context-client',
@@ -2482,6 +2483,7 @@ describe('MastraMCPClient - Custom _meta', () => {
       traceparent: '00-22222222222222222222222222222222-2222222222222222-01',
       tracestate: 'vendor=second',
       baggage: 'tenant=two',
+      'io.modelcontextprotocol/protocolVersion': 'attacker-controlled',
     };
     await tools['echo']?.execute?.(
       { msg: 'second' },
@@ -2499,6 +2501,14 @@ describe('MastraMCPClient - Custom _meta', () => {
       tracestate: 'vendor=second',
       baggage: 'tenant=two',
       custom: true,
+    });
+
+    await client.listResources();
+    const resourceRequest = sendSpy.mock.calls.map(call => call[0]).find(message => message.method === 'resources/list');
+    expect(resourceRequest?.params?._meta).toEqual({
+      traceparent: '00-22222222222222222222222222222222-2222222222222222-01',
+      tracestate: 'vendor=second',
+      baggage: 'tenant=two',
     });
   });
 

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -2474,11 +2474,8 @@ describe('MastraMCPClient - Custom _meta', () => {
     await client.connect();
 
     const sdkClient = (client as any).client as Client;
-    const callToolSpy = vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
-      content: [{ type: 'text', text: 'ok' }],
-      isError: false,
-    });
     const tools = await client.tools();
+    const sendSpy = vi.spyOn((sdkClient as any).transport, 'send');
 
     await tools['echo']?.execute?.({ msg: 'first' });
     activeTrace = {
@@ -2491,12 +2488,13 @@ describe('MastraMCPClient - Custom _meta', () => {
       { _meta: { traceparent: '00-33333333333333333333333333333333-3333333333333333-01', custom: true } },
     );
 
-    expect(callToolSpy.mock.calls[0]?.[0]._meta).toEqual({
+    const callRequests = sendSpy.mock.calls.map(call => call[0]).filter(message => message.method === 'tools/call');
+    expect(callRequests[0]?.params?._meta).toEqual({
       traceparent: '00-11111111111111111111111111111111-1111111111111111-01',
       tracestate: 'vendor=first',
       baggage: 'tenant=one',
     });
-    expect(callToolSpy.mock.calls[1]?.[0]._meta).toEqual({
+    expect(callRequests[1]?.params?._meta).toEqual({
       traceparent: '00-33333333333333333333333333333333-3333333333333333-01',
       tracestate: 'vendor=second',
       baggage: 'tenant=two',

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -371,7 +371,14 @@ class MastraMCPProtocolClient extends Client {
   protected override _outboundMetaEnvelope(): Readonly<Record<string, unknown>> | undefined {
     const envelope = super._outboundMetaEnvelope();
     const traceContext = this.traceContext?.();
-    return envelope || traceContext ? { ...envelope, ...traceContext } : undefined;
+    const traceMeta = traceContext
+      ? {
+          traceparent: traceContext.traceparent,
+          ...(traceContext.tracestate !== undefined ? { tracestate: traceContext.tracestate } : {}),
+          ...(traceContext.baggage !== undefined ? { baggage: traceContext.baggage } : {}),
+        }
+      : undefined;
+    return envelope || traceMeta ? { ...envelope, ...traceMeta } : undefined;
   }
 }
 

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -46,6 +46,7 @@ import type {
   InternalMastraMCPClientOptions,
   Root,
   RequireToolApproval,
+  MCPTraceContext,
   SerializableMCPToolDefinition,
 } from './types';
 import {
@@ -69,6 +70,7 @@ export type {
   RequireToolApproval,
   RequireToolApprovalFn,
   RequireToolApprovalContext,
+  MCPTraceContext,
   SerializableMCPToolDefinition,
 } from './types';
 
@@ -357,6 +359,22 @@ function convertLogLevelToLoggerMethod(level: LoggingLevel): 'debug' | 'info' | 
   }
 }
 
+class MastraMCPProtocolClient extends Client {
+  constructor(
+    clientInfo: ConstructorParameters<typeof Client>[0],
+    options: ConstructorParameters<typeof Client>[1],
+    private readonly traceContext?: () => MCPTraceContext | undefined,
+  ) {
+    super(clientInfo, options);
+  }
+
+  protected override _outboundMetaEnvelope(): Readonly<Record<string, unknown>> | undefined {
+    const envelope = super._outboundMetaEnvelope();
+    const traceContext = this.traceContext?.();
+    return envelope || traceContext ? { ...envelope, ...traceContext } : undefined;
+  }
+}
+
 /**
  * Internal MCP client implementation for connecting to a single MCP server.
  *
@@ -452,7 +470,7 @@ export class InternalMastraMCPClient extends MastraBase {
         ? undefined
         : { mode: server.protocolVersion === 'auto' ? ('auto' as const) : { pin: server.protocolVersion } };
 
-    this.client = new Client(
+    this.client = new MastraMCPProtocolClient(
       {
         name,
         version,
@@ -462,6 +480,7 @@ export class InternalMastraMCPClient extends MastraBase {
         ...(server.jsonSchemaValidator ? { jsonSchemaValidator: server.jsonSchemaValidator } : {}),
         ...(versionNegotiation ? { versionNegotiation } : {}),
       },
+      server.traceContext,
     );
 
     // Set up log message capturing
@@ -1695,7 +1714,8 @@ export class InternalMastraMCPClient extends MastraBase {
               const executeToolCall = async () => {
                 this.log('debug', `Executing tool: ${tool.name}`, { toolArgs: input, runId: context?.runId });
                 const userMeta = context?._meta;
-                // progressMeta spreads last so Mastra-managed progressToken takes precedence over any user-supplied one
+                // Explicit caller metadata wins over provider trace keys at the SDK envelope boundary.
+                // progressMeta spreads last so Mastra-managed progressToken takes precedence over any user-supplied one.
                 const progressMeta = this.enableProgressTracking
                   ? { progressToken: context?.runId || crypto.randomUUID() }
                   : undefined;

--- a/packages/mcp/src/client/index.ts
+++ b/packages/mcp/src/client/index.ts
@@ -9,6 +9,7 @@ export type {
   RequireToolApproval,
   RequireToolApprovalFn,
   RequireToolApprovalContext,
+  MCPTraceContext,
   ToolAnnotations,
   SerializableMCPToolDefinition,
   SerializableMCPToolCatalog,

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -163,6 +163,13 @@ export type RequireToolApprovalFn = (ctx: RequireToolApprovalContext) => boolean
  */
 export type RequireToolApproval = boolean | RequireToolApprovalFn;
 
+/** W3C trace fields carried in MCP request `_meta`. */
+export interface MCPTraceContext {
+  traceparent: string;
+  tracestate?: string;
+  baggage?: string;
+}
+
 /**
  * Base options common to all MCP server definitions.
  */
@@ -177,6 +184,13 @@ export type BaseServerOptions = {
   enableServerLogs?: boolean;
   /** Whether to enable progress tracking (default: false) */
   enableProgressTracking?: boolean;
+  /**
+   * Returns W3C trace fields to attach to each outgoing MCP request.
+   *
+   * The provider is called when the request is sent so consumers can read from
+   * their own request-local trace carrier without coupling MCP to a tracing SDK.
+   */
+  traceContext?: () => MCPTraceContext | undefined;
   /**
    * Whether instructions returned by this MCP server during initialization should
    * be forwarded to agents that use the server's tools.

--- a/packages/mcp/src/server/server-modern-era-http.test.ts
+++ b/packages/mcp/src/server/server-modern-era-http.test.ts
@@ -47,6 +47,20 @@ const makeTools = () => ({
     inputSchema: z.object({}),
     execute: async (_inputData, options) => options?.mcp?.extra?.authInfo?.clientId ?? 'missing',
   }),
+  traceContextTool: createTool({
+    id: 'traceContextTool',
+    description: 'Returns request trace metadata and authenticated client ID',
+    inputSchema: z.object({}),
+    execute: async (_inputData, options) => {
+      const meta = options?.mcp?.extra?._meta;
+      return JSON.stringify({
+        traceparent: meta?.traceparent,
+        tracestate: meta?.tracestate,
+        baggage: meta?.baggage,
+        clientId: options?.mcp?.extra?.authInfo?.clientId,
+      });
+    },
+  }),
   nullTool: createTool({
     id: 'nullTool',
     description: 'Returns a null structured result',
@@ -197,6 +211,67 @@ describe('MCPServer with protocolVersion 2026-07-28 (dual-era HTTP)', () => {
       expect(result.isError).not.toBe(true);
       expect(result.structuredContent).toBeNull();
       expect(result.content).toEqual([{ type: 'text', text: 'null' }]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('keeps W3C trace metadata request-scoped without using baggage for authorization', async () => {
+    const client = new Client(
+      { name: 'trace-context-http-client', version: '1.0.0' },
+      { versionNegotiation: { mode: { pin: '2026-07-28' } } },
+    );
+    await client.connect(new StreamableHTTPClientTransport(baseUrl));
+    const readTrace = async (_meta?: Record<string, unknown>) => {
+      const result = (await client.callTool({ name: 'traceContextTool', arguments: {}, _meta })) as {
+        content: Array<{ text?: string }>;
+      };
+      return JSON.parse(result.content[0]?.text ?? '{}');
+    };
+
+    try {
+      await expect(
+        readTrace({
+          traceparent: '00-11111111111111111111111111111111-1111111111111111-01',
+          tracestate: 'vendor=first',
+          baggage: 'clientId=attacker,tenant=one',
+        }),
+      ).resolves.toEqual({
+        traceparent: '00-11111111111111111111111111111111-1111111111111111-01',
+        tracestate: 'vendor=first',
+        baggage: 'clientId=attacker,tenant=one',
+        clientId: authInfo.clientId,
+      });
+      await expect(
+        readTrace({ traceparent: '00-22222222222222222222222222222222-2222222222222222-01' }),
+      ).resolves.toEqual({
+        traceparent: '00-22222222222222222222222222222222-2222222222222222-01',
+        clientId: authInfo.clientId,
+      });
+      await expect(readTrace()).resolves.toEqual({ clientId: authInfo.clientId });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('exposes malformed and oversized W3C values opaquely without crashing tool execution', async () => {
+    const client = new Client(
+      { name: 'trace-context-invalid-http-client', version: '1.0.0' },
+      { versionNegotiation: { mode: { pin: '2026-07-28' } } },
+    );
+    await client.connect(new StreamableHTTPClientTransport(baseUrl));
+    const baggage = `value=${'x'.repeat(9000)}`;
+    try {
+      const result = (await client.callTool({
+        name: 'traceContextTool',
+        arguments: {},
+        _meta: { traceparent: 'not-a-traceparent', baggage },
+      })) as { content: Array<{ text?: string }> };
+      expect(JSON.parse(result.content[0]?.text ?? '{}')).toEqual({
+        traceparent: 'not-a-traceparent',
+        baggage,
+        clientId: authInfo.clientId,
+      });
     } finally {
       await client.close();
     }

--- a/packages/mcp/src/server/server-modern-era-stdio.test.ts
+++ b/packages/mcp/src/server/server-modern-era-stdio.test.ts
@@ -14,6 +14,42 @@ describe('MCPServer with protocolVersion 2026-07-28 over stdio', () => {
     client = undefined;
   });
 
+  it('preserves distinct W3C trace metadata on consecutive stdio requests', async () => {
+    client = new Client(
+      { name: 'modern-era-stdio-trace-client', version: '1.0.0' },
+      { versionNegotiation: { mode: { pin: '2026-07-28' } } },
+    );
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [tsxCli, fixturePath],
+      stderr: 'pipe',
+    });
+    transport.stderr?.on('data', (chunk: Buffer) => process.stderr.write(chunk));
+    await client.connect(transport);
+
+    const call = async (_meta?: Record<string, unknown>) => {
+      const result = (await client!.callTool({ name: 'traceContextTool', arguments: {}, _meta })) as {
+        content: Array<{ text?: string }>;
+      };
+      return JSON.parse(result.content[0]?.text ?? '{}');
+    };
+    await expect(
+      call({
+        traceparent: '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-aaaaaaaaaaaaaaaa-01',
+        tracestate: 'vendor=stdio',
+        baggage: 'tenant=first',
+      }),
+    ).resolves.toEqual({
+      traceparent: '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-aaaaaaaaaaaaaaaa-01',
+      tracestate: 'vendor=stdio',
+      baggage: 'tenant=first',
+    });
+    await expect(call({ traceparent: '00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-bbbbbbbbbbbbbbbb-01' })).resolves.toEqual({
+      traceparent: '00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-bbbbbbbbbbbbbbbb-01',
+    });
+    await expect(call()).resolves.toEqual({});
+  }, 30000);
+
   it('delivers tool-list-changed notifications through a modern-era subscription', async () => {
     client = new Client(
       { name: 'modern-era-stdio-client', version: '1.0.0' },


### PR DESCRIPTION
## Summary

- add a package-local `traceContext` provider that resolves W3C `traceparent`, `tracestate`, and `baggage` for every outbound MCP request
- preserve explicit tool-call metadata precedence while preventing providers from overriding SDK-managed protocol metadata
- expose inbound trace metadata through the existing MCP request context across Streamable HTTP and stdio
- document trust boundaries and add packed-package proof of request isolation

## Test plan

- `pnpm turbo build --filter=@mastra/mcp...`
- `pnpm --filter ./packages/mcp test:client`
- `pnpm --filter ./packages/mcp test:server`
- `pnpm --filter ./packages/mcp lint`
- `pnpm --dir docs exec oxfmt-mdx --check src/content/en/reference/tools/mcp-client.mdx src/content/en/reference/tools/mcp-server.mdx`
- `.mastracode/plans/mcp-2026-adoption-stack.proof/04-trace-context/demo.sh`