### PR TITLE
fix(mcp): return _meta on tools/call results

### DIFF
--- a/.changeset/mcp-call-result-meta.md
+++ b/.changeset/mcp-call-result-meta.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+`MCPServer` now includes `_meta` on successful `tools/call` results when metadata is present. The tool's MCP Apps linkage (`_meta.ui.resourceUri`, plus the legacy flat `ui/resourceUri` key) is mirrored from `tools/list` so spec-compliant hosts can detect the app from the call result, and `_meta` returned by an MCP-aware tool alongside `structuredContent` is preserved (the author's UI linkage replaces the descriptor's and is normalized to both forms). Results with no metadata from either source are unchanged. Fixes #21277.

--- a/packages/mcp/src/server/server-call-result-meta.test.ts
+++ b/packages/mcp/src/server/server-call-result-meta.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression test for #21277: `tools/call` results must carry `_meta` so MCP Apps
+ * hosts can detect the app (`_meta.ui.resourceUri`) from the call result, and so
+ * `_meta` returned by an MCP-aware tool alongside `structuredContent` is preserved.
+ */
+import http from 'node:http';
+import { createTool } from '@mastra/core/tools';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { z } from 'zod/v3';
+import { MCPServer } from './server';
+
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 });
+
+const APP_URI = 'ui://weather/app.html';
+const LEGACY_URI = 'ui://legacy/app.html';
+
+describe('MCPServer tools/call result _meta (Issue #21277)', () => {
+  let server: MCPServer;
+  let httpServer: http.Server;
+  let client: Client;
+  const PORT = 9900 + Math.floor(Math.random() * 100);
+
+  beforeAll(async () => {
+    const outputSchema = z.object({ temperature: z.number() });
+
+    const appTool = createTool({
+      id: 'app-tool',
+      description: 'Tool linked to an MCP App via nested ui.resourceUri',
+      inputSchema: z.object({}),
+      outputSchema,
+      mcp: { _meta: { ui: { resourceUri: APP_URI }, customField: 'descriptor-only' } },
+      execute: async () => ({ temperature: 21 }),
+    });
+
+    const legacyAppTool = createTool({
+      id: 'legacy-app-tool',
+      description: 'Tool linked to an MCP App via the legacy flat key',
+      inputSchema: z.object({}),
+      outputSchema,
+      mcp: { _meta: { 'ui/resourceUri': LEGACY_URI } },
+      execute: async () => ({ temperature: 22 }),
+    });
+
+    const authorMetaTool = createTool({
+      id: 'author-meta-tool',
+      description: 'MCP-aware tool returning its own _meta',
+      inputSchema: z.object({}),
+      outputSchema,
+      mcp: { _meta: { ui: { resourceUri: APP_URI } } },
+      execute: async () => ({ temperature: 0 }),
+    });
+
+    const plainTool = createTool({
+      id: 'plain-tool',
+      description: 'Tool with no _meta anywhere',
+      inputSchema: z.object({}),
+      outputSchema,
+      execute: async () => ({ temperature: 24 }),
+    });
+
+    server = new MCPServer({
+      name: 'CallResultMetaTestServer',
+      version: '1.0.0',
+      tools: { appTool, legacyAppTool, authorMetaTool, plainTool },
+    });
+
+    // The MCP-aware return shape ({ structuredContent, _meta }) bypasses core's output
+    // validation only when returned by the converted tool, so mock it there (as server.test.ts does).
+    vi.spyOn(server.convertedTools.authorMetaTool!, 'execute').mockResolvedValue({
+      structuredContent: { temperature: 23 },
+      _meta: { ui: { resourceUri: 'ui://author/override.html' }, requestId: 'abc' },
+    });
+
+    httpServer = http.createServer(async (req, res) => {
+      const url = new URL(req.url || '', `http://localhost:${PORT}`);
+      await server.startHTTP({ url, httpPath: '/http', req, res, options: { sessionIdGenerator: undefined } });
+    });
+    await new Promise<void>(resolve => httpServer.listen(PORT, resolve));
+
+    client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} });
+    await client.connect(new StreamableHTTPClientTransport(new URL(`http://localhost:${PORT}/http`)));
+  });
+
+  afterAll(async () => {
+    await client?.close();
+    await server?.close();
+    await new Promise<void>((resolve, reject) => httpServer?.close(err => (err ? reject(err) : resolve())));
+  });
+
+  it('mirrors the tool descriptor ui.resourceUri onto the call result in both forms', async () => {
+    const result = await client.callTool({ name: 'appTool', arguments: {} });
+    expect(result.structuredContent).toEqual({ temperature: 21 });
+    expect(result._meta).toEqual({ ui: { resourceUri: APP_URI }, 'ui/resourceUri': APP_URI });
+  });
+
+  it('normalizes the legacy flat key into ui.resourceUri on the call result', async () => {
+    const result = await client.callTool({ name: 'legacyAppTool', arguments: {} });
+    expect(result._meta).toEqual({ ui: { resourceUri: LEGACY_URI }, 'ui/resourceUri': LEGACY_URI });
+  });
+
+  it('preserves _meta returned by an MCP-aware tool, letting the author override the descriptor', async () => {
+    const result = await client.callTool({ name: 'authorMetaTool', arguments: {} });
+    expect(result.structuredContent).toEqual({ temperature: 23 });
+    // Author's linkage replaces the descriptor's in BOTH forms — never split-brain.
+    expect(result._meta).toEqual({
+      ui: { resourceUri: 'ui://author/override.html' },
+      'ui/resourceUri': 'ui://author/override.html',
+      requestId: 'abc',
+    });
+  });
+
+  it('normalizes an author-supplied legacy-only key and drops the descriptor linkage', async () => {
+    vi.spyOn(server.convertedTools.authorMetaTool!, 'execute').mockResolvedValueOnce({
+      structuredContent: { temperature: 25 },
+      _meta: { 'ui/resourceUri': 'ui://author/legacy.html' },
+    });
+    const result = await client.callTool({ name: 'authorMetaTool', arguments: {} });
+    expect(result._meta).toEqual({
+      ui: { resourceUri: 'ui://author/legacy.html' },
+      'ui/resourceUri': 'ui://author/legacy.html',
+    });
+  });
+
+  it('keeps other author ui.* fields when the resourceUri comes from the descriptor', async () => {
+    vi.spyOn(server.convertedTools.authorMetaTool!, 'execute').mockResolvedValueOnce({
+      structuredContent: { temperature: 26 },
+      _meta: { ui: { visibility: ['model'] } },
+    });
+    const result = await client.callTool({ name: 'authorMetaTool', arguments: {} });
+    expect(result._meta).toEqual({
+      ui: { visibility: ['model'], resourceUri: APP_URI },
+      'ui/resourceUri': APP_URI,
+    });
+  });
+
+  it('does not copy descriptor-only _meta keys onto the call result, and leaves tools/list unchanged', async () => {
+    const result = await client.callTool({ name: 'appTool', arguments: {} });
+    expect(result._meta).not.toHaveProperty('customField');
+
+    const { tools } = await client.listTools();
+    const listed = tools.find(t => t.name === 'appTool');
+    expect(listed?._meta).toEqual({
+      ui: { resourceUri: APP_URI },
+      'ui/resourceUri': APP_URI,
+      customField: 'descriptor-only',
+    });
+  });
+
+  it('omits _meta when neither the descriptor nor the tool provides one', async () => {
+    const result = await client.callTool({ name: 'plainTool', arguments: {} });
+    expect(result.structuredContent).toEqual({ temperature: 24 });
+    expect(result._meta).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -91,6 +91,37 @@ const toMCPRequestHandlerExtra = (ctx: ServerContext): MCPRequestHandlerExtra =>
   };
 };
 
