### PR TITLE
feat(observability): enrich score trace predicates

### DIFF
--- a/.changeset/six-ads-look.md
+++ b/.changeset/six-ads-look.md
@@ -1,0 +1,9 @@
+---
+'@mastra/duckdb': minor
+---
+
+Added DuckDB support for richer score predicates in advanced trace queries.
+
+```ts
+where: { scores: { some: { op: "eq", left: { path: "scoreSource" }, right: { literal: "automated" } } } }
+```

--- a/.changeset/six-ads-look.md
+++ b/.changeset/six-ads-look.md
@@ -5,5 +5,8 @@
 Added DuckDB support for richer score predicates in advanced trace queries.
 
 ```ts
-where: { scores: { some: { op: "eq", left: { path: "scoreSource" }, right: { literal: "automated" } } } }
+await mastraClient.queryTraces({
+  timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
+  where: { scores: { some: { op: 'eq', left: { path: 'scoreSource' }, right: { literal: 'automated' } } } },
+})
 ```

--- a/.changeset/thirty-coins-sit.md
+++ b/.changeset/thirty-coins-sit.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': minor
+---
+
+Added richer `scores.some` and `scores.none` predicates for scorer versions, sources, timestamps, span anchoring, and version lineage.
+
+```ts
+where: { scores: { some: { op: "eq", left: { path: "scorerVersion" }, right: { literal: "2.1.0" } } } }
+```

--- a/.changeset/thirty-coins-sit.md
+++ b/.changeset/thirty-coins-sit.md
@@ -5,5 +5,8 @@
 Added richer `scores.some` and `scores.none` predicates for scorer versions, sources, timestamps, span anchoring, and version lineage.
 
 ```ts
-where: { scores: { some: { op: "eq", left: { path: "scorerVersion" }, right: { literal: "2.1.0" } } } }
+await mastraClient.queryTraces({
+  timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
+  where: { scores: { some: { op: 'eq', left: { path: 'scorerVersion' }, right: { literal: '2.1.0' } } } },
+})
 ```

--- a/.changeset/tired-hotels-dress.md
+++ b/.changeset/tired-hotels-dress.md
@@ -1,0 +1,9 @@
+---
+'@mastra/pg': minor
+---
+
+Added PostgreSQL support for richer score predicates in advanced trace queries.
+
+```ts
+where: { scores: { some: { op: "exists", path: "spanId" } } }
+```

--- a/.changeset/tired-hotels-dress.md
+++ b/.changeset/tired-hotels-dress.md
@@ -5,5 +5,8 @@
 Added PostgreSQL support for richer score predicates in advanced trace queries.
 
 ```ts
-where: { scores: { some: { op: "exists", path: "spanId" } } }
+await mastraClient.queryTraces({
+  timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
+  where: { scores: { some: { op: 'exists', path: 'spanId' } } },
+})
 ```

--- a/.changeset/tough-dryers-carry.md
+++ b/.changeset/tough-dryers-carry.md
@@ -1,0 +1,9 @@
+---
+'@mastra/clickhouse': minor
+---
+
+Added ClickHouse support for richer score predicates in advanced trace queries.
+
+```ts
+where: { scores: { some: { op: "gte", left: { path: "timestamp" }, right: { literal: "2026-08-01T00:00:00.000Z" } } } }
+```

--- a/.changeset/tough-dryers-carry.md
+++ b/.changeset/tough-dryers-carry.md
@@ -5,5 +5,8 @@
 Added ClickHouse support for richer score predicates in advanced trace queries.
 
 ```ts
-where: { scores: { some: { op: "gte", left: { path: "timestamp" }, right: { literal: "2026-08-01T00:00:00.000Z" } } } }
+await mastraClient.queryTraces({
+  timeRange: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' },
+  where: { scores: { some: { op: 'gte', left: { path: 'timestamp' }, right: { literal: '2026-08-01T00:00:00.000Z' } } } },
+})
 ```

