### PR TITLE
feat(agent-controller): paginate stored thread messages

### DIFF
--- a/.changeset/olive-kiwis-hug.md
+++ b/.changeset/olive-kiwis-hug.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+'@mastra/server': patch
+'@mastra/client-js': patch
+---
+
+Added storage-backed pagination, ordering, filtering, and message includes to Agent Controller message listing. Existing Session and numeric client APIs continue to return message arrays for compatibility.

--- a/.changeset/olive-kiwis-hug.md
+++ b/.changeset/olive-kiwis-hug.md
@@ -5,3 +5,7 @@
 ---
 
 Added storage-backed pagination, ordering, filtering, and message includes to Agent Controller message listing. Existing Session and numeric client APIs continue to return message arrays for compatibility.
+
+```ts
+const page = await session.listMessages('thread-id', { perPage: 20, page: 0 });
+```

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -287,52 +287,56 @@ describe('AgentController Resource', () => {
       '2026-01-01T00:00:00.000Z',
       '2026-01-01T00:00:01.000Z',
     ]);
-    expect(lastCall()[0]).toBe('http://localhost:4111/api/agent-controller/code/sessions/user-1/threads/t-1/messages');
+    expect(lastCall()[0]).toBe(
+      'http://localhost:4111/api/agent-controller/code/sessions/user-1/threads/t-1/messages?perPage=false',
+    );
   });
 