+/**
+ * Normalizes MCP Apps UI metadata for backward compatibility with older hosts:
+ * if `_meta.ui.resourceUri` is set, also set the legacy flat `ui/resourceUri` key,
+ * and vice versa. Returns the input untouched when neither is present.
+ */
+const normalizeUiResourceUriMeta = (meta: Record<string, unknown>): Record<string, unknown> => {
+  const uiMeta = meta.ui as { resourceUri?: string } | undefined;
+  const legacyUri = meta[RESOURCE_URI_META_KEY] as string | undefined;
+  if (uiMeta?.resourceUri && !legacyUri) {
+    return { ...meta, [RESOURCE_URI_META_KEY]: uiMeta.resourceUri };
+  }
+  if (legacyUri && !uiMeta?.resourceUri) {
+    return { ...meta, ui: { ...((meta.ui as object) ?? {}), resourceUri: legacyUri } };
+  }
+  return meta;
+};
+
+/**
+ * Extracts the MCP Apps UI linkage (`ui.resourceUri` in both nested and legacy flat
+ * form) from a tool's descriptor `_meta`, or `undefined` when the tool has no app.
+ * Only the linkage is extracted: the rest of the descriptor `_meta` (e.g.
+ * `mastra.strict`, author-defined keys) describes the tool, not a call result.
+ */
+const getUiResourceUriMeta = (toolMeta: Record<string, unknown> | undefined): Record<string, unknown> | undefined => {
+  if (!toolMeta) return undefined;
+  const normalized = normalizeUiResourceUriMeta(toolMeta);
+  const resourceUri = (normalized.ui as { resourceUri?: string } | undefined)?.resourceUri;
+  if (!resourceUri) return undefined;
+  return { ui: { resourceUri }, [RESOURCE_URI_META_KEY]: resourceUri };
+};
+
 // RFC 5424 syslog severity ordering used by the MCP logging utility.
 // Higher numbers are more severe; messages below a client's minimum level are dropped.
 const LOG_LEVEL_SEVERITY: Record<LoggingLevel, number> = {
@@ -990,17 +1021,7 @@ export class MCPServer extends MCPServerBase {
           }
           const toolMeta = withMastraToolStrictMeta(tool.mcp?._meta, tool.strict);
           if (toolMeta) {
-            // Normalize UI metadata for backward compatibility with older hosts:
-            // If _meta.ui.resourceUri is set, also set the legacy flat key and vice versa
-            const uiMeta = toolMeta.ui as { resourceUri?: string } | undefined;
-            const legacyUri = toolMeta[RESOURCE_URI_META_KEY] as string | undefined;
-            if (uiMeta?.resourceUri && !legacyUri) {
-              toolSpec._meta = { ...toolMeta, [RESOURCE_URI_META_KEY]: uiMeta.resourceUri };
-            } else if (legacyUri && !uiMeta?.resourceUri) {
-              toolSpec._meta = { ...toolMeta, ui: { ...((toolMeta.ui as object) ?? {}), resourceUri: legacyUri } };
-            } else {
-              toolSpec._meta = toolMeta;
-            }
+            toolSpec._meta = normalizeUiResourceUriMeta(toolMeta);
           }
           return toolSpec;
         }),