--- a/docs/src/content/en/reference/observability/tracing/trace-query.mdx
+++ b/docs/src/content/en/reference/observability/tracing/trace-query.mdx
@@ -28,6 +28,7 @@ const result = await mastraClient.queryTraces({
         op: 'and',
         args: [
           { op: 'eq', left: { path: 'scorerId' }, right: { literal: 'factuality' } },
+          { op: 'eq', left: { path: 'scorerVersion' }, right: { literal: '2.1.0' } },
           { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
         ],
       },
@@ -38,7 +39,7 @@ const result = await mastraClient.queryTraces({
 })
 ```
 
-A `some` clause matches when one related record satisfies its complete nested predicate. In this example, `scorerId` and `score` must match on the same score record. A `none` clause matches when no related record satisfies its complete nested predicate.
+A `some` clause matches when one related record satisfies its complete nested predicate. In this example, `scorerId`, `scorerVersion`, and `score` must match on the same score record. A `none` clause uses anti-existence semantics: it matches when no related record satisfies its complete nested predicate. A trace with no related scores therefore matches `scores.none`.
 
 Span clauses examine the current root span and current child spans. The root `timeRange` applies only to the selected current root's `startedAt`. Related spans and scores can participate even when their own timestamps are outside that range. Related records correlate only through a matching non-null `traceId`.
 
@@ -109,10 +110,56 @@ Hono and Fastify enforce the request-body limit before JSON parsing. Express and
 | Trace | `startedAt`, `endedAt` | `eq`, `ne`, `in`, `notIn`, `lt`, `lte`, `gt`, `gte`, `exists`, `notExists` |
 | Span | `spanType` | `eq`, `ne`, `in`, `notIn`, `exists`, `notExists` |
 | Span | `error` | `exists`, `notExists` |
-| Score | `scorerId` | `eq`, `ne`, `in`, `notIn`, `exists`, `notExists` |
-| Score | `score` | `eq`, `ne`, `in`, `notIn`, `lt`, `lte`, `gt`, `gte`, `exists`, `notExists` |
+| Score | `scorerId`, `scorerVersion`, `scoreSource`, `entityVersionId`, `parentEntityVersionId`, `rootEntityVersionId` | `eq`, `ne`, `in`, `notIn`, `exists`, `notExists` |
+| Score | `score`, `timestamp` | `eq`, `ne`, `in`, `notIn`, `lt`, `lte`, `gt`, `gte`, `exists`, `notExists` |
+| Score | `spanId` | `exists`, `notExists` |
 
 Compose predicates with `{ op: 'and', args: [...] }`, `{ op: 'or', args: [...] }`, and `{ op: 'not', arg: ... }`. Comparison predicates place a field reference on the left and a literal on the right. Membership predicates use a field reference in `value` and a homogeneous literal array in `set`.
+
+String comparisons are exact and case-sensitive. Literals are never coerced: numeric score predicates require numbers, and timestamp predicates require ISO timestamp strings. Positive and ordered predicates don't match a missing value. The negative operators `ne` and `notIn` do match a missing value. Combine a negative predicate with `exists` when the field must also be present.
+
+### Filter by score time
+
+Score timestamps are independent of the required top-level trace `timeRange`. The top-level range selects trace candidates by trace start time. A nested `timestamp` predicate limits related score records:
+
+```typescript
+const query = {
+  where: {
+    scores: {
+      some: {
+        op: 'and',
+        args: [
+          { op: 'eq', left: { path: 'scoreSource' }, right: { literal: 'automated' } },
+          {
+            op: 'gte',
+            left: { path: 'timestamp' },
+            right: { literal: '2026-07-15T00:00:00.000Z' },
+          },
+          {
+            op: 'lt',
+            left: { path: 'timestamp' },
+            right: { literal: '2026-08-01T00:00:00.000Z' },
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+### Filter by span anchoring
+
+Use `spanId` only to test whether a score targets a span. The predicate doesn't join the score to a matching span predicate:
+
+```typescript
+// At least one score targets a span.
+const anchoredToSpanWhere = { scores: { some: { op: 'exists', path: 'spanId' } } }
+
+// At least one score applies to the trace rather than a span.
+const traceLevelScoreWhere = { scores: { some: { op: 'notExists', path: 'spanId' } } }
+```
+
+The deprecated `source` field and `scorerName` aren't available as score predicate fields. Use the canonical `scoreSource` and `scorerId` fields.
 
 ## Responses
 

--- a/docs/src/content/en/reference/observability/tracing/trace-query.mdx
+++ b/docs/src/content/en/reference/observability/tracing/trace-query.mdx
@@ -116,7 +116,7 @@ Hono and Fastify enforce the request-body limit before JSON parsing. Express and
 
 Compose predicates with `{ op: 'and', args: [...] }`, `{ op: 'or', args: [...] }`, and `{ op: 'not', arg: ... }`. Comparison predicates place a field reference on the left and a literal on the right. Membership predicates use a field reference in `value` and a homogeneous literal array in `set`.
 
-String comparisons are exact and case-sensitive. Literals are never coerced: numeric score predicates require numbers, and timestamp predicates require ISO timestamp strings. Positive and ordered predicates don't match a missing value. The negative operators `ne` and `notIn` do match a missing value. Combine a negative predicate with `exists` when the field must also be present.
+String comparisons are exact and case-sensitive, and literals are never coerced. Numeric score predicates therefore require numbers, while timestamp predicates require ISO timestamp strings. A missing value satisfies neither positive nor ordered predicates, although it does satisfy the negative operators `ne` and `notIn`. Combine a negative predicate with `exists` when the field must also be present.
 
 ### Filter by score time
 

--- a/docs/src/content/en/reference/observability/tracing/trace-query.mdx
+++ b/docs/src/content/en/reference/observability/tracing/trace-query.mdx
@@ -124,6 +124,10 @@ Score timestamps are independent of the required top-level trace `timeRange`. Th
 
 ```typescript
 const query = {
+  timeRange: {
+    from: '2026-08-01T00:00:00.000Z',
+    to: '2026-08-08T00:00:00.000Z',
+  },
   where: {
     scores: {
       some: {

--- a/packages/core/src/storage/domains/observability/trace-query.test.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.test.ts
@@ -211,6 +211,115 @@ describe('planTraceQuery', () => {
     });
   });
 
+  it('plans richer score fields with their field-specific semantics', () => {
+    const plan = planTraceQuery(
+      parsed({
+        ...baseRequest,
+        where: {
+          scores: {
+            some: {
+              op: 'and',
+              args: [
+                { op: 'in', value: { path: 'scorerVersion' }, set: ['v1', 'v2'] },
+                { op: 'eq', left: { path: 'scoreSource' }, right: { literal: 'automated' } },
+                {
+                  op: 'gte',
+                  left: { path: 'timestamp' },
+                  right: { literal: '2026-08-10T02:00:00+02:00' },
+                },
+                { op: 'exists', path: 'spanId' },
+                { op: 'notExists', path: 'parentEntityVersionId' },
+                { op: 'eq', left: { path: 'entityVersionId' }, right: { literal: 'entity-v2' } },
+                { op: 'notIn', value: { path: 'rootEntityVersionId' }, set: ['root-v1'] },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    expect(plan.where).toMatchObject({
+      type: 'relation',
+      collection: 'scores',
+      quantifier: 'some',
+      predicate: {
+        type: 'boolean',
+        operator: 'and',
+        args: [
+          { type: 'membership', field: 'scorerVersion', operator: 'in', values: ['v1', 'v2'] },
+          { type: 'comparison', field: 'scoreSource', operator: 'eq', value: 'automated' },
+          { type: 'comparison', field: 'timestamp', operator: 'gte', value: '2026-08-10T00:00:00.000Z' },
+          { type: 'presence', field: 'spanId', operator: 'exists' },
+          { type: 'presence', field: 'parentEntityVersionId', operator: 'notExists' },
+          { type: 'comparison', field: 'entityVersionId', operator: 'eq', value: 'entity-v2' },
+          { type: 'membership', field: 'rootEntityVersionId', operator: 'notIn', values: ['root-v1'] },
+        ],
+      },
+    });
+  });
+
+  it('rejects unapproved score fields and invalid score operator/type combinations', () => {
+    for (const field of ['source', 'scorerName']) {
+      const error = validationError(() =>
+        planTraceQuery(
+          parsed({
+            ...baseRequest,
+            where: { scores: { some: { op: 'exists', path: field } } },
+          }),
+        ),
+      );
+      expect(error.issues[0]).toMatchObject({
+        code: 'field_not_allowed',
+        path: ['where', 'scores', 'some', 'path'],
+      });
+    }
+
+    const orderedString = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          where: {
+            scores: { some: { op: 'lt', left: { path: 'scoreSource' }, right: { literal: 'manual' } } },
+          },
+        }),
+      ),
+    );
+    expect(orderedString.issues).toContainEqual(
+      expect.objectContaining({ code: 'operator_not_allowed', path: ['where', 'scores', 'some', 'op'] }),
+    );
+
+    const comparedSpanId = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          where: { scores: { some: { op: 'eq', left: { path: 'spanId' }, right: { literal: 'span-1' } } } },
+        }),
+      ),
+    );
+    expect(comparedSpanId.issues).toContainEqual(
+      expect.objectContaining({ code: 'operator_not_allowed', path: ['where', 'scores', 'some', 'op'] }),
+    );
+
+    const malformedTimestamp = validationError(() =>
+      planTraceQuery(
+        parsed({
+          ...baseRequest,
+          where: {
+            scores: {
+              some: { op: 'gte', left: { path: 'timestamp' }, right: { literal: 'August 10, 2026' } },
+            },
+          },
+        }),
+      ),
+    );
+    expect(malformedTimestamp.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'invalid_literal',
+        path: ['where', 'scores', 'some', 'right', 'literal'],
+      }),
+    );
+  });
+
   it('enforces field-specific operators and literal types', () => {
     const badErrorOperator = validationError(() =>
       planTraceQuery(

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -23,6 +23,7 @@ const hasMaxUtf8Bytes = (value: string, maxBytes: number) => Buffer.byteLength(v
 const literalStringSchema = z
   .string()
   .refine(value => hasMaxUtf8Bytes(value, TRACE_QUERY_MAX_STRING_BYTES), 'String literal is too large');
+const timestampLiteralSchema = z.string().datetime({ offset: true });
 const predicatePathSchema = z
   .string()
   .min(1)
@@ -215,7 +216,16 @@ export type TraceQueryField =
   | 'environment'
   | 'status';
 export type TraceQuerySpanField = 'spanType' | 'error';
-export type TraceQueryScoreField = 'scorerId' | 'score';
+export type TraceQueryScoreField =
+  | 'scorerId'
+  | 'scorerVersion'
+  | 'scoreSource'
+  | 'score'
+  | 'timestamp'
+  | 'spanId'
+  | 'entityVersionId'
+  | 'parentEntityVersionId'
+  | 'rootEntityVersionId';
 export type TraceQueryCanonicalField = TraceQueryField | TraceQuerySpanField | TraceQueryScoreField;
 export type TraceQueryComparisonOperator = 'eq' | 'ne' | 'lt' | 'lte' | 'gt' | 'gte';
 export type TraceQueryMembershipOperator = 'in' | 'notIn';
@@ -362,7 +372,14 @@ const SPAN_FIELD_RULES: Record<TraceQuerySpanField, FieldRule> = {
 
 const SCORE_FIELD_RULES: Record<TraceQueryScoreField, FieldRule> = {
   scorerId: { type: 'string', operators: STRING_OPERATORS },
+  scorerVersion: { type: 'string', operators: STRING_OPERATORS },
+  scoreSource: { type: 'string', operators: STRING_OPERATORS },
   score: { type: 'number', operators: ORDERED_OPERATORS },
+  timestamp: { type: 'timestamp', operators: ORDERED_OPERATORS },
+  spanId: { type: 'presence', operators: PRESENCE_OPERATORS },
+  entityVersionId: { type: 'string', operators: STRING_OPERATORS },
+  parentEntityVersionId: { type: 'string', operators: STRING_OPERATORS },
+  rootEntityVersionId: { type: 'string', operators: STRING_OPERATORS },
 };
 
 type PredicateContext = 'trace' | 'spans' | 'scores';
@@ -722,9 +739,8 @@ function normalizePath(path: string): string {
 function normalizeLiteral(value: TraceQueryLiteral, rule: FieldRule): string | number | undefined {
   if (rule.type === 'number') return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
   if (rule.type === 'timestamp') {
-    if (typeof value !== 'string') return undefined;
-    const timestamp = new Date(value);
-    return Number.isNaN(timestamp.getTime()) ? undefined : timestamp.toISOString();
+    const timestamp = timestampLiteralSchema.safeParse(value);
+    return timestamp.success ? new Date(timestamp.data).toISOString() : undefined;
   }
   if (rule.type === 'string') return typeof value === 'string' ? value : undefined;
   return undefined;

--- a/packages/core/src/storage/domains/observability/trace-query.ts
+++ b/packages/core/src/storage/domains/observability/trace-query.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { z } from 'zod/v4';
+import type { ScoreRecord } from './scores';
 
 export const TRACE_QUERY_MAX_DEPTH = 12;
 export const TRACE_QUERY_MAX_NODES = 100;
@@ -216,16 +217,7 @@ export type TraceQueryField =
   | 'environment'
   | 'status';
 export type TraceQuerySpanField = 'spanType' | 'error';
-export type TraceQueryScoreField =
-  | 'scorerId'
-  | 'scorerVersion'
-  | 'scoreSource'
-  | 'score'
-  | 'timestamp'
-  | 'spanId'
-  | 'entityVersionId'
-  | 'parentEntityVersionId'
-  | 'rootEntityVersionId';
+export type TraceQueryScoreField = keyof typeof SCORE_FIELD_RULES;
 export type TraceQueryCanonicalField = TraceQueryField | TraceQuerySpanField | TraceQueryScoreField;
 export type TraceQueryComparisonOperator = 'eq' | 'ne' | 'lt' | 'lte' | 'gt' | 'gte';
 export type TraceQueryMembershipOperator = 'in' | 'notIn';
@@ -370,7 +362,7 @@ const SPAN_FIELD_RULES: Record<TraceQuerySpanField, FieldRule> = {
   error: { type: 'presence', operators: PRESENCE_OPERATORS },
 };
 
-const SCORE_FIELD_RULES: Record<TraceQueryScoreField, FieldRule> = {
+const SCORE_FIELD_RULES = {
   scorerId: { type: 'string', operators: STRING_OPERATORS },
   scorerVersion: { type: 'string', operators: STRING_OPERATORS },
   scoreSource: { type: 'string', operators: STRING_OPERATORS },
@@ -380,7 +372,7 @@ const SCORE_FIELD_RULES: Record<TraceQueryScoreField, FieldRule> = {
   entityVersionId: { type: 'string', operators: STRING_OPERATORS },
   parentEntityVersionId: { type: 'string', operators: STRING_OPERATORS },
   rootEntityVersionId: { type: 'string', operators: STRING_OPERATORS },
-};
+} as const satisfies Partial<Record<Extract<keyof ScoreRecord, string>, FieldRule>>;
 
 type PredicateContext = 'trace' | 'spans' | 'scores';
 

--- a/packages/server/src/server/handlers/observability-trace-query.test.ts
+++ b/packages/server/src/server/handlers/observability-trace-query.test.ts
@@ -88,6 +88,9 @@ describe('QUERY_TRACES', () => {
     );
 
     expect(response).toMatchObject({ traces: [{ traceId: 'trace-a' }] });
+    if (!('traces' in response)) throw new Error('Expected trace results');
+    expect(Object.keys(response.traces[0]!)).toHaveLength(10);
+    expect(response.traces[0]).not.toHaveProperty('scores');
     expect(getStore).toHaveBeenCalledWith('observability');
     expect(observabilityStore.queryTraces).toHaveBeenCalledWith(
       expect.objectContaining({ result: 'traces', limit: 100, binding: expect.any(String) }),
@@ -122,6 +125,47 @@ describe('QUERY_TRACES', () => {
       issues: [{ code: 'field_not_allowed', path: ['where', 'left', 'path'] }],
     });
     expect(JSON.stringify(body)).not.toContain('sensitive search');
+    expect(getStore).not.toHaveBeenCalled();
+    expect(observabilityStore.queryTraces).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid score operators and literals before touching storage', async () => {
+    const { mastra, observabilityStore, getStore } = createHarness();
+    const cases = [
+      {
+        predicate: { op: 'lt', left: { path: 'scoreSource' }, right: { literal: 'sensitive-source' } },
+        issue: { code: 'operator_not_allowed', path: ['where', 'scores', 'some', 'op'] },
+      },
+      {
+        predicate: { op: 'eq', left: { path: 'spanId' }, right: { literal: 'sensitive-span' } },
+        issue: { code: 'operator_not_allowed', path: ['where', 'scores', 'some', 'op'] },
+      },
+      {
+        predicate: { op: 'lt', left: { path: 'score' }, right: { literal: '0.6-sensitive' } },
+        issue: { code: 'invalid_literal', path: ['where', 'scores', 'some', 'right', 'literal'] },
+      },
+      {
+        predicate: { op: 'gte', left: { path: 'timestamp' }, right: { literal: 'sensitive-date' } },
+        issue: { code: 'invalid_literal', path: ['where', 'scores', 'some', 'right', 'literal'] },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const error = await captureHttpException(
+        QUERY_TRACES.handler(
+          params(mastra, {
+            timeRange: TIME_RANGE,
+            where: { scores: { some: testCase.predicate } },
+          }),
+        ),
+      );
+      expect(error.status).toBe(422);
+      const body = await error.getResponse().json();
+      expect(body).toMatchObject({ code: 'TRACE_QUERY_INVALID' });
+      expect(body.issues).toContainEqual(expect.objectContaining(testCase.issue));
+      expect(JSON.stringify(body)).not.toContain('sensitive');
+    }
+
     expect(getStore).not.toHaveBeenCalled();
     expect(observabilityStore.queryTraces).not.toHaveBeenCalled();
   });

--- a/stores/_test-utils/src/domains/observability-vnext/index.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/index.ts
@@ -178,17 +178,21 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
         for (const span of records) await storage.createSpan({ span });
 
         const scores = fixture.scores
-          .filter(score => score.traceId !== null && score.score !== null)
+          .filter(score => score.score !== null)
           .map(score => {
-            const timestamp = score.timestamp
-              ? new Date(score.timestamp)
-              : new Date(Date.UTC(2026, 7, 1, 0, 0, 0, score.cursorId));
+            const timestamp = new Date(score.timestamp);
             return {
               id: score.scoreId,
               scoreId: score.scoreId,
-              traceId: score.traceId!,
+              traceId: score.traceId,
+              spanId: score.spanId,
               scorerId: score.scorerId,
+              scorerVersion: score.scorerVersion,
+              scoreSource: score.scoreSource,
               score: score.score!,
+              entityVersionId: score.entityVersionId,
+              parentEntityVersionId: score.parentEntityVersionId,
+              rootEntityVersionId: score.rootEntityVersionId,
               timestamp,
               createdAt: timestamp,
               updatedAt: null,

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
@@ -275,22 +275,8 @@ export const TRACE_QUERY_TIED_TIMESTAMP_FIXTURE_DATA: TraceQueryFixtureData = {
     }),
   ],
   scores: [
-    {
-      cursorId: 100,
-      scoreId: 'score-tied',
-      traceId: 'trace-tied',
-      scorerId: 'factuality',
-      score: 0.9,
-      timestamp: tiedScoreTimestamp,
-    },
-    {
-      cursorId: 101,
-      scoreId: 'score-tied',
-      traceId: 'trace-tied',
-      scorerId: 'factuality',
-      score: 0.2,
-      timestamp: tiedScoreTimestamp,
-    },
+    scoreRecord(100, 'score-tied', 'trace-tied', 'factuality', 0.9, { timestamp: tiedScoreTimestamp }),
+    scoreRecord(101, 'score-tied', 'trace-tied', 'factuality', 0.2, { timestamp: tiedScoreTimestamp }),
   ],
 };
 

--- a/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/trace-query.ts
@@ -35,9 +35,15 @@ export interface RawTraceQueryScore {
   cursorId: number;
   scoreId: string;
   traceId: string | null;
+  spanId: string | null;
+  timestamp: string;
   scorerId: string;
+  scorerVersion: string | null;
+  scoreSource: string | null;
   score: number | null;
-  timestamp?: string;
+  entityVersionId: string | null;
+  parentEntityVersionId: string | null;
+  rootEntityVersionId: string | null;
 }
 
 export interface TraceQueryFixtureData {
@@ -65,6 +71,29 @@ const span = (
   entityName: 'agent',
   entityType: 'agent',
   environment: 'production',
+  ...overrides,
+});
+
+const scoreRecord = (
+  cursorId: number,
+  scoreId: string,
+  traceId: string | null,
+  scorerId: string,
+  score: number | null,
+  overrides: Partial<RawTraceQueryScore> = {},
+): RawTraceQueryScore => ({
+  cursorId,
+  scoreId,
+  traceId,
+  spanId: null,
+  timestamp: '2026-08-10T00:00:00.000Z',
+  scorerId,
+  scorerVersion: null,
+  scoreSource: null,
+  score,
+  entityVersionId: null,
+  parentEntityVersionId: null,
+  rootEntityVersionId: null,
   ...overrides,
 });
 
@@ -144,13 +173,60 @@ export const TRACE_QUERY_FIXTURE_DATA: TraceQueryFixtureData = {
     }),
   ],
   scores: [
-    { cursorId: 1, scoreId: 'score-a-factuality', traceId: 'trace-a', scorerId: 'factuality', score: 0.9 },
-    { cursorId: 2, scoreId: 'score-a-factuality', traceId: 'trace-a', scorerId: 'factuality', score: 0.4 },
-    { cursorId: 3, scoreId: 'score-a-safety', traceId: 'trace-a', scorerId: 'safety', score: 0.95 },
-    { cursorId: 4, scoreId: 'score-b-factuality', traceId: 'trace-b', scorerId: 'factuality', score: 0.9 },
-    { cursorId: 5, scoreId: 'score-b-safety', traceId: 'trace-b', scorerId: 'safety', score: 0.4 },
-    { cursorId: 6, scoreId: 'score-c-factuality', traceId: 'trace-c', scorerId: 'factuality', score: null },
-    { cursorId: 7, scoreId: 'score-uncorrelated', traceId: null, scorerId: 'factuality', score: 0.1 },
+    scoreRecord(1, 'score-a-factuality', 'trace-a', 'factuality', 0.9, {
+      spanId: 'span-a-tool',
+      timestamp: '2026-07-19T10:00:00.000Z',
+      scorerVersion: 'v1',
+      scoreSource: 'manual',
+      entityVersionId: 'entity-v1',
+      parentEntityVersionId: 'parent-v1',
+      rootEntityVersionId: 'root-v1',
+    }),
+    scoreRecord(2, 'score-a-factuality', 'trace-a', 'factuality', 0.4, {
+      spanId: 'span-a-tool',
+      timestamp: '2026-07-20T10:00:00.000Z',
+      scorerVersion: 'v2',
+      scoreSource: 'automated',
+      entityVersionId: 'entity-v2',
+      parentEntityVersionId: 'parent-v2',
+      rootEntityVersionId: 'root-v1',
+    }),
+    scoreRecord(3, 'score-a-safety', 'trace-a', 'safety', 0.95, {
+      timestamp: '2026-08-05T10:00:03.000Z',
+      scorerVersion: 'v1',
+      scoreSource: 'automated',
+      entityVersionId: 'safety-v1',
+      rootEntityVersionId: 'root-v1',
+    }),
+    scoreRecord(4, 'score-b-factuality', 'trace-b', 'factuality', 0.9, {
+      spanId: 'span-b-tool',
+      timestamp: '2026-08-06T10:00:00.000Z',
+      scorerVersion: 'v2',
+      scoreSource: 'automated',
+      entityVersionId: 'entity-v2',
+      parentEntityVersionId: 'parent-v2',
+      rootEntityVersionId: 'root-v1',
+    }),
+    scoreRecord(5, 'score-b-safety', 'trace-b', 'safety', 0.4, {
+      timestamp: '2026-08-06T10:00:01.000Z',
+      scorerVersion: 'v1',
+      scoreSource: 'manual',
+      entityVersionId: 'safety-v1',
+      rootEntityVersionId: 'root-v2',
+    }),
+    scoreRecord(6, 'score-c-factuality', 'trace-c', 'factuality', 0.7, {
+      timestamp: '2026-08-07T10:00:03.000Z',
+    }),
+    scoreRecord(7, 'score-uncorrelated', null, 'factuality', 0.1, {
+      timestamp: '2026-07-20T10:00:00.000Z',
+      scorerVersion: 'v2',
+      scoreSource: 'automated',
+    }),
+    scoreRecord(8, 'score-nonmatching-trace', 'trace-without-root', 'factuality', 0.1, {
+      timestamp: '2026-07-20T10:00:00.000Z',
+      scorerVersion: 'v2',
+      scoreSource: 'automated',
+    }),
   ],
 };
 
@@ -296,6 +372,115 @@ export const TRACE_QUERY_CONFORMANCE_CASES: TraceQueryConformanceCase[] = [
       },
     },
     expected: [{ traceId: 'trace-a' }],
+  },
+  {
+    name: 'binds scorer version and threshold to one current score record',
+    request: {
+      timeRange: fullRange,
+      where: {
+        scores: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'scorerVersion' }, right: { literal: 'v2' } },
+              { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-a' }],
+  },
+  {
+    name: 'filters current scores by source and an independent score-time range',
+    request: {
+      timeRange: fullRange,
+      where: {
+        scores: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'scoreSource' }, right: { literal: 'automated' } },
+              {
+                op: 'gte',
+                left: { path: 'timestamp' },
+                right: { literal: '2026-07-15T00:00:00Z' },
+              },
+              {
+                op: 'lt',
+                left: { path: 'timestamp' },
+                right: { literal: '2026-08-01T00:00:00Z' },
+              },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-a' }],
+  },
+  {
+    name: 'filters scores by span anchoring presence',
+    request: {
+      timeRange: fullRange,
+      where: { scores: { some: { op: 'exists', path: 'spanId' } } },
+    },
+    expected: [{ traceId: 'trace-a' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'filters scores by missing span anchoring',
+    request: {
+      timeRange: fullRange,
+      where: { scores: { some: { op: 'notExists', path: 'spanId' } } },
+    },
+    expected: [{ traceId: 'trace-c' }, { traceId: 'trace-a' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'binds version lineage and threshold to one current score record',
+    request: {
+      timeRange: fullRange,
+      where: {
+        scores: {
+          some: {
+            op: 'and',
+            args: [
+              { op: 'eq', left: { path: 'entityVersionId' }, right: { literal: 'entity-v2' } },
+              { op: 'in', value: { path: 'parentEntityVersionId' }, set: ['parent-v2'] },
+              { op: 'notIn', value: { path: 'rootEntityVersionId' }, set: ['root-v2'] },
+              { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
+            ],
+          },
+        },
+      },
+    },
+    expected: [{ traceId: 'trace-a' }],
+  },
+  {
+    name: 'supports missing-required-scorer anti-existence',
+    request: {
+      timeRange: fullRange,
+      where: {
+        scores: { none: { op: 'eq', left: { path: 'scorerId' }, right: { literal: 'safety' } } },
+      },
+    },
+    expected: [{ traceId: 'trace-d' }, { traceId: 'trace-c' }],
+  },
+  {
+    name: 'includes missing string values in negative membership predicates',
+    request: {
+      timeRange: fullRange,
+      where: { scores: { some: { op: 'notIn', value: { path: 'scorerVersion' }, set: ['v2'] } } },
+    },
+    expected: [{ traceId: 'trace-c' }, { traceId: 'trace-a' }, { traceId: 'trace-b' }],
+  },
+  {
+    name: 'includes missing string values in negative equality predicates',
+    request: {
+      timeRange: fullRange,
+      where: {
+        scores: { some: { op: 'ne', left: { path: 'scorerVersion' }, right: { literal: 'v2' } } },
+      },
+    },
+    expected: [{ traceId: 'trace-c' }, { traceId: 'trace-a' }, { traceId: 'trace-b' }],
   },
   {
     name: 'binds span type and error predicates to one current span record',

--- a/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.test.ts
@@ -38,7 +38,18 @@ describe('ClickHouse advanced trace query', () => {
               op: 'and',
               args: [
                 { op: 'eq', left: { path: 'scorerId' }, right: { literal: "factuality' OR 1" } },
+                { op: 'eq', left: { path: 'scorerVersion' }, right: { literal: 'v2' } },
+                { op: 'in', value: { path: 'scoreSource' }, set: ['automated'] },
+                {
+                  op: 'gte',
+                  left: { path: 'timestamp' },
+                  right: { literal: '2026-01-01T06:00:00-06:00' },
+                },
                 { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
+                { op: 'exists', path: 'spanId' },
+                { op: 'eq', left: { path: 'entityVersionId' }, right: { literal: 'entity-v2' } },
+                { op: 'exists', path: 'parentEntityVersionId' },
+                { op: 'notIn', value: { path: 'rootEntityVersionId' }, set: ['root-v2'] },
               ],
             },
           },
@@ -50,6 +61,17 @@ describe('ClickHouse advanced trace query', () => {
     expect(Object.values(compiled.query_params)).toContain("factuality' OR 1");
     expect(compiled.query.match(/EXISTS \(/g)).toHaveLength(1);
     expect(compiled.query).toContain('s.traceId = r.traceId');
+    expect(compiled.query).toContain('LIMIT 1 BY scoreId');
+    expect(compiled.query).toContain('scorerVersion,');
+    expect(compiled.query).toContain('scoreSource,');
+    expect(compiled.query).toContain('timestamp,');
+    expect(compiled.query).toContain('spanId,');
+    expect(compiled.query).toContain('entityVersionId,');
+    expect(compiled.query).toContain('parentEntityVersionId,');
+    expect(compiled.query).toContain('rootEntityVersionId');
+    expect(compiled.query).toMatch(/s\.timestamp >= \{trace_query_6:DateTime64\(3, 'UTC'\)\}/);
+    expect(compiled.query).toContain('isNotNull(s.spanId)');
+    expect(Object.values(compiled.query_params)).toContain('2026-01-01 12:00:00.000');
   });
 
   it('deduplicates completed span deliveries without relying on background merges', () => {

--- a/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/trace-query.ts
@@ -41,7 +41,14 @@ const SPAN_FIELDS = {
 
 const SCORE_FIELDS = {
   scorerId: { sql: 's.scorerId', parameterType: 'String' },
+  scorerVersion: { sql: 's.scorerVersion', parameterType: 'String' },
+  scoreSource: { sql: 's.scoreSource', parameterType: 'String' },
   score: { sql: 's.score', parameterType: 'Float64' },
+  timestamp: { sql: 's.timestamp', parameterType: "DateTime64(3, 'UTC')" },
+  spanId: { sql: 's.spanId', parameterType: 'String' },
+  entityVersionId: { sql: 's.entityVersionId', parameterType: 'String' },
+  parentEntityVersionId: { sql: 's.parentEntityVersionId', parameterType: 'String' },
+  rootEntityVersionId: { sql: 's.rootEntityVersionId', parameterType: 'String' },
 } satisfies FieldRegistry<TraceQueryScoreField>;
 
 const TRACE_SELECT = `
@@ -189,10 +196,22 @@ export function compileClickHouseTraceQuery(plan: TrustedTraceQueryPlan): Compil
   }
   if (relationCollections.has('scores')) {
     ctes.push(`current_scores AS (
-    SELECT traceId, scorerId, score
+    SELECT
+      traceId,
+      spanId,
+      timestamp,
+      scorerId,
+      scorerVersion,
+      scoreSource,
+      score,
+      entityVersionId,
+      parentEntityVersionId,
+      rootEntityVersionId
     FROM ${TABLE_SCORE_EVENTS}
     WHERE isNotNull(traceId)
       AND traceId IN (SELECT traceId FROM root_scope)
+    ORDER BY scoreId, timestamp DESC
+    LIMIT 1 BY scoreId
   )`);
   }
 

--- a/stores/duckdb/src/storage/domains/observability/trace-query.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/trace-query.test.ts
@@ -21,7 +21,18 @@ describe('DuckDB advanced trace query', () => {
               op: 'and',
               args: [
                 { op: 'eq', left: { path: 'scorerId' }, right: { literal: "factuality' OR TRUE --" } },
+                { op: 'eq', left: { path: 'scorerVersion' }, right: { literal: 'v2' } },
+                { op: 'in', value: { path: 'scoreSource' }, set: ['automated'] },
+                {
+                  op: 'gte',
+                  left: { path: 'timestamp' },
+                  right: { literal: '2026-01-01T06:00:00-06:00' },
+                },
                 { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
+                { op: 'exists', path: 'spanId' },
+                { op: 'eq', left: { path: 'entityVersionId' }, right: { literal: 'entity-v2' } },
+                { op: 'exists', path: 'parentEntityVersionId' },
+                { op: 'notIn', value: { path: 'rootEntityVersionId' }, set: ['root-v2'] },
               ],
             },
           },
@@ -34,6 +45,14 @@ describe('DuckDB advanced trace query', () => {
     expect(compiled.sql.match(/EXISTS \(/g)).toHaveLength(1);
     expect(compiled.sql).toContain('s.traceId = r.traceId');
     expect(compiled.sql).toContain('FROM current_scores s');
+    expect(compiled.sql).toContain('s.scorerVersion IS NOT DISTINCT FROM ?');
+    expect(compiled.sql).toContain('s.scoreSource IS NOT NULL AND s.scoreSource IN (?)');
+    expect(compiled.sql).toContain('s.timestamp IS NOT NULL AND s.timestamp >= CAST(? AS TIMESTAMP)');
+    expect(compiled.sql).toContain('s.spanId IS NOT NULL');
+    expect(compiled.sql).toContain('s.entityVersionId IS NOT DISTINCT FROM ?');
+    expect(compiled.sql).toContain('s.parentEntityVersionId IS NOT NULL');
+    expect(compiled.sql).toContain('s.rootEntityVersionId IS NULL OR s.rootEntityVersionId NOT IN (?)');
+    expect(compiled.values).toContain('2026-01-01T12:00:00.000Z');
   });
 
   it('selects the latest logical root before applying completion and time filters', () => {

--- a/stores/duckdb/src/storage/domains/observability/trace-query.ts
+++ b/stores/duckdb/src/storage/domains/observability/trace-query.ts
@@ -38,7 +38,14 @@ const SPAN_FIELDS = {
 
 const SCORE_FIELDS = {
   scorerId: { sql: 's.scorerId', parameterType: 'scalar' },
+  scorerVersion: { sql: 's.scorerVersion', parameterType: 'scalar' },
+  scoreSource: { sql: 's.scoreSource', parameterType: 'scalar' },
   score: { sql: 's.score', parameterType: 'scalar' },
+  timestamp: { sql: 's.timestamp', parameterType: 'timestamp' },
+  spanId: { sql: 's.spanId', parameterType: 'scalar' },
+  entityVersionId: { sql: 's.entityVersionId', parameterType: 'scalar' },
+  parentEntityVersionId: { sql: 's.parentEntityVersionId', parameterType: 'scalar' },
+  rootEntityVersionId: { sql: 's.rootEntityVersionId', parameterType: 'scalar' },
 } satisfies FieldRegistry<TraceQueryScoreField>;
 
 const TRACE_SELECT = `

--- a/stores/pg/src/storage/domains/observability/v-next/trace-query.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/trace-query.test.ts
@@ -38,7 +38,18 @@ describe('Postgres advanced trace query', () => {
               op: 'and',
               args: [
                 { op: 'eq', left: { path: 'scorerId' }, right: { literal: "factuality' OR TRUE --" } },
+                { op: 'eq', left: { path: 'scorerVersion' }, right: { literal: 'v2' } },
+                { op: 'in', value: { path: 'scoreSource' }, set: ['automated'] },
+                {
+                  op: 'gte',
+                  left: { path: 'timestamp' },
+                  right: { literal: '2026-01-01T06:00:00-06:00' },
+                },
                 { op: 'lt', left: { path: 'score' }, right: { literal: 0.6 } },
+                { op: 'exists', path: 'spanId' },
+                { op: 'eq', left: { path: 'entityVersionId' }, right: { literal: 'entity-v2' } },
+                { op: 'exists', path: 'parentEntityVersionId' },
+                { op: 'notIn', value: { path: 'rootEntityVersionId' }, set: ['root-v2'] },
               ],
             },
           },
@@ -51,6 +62,14 @@ describe('Postgres advanced trace query', () => {
     expect(compiled.text.match(/EXISTS \(/g)).toHaveLength(3);
     expect(compiled.text).toContain('s."traceId" = r."traceId"');
     expect(compiled.text).toContain('newer."scoreId" = s."scoreId"');
+    expect(compiled.text).toContain('s."scorerVersion" IS NOT DISTINCT FROM');
+    expect(compiled.text).toContain('s."scoreSource" IS NOT NULL');
+    expect(compiled.text).toContain('s."timestamp" IS NOT NULL AND s."timestamp" >=');
+    expect(compiled.text).toContain('s."spanId" IS NOT NULL');
+    expect(compiled.text).toContain('s."entityVersionId" IS NOT DISTINCT FROM');
+    expect(compiled.text).toContain('s."parentEntityVersionId" IS NOT NULL');
+    expect(compiled.text).toContain('s."rootEntityVersionId" IS NULL OR s."rootEntityVersionId" NOT IN');
+    expect(compiled.values).toContain('2026-01-01T12:00:00.000Z');
   });
 
   it('emits only referenced relation scopes and reuses each current-record reconstruction', () => {

--- a/stores/pg/src/storage/domains/observability/v-next/trace-query.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/trace-query.test.ts
@@ -59,6 +59,19 @@ describe('Postgres advanced trace query', () => {
 
     expect(compiled.text).not.toContain("factuality' OR TRUE --");
     expect(compiled.values).toContain("factuality' OR TRUE --");
+    expect(compiled.text).toContain(`current_scores AS MATERIALIZED (
+    SELECT
+      s."traceId",
+      s."spanId",
+      s."timestamp",
+      s."scorerId",
+      s."scorerVersion",
+      s."scoreSource",
+      s."score",
+      s."entityVersionId",
+      s."parentEntityVersionId",
+      s."rootEntityVersionId"
+    FROM`);
     expect(compiled.text.match(/EXISTS \(/g)).toHaveLength(3);
     expect(compiled.text).toContain('s."traceId" = r."traceId"');
     expect(compiled.text).toContain('newer."scoreId" = s."scoreId"');

--- a/stores/pg/src/storage/domains/observability/v-next/trace-query.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/trace-query.ts
@@ -37,7 +37,14 @@ const SPAN_FIELDS = {
 
 const SCORE_FIELDS = {
   scorerId: 's."scorerId"',
+  scorerVersion: 's."scorerVersion"',
+  scoreSource: 's."scoreSource"',
   score: 's."score"',
+  timestamp: 's."timestamp"',
+  spanId: 's."spanId"',
+  entityVersionId: 's."entityVersionId"',
+  parentEntityVersionId: 's."parentEntityVersionId"',
+  rootEntityVersionId: 's."rootEntityVersionId"',
 } satisfies FieldRegistry<TraceQueryScoreField>;
 
 const TRACE_SELECT = `

--- a/stores/pg/src/storage/domains/observability/v-next/trace-query.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/trace-query.ts
@@ -233,7 +233,17 @@ export function compilePostgresTraceQuery(schema: string, plan: TrustedTraceQuer
   }
   if (relationCollections.has('scores')) {
     ctes.push(`current_scores AS MATERIALIZED (
-    SELECT s."traceId", s."scorerId", s."score"
+    SELECT
+      s."traceId",
+      s."spanId",
+      s."timestamp",
+      s."scorerId",
+      s."scorerVersion",
+      s."scoreSource",
+      s."score",
+      s."entityVersionId",
+      s."parentEntityVersionId",
+      s."rootEntityVersionId"
     FROM ${scoreTable} s
     WHERE s."traceId" IS NOT NULL
       AND s."traceId" IN (SELECT "traceId" FROM root_scope)


### PR DESCRIPTION
Extends advanced trace queries so `scores.some` and `scores.none` can filter a single current score record by scorer version, source, numeric value, timestamp, span anchoring, and version lineage. The trusted planner enforces field-specific operators and strict literal types, and PostgreSQL, ClickHouse, DuckDB, the reference evaluator, and REST tests share the same semantics.

Documents the expanded score predicate contract and adds separate minor changesets for `@mastra/core`, `@mastra/pg`, `@mastra/clickhouse`, and `@mastra/duckdb`.

Test plan:
- `pnpm --filter ./packages/core test src/storage/domains/observability/trace-query.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter @internal/storage-test-utils exec vitest run src/domains/observability-vnext/trace-query.test.ts`
- `pnpm --filter @mastra/pg exec vitest run src/storage/domains/observability/v-next/trace-query.test.ts`
- `pnpm --filter @mastra/clickhouse exec vitest run src/storage/domains/observability/v-next/trace-query.test.ts`
- `pnpm --filter @mastra/duckdb test -- src/storage/domains/observability/trace-query.test.ts`
- `pnpm --filter @mastra/duckdb exec vitest run src/storage/domains/observability/index.test.ts`
- `pnpm --filter @mastra/server test -- src/server/handlers/observability-trace-query.test.ts`
- `pnpm build:core`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Trace queries can now find traces using more score details, such as the scorer version, source, timestamp, and related entity. This makes score-based searches more useful and consistent across storage systems.

## Changes

- Expanded `scores.some` and `scores.none` predicates with support for:
  - `scorerVersion`
  - `scoreSource`
  - `timestamp`
  - `spanId`
  - `entityVersionId`
  - `parentEntityVersionId`
  - `rootEntityVersionId`
- Added strict field, operator, and literal validation.
- Added strict ISO datetime validation and UTC timestamp normalization.
- Updated PostgreSQL, ClickHouse, and DuckDB query generation.
- Updated the reference evaluator, shared fixtures, and conformance tests.
- Added server validation tests for invalid score predicates and sensitive-value redaction.
- Updated trace-query documentation with predicate semantics and examples.
- Added package changesets for `@mastra/core`, `@mastra/pg`, `@mastra/clickhouse`, and `@mastra/duckdb`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->