### PR TITLE
fix(platform-workspace): pin repo templates to the last known head when the lookup fails

### DIFF
--- a/.changeset/platform-workspace-last-known-head.md
+++ b/.changeset/platform-workspace-last-known-head.md
@@ -1,0 +1,5 @@
+---
+'@mastra/platform-workspace': patch
+---
+
+Repository templates now pin to the last default-branch head resolved for the same clone URL when the lookup fails, instead of dropping the repo steps and booting the base image.

--- a/workspaces/platform-workspace/src/repo-template.test.ts
+++ b/workspaces/platform-workspace/src/repo-template.test.ts
@@ -220,7 +220,7 @@ describe('createRepoTemplate', () => {
 
   it('returns undefined when a public head cannot be resolved so sandbox creation can fall back cold', async () => {
     const resolveTemplate = createRepoTemplate({
-      getRepositoryAccess: accessFor('https://github.com/acme/private-repo.git'),
+      getRepositoryAccess: accessFor('https://github.com/acme/no-head.git'),
       resolveHead: vi.fn().mockResolvedValue(undefined),
     })!;
 
@@ -229,11 +229,56 @@ describe('createRepoTemplate', () => {
 
   it('rejects a malformed resolved head instead of interpolating it into build commands', async () => {
     const resolveTemplate = createRepoTemplate({
-      getRepositoryAccess: accessFor('https://github.com/acme/widgets.git'),
+      getRepositoryAccess: accessFor('https://github.com/acme/malformed-head.git'),
       resolveHead: headOf('main; rm -rf /'),
     })!;
 
     await expect(resolveTemplate()).resolves.toBeUndefined();
+  });
+
+  it('pins to the last known head of the same clone URL when a later lookup fails', async () => {
+    const getRepositoryAccess = accessFor('https://github.com/acme/flaky-head.git');
+    const warm = await createRepoTemplate({ getRepositoryAccess, resolveHead: headOf(SHA_1) })!();
+    const rateLimited = await createRepoTemplate({
+      getRepositoryAccess,
+      resolveHead: vi.fn().mockRejectedValue(new Error('rate limited')),
+    })!();
+    const malformed = await createRepoTemplate({ getRepositoryAccess, resolveHead: headOf('main; rm -rf /') })!();
+
+    expect(serializeSandboxTemplate(rateLimited!)).toEqual(serializeSandboxTemplate(warm!));
+    expect(serializeSandboxTemplate(malformed!)).toEqual(serializeSandboxTemplate(warm!));
+    expect(serializeSandboxTemplate(warm!).operations).toContainEqual({
+      method: 'runCmd',
+      args: [`git -C "flaky-head" checkout ${SHA_1}`],
+    });
+  });
+
+  it('replaces the remembered head once a lookup succeeds again', async () => {
+    const getRepositoryAccess = accessFor('https://github.com/acme/moving-head.git');
+    await createRepoTemplate({ getRepositoryAccess, resolveHead: headOf(SHA_1) })!();
+    await createRepoTemplate({ getRepositoryAccess, resolveHead: headOf(SHA_2) })!();
+    const fallback = await createRepoTemplate({
+      getRepositoryAccess,
+      resolveHead: vi.fn().mockRejectedValue(new Error('rate limited')),
+    })!();
+
+    expect(serializeSandboxTemplate(fallback!).operations).toContainEqual({
+      method: 'runCmd',
+      args: [`git -C "moving-head" checkout ${SHA_2}`],
+    });
+  });
+
+  it('does not reuse a head remembered for a different clone URL', async () => {
+    await createRepoTemplate({
+      getRepositoryAccess: accessFor('https://github.com/acme/remembered.git'),
+      resolveHead: headOf(SHA_1),
+    })!();
+    const other = await createRepoTemplate({
+      getRepositoryAccess: accessFor('https://github.com/acme/never-resolved.git'),
+      resolveHead: vi.fn().mockRejectedValue(new Error('rate limited')),
+    })!();
+
+    expect(other).toBeUndefined();
   });
 
   it('keeps the requested resources when the repository template cannot be resolved', async () => {
@@ -248,7 +293,7 @@ describe('createRepoTemplate', () => {
 
     const noHead = await createRepoTemplate({
       ...sized,
-      getRepositoryAccess: accessFor('https://github.com/acme/widgets.git'),
+      getRepositoryAccess: accessFor('https://github.com/acme/unresolved.git'),
       resolveHead: vi.fn().mockRejectedValue(new Error('rate limited')),
     })!();
     expect(serializeSandboxTemplate(noHead!)).toEqual(expected);

--- a/workspaces/platform-workspace/src/repo-template.ts
+++ b/workspaces/platform-workspace/src/repo-template.ts
@@ -81,6 +81,9 @@ export interface PlatformRepoTemplateOptions {
 
 export type PlatformRepoTemplateResolver = () => Promise<SandboxTemplateBuilder | undefined>;
 
+/** Last default-branch head resolved per clone URL, shared across resolvers in this process. */
+const lastKnownHeads = new Map<string, string>();
+
 /**
  * Create a lazy repository template definition for PlatformSandbox, mirroring
  * `@mastra/e2b`'s `createRepoTemplate`: pass the sandbox context through and a
@@ -131,17 +134,34 @@ export function createRepoTemplate(options: PlatformRepoTemplateOptions): Platfo
 
     const token = access.authorization?.token;
     let headError: unknown;
-    const sha = await (token ? resolveHead(cloneUrl, token) : resolveHead(cloneUrl)).catch(error => {
+    const resolved = await (token ? resolveHead(cloneUrl, token) : resolveHead(cloneUrl)).catch(error => {
       headError = error;
       return undefined;
     });
-    if (!sha || !SHA_PATTERN.test(sha)) {
-      console.warn('[platform-workspace] repo template skipped: could not resolve default-branch head', {
+    let sha: string;
+    if (resolved && SHA_PATTERN.test(resolved)) {
+      sha = resolved;
+      lastKnownHeads.set(cloneUrl, sha);
+    } else {
+      // A transient lookup failure (rate limit, timeout) must not drop the
+      // repo steps: an older pin still boots a warm family image, and the
+      // caller's checkout fetches the current tip regardless of the pin.
+      const lastKnown = lastKnownHeads.get(cloneUrl);
+      if (!lastKnown) {
+        console.warn('[platform-workspace] repo template skipped: could not resolve default-branch head', {
+          cloneUrl,
+          sha: resolved,
+          error: redactSecrets(headError),
+        });
+        return resourcesOnly();
+      }
+      console.warn('[platform-workspace] repo template pinned to the last known default-branch head', {
         cloneUrl,
-        sha,
+        sha: lastKnown,
+        resolved,
         error: redactSecrets(headError),
       });
-      return resourcesOnly();
+      sha = lastKnown;
     }
 
     const workingDirectory =

--- a/workspaces/platform-workspace/src/repo-template.ts
+++ b/workspaces/platform-workspace/src/repo-template.ts
@@ -94,8 +94,10 @@ const lastKnownHeads = new Map<string, string>();
  * what gets cloned and what the template is identified by can't drift — and
  * pins repositories to their current default-branch commit. Private repository
  * credentials are used for head resolution and sent to the provider as
- * transient build envs; they never enter the serialized definition. If the
- * repository or its head cannot be resolved, the resolver keeps `cpuCount` and
+ * transient build envs; they never enter the serialized definition. A failed
+ * head lookup reuses the last head resolved for the same clone URL in this
+ * process. If the repository cannot be resolved, or no head has been resolved
+ * yet, the resolver keeps `cpuCount` and
  * `memoryMB` in a resources-only template so the sandbox still boots at the
  * requested size, and the caller's runtime setup materializes the checkout.
  */

--- a/workspaces/platform-workspace/src/repo-template.ts
+++ b/workspaces/platform-workspace/src/repo-template.ts
@@ -83,6 +83,16 @@ export type PlatformRepoTemplateResolver = () => Promise<SandboxTemplateBuilder 
 
 /** Last default-branch head resolved per clone URL, shared across resolvers in this process. */
 const lastKnownHeads = new Map<string, string>();
+const MAX_LAST_KNOWN_HEADS = 1000;
+
+function rememberHead(cloneUrl: string, sha: string): void {
+  // Re-insert so the map stays in recency order and the oldest URL is evicted first.
+  lastKnownHeads.delete(cloneUrl);
+  lastKnownHeads.set(cloneUrl, sha);
+  if (lastKnownHeads.size > MAX_LAST_KNOWN_HEADS) {
+    lastKnownHeads.delete(lastKnownHeads.keys().next().value!);
+  }
+}
 
 /**
  * Create a lazy repository template definition for PlatformSandbox, mirroring
@@ -143,7 +153,7 @@ export function createRepoTemplate(options: PlatformRepoTemplateOptions): Platfo
     let sha: string;
     if (resolved && SHA_PATTERN.test(resolved)) {
       sha = resolved;
-      lastKnownHeads.set(cloneUrl, sha);
+      rememberHead(cloneUrl, sha);
     } else {
       // A transient lookup failure (rate limit, timeout) must not drop the
       // repo steps: an older pin still boots a warm family image, and the


### PR DESCRIPTION
## Summary
When resolving a repository's default-branch head fails (GitHub rate limit, timeout), `createPlatformRepoTemplate` dropped the repo steps and returned a resources-only template, so the platform provisioned the bare base image and the session ran a full clone plus setup (~99s instead of ~4s on a warm family boot).

The resolver now remembers the last head it resolved per clone URL in-process and reuses it when a later lookup fails or returns a malformed value. An older pin still boots a warm family image, and the session checkout fetches the current tip regardless of the pin. Resources-only remains the fallback only when nothing has been resolved yet in this process.

## Test plan
- [x] `repo-template.test.ts`: falls back to the remembered head on rejection and on a malformed value; newer successful lookups replace it; heads are not shared across clone URLs; cold-process failure still yields resources-only
- [x] `vitest run`, `tsc --noEmit`, lint, oxfmt on `@mastra/platform-workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The template remembers the last working version of each repository. If a later lookup fails, it can reuse that version instead of removing the repository.

## Changes

- Cache the last valid default-branch head by clone URL.
- Limit the cache to 1,000 entries.
- Reuse cached heads when lookups fail or return malformed values.
- Replace cached heads after successful newer lookups.
- Keep cached heads isolated by clone URL.
- Preserve the resources-only fallback when no cached head exists.
- Keep session checkout fetching the current tip.
- Add tests for fallback behavior, head replacement, URL isolation, and cold-process behavior.
- Add a changeset for `@mastra/platform-workspace`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->