### PR TITLE
feat(playground): review queue lists all reviews by default, experiments description column, datasets infinite scroll

### DIFF
--- a/.changeset/review-queue-all-experiments.md
+++ b/.changeset/review-queue-all-experiments.md
@@ -1,5 +1,0 @@
----
-'@mastra/playground': patch
----
-
-Studio experiments & datasets polish: the review queue now lists every item awaiting review across the project by default, with the experiment selector acting as an optional filter ("All experiments" clears it). The experiments table shows the description in its own truncated column instead of a two-line name cell, the experiment results input column is capped and truncated, and the datasets page uses infinite scroll like the other list pages.

--- a/.changeset/review-queue-all-experiments.md
+++ b/.changeset/review-queue-all-experiments.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground': patch
+---
+
+Studio experiments & datasets polish: the review queue now lists every item awaiting review across the project by default, with the experiment selector acting as an optional filter ("All experiments" clears it). The experiments table shows the description in its own truncated column instead of a two-line name cell, the experiment results input column is capped and truncated, and the datasets page uses infinite scroll like the other list pages.

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -24,10 +24,9 @@ export interface DatasetsListProps {
   targetFilter?: string;
   experimentFilter?: string;
   tagFilter?: string;
-  currentPage?: number;
-  hasMore?: boolean;
-  onNextPage?: () => void;
-  onPrevPage?: () => void;
+  isFetchingNextPage?: boolean;
+  hasNextPage?: boolean;
+  setEndOfListElement?: (element: HTMLDivElement | null) => void;
 }
 
 const COLUMNS = 'auto 1fr auto 5rem 9rem 10rem 7rem';
@@ -68,10 +67,9 @@ export function DatasetsList({
   targetFilter = 'all',
   experimentFilter = 'all',
   tagFilter = 'all',
-  currentPage,
-  hasMore,
-  onNextPage,
-  onPrevPage,
+  isFetchingNextPage,
+  hasNextPage,
+  setEndOfListElement,
 }: DatasetsListProps) {
   const { paths, Link } = useLinkComponent();
 
@@ -183,11 +181,10 @@ export function DatasetsList({
         );
       })}
 
-      <EntityList.Pagination
-        currentPage={currentPage}
-        hasMore={hasMore}
-        onNextPage={onNextPage}
-        onPrevPage={onPrevPage}
+      <EntityList.NextPageLoading
+        isLoading={isFetchingNextPage}
+        hasMore={hasNextPage}
+        setEndOfListElement={setEndOfListElement}
       />
     </EntityList>
   );