-  it('hydrates message timestamps from SSE events while skipping heartbeats', async () => {
-    const createdAt = '2026-01-01T00:00:00.000Z';
-    const message = {
+  it('lists paginated messages and preserves the legacy numeric limit overload', async () => {
+    const session = client.getAgentController('code').session('user-1');
+    const sourceMessage = {
       id: 'm1',
-      role: 'assistant',
-      content: { format: 2, parts: [{ type: 'text', text: 'hi' }] },
-      createdAt,
+      role: 'user',
+      content: { format: 2, parts: [{ type: 'text', text: 'hello' }] },
+      createdAt: '2026-01-01T00:00:00.000Z',
     };
-    const events = [
-      { type: 'agent_start' },
-      { type: 'message_start', message },
-      { type: 'message_update', message },
-      { type: 'message_end', message },
-    ];
-    mockSse([
-      `data: ${JSON.stringify(events[0])}\n\n`,
-      `: heartbeat\n\n`,
-      ...events.slice(1).map(event => `data: ${JSON.stringify(event)}\n\n`),
-    ]);
 
-    const received: KnownAgentControllerEvent[] = [];
-    const sub = await client
-      .getAgentController('code')
-      .session('user-1')
-      .subscribe({
-        onEvent: e => {
-          if (isKnownAgentControllerEvent(e)) received.push(e);
-        },
-      });
+    mockJson({ messages: [sourceMessage], total: 5, page: 1, perPage: 2, hasMore: true });
+    const page = await session.listMessages('t-1', {
+      page: 1,
+      perPage: 2,
+      orderBy: { field: 'createdAt', direction: 'DESC' },
+      filter: { metadata: { category: 'support' } },
+      include: [{ id: 'm1', withPreviousMessages: 1 }],
+    });
 
-    // Allow the async pump to drain the (already-closed) stream.
-    await new Promise(r => setTimeout(r, 10));
-    sub.unsubscribe();
+    expect(page).toMatchObject({ total: 5, page: 1, perPage: 2, hasMore: true });
+    expect(page.messages[0]?.createdAt).toEqual(new Date('2026-01-01T00:00:00.000Z'));
+    const paginatedUrl = new URL(lastCall()[0] as string);
+    expect(paginatedUrl.searchParams.get('page')).toBe('1');
+    expect(paginatedUrl.searchParams.get('limit')).toBeNull();
+    expect(paginatedUrl.searchParams.get('perPage')).toBe('2');
+    expect(paginatedUrl.searchParams.get('orderBy')).toBe(JSON.stringify({ field: 'createdAt', direction: 'DESC' }));
+    expect(paginatedUrl.searchParams.get('filter')).toBe(JSON.stringify({ metadata: { category: 'support' } }));
+    expect(paginatedUrl.searchParams.get('include')).toBe(JSON.stringify([{ id: 'm1', withPreviousMessages: 1 }]));
 
-    const [url] = lastCall();
-    expect(url).toBe('http://localhost:4111/api/agent-controller/code/sessions/user-1/stream');
-    expect(received.map(e => e.type)).toEqual(['agent_start', 'message_start', 'message_update', 'message_end']);
-    for (const event of received.slice(1)) {
-      if (event.type !== 'message_start' && event.type !== 'message_update' && event.type !== 'message_end') continue;
-      expect(event.message.createdAt).toBeInstanceOf(Date);
-      expect(event.message.createdAt.toISOString()).toBe(createdAt);
-      expect(agentControllerMessageText(event.message)).toBe('hi');
-    }
+    mockJson({ messages: [sourceMessage], total: 1, page: 0, perPage: 1, hasMore: false });
+    const legacyPaged = await session.listMessages('t-1', { limit: 1, page: 0 });
+    expect(legacyPaged).toMatchObject({ total: 1, page: 0, perPage: 1, hasMore: false });
+    expect(lastCall()[0]).toBe(
+      'http://localhost:4111/api/agent-controller/code/sessions/user-1/threads/t-1/messages?limit=1&page=0',
+    );
+
+    await expect(
+      session.listMessages('t-1', { limit: 1, orderBy: { field: 'createdAt', direction: 'DESC' } } as any),
+    ).rejects.toThrow('limit can only be combined with page');
+
+    mockJson({ messages: [sourceMessage], total: 1, page: 0, perPage: 1, hasMore: false });
+    const messages = await session.listMessages('t-1', 1);
+    expect(messages).toHaveLength(1);
+    expect(lastCall()[0]).toBe(
+      'http://localhost:4111/api/agent-controller/code/sessions/user-1/threads/t-1/messages?limit=1',
+    );
   });
 
   it('hydrates thread timestamps from SSE events', async () => {

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -6,6 +6,7 @@ import type {
 } from '@mastra/core/agent-controller';
 export type { MastraDBMessage, MastraMessageContentV2, MastraMessagePart } from '@mastra/core/agent-controller';
 import type { RequestContext } from '@mastra/core/request-context';
+import type { StorageListMessagesInput, StorageListMessagesOutput } from '@mastra/core/storage';
 
 import type {
   AgentControllerActiveRun,
@@ -47,6 +48,31 @@ type WireEventOf<T extends AgentControllerWireEvent['type']> = Extract<AgentCont
 
 /** A `MastraDBMessage` before {@link hydrateMessage} turns its `createdAt` back into a `Date`. */
 type SerializedMastraDBMessage = WireEventOf<'message_start'>['message'];
+
+type AgentControllerModernListMessagesOptions = Omit<StorageListMessagesInput, 'threadId' | 'resourceId'> & {
+  limit?: never;
+};
+
+type AgentControllerLegacyPagedListMessagesOptions = {
+  /** @deprecated Use `perPage` instead. May only be combined with `page`. */
+  limit: number;
+  page?: number;
+  perPage?: never;
+  orderBy?: never;
+  filter?: never;
+  include?: never;
+};
+
+/** Pagination, ordering, filtering, and include options for an Agent Controller thread's messages. */
+export type AgentControllerListMessagesOptions =
+  AgentControllerModernListMessagesOptions | AgentControllerLegacyPagedListMessagesOptions;
+
+/** A page of hydrated Agent Controller thread messages. */
+export type AgentControllerListMessagesResult = StorageListMessagesOutput;
+
+type SerializedAgentControllerListMessagesResult = Omit<StorageListMessagesOutput, 'messages'> & {
+  messages: SerializedMastraDBMessage[];
+};
 
 /** An `AgentControllerThread` before {@link hydrateThread} turns its timestamps back into `Date`s. */
 type SerializedThread = WireEventOf<'thread_created'>['thread'];
@@ -685,13 +711,47 @@ export class AgentControllerSession extends BaseResource {
     });
   }
 
-  /** List messages for a specific thread. */
-  async listMessages(threadId: string, limit?: number): Promise<MastraDBMessage[]> {
-    const params = limit != null ? `?limit=${limit}` : '';
-    const body = await this.request<{ messages: SerializedMastraDBMessage[] }>(
-      this.url(`${this.base()}/threads/${encodeURIComponent(threadId)}/messages${params}`),
+  /** List messages for a specific thread, preserving the legacy array-returning limit overload. */
+  async listMessages(threadId: string, limit?: number): Promise<MastraDBMessage[]>;
+  async listMessages(
+    threadId: string,
+    options: AgentControllerListMessagesOptions,
+  ): Promise<AgentControllerListMessagesResult>;
+  async listMessages(
+    threadId: string,
+    options?: number | AgentControllerListMessagesOptions,
+  ): Promise<MastraDBMessage[] | AgentControllerListMessagesResult> {
+    const queryParams = new URLSearchParams();
+    const legacy = typeof options === 'number' || options === undefined;
+
+    if (typeof options === 'number') {
+      queryParams.set('limit', String(options));
+    } else if (options === undefined) {
+      queryParams.set('perPage', 'false');
+    } else {
+      const { limit, page, perPage, orderBy, filter, include } = options;
+      if (
+        limit !== undefined &&
+        (perPage !== undefined || orderBy !== undefined || filter !== undefined || include !== undefined)
+      ) {
+        throw new Error('limit can only be combined with page; use perPage with orderBy, filter, or include');
+      }
+      if (limit !== undefined) queryParams.set('limit', String(limit));
+      if (page !== undefined) queryParams.set('page', String(page));
+      if (perPage !== undefined) queryParams.set('perPage', String(perPage));
+      if (orderBy) queryParams.set('orderBy', JSON.stringify(orderBy));
+      if (filter) queryParams.set('filter', JSON.stringify(filter));
+      if (include) queryParams.set('include', JSON.stringify(include));
+    }
+
+    const query = queryParams.toString();
+    const body = await this.request<SerializedAgentControllerListMessagesResult>(
+      this.url(`${this.base()}/threads/${encodeURIComponent(threadId)}/messages${query ? `?${query}` : ''}`),
     );
-    return body.messages.map(hydrateMessage);
+    const messages = body.messages.map(hydrateMessage);
+
+    if (legacy) return messages;
+    return { ...body, messages };
   }
 
   /**

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -65,7 +65,8 @@ type AgentControllerLegacyPagedListMessagesOptions = {
 
 /** Pagination, ordering, filtering, and include options for an Agent Controller thread's messages. */
 export type AgentControllerListMessagesOptions =
-  AgentControllerModernListMessagesOptions | AgentControllerLegacyPagedListMessagesOptions;
+  | AgentControllerModernListMessagesOptions
+  | AgentControllerLegacyPagedListMessagesOptions;
 
 /** A page of hydrated Agent Controller thread messages. */
 export type AgentControllerListMessagesResult = StorageListMessagesOutput;

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -21225,6 +21225,26 @@ export type GetAgentControllerControllerIdSessionsResourceIdThreadsThreadIdMessa
 
 export type GetAgentControllerControllerIdSessionsResourceIdThreadsThreadIdMessages_QueryParams = {
   limit?: number | undefined;
+  page?: number | undefined;
+  perPage?: (false | number) | undefined;
+  orderBy?:
+    | (
+        | {
+            field?: 'createdAt' | undefined;
+            direction?: ('ASC' | 'DESC') | undefined;
+          }
+        | undefined
+      )
+    | undefined;
+  include?:
+    | {
+        id: string;
+        threadId?: string | undefined;
+        withPreviousMessages?: number | undefined;
+        withNextMessages?: number | undefined;
+      }[]
+    | undefined;
+  filter?: Shared_Type_66 | undefined;
   sessionScope?: string | undefined;
 };
 
@@ -21245,6 +21265,10 @@ export type GetAgentControllerControllerIdSessionsResourceIdThreadsThreadIdMessa
     resourceId?: string | undefined;
     type?: string | undefined;
   }[];
+  total: number;
+  page: number;
+  perPage: number | false;
+  hasMore: boolean;
 };
 
 export type GetAgentControllerControllerIdSessionsResourceIdThreadsThreadIdMessages_Request = Simplify<

--- a/docs/src/content/en/docs/harness/agent-controller.mdx
+++ b/docs/src/content/en/docs/harness/agent-controller.mdx
@@ -141,6 +141,32 @@ const session = await controller.createSession({
 
 Use [`session.thread.create()`](/reference/agent-controller/session#sessionthreadcreate-title-id-) and [`session.thread.switch()`](/reference/agent-controller/session#sessionthreadswitch-threadid-emitevent-) to move one live Session between conversations.
 
+### List stored messages from the client
+
+Use the Agent Controller client to page through a thread's stored messages. Passing an options object returns the messages with pagination metadata:
+
+```typescript
+import { MastraClient } from '@mastra/client-js'
+
+const client = new MastraClient({ baseUrl: 'http://localhost:4111' })
+const session = client.getAgentController('assistant-controller').session('user-123')
+
+const result = await session.listMessages('support-ticket-42', {
+  page: 0,
+  perPage: 20,
+  orderBy: { field: 'createdAt', direction: 'DESC' },
+  filter: {
+    dateRange: { start: new Date('2026-01-01') },
+  },
+})
+
+console.log(result.messages)
+console.log(result.total)
+console.log(result.hasMore)
+```
+
+`page` is zero-indexed. Omitting `perPage` uses the storage default of 40 messages. Use `include` to request a message by ID with adjacent messages. `limit` is a deprecated alias for `perPage`; existing paged callers may use `{ limit, page }`, but must use `perPage` with `orderBy`, `filter`, or `include`. The existing numeric form, `session.listMessages(threadId, limit)`, remains available when you need the newest message window as an array, ordered oldest-first.
+
 ## Switch modes and models
 
 Modes change the instructions and tools used by the shared backing agent without replacing the Session or thread. Configure mode-specific tools and visibility on the controller:

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -6348,7 +6348,12 @@ export const API_ROUTE_METADATA = {
       "threadId"
     ],
     "queryParams": [
+      "filter",
+      "include",
       "limit",
+      "orderBy",
+      "page",
+      "perPage",
       "sessionScope"
     ],
     "bodyParams": [],
@@ -6356,7 +6361,8 @@ export const API_ROUTE_METADATA = {
     "hasBody": false,
     "responseShape": {
       "kind": "object-property",
-      "listProperty": "messages"
+      "listProperty": "messages",
+      "paginationProperty": "page"
     }
   },
   "POST /agent-controller/:controllerId/sessions/:resourceId/messages": {

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -997,7 +997,7 @@ export class AgentController<TState = {}> {
         this.queryThreads({ resourceId, includeForkedSubagents, metadata }),
       getById: ({ threadId }) => this.queryThreadById({ threadId }),
       listMessages: async ({ threadId, limit }) => {
-        if (limit) {
+        if (limit !== undefined) {
           const result = await this.queryThreadMessages({
             threadId,
             perPage: limit,

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -18,7 +18,7 @@ import type { TracingContext, TracingOptions } from '../observability';
 import { RequestContext } from '../request-context';
 import type { MastraCompositeStore } from '../storage/base';
 import type { MemoryStorage } from '../storage/domains/memory/base';
-import type { ObservationalMemoryRecord } from '../storage/types';
+import type { ObservationalMemoryRecord, StorageListMessagesInput, StorageListMessagesOutput } from '../storage/types';
 import type { DynamicArgument } from '../types';
 import { Workspace } from '../workspace/workspace';
 
@@ -172,7 +172,7 @@ const TITLE_WINDOW_MESSAGES = 20;
  * })
  *
  * controller.subscribe((event) => {
- *   if (event.type === "message_update") renderMessage(event.message)
+ *   if (event.type === "message_update") appendText(event.id, event.event.delta)
  * })
  *
  * await controller.init()
@@ -996,7 +996,23 @@ export class AgentController<TState = {}> {
       listThreads: ({ resourceId, includeForkedSubagents, metadata }) =>
         this.queryThreads({ resourceId, includeForkedSubagents, metadata }),
       getById: ({ threadId }) => this.queryThreadById({ threadId }),
-      listMessages: ({ threadId, limit }) => this.queryThreadMessages({ threadId, limit }),
+      listMessages: async ({ threadId, limit }) => {
+        if (limit) {
+          const result = await this.queryThreadMessages({
+            threadId,
+            perPage: limit,
+            page: 0,
+            orderBy: { field: 'createdAt', direction: 'DESC' },
+          });
+          return { ...result, messages: result.messages.reverse() };
+        }
+
+        return this.queryThreadMessages({
+          threadId,
+          perPage: false,
+          orderBy: { field: 'createdAt', direction: 'ASC' },
+        });
+      },
       firstUserMessages: ({ threadIds }) => this.queryFirstUserMessages({ threadIds }),
       getMetadata: ({ threadId, key }) => this.readThreadMetadataValue({ threadId, key }),
       setMetadata: ({ threadId, key, value }) => this.writeThreadMetadataValue({ threadId, key, value }),
@@ -1201,28 +1217,43 @@ export class AgentController<TState = {}> {
 
   /**
    * List messages for a thread directly from storage, without constructing a
-   * {@link Session}. Read-only server endpoints use this so a GET on a thread's
-   * messages doesn't spin up a workspace/sandbox as a side effect of session
-   * creation.
+   * {@link Session}. The session thread-data adapter and read-only server
+   * endpoints use this shared path so message reads never provision a
+   * workspace/sandbox.
    */
-  async queryThreadMessages({ threadId, limit }: { threadId: string; limit?: number }): Promise<MastraDBMessage[]> {
+  async queryThreadMessages({
+    threadId,
+    resourceId,
+    perPage,
+    page,
+    orderBy = { field: 'createdAt', direction: 'DESC' },
+    include,
+    filter,
+  }: Omit<StorageListMessagesInput, 'threadId'> & { threadId: string }): Promise<StorageListMessagesOutput> {
     await this.initStorage();
-    if (!this.#resolveStorage()) return [];
-
-    const memoryStorage = await this.getMemoryStorage();
-
-    if (limit) {
-      const result = await memoryStorage.listMessages({
-        threadId,
-        perPage: limit,
-        page: 0,
-        orderBy: { field: 'createdAt', direction: 'DESC' },
-      });
-      return result.messages.map(msg => this.convertToControllerMessage(msg)).reverse();
+    if (!this.#resolveStorage()) {
+      return {
+        messages: [],
+        total: 0,
+        page: page ?? 0,
+        perPage: perPage ?? 40,
+        hasMore: false,
+      };
     }
 
-    const result = await memoryStorage.listMessages({ threadId, perPage: false });
-    return result.messages.map(msg => this.convertToControllerMessage(msg));
+    const result = await (
+      await this.getMemoryStorage()
+    ).listMessages({
+      threadId,
+      ...(resourceId !== undefined ? { resourceId } : {}),
+      ...(perPage !== undefined ? { perPage } : {}),
+      ...(page !== undefined ? { page } : {}),
+      ...(orderBy !== undefined ? { orderBy } : {}),
+      ...(include !== undefined ? { include } : {}),
+      ...(filter !== undefined ? { filter } : {}),
+    });
+
+    return { ...result, messages: result.messages.map(msg => this.convertToControllerMessage(msg)) };
   }
 
   private async queryFirstUserMessages({ threadIds }: { threadIds: string[] }): Promise<Map<string, MastraDBMessage>> {
@@ -1280,8 +1311,13 @@ export class AgentController<TState = {}> {
     const thread = await this.queryThreadById({ threadId });
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
 
-    const recent = await this.queryThreadMessages({ threadId, limit: TITLE_WINDOW_MESSAGES });
-    const messages = new MessageList().add(recent, 'memory').get.all.ui();
+    const recent = await this.queryThreadMessages({
+      threadId,
+      perPage: TITLE_WINDOW_MESSAGES,
+      page: 0,
+      orderBy: { field: 'createdAt', direction: 'DESC' },
+    });
+    const messages = new MessageList().add(recent.messages.reverse(), 'memory').get.all.ui();
     if (!messages.some(message => message.role === 'user')) {
       throw new Error('This conversation has no message to name it from yet.');
     }

--- a/packages/core/src/agent-controller/query-thread-messages.test.ts
+++ b/packages/core/src/agent-controller/query-thread-messages.test.ts
@@ -120,5 +120,6 @@ describe('AgentController queryThreadMessages', () => {
       { id: 'second' },
       { id: 'third' },
     ]);
+    await expect(session.thread.listMessages({ threadId, limit: 0 })).resolves.toEqual([]);
   });
 });

--- a/packages/core/src/agent-controller/query-thread-messages.test.ts
+++ b/packages/core/src/agent-controller/query-thread-messages.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Mastra } from '../mastra';
+import { InMemoryStore } from '../storage/mock';
+import { AgentController } from './agent-controller';
+import { createMockWorkspace, createTestAgent, createTestController } from './test-utils';
+
+describe('AgentController queryThreadMessages', () => {
+  it('forwards memory pagination, ordering, filters, includes, and resource scope through inherited storage', async () => {
+    const controllerStore = new InMemoryStore();
+    const parentStore = new InMemoryStore();
+    const controller = createTestController({ storage: controllerStore });
+    new Mastra({ agentControllers: { code: controller }, storage: parentStore });
+
+    const threadId = 'parent-thread';
+    const parentMemory = await parentStore.getStore('memory');
+    await parentMemory!.saveMessages({
+      messages: [
+        ['first', '2026-01-01T00:00:00.000Z', 'parent-user', 'keep'],
+        ['second', '2026-01-02T00:00:00.000Z', 'parent-user', 'discard'],
+        ['third', '2026-01-03T00:00:00.000Z', 'parent-user', 'keep'],
+        ['other-resource', '2026-01-04T00:00:00.000Z', 'other-user', 'keep'],
+      ].map(([id, createdAt, resourceId, category]) => ({
+        id,
+        role: 'user',
+        threadId,
+        resourceId,
+        createdAt: new Date(createdAt),
+        content: { format: 2, parts: [{ type: 'text', text: id }], metadata: { category } },
+      })) as any,
+    });
+
+    const initStorage = vi.spyOn(controller, 'initStorage');
+    const createSession = vi.spyOn(controller, 'createSession');
+    try {
+      const paged = await controller.queryThreadMessages({
+        threadId,
+        resourceId: 'parent-user',
+        page: 1,
+        perPage: 1,
+        orderBy: { field: 'createdAt', direction: 'DESC' },
+      });
+      const filtered = await controller.queryThreadMessages({
+        threadId,
+        resourceId: 'parent-user',
+        perPage: false,
+        filter: {
+          dateRange: { start: new Date('2026-01-02T00:00:00.000Z') },
+          metadata: { category: 'keep' },
+        },
+      });
+      const included = await controller.queryThreadMessages({
+        threadId,
+        resourceId: 'parent-user',
+        perPage: 0,
+        include: [{ id: 'third', withPreviousMessages: 1 }],
+      });
+
+      expect(paged).toMatchObject({ total: 3, page: 1, perPage: 1, hasMore: true });
+      expect(paged.messages.map(message => message.id)).toEqual(['second']);
+      expect(filtered.messages.map(message => message.id)).toEqual(['third']);
+      expect(included.messages.map(message => message.id)).toEqual(['third', 'second']);
+      expect(initStorage).toHaveBeenCalled();
+      expect(createSession).not.toHaveBeenCalled();
+
+      const controllerMemory = await controllerStore.getStore('memory');
+      expect((await controllerMemory!.listMessages({ threadId, perPage: false })).messages).toEqual([]);
+    } finally {
+      initStorage.mockRestore();
+      createSession.mockRestore();
+    }
+  });
+
+  it('returns an empty result using storage pagination defaults when storage is unavailable', async () => {
+    const controller = new AgentController({
+      id: 'no-storage-controller',
+      workspace: createMockWorkspace(),
+      modes: [
+        {
+          id: 'default',
+          name: 'Default',
+          default: true,
+          agent: createTestAgent(),
+        },
+      ],
+    });
+
+    await expect(controller.queryThreadMessages({ threadId: 'missing', page: 2 })).resolves.toEqual({
+      messages: [],
+      total: 0,
+      page: 2,
+      perPage: 40,
+      hasMore: false,
+    });
+  });
+
+  it('keeps Session thread reads array-returning and newest-window chronological', async () => {
+    const store = new InMemoryStore();
+    const controller = createTestController({ storage: store });
+    await controller.init();
+    const session = await controller.createSession({ resourceId: 'session-user' });
+    const threadId = session.thread.requireId();
+    const memory = await store.getStore('memory');
+    await memory!.saveMessages({
+      messages: ['first', 'second', 'third'].map((id, index) => ({
+        id,
+        role: 'user',
+        threadId,
+        resourceId: 'session-user',
+        createdAt: new Date(`2026-01-0${index + 1}T00:00:00.000Z`),
+        content: { format: 2, parts: [{ type: 'text', text: id }] },
+      })) as any,
+    });
+
+    await expect(session.thread.listMessages({ threadId })).resolves.toMatchObject([
+      { id: 'first' },
+      { id: 'second' },
+      { id: 'third' },
+    ]);
+    await expect(session.thread.listMessages({ threadId, limit: 2 })).resolves.toMatchObject([
+      { id: 'second' },
+      { id: 'third' },
+    ]);
+  });
+});

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -26,6 +26,7 @@ import type { TracingContext, TracingOptions } from '../observability';
 import type { RequestContext } from '../request-context';
 import { toStandardSchema } from '../schema';
 import type { PublicSchema, StandardSchemaWithJSON } from '../schema';
+import type { StorageListMessagesOutput } from '../storage/types';
 import type { SubmitPlanResumeData } from '../tools/builtin/submit-plan';
 import { safeStringify } from '../utils';
 import { Workspace } from '../workspace';
@@ -222,7 +223,7 @@ export interface ThreadDataStore {
   /** Fetch a single thread by id, or null when it doesn't exist. */
   getById(input: { threadId: string }): Promise<AgentControllerThread | null>;
   /** List messages for a thread, newest-`limit` (returned oldest-first) or all. */
-  listMessages(input: { threadId: string; limit?: number }): Promise<MastraDBMessage[]>;
+  listMessages(input: { threadId: string; limit?: number }): Promise<StorageListMessagesOutput>;
   /** The first user message for each given thread id. */
   firstUserMessages(input: { threadIds: string[] }): Promise<Map<string, MastraDBMessage>>;
   /** Read a value from a thread's metadata. */
@@ -483,7 +484,7 @@ export class SessionThread {
     if (!this.#store) return [];
     // Only expose messages for threads this session owns.
     await this.#requireOwnedThread({ threadId });
-    return this.#store.listMessages({ threadId, limit });
+    return (await this.#store.listMessages({ threadId, limit })).messages;
   }
 
   /** List messages for the session's active thread (empty when not bound). */

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -849,7 +849,7 @@ describe('agent-controller routes', () => {
           controllerId: 'storage-fallback',
           resourceId: 'storage-user',
           threadId,
-          limit: 1,
+          limit: 2,
           page: 0,
         } as any)) as { messages: { id: string }[]; total: number; page: number; perPage: number; hasMore: boolean };
 
@@ -861,8 +861,8 @@ describe('agent-controller routes', () => {
         expect(filtered.messages.map(message => message.id)).toEqual(['third', 'first']);
         expect(limited).toMatchObject({ total: 3, page: 0, perPage: 2, hasMore: true });
         expect(limited.messages.map(message => message.id)).toEqual(['second', 'third']);
-        expect(limitPaged).toMatchObject({ total: 3, page: 0, perPage: 1, hasMore: true });
-        expect(limitPaged.messages.map(message => message.id)).toEqual(['third']);
+        expect(limitPaged).toMatchObject({ total: 3, page: 0, perPage: 2, hasMore: true });
+        expect(limitPaged.messages.map(message => message.id)).toEqual(['second', 'third']);
         expect(queryThreadMessages).toHaveBeenNthCalledWith(1, { threadId, resourceId: 'storage-user' });
         expect(queryThreadMessages).toHaveBeenNthCalledWith(2, {
           threadId,
@@ -887,8 +887,9 @@ describe('agent-controller routes', () => {
         expect(queryThreadMessages).toHaveBeenNthCalledWith(5, {
           threadId,
           resourceId: 'storage-user',
-          perPage: 1,
+          perPage: 2,
           page: 0,
+          orderBy: { field: 'createdAt', direction: 'DESC' },
         });
         expect(initStorage).toHaveBeenCalled();
       } finally {

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -902,7 +902,9 @@ describe('agent-controller routes', () => {
 
       expect(querySchema.parse({ limit: 2, page: 1 })).toMatchObject({ limit: 2, page: 1 });
       expect(querySchema.safeParse({ limit: 2, perPage: 1 }).success).toBe(false);
-      expect(querySchema.safeParse({ limit: 2, orderBy: { field: 'createdAt', direction: 'DESC' } }).success).toBe(false);
+      expect(querySchema.safeParse({ limit: 2, orderBy: { field: 'createdAt', direction: 'DESC' } }).success).toBe(
+        false,
+      );
       expect(querySchema.safeParse({ limit: 2, include: [{ id: 'message-1' }] }).success).toBe(false);
       expect(querySchema.safeParse({ limit: 2, filter: { metadata: { category: 'support' } } }).success).toBe(false);
       expect(querySchema.parse({ perPage: 'false' })).toMatchObject({ perPage: false });
@@ -1274,7 +1276,7 @@ describe('agent-controller routes', () => {
       ).rejects.toThrow('Thread not found');
     });
 
-    it('LIST messages rejects a thread owned by another resource', async () => {
+    it('LIST messages does not disclose a thread owned by another resource', async () => {
       const { victimThreadId } = await setupTwoSessions();
       await expect(
         LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE.handler({
@@ -1283,7 +1285,7 @@ describe('agent-controller routes', () => {
           resourceId: 'attacker',
           threadId: victimThreadId,
         } as any),
-      ).rejects.toThrow('Access denied: thread belongs to a different resource');
+      ).rejects.toThrow('Thread not found');
     });
 
     it('SWITCH rejects a thread owned by another resource', async () => {

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -483,7 +483,7 @@ describe('agent-controller routes', () => {
       expect(received.type).toBe('agent_start');
     });
 
-    it('preserves live streamed messages across the SSE boundary without cloning', async () => {
+    it('preserves compact message lifecycle payloads across the SSE boundary', async () => {
       const stream = (await STREAM_AGENT_CONTROLLER_SESSION_ROUTE.handler({
         mastra,
         controllerId: 'code',
@@ -503,22 +503,31 @@ describe('agent-controller routes', () => {
         id: 'assistant-live-1',
         role: 'assistant',
         createdAt: new Date('2026-01-02T03:04:05.000Z'),
-        content: { format: 2, parts: [{ type: 'text', text: 'first' }] },
+        content: { format: 2, parts: [{ type: 'text', text: '' }] },
       } as any;
 
-      session.emit({ type: 'message_update', message });
-      message.content.parts[0].text = 'later';
+      session.emit({ type: 'message_start', message });
+      session.emit({ type: 'message_update', id: message.id, event: { type: 'text-delta', delta: 'later' } });
+      session.emit({ type: 'message_end', id: message.id });
 
-      let received: any;
-      for (let i = 0; i < 10 && received === undefined; i++) {
+      const received: any[] = [];
+      for (let i = 0; i < 20 && received.length < 3; i++) {
         const { value } = await reader.read();
-        if (value && typeof value === 'object' && (value as any).type === 'message_update') received = value;
+        if (
+          value &&
+          typeof value === 'object' &&
+          ['message_start', 'message_update', 'message_end'].includes((value as any).type)
+        ) {
+          received.push(value);
+        }
       }
       await reader.cancel();
 
-      expect(received.message).toBe(message);
-      expect(received.message.content.parts[0].text).toBe('later');
-      expect(received.message.createdAt).toEqual(new Date('2026-01-02T03:04:05.000Z'));
+      expect(received).toEqual([
+        { type: 'message_start', message },
+        { type: 'message_update', id: message.id, event: { type: 'text-delta', delta: 'later' } },
+        { type: 'message_end', id: message.id },
+      ]);
     });
 
     it('flattens Error instances on error events so the message survives JSON serialization', async () => {
@@ -757,6 +766,177 @@ describe('agent-controller routes', () => {
       expect(message.content.format).toBe(2);
       expect(message.content.parts).toEqual([{ type: 'text', text: 'hello world' }]);
       expect(message.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    });
+
+    it('delegates unlimited and limited reads to the controller against inherited Mastra storage', async () => {
+      const mastraStorage = new InMemoryStore();
+      const controller = new AgentController({
+        id: 'storage-fallback',
+        storage: new InMemoryStore(),
+        workspace: new Workspace({ name: 'storage-fallback-workspace', skills: ['/tmp/test-skills'] }),
+        modes: [{ id: 'build', name: 'Build', default: true, agent: makeAgent() }],
+      });
+      const fallbackMastra = new Mastra({
+        agentControllers: { 'storage-fallback': controller },
+        storage: mastraStorage,
+      });
+      const memory = await mastraStorage.getStore('memory');
+      const threadId = 'storage-fallback-thread';
+      await memory!.saveThread({
+        thread: {
+          id: threadId,
+          resourceId: 'storage-user',
+          title: 'storage fallback',
+          metadata: {},
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        },
+      });
+      await memory!.saveMessages({
+        messages: [
+          ['first', '2026-01-01T00:00:00.000Z'],
+          ['second', '2026-01-02T00:00:00.000Z'],
+          ['third', '2026-01-03T00:00:00.000Z'],
+        ].map(([id, createdAt]) => ({
+          id,
+          role: 'user',
+          threadId,
+          resourceId: 'storage-user',
+          createdAt: new Date(createdAt),
+          content: {
+            format: 2,
+            parts: [{ type: 'text', text: id }],
+            metadata: { category: id === 'second' ? 'discard' : 'keep' },
+          },
+        })) as any,
+      });
+      const initStorage = vi.spyOn(controller, 'initStorage');
+      const queryThreadMessages = vi.spyOn(controller, 'queryThreadMessages');
+
+      try {
+        const unlimited = (await LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE.handler({
+          mastra: fallbackMastra,
+          controllerId: 'storage-fallback',
+          resourceId: 'storage-user',
+          threadId,
+        } as any)) as { messages: { id: string }[]; total: number; page: number; perPage: number; hasMore: boolean };
+        const paged = (await LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE.handler({
+          mastra: fallbackMastra,
+          controllerId: 'storage-fallback',
+          resourceId: 'storage-user',
+          threadId,
+          page: 1,
+          perPage: 1,
+          orderBy: { field: 'createdAt', direction: 'DESC' },
+        } as any)) as { messages: { id: string }[]; total: number; page: number; perPage: number; hasMore: boolean };
+        const filtered = (await LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE.handler({
+          mastra: fallbackMastra,
+          controllerId: 'storage-fallback',
+          resourceId: 'storage-user',
+          threadId,
+          perPage: false,
+          filter: { metadata: { category: 'keep' } },
+        } as any)) as { messages: { id: string }[]; total: number; page: number; perPage: false; hasMore: boolean };
+        const limited = (await LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE.handler({
+          mastra: fallbackMastra,
+          controllerId: 'storage-fallback',
+          resourceId: 'storage-user',
+          threadId,
+          limit: 2,
+        } as any)) as { messages: { id: string }[]; total: number; page: number; perPage: number; hasMore: boolean };
+        const limitPaged = (await LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE.handler({
+          mastra: fallbackMastra,
+          controllerId: 'storage-fallback',
+          resourceId: 'storage-user',
+          threadId,
+          limit: 1,
+          page: 0,
+        } as any)) as { messages: { id: string }[]; total: number; page: number; perPage: number; hasMore: boolean };
+
+        expect(unlimited).toMatchObject({ total: 3, page: 0, perPage: 40, hasMore: false });
+        expect(unlimited.messages.map(message => message.id)).toEqual(['third', 'second', 'first']);
+        expect(paged).toMatchObject({ total: 3, page: 1, perPage: 1, hasMore: true });
+        expect(paged.messages.map(message => message.id)).toEqual(['second']);
+        expect(filtered).toMatchObject({ total: 2, page: 0, perPage: false, hasMore: false });
+        expect(filtered.messages.map(message => message.id)).toEqual(['third', 'first']);
+        expect(limited).toMatchObject({ total: 3, page: 0, perPage: 2, hasMore: true });
+        expect(limited.messages.map(message => message.id)).toEqual(['second', 'third']);
+        expect(limitPaged).toMatchObject({ total: 3, page: 0, perPage: 1, hasMore: true });
+        expect(limitPaged.messages.map(message => message.id)).toEqual(['third']);
+        expect(queryThreadMessages).toHaveBeenNthCalledWith(1, { threadId, resourceId: 'storage-user' });
+        expect(queryThreadMessages).toHaveBeenNthCalledWith(2, {
+          threadId,
+          resourceId: 'storage-user',
+          page: 1,
+          perPage: 1,
+          orderBy: { field: 'createdAt', direction: 'DESC' },
+        });
+        expect(queryThreadMessages).toHaveBeenNthCalledWith(3, {
+          threadId,
+          resourceId: 'storage-user',
+          perPage: false,
+          filter: { metadata: { category: 'keep' } },
+        });
+        expect(queryThreadMessages).toHaveBeenNthCalledWith(4, {
+          threadId,
+          resourceId: 'storage-user',
+          perPage: 2,
+          page: 0,
+          orderBy: { field: 'createdAt', direction: 'DESC' },
+        });
+        expect(queryThreadMessages).toHaveBeenNthCalledWith(5, {
+          threadId,
+          resourceId: 'storage-user',
+          perPage: 1,
+          page: 0,
+        });
+        expect(initStorage).toHaveBeenCalled();
+      } finally {
+        initStorage.mockRestore();
+        queryThreadMessages.mockRestore();
+      }
+    });
+
+    it('accepts limit with page as a deprecated perPage alias and rejects other modern options', () => {
+      const querySchema = (LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE as any).queryParamSchema;
+
+      expect(querySchema.parse({ limit: 2, page: 1 })).toMatchObject({ limit: 2, page: 1 });
+      expect(querySchema.safeParse({ limit: 2, perPage: 1 }).success).toBe(false);
+      expect(querySchema.safeParse({ limit: 2, orderBy: { field: 'createdAt', direction: 'DESC' } }).success).toBe(false);
+      expect(querySchema.safeParse({ limit: 2, include: [{ id: 'message-1' }] }).success).toBe(false);
+      expect(querySchema.safeParse({ limit: 2, filter: { metadata: { category: 'support' } } }).success).toBe(false);
+      expect(querySchema.parse({ perPage: 'false' })).toMatchObject({ perPage: false });
+    });
+
+    it('forwards request context to memory FGA checks', async () => {
+      const created = (await CREATE_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'fga-user',
+      } as any)) as { threadId: string };
+      const require = vi.fn().mockResolvedValue(undefined);
+      vi.spyOn(mastra, 'getServer').mockReturnValue({ fga: { require } } as any);
+      const requestContext = new RequestContext();
+      const user = {
+        id: 'user-1',
+        organizationMembershipId: 'om-1',
+        memberships: [{ id: 'om-1', organizationId: 'org-1' }],
+      };
+      requestContext.set('user', user);
+
+      await LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'fga-user',
+        threadId: created.threadId,
+        requestContext,
+      } as any);
+
+      expect(require).toHaveBeenCalledWith(user, {
+        resource: { type: 'thread', id: created.threadId },
+        permission: 'memory:read',
+        context: expect.objectContaining({ resourceId: 'fga-user' }),
+      });
     });
 
     it('preserves signal-role messages with their data parts', async () => {
@@ -1103,7 +1283,7 @@ describe('agent-controller routes', () => {
           resourceId: 'attacker',
           threadId: victimThreadId,
         } as any),
-      ).rejects.toThrow('Thread not found');
+      ).rejects.toThrow('Access denied: thread belongs to a different resource');
     });
 
     it('SWITCH rejects a thread owned by another resource', async () => {

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -18,8 +18,10 @@ import type { RequestContext } from '@mastra/core/request-context';
 import { z } from 'zod/v4';
 
 import { HTTPException } from '../http-exception';
+import { filterSchema, includeSchema, messageOrderBySchema } from '../schemas/memory';
 import { createRoute } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
+import { enforceThreadAccess } from './utils';
 
 /**
  * AgentController session routes.
@@ -213,7 +215,33 @@ const cloneThreadBodySchema = z.object({
   sourceThreadId: z.string().optional(),
   title: z.string().optional(),
 });
-const listMessagesQuerySchema = z.object({ limit: z.coerce.number().optional(), sessionScope: z.string().optional() });
+const controllerPaginationNumber = z.coerce.number().int().min(0);
+const listMessagesQuerySchema = z
+  .object({
+    /** @deprecated Use page and perPage instead. */
+    limit: controllerPaginationNumber.optional(),
+    page: controllerPaginationNumber.optional(),
+    perPage: z
+      .preprocess(value => (value === 'false' ? false : value), z.union([z.literal(false), controllerPaginationNumber]))
+      .optional(),
+    orderBy: messageOrderBySchema,
+    include: includeSchema,
+    filter: filterSchema,
+    sessionScope: z.string().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.limit === undefined) return;
+
+    for (const field of ['perPage', 'orderBy', 'include', 'filter'] as const) {
+      if (value[field] !== undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `limit cannot be combined with ${field}; use perPage instead`,
+          path: ['limit'],
+        });
+      }
+    }
+  });
 /**
  * `tags` arrives as a JSON-encoded object in the query string (query params are
  * flat strings). It scopes the listing to threads whose metadata matches every
@@ -363,6 +391,10 @@ const listMessagesResponseSchema = z.object({
       type: z.string().optional(),
     }),
   ),
+  total: z.number(),
+  page: z.number(),
+  perPage: z.union([z.number(), z.literal(false)]),
+  hasMore: z.boolean(),
 });
 const listModelsResponseSchema = z.object({
   models: z.array(
@@ -476,7 +508,7 @@ function carriesError(event: AgentControllerEvent): event is ErrorCarryingAgentC
  * An `Error`'s `message`/`name` are non-enumerable, so flatten it before JSON
  * serialization. Streamed message events intentionally retain the controller's
  * live accumulated message; consumers requiring temporal isolation must copy or
- * serialize at their own ownership boundary.
+ * serialize the value there.
  */
 function toWireEvent(event: AgentControllerEvent): JsonReadyAgentControllerEvent {
   if ('displayState' in event) {
@@ -1204,28 +1236,71 @@ export const LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE = createRoute({
   queryParamSchema: listMessagesQuerySchema,
   responseSchema: listMessagesResponseSchema,
   summary: 'List thread messages',
-  description: 'Lists messages for a specific thread. Returns most recent messages first.',
+  description:
+    'Returns a paginated list of messages in a specific thread. The deprecated limit parameter may only be combined with page.',
   tags: ['AgentController', 'Threads'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId, resourceId, threadId, limit }) => {
+  handler: async ({
+    mastra,
+    controllerId,
+    resourceId,
+    threadId,
+    limit,
+    page,
+    perPage,
+    orderBy,
+    include,
+    filter,
+    requestContext,
+  }) => {
     try {
-      const controller = getAgentControllerOrThrow(mastra, controllerId);
-      // Read-only route: query storage directly instead of constructing a
-      // Session. Session creation would trigger workspace/sandbox
-      // initialization as a side effect; reads should never pay that cost.
-      // The query methods lazily initialize storage (not workspace) on their own.
-      // The route is authorized for the URL's resourceId, but `threadId` is
-      // otherwise unscoped. Verify the thread belongs to this resource so a
-      // caller can't peek at another resource's messages by guessing an id
-      // — matches the check `session.thread.listMessages` performed via
-      // `session.thread.set` before we bypassed session construction.
-      const thread = await controller.queryThreadById({ threadId });
-      if (!thread || thread.resourceId !== resourceId) {
-        throw new Error(`Thread not found: ${threadId}`);
+      if (
+        limit !== undefined &&
+        (perPage !== undefined || orderBy !== undefined || include !== undefined || filter !== undefined)
+      ) {
+        throw new HTTPException(400, { message: 'limit can only be combined with page; use perPage instead' });
       }
-      const messages = await controller.queryThreadMessages({ threadId, limit });
+
+      const controller = getAgentControllerOrThrow(mastra, controllerId);
+      const thread = await controller.queryThreadById({ threadId });
+      if (!thread) {
+        throw new HTTPException(404, { message: 'Thread not found' });
+      }
+      await enforceThreadAccess({
+        mastra,
+        requestContext,
+        threadId,
+        thread,
+        effectiveResourceId: resourceId,
+      });
+
+      // Read-only route: delegate storage retrieval to the controller without
+      // constructing a Session, which would initialize the workspace/sandbox.
+      const isLegacyLimitQuery = limit !== undefined && page === undefined;
+      const result = await controller.queryThreadMessages(
+        limit !== undefined
+          ? {
+              threadId,
+              resourceId,
+              perPage: limit,
+              ...(isLegacyLimitQuery ? { page: 0, orderBy: { field: 'createdAt', direction: 'DESC' as const } } : {}),
+              ...(page !== undefined ? { page } : {}),
+            }
+          : {
+              threadId,
+              resourceId,
+              ...(perPage !== undefined ? { perPage } : {}),
+              ...(page !== undefined ? { page } : {}),
+              ...(orderBy !== undefined ? { orderBy } : {}),
+              ...(include !== undefined ? { include } : {}),
+              ...(filter !== undefined ? { filter } : {}),
+            },
+      );
+      const messages = isLegacyLimitQuery ? result.messages.reverse() : result.messages;
+
       return {
+        ...result,
         messages: messages.map(m => ({
           id: m.id,
           role: m.role,

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -1264,7 +1264,7 @@ export const LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE = createRoute({
 
       const controller = getAgentControllerOrThrow(mastra, controllerId);
       const thread = await controller.queryThreadById({ threadId });
-      if (!thread) {
+      if (!thread || (resourceId && thread.resourceId && thread.resourceId !== resourceId)) {
         throw new HTTPException(404, { message: 'Thread not found' });
       }
       await enforceThreadAccess({

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -1277,15 +1277,15 @@ export const LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE = createRoute({
 
       // Read-only route: delegate storage retrieval to the controller without
       // constructing a Session, which would initialize the workspace/sandbox.
-      const isLegacyLimitQuery = limit !== undefined && page === undefined;
+      const isLegacyLimitQuery = limit !== undefined;
       const result = await controller.queryThreadMessages(
         limit !== undefined
           ? {
               threadId,
               resourceId,
               perPage: limit,
-              ...(isLegacyLimitQuery ? { page: 0, orderBy: { field: 'createdAt', direction: 'DESC' as const } } : {}),
-              ...(page !== undefined ? { page } : {}),
+              page: page ?? 0,
+              orderBy: { field: 'createdAt', direction: 'DESC' as const },
             }
           : {
               threadId,

--- a/packages/server/src/server/schemas/memory.ts
+++ b/packages/server/src/server/schemas/memory.ts
@@ -58,7 +58,7 @@ const storageOrderBySchema = z
  * Handles JSON parsing from query strings. See `storageOrderBySchema` for why
  * the inner object schema is also `.optional()`.
  */
-const messageOrderBySchema = z
+export const messageOrderBySchema = z
   .preprocess(
     val => {
       if (val === undefined) return val;
@@ -83,7 +83,7 @@ const messageOrderBySchema = z
 /**
  * Include schema for message listing - handles JSON parsing from query strings
  */
-const includeSchema = z
+export const includeSchema = z
   .preprocess(
     val => {
       if (val === undefined) return val;
@@ -124,7 +124,7 @@ const metadataFilterSchema = z.record(metadataFilterKeySchema, metadataFilterVal
 /**
  * Filter schema for message listing - handles JSON parsing from query strings
  */
-const filterSchema = z
+export const filterSchema = z
   .preprocess(
     val => {
       if (val === undefined) return val;


### PR DESCRIPTION
## Description

PR 1 of 2. Adds storage-backed pagination to Agent Controller thread message retrieval without changing the existing Session or numeric client APIs.

The endpoint and client SDK now support `page`, `perPage`, ordering, filters, and includes, and return pagination metadata. Existing `session.thread.listMessages({ limit })` callers continue receiving the newest matching messages in chronological order. Generated route metadata and the Agent Controller docs are included with the API change.

Example:

```ts
const page = await session.listMessages(threadId, {
  page: 0,
  perPage: 50,
  orderBy: { field: 'createdAt', direction: 'DESC' },
});

page.messages;
page.hasMore;
```

## Related issue(s)

None.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Verification

- `pnpm --filter @mastra/core exec vitest run src/agent-controller/query-thread-messages.test.ts --passWithNoTests`
- `pnpm --filter @mastra/client-js exec vitest run src/resources/agent-controller.test.ts`

The focused server handler suite could not start locally because existing core build output imports a missing `@ai-sdk/provider-utils-v5` dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The Agent Controller can now load thread messages in pages instead of loading everything at once. Existing Session and client methods still return message arrays for backward compatibility.

## What changed

- Added pagination, ordering, filtering, message inclusion, and resource scoping to Agent Controller message queries.
- Added pagination metadata: `total`, `page`, `perPage`, and `hasMore`.
- Preserved legacy numeric `limit` support for Session and client APIs.
- Added validation for incompatible query options.
- Added thread access checks and 404 handling for missing or mismatched threads.
- Exported message query schemas and new client message-listing types.
- Added documentation and test coverage for pagination, filtering, ordering, access control, storage inheritance, and legacy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->