@@ -1205,6 +1226,33 @@ export class MCPServer extends MCPServerBase {
               text: typeof result === 'string' ? result : JSON.stringify(result),
             },
           ];
+        }
+
+        // MCP Apps hosts read `_meta.ui.resourceUri` off the call result to open the app
+        // (#21277). Preserve any `_meta` an MCP-aware tool returned alongside
+        // `structuredContent`, and ensure the UI linkage is present in both nested and
+        // legacy form — from the author if they supplied one, else from the descriptor.
+        const authorMeta =
+          result &&
+          typeof result === 'object' &&
+          'structuredContent' in result &&
+          result._meta &&
+          typeof result._meta === 'object' &&
+          !Array.isArray(result._meta)
+            ? (result._meta as Record<string, unknown>)
+            : undefined;
+        // An author-supplied linkage (either form) wins over the descriptor's so nested and
+        // legacy keys never disagree; other author `ui.*` fields are kept.
+        const uiMeta = getUiResourceUriMeta(authorMeta) ?? getUiResourceUriMeta(tool.mcp?._meta);
+        if (uiMeta || authorMeta) {
+          const authorUi = authorMeta?.ui;
+          response._meta = {
+            ...authorMeta,
+            ...uiMeta,
+            ...(uiMeta && authorUi && typeof authorUi === 'object' && !Array.isArray(authorUi)
+              ? { ui: { ...(authorUi as Record<string, unknown>), ...(uiMeta.ui as Record<string, unknown>) } }
+              : {}),
+          };
         }
 
         return response;


