### PR TITLE
test(playground): target the renamed Scores tab in trace panel tests

### DIFF
--- a/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/__tests__/experiment-item-route.msw.test.tsx
@@ -202,16 +202,16 @@ describe('experiment item sub-route', () => {
   });
 
   describe('when the user opens a result trace and selects a span', () => {
-    it('shows trace feedback and anchor-span evaluations with badge counts', async () => {
+    it('shows trace feedback and anchor-span scores with badge counts', async () => {
       renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-1`);
 
       await screen.findByRole('dialog');
       fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
 
-      const evaluationsTab = await screen.findByRole('tab', { name: /evaluations \(1\)/i });
+      const scoresTab = await screen.findByRole('tab', { name: /scores \(1\)/i });
       const feedbackTab = screen.getByRole('tab', { name: /feedback \(1\)/i });
 
-      fireEvent.click(evaluationsTab);
+      fireEvent.click(scoresTab);
       expect((await screen.findAllByText('Experiment relevance')).length).toBeGreaterThan(0);
 
       fireEvent.click(feedbackTab);
@@ -228,24 +228,24 @@ describe('experiment item sub-route', () => {
 
       await screen.findByRole('dialog');
       fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
-      fireEvent.click(await screen.findByRole('tab', { name: /evaluations \(1\)/i }));
+      fireEvent.click(await screen.findByRole('tab', { name: /scores \(1\)/i }));
       fireEvent.click(await screen.findByRole('button', { name: /0\.9Experiment relevance/i }));
 
       expect(await screen.findByText('Matches the experiment result score')).toBeDefined();
     });
 
-    it('keeps the trace evaluations open when a trace score has no experiment score match', async () => {
+    it('keeps the trace scores open when a trace score has no experiment score match', async () => {
       renderExperimentRoute(`/experiments/${EXPERIMENT_ID}/items/item-1`);
 
       await screen.findByRole('dialog');
       fireEvent.click(await screen.findByRole('button', { name: 'Trace' }));
-      const evaluationsTab = await screen.findByRole('tab', { name: /evaluations \(1\)/i });
-      fireEvent.click(evaluationsTab);
+      const scoresTab = await screen.findByRole('tab', { name: /scores \(1\)/i });
+      fireEvent.click(scoresTab);
       fireEvent.click(await screen.findByRole('button', { name: /0\.9Experiment relevance/i }));
 
-      expect(evaluationsTab.getAttribute('aria-selected')).toBe('true');
+      expect(scoresTab.getAttribute('aria-selected')).toBe('true');
       expect(screen.queryByText('Matches the experiment result score')).toBeNull();
-      expect(screen.getByRole('tab', { name: /evaluations \(1\)/i })).toBeDefined();
+      expect(screen.getByRole('tab', { name: /scores \(1\)/i })).toBeDefined();
     });
 
     it('shows selected-span feedback and widens the route overlay', async () => {

--- a/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
+++ b/packages/playground/src/pages/traces/__tests__/index.msw.test.tsx
@@ -272,7 +272,7 @@ describe('Traces side panel Scores tab', () => {
     const { queryClient } = renderPage('/traces?traceId=trace-a');
     await waitFor(() => expect(queryClient.isFetching()).toBe(0));
 
-    fireEvent.click(screen.getByRole('tab', { name: /evaluations/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /scores/i }));
     return queryClient;
   };
 


### PR DESCRIPTION
## Summary

`main` is currently red on `Unit and E2E Tests / Affected UNIT Test`, which makes the required `Merge Test Reports` check fail on every PR that touches an affected path (observed on #22931, `dynamic-workflow-steps`, `fix/gpt-mastracode`, `pltfrm-1461`, `pltfrm-1463`).

#22911 renamed the trace side-panel tab from **Evaluations** to **Scores** in `@mastra/playground-ui` and updated that package's tests, but two MSW tests in `packages/playground` still query `/evaluations/i`. They weren't in #22911's affected set, so CI didn't catch it there.

This updates the two tests to target the tab by its current name. Test-only change; no changeset.

Closes #22951

## Test plan

- [x] Red on `main` @ `936404b7c0`: `experiment-item-route.msw.test.tsx` ×3 + `traces/index.msw.test.tsx` ×2 fail with `Unable to find role="tab" and name /evaluations/i` (matches CI)
- [x] Green with this change: both files, 32/32
- [x] `tsc --noEmit -p tsconfig.build.json`, eslint, prettier on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The trace panel renamed the **Evaluations** tab to **Scores**. This PR updates two tests to use **Scores**, so the tests can pass again.

## Changes

- Updated `experiment-item-route.msw.test.tsx` to query the **Scores** tab.
- Updated `index.msw.test.tsx` to click the **Scores** tab.
- Preserved score details and feedback assertions.
- No production code or changeset changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->