--- a/packages/playground/src/domains/datasets/hooks/__tests__/use-infinite-datasets.msw.test.tsx
+++ b/packages/playground/src/domains/datasets/hooks/__tests__/use-infinite-datasets.msw.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useInfiniteDatasets } from '../use-datasets';
+import { server } from '@/test/msw-server';
+import { makeWrapper } from '@/test/render';
+
+const makeDataset = (id: string) => ({
+  id,
+  name: `Dataset ${id}`,
+  description: '',
+  version: 1,
+  tags: [],
+  createdAt: '2026-09-01T00:00:00.000Z',
+  updatedAt: '2026-09-01T00:00:00.000Z',
+});
+
+afterEach(() => cleanup());
+
+describe('useInfiniteDatasets', () => {
+  it('loads the first page and appends the next page while the server reports more', async () => {
+    const onRequest = vi.fn<(url: URL) => void>();
+    server.use(
+      http.get('*/api/datasets', ({ request }) => {
+        const url = new URL(request.url);
+        onRequest(url);
+        const page = Number(url.searchParams.get('page'));
+        return HttpResponse.json({
+          datasets: [makeDataset(`ds-${page}`)],
+          pagination: { total: 2, page, perPage: 20, hasMore: page === 0 },
+        });
+      }),
+    );
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useInfiniteDatasets(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(onRequest.mock.calls[0][0].searchParams.get('page')).toBe('0');
+    expect(onRequest.mock.calls[0][0].searchParams.get('perPage')).toBe('20');
+    expect(result.current.data?.map(d => d.id)).toEqual(['ds-0']);
+    expect(result.current.hasNextPage).toBe(true);
+
+    await act(() => result.current.fetchNextPage());
+
+    await waitFor(() => expect(result.current.data?.map(d => d.id)).toEqual(['ds-0', 'ds-1']));
+    expect(onRequest.mock.calls[1][0].searchParams.get('page')).toBe('1');
+    expect(result.current.hasNextPage).toBe(false);
+  });
+});

--- a/packages/playground/src/domains/datasets/hooks/use-datasets.ts
+++ b/packages/playground/src/domains/datasets/hooks/use-datasets.ts
@@ -1,5 +1,7 @@
+import { useInView } from '@mastra/playground-ui/hooks/use-in-view';
 import { useMastraClient } from '@mastra/react';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 
 /**
  * Hook to list all datasets with optional pagination
@@ -11,6 +13,37 @@ export const useDatasets = (pagination?: { page?: number; perPage?: number }) =>
     queryFn: () => client.listDatasets(pagination),
     placeholderData: previousData => previousData,
   });
+};
+
+const DATASETS_PER_PAGE = 20;
+
+/**
+ * Hook to list datasets with infinite scroll pagination
+ */
+export const useInfiniteDatasets = () => {
+  const client = useMastraClient();
+  const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
+
+  const query = useInfiniteQuery({
+    queryKey: ['datasets', 'infinite'],
+    queryFn: ({ pageParam }) => client.listDatasets({ page: pageParam, perPage: DATASETS_PER_PAGE }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      if (!lastPage?.datasets?.length || !lastPage.pagination?.hasMore) {
+        return undefined;
+      }
+      return lastPageParam + 1;
+    },
+    select: data => data.pages.flatMap(page => page?.datasets ?? []),
+  });
+
+  useEffect(() => {
+    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
+      void query.fetchNextPage();
+    }
+  }, [isEndOfListInView, query]);
+
+  return { ...query, setEndOfListElement };
 };
 
 /**

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-combobox.msw.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-combobox.msw.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ExperimentCombobox } from '../experiment-combobox';
+import { ALL_EXPERIMENTS, ExperimentCombobox } from '../experiment-combobox';
 import { experiment, experimentsResponse } from '@/domains/experiments/__tests__/fixtures/experiment-item-route';
 import { server } from '@/test/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '@/test/render';
@@ -85,6 +85,24 @@ describe('ExperimentCombobox', () => {
       renderWithProviders(<ExperimentCombobox value={experiment.id} onValueChange={() => {}} />);
 
       await screen.findByTestId('experiments-icon');
+    });
+  });
+
+  describe('with the "All experiments" option', () => {
+    it('lists it first and selects it when no value is set', async () => {
+      renderWithProviders(<ExperimentCombobox allOption onValueChange={() => {}} />);
+
+      const all = await screen.findByRole('option', { name: 'All experiments' });
+      const options = screen.getAllByRole('option').filter(option => option.getAttribute('value') !== '');
+      expect(options[0]).toBe(all);
+      expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe(ALL_EXPERIMENTS);
+    });
+
+    it('is absent by default', async () => {
+      renderWithProviders(<ExperimentCombobox onValueChange={() => {}} />);
+
+      await screen.findByRole('option', { name: 'entity-extraction / model-a' });
+      expect(screen.queryByRole('option', { name: 'All experiments' })).toBeNull();
     });
   });
 

--- a/packages/playground/src/domains/experiments/components/__tests__/experiment-name-label.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiment-name-label.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { ExperimentNameLabel } from '../experiment-name-label';
+import { ExperimentDescriptionLabel, ExperimentNameLabel } from '../experiment-name-label';
 import { experiments } from './fixtures/experiments';
 import { getExperimentDisplayName } from '@/domains/experiments/utils/experiment-display-name';
 
@@ -19,45 +19,26 @@ describe('getExperimentDisplayName', () => {
 });
 
 describe('ExperimentNameLabel', () => {
-  it('shows the name with the description underneath when both exist', () => {
+  it('renders the name on a single line', () => {
     render(<ExperimentNameLabel experiment={{ ...base, name: 'Baseline run', description: 'Nightly check' }} />);
     expect(screen.getByText('Baseline run')).toBeDefined();
-    expect(screen.getByText('Nightly check')).toBeDefined();
+    expect(screen.queryByText('Nightly check')).toBeNull();
   });
 
-  it('falls back to a readable id and the version/scorer summary when unnamed', () => {
-    render(
-      <ExperimentNameLabel
-        experiment={{
-          ...base,
-          id: 'abcdef1234567890',
-          name: null,
-          description: null,
-          datasetVersion: 3,
-          scorerIds: ['a', 'b'],
-        }}
-      />,
-    );
+  it('falls back to a readable id when unnamed', () => {
+    render(<ExperimentNameLabel experiment={{ ...base, id: 'abcdef1234567890', name: null }} />);
     expect(screen.getByText('Experiment #abcdef12')).toBeDefined();
-    expect(screen.getByText('v3 · 2 scorers')).toBeDefined();
+  });
+});
+
+describe('ExperimentDescriptionLabel', () => {
+  it('renders the description truncated to one line', () => {
+    render(<ExperimentDescriptionLabel experiment={{ ...base, description: 'Nightly check' }} />);
+    expect(screen.getByText('Nightly check').className).toContain('truncate');
   });
 
-  it('uses the singular scorer label and omits the version when unknown', () => {
-    render(
-      <ExperimentNameLabel
-        experiment={{ ...base, name: 'Single', description: null, datasetVersion: null, scorerIds: ['a'] }}
-      />,
-    );
-    expect(screen.getByText('1 scorer')).toBeDefined();
-  });
-
-  it('renders only the primary line when there is nothing to summarise', () => {
-    const { container } = render(
-      <ExperimentNameLabel
-        experiment={{ ...base, name: 'Bare', description: null, datasetVersion: null, scorerIds: null }}
-      />,
-    );
-    expect(screen.getByText('Bare')).toBeDefined();
-    expect(container.querySelectorAll('span').length).toBe(2);
+  it('shows a placeholder when there is no description', () => {
+    render(<ExperimentDescriptionLabel experiment={{ ...base, description: null }} />);
+    expect(screen.getByText('—')).toBeDefined();
   });
 });

--- a/packages/playground/src/domains/experiments/components/__tests__/experiments-list.test.tsx
+++ b/packages/playground/src/domains/experiments/components/__tests__/experiments-list.test.tsx
@@ -33,10 +33,11 @@ describe('ExperimentsList', () => {
       expect(screen.getByText('entity-extraction / model-b')).toBeDefined();
     });
 
-    it('shows the description beneath a named experiment', () => {
+    it('shows the description in its own truncated column', () => {
       renderList(<ExperimentsList experiments={experiments} isLoading={false} />);
 
-      expect(screen.getByText('Entity extraction evaluation using Model B')).toBeDefined();
+      expect(screen.getByText('Description')).toBeDefined();
+      expect(screen.getByText('Entity extraction evaluation using Model B').className).toContain('truncate');
     });
 
     it('links each row to the experiment by its full id', () => {
@@ -44,7 +45,6 @@ describe('ExperimentsList', () => {
 
       const link = screen.getByRole('link', { name: /entity-extraction \/ model-a/ });
       expect(link.getAttribute('href')).toBe('/experiments/a1b2c3d4-0000-0000-0000-000000000001');
-      // The name and its description both live inside that one row link.
       expect(within(link).getByText(experiments[0].description!)).toBeDefined();
     });
   });

--- a/packages/playground/src/domains/experiments/components/experiment-columns.ts
+++ b/packages/playground/src/domains/experiments/components/experiment-columns.ts
@@ -2,11 +2,14 @@ import type { BadgeVariant } from '@mastra/playground-ui/components/Badge';
 
 // experiment name is free-form — an `auto` track would let it starve its neighbours
 export const EXPERIMENT_NAME_COLUMN = 'minmax(9rem,1fr)';
+// description is truncated to a single line; cap it so it never crowds the metric columns
+export const EXPERIMENT_DESCRIPTION_COLUMN = 'minmax(8rem,16rem)';
 export const EXPERIMENT_DATASET_COLUMN = '1fr';
 export const EXPERIMENT_DETAIL_COLUMNS = 'auto auto auto auto auto auto auto';
 
 export const experimentColumnLabels = {
   experiment: 'Experiment',
+  description: 'Description',
   dataset: 'Dataset',
   target: 'Target',
   status: 'Status',

--- a/packages/playground/src/domains/experiments/components/experiment-combobox.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-combobox.tsx
@@ -5,11 +5,16 @@ import { ExperimentsIcon } from '@mastra/playground-ui/icons/ExperimentsIcon';
 import { useExperimentsForDatasetFilter } from '../hooks/use-experiments-for-dataset-filter';
 import { getExperimentDisplayName } from '@/domains/experiments/utils/experiment-display-name';
 
+/** Sentinel value emitted when the "All experiments" option is picked. */
+export const ALL_EXPERIMENTS = 'all';
+
 export interface ExperimentComboboxProps {
   value?: string;
   onValueChange: (experimentId: string) => void;
   className?: string;
   variant?: ComboboxProps['variant'];
+  /** Prepend an "All experiments" option (value `ALL_EXPERIMENTS`), selected when `value` is unset. */
+  allOption?: boolean;
 }
 
 const DESCRIPTION_MAX = 60;
@@ -17,10 +22,10 @@ const DESCRIPTION_MAX = 60;
 const truncate = (text: string) => (text.length > DESCRIPTION_MAX ? `${text.slice(0, DESCRIPTION_MAX)}…` : text);
 
 /** Single-select picker over every experiment in the project, labelled by display name. */