### PR DESCRIPTION
## Summary

`MCPServer` stamps `_meta.ui.resourceUri` on tool descriptors in `tools/list`, but built every `tools/call` result as `{ isError, content }` with no `_meta`. MCP Apps hosts that read the app linkage off the call result never saw it, and any `_meta` an MCP-aware tool returned alongside `structuredContent` was dropped.

Successful `tools/call` results now carry `_meta` when there is metadata to carry:

- The tool's UI linkage is mirrored from the descriptor in both forms — nested `ui.resourceUri` and the legacy flat `ui/resourceUri` key — using the same normalization `tools/list` already applies (extracted into `normalizeUiResourceUriMeta`).
- `_meta` returned by an MCP-aware tool (`{ structuredContent, _meta }`) is preserved. If the author supplies a UI linkage in either form, theirs replaces the descriptor's and is normalized so the two keys never disagree; other author `ui.*` fields are kept.
- Results with no metadata from either source are unchanged (no empty `_meta`).

Only the UI linkage is mirrored from the descriptor. The rest of descriptor `_meta` (e.g. `mastra.strict`, arbitrary author keys) describes the tool, not a call result, so it stays on `tools/list`.

### Scope decisions

- **Error results get no `_meta`.** The linkage matters when a host has a result to render; the unknown-tool / validation / thrown-error paths return early and are untouched.
- **Author `_meta` requires the MCP-aware envelope.** `createTool` validates raw output against `outputSchema` before the server sees it, so a Mastra tool with an `outputSchema` cannot return `{ structuredContent, _meta }` today. That is pre-existing (the same is true of author-supplied `content`), and the test for this path mocks the converted tool's executor, as `server.test.ts` already does for `content`.

### Prior work

Two earlier PRs address the same issue and both mirror the *full* descriptor `_meta` onto call results:

- #21344 by @ameyypawar
- #22454 by @Linz1248

This PR credits both as co-authors and narrows the mirrored set to the UI linkage.

Closes #21277

## Test plan

- [x] New `server-call-result-meta.test.ts` (7 tests): 6 fail on `main` (`_meta` undefined; only the no-metadata case passes), 7 pass with the fix. Covers nested and legacy descriptor forms, author override in both forms, author `ui.*` sibling preservation, descriptor-only keys excluded, `tools/list` unchanged, no-metadata result unchanged.
- [x] `pnpm vitest run src/server` in `packages/mcp`: 162/162
- [x] `tsc --noEmit`, eslint, prettier clean
- [x] Changeset: `@mastra/mcp` patch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a tool runs successfully, MCP hosts can now find its related app. The server also keeps metadata returned by the tool.

## Changes

- Adds `_meta` to successful `tools/call` results when metadata exists.
- Supports nested `ui.resourceUri` and legacy `ui/resourceUri` formats.
- Preserves tool-provided `_meta` and other `ui.*` fields.
- Gives tool-provided UI linkage priority over descriptor metadata.
- Excludes unrelated descriptor metadata.
- Omits empty `_meta`.
- Detects legacy UI linkage when advertising MCP Apps capabilities.
- Keeps error responses and `tools/list` behavior unchanged.
- Adds regression tests and a patch changeset for `@mastra/mcp`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->