### PR TITLE
fix(playground): scroll lists internally on every top-level list page

### DIFF
--- a/.changeset/data-list-pages-internal-scroll.md
+++ b/.changeset/data-list-pages-internal-scroll.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+---
+
+Studio list pages (Workflows, Tools, MCP Servers, Scorers, Processors, Datasets, Experiments, Prompts) now scroll the list itself instead of the whole page, matching the Agents page: the header and filters stay fixed while the list scrolls. `DataList` no longer stretches to fill its container, so short lists and loading skeletons stay compact instead of rendering a full-height empty panel. `PageLayout height="full"` now bounds its main row to the remaining page height so nested lists can scroll internally.

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.test.tsx
@@ -45,6 +45,8 @@ describe('DataListRoot', () => {
       expect(grid?.className).not.toContain('overflow-auto');
       expect(container.firstElementChild?.className).toContain('rounded-xl');
       expect(container.firstElementChild?.className).toContain('bg-surface4');
+      expect(container.firstElementChild?.className).toContain('self-start');
+      expect(container.firstElementChild?.className).toContain('max-h-full');
       expect(grid?.className).toContain('gap-y-px');
       expect(grid?.className).toContain('[&_.data-list-subheader+.data-list-row]:rounded-t-lg');
       expect(grid?.className).toContain('[&_.data-list-row:has(+.data-list-subheader)]:rounded-b-lg');

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
@@ -134,9 +134,14 @@ export function DataListRoot({
       // Outer radius = row radius (8px) + 4px inset so the corners stay concentric.
       // Size to content but never exceed the parent. Flex (unlike grid `1fr`) lays
       // items out against the max-height-clamped container, so short lists stay
-      // compact and long ones shrink the viewport and scroll.
+      // compact and long ones shrink the viewport and scroll. `self-start` stops
+      // a grid/flex parent from stretching the root to the full row height.
       viewPortClassName="min-h-0 flex-1 basis-auto"
-      className={cn('flex max-h-full w-full flex-col rounded-xl px-1 pb-1', dataListVariantClasses[variant], className)}
+      className={cn(
+        'flex max-h-full w-full flex-col self-start rounded-xl px-1 pb-1',
+        dataListVariantClasses[variant],
+        className,
+      )}
     >
       {grid}
     </ScrollArea>

--- a/packages/playground-ui/src/ds/components/PageLayout/page-layout-root.tsx
+++ b/packages/playground-ui/src/ds/components/PageLayout/page-layout-root.tsx
@@ -21,7 +21,7 @@ export function PageLayoutRoot({
         'grid w-full grid-rows-[auto_auto] content-start p-6',
         {
           'max-w-screen-lg mx-auto pt-8': width === 'narrow',
-          'h-full grid-rows-[auto_1fr] overflow-y-auto': height === 'full',
+          'h-full grid-rows-[auto_minmax(0,1fr)] overflow-y-auto': height === 'full',
         },
         className,
         //   'LAYOUT_ROOT border border-dashed border-orange-400',

--- a/packages/playground/src/pages/agents/index.tsx
+++ b/packages/playground/src/pages/agents/index.tsx
@@ -68,7 +68,7 @@ function Agents() {
   }
 
   return (
-    <PageLayout height="full" className="grid-rows-[auto_minmax(0,1fr)] content-normal">
+    <PageLayout height="full">
       <AgentHeaderCreateAction />
       <PageLayout.TopArea>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/packages/playground/src/pages/datasets/index.tsx
+++ b/packages/playground/src/pages/datasets/index.tsx
@@ -100,7 +100,7 @@ export default function Datasets() {
   };
 
   return (
-    <PageLayout>
+    <PageLayout height="full">
       <PageLayout.TopArea>
         <DatasetsToolbar
           search={search}

--- a/packages/playground/src/pages/experiments/index.tsx
+++ b/packages/playground/src/pages/experiments/index.tsx
@@ -154,7 +154,7 @@ export default function Experiments() {
   };
 
   return (
-    <PageLayout>
+    <PageLayout height="full">
       <PageLayout.TopArea>
         <ExperimentsToolbar
           search={search}

--- a/packages/playground/src/pages/mcps/index.tsx
+++ b/packages/playground/src/pages/mcps/index.tsx
@@ -46,7 +46,7 @@ const MCPs = () => {
   }
 
   return (
-    <PageLayout>
+    <PageLayout height="full">
       <PageLayout.TopArea>
         <div className="max-w-120">
           <ListSearch onSearch={setSearch} label="Filter MCP servers" placeholder="Filter by name" />

--- a/packages/playground/src/pages/processors/index.tsx
+++ b/packages/playground/src/pages/processors/index.tsx
@@ -46,7 +46,7 @@ export function Processors() {
   }
 
   return (
-    <PageLayout>
+    <PageLayout height="full">
       <PageLayout.TopArea>
         <div className="max-w-120">
           <ListSearch onSearch={setSearch} label="Filter processors" placeholder="Filter by name" />

--- a/packages/playground/src/pages/prompt-blocks/index.tsx
+++ b/packages/playground/src/pages/prompt-blocks/index.tsx
@@ -71,7 +71,7 @@ export default function PromptBlocks() {
   }
 
   return (
-    <PageLayout>
+    <PageLayout height="full">
       <PageLayout.TopArea>
         <PageLayout.Row align="center" stack="responsive">
           <div className="max-w-120 flex-1">

--- a/packages/playground/src/pages/scorers/index.tsx
+++ b/packages/playground/src/pages/scorers/index.tsx
@@ -53,7 +53,7 @@ export default function Scorers() {
   };
 
   return (
-    <PageLayout>
+    <PageLayout height="full">
       <PageLayout.TopArea>
         <ScorersToolbar
           search={search}

--- a/packages/playground/src/pages/tools/index.tsx
+++ b/packages/playground/src/pages/tools/index.tsx
@@ -51,7 +51,7 @@ export default function Tools() {
   }
 
   return (
-    <PageLayout>
+    <PageLayout height="full">
       <PageLayout.TopArea>
         <div className="max-w-120">
           <ListSearch onSearch={setSearch} label="Filter tools" placeholder="Filter by name" />

--- a/packages/playground/src/pages/workflows/index.tsx
+++ b/packages/playground/src/pages/workflows/index.tsx
@@ -49,7 +49,7 @@ function Workflows() {
   }
 
   return (
-    <PageLayout>
+    <PageLayout height="full">
       <PageLayout.TopArea>
         <PageLayout.Row align="center" stack="responsive">
           <div className="max-w-120 flex-1">


### PR DESCRIPTION
Only the Agents page kept its header and filters fixed while the list scrolled; the other list pages (Workflows, Tools, MCP Servers, Scorers, Processors, Datasets, Experiments, Prompts) scrolled the whole page instead. The agents loading skeleton (and any short list) also stretched to fill the full page height.

This fixes it once in the design system and moves every top-level list page onto the same layout. `DataListRoot` now uses `self-start` so it sizes to its content and is only clamped by `max-h-full`, and `PageLayout height="full"` uses `minmax(0,1fr)` for the main row so a nested list actually gets a bounded height to scroll within.

Before:

```tsx
<PageLayout>
  <PageLayout.TopArea>...</PageLayout.TopArea>
  <WorkflowsList />
</PageLayout>
```

After:

```tsx
<PageLayout height="full">
  <PageLayout.TopArea>...</PageLayout.TopArea>
  <WorkflowsList />
</PageLayout>
```

Verified with the DataList/PageLayout unit tests, the playground page tests, typecheck, and in the browser: skeletons are now compact, long lists scroll inside the panel with the toolbar fixed, short lists hug their content, and wide lists still scroll horizontally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Long lists now scroll inside their pages instead of moving the whole page. Headers and filters stay visible while you browse.

## Changes

- Updated `DataListRoot` to use `self-start` and `max-h-full`.
- Updated `PageLayout height="full"` to constrain the main row with `minmax(0, 1fr)`.
- Enabled full-height layouts for Workflows, Tools, MCP Servers, Scorers, Processors, Datasets, Experiments, Prompt Blocks, and Agents.
- Preserved compact loading states, short lists, and horizontal scrolling for wide lists.
- Added tests for the new `DataListRoot` classes.
- Added a changeset for `@mastra/playground-ui` and `mastra`.

## Verification

- Tests completed.
- Typecheck completed.
- Browser verification completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->