-export function ExperimentCombobox({ value, onValueChange, className, variant }: ExperimentComboboxProps) {
+export function ExperimentCombobox({ value, onValueChange, className, variant, allOption }: ExperimentComboboxProps) {
   const { data, isLoading, isError } = useExperimentsForDatasetFilter(undefined);
 
-  const options = (data?.experiments ?? []).map(experiment => ({
+  const experimentOptions = (data?.experiments ?? []).map(experiment => ({
     label: getExperimentDisplayName(experiment),
     value: experiment.id,
     start: <ExperimentsIcon className="text-neutral3 size-4 shrink-0" data-testid="experiments-icon" />,
@@ -28,11 +33,14 @@ export function ExperimentCombobox({ value, onValueChange, className, variant }:
       ? truncate(experiment.description)
       : (getShortId(experiment.id) ?? experiment.id),
   }));
+  const options = allOption
+    ? [{ label: 'All experiments', value: ALL_EXPERIMENTS }, ...experimentOptions]
+    : experimentOptions;
 
   return (
     <Combobox
       options={options}
-      value={value ?? ''}
+      value={value ?? (allOption ? ALL_EXPERIMENTS : '')}
       onValueChange={onValueChange}
       placeholder={isLoading ? 'Loading experiments...' : isError ? 'Failed to load experiments' : 'Select experiment'}
       searchPlaceholder="Search experiments..."

--- a/packages/playground/src/domains/experiments/components/experiment-name-label.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-name-label.tsx
@@ -4,38 +4,31 @@ import { getExperimentDisplayName } from '@/domains/experiments/utils/experiment
 
 const LONG_DESCRIPTION = 60;
 
-/**
- * Primary line: the experiment display name. Secondary line: the description,
- * or a version/scorer summary so an unnamed run is still identifiable at a
- * glance. Caller supplies the cell.
- */
+/** Single truncated line with the experiment display name. Caller supplies the cell. */
 export function ExperimentNameLabel({ experiment }: { experiment: DatasetExperiment }) {
-  const primary = getExperimentDisplayName(experiment);
-  const secondary = experiment.description || buildRunSummary(experiment);
+  return <span className="text-neutral4 block min-w-0 truncate text-left">{getExperimentDisplayName(experiment)}</span>;
+}
 
-  const label = (
-    <span className="flex min-w-0 flex-col gap-0.5 py-0.5 text-left">
-      <span className="text-neutral4 block truncate">{primary}</span>
-      {secondary && <span className="text-ui-sm text-neutral2 block truncate">{secondary}</span>}
-    </span>
-  );
+/**
+ * Single truncated line with the description; long descriptions get a tooltip
+ * with the full text. Caller supplies the cell.
+ */
+export function ExperimentDescriptionLabel({ experiment }: { experiment: DatasetExperiment }) {
+  const description = experiment.description;
+  if (!description) {
+    return <span className="text-neutral2">—</span>;
+  }
 
-  if (!experiment.description || experiment.description.length <= LONG_DESCRIPTION) {
+  const label = <span className="text-neutral3 block min-w-0 truncate text-left">{description}</span>;
+
+  if (description.length <= LONG_DESCRIPTION) {
     return label;
   }
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>{label}</TooltipTrigger>
-      <TooltipContent>{experiment.description}</TooltipContent>
+      <TooltipContent>{description}</TooltipContent>
     </Tooltip>
   );
-}
-
-function buildRunSummary(experiment: DatasetExperiment): string | null {
-  const parts: string[] = [];
-  if (experiment.datasetVersion != null) parts.push(`v${experiment.datasetVersion}`);
-  const scorerCount = experiment.scorerIds?.length ?? 0;
-  if (scorerCount > 0) parts.push(`${scorerCount} scorer${scorerCount > 1 ? 's' : ''}`);
-  return parts.length ? parts.join(' · ') : null;
 }

--- a/packages/playground/src/domains/experiments/components/experiment-results-section.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-section.tsx
@@ -135,7 +135,7 @@ export function ExperimentResultsSection({
   const resultsListColumns = useMemo(
     () => [
       { name: 'itemId', label: 'Item ID', size: '7rem' },
-      { name: 'input', label: 'Input', size: 'minmax(15rem,1fr)' },
+      { name: 'input', label: 'Input', size: 'minmax(10rem,20rem)' },
       ...scorerIds.map(id => ({ name: id, label: id, size: '12rem' })),
     ],
     [scorerIds],

--- a/packages/playground/src/domains/experiments/components/experiment-row-cells.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-row-cells.tsx
@@ -2,7 +2,7 @@ import type { DatasetExperiment } from '@mastra/client-js';
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { DataList as EntityList } from '@mastra/playground-ui/components/DataList';
 import { formatExperimentDate, STATUS_LABEL, STATUS_VARIANT } from './experiment-columns';
-import { ExperimentNameLabel } from './experiment-name-label';
+import { ExperimentDescriptionLabel, ExperimentNameLabel } from './experiment-name-label';
 import { useTargetRegistries } from '@/domains/experiments/hooks/use-target-registries';
 import { resolveTargetName, TARGET_ICON, TARGET_LABEL } from '@/domains/experiments/utils/target-name';
 
@@ -28,6 +28,9 @@ export function ExperimentRowCells({ experiment: exp, datasetName, review }: Exp
     <>
       <EntityList.Cell>
         <ExperimentNameLabel experiment={exp} />
+      </EntityList.Cell>
+      <EntityList.Cell>
+        <ExperimentDescriptionLabel experiment={exp} />
       </EntityList.Cell>
       {datasetName !== undefined && <EntityList.TextCell>{datasetName}</EntityList.TextCell>}
       <EntityList.Cell>

--- a/packages/playground/src/domains/experiments/components/experiments-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiments-list.tsx
@@ -8,6 +8,7 @@ import { getShortId } from '@mastra/playground-ui/components/Text';
 import { useMemo } from 'react';
 import {
   EXPERIMENT_DATASET_COLUMN,
+  EXPERIMENT_DESCRIPTION_COLUMN,
   EXPERIMENT_DETAIL_COLUMNS,
   EXPERIMENT_NAME_COLUMN,
   experimentColumnLabels,
@@ -32,10 +33,11 @@ export interface ExperimentsListSelection {
   onToggleSelection: (experimentId: string) => void;
 }
 
-const COLUMNS = `${EXPERIMENT_NAME_COLUMN} ${EXPERIMENT_DATASET_COLUMN} ${EXPERIMENT_DETAIL_COLUMNS}`;
+const COLUMNS = `${EXPERIMENT_NAME_COLUMN} ${EXPERIMENT_DESCRIPTION_COLUMN} ${EXPERIMENT_DATASET_COLUMN} ${EXPERIMENT_DETAIL_COLUMNS}`;
 
 const columnHeaders = [
   { label: experimentColumnLabels.experiment },
+  { label: experimentColumnLabels.description },
   { label: experimentColumnLabels.dataset },
   { label: experimentColumnLabels.target },
   { label: experimentColumnLabels.status },

--- a/packages/playground/src/domains/review/components/__tests__/dataset-review.experiment-scope.msw.test.tsx
+++ b/packages/playground/src/domains/review/components/__tests__/dataset-review.experiment-scope.msw.test.tsx
@@ -1,11 +1,11 @@
 import type { DatasetExperiment, DatasetExperimentResult, DatasetRecord } from '@mastra/client-js';
-import { screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { http, HttpResponse, delay } from 'msw';
 import { describe, expect, it } from 'vitest';
 
 import { DatasetReview } from '../dataset-review';
 import { server } from '@/test/msw-server';
-import { renderWithProviders } from '@/test/render';
+import { makeWrapper, renderWithProviders } from '@/test/render';
 
 const dataset: DatasetRecord = {
   id: 'ds-1',
@@ -69,7 +69,7 @@ const resultsByExperiment: Record<string, DatasetExperimentResult[]> = {
 const setupHandlers = () => {
   server.use(
     http.get('*/api/datasets/ds-1', () => HttpResponse.json(dataset)),
-    http.get('*/api/datasets/:datasetId/experiments', async () => {
+    http.get('*/api/experiments', async () => {
       await delay(50);
       return HttpResponse.json({
         experiments: [makeExperiment('exp-1'), makeExperiment('exp-2')],
@@ -105,5 +105,43 @@ describe('DatasetReview scoped to an experiment', () => {
       expect(screen.queryByText('No items to review')).toBeNull();
       await screen.findByText(/exp two input/);
     });
+  });
+});
+
+describe('DatasetReview without a scope', () => {
+  it('lists review items from every experiment in the project', async () => {
+    setupHandlers();
+    renderWithProviders(<DatasetReview />);
+
+    expect(await screen.findByText(/exp one input/)).toBeTruthy();
+    expect(await screen.findByText(/exp two input/)).toBeTruthy();
+  });
+
+  // Flagging a result elsewhere (experiment page) invalidates the cached queue; when the
+  // user comes back, the stale snapshot must not stick — the refetched one has to win.
+  it('shows a result flagged elsewhere when returning with a stale cached queue', async () => {
+    const results: DatasetExperimentResult[] = [];
+    server.use(
+      http.get('*/api/experiments', () =>
+        HttpResponse.json({
+          experiments: [makeExperiment('exp-1')],
+          pagination: { total: 1, page: 0, perPage: 100, hasMore: false },
+        }),
+      ),
+      http.get('*/api/datasets/:datasetId/experiments/:experimentId/results', () =>
+        HttpResponse.json({ results, pagination: { total: results.length, page: 0, perPage: 100, hasMore: false } }),
+      ),
+    );
+
+    const { wrapper, queryClient } = makeWrapper();
+    const first = render(<DatasetReview />, { wrapper });
+    expect(await screen.findByText('No items to review')).toBeTruthy();
+    first.unmount();
+
+    results.push(makeResult('r-1', 'exp-1', 'freshly flagged input'));
+    await queryClient.invalidateQueries({ queryKey: ['review-items'] });
+
+    render(<DatasetReview />, { wrapper });
+    expect(await screen.findByText(/freshly flagged input/)).toBeTruthy();
   });
 });

--- a/packages/playground/src/domains/review/components/__tests__/dataset-review.keyboard.test.tsx
+++ b/packages/playground/src/domains/review/components/__tests__/dataset-review.keyboard.test.tsx
@@ -64,7 +64,7 @@ const results = [makeResult('r-1', 'first input'), makeResult('r-2', 'second inp
 const setupHandlers = (reviewResults = results) => {
   server.use(
     http.get('*/api/datasets/ds-1', () => HttpResponse.json(dataset)),
-    http.get('*/api/datasets/:datasetId/experiments', () =>
+    http.get('*/api/experiments', () =>
       HttpResponse.json({ experiments: [experiment], pagination: { total: 1, page: 0, perPage: 100, hasMore: false } }),
     ),
     http.get('*/api/datasets/:datasetId/experiments/:experimentId/results', () =>

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -32,7 +32,7 @@ import {
   XIcon,
 } from 'lucide-react';
 import { useState, useMemo, useCallback, useEffect } from 'react';
-import { useDatasetReviewItems, useDatasetCompletedItems } from '../hooks/use-dataset-review-items';
+import { useReviewItems, useCompletedItems } from '../hooks/use-dataset-review-items';
 import { ProposalTag } from './proposal-tag';
 import type { ReviewItem } from './review-item-card';
 import { ReviewItemPanel } from './review-item-panel';
@@ -53,8 +53,9 @@ function truncateInput(value: unknown, max: number): string {
 }
 
 export interface DatasetReviewProps {
-  datasetId: string;
-  /** When set, scopes the review (and completed) lists to items produced by this experiment. */
+  /** When set, the dataset's tags seed the tag vocabulary. Without it, tags come from the items only. */
+  datasetId?: string;
+  /** When set, scopes the review (and completed) lists to items produced by this experiment; otherwise project-wide. */
   experimentId?: string;
   /**
    * Optional request from the parent to auto-feature this item. Whenever this prop changes
@@ -73,19 +74,11 @@ export function DatasetReview({
   detailPanelVariant = 'inline',
 }: DatasetReviewProps) {
   const client = useMastraClient();
-  const { data: dataset } = useDataset(datasetId);
-  const { data: reviewItemsRaw, isLoading: isLoadingReview } = useDatasetReviewItems(datasetId);
-  const { data: completedItemsRaw, isLoading: isLoadingCompleted } = useDatasetCompletedItems(datasetId);
+  const { data: dataset } = useDataset(datasetId ?? '');
   // Keep `undefined` while loading: the hydration effect below treats a defined
   // value as "server data arrived", so coercing to [] here would lock in an empty queue.
-  const reviewItems = useMemo(
-    () => (experimentId ? reviewItemsRaw?.filter(i => i.experimentId === experimentId) : reviewItemsRaw),
-    [reviewItemsRaw, experimentId],
-  );
-  const completedItems = useMemo(
-    () => (experimentId ? completedItemsRaw?.filter(i => i.experimentId === experimentId) : completedItemsRaw),
-    [completedItemsRaw, experimentId],
-  );
+  const { data: reviewItems, isLoading: isLoadingReview } = useReviewItems({ experimentId });
+  const { data: completedItems, isLoading: isLoadingCompleted } = useCompletedItems({ experimentId });
   const { updateExperimentResult } = useDatasetMutations();
 
   // Local state
@@ -115,23 +108,13 @@ export function DatasetReview({
   >([]);
   const [showProposalDialog, setShowProposalDialog] = useState(false);
 
-  // Items in local state — null means "not hydrated yet", [] means "user cleared all"
-  const [localItems, setLocalItems] = useState<ReviewItem[] | null>(null);
-  const items = useMemo(() => localItems ?? reviewItems ?? [], [localItems, reviewItems]);
-
-  // Reset the local cache when the scope changes (different experiment or dataset)
-  // so it re-hydrates from the new queue below, instead of keeping the previous
-  // experiment's rows and running mutations against the wrong results.
-  useEffect(() => {
-    setLocalItems(null);
-  }, [datasetId, experimentId]);
-
-  // Sync server data to local on initial load (and after a scope reset above)
-  useEffect(() => {
-    if (reviewItems && localItems === null) {
-      setLocalItems(reviewItems);
-    }
-  }, [reviewItems, localItems]);
+  // Ratings are only sent as feedback, never stored on the result, so they live here.
+  // Everything else comes straight from the query; mutations invalidate it.
+  const [ratings, setRatings] = useState<Record<string, ReviewItem['rating']>>({});
+  const items = useMemo(
+    () => (reviewItems ?? []).map(i => (i.id in ratings ? { ...i, rating: ratings[i.id] } : i)),
+    [reviewItems, ratings],
+  );
 
   // Tag vocabulary from dataset + existing item tags
   const datasetTagVocabulary = useMemo(() => {
@@ -186,7 +169,6 @@ export function DatasetReview({
   // Item actions
   const setItemTags = useCallback(
     (itemId: string, tags: string[]) => {
-      setLocalItems(prev => (prev ?? []).map(i => (i.id === itemId ? { ...i, tags } : i)));
       const item = items.find(i => i.id === itemId);
       if (item?.experimentId && item?.datasetId) {
         updateExperimentResult.mutate({
@@ -219,7 +201,7 @@ export function DatasetReview({
           })
           .catch(() => {});
       }
-      setLocalItems(prev => (prev ?? []).map(i => (i.id === itemId ? { ...i, rating } : i)));
+      setRatings(prev => ({ ...prev, [itemId]: rating }));
     },
     [items, client],
   );
@@ -252,7 +234,6 @@ export function DatasetReview({
           })
           .catch(() => {});
       }
-      setLocalItems(prev => (prev ?? []).map(i => (i.id === itemId ? { ...i, comment } : i)));
     },
     [items, client, updateExperimentResult],
   );
@@ -260,7 +241,6 @@ export function DatasetReview({
   const removeItem = useCallback(
     (itemId: string) => {
       const item = items.find(i => i.id === itemId);
-      setLocalItems(prev => (prev ?? []).filter(i => i.id !== itemId));
       setSelectedItemIds(prev => {
         const next = new Set(prev);
         next.delete(itemId);
@@ -282,7 +262,6 @@ export function DatasetReview({
   const completeItem = useCallback(
     (itemId: string) => {
       const item = items.find(i => i.id === itemId);
-      setLocalItems(prev => (prev ?? []).filter(i => i.id !== itemId));
       setSelectedItemIds(prev => {
         const next = new Set(prev);
         next.delete(itemId);
@@ -452,7 +431,7 @@ export function DatasetReview({
       ? () => setFeaturedItemId(displayItems[featuredIndex + 1].id)
       : undefined;
 
-  const gridColumns = 'auto minmax(0,1fr) minmax(0,10rem) minmax(0,8rem) 6rem 6rem';
+  const gridColumns = 'auto minmax(0,20rem) minmax(0,1fr) minmax(0,8rem) 6rem 6rem';
 
   const { containerRef, getRowProps } = useDataListKeyboard({ count: displayItems.length });
 

--- a/packages/playground/src/domains/review/hooks/__tests__/use-dataset-review-items.msw.test.tsx
+++ b/packages/playground/src/domains/review/hooks/__tests__/use-dataset-review-items.msw.test.tsx
@@ -7,7 +7,7 @@ import { http, HttpResponse } from 'msw';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useDatasetReviewItems } from '../use-dataset-review-items';
+import { useReviewItems } from '../use-dataset-review-items';
 import {
   DATASET_ID,
   EXPERIMENT_ID,
@@ -32,16 +32,30 @@ const makeWrapper = () => {
 
 afterEach(() => cleanup());
 
-describe('useDatasetReviewItems', () => {
-  it('hydrates the persisted comment (and tags) from the experiment result', async () => {
-    server.use(
-      http.get(`${BASE_URL}/api/datasets/${DATASET_ID}/experiments`, () => HttpResponse.json(experimentsResponse)),
-      http.get(`${BASE_URL}/api/datasets/${DATASET_ID}/experiments/${EXPERIMENT_ID}/results`, () =>
-        HttpResponse.json(resultsResponse),
-      ),
-    );
+const OTHER_EXPERIMENT_ID = 'exp-2';
+const projectExperimentsResponse = {
+  ...experimentsResponse,
+  experiments: [...experimentsResponse.experiments, { ...experimentsResponse.experiments[0], id: OTHER_EXPERIMENT_ID }],
+};
 
-    const { result } = renderHook(() => useDatasetReviewItems(DATASET_ID), { wrapper: makeWrapper() });
+describe('useReviewItems', () => {
+  const resultRequests: string[] = [];
+
+  const setupHandlers = () => {
+    resultRequests.length = 0;
+    server.use(
+      http.get(`${BASE_URL}/api/experiments`, () => HttpResponse.json(projectExperimentsResponse)),
+      http.get(`${BASE_URL}/api/datasets/${DATASET_ID}/experiments/:experimentId/results`, ({ params }) => {
+        resultRequests.push(String(params.experimentId));
+        return HttpResponse.json(resultsResponse);
+      }),
+    );
+  };
+
+  it('hydrates the persisted comment (and tags) from the experiment result', async () => {
+    setupHandlers();
+
+    const { result } = renderHook(() => useReviewItems({ experimentId: EXPERIMENT_ID }), { wrapper: makeWrapper() });
 
     await waitFor(() => {
       expect(result.current.data).toHaveLength(1);
@@ -49,10 +63,29 @@ describe('useDatasetReviewItems', () => {
 
     const item = result.current.data![0];
     expect(item.id).toBe(RESULT_ID);
+    expect(item.datasetId).toBe(DATASET_ID);
     expect(item.tags).toEqual(['hallucination']);
     // Regression guard for #19857: the comment used to be hardcoded to ''
     // on rehydrate, wiping saved comments on every reload.
     expect(item.comment).toBe('The agent ignored the second question');
+  });
+
+  it('only fetches the selected experiment when scoped', async () => {
+    setupHandlers();
+
+    const { result } = renderHook(() => useReviewItems({ experimentId: EXPERIMENT_ID }), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.data).toHaveLength(1));
+    expect(resultRequests).toEqual([EXPERIMENT_ID]);
+  });
+
+  it('fetches every experiment in the project when unscoped', async () => {
+    setupHandlers();
+
+    const { result } = renderHook(() => useReviewItems(), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.data).toHaveLength(2));
+    expect(resultRequests.sort()).toEqual([EXPERIMENT_ID, OTHER_EXPERIMENT_ID].sort());
   });
 });
 

--- a/packages/playground/src/domains/review/hooks/index.ts
+++ b/packages/playground/src/domains/review/hooks/index.ts
@@ -1,1 +1,2 @@
-export { useDatasetReviewItems, useDatasetCompletedItems } from './use-dataset-review-items';
+export { useReviewItems, useCompletedItems } from './use-dataset-review-items';
+export type { ReviewItemsOptions } from './use-dataset-review-items';

--- a/packages/playground/src/domains/review/hooks/use-dataset-review-items.ts
+++ b/packages/playground/src/domains/review/hooks/use-dataset-review-items.ts
@@ -1,28 +1,36 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import type { ReviewItem } from '../components/review-item-card';
-import { useDatasetExperiments } from '@/domains/datasets/hooks/use-dataset-experiments';
+import { useExperimentsForDatasetFilter } from '@/domains/experiments/hooks/use-experiments-for-dataset-filter';
+
+type ReviewStatus = 'needs-review' | 'complete';
+
+export interface ReviewItemsOptions {
+  /** When set, only this experiment's results are loaded; otherwise every experiment in the project. */
+  experimentId?: string;
+}
 
 /**
- * Loads persisted review items (status='needs-review') across ALL experiments for a dataset.
+ * Loads experiment results with the given review status, across the project or scoped to one experiment.
  */
-export const useDatasetReviewItems = (datasetId: string) => {
+const useReviewItemsByStatus = (status: ReviewStatus, experimentId: string | undefined) => {
   const client = useMastraClient();
-  const { data: experimentsData, isLoading: isLoadingExperiments } = useDatasetExperiments(datasetId);
+  const { data: experimentsData, isLoading: isLoadingExperiments } = useExperimentsForDatasetFilter(undefined);
   const experiments = experimentsData?.experiments;
+  const scopedExperiments = experimentId ? experiments?.filter(exp => exp.id === experimentId) : experiments;
 
   const query = useQuery({
-    queryKey: ['dataset-review-items', datasetId, experiments?.map(e => e.id)],
+    queryKey: ['review-items', status, experimentId ?? 'all', scopedExperiments?.map(e => e.id)],
     queryFn: async () => {
-      if (!experiments || experiments.length === 0) return [] as ReviewItem[];
+      if (!scopedExperiments || scopedExperiments.length === 0) return [] as ReviewItem[];
 
       const allResults = await Promise.all(
-        experiments.map(async exp => {
+        scopedExperiments.map(async exp => {
           if (!exp.datasetId) return [];
           try {
             const { results } = await client.listDatasetExperimentResults(exp.datasetId, exp.id);
             return results
-              .filter(r => r.status === 'needs-review')
+              .filter(r => r.status === status)
               .map(r => ({
                 id: r.id,
                 input: r.input,
@@ -44,7 +52,7 @@ export const useDatasetReviewItems = (datasetId: string) => {
 
       return allResults.flat() as ReviewItem[];
     },
-    enabled: Boolean(datasetId) && Boolean(experiments) && experiments!.length > 0,
+    enabled: Boolean(experiments),
     refetchOnWindowFocus: false,
   });
 
@@ -53,52 +61,10 @@ export const useDatasetReviewItems = (datasetId: string) => {
   return { ...query, isLoading: query.isLoading || isLoadingExperiments };
 };
 
-/**
- * Loads completed review items (status='complete') across ALL experiments for a dataset.
- */
-export const useDatasetCompletedItems = (datasetId: string) => {
-  const client = useMastraClient();
-  const { data: experimentsData, isLoading: isLoadingExperiments } = useDatasetExperiments(datasetId);
-  const experiments = experimentsData?.experiments;
+/** Loads persisted review items (status='needs-review'), project-wide or for one experiment. */
+export const useReviewItems = ({ experimentId }: ReviewItemsOptions = {}) =>
+  useReviewItemsByStatus('needs-review', experimentId);
 
-  const query = useQuery({
-    queryKey: ['dataset-completed-items', datasetId, experiments?.map(e => e.id)],
-    queryFn: async () => {
-      if (!experiments || experiments.length === 0) return [] as ReviewItem[];
-
-      const allResults = await Promise.all(
-        experiments.map(async exp => {
-          if (!exp.datasetId) return [];
-          try {
-            const { results } = await client.listDatasetExperimentResults(exp.datasetId, exp.id);
-            return results
-              .filter(r => r.status === 'complete')
-              .map(r => ({
-                id: r.id,
-                input: r.input,
-                output: r.output,
-                error: r.error,
-                itemId: r.itemId,
-                experimentId: r.experimentId,
-                datasetId: exp.datasetId ?? undefined,
-                traceId: r.traceId ?? undefined,
-                scores: r.scores ? Object.fromEntries(r.scores.map(s => [s.scorerId, s.score ?? 0])) : {},
-                tags: r.tags ?? [],
-                comment: r.comment ?? '',
-              }));
-          } catch {
-            return [];
-          }
-        }),
-      );
-
-      return allResults.flat() as ReviewItem[];
-    },
-    enabled: Boolean(datasetId) && Boolean(experiments) && experiments!.length > 0,
-    refetchOnWindowFocus: false,
-  });
-
-  // The results query is disabled until experiments arrive, so its own `isLoading`
-  // is false during that window; surface the upstream load to avoid an empty flash.
-  return { ...query, isLoading: query.isLoading || isLoadingExperiments };
-};
+/** Loads completed review items (status='complete'), project-wide or for one experiment. */
+export const useCompletedItems = ({ experimentId }: ReviewItemsOptions = {}) =>
+  useReviewItemsByStatus('complete', experimentId);

--- a/packages/playground/src/domains/review/index.ts
+++ b/packages/playground/src/domains/review/index.ts
@@ -1,6 +1,6 @@
 export { ReviewItemCard, TagPicker, BulkTagPicker, ProposalTag } from './components';
 export { DatasetReview } from './components/dataset-review';
 export { ReviewPipelineCard } from './components/review-pipeline-card';
-export { useDatasetReviewItems, useDatasetCompletedItems } from './hooks';
+export { useReviewItems, useCompletedItems } from './hooks';
 export { useReviewSummary } from './hooks/use-review-summary';
 export * from './review-maps';

--- a/packages/playground/src/pages/datasets/index.tsx
+++ b/packages/playground/src/pages/datasets/index.tsx
@@ -3,14 +3,12 @@ import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/P
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { DatasetsList, DatasetsToolbar, getDatasetTagOptions } from '@/domains/datasets';
 import { NoDatasetsInfo } from '@/domains/datasets/components/datasets-list/no-datasets-info';
-import { useDatasets } from '@/domains/datasets/hooks/use-datasets';
+import { useInfiniteDatasets } from '@/domains/datasets/hooks/use-datasets';
 import { useExperiments } from '@/domains/datasets/hooks/use-experiments';
-
-const DATASETS_PER_PAGE = 10;
 
 export default function Datasets() {
   const navigate = useNavigate();
@@ -18,17 +16,17 @@ export default function Datasets() {
   const [targetFilter, setTargetFilter] = useState('all');
   const [experimentFilter, setExperimentFilter] = useState('all');
   const [tagFilter, setTagFilter] = useState('all');
-  const [page, setPage] = useState(0);
 
   const {
-    data: datasetsData,
+    data: datasets = [],
     isLoading: isLoadingDatasets,
     error: errorDatasets,
-  } = useDatasets({ page, perPage: DATASETS_PER_PAGE });
+    isFetchingNextPage,
+    hasNextPage,
+    setEndOfListElement,
+  } = useInfiniteDatasets();
   const { data: experimentsData, isLoading: isLoadingExperiments, error: errorExperiments } = useExperiments();
 
-  const datasets = useMemo(() => datasetsData?.datasets ?? [], [datasetsData?.datasets]);
-  const hasMore = datasetsData?.pagination?.hasMore ?? false;
   const experiments = useMemo(() => experimentsData?.experiments ?? [], [experimentsData?.experiments]);
   const datasetTagOptions = useMemo(() => getDatasetTagOptions(datasets), [datasets]);
 
@@ -36,26 +34,6 @@ export default function Datasets() {
   const error = errorDatasets || errorExperiments;
 
   const openCreatePage = () => void navigate('/datasets/new');
-
-  const handleNextPage = useCallback(() => setPage(p => p + 1), []);
-  const handlePrevPage = useCallback(() => setPage(p => Math.max(0, p - 1)), []);
-
-  const handleSearchChange = useCallback((value: string) => {
-    setSearch(value);
-    setPage(0);
-  }, []);
-  const handleTargetFilterChange = useCallback((value: string) => {
-    setTargetFilter(value);
-    setPage(0);
-  }, []);
-  const handleExperimentFilterChange = useCallback((value: string) => {
-    setExperimentFilter(value);
-    setPage(0);
-  }, []);
-  const handleTagFilterChange = useCallback((value: string) => {
-    setTagFilter(value);
-    setPage(0);
-  }, []);
 
   if (error && is401UnauthorizedError(error)) {
     return (
@@ -81,7 +59,7 @@ export default function Datasets() {
     );
   }
 
-  if (datasets.length === 0 && !isLoading && page === 0) {
+  if (datasets.length === 0 && !isLoading) {
     return (
       <NoDataPageLayout>
         <NoDatasetsInfo onCreateClick={openCreatePage} />
@@ -96,7 +74,6 @@ export default function Datasets() {
     setTargetFilter('all');
     setExperimentFilter('all');
     setTagFilter('all');
-    setPage(0);
   };
 
   return (
@@ -104,13 +81,13 @@ export default function Datasets() {
       <PageLayout.TopArea>
         <DatasetsToolbar
           search={search}
-          onSearchChange={handleSearchChange}
+          onSearchChange={setSearch}
           targetFilter={targetFilter}
-          onTargetFilterChange={handleTargetFilterChange}
+          onTargetFilterChange={setTargetFilter}
           experimentFilter={experimentFilter}
-          onExperimentFilterChange={handleExperimentFilterChange}
+          onExperimentFilterChange={setExperimentFilter}
           tagFilter={tagFilter}
-          onTagFilterChange={handleTagFilterChange}
+          onTagFilterChange={setTagFilter}
           tagOptions={datasetTagOptions}
           onReset={resetFilters}
           hasActiveFilters={hasFilters}
@@ -126,10 +103,9 @@ export default function Datasets() {
         targetFilter={targetFilter}
         experimentFilter={experimentFilter}
         tagFilter={tagFilter}
-        currentPage={page}
-        hasMore={hasMore}
-        onNextPage={handleNextPage}
-        onPrevPage={handlePrevPage}
+        isFetchingNextPage={isFetchingNextPage}
+        hasNextPage={hasNextPage}
+        setEndOfListElement={setEndOfListElement}
       />
     </PageLayout>
   );

--- a/packages/playground/src/pages/experiments/review-queue/index.tsx
+++ b/packages/playground/src/pages/experiments/review-queue/index.tsx
@@ -1,32 +1,28 @@
-import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { ErrorState } from '@mastra/playground-ui/components/ErrorState';
 import { NoDataPageLayout, PageLayout } from '@mastra/playground-ui/components/PageLayout';
 import { PermissionDenied } from '@mastra/playground-ui/components/PermissionDenied';
 import { SessionExpired } from '@mastra/playground-ui/components/SessionExpired';
 import { is401UnauthorizedError, is403ForbiddenError } from '@mastra/playground-ui/utils/errors';
-import { ClipboardCheck } from 'lucide-react';
 import { useSearchParams } from 'react-router';
-import { ExperimentCombobox } from '@/domains/experiments/components/experiment-combobox';
+import { ALL_EXPERIMENTS, ExperimentCombobox } from '@/domains/experiments/components/experiment-combobox';
 import { useExperimentsForDatasetFilter } from '@/domains/experiments/hooks/use-experiments-for-dataset-filter';
 import { DatasetReview } from '@/domains/review/components/dataset-review';
 
 /**
- * Single review queue across the project, scoped by experiment. `?experiment=<id>`
- * selects the experiment; `?review=<resultId>` features one of its results.
+ * Single review queue across the project. Lists every item awaiting review by default;
+ * `?experiment=<id>` narrows it to one experiment and `?review=<resultId>` features one of its results.
  */
 function ReviewQueuePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedId = searchParams.get('experiment');
   const featuredResultId = searchParams.get('review');
 
-  const { data, isLoading, error } = useExperimentsForDatasetFilter(undefined);
+  const { data, error } = useExperimentsForDatasetFilter(undefined);
   const selected = data?.experiments.find(experiment => experiment.id === selectedId);
-  // An experiment with no dataset has nothing to review; treat it as no selection.
-  const datasetId = selected?.datasetId ?? null;
 
   const selectExperiment = (experimentId: string) => {
-    // Changing experiment drops `review`: the featured result belongs to the previous one.
-    setSearchParams(experimentId ? { experiment: experimentId } : {}, { replace: true });
+    // Changing the filter drops `review`: the featured result belongs to the previous scope.
+    setSearchParams(experimentId === ALL_EXPERIMENTS ? {} : { experiment: experimentId }, { replace: true });
   };
 
   if (error && is401UnauthorizedError(error)) {
@@ -53,36 +49,26 @@ function ReviewQueuePage() {
     );
   }
 
-  const combobox = <ExperimentCombobox value={selected?.id} onValueChange={selectExperiment} className="w-80" />;
-
-  if (!selected || !datasetId) {
-    return (
-      <NoDataPageLayout>
-        {isLoading ? null : (
-          <EmptyState
-            iconSlot={<ClipboardCheck />}
-            titleSlot="No experiment selected"
-            descriptionSlot="Select an experiment to review its queue"
-            actionSlot={combobox}
-          />
-        )}
-      </NoDataPageLayout>
-    );
-  }
-
   return (
     <PageLayout height="full">
       <PageLayout.TopArea>
         <PageLayout.Row>
-          <PageLayout.Column className="justify-items-start">{combobox}</PageLayout.Column>
+          <PageLayout.Column className="justify-items-start">
+            <ExperimentCombobox
+              allOption
+              value={selectedId ?? undefined}
+              onValueChange={selectExperiment}
+              className="w-80"
+            />
+          </PageLayout.Column>
         </PageLayout.Row>
       </PageLayout.TopArea>
 
       <PageLayout.MainArea className="overflow-visible">
         <DatasetReview
-          key={selected.id}
-          datasetId={datasetId}
-          experimentId={selected.id}
+          key={selectedId ?? ALL_EXPERIMENTS}
+          datasetId={selected?.datasetId ?? undefined}
+          experimentId={selectedId ?? undefined}
           featuredItemId={featuredResultId}
           detailPanelVariant="overlay"
         />

--- a/packages/playground/src/pages/experiments/review-queue/review-queue-page.msw.test.tsx
+++ b/packages/playground/src/pages/experiments/review-queue/review-queue-page.msw.test.tsx
@@ -1,6 +1,6 @@
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -74,6 +74,8 @@ afterAll(() => {
 });
 
 const resultRequests: string[] = [];
+// The review and completed queues each fetch results, so dedupe before asserting scope.
+const requestedExperiments = () => [...new Set(resultRequests)].sort();
 
 beforeEach(() => {
   resultRequests.length = 0;
@@ -82,7 +84,6 @@ beforeEach(() => {
     http.get(`${TEST_BASE_URL}/api/datasets/${DATASET_ID}`, () =>
       HttpResponse.json({ error: 'not found' }, { status: 404 }),
     ),
-    http.get(`${TEST_BASE_URL}/api/datasets/${DATASET_ID}/experiments`, () => HttpResponse.json(experimentsResponse)),
     http.get(`${TEST_BASE_URL}/api/datasets/${DATASET_ID}/experiments/:experimentId/results`, ({ params }) => {
       resultRequests.push(String(params.experimentId));
       const list = params.experimentId === EXPERIMENT_ID ? results : otherResults;
@@ -113,14 +114,16 @@ const renderPage = (search = '') => {
 
 describe('Review Queue page', () => {
   describe('when no experiment is selected', () => {
-    it('shows an empty state with the experiment picker as its call to action', async () => {
+    it('lists items awaiting review across every experiment', async () => {
       renderPage();
 
-      const emptyState = (await screen.findByText('Select an experiment to review its queue')).closest('div')!;
-      await screen.findByRole('option', { name: 'entity-extraction / model-a' });
-      expect(screen.getAllByRole('combobox')).toHaveLength(1);
-      expect(within(emptyState).getByRole('combobox')).toBeDefined();
-      expect(resultRequests).toEqual([]);
+      const select = (await screen.findByRole('combobox')) as HTMLSelectElement;
+      await screen.findByRole('option', { name: 'All experiments' });
+      expect(select.value).toBe('all');
+
+      await screen.findByText(/third question/);
+      await screen.findByText(/other question/);
+      expect(requestedExperiments()).toEqual([EXPERIMENT_ID, OTHER_EXPERIMENT_ID]);
     });
   });
 
@@ -133,16 +136,30 @@ describe('Review Queue page', () => {
 
       await screen.findByText(/third question/);
       expect(screen.queryByText(/other question/)).toBeNull();
-      expect(screen.getAllByRole('combobox')).toHaveLength(1);
-      expect(screen.queryByText('Select an experiment to review its queue')).toBeNull();
+      expect(requestedExperiments()).toEqual([EXPERIMENT_ID]);
     });
   });
 
   describe('when ?experiment does not match any experiment', () => {
-    it('falls back to the empty state', async () => {
+    it('shows an empty queue without fetching results', async () => {
       renderPage('?experiment=unknown');
 
-      await screen.findByText('Select an experiment to review its queue');
+      await screen.findByText('No items to review');
+      expect(resultRequests).toEqual([]);
+    });
+  });
+
+  describe('when the user picks "All experiments"', () => {
+    it('clears ?experiment and shows every queue', async () => {
+      const { router } = renderPage(`?experiment=${EXPERIMENT_ID}`);
+
+      const select = await screen.findByRole('combobox');
+      await screen.findByRole('option', { name: 'All experiments' });
+      fireEvent.change(select, { target: { value: 'all' } });
+
+      await waitFor(() => expect(router.state.location.search).toBe(''));
+      await screen.findByText(/third question/);
+      await screen.findByText(/other question/);
     });
   });
 


### PR DESCRIPTION
## Summary

Studio polish across the experiments / datasets pages.

**Review queue lists everything by default.** `/experiments/review-queue` used to show a "No experiment selected" empty state until you picked an experiment. It now lists every item awaiting review across the project; the experiment combobox is an optional filter with an **All experiments** entry to clear it (URL: `?experiment=<id>` when filtered, cleared otherwise; `&review=<resultId>` deep links still open the dialog). The review hooks (`useReviewItems` / `useCompletedItems`) are now experiment-driven rather than dataset-keyed, and `DatasetReview` accepts optional `datasetId` / `experimentId`. The list also re-syncs from the server when a refetch lands, fixing an empty queue after flagging a review and navigating back.

**Experiments table: dedicated Description column.** The experiment name cell no longer stacks the description under the name; the description gets its own single-line truncated column (tooltip for long text, `—` when empty).

**Experiment results: smaller input column.** The input track is capped (`minmax(10rem,20rem)`) so it stops stretching across the row when there are few scorer columns.

**Datasets page: infinite scroll.** Replaced prev/next pagination with the same sentinel-based `useInfiniteQuery` pattern used by dataset items, results and scores (`useInfiniteDatasets`).

## Test plan

- [x] `pnpm --filter @mastra/playground vitest run` — 326 files, 2194 tests green
- [x] `tsc --noEmit`, eslint 0 errors
- [x] MSW tests updated/added: review-queue page (all / scoped / unknown id / reset), `DatasetReview` unscoped + stale-cache resync, review hooks scoping, `ExperimentCombobox` `allOption`, `ExperimentNameLabel` / `ExperimentDescriptionLabel`, `ExperimentsList` description column, `useInfiniteDatasets` paging
- [ ] Manual in Studio: open review queue without query → all items; filter by experiment → narrowed + URL updated; "All experiments" → cleared; experiments table shows Description column; datasets page loads more on scroll

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Studio review queue now shows all items that need review, with an option to filter by experiment. The experiments and datasets pages also have clearer layouts and easier scrolling.

## Changes

- Added project-wide review queue support with optional experiment filtering.
- Added the “All experiments” option and URL-based filter state.
- Kept review dialogs deep-linkable.
- Updated review hooks to support optional experiment scoping.
- Made `DatasetReview.datasetId` optional.
- Added review-list refresh behavior after refetches.
- Added a separate truncated Description column to the experiments list.
- Limited experiment result inputs to 20rem.
- Replaced dataset pagination with sentinel-based infinite scrolling.
- Added and updated tests for review filtering, experiment descriptions, and infinite dataset loading.
- Added a patch changeset for `@mastra/playground`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->