### PR TITLE
Studio: breadcrumbs inside content frame, consistent crumb sizing

### DIFF
--- a/.changeset/clever-pots-arrive.md
+++ b/.changeset/clever-pots-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Moved Studio breadcrumbs inside the main content frame as a fixed header with a full-width bottom border. Fixed the first breadcrumb shifting left when navigating from a list page to a detail page, and unified the font size of all breadcrumb items. Removed the heavy card shadows on the Agent overview and settings pages in light mode.

--- a/.changeset/seven-geese-stop.md
+++ b/.changeset/seven-geese-stop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Reduced the Breadcrumb crumb font size to the small UI size so breadcrumb items render consistently regardless of whether they are text, links, or comboboxes.

--- a/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
@@ -53,7 +53,7 @@ export const Crumb = ({ className, as, isCurrent, action, children, ...props }: 
         <Root
           aria-current={isCurrent ? 'page' : undefined}
           className={cn(
-            'flex min-w-0 items-center gap-2 overflow-hidden rounded-md px-1 py-0.5 text-ui-md leading-ui-md',
+            'flex min-w-0 items-center gap-2 overflow-hidden rounded-md px-1 py-0.5 text-ui-sm leading-ui-sm',
             transitions.colors,
             isCurrent
               ? 'font-medium text-neutral6'

--- a/packages/playground/src/components/layout.tsx
+++ b/packages/playground/src/components/layout.tsx
@@ -76,21 +76,19 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
         {shouldShowSidebar && <AppSidebar />}
         <div className="flex h-full min-h-0 flex-col">
           {shouldShowSidebar && <MobileNavbar />}
-          {shouldShowSidebar && (
-            <div className="mx-1.5 mt-1 shrink-0 lg:mx-2 lg:mt-1">
-              <RouteHeader />
-            </div>
-          )}
           <PageHeadingContext.Provider value={pageHeading}>
             <div
               className={cn(
-                'ml-0 mx-1.5 mb-1.5 flex-1 min-h-0 overflow-y-auto [--studio-frame-radius:1.5rem] [--studio-frame-inset:0.5rem] rounded-studio-frame border border-border1 bg-surface2 shadow-main-frame lg:mx-2 lg:mb-2 lg:ml-0',
-                shouldShowSidebar ? 'mt-0' : 'mt-1.5 lg:mt-2 h-[calc(100%-1.5rem)]',
+                'ml-0 mx-1.5 my-1.5 grid flex-1 min-h-0 overflow-hidden [--studio-frame-radius:1.5rem] [--studio-frame-inset:0.5rem] rounded-studio-frame border border-border1 bg-surface2 shadow-main-frame lg:mx-2 lg:my-2 lg:ml-0',
+                shouldShowSidebar ? 'grid-rows-[auto_1fr]' : 'grid-rows-[1fr] h-[calc(100%-1.5rem)]',
               )}
             >
-              <AuthRequired>
-                <ErrorBoundary resetKeys={[pathname]}>{children}</ErrorBoundary>
-              </AuthRequired>
+              {shouldShowSidebar && <RouteHeader />}
+              <div className="min-h-0 overflow-y-auto">
+                <AuthRequired>
+                  <ErrorBoundary resetKeys={[pathname]}>{children}</ErrorBoundary>
+                </AuthRequired>
+              </div>
             </div>
           </PageHeadingContext.Provider>
         </div>

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -90,7 +90,7 @@ export const AgentMetadata = ({ agentId }: AgentMetadataProps) => {
   return (
     <div className="flex flex-col gap-4" data-testid="agent-metadata">
       {agent.modelList && (
-        <Card elevation="elevated" className="bg-surface3">
+        <Card className="bg-surface3">
           <CardHeader>
             <CardTitle>Models</CardTitle>
           </CardHeader>
@@ -104,7 +104,7 @@ export const AgentMetadata = ({ agentId }: AgentMetadataProps) => {
         </Card>
       )}
 
-      <Card elevation="elevated" className="bg-surface3">
+      <Card className="bg-surface3">
         <CardHeader className="flex-row items-baseline gap-2 space-y-0">
           <CardTitle>Capabilities</CardTitle>
           <CardDescription>Everything this agent can call at runtime</CardDescription>
@@ -197,7 +197,7 @@ export const AgentMetadata = ({ agentId }: AgentMetadataProps) => {
         </CardContent>
       </Card>
 
-      <Card elevation="elevated" className="bg-surface3">
+      <Card className="bg-surface3">
         <CardHeader>
           <CardTitle>System Prompt</CardTitle>
         </CardHeader>

--- a/packages/playground/src/domains/agents/components/agent-settings/agent-settings-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-settings/agent-settings-view.tsx
@@ -21,7 +21,7 @@ export function AgentSettingsView({ agentId }: AgentSettingsViewProps) {
           <AgentMetadata agentId={agentId} />
 
           <div className="flex flex-col gap-4">
-            <Card elevation="elevated" className="bg-surface3">
+            <Card className="bg-surface3">
               <CardHeader>
                 <CardTitle>Memory</CardTitle>
               </CardHeader>
@@ -31,7 +31,7 @@ export function AgentSettingsView({ agentId }: AgentSettingsViewProps) {
             </Card>
 
             {hasChannels && (
-              <Card elevation="elevated" className="bg-surface3">
+              <Card className="bg-surface3">
                 <CardHeader>
                   <CardTitle>Channels</CardTitle>
                 </CardHeader>

--- a/packages/playground/src/domains/mcps/components/mcp-server-combobox.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-server-combobox.tsx
@@ -14,6 +14,7 @@ export interface MCPServerComboboxProps {
   className?: string;
   disabled?: boolean;
   variant?: ComboboxProps['variant'];
+  size?: ComboboxProps['size'];
   container?: HTMLElement | ShadowRoot | null | React.RefObject<HTMLElement | ShadowRoot | null>;
 }
 
@@ -26,6 +27,7 @@ export function MCPServerCombobox({
   className,
   disabled = false,
   variant,
+  size,
   container,
 }: MCPServerComboboxProps) {
   const { data: mcpServers = [], isLoading, isError, error } = useMCPServers();
@@ -62,6 +64,7 @@ export function MCPServerCombobox({
       className={className}
       disabled={disabled || isLoading || isError}
       variant={variant}
+      size={size}
       container={container}
     />
   );

--- a/packages/playground/src/domains/mcps/mcp-crumbs.tsx
+++ b/packages/playground/src/domains/mcps/mcp-crumbs.tsx
@@ -6,7 +6,7 @@ export function McpServerCrumb() {
   const { serverId } = useParams<{ serverId: string }>();
   if (!serverId) return null;
 
-  return <MCPServerCombobox value={serverId} variant="ghost" />;
+  return <MCPServerCombobox value={serverId} variant="ghost" size="sm" />;
 }
 
 export function McpServerToolCrumb() {

--- a/packages/playground/src/domains/processors/components/processor-combobox.tsx
+++ b/packages/playground/src/domains/processors/components/processor-combobox.tsx
@@ -14,6 +14,7 @@ export interface ProcessorComboboxProps {
   className?: string;
   disabled?: boolean;
   variant?: ComboboxProps['variant'];
+  size?: ComboboxProps['size'];
 }
 
 export function ProcessorCombobox({
@@ -25,6 +26,7 @@ export function ProcessorCombobox({
   className,
   disabled = false,
   variant,
+  size,
 }: ProcessorComboboxProps) {
   const { data: processors = {}, isLoading, isError, error } = useProcessors();
   const { navigate, paths } = useLinkComponent();
@@ -70,6 +72,7 @@ export function ProcessorCombobox({
       className={className}
       disabled={disabled || isLoading || isError}
       variant={variant}
+      size={size}
     />
   );
 }

--- a/packages/playground/src/domains/processors/processor-crumb.tsx
+++ b/packages/playground/src/domains/processors/processor-crumb.tsx
@@ -5,5 +5,5 @@ export function ProcessorCrumb() {
   const { processorId } = useParams<{ processorId: string }>();
   if (!processorId) return null;
 
-  return <ProcessorCombobox value={processorId} variant="ghost" />;
+  return <ProcessorCombobox value={processorId} variant="ghost" size="sm" />;
 }

--- a/packages/playground/src/domains/scores/components/scorer-combobox.tsx
+++ b/packages/playground/src/domains/scores/components/scorer-combobox.tsx
@@ -14,6 +14,7 @@ export interface ScorerComboboxProps {
   className?: string;
   disabled?: boolean;
   variant?: ComboboxProps['variant'];
+  size?: ComboboxProps['size'];
 }
 
 export function ScorerCombobox({
@@ -25,6 +26,7 @@ export function ScorerCombobox({
   className,
   disabled = false,
   variant,
+  size,
 }: ScorerComboboxProps) {
   const { data: scorers = {}, isLoading, isError, error } = useScorers();
   const { navigate, paths } = useLinkComponent();
@@ -60,7 +62,7 @@ export function ScorerCombobox({
       className={className}
       disabled={disabled || isLoading || isError}
       variant={variant}
-      size={'md'}
+      size={size}
     />
   );
 }

--- a/packages/playground/src/domains/scores/scorer-crumb.tsx
+++ b/packages/playground/src/domains/scores/scorer-crumb.tsx
@@ -7,7 +7,7 @@ export function ScorerCrumb() {
   const { scorerId } = useParams<{ scorerId: string }>();
   if (!scorerId) return null;
 
-  return <ScorerCombobox value={scorerId} variant="ghost" />;
+  return <ScorerCombobox value={scorerId} variant="ghost" size="sm" />;
 }
 
 export function StoredScorerCrumb() {

--- a/packages/playground/src/domains/tools/components/tool-combobox.tsx
+++ b/packages/playground/src/domains/tools/components/tool-combobox.tsx
@@ -15,6 +15,7 @@ export interface ToolComboboxProps {
   className?: string;
   disabled?: boolean;
   variant?: ComboboxProps['variant'];
+  size?: ComboboxProps['size'];
 }
 
 export function ToolCombobox({
@@ -26,6 +27,7 @@ export function ToolCombobox({
   className,
   disabled = false,
   variant,
+  size,
 }: ToolComboboxProps) {
   const { data: tools = {}, isLoading: isLoadingTools, isError: isErrorTools, error: errorTools } = useTools();
   const { data: agents = {}, isLoading: isLoadingAgents, isError: isErrorAgents, error: errorAgents } = useAgents();
@@ -89,6 +91,7 @@ export function ToolCombobox({
       className={className}
       disabled={disabled || isLoadingTools || isLoadingAgents || isErrorTools || isErrorAgents}
       variant={variant}
+      size={size}
     />
   );
 }

--- a/packages/playground/src/domains/tools/tool-crumb.tsx
+++ b/packages/playground/src/domains/tools/tool-crumb.tsx
@@ -5,5 +5,5 @@ export function ToolCrumb() {
   const { toolId } = useParams<{ toolId: string }>();
   if (!toolId) return null;
 
-  return <ToolCombobox value={toolId} variant="ghost" />;
+  return <ToolCombobox value={toolId} variant="ghost" size="sm" />;
 }

--- a/packages/playground/src/domains/workflows/components/workflow-combobox.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-combobox.tsx
@@ -14,6 +14,7 @@ export interface WorkflowComboboxProps {
   className?: string;
   disabled?: boolean;
   variant?: ComboboxProps['variant'];
+  size?: ComboboxProps['size'];
 }
 
 export function WorkflowCombobox({
@@ -25,6 +26,7 @@ export function WorkflowCombobox({
   className,
   disabled = false,
   variant,
+  size,
 }: WorkflowComboboxProps) {
   const { data: workflows = {}, isLoading, isError, error } = useWorkflows();
   const { navigate, paths } = useLinkComponent();
@@ -60,6 +62,7 @@ export function WorkflowCombobox({
       className={className}
       disabled={disabled || isLoading || isError}
       variant={variant}
+      size={size}
     />
   );
 }

--- a/packages/playground/src/domains/workflows/workflow-crumbs.tsx
+++ b/packages/playground/src/domains/workflows/workflow-crumbs.tsx
@@ -6,7 +6,7 @@ export function WorkflowCrumb() {
   const { workflowId } = useParams<{ workflowId: string }>();
   if (!workflowId) return null;
 
-  return <WorkflowCombobox value={workflowId} variant="ghost" />;
+  return <WorkflowCombobox value={workflowId} variant="ghost" size="sm" />;
 }
 
 export function WorkflowRunCrumb() {

--- a/packages/playground/src/lib/route-header/route-header.tsx
+++ b/packages/playground/src/lib/route-header/route-header.tsx
@@ -29,7 +29,7 @@ export function RouteHeader() {
   const lastIdx = crumbs.length - 1;
 
   return (
-    <Header border={false} className="h-10 min-h-10 gap-2 overflow-hidden px-2">
+    <Header className="h-10 min-h-10 gap-2 overflow-hidden px-2">
       {crumbs.length > 0 && (
         <Breadcrumb label="Breadcrumb" className="min-w-0 flex-1 overflow-hidden" listClassName="min-w-0">
           {crumbs.map((def, i) => {
@@ -45,7 +45,7 @@ export function RouteHeader() {
                 className={isCurrent ? 'max-w-[28rem]' : 'max-w-[18rem]'}
               >
                 {IconComponent && (
-                  <Icon className={isCurrent ? 'flex w-6 justify-center' : undefined}>
+                  <Icon className="flex w-6 justify-center">
                     <IconComponent />
                   </Icon>
                 )}

--- a/packages/playground/src/pages/agents/index.tsx
+++ b/packages/playground/src/pages/agents/index.tsx
@@ -68,7 +68,7 @@ function Agents() {
   }
 
   return (
-    <PageLayout width="narrow" height="full" className="max-w-7xl grid-rows-[auto_minmax(0,1fr)] content-normal">
+    <PageLayout height="full" className="grid-rows-[auto_minmax(0,1fr)] content-normal">
       <AgentHeaderCreateAction />
       <PageLayout.TopArea>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">


### PR DESCRIPTION


<img width="3840" height="2160" alt="CleanShot 2026-09-03 at 10 22 32@2x" src="https://github.com/user-attachments/assets/7e76e67e-6c17-4a7c-838e-10122aa4adc7" />
## Summary
- Move the route header (breadcrumbs / actions / docs link) inside the rounded main-content frame as a fixed top row with a full-width bottom border; page content scrolls beneath it.
- Fix the first crumb shifting left when navigating from a list page to a detail page: crumb icons now always use a fixed 24px box.
- Harmonize crumb typography: every crumb (label, link, combobox) uses `text-ui-sm`; the domain combobox wrappers gain a `size` prop.
- Remove the `elevated` shadow on Agent overview/settings cards, which looked harsh in light mode.

## Test plan
- [x] `@mastra/playground-ui` tests (2960) and typecheck green
- [x] `@internal/playground` typecheck and lint (0 errors) green
- [x] `@internal/playground` tests: 2165 pass; `experiments-run.msw.test.tsx` also fails on `main` (pre-existing, unrelated)
- [x] `/agents` → `/agents/<id>`: "Agents" crumb no longer moves; all crumbs share the same font size
- [x] Breadcrumb border spans the frame edge to edge; header fixed, content scrolls, no double scrollbar
- [x] Mobile: MobileNavbar above, breadcrumbs inside the frame
- [x] Agent overview in light mode: cards flat, no shadow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Studio now keeps navigation and actions in a fixed bar at the top of the content area. Page content scrolls below it, while breadcrumbs and agent cards use more consistent sizing and styling.

## Changes

- Moved the route header inside the rounded Studio content frame.
- Added a fixed header row with a full-width bottom border.
- Made page content scroll below the route header.
- Standardized breadcrumb text to `text-ui-sm`.
- Added fixed 24px breadcrumb icon containers to prevent layout shifts.
- Added optional `size` props to domain combobox wrappers.
- Set domain breadcrumb comboboxes to the small size.
- Removed elevated shadows from Agent overview and settings cards.
- Updated the Agents list page to use the full available width.
- Added patch changesets for `@mastra/playground-ui`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->