### PR TITLE
perf(factory): defer repository registration until selection

### DIFF
--- a/.changeset/afraid-cougars-own.md
+++ b/.changeset/afraid-cougars-own.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Improved Factory repository search by persisting only the repository selected for a project.

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/CreateFactoryFlow.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/CreateFactoryFlow.msw.test.tsx
@@ -43,7 +43,6 @@ const repo = {
   private: false,
   installationId: 7,
   installationStorageId: 'inst-7',
-  repositoryStorageId: 'repo-99',
   sandboxProvider: 'local',
   sandboxWorkdir: '/workspace/hello',
 };
@@ -584,7 +583,10 @@ function stubModelStepEndpoints(calls: string[], intakeConfig: Record<string, un
       `${TEST_BASE_URL}/web/factory/projects/fp-1/source-control-connections/conn-1/repositories`,
       async ({ request }) => {
         calls.push('link');
-        expect(await request.json()).toMatchObject({ repositoryId: 'repo-99', branch: 'main' });
+        expect(await request.json()).toMatchObject({
+          repository: { externalId: '99', slug: 'octo/hello' },
+          branch: 'main',
+        });
         return HttpResponse.json({ projectRepository: linkedRepository });
       },
     ),

--- a/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/FactoryCreateRefresh.msw.test.tsx
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/components/__tests__/FactoryCreateRefresh.msw.test.tsx
@@ -28,7 +28,6 @@ const repo = {
   private: false,
   installationId: 7,
   installationStorageId: 'inst-7',
-  repositoryStorageId: 'repo-99',
   sandboxProvider: 'local',
   sandboxWorkdir: '/workspace/hello',
 };

--- a/mastracode/factory-ui/src/ui/domains/workspaces/hooks/useCreateFactoryFlow.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/hooks/useCreateFactoryFlow.ts
@@ -32,8 +32,7 @@ function isGithubRepo(value: unknown): value is GithubRepo {
     typeof candidate.id === 'number' &&
     typeof candidate.fullName === 'string' &&
     typeof candidate.defaultBranch === 'string' &&
-    typeof candidate.installationStorageId === 'string' &&
-    typeof candidate.repositoryStorageId === 'string'
+    typeof candidate.installationStorageId === 'string'
   );
 }
 

--- a/mastracode/factory-ui/src/ui/domains/workspaces/services/github.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/services/github.ts
@@ -23,7 +23,11 @@ export interface GithubInstallation {
 
 /** Reason the GitHub feature is in its current state, returned by the server. */
 export type GithubStatusReason =
-  'missing_config' | 'auth_required' | 'organization_required' | 'not_connected' | 'ready';
+  | 'missing_config'
+  | 'auth_required'
+  | 'organization_required'
+  | 'not_connected'
+  | 'ready';
 
 /** Non-secret diagnostic snapshot of every GitHub feature gate. */
 export interface GithubFeatureDiagnostics {

--- a/mastracode/factory-ui/src/ui/domains/workspaces/services/github.ts
+++ b/mastracode/factory-ui/src/ui/domains/workspaces/services/github.ts
@@ -23,11 +23,7 @@ export interface GithubInstallation {
 
 /** Reason the GitHub feature is in its current state, returned by the server. */
 export type GithubStatusReason =
-  | 'missing_config'
-  | 'auth_required'
-  | 'organization_required'
-  | 'not_connected'
-  | 'ready';
+  'missing_config' | 'auth_required' | 'organization_required' | 'not_connected' | 'ready';
 
 /** Non-secret diagnostic snapshot of every GitHub feature gate. */
 export interface GithubFeatureDiagnostics {
@@ -78,8 +74,6 @@ export interface GithubRepo {
   installationId: number;
   /** Storage UUID of the installation row backing this repo. */
   installationStorageId: string;
-  /** Storage UUID of the repository row backing this repo. */
-  repositoryStorageId: string;
   sandboxProvider: string;
   sandboxWorkdir: string;
 }
@@ -416,7 +410,7 @@ export async function linkRepository(
       credentials: 'include',
       headers: { 'content-type': 'application/json', Accept: 'application/json' },
       body: JSON.stringify({
-        repositoryId: repo.repositoryStorageId,
+        repository: { externalId: String(repo.id), slug: repo.fullName },
         branch: repo.defaultBranch,
         sandboxProvider: repo.sandboxProvider,
         sandboxWorkdir: repo.sandboxWorkdir,

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { VersionControl } from './capabilities/version-control.js';
 import { MastraFactory } from './factory.js';
 import type { FactoryIntegration, IntegrationContext } from './integrations/base.js';
+import type * as projectRoutesModule from './routes/projects.js';
 import type * as surfaceModule from './routes/surface.js';
 import type * as tenantCredentialsModule from './routes/tenant-credentials.js';
 import { defaultFactoryRules, DEFAULT_FACTORY_RULE_VERSION } from './rules/defaults.js';
@@ -61,6 +62,20 @@ const prepareMock = vi.fn(async (config: Record<string, unknown>) => ({
 vi.mock('@mastra/code-sdk', () => ({
   prepareAgentControllerMount: (config: Record<string, unknown>) => prepareMock(config),
 }));
+
+const projectRouteOptions = vi.hoisted(
+  () => [] as Array<ConstructorParameters<typeof projectRoutesModule.ProjectRoutes>[0]>,
+);
+vi.mock('./routes/projects', async importOriginal => {
+  const actual = await importOriginal<typeof projectRoutesModule>();
+  class TrackedProjectRoutes extends actual.ProjectRoutes {
+    constructor(options: ConstructorParameters<typeof actual.ProjectRoutes>[0]) {
+      super(options);
+      projectRouteOptions.push(options);
+    }
+  }
+  return { ...actual, ProjectRoutes: TrackedProjectRoutes };
+});
 
 // Track what the factory actually wires as the terminal-stage hook: the
 // cleanup must be constructed by production code (not just by its own unit
@@ -836,6 +851,43 @@ describe('MastraFactory.prepare integrations', () => {
       integrations: [fakeIntegration({ id: 'custom' }), fakeIntegration({ id: 'custom' })],
     });
     await expect(factory.prepare()).rejects.toThrow(/duplicate integration id 'custom'/);
+  });
+
+  it('sanitizes an invalid GitHub default branch when resolving a selected repository', async () => {
+    const storage = fakeStorage();
+    const installation = { id: 'installation-1', externalId: '123' };
+    const sourceControlStorage = {
+      installations: { get: vi.fn(async () => installation) },
+      repositories: {
+        upsert: vi.fn(async ({ input }: { input: { defaultBranch: string } }) => input),
+      },
+    };
+    const github = fakeIntegration({
+      id: 'github',
+      sourceControlStorage,
+      listInstallationRepos: vi.fn(async () => [
+        {
+          id: 456,
+          fullName: 'acme/api',
+          name: 'api',
+          owner: 'acme',
+          defaultBranch: 'invalid branch',
+          private: false,
+        },
+      ]),
+    } as Partial<FactoryIntegration> & { id: string });
+
+    await prepareFactory({ storage, integrations: [github] });
+    const resolveRepository = projectRouteOptions.at(-1)?.resolveRepository;
+    const repository = await resolveRepository?.({
+      integrationId: 'github',
+      orgId: 'org-1',
+      installationId: installation.id,
+      externalId: '456',
+      slug: 'acme/api',
+    });
+
+    expect(repository?.defaultBranch).toBe('main');
   });
 
   it('initializes version-control capabilities with integration-scoped storage', async () => {

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -47,6 +47,7 @@ import {
   resolveFactoryPullRequestParentWorkItemId,
 } from './integrations/github/provenance.js';
 import type { FactoryPullRequestProvenanceData } from './integrations/github/provenance.js';
+import { isValidGitRef } from './integrations/github/sandbox.js';
 import { PlatformGithubIntegration } from './integrations/platform/github/integration.js';
 import { PlatformLinearIntegration } from './integrations/platform/linear/integration.js';
 import { createCustomProvidersPrimer, registerCustomProvidersSource } from './routes/custom-provider-source.js';
@@ -534,7 +535,8 @@ export class MastraFactory {
     const factoryReady = storage.isDomainReady('projects') && storage.isDomainReady('work-items');
     const knowledgeEnabled = process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS === '1';
     const githubIntegration = integrations.find(integration => integration.id === 'github') as
-      GithubIntegration | undefined;
+      | GithubIntegration
+      | undefined;
     const workItemsReady = storage.isDomainReady('work-items');
     const sessionRetirement =
       sandboxConfig && storage.isDomainReady('source-control')
@@ -612,7 +614,7 @@ export class MastraFactory {
                   installationId,
                   externalId,
                   slug: selected.fullName,
-                  defaultBranch: selected.defaultBranch,
+                  defaultBranch: isValidGitRef(selected.defaultBranch) ? selected.defaultBranch : 'main',
                   providerMetadata: { private: selected.private, owner: selected.owner },
                 },
               });

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -534,8 +534,7 @@ export class MastraFactory {
     const factoryReady = storage.isDomainReady('projects') && storage.isDomainReady('work-items');
     const knowledgeEnabled = process.env.MASTRACODE_EXPERIMENTAL_SUBCONSCIOUS === '1';
     const githubIntegration = integrations.find(integration => integration.id === 'github') as
-      | GithubIntegration
-      | undefined;
+      GithubIntegration | undefined;
     const workItemsReady = storage.isDomainReady('work-items');
     const sessionRetirement =
       sandboxConfig && storage.isDomainReady('source-control')
@@ -595,6 +594,31 @@ export class MastraFactory {
       versionControlIntegrationIds: integrations
         .filter(integration => integration.versionControl)
         .map(integration => integration.id),
+      ...(githubIntegration
+        ? {
+            resolveRepository: async ({ integrationId, orgId, installationId, externalId, slug }) => {
+              if (integrationId !== githubIntegration.id) return null;
+              const installation = await githubIntegration.sourceControlStorage.installations.get({
+                orgId,
+                id: installationId,
+              });
+              if (!installation) return null;
+              const repositories = await githubIntegration.listInstallationRepos(Number(installation.externalId));
+              const selected = repositories.find(repo => repo.id.toString() === externalId && repo.fullName === slug);
+              if (!selected) return null;
+              return githubIntegration.sourceControlStorage.repositories.upsert({
+                orgId,
+                input: {
+                  installationId,
+                  externalId,
+                  slug: selected.fullName,
+                  defaultBranch: selected.defaultBranch,
+                  providerMetadata: { private: selected.private, owner: selected.owner },
+                },
+              });
+            },
+          }
+        : {}),
       ...(sessionRetirement ? { sessionRetirement } : {}),
       ...(workItemsReady ? { workItems: workItemsStorage } : {}),
     });

--- a/mastracode/factory/src/integrations/github/org-isolation-scenario.test.ts
+++ b/mastracode/factory/src/integrations/github/org-isolation-scenario.test.ts
@@ -447,12 +447,15 @@ describe('two users in one org each get their own sandbox + session workspace', 
     });
     // Materialization memoizes the session sandbox in-process; git write
     // routes resolve through the memo, not persisted columns.
-    getSessionSandbox(session.id, 'a1/feat-x', () =>
-      ({
-        id: 'sb-a1-session',
-        provider: 'stub',
-        executeCommand: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
-      }) as never,
+    getSessionSandbox(
+      session.id,
+      'a1/feat-x',
+      () =>
+        ({
+          id: 'sb-a1-session',
+          provider: 'stub',
+          executeCommand: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+        }) as never,
     ).workdir = '/workspace/a1/feat-x';
 
     // User 2 cannot address user 1's session workspace.
@@ -494,12 +497,15 @@ describe('cross-user session workspaces are rejected', () => {
         sandboxId: `sb-${userId}`,
         sandboxWorkdir: `/workspace/sessions/${userId}/feat-x`,
       });
-      getSessionSandbox(session.id, `sessions/${userId}`, () =>
-        ({
-          id: `sb-${userId}`,
-          provider: 'stub',
-          executeCommand: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
-        }) as never,
+      getSessionSandbox(
+        session.id,
+        `sessions/${userId}`,
+        () =>
+          ({
+            id: `sb-${userId}`,
+            provider: 'stub',
+            executeCommand: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+          }) as never,
       ).workdir = `/workspace/sessions/${userId}/feat-x`;
       sessions.set(userId, session);
     }
@@ -564,13 +570,7 @@ describe('install flow binds the installation to the org', () => {
 
     const repos = await user2.request('/web/github/repos');
     expect(repos.status).toBe(200);
-    expect(tables.repositories).toHaveLength(1);
-    expect(tables.repositories[0]).toMatchObject({
-      installationId: tables.installations[0]!.id,
-      externalId: '99',
-      slug: 'octo/hello',
-      defaultBranch: 'main',
-    });
+    expect(tables.repositories).toHaveLength(0);
     expect(await repos.json()).toMatchObject({
       repos: [
         {
@@ -578,7 +578,6 @@ describe('install flow binds the installation to the org', () => {
           fullName: 'octo/hello',
           installationId: 7,
           installationStorageId: tables.installations[0]!.id,
-          repositoryStorageId: tables.repositories[0]!.id,
           sandboxProvider: 'custom',
           // Display-only listing guess: repos clone into the VM's home.
           sandboxWorkdir: '~/hello',

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -461,11 +461,9 @@ const stateSigner = {
   },
 };
 
-const materializeRepo = vi.fn(
-  async (opts: { onProgress?: (e: any) => void }) => {
-    opts.onProgress?.({ phase: 'cloning', message: 'Cloning octo/hello…' });
-  },
-);
+const materializeRepo = vi.fn(async (opts: { onProgress?: (e: any) => void }) => {
+  opts.onProgress?.({ phase: 'cloning', message: 'Cloning octo/hello…' });
+});
 const runSetupCommand = vi.fn(async (_sb: any, _worktreePath: string, _command: string) => {});
 const runTeardownCommand = vi.fn(async (_sb: any, _worktreePath: string, _command: string) => {});
 const commitAll = vi.fn(async () => ({ committed: true }));
@@ -1097,8 +1095,13 @@ describe('repos route', () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.repos).toHaveLength(1);
-    expect(json.repos[0].fullName).toBe('octo/hello');
-    expect(tables.repositories).toHaveLength(1);
+    expect(json.repos[0]).toMatchObject({
+      fullName: 'octo/hello',
+      installationStorageId: tables.installations[0]!.id,
+      sandboxWorkdir: '~/hello',
+    });
+    expect(json.repos[0]).not.toHaveProperty('repositoryStorageId');
+    expect(tables.repositories).toHaveLength(0);
   });
 
   it('prunes installations GitHub no longer knows (404) and keeps listing the rest', async () => {
@@ -2117,12 +2120,9 @@ describe('Factory session routes', () => {
 
     expect(deleted.status).toBe(200);
     expect(controller.deleteSession).toHaveBeenCalledWith({ resourceId: sessionId });
-    expect(runTeardownCommand).toHaveBeenCalledWith(
-      live,
-      '/workspace/hello',
-      'docker compose down --remove-orphans',
-      { timeoutMs: 15 * 60_000 },
-    );
+    expect(runTeardownCommand).toHaveBeenCalledWith(live, '/workspace/hello', 'docker compose down --remove-orphans', {
+      timeoutMs: 15 * 60_000,
+    });
     expect(invalidateSession).toHaveBeenCalledWith(sessionId);
     expect(tables.sessions).toHaveLength(0);
     // Deleted sessions destroy their VM — nothing resolves this id again.

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -659,37 +659,15 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
           }
         }
 
-        // Mirror matches into storage with bounded concurrency instead of one
-        // awaited upsert per repository.
-        const repos = new Array(matches.length);
-        const upsertConcurrency = 10;
-        for (let start = 0; start < matches.length; start += upsertConcurrency) {
-          await Promise.all(
-            matches.slice(start, start + upsertConcurrency).map(async ({ inst, repo }, offset) => {
-              const repository = await github.sourceControlStorage.repositories.upsert({
-                orgId,
-                input: {
-                  installationId: inst.id,
-                  externalId: repo.id.toString(),
-                  slug: repo.fullName,
-                  defaultBranch: isValidGitRef(repo.defaultBranch) ? repo.defaultBranch : 'main',
-                  providerMetadata: { private: repo.private, owner: repo.owner },
-                },
-              });
-              repos[start + offset] = {
-                ...repo,
-                installationStorageId: inst.id,
-                repositoryStorageId: repository.id,
-                sandboxProvider: sandbox ? 'custom' : 'none',
-                // Display only — the runtime workdir is resolved from the
-                // live sandbox at open time, never read from this row. Repos
-                // clone into the VM's home; `~/<repo>` is the honest
-                // listing-time guess.
-                sandboxWorkdir: `~/${sanitizeSegment(repo.fullName.split('/', 2)[1] || 'repo')}`,
-              };
-            }),
-          );
-        }
+        const repos = matches.map(({ inst, repo }) => ({
+          ...repo,
+          installationStorageId: inst.id,
+          sandboxProvider: sandbox ? 'custom' : 'none',
+          // Display only — the runtime workdir is resolved from the
+          // live sandbox at open time. Repositories are persisted only after
+          // selection, so `~/<repo>` is the honest listing-time guess.
+          sandboxWorkdir: `~/${sanitizeSegment(repo.fullName.split('/', 2)[1] || 'repo')}`,
+        }));
         return c.json({ repos });
       },
     }),
@@ -1086,9 +1064,7 @@ async function loadOwnedProject(options: {
   auth: RouteAuth;
   sandbox?: MastraFactorySandboxConfig;
   c: RouteContext;
-}): Promise<
-  { orgId: string; userId: string; project: ResolvedProjectRepository } | { response: Response }
-> {
+}): Promise<{ orgId: string; userId: string; project: ResolvedProjectRepository } | { response: Response }> {
   const { github, auth, sandbox, c } = options;
   const resolved = await resolveOrgTenant(c, auth);
   if ('response' in resolved) return { response: resolved.response };
@@ -1701,7 +1677,6 @@ function buildProjectGitRoutes({
         }
       },
     }),
-
   ];
 }
 

--- a/mastracode/factory/src/routes/projects.test.ts
+++ b/mastracode/factory/src/routes/projects.test.ts
@@ -10,6 +10,7 @@ const projectRoutes = (
   seed: FactoryStorageTestSeed,
   versionControlIntegrationIds?: string[],
   sessionRetirement?: ConstructorParameters<typeof ProjectRoutes>[0]['sessionRetirement'],
+  resolveRepository?: ConstructorParameters<typeof ProjectRoutes>[0]['resolveRepository'],
 ) =>
   new ProjectRoutes({
     auth: fakeRouteAuth(),
@@ -17,6 +18,7 @@ const projectRoutes = (
     sourceControl: seed.sourceControl,
     versionControlIntegrationIds,
     sessionRetirement,
+    resolveRepository,
   }).routes();
 
 describe('ProjectRoutes', () => {
@@ -222,15 +224,18 @@ describe('ProjectRoutes', () => {
       externalId: 'gl-1',
       accountName: 'acme-group',
     });
-    const githubRepository = await github.repositories.upsert({
-      orgId: 'org-1',
-      input: {
-        installationId: githubInstallation.id,
-        externalId: 'repo-1',
-        slug: 'acme/api',
-        defaultBranch: 'main',
-      },
-    });
+    const resolveRepository = vi.fn(
+      async ({
+        orgId,
+        installationId,
+        externalId,
+        slug,
+      }: Parameters<NonNullable<ConstructorParameters<typeof ProjectRoutes>[0]['resolveRepository']>>[0]) =>
+        github.repositories.upsert({
+          orgId,
+          input: { installationId, externalId, slug, defaultBranch: 'main' },
+        }),
+    );
     const gitlabRepository = await gitlab.repositories.upsert({
       orgId: 'org-1',
       input: {
@@ -245,7 +250,7 @@ describe('ProjectRoutes', () => {
       context.set('factoryAuthUser' as never, { workosId: 'user-1', organizationId: 'org-1' } as never);
       await next();
     });
-    mountApiRoutes(app as never, projectRoutes(seed, ['github', 'gitlab']));
+    mountApiRoutes(app as never, projectRoutes(seed, ['github', 'gitlab'], undefined, resolveRepository));
 
     const connect = async (integrationId: string, installationId: string) => {
       const response = await app.request(`/web/factory/projects/${project.id}/source-control-connections`, {
@@ -278,7 +283,30 @@ describe('ProjectRoutes', () => {
       expect(response.status).toBe(201);
       return ((await response.json()) as { projectRepository: { id: string } }).projectRepository;
     };
-    const githubLink = await link(githubConnection.id, githubRepository.id, 'release');
+    const githubLinkResponse = await app.request(
+      `/web/factory/projects/${project.id}/source-control-connections/${githubConnection.id}/repositories`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          repository: { externalId: 'repo-1', slug: 'acme/api' },
+          branch: 'release',
+          sandboxProvider: 'local',
+          sandboxWorkdir: '/workspace/api',
+          setupCommand: 'pnpm install',
+          teardownCommand: 'pnpm local worktree teardown',
+        }),
+      },
+    );
+    expect(githubLinkResponse.status).toBe(201);
+    const githubLink = ((await githubLinkResponse.json()) as { projectRepository: { id: string } }).projectRepository;
+    expect(resolveRepository).toHaveBeenCalledWith({
+      integrationId: 'github',
+      orgId: 'org-1',
+      installationId: githubInstallation.id,
+      externalId: 'repo-1',
+      slug: 'acme/api',
+    });
     await link(gitlabConnection.id, gitlabRepository.id, 'trunk');
 
     const listResponse = await app.request(`/web/factory/projects/${project.id}/source-control-connections`);

--- a/mastracode/factory/src/routes/projects.ts
+++ b/mastracode/factory/src/routes/projects.ts
@@ -10,6 +10,7 @@ import type {
 } from '../storage/domains/projects/base.js';
 import type {
   ProjectRepository,
+  SourceControlRepository,
   SourceControlStorage,
   SourceControlStorageHandle,
   UpdateProjectRepositoryInput,
@@ -110,7 +111,8 @@ function parseOptionalString(
 }
 
 function parseRepositoryLinkInput(value: unknown): {
-  repositoryId: string;
+  repositoryId?: string;
+  repository?: { externalId: string; slug: string };
   branch: string | null;
   sandboxProvider: string;
   sandboxWorkdir: string;
@@ -119,7 +121,18 @@ function parseRepositoryLinkInput(value: unknown): {
 } | null {
   if (!value || typeof value !== 'object') return null;
   const input = value as Record<string, unknown>;
-  if (typeof input.repositoryId !== 'string' || !UUID_RE.test(input.repositoryId)) return null;
+  const repositoryId =
+    typeof input.repositoryId === 'string' && UUID_RE.test(input.repositoryId) ? input.repositoryId : undefined;
+  const repositoryInput = input.repository;
+  let repository: { externalId: string; slug: string } | undefined;
+  if (repositoryInput && typeof repositoryInput === 'object') {
+    const candidate = repositoryInput as Record<string, unknown>;
+    const externalId = parseOptionalString(candidate.externalId, { maxLength: MAX_NAME_LENGTH });
+    const slug = parseOptionalString(candidate.slug, { maxLength: MAX_NAME_LENGTH });
+    if (typeof externalId !== 'string' || typeof slug !== 'string') return null;
+    repository = { externalId, slug };
+  }
+  if (!repositoryId && !repository) return null;
   const branch = parseOptionalString(input.branch, { maxLength: MAX_BRANCH_LENGTH, nullable: true });
   const sandboxProvider = parseOptionalString(input.sandboxProvider, { maxLength: MAX_SANDBOX_PROVIDER_LENGTH });
   const sandboxWorkdir = parseOptionalString(input.sandboxWorkdir, { maxLength: MAX_SANDBOX_WORKDIR_LENGTH });
@@ -140,7 +153,8 @@ function parseRepositoryLinkInput(value: unknown): {
   )
     return null;
   return {
-    repositoryId: input.repositoryId,
+    ...(repositoryId ? { repositoryId } : {}),
+    ...(repository ? { repository } : {}),
     branch: branch ?? null,
     sandboxProvider,
     sandboxWorkdir,
@@ -189,6 +203,14 @@ export interface ProjectRoutesDeps extends RouteDependencies {
   sourceControl: SourceControlStorage;
   /** Integration ids allowed as source-control connection targets. */
   versionControlIntegrationIds?: string[];
+  /** Validate and persist a repository selected from a provider-backed listing. */
+  resolveRepository?: (input: {
+    integrationId: string;
+    orgId: string;
+    installationId: string;
+    externalId: string;
+    slug: string;
+  }) => Promise<SourceControlRepository | null>;
   /**
    * Fire-and-forget hook invoked after a repository is linked to a project —
    * kicks the initial base-checkpoint build. Must never throw.
@@ -467,14 +489,25 @@ export class ProjectRoutes extends Route<ProjectRoutesDeps> {
           if (!found) return context.json({ error: 'Source-control connection not found' }, 404);
           const input = parseRepositoryLinkInput(await readJson(context));
           if (!input) return context.json({ error: 'invalid_project_repository' }, 400);
-          const repository = await found.handle.repositories.get({ orgId: tenant.orgId, id: input.repositoryId });
+          const repository = input.repositoryId
+            ? await found.handle.repositories.get({ orgId: tenant.orgId, id: input.repositoryId })
+            : input.repository && this.deps.resolveRepository
+              ? await this.deps.resolveRepository({
+                  integrationId: found.connection.integrationId,
+                  orgId: tenant.orgId,
+                  installationId: found.connection.installationId,
+                  ...input.repository,
+                })
+              : null;
           if (!repository || repository.installationId !== found.connection.installationId)
             return context.json({ error: 'Source-control repository not found' }, 404);
+          const { repositoryId: _repositoryId, repository: _repository, ...linkInput } = input;
           const projectRepository = await found.handle.projectRepositories.link({
             orgId: tenant.orgId,
             connectionId,
             createdByUserId: tenant.userId,
-            ...input,
+            repositoryId: repository.id,
+            ...linkInput,
           });
           try {
             this.deps.onProjectRepositoryLinked?.({ orgId: tenant.orgId, projectRepository });


### PR DESCRIPTION
## Problem

The Factory repository picker calls `/web/github/repos` to discover repositories available through connected GitHub installations. That route previously persisted every repository matching the current search before returning the response.

This made repository discovery unnecessarily expensive. An empty or broad search could fetch multiple pages from GitHub and then block on database upserts for every accessible repository, even though the user ultimately selects only one repository.

## Solution

Repository discovery is now read-only. `/web/github/repos` returns the lightweight GitHub repository data required by the picker without creating repository storage records.

When a user selects a repository, the project-link request sends its GitHub repository ID and slug. The server then:

1. Resolves the project-scoped source-control connection.
2. Confirms the selected repository belongs to that connection's GitHub installation.
3. Upserts only the selected repository under the resolved installation.
4. Links the persisted repository to the Factory project.

The existing repository-storage-ID request path remains supported for existing callers.

## Approach

- Removed repository upserts from the GitHub repository-list route.
- Removed `repositoryStorageId` from the repository-picker response and UI model.
- Added a validated lightweight repository identity to the project repository-link request.
- Added a connection-scoped repository resolver that verifies the repository against GitHub before persisting it.
- Updated Factory creation and restored-draft handling for the lightweight repository model.
- Updated route, organization-isolation, Factory creation, and refresh fixtures and expectations.
- Added a patch changeset for `@mastra/factory`.

## Tests

Added and updated coverage verifying that:

- Repository listing does not create repository rows.
- Listed repositories no longer include `repositoryStorageId`.
- Selecting a repository resolves, registers, and links it at selection time.
- Unknown or mismatched repositories are rejected.
- Existing persisted-repository-ID linking remains supported.
- Factory creation and refresh/resume flows send and retain the lightweight repository data.

Verification run:

- Factory route and integration tests: 140 passed.
- Factory UI MSW flow tests: 22 passed.
- Factory UI typecheck passed.
- Factory UI production build passed.
- Prettier and `git diff --check` passed.
- Local Factory runtime check passed: UI returned 200 and API returned the expected authenticated-route 401.

The Factory package typecheck still reports two pre-existing errors in `src/workspace.ts:458`, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Factory waits until a user selects a GitHub repository before saving it. This avoids storing unused repositories and ensures that Factory validates and links only the selected repository.

## Changes

- Return lightweight, read-only data from `/web/github/repos`.
- Remove `repositoryStorageId` from repository-list responses and UI types.
- Resolve and upsert the selected repository during project linking.
- Validate the repository against its project-scoped GitHub installation.
- Validate the selected repository branch and use `main` when it is invalid.
- Preserve existing repository-storage-ID linking.
- Update Factory creation, draft restoration, refresh flows, fixtures, and tests.
- Add a patch changeset for `@mastra/factory`.

## Testing

- Add coverage for read-only repository listing.
- Add coverage for selection-time registration and branch validation.
- Update coverage for existing ID-based linking and lightweight repository data.
- Reported route and integration tests, UI MSW tests, UI typecheck, production build, formatting checks, diff validation, and local runtime validation pass.
- Two unrelated pre-existing Factory package typecheck errors remain in `src/workspace.ts:458